### PR TITLE
feat: centralize rental day calculation

### DIFF
--- a/apps/shop-abc/src/app/api/checkout-session/route.js
+++ b/apps/shop-abc/src/app/api/checkout-session/route.js
@@ -1,27 +1,12 @@
 // apps/shop-abc/src/app/api/checkout-session/route.ts
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
-import { parseIsoDate } from "@/lib/date";
+import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@/lib/stripeServer";
 import { priceForDays } from "@platform-core/pricing";
 import { NextResponse } from "next/server";
 /* ------------------------------------------------------------------ *
  *  Helpers
  * ------------------------------------------------------------------ */
-/**
- * Calculate the number of rental days between “now” and `returnDate`
- * (inclusive). Returns `1` when `returnDate` is missing or in the past.
- */
-const calculateRentalDays = (returnDate) => {
-    if (!returnDate)
-        return 1;
-    const parsed = parseIsoDate(returnDate);
-    if (!parsed)
-        throw new Error("Invalid returnDate");
-    const end = parsed.getTime();
-    const start = Date.now();
-    const diffDays = Math.ceil((end - start) / 86_400_000); // 86 400 000 ms = 1 day
-    return diffDays > 0 ? diffDays : 1;
-};
 /**
  * Produce the two Stripe line-items (rental + deposit) for a single cart item.
  */

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -1,7 +1,7 @@
 // apps/shop-abc/src/app/api/checkout-session/route.ts
 
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
-import { parseIsoDate } from "@/lib/date";
+import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer";
 import { priceForDays } from "@platform-core/pricing";
 
@@ -19,20 +19,6 @@ type Cart = CartState;
 /* ------------------------------------------------------------------ *
  *  Helpers
  * ------------------------------------------------------------------ */
-
-/**
- * Calculate the number of rental days between “now” and `returnDate`
- * (inclusive). Returns `1` when `returnDate` is missing or in the past.
- */
-const calculateRentalDays = (returnDate?: string): number => {
-  if (!returnDate) return 1;
-  const parsed = parseIsoDate(returnDate);
-  if (!parsed) throw new Error("Invalid returnDate");
-  const end = parsed.getTime();
-  const start = Date.now();
-  const diffDays = Math.ceil((end - start) / 86_400_000); // 86 400 000 ms = 1 day
-  return diffDays > 0 ? diffDays : 1;
-};
 
 /**
  * Produce the two Stripe line-items (rental + deposit) for a single cart item.

--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -1,8 +1,8 @@
-// apps/shop-abc/__tests__/checkoutSession.test.ts
+// apps/shop-bcd/__tests__/checkout-session.test.ts
 import { encodeCartCookie } from "@/lib/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { calculateRentalDays } from "@/lib/date";
-import { POST } from "../src/app/api/checkout-session/route";
+import { POST } from "../src/api/checkout-session/route";
 
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -11,7 +11,7 @@ jest.mock("next/server", () => ({
   },
 }));
 
-jest.mock("@/lib/stripeServer", () => ({
+jest.mock("@lib/stripeServer.server", () => ({
   stripe: { checkout: { sessions: { create: jest.fn() } } },
 }));
 
@@ -19,7 +19,7 @@ jest.mock("@platform-core/pricing", () => ({
   priceForDays: jest.fn(async () => 10),
 }));
 
-import { stripe } from "@/lib/stripeServer";
+import { stripe } from "@lib/stripeServer.server";
 const stripeCreate = stripe.checkout.sessions.create as jest.Mock;
 
 function createRequest(
@@ -49,7 +49,7 @@ test("builds Stripe session with correct items and metadata", async () => {
   const req = createRequest({ returnDate }, cookie);
 
   const res = await POST(req);
-  const body = (await res.json()) as any;
+  const body = await res.json();
 
   expect(stripeCreate).toHaveBeenCalled();
   const args = stripeCreate.mock.calls[0][0];
@@ -70,6 +70,7 @@ test("responds with 400 on invalid returnDate", async () => {
   const req = createRequest({ returnDate: "not-a-date" }, cookie);
   const res = await POST(req);
   expect(res.status).toBe(400);
-  const body = (await res.json()) as any;
+  const body = await res.json();
   expect(body.error).toMatch(/invalid/i);
 });
+

--- a/apps/shop-bcd/src/api/checkout-session/route.js
+++ b/apps/shop-bcd/src/api/checkout-session/route.js
@@ -1,30 +1,16 @@
 // apps/shop-bcd/src/app/api/checkout-session/route.ts
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
-import { parseIsoDate } from "@/lib/date";
-import { stripe } from "@/lib/stripeServer";
+import { calculateRentalDays } from "@/lib/date";
+import { stripe } from "@lib/stripeServer.server";
 import { priceForDays } from "@platform-core/pricing";
 import { NextResponse } from "next/server";
 /* ------------------------------------------------------------------ *
  *  Constants
  * ------------------------------------------------------------------ */
 export const runtime = "edge";
-const DAY_MS = 86_400_000;
 /* ------------------------------------------------------------------ *
  *  Helper functions
  * ------------------------------------------------------------------ */
