### PR TITLE
feat(auth): make roles configurable and validated

### DIFF
--- a/packages/auth/__tests__/rbac.test.ts
+++ b/packages/auth/__tests__/rbac.test.ts
@@ -1,33 +1,35 @@
 import { canRead, canWrite } from "../src/rbac";
-import type { Role } from "../src/types";
 
 describe("canRead", () => {
-  const cases: [Role, boolean][] = [
+  const cases: [unknown, boolean][] = [
     ["admin", true],
     ["ShopAdmin", true],
     ["CatalogManager", true],
     ["ThemeEditor", true],
     ["viewer", true],
+    ["bad", false],
+    [null, false],
   ];
 
   for (const [role, expected] of cases) {
-    it(`${role} -> ${expected}`, () => {
+    it(`${String(role)} -> ${expected}`, () => {
       expect(canRead(role)).toBe(expected);
     });
   }
 });
 
 describe("canWrite", () => {
-  const cases: [Role, boolean][] = [
+  const cases: [unknown, boolean][] = [
     ["admin", true],
     ["ShopAdmin", true],
     ["CatalogManager", true],
     ["ThemeEditor", true],
     ["viewer", false],
+    ["bad", false],
   ];
 
   for (const [role, expected] of cases) {
-    it(`${role} -> ${expected}`, () => {
+    it(`${String(role)} -> ${expected}`, () => {
       expect(canWrite(role)).toBe(expected);
     });
   }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,5 @@
 // packages/auth/src/index.ts
 
 export { canRead, canWrite, READ_ROLES, WRITE_ROLES } from "./rbac";
+export { extendRoles, isRole } from "./types/roles";
 export type { Role } from "./types";

--- a/packages/auth/src/rbac.ts
+++ b/packages/auth/src/rbac.ts
@@ -1,22 +1,20 @@
 // packages/auth/src/rbac.ts
 
-import type { Role } from "./types/roles";
+import {
+  READ_ROLES,
+  WRITE_ROLES,
+  isRole,
+  type Role,
+} from "./types/roles";
 
-export const WRITE_ROLES: Role[] = [
-  "admin",
-  "ShopAdmin",
-  "CatalogManager",
-  "ThemeEditor",
-];
+export { READ_ROLES, WRITE_ROLES };
 
-export const READ_ROLES: Role[] = [...WRITE_ROLES, "viewer"];
-
-export function canWrite(role?: Role | null): boolean {
-  return role ? WRITE_ROLES.includes(role) : false;
+export function canWrite(role?: unknown): boolean {
+  return isRole(role) ? WRITE_ROLES.includes(role) : false;
 }
 
-export function canRead(role?: Role | null): boolean {
-  return role ? READ_ROLES.includes(role) : false;
+export function canRead(role?: unknown): boolean {
+  return isRole(role) ? READ_ROLES.includes(role) : false;
 }
 
 export type { Role };

--- a/packages/auth/src/roles.json
+++ b/packages/auth/src/roles.json
@@ -1,0 +1,4 @@
+{
+  "write": ["admin", "ShopAdmin", "CatalogManager", "ThemeEditor"],
+  "read": ["viewer"]
+}

--- a/packages/auth/src/types/roles.ts
+++ b/packages/auth/src/types/roles.ts
@@ -1,8 +1,51 @@
 // packages/auth/src/types/roles.ts
 
-export type Role =
-  | "admin"
-  | "ShopAdmin"
-  | "CatalogManager"
-  | "ThemeEditor"
-  | "viewer";
+import rolesConfig from "../roles.json";
+import { z } from "zod";
+
+type RolesConfig = {
+  write: readonly string[];
+  read: readonly string[];
+};
+
+const config: RolesConfig = rolesConfig;
+
+const allRolesFromConfig = [
+  ...new Set([...config.write, ...config.read]),
+] as const;
+
+export type Role = (typeof allRolesFromConfig)[number];
+
+export const WRITE_ROLES: Role[] = [...config.write];
+export const READ_ROLES: Role[] = [...allRolesFromConfig];
+
+let RoleSchema = z.enum(allRolesFromConfig);
+
+export function isRole(role: unknown): role is Role {
+  return RoleSchema.safeParse(role).success;
+}
+
+export function extendRoles(extension: Partial<RolesConfig>): void {
+  if (extension.write) {
+    for (const role of extension.write) {
+      if (!WRITE_ROLES.includes(role as Role)) {
+        WRITE_ROLES.push(role as Role);
+      }
+      if (!READ_ROLES.includes(role as Role)) {
+        READ_ROLES.push(role as Role);
+      }
+    }
+  }
+
+  if (extension.read) {
+    for (const role of extension.read) {
+      if (!READ_ROLES.includes(role as Role)) {
+        READ_ROLES.push(role as Role);
+      }
+    }
+  }
+
+  RoleSchema = z.enum(READ_ROLES as [Role, ...Role[]]);
+}
+
+export { RoleSchema };


### PR DESCRIPTION
## Summary
- load read/write roles from new roles.json config
- expose utilities for role validation and dynamic extension
- guard rbac helpers against unknown roles

## Testing
- `pnpm --filter @acme/auth test -- packages/auth/__tests__/rbac.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897b82f0094832fb8ea3dbbf8e1c9c7