### PR TITLE
Add dynamic slug route for custom pages

### DIFF
--- a/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+import type { PageComponent } from "@types";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import shop from "../../../../shop.json";
+
+async function loadComponents(slug: string): Promise<PageComponent[] | null> {
+  const pages = await getPages(shop.id);
+  const page = pages.find((p) => p.slug === slug && p.status === "published");
+  return page?.components ?? null;
+}
+
+export default async function Page({
+  params,
+}: {
+  params: { lang: string; slug: string[] };
+}) {
+  const slug = params.slug.join("/");
+  const components = await loadComponents(slug);
+  if (!components) notFound();
+  return <DynamicRenderer components={components} />;
+}
+

--- a/apps/shop-abc/src/app/[lang]/generateStaticParams.ts
+++ b/apps/shop-abc/src/app/[lang]/generateStaticParams.ts
@@ -1,7 +1,22 @@
-// apps/shop-abc/src/app/[[...lang]]/generateStaticParams.ts
+// apps/shop-abc/src/app/[lang]/generateStaticParams.ts
 import { LOCALES } from "@acme/i18n";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import shop from "../../../shop.json";
 
-export default function generateStaticParams() {
-  /* prerender /en, /de, /it — Next will also serve `/` via default locale */
-  return LOCALES.map((lang) => ({ lang }));
+export default async function generateStaticParams() {
+  const pages = await getPages(shop.id);
+  const published = pages.filter((p) => p.status === "published");
+
+  const params: { lang: string; slug?: string[] }[] = [];
+
+  for (const lang of LOCALES) {
+    params.push({ lang });
+    for (const page of published) {
+      if (page.slug === "home") continue;
+      params.push({ lang, slug: page.slug.split("/") });
+    }
+  }
+
+  return params;
 }
+


### PR DESCRIPTION
## Summary
- render published custom pages with new `[...slug]` catch-all route
- enumerate published custom pages in `generateStaticParams`

## Testing
- `pnpm lint --filter @apps/shop-abc`
- `pnpm test --filter @apps/shop-abc`


------
https://chatgpt.com/codex/tasks/task_e_68977bf095e4832fb73e58c2afe76532