### PR TITLE
feat: persist page builder history

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -9,7 +9,7 @@ import {
   updatePage as updatePageInRepo,
 } from "@platform-core/repositories/pages/index.server";
 import * as Sentry from "@sentry/node";
-import type { Locale, Page, PageComponent } from "@types";
+import type { Locale, Page, PageComponent, HistoryState } from "@types";
 import { historyStateSchema, pageComponentSchema } from "@types";
 import { getServerSession } from "next-auth";
 import { ulid } from "ulid";
@@ -150,6 +150,16 @@ export async function createPage(
     return { errors: compErrs };
   }
 
+  let history: HistoryState | undefined;
+  const historyStr = formData.get("history");
+  if (typeof historyStr === "string") {
+    try {
+      history = historyStateSchema.parse(JSON.parse(historyStr));
+    } catch {
+      /* ignore invalid history */
+    }
+  }
+
   const title: Record<Locale, string> = {} as Record<Locale, string>;
   const description: Record<Locale, string> = {} as Record<Locale, string>;
   const image: Record<Locale, string> = {} as Record<Locale, string>;
@@ -286,6 +296,16 @@ export async function updatePage(
     return { errors: compErrs };
   }
 
+  let history: HistoryState | undefined;
+  const historyStr = formData.get("history");
+  if (typeof historyStr === "string") {
+    try {
+      history = historyStateSchema.parse(JSON.parse(historyStr));
+    } catch {
+      /* ignore invalid history */
+    }
+  }
+
   const title: Record<Locale, string> = {} as Record<Locale, string>;
   const description: Record<Locale, string> = {} as Record<Locale, string>;
   const image: Record<Locale, string> = {} as Record<Locale, string>;
@@ -302,6 +322,7 @@ export async function updatePage(
     status: data.status,
     components: data.components,
     seo: { title, description, image },
+    ...(history ? { history } : {}),
   };
 
   try {

--- a/apps/cms/src/app/cms/shop/[shop]/pages/[page]/builder/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/[page]/builder/page.tsx
@@ -41,7 +41,12 @@ export default async function PageBuilderRoute({
       <h1 className="mb-6 text-2xl font-semibold">
         Edit page - {shop}/{current.slug}
       </h1>
-      <PageBuilder page={current} onSave={save} onPublish={publish} />
+      <PageBuilder
+        page={current}
+        history={current.history}
+        onSave={save}
+        onPublish={publish}
+      />
     </>
   );
 }

--- a/packages/ui/__tests__/PageBuilder.history.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.history.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PageBuilder from "@/components/cms/PageBuilder";
+
+describe("PageBuilder history persistence", () => {
+  const basePage = {
+    id: "p1",
+    updatedAt: "2024-01-01",
+    slug: "slug",
+    status: "draft",
+    seo: { title: { en: "" }, description: {} },
+    components: [],
+  } as any;
+
+  it("restores history from localStorage on reload", async () => {
+    const history = {
+      past: [[{ id: "p", type: "Text" }]],
+      present: [{ id: "c", type: "Text" }],
+      future: [],
+    };
+    localStorage.setItem(
+      `page-builder-history-${basePage.id}`,
+      JSON.stringify(history)
+    );
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const onPublish = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <PageBuilder page={basePage} onSave={onSave} onPublish={onPublish} />
+    );
+
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const fd = onSave.mock.calls[0][0] as FormData;
+    expect(JSON.parse(fd.get("components") as string)).toEqual(
+      history.present
+    );
+    expect(JSON.parse(fd.get("history") as string)).toEqual(history);
+  });
+
+  it("uses server-provided history when localStorage empty", async () => {
+    localStorage.clear();
+    const history = {
+      past: [],
+      present: [{ id: "c1", type: "Text" }],
+      future: [],
+    };
+    const page = { ...basePage, history };
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const onPublish = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <PageBuilder
+        page={page}
+        history={history}
+        onSave={onSave}
+        onPublish={onPublish}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const fd = onSave.mock.calls[0][0] as FormData;
+    expect(JSON.parse(fd.get("components") as string)).toEqual(
+      history.present
+    );
+    expect(JSON.parse(fd.get("history") as string)).toEqual(history);
+  });
+});


### PR DESCRIPTION
## Summary
- propagate page history to the PageBuilder client
- initialise PageBuilder reducer from persisted history and embed it in form submissions
- parse and store history when updating pages
- test history persistence across reloads and cross-browser edits

## Testing
- `pnpm --filter @acme/ui test` *(fails: apps/cms/__tests__/wizard.test.tsx, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689766c86f9c832faae36127f7fcb0c4