### PR TITLE
refactor: split component editor into subcomponents

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -1,26 +1,9 @@
 // packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
 "use client";
 
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
-import type { MediaItem, PageComponent } from "@types";
-import useMediaUpload from "@ui/hooks/useMediaUpload";
-import Image from "next/image";
-import { usePathname } from "next/navigation";
-import * as React from "react";
+import type { PageComponent } from "@types";
+import { memo, useCallback } from "react";
 import {
-  ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  DialogTrigger,
   Input,
   Select,
   SelectContent,
@@ -28,6 +11,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../atoms-shadcn";
+import ContactFormEditor from "./ContactFormEditor";
+import GalleryEditor from "./GalleryEditor";
+import ImageBlockEditor from "./ImageBlockEditor";
+import TestimonialsEditor from "./TestimonialsEditor";
+import HeroBannerEditor from "./HeroBannerEditor";
+import ValuePropsEditor from "./ValuePropsEditor";
+import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -35,301 +25,45 @@ interface Props {
 }
 
 function ComponentEditor({ component, onChange }: Props) {
-  /* ─────────── hooks ─────────── */
-  const pathname = usePathname() ?? "";
-  const shop = useMemo(() => getShopFromPath(pathname), [pathname]);
-  const [media, setMedia] = useState<MediaItem[]>([]);
-
-  /* ─────────── media helpers ─────────── */
-  const loadMedia = useCallback(async () => {
-    if (!shop) return;
-    try {
-      const res = await fetch(`/cms/api/media?shop=${shop}`);
-      if (res.ok) {
-        const data = await res.json();
-        if (Array.isArray(data)) setMedia(data);
-      }
-    } catch {
-      /* silent */
-    }
-  }, [shop]);
-
-  useEffect(() => {
-    void loadMedia();
-  }, [loadMedia]);
-
-  /* ─────────── reusable image-picker ─────────── */
-  const ImagePicker = memo(
-    ({
-      onSelect,
-      children,
-    }: {
-      onSelect: (url: string) => void;
-      children: React.ReactNode;
-    }) => {
-      const [open, setOpen] = useState(false);
-
-      const {
-        pendingFile,
-        altText,
-        setAltText,
-        isValid,
-        actual,
-        inputRef,
-        onFileChange,
-        handleUpload,
-        error,
-      } = useMediaUpload({
-        shop: shop ?? "",
-        requiredOrientation: "landscape",
-        onUploaded: (item: MediaItem) => {
-          setMedia((m) => [item, ...m]);
-        },
-      });
-
-      useEffect(() => {
-        if (open) void loadMedia();
-      }, [open, loadMedia]);
-
-      return (
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>{children}</DialogTrigger>
-          <DialogContent className="max-w-xl space-y-4">
-            <DialogTitle>Select image</DialogTitle>
-
-            {/* file picker + upload */}
-            <div className="flex items-center gap-2">
-              <Input
-                ref={inputRef}
-                type="file"
-                accept="image/*"
-                onChange={onFileChange}
-                className="flex-1"
-              />
-              {pendingFile && isValid && (
-                <Button type="button" onClick={handleUpload}>
-                  Upload
-                </Button>
-              )}
-            </div>
-
-            {/* alt-text input */}
-            {pendingFile && isValid && (
-              <Input
-                value={altText}
-                onChange={(e) => setAltText(e.target.value)}
-                placeholder="Alt text"
-              />
-            )}
-
-            {/* orientation check message */}
-            {pendingFile && isValid !== null && (
-              <p className="text-sm">
-                {isValid
-                  ? `Image orientation is ${actual}`
-                  : `Selected image is ${actual}; please upload a landscape image.`}
-              </p>
-            )}
-
-            {/* upload error */}
-            {error && <p className="text-sm text-red-600">{error}</p>}
-
-            {/* media grid */}
-            <div className="grid max-h-64 grid-cols-3 gap-2 overflow-auto">
-              {media.map((m) => (
-                <button
-                  key={m.url}
-                  type="button"
-                  onClick={() => {
-                    onSelect(m.url);
-                    setOpen(false);
-                  }}
-                  className="relative aspect-square"
-                >
-                  <Image
-                    src={m.url}
-                    alt={m.altText || "media"}
-                    fill
-                    className="object-cover"
-                  />
-                </button>
-              ))}
-              {media.length === 0 && (
-                <p className="text-muted-foreground col-span-3 text-sm">
-                  No media found.
-                </p>
-              )}
-            </div>
-          </DialogContent>
-        </Dialog>
-      );
-    }
-  );
-  ImagePicker.displayName = "ImagePicker";
-
-  /* ─────────── guard ─────────── */
   if (!component) return null;
 
-  /* ─────────── generic helpers ─────────── */
   const handleInput = useCallback(
     (field: string, value: string | number | undefined) => {
       onChange({ [field]: value } as Partial<PageComponent>);
     },
-    [onChange]
+    [onChange],
   );
 
-  /**
-   * Utility for editing array-of-objects props
-   * (e.g. `slides`, `testimonials`, …).
-   */
-  const arrayEditor = useCallback(
-    (prop: string, items: unknown[] | undefined, fields: string[]) => {
-      const list = (items ?? []) as Record<string, unknown>[];
-      return (
-        <div className="space-y-2">
-          {list.map((item, idx) => (
-            <div key={idx} className="space-y-1 rounded border p-2">
-              {fields.map((f) => (
-                <div key={f} className="flex items-start gap-2">
-                  <Input
-                    value={(item[f] as string) ?? ""}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                      const next = [...list];
-                      next[idx] = { ...next[idx], [f]: e.target.value };
-                      onChange({ [prop]: next } as Partial<PageComponent>);
-                    }}
-                    placeholder={f}
-                    className="flex-1"
-                  />
-                  {f === "src" && (
-                    <ImagePicker
-                      onSelect={(url) => {
-                        const next = [...list];
-                        next[idx] = { ...next[idx], src: url };
-                        onChange({ [prop]: next } as Partial<PageComponent>);
-                      }}
-                    >
-                      <Button type="button" variant="outline">
-                        Pick
-                      </Button>
-                    </ImagePicker>
-                  )}
-                </div>
-              ))}
-              <Button
-                variant="destructive"
-                onClick={() => {
-                  const next = list.filter((_, i) => i !== idx);
-                  onChange({ [prop]: next } as Partial<PageComponent>);
-                }}
-              >
-                Remove
-              </Button>
-            </div>
-          ))}
-          <Button
-            onClick={() => {
-              const blank = Object.fromEntries(fields.map((f) => [f, ""]));
-              onChange({ [prop]: [...list, blank] } as Partial<PageComponent>);
-            }}
-          >
-            Add
-          </Button>
-        </div>
-      );
-    },
-    [onChange]
-  );
-
-  /* ─────────── per‑component editors ─────────── */
   let specific: React.ReactNode = null;
 
   switch (component.type) {
     case "ContactForm":
-      specific = (
-        <div className="space-y-2">
-          <Input
-            label="Action"
-            value={(component as any).action ?? ""}
-            onChange={(e) => handleInput("action", e.target.value)}
-          />
-          <Input
-            label="Method"
-            value={(component as any).method ?? ""}
-            onChange={(e) => handleInput("method", e.target.value)}
-          />
-        </div>
-      );
+      specific = <ContactFormEditor component={component} onChange={onChange} />;
       break;
-
     case "Gallery":
-      specific = arrayEditor("images", (component as any).images, [
-        "src",
-        "alt",
-      ]);
+      specific = <GalleryEditor component={component} onChange={onChange} />;
       break;
-
     case "Image":
+      specific = <ImageBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "Testimonials":
+      specific = <TestimonialsEditor component={component} onChange={onChange} />;
+      break;
+    case "HeroBanner":
+      specific = <HeroBannerEditor component={component} onChange={onChange} />;
+      break;
+    case "ValueProps":
+      specific = <ValuePropsEditor component={component} onChange={onChange} />;
+      break;
+    case "ReviewsCarousel":
       specific = (
-        <div className="space-y-2">
-          <div className="flex items-start gap-2">
-            <Input
-              value={(component as any).src ?? ""}
-              onChange={(e) => handleInput("src", e.target.value)}
-              placeholder="src"
-              className="flex-1"
-            />
-            <ImagePicker onSelect={(url) => handleInput("src", url)}>
-              <Button type="button" variant="outline">
-                Pick
-              </Button>
-            </ImagePicker>
-          </div>
-          <Input
-            value={(component as any).alt ?? ""}
-            onChange={(e) => handleInput("alt", e.target.value)}
-            placeholder="alt"
-          />
-        </div>
+        <ReviewsCarouselEditor component={component} onChange={onChange} />
       );
       break;
-
-    case "Testimonials":
-      specific = arrayEditor("testimonials", (component as any).testimonials, [
-        "quote",
-        "name",
-      ]);
-      break;
-
-    case "HeroBanner":
-      specific = arrayEditor("slides", (component as any).slides, [
-        "src",
-        "alt",
-        "headlineKey",
-        "ctaKey",
-      ]);
-      break;
-
-    case "ValueProps":
-      specific = arrayEditor("items", (component as any).items, [
-        "icon",
-        "title",
-        "desc",
-      ]);
-      break;
-
-    case "ReviewsCarousel":
-      specific = arrayEditor("reviews", (component as any).reviews, [
-        "nameKey",
-        "quoteKey",
-      ]);
-      break;
-
     default:
       specific = <p className="text-sm text-gray-500">No editable props</p>;
   }
 
