### PR TITLE
Add token validation tests for theme packages

### DIFF
--- a/packages/themes/abc/__tests__/__snapshots__/tokens.test.ts.snap
+++ b/packages/themes/abc/__tests__/__snapshots__/tokens.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`abc theme tokens tokens snapshot 1`] = `
+{
+  "--color-accent": "200 90% 45%",
+  "--color-bg": "0 0% 100%",
+  "--color-fg": "0 0% 10%",
+  "--color-muted": "0 0% 88%",
+  "--color-primary": "160 80% 40%",
+  "--color-primary-fg": "0 0% 100%",
+  "--font-mono": ""Geist Mono", ui-monospace, monospace",
+  "--font-sans": ""Geist Sans", system-ui, sans-serif",
+  "--radius-lg": "12px",
+  "--radius-md": "8px",
+  "--radius-sm": "4px",
+  "--shadow-lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  "--space-1": "4px",
+  "--space-2": "8px",
+  "--space-3": "12px",
+  "--space-4": "16px",
+}
+`;

--- a/packages/themes/abc/__tests__/tokens.test.ts
+++ b/packages/themes/abc/__tests__/tokens.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tokens } from '../src/tailwind-tokens';
+
+const expectedKeys = [
+  '--color-bg',
+  '--color-fg',
+  '--color-primary',
+  '--color-primary-fg',
+  '--color-accent',
+  '--color-muted',
+  '--font-sans',
+  '--font-mono',
+  '--space-1',
+  '--space-2',
+  '--space-3',
+  '--space-4',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--shadow-sm',
+  '--shadow-md',
+  '--shadow-lg',
+] as const;
+
+describe('abc theme tokens', () => {
+  test('exports expected token keys', () => {
+    expect(Object.keys(tokens).sort()).toEqual([...expectedKeys].sort());
+  });
+
+  test('css contains token variables', () => {
+    const cssPath = path.join(__dirname, '..', 'src', 'tokens.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    for (const key of expectedKeys) {
+      expect(css).toContain(key);
+    }
+  });
+
+  test('tokens snapshot', () => {
+    expect(tokens).toMatchSnapshot();
+  });
+});

--- a/packages/themes/base/__tests__/__snapshots__/tokens.test.ts.snap
+++ b/packages/themes/base/__tests__/__snapshots__/tokens.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`base theme tokens tokens snapshot 1`] = `
+{
+  "--color-accent": {
+    "light": "260 83% 67%",
+  },
+  "--color-bg": {
+    "dark": "0 0% 4%",
+    "light": "0 0% 100%",
+  },
+  "--color-fg": {
+    "dark": "0 0% 93%",
+    "light": "0 0% 10%",
+  },
+  "--color-muted": {
+    "dark": "0 0% 60%",
+    "light": "0 0% 88%",
+  },
+  "--color-primary": {
+    "dark": "220 90% 66%",
+    "light": "220 90% 56%",
+  },
+  "--color-primary-fg": {
+    "light": "0 0% 100%",
+  },
+  "--font-mono": {
+    "light": ""Geist Mono", ui-monospace, monospace",
+  },
+  "--font-sans": {
+    "light": ""Geist Sans", system-ui, sans-serif",
+  },
+  "--radius-lg": {
+    "light": "12px",
+  },
+  "--radius-md": {
+    "light": "8px",
+  },
+  "--radius-sm": {
+    "light": "4px",
+  },
+  "--shadow-lg": {
+    "light": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  },
+  "--shadow-md": {
+    "light": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  },
+  "--shadow-sm": {
+    "light": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  },
+  "--space-1": {
+    "light": "4px",
+  },
+  "--space-2": {
+    "light": "8px",
+  },
+  "--space-3": {
+    "light": "12px",
+  },
+  "--space-4": {
+    "light": "16px",
+  },
+}
+`;

