### PR TITLE
feat: add runtime block registry

### DIFF
--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -3,7 +3,8 @@
 "use client";
 
 import { blockRegistry } from "@/components/cms/blocks";
-import type { PageComponent } from "@types";
+import { PRODUCTS } from "@platform-core/src/products";
+import type { PageComponent, SKU } from "@types";
 import type { ReactNode, CSSProperties } from "react";
 
 export default function DynamicRenderer({
@@ -41,9 +42,14 @@ export default function DynamicRenderer({
       left,
     };
 
+    let extraProps: Record<string, unknown> = {};
+    if (block.type === "ProductGrid") {
+      extraProps = { skus: PRODUCTS as SKU[] };
+    }
+
     return (
       <div key={id} style={style}>
-        <Comp {...props}>
+        <Comp {...props} {...extraProps}>
           {children?.map((child: PageComponent) => renderBlock(child))}
         </Comp>
       </div>

--- a/packages/ui/src/components/cms/blocks/ProductGrid.client.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductGrid.client.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { ProductGrid as BaseGrid } from "@platform-core/src/components/shop/ProductGrid";
-import { PRODUCTS } from "@platform-core/src/products";
 import type { SKU } from "@types";
 
-export default function ProductGrid() {
-  return <BaseGrid skus={PRODUCTS as SKU[]} />;
+export interface ProductGridProps {
+  skus: SKU[];
+}
+
+export default function ProductGrid({ skus }: ProductGridProps) {
+  return <BaseGrid skus={skus} />;
 }

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -9,6 +9,8 @@ import ReviewsCarousel from "./ReviewsCarousel";
 import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
+import Section from "./Section";
+import { NewsletterForm, PromoBanner, CategoryList } from "./molecules";
 
 export {
   BlogListing,
@@ -22,6 +24,10 @@ export {
   Testimonials,
   TestimonialSlider,
   ValueProps,
+  NewsletterForm,
+  PromoBanner,
+  CategoryList,
+  Section,
 };
 
 export * from "./atoms";


### PR DESCRIPTION
## Summary
- enable dynamic renderer to pass SKUs to ProductGrid
- expose missing CMS blocks in block registry
- allow ProductGrid CMS block to accept SKUs

## Testing
- `npx jest packages/ui/__tests__/DynamicRenderer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68977ea38e64832f9038736fe3a3fbfc