### PR TITLE
Centralize createShop call and test single invocation

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -33,6 +33,7 @@ describe("create-shop API", () => {
     const req = { json: () => Promise.resolve(body) } as Request;
     const res = await POST(req);
     expect(res.status).toBe(201);
+    expect(createNewShop).toHaveBeenCalledTimes(1);
     expect(createNewShop).toHaveBeenCalledWith("new", {});
     (process.env as Record<string, string>).NODE_ENV = prevEnv as string;
   });

--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -90,6 +90,7 @@ describe("createNewShop authorization", () => {
     );
     await createNewShop("shop2", { theme: "base" } as any);
 
+    expect(createShop).toHaveBeenCalledTimes(1);
     expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" });
 
     (process.env as Record<string, string>).NODE_ENV = prevEnv;

--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -22,7 +22,6 @@ export async function createNewShop(
   const session = await getServerSession(authOptions);
   if (!session) throw new Error("Forbidden");
 
-  await createShop(id, options);
   try {
     await createShop(id, options);
   } catch (err) {

--- a/packages/platform-core/__tests__/createShopRoute.test.ts
+++ b/packages/platform-core/__tests__/createShopRoute.test.ts
@@ -49,8 +49,9 @@ describe("POST /api/create-shop", () => {
       body: JSON.stringify({ id: "shop1", options: { theme: "base" } }),
     });
     const res = await POST(req);
+    expect(createNewShop).toHaveBeenCalledTimes(1);
     expect(createNewShop).toHaveBeenCalledWith("shop1", { theme: "base" });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     await expect(res.json()).resolves.toEqual({ success: true });
   });
 


### PR DESCRIPTION
## Summary
- remove redundant `createShop` call before try/catch in `createNewShop`
- add test expectations to ensure `createShop` is called exactly once
- align API route test with 201 status

## Testing
- `npx jest apps/cms/__tests__/createShopActions.test.tsx apps/cms/__tests__/api.create-shop.test.ts packages/platform-core/__tests__/createShopRoute.test.ts`
- `pnpm --filter @apps/cms test` *(fails: Wizard, VersionTimeline)*

------
https://chatgpt.com/codex/tasks/task_e_68976ac2f234832fb63188951d6f8dc4