### PR TITLE
refactor(ui): use theme tokens instead of gray utilities

### DIFF
--- a/packages/ui/src/components/atoms/ProductBadge.tsx
+++ b/packages/ui/src/components/atoms/ProductBadge.tsx
@@ -12,7 +12,7 @@ export const ProductBadge = React.forwardRef<
   ProductBadgeProps
 >(({ label, variant = "default", className, ...props }, ref) => {
   const variants: Record<string, string> = {
-    default: "bg-gray-200 text-gray-800",
+      default: "bg-muted text-fg",
     sale: "bg-red-500 text-white",
     new: "bg-green-500 text-white",
   };

--- a/packages/ui/src/components/atoms/RatingStars.tsx
+++ b/packages/ui/src/components/atoms/RatingStars.tsx
@@ -11,7 +11,7 @@ function Star({ filled, size = 16 }: { filled: boolean; size?: number }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className={filled ? "fill-yellow-500" : "fill-gray-300"}
+      className={filled ? "fill-yellow-500" : "fill-muted"}
       width={size}
       height={size}
     >

--- a/packages/ui/src/components/atoms/primitives/textarea.tsx
+++ b/packages/ui/src/components/atoms/primitives/textarea.tsx
@@ -41,7 +41,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const hasError = Boolean(error); // avoids 0 | 0n union in type-inference
 
     const baseClasses = cn(
-      "min-h-[6rem] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-900",
+      "min-h-[6rem] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 bg-bg",
       floatingLabel && "peer pt-5",
       hasError && "border-red-500",
       className

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -115,7 +115,7 @@ function PaymentForm({
       <button
         type="submit"
         disabled={!stripe || processing}
-        className="w-full rounded bg-gray-900 py-2 text-white disabled:opacity-50"
+        className="w-full rounded bg-fg py-2 text-bg disabled:opacity-50"
       >
         {processing ? t("checkout.processing") : t("checkout.pay")}
       </button>

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -94,7 +94,7 @@ function MediaManagerBase({
             openFileDialog();
           }
         }}
-        className={`flex h-32 cursor-pointer items-center justify-center rounded-md border-2 border-dashed border-gray-300 text-sm text-gray-500${
+        className={`flex h-32 cursor-pointer items-center justify-center rounded-md border-2 border-dashed border-muted text-sm text-muted${
           dragActive ? " highlighted" : ""
         }`}
       >
@@ -112,7 +112,7 @@ function MediaManagerBase({
       {/* Validation / progress feedback */}
       {error && <p className="text-sm text-red-600">{error}</p>}
       {progress && (
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-muted">
           Uploaded {progress.done}/{progress.total}
         </p>
       )}

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -90,7 +90,7 @@ export default function Sidebar({ role }: { role?: string }) {
 
   const dashboardBase = shop ? `/cms/shop/${shop}` : "/cms";
   return (
-    <aside className="w-56 shrink-0 border-r border-gray-200 dark:border-gray-800">
+    <aside className="w-56 shrink-0 border-r border-muted">
       <h1 className="px-4 py-6 text-lg font-semibold tracking-tight">CMS</h1>
       <nav className="flex flex-col gap-1 px-2">
         {links.map(({ href, label, icon, title }) => {
@@ -115,7 +115,7 @@ export default function Sidebar({ role }: { role?: string }) {
               href={fullHref}
               onClick={handleClick}
               aria-current={active ? "page" : undefined}
-              className={`focus-visible:ring-primary flex items-center gap-2 rounded-md px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none ${active ? "bg-primary/10 font-medium" : "hover:bg-gray-100 dark:hover:bg-gray-800"}`}
+              className={`focus-visible:ring-primary flex items-center gap-2 rounded-md px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none ${active ? "bg-primary/10 font-medium" : "hover:bg-muted"}`}
               title={title}
             >
               <span aria-hidden="true">{icon}</span>

--- a/packages/ui/src/components/cms/TopBar.client.tsx
+++ b/packages/ui/src/components/cms/TopBar.client.tsx
@@ -24,14 +24,14 @@ function TopBarInner() {
   const showNewPage = shop && last === "pages";
 
   return (
-    <header className="bg-background/60 flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-2 backdrop-blur dark:border-gray-800">
+    <header className="bg-background/60 flex items-center justify-between gap-3 border-b border-muted px-4 py-2 backdrop-blur">
       <div className="flex items-center gap-2">
         <Button variant="ghost" className="sm:hidden" onClick={toggleNav}>
           <span className="sr-only">Toggle navigation</span>☰
         </Button>
         <Link
           href="/cms"
-          className="focus-visible:ring-primary rounded-md px-3 py-2 text-sm hover:bg-gray-100 focus-visible:ring-2 focus-visible:outline-none dark:hover:bg-gray-800"
+          className="focus-visible:ring-primary rounded-md px-3 py-2 text-sm hover:bg-muted focus-visible:ring-2 focus-visible:outline-none"
         >
           Home
         </Link>

--- a/packages/ui/src/components/cms/blocks/BlogListing.tsx
+++ b/packages/ui/src/components/cms/blocks/BlogListing.tsx
@@ -16,7 +16,7 @@ export default function BlogListing({ posts = [] }: { posts?: BlogPost[] }) {
           ) : (
             <h3 className="text-lg font-semibold">{p.title}</h3>
           )}
-          {p.excerpt && <p className="text-gray-600">{p.excerpt}</p>}
+          {p.excerpt && <p className="text-muted">{p.excerpt}</p>}
         </article>
       ))}
     </section>

--- a/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
+++ b/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
@@ -23,7 +23,7 @@ export default function TestimonialSlider({
   return (
     <section className="space-y-2 text-center">
       <blockquote className="italic">“{t.quote}”</blockquote>
-      {t.name && <footer className="text-sm text-gray-600">— {t.name}</footer>}
+      {t.name && <footer className="text-sm text-muted">— {t.name}</footer>}
     </section>
   );
 }

--- a/packages/ui/src/components/cms/blocks/Testimonials.tsx
+++ b/packages/ui/src/components/cms/blocks/Testimonials.tsx
@@ -14,7 +14,7 @@ export default function Testimonials({
         <blockquote key={i} className="text-center">
           <p className="mb-2 italic">“{t.quote}”</p>
           {t.name && (
-            <footer className="text-sm text-gray-600">— {t.name}</footer>
+            <footer className="text-sm text-muted">— {t.name}</footer>
           )}
         </blockquote>
       ))}

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -70,10 +70,10 @@ export const PromoBanner = memo(function PromoBanner({
     typeof buttonLabel === "string" ? buttonLabel : (buttonLabel[locale] ?? "");
 
   return (
-    <div className="flex items-center justify-between bg-gray-900 p-4 text-white">
+    <div className="flex items-center justify-between bg-fg p-4 text-bg">
       <span>{txt}</span>
       {href && (
-        <a href={href} className="rounded bg-white px-3 py-1 text-gray-900">
+        <a href={href} className="rounded bg-bg px-3 py-1 text-fg">
           {label}
         </a>
       )}

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -283,7 +283,7 @@ const CanvasItem = memo(function CanvasItem({
       }
     >
       <div
-        className="absolute left-0 top-0 z-10 h-3 w-3 cursor-move bg-gray-200"
+        className="absolute left-0 top-0 z-10 h-3 w-3 cursor-move bg-muted"
         {...attributes}
         {...listeners}
         onPointerDown={(e) => {
@@ -364,7 +364,7 @@ const CanvasItem = memo(function CanvasItem({
             id={`container-${component.id}`}
             role="list"
             aria-dropeffect="move"
-            className="m-2 flex flex-col gap-4 border border-dashed border-gray-300 p-2"
+            className="m-2 flex flex-col gap-4 border border-dashed border-muted p-2"
           >
             {isOver && (
               <div

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -62,7 +62,7 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       );
       break;
     default:
-      specific = <p className="text-sm text-gray-500">No editable props</p>;
+      specific = <p className="text-sm text-muted">No editable props</p>;
   }
 
   return (

--- a/packages/ui/src/components/cms/products/ProductRowActions.tsx
+++ b/packages/ui/src/components/cms/products/ProductRowActions.tsx
@@ -27,7 +27,7 @@ export default function ProductRowActions({
       </Link>
       <Link
         href={`/en/product/${product.id}`}
-        className="rounded border px-2 py-1 text-xs hover:bg-gray-100 dark:hover:bg-gray-800"
+        className="rounded border px-2 py-1 text-xs hover:bg-muted"
       >
         View
       </Link>

--- a/packages/ui/src/components/home/HeroBanner.client.tsx
+++ b/packages/ui/src/components/home/HeroBanner.client.tsx
@@ -85,7 +85,7 @@ export default function HeroBanner({
         {/* locale-aware route link */}
         <Link
           href={`/${langPrefix}/shop`}
-          className="inline-block rounded-full bg-white px-[calc(var(--space-4)*2)] py-3 font-semibold text-gray-900 shadow-lg transition-colors hover:bg-gray-100"
+          className="inline-block rounded-full bg-fg px-[calc(var(--space-4)*2)] py-3 font-semibold text-bg shadow-lg transition-colors hover:bg-muted"
         >
           {t(slide.ctaKey)}
         </Link>

--- a/packages/ui/src/components/home/ReviewsCarousel.tsx
+++ b/packages/ui/src/components/home/ReviewsCarousel.tsx
@@ -33,12 +33,12 @@ export default function ReviewsCarousel({
   const { nameKey, quoteKey } = list[i];
 
   return (
-    <section className="bg-gray-50 py-16">
+    <section className="bg-muted py-16">
       <div className="mx-auto max-w-2xl px-4 text-center">
-        <blockquote className="mb-6 text-2xl font-medium text-gray-800 italic">
+        <blockquote className="mb-6 text-2xl font-medium text-fg italic">
           “{t(quoteKey)}”
         </blockquote>
-        <div className="font-semibold text-gray-600">— {t(nameKey)}</div>
+        <div className="font-semibold text-muted">— {t(nameKey)}</div>
       </div>
     </section>
   );

--- a/packages/ui/src/components/home/ValueProps.tsx
+++ b/packages/ui/src/components/home/ValueProps.tsx
@@ -34,7 +34,7 @@ function ValuePropsInner({ items = [] }: { items?: ValuePropItem[] }) {
         <article key={title} className="text-center">
           <div className="mb-4 text-4xl">{icon}</div>
           <h3 className="mb-2 text-xl font-semibold">{title}</h3>
-          <p className="text-gray-600">{desc}</p>
+          <p className="text-muted">{desc}</p>
         </article>
       ))}
     </section>

--- a/packages/ui/src/components/layout/Footer.tsx
+++ b/packages/ui/src/components/layout/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = memo(function Footer({
   return (
     <footer
       className={cn(
-        "flex items-center justify-center bg-gray-100 text-sm text-gray-500",
+        "flex items-center justify-center bg-muted text-sm text-muted",
         height,
         padding
       )}

--- a/packages/ui/src/components/molecules/LanguageSwitcher.tsx
+++ b/packages/ui/src/components/molecules/LanguageSwitcher.tsx
@@ -14,7 +14,7 @@ export default function LanguageSwitcher({ current }: { current: Locale }) {
           className={
             l === current
               ? "font-semibold underline"
-              : "text-gray-500 hover:underline"
+              : "text-muted hover:underline"
           }
         >
           {l.toUpperCase()}

--- a/packages/ui/src/components/molecules/RatingSummary.tsx
+++ b/packages/ui/src/components/molecules/RatingSummary.tsx
@@ -26,7 +26,7 @@ export const RatingSummary = React.forwardRef<
       <span className="text-sm">
         {rounded}
         {typeof count === "number" && (
-          <span className="text-gray-500"> ({count})</span>
+          <span className="text-muted"> ({count})</span>
         )}
       </span>
     </div>

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -50,7 +50,7 @@ function OrderSummary() {
             <td className="py-2">
               {line.sku.title}
               {line.size && (
-                <span className="ml-1 text-xs text-gray-500">
+                <span className="ml-1 text-xs text-muted">
                   ({line.size})
                 </span>
               )}

--- a/packages/ui/src/components/organisms/OrderTrackingTimeline.tsx
+++ b/packages/ui/src/components/organisms/OrderTrackingTimeline.tsx
@@ -44,7 +44,7 @@ export function OrderTrackingTimeline({
           </span>
           <p className="font-medium">{step.label}</p>
           {step.date && (
-            <time className="block text-sm text-gray-500">{step.date}</time>
+            <time className="block text-sm text-muted">{step.date}</time>
           )}
         </li>
       ))}

--- a/packages/ui/src/components/organisms/QAModule.tsx
+++ b/packages/ui/src/components/organisms/QAModule.tsx
@@ -21,7 +21,7 @@ export function QAModule({ items, className, ...props }: QAModuleProps) {
           <summary className="cursor-pointer font-medium group-open:mb-2">
             {qa.question}
           </summary>
-          <div className="text-sm text-gray-600">{qa.answer}</div>
+          <div className="text-sm text-muted">{qa.answer}</div>
         </details>
       ))}
     </div>

--- a/packages/ui/src/components/templates/MarketingEmailTemplate.tsx
+++ b/packages/ui/src/components/templates/MarketingEmailTemplate.tsx
@@ -57,7 +57,7 @@ export function MarketingEmailTemplate({
         )}
       </div>
       {footer && (
-        <div className="bg-muted border-t p-4 text-center text-xs text-gray-600">
+        <div className="bg-muted border-t p-4 text-center text-xs text-muted">
           {footer}
         </div>
       )}


### PR DESCRIPTION
## Summary
- replace `gray-*` Tailwind classes with token-based variants across UI components
- ensure backgrounds, borders, and text leverage `bg`, `fg`, and `muted` tokens for consistent theming

## Testing
- `pnpm lint -F @acme/ui` *(no tasks executed)*
- `pnpm test -F @acme/ui` *(fails: Cannot find module '../../scripts/release-deposits')*
- `pnpm tailwind:check` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897bc79465c832f85c185afab60e4a7