### PR TITLE
feat: enforce schema strictness and centralize toggles

### DIFF
--- a/apps/cms/__tests__/toggleItem.test.ts
+++ b/apps/cms/__tests__/toggleItem.test.ts
@@ -1,16 +1,16 @@
 // apps/cms/__tests__/listUtils.test.ts
 /* eslint-env jest */
 
-import { toggle } from "../src/app/cms/wizard/listUtils";
+import { toggleItem } from "@ui/utils/toggleItem";
 
-describe("listUtils", () => {
+describe("toggleItem", () => {
   it("toggles values within an array", () => {
     let items: string[] = [];
-    items = toggle(items, "a");
+    items = toggleItem(items, "a");
     expect(items).toEqual(["a"]);
-    items = toggle(items, "a");
+    items = toggleItem(items, "a");
     expect(items).toEqual([]);
-    items = toggle(items, "b");
+    items = toggleItem(items, "b");
     expect(items).toEqual(["b"]);
   });
 });

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -3,12 +3,14 @@
 import { localeSchema } from "@types";
 import { z } from "zod";
 
-export const productSchema = z.object({
-  id: z.string(),
-  price: z.coerce.number().min(0, "Invalid price"),
-  title: z.record(localeSchema, z.string().min(1)),
-  description: z.record(localeSchema, z.string().min(1)),
-});
+export const productSchema = z
+  .object({
+    id: z.string(),
+    price: z.coerce.number().min(0, "Invalid price"),
+    title: z.record(localeSchema, z.string().min(1)),
+    description: z.record(localeSchema, z.string().min(1)),
+  })
+  .strict();
 
 const jsonRecord = z
   .string()
@@ -23,25 +25,27 @@ const jsonRecord = z
     }
   });
 
-export const shopSchema = z.object({
-  id: z.string(),
-  name: z.string().min(1, "Required"),
-  themeId: z.string().min(1, "Required"),
-  catalogFilters: z
-    .string()
-    .optional()
-    .default("")
-    .transform((s) =>
-      s
-        .split(/,\s*/)
-        .map((v) => v.trim())
-        .filter(Boolean)
-    ),
-  themeTokens: jsonRecord,
-  filterMappings: jsonRecord,
-  priceOverrides: jsonRecord,
-  localeOverrides: jsonRecord,
-});
+export const shopSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().min(1, "Required"),
+    themeId: z.string().min(1, "Required"),
+    catalogFilters: z
+      .string()
+      .optional()
+      .default("")
+      .transform((s) =>
+        s
+          .split(/,\s*/)
+          .map((v) => v.trim())
+          .filter(Boolean)
+      ),
+    themeTokens: jsonRecord,
+    filterMappings: jsonRecord,
+    priceOverrides: jsonRecord,
+    localeOverrides: jsonRecord,
+  })
+  .strict();
 
 export type ProductForm = z.infer<typeof productSchema>;
 export type ShopForm = z.infer<typeof shopSchema>;

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -68,20 +68,22 @@ export async function getSettings(shop: string) {
   return getShopSettings(shop);
 }
 
