### PR TITLE
refactor: centralize iso timestamp

### DIFF
--- a/apps/cms/__tests__/pages.test.ts
+++ b/apps/cms/__tests__/pages.test.ts
@@ -30,6 +30,8 @@ describe("page actions", () => {
 
   it("createPage stores new page", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const { createPage } = await import("../src/actions/pages.server");
 
@@ -54,11 +56,12 @@ describe("page actions", () => {
 
   it("updatePage modifies page data", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
         "../../../packages/platform-core/src/repositories/pages/index.server"
       );
-      const now = new Date().toISOString();
       const page = {
         id: "1",
         slug: "home",
@@ -92,11 +95,12 @@ describe("page actions", () => {
 
   it("updatePage persists history", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
         "../../../packages/platform-core/src/repositories/pages/index.server"
       );
-      const now = new Date().toISOString();
       const page = {
         id: "1",
         slug: "home",
@@ -135,11 +139,12 @@ describe("page actions", () => {
 
   it("deletePage removes page from repo", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
         "../../../packages/platform-core/src/repositories/pages/index.server"
       );
-      const now = new Date().toISOString();
       const page = {
         id: "1",
         slug: "remove",
@@ -162,6 +167,8 @@ describe("page actions", () => {
 
   it("createPage returns validation error for bad components", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const { createPage } = await import("../src/actions/pages.server");
       const fd = new FormData();

--- a/apps/cms/__tests__/products.test.ts
+++ b/apps/cms/__tests__/products.test.ts
@@ -41,6 +41,8 @@ describe("product actions", () => {
   afterEach(() => jest.resetAllMocks());
   it("createDraftRecord creates placeholders", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       const { createDraftRecord } = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -54,6 +56,8 @@ describe("product actions", () => {
 
   it("updateProduct merges form data and bumps version", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -78,6 +82,8 @@ describe("product actions", () => {
 
   it("rejects invalid product payloads", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -108,6 +114,8 @@ describe("product actions", () => {
 
   it("duplicateProduct copies a product", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -133,6 +141,8 @@ describe("product actions", () => {
 
   it("deleteProduct removes product and redirects", async () => {
     await withRepo(async () => {
+      const now = "2024-01-01T00:00:00.000Z";
+      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");

--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -14,6 +14,7 @@ import { historyStateSchema, pageComponentSchema } from "@types";
 import { getServerSession } from "next-auth";
 import { ulid } from "ulid";
 import { z } from "zod";
+import { nowIso } from "../../../../packages/shared/date";
 
 /* -------------------------------------------------------------------------- */
 /*  Helpers                                                                   */
@@ -169,7 +170,7 @@ export async function createPage(
     image[l] = data.image ?? "";
   });
 
-  const now = new Date().toISOString();
+  const now = nowIso();
   const page: Page = {
     id,
     slug: data.slug,
@@ -228,7 +229,7 @@ export async function savePageDraft(
   }
 
   const pages = await getPages(shop);
-  const now = new Date().toISOString();
+  const now = nowIso();
   const existing = pages.find((p) => p.id === id);
 
   const page: Page = existing

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -19,6 +19,7 @@ import type { Locale } from "@types";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { ulid } from "ulid";
+import { nowIso } from "../../../../packages/shared/date";
 
 /* -------------------------------------------------------------------------- */
 /*  Helpers                                                                    */
@@ -43,7 +44,7 @@ export async function createDraftRecord(
 ): Promise<ProductPublication> {
   await ensureAuthorized();
 
-  const now = new Date().toISOString();
+  const now = nowIso();
   const locales = await getLocales(shop);
   const blank: Record<string, string> = {};
   locales.forEach((l) => {
@@ -127,7 +128,7 @@ export async function updateProduct(
     description: nextDesc,
     price,
     row_version: current.row_version + 1,
-    updated_at: new Date().toISOString(),
+    updated_at: nowIso(),
   };
 
   const saved = await updateProductInRepo<ProductPublication>(shop, updated);

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -29,6 +29,7 @@ import {
   loadBaseTokens,
   loadThemeTokens,
 } from "./createShop/utils";
+import { nowIso } from "../../shared/date";
 import { defaultFilterMappings } from "./defaultFilterMappings";
 
 export const createShopOptionsSchema = z.object({
@@ -260,7 +261,7 @@ export function createShop(id: string, opts: CreateShopOptions = {}): void {
     )
   );
 
-  const now = new Date().toISOString();
+  const now = nowIso();
   const sampleProduct = {
     id: ulid(),
     sku: "SAMPLE-1",

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -7,6 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../../../../lib/src/validateShopName";
 import { DATA_ROOT } from "../utils";
+import { nowIso } from "../../../../shared/date";
 
 /* -------------------------------------------------------------------------- */
 /*  Helpers                                                                   */
@@ -96,7 +97,7 @@ export async function updatePage(
   }
 
   const updated: Page = mergeDefined(current, patch);
-  updated.updatedAt = new Date().toISOString();
+  updated.updatedAt = nowIso();
 
   pages[idx] = updated;
   await writePages(shop, pages);

--- a/packages/platform-core/src/repositories/products.server.ts
+++ b/packages/platform-core/src/repositories/products.server.ts
@@ -6,6 +6,7 @@ import { ulid } from "ulid";
 import { ProductPublication } from "../products";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "./utils";
+import { nowIso } from "../../../shared/date";
 
 function filePath(shop: string): string {
   shop = validateShopName(shop);
@@ -78,7 +79,7 @@ export async function duplicateProductInRepo<
   const catalogue = await readRepo<T>(shop);
   const original = catalogue.find((p) => p.id === id);
   if (!original) throw new Error(`Product ${id} not found in ${shop}`);
-  const now = new Date().toISOString();
+  const now = nowIso();
   const copy: T = {
     ...original,
     id: ulid(),

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { ulid } from "ulid";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "./utils";
+import { nowIso } from "../../../shared/date";
 
 function ordersPath(shop: string): string {
   shop = validateShopName(shop);
@@ -54,7 +55,7 @@ export async function addOrder(
     shop,
     deposit,
     expectedReturnDate,
-    startedAt: new Date().toISOString(),
+    startedAt: nowIso(),
   };
   orders.push(order);
   await writeOrders(shop, orders);
@@ -69,7 +70,7 @@ export async function markReturned(
   const orders = await readOrders(shop);
   const idx = orders.findIndex((o) => o.sessionId === sessionId);
   if (idx === -1) return null;
-  orders[idx].returnedAt = new Date().toISOString();
+  orders[idx].returnedAt = nowIso();
   if (typeof damageFee === "number") {
     orders[idx].damageFee = damageFee;
   }
@@ -84,7 +85,7 @@ export async function markRefunded(
   const orders = await readOrders(shop);
   const idx = orders.findIndex((o) => o.sessionId === sessionId);
   if (idx === -1) return null;
-  orders[idx].refundedAt = new Date().toISOString();
+  orders[idx].refundedAt = nowIso();
   await writeOrders(shop, orders);
   return orders[idx];
 }

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { z } from "zod";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "./utils";
+import { nowIso } from "../../../shared/date";
 const DEFAULT_LANGUAGES: Locale[] = [...LOCALES];
 
 function settingsPath(shop: string): string {
@@ -77,7 +78,7 @@ export async function saveShopSettings(
 
   const patch = diffSettings(current, settings);
   if (Object.keys(patch).length > 0) {
-    const entry = { timestamp: new Date().toISOString(), diff: patch };
+    const entry = { timestamp: nowIso(), diff: patch };
     await fs.appendFile(
       historyPath(shop),
       JSON.stringify(entry) + "\n",

--- a/packages/shared/date.ts
+++ b/packages/shared/date.ts
@@ -1,0 +1,1 @@
+export const nowIso = () => new Date().toISOString();


### PR DESCRIPTION
## Summary
- add shared `nowIso` helper for consistent ISO timestamps
- use `nowIso` across CMS actions and platform-core repositories
- mock `nowIso` in related tests

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: wizard.test.tsx, checkout.test.tsx, StoreLocatorMap.test.tsx)*
- `pnpm --filter @apps/cms test` *(fails: wizard.test.tsx, versionTimeline.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68976e41c24c832fb0144889dfc2436a