### PR TITLE
test: cover fetchJson utility

### DIFF
--- a/packages/ui/src/utils/__tests__/fetchJson.test.ts
+++ b/packages/ui/src/utils/__tests__/fetchJson.test.ts
@@ -1,0 +1,57 @@
+import { fetchJson } from '../fetchJson';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns parsed data on success', async () => {
+    const responseData = { message: 'ok' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(JSON.stringify(responseData)),
+    });
+
+    await expect(fetchJson<typeof responseData>('https://example.com'))
+      .resolves.toEqual(responseData);
+  });
+
+  it('throws error message from JSON error payload', async () => {
+    const errorPayload = { error: 'Bad Request' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+      status: 400,
+      text: jest.fn().mockResolvedValue(JSON.stringify(errorPayload)),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow(
+      'Bad Request',
+    );
+  });
+
+  it('throws status text when response body is not JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Internal Server Error',
+      status: 500,
+      text: jest.fn().mockResolvedValue('not json'),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow(
+      'Internal Server Error',
+    );
+  });
+
+  it('propagates network errors', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network failure'));
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow(
+      'Network failure',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for fetchJson handling of success and error scenarios

## Testing
- `pnpm --filter @acme/ui test` *(fails: step did not advance yet, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689859e933cc832f896754f96b5027bc