### PR TITLE
Pipe parsed JSON through record schema for shop forms

### DIFF
--- a/apps/cms/src/actions/schemas.d.ts
+++ b/apps/cms/src/actions/schemas.d.ts
@@ -21,19 +21,19 @@ export declare const shopSchema: z.ZodObject<{
     name: z.ZodString;
     themeId: z.ZodString;
     catalogFilters: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, string[], string | undefined>;
-    themeTokens: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, any, string | undefined>;
-    filterMappings: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, any, string | undefined>;
-    priceOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, any, string | undefined>;
-    localeOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, any, string | undefined>;
+    themeTokens: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
+    filterMappings: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
+    priceOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
+    localeOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
 }, "strip", z.ZodTypeAny, {
     id: string;
     name: string;
     themeId: string;
     catalogFilters: string[];
-    themeTokens?: any;
-    filterMappings?: any;
-    priceOverrides?: any;
-    localeOverrides?: any;
+    themeTokens?: Record<string, unknown>;
+    filterMappings?: Record<string, unknown>;
+    priceOverrides?: Record<string, unknown>;
+    localeOverrides?: Record<string, unknown>;
 }, {
     id: string;
     name: string;

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -23,7 +23,8 @@ const jsonRecord = z
       ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid JSON" });
       return {};
     }
-  });
+  })
+  .pipe(z.record(z.unknown()));
 
 export const shopSchema = z
   .object({

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -54,10 +54,10 @@ export async function updateShop(
     name: data.name,
     themeId: data.themeId,
     catalogFilters: data.catalogFilters,
-    themeTokens: data.themeTokens,
-    filterMappings: data.filterMappings,
-    priceOverrides: data.priceOverrides,
-    localeOverrides: data.localeOverrides,
+    themeTokens: data.themeTokens as Record<string, string>,
+    filterMappings: data.filterMappings as Record<string, string>,
+    priceOverrides: data.priceOverrides as Partial<Record<Locale, number>>,
+    localeOverrides: data.localeOverrides as Record<string, Locale>,
   };
 
   const saved = await updateShopInRepo(shop, patch);


### PR DESCRIPTION
## Summary
- ensure jsonRecord parsing is piped through `z.record(z.unknown())`
- cast JSON record fields when building shop update patches
- update generated type definitions for new record output

## Testing
- `pnpm test:cms` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689864ffe350832f8c79cab7e83cb490