-const seoSchema = z.object({
-  locale: z.string(),
-  title: z.string().min(1, "Required"),
-  description: z.string().optional().default(""),
-  image: z
-    .string()
-    .optional()
-    .refine((v) => !v || /^https?:\/\/\S+$/.test(v), {
-      message: "Invalid image URL",
-    }),
-  canonicalBase: z.string().url().optional(),
-  ogUrl: z.string().url().optional(),
-  twitterCard: z.string().optional(),
-});
+const seoSchema = z
+  .object({
+    locale: z.string(),
+    title: z.string().min(1, "Required"),
+    description: z.string().optional().default(""),
+    image: z
+      .string()
+      .optional()
+      .refine((v) => !v || /^https?:\/\/\S+$/.test(v), {
+        message: "Invalid image URL",
+      }),
+    canonicalBase: z.string().url().optional(),
+    ogUrl: z.string().url().optional(),
+    twitterCard: z.string().optional(),
+  })
+  .strict();
 
 export async function updateSeo(
   shop: string,

--- a/apps/cms/src/app/cms/wizard/listUtils.ts
+++ b/apps/cms/src/app/cms/wizard/listUtils.ts
@@ -1,7 +1,0 @@
-// apps/cms/src/app/cms/wizard/listUtils.ts
-
-export function toggle(list: string[], value: string): string[] {
-  return list.includes(value)
-    ? list.filter((v) => v !== value)
-    : [...list, value];
-}

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -38,12 +38,14 @@ export interface NavItem {
 
 const _navItemSchema: z.ZodType<NavItem> = z.lazy(
   () =>
-    z.object({
-      id: z.string(),
-      label: z.string(),
-      url: z.string(),
-      children: z.array(_navItemSchema).optional(),
-    }) as z.ZodType<NavItem>
+    z
+      .object({
+        id: z.string(),
+        label: z.string(),
+        url: z.string(),
+        children: z.array(_navItemSchema).optional(),
+      })
+      .strict() as z.ZodType<NavItem>
 );
 
 export const navItemSchema = _navItemSchema as unknown as z.ZodType<
@@ -56,17 +58,19 @@ export const navItemSchema = _navItemSchema as unknown as z.ZodType<
 /*  Page‑info schema                                                          */
 /* -------------------------------------------------------------------------- */
 
-export const pageInfoSchema = z.object({
-  id: z.string().optional(),
-  /** `slug` is **required** so routing can never break. */
-  slug: z.string(),
-  /** All locale keys are required – no `Partial`. */
-  title: localeRecordSchema,
-  description: localeRecordSchema,
-  image: localeRecordSchema,
-  /** Components are serialised PageComponent instances. */
-  components: z.array(pageComponentSchema).default([]),
-});
+export const pageInfoSchema = z
+  .object({
+    id: z.string().optional(),
+    /** `slug` is **required** so routing can never break. */
+    slug: z.string(),
+    /** All locale keys are required – no `Partial`. */
+    title: localeRecordSchema,
+    description: localeRecordSchema,
+    image: localeRecordSchema,
+    /** Components are serialised PageComponent instances. */
+    components: z.array(pageComponentSchema).default([]),
+  })
+  .strict();
 
 export type PageInfo = z.infer<typeof pageInfoSchema>; // <- slug & components **required**
 
@@ -140,6 +144,6 @@ export const wizardStateSchema = z.object({
   newPageLayout: z.string().optional().default(""),
   domain: z.string().optional().default(""),
   categoriesText: z.string().optional().default(""),
-});
+}).strict();
 
 export type WizardState = z.infer<typeof wizardStateSchema>;

