### PR TITLE
test: add shop-bcd API and page tests

### DIFF
--- a/apps/shop-bcd/__tests__/cart-api.test.ts
+++ b/apps/shop-bcd/__tests__/cart-api.test.ts
@@ -1,0 +1,71 @@
+// apps/shop-bcd/__tests__/cart-api.test.ts
+import {
+  asSetCookieHeader,
+  decodeCartCookie,
+  encodeCartCookie,
+} from "@/lib/cartCookie";
+import { PRODUCTS } from "@platform-core/products";
+import { PATCH, POST } from "../src/api/cart/route";
+
+declare function expectType<T>(value: T): void;
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+function createRequest(
+  body: any,
+  cookie?: string,
+  url = "http://localhost/api/cart"
+): Parameters<typeof POST>[0] {
+  return {
+    json: async () => body,
+    cookies: {
+      get: (name: string) => (cookie ? { name, value: cookie } : undefined),
+    },
+    nextUrl: Object.assign(new URL(url), { clone: () => new URL(url) }),
+  } as any;
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test("POST adds items and sets cookie", async () => {
+  const sku = PRODUCTS[0];
+  const req = createRequest({ sku, qty: 2 });
+  const res = await POST(req);
+  const body = (await res.json()) as any;
+
+  expect(body.cart[sku.id].qty).toBe(2);
+  const expected = asSetCookieHeader(
+    encodeCartCookie({ [sku.id]: { sku, qty: 2 } })
+  );
+  expect(res.headers.get("Set-Cookie")).toBe(expected);
+});
+
+test("POST validates body", async () => {
+  const res = await POST(createRequest({ wrong: true }));
+  expect(res.status).toBe(400);
+});
+
+test("PATCH updates quantity", async () => {
+  const sku = PRODUCTS[0];
+  const cart = { [sku.id]: { sku, qty: 1 } };
+  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cart));
+  const res = await PATCH(req);
+  const body = (await res.json()) as any;
+  expect(body.cart[sku.id].qty).toBe(5);
+  const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
+  expect(decodeCartCookie(encoded)).toEqual(body.cart);
+});
+
+test("PATCH returns 404 for missing item", async () => {
+  const res = await PATCH(
+    createRequest({ id: "missing", qty: 1 }, encodeCartCookie({}))
+  );
+  expect(res.status).toBe(404);
+});

