### PR TITLE
test: add nowIso utility test

### DIFF
--- a/packages/shared/date.test.ts
+++ b/packages/shared/date.test.ts
@@ -1,0 +1,13 @@
+import { nowIso } from "./date";
+
+describe("nowIso", () => {
+  it("returns a valid ISO 8601 string near current time", () => {
+    const isoString = nowIso();
+
+    // Should be a valid ISO string
+    expect(new Date(isoString).toISOString()).toBe(isoString);
+
+    const timestamp = Date.parse(isoString);
+    expect(Math.abs(Date.now() - timestamp)).toBeLessThanOrEqual(1000);
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring `nowIso` outputs a valid ISO string and close timestamp

## Testing
- `pnpm test` *(fails: WizardPage › renders notice and disabled form when no themes or templates - timeout)*
- `pnpm exec jest packages/shared/date.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897b89bd6c4832facdf64b40bef7baf