### PR TITLE
feat(cms-wizard): add toast notifications

### DIFF
--- a/apps/cms/__tests__/StepHomePage.toast.test.tsx
+++ b/apps/cms/__tests__/StepHomePage.toast.test.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import StepHomePage from "../src/app/cms/wizard/steps/StepHomePage";
+import { fetchJson } from "@ui/utils/fetchJson";
+
+jest.mock("@/components/atoms-shadcn", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Select: ({ value, onValueChange, children }: any) => (
+      <select value={value} onChange={(e) => onValueChange(e.target.value)}>
+        {children}
+      </select>
+    ),
+    SelectContent: ({ children }: any) => <>{children}</>,
+    SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+    SelectTrigger: ({ children }: any) => <>{children}</>,
+    SelectValue: ({ placeholder }: any) => (
+      <option disabled value="">
+        {placeholder}
+      </option>
+    ),
+  };
+});
+
+jest.mock("@/components/cms/PageBuilder", () => {
+  const React = require("react");
+  return function PageBuilder({ onSave, onPublish }: any) {
+    return (
+      <div>
+        <button onClick={() => onSave(new FormData())}>save</button>
+        <button onClick={() => onPublish(new FormData())}>publish</button>
+      </div>
+    );
+  };
+});
+
+jest.mock("@ui/utils/fetchJson");
+
+const defaultProps = {
+  pageTemplates: [],
+  homeLayout: "",
+  setHomeLayout: jest.fn(),
+  components: [],
+  setComponents: jest.fn(),
+  homePageId: null,
+  setHomePageId: jest.fn(),
+  shopId: "shop",
+  themeStyle: {},
+  onBack: jest.fn(),
+  onNext: jest.fn(),
+};
+
+describe("StepHomePage notifications", () => {
+  beforeEach(() => {
+    (fetchJson as jest.Mock).mockReset();
+  });
+
+  it("shows success toast on publish", async () => {
+    (fetchJson as jest.Mock).mockResolvedValueOnce([]); // initial load
+    (fetchJson as jest.Mock).mockResolvedValueOnce({ id: "1" }); // publish
+    render(<StepHomePage {...defaultProps} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("publish"));
+    });
+    await screen.findByText(/page published/i);
+  });
+
+  it("shows error toast on publish failure", async () => {
+    (fetchJson as jest.Mock).mockResolvedValueOnce([]); // initial load
+    (fetchJson as jest.Mock).mockRejectedValueOnce(new Error("err"));
+    render(<StepHomePage {...defaultProps} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("publish"));
+    });
+    await screen.findByText(/failed to publish page/i);
+  });
+});

--- a/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
@@ -13,6 +13,8 @@ import { LOCALES } from "@acme/i18n";
 import type { Locale, Page, PageComponent } from "@types";
 import { fetchJson } from "@ui/utils/fetchJson";
 import { ulid } from "ulid";
