### PR TITLE
Pass locale through DynamicRenderer blocks

### DIFF
--- a/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import type { PageComponent } from "@types";
+import type { Locale } from "@/i18n/locales";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import shop from "../../../../shop.json";
@@ -13,7 +14,7 @@ async function loadComponents(slug: string): Promise<PageComponent[] | null> {
 export default async function Page({
   params,
 }: {
-  params: { lang: string; slug: string[] };
+  params: { lang: Locale; slug: string[] };
 }) {
   const slug = params.slug.join("/");
   const components = await loadComponents(slug);

--- a/apps/shop-abc/src/app/[lang]/page.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.client.tsx
@@ -3,13 +3,14 @@
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@types";
+import type { Locale } from "@/i18n/locales";
 
 export default function Home({
   components,
   locale,
 }: {
   components: PageComponent[];
-  locale: string;
+  locale: Locale;
 }) {
   return <DynamicRenderer components={components} locale={locale} />;
 }

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -38,6 +38,21 @@ describe("DynamicRenderer", () => {
     expect(screen.getByText("bonjour")).toBeInTheDocument();
   });
 
+  it("overrides block-provided locale", () => {
+    const components: PageComponent[] = [
+      {
+        id: "1",
+        type: "Text",
+        text: { en: "hello", fr: "bonjour" },
+        locale: "en",
+      } as any,
+    ];
+
+    render(<DynamicRenderer components={components} locale="fr" />);
+
+    expect(screen.getByText("bonjour")).toBeInTheDocument();
+  });
+
   it("renders a nested Section with child blocks", () => {
     const components: PageComponent[] = [
       {
@@ -118,8 +133,11 @@ describe("DynamicRenderer", () => {
 describe("DynamicRenderer block registry coverage", () => {
   const blockTypes = Object.keys(blockRegistry);
   const stubRegistry = Object.fromEntries(
-    blockTypes.map((key) => [key, ({ children }: any) => <div data-testid={key}>{children}</div>])
-  );
+    blockTypes.map((key) => [
+      key,
+      jest.fn(({ children }: any) => <div data-testid={key}>{children}</div>),
+    ])
+  ) as Record<string, jest.Mock>;
 
   let StubDynamicRenderer: typeof DynamicRenderer;
   beforeAll(() => {
@@ -140,5 +158,9 @@ describe("DynamicRenderer block registry coverage", () => {
       />
     );
     expect(screen.getByTestId(type)).toBeInTheDocument();
+    expect(stubRegistry[type]).toHaveBeenCalled();
+    expect(stubRegistry[type].mock.calls[0][0]).toEqual(
+      expect.objectContaining({ locale: "en" })
+    );
   });
 });

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -52,7 +52,7 @@ export default function DynamicRenderer({
 
     return (
       <div key={id} style={style}>
-        <Comp locale={locale} {...props} {...extraProps}>
+        <Comp {...props} {...extraProps} locale={locale}>
           {children?.map((child: PageComponent) => renderBlock(child))}
         </Comp>
       </div>


### PR DESCRIPTION
## Summary
- ensure DynamicRenderer forwards locale prop to block components
- pass `params.lang` as locale in shop pages
- test locale override handling and block registry coverage

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/DynamicRenderer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6897b70b1aa0832fad8c2f34f56f8fea