### PR TITLE
feat: add responsive carousel bounds

### DIFF
--- a/doc/storybook.md
+++ b/doc/storybook.md
@@ -12,6 +12,10 @@ pnpm storybook
 
 Stories are located under `packages/ui` and `.storybook/stories`.
 
+Carousel components such as `ProductCarousel` and `RecommendationCarousel`
+include stories demonstrating how the number of visible items adjusts with
+screen size between configurable minimum and maximum values.
+
 ## Accessibility Tests
 
 Automated accessibility checks run via `@storybook/test-runner` and `axe-playwright`.

--- a/packages/ui/__tests__/ProductCarousel.test.tsx
+++ b/packages/ui/__tests__/ProductCarousel.test.tsx
@@ -1,0 +1,39 @@
+import { act, render } from "@testing-library/react";
+import { ProductCarousel } from "../src/components/organisms/ProductCarousel";
+
+jest.mock("../src/components/organisms/ProductCard", () => ({
+  ProductCard: ({ product }: any) => <div data-testid={product.id} />,
+}));
+
+type Product = { id: string; title: string; image: string; price: number };
+
+describe("ProductCarousel responsive display", () => {
+  const products: Product[] = Array.from({ length: 3 }).map((_, i) => ({
+    id: String(i),
+    title: `P${i}`,
+    image: "",
+    price: i,
+  }));
+
+  function setWidth(w: number) {
+    // @ts-ignore
+    window.innerWidth = w;
+    window.dispatchEvent(new Event("resize"));
+  }
+
+  it("clamps items per slide between min and max", () => {
+    setWidth(400);
+    const { container } = render(
+      <ProductCarousel
+        products={products}
+        minItemsPerSlide={1}
+        maxItemsPerSlide={4}
+      />
+    );
+    const slide = container.querySelector(".snap-start") as HTMLElement;
+    expect(slide).toHaveStyle({ flex: "0 0 100%" });
+
+    act(() => setWidth(1600));
+    expect(slide).toHaveStyle({ flex: "0 0 25%" });
+  });
+});

--- a/packages/ui/__tests__/ProductGalleryTemplate.test.tsx
+++ b/packages/ui/__tests__/ProductGalleryTemplate.test.tsx
@@ -1,0 +1,39 @@
+import { act, render } from "@testing-library/react";
+import { ProductGalleryTemplate } from "../src/components/templates/ProductGalleryTemplate";
+
+jest.mock("../src/components/organisms/ProductCard", () => ({
+  ProductCard: ({ product }: any) => <div data-testid={product.id} />,
+}));
+
+type Product = { id: string; title: string; image: string; price: number };
+
+describe("ProductGalleryTemplate carousel", () => {
+  const products: Product[] = Array.from({ length: 3 }).map((_, i) => ({
+    id: String(i),
+    title: `P${i}`,
+    image: "",
+    price: i,
+  }));
+
+  function setWidth(w: number) {
+    // @ts-ignore
+    window.innerWidth = w;
+    window.dispatchEvent(new Event("resize"));
+  }
+
+  it("passes min/max bounds to carousel", () => {
+    setWidth(400);
+    const { container } = render(
+      <ProductGalleryTemplate
+        products={products}
+        useCarousel
+        minItemsPerSlide={1}
+        maxItemsPerSlide={4}
+      />
+    );
+    const slide = container.querySelector(".snap-start") as HTMLElement;
+    expect(slide).toHaveStyle({ flex: "0 0 100%" });
+    act(() => setWidth(1600));
+    expect(slide).toHaveStyle({ flex: "0 0 25%" });
+  });
+});

--- a/packages/ui/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/__tests__/RecommendationCarousel.test.tsx
@@ -1,0 +1,53 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { RecommendationCarousel } from "../src/components/organisms/RecommendationCarousel";
+
+jest.mock("../src/components/organisms/ProductCard", () => ({
+  ProductCard: ({ product }: any) => <div data-testid={product.id} />,
+}));
+
+type Product = { id: string; title: string; image: string; price: number };
+
+describe("RecommendationCarousel responsive display", () => {
+  const products: Product[] = Array.from({ length: 3 }).map((_, i) => ({
+    id: String(i),
+    title: `P${i}`,
+    image: "",
+    price: i,
+  }));
+
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => products,
+    }) as any;
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function setWidth(w: number) {
+    // @ts-ignore
+    window.innerWidth = w;
+    window.dispatchEvent(new Event("resize"));
+  }
+
+  it("clamps items per slide between min and max", async () => {
+    setWidth(400);
+    const { container } = render(
+      <RecommendationCarousel
+        endpoint="/api"
+        minItemsPerSlide={1}
+        maxItemsPerSlide={4}
+      />
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll(".snap-start").length).toBe(products.length)
+    );
+    const slide = container.querySelector(".snap-start") as HTMLElement;
+    expect(slide).toHaveStyle({ flex: "0 0 100%" });
+
+    act(() => setWidth(1600));
+    expect(slide).toHaveStyle({ flex: "0 0 25%" });
+  });
+});

