### PR TITLE
Persist CMS page builder history and render stored pages

### DIFF
--- a/apps/shop-abc/src/app/[lang]/page.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.client.tsx
@@ -1,16 +1,13 @@
 // apps/shop-abc/src/app/[[...lang]]/page.tsx
 "use client";
 
-import HeroBanner from "@/components/home/HeroBanner";
-import ReviewsCarousel from "@/components/home/ReviewsCarousel";
-import { ValueProps } from "@/components/home/ValueProps";
+import DynamicRenderer from "@/components/DynamicRenderer.client";
+import type { PageComponent } from "@types";
 
-export default function Home() {
-  return (
-    <>
-      <HeroBanner />
-      <ValueProps />
-      <ReviewsCarousel />
-    </>
-  );
+export default function Home({
+  components,
+}: {
+  components: PageComponent[];
+}) {
+  return <DynamicRenderer components={components} />;
 }

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -1,0 +1,30 @@
+import type { PageComponent } from "@types";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import shop from "../../../shop.json";
+import Home from "./page.client";
+
+async function loadComponents(): Promise<PageComponent[]> {
+  try {
+    const file = path.join(
+      process.cwd(),
+      "..",
+      "..",
+      "data",
+      "shops",
+      shop.id,
+      "pages",
+      "home.json"
+    );
+    const json = await fs.readFile(file, "utf8");
+    const data = JSON.parse(json);
+    return Array.isArray(data) ? (data as PageComponent[]) : (data.components ?? []);
+  } catch {
+    return [];
+  }
+}
+
+export default async function Page() {
+  const components = await loadComponents();
+  return <Home components={components} />;
+}

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -1,16 +1,13 @@
 // apps/shop-bcd/src/app/[lang]/page.tsx
 "use client";
 
-import HeroBanner from "@/components/home/HeroBanner";
-import ReviewsCarousel from "@/components/home/ReviewsCarousel";
-import { ValueProps } from "@/components/home/ValueProps";
+import DynamicRenderer from "@/components/DynamicRenderer.client";
+import type { PageComponent } from "@types";
 
-export default function Home() {
-  return (
-    <>
-      <HeroBanner />
-      <ValueProps />
-      <ReviewsCarousel />
-    </>
-  );
+export default function Home({
+  components,
+}: {
+  components: PageComponent[];
+}) {
+  return <DynamicRenderer components={components} />;
 }

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -1,0 +1,30 @@
+import type { PageComponent } from "@types";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import shop from "../../../shop.json";
+import Home from "./page.client";
+
+async function loadComponents(): Promise<PageComponent[]> {
+  try {
+    const file = path.join(
+      process.cwd(),
+      "..",
+      "..",
+      "data",
+      "shops",
+      shop.id,
+      "pages",
+      "home.json"
+    );
+    const json = await fs.readFile(file, "utf8");
+    const data = JSON.parse(json);
+    return Array.isArray(data) ? (data as PageComponent[]) : (data.components ?? []);
+  } catch {
+    return [];
+  }
+}
+
+export default async function Page() {
+  const components = await loadComponents();
+  return <Home components={components} />;
+}

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -130,6 +130,20 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z
   .object({ id: z.string(), type: z.string() })
   .passthrough();
 
+export interface HistoryState {
+  past: PageComponent[][];
+  present: PageComponent[];
+  future: PageComponent[][];
+}
+
+export const historyStateSchema: z.ZodType<HistoryState> = z
+  .object({
+    past: z.array(z.array(pageComponentSchema)),
+    present: z.array(pageComponentSchema),
+    future: z.array(z.array(pageComponentSchema)),
+  })
+  .default({ past: [], present: [], future: [] });
+
 export const pageSchema = z.object({
   id: z.string(),
   slug: z.string(),
@@ -145,6 +159,7 @@ export const pageSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   createdBy: z.string(),
+  history: historyStateSchema.optional(),
 });
 
 export type Page = z.infer<typeof pageSchema>;

--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -17,7 +17,10 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import type { Page, PageComponent } from "@types";
+import { historyStateSchema, type HistoryState } from "@types";
 import type { CSSProperties } from "react";
+
+export { historyStateSchema };
 import {
   memo,
   useCallback,
@@ -69,12 +72,6 @@ interface Props {
   style?: CSSProperties;
 }
 
-export interface HistoryState {
-  past: PageComponent[][];
-  present: PageComponent[];
-  future: PageComponent[][];
-}
-
 /* ════════════════ runtime validation (Zod) ════════════════ */
 const pageComponentSchema: z.ZodType<PageComponent> = z
   .object({
@@ -86,22 +83,6 @@ const pageComponentSchema: z.ZodType<PageComponent> = z
     top: z.string().optional(),
   })
   .passthrough();
-
-/**
- *  Build → default → cast; the cast is safe because the default value
- *  fully satisfies the `HistoryState` contract.
- */
-export const historyStateSchema = z
-  .object({
-    past: z.array(z.array(pageComponentSchema)),
-    present: z.array(pageComponentSchema),
-    future: z.array(z.array(pageComponentSchema)),
-  })
-  .default({
-    past: [],
-    present: [],
-    future: [],
-  }) as unknown as z.ZodType<HistoryState>;
 
 /* ════════════════ reducers ════════════════ */
 type ChangeAction =
@@ -311,8 +292,9 @@ const PageBuilder = memo(function PageBuilder({
     fd.append("title", JSON.stringify(page.seo.title));
     fd.append("description", JSON.stringify(page.seo.description ?? {}));
     fd.append("components", JSON.stringify(components));
+    fd.append("history", JSON.stringify(state));
     return fd;
-  }, [page, components]);
+  }, [page, components, state]);
 
   /* ── render ───────────────────────────────────────────────────── */
   return (


### PR DESCRIPTION
## Summary
- Persist PageBuilder undo/redo history and serialize it with page drafts
- Load existing page components in wizard steps and restore history from server
- Render storefront home pages from saved page JSON for shops abc and bcd

## Testing
- `pnpm test` *(fails: WizardPage › renders notice and disabled form when no themes or templates - Exceeded timeout of 5000 ms)*

------
https://chatgpt.com/codex/tasks/task_e_6896258634d0832fb7a31fa5bc0bcc48