### PR TITLE
feat: add theme toggle

### DIFF
--- a/packages/platform-core/__tests__/themeContext.test.tsx
+++ b/packages/platform-core/__tests__/themeContext.test.tsx
@@ -12,11 +12,15 @@ function Buttons() {
 }
 
 describe("ThemeContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
     document.documentElement.className = "";
   });
 
-  it("applies classes to <html> element", () => {
+  it("applies classes to <html> element and persists", () => {
     const { getByText } = render(
       <ThemeProvider>
         <Buttons />
@@ -27,9 +31,11 @@ describe("ThemeContext", () => {
     expect(html.className).toBe("");
     fireEvent.click(getByText("dark"));
     expect(html.classList.contains("theme-dark")).toBe(true);
+    expect(localStorage.getItem("PREFERRED_THEME")).toBe("dark");
     fireEvent.click(getByText("brandx"));
     expect(html.classList.contains("theme-dark")).toBe(false);
     expect(html.classList.contains("theme-brandx")).toBe(true);
+    expect(localStorage.getItem("PREFERRED_THEME")).toBe("brandx");
   });
 
   it("matches snapshot on initial render", () => {

--- a/packages/platform-core/src/contexts/ThemeContext.tsx
+++ b/packages/platform-core/src/contexts/ThemeContext.tsx
@@ -17,10 +17,25 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
+const LS_KEY = "PREFERRED_THEME";
+
+function readInitial(): Theme {
+  if (typeof window === "undefined") return "base";
+  try {
+    const stored = localStorage.getItem(LS_KEY) as Theme | null;
+    if (stored === "base" || stored === "dark" || stored === "brandx") return stored;
+  } catch {}
+  return "base";
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("base");
+  const [theme, setTheme] = useState<Theme>(readInitial);
 
   useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(LS_KEY, theme);
+    }
+
     const root = document.documentElement;
     root.classList.remove("theme-dark", "theme-brandx");
     if (theme === "dark") root.classList.add("theme-dark");

--- a/packages/ui/__tests__/ThemeToggle.test.tsx
+++ b/packages/ui/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render } from "@testing-library/react";
+import { ThemeProvider } from "@platform-core/src/contexts/ThemeContext";
+import ThemeToggle from "../src/components/ThemeToggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    document.documentElement.className = "";
+    localStorage.clear();
+  });
+
+  it("toggles between base and dark themes", () => {
+    const { getByRole } = render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>
+    );
+
+    const toggle = getByRole("checkbox");
+    fireEvent.click(toggle);
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(true);
+    expect(localStorage.getItem("PREFERRED_THEME")).toBe("dark");
+    fireEvent.click(toggle);
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(false);
+    expect(localStorage.getItem("PREFERRED_THEME")).toBe("base");
+  });
+});

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useTheme } from "@platform-core/src/contexts/ThemeContext";
+import { Switch } from "./atoms/Switch";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <Switch
+      aria-label="Toggle dark mode"
+      checked={theme === "dark"}
+      onChange={(e) => setTheme(e.target.checked ? "dark" : "base")}
+    />
+  );
+}

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -4,6 +4,7 @@ import { useCart } from "@platform-core/src/contexts/CartContext";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { cn } from "../../utils/cn";
+import ThemeToggle from "../ThemeToggle";
 
 export default function HeaderClient({
   lang,
@@ -43,6 +44,7 @@ export default function HeaderClient({
             {item.label}
           </Link>
         ))}
+        <ThemeToggle />
         <Link href={`/${lang}/checkout`} className="relative hover:underline">
           Cart
           {qty > 0 && (

--- a/packages/ui/src/components/organisms/Header.tsx
+++ b/packages/ui/src/components/organisms/Header.tsx
@@ -2,6 +2,7 @@ import type { Locale } from "@/i18n/locales";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { LanguageSwitcher, SearchBar } from "../molecules";
+import ThemeToggle from "../ThemeToggle";
 
 export interface NavItem {
   title: string;
@@ -57,6 +58,7 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
             <SearchBar suggestions={searchSuggestions} />
           </div>
           <LanguageSwitcher current={locale} />
+          <ThemeToggle />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add persistent ThemeContext to store user preference
- add ThemeToggle component and wire into headers

## Testing
- `pnpm --filter @acme/platform-core --filter @acme/ui test` *(fails: Failed in 26.3s at packages/ui)*


------
https://chatgpt.com/codex/tasks/task_e_6897b868cc80832f8323e724a8265bc0