### PR TITLE
refactor: add reusable array toggle utility

### DIFF
--- a/packages/ui/src/components/cms/DataTable.js
+++ b/packages/ui/src/components/cms/DataTable.js
@@ -1,19 +1,14 @@
 "use client";
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { useState } from "react";
+import { toggleItem } from "@ui/utils/toggleItem";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, } from "../atoms/shadcn/Table";
 export default function DataTable({ rows, columns, selectable = false, onSelectionChange, }) {
-    const [selected, setSelected] = useState(new Set());
+    const [selected, setSelected] = useState([]);
     const toggle = (idx) => {
-        const next = new Set(selected);
-        if (next.has(idx)) {
-            next.delete(idx);
-        }
-        else {
-            next.add(idx);
-        }
+        const next = toggleItem(selected, idx);
         setSelected(next);
-        onSelectionChange?.(Array.from(next).map((i) => rows[i]));
+        onSelectionChange?.(next.map((i) => rows[i]));
     };
-    return (_jsx("div", { className: "overflow-x-auto", children: _jsxs(Table, { className: "min-w-full", children: [_jsx(TableHeader, { children: _jsxs(TableRow, { children: [selectable && _jsx(TableHead, { className: "w-4" }), columns.map((col) => (_jsx(TableHead, { style: { width: col.width }, children: col.header }, col.header)))] }) }), _jsx(TableBody, { children: rows.map((row, i) => (_jsxs(TableRow, { "data-state": selected.has(i) ? "selected" : undefined, onClick: selectable ? () => toggle(i) : undefined, className: selectable ? "cursor-pointer" : undefined, children: [selectable && (_jsx(TableCell, { className: "w-4", children: _jsx("input", { type: "checkbox", className: "accent-primary size-4", checked: selected.has(i), onChange: () => toggle(i), onClick: (e) => e.stopPropagation() }) })), columns.map((col) => (_jsx(TableCell, { children: col.render(row) }, col.header)))] }, i))) })] }) }));
+    return (_jsx("div", { className: "overflow-x-auto", children: _jsxs(Table, { className: "min-w-full", children: [_jsx(TableHeader, { children: _jsxs(TableRow, { children: [selectable && _jsx(TableHead, { className: "w-4" }), columns.map((col) => (_jsx(TableHead, { style: { width: col.width }, children: col.header }, col.header)))] }) }), _jsx(TableBody, { children: rows.map((row, i) => (_jsxs(TableRow, { "data-state": selected.includes(i) ? "selected" : undefined, onClick: selectable ? () => toggle(i) : undefined, className: selectable ? "cursor-pointer" : undefined, children: [selectable && (_jsx(TableCell, { className: "w-4", children: _jsx("input", { type: "checkbox", className: "accent-primary size-4", checked: selected.includes(i), onChange: () => toggle(i), onClick: (e) => e.stopPropagation() }) })), columns.map((col) => (_jsx(TableCell, { children: col.render(row) }, col.header)))] }, i))) })] }) }));
 }

