### PR TITLE
feat(ui): add bounds for recommendation carousel

### DIFF
--- a/packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx
+++ b/packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx
@@ -5,7 +5,8 @@ const meta: Meta<typeof RecommendationCarousel> = {
   component: RecommendationCarousel,
   args: {
     endpoint: "/api/products",
-    itemsPerSlide: 3,
+    minItems: 1,
+    maxItems: 4,
   },
 };
 export default meta;


### PR DESCRIPTION
## Summary
- add `minItems` and `maxItems` props to `RecommendationCarousel`
- compute responsive `itemsPerSlide` and fetch recommendations with bounds
- update story to use new props

## Testing
- `pnpm --filter @acme/ui test` *(fails: Unable to find an element by: [data-testid="payment-element"])*
- `pnpm exec eslint packages/ui/src/components/organisms/RecommendationCarousel.tsx packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx` *(fails: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbc1cce8832facc7dc7bfa8af8cb