+import { useState } from "react";
+import { Toast } from "@/components/atoms";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -41,6 +43,11 @@ export default function StepCheckoutPage({
   onBack,
   onNext,
 }: Props): React.JSX.Element {
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Checkout Page</h2>
@@ -95,14 +102,19 @@ export default function StepCheckoutPage({
           } as Page
         }
         onSave={async (fd) => {
-          const json = await fetchJson<{ id: string }>(
-            `/cms/api/page-draft/${shopId}`,
-            {
-              method: "POST",
-              body: fd,
-            }
-          );
-          setCheckoutPageId(json.id);
+          try {
+            const json = await fetchJson<{ id: string }>(
+              `/cms/api/page-draft/${shopId}`,
+              {
+                method: "POST",
+                body: fd,
+              }
+            );
+            setCheckoutPageId(json.id);
+            setToast({ open: true, message: "Draft saved" });
+          } catch {
+            setToast({ open: true, message: "Failed to save page" });
+          }
         }}
         onPublish={async () => {}}
         onChange={setCheckoutComponents}
@@ -114,6 +126,11 @@ export default function StepCheckoutPage({
         </Button>
         <Button onClick={onNext}>Next</Button>
       </div>
+      <Toast
+        open={toast.open}
+        onClose={() => setToast((t) => ({ ...t, open: false }))}
+        message={toast.message}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
@@ -6,7 +6,8 @@ import PageBuilder from "@/components/cms/PageBuilder";
 import { LOCALES } from "@acme/i18n";
 import type { Locale, Page, PageComponent } from "@types";
 import { fetchJson } from "@ui/utils/fetchJson";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
+import { Toast } from "@/components/atoms";
 
 interface Props {
   currentStep: number;
@@ -67,6 +68,11 @@ export default function StepLayout({
    */
   if (stepIndex !== currentStep) return null;
 
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+
   return (
     <fieldset className="space-y-4">
       <h2 className="text-xl font-semibold">Layout</h2>
@@ -92,14 +98,19 @@ export default function StepLayout({
             } as Page
           }
           onSave={async (fd) => {
-            const json = await fetchJson<{ id: string }>(
-              `/cms/api/page-draft/${shopId}`,
-              {
-                method: "POST",
-                body: fd,
-              }
-            );
-            setHeaderPageId(json.id);
+            try {
+              const json = await fetchJson<{ id: string }>(
+                `/cms/api/page-draft/${shopId}`,
+                {
+                  method: "POST",
+                  body: fd,
+                }
+              );
+              setHeaderPageId(json.id);
+              setToast({ open: true, message: "Header saved" });
+            } catch {
+              setToast({ open: true, message: "Failed to save header" });
+            }
           }}
           onPublish={async () => {}}
           onChange={setHeaderComponents}
@@ -128,14 +139,19 @@ export default function StepLayout({
             } as Page
           }
           onSave={async (fd) => {
-            const json = await fetchJson<{ id: string }>(
-              `/cms/api/page-draft/${shopId}`,
-              {
-                method: "POST",
-                body: fd,
-              }
-            );
-            setFooterPageId(json.id);
+            try {
+              const json = await fetchJson<{ id: string }>(
+                `/cms/api/page-draft/${shopId}`,
+                {
+                  method: "POST",
+                  body: fd,
+                }
+              );
+              setFooterPageId(json.id);
+              setToast({ open: true, message: "Footer saved" });
+            } catch {
+              setToast({ open: true, message: "Failed to save footer" });
+            }
           }}
           onPublish={async () => {}}
           onChange={setFooterComponents}
@@ -153,6 +169,11 @@ export default function StepLayout({
         </Button>
         <Button onClick={onNext}>Next</Button>
       </div>
+      <Toast
+        open={toast.open}
+        onClose={() => setToast((t) => ({ ...t, open: false }))}
+        message={toast.message}
+      />
     </fieldset>
   );
 }

--- a/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
@@ -13,6 +13,8 @@ import { LOCALES } from "@acme/i18n";
 import type { Locale, Page, PageComponent } from "@types";
 import { fetchJson } from "@ui/utils/fetchJson";
 import { ulid } from "ulid";
+import { useState } from "react";
+import { Toast } from "@/components/atoms";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -41,6 +43,11 @@ export default function StepShopPage({
   onBack,
   onNext,
 }: Props): React.JSX.Element {
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Shop Page</h2>
@@ -95,14 +102,19 @@ export default function StepShopPage({
           } as Page
         }
         onSave={async (fd) => {
-          const json = await fetchJson<{ id: string }>(
-            `/cms/api/page-draft/${shopId}`,
-            {
-              method: "POST",
-              body: fd,
-            }
-          );
-          setShopPageId(json.id);
+          try {
+            const json = await fetchJson<{ id: string }>(
+              `/cms/api/page-draft/${shopId}`,
+              {
+                method: "POST",
+                body: fd,
+              }
+            );
+            setShopPageId(json.id);
+            setToast({ open: true, message: "Draft saved" });
+          } catch {
+            setToast({ open: true, message: "Failed to save page" });
+          }
         }}
         onPublish={async (fd) => {
           try {
@@ -115,9 +127,9 @@ export default function StepShopPage({
               }
             );
             setShopPageId(json.id);
-            alert("Page published");
+            setToast({ open: true, message: "Page published" });
           } catch {
-            alert("Failed to publish page");
+            setToast({ open: true, message: "Failed to publish page" });
           }
         }}
         onChange={setShopComponents}
@@ -129,6 +141,11 @@ export default function StepShopPage({
         </Button>
         <Button onClick={onNext}>Next</Button>
       </div>
+      <Toast
+        open={toast.open}
+        onClose={() => setToast((t) => ({ ...t, open: false }))}
+        message={toast.message}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show toast notifications for draft saves, publishes, and fetch errors across wizard steps
- add StepHomePage toast test

## Testing
- `pnpm --filter @apps/cms test __tests__/StepHomePage.toast.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689781385ef0832f8287006778937df8