### PR TITLE
refactor: centralize resolveDataRoot utility

### DIFF
--- a/apps/cms/src/app/api/categories/[shop]/route.ts
+++ b/apps/cms/src/app/api/categories/[shop]/route.ts
@@ -1,20 +1,9 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import fsSync, { promises as fs } from "node:fs";
+import { promises as fs } from "node:fs";
 import path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "@platform-core/utils";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/api/import-products/[shop]/route.ts
+++ b/apps/cms/src/app/api/import-products/[shop]/route.ts
@@ -1,20 +1,9 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import fsSync, { promises as fs } from "node:fs";
+import { promises as fs } from "node:fs";
 import path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "@platform-core/utils";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/api/providers/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/[shop]/route.ts
@@ -1,20 +1,9 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import fsSync, { promises as fs } from "node:fs";
+import { promises as fs } from "node:fs";
 import path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "@platform-core/utils";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -1,20 +1,9 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import fsSync, { promises as fs } from "node:fs";
+import { promises as fs } from "node:fs";
 import path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "@platform-core/utils";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/cms/listShops.ts
+++ b/apps/cms/src/app/cms/listShops.ts
@@ -1,24 +1,7 @@
 // apps/cms/src/app/cms/listShops.ts
 
-import fsSync from "node:fs";
 import fs from "node:fs/promises";
-
-import path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-
-    const parent = path.dirname(dir);
-    if (parent === dir) break; // reached FS root
-    dir = parent;
-  }
-
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "@platform-core/utils";
 
 export async function listShops(): Promise<string[]> {
   const shopsDir = resolveDataRoot();

--- a/apps/cms/src/app/cms/page.tsx
+++ b/apps/cms/src/app/cms/page.tsx
@@ -9,9 +9,9 @@ import { DashboardTemplate } from "@ui/components/templates";
 import type { Metadata } from "next";
 import { getServerSession } from "next-auth";
 import Link from "next/link";
-import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveDataRoot } from "@platform-core/utils";
 
 export const metadata: Metadata = {
   title: "Dashboard · Base-Shop",
@@ -24,26 +24,6 @@ type Stats = {
   shops: number;
   products: number;
 };
-
-/**
- * Walk upward from the current working directory to locate the monorepo-level
- * `data/shops` folder. Falls back to `<cwd>/data/shops` if the search reaches
- * the filesystem root without a hit.
- */
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-
-    const parent = path.dirname(dir);
-    if (parent === dir) break; // reached FS root
-    dir = parent;
-  }
-
-  return path.resolve(process.cwd(), "data", "shops");
-}
 
 async function collectStats(): Promise<Stats> {
   const shopsDir = resolveDataRoot();

--- a/packages/lib/src/checkShopExists.server.ts
+++ b/packages/lib/src/checkShopExists.server.ts
@@ -1,22 +1,10 @@
 // packages/lib/checkShopExists.server.ts
 import "server-only";
 
-import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { resolveDataRoot } from "@platform-core/utils";
 import { validateShopName } from "./validateShopName";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
 
 const DATA_ROOT = resolveDataRoot();
 

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -2,21 +2,9 @@ import "server-only";
 
 import type { PricingMatrix, SKU } from "@types";
 import { pricingSchema } from "@types";
-import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "./utils";
 
 let cached: PricingMatrix | null = null;
 

--- a/packages/platform-core/src/repositories/pricing.server.ts
+++ b/packages/platform-core/src/repositories/pricing.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { pricingSchema, type PricingMatrix } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "./utils";
+import { resolveDataRoot } from "../utils";
 
 function pricingPath(): string {
   return path.join(resolveDataRoot(), "..", "rental", "pricing.json");

--- a/packages/platform-core/src/repositories/returnLogistics.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { returnLogisticsSchema, type ReturnLogistics } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "./utils";
+import { resolveDataRoot } from "../utils";
 
 function logisticsPath(): string {
   return path.join(resolveDataRoot(), "..", "return-logistics.json");

--- a/packages/platform-core/src/repositories/utils.ts
+++ b/packages/platform-core/src/repositories/utils.ts
@@ -1,20 +1,6 @@
 import "server-only";
 
-import * as fsSync from "node:fs";
-import * as path from "node:path";
-
 export { loadThemeTokens } from "../themeTokens";
-
-export function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "../utils";
 
 export const DATA_ROOT = resolveDataRoot();

--- a/packages/platform-core/src/returnLogistics.ts
+++ b/packages/platform-core/src/returnLogistics.ts
@@ -1,20 +1,8 @@
 import type { ReturnLogistics } from "@types";
 import { returnLogisticsSchema } from "@types";
-import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "./utils";
 
 let cached: ReturnLogistics | null = null;
 

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { getShopFromPath } from "./getShopFromPath";
+export { replaceShopInPath } from "./replaceShopInPath";
+export { resolveDataRoot } from "./resolveDataRoot";

--- a/packages/platform-core/src/utils/resolveDataRoot.ts
+++ b/packages/platform-core/src/utils/resolveDataRoot.ts
@@ -1,0 +1,20 @@
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Walk upward from the current working directory to locate the monorepo-level
+ * `data/shops` folder. Falls back to `<cwd>/data/shops` if the search reaches
+ * the filesystem root without a hit.
+ */
+export function resolveDataRoot(): string {
+  let dir = process.cwd();
+  while (true) {
+    const candidate = path.join(dir, "data", "shops");
+    if (fsSync.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(process.cwd(), "data", "shops");
+}
+


### PR DESCRIPTION
## Summary
- add shared resolveDataRoot util and export via utils barrel
- replace inline resolveDataRoot implementations across cms API routes, pages, and shared libraries
- update repositories to import from new util

## Testing
- `pnpm test --filter=@acme/platform-core --filter=@acme/lib --filter=@apps/cms` *(fails: Test Suites: 2 failed, 27 passed, 29 total)*

------
https://chatgpt.com/codex/tasks/task_e_6897bce4c728832f9663e979cafd4e43