### PR TITLE
refactor: extract data root utilities

### DIFF
--- a/apps/cms/src/app/api/categories/[shop]/route.ts
+++ b/apps/cms/src/app/api/categories/[shop]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/api/import-products/[shop]/route.ts
+++ b/apps/cms/src/app/api/import-products/[shop]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/api/providers/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/[shop]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/cms/listShops.ts
+++ b/apps/cms/src/app/cms/listShops.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/listShops.ts
 
 import fs from "node:fs/promises";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 
 export async function listShops(): Promise<string[]> {
   const shopsDir = resolveDataRoot();

--- a/apps/cms/src/app/cms/page.tsx
+++ b/apps/cms/src/app/cms/page.tsx
@@ -11,7 +11,7 @@ import { getServerSession } from "next-auth";
 import Link from "next/link";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 
 export const metadata: Metadata = {
   title: "Dashboard · Base-Shop",

--- a/packages/lib/src/checkShopExists.server.ts
+++ b/packages/lib/src/checkShopExists.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "@platform-core/utils";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "./validateShopName";
 
 const DATA_ROOT = resolveDataRoot();

--- a/packages/platform-core/__tests__/resolveDataRoot.test.ts
+++ b/packages/platform-core/__tests__/resolveDataRoot.test.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { resolveDataRoot } from "../src/dataRoot";
+
+describe("resolveDataRoot", () => {
+  it("points to the monorepo data/shops directory", () => {
+    const dir = resolveDataRoot();
+    const expected = path.resolve(__dirname, "..", "..", "..", "data", "shops");
+    expect(dir).toBe(expected);
+  });
+});

--- a/packages/platform-core/src/dataRoot.ts
+++ b/packages/platform-core/src/dataRoot.ts
@@ -18,3 +18,4 @@ export function resolveDataRoot(): string {
   return path.resolve(process.cwd(), "data", "shops");
 }
 
+export const DATA_ROOT = resolveDataRoot();

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./contexts/LayoutContext";
 export * from "./contexts/ThemeContext";
 export * from "./defaultFilterMappings";
 export * from "./themeTokens";
+export * from "./dataRoot";

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -4,7 +4,7 @@ import type { PricingMatrix, SKU } from "@types";
 import { pricingSchema } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "./utils";
+import { resolveDataRoot } from "./dataRoot";
 
 let cached: PricingMatrix | null = null;
 

--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -7,7 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../shops";
 
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 
 function inventoryPath(shop: string): string {
   shop = validateShopName(shop);

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -6,7 +6,7 @@ import { pageSchema, type Page } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../../../../lib/src/validateShopName";
-import { DATA_ROOT } from "../utils";
+import { DATA_ROOT } from "../../dataRoot";
 import { nowIso } from "@shared/date";
 
 /* -------------------------------------------------------------------------- */

--- a/packages/platform-core/src/repositories/pricing.server.ts
+++ b/packages/platform-core/src/repositories/pricing.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { pricingSchema, type PricingMatrix } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "../utils";
+import { resolveDataRoot } from "../dataRoot";
 
 function pricingPath(): string {
   return path.join(resolveDataRoot(), "..", "rental", "pricing.json");
@@ -25,4 +25,3 @@ export async function writePricing(data: PricingMatrix): Promise<void> {
   await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
   await fs.rename(tmp, file);
 }
-

--- a/packages/platform-core/src/repositories/products.server.ts
+++ b/packages/platform-core/src/repositories/products.server.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { ulid } from "ulid";
 import { ProductPublication } from "../products";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
 
 function filePath(shop: string): string {

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -7,7 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { ulid } from "ulid";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
 
 function ordersPath(shop: string): string {

--- a/packages/platform-core/src/repositories/returnLogistics.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { returnLogisticsSchema, type ReturnLogistics } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "../utils";
+import { resolveDataRoot } from "../dataRoot";
 
 function logisticsPath(): string {
   return path.join(resolveDataRoot(), "..", "return-logistics.json");
@@ -18,11 +18,12 @@ export async function readReturnLogistics(): Promise<ReturnLogistics> {
   return parsed.data;
 }
 
-export async function writeReturnLogistics(data: ReturnLogistics): Promise<void> {
+export async function writeReturnLogistics(
+  data: ReturnLogistics
+): Promise<void> {
   const file = logisticsPath();
   const tmp = `${file}.${Date.now()}.tmp`;
   await fs.mkdir(path.dirname(file), { recursive: true });
   await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
   await fs.rename(tmp, file);
 }
-

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -7,7 +7,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
 const DEFAULT_LANGUAGES: Locale[] = [...LOCALES];
 

--- a/packages/platform-core/src/repositories/shop.server.ts
+++ b/packages/platform-core/src/repositories/shop.server.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { shopSchema, type Shop } from "@types";
 import { validateShopName } from "../shops";
 
-import { DATA_ROOT } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
 
 function shopPath(shop: string): string {
   shop = validateShopName(shop);

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -6,7 +6,8 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { defaultFilterMappings } from "../defaultFilterMappings";
 import { validateShopName } from "../shops";
-import { DATA_ROOT, loadThemeTokens } from "./utils";
+import { DATA_ROOT } from "../dataRoot";
+import { loadThemeTokens } from "../themeTokens";
 export {
   diffHistory,
   getShopSettings,

--- a/packages/platform-core/src/repositories/utils.ts
+++ b/packages/platform-core/src/repositories/utils.ts
@@ -1,6 +1,0 @@
-import "server-only";
-
-export { loadThemeTokens } from "../themeTokens";
-import { resolveDataRoot } from "../utils";
-
-export const DATA_ROOT = resolveDataRoot();

--- a/packages/platform-core/src/returnLogistics.ts
+++ b/packages/platform-core/src/returnLogistics.ts
@@ -2,7 +2,7 @@ import type { ReturnLogistics } from "@types";
 import { returnLogisticsSchema } from "@types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "./utils";
+import { resolveDataRoot } from "./dataRoot";
 
 let cached: ReturnLogistics | null = null;
 

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,3 +1,2 @@
 export { getShopFromPath } from "./getShopFromPath";
 export { replaceShopInPath } from "./replaceShopInPath";
-export { resolveDataRoot } from "./resolveDataRoot";


### PR DESCRIPTION
## Summary
- extract resolveDataRoot into dedicated module and remove legacy repository utils
- rehome loadThemeTokens via themeTokens barrel
- adjust imports across repos and add resolveDataRoot tests

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/resolveDataRoot.test.ts packages/platform-core/__tests__/themeTokens.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689841517fc4832fa32391515983211a