-  /* ─────────── generic property editors ─────────── */
   return (
     <div className="space-y-2">
       <Input

--- a/packages/ui/src/components/cms/page-builder/ContactFormEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ContactFormEditor.tsx
@@ -1,0 +1,28 @@
+import type { PageComponent } from "@types";
+import { Input } from "../../atoms-shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ContactFormEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).action ?? ""}
+        onChange={(e) => handleInput("action", e.target.value)}
+        placeholder="action"
+      />
+      <Input
+        value={(component as any).method ?? ""}
+        onChange={(e) => handleInput("method", e.target.value)}
+        placeholder="method"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/GalleryEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/GalleryEditor.tsx
@@ -1,0 +1,12 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function GalleryEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor("images", (component as any).images, ["src", "alt"]);
+}

--- a/packages/ui/src/components/cms/page-builder/HeroBannerEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/HeroBannerEditor.tsx
@@ -1,0 +1,17 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function HeroBannerEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor("slides", (component as any).slides, [
+    "src",
+    "alt",
+    "headlineKey",
+    "ctaKey",
+  ]);
+}

--- a/packages/ui/src/components/cms/page-builder/ImageBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImageBlockEditor.tsx
@@ -1,0 +1,37 @@
+import type { PageComponent } from "@types";
+import { Button, Input } from "../../atoms-shadcn";
+import ImagePicker from "./ImagePicker";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ImageBlockEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start gap-2">
+        <Input
+          value={(component as any).src ?? ""}
+          onChange={(e) => handleInput("src", e.target.value)}
+          placeholder="src"
+          className="flex-1"
+        />
+        <ImagePicker onSelect={(url) => handleInput("src", url)}>
+          <Button type="button" variant="outline">
+            Pick
+          </Button>
+        </ImagePicker>
+      </div>
+      <Input
+        value={(component as any).alt ?? ""}
+        onChange={(e) => handleInput("alt", e.target.value)}
+        placeholder="alt"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
@@ -1,0 +1,113 @@
+// packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+"use client";
+
+import type { MediaItem } from "@types";
+import useMediaUpload from "@ui/hooks/useMediaUpload";
+import Image from "next/image";
+import { memo, useEffect, useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+  Input,
+} from "../../atoms-shadcn";
+import useMediaLibrary from "./useMediaLibrary";
+
+interface Props {
+  onSelect: (url: string) => void;
+  children: React.ReactNode;
+}
+
+function ImagePicker({ onSelect, children }: Props) {
+  const [open, setOpen] = useState(false);
+  const { media, setMedia, loadMedia, shop } = useMediaLibrary();
+
+  const {
+    pendingFile,
+    altText,
+    setAltText,
+    isValid,
+    actual,
+    inputRef,
+    onFileChange,
+    handleUpload,
+    error,
+  } = useMediaUpload({
+    shop: shop ?? "",
+    requiredOrientation: "landscape",
+    onUploaded: (item: MediaItem) => {
+      setMedia((m) => [item, ...m]);
+    },
+  });
+
+  useEffect(() => {
+    if (open) void loadMedia();
+  }, [open, loadMedia]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-xl space-y-4">
+        <DialogTitle>Select image</DialogTitle>
+        <div className="flex items-center gap-2">
+          <Input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            onChange={onFileChange}
+            className="flex-1"
+          />
+          {pendingFile && isValid && (
+            <Button type="button" onClick={handleUpload}>
+              Upload
+            </Button>
+          )}
+        </div>
+        {pendingFile && isValid && (
+          <Input
+            value={altText}
+            onChange={(e) => setAltText(e.target.value)}
+            placeholder="Alt text"
+          />
+        )}
+        {pendingFile && isValid !== null && (
+          <p className="text-sm">
+            {isValid
+              ? `Image orientation is ${actual}`
+              : `Selected image is ${actual}; please upload a landscape image.`}
+          </p>
+        )}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="grid max-h-64 grid-cols-3 gap-2 overflow-auto">
+          {media.map((m) => (
+            <button
+              key={m.url}
+              type="button"
+              onClick={() => {
+                onSelect(m.url);
+                setOpen(false);
+              }}
+              className="relative aspect-square"
+            >
+              <Image
+                src={m.url}
+                alt={m.altText || "media"}
+                fill
+                className="object-cover"
+              />
+            </button>
+          ))}
+          {media.length === 0 && (
+            <p className="text-muted-foreground col-span-3 text-sm">
+              No media found.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default memo(ImagePicker);

--- a/packages/ui/src/components/cms/page-builder/ReviewsCarouselEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ReviewsCarouselEditor.tsx
@@ -1,0 +1,15 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ReviewsCarouselEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor("reviews", (component as any).reviews, [
+    "nameKey",
+    "quoteKey",
+  ]);
+}

--- a/packages/ui/src/components/cms/page-builder/TestimonialsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/TestimonialsEditor.tsx
@@ -1,0 +1,15 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function TestimonialsEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor("testimonials", (component as any).testimonials, [
+    "quote",
+    "name",
+  ]);
+}

--- a/packages/ui/src/components/cms/page-builder/ValuePropsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ValuePropsEditor.tsx
@@ -1,0 +1,16 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ValuePropsEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor("items", (component as any).items, [
+    "icon",
+    "title",
+    "desc",
+  ]);
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ContactFormEditor from "../ContactFormEditor";
+import GalleryEditor from "../GalleryEditor";
+import ImageBlockEditor from "../ImageBlockEditor";
+import TestimonialsEditor from "../TestimonialsEditor";
+import HeroBannerEditor from "../HeroBannerEditor";
+import ValuePropsEditor from "../ValuePropsEditor";
+import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
+
+jest.mock("../ImagePicker", () => ({
+  __esModule: true,
+  default: ({ children }: any) => <>{children}</>,
+}));
+
+describe("block editors", () => {
+  const cases: [string, React.ComponentType<any>, any, string][] = [
+    [
+      "ContactFormEditor",
+      ContactFormEditor,
+      { type: "ContactForm", action: "", method: "" },
+      "action",
+    ],
+    [
+      "ImageBlockEditor",
+      ImageBlockEditor,
+      { type: "Image", src: "", alt: "" },
+      "alt",
+    ],
+    [
+      "GalleryEditor",
+      GalleryEditor,
+      { type: "Gallery", images: [{ src: "", alt: "" }] },
+      "src",
+    ],
+    [
+      "TestimonialsEditor",
+      TestimonialsEditor,
+      { type: "Testimonials", testimonials: [{ quote: "", name: "" }] },
+      "quote",
+    ],
+    [
+      "HeroBannerEditor",
+      HeroBannerEditor,
+      {
+        type: "HeroBanner",
+        slides: [{ src: "", alt: "", headlineKey: "", ctaKey: "" }],
+      },
+      "src",
+    ],
+    [
+      "ValuePropsEditor",
+      ValuePropsEditor,
+      { type: "ValueProps", items: [{ icon: "", title: "", desc: "" }] },
+      "icon",
+    ],
+    [
+      "ReviewsCarouselEditor",
+      ReviewsCarouselEditor,
+      { type: "ReviewsCarousel", reviews: [{ nameKey: "", quoteKey: "" }] },
+      "nameKey",
+    ],
+  ];
+
+  it.each(cases)("%s triggers onChange", (_name, Comp, component, placeholder) => {
+    const onChange = jest.fn();
+    render(<Comp component={component} onChange={onChange} />);
+    fireEvent.change(screen.getByPlaceholderText(placeholder), {
+      target: { value: "x" },
+    });
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ImagePicker from "../ImagePicker";
+
+jest.mock("@ui/hooks/useMediaUpload", () => () => ({
+  pendingFile: null,
+  altText: "",
+  setAltText: jest.fn(),
+  isValid: null,
+  actual: "",
+  inputRef: { current: null },
+  onFileChange: jest.fn(),
+  handleUpload: jest.fn(),
+  error: "",
+}));
+
+jest.mock("next/navigation", () => ({ usePathname: () => "/shop" }));
+jest.mock("next/image", () => (props: any) => <img {...props} />);
+
+describe("ImagePicker", () => {
+  it("loads media and selects image", async () => {
+    const media = [{ url: "/img.jpg", altText: "img" }];
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: true, json: async () => media } as any);
+
+    const onSelect = jest.fn();
+    render(
+      <ImagePicker onSelect={onSelect}>
+        <button>open</button>
+      </ImagePicker>,
+    );
+
+    fireEvent.click(screen.getByText("open"));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    fireEvent.click(await screen.findByAltText("img"));
+    expect(onSelect).toHaveBeenCalledWith("/img.jpg");
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -1,0 +1,11 @@
+export { default as ComponentEditor } from "./ComponentEditor";
+export { default as ImagePicker } from "./ImagePicker";
+export { default as ContactFormEditor } from "./ContactFormEditor";
+export { default as GalleryEditor } from "./GalleryEditor";
+export { default as ImageBlockEditor } from "./ImageBlockEditor";
+export { default as TestimonialsEditor } from "./TestimonialsEditor";
+export { default as HeroBannerEditor } from "./HeroBannerEditor";
+export { default as ValuePropsEditor } from "./ValuePropsEditor";
+export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
+export { default as useMediaLibrary } from "./useMediaLibrary";
+export { useArrayEditor } from "./useArrayEditor";

--- a/packages/ui/src/components/cms/page-builder/useArrayEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/useArrayEditor.tsx
@@ -1,0 +1,68 @@
+import type { ChangeEvent } from "react";
+import { useCallback } from "react";
+import type { PageComponent } from "@types";
+import { Button, Input } from "../../atoms-shadcn";
+import ImagePicker from "./ImagePicker";
+
+export function useArrayEditor(
+  onChange: (patch: Partial<PageComponent>) => void,
+) {
+  return useCallback(
+    (prop: string, items: unknown[] | undefined, fields: string[]) => {
+      const list = (items ?? []) as Record<string, unknown>[];
+      return (
+        <div className="space-y-2">
+          {list.map((item, idx) => (
+            <div key={idx} className="space-y-1 rounded border p-2">
+              {fields.map((f) => (
+                <div key={f} className="flex items-start gap-2">
+                  <Input
+                    value={(item[f] as string) ?? ""}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      const next = [...list];
+                      next[idx] = { ...next[idx], [f]: e.target.value };
+                      onChange({ [prop]: next } as Partial<PageComponent>);
+                    }}
+                    placeholder={f}
+                    className="flex-1"
+                  />
+                  {f === "src" && (
+                    <ImagePicker
+                      onSelect={(url) => {
+                        const next = [...list];
+                        next[idx] = { ...next[idx], src: url };
+                        onChange({ [prop]: next } as Partial<PageComponent>);
+                      }}
+                    >
+                      <Button type="button" variant="outline">
+                        Pick
+                      </Button>
+                    </ImagePicker>
+                  )}
+                </div>
+              ))}
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  const next = list.filter((_, i) => i !== idx);
+                  onChange({ [prop]: next } as Partial<PageComponent>);
+                }}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          <Button
+            onClick={() => {
+              const blank = Object.fromEntries(fields.map((f) => [f, ""]));
+              onChange({ [prop]: [...list, blank] } as Partial<PageComponent>);
+            }}
+          >
+            Add
+          </Button>
+        </div>
+      );
+    },
+    [onChange],
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
+++ b/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
@@ -1,0 +1,25 @@
+import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
+import type { MediaItem } from "@types";
+import { usePathname } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
+
+export default function useMediaLibrary() {
+  const pathname = usePathname() ?? "";
+  const shop = useMemo(() => getShopFromPath(pathname), [pathname]);
+  const [media, setMedia] = useState<MediaItem[]>([]);
+
+  const loadMedia = useCallback(async () => {
+    if (!shop) return;
+    try {
+      const res = await fetch(`/cms/api/media?shop=${shop}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data)) setMedia(data);
+      }
+    } catch {
+      /* silent */
+    }
+  }, [shop]);
+
+  return { media, setMedia, loadMedia, shop };
+}


### PR DESCRIPTION
## Summary
- extract reusable `ImagePicker` and utility hooks for media and list editing
- add dedicated editors for each page block and rewire `ComponentEditor`
- cover `ImagePicker` media loading and editor block updates with unit tests

## Testing
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx` *(fails: Missing modules across monorepo)*

------
https://chatgpt.com/codex/tasks/task_e_68965be061e0832f9c5cd500d3134e36