### PR TITLE
feat: add recursive dynamic renderer

### DIFF
--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -22,4 +22,52 @@ describe("DynamicRenderer", () => {
 
     expect(screen.getByText("hello")).toBeInTheDocument();
   });
+
+  it("renders nested components recursively", () => {
+    const components: PageComponent[] = [
+      {
+        id: "1",
+        type: "Section",
+        children: [
+          {
+            id: "2",
+            type: "Text",
+            text: { en: "nested" },
+            locale: "en",
+          } as any,
+        ],
+      } as any,
+    ];
+
+    render(<DynamicRenderer components={components} />);
+
+    expect(screen.getByText("nested")).toBeInTheDocument();
+  });
+
+  it("applies style props to wrapper div", () => {
+    const components: PageComponent[] = [
+      {
+        id: "1",
+        type: "Text",
+        text: { en: "styled" },
+        locale: "en",
+        margin: "1px",
+        padding: "2px",
+        position: "absolute",
+        top: "3px",
+        left: "4px",
+      } as any,
+    ];
+
+    const { container } = render(<DynamicRenderer components={components} />);
+    const wrapper = container.firstChild as HTMLElement;
+
+    expect(wrapper).toHaveStyle({
+      margin: "1px",
+      padding: "2px",
+      position: "absolute",
+      top: "3px",
+      left: "4px",
+    });
+  });
 });

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -2,61 +2,54 @@
 
 "use client";
 
-import { Image, Text } from "@/components/cms/blocks";
-import BlogListing from "@/components/cms/blocks/BlogListing";
-import ContactForm from "@/components/cms/blocks/ContactForm";
-import ContactFormWithMap from "@/components/cms/blocks/ContactFormWithMap";
-import Gallery from "@/components/cms/blocks/Gallery";
-import Testimonials from "@/components/cms/blocks/Testimonials";
-import TestimonialSlider from "@/components/cms/blocks/TestimonialSlider";
-import HeroBanner from "@/components/home/HeroBanner";
-import ReviewsCarousel from "@/components/home/ReviewsCarousel";
-import { ValueProps } from "@/components/home/ValueProps";
-import { PRODUCTS } from "@/lib/products";
-import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
-import type { PageComponent, SKU } from "@types";
-
-const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
-  HeroBanner,
-  ValueProps,
-  ReviewsCarousel,
-  ProductGrid,
-  Gallery,
-  ContactForm,
-  ContactFormWithMap,
-  BlogListing,
-  Testimonials,
-  TestimonialSlider,
-  Image,
-  Text,
-};
+import { blockRegistry } from "@/components/cms/blocks";
+import type { PageComponent } from "@types";
+import type { ReactNode, CSSProperties } from "react";
 
 export default function DynamicRenderer({
   components,
 }: {
   components: PageComponent[];
 }) {
-  return (
-    <>
-      {components.map((c) => {
-        const Comp = registry[c.type];
-        if (!Comp) {
-          console.warn(`Unknown component type: ${c.type}`);
-          return null;
-        }
+  const renderBlock = (block: PageComponent): ReactNode => {
+    const Comp = blockRegistry[block.type as keyof typeof blockRegistry];
+    if (!Comp) {
+      console.warn(`Unknown component type: ${block.type}`);
+      return null;
+    }
 
-        const { id, type, width, height, ...props } = c as any;
-        return (
-          <div key={id} style={{ width, height }}>
-            {type === "ProductGrid" ? (
-              <Comp {...props} skus={PRODUCTS as SKU[]} />
-            ) : (
-              <Comp {...props} />
-            )}
-          </div>
-        );
-      })}
-    </>
-  );
+    const {
+      id,
+      children,
+      width,
+      height,
+      margin,
+      padding,
+      position,
+      top,
+      left,
+      ...props
+    } = block as any;
+
+    const style: CSSProperties = {
+      width,
+      height,
+      margin,
+      padding,
+      position,
+      top,
+      left,
+    };
+
+    return (
+      <div key={id} style={style}>
+        <Comp {...props}>
+          {children?.map((child: PageComponent) => renderBlock(child))}
+        </Comp>
+      </div>
+    );
+  };
+
+  return <>{components.map((c) => renderBlock(c))}</>;
 }
 


### PR DESCRIPTION
## Summary
- use shared `blockRegistry` for dynamic block lookup
- render nested blocks recursively and apply editor styles
- test nested rendering and style propagation

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/DynamicRenderer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68977bea05ac832fabfe1a3346cc8e90