### PR TITLE
feat: add future date helper

### DIFF
--- a/packages/lib/__tests__/date.test.ts
+++ b/packages/lib/__tests__/date.test.ts
@@ -1,4 +1,4 @@
-import { parseIsoDate, calculateRentalDays } from '../src/date';
+import { parseIsoDate, calculateRentalDays, isoDateInNDays } from '../src/date';
 
 describe('parseIsoDate', () => {
   test('parses valid YYYY-MM-DD string', () => {
@@ -32,5 +32,19 @@ describe('calculateRentalDays', () => {
 
   test('throws on invalid date', () => {
     expect(() => calculateRentalDays('invalid')).toThrow();
+  });
+});
+
+describe('isoDateInNDays', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns ISO date string N days ahead', () => {
+    expect(isoDateInNDays(7)).toBe('2025-01-08');
   });
 });

--- a/packages/lib/src/date.ts
+++ b/packages/lib/src/date.ts
@@ -10,6 +10,13 @@ export function parseIsoDate(str: string): Date | null {
 export const DAY_MS = 86_400_000;
 
 /**
+ * Return an ISO `YYYY-MM-DD` string representing the date `days` from now.
+ */
+export function isoDateInNDays(days: number): string {
+  return new Date(Date.now() + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+/**
  * Calculate the number of rental days between "now" and `returnDate` (inclusive).
  *
  * Throws an error when `returnDate` is invalid. Past or missing dates resolve to

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -14,6 +14,7 @@ import { fetchJson } from "@ui/utils/fetchJson";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm, UseFormReturn } from "react-hook-form";
+import { isoDateInNDays } from "@/lib/date";
 
 const stripePromise = loadStripe(env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
 
@@ -24,11 +25,7 @@ type FormValues = { returnDate: string };
 export default function CheckoutForm({ locale }: Props) {
   const [clientSecret, setClientSecret] = useState<string>();
 
-  const defaultDate = (() => {
-    const d = new Date();
-    d.setDate(d.getDate() + 7);
-    return d.toISOString().slice(0, 10);
-  })();
+  const defaultDate = isoDateInNDays(7);
 
   const form = useForm<FormValues>({
     defaultValues: { returnDate: defaultDate },


### PR DESCRIPTION
## Summary
- add `isoDateInNDays` for ISO-formatted future dates
- use `isoDateInNDays` in checkout form and tests
- document helper with unit tests for future use

## Testing
- `pnpm --filter @acme/lib test`
- `pnpm test:cms test/checkout.test.tsx -t "default return date is 7 days ahead"`


------
https://chatgpt.com/codex/tasks/task_e_689781218de0832f98289f56236e49d5