### PR TITLE
feat(ui): add responsive product carousel

### DIFF
--- a/packages/ui/src/components/organisms/ProductCarousel.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.tsx
@@ -5,7 +5,10 @@ import { Product, ProductCard } from "./ProductCard";
 export interface ProductCarouselProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
-  itemsPerSlide?: number;
+  /** Minimum number of items to show at once */
+  minItems?: number;
+  /** Maximum number of items to show at once */
+  maxItems?: number;
   /** flex gap class applied to the inner scroller */
   gapClassName?: string;
   /**
@@ -19,20 +22,46 @@ export interface ProductCarouselProps
 
 /**
  * Horizontally scrollable carousel for product cards.
- * Items per slide can be controlled via the `itemsPerSlide` prop.
+ * The number of items per slide adapts to the component width
+ * and stays within the provided `minItems`/`maxItems` range.
  */
 export function ProductCarousel({
   products,
-  itemsPerSlide = 3,
+  minItems = 1,
+  maxItems = 5,
   gapClassName = "gap-4",
   getSlideWidth = (n) => `${100 / n}%`,
   className,
   ...props
 }: ProductCarouselProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [itemsPerSlide, setItemsPerSlide] = React.useState(minItems);
+
+  React.useEffect(() => {
+    if (!containerRef.current || typeof ResizeObserver === "undefined")
+      return;
+    const el = containerRef.current;
+    const ITEM_WIDTH = 250;
+    const update = () => {
+      const width = el.clientWidth;
+      const ideal = Math.floor(width / ITEM_WIDTH) || 1;
+      const clamped = Math.max(minItems, Math.min(maxItems, ideal));
+      setItemsPerSlide(clamped);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [minItems, maxItems]);
+
   const width = getSlideWidth(itemsPerSlide);
   const slideStyle = { flex: `0 0 ${width}` } as React.CSSProperties;
   return (
-    <div className={cn("overflow-hidden", className)} {...props}>
+    <div
+      ref={containerRef}
+      className={cn("overflow-hidden", className)}
+      {...props}
+    >
       <div className={cn("flex snap-x overflow-x-auto pb-4", gapClassName)}>
         {products.map((p) => (
           <div key={p.id} style={slideStyle} className="snap-start">

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.stories.tsx
@@ -10,12 +10,14 @@ const meta: Meta<typeof ProductGalleryTemplate> = {
       { id: "3", title: "Product 3", image: "/placeholder.svg", price: 30 },
     ],
     useCarousel: false,
-    itemsPerSlide: 3,
+    minItems: 1,
+    maxItems: 5,
   },
   argTypes: {
     products: { control: "object" },
     useCarousel: { control: "boolean" },
-    itemsPerSlide: { control: { type: "number" } },
+    minItems: { control: { type: "number" } },
+    maxItems: { control: { type: "number" } },
   },
 };
 export default meta;

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
@@ -7,7 +7,10 @@ export interface ProductGalleryTemplateProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
   useCarousel?: boolean;
-  itemsPerSlide?: number;
+  /** Minimum items to show when using the carousel */
+  minItems?: number;
+  /** Maximum items to show when using the carousel */
+  maxItems?: number;
 }
 
 /**
@@ -16,7 +19,8 @@ export interface ProductGalleryTemplateProps
 export function ProductGalleryTemplate({
   products,
   useCarousel = false,
-  itemsPerSlide,
+  minItems,
+  maxItems,
   className,
   ...props
 }: ProductGalleryTemplateProps) {
@@ -24,7 +28,8 @@ export function ProductGalleryTemplate({
     return (
       <ProductCarousel
         products={products}
-        itemsPerSlide={itemsPerSlide}
+        minItems={minItems}
+        maxItems={maxItems}
         className={className}
         {...props}
       />


### PR DESCRIPTION
## Summary
- make `ProductCarousel` responsive with dynamic item calculation
- propagate new min/max item controls through `ProductGalleryTemplate`
- update storybook examples

## Testing
- `pnpm --filter @acme/ui test` *(fails: wizard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbb47504832fb4e8ef6a39c7c656