### PR TITLE
feat: preload saved theme

### DIFF
--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -29,7 +29,27 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                var theme = localStorage.getItem('theme');
+                if (theme === 'dark') {
+                  document.documentElement.classList.add('theme-dark');
+                } else {
+                  document.documentElement.classList.remove('theme-dark');
+                }
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className="antialiased">
         {/* Global providers go here */}
         <CartProvider>{children}</CartProvider>

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -24,7 +24,27 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                var theme = localStorage.getItem('theme');
+                if (theme === 'dark') {
+                  document.documentElement.classList.add('theme-dark');
+                } else {
+                  document.documentElement.classList.remove('theme-dark');
+                }
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className="antialiased">
         {/* Global providers go here */}
         <CartProvider>{children}</CartProvider>

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -24,7 +24,27 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                var theme = localStorage.getItem('theme');
+                if (theme === 'dark') {
+                  document.documentElement.classList.add('theme-dark');
+                } else {
+                  document.documentElement.classList.remove('theme-dark');
+                }
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className="antialiased">
         {/* Global providers go here */}
         <CartProvider>{children}</CartProvider>

--- a/packages/platform-core/src/contexts/ThemeContext.tsx
+++ b/packages/platform-core/src/contexts/ThemeContext.tsx
@@ -17,13 +17,19 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
+export function getSavedTheme(): Theme | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem("theme") as Theme | null;
+}
+
 function getInitialTheme(): Theme {
-  if (typeof window !== "undefined") {
-    const storedTheme = window.localStorage.getItem("theme") as Theme | null;
-    if (storedTheme) return storedTheme;
-    if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
-      return "dark";
-    }
+  const storedTheme = getSavedTheme();
+  if (storedTheme) return storedTheme;
+  if (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
   }
   return "base";
 }


### PR DESCRIPTION
## Summary
- expose helper to read persisted theme from `localStorage`
- inline script in each app layout applies `theme-dark` before styles load

## Testing
- `pnpm test` *(fails: Test Suites: 2 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689860d3f57c832f8d7f77522dbf3939