### PR TITLE
refactor: use pageComponentSchema for shop pages

### DIFF
--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -2,6 +2,7 @@
 import { LOCALES } from "@i18n/locales";
 import type { Locale, PageComponent } from "@types";
 import { localeSchema } from "@types";
+import { pageComponentSchema } from "@types/Page";
 import { spawnSync } from "child_process";
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
@@ -47,11 +48,11 @@ export const createShopOptionsSchema = z.object({
         title: z.record(localeSchema, z.string()),
         description: z.record(localeSchema, z.string()).optional(),
         image: z.record(localeSchema, z.string()).optional(),
-        components: z.array(z.any()),
+        components: z.array(pageComponentSchema),
       })
     )
     .default([]),
-  checkoutPage: z.array(z.any()).default([]),
+  checkoutPage: z.array(pageComponentSchema).default([]),
 });
 
 export interface CreateShopOptions {


### PR DESCRIPTION
## Summary
- import and use `pageComponentSchema` to validate shop page components
- apply the schema to checkout and page component arrays

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Unable to find an element by [data-testid="payment-element"])*


------
https://chatgpt.com/codex/tasks/task_e_6897b8a9211c832f839729287bb8aa3c