### PR TITLE
feat: highlight drop zones during drag

### DIFF
--- a/packages/ui/__tests__/PageBuilder.highlight.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.highlight.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import PageBuilder from "@/components/cms/PageBuilder";
+import CanvasItem from "@/components/cms/page-builder/CanvasItem";
+import React from "react";
+
+type Page = any; // use 'any' to simplify
+
+// mock useDroppable to control isOver state
+let droppableIsOver = false;
+
+jest.mock("@dnd-kit/core", () => {
+  const actual = jest.requireActual("@dnd-kit/core");
+  return {
+    ...actual,
+    useDroppable: jest.fn(() => ({
+      setNodeRef: jest.fn(),
+      isOver: droppableIsOver,
+    })),
+  };
+});
+
+jest.mock("@dnd-kit/sortable", () => {
+  const actual = jest.requireActual("@dnd-kit/sortable");
+  return {
+    ...actual,
+    useSortable: jest.fn(() => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: jest.fn(),
+      transform: null,
+    })),
+    SortableContext: ({ children }: any) => <div>{children}</div>,
+    rectSortingStrategy: jest.fn(),
+  };
+});
+
+describe("PageBuilder drag highlight", () => {
+  const basePage = {
+    id: "p1",
+    updatedAt: "2024-01-01",
+    slug: "slug",
+    status: "draft",
+    seo: { title: { en: "" }, description: {} },
+    components: [],
+  } as Page;
+
+  it("toggles ring on canvas during drag", () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const onPublish = jest.fn().mockResolvedValue(undefined);
+    const { container } = render(
+      <PageBuilder page={basePage} onSave={onSave} onPublish={onPublish} />
+    );
+    const canvas = container.querySelector("#canvas") as HTMLElement;
+    expect(canvas.className).not.toMatch(/ring-2/);
+    fireEvent.dragOver(canvas);
+    expect(canvas.className).toMatch(/ring-2/);
+    fireEvent.dragLeave(canvas);
+    expect(canvas.className).not.toMatch(/ring-2/);
+  });
+
+  it("shows placeholder when dragging over container", () => {
+    const component: any = { id: "c1", type: "Section", children: [] };
+    droppableIsOver = true;
+    const { queryByTestId, rerender } = render(
+      <CanvasItem
+        component={component}
+        index={0}
+        parentId={undefined}
+        selectedId={null}
+        onSelectId={() => {}}
+        onRemove={() => {}}
+        dispatch={() => {}}
+        locale="en"
+      />
+    );
+    expect(queryByTestId("drop-placeholder")).toBeInTheDocument();
+    droppableIsOver = false;
+    rerender(
+      <CanvasItem
+        component={component}
+        index={0}
+        parentId={undefined}
+        selectedId={null}
+        onSelectId={() => {}}
+        onRemove={() => {}}
+        dispatch={() => {}}
+        locale="en"
+      />
+    );
+    expect(queryByTestId("drop-placeholder")).toBeNull();
+  });
+});
+

--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -560,6 +560,7 @@ const PageBuilder = memo(function PageBuilder({
                 setDragOver(true);
               }}
               onDragLeave={() => setDragOver(false)}
+              onDragEnd={() => setDragOver(false)}
               className={cn(
                 "mx-auto flex flex-col gap-4 rounded border",
                 dragOver && "ring-2 ring-primary"

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -129,7 +129,7 @@ const CanvasItem = memo(function CanvasItem({
   const childIds = hasChildren
     ? ((component as any).children as PageComponent[]).map((c) => c.id)
     : [];
-  const { setNodeRef: setDropRef } = useDroppable({
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `container-${component.id}`,
     data: { parentId: component.id },
   });
@@ -342,6 +342,12 @@ const CanvasItem = memo(function CanvasItem({
             id={`container-${component.id}`}
             className="m-2 flex flex-col gap-4 border border-dashed border-gray-300 p-2"
           >
+            {isOver && (
+              <div
+                data-testid="drop-placeholder"
+                className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10"
+              />
+            )}
             {(component as any).children.map(
               (child: PageComponent, i: number) => (
                 <CanvasItem


### PR DESCRIPTION
## Summary
- highlight canvas with ring when dragging over
- show placeholder in containers when dragging component
- test drag highlight behavior

## Testing
- `pnpm test:cms packages/ui/__tests__/PageBuilder.highlight.test.tsx --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_689781368628832f8d87b14e89fbeb67