### PR TITLE
refactor: extract tailwind preset check

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pnpm e2e Cypress e2e suite
 pnpm test:coverage Jest tests with coverage summary
 pnpm run lh:checkout Lighthouse audit for /en/checkout
 pnpm chromatic Publish Storybook to Chromatic
+pnpm check:tailwind-preset Ensure Tailwind preset resolves
 pnpm tailwind:check Validate Tailwind build
 
 # Requires `CHROMATIC_PROJECT_TOKEN` to be set

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "turbo run dev --parallel",
     "dev:trace": "cross-env NODE_OPTIONS=\"--trace-uncaught --enable-source-maps\" pnpm --filter cms dev",
-    "build": "pnpm run build:tokens && turbo run build",
+    "build": "pnpm run build:tokens && pnpm run check:tailwind-preset && turbo run build",
     "build:tokens": "tsx ./scripts/src/build-tokens.ts",
     "build:trace": "cross-env NODE_OPTIONS=\"--trace-uncaught --enable-source-maps\" pnpm --filter cms exec next build --debug",
     "start": "turbo run start --parallel",
@@ -46,6 +46,7 @@
     "lh:checkout": "lighthouse http://localhost:3000/en/checkout --chrome-flags=\"--headless\" --only-categories=performance,accessibility,best-practices,seo --preset=desktop",
     "validate-env": "ts-node scripts/src/validate-env.ts",
     "check:locales": "ts-node scripts/src/check-locales.ts",
+    "check:tailwind-preset": "tsx scripts/check-tailwind-preset.ts",
     "shadcn:diff": "ts-node scripts/diff-shadcn.ts",
     "tailwind:check": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest test/unit/tailwind-build.spec.ts test/unit/postcss-config.spec.ts test/unit/tailwind-postcss.spec.ts",
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",

--- a/scripts/check-tailwind-preset.ts
+++ b/scripts/check-tailwind-preset.ts
@@ -1,0 +1,26 @@
+import { createRequire } from "node:module";
+import preset from "../packages/tailwind-config/src/index.ts";
+
+const require = createRequire(import.meta.url);
+
+let resolvedPresetPath = "<unresolved>";
+try {
+  resolvedPresetPath = require.resolve("@acme/tailwind-config");
+  // eslint-disable-next-line no-console
+  console.log(
+    `[tailwind.config] ✅  @acme/tailwind-config resolved → ${resolvedPresetPath}`
+  );
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(
+    "[tailwind.config] ❌  @acme/tailwind-config could NOT be resolved.\n" +
+      "Is the package in pnpm-workspace.yaml? Did you run `pnpm install`?",
+    err
+  );
+}
+
+// eslint-disable-next-line no-console
+console.log(
+  "[tailwind.config] ℹ️  preset keys:",
+  preset && typeof preset === "object" ? Object.keys(preset) : "not an object"
+);

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,35 +1,7 @@
 // /tailwind.config.mjs
 // Use workspace source paths to avoid requiring built packages
-import { createRequire } from "node:module";
 import tokens from "./packages/design-tokens/index.ts";
 import preset from "./packages/tailwind-config/src/index.ts";
-
-/* ------------------------------------------------------------
- *  Runtime diagnostics — module resolution + preset sanity
- * ------------------------------------------------------------ */
-const require = createRequire(import.meta.url);
-
-let resolvedPresetPath = "<unresolved>";
-try {
-  resolvedPresetPath = require.resolve("@acme/tailwind-config");
-  // eslint-disable-next-line no-console
-  console.log(
-    `[tailwind.config] ✅  @acme/tailwind-config resolved → ${resolvedPresetPath}`
-  );
-} catch (err) {
-  // eslint-disable-next-line no-console
-  console.error(
-    "[tailwind.config] ❌  @acme/tailwind-config could NOT be resolved.\n" +
-      "Is the package in pnpm-workspace.yaml? Did you run `pnpm install`?",
-    err
-  );
-}
-
-// eslint-disable-next-line no-console
-console.log(
-  "[tailwind.config] ℹ️  preset keys:",
-  preset && typeof preset === "object" ? Object.keys(preset) : "not an object"
-);
 
 /** @type {import('tailwindcss').Config} */
 const config = {


### PR DESCRIPTION
## Summary
- move tailwind preset diagnostics into `scripts/check-tailwind-preset.ts`
- strip side-effect logging from `tailwind.config.mjs`
- run preset check before build and document helper

## Testing
- `pnpm run check:tailwind-preset`
- `pnpm tailwind:check` *(fails: ReferenceError: require is not defined)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6897895e622c832fb7e245f6e597db1b