--- a/packages/ui/src/components/organisms/ProductCarousel.stories.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.stories.tsx
@@ -41,6 +41,13 @@ const meta: Meta<typeof AutoCarousel> = {
   args: {
     products,
     autoplay: false,
+    minItemsPerSlide: 1,
+    maxItemsPerSlide: 4,
+  },
+  argTypes: {
+    products: { control: "object" },
+    minItemsPerSlide: { control: { type: "number" } },
+    maxItemsPerSlide: { control: { type: "number" } },
   },
 };
 export default meta;
@@ -48,4 +55,7 @@ export default meta;
 export const Default: StoryObj<typeof AutoCarousel> = {};
 export const Autoplay: StoryObj<typeof AutoCarousel> = {
   args: { autoplay: true },
+};
+export const MinMax: StoryObj<typeof AutoCarousel> = {
+  args: { minItemsPerSlide: 2, maxItemsPerSlide: 5 },
 };

--- a/packages/ui/src/components/organisms/ProductCarousel.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.tsx
@@ -1,11 +1,15 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import useResponsiveDisplayCount from "../../hooks/useResponsiveDisplayCount";
 import { Product, ProductCard } from "./ProductCard";
 
 export interface ProductCarouselProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
-  itemsPerSlide?: number;
+  /** Minimum number of items visible per slide */
+  minItemsPerSlide?: number;
+  /** Maximum number of items visible per slide */
+  maxItemsPerSlide?: number;
   /** flex gap class applied to the inner scroller */
   gapClassName?: string;
   /**
@@ -19,16 +23,22 @@ export interface ProductCarouselProps
 
 /**
  * Horizontally scrollable carousel for product cards.
- * Items per slide can be controlled via the `itemsPerSlide` prop.
- */
+ * Display count adapts to screen width within `minItemsPerSlide` and
+ * `maxItemsPerSlide` bounds.
+*/
 export function ProductCarousel({
   products,
-  itemsPerSlide = 3,
+  minItemsPerSlide = 1,
+  maxItemsPerSlide = 4,
   gapClassName = "gap-4",
   getSlideWidth = (n) => `${100 / n}%`,
   className,
   ...props
 }: ProductCarouselProps) {
+  const itemsPerSlide = useResponsiveDisplayCount({
+    min: minItemsPerSlide,
+    max: maxItemsPerSlide,
+  });
   const width = getSlideWidth(itemsPerSlide);
   const slideStyle = { flex: `0 0 ${width}` } as React.CSSProperties;
   return (

--- a/packages/ui/src/components/organisms/README.md
+++ b/packages/ui/src/components/organisms/README.md
@@ -14,7 +14,7 @@ Current components:
 - `StatsGrid`
 - `DataTable`
   `ProductCard`
-- `ProductCarousel`
+ - `ProductCarousel` – display count determined by screen width within user-specified min/max bounds.
 - `ProductGrid`
 - `ProductFeatures`
 - `ProductVariantSelector`
@@ -30,7 +30,7 @@ Current components:
 - `QAModule`
 - `MiniCart`
 - `StickyAddToCartBar`
-- `RecommendationCarousel`
+ - `RecommendationCarousel` – recommended products carousel with responsive display count between min and max limits.
 - `CategoryCard`
 - `ProductGallery`
 - `OrderSummary`

--- a/packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx
+++ b/packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx
@@ -5,9 +5,17 @@ const meta: Meta<typeof RecommendationCarousel> = {
   component: RecommendationCarousel,
   args: {
     endpoint: "/api/products",
-    itemsPerSlide: 3,
+    minItemsPerSlide: 1,
+    maxItemsPerSlide: 4,
+  },
+  argTypes: {
+    minItemsPerSlide: { control: { type: "number" } },
+    maxItemsPerSlide: { control: { type: "number" } },
   },
 };
 export default meta;
 
 export const Default: StoryObj<typeof RecommendationCarousel> = {};
+export const MinMax: StoryObj<typeof RecommendationCarousel> = {
+  args: { minItemsPerSlide: 2, maxItemsPerSlide: 5 },
+};

--- a/packages/ui/src/components/organisms/RecommendationCarousel.tsx
+++ b/packages/ui/src/components/organisms/RecommendationCarousel.tsx
@@ -2,14 +2,17 @@
 
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import useResponsiveDisplayCount from "../../hooks/useResponsiveDisplayCount";
 import { Product, ProductCard } from "./ProductCard";
 
 export interface RecommendationCarouselProps
   extends React.HTMLAttributes<HTMLDivElement> {
   /** API endpoint providing recommended products. */
   endpoint: string;
-  /** Number of items visible per slide. */
-  itemsPerSlide?: number;
+  /** Minimum number of items visible per slide. */
+  minItemsPerSlide?: number;
+  /** Maximum number of items visible per slide. */
+  maxItemsPerSlide?: number;
   /** Tailwind class controlling gap between slides */
   gapClassName?: string;
   /** Function to calculate individual slide width */
@@ -18,11 +21,13 @@ export interface RecommendationCarouselProps
 
 /**
  * Horizontally scrollable carousel that fetches product
- * recommendations from an API.
- */
+ * recommendations from an API. Display count adapts to
+ * screen width within provided min/max bounds.
+*/
 export function RecommendationCarousel({
   endpoint,
-  itemsPerSlide = 3,
+  minItemsPerSlide = 1,
+  maxItemsPerSlide = 4,
   gapClassName = "gap-4",
   getSlideWidth = (n) => `${100 / n}%`,
   className,
@@ -44,6 +49,10 @@ export function RecommendationCarousel({
     void load();
   }, [endpoint]);
 
+  const itemsPerSlide = useResponsiveDisplayCount({
+    min: minItemsPerSlide,
+    max: maxItemsPerSlide,
+  });
   const width = getSlideWidth(itemsPerSlide);
 
   const slideStyle = React.useMemo<React.CSSProperties>(

--- a/packages/ui/src/components/organisms/index.ts
+++ b/packages/ui/src/components/organisms/index.ts
@@ -14,13 +14,16 @@ export { MiniCart } from "./MiniCart.client";
 export { default as OrderSummary } from "./OrderSummary";
 export { OrderTrackingTimeline } from "./OrderTrackingTimeline";
 export { ProductCard } from "./ProductCard";
-export { ProductCarousel } from "./ProductCarousel";
+export { ProductCarousel, type ProductCarouselProps } from "./ProductCarousel";
 export { ProductFeatures } from "./ProductFeatures";
 export { ProductGallery } from "./ProductGallery";
 export { ProductGrid } from "./ProductGrid";
 export { ProductVariantSelector } from "./ProductVariantSelector";
 export { QAModule } from "./QAModule";
-export { RecommendationCarousel } from "./RecommendationCarousel";
+export {
+  RecommendationCarousel,
+  type RecommendationCarouselProps,
+} from "./RecommendationCarousel";
 export { ReviewsList } from "./ReviewsList";
 export { SideNav } from "./SideNav";
 export { StatsGrid } from "./StatsGrid";

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.stories.tsx
@@ -10,14 +10,19 @@ const meta: Meta<typeof ProductGalleryTemplate> = {
       { id: "3", title: "Product 3", image: "/placeholder.svg", price: 30 },
     ],
     useCarousel: false,
-    itemsPerSlide: 3,
+    minItemsPerSlide: 1,
+    maxItemsPerSlide: 4,
   },
   argTypes: {
     products: { control: "object" },
     useCarousel: { control: "boolean" },
-    itemsPerSlide: { control: { type: "number" } },
+    minItemsPerSlide: { control: { type: "number" } },
+    maxItemsPerSlide: { control: { type: "number" } },
   },
 };
 export default meta;
 
 export const Default: StoryObj<typeof ProductGalleryTemplate> = {};
+export const Carousel: StoryObj<typeof ProductGalleryTemplate> = {
+  args: { useCarousel: true },
+};

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
@@ -7,16 +7,20 @@ export interface ProductGalleryTemplateProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
   useCarousel?: boolean;
-  itemsPerSlide?: number;
+  minItemsPerSlide?: number;
+  maxItemsPerSlide?: number;
 }
 
 /**
- * Display a list of products in a grid or carousel layout.
- */
+ * Display a list of products in a grid or carousel layout. When
+ * `useCarousel` is true, the number of visible items adapts to
+ * screen size within the provided min/max bounds.
+*/
 export function ProductGalleryTemplate({
   products,
   useCarousel = false,
-  itemsPerSlide,
+  minItemsPerSlide,
+  maxItemsPerSlide,
   className,
   ...props
 }: ProductGalleryTemplateProps) {
@@ -24,7 +28,8 @@ export function ProductGalleryTemplate({
     return (
       <ProductCarousel
         products={products}
-        itemsPerSlide={itemsPerSlide}
+        minItemsPerSlide={minItemsPerSlide}
+        maxItemsPerSlide={maxItemsPerSlide}
         className={className}
         {...props}
       />

--- a/packages/ui/src/components/templates/README.md
+++ b/packages/ui/src/components/templates/README.md
@@ -7,7 +7,7 @@ Shared page-level layouts used across apps. Currently includes:
   navigation state are available via `useLayout()`.
   - `DashboardTemplate` – basic stats overview.
 - `AnalyticsDashboardTemplate` – stats, line chart and table for dashboards.
-- `ProductGalleryTemplate` – grid or carousel listing of products.
+- `ProductGalleryTemplate` – grid or carousel listing of products with responsive item counts bounded by minimum and maximum values.
 - `ProductDetailTemplate` – hero-style view for a single product.
 - `FeaturedProductTemplate` – showcase layout for highlighting a product.
 - `ProductComparisonTemplate` – side-by-side view of multiple products.

--- a/packages/ui/src/components/templates/index.ts
+++ b/packages/ui/src/components/templates/index.ts
@@ -16,7 +16,7 @@ export { OrderConfirmationTemplate } from "./OrderConfirmationTemplate";
 export { OrderTrackingTemplate } from "./OrderTrackingTemplate";
 export { ProductComparisonTemplate } from "./ProductComparisonTemplate";
 export { ProductDetailTemplate } from "./ProductDetailTemplate";
-export { ProductGalleryTemplate } from "./ProductGalleryTemplate";
+export { ProductGalleryTemplate, type ProductGalleryTemplateProps } from "./ProductGalleryTemplate";
 export { ProductMediaGalleryTemplate } from "./ProductMediaGalleryTemplate";
 export { SearchResultsTemplate } from "./SearchResultsTemplate";
 export { StoreLocatorTemplate } from "./StoreLocatorTemplate";

--- a/packages/ui/src/hooks/useResponsiveDisplayCount.ts
+++ b/packages/ui/src/hooks/useResponsiveDisplayCount.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+export interface ResponsiveDisplayCountOptions {
+  /** Minimum number of items to display */
+  min?: number;
+  /** Maximum number of items to display */
+  max?: number;
+  /**
+   * Minimum width in pixels for each item.
+   * Used to approximate how many items can fit
+   * within the current viewport width.
+   */
+  itemMinWidth?: number;
+}
+
+export function useResponsiveDisplayCount({
+  min = 1,
+  max = 4,
+  itemMinWidth = 300,
+}: ResponsiveDisplayCountOptions = {}) {
+  const [count, setCount] = useState(min);
+
+  useEffect(() => {
+    const update = () => {
+      const width = typeof window !== "undefined" ? window.innerWidth : 0;
+      const possible = Math.floor(width / itemMinWidth);
+      const next = Math.max(min, Math.min(max, possible || min));
+      setCount(next);
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [min, max, itemMinWidth]);
+
+  return count;
+}
+
+export default useResponsiveDisplayCount;


### PR DESCRIPTION
## Summary
- add useResponsiveDisplayCount hook and apply to product/recommendation carousels
- document min/max screen-dependent display counts in stories and docs
- export updated types and add unit tests

## Testing
- `pnpm --filter @acme/ui test -- ProductCarousel.test.tsx RecommendationCarousel.test.tsx ProductGalleryTemplate.test.tsx`
- `pnpm --filter @acme/ui build` *(fails: packages/platform-core dist types missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897bc633aa0832fa23ff0ced3a8f057