### PR TITLE
feat: normalize page builder dimensions

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -13,12 +13,14 @@ export interface PageComponentBase {
   id: string;
   type: string;
   /**
-   * Width of the rendered component. Can be a pixel value (e.g. "300px")
-   * or a percentage (e.g. "50%").
+   * Width of the rendered component. Supports any CSS length including
+   * pixel values (e.g. "300px"), percentages (e.g. "50%"), or viewport
+   * units (e.g. "30vw").
    */
   width?: string;
   /**
-   * Height of the rendered component. Can be a pixel value or percentage.
+   * Height of the rendered component. Supports any CSS length such as
+   * pixels, percentages or viewport units.
    */
   height?: string;
   /**
@@ -26,11 +28,13 @@ export interface PageComponentBase {
    */
   position?: "relative" | "absolute";
   /**
-   * Offset from the top when position is absolute.
+   * Offset from the top when position is absolute. Accepts any CSS length
+   * including pixels, percentages or viewport units.
    */
   top?: string;
   /**
-   * Offset from the left when position is absolute.
+   * Offset from the left when position is absolute. Accepts any CSS length
+   * including pixels, percentages or viewport units.
    */
   left?: string;
   /**

--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -225,11 +225,17 @@ function componentsReducer(
     case "update":
       return updateComponent(state, action.id, action.patch);
     case "resize":
+      const normalize = (v?: string) => {
+        if (v === undefined) return undefined;
+        const trimmed = v.trim();
+        if (trimmed === "") return undefined;
+        return /^-?\d+(\.\d+)?$/.test(trimmed) ? `${trimmed}px` : trimmed;
+      };
       return resizeComponent(state, action.id, {
-        width: action.width,
-        height: action.height,
-        left: action.left,
-        top: action.top,
+        width: normalize(action.width),
+        height: normalize(action.height),
+        left: normalize(action.left),
+        top: normalize(action.top),
       });
     case "set":
       return action.components;
@@ -733,6 +739,9 @@ const PageBuilder = memo(function PageBuilder({
             component={components.find((c) => c.id === selectedId)!}
             onChange={(patch) =>
               dispatch({ type: "update", id: selectedId, patch })
+            }
+            onResize={(size) =>
+              dispatch({ type: "resize", id: selectedId, ...size })
             }
           />
         </aside>

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -180,7 +180,7 @@ const CanvasItem = memo(function CanvasItem({
       window.removeEventListener("pointermove", handleMove);
       window.removeEventListener("pointerup", stop);
     };
-  }, [resizing, component.id, dispatch]);
+  }, [resizing, component.id, component.position, dispatch]);
 
   useEffect(() => {
     if (!moving) return;
@@ -209,11 +209,19 @@ const CanvasItem = memo(function CanvasItem({
     e.stopPropagation();
     const el = containerRef.current;
     if (!el) return;
+    const startWidth =
+      component.width && component.width.endsWith("px")
+        ? parseFloat(component.width)
+        : el.offsetWidth;
+    const startHeight =
+      component.height && component.height.endsWith("px")
+        ? parseFloat(component.height)
+        : el.offsetHeight;
     startRef.current = {
       x: e.clientX,
       y: e.clientY,
-      w: el.offsetWidth,
-      h: el.offsetHeight,
+      w: startWidth,
+      h: startHeight,
       l: el.offsetLeft,
       t: el.offsetTop,
     };

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -22,9 +22,10 @@ import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 interface Props {
   component: PageComponent | null;
   onChange: (patch: Partial<PageComponent>) => void;
+  onResize: (patch: { width?: string; height?: string }) => void;
 }
 
-function ComponentEditor({ component, onChange }: Props) {
+function ComponentEditor({ component, onChange, onResize }: Props) {
   if (!component) return null;
 
   const handleInput = useCallback(
@@ -68,13 +69,19 @@ function ComponentEditor({ component, onChange }: Props) {
     <div className="space-y-2">
       <Input
         label="Width"
+        placeholder="e.g. 100px or 50%"
         value={component.width ?? ""}
-        onChange={(e) => handleInput("width", e.target.value)}
+        onChange={(e) =>
+          onResize({ width: e.target.value ? e.target.value : undefined })
+        }
       />
       <Input
         label="Height"
+        placeholder="e.g. 100px or 50%"
         value={component.height ?? ""}
-        onChange={(e) => handleInput("height", e.target.value)}
+        onChange={(e) =>
+          onResize({ height: e.target.value ? e.target.value : undefined })
+        }
       />
       <Input
         label="Margin"


### PR DESCRIPTION
## Summary
- add width/height placeholders and resize handling in `ComponentEditor`
- sync drag resizing with component state in `CanvasItem`
- normalize numeric dimensions to px in `PageBuilder` reducer
- document supported dimension units in `Page` types

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../components/organisms/StoreLocatorMap')*
- `pnpm exec eslint packages/ui/src/components/cms/page-builder/ComponentEditor.tsx packages/ui/src/components/cms/page-builder/CanvasItem.tsx packages/ui/src/components/cms/PageBuilder.tsx packages/types/src/Page.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897bfd36d50832faa13462b4402b8bb