### PR TITLE
feat: add theme-based dark mode

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,6 +6,7 @@ import preset from "./packages/tailwind-config/src/index.ts";
 /** @type {import('tailwindcss').Config} */
 const config = {
   presets: [tokens, preset],
+  darkMode: ["class", ".theme-dark"],
   content: [
     "./apps/**/*.{ts,tsx,mdx}",
     "./packages/{ui,platform-core,platform-machine,i18n,themes}/**/*.{ts,tsx,mdx}",


### PR DESCRIPTION
## Summary
- include `darkMode: ["class", ".theme-dark"]` in Tailwind config
- ensure `ThemeContext` continues toggling `theme-dark` class on `<html>`

## Testing
- `pnpm --filter @acme/platform-core run test` *(fails: wizard and checkout tests)*
- `pnpm tailwind:check` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897b865cfb0832f8ad0982a25caf105