### PR TITLE
Validate shop name in create-shop CLI

### DIFF
--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -4,6 +4,7 @@ import { readdirSync, existsSync } from "fs";
 import readline from "node:readline";
 import { join } from "path";
 import { createShop } from "../../packages/platform-core/src/createShop";
+import { validateShopName } from "../../packages/platform-core/src/shops";
 
 /* ────────────────────────────────────────────────────────── *
  * Command-line parsing                                       *
@@ -18,11 +19,18 @@ interface Options {
 }
 
 function parseArgs(argv: string[]): [string, Options, boolean] {
-  const id = argv[0];
+  let id = argv[0];
   if (!id) {
     console.error(
       "Usage: pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--payment=p1,p2] [--shipping=s1,s2] [--template=name]"
     );
+    process.exit(1);
+  }
+
+  try {
+    id = validateShopName(id);
+  } catch (err) {
+    console.error((err as Error).message);
     process.exit(1);
   }
 

--- a/test/unit/create-shop-cli.spec.ts
+++ b/test/unit/create-shop-cli.spec.ts
@@ -73,6 +73,13 @@ describe("parseArgs", () => {
     parseArgs(["s", "--type=foo"]);
     expect(sandbox.process.exit).toHaveBeenCalled();
   });
+
+  it("exits on invalid shop name", () => {
+    const { parseArgs, sandbox } = loadParseArgs();
+    parseArgs(["bad/name"]);
+    expect(sandbox.console.error).toHaveBeenCalled();
+    expect(sandbox.process.exit).toHaveBeenCalled();
+  });
 });
 
 function runCli(args: string[]) {
@@ -104,6 +111,12 @@ function runCli(args: string[]) {
 describe("CLI", () => {
   it("exits when theme does not exist", () => {
     const sandbox = runCli(["shop", "--theme=missing"]);
+    expect(sandbox.console.error).toHaveBeenCalled();
+    expect(sandbox.process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits when shop name is invalid", () => {
+    const sandbox = runCli(["bad/name"]);
     expect(sandbox.console.error).toHaveBeenCalled();
     expect(sandbox.process.exit).toHaveBeenCalledWith(1);
   });


### PR DESCRIPTION
## Summary
- validate shop id using `validateShopName` before running create-shop script
- test CLI and parser behavior with invalid shop names

## Testing
- `pnpm exec jest test/unit/create-shop-cli.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68976ac14fc8832f82ac93f4ae8511c9