### PR TITLE
feat: support min/max constraints in templates

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -43,6 +43,14 @@ export interface PageComponentBase {
    * Accepts any valid CSS padding value or Tailwind class.
    */
   padding?: string;
+  /** Minimum number of items allowed for components with lists */
+  minItems?: number;
+  /** Maximum number of items allowed for components with lists */
+  maxItems?: number;
+  /** Minimum columns allowed for grid components */
+  minCols?: number;
+  /** Maximum columns allowed for grid components */
+  maxCols?: number;
   [key: string]: unknown;
 }
 
@@ -137,6 +145,10 @@ const baseComponentSchema = z
     left: z.string().optional(),
     margin: z.string().optional(),
     padding: z.string().optional(),
+    minItems: z.number().optional(),
+    maxItems: z.number().optional(),
+    minCols: z.number().optional(),
+    maxCols: z.number().optional(),
   })
   .passthrough();
 

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -86,6 +86,21 @@ function ComponentEditor({ component, onChange }: Props) {
         value={component.padding ?? ""}
         onChange={(e) => handleInput("padding", e.target.value)}
       />
+      {"columns" in component && (
+        <Input
+          label="Columns"
+          type="number"
+          value={(component as any).columns ?? ""}
+          onChange={(e) =>
+            handleInput(
+              "columns",
+              e.target.value === "" ? undefined : Number(e.target.value)
+            )
+          }
+          min={(component as any).minCols}
+          max={(component as any).maxCols}
+        />
+      )}
       <Select
         value={component.position ?? ""}
         onValueChange={(v) => handleInput("position", v || undefined)}

--- a/packages/ui/src/components/cms/page-builder/GalleryEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/GalleryEditor.tsx
@@ -8,5 +8,13 @@ interface Props {
 
 export default function GalleryEditor({ component, onChange }: Props) {
   const arrayEditor = useArrayEditor(onChange);
-  return arrayEditor("images", (component as any).images, ["src", "alt"]);
+  return arrayEditor(
+    "images",
+    (component as any).images,
+    ["src", "alt"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/HeroBannerEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/HeroBannerEditor.tsx
@@ -8,10 +8,13 @@ interface Props {
 
 export default function HeroBannerEditor({ component, onChange }: Props) {
   const arrayEditor = useArrayEditor(onChange);
-  return arrayEditor("slides", (component as any).slides, [
-    "src",
-    "alt",
-    "headlineKey",
-    "ctaKey",
-  ]);
+  return arrayEditor(
+    "slides",
+    (component as any).slides,
+    ["src", "alt", "headlineKey", "ctaKey"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/ReviewsCarouselEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ReviewsCarouselEditor.tsx
@@ -8,8 +8,13 @@ interface Props {
 
 export default function ReviewsCarouselEditor({ component, onChange }: Props) {
   const arrayEditor = useArrayEditor(onChange);
-  return arrayEditor("reviews", (component as any).reviews, [
-    "nameKey",
-    "quoteKey",
-  ]);
+  return arrayEditor(
+    "reviews",
+    (component as any).reviews,
+    ["nameKey", "quoteKey"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/TestimonialsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/TestimonialsEditor.tsx
@@ -8,8 +8,13 @@ interface Props {
 
 export default function TestimonialsEditor({ component, onChange }: Props) {
   const arrayEditor = useArrayEditor(onChange);
-  return arrayEditor("testimonials", (component as any).testimonials, [
-    "quote",
-    "name",
-  ]);
+  return arrayEditor(
+    "testimonials",
+    (component as any).testimonials,
+    ["quote", "name"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/ValuePropsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ValuePropsEditor.tsx
@@ -8,9 +8,13 @@ interface Props {
 
 export default function ValuePropsEditor({ component, onChange }: Props) {
   const arrayEditor = useArrayEditor(onChange);
-  return arrayEditor("items", (component as any).items, [
-    "icon",
-    "title",
-    "desc",
-  ]);
+  return arrayEditor(
+    "items",
+    (component as any).items,
+    ["icon", "title", "desc"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/useArrayEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/useArrayEditor.tsx
@@ -8,8 +8,15 @@ export function useArrayEditor(
   onChange: (patch: Partial<PageComponent>) => void,
 ) {
   return useCallback(
-    (prop: string, items: unknown[] | undefined, fields: string[]) => {
+    (
+      prop: string,
+      items: unknown[] | undefined,
+      fields: string[],
+      limits?: { minItems?: number; maxItems?: number }
+    ) => {
       const list = (items ?? []) as Record<string, unknown>[];
+      const min = limits?.minItems ?? 0;
+      const max = limits?.maxItems ?? Infinity;
       return (
         <div className="space-y-2">
           {list.map((item, idx) => (
@@ -47,6 +54,7 @@ export function useArrayEditor(
                   const next = list.filter((_, i) => i !== idx);
                   onChange({ [prop]: next } as Partial<PageComponent>);
                 }}
+                disabled={list.length <= min}
               >
                 Remove
               </Button>
@@ -57,6 +65,7 @@ export function useArrayEditor(
               const blank = Object.fromEntries(fields.map((f) => [f, ""]));
               onChange({ [prop]: [...list, blank] } as Partial<PageComponent>);
             }}
+            disabled={list.length >= max}
           >
             Add
           </Button>

--- a/packages/ui/src/components/templates/collection.json
+++ b/packages/ui/src/components/templates/collection.json
@@ -1,4 +1,7 @@
 {
   "name": "Collection Showcase",
-  "components": [{ "type": "CategoryList" }, { "type": "ProductCarousel" }]
+  "components": [
+    { "type": "CategoryList", "minCols": 2, "maxCols": 4, "columns": 3 },
+    { "type": "ProductCarousel", "minItems": 1, "maxItems": 10 }
+  ]
 }

--- a/packages/ui/src/components/templates/homepage.json
+++ b/packages/ui/src/components/templates/homepage.json
@@ -1,9 +1,9 @@
 {
   "name": "Homepage",
   "components": [
-    { "type": "HeroBanner" },
+    { "type": "HeroBanner", "minItems": 1, "maxItems": 5 },
     { "type": "PromoBanner" },
-    { "type": "ProductCarousel" },
-    { "type": "CategoryList" }
+    { "type": "ProductCarousel", "minItems": 1, "maxItems": 10 },
+    { "type": "CategoryList", "minCols": 2, "maxCols": 4, "columns": 3 }
   ]
 }

--- a/packages/ui/src/components/templates/landing.json
+++ b/packages/ui/src/components/templates/landing.json
@@ -1,8 +1,8 @@
 {
   "name": "Landing",
   "components": [
-    { "type": "HeroBanner" },
-    { "type": "ValueProps" },
-    { "type": "ReviewsCarousel" }
+    { "type": "HeroBanner", "minItems": 1, "maxItems": 5 },
+    { "type": "ValueProps", "minItems": 1, "maxItems": 6 },
+    { "type": "ReviewsCarousel", "minItems": 1, "maxItems": 10 }
   ]
 }


### PR DESCRIPTION
## Summary
- allow components in templates to define min/max items or column constraints
- expose min/max metadata on Page components and pass to editors
- honor min/max limits in array editors and column inputs

## Testing
- `pnpm --filter @acme/ui test` *(fails: Wizard › submits after navigating steps; Wizard test still failing)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbee08b0832f8cb637221852ed75