### PR TITLE
Validate shop IDs when creating shops

### DIFF
--- a/packages/platform-core/__tests__/createShop.test.ts
+++ b/packages/platform-core/__tests__/createShop.test.ts
@@ -68,7 +68,10 @@ describe("createShop", () => {
 
   it("throws when template missing", () => {
     fsMock.existsSync.mockImplementation((p: fs.PathLike) => {
-      return !String(p).includes("missing-template");
+      const path = String(p);
+      if (path.includes("data/shops")) return false;
+      if (path.includes("apps/")) return false;
+      return !path.includes("missing-template");
     });
     expect(() => createShop("id", { template: "missing-template" })).toThrow(
       "Template 'missing-template'"
@@ -85,5 +88,18 @@ describe("createShop", () => {
     expect(() => createShop("existing", {})).toThrow(
       "Pick a different ID or remove the existing folder"
     );
+  });
+
+  it("validates and trims shop ID", () => {
+    createShop("  new_shop  ", {});
+    expect(fsMock.cpSync).toHaveBeenCalledWith(
+      expect.stringContaining("packages/template-app"),
+      expect.stringContaining("apps/new_shop"),
+      expect.objectContaining({ recursive: true, filter: expect.any(Function) })
+    );
+  });
+
+  it("throws on invalid shop ID", () => {
+    expect(() => createShop("bad/id", {})).toThrow("Invalid shop name");
   });
 });


### PR DESCRIPTION
## Summary
- validate shop IDs using `validateShopName`
- abort if target app or data directories already exist
- test valid and invalid shop IDs for `createShop`

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/createShop.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68976fc870cc832fb8e959e04ee91f8d