### PR TITLE
Add CMS and Chromatic env placeholders

### DIFF
--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -10,6 +10,9 @@ export const envSchema = z.object({
   NEXT_PUBLIC_PHASE: z.string().optional(),
   NEXT_PUBLIC_DEFAULT_SHOP: z.string().optional(),
   NEXT_PUBLIC_SHOP_ID: z.string().optional(),
+  CMS_SPACE_URL: z.string().optional(),
+  CMS_ACCESS_TOKEN: z.string().optional(),
+  CHROMATIC_PROJECT_TOKEN: z.string().optional(),
   GMAIL_USER: z.string().optional(),
   GMAIL_PASS: z.string().optional(),
 });

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -220,6 +220,9 @@ export function createShop(id: string, opts: CreateShopOptions = {}): void {
     }
   }
   envContent += `NEXTAUTH_SECRET=${genSecret()}\n`;
+  envContent += `CMS_SPACE_URL=\n`;
+  envContent += `CMS_ACCESS_TOKEN=\n`;
+  envContent += `CHROMATIC_PROJECT_TOKEN=\n`;
   writeFileSync(join(newApp, ".env"), envContent);
 
   mkdirSync(newData, { recursive: true });


### PR DESCRIPTION
## Summary
- include CMS and Chromatic placeholders in generated shop `.env`
- expand config env schema so setup-ci validates new variables

## Testing
- `pnpm lint:all`
- `pnpm exec jest packages/config/__tests__/env.test.ts`
- `pnpm exec jest packages/platform-core/__tests__/createShop.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68977c06b720832fb292eb3217d28ab5