### PR TITLE
test: add shop validation and existence tests

### DIFF
--- a/packages/lib/__tests__/checkShopExists.server.test.ts
+++ b/packages/lib/__tests__/checkShopExists.server.test.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from 'node:fs';
+
+jest.mock('@platform-core/dataRoot', () => ({
+  resolveDataRoot: jest.fn(() => '/data/root'),
+}));
+
+jest.mock('node:fs', () => ({
+  promises: {
+    stat: jest.fn(),
+  },
+}));
+
+import { checkShopExists } from '../src/checkShopExists.server';
+
+describe('checkShopExists', () => {
+  const statMock = fs.stat as jest.Mock;
+
+  afterEach(() => {
+    statMock.mockReset();
+  });
+
+  it('returns true when directory exists', async () => {
+    statMock.mockResolvedValue({ isDirectory: () => true });
+    await expect(checkShopExists('shop')).resolves.toBe(true);
+  });
+
+  it('returns false when directory does not exist', async () => {
+    statMock.mockRejectedValue(new Error('ENOENT'));
+    await expect(checkShopExists('shop')).resolves.toBe(false);
+  });
+});

--- a/packages/lib/__tests__/validateShopName.test.ts
+++ b/packages/lib/__tests__/validateShopName.test.ts
@@ -1,0 +1,16 @@
+import { validateShopName } from '../src/validateShopName';
+
+describe('validateShopName', () => {
+  it('accepts valid shop names', () => {
+    expect(validateShopName('shop-name_123')).toBe('shop-name_123');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(validateShopName('  shop  ')).toBe('shop');
+  });
+
+  it('throws for invalid names', () => {
+    expect(() => validateShopName('bad name')).toThrow('Invalid shop name');
+    expect(() => validateShopName('bad/name')).toThrow('Invalid shop name');
+  });
+});


### PR DESCRIPTION
## Summary
- test shop existence by mocking fs/stat and data root
- validate shop names including trimming and invalid cases

## Testing
- `pnpm exec jest packages/lib/__tests__/checkShopExists.server.test.ts packages/lib/__tests__/validateShopName.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689859e161ac832f8ff4455d8acee81a