### PR TITLE
refactor(create-shop): extract helpers

### DIFF
--- a/packages/platform-core/__tests__/createShopHelpers.test.ts
+++ b/packages/platform-core/__tests__/createShopHelpers.test.ts
@@ -1,0 +1,100 @@
+// packages/platform-core/__tests__/createShopHelpers.test.ts
+import fs from "fs";
+import {
+  prepareOptions,
+  ensureTemplateExists,
+  writeFiles,
+} from "../src/createShop";
+
+jest.mock("fs");
+
+const fsMock = fs as jest.Mocked<typeof fs>;
+
+describe("createShop helpers", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("prepareOptions", () => {
+    it("applies defaults", () => {
+      const opts = prepareOptions("shop", {
+        pages: [{ slug: "test", title: { en: "Test Page" }, components: [] }],
+      });
+      expect(opts.name).toBe("shop");
+      expect(opts.pages[0].slug).toBe("test");
+    });
+  });
+
+  describe("ensureTemplateExists", () => {
+    it("returns template path when both exist", () => {
+      fsMock.existsSync.mockImplementation((p: fs.PathLike) => {
+        const path = String(p);
+        return (
+          path.includes("packages/themes/base") ||
+          path.includes("packages/template-app")
+        );
+      });
+      const res = ensureTemplateExists("base", "template-app");
+      expect(res).toContain("packages/template-app");
+    });
+
+    it("throws for missing theme", () => {
+      fsMock.existsSync.mockReturnValue(false);
+      expect(() => ensureTemplateExists("missing", "template-app")).toThrow(
+        "Theme 'missing'"
+      );
+    });
+
+    it("throws for missing template", () => {
+      fsMock.existsSync.mockImplementation((p: fs.PathLike) => {
+        const path = String(p);
+        return path.includes("packages/themes/base");
+      });
+      expect(() => ensureTemplateExists("base", "missing")).toThrow(
+        "Template 'missing'"
+      );
+    });
+  });
+
+  describe("writeFiles", () => {
+    beforeEach(() => {
+      fsMock.readFileSync.mockImplementation((p: fs.PathLike) => {
+        const file = String(p);
+        if (file.endsWith("package.json")) {
+          return JSON.stringify({
+            name: "template",
+            dependencies: { "@themes/base": "*" },
+          });
+        }
+        if (file.endsWith("globals.css")) {
+          return "@import '@themes/base/tokens.css';";
+        }
+        if (file.includes("packages/themes/base/tokens.ts")) {
+          return "export const tokens = { foo: { light: '#fff' } };";
+        }
+        return "";
+      });
+      fsMock.existsSync.mockReturnValue(true);
+    });
+
+    it("writes env and shop files", () => {
+      const options = prepareOptions("shop", {});
+      writeFiles(
+        "shop",
+        options,
+        "packages/template-app",
+        "apps/shop",
+        "data/shops/shop"
+      );
+      const envCall = fsMock.writeFileSync.mock.calls.find((c) =>
+        String(c[0]).includes(".env")
+      );
+      expect(envCall).toBeTruthy();
+      const shopCall = fsMock.writeFileSync.mock.calls.find((c) =>
+        String(c[0]).includes("shop.json")
+      );
+      expect(shopCall).toBeTruthy();
+    });
+  });
+});
+

--- a/packages/platform-core/src/createShop/utils.ts
+++ b/packages/platform-core/src/createShop/utils.ts
@@ -1,0 +1,43 @@
+// packages/platform-core/src/createShop/utils.ts
+import { LOCALES } from "@i18n/locales";
+import type { Locale } from "@types";
+import { randomBytes } from "crypto";
+
+export { copyTemplate } from "./utils/copyTemplate";
+export { loadBaseTokens } from "./utils/loadBaseTokens";
+export { loadThemeTokens } from "./utils/loadThemeTokens";
+
+/**
+ * Convert a string into a URL-friendly slug.
+ */
+export function slugify(str: string): string {
+  return str
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Generate a random secret represented as a hexadecimal string.
+ */
+export function genSecret(bytes = 16): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+/**
+ * Ensure all locales have a value, filling in missing entries with a fallback.
+ */
+export function fillLocales(
+  values: Partial<Record<Locale, string>> | undefined,
+  fallback: string
+): Record<Locale, string> {
+  return LOCALES.reduce<Record<Locale, string>>(
+    (acc, locale: Locale) => {
+      acc[locale] = values?.[locale] ?? fallback;
+      return acc;
+    },
+    {} as Record<Locale, string>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move slugify, secret generation, and locale filling helpers into dedicated utils file
- split createShop into prepareOptions, ensureTemplateExists, and writeFiles
- cover new helpers with unit tests

## Testing
- `npx jest packages/platform-core/__tests__/createShop.test.ts packages/platform-core/__tests__/createShopHelpers.test.ts packages/platform-core/__tests__/createShopUtils.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6897895d7398832fad50126ccc5e273a