### PR TITLE
feat: centralize shared string utilities

### DIFF
--- a/packages/platform-core/README.md
+++ b/packages/platform-core/README.md
@@ -1,0 +1,18 @@
+# Platform Core
+
+## Utilities
+
+The `utils` module exposes a collection of helper functions that can be
+used across the platform:
+
+- **`slugify`** – Convert a string into a URL-friendly slug.
+- **`genSecret`** – Generate a random hexadecimal secret.
+- **`fillLocales`** – Ensure values exist for all supported locales, filling
+  missing entries with a fallback.
+
+Import them via the package index:
+
+```ts
+import { slugify, genSecret, fillLocales } from "@acme/platform-core";
+```
+

--- a/packages/platform-core/__tests__/createShopUtils.test.ts
+++ b/packages/platform-core/__tests__/createShopUtils.test.ts
@@ -1,12 +1,6 @@
 // packages/platform-core/__tests__/createShopUtils.test.ts
 import fs from "fs";
-import {
-  copyTemplate,
-  loadBaseTokens,
-  slugify,
-  genSecret,
-  fillLocales,
-} from "../src/createShop/utils";
+import { copyTemplate, loadBaseTokens } from "../src/createShop/utils";
 
 describe("createShop utils", () => {
   beforeEach(() => {
@@ -39,18 +33,4 @@ describe("createShop utils", () => {
     expect(tokens["--color-bg"]).toBeDefined();
   });
 
-  it("slugifies strings", () => {
-    expect(slugify(" Hello World! ")).toBe("hello-world");
-  });
-
-  it("generates secrets of correct length", () => {
-    const secret = genSecret(8);
-    expect(secret).toHaveLength(16);
-  });
-
-  it("fills locales with fallback", () => {
-    const result = fillLocales({ en: "Hello" }, "Hi");
-    expect(result.en).toBe("Hello");
-    expect(result.de).toBe("Hi");
-  });
 });

--- a/packages/platform-core/__tests__/stringUtils.test.ts
+++ b/packages/platform-core/__tests__/stringUtils.test.ts
@@ -1,0 +1,20 @@
+// packages-platform-core/__tests__/stringUtils.test.ts
+import { slugify, genSecret, fillLocales } from "../src/utils";
+
+describe("string utilities", () => {
+  it("slugifies strings", () => {
+    expect(slugify(" Hello World! ")).toBe("hello-world");
+  });
+
+  it("generates secrets of correct length", () => {
+    const secret = genSecret(8);
+    expect(secret).toHaveLength(16);
+  });
+
+  it("fills locales with fallback", () => {
+    const result = fillLocales({ en: "Hello" }, "Hi");
+    expect(result.en).toBe("Hello");
+    expect(result.de).toBe("Hi");
+  });
+});
+

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -9,13 +9,8 @@ import { join } from "path";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { validateShopName } from "./shops";
-import {
-  copyTemplate,
-  loadBaseTokens,
-  slugify,
-  genSecret,
-  fillLocales,
-} from "./createShop/utils";
+import { copyTemplate, loadBaseTokens } from "./createShop/utils";
+import { slugify, genSecret, fillLocales } from "./utils";
 import { loadThemeTokensNode } from "./themeTokens";
 import { nowIso } from "@shared/date";
 import { defaultFilterMappings } from "./defaultFilterMappings";

--- a/packages/platform-core/src/createShop/utils.ts
+++ b/packages/platform-core/src/createShop/utils.ts
@@ -1,42 +1,5 @@
 // packages/platform-core/src/createShop/utils.ts
-import { LOCALES } from "@i18n/locales";
-import type { Locale } from "@types";
-import { randomBytes } from "crypto";
 
 export { copyTemplate } from "./utils/copyTemplate";
 export { loadBaseTokens } from "./utils/loadBaseTokens";
-
-/**
- * Convert a string into a URL-friendly slug.
- */
-export function slugify(str: string): string {
-  return str
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-/**
- * Generate a random secret represented as a hexadecimal string.
- */
-export function genSecret(bytes = 16): string {
-  return randomBytes(bytes).toString("hex");
-}
-
-/**
- * Ensure all locales have a value, filling in missing entries with a fallback.
- */
-export function fillLocales(
-  values: Partial<Record<Locale, string>> | undefined,
-  fallback: string
-): Record<Locale, string> {
-  return LOCALES.reduce<Record<Locale, string>>(
-    (acc, locale: Locale) => {
-      acc[locale] = values?.[locale] ?? fallback;
-      return acc;
-    },
-    {} as Record<Locale, string>
-  );
-}
 

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./contexts/LayoutContext";
 export * from "./contexts/ThemeContext";
 export * from "./defaultFilterMappings";
 export * from "./themeTokens";
+export * from "./utils";

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,0 +1,6 @@
+// packages-platform-core/utils/index.ts
+
+export * from "./getShopFromPath";
+export * from "./replaceShopInPath";
+export * from "./string";
+

--- a/packages/platform-core/src/utils/string.ts
+++ b/packages/platform-core/src/utils/string.ts
@@ -1,0 +1,39 @@
+// packages/platform-core/utils/string.ts
+import { LOCALES } from "@i18n/locales";
+import type { Locale } from "@types";
+import { randomBytes } from "crypto";
+
+/**
+ * Convert a string into a URL-friendly slug.
+ */
+export function slugify(str: string): string {
+  return str
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Generate a random secret represented as a hexadecimal string.
+ */
+export function genSecret(bytes = 16): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+/**
+ * Ensure all locales have a value, filling in missing entries with a fallback.
+ */
+export function fillLocales(
+  values: Partial<Record<Locale, string>> | undefined,
+  fallback: string
+): Record<Locale, string> {
+  return LOCALES.reduce<Record<Locale, string>>(
+    (acc, locale: Locale) => {
+      acc[locale] = values?.[locale] ?? fallback;
+      return acc;
+    },
+    {} as Record<Locale, string>
+  );
+}
+


### PR DESCRIPTION
## Summary
- centralize slugify, genSecret, and fillLocales in shared utils and re-export
- update createShop to use new utilities
- document and test shared string helpers

## Testing
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/stringUtils.test.ts packages/platform-core/__tests__/createShopUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897beb705f0832fa67d270dae60b7cd