### PR TITLE
Normalize page builder resize dimensions

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -13,12 +13,15 @@ export interface PageComponentBase {
   id: string;
   type: string;
   /**
-   * Width of the rendered component. Can be a pixel value (e.g. "300px")
-   * or a percentage (e.g. "50%").
+   * Width of the rendered component. Accepts any valid CSS length such as
+   * pixel values (e.g. "300px"), percentages (e.g. "50%"), or viewport
+   * units (e.g. "50vw"). Numeric values are treated as pixels.
    */
   width?: string;
   /**
-   * Height of the rendered component. Can be a pixel value or percentage.
+   * Height of the rendered component. Accepts any valid CSS length including
+   * pixels, percentages, or viewport units. Numeric values are treated as
+   * pixels.
    */
   height?: string;
   /**
@@ -26,11 +29,13 @@ export interface PageComponentBase {
    */
   position?: "relative" | "absolute";
   /**
-   * Offset from the top when position is absolute.
+   * Offset from the top when position is absolute. Accepts any CSS length; numeric
+   * values are interpreted as pixels.
    */
   top?: string;
   /**
-   * Offset from the left when position is absolute.
+   * Offset from the left when position is absolute. Accepts any CSS length; numeric
+   * values are interpreted as pixels.
    */
   left?: string;
   /**

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -158,13 +158,15 @@ const CanvasItem = memo(function CanvasItem({
       const payload: Action = {
         type: "resize",
         id: component.id,
-        width: `${startRef.current.w + dx}px`,
-        height: `${startRef.current.h + dy}px`,
+        width: startRef.current.w + dx,
+        height: startRef.current.h + dy,
+        ...(component.position === "absolute"
+          ? {
+              left: startRef.current.l + dx,
+              top: startRef.current.t + dy,
+            }
+          : {}),
       };
-      if (component.position === "absolute") {
-        payload.left = `${startRef.current.l + dx}px`;
-        payload.top = `${startRef.current.t + dy}px`;
-      }
       dispatch(payload);
     };
     const stop = () => setResizing(false);
@@ -185,8 +187,8 @@ const CanvasItem = memo(function CanvasItem({
       dispatch({
         type: "resize",
         id: component.id,
-        left: `${moveRef.current.l + dx}px`,
-        top: `${moveRef.current.t + dy}px`,
+        left: moveRef.current.l + dx,
+        top: moveRef.current.t + dy,
       });
     };
     const stop = () => setMoving(false);

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -22,9 +22,10 @@ import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 interface Props {
   component: PageComponent | null;
   onChange: (patch: Partial<PageComponent>) => void;
+  onResize: (patch: { width?: string | number; height?: string | number }) => void;
 }
 
-function ComponentEditor({ component, onChange }: Props) {
+function ComponentEditor({ component, onChange, onResize }: Props) {
   if (!component) return null;
 
   const handleInput = useCallback(
@@ -69,12 +70,14 @@ function ComponentEditor({ component, onChange }: Props) {
       <Input
         label="Width"
         value={component.width ?? ""}
-        onChange={(e) => handleInput("width", e.target.value)}
+        placeholder="e.g. 300px or 50%"
+        onChange={(e) => onResize({ width: e.target.value })}
       />
       <Input
         label="Height"
         value={component.height ?? ""}
-        onChange={(e) => handleInput("height", e.target.value)}
+        placeholder="e.g. 200px or 50vh"
+        onChange={(e) => onResize({ height: e.target.value })}
       />
       <Input
         label="Margin"


### PR DESCRIPTION
## Summary
- add width/height placeholders and resize events in component editor
- route drag resize through reducer with normalized numeric values
- document CSS length handling for width and height

## Testing
- `pnpm --filter @acme/ui test` *(fails: Unable to find payment-element etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6897b69294c8832f9674e813321460b7