### PR TITLE
feat(ui): sanitize HTML rendering in CanvasItem

### DIFF
--- a/packages/ui/__tests__/CanvasItem.test.tsx
+++ b/packages/ui/__tests__/CanvasItem.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { DndContext } from "@dnd-kit/core";
+import { SortableContext } from "@dnd-kit/sortable";
+import CanvasItem from "../src/components/cms/page-builder/CanvasItem";
+
+describe("CanvasItem", () => {
+  it("sanitizes HTML before rendering", () => {
+    const component: any = {
+      id: "1",
+      type: "Text",
+      text: "<p>Hello</p><script>window.evil()</script>",
+    };
+
+    const { container } = render(
+      <DndContext>
+        <SortableContext items={[component.id]}>
+          <CanvasItem
+            component={component}
+            index={0}
+            onRemove={() => {}}
+            selected={false}
+            onSelect={() => {}}
+            dispatch={() => {}}
+            locale="en"
+          />
+        </SortableContext>
+      </DndContext>
+    );
+
+    expect(container.querySelector("script")).toBeNull();
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "@tiptap/extension-link": "^2.24.0",
     "@tiptap/react": "^2.24.0",
     "@tiptap/starter-kit": "^2.24.0",
+    "dompurify": "^3.2.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "shadcn-ui": "^0.9.5"

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -11,6 +11,7 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "../../atoms-shadcn";
 import { blockRegistry } from "../blocks";
 import type { Action } from "../PageBuilder";
+import DOMPurify from "dompurify";
 
 function Block({
   component,
@@ -20,10 +21,11 @@ function Block({
   locale: Locale;
 }) {
   if (component.type === "Text") {
-    return <div>{(component as any).text ?? ""}</div>;
     const text = (component as any).text;
-    const value = typeof text === "string" ? text : (text?.[locale] ?? "");
-    return <div dangerouslySetInnerHTML={{ __html: value }} />;
+    const value =
+      typeof text === "string" ? text : (text?.[locale] ?? "");
+    const sanitized = DOMPurify.sanitize(value);
+    return <div dangerouslySetInnerHTML={{ __html: sanitized }} />;
   }
   const Comp = blockRegistry[component.type];
   if (!Comp) return null;
@@ -277,10 +279,11 @@ const CanvasItem = memo(function CanvasItem({
               onSelect();
             }}
             dangerouslySetInnerHTML={{
-              __html:
+              __html: DOMPurify.sanitize(
                 typeof (component as any).text === "string"
                   ? (component as any).text
-                  : ((component as any).text?.[locale] ?? ""),
+                  : (component as any).text?.[locale] ?? ""
+              ),
             }}
           />
         )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.24.0
         version: 2.24.1
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -3515,6 +3518,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -5016,6 +5022,9 @@ packages:
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
@@ -13044,6 +13053,9 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/wait-on@5.3.4':
@@ -14763,6 +14775,10 @@ snapshots:
   domhandler@4.3.1:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@1.7.0:
     dependencies:


### PR DESCRIPTION
## Summary
- sanitize CanvasItem HTML with DOMPurify before rendering
- add CanvasItem unit test to ensure script tags are removed
- install dompurify

## Testing
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/CanvasItem.test.tsx --runInBand --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68965bc73e0c832faafa989079049445