### PR TITLE
chore: route ui builds to dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,10 @@
 /.turbo/
 **/.turbo/
 
-# Generated CMS block builds
-packages/ui/src/components/cms/blocks/*.js
-packages/ui/src/components/cms/blocks/*.d.ts
-packages/ui/src/components/cms/blocks/*.d.ts.map
+# Ignore generated files from UI package source directory
+packages/ui/src/**/*.js
+packages/ui/src/**/*.d.ts
+packages/ui/src/**/*.d.ts.map
 
 # ---------------------------
 # Misc

--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,4 +1,0 @@
-# Ignore generated JS and declaration files in source tree
-src/**/*.js
-src/**/*.d.ts
-src/**/*.d.ts.map

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -9,9 +9,9 @@
     "emitDeclarationOnly": false,
 
     /* ---------- output locations ---------------------------------- */
-    "rootDir": "src", // <- compiled sources live here
-    "outDir": "dist", // <- JS + d.ts land here
-    "declarationDir": "dist",
+    "rootDir": "./src", // <- compiled sources live here
+    "outDir": "./dist", // <- JS + d.ts land here
+    "declarationDir": "./dist",
     "declarationMap": true,
 
     /* ---------- React / JSX --------------------------------------- */


### PR DESCRIPTION
## Summary
- ensure ui package outputs compiled files to `dist`
- centralize ignore rules for generated ui source files

## Testing
- `pnpm -F @acme/ui build` *(fails: Output file '../platform-core/dist/products.d.ts' has not been built from source)*
- `pnpm -F @acme/ui test` *(fails: Cannot find module '../components/organisms/StoreLocatorMap')*

------
https://chatgpt.com/codex/tasks/task_e_6897becd3938832f94a5556805ee1f4d