### PR TITLE
feat: add timestamp formatter

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/VersionTimeline.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/VersionTimeline.tsx
@@ -11,6 +11,7 @@ import {
 import { revertSeo } from "@cms/actions/shops.server";
 import type { SettingsDiffEntry } from "@platform-core/repositories/settings.server";
 import { diffHistory } from "@platform-core/repositories/settings.server";
+import { formatTimestamp } from "@lib/date";
 import { useEffect, useState } from "react";
 
 interface VersionTimelineProps {
@@ -66,7 +67,7 @@ export default function VersionTimeline({
                 <li key={entry.timestamp} className="space-y-2">
                   <div className="flex justify-between">
                     <span className="text-muted-foreground font-mono text-xs">
-                      {new Date(entry.timestamp).toLocaleString()}
+                      {formatTimestamp(entry.timestamp)}
                     </span>
                     <Button
                       variant="outline"

--- a/doc/storybook.md
+++ b/doc/storybook.md
@@ -40,3 +40,17 @@ pnpm chromatic
 
 to upload your Storybook to [Chromatic](https://www.chromatic.com/) for visual
 review and regression testing.
+
+## Date & Time Formatting
+
+For consistent locale-aware timestamps across UI components, use the
+`formatTimestamp` helper from `@lib/date` instead of calling
+`toLocaleString` directly:
+
+```ts
+import { formatTimestamp } from "@lib/date";
+
+formatTimestamp("2025-01-01T12:34:56Z");
+```
+
+This central utility ensures future components render dates uniformly.

--- a/packages/lib/__tests__/date.test.ts
+++ b/packages/lib/__tests__/date.test.ts
@@ -1,4 +1,9 @@
-import { parseIsoDate, calculateRentalDays, isoDateInNDays } from '../src/date';
+import {
+  parseIsoDate,
+  calculateRentalDays,
+  isoDateInNDays,
+  formatTimestamp,
+} from '../src/date';
 
 describe('parseIsoDate', () => {
   test('parses valid YYYY-MM-DD string', () => {
@@ -46,5 +51,18 @@ describe('isoDateInNDays', () => {
 
   test('returns ISO date string N days ahead', () => {
     expect(isoDateInNDays(7)).toBe('2025-01-08');
+  });
+});
+
+describe('formatTimestamp', () => {
+  test('formats ISO timestamp', () => {
+    const ts = '2025-01-01T05:06:07Z';
+    const formatted = formatTimestamp(ts, 'en-US');
+    expect(formatted).toContain('2025');
+    expect(formatted).not.toBe(ts);
+  });
+
+  test('returns input for invalid timestamp', () => {
+    expect(formatTimestamp('nope')).toBe('nope');
   });
 });

--- a/packages/lib/src/date.ts
+++ b/packages/lib/src/date.ts
@@ -29,3 +29,16 @@ export function calculateRentalDays(returnDate?: string): number {
   const diff = Math.ceil((parsed.getTime() - Date.now()) / DAY_MS);
   return diff > 0 ? diff : 1;
 }
+
+/**
+ * Format an ISO timestamp using `toLocaleString`.
+ *
+ * Falls back to the original string when the timestamp is invalid.
+ */
+export function formatTimestamp(
+  ts: string,
+  locale?: string
+): string {
+  const date = new Date(ts);
+  return Number.isNaN(date.getTime()) ? ts : date.toLocaleString(locale);
+}


### PR DESCRIPTION
## Summary
- add formatTimestamp helper to date utilities
- use formatTimestamp in SEO version timeline
- document timestamp helper for UI components

## Testing
- `pnpm lint --filter=@acme/lib --filter=@apps/cms`
- `pnpm test --filter=@acme/lib --filter=@apps/cms` *(fails: Test Suites: 2 failed, 27 passed, 29 total)*

------
https://chatgpt.com/codex/tasks/task_e_68977c543e88832fb7c19cfd74b98aff