### PR TITLE
feat: persist and apply theme

### DIFF
--- a/packages/platform-core/__tests__/themeContext.test.tsx
+++ b/packages/platform-core/__tests__/themeContext.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from "@testing-library/react";
-import { ThemeProvider, useTheme } from "../contexts/ThemeContext";
+import { ThemeProvider, useTheme } from "../src/contexts/ThemeContext";
 
 function Buttons() {
   const { setTheme } = useTheme();
@@ -14,6 +14,7 @@ function Buttons() {
 describe("ThemeContext", () => {
   afterEach(() => {
     document.documentElement.className = "";
+    localStorage.clear();
   });
 
   it("applies classes to <html> element", () => {

--- a/packages/platform-core/src/contexts/ThemeContext.tsx
+++ b/packages/platform-core/src/contexts/ThemeContext.tsx
@@ -4,7 +4,7 @@ import {
   createContext,
   ReactNode,
   useContext,
-  useEffect,
+  useLayoutEffect,
   useState,
 } from "react";
 
@@ -17,14 +17,26 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("base");
+function getInitialTheme(): Theme {
+  if (typeof window !== "undefined") {
+    const storedTheme = window.localStorage.getItem("theme") as Theme | null;
+    if (storedTheme) return storedTheme;
+    if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
+      return "dark";
+    }
+  }
+  return "base";
+}
 
-  useEffect(() => {
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useLayoutEffect(() => {
     const root = document.documentElement;
     root.classList.remove("theme-dark", "theme-brandx");
     if (theme === "dark") root.classList.add("theme-dark");
     if (theme === "brandx") root.classList.add("theme-brandx");
+    window.localStorage.setItem("theme", theme);
   }, [theme]);
 
   return (


### PR DESCRIPTION
## Summary
- initialize theme from localStorage or system preference
- persist selected theme and apply it without flash
- clear theme from tests to avoid cross-test leakage

## Testing
- `pnpm test __tests__/themeContext.test.tsx --runTestsByPath --runInBand` *(fails: A React Element from an older version of React was rendered)*

------
https://chatgpt.com/codex/tasks/task_e_6897b867e040832fa814d3257bf3cb96