### PR TITLE
feat(cms): add data management forms

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/inventory/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/route.ts
@@ -1,0 +1,33 @@
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse, type NextRequest } from "next/server";
+import { inventoryItemSchema } from "@types";
+import { writeInventory } from "@platform-core/repositories/inventory.server";
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ shop: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const body = await req.json();
+    const parsed = inventoryItemSchema.array().safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().formErrors.join(", ") },
+        { status: 400 }
+      );
+    }
+    const { shop } = await context.params;
+    await writeInventory(shop, parsed.data);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/api/data/[shop]/rental/pricing/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/rental/pricing/route.ts
@@ -1,0 +1,32 @@
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse, type NextRequest } from "next/server";
+import { pricingSchema } from "@types";
+import { writePricing } from "@platform-core/repositories/pricing.server";
+
+export async function POST(
+  req: NextRequest,
+  _context: { params: Promise<{ shop: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const body = await req.json();
+    const parsed = pricingSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().formErrors.join(", ") },
+        { status: 400 }
+      );
+    }
+    await writePricing(parsed.data);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
@@ -1,0 +1,32 @@
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse, type NextRequest } from "next/server";
+import { returnLogisticsSchema } from "@types";
+import { writeReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
+
+export async function POST(
+  req: NextRequest,
+  _context: { params: Promise<{ shop: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const body = await req.json();
+    const parsed = returnLogisticsSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().formErrors.join(", ") },
+        { status: 400 }
+      );
+    }
+    await writeReturnLogistics(parsed.data);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Button, Textarea } from "@/components/atoms-shadcn";
+import { inventoryItemSchema, type InventoryItem } from "@types";
+import { FormEvent, useState } from "react";
+
+interface Props {
+  shop: string;
+  initial: InventoryItem[];
+}
+
+export default function InventoryForm({ shop, initial }: Props) {
+  const [text, setText] = useState(
+    () => JSON.stringify(initial, null, 2)
+  );
+  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      const json = JSON.parse(text);
+      const parsed = inventoryItemSchema.array().safeParse(json);
+      if (!parsed.success) {
+        setStatus("error");
+        setError(parsed.error.issues.map((i) => i.message).join(", "));
+        return;
+      }
+      setStatus("saved");
+      setError(null);
+      const res = await fetch(`/api/data/${shop}/inventory`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setStatus("error");
+        setError(body.error || "Failed to save");
+      }
+    } catch (err) {
+      setStatus("error");
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={10}
+      />
+      {status === "saved" && (
+        <p className="text-sm text-green-600">Saved!</p>
+      )}
+      {status === "error" && error && (
+        <p className="text-sm text-red-600">{error}</p>
+      )}
+      <Button type="submit">Save</Button>
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/page.tsx
@@ -1,0 +1,22 @@
+import { checkShopExists } from "@lib/checkShopExists.server";
+import { readInventory } from "@platform-core/repositories/inventory.server";
+import { notFound } from "next/navigation";
+import InventoryForm from "./InventoryForm";
+
+export const revalidate = 0;
+
+export default async function InventoryPage({
+  params,
+}: {
+  params: Promise<{ shop: string }>;
+}) {
+  const { shop } = await params;
+  if (!(await checkShopExists(shop))) return notFound();
+  const initial = await readInventory(shop);
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Inventory</h2>
+      <InventoryForm shop={shop} initial={initial} />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default async function DataIndex({
+  params,
+}: {
+  params: Promise<{ shop: string }>;
+}) {
+  const { shop } = await params;
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Data</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <Link href={`/cms/shop/${shop}/data/inventory`} className="text-primary underline">
+            Inventory
+          </Link>
+        </li>
+        <li>
+          <Link href={`/cms/shop/${shop}/data/rental/pricing`} className="text-primary underline">
+            Rental Pricing
+          </Link>
+        </li>
+        <li>
+          <Link href={`/cms/shop/${shop}/data/return-logistics`} className="text-primary underline">
+            Return Logistics
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Button, Textarea } from "@/components/atoms-shadcn";
+import { pricingSchema, type PricingMatrix } from "@types";
+import { FormEvent, useState } from "react";
+
+interface Props {
+  shop: string;
+  initial: PricingMatrix;
+}
+
+export default function PricingForm({ shop, initial }: Props) {
+  const [text, setText] = useState(
+    () => JSON.stringify(initial, null, 2)
+  );
+  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      const json = JSON.parse(text);
+      const parsed = pricingSchema.safeParse(json);
+      if (!parsed.success) {
+        setStatus("error");
+        setError(parsed.error.issues.map((i) => i.message).join(", "));
+        return;
+      }
+      setStatus("saved");
+      setError(null);
+      const res = await fetch(`/api/data/${shop}/rental/pricing`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setStatus("error");
+        setError(body.error || "Failed to save");
+      }
+    } catch (err) {
+      setStatus("error");
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={10}
+      />
+      {status === "saved" && (
+        <p className="text-sm text-green-600">Saved!</p>
+      )}
+      {status === "error" && error && (
+        <p className="text-sm text-red-600">{error}</p>
+      )}
+      <Button type="submit">Save</Button>
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/page.tsx
@@ -1,0 +1,22 @@
+import { checkShopExists } from "@lib/checkShopExists.server";
+import { readPricing } from "@platform-core/repositories/pricing.server";
+import { notFound } from "next/navigation";
+import PricingForm from "./PricingForm";
+
+export const revalidate = 0;
+
+export default async function PricingPage({
+  params,
+}: {
+  params: Promise<{ shop: string }>;
+}) {
+  const { shop } = await params;
+  if (!(await checkShopExists(shop))) return notFound();
+  const initial = await readPricing();
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Rental Pricing</h2>
+      <PricingForm shop={shop} initial={initial} />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Button, Input, Checkbox } from "@/components/atoms-shadcn";
+import { returnLogisticsSchema, type ReturnLogistics } from "@types";
+import { FormEvent, useState } from "react";
+
+interface Props {
+  shop: string;
+  initial: ReturnLogistics;
+}
+
+export default function ReturnLogisticsForm({ shop, initial }: Props) {
+  const [form, setForm] = useState<ReturnLogistics>(initial);
+  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const parsed = returnLogisticsSchema.safeParse(form);
+    if (!parsed.success) {
+      setStatus("error");
+      setError(parsed.error.issues.map((i) => i.message).join(", "));
+      return;
+    }
+    try {
+      setStatus("saved");
+      setError(null);
+      const res = await fetch(`/api/data/${shop}/return-logistics`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setStatus("error");
+        setError(body.error || "Failed to save");
+      }
+    } catch (err) {
+      setStatus("error");
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <label className="flex flex-col gap-1">
+        <span>Label Service</span>
+        <Input
+          value={form.labelService}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, labelService: e.target.value }))
+          }
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        <Checkbox
+          checked={form.inStore}
+          onCheckedChange={(v) =>
+            setForm((f) => ({ ...f, inStore: Boolean(v) }))
+          }
+        />
+        <span>Allow in-store returns</span>
+      </label>
+      {status === "saved" && (
+        <p className="text-sm text-green-600">Saved!</p>
+      )}
+      {status === "error" && error && (
+        <p className="text-sm text-red-600">{error}</p>
+      )}
+      <Button type="submit">Save</Button>
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
@@ -1,0 +1,22 @@
+import { checkShopExists } from "@lib/checkShopExists.server";
+import { readReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
+import { notFound } from "next/navigation";
+import ReturnLogisticsForm from "./ReturnLogisticsForm";
+
+export const revalidate = 0;
+
+export default async function ReturnLogisticsPage({
+  params,
+}: {
+  params: Promise<{ shop: string }>;
+}) {
+  const { shop } = await params;
+  if (!(await checkShopExists(shop))) return notFound();
+  const initial = await readReturnLogistics();
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Return Logistics</h2>
+      <ReturnLogisticsForm shop={shop} initial={initial} />
+    </div>
+  );
+}

--- a/packages/platform-core/src/repositories/json.server.ts
+++ b/packages/platform-core/src/repositories/json.server.ts
@@ -16,6 +16,9 @@ export { readShop } from "./shops.server";
 export { getShopSettings as readSettings } from "./settings.server";
 
 export * from "./products.server";
+export * from "./inventory.server";
+export * from "./pricing.server";
+export * from "./returnLogistics.server";
 
 export {
   diffHistory,

--- a/packages/platform-core/src/repositories/pricing.server.ts
+++ b/packages/platform-core/src/repositories/pricing.server.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { pricingSchema, type PricingMatrix } from "@types";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { resolveDataRoot } from "./utils";
+
+function pricingPath(): string {
+  return path.join(resolveDataRoot(), "..", "rental", "pricing.json");
+}
+
+export async function readPricing(): Promise<PricingMatrix> {
+  const buf = await fs.readFile(pricingPath(), "utf8");
+  const parsed = pricingSchema.safeParse(JSON.parse(buf));
+  if (!parsed.success) {
+    throw new Error("Invalid pricing data");
+  }
+  return parsed.data;
+}
+
+export async function writePricing(data: PricingMatrix): Promise<void> {
+  const file = pricingPath();
+  const tmp = `${file}.${Date.now()}.tmp`;
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  await fs.rename(tmp, file);
+}
+

--- a/packages/platform-core/src/repositories/returnLogistics.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.server.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { returnLogisticsSchema, type ReturnLogistics } from "@types";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { resolveDataRoot } from "./utils";
+
+function logisticsPath(): string {
+  return path.join(resolveDataRoot(), "..", "return-logistics.json");
+}
+
+export async function readReturnLogistics(): Promise<ReturnLogistics> {
+  const buf = await fs.readFile(logisticsPath(), "utf8");
+  const parsed = returnLogisticsSchema.safeParse(JSON.parse(buf));
+  if (!parsed.success) {
+    throw new Error("Invalid return logistics data");
+  }
+  return parsed.data;
+}
+
+export async function writeReturnLogistics(data: ReturnLogistics): Promise<void> {
+  const file = logisticsPath();
+  const tmp = `${file}.${Date.now()}.tmp`;
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  await fs.rename(tmp, file);
+}
+


### PR DESCRIPTION
## Summary
- add filesystem repositories for rental pricing and return logistics
- expose APIs for inventory, pricing and return logistics data
- add CMS forms with optimistic saves and schema validation

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: step did not advance yet, unable to find button)*
- `pnpm --filter @acme/platform-core test` *(fails: captured a request without a matching request handler)*

------
https://chatgpt.com/codex/tasks/task_e_68961cc54770832f854d2ef2727f19f3