### PR TITLE
test: add default filter mappings test

### DIFF
--- a/packages/platform-core/__tests__/defaultFilterMappings.test.ts
+++ b/packages/platform-core/__tests__/defaultFilterMappings.test.ts
@@ -1,0 +1,21 @@
+// packages/platform-core/__tests__/defaultFilterMappings.test.ts
+
+import { defaultFilterMappings } from "../defaultFilterMappings";
+
+describe("defaultFilterMappings", () => {
+  it("contains required keys and values", () => {
+    expect(defaultFilterMappings).toHaveProperty("brand", "brand");
+    expect(defaultFilterMappings).toHaveProperty("size", "size");
+    expect(defaultFilterMappings).toHaveProperty("color", "color");
+  });
+
+  it("is immutable when frozen", () => {
+    Object.freeze(defaultFilterMappings);
+    expect(Object.isFrozen(defaultFilterMappings)).toBe(true);
+    expect(() => {
+      (defaultFilterMappings as any).brand = "foo";
+    }).toThrow(TypeError);
+    expect(defaultFilterMappings.brand).toBe("brand");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test for default filter mappings ensuring required keys and values
- verify the filter mapping object is immutable when frozen

## Testing
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/defaultFilterMappings.test.ts` *(fails: ReferenceError: server is not defined)*
- `pnpm exec tsx /tmp/checkDefaultFilterMappings.ts`

------
https://chatgpt.com/codex/tasks/task_e_689859e5462c832f9832514f4318aa43