### PR TITLE
test: expand DynamicRenderer coverage

### DIFF
--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -1,6 +1,95 @@
 import { render, screen } from "@testing-library/react";
-import DynamicRenderer from "../src/components/DynamicRenderer";
 import type { PageComponent } from "@types";
+import DynamicRenderer from "../src/components/DynamicRenderer";
+import { blockRegistry, type BlockType } from "../src/components/cms/blocks";
+
+const productGridProps = jest.fn();
+function stub(name: string) {
+  return () => <div>{name}</div>;
+}
+
+jest.mock("@/components/home/HeroBanner", () => ({
+  __esModule: true,
+  default: stub("HeroBanner"),
+}));
+jest.mock("@/components/home/ReviewsCarousel", () => ({
+  __esModule: true,
+  default: stub("ReviewsCarousel"),
+}));
+jest.mock("@/components/home/ValueProps", () => ({
+  __esModule: true,
+  ValueProps: stub("ValueProps"),
+}));
+jest.mock("@/components/cms/blocks/BlogListing", () => ({
+  __esModule: true,
+  default: stub("BlogListing"),
+}));
+jest.mock("@/components/cms/blocks/ContactForm", () => ({
+  __esModule: true,
+  default: stub("ContactForm"),
+}));
+jest.mock("@/components/cms/blocks/ContactFormWithMap", () => ({
+  __esModule: true,
+  default: stub("ContactFormWithMap"),
+}));
+jest.mock("@/components/cms/blocks/Gallery", () => ({
+  __esModule: true,
+  default: stub("Gallery"),
+}));
+jest.mock("@/components/cms/blocks/Testimonials", () => ({
+  __esModule: true,
+  default: stub("Testimonials"),
+}));
+jest.mock("@/components/cms/blocks/TestimonialSlider", () => ({
+  __esModule: true,
+  default: stub("TestimonialSlider"),
+}));
+jest.mock("@/components/cms/blocks/ProductCarousel", () => ({
+  __esModule: true,
+  default: stub("ProductCarousel"),
+}));
+jest.mock("@/components/cms/blocks/molecules", () => ({
+  __esModule: true,
+  NewsletterForm: stub("NewsletterForm"),
+  PromoBanner: stub("PromoBanner"),
+  CategoryList: stub("CategoryList"),
+}));
+jest.mock("@platform-core/src/components/shop/ProductGrid", () => ({
+  ProductGrid: (props: any) => {
+    productGridProps(props);
+    return stub("ProductGrid")();
+  },
+}));
+jest.mock("@/components/cms/blocks", () => {
+  const actual = jest.requireActual("@/components/cms/blocks");
+  return {
+    __esModule: true,
+    ...actual,
+    Image: stub("Image"),
+  };
+});
+
+function createComponent(type: BlockType): PageComponent {
+  switch (type) {
+    case "Text":
+      return {
+        id: "1",
+        type,
+        text: { en: type },
+        locale: "en",
+      } as any;
+    case "Image":
+      return { id: "1", type, src: "/img.png", alt: "" } as any;
+    case "Section":
+      return { id: "1", type, children: [] } as any;
+    default:
+      return { id: "1", type } as any;
+  }
+}
+
+beforeEach(() => {
+  productGridProps.mockClear();
+});
 
 describe("DynamicRenderer", () => {
   it("warns on unknown component type", () => {
@@ -13,13 +102,60 @@ describe("DynamicRenderer", () => {
     warnSpy.mockRestore();
   });
 
-  it("renders known component", () => {
+  it("renders a nested Section with child blocks", () => {
     const components: PageComponent[] = [
-      { id: "1", type: "Text", text: { en: "hello" }, locale: "en" } as any,
+      {
+        id: "1",
+        type: "Section",
+        children: [
+          { id: "2", type: "Text", text: { en: "inner" }, locale: "en" } as any,
+        ],
+      } as any,
     ];
 
     render(<DynamicRenderer components={components} />);
 
-    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("inner")).toBeInTheDocument();
+  });
+
+  it("passes runtime props to ProductGrid", () => {
+    const components: PageComponent[] = [
+      { id: "1", type: "ProductGrid" } as any,
+    ];
+
+    render(<DynamicRenderer components={components} />);
+
+    expect(productGridProps).toHaveBeenCalledWith(
+      expect.objectContaining({ skus: expect.any(Array) })
+    );
+  });
+
+  it("renders locale-specific text", () => {
+    const components: PageComponent[] = [
+      {
+        id: "1",
+        type: "Text",
+        text: { en: "hello", fr: "bonjour" },
+        locale: "fr",
+      } as any,
+    ];
+
+    render(<DynamicRenderer components={components} />);
+
+    expect(screen.getByText("bonjour")).toBeInTheDocument();
+  });
+
+  describe.each(Object.keys(blockRegistry))("%s block", (type) => {
+    it("renders without warning", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      const component = createComponent(type as BlockType);
+
+      render(<DynamicRenderer components={[component]} />);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
   });
 });
+

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -7,8 +7,11 @@ import BlogListing from "@/components/cms/blocks/BlogListing";
 import ContactForm from "@/components/cms/blocks/ContactForm";
 import ContactFormWithMap from "@/components/cms/blocks/ContactFormWithMap";
 import Gallery from "@/components/cms/blocks/Gallery";
+import ProductCarousel from "@/components/cms/blocks/ProductCarousel";
+import Section from "@/components/cms/blocks/Section";
 import Testimonials from "@/components/cms/blocks/Testimonials";
 import TestimonialSlider from "@/components/cms/blocks/TestimonialSlider";
+import { CategoryList, NewsletterForm, PromoBanner } from "@/components/cms/blocks/molecules";
 import HeroBanner from "@/components/home/HeroBanner";
 import ReviewsCarousel from "@/components/home/ReviewsCarousel";
 import { ValueProps } from "@/components/home/ValueProps";
@@ -17,14 +20,19 @@ import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
 import type { PageComponent, SKU } from "@types";
 
 const registry: Record<PageComponent["type"], React.ComponentType<any>> = {
+  Section,
   HeroBanner,
   ValueProps,
   ReviewsCarousel,
   ProductGrid,
+  ProductCarousel,
   Gallery,
   ContactForm,
   ContactFormWithMap,
   BlogListing,
+  NewsletterForm,
+  PromoBanner,
+  CategoryList,
   Testimonials,
   TestimonialSlider,
   Image,
@@ -46,6 +54,19 @@ export default function DynamicRenderer({
         }
 
         const { id, type, width, height, ...props } = c as any;
+
+        if (type === "Section") {
+          const { children = [], ...rest } = props as {
+            children?: PageComponent[];
+          };
+
+          return (
+            <Comp key={id} {...rest}>
+              <DynamicRenderer components={children} />
+            </Comp>
+          );
+        }
+
         return (
           <div key={id} style={{ width, height }}>
             {type === "ProductGrid" ? (


### PR DESCRIPTION
## Summary
- handle Section blocks recursively and register all block types
- add parameterized tests to ensure coverage for every registered block
- verify ProductGrid runtime props and locale-sensitive text rendering

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/DynamicRenderer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68977bf2b25c832fb6d269248cd74684