--- a/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/atoms/shadcn";
-import { toggle } from "../listUtils";
+import { toggleItem } from "@ui/utils/toggleItem";
 
 interface Props {
   payment: string[];
@@ -45,14 +45,14 @@ export default function StepOptions({
         <label className="flex items-center gap-2 text-sm">
           <Checkbox
             checked={payment.includes("stripe")}
-            onCheckedChange={() => setPayment((l) => toggle(l, "stripe"))}
+            onCheckedChange={() => setPayment((l) => toggleItem(l, "stripe"))}
           />
           Stripe
         </label>
         <label className="flex items-center gap-2 text-sm">
           <Checkbox
             checked={payment.includes("paypal")}
-            onCheckedChange={() => setPayment((l) => toggle(l, "paypal"))}
+            onCheckedChange={() => setPayment((l) => toggleItem(l, "paypal"))}
           />
           PayPal
         </label>
@@ -62,14 +62,14 @@ export default function StepOptions({
         <label className="flex items-center gap-2 text-sm">
           <Checkbox
             checked={shipping.includes("dhl")}
-            onCheckedChange={() => setShipping((l) => toggle(l, "dhl"))}
+            onCheckedChange={() => setShipping((l) => toggleItem(l, "dhl"))}
           />
           DHL
         </label>
         <label className="flex items-center gap-2 text-sm">
           <Checkbox
             checked={shipping.includes("ups")}
-            onCheckedChange={() => setShipping((l) => toggle(l, "ups"))}
+            onCheckedChange={() => setShipping((l) => toggleItem(l, "ups"))}
           />
           UPS
         </label>

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -13,15 +13,19 @@ import { z } from "zod";
 
 export const runtime = "edge";
 
-const postSchema = z.object({
-  sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-  qty: z.number().int().min(1).default(1),
-});
+const postSchema = z
+  .object({
+    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
+    qty: z.number().int().min(1).default(1),
+  })
+  .strict();
 
-const patchSchema = z.object({
-  id: z.string(),
-  qty: z.number().int().min(1),
-});
+const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.number().int().min(1),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const json = await req.json();

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -16,15 +16,19 @@ export const runtime = "edge";
 // This simple handler echoes back the posted body and status 200.
 // Stripe / KV integration will extend this in Sprint 5.
 
-const postSchema = z.object({
-  sku: skuSchema,
-  qty: z.number().int().min(1).default(1),
-});
+const postSchema = z
+  .object({
+    sku: skuSchema,
+    qty: z.number().int().min(1).default(1),
+  })
+  .strict();
 
-const patchSchema = z.object({
-  id: z.string(),
-  qty: z.number().int().min(1),
-});
+const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.number().int().min(1),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const json = await req.json();

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -16,15 +16,19 @@ export const runtime = "edge";
 /* ------------------------------------------------------------------
  * Zod schemas for request bodies
  * ------------------------------------------------------------------ */
-const postSchema = z.object({
-  sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-  qty: z.number().int().min(1).default(1),
-});
+const postSchema = z
+  .object({
+    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
+    qty: z.number().int().min(1).default(1),
+  })
+  .strict();
 
-const patchSchema = z.object({
-  id: z.string(),
-  qty: z.number().int().min(1),
-});
+const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.number().int().min(1),
+  })
+  .strict();
 
 /* ------------------------------------------------------------------
  * POST – add an item to the cart

--- a/packages/ui/src/components/cms/DataTable.tsx
+++ b/packages/ui/src/components/cms/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useState } from "react";
+import { toggleItem } from "../../utils/toggleItem";
 import {
   Table,
   TableBody,
@@ -30,17 +31,12 @@ export default function DataTable<T>({
   selectable = false,
   onSelectionChange,
 }: DataTableProps<T>) {
-  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<number[]>([]);
 
   const toggle = (idx: number) => {
-    const next = new Set(selected);
-    if (next.has(idx)) {
-      next.delete(idx);
-    } else {
-      next.add(idx);
-    }
+    const next = toggleItem(selected, idx);
     setSelected(next);
-    onSelectionChange?.(Array.from(next).map((i) => rows[i]));
+    onSelectionChange?.(next.map((i) => rows[i]));
   };
 
   return (
@@ -61,7 +57,7 @@ export default function DataTable<T>({
           {rows.map((row, i) => (
             <TableRow
               key={i}
-              data-state={selected.has(i) ? "selected" : undefined}
+              data-state={selected.includes(i) ? "selected" : undefined}
               onClick={selectable ? () => toggle(i) : undefined}
               className={selectable ? "cursor-pointer" : undefined}
             >
@@ -70,7 +66,7 @@ export default function DataTable<T>({
                   <input
                     type="checkbox"
                     className="accent-primary size-4"
-                    checked={selected.has(i)}
+                    checked={selected.includes(i)}
                     onChange={() => toggle(i)}
                     onClick={(e) => e.stopPropagation()}
                   />

--- a/packages/ui/src/components/cms/PublishLocationSelector.tsx
+++ b/packages/ui/src/components/cms/PublishLocationSelector.tsx
@@ -4,6 +4,7 @@
 import { Button, Input } from "@/components/atoms/shadcn";
 import type { PublishLocation } from "@types";
 import { usePublishLocations } from "@ui/hooks/usePublishLocations";
+import { toggleItem } from "../../utils/toggleItem";
 import { memo, useCallback } from "react";
 
 export interface PublishLocationSelectorProps {
@@ -29,12 +30,7 @@ function PublishLocationSelectorInner({
 
   const toggle = useCallback(
     (id: string) => {
-      const idx = selectedIds.indexOf(id);
-      const next =
-        idx === -1
-          ? [...selectedIds, id]
-          : [...selectedIds.slice(0, idx), ...selectedIds.slice(idx + 1)];
-      onChange(next);
+      onChange(toggleItem(selectedIds, id));
     },
     [selectedIds, onChange]
   );

--- a/packages/ui/src/components/organisms/DataTable.tsx
+++ b/packages/ui/src/components/organisms/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useState } from "react";
+import { toggleItem } from "../../utils/toggleItem";
 import {
   Table,
   TableBody,
@@ -29,17 +30,12 @@ export function DataTable<T>({
   selectable = false,
   onSelectionChange,
 }: DataTableProps<T>) {
-  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<number[]>([]);
 
   const toggle = (idx: number) => {
-    const next = new Set(selected);
-    if (next.has(idx)) {
-      next.delete(idx);
-    } else {
-      next.add(idx);
-    }
+    const next = toggleItem(selected, idx);
     setSelected(next);
-    onSelectionChange?.(Array.from(next).map((i) => rows[i]));
+    onSelectionChange?.(next.map((i) => rows[i]));
   };
 
   return (
@@ -59,7 +55,7 @@ export function DataTable<T>({
           {rows.map((row, i) => (
             <TableRow
               key={i}
-              data-state={selected.has(i) ? "selected" : undefined}
+              data-state={selected.includes(i) ? "selected" : undefined}
               onClick={selectable ? () => toggle(i) : undefined}
               className={selectable ? "cursor-pointer" : undefined}
             >
@@ -68,7 +64,7 @@ export function DataTable<T>({
                   <input
                     type="checkbox"
                     className="accent-primary size-4"
-                    checked={selected.has(i)}
+                    checked={selected.includes(i)}
                     onChange={() => toggle(i)}
                     onClick={(e) => e.stopPropagation()}
                   />

--- a/packages/ui/src/utils/__tests__/toggleItem.test.ts
+++ b/packages/ui/src/utils/__tests__/toggleItem.test.ts
@@ -1,0 +1,13 @@
+import { toggleItem } from '../toggleItem';
+
+describe('toggleItem', () => {
+  it('adds and removes values from an array', () => {
+    let items: string[] = [];
+    items = toggleItem(items, 'a');
+    expect(items).toEqual(['a']);
+    items = toggleItem(items, 'a');
+    expect(items).toEqual([]);
+    items = toggleItem(items, 'b');
+    expect(items).toEqual(['b']);
+  });
+});

--- a/packages/ui/src/utils/toggleItem.ts
+++ b/packages/ui/src/utils/toggleItem.ts
@@ -1,0 +1,5 @@
+export function toggleItem<T>(list: readonly T[], value: T): T[] {
+  return list.includes(value)
+    ? list.filter((v) => v !== value)
+    : [...list, value];
+}


### PR DESCRIPTION
## Summary
- enforce strict object validation across cart and CMS schemas
- add shared `toggleItem` util and refactor components to use it
- test coverage for new toggle helper

## Testing
- `pnpm test --filter @apps/cms --filter @acme/ui --filter @apps/shop-abc --filter @apps/shop-bcd --filter @acme/template-app` *(fails: Test Suites: 2 failed, 30 passed)*
- `pnpm test --filter @acme/ui` *(fails: ENOENT /tmp/wizard-xCDUMg/packages/themes)*

------
https://chatgpt.com/codex/tasks/task_e_68985977b368832f9d335e5e4573ed10