### PR TITLE
refactor: derive page component types from registry

### DIFF
--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -34,24 +34,12 @@ import { Button } from "../atoms-shadcn";
 import CanvasItem from "./page-builder/CanvasItem";
 import ComponentEditor from "./page-builder/ComponentEditor";
 import Palette from "./page-builder/Palette";
+import { atomRegistry, moleculeRegistry, organismRegistry } from "./blocks";
 
-/* ════════════════ component catalogue ════════════════ */
-const COMPONENT_TYPES = [
-  "HeroBanner",
-  "ValueProps",
-  "ReviewsCarousel",
-  "ProductGrid",
-  "Gallery",
-  "ContactForm",
-  "ContactFormWithMap",
-  "BlogListing",
-  "Testimonials",
-  "TestimonialSlider",
-  "Image",
-  "Text",
-] as const;
-
-type ComponentType = (typeof COMPONENT_TYPES)[number];
+type ComponentType =
+  | keyof typeof atomRegistry
+  | keyof typeof moleculeRegistry
+  | keyof typeof organismRegistry;
 
 /* ════════════════ external contracts ════════════════ */
 interface Props {
@@ -266,7 +254,7 @@ const PageBuilder = memo(function PageBuilder({
 
       const a = active.data.current as {
         from: string;
-        type?: string;
+        type?: ComponentType;
         index?: number;
       };
       const o = over.data.current as { from: string; index?: number };
@@ -276,7 +264,7 @@ const PageBuilder = memo(function PageBuilder({
           type: "add",
           component: {
             id: ulid(),
-            type: a.type! as ComponentType,
+            type: a.type!,
           } as PageComponent,
         });
       } else if (a?.from === "canvas" && o?.from === "canvas") {


### PR DESCRIPTION
## Summary
- derive page builder component types from block registries
- use registry-based types when adding components

## Testing
- `pnpm --filter @acme/ui test` *(fails: unable to parse wizard state, missing request handlers, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689663a366b0832f84056dd06ddf1c4e