### PR TITLE
Validate ShopEditor inputs client-side

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ShopEditor from "../src/app/cms/shop/[shop]/settings/ShopEditor";
+import { updateShop } from "@cms/actions/shops.server";
+
+jest.mock("@cms/actions/shops.server", () => ({
+  updateShop: jest.fn(),
+}));
+
+describe("ShopEditor", () => {
+  it("shows error for invalid JSON and prevents submission", async () => {
+    const initial = {
+      id: "1",
+      name: "Test",
+      themeId: "base",
+      catalogFilters: [],
+      themeTokens: {},
+      filterMappings: {},
+      priceOverrides: {},
+      localeOverrides: {},
+    };
+
+    render(<ShopEditor shop="shop" initial={initial} />);
+
+    fireEvent.change(screen.getByLabelText(/theme tokens/i), {
+      target: { value: "{invalid" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText(/invalid json/i)).toBeInTheDocument();
+    expect(updateShop).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate ShopEditor fields with `shopSchema.safeParse`
- show field-specific errors instead of console logs
- add test preventing submission when JSON is invalid

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test __tests__/ShopEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68964c949a94832fb5833844cbb4fbd9