### PR TITLE
Validate cart quantities as non-negative integers

### DIFF
--- a/apps/shop-abc/__tests__/cartApi.test.ts
+++ b/apps/shop-abc/__tests__/cartApi.test.ts
@@ -71,3 +71,24 @@ test("PATCH returns 404 for missing item", async () => {
   );
   expect(res.status).toBe(404);
 });
+
+test("POST rejects negative or non-integer quantity", async () => {
+  const sku = PRODUCTS[0];
+  let res = await POST(createRequest({ sku, qty: -1 }));
+  expect(res.status).toBe(400);
+  res = await POST(createRequest({ sku, qty: 1.5 }));
+  expect(res.status).toBe(400);
+});
+
+test("PATCH rejects negative or non-integer quantity", async () => {
+  const sku = PRODUCTS[0];
+  const cart = { [sku.id]: { sku, qty: 1 } };
+  let res = await PATCH(
+    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cart))
+  );
+  expect(res.status).toBe(400);
+  res = await PATCH(
+    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cart))
+  );
+  expect(res.status).toBe(400);
+});

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -15,12 +15,12 @@ export const runtime = "edge";
 
 const postSchema = z.object({
   sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-  qty: z.number().int().positive().optional(),
+  qty: z.number().int().min(1).default(1),
 });
 
 const patchSchema = z.object({
   id: z.string(),
-  qty: z.number().int().positive(),
+  qty: z.number().int().min(1),
 });
 
 export async function POST(req: NextRequest) {
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid body" }, { status: 400 });
   }
 
-  const { sku, qty = 1 } = parsed.data;
+  const { sku, qty } = parsed.data;
   const skuObj = "title" in sku ? sku : getProductById(sku.id);
   if (!skuObj) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });

--- a/apps/shop-bcd/__tests__/cartApi.test.ts
+++ b/apps/shop-bcd/__tests__/cartApi.test.ts
@@ -1,0 +1,48 @@
+// apps/shop-bcd/__tests__/cartApi.test.ts
+import { encodeCartCookie } from "@/lib/cartCookie";
+import { PRODUCTS } from "@platform-core/products";
+import { PATCH, POST } from "../src/api/cart/route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+function createRequest(
+  body: any,
+  cookie?: string,
+  url = "http://localhost/api/cart"
+): Parameters<typeof POST>[0] {
+  return {
+    json: async () => body,
+    cookies: {
+      get: () => (cookie ? { name: "", value: cookie } : undefined),
+    },
+    nextUrl: Object.assign(new URL(url), { clone: () => new URL(url) }),
+  } as any;
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test("POST rejects negative or non-integer quantity", async () => {
+  const sku = PRODUCTS[0];
+  let res = await POST(createRequest({ sku, qty: -1 }));
+  expect(res.status).toBe(400);
+  res = await POST(createRequest({ sku, qty: 1.5 }));
+  expect(res.status).toBe(400);
+});
+
+test("PATCH rejects negative or non-integer quantity", async () => {
+  const sku = PRODUCTS[0];
+  const cart = { [sku.id]: { sku, qty: 1 } };
+  const cookie = encodeCartCookie(cart);
+  let res = await PATCH(createRequest({ id: sku.id, qty: -2 }, cookie));
+  expect(res.status).toBe(400);
+  res = await PATCH(createRequest({ id: sku.id, qty: 1.5 }, cookie));
+  expect(res.status).toBe(400);
+});
+

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -18,12 +18,12 @@ export const runtime = "edge";
 
 const postSchema = z.object({
   sku: skuSchema,
-  qty: z.number().int().positive().optional(),
+  qty: z.number().int().min(1).default(1),
 });
 
 const patchSchema = z.object({
   id: z.string(),
-  qty: z.number().int().positive(),
+  qty: z.number().int().min(1),
 });
 
 export async function POST(req: NextRequest) {
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid body" }, { status: 400 });
   }
 
-  const { sku, qty = 1 } = parsed.data;
+  const { sku, qty } = parsed.data;
   const cookie = req.cookies.get(CART_COOKIE)?.value;
   const cart = decodeCartCookie(cookie);
   const line = cart[sku.id];

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -22,7 +22,7 @@ const MAX_AGE = 60 * 60 * 24 * 30; // 30 days
  */
 export const cartLineSchema = z.object({
   sku: skuSchema, // full SKU object
-  qty: z.number(), // quantity ≥ 0 already validated elsewhere
+  qty: z.number().int().min(0), // quantity validated by API schemas
   size: z.string().optional(),
 });
 

--- a/packages/template-app/__tests__/cart.test.ts
+++ b/packages/template-app/__tests__/cart.test.ts
@@ -3,8 +3,8 @@ import {
   asSetCookieHeader,
   decodeCartCookie,
   encodeCartCookie,
-} from "../../platform-core/cartCookie";
-import { PRODUCTS } from "../../platform-core/products";
+} from "@platform-core/src/cartCookie";
+import { PRODUCTS } from "@platform-core/src/products";
 import { PATCH, POST } from "../src/api/cart/route";
 
 // Minimal NextResponse mock using the native Response class
@@ -73,4 +73,25 @@ test("PATCH returns 404 for missing item", async () => {
 test("POST returns 404 for unknown SKU", async () => {
   const res = await POST(createRequest({ sku: { id: "nope" } }));
   expect(res.status).toBe(404);
+});
+
+test("POST rejects negative or non-integer quantity", async () => {
+  const sku = PRODUCTS[0];
+  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
+  expect(res.status).toBe(400);
+  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
+  expect(res.status).toBe(400);
+});
+
+test("PATCH rejects negative or non-integer quantity", async () => {
+  const sku = PRODUCTS[0];
+  const cart = { [sku.id]: { sku, qty: 1 } };
+  let res = await PATCH(
+    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cart))
+  );
+  expect(res.status).toBe(400);
+  res = await PATCH(
+    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cart))
+  );
+  expect(res.status).toBe(400);
 });

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -18,12 +18,12 @@ export const runtime = "edge";
  * ------------------------------------------------------------------ */
 const postSchema = z.object({
   sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-  qty: z.number().int().positive().optional(),
+  qty: z.number().int().min(1).default(1),
 });
 
 const patchSchema = z.object({
   id: z.string(),
-  qty: z.number().int().positive(),
+  qty: z.number().int().min(1),
 });
 
 /* ------------------------------------------------------------------
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid body" }, { status: 400 });
   }
 
-  const { sku: skuInput, qty = 1 } = parsed.data;
+  const { sku: skuInput, qty } = parsed.data;
   const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
 
   if (!sku) {


### PR DESCRIPTION
## Summary
- ensure cart cookie schema only allows integer quantities ≥0
- validate cart API quantity params as integers ≥1 with default 1
- add tests rejecting negative or non-integer quantities

## Testing
- `pnpm jest packages/template-app/__tests__/cart.test.ts apps/shop-abc/__tests__/cartApi.test.ts apps/shop-bcd/__tests__/cartApi.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897b8a820a4832f9ffe32868e835081