### PR TITLE
feat: render CMS pages with dynamic data

### DIFF
--- a/apps/shop-abc/__tests__/cmsLayouts.test.tsx
+++ b/apps/shop-abc/__tests__/cmsLayouts.test.tsx
@@ -1,0 +1,109 @@
+jest.mock("@platform-core/repositories/pages/index.server", () => ({
+  __esModule: true,
+  getPages: jest.fn(),
+}));
+jest.mock("@ui/components/DynamicRenderer", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+jest.mock("@/components/checkout/CheckoutForm", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+jest.mock("@/components/organisms/OrderSummary", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+import type { PageComponent, SKU } from "@types";
+import { PRODUCTS } from "@/lib/products";
+import { CART_COOKIE, encodeCartCookie } from "@/lib/cartCookie";
+import ShopPage from "../src/app/[lang]/shop/page";
+import ProductPage from "../src/app/[lang]/product/[slug]/page";
+import CheckoutPage from "../src/app/[lang]/checkout/page";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import { cookies } from "next/headers";
+
+const mockedGetPages = getPages as jest.Mock;
+const MockedRenderer = DynamicRenderer as jest.Mock;
+const mockedCookies = cookies as jest.Mock;
+
+describe("CMS-driven layouts", () => {
+  beforeEach(() => {
+    mockedGetPages.mockReset();
+    MockedRenderer.mockClear();
+    mockedCookies.mockReset();
+  });
+
+  test("shop page uses CMS components when available", async () => {
+    const components: PageComponent[] = [
+      { id: "c1", type: "HeroBanner" } as any,
+    ];
+    mockedGetPages.mockResolvedValue([
+      { slug: "shop", status: "published", components },
+    ]);
+
+    const element = await ShopPage({ params: { lang: "en" } });
+
+    expect(mockedGetPages).toHaveBeenCalledWith("abc");
+    expect(element.type).toBe(DynamicRenderer);
+    expect(element.props.components).toEqual(components);
+    expect(element.props.data).toEqual({
+      locale: "en",
+      products: PRODUCTS as SKU[],
+    });
+  });
+
+  test("product page injects product into CMS components", async () => {
+    const components: PageComponent[] = [
+      { id: "c1", type: "HeroBanner" } as any,
+    ];
+    mockedGetPages.mockResolvedValue([
+      {
+        slug: "product/green-sneaker",
+        status: "published",
+        components,
+      },
+    ]);
+
+    const element = await ProductPage({
+      params: { lang: "en", slug: "green-sneaker" },
+    });
+
+    expect(mockedGetPages).toHaveBeenCalledWith("abc");
+    expect(element.type).toBe(DynamicRenderer);
+    expect(element.props.components).toEqual(components);
+    expect(element.props.data.locale).toBe("en");
+    expect(element.props.data.product.slug).toBe("green-sneaker");
+  });
+
+  test("checkout page passes cart state", async () => {
+    const components: PageComponent[] = [
+      { id: "c1", type: "HeroBanner" } as any,
+    ];
+    mockedGetPages.mockResolvedValue([
+      { slug: "checkout", status: "published", components },
+    ]);
+
+    const cart = { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } as Record<string, any>;
+    const cookieValue = encodeCartCookie(cart);
+    mockedCookies.mockResolvedValue({
+      get: (name: string) =>
+        name === CART_COOKIE ? { value: cookieValue } : undefined,
+    });
+
+    const element = await CheckoutPage({
+      params: Promise.resolve({ lang: "en" }),
+    });
+
+    expect(mockedGetPages).toHaveBeenCalledWith("abc");
+    expect(element.type).toBe(DynamicRenderer);
+    expect(element.props.components).toEqual(components);
+    expect(element.props.data.locale).toBe("en");
+    expect(element.props.data.cart).toEqual(cart);
+  });
+});

--- a/apps/shop-abc/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/checkout/page.tsx
@@ -4,6 +4,10 @@ import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import type { PageComponent } from "@types";
+import shop from "../../../../shop.json";
 import { cookies } from "next/headers";
 
 export const metadata = {
@@ -32,7 +36,20 @@ export default async function CheckoutPage({
     return <p className="p-8 text-center">Your cart is empty.</p>;
   }
 
-  /* ---------- render ---------- */
+  /* ---------- check for CMS layout ---------- */
+  const pages = await getPages(shop.id);
+  const page = pages.find(
+    (p) => p.slug === "checkout" && p.status === "published"
+  );
+  const components: PageComponent[] | null = page?.components ?? null;
+
+  if (components && components.length) {
+    return (
+      <DynamicRenderer components={components} data={{ locale: lang, cart }} />
+    );
+  }
+
+  /* ---------- fallback render ---------- */
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-10 p-6">
       <OrderSummary />

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -1,9 +1,14 @@
-// apps/shop-abc/src/app/[lang]/[lang]/product/[slug]/page.tsx
+// apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
 import { getProductBySlug } from "@/lib/products";
+import { Locale, resolveLocale } from "@/i18n/locales";
 import { LOCALES } from "@acme/i18n";
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import shop from "../../../../../shop.json";
+import type { PageComponent } from "@types";
 import PdpClient from "./PdpClient.client";
 
 export async function generateStaticParams() {
@@ -28,14 +33,33 @@ export function generateMetadata({
   };
 }
 
-export default function ProductDetailPage({
+async function loadComponents(slug: string): Promise<PageComponent[] | null> {
+  const pages = await getPages(shop.id);
+  const page = pages.find(
+    (p) => p.slug === `product/${slug}` && p.status === "published"
+  );
+  return page?.components ?? null;
+}
+
+export default async function ProductDetailPage({
   params,
 }: {
-  params: { slug: string };
+  params: { lang: string; slug: string };
 }) {
+  const lang: Locale = resolveLocale(params.lang);
   const product = getProductBySlug(params.slug);
   if (!product) return notFound();
 
-  /* ⬇️  Only data, no event handlers */
+  const components = await loadComponents(params.slug);
+  if (components && components.length) {
+    return (
+      <DynamicRenderer
+        components={components}
+        data={{ locale: lang, product }}
+      />
+    );
+  }
+
+  // Fallback to default product detail page
   return <PdpClient product={product} />;
 }

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -1,14 +1,42 @@
-// apps/shop-abc/src/app/[lang]/[lang]/shop/page.tsx
+// apps/shop-abc/src/app/[lang]/shop/page.tsx
 import { PRODUCTS } from "@/lib/products";
-import type { SKU } from "@types";
+import { Locale, resolveLocale } from "@/i18n/locales";
+import type { PageComponent, SKU } from "@types";
 import type { Metadata } from "next";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import DynamicRenderer from "@ui/components/DynamicRenderer";
+import shop from "../../../../shop.json";
 import ShopClient from "./ShopClient.client";
 
 export const metadata: Metadata = {
   title: "Shop · Base-Shop",
 };
 
-export default function ShopIndexPage() {
-  // ⬇️ Purely server-side: just pass static data to the client component
+async function loadComponents(): Promise<PageComponent[] | null> {
+  const pages = await getPages(shop.id);
+  const page = pages.find(
+    (p) => p.slug === "shop" && p.status === "published"
+  );
+  return page?.components ?? null;
+}
+
+export default async function ShopIndexPage({
+  params,
+}: {
+  params: { lang?: string };
+}) {
+  const lang: Locale = resolveLocale(params.lang);
+  const components = await loadComponents();
+
+  if (components && components.length) {
+    return (
+      <DynamicRenderer
+        components={components}
+        data={{ locale: lang, products: PRODUCTS as SKU[] }}
+      />
+    );
+  }
+
+  // Fallback to default shop view
   return <ShopClient skus={PRODUCTS as SKU[]} />;
 }

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -8,8 +8,14 @@ import type { ReactNode, CSSProperties } from "react";
 
 export default function DynamicRenderer({
   components,
+  data = {},
 }: {
   components: PageComponent[];
+  /**
+   * Arbitrary runtime data passed to every block. Individual components can
+   * pick the keys they need (e.g. locale, cart, product, …).
+   */
+  data?: Record<string, unknown>;
 }) {
   const renderBlock = (block: PageComponent): ReactNode => {
     const Comp = blockRegistry[block.type as keyof typeof blockRegistry];
@@ -43,7 +49,7 @@ export default function DynamicRenderer({
 
     return (
       <div key={id} style={style}>
-        <Comp {...props}>
+        <Comp {...data} {...props}>
           {children?.map((child: PageComponent) => renderBlock(child))}
         </Comp>
       </div>


### PR DESCRIPTION
## Summary
- fetch CMS page components for shop, product, and checkout routes
- render custom layouts via DynamicRenderer with locale & runtime data
- add tests verifying CMS components appear on storefront

## Testing
- `pnpm test` *(fails: wizard.test.tsx etc.)*
- `pnpm --filter shop-abc exec jest apps/shop-abc/__tests__/cmsLayouts.test.tsx --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68977f3843c0832f8dfb0841e2f8ba04