### PR TITLE
feat(ui): add min/max item props to templates

### DIFF
--- a/packages/ui/src/components/organisms/ProductGrid.tsx
+++ b/packages/ui/src/components/organisms/ProductGrid.tsx
@@ -4,7 +4,16 @@ import { Product, ProductCard } from "./ProductCard";
 
 export interface ProductGridProps extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
+  /**
+   * Explicit number of columns. If omitted, the grid will
+   * determine a responsive column count within the
+   * `minItems`/`maxItems` range based on its width.
+   */
   columns?: number;
+  /** Minimum number of items to show per row */
+  minItems?: number;
+  /** Maximum number of items to show per row */
+  maxItems?: number;
   showImage?: boolean;
   showPrice?: boolean;
   ctaLabel?: string;
@@ -13,7 +22,9 @@ export interface ProductGridProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export function ProductGrid({
   products,
-  columns = 3,
+  columns,
+  minItems = 1,
+  maxItems = 4,
   showImage = true,
   showPrice = true,
   ctaLabel = "Add to cart",
@@ -21,11 +32,36 @@ export function ProductGrid({
   className,
   ...props
 }: ProductGridProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [cols, setCols] = React.useState(columns ?? minItems);
+
+  React.useEffect(() => {
+    if (columns || typeof ResizeObserver === "undefined" || !containerRef.current)
+      return;
+    const el = containerRef.current;
+    const ITEM_WIDTH = 250;
+    const update = () => {
+      const width = el.clientWidth;
+      const ideal = Math.floor(width / ITEM_WIDTH) || 1;
+      const clamped = Math.max(minItems, Math.min(maxItems, ideal));
+      setCols(clamped);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [columns, minItems, maxItems]);
+
   const style = {
-    gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${columns ?? cols}, minmax(0, 1fr))`,
   } as React.CSSProperties;
   return (
-    <div className={cn("grid gap-6", className)} style={style} {...props}>
+    <div
+      ref={containerRef}
+      className={cn("grid gap-6", className)}
+      style={style}
+      {...props}
+    >
       {products.map((p) => (
         <ProductCard
           key={p.id}

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
-import { cn } from "../../utils/cn";
-import { Product, ProductCard } from "../organisms/ProductCard";
+import { Product } from "../organisms/ProductCard";
 import { ProductCarousel } from "../organisms/ProductCarousel";
+import { ProductGrid } from "../organisms/ProductGrid";
 
 export interface ProductGalleryTemplateProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
   useCarousel?: boolean;
-  /** Minimum items to show when using the carousel */
+  /** Minimum items to show per row or slide */
   minItems?: number;
-  /** Maximum items to show when using the carousel */
+  /** Maximum items to show per row or slide */
   maxItems?: number;
 }
 
@@ -36,13 +36,12 @@ export function ProductGalleryTemplate({
     );
   }
   return (
-    <div
-      className={cn("grid gap-6 sm:grid-cols-2 lg:grid-cols-3", className)}
+    <ProductGrid
+      products={products}
+      minItems={minItems}
+      maxItems={maxItems}
+      className={className}
       {...props}
-    >
-      {products.map((p) => (
-        <ProductCard key={p.id} product={p} />
-      ))}
-    </div>
+    />
   );
 }

--- a/packages/ui/src/components/templates/README.md
+++ b/packages/ui/src/components/templates/README.md
@@ -7,14 +7,17 @@ Shared page-level layouts used across apps. Currently includes:
   navigation state are available via `useLayout()`.
   - `DashboardTemplate` – basic stats overview.
 - `AnalyticsDashboardTemplate` – stats, line chart and table for dashboards.
-- `ProductGalleryTemplate` – grid or carousel listing of products.
+- `ProductGalleryTemplate` – grid or carousel listing of products. Supports
+  `minItems` and `maxItems` to control the responsive number of items per row
+  or slide.
 - `ProductDetailTemplate` – hero-style view for a single product.
 - `FeaturedProductTemplate` – showcase layout for highlighting a product.
 - `ProductComparisonTemplate` – side-by-side view of multiple products.
 - `HomepageTemplate` – layout with hero and recommendation slots.
 - `CartTemplate` – editable list of cart items with totals.
 - `CategoryCollectionTemplate` – grid of category cards.
-- `SearchResultsTemplate` – search bar with paginated product results.
+- `SearchResultsTemplate` – search bar with paginated product results. Accepts
+  `minItems` and `maxItems` to adjust the responsive product grid.
 - `CheckoutTemplate` – multi-step layout for collecting checkout information.
 - `OrderConfirmationTemplate` – summary of purchased items and totals.
 - `WishlistTemplate` – list of saved items with add-to-cart and remove actions.

--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -11,6 +11,10 @@ export interface SearchResultsTemplateProps
   results: Product[];
   page: number;
   pageCount: number;
+  /** Minimum items to show per row */
+  minItems?: number;
+  /** Maximum items to show per row */
+  maxItems?: number;
   onQueryChange?: (query: string) => void;
   onPageChange?: (page: number) => void;
 }
@@ -20,6 +24,8 @@ export function SearchResultsTemplate({
   results,
   page,
   pageCount,
+  minItems,
+  maxItems,
   onQueryChange,
   onPageChange,
   className,
@@ -33,7 +39,11 @@ export function SearchResultsTemplate({
         placeholder="Search products…"
       />
       {results.length > 0 ? (
-        <ProductGrid products={results} />
+        <ProductGrid
+          products={results}
+          minItems={minItems}
+          maxItems={maxItems}
+        />
       ) : (
         <p>No results found.</p>
       )}


### PR DESCRIPTION
## Summary
- allow templates to pass min/max item counts to ProductGrid/ProductCarousel
- wire min/max items through ProductGalleryTemplate and SearchResultsTemplate
- document min/max options for product templates

## Testing
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/src` *(fails: Test Suites: 3 failed, 7 passed, 10 total)*

------
https://chatgpt.com/codex/tasks/task_e_6898412bfc98832fbdd95b4c2a44cfb6