### PR TITLE
Enforce strict validation on cart and CMS schemas

### DIFF
--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -15,7 +15,8 @@ export const productSchema = z
     id: z.string(),
     price: z.coerce.number().min(0, "Invalid price"),
   })
-  .extend(localeFields);
+  .extend(localeFields)
+  .strict();
 
 const jsonRecord = z
   .string()
@@ -30,25 +31,27 @@ const jsonRecord = z
     }
   });
 
-export const shopSchema = z.object({
-  id: z.string(),
-  name: z.string().min(1, "Required"),
-  themeId: z.string().min(1, "Required"),
-  catalogFilters: z
-    .string()
-    .optional()
-    .default("")
-    .transform((s) =>
-      s
-        .split(/,\s*/)
-        .map((v) => v.trim())
-        .filter(Boolean)
-    ),
-  themeTokens: jsonRecord,
-  filterMappings: jsonRecord,
-  priceOverrides: jsonRecord,
-  localeOverrides: jsonRecord,
-});
+export const shopSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().min(1, "Required"),
+    themeId: z.string().min(1, "Required"),
+    catalogFilters: z
+      .string()
+      .optional()
+      .default("")
+      .transform((s) =>
+        s
+          .split(/,\s*/)
+          .map((v) => v.trim())
+          .filter(Boolean)
+      ),
+    themeTokens: jsonRecord,
+    filterMappings: jsonRecord,
+    priceOverrides: jsonRecord,
+    localeOverrides: jsonRecord,
+  })
+  .strict();
 
 export type ProductForm = z.infer<typeof productSchema>;
 export type ShopForm = z.infer<typeof shopSchema>;

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -68,20 +68,22 @@ export async function getSettings(shop: string) {
   return getShopSettings(shop);
 }
 
-const seoSchema = z.object({
-  locale: z.string(),
-  title: z.string().min(1, "Required"),
-  description: z.string().optional().default(""),
-  image: z
-    .string()
-    .optional()
-    .refine((v) => !v || /^https?:\/\/\S+$/.test(v), {
-      message: "Invalid image URL",
-    }),
-  canonicalBase: z.string().url().optional(),
-  ogUrl: z.string().url().optional(),
-  twitterCard: z.string().optional(),
-});
+const seoSchema = z
+  .object({
+    locale: z.string(),
+    title: z.string().min(1, "Required"),
+    description: z.string().optional().default(""),
+    image: z
+      .string()
+      .optional()
+      .refine((v) => !v || /^https?:\/\/\S+$/.test(v), {
+        message: "Invalid image URL",
+      }),
+    canonicalBase: z.string().url().optional(),
+    ogUrl: z.string().url().optional(),
+    twitterCard: z.string().optional(),
+  })
+  .strict();
 
 export async function updateSeo(
   shop: string,

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -54,12 +54,14 @@ export interface NavItem {
 
 const _navItemSchema: z.ZodType<NavItem> = z.lazy(
   () =>
-    z.object({
-      id: z.string(),
-      label: z.string(),
-      url: z.string(),
-      children: z.array(_navItemSchema).optional(),
-    }) as z.ZodType<NavItem>
+    z
+      .object({
+        id: z.string(),
+        label: z.string(),
+        url: z.string(),
+        children: z.array(_navItemSchema).optional(),
+      })
+      .strict() as z.ZodType<NavItem>
 );
 
 export const navItemSchema = _navItemSchema as unknown as z.ZodType<
@@ -72,17 +74,19 @@ export const navItemSchema = _navItemSchema as unknown as z.ZodType<
 /*  Page‑info schema                                                          */
 /* -------------------------------------------------------------------------- */
 
-export const pageInfoSchema = z.object({
-  id: z.string().optional(),
-  /** `slug` is **required** so routing can never break. */
-  slug: z.string(),
-  /** All locale keys are required – no `Partial`. */
-  title: localeRecordSchema,
-  description: localeRecordSchema,
-  image: localeRecordSchema,
-  /** Components are serialised PageComponent instances. */
-  components: z.array(pageComponentSchema).default([]),
-});
+export const pageInfoSchema = z
+  .object({
+    id: z.string().optional(),
+    /** `slug` is **required** so routing can never break. */
+    slug: z.string(),
+    /** All locale keys are required – no `Partial`. */
+    title: localeRecordSchema,
+    description: localeRecordSchema,
+    image: localeRecordSchema,
+    /** Components are serialised PageComponent instances. */
+    components: z.array(pageComponentSchema).default([]),
+  })
+  .strict();
 
 export type PageInfo = z.infer<typeof pageInfoSchema>; // <- slug & components **required**
 
@@ -156,6 +160,6 @@ export const wizardStateSchema = z.object({
   newPageLayout: z.string().optional().default(""),
   domain: z.string().optional().default(""),
   categoriesText: z.string().optional().default(""),
-});
+}).strict();
 
 export type WizardState = z.infer<typeof wizardStateSchema>;

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -13,15 +13,19 @@ import { z } from "zod";
 
 export const runtime = "edge";
 
-const postSchema = z.object({
-  sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-  qty: z.number().int().positive().optional(),
-});
+const postSchema = z
+  .object({
+    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
+    qty: z.number().int().positive().optional(),
+  })
+  .strict();
 
-const patchSchema = z.object({
-  id: z.string(),
-  qty: z.number().int().positive(),
-});
+const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.number().int().positive(),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const json = await req.json();

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -16,15 +16,19 @@ export const runtime = "edge";
 // This simple handler echoes back the posted body and status 200.
 // Stripe / KV integration will extend this in Sprint 5.
 
-const postSchema = z.object({
-  sku: skuSchema,
-  qty: z.number().int().positive().optional(),
-});
+const postSchema = z
+  .object({
+    sku: skuSchema,
+    qty: z.number().int().positive().optional(),
+  })
+  .strict();
 
-const patchSchema = z.object({
-  id: z.string(),
-  qty: z.number().int().positive(),
-});
+const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.number().int().positive(),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const json = await req.json();

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -16,15 +16,19 @@ export const runtime = "edge";
 /* ------------------------------------------------------------------
  * Zod schemas for request bodies
  * ------------------------------------------------------------------ */
-const postSchema = z.object({
-  sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-  qty: z.number().int().positive().optional(),
-});
+const postSchema = z
+  .object({
+    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
+    qty: z.number().int().positive().optional(),
+  })
+  .strict();
 
-const patchSchema = z.object({
-  id: z.string(),
-  qty: z.number().int().positive(),
-});
+const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.number().int().positive(),
+  })
+  .strict();
 
 /* ------------------------------------------------------------------
  * POST – add an item to the cart


### PR DESCRIPTION
## Summary
- enforce strict Zod validation on cart API schemas across shops and template app
- tighten CMS product and shop forms with strict schemas
- apply strict validation to SEO, navigation, and wizard state schemas

## Testing
- `pnpm test` (failed: 5 failed tests in apps/cms)
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6897b8aa4690832f8b834ca3b3230944