--- a/packages/themes/base/__tests__/tokens.test.ts
+++ b/packages/themes/base/__tests__/tokens.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tokens } from '../src/tokens';
+
+const expectedKeys = [
+  '--color-bg',
+  '--color-fg',
+  '--color-primary',
+  '--color-primary-fg',
+  '--color-accent',
+  '--color-muted',
+  '--font-sans',
+  '--font-mono',
+  '--space-1',
+  '--space-2',
+  '--space-3',
+  '--space-4',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--shadow-sm',
+  '--shadow-md',
+  '--shadow-lg',
+] as const;
+
+describe('base theme tokens', () => {
+  test('exports expected token keys', () => {
+    expect(Object.keys(tokens).sort()).toEqual([...expectedKeys].sort());
+  });
+
+  test('css contains token variables', () => {
+    const cssDir = path.join(__dirname, '..', 'src');
+    const cssFiles = ['tokens.css', 'tokens.dynamic.css']
+      .map((f) => path.join(cssDir, f))
+      .filter(fs.existsSync);
+    const css = cssFiles.map((f) => fs.readFileSync(f, 'utf8')).join('\n');
+
+    for (const key of expectedKeys) {
+      expect(css).toContain(key);
+    }
+  });
+
+  test('tokens snapshot', () => {
+    expect(tokens).toMatchSnapshot();
+  });
+});

--- a/packages/themes/bcd/__tests__/__snapshots__/tokens.test.ts.snap
+++ b/packages/themes/bcd/__tests__/__snapshots__/tokens.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bcd theme tokens tokens snapshot 1`] = `
+{
+  "--color-accent": "40 95% 50%",
+  "--color-bg": "0 0% 100%",
+  "--color-fg": "0 0% 10%",
+  "--color-muted": "0 0% 88%",
+  "--color-primary": "340 80% 50%",
+  "--color-primary-fg": "0 0% 100%",
+  "--font-mono": ""Geist Mono", ui-monospace, monospace",
+  "--font-sans": ""Geist Sans", system-ui, sans-serif",
+  "--radius-lg": "12px",
+  "--radius-md": "8px",
+  "--radius-sm": "4px",
+  "--shadow-lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  "--space-1": "4px",
+  "--space-2": "8px",
+  "--space-3": "12px",
+  "--space-4": "16px",
+}
+`;

--- a/packages/themes/bcd/__tests__/tokens.test.ts
+++ b/packages/themes/bcd/__tests__/tokens.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tokens } from '../src/tailwind-tokens';
+
+const expectedKeys = [
+  '--color-bg',
+  '--color-fg',
+  '--color-primary',
+  '--color-primary-fg',
+  '--color-accent',
+  '--color-muted',
+  '--font-sans',
+  '--font-mono',
+  '--space-1',
+  '--space-2',
+  '--space-3',
+  '--space-4',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--shadow-sm',
+  '--shadow-md',
+  '--shadow-lg',
+] as const;
+
+describe('bcd theme tokens', () => {
+  test('exports expected token keys', () => {
+    expect(Object.keys(tokens).sort()).toEqual([...expectedKeys].sort());
+  });
+
+  test('css contains token variables', () => {
+    const cssPath = path.join(__dirname, '..', 'src', 'tokens.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    for (const key of expectedKeys) {
+      expect(css).toContain(key);
+    }
+  });
+
+  test('tokens snapshot', () => {
+    expect(tokens).toMatchSnapshot();
+  });
+});

--- a/packages/themes/brandx/__tests__/__snapshots__/tokens.test.ts.snap
+++ b/packages/themes/brandx/__tests__/__snapshots__/tokens.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`brandx theme tokens tokens snapshot 1`] = `
+{
+  "--color-accent": "40 95% 50%",
+  "--color-bg": "0 0% 100%",
+  "--color-fg": "0 0% 10%",
+  "--color-muted": "0 0% 88%",
+  "--color-primary": "340 80% 50%",
+  "--color-primary-fg": "0 0% 100%",
+  "--font-mono": ""Geist Mono", ui-monospace, monospace",
+  "--font-sans": ""Geist Sans", system-ui, sans-serif",
+  "--radius-lg": "12px",
+  "--radius-md": "8px",
+  "--radius-sm": "4px",
+  "--shadow-lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  "--space-1": "4px",
+  "--space-2": "8px",
+  "--space-3": "12px",
+  "--space-4": "16px",
+}
+`;

--- a/packages/themes/brandx/__tests__/tokens.test.ts
+++ b/packages/themes/brandx/__tests__/tokens.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tokens } from '../src/tailwind-tokens';
+
+const expectedKeys = [
+  '--color-bg',
+  '--color-fg',
+  '--color-primary',
+  '--color-primary-fg',
+  '--color-accent',
+  '--color-muted',
+  '--font-sans',
+  '--font-mono',
+  '--space-1',
+  '--space-2',
+  '--space-3',
+  '--space-4',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--shadow-sm',
+  '--shadow-md',
+  '--shadow-lg',
+] as const;
+
+describe('brandx theme tokens', () => {
+  test('exports expected token keys', () => {
+    expect(Object.keys(tokens).sort()).toEqual([...expectedKeys].sort());
+  });
+
+  test('css contains token variables', () => {
+    const cssPath = path.join(__dirname, '..', 'src', 'tokens.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    for (const key of expectedKeys) {
+      expect(css).toContain(key);
+    }
+  });
+
+  test('tokens snapshot', () => {
+    expect(tokens).toMatchSnapshot();
+  });
+});

--- a/packages/themes/dark/__tests__/__snapshots__/tokens.test.ts.snap
+++ b/packages/themes/dark/__tests__/__snapshots__/tokens.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dark theme tokens tokens snapshot 1`] = `
+{
+  "--color-accent": "260 83% 67%",
+  "--color-bg": "0 0% 4%",
+  "--color-fg": "0 0% 93%",
+  "--color-muted": "0 0% 60%",
+  "--color-primary": "220 90% 66%",
+  "--color-primary-fg": "0 0% 100%",
+  "--font-mono": ""Geist Mono", ui-monospace, monospace",
+  "--font-sans": ""Geist Sans", system-ui, sans-serif",
+  "--radius-lg": "12px",
+  "--radius-md": "8px",
+  "--radius-sm": "4px",
+  "--shadow-lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  "--space-1": "4px",
+  "--space-2": "8px",
+  "--space-3": "12px",
+  "--space-4": "16px",
+}
+`;

