### PR TITLE
Validate settings history timestamps

### DIFF
--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -92,13 +92,14 @@ export interface SettingsDiffEntry {
   diff: Partial<ShopSettings>;
 }
 
+const entrySchema = z.object({
+  timestamp: z.string().datetime(),
+  diff: shopSettingsSchema.partial(),
+});
+
 export async function diffHistory(shop: string): Promise<SettingsDiffEntry[]> {
   try {
     const buf = await fs.readFile(historyPath(shop), "utf8");
-    const entrySchema = z.object({
-      timestamp: z.string(),
-      diff: shopSettingsSchema.partial(),
-    });
     return buf
       .trim()
       .split(/\n+/)


### PR DESCRIPTION
## Summary
- validate `diffHistory` timestamps using `z.string().datetime()`
- reuse diff entry schema outside of `diffHistory`

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689864fd04a0832f8a5fe58fcb2d14ad