### PR TITLE
feat: add theme toggle to header

### DIFF
--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useTheme } from "@platform-core/src/contexts/ThemeContext";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  const toggleTheme = () => {
+    setTheme(isDark ? "base" : "dark");
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="hover:underline"
+      aria-label="Toggle theme"
+    >
+      {isDark ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -4,6 +4,7 @@ import { useCart } from "@platform-core/src/contexts/CartContext";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { cn } from "../../utils/cn";
+import ThemeToggle from "../ThemeToggle";
 
 export default function HeaderClient({
   lang,
@@ -43,6 +44,7 @@ export default function HeaderClient({
             {item.label}
           </Link>
         ))}
+        <ThemeToggle />
         <Link href={`/${lang}/checkout`} className="relative hover:underline">
           Cart
           {qty > 0 && (

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,5 @@
 // packages/ui/src/index.ts
 
 export { default as DynamicRenderer } from "./components/DynamicRenderer";
+export { default as ThemeToggle } from "./components/ThemeToggle";
 


### PR DESCRIPTION
## Summary
- add ThemeToggle component to switch between base and dark themes
- expose ThemeToggle in UI package and render in header nav

## Testing
- `pnpm lint`
- `pnpm test --filter @acme/ui` *(fails: ManagedMessageChannel is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897bc4085f8832fa929c34ad9ada0a3