### PR TITLE
feat: expose all CMS blocks at runtime

### DIFF
--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -2,33 +2,24 @@
 
 "use client";
 
-import { Image, Text } from "@/components/cms/blocks";
-import BlogListing from "@/components/cms/blocks/BlogListing";
-import ContactForm from "@/components/cms/blocks/ContactForm";
-import ContactFormWithMap from "@/components/cms/blocks/ContactFormWithMap";
-import Gallery from "@/components/cms/blocks/Gallery";
-import Testimonials from "@/components/cms/blocks/Testimonials";
-import TestimonialSlider from "@/components/cms/blocks/TestimonialSlider";
-import HeroBanner from "@/components/home/HeroBanner";
-import ReviewsCarousel from "@/components/home/ReviewsCarousel";
-import { ValueProps } from "@/components/home/ValueProps";
+import {
+  blockRegistry,
+  ProductCarousel,
+  NewsletterForm,
+  PromoBanner,
+  CategoryList,
+  Section,
+} from "@/components/cms/blocks";
 import { PRODUCTS } from "@/lib/products";
-import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
 import type { PageComponent, SKU } from "@types";
 
-const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
-  HeroBanner,
-  ValueProps,
-  ReviewsCarousel,
-  ProductGrid,
-  Gallery,
-  ContactForm,
-  ContactFormWithMap,
-  BlogListing,
-  Testimonials,
-  TestimonialSlider,
-  Image,
-  Text,
+const registry: Record<string, React.ComponentType<any>> = {
+  ...blockRegistry,
+  ProductCarousel,
+  NewsletterForm,
+  PromoBanner,
+  CategoryList,
+  Section,
 };
 
 export default function DynamicRenderer({

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -9,6 +9,8 @@ import ReviewsCarousel from "./ReviewsCarousel";
 import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
+import Section from "./Section";
+import { NewsletterForm, PromoBanner, CategoryList } from "./molecules";
 
 export {
   BlogListing,
@@ -22,6 +24,10 @@ export {
   Testimonials,
   TestimonialSlider,
   ValueProps,
+  NewsletterForm,
+  PromoBanner,
+  CategoryList,
+  Section,
 };
 
 export * from "./atoms";


### PR DESCRIPTION
## Summary
- use blockRegistry so CMS builder components resolve at runtime
- include ProductCarousel, NewsletterForm, PromoBanner, CategoryList, and Section in registry
- keep ProductGrid special handling for SKU data

## Testing
- `pnpm --filter @acme/ui test` *(fails: Failed to parse wizard state SyntaxError: Expected property name or '}' in JSON at position 1)*

------
https://chatgpt.com/codex/tasks/task_e_68977bebc4bc832fbc6867d4c7a0747d