### PR TITLE
feat(config): tighten env schema validation

### DIFF
--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
 
 export const envSchema = z.object({
-  STRIPE_SECRET_KEY: z.string(),
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string(),
+  STRIPE_SECRET_KEY: z.string().min(1),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
   NEXTAUTH_SECRET: z.string().optional(),
   PREVIEW_TOKEN_SECRET: z.string().optional(),
-  NODE_ENV: z.string().optional(),
-  OUTPUT_EXPORT: z.string().optional(),
+  NODE_ENV: z.enum(["development", "test", "production"]).optional(),
+  OUTPUT_EXPORT: z
+    .preprocess((val) => {
+      if (typeof val === "string") {
+        return ["1", "true"].includes(val.toLowerCase());
+      }
+      return val;
+    }, z.boolean())
+    .optional(),
   NEXT_PUBLIC_PHASE: z.string().optional(),
   NEXT_PUBLIC_DEFAULT_SHOP: z.string().optional(),
   NEXT_PUBLIC_SHOP_ID: z.string().optional(),

--- a/scripts/src/migrate-cms.ts
+++ b/scripts/src/migrate-cms.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 import { z } from "zod";
 
 const cliEnvSchema = envSchema.extend({
-  CMS_SPACE_URL: z.string(),
-  CMS_ACCESS_TOKEN: z.string(),
+  CMS_SPACE_URL: z.string().min(1),
+  CMS_ACCESS_TOKEN: z.string().min(1),
 });
 
 let env: z.infer<typeof cliEnvSchema>;


### PR DESCRIPTION
## Summary
- enforce stricter env schema: non-empty secrets, enumerated NODE_ENV and boolean OUTPUT_EXPORT
- require CMS credentials when running migrate-cms script

## Testing
- `pnpm exec eslint packages/config/src/env.ts scripts/src/migrate-cms.ts` (warnings: File ignored because no matching configuration was supplied)
- `pnpm exec jest packages/config/__tests__/env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897b8a719dc832f8d9884c7a57a257e