### PR TITLE
feat: add discriminated union for page components

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -10,7 +10,7 @@ import {
 } from "@platform-core/repositories/pages/index.server";
 import * as Sentry from "@sentry/node";
 import type { Locale, Page, PageComponent } from "@types";
-import { historyStateSchema, pageComponentSchema } from "@types/Page";
+import { historyStateSchema, pageComponentSchema } from "@types";
 import { getServerSession } from "next-auth";
 import { ulid } from "ulid";
 import { z } from "zod";

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -87,11 +87,6 @@ export interface ImageComponent extends PageComponentBase {
   alt?: string;
 }
 
-export interface TextComponent extends PageComponentBase {
-  type: "Text";
-  text?: string;
-}
-
 export interface BlogListingComponent extends PageComponentBase {
   type: "BlogListing";
   posts?: { title: string; excerpt?: string; url?: string }[];
@@ -126,9 +121,129 @@ export type PageComponent =
   | ImageComponent
   | TextComponent;
 
-export const pageComponentSchema: z.ZodType<PageComponent> = z
-  .object({ id: z.string(), type: z.string() })
+const baseComponentSchema = z
+  .object({
+    id: z.string(),
+    width: z.string().optional(),
+    height: z.string().optional(),
+    position: z.enum(["relative", "absolute"]).optional(),
+    top: z.string().optional(),
+    left: z.string().optional(),
+    margin: z.string().optional(),
+    padding: z.string().optional(),
+  })
   .passthrough();
+
+const heroBannerComponentSchema = baseComponentSchema.extend({
+  type: z.literal("HeroBanner"),
+  slides: z
+    .array(
+      z.object({
+        src: z.string(),
+        alt: z.string().optional(),
+        headlineKey: z.string(),
+        ctaKey: z.string(),
+      })
+    )
+    .optional(),
+});
+
+const valuePropsComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ValueProps"),
+  items: z
+    .array(
+      z.object({ icon: z.string(), title: z.string(), desc: z.string() })
+    )
+    .optional(),
+});
+
+const reviewsCarouselComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ReviewsCarousel"),
+  reviews: z
+    .array(
+      z.object({ nameKey: z.string(), quoteKey: z.string() })
+    )
+    .optional(),
+});
+
+const productGridComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ProductGrid"),
+});
+
+const galleryComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Gallery"),
+  images: z
+    .array(z.object({ src: z.string(), alt: z.string().optional() }))
+    .optional(),
+});
+
+const contactFormComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ContactForm"),
+  action: z.string().optional(),
+  method: z.string().optional(),
+});
+
+const contactFormWithMapComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ContactFormWithMap"),
+  mapSrc: z.string().optional(),
+});
+
+const blogListingComponentSchema = baseComponentSchema.extend({
+  type: z.literal("BlogListing"),
+  posts: z
+    .array(
+      z.object({
+        title: z.string(),
+        excerpt: z.string().optional(),
+        url: z.string().optional(),
+      })
+    )
+    .optional(),
+});
+
+const testimonialSliderComponentSchema = baseComponentSchema.extend({
+  type: z.literal("TestimonialSlider"),
+  testimonials: z
+    .array(
+      z.object({ quote: z.string(), name: z.string().optional() })
+    )
+    .optional(),
+});
+
+const testimonialsComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Testimonials"),
+  testimonials: z
+    .array(
+      z.object({ quote: z.string(), name: z.string().optional() })
+    )
+    .optional(),
+});
+
+const imageComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Image"),
+  src: z.string().optional(),
+  alt: z.string().optional(),
+});
+
+const textComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Text"),
+  text: z.string().optional(),
+});
+
+export const pageComponentSchema = z.discriminatedUnion("type", [
+  heroBannerComponentSchema,
+  valuePropsComponentSchema,
+  reviewsCarouselComponentSchema,
+  productGridComponentSchema,
+  galleryComponentSchema,
+  contactFormComponentSchema,
+  contactFormWithMapComponentSchema,
+  blogListingComponentSchema,
+  testimonialsComponentSchema,
+  testimonialSliderComponentSchema,
+  imageComponentSchema,
+  textComponentSchema,
+]);
 
 export interface HistoryState {
   past: PageComponent[][];
@@ -148,9 +263,7 @@ export const pageSchema = z.object({
   id: z.string(),
   slug: z.string(),
   status: z.enum(["draft", "published"]),
-  components: z
-    .array(z.object({ id: z.string(), type: z.string() }).passthrough())
-    .default([]),
+  components: z.array(pageComponentSchema).default([]),
   seo: z.object({
     title: z.record(localeSchema, z.string()),
     description: z.record(localeSchema, z.string()).optional(),

--- a/packages/ui/__tests__/pageComponentSchema.test.ts
+++ b/packages/ui/__tests__/pageComponentSchema.test.ts
@@ -1,0 +1,26 @@
+import { pageComponentSchema } from "@types/Page";
+
+describe("pageComponentSchema", () => {
+  it("rejects unknown component type", () => {
+    const res = pageComponentSchema.safeParse({ id: "1", type: "Foo" });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects HeroBanner with invalid slides", () => {
+    const res = pageComponentSchema.safeParse({
+      id: "1",
+      type: "HeroBanner",
+      slides: [{ src: "/a.jpg" }],
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects ValueProps with invalid items", () => {
+    const res = pageComponentSchema.safeParse({
+      id: "1",
+      type: "ValueProps",
+      items: [{ icon: "i", title: "t" }],
+    });
+    expect(res.success).toBe(false);
+  });
+});

--- a/packages/ui/src/components/cms/PageBuilder.js
+++ b/packages/ui/src/components/cms/PageBuilder.js
@@ -6,7 +6,7 @@ import { arrayMove, rectSortingStrategy, SortableContext, sortableKeyboardCoordi
 import { memo, useCallback, useEffect, useMemo, useReducer, useState, } from "react";
 import { ulid } from "ulid";
 import { z } from "zod";
-import { pageComponentSchema as pageComponentSchemaBase } from "@types";
+import { pageComponentSchema } from "@types";
 import { Button } from "../atoms-shadcn";
 import CanvasItem from "./page-builder/CanvasItem";
 import ComponentEditor from "./page-builder/ComponentEditor";
@@ -24,21 +24,9 @@ const COMPONENT_TYPES = [
     "Testimonials",
     "TestimonialSlider",
     "Image",
-    "Text",
+"Text",
 ];
-/**
- *  Trick for Zod / TS: give `z.enum()` a statically-sized tuple.
- *  `as const` → readonly array  ⟶ spread into a tuple literal.
- */
-const COMPONENT_TYPE_TUPLE = [...COMPONENT_TYPES];
 /* ════════════════ runtime validation (Zod) ════════════════ */
-const pageComponentSchema = pageComponentSchemaBase.extend({
-    type: z.enum(COMPONENT_TYPE_TUPLE),
-    width: z.string().optional(),
-    height: z.string().optional(),
-    left: z.string().optional(),
-    top: z.string().optional(),
-});
 /**
  *  Build → default → cast; the cast is safe because the default value
  *  fully satisfies the `HistoryState` contract.

--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -17,7 +17,7 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import type { Page, PageComponent, HistoryState } from "@types";
-import { pageComponentSchema as pageComponentSchemaBase } from "@types";
+import { pageComponentSchema } from "@types";
 import type { CSSProperties } from "react";
 import {
   memo,
@@ -52,14 +52,6 @@ const COMPONENT_TYPES = [
 
 type ComponentType = (typeof COMPONENT_TYPES)[number];
 
-/**
- *  Trick for Zod / TS: give `z.enum()` a statically-sized tuple.
- *  `as const` → readonly array  ⟶ spread into a tuple literal.
- */
-const COMPONENT_TYPE_TUPLE = [...COMPONENT_TYPES] as [
-  ComponentType,
-  ...ComponentType[],
-];
 
 /* ════════════════ external contracts ════════════════ */
 interface Props {
@@ -71,14 +63,6 @@ interface Props {
 }
 
 /* ════════════════ runtime validation (Zod) ════════════════ */
-const pageComponentSchema = pageComponentSchemaBase.extend({
-  type: z.enum(COMPONENT_TYPE_TUPLE),
-  width: z.string().optional(),
-  height: z.string().optional(),
-  left: z.string().optional(),
-  top: z.string().optional(),
-});
-
 export const historyStateSchema: z.ZodType<HistoryState> = z
   .object({
     past: z.array(z.array(pageComponentSchema)),


### PR DESCRIPTION
## Summary
- replace generic page component schema with discriminated union of all component types
- use refined schema in CMS page builder and server actions
- add unit tests ensuring invalid component props are rejected

## Testing
- `cd packages/ui && pnpm exec jest --runTestsByPath __tests__/pageComponentSchema.test.ts --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6896562d84e4832f97057729f0afabf8