### PR TITLE
feat: improve page builder accessibility

### DIFF
--- a/doc/cms.md
+++ b/doc/cms.md
@@ -63,6 +63,12 @@ Open `/cms/shop/{shop}/pages/{slug}/builder` to edit an existing page or
 - Blocks can be resized directly on the canvas. Adjust margin and padding from
   the side panel before saving.
 
+### Keyboard & screen reader support
+
+- Press <kbd>Space</kbd> to grab the selected block, use the arrow keys to move
+  it, then press <kbd>Space</kbd> again to drop it.
+- Screen readers announce when blocks are moved or added to the canvas.
+
 ### Publish changes
 
 1. Use **Save** to keep a draft version.

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -96,7 +96,13 @@ const CanvasItem = memo(function CanvasItem({
 }) {
   const selected = selectedId === component.id;
 
-  const { attributes, listeners, setNodeRef, transform } = useSortable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging,
+  } = useSortable({
     id: component.id,
     data: { from: "canvas", index, parentId },
   });
@@ -251,6 +257,9 @@ const CanvasItem = memo(function CanvasItem({
         containerRef.current = node;
       }}
       onClick={() => onSelectId(component.id)}
+      role="listitem"
+      aria-grabbed={isDragging}
+      aria-dropeffect="move"
       style={{
         transform: CSS.Transform.toString(transform),
         ...(component.width ? { width: component.width } : {}),
@@ -345,6 +354,8 @@ const CanvasItem = memo(function CanvasItem({
           <div
             ref={setDropRef}
             id={`container-${component.id}`}
+            role="list"
+            aria-dropeffect="move"
             className="m-2 flex flex-col gap-4 border border-dashed border-gray-300 p-2"
           >
             {isOver && (


### PR DESCRIPTION
## Summary
- add list semantics and ARIA attributes to page builder canvas and items
- announce item additions and moves via aria-live region
- document keyboard navigation and screen reader behaviour

## Testing
- `pnpm lint`
- `pnpm --filter @acme/ui test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6897b8f908b8832f8cd2cf96c5ebb092