### PR TITLE
refactor: use locale record schemas

### DIFF
--- a/apps/cms/__tests__/schemas.test.ts
+++ b/apps/cms/__tests__/schemas.test.ts
@@ -10,25 +10,23 @@ describe("zod schemas", () => {
     const data = {
       id: "p1",
       price: "10",
-      title_en: "Hello",
-      title_de: "Hallo",
-      title_it: "Ciao",
+      title: { en: "Hello", de: "Hallo", it: "Ciao" },
+      description: { en: "World", de: "Welt", it: "Mondo" },
     };
 
     const parsed = productSchema.parse(data);
 
     expect(parsed.price).toBe(10);
-    expect(parsed.title_en).toBe("Hello");
-    expect(parsed.desc_en).toBe(""); // default filled by transform
+    expect(parsed.title.en).toBe("Hello");
+    expect(parsed.description.en).toBe("World");
   });
 
   it("productSchema rejects invalid price", () => {
     const result = productSchema.safeParse({
       id: "p1",
       price: "-1",
-      title_en: "Hey",
-      title_de: "Hallo",
-      title_it: "Ciao",
+      title: { en: "Hey", de: "Hallo", it: "Ciao" },
+      description: { en: "World", de: "Welt", it: "Mondo" },
     });
 
     expect(result.success).toBe(false);

--- a/apps/cms/src/actions/schemas.d.ts
+++ b/apps/cms/src/actions/schemas.d.ts
@@ -1,10 +1,20 @@
+import { localeSchema } from "@types";
 import { z } from "zod";
-export declare const productSchema: z.ZodObject<{} & {
-    [x: string]: z.ZodTypeAny;
+export declare const productSchema: z.ZodObject<{
+    id: z.ZodString;
+    price: z.ZodEffects<z.ZodNumber, number, string | number>;
+    title: z.ZodRecord<typeof localeSchema, z.ZodString>;
+    description: z.ZodRecord<typeof localeSchema, z.ZodString>;
 }, "strip", z.ZodTypeAny, {
-    [x: string]: any;
+    id: string;
+    price: number;
+    title: Record<z.infer<typeof localeSchema>, string>;
+    description: Record<z.infer<typeof localeSchema>, string>;
 }, {
-    [x: string]: any;
+    id: string;
+    price: string | number;
+    title: Record<z.infer<typeof localeSchema>, string>;
+    description: Record<z.infer<typeof localeSchema>, string>;
 }>;
 export declare const shopSchema: z.ZodObject<{
     id: z.ZodString;

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -1,21 +1,14 @@
 // apps/cms/src/actions/schemas.ts
 
-import { LOCALES } from "@acme/i18n";
+import { localeSchema } from "@types";
 import { z } from "zod";
 
-// Dynamically build locale fields for title and description
-const localeFields: z.ZodRawShape = {};
-for (const l of LOCALES) {
-  localeFields[`title_${l}`] = z.string().min(1, "Required");
-  localeFields[`desc_${l}`] = z.string().optional().default("");
-}
-
-export const productSchema = z
-  .object({
-    id: z.string(),
-    price: z.coerce.number().min(0, "Invalid price"),
-  })
-  .extend(localeFields);
+export const productSchema = z.object({
+  id: z.string(),
+  price: z.coerce.number().min(0, "Invalid price"),
+  title: z.record(localeSchema, z.string().min(1)),
+  description: z.record(localeSchema, z.string().min(1)),
+});
 
 const jsonRecord = z
   .string()

--- a/apps/cms/src/actions/updateProduct.server.ts
+++ b/apps/cms/src/actions/updateProduct.server.ts
@@ -1,11 +1,13 @@
 // apps/cms/src/actions/updateProduct.ts
 "use server";
 
+import { LOCALES } from "@acme/i18n";
 import { ProductPublication } from "@platform-core/products";
 import {
   getProductById,
   updateProductInRepo,
 } from "@platform-core/repositories/json.server";
+import type { Locale } from "@types";
 
 /**
  * Server Action: patch an existing product (optimistic locking).
@@ -29,9 +31,14 @@ export async function updateProduct(
   /* ------------------------------------------------------------------ */
   /*  Merge patch                                                       */
   /* ------------------------------------------------------------------ */
+  const title = { ...current.title };
+  LOCALES.forEach((l) => {
+    const v = formData.get(`title_${l}`);
+    if (typeof v === "string") title[l as Locale] = v;
+  });
   const updated: ProductPublication = {
     ...current,
-    title: { ...current.title, en: String(formData.get("title_en")) },
+    title,
     price: Number(formData.get("price")),
     row_version: (current.row_version ?? 0) + 1,
   };

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -1,8 +1,7 @@
 // apps/cms/src/app/cms/wizard/schema.ts
-/* eslint‑disable @typescript-eslint/consistent‑type‑assertions */
 import { LOCALES } from "@acme/i18n";
 import { pageComponentSchema } from "@types/Page";
-import type { Locale } from "@types";
+import { localeSchema, type Locale } from "@types";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { baseTokens } from "./utils";
@@ -24,22 +23,7 @@ function defaultLocaleRecord(
   );
 }
 
-/**
- * Strongly typed record where **every** locale key is required.
- * We cast once to satisfy the compiler; both input and output types are identical.
- */
-const localeRecordSchema = z
-  .object(
-    LOCALES.reduce(
-      (acc, l) => ({ ...acc, [l]: z.string() }),
-      {} as Record<Locale, z.ZodString>
-    )
-  )
-  .transform((x) => x as Record<Locale, string>) as unknown as z.ZodType<
-  Record<Locale, string>,
-  z.ZodTypeDef,
-  Record<Locale, string>
->;
+const localeRecordSchema = z.record(localeSchema, z.string());
 
 /* -------------------------------------------------------------------------- */
 /*  Nav‑item schema (recursive)                                               */


### PR DESCRIPTION
## Summary
- use `z.record(localeSchema, z.string().min(1))` for product title and description
- simplify wizard `localeRecordSchema` with `z.record`
- update product actions and tests for record-based locales

## Testing
- `pnpm --filter cms test` *(fails: wizard.test.tsx, versionTimeline.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6897b8abcf14832f9d71c6232a048e00