### PR TITLE
feat: validate user-provided dates

### DIFF
--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -58,3 +58,14 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(args.metadata.subtotal).toBe("20");
   expect(body.clientSecret).toBe("cs_test");
 });
+
+test("responds with 400 on invalid returnDate", async () => {
+  const sku = PRODUCTS[0];
+  const cart = { [sku.id]: { sku, qty: 1 } };
+  const cookie = encodeCartCookie(cart);
+  const req = createRequest({ returnDate: "not-a-date" }, cookie);
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+  const body = (await res.json()) as any;
+  expect(body.error).toMatch(/invalid/i);
+});

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -1,6 +1,7 @@
 // apps/shop-abc/src/app/api/checkout-session/route.ts
 
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import { parseIsoDate } from "@/lib/date";
 import { stripe } from "@lib/stripeServer";
 import { priceForDays } from "@platform-core/pricing";
 
@@ -25,11 +26,11 @@ type Cart = CartState;
  */
 const calculateRentalDays = (returnDate?: string): number => {
   if (!returnDate) return 1;
-
-  const end = new Date(returnDate).getTime();
+  const parsed = parseIsoDate(returnDate);
+  if (!parsed) throw new Error("Invalid returnDate");
+  const end = parsed.getTime();
   const start = Date.now();
   const diffDays = Math.ceil((end - start) / 86_400_000); // 86 400 000 ms = 1 day
-
   return diffDays > 0 ? diffDays : 1;
 };
 
@@ -111,7 +112,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const { returnDate } = (await req.json().catch(() => ({}))) as {
     returnDate?: string;
   };
-  const rentalDays = calculateRentalDays(returnDate);
+  let rentalDays: number;
+  try {
+    rentalDays = calculateRentalDays(returnDate);
+  } catch {
+    return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
+  }
 
   /* 3️⃣ Build Stripe line-items & totals ------------------------------------ */
   const lineItemsNested = await Promise.all(

--- a/packages/lib/__tests__/date.test.ts
+++ b/packages/lib/__tests__/date.test.ts
@@ -1,0 +1,14 @@
+import { parseIsoDate } from '../src/date';
+
+describe('parseIsoDate', () => {
+  test('parses valid YYYY-MM-DD string', () => {
+    const d = parseIsoDate('2025-01-02');
+    expect(d).toBeInstanceOf(Date);
+    expect(d?.toISOString().slice(0, 10)).toBe('2025-01-02');
+  });
+
+  test('returns null for invalid input', () => {
+    expect(parseIsoDate('not-a-date')).toBeNull();
+    expect(parseIsoDate('2025-99-99')).toBeNull();
+  });
+});

--- a/packages/lib/src/date.ts
+++ b/packages/lib/src/date.ts
@@ -1,0 +1,7 @@
+export function parseIsoDate(str: string): Date | null {
+  if (typeof str !== "string") return null;
+  const ISO_REGEX = /^(\d{4}-\d{2}-\d{2})(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+  if (!ISO_REGEX.test(str)) return null;
+  const date = new Date(str);
+  return Number.isNaN(date.getTime()) ? null : date;
+}


### PR DESCRIPTION
## Summary
- add ISO date parser utility
- validate returnDate in checkout session routes
- cover invalid date paths with tests

## Testing
- `pnpm exec jest packages/lib/__tests__/date.test.ts apps/shop-abc/__tests__/checkoutSession.test.ts packages/template-app/__tests__/checkout-session.test.ts`
- `pnpm exec eslint packages/lib/src/date.ts apps/shop-abc/src/app/api/checkout-session/route.ts apps/shop-abc/src/app/api/checkout-session/route.js apps/shop-bcd/src/api/checkout-session/route.ts apps/shop-bcd/src/api/checkout-session/route.js packages/template-app/src/api/checkout-session/route.ts apps/shop-abc/__tests__/checkoutSession.test.ts packages/template-app/__tests__/checkout-session.test.ts packages/lib/__tests__/date.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68976e333294832f830a057d22785696