### PR TITLE
refactor: centralize string utilities

### DIFF
--- a/doc/utils.md
+++ b/doc/utils.md
@@ -1,0 +1,34 @@
+# Utility Functions
+
+Common string helpers are available from `@acme/platform-core/utils`.
+
+## `slugify`
+
+Converts a string into a URL‑friendly slug by trimming whitespace, lowercasing
+and replacing non‑alphanumeric characters with dashes.
+
+```ts
+import { slugify } from "@acme/platform-core/utils";
+slugify(" Hello World! "); // "hello-world"
+```
+
+## `genSecret`
+
+Generates a random hexadecimal string. Pass the number of bytes to control the
+length.
+
+```ts
+import { genSecret } from "@acme/platform-core/utils";
+const secret = genSecret(8); // 16‑char string
+```
+
+## `fillLocales`
+
+Ensures a value exists for all supported locales. Missing entries are filled
+with a provided fallback.
+
+```ts
+import { fillLocales } from "@acme/platform-core/utils";
+fillLocales({ en: "Hello" }, "Hi");
+// => { en: "Hello", de: "Hi", ... }
+```

--- a/packages/platform-core/__tests__/createShopUtils.test.ts
+++ b/packages/platform-core/__tests__/createShopUtils.test.ts
@@ -4,9 +4,6 @@ import {
   copyTemplate,
   loadBaseTokens,
   loadThemeTokens,
-  slugify,
-  genSecret,
-  fillLocales,
 } from "../src/createShop/utils";
 
 describe("createShop utils", () => {
@@ -56,20 +53,5 @@ describe("createShop utils", () => {
   it("returns empty object for missing theme", () => {
     const tokens = loadThemeTokens("nope");
     expect(tokens).toEqual({});
-  });
-
-  it("slugifies strings", () => {
-    expect(slugify(" Hello World! ")).toBe("hello-world");
-  });
-
-  it("generates secrets of correct length", () => {
-    const secret = genSecret(8);
-    expect(secret).toHaveLength(16);
-  });
-
-  it("fills locales with fallback", () => {
-    const result = fillLocales({ en: "Hello" }, "Hi");
-    expect(result.en).toBe("Hello");
-    expect(result.de).toBe("Hi");
   });
 });

--- a/packages/platform-core/__tests__/stringUtils.test.ts
+++ b/packages/platform-core/__tests__/stringUtils.test.ts
@@ -1,0 +1,19 @@
+// packages/platform-core/__tests__/stringUtils.test.ts
+import { genSecret, slugify, fillLocales } from "../src/utils";
+
+describe("string utils", () => {
+  it("slugifies strings", () => {
+    expect(slugify(" Hello World! ")).toBe("hello-world");
+  });
+
+  it("generates secrets of correct length", () => {
+    const secret = genSecret(8);
+    expect(secret).toHaveLength(16);
+  });
+
+  it("fills locales with fallback", () => {
+    const result = fillLocales({ en: "Hello" }, "Hi");
+    expect(result.en).toBe("Hello");
+    expect(result.de).toBe("Hi");
+  });
+});

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": "./index.ts",
+    "./utils": "./src/utils/index.ts"
   },
   "peerDependencies": {
     "next": "^15.0.0",

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -12,10 +12,8 @@ import {
   copyTemplate,
   loadBaseTokens,
   loadThemeTokens,
-  slugify,
-  genSecret,
-  fillLocales,
 } from "./createShop/utils";
+import { slugify, genSecret, fillLocales } from "./utils";
 import { nowIso } from "@shared/date";
 import { defaultFilterMappings } from "./defaultFilterMappings";
 

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,0 +1,4 @@
+// packages/platform-core/utils/index.ts
+export * from "./getShopFromPath";
+export * from "./replaceShopInPath";
+export * from "./string";

--- a/packages/platform-core/src/utils/string.ts
+++ b/packages/platform-core/src/utils/string.ts
@@ -1,11 +1,7 @@
-// packages/platform-core/src/createShop/utils.ts
+// packages/platform-core/utils/string.ts
 import { LOCALES } from "@i18n/locales";
 import type { Locale } from "@types";
 import { randomBytes } from "crypto";
-
-export { copyTemplate } from "./utils/copyTemplate";
-export { loadBaseTokens } from "./utils/loadBaseTokens";
-export { loadThemeTokens } from "./utils/loadThemeTokens";
 
 /**
  * Convert a string into a URL-friendly slug.


### PR DESCRIPTION
## Summary
- move slugify, genSecret, and fillLocales into a shared utils module
- expose new string helpers via `@acme/platform-core/utils`
- document and test shared string utilities

## Testing
- `pnpm lint --filter @acme/platform-core` *(no tasks)*
- `pnpm --filter @acme/platform-core test` *(fails: shopsRepo.test.ts, pagesRepo.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6897b8825588832f90cbf61def7ecbaf