### PR TITLE
test: add page schema and publish action cases

### DIFF
--- a/test/unit/page-schema.spec.ts
+++ b/test/unit/page-schema.spec.ts
@@ -1,0 +1,34 @@
+import Ajv from "ajv";
+import schema from "../../packages/platform-core/src/repositories/pages/schema.json";
+
+describe("page component discriminated union", () => {
+  const ajv = new Ajv();
+  const validate = ajv.compile(schema as any);
+
+  const basePage = {
+    id: "p1",
+    slug: "home",
+    status: "draft",
+    components: [] as any[],
+    seo: { title: "Home" },
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    createdBy: "tester",
+  };
+
+  it("accepts a valid component", () => {
+    const page = {
+      ...basePage,
+      components: [{ id: "c1", type: "HeroBanner" }],
+    };
+    expect(validate(page)).toBe(true);
+  });
+
+  it("rejects component with invalid prop", () => {
+    const page = {
+      ...basePage,
+      components: [{ id: "c1", type: "HeroBanner", extra: "nope" }],
+    };
+    expect(validate(page)).toBe(false);
+  });
+});

--- a/test/unit/publish-action.spec.ts
+++ b/test/unit/publish-action.spec.ts
@@ -1,0 +1,69 @@
+/** @jest-environment node */
+import type { Page } from "../../packages/types/src/Page";
+
+function mockAuth() {
+  jest.doMock("next-auth", () => ({
+    getServerSession: jest.fn().mockResolvedValue({
+      user: { role: "admin", email: "admin@example.com" },
+    }),
+  }));
+}
+
+describe("publish page action", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("saves page with published status", async () => {
+    const pages: Page[] = [];
+    jest.doMock(
+      "../../packages/platform-core/src/repositories/pages/index.server",
+      () => ({
+        getPages: jest.fn().mockResolvedValue(pages),
+        savePage: jest
+          .fn()
+          .mockImplementation(async (_shop: string, page: Page) => {
+            pages.push(page);
+            return page;
+          }),
+        updatePage: jest.fn(),
+        deletePage: jest.fn(),
+      })
+    );
+    mockAuth();
+    const { createPage } = await import(
+      "../../apps/cms/src/actions/pages.server"
+    );
+    const fd = new FormData();
+    fd.append("slug", "home");
+    fd.append("status", "published");
+    fd.append("components", "[]");
+
+    const result = await createPage("test", fd);
+    expect(result.page?.status).toBe("published");
+  });
+
+  it("rejects invalid payload", async () => {
+    jest.doMock(
+      "../../packages/platform-core/src/repositories/pages/index.server",
+      () => ({
+        getPages: jest.fn().mockResolvedValue([]),
+        savePage: jest.fn(),
+        updatePage: jest.fn(),
+        deletePage: jest.fn(),
+      })
+    );
+    mockAuth();
+    const { createPage } = await import(
+      "../../apps/cms/src/actions/pages.server"
+    );
+    const fd = new FormData();
+    fd.append("slug", "home");
+    fd.append("status", "published");
+    fd.append("components", "not-json");
+
+    const result = await createPage("test", fd);
+    expect(result.errors?.components[0]).toBe("Invalid components");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests ensuring page schema discriminated union accepts valid components and rejects extra props
- add publish action tests ensuring pages save with `status: "published"` and invalid payloads return errors

## Testing
- `npx jest test/unit/page-schema.spec.ts test/unit/publish-action.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6896564a3728832f905ec2138c72bb9d