### PR TITLE
docs: add page builder walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ executing accessibility tests and publishing Chromatic previews.
 ## CMS Guide
 
 See [doc/cms.md](doc/cms.md) for an overview of the CMS navigation,
-switching shops and admin-only routes.
+switching shops and admin-only routes. Newcomers can follow the
+[Page Builder](doc/cms.md#page-builder) section to learn how to add,
+rearrange and publish blocks.
 
 # Environment Variables
 

--- a/doc/cms.md
+++ b/doc/cms.md
@@ -45,9 +45,26 @@ Edit drafts at `/cms/shop/{shop}/pages/{slug}/builder` or start a new page at
 `/cms/shop/{shop}/pages/new/builder`. A list of pages (including drafts) is
 available via `GET /cms/api/pages/{shop}`.
 
-## Page Builder Controls
+## Page Builder
 
-Selected blocks now display drag handles for repositioning. You can also resize
-blocks directly on the canvas and adjust their margin or padding before saving
-or publishing. A side panel shows editable properties for the currently
-selected block.
+Open `/cms/shop/{shop}/pages/{slug}/builder` to edit an existing page or
+`/cms/shop/{shop}/pages/new/builder` to start from scratch.
+
+### Add blocks
+
+1. Click **Add Block** in the toolbar or hover near a section and press the **+**
+   button.
+2. Pick a component from the list and adjust its options in the side panel.
+3. Confirm to insert the block onto the page.
+
+### Rearrange blocks
+
+- Select a block to reveal drag handles, then drag it to a new position.
+- Blocks can be resized directly on the canvas. Adjust margin and padding from
+  the side panel before saving.
+
+### Publish changes
+
+1. Use **Save** to keep a draft version.
+2. Click **Publish** when you're ready for the page to go live at
+   `/shop/{shop}/{slug}`.


### PR DESCRIPTION
## Summary
- document how to open the CMS page builder and manage blocks
- link the new guide from the main README

## Testing
- `pnpm exec prettier --check doc/cms.md README.md`
- `pnpm exec eslint doc/cms.md README.md` *(files ignored)*

------
https://chatgpt.com/codex/tasks/task_e_689781401104832f8e39823da51dd166