### PR TITLE
feat: support product list limits

### DIFF
--- a/doc/cms.md
+++ b/doc/cms.md
@@ -69,8 +69,15 @@ Open `/cms/shop/{shop}/pages/{slug}/builder` to edit an existing page or
   it, then press <kbd>Space</kbd> again to drop it.
 - Screen readers announce when blocks are moved or added to the canvas.
 
+### Product grids and carousels
+
+Blocks that show multiple products (grids or carousels) expose **Min Items** and
+**Max Items** settings. The block observes its width and automatically adjusts
+how many products are visible within those bounds. Wide screens may show more
+items up to `maxItems`, while narrow screens never drop below `minItems`.
+
 ### Publish changes
 
 1. Use **Save** to keep a draft version.
 2. Click **Publish** when you're ready for the page to go live at
-   `/shop/{shop}/{slug}`.
+  `/shop/{shop}/{slug}`.

--- a/packages/platform-core/__tests__/productGrid.test.tsx
+++ b/packages/platform-core/__tests__/productGrid.test.tsx
@@ -1,7 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { ProductGrid } from "../src/components/shop/ProductGrid";
 import { CartProvider } from "../src/contexts/CartContext";
 import { PRODUCTS } from "../src/products";
+
+let resizeCb: ResizeObserverCallback;
+
+beforeEach(() => {
+  // @ts-expect-error ResizeObserver not in jsdom
+  global.ResizeObserver = class {
+    constructor(cb: ResizeObserverCallback) {
+      resizeCb = cb;
+    }
+    observe() {}
+    disconnect() {}
+  };
+});
 
 describe("ProductGrid", () => {
   it("renders all products", () => {
@@ -21,5 +34,25 @@ describe("ProductGrid", () => {
     );
     const grid = screen.getByTestId("grid");
     expect(grid).toHaveStyle({ gridTemplateColumns: "repeat(2, minmax(0, 1fr))" });
+  });
+
+  it("respects min/max when resized", () => {
+    render(
+      <CartProvider>
+        <ProductGrid
+          skus={[PRODUCTS[0], PRODUCTS[1], PRODUCTS[2]]}
+          minItems={1}
+          maxItems={3}
+          data-testid="grid"
+        />
+      </CartProvider>
+    );
+    const grid = screen.getByTestId("grid") as HTMLElement;
+    Object.defineProperty(grid, "clientWidth", { value: 2000, configurable: true });
+    act(() => resizeCb([] as any));
+    expect(grid).toHaveStyle({ gridTemplateColumns: "repeat(3, minmax(0, 1fr))" });
+    Object.defineProperty(grid, "clientWidth", { value: 100, configurable: true });
+    act(() => resizeCb([] as any));
+    expect(grid).toHaveStyle({ gridTemplateColumns: "repeat(1, minmax(0, 1fr))" });
   });
 });

--- a/packages/platform-core/src/components/shop/ProductGrid.tsx
+++ b/packages/platform-core/src/components/shop/ProductGrid.tsx
@@ -8,16 +8,18 @@ import { ProductCard } from "./ProductCard";
 type Props = {
   skus: SKU[];
   columns?: number;
-  minCols?: number;
-  maxCols?: number;
+  /** Minimum number of products to display */
+  minItems?: number;
+  /** Maximum number of products to display */
+  maxItems?: number;
   className?: string;
 };
 
 function ProductGridInner({
   skus,
   columns,
-  minCols = 1,
-  maxCols = 3,
+  minItems = 1,
+  maxItems = 3,
   className,
 }: Props) {
   // simple alphabetic sort for deterministic order (SSR/CSR match)
@@ -27,7 +29,7 @@ function ProductGridInner({
   );
 
   const containerRef = useRef<HTMLElement>(null);
-  const [cols, setCols] = useState(columns ?? minCols);
+  const [cols, setCols] = useState(columns ?? minItems);
 
   useEffect(() => {
     if (columns || typeof ResizeObserver === "undefined" || !containerRef.current)
@@ -37,14 +39,14 @@ function ProductGridInner({
     const update = () => {
       const width = el.clientWidth;
       const ideal = Math.floor(width / ITEM_WIDTH) || 1;
-      const clamped = Math.max(minCols, Math.min(maxCols, ideal));
+      const clamped = Math.max(minItems, Math.min(maxItems, ideal));
       setCols(clamped);
     };
     update();
     const observer = new ResizeObserver(update);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [columns, minCols, maxCols]);
+  }, [columns, minItems, maxItems]);
 
   return (
     <section

--- a/packages/platform-core/src/repositories/pages/schema.json
+++ b/packages/platform-core/src/repositories/pages/schema.json
@@ -3,6 +3,9 @@
   "$id": "https://example.com/schemas/page.json",
   "title": "Page",
   "type": "object",
+  "definitions": {
+    "nonNegativeInteger": { "type": "integer", "minimum": 0 }
+  },
   "required": [
     "id",
     "slug",
@@ -33,7 +36,9 @@
             "required": ["id", "type"],
             "properties": {
               "id": { "type": "string" },
-              "type": { "const": "HeroBanner" }
+              "type": { "const": "HeroBanner" },
+              "minItems": { "$ref": "#/definitions/nonNegativeInteger" },
+              "maxItems": { "$ref": "#/definitions/nonNegativeInteger" }
             },
             "additionalProperties": false
           },
@@ -42,7 +47,9 @@
             "required": ["id", "type"],
             "properties": {
               "id": { "type": "string" },
-              "type": { "const": "ValueProps" }
+              "type": { "const": "ValueProps" },
+              "minItems": { "$ref": "#/definitions/nonNegativeInteger" },
+              "maxItems": { "$ref": "#/definitions/nonNegativeInteger" }
             },
             "additionalProperties": false
           },
@@ -51,7 +58,9 @@
             "required": ["id", "type"],
             "properties": {
               "id": { "type": "string" },
-              "type": { "const": "ReviewsCarousel" }
+              "type": { "const": "ReviewsCarousel" },
+              "minItems": { "$ref": "#/definitions/nonNegativeInteger" },
+              "maxItems": { "$ref": "#/definitions/nonNegativeInteger" }
             },
             "additionalProperties": false
           },
@@ -60,7 +69,9 @@
             "required": ["id", "type"],
             "properties": {
               "id": { "type": "string" },
-              "type": { "const": "ProductGrid" }
+              "type": { "const": "ProductGrid" },
+              "minItems": { "$ref": "#/definitions/nonNegativeInteger" },
+              "maxItems": { "$ref": "#/definitions/nonNegativeInteger" }
             },
             "additionalProperties": false
           }

--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -40,6 +40,14 @@ export interface PageComponentBase {
      * Accepts any valid CSS padding value or Tailwind class.
      */
     padding?: string;
+    /** Minimum number of items allowed for list components */
+    minItems?: number;
+    /** Maximum number of items allowed for list components */
+    maxItems?: number;
+    /** Minimum columns allowed for grid components */
+    minCols?: number;
+    /** Maximum columns allowed for grid components */
+    maxCols?: number;
     [key: string]: unknown;
 }
 export interface HeroBannerComponent extends PageComponentBase {
@@ -59,6 +67,7 @@ export interface ValuePropsComponent extends PageComponentBase {
         desc: string;
     }[];
 }
+/** Carousel of customer reviews. `minItems`/`maxItems` limit visible reviews */
 export interface ReviewsCarouselComponent extends PageComponentBase {
     type: "ReviewsCarousel";
     reviews?: {
@@ -66,6 +75,7 @@ export interface ReviewsCarouselComponent extends PageComponentBase {
         quoteKey: string;
     }[];
 }
+/** Grid of products; `minItems`/`maxItems` clamp the responsive product count */
 export interface ProductGridComponent extends PageComponentBase {
     type: "ProductGrid";
 }
@@ -102,6 +112,7 @@ export interface BlogListingComponent extends PageComponentBase {
         url?: string;
     }[];
 }
+/** Slider of testimonials. `minItems`/`maxItems` limit visible testimonials */
 export interface TestimonialSliderComponent extends PageComponentBase {
     type: "TestimonialSlider";
     testimonials?: {

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -68,11 +68,13 @@ export interface ValuePropsComponent extends PageComponentBase {
   items?: { icon: string; title: string; desc: string }[];
 }
 
+/** Carousel of customer reviews. `minItems`/`maxItems` limit visible reviews */
 export interface ReviewsCarouselComponent extends PageComponentBase {
   type: "ReviewsCarousel";
   reviews?: { nameKey: string; quoteKey: string }[];
 }
 
+/** Grid of products; `minItems`/`maxItems` clamp the responsive product count */
 export interface ProductGridComponent extends PageComponentBase {
   type: "ProductGrid";
 }
@@ -104,6 +106,7 @@ export interface BlogListingComponent extends PageComponentBase {
   posts?: { title: string; excerpt?: string; url?: string }[];
 }
 
+/** Slider of testimonials. `minItems`/`maxItems` limit visible testimonials */
 export interface TestimonialSliderComponent extends PageComponentBase {
   type: "TestimonialSlider";
   testimonials?: { quote: string; name?: string }[];
@@ -149,10 +152,10 @@ const baseComponentSchema = z
     left: z.string().optional(),
     margin: z.string().optional(),
     padding: z.string().optional(),
-    minItems: z.number().optional(),
-    maxItems: z.number().optional(),
-    minCols: z.number().optional(),
-    maxCols: z.number().optional(),
+    minItems: z.number().int().min(0).optional(),
+    maxItems: z.number().int().min(0).optional(),
+    minCols: z.number().int().min(0).optional(),
+    maxCols: z.number().int().min(0).optional(),
   })
   .passthrough();
 

--- a/packages/ui/src/components/cms/blocks/ProductGrid.client.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductGrid.client.tsx
@@ -6,24 +6,24 @@ import type { SKU } from "@types";
 export interface ProductGridProps {
   skus: SKU[];
   columns?: number;
-  minCols?: number;
-  maxCols?: number;
+  minItems?: number;
+  maxItems?: number;
   className?: string;
 }
 
 export default function ProductGrid({
   skus,
   columns,
-  minCols,
-  maxCols,
+  minItems,
+  maxItems,
   className,
 }: ProductGridProps) {
   return (
     <BaseGrid
       skus={skus}
       columns={columns}
-      minCols={minCols}
-      maxCols={maxCols}
+      minItems={minItems}
+      maxItems={maxItems}
       className={className}
     />
   );

--- a/packages/ui/src/components/cms/blocks/ProductGrid.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductGrid.stories.tsx
@@ -1,10 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import ProductGrid from "./ProductGrid";
+import { PRODUCTS } from "@platform-core/src/products";
 
 const meta: Meta<typeof ProductGrid> = {
   component: ProductGrid,
-  args: {},
+  args: { skus: PRODUCTS },
 };
 export default meta;
 
 export const Default: StoryObj<typeof ProductGrid> = {};
+
+export const Bounded: StoryObj<typeof ProductGrid> = {
+  args: { minItems: 1, maxItems: 2 },
+};

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -112,6 +112,34 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
         value={component.padding ?? ""}
         onChange={(e) => handleInput("padding", e.target.value)}
       />
+      {("minItems" in component || "maxItems" in component) && (
+        <>
+          <Input
+            label="Min Items"
+            type="number"
+            value={(component as any).minItems ?? ""}
+            onChange={(e) =>
+              handleInput(
+                "minItems",
+                e.target.value === "" ? undefined : Number(e.target.value)
+              )
+            }
+            min={0}
+          />
+          <Input
+            label="Max Items"
+            type="number"
+            value={(component as any).maxItems ?? ""}
+            onChange={(e) =>
+              handleInput(
+                "maxItems",
+                e.target.value === "" ? undefined : Number(e.target.value)
+              )
+            }
+            min={(component as any).minItems ?? 0}
+          />
+        </>
+      )}
       {"columns" in component && (
         <Input
           label="Columns"
@@ -123,8 +151,8 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
               e.target.value === "" ? undefined : Number(e.target.value)
             )
           }
-          min={(component as any).minCols}
-          max={(component as any).maxCols}
+          min={(component as any).minItems ?? (component as any).minCols}
+          max={(component as any).maxItems ?? (component as any).maxCols}
         />
       )}
       <Select

--- a/packages/ui/src/components/organisms/ProductCarousel.stories.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.stories.tsx
@@ -54,6 +54,10 @@ export const Bounded: StoryObj<typeof AutoCarousel> = {
   args: { minItems: 2, maxItems: 3 },
 };
 
+export const Wide: StoryObj<typeof AutoCarousel> = {
+  args: { minItems: 1, maxItems: 4 },
+};
+
 export const Mobile: StoryObj<typeof AutoCarousel> = {
   parameters: { viewport: { defaultViewport: "mobile1" } },
 };


### PR DESCRIPTION
## Summary
- add min/max item bounds to ProductGrid and CMS block
- validate minItems/maxItems in page schema and types
- surface list limits in page builder UI, stories, and docs

## Testing
- `pnpm test` *(fails: ENOENT: no such file or directory, scandir '/tmp/media-7xX7FI/public/uploads/shop1')*


------
https://chatgpt.com/codex/tasks/task_e_689864d132d8832f9645195d77065349