### PR TITLE
feat: improve theme toggle accessibility

### DIFF
--- a/packages/ui/__tests__/ThemeToggle.test.tsx
+++ b/packages/ui/__tests__/ThemeToggle.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import ThemeToggle from "../src/components/ThemeToggle";
 
 const setTheme = jest.fn();
-let mockTheme = "base";
+let mockTheme: string = "base";
 
 jest.mock("@platform-core/src/contexts/ThemeContext", () => ({
   useTheme: () => ({ theme: mockTheme, setTheme }),
@@ -14,11 +14,14 @@ describe("ThemeToggle", () => {
     mockTheme = "base";
   });
 
-  it("switches label and theme between Dark and Light", () => {
+  it("cycles themes and updates ARIA attributes", () => {
     const { rerender } = render(<ThemeToggle />);
 
     let button = screen.getByRole("button", { name: /toggle theme/i });
+    let live = screen.getByText(/light theme selected/i);
+    expect(live).toHaveAttribute("aria-live", "polite");
     expect(button).toHaveTextContent("Dark");
+    expect(button).toHaveAttribute("aria-pressed", "false");
 
     fireEvent.click(button);
     expect(setTheme).toHaveBeenNthCalledWith(1, "dark");
@@ -26,15 +29,22 @@ describe("ThemeToggle", () => {
     mockTheme = "dark";
     rerender(<ThemeToggle />);
     button = screen.getByRole("button", { name: /toggle theme/i });
-    expect(button).toHaveTextContent("Light");
+    live = screen.getByText(/dark theme selected/i);
+    expect(button).toHaveTextContent("System");
+    expect(button).toHaveAttribute("aria-pressed", "true");
 
     fireEvent.click(button);
-    expect(setTheme).toHaveBeenNthCalledWith(2, "base");
+    expect(setTheme).toHaveBeenNthCalledWith(2, "system");
 
-    mockTheme = "base";
+    mockTheme = "system";
     rerender(<ThemeToggle />);
     button = screen.getByRole("button", { name: /toggle theme/i });
-    expect(button).toHaveTextContent("Dark");
+    live = screen.getByText(/system theme selected/i);
+    expect(button).toHaveTextContent("Light");
+    expect(button).toHaveAttribute("aria-pressed", "mixed");
+
+    fireEvent.click(button);
+    expect(setTheme).toHaveBeenNthCalledWith(3, "base");
   });
 });
 

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -2,22 +2,42 @@
 
 import { useTheme } from "@platform-core/src/contexts/ThemeContext";
 
+const themes = ["base", "dark", "system"] as const;
+const labels: Record<(typeof themes)[number], string> = {
+  base: "Light",
+  dark: "Dark",
+  system: "System",
+};
+
 export default function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  const isDark = theme === "dark";
+  const { theme, setTheme } = useTheme() as unknown as {
+    theme: string;
+    setTheme: (t: string) => void;
+  };
+
+  const currentIndex = themes.indexOf(theme as any);
+  const nextTheme = themes[(currentIndex + 1) % themes.length];
+  const ariaPressed: boolean | "mixed" =
+    theme === "dark" ? true : theme === "base" ? false : "mixed";
 
   const toggleTheme = () => {
-    setTheme(isDark ? "base" : "dark");
+    setTheme(nextTheme);
   };
 
   return (
-    <button
-      type="button"
-      onClick={toggleTheme}
-      className="hover:underline"
-      aria-label="Toggle theme"
-    >
-      {isDark ? "Light" : "Dark"}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        aria-label="Toggle theme"
+        aria-pressed={ariaPressed}
+      >
+        {labels[nextTheme]}
+      </button>
+      <span aria-live="polite" className="sr-only">
+        {labels[theme as keyof typeof labels]} theme selected
+      </span>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- enhance theme toggle to cycle through light, dark, and system themes using `aria-pressed`
- add focus styles and `aria-live` region to announce selected theme
- test theme toggle ARIA attributes and cycling behaviour

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/ThemeToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689860db0258832fbba40dd94a310b7f