### PR TITLE
feat: add product carousel component limits

### DIFF
--- a/packages/platform-core/src/repositories/pages/schema.json
+++ b/packages/platform-core/src/repositories/pages/schema.json
@@ -74,6 +74,17 @@
               "maxItems": { "$ref": "#/definitions/nonNegativeInteger" }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": ["id", "type"],
+            "properties": {
+              "id": { "type": "string" },
+              "type": { "const": "ProductCarousel" },
+              "minItems": { "$ref": "#/definitions/nonNegativeInteger" },
+              "maxItems": { "$ref": "#/definitions/nonNegativeInteger" }
+            },
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -79,6 +79,10 @@ export interface ReviewsCarouselComponent extends PageComponentBase {
 export interface ProductGridComponent extends PageComponentBase {
     type: "ProductGrid";
 }
+/** Carousel of products; `minItems`/`maxItems` clamp visible products */
+export interface ProductCarouselComponent extends PageComponentBase {
+    type: "ProductCarousel";
+}
 export interface GalleryComponent extends PageComponentBase {
     type: "Gallery";
     images?: {
@@ -127,11 +131,11 @@ export interface TestimonialsComponent extends PageComponentBase {
         name?: string;
     }[];
 }
-export interface TextComponent extends PageComponentBase {
-    type: "Text";
-    text?: string;
+export interface SectionComponent extends PageComponentBase {
+    type: "Section";
+    children?: PageComponent[];
 }
-export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent;
+export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
 export declare const pageSchema: z.ZodObject<{
     id: z.ZodString;
     slug: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -79,6 +79,11 @@ export interface ProductGridComponent extends PageComponentBase {
   type: "ProductGrid";
 }
 
+/** Carousel of products; `minItems`/`maxItems` clamp visible products */
+export interface ProductCarouselComponent extends PageComponentBase {
+  type: "ProductCarousel";
+}
+
 export interface GalleryComponent extends PageComponentBase {
   type: "Gallery";
   images?: { src: string; alt?: string }[];
@@ -132,6 +137,7 @@ export type PageComponent =
   | ValuePropsComponent
   | ReviewsCarouselComponent
   | ProductGridComponent
+  | ProductCarouselComponent
   | GalleryComponent
   | ContactFormComponent
   | ContactFormWithMapComponent
@@ -193,6 +199,10 @@ const reviewsCarouselComponentSchema = baseComponentSchema.extend({
 
 const productGridComponentSchema = baseComponentSchema.extend({
   type: z.literal("ProductGrid"),
+});
+
+const productCarouselComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ProductCarousel"),
 });
 
 const galleryComponentSchema = baseComponentSchema.extend({
@@ -266,6 +276,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     valuePropsComponentSchema,
     reviewsCarouselComponentSchema,
     productGridComponentSchema,
+    productCarouselComponentSchema,
     galleryComponentSchema,
     contactFormComponentSchema,
     contactFormWithMapComponentSchema,

--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -56,6 +56,16 @@ type ComponentType =
 
 const CONTAINER_TYPES = Object.keys(containerRegistry) as ComponentType[];
 
+const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
+  HeroBanner: { minItems: 1, maxItems: 5 },
+  ValueProps: { minItems: 1, maxItems: 6 },
+  ReviewsCarousel: { minItems: 1, maxItems: 10 },
+  ProductGrid: { minItems: 1, maxItems: 3 },
+  ProductCarousel: { minItems: 1, maxItems: 10 },
+  Testimonials: { minItems: 1, maxItems: 10 },
+  TestimonialSlider: { minItems: 1, maxItems: 10 },
+};
+
 /* ════════════════ external contracts ════════════════ */
 interface Props {
   page: Page;
@@ -382,6 +392,7 @@ const PageBuilder = memo(function PageBuilder({
           type: "Image",
           src: item.url,
           alt: item.altText,
+          ...(defaults.Image ?? {}),
         } as PageComponent,
       });
     },
@@ -560,6 +571,7 @@ const PageBuilder = memo(function PageBuilder({
         const component = {
           id: ulid(),
           type: a.type! as ComponentType,
+          ...(defaults[a.type! as ComponentType] ?? {}),
           ...(isContainer ? { children: [] } : {}),
         } as PageComponent;
         dispatch({

--- a/packages/ui/src/components/cms/blocks/ProductCarousel.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductCarousel.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ProductCarousel from "./ProductCarousel";
+import { PRODUCTS } from "@platform-core/src/products";
+
+const meta: Meta<typeof ProductCarousel> = {
+  component: ProductCarousel,
+  args: { products: PRODUCTS as any },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ProductCarousel> = {};
+
+export const Bounded: StoryObj<typeof ProductCarousel> = {
+  args: { minItems: 2, maxItems: 4 },
+};

--- a/packages/ui/src/components/cms/blocks/ProductCarousel.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductCarousel.tsx
@@ -3,6 +3,12 @@ import {
   type ProductCarouselProps,
 } from "../../organisms/ProductCarousel";
 
-export default function CmsProductCarousel(props: ProductCarouselProps) {
-  return <BaseCarousel {...props} />;
+export default function CmsProductCarousel({
+  minItems,
+  maxItems,
+  ...rest
+}: ProductCarouselProps) {
+  return (
+    <BaseCarousel minItems={minItems} maxItems={maxItems} {...rest} />
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -125,6 +125,7 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
               )
             }
             min={0}
+            max={(component as any).maxItems ?? undefined}
           />
           <Input
             label="Max Items"


### PR DESCRIPTION
## Summary
- add ProductCarousel component type and schema entry
- default min/max limits for new page builder blocks
- forward list limits and document in storybook

## Testing
- `pnpm --filter @types/shared exec tsc -p tsconfig.json` (fails: property 'id' is missing in type)
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/productGrid.test.tsx` (fails: A React Element from an older version of React was rendered)
- `pnpm --filter @acme/ui test packages/ui/__tests__/ProductCarousel.test.tsx packages/ui/__tests__/ProductGrid.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68988ed62fc4832f9153e0a93b487c54