--- a/packages/ui/src/components/cms/DataTable.tsx
+++ b/packages/ui/src/components/cms/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useState } from "react";
+import { toggleItem } from "@ui/utils/toggleItem";
 import {
   Table,
   TableBody,
@@ -30,17 +31,12 @@ export default function DataTable<T>({
   selectable = false,
   onSelectionChange,
 }: DataTableProps<T>) {
-  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<number[]>([]);
 
   const toggle = (idx: number) => {
-    const next = new Set(selected);
-    if (next.has(idx)) {
-      next.delete(idx);
-    } else {
-      next.add(idx);
-    }
+    const next = toggleItem(selected, idx);
     setSelected(next);
-    onSelectionChange?.(Array.from(next).map((i) => rows[i]));
+    onSelectionChange?.(next.map((i) => rows[i]));
   };
 
   return (
@@ -61,7 +57,7 @@ export default function DataTable<T>({
           {rows.map((row, i) => (
             <TableRow
               key={i}
-              data-state={selected.has(i) ? "selected" : undefined}
+              data-state={selected.includes(i) ? "selected" : undefined}
               onClick={selectable ? () => toggle(i) : undefined}
               className={selectable ? "cursor-pointer" : undefined}
             >
@@ -70,7 +66,7 @@ export default function DataTable<T>({
                   <input
                     type="checkbox"
                     className="accent-primary size-4"
-                    checked={selected.has(i)}
+                    checked={selected.includes(i)}
                     onChange={() => toggle(i)}
                     onClick={(e) => e.stopPropagation()}
                   />

--- a/packages/ui/src/components/cms/PublishLocationSelector.js
+++ b/packages/ui/src/components/cms/PublishLocationSelector.js
@@ -4,16 +4,14 @@ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-run
 import { Button, Input } from "@/components/atoms/shadcn";
 import { usePublishLocations } from "@ui/hooks/usePublishLocations";
 import { memo, useCallback } from "react";
+import { toggleItem } from "@ui/utils/toggleItem";
 const equal = (p, n) => p.selectedIds === n.selectedIds &&
     p.onChange === n.onChange &&
     p.showReload === n.showReload;
 function PublishLocationSelectorInner({ selectedIds, onChange, showReload = false, }) {
     const { locations, reload } = usePublishLocations();
     const toggle = useCallback((id) => {
-        const idx = selectedIds.indexOf(id);
-        const next = idx === -1
-            ? [...selectedIds, id]
-            : [...selectedIds.slice(0, idx), ...selectedIds.slice(idx + 1)];
+        const next = toggleItem(selectedIds, id);
         onChange(next);
     }, [selectedIds, onChange]);
     return (_jsxs(_Fragment, { children: [_jsx("div", { className: "flex flex-col gap-2", children: locations.map(({ id, name, description, requiredOrientation }) => (_jsxs("label", { className: "flex cursor-pointer items-start gap-2 select-none", children: [_jsx(Input, { type: "checkbox", checked: selectedIds.includes(id), onChange: () => toggle(id), className: "mt-1 h-4 w-4" }), _jsxs("span", { children: [_jsx("span", { className: "font-medium", children: name }), _jsxs("span", { className: "text-muted-foreground ml-1 text-xs", children: ["(", requiredOrientation, ")"] }), description && (_jsxs(_Fragment, { children: [_jsx("br", {}), _jsx("span", { className: "text-muted-foreground text-sm", children: description })] }))] })] }, id))) }), showReload && (_jsx(Button, { type: "button", onClick: reload, variant: "outline", className: "mt-4 inline-flex items-center rounded-2xl p-2 text-sm shadow", children: "Refresh list" }))] }));

--- a/packages/ui/src/components/cms/PublishLocationSelector.tsx
+++ b/packages/ui/src/components/cms/PublishLocationSelector.tsx
@@ -5,6 +5,7 @@ import { Button, Input } from "@/components/atoms/shadcn";
 import type { PublishLocation } from "@types";
 import { usePublishLocations } from "@ui/hooks/usePublishLocations";
 import { memo, useCallback } from "react";
+import { toggleItem } from "@ui/utils/toggleItem";
 
 export interface PublishLocationSelectorProps {
   selectedIds: string[];
@@ -29,11 +30,7 @@ function PublishLocationSelectorInner({
 
   const toggle = useCallback(
     (id: string) => {
-      const idx = selectedIds.indexOf(id);
-      const next =
-        idx === -1
-          ? [...selectedIds, id]
-          : [...selectedIds.slice(0, idx), ...selectedIds.slice(idx + 1)];
+      const next = toggleItem(selectedIds, id);
       onChange(next);
     },
     [selectedIds, onChange]

--- a/packages/ui/src/components/organisms/DataTable.js
+++ b/packages/ui/src/components/organisms/DataTable.js
@@ -1,19 +1,14 @@
 "use client";
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { useState } from "react";
+import { toggleItem } from "@ui/utils/toggleItem";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, } from "../atoms/primitives/table";
 export function DataTable({ rows, columns, selectable = false, onSelectionChange, }) {
-    const [selected, setSelected] = useState(new Set());
+    const [selected, setSelected] = useState([]);
     const toggle = (idx) => {
-        const next = new Set(selected);
-        if (next.has(idx)) {
-            next.delete(idx);
-        }
-        else {
-            next.add(idx);
-        }
+        const next = toggleItem(selected, idx);
         setSelected(next);
-        onSelectionChange?.(Array.from(next).map((i) => rows[i]));
+        onSelectionChange?.(next.map((i) => rows[i]));
     };
-    return (_jsx("div", { className: "overflow-x-auto", children: _jsxs(Table, { className: "min-w-full", children: [_jsx(TableHeader, { children: _jsxs(TableRow, { children: [selectable && _jsx(TableHead, { className: "w-4" }), columns.map((col) => (_jsx(TableHead, { style: { width: col.width }, children: col.header }, col.header)))] }) }), _jsx(TableBody, { children: rows.map((row, i) => (_jsxs(TableRow, { "data-state": selected.has(i) ? "selected" : undefined, onClick: selectable ? () => toggle(i) : undefined, className: selectable ? "cursor-pointer" : undefined, children: [selectable && (_jsx(TableCell, { className: "w-4", children: _jsx("input", { type: "checkbox", className: "accent-primary size-4", checked: selected.has(i), onChange: () => toggle(i), onClick: (e) => e.stopPropagation() }) })), columns.map((col) => (_jsx(TableCell, { children: col.render(row) }, col.header)))] }, i))) })] }) }));
+    return (_jsx("div", { className: "overflow-x-auto", children: _jsxs(Table, { className: "min-w-full", children: [_jsx(TableHeader, { children: _jsxs(TableRow, { children: [selectable && _jsx(TableHead, { className: "w-4" }), columns.map((col) => (_jsx(TableHead, { style: { width: col.width }, children: col.header }, col.header)))] }) }), _jsx(TableBody, { children: rows.map((row, i) => (_jsxs(TableRow, { "data-state": selected.includes(i) ? "selected" : undefined, onClick: selectable ? () => toggle(i) : undefined, className: selectable ? "cursor-pointer" : undefined, children: [selectable && (_jsx(TableCell, { className: "w-4", children: _jsx("input", { type: "checkbox", className: "accent-primary size-4", checked: selected.includes(i), onChange: () => toggle(i), onClick: (e) => e.stopPropagation() }) })), columns.map((col) => (_jsx(TableCell, { children: col.render(row) }, col.header)))] }, i))) })] }) }));
 }

--- a/packages/ui/src/components/organisms/DataTable.tsx
+++ b/packages/ui/src/components/organisms/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useState } from "react";
+import { toggleItem } from "@ui/utils/toggleItem";
 import {
   Table,
   TableBody,
@@ -29,17 +30,12 @@ export function DataTable<T>({
   selectable = false,
   onSelectionChange,
 }: DataTableProps<T>) {
-  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<number[]>([]);
 
   const toggle = (idx: number) => {
-    const next = new Set(selected);
-    if (next.has(idx)) {
-      next.delete(idx);
-    } else {
-      next.add(idx);
-    }
+    const next = toggleItem(selected, idx);
     setSelected(next);
-    onSelectionChange?.(Array.from(next).map((i) => rows[i]));
+    onSelectionChange?.(next.map((i) => rows[i]));
   };
 
   return (
@@ -59,7 +55,7 @@ export function DataTable<T>({
           {rows.map((row, i) => (
             <TableRow
               key={i}
-              data-state={selected.has(i) ? "selected" : undefined}
+              data-state={selected.includes(i) ? "selected" : undefined}
               onClick={selectable ? () => toggle(i) : undefined}
               className={selectable ? "cursor-pointer" : undefined}
             >
@@ -68,7 +64,7 @@ export function DataTable<T>({
                   <input
                     type="checkbox"
                     className="accent-primary size-4"
-                    checked={selected.has(i)}
+                    checked={selected.includes(i)}
                     onChange={() => toggle(i)}
                     onClick={(e) => e.stopPropagation()}
                   />

--- a/packages/ui/src/utils/__tests__/utils.test.js
+++ b/packages/ui/src/utils/__tests__/utils.test.js
@@ -2,6 +2,7 @@ import { boxProps } from "../boxProps";
 import { cn } from "../cn";
 import { drawerWidthProps } from "../drawerWidth";
 import { parseMultilingualInput } from "../multilingual";
+import { toggleItem } from "../toggleItem";
 describe("cn", () => {
     it("filters out falsey values", () => {
         expect(cn("a", "", false, null, undefined, "b")).toBe("a b");
@@ -48,5 +49,14 @@ describe("parseMultilingualInput", () => {
     });
     it("returns null for invalid input", () => {
         expect(parseMultilingualInput("foo_en", locales)).toBeNull();
+    });
+});
+
+describe("toggleItem", () => {
+    it("adds the value when not present", () => {
+        expect(toggleItem([1, 2], 3)).toEqual([1, 2, 3]);
+    });
+    it("removes the value when present", () => {
+        expect(toggleItem([1, 2, 3], 2)).toEqual([1, 3]);
     });
 });

--- a/packages/ui/src/utils/__tests__/utils.test.ts
+++ b/packages/ui/src/utils/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import { boxProps } from "../boxProps";
 import { cn } from "../cn";
 import { drawerWidthProps } from "../drawerWidth";
 import { parseMultilingualInput } from "../multilingual";
+import { toggleItem } from "../toggleItem";
 
 describe("cn", () => {
   it("filters out falsey values", () => {
@@ -57,5 +58,15 @@ describe("parseMultilingualInput", () => {
 
   it("returns null for invalid input", () => {
     expect(parseMultilingualInput("foo_en", locales)).toBeNull();
+  });
+});
+
+describe("toggleItem", () => {
+  it("adds the value when not present", () => {
+    expect(toggleItem([1, 2], 3)).toEqual([1, 2, 3]);
+  });
+
+  it("removes the value when present", () => {
+    expect(toggleItem([1, 2, 3], 2)).toEqual([1, 3]);
   });
 });

--- a/packages/ui/src/utils/toggleItem.d.ts
+++ b/packages/ui/src/utils/toggleItem.d.ts
@@ -1,0 +1,2 @@
+export declare function toggleItem<T>(array: readonly T[], value: T): T[];
+//# sourceMappingURL=toggleItem.d.ts.map

--- a/packages/ui/src/utils/toggleItem.d.ts.map
+++ b/packages/ui/src/utils/toggleItem.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"toggleItem.d.ts","sourceRoot":"","sources":["toggleItem.ts"],"names":[],"mappings":"AAAA,wBAAgB,UAAU,CAAC,CAAC,EAAE,KAAK,EAAE,SAAS,CAAC,EAAE,EAAE,KAAK,EAAE,CAAC,GAAG,CAAC,EAAE,CAKhE"}

--- a/packages/ui/src/utils/toggleItem.js
+++ b/packages/ui/src/utils/toggleItem.js
@@ -1,0 +1,6 @@
+export function toggleItem(array, value) {
+    const index = array.indexOf(value);
+    return index === -1
+        ? [...array, value]
+        : [...array.slice(0, index), ...array.slice(index + 1)];
+}

--- a/packages/ui/src/utils/toggleItem.ts
+++ b/packages/ui/src/utils/toggleItem.ts
@@ -1,0 +1,6 @@
+export function toggleItem<T>(array: readonly T[], value: T): T[] {
+  const index = array.indexOf(value);
+  return index === -1
+    ? [...array, value]
+    : [...array.slice(0, index), ...array.slice(index + 1)];
+}


### PR DESCRIPTION
## Summary
- add `toggleItem` helper for array value toggling
- refactor DataTable and PublishLocationSelector to use shared toggle helper
- add unit tests for the helper

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../components/cms/DataTable' from 'packages/ui/__tests__/DataTable.test.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6897b888bc14832f952b8d2ccaa5a1d4