### PR TITLE
feat: pass locale through DynamicRenderer

### DIFF
--- a/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import type { PageComponent } from "@types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import shop from "../../../../shop.json";
+import { Locale, resolveLocale } from "@i18n/locales";
 
 async function loadComponents(slug: string): Promise<PageComponent[] | null> {
   const pages = await getPages(shop.id);
@@ -18,6 +19,7 @@ export default async function Page({
   const slug = params.slug.join("/");
   const components = await loadComponents(slug);
   if (!components) notFound();
-  return <DynamicRenderer components={components} />;
+  const lang: Locale = resolveLocale(params.lang);
+  return <DynamicRenderer components={components} locale={lang} />;
 }
 

--- a/apps/shop-abc/src/app/[lang]/page.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.client.tsx
@@ -3,11 +3,15 @@
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@types";
+import { resolveLocale } from "@i18n/locales";
+import { useParams } from "next/navigation";
 
 export default function Home({
   components,
 }: {
   components: PageComponent[];
 }) {
-  return <DynamicRenderer components={components} />;
+  const { lang } = useParams<{ lang: string }>();
+  const locale = resolveLocale(lang);
+  return <DynamicRenderer components={components} locale={locale} />;
 }

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -3,11 +3,15 @@
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@types";
+import { resolveLocale } from "@i18n/locales";
+import { useParams } from "next/navigation";
 
 export default function Home({
   components,
 }: {
   components: PageComponent[];
 }) {
-  return <DynamicRenderer components={components} />;
+  const { lang } = useParams<{ lang: string }>();
+  const locale = resolveLocale(lang);
+  return <DynamicRenderer components={components} locale={locale} />;
 }

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -7,7 +7,7 @@ describe("DynamicRenderer", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const components = [{ id: "1", type: "Unknown" } as PageComponent];
 
-    render(<DynamicRenderer components={components} />);
+    render(<DynamicRenderer components={components} locale="en" />);
 
     expect(warnSpy).toHaveBeenCalledWith("Unknown component type: Unknown");
     warnSpy.mockRestore();
@@ -15,12 +15,22 @@ describe("DynamicRenderer", () => {
 
   it("renders known component", () => {
     const components: PageComponent[] = [
-      { id: "1", type: "Text", text: { en: "hello" }, locale: "en" } as any,
+      { id: "1", type: "Text", text: { en: "hello", de: "hallo" } } as any,
     ];
 
-    render(<DynamicRenderer components={components} />);
+    render(<DynamicRenderer components={components} locale="en" />);
 
     expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("renders localized text based on locale", () => {
+    const components: PageComponent[] = [
+      { id: "1", type: "Text", text: { en: "hello", de: "hallo" } } as any,
+    ];
+
+    render(<DynamicRenderer components={components} locale="de" />);
+
+    expect(screen.getByText("hallo")).toBeInTheDocument();
   });
 
   it("renders nested components recursively", () => {
@@ -33,13 +43,12 @@ describe("DynamicRenderer", () => {
             id: "2",
             type: "Text",
             text: { en: "nested" },
-            locale: "en",
           } as any,
         ],
       } as any,
     ];
 
-    render(<DynamicRenderer components={components} />);
+    render(<DynamicRenderer components={components} locale="en" />);
 
     expect(screen.getByText("nested")).toBeInTheDocument();
   });
@@ -50,7 +59,6 @@ describe("DynamicRenderer", () => {
         id: "1",
         type: "Text",
         text: { en: "styled" },
-        locale: "en",
         margin: "1px",
         padding: "2px",
         position: "absolute",
@@ -59,7 +67,9 @@ describe("DynamicRenderer", () => {
       } as any,
     ];
 
-    const { container } = render(<DynamicRenderer components={components} />);
+    const { container } = render(
+      <DynamicRenderer components={components} locale="en" />
+    );
     const wrapper = container.firstChild as HTMLElement;
 
     expect(wrapper).toHaveStyle({

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -3,13 +3,16 @@
 "use client";
 
 import { blockRegistry } from "@/components/cms/blocks";
+import type { Locale } from "@/i18n/locales";
 import type { PageComponent } from "@types";
 import type { ReactNode, CSSProperties } from "react";
 
 export default function DynamicRenderer({
   components,
+  locale,
 }: {
   components: PageComponent[];
+  locale: Locale;
 }) {
   const renderBlock = (block: PageComponent): ReactNode => {
     const Comp = blockRegistry[block.type as keyof typeof blockRegistry];
@@ -43,7 +46,7 @@ export default function DynamicRenderer({
 
     return (
       <div key={id} style={style}>
-        <Comp {...props}>
+        <Comp {...props} locale={locale}>
           {children?.map((child: PageComponent) => renderBlock(child))}
         </Comp>
       </div>


### PR DESCRIPTION
## Summary
- add `locale` prop to DynamicRenderer and forward to blocks
- pass locale from route params when rendering DynamicRenderer
- test localized block rendering

## Testing
- `pnpm exec jest packages/ui/__tests__/DynamicRenderer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6897812ef1e0832fb3ae84759925bde3