### PR TITLE
Load shop home components from pages repo

### DIFF
--- a/apps/shop-abc/__tests__/homePage.test.tsx
+++ b/apps/shop-abc/__tests__/homePage.test.tsx
@@ -1,0 +1,29 @@
+// apps/shop-abc/__tests__/homePage.test.tsx
+jest.mock("@platform-core/repositories/pages/index.server", () => ({
+  __esModule: true,
+  getPages: jest.fn(),
+}));
+jest.mock("../src/app/[lang]/page.client", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+import type { PageComponent } from "@types";
+import Page from "../src/app/[lang]/page";
+import Home from "../src/app/[lang]/page.client";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+
+test("Home receives components from pages repo", async () => {
+  const components: PageComponent[] = [
+    { id: "c1", type: "HeroBanner" } as any,
+  ];
+  (getPages as jest.Mock).mockResolvedValue([
+    { slug: "home", components } as any,
+  ]);
+
+  const element = await Page();
+
+  expect(getPages).toHaveBeenCalledWith("abc");
+  expect(element.type).toBe(Home);
+  expect(element.props.components).toEqual(components);
+});

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -1,27 +1,11 @@
 import type { PageComponent } from "@types";
-import { promises as fs } from "node:fs";
-import path from "node:path";
+import { getPages } from "@platform-core/repositories/pages/index.server";
 import shop from "../../../shop.json";
 import Home from "./page.client";
 
 async function loadComponents(): Promise<PageComponent[]> {
-  try {
-    const file = path.join(
-      process.cwd(),
-      "..",
-      "..",
-      "data",
-      "shops",
-      shop.id,
-      "pages",
-      "home.json"
-    );
-    const json = await fs.readFile(file, "utf8");
-    const data = JSON.parse(json);
-    return Array.isArray(data) ? (data as PageComponent[]) : (data.components ?? []);
-  } catch {
-    return [];
-  }
+  const pages = await getPages(shop.id);
+  return pages.find((p) => p.slug === "home")?.components ?? [];
 }
 
 export default async function Page() {


### PR DESCRIPTION
## Summary
- fetch home page components using `getPages`
- add unit test for home page components loading

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/homePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68964c727d44832f9d519e6e55f47735