### PR TITLE
Clear page builder history after publish

### DIFF
--- a/packages/ui/__tests__/PageBuilder.publish.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.publish.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PageBuilder from "@/components/cms/PageBuilder";
+
+describe("PageBuilder publishing", () => {
+  const page = {
+    id: "p1",
+    updatedAt: "2024-01-01",
+    slug: "slug",
+    status: "draft",
+    seo: { title: { en: "" }, description: {} },
+    components: [],
+  } as any;
+
+  it("clears history from localStorage after publishing", async () => {
+    const onPublish = jest.fn().mockResolvedValue(undefined);
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const storageKey = `page-builder-history-${page.id}`;
+    localStorage.setItem(storageKey, "history");
+
+    render(<PageBuilder page={page} onSave={onSave} onPublish={onPublish} />);
+
+    expect(localStorage.getItem(storageKey)).not.toBeNull();
+
+    fireEvent.click(screen.getByText("Publish"));
+
+    await waitFor(() => expect(localStorage.getItem(storageKey)).toBeNull());
+    expect(onPublish).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- clear saved PageBuilder history in localStorage after publishing or switching pages
- add regression test for clearing history on publish

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/PageBuilder.publish.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68965bcc889c832f95f0e7b5d4fb5540