### PR TITLE
feat: add reusable timestamp formatter

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/VersionTimeline.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/VersionTimeline.tsx
@@ -12,6 +12,7 @@ import { revertSeo } from "@cms/actions/shops.server";
 import type { SettingsDiffEntry } from "@platform-core/repositories/settings.server";
 import { diffHistory } from "@platform-core/repositories/settings.server";
 import { useEffect, useState } from "react";
+import { formatTimestamp } from "@/lib/date";
 
 interface VersionTimelineProps {
   /** Shop identifier */
@@ -66,7 +67,7 @@ export default function VersionTimeline({
                 <li key={entry.timestamp} className="space-y-2">
                   <div className="flex justify-between">
                     <span className="text-muted-foreground font-mono text-xs">
-                      {new Date(entry.timestamp).toLocaleString()}
+                      {formatTimestamp(entry.timestamp)}
                     </span>
                     <Button
                       variant="outline"

--- a/doc/date-formatting.md
+++ b/doc/date-formatting.md
@@ -1,0 +1,15 @@
+# Date Formatting Helper
+
+UI components should use `formatTimestamp(ts, locale?)` from `@/lib/date` to display dates. It wraps `new Date(ts).toLocaleString(locale)` to ensure consistent, locale-aware formatting across the application.
+
+```ts
+import { formatTimestamp } from "@/lib/date";
+
+formatTimestamp("2024-07-01T12:00:00Z");
+```
+
+Provide a locale string if you need to override the user's default:
+
+```ts
+formatTimestamp("2024-07-01T12:00:00Z", "en-GB");
+```

--- a/packages/lib/src/date.ts
+++ b/packages/lib/src/date.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/date.ts
+
+/**
+ * Format an ISO timestamp using the provided locale or the runtime's default.
+ *
+ * @param ts - ISO timestamp string to format
+ * @param locale - Optional BCP 47 locale string overriding the default locale
+ * @returns Localized date/time string
+ */
+export function formatTimestamp(ts: string, locale?: string): string {
+  return new Date(ts).toLocaleString(locale);
+}
+


### PR DESCRIPTION
## Summary
- add formatTimestamp helper for consistent locale-aware timestamps
- use formatTimestamp in SEO VersionTimeline
- document timestamp formatting for UI components

## Testing
- `pnpm test:cms` *(fails: apps/cms/__tests__/wizard.test.tsx, test/checkout.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68976e48688c832fad9805fb567feb41