### PR TITLE
refactor: extract data root and theme token helpers

### DIFF
--- a/packages/platform-core/src/dataRoot.ts
+++ b/packages/platform-core/src/dataRoot.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+
+export function resolveDataRoot(): string {
+  let dir = process.cwd();
+  while (true) {
+    const candidate = path.join(dir, "data", "shops");
+    if (fsSync.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(process.cwd(), "data", "shops");
+}
+
+export const DATA_ROOT = resolveDataRoot();

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -4,3 +4,4 @@ export * from "./contexts/CurrencyContext";
 export * from "./contexts/LayoutContext";
 export * from "./contexts/ThemeContext";
 export * from "./defaultFilterMappings";
+export { loadThemeTokens } from "./themeTokens";

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -2,21 +2,9 @@ import "server-only";
 
 import type { PricingMatrix, SKU } from "@types";
 import { pricingSchema } from "@types";
-import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "./dataRoot";
 
 let cached: PricingMatrix | null = null;
 

--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -7,7 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../shops";
 
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 
 function inventoryPath(shop: string): string {
   shop = validateShopName(shop);

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -6,7 +6,7 @@ import { pageSchema, type Page } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../../../../lib/src/validateShopName";
-import { DATA_ROOT } from "../utils";
+import { DATA_ROOT } from "../../dataRoot";
 import { nowIso } from "@shared/date";
 
 /* -------------------------------------------------------------------------- */

--- a/packages/platform-core/src/repositories/pricing.server.ts
+++ b/packages/platform-core/src/repositories/pricing.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { pricingSchema, type PricingMatrix } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "./utils";
+import { resolveDataRoot } from "../dataRoot";
 
 function pricingPath(): string {
   return path.join(resolveDataRoot(), "..", "rental", "pricing.json");

--- a/packages/platform-core/src/repositories/products.server.ts
+++ b/packages/platform-core/src/repositories/products.server.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { ulid } from "ulid";
 import { ProductPublication } from "../products";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
 
 function filePath(shop: string): string {

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -7,7 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { ulid } from "ulid";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
 
 function ordersPath(shop: string): string {

--- a/packages/platform-core/src/repositories/returnLogistics.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { returnLogisticsSchema, type ReturnLogistics } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "./utils";
+import { resolveDataRoot } from "../dataRoot";
 
 function logisticsPath(): string {
   return path.join(resolveDataRoot(), "..", "return-logistics.json");

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -7,7 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
 const DEFAULT_LANGUAGES: Locale[] = [...LOCALES];
 

--- a/packages/platform-core/src/repositories/shop.server.ts
+++ b/packages/platform-core/src/repositories/shop.server.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { shopSchema, type Shop } from "@types";
 import { validateShopName } from "../shops";
 
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 
 function shopPath(shop: string): string {
   shop = validateShopName(shop);

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -6,7 +6,8 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { defaultFilterMappings } from "../defaultFilterMappings";
 import { validateShopName } from "../shops";
-import { DATA_ROOT, loadThemeTokens } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
+import { loadThemeTokens } from "../themeTokens";
 export {
   diffHistory,
   getShopSettings,

--- a/packages/platform-core/src/returnLogistics.ts
+++ b/packages/platform-core/src/returnLogistics.ts
@@ -1,20 +1,8 @@
 import type { ReturnLogistics } from "@types";
 import { returnLogisticsSchema } from "@types";
-import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-
-function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
+import { resolveDataRoot } from "./dataRoot";
 
 let cached: ReturnLogistics | null = null;
 

--- a/packages/platform-core/src/themeTokens.ts
+++ b/packages/platform-core/src/themeTokens.ts
@@ -1,22 +1,5 @@
 import "server-only";
 
-import * as fsSync from "node:fs";
-import * as path from "node:path";
-
-export function resolveDataRoot(): string {
-  let dir = process.cwd();
-  while (true) {
-    const candidate = path.join(dir, "data", "shops");
-    if (fsSync.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(process.cwd(), "data", "shops");
-}
-
-export const DATA_ROOT = resolveDataRoot();
-
 /**
  * Load Tailwind design tokens for the given theme.
  * Falls back to an empty object when the theme does not


### PR DESCRIPTION
## Summary
- move `resolveDataRoot`/`DATA_ROOT` into a new `dataRoot` module
- relocate asynchronous `loadThemeTokens` into a dedicated `themeTokens` helper and re-export it
- update repository modules to consume the new helpers and drop `repositories/utils`
- clear duplicate `resolveDataRoot` implementations

## Testing
- `pnpm --filter @acme/platform-core test -- repositories.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897b883d060832faeebf2055ef72d19