### PR TITLE
test(ui): add ThemeToggle tests

### DIFF
--- a/packages/ui/__tests__/ThemeToggle.test.tsx
+++ b/packages/ui/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ThemeToggle from "../src/components/ThemeToggle";
+
+const setTheme = jest.fn();
+let mockTheme = "base";
+
+jest.mock("@platform-core/src/contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: mockTheme, setTheme }),
+}));
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    setTheme.mockClear();
+    mockTheme = "base";
+  });
+
+  it("switches label and theme between Dark and Light", () => {
+    const { rerender } = render(<ThemeToggle />);
+
+    let button = screen.getByRole("button", { name: /toggle theme/i });
+    expect(button).toHaveTextContent("Dark");
+
+    fireEvent.click(button);
+    expect(setTheme).toHaveBeenNthCalledWith(1, "dark");
+
+    mockTheme = "dark";
+    rerender(<ThemeToggle />);
+    button = screen.getByRole("button", { name: /toggle theme/i });
+    expect(button).toHaveTextContent("Light");
+
+    fireEvent.click(button);
+    expect(setTheme).toHaveBeenNthCalledWith(2, "base");
+
+    mockTheme = "base";
+    rerender(<ThemeToggle />);
+    button = screen.getByRole("button", { name: /toggle theme/i });
+    expect(button).toHaveTextContent("Dark");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for ThemeToggle toggling between dark and base themes

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/ThemeToggle.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689859e683d8832f9a84e54e154e4f4a