### PR TITLE
feat: render shop pages via CMS DynamicRenderer

### DIFF
--- a/apps/shop-abc/__tests__/cmsPages.test.tsx
+++ b/apps/shop-abc/__tests__/cmsPages.test.tsx
@@ -1,0 +1,128 @@
+import type { PageComponent } from "@types";
+import { PRODUCTS, getProductBySlug } from "@/lib/products";
+
+jest.mock("@platform-core/repositories/pages/index.server", () => ({
+  __esModule: true,
+  getPages: jest.fn(),
+}));
+
+jest.mock("@ui/components/DynamicRenderer", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock("@/components/checkout/CheckoutForm", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock("@/components/organisms/OrderSummary", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+jest.mock("@/lib/cartCookie", () => ({
+  CART_COOKIE: "cart",
+  decodeCartCookie: jest.fn(() => ({ sku1: 1 })),
+}));
+
+jest.mock("../src/app/[lang]/shop/ShopClient.client", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock("../src/app/[lang]/product/[slug]/PdpClient.client", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import ShopPage from "../src/app/[lang]/shop/page";
+import ProductPage from "../src/app/[lang]/product/[slug]/page";
+import CheckoutPage from "../src/app/[lang]/checkout/page";
+import ShopClient from "../src/app/[lang]/shop/ShopClient.client";
+import PdpClient from "../src/app/[lang]/product/[slug]/PdpClient.client";
+import { cookies } from "next/headers";
+
+describe("CMS integration", () => {
+  beforeEach(() => {
+    (getPages as jest.Mock).mockReset();
+    (DynamicRenderer as jest.Mock).mockClear();
+    (ShopClient as jest.Mock).mockClear();
+    (PdpClient as jest.Mock).mockClear();
+    (cookies as jest.Mock).mockResolvedValue({ get: () => ({ value: "cookie" }) });
+  });
+
+  test("shop page renders CMS components", async () => {
+    const components: PageComponent[] = [
+      { id: "c1", type: "Text", text: { en: "hi" } } as any,
+    ];
+    (getPages as jest.Mock).mockResolvedValue([{ slug: "shop", components }]);
+
+    const element = await ShopPage({
+      params: Promise.resolve({ lang: "en" }),
+    } as any);
+
+    expect(getPages).toHaveBeenCalledWith("abc");
+    expect(element.type).toBe(DynamicRenderer);
+    expect(element.props).toEqual({
+      components,
+      locale: "en",
+      runtimeData: { skus: PRODUCTS },
+    });
+  });
+
+  test("shop page falls back without CMS components", async () => {
+    (getPages as jest.Mock).mockResolvedValue([]);
+    const el = await ShopPage({ params: Promise.resolve({ lang: "en" }) } as any);
+
+    expect(DynamicRenderer).not.toHaveBeenCalled();
+    expect(el.type).toBe(ShopClient);
+  });
+
+  test("product page renders CMS components", async () => {
+    const slug = "green-sneaker";
+    const components: PageComponent[] = [
+      { id: "c1", type: "Text", text: { en: "hi" } } as any,
+    ];
+    (getPages as jest.Mock).mockResolvedValue([
+      { slug: `product/${slug}`, components },
+    ]);
+
+    const element = await ProductPage({
+      params: Promise.resolve({ lang: "en", slug }),
+    } as any);
+
+    expect(element.type).toBe(DynamicRenderer);
+    expect(element.props).toEqual({
+      components,
+      locale: "en",
+      runtimeData: { product: getProductBySlug(slug)! },
+    });
+  });
+
+  test("checkout page renders CMS components", async () => {
+    const components: PageComponent[] = [
+      { id: "c1", type: "Text", text: { en: "hi" } } as any,
+    ];
+    (getPages as jest.Mock).mockResolvedValue([
+      { slug: "checkout", components },
+    ]);
+
+    const element = await CheckoutPage({
+      params: Promise.resolve({ lang: "en" }),
+    } as any);
+
+    expect(element.type).toBe(DynamicRenderer);
+    expect(element.props).toEqual({
+      components,
+      locale: "en",
+      runtimeData: { cart: { sku1: 1 } },
+    });
+  });
+});

--- a/apps/shop-abc/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/checkout/page.tsx
@@ -5,6 +5,9 @@ import OrderSummary from "@/components/organisms/OrderSummary";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
 import { cookies } from "next/headers";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import shop from "../../../../shop.json";
 
 export const metadata = {
   title: "Checkout · Base-Shop",
@@ -32,11 +35,23 @@ export default async function CheckoutPage({
     return <p className="p-8 text-center">Your cart is empty.</p>;
   }
 
-  /* ---------- render ---------- */
+  const pages = await getPages(shop.id);
+  const components = pages.find((p) => p.slug === "checkout")?.components ?? [];
+
+  if (!components.length) {
+    return (
+      <div className="mx-auto flex max-w-4xl flex-col gap-10 p-6">
+        <OrderSummary />
+        <CheckoutForm locale={lang} />
+      </div>
+    );
+  }
+
   return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-10 p-6">
-      <OrderSummary />
-      <CheckoutForm locale={lang} />
-    </div>
+    <DynamicRenderer
+      components={components}
+      locale={lang}
+      runtimeData={{ cart }}
+    />
   );
 }

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -2,13 +2,36 @@
 import { PRODUCTS } from "@/lib/products";
 import type { SKU } from "@types";
 import type { Metadata } from "next";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import { Locale, resolveLocale } from "@/i18n/locales";
+import shop from "../../../../shop.json";
 import ShopClient from "./ShopClient.client";
 
 export const metadata: Metadata = {
   title: "Shop · Base-Shop",
 };
 
-export default function ShopIndexPage() {
-  // ⬇️ Purely server-side: just pass static data to the client component
-  return <ShopClient skus={PRODUCTS as SKU[]} />;
+export default async function ShopIndexPage({
+  params,
+}: {
+  params: Promise<{ lang?: string }>;
+}) {
+  const { lang: rawLang } = await params;
+  const locale: Locale = resolveLocale(rawLang);
+
+  const pages = await getPages(shop.id);
+  const components = pages.find((p) => p.slug === "shop")?.components ?? [];
+
+  if (!components.length) {
+    return <ShopClient skus={PRODUCTS as SKU[]} />;
+  }
+
+  return (
+    <DynamicRenderer
+      components={components}
+      locale={locale}
+      runtimeData={{ skus: PRODUCTS as SKU[] }}
+    />
+  );
 }

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -15,11 +15,11 @@ describe("DynamicRenderer", () => {
 
   it("renders known component", () => {
     const components: PageComponent[] = [
-      { id: "1", type: "Text", text: { en: "hello" }, locale: "en" } as any,
+      { id: "1", type: "Text", text: { en: "hello", de: "hallo" } } as any,
     ];
 
-    render(<DynamicRenderer components={components} />);
+    render(<DynamicRenderer components={components} locale="de" />);
 
-    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("hallo")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -15,6 +15,7 @@ import { ValueProps } from "@/components/home/ValueProps";
 import { PRODUCTS } from "@/lib/products";
 import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
 import type { PageComponent, SKU } from "@types";
+import type { Locale } from "@/i18n/locales";
 
 const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
   HeroBanner,
@@ -33,8 +34,12 @@ const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
 
 export default function DynamicRenderer({
   components,
+  locale = "en",
+  runtimeData = {},
 }: {
   components: PageComponent[];
+  locale?: Locale;
+  runtimeData?: Record<string, unknown>;
 }) {
   return (
     <>
@@ -45,14 +50,37 @@ export default function DynamicRenderer({
           return null;
         }
 
-        const { id, type, width, height, ...props } = c as any;
+        const {
+          id,
+          type,
+          width,
+          height,
+          position,
+          top,
+          left,
+          margin,
+          padding,
+          ...props
+        } = c as any;
+
+        const style: React.CSSProperties = {
+          width,
+          height,
+          position,
+          top,
+          left,
+          margin,
+          padding,
+        };
+
+        const extra: Record<string, unknown> = { locale, ...runtimeData };
+        if (type === "ProductGrid") {
+          extra.skus = (runtimeData as any).skus ?? (PRODUCTS as SKU[]);
+        }
+
         return (
-          <div key={id} style={{ width, height }}>
-            {type === "ProductGrid" ? (
-              <Comp {...props} skus={PRODUCTS as SKU[]} />
-            ) : (
-              <Comp {...props} />
-            )}
+          <div key={id} style={style}>
+            <Comp {...props} {...extra} />
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- enhance DynamicRenderer to pass locale and runtime data
- load CMS page components for shop, product, and checkout routes with fallbacks
- add integration tests to ensure CMS layouts render in shop

## Testing
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/__tests__/DynamicRenderer.test.tsx`
- `npx jest apps/shop-abc/__tests__/cmsPages.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68977bef54d4832fa2963e2058379002