### PR TITLE
feat: localize dynamic renderer blocks

### DIFF
--- a/apps/shop-abc/src/app/[lang]/page.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.client.tsx
@@ -3,11 +3,14 @@
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@types";
+import type { Locale } from "@i18n/locales";
 
 export default function Home({
   components,
+  locale,
 }: {
   components: PageComponent[];
+  locale: Locale;
 }) {
-  return <DynamicRenderer components={components} />;
+  return <DynamicRenderer components={components} locale={locale} />;
 }

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -2,13 +2,20 @@ import type { PageComponent } from "@types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import shop from "../../../shop.json";
 import Home from "./page.client";
+import { Locale, resolveLocale } from "@i18n/locales";
 
 async function loadComponents(): Promise<PageComponent[]> {
   const pages = await getPages(shop.id);
   return pages.find((p) => p.slug === "home")?.components ?? [];
 }
 
-export default async function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang?: string }>;
+}) {
+  const { lang: raw } = await params;
+  const locale: Locale = resolveLocale(raw);
   const components = await loadComponents();
-  return <Home components={components} />;
+  return <Home components={components} locale={locale} />;
 }

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -3,11 +3,14 @@
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@types";
+import type { Locale } from "@i18n/locales";
 
 export default function Home({
   components,
+  locale,
 }: {
   components: PageComponent[];
+  locale: Locale;
 }) {
-  return <DynamicRenderer components={components} />;
+  return <DynamicRenderer components={components} locale={locale} />;
 }

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import shop from "../../../shop.json";
 import Home from "./page.client";
+import { Locale, resolveLocale } from "@i18n/locales";
 
 async function loadComponents(): Promise<PageComponent[]> {
   try {
@@ -24,7 +25,13 @@ async function loadComponents(): Promise<PageComponent[]> {
   }
 }
 
-export default async function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang?: string }>;
+}) {
+  const { lang: raw } = await params;
+  const locale: Locale = resolveLocale(raw);
   const components = await loadComponents();
-  return <Home components={components} />;
+  return <Home components={components} locale={locale} />;
 }

--- a/packages/template-app/src/components/DynamicRenderer.tsx
+++ b/packages/template-app/src/components/DynamicRenderer.tsx
@@ -19,6 +19,7 @@ import { Textarea as TextBlock } from "@/components/ui/textarea";
 
 import { PRODUCTS } from "@platform-core/src/products";
 import type { PageComponent, SKU } from "@types";
+import type { Locale } from "@i18n/locales";
 
 /* ------------------------------------------------------------------
  * next/image wrapper usable in CMS blocks
@@ -64,7 +65,13 @@ const registry: Record<
 /* ------------------------------------------------------------------
  * DynamicRenderer
  * ------------------------------------------------------------------ */
-function DynamicRenderer({ components }: { components: PageComponent[] }) {
+function DynamicRenderer({
+  components,
+  locale = "en",
+}: {
+  components: PageComponent[];
+  locale?: Locale;
+}) {
   return (
     <>
       {components.map((block) => {
@@ -77,13 +84,15 @@ function DynamicRenderer({ components }: { components: PageComponent[] }) {
 
         /* Runtime props for specific blocks */
         if (block.type === "ProductGrid") {
-          return <Comp key={block.id} skus={PRODUCTS as SKU[]} />;
+          return (
+            <Comp key={block.id} skus={PRODUCTS as SKU[]} locale={locale} />
+          );
         }
 
         const props =
           (block as { props?: Record<string, unknown> }).props ?? {};
 
-        return <Comp key={block.id} {...props} />;
+        return <Comp key={block.id} {...props} locale={locale} />;
       })}
     </>
   );

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -13,13 +13,13 @@ describe("DynamicRenderer", () => {
     warnSpy.mockRestore();
   });
 
-  it("renders known component", () => {
+  it("renders locale-specific text", () => {
     const components: PageComponent[] = [
-      { id: "1", type: "Text", text: { en: "hello" }, locale: "en" } as any,
+      { id: "1", type: "Text", text: { en: "hello", de: "hallo" } } as any,
     ];
 
-    render(<DynamicRenderer components={components} />);
+    render(<DynamicRenderer components={components} locale="de" />);
 
-    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("hallo")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -15,6 +15,7 @@ import { ValueProps } from "@/components/home/ValueProps";
 import { PRODUCTS } from "@/lib/products";
 import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
 import type { PageComponent, SKU } from "@types";
+import type { Locale } from "@i18n/locales";
 
 const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
   HeroBanner,
@@ -33,8 +34,10 @@ const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
 
 export default function DynamicRenderer({
   components,
+  locale = "en",
 }: {
   components: PageComponent[];
+  locale?: Locale;
 }) {
   return (
     <>
@@ -49,9 +52,9 @@ export default function DynamicRenderer({
         return (
           <div key={id} style={{ width, height }}>
             {type === "ProductGrid" ? (
-              <Comp {...props} skus={PRODUCTS as SKU[]} />
+              <Comp {...props} skus={PRODUCTS as SKU[]} locale={locale} />
             ) : (
-              <Comp {...props} />
+              <Comp {...props} locale={locale} />
             )}
           </div>
         );


### PR DESCRIPTION
## Summary
- propagate locale through DynamicRenderer so blocks can render language-specific content
- pass active locale from shop pages
- test DynamicRenderer renders locale-specific text

## Testing
- `npx jest packages/ui/__tests__/DynamicRenderer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68977becc6c8832f8ade9a854bab80a2