--- a/packages/themes/dark/__tests__/tokens.test.ts
+++ b/packages/themes/dark/__tests__/tokens.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tokens } from '../src/tailwind-tokens';
+
+const expectedKeys = [
+  '--color-bg',
+  '--color-fg',
+  '--color-primary',
+  '--color-primary-fg',
+  '--color-accent',
+  '--color-muted',
+  '--font-sans',
+  '--font-mono',
+  '--space-1',
+  '--space-2',
+  '--space-3',
+  '--space-4',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--shadow-sm',
+  '--shadow-md',
+  '--shadow-lg',
+] as const;
+
+describe('dark theme tokens', () => {
+  test('exports expected token keys', () => {
+    expect(Object.keys(tokens).sort()).toEqual([...expectedKeys].sort());
+  });
+
+  test('css contains token variables', () => {
+    const cssPath = path.join(__dirname, '..', 'src', 'tokens.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    for (const key of expectedKeys) {
+      expect(css).toContain(key);
+    }
+  });
+
+  test('tokens snapshot', () => {
+    expect(tokens).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- add `tokens.test.ts` for each theme package
- verify exported token keys and CSS variable definitions
- snapshot token objects for regression detection

## Testing
- `pnpm jest packages/themes/*/__tests__ --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6897b89ce914832fa19fb65c7486d67b