### PR TITLE
refine shop and product type validations

### DIFF
--- a/packages/types/src/Product.ts
+++ b/packages/types/src/Product.ts
@@ -7,23 +7,23 @@ export const localeSchema = z.enum(LOCALES);
 
 /** Runtime validator + compile-time source of truth */
 export const skuSchema = z.object({
-  id: z.string(),
+  id: z.string().ulid(),
   slug: z.string(),
   title: z.string(),
   /** Unit price in minor currency units (e.g. cents) */
-  price: z.number(),
+  price: z.number().int().nonnegative(),
   /** Refundable deposit, required by business rules */
-  deposit: z.number(),
+  deposit: z.number().int().nonnegative(),
   /** Item can be sold */
   forSale: z.boolean().default(true),
   /** Item can be rented */
   forRental: z.boolean().default(false),
   /** daily rental rate in minor currency units */
-  dailyRate: z.number().optional(),
+  dailyRate: z.number().int().nonnegative().optional(),
   /** weekly rental rate in minor currency units */
-  weeklyRate: z.number().optional(),
+  weeklyRate: z.number().int().nonnegative().optional(),
   /** monthly rental rate in minor currency units */
-  monthlyRate: z.number().optional(),
+  monthlyRate: z.number().int().nonnegative().optional(),
   /** availability windows as ISO timestamps */
   availability: z
     .array(z.object({ from: z.string(), to: z.string() }))

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -2,16 +2,16 @@ import { z } from "zod";
 import { localeSchema, type Locale, type Translated } from "./Product";
 
 export const shopSeoFieldsSchema = z.object({
-  canonicalBase: z.string().optional(),
+  canonicalBase: z.string().url().optional(),
   title: z.string().optional(),
   description: z.string().optional(),
-  image: z.string().optional(),
+  image: z.string().url().optional(),
   openGraph: z
     .object({
       title: z.string().optional(),
       description: z.string().optional(),
-      url: z.string().optional(),
-      image: z.string().optional(),
+      url: z.string().url().optional(),
+      image: z.string().url().optional(),
     })
     .optional(),
   twitter: z
@@ -19,7 +19,7 @@ export const shopSeoFieldsSchema = z.object({
       card: z.string().optional(),
       title: z.string().optional(),
       description: z.string().optional(),
-      image: z.string().optional(),
+      image: z.string().url().optional(),
     })
     .optional(),
   structuredData: z.string().optional(),
@@ -66,7 +66,9 @@ export const shopSchema = z.object({
   /** Mapping of logical filter keys to catalog attributes */
   filterMappings: z.record(z.string()),
   /** Optional price overrides per locale (minor units) */
-  priceOverrides: z.record(localeSchema, z.number()).default({}),
+  priceOverrides: z
+    .record(localeSchema, z.number().int().nonnegative())
+    .default({}),
   /** Optional redirect overrides for locale detection */
   localeOverrides: z.record(z.string(), localeSchema).default({}),
   type: z.string().optional(),


### PR DESCRIPTION
## Summary
- validate shop SEO URLs
- ensure price overrides are non-negative integers
- tighten SKU fields with ULID and integer checks

## Testing
- `pnpm test --filter @types/shared`

------
https://chatgpt.com/codex/tasks/task_e_6897b8ace714832f9f90fd0b49ab3514