### PR TITLE
refactor: centralize createShop utils export

### DIFF
--- a/packages/platform-core/__tests__/createShopUtils.test.ts
+++ b/packages/platform-core/__tests__/createShopUtils.test.ts
@@ -1,6 +1,6 @@
 // packages/platform-core/__tests__/createShopUtils.test.ts
 import fs from "fs";
-import { copyTemplate, loadBaseTokens } from "../src/createShop/utils";
+import { copyTemplate, loadBaseTokens } from "../src/createShop/utils/index";
 import { slugify, genSecret, fillLocales } from "../src/utils";
 
 describe("createShop utils", () => {

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -9,7 +9,7 @@ import { join } from "path";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { validateShopName } from "./shops";
-import { copyTemplate, loadBaseTokens } from "./createShop/utils";
+import { copyTemplate, loadBaseTokens } from "./createShop/utils/index";
 import { slugify, genSecret, fillLocales } from "./utils";
 import { loadThemeTokensNode } from "./themeTokens";
 import { nowIso } from "@shared/date";

--- a/packages/platform-core/src/createShop/utils.ts
+++ b/packages/platform-core/src/createShop/utils.ts
@@ -1,3 +1,0 @@
-// packages/platform-core/src/createShop/utils.ts
-export { copyTemplate } from "./utils/copyTemplate";
-export { loadBaseTokens } from "./utils/loadBaseTokens";


### PR DESCRIPTION
## Summary
- export shared createShop helpers via utils index only
- drop legacy createShop/utils re-exports
- update imports to point at new utils index

## Testing
- `pnpm exec jest --runTestsByPath packages/platform-core/__tests__/createShopUtils.test.ts --runInBand --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6898976404c8832f87b306919d22c606