-/**
- * Convert a `returnDate` (ISO string) into a positive number of
- * chargeable days. Defaults to `1` when invalid or not provided.
- */
-const calculateRentalDays = (returnDate) => {
-    if (!returnDate)
-        return 1;
-    const parsed = parseIsoDate(returnDate);
-    if (!parsed)
-        throw new Error("Invalid returnDate");
-    const diff = Math.ceil((parsed.getTime() - Date.now()) / DAY_MS);
-    return diff > 0 ? diff : 1;
-};
 /**
  * Build the rental-fee line-item and the refundable deposit line-item
  * for a single cart entry.

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -1,7 +1,7 @@
 // apps/shop-bcd/src/app/api/checkout-session/route.ts
 
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
-import { parseIsoDate } from "@/lib/date";
+import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer.server";
 import { priceForDays } from "@platform-core/pricing";
 import type { CartLine, CartState } from "@types";
@@ -24,23 +24,10 @@ type Cart = CartState;
  * ------------------------------------------------------------------ */
 
 export const runtime = "edge";
-const DAY_MS = 86_400_000;
 
 /* ------------------------------------------------------------------ *
  *  Helper functions
  * ------------------------------------------------------------------ */
-
-/**
- * Convert a `returnDate` (ISO string) into a positive number of
- * chargeable days. Defaults to `1` when invalid or not provided.
- */
-const calculateRentalDays = (returnDate?: string): number => {
-  if (!returnDate) return 1;
-  const parsed = parseIsoDate(returnDate);
-  if (!parsed) throw new Error("Invalid returnDate");
-  const diff = Math.ceil((parsed.getTime() - Date.now()) / DAY_MS);
-  return diff > 0 ? diff : 1;
-};
 
 /**
  * Build the rental-fee line-item and the refundable deposit line-item

--- a/packages/lib/__tests__/date.test.ts
+++ b/packages/lib/__tests__/date.test.ts
@@ -1,4 +1,4 @@
-import { parseIsoDate } from '../src/date';
+import { parseIsoDate, calculateRentalDays } from '../src/date';
 
 describe('parseIsoDate', () => {
   test('parses valid YYYY-MM-DD string', () => {
@@ -10,5 +10,27 @@ describe('parseIsoDate', () => {
   test('returns null for invalid input', () => {
     expect(parseIsoDate('not-a-date')).toBeNull();
     expect(parseIsoDate('2025-99-99')).toBeNull();
+  });
+});
+
+describe('calculateRentalDays', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('computes positive day difference', () => {
+    expect(calculateRentalDays('2025-01-03')).toBe(2);
+  });
+
+  test('floors past dates to one day', () => {
+    expect(calculateRentalDays('2024-12-31')).toBe(1);
+  });
+
+  test('throws on invalid date', () => {
+    expect(() => calculateRentalDays('invalid')).toThrow();
   });
 });

--- a/packages/lib/src/date.ts
+++ b/packages/lib/src/date.ts
@@ -5,3 +5,20 @@ export function parseIsoDate(str: string): Date | null {
   const date = new Date(str);
   return Number.isNaN(date.getTime()) ? null : date;
 }
+
+/** Milliseconds in one day */
+export const DAY_MS = 86_400_000;
+
+/**
+ * Calculate the number of rental days between "now" and `returnDate` (inclusive).
+ *
+ * Throws an error when `returnDate` is invalid. Past or missing dates resolve to
+ * a minimum of `1` day.
+ */
+export function calculateRentalDays(returnDate?: string): number {
+  if (!returnDate) return 1;
+  const parsed = parseIsoDate(returnDate);
+  if (!parsed) throw new Error("Invalid returnDate");
+  const diff = Math.ceil((parsed.getTime() - Date.now()) / DAY_MS);
+  return diff > 0 ? diff : 1;
+}

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -1,6 +1,6 @@
 // packages/template-app/src/api/checkout-session/route.ts
 import { stripe } from "@/lib/stripeServer";
-import { parseIsoDate } from "@/lib/date";
+import { calculateRentalDays } from "@/lib/date";
 import { CART_COOKIE, decodeCartCookie } from "@platform-core/src/cartCookie";
 import { priceForDays } from "@platform-core/src/pricing";
 import { getProductById } from "@platform-core/src/products";
@@ -27,16 +27,6 @@ type Cart = Record<string, CartItem>;
 /* ------------------------------------------------------------------
  * Helpers
  * ------------------------------------------------------------------ */
-const DAY_MS = 86_400_000;
-
-/** Chargeable rental days */
-const calculateRentalDays = (returnDate?: string): number => {
-  if (!returnDate) return 1;
-  const parsed = parseIsoDate(returnDate);
-  if (!parsed) throw new Error("Invalid returnDate");
-  const diffDays = Math.ceil((parsed.getTime() - Date.now()) / DAY_MS);
-  return diffDays > 0 ? diffDays : 1;
-};
 
 /** Build Stripe line-items for one cart entry */
 async function buildLineItemsForItem(


### PR DESCRIPTION
## Summary
- centralize rental day logic with shared `DAY_MS` and `calculateRentalDays`
- use new helper in all checkout-session routes
- update and expand tests for rental day calculation

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/checkoutSession.test.ts apps/shop-bcd/__tests__/checkout-session.test.ts packages/template-app/__tests__/checkout-session.test.ts packages/lib/__tests__/date.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689771c5f270832fb0a3f7982d7b387f