--- a/apps/shop-bcd/__tests__/home-page.test.tsx
+++ b/apps/shop-bcd/__tests__/home-page.test.tsx
@@ -1,0 +1,30 @@
+// apps/shop-bcd/__tests__/home-page.test.tsx
+jest.mock("node:fs", () => ({
+  promises: { readFile: jest.fn() },
+}));
+jest.mock("../src/app/[lang]/page.client", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+import type { PageComponent } from "@types";
+import { promises as fs } from "node:fs";
+import Page from "../src/app/[lang]/page";
+import Home from "../src/app/[lang]/page.client";
+
+test("Home receives components from fs", async () => {
+  const components: PageComponent[] = [
+    { id: "c1", type: "HeroBanner" } as any,
+  ];
+  (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(components));
+
+  const element = await Page({ params: { lang: "en" } });
+
+  expect(fs.readFile).toHaveBeenCalledWith(
+    expect.stringContaining("data/shops/bcd/pages/home.json"),
+    "utf8"
+  );
+  expect(element.type).toBe(Home);
+  expect(element.props.components).toEqual(components);
+  expect(element.props.locale).toBe("en");
+});

--- a/apps/shop-bcd/__tests__/middleware.test.ts
+++ b/apps/shop-bcd/__tests__/middleware.test.ts
@@ -1,0 +1,30 @@
+// apps/shop-bcd/__tests__/middleware.test.ts
+import { middleware } from "../middleware";
+
+type MiddlewareRequest = Parameters<typeof middleware>[0];
+
+function createRequest(path: string): MiddlewareRequest {
+  const url = new URL(`http://localhost${path}`) as URL & { clone(): URL };
+  url.clone = () => new URL(url.toString());
+  return { nextUrl: url, url: url.toString() } as unknown as MiddlewareRequest;
+}
+
+describe("middleware", () => {
+  it("allows valid locale paths", () => {
+    const res = middleware(createRequest("/en/products"));
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("redirects invalid paths to /en", () => {
+    const res = middleware(createRequest("/fr/foo"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/en");
+  });
+
+  it("skips static and Next internals", () => {
+    const res1 = middleware(createRequest("/_next/static/file.js"));
+    const res2 = middleware(createRequest("/styles.css"));
+    expect(res1.headers.get("x-middleware-next")).toBe("1");
+    expect(res2.headers.get("x-middleware-next")).toBe("1");
+  });
+});

--- a/apps/shop-bcd/__tests__/return-api.test.ts
+++ b/apps/shop-bcd/__tests__/return-api.test.ts
@@ -1,0 +1,154 @@
+// apps/shop-bcd/__tests__/return-api.test.ts
+import type Stripe from "stripe";
+
+process.env.STRIPE_SECRET_KEY = "sk_test";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+afterEach(() => jest.resetModules());
+
+describe("/api/return", () => {
+  test("refunds deposit minus damage fee", async () => {
+    const retrieve = jest
+      .fn<Promise<Stripe.Checkout.Session>, [string, { expand: string[] }]>()
+      .mockResolvedValue({
+        metadata: { depositTotal: "50" },
+        payment_intent: { id: "pi_123" },
+      } as unknown as Stripe.Checkout.Session);
+    const refundCreate = jest.fn<Promise<unknown>, [Stripe.RefundCreateParams]>();
+    const markReturned = jest
+      .fn<Promise<unknown>, [string, string, number?]>()
+      .mockResolvedValueOnce({})
+      .mockResolvedValue({});
+    const markRefunded = jest.fn();
+    const computeDamageFee = jest.fn().mockResolvedValue(20);
+
+    jest.doMock(
+      "@lib/stripeServer",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: { sessions: { retrieve } },
+          refunds: { create: refundCreate },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned,
+      markRefunded,
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@platform-core/pricing", () => ({
+      __esModule: true,
+      computeDamageFee,
+      priceForDays: jest.fn(),
+    }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess", damage: "scratch" }),
+    } as any);
+
+    expect(retrieve).toHaveBeenCalledWith("sess", { expand: ["payment_intent"] });
+    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50);
+    expect(refundCreate).toHaveBeenCalledWith({
+      payment_intent: "pi_123",
+      amount: 30 * 100,
+    });
+    expect(markReturned).toHaveBeenNthCalledWith(1, "bcd", "sess");
+    expect(markReturned).toHaveBeenNthCalledWith(2, "bcd", "sess", 20);
+    expect(markRefunded).toHaveBeenCalledWith("bcd", "sess");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("returns message when no deposit found", async () => {
+    const retrieve = jest
+      .fn<Promise<Stripe.Checkout.Session>, [string, { expand: string[] }]>()
+      .mockResolvedValue({
+        metadata: {},
+        payment_intent: null,
+      } as unknown as Stripe.Checkout.Session);
+    const refundCreate = jest.fn<Promise<unknown>, [Stripe.RefundCreateParams]>();
+    const markReturned = jest
+      .fn<Promise<unknown>, [string, string, number?]>()
+      .mockResolvedValue({});
+    const markRefunded = jest.fn();
+    const computeDamageFee = jest.fn().mockResolvedValue(10);
+
+    jest.doMock(
+      "@lib/stripeServer",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: { sessions: { retrieve } },
+          refunds: { create: refundCreate },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned,
+      markRefunded,
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@platform-core/pricing", () => ({
+      __esModule: true,
+      computeDamageFee,
+      priceForDays: jest.fn(),
+    }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess", damage: 5 }),
+    } as any);
+
+    expect(refundCreate).not.toHaveBeenCalled();
+    expect(markRefunded).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: false, message: "No deposit found" });
+  });
+
+  test("returns 404 when order not found", async () => {
+    const markReturned = jest
+      .fn<Promise<unknown>, [string, string, number?]>()
+      .mockResolvedValue(undefined);
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned,
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@lib/stripeServer", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({
+      __esModule: true,
+      computeDamageFee: jest.fn(),
+      priceForDays: jest.fn(),
+    }));
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({ json: async () => ({ sessionId: "missing" }) } as any);
+    expect(markReturned).toHaveBeenCalledWith("bcd", "missing");
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 400 for missing sessionId", async () => {
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({ json: async () => ({}) } as any);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 for invalid request body", async () => {
+    const { POST } = await import("../src/api/return/route");
+    await expect(POST({ json: async () => null } as any)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add cart API tests for shop-bcd
- cover return API scenarios including refunds and errors
- verify home page and middleware behaviour for shop-bcd

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__ --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6897b89ddc4c832fb4d798e52a662c8b