### PR TITLE
feat(ui): add accessible theme selector

### DIFF
--- a/packages/ui/__tests__/ThemeToggle.test.tsx
+++ b/packages/ui/__tests__/ThemeToggle.test.tsx
@@ -14,36 +14,46 @@ describe("ThemeToggle", () => {
     mockTheme = "base";
   });
 
-  it("cycles themes and updates ARIA attributes", () => {
+  it("selects themes and updates ARIA attributes", () => {
     const { rerender } = render(<ThemeToggle />);
 
-    let button = screen.getByRole("button", { name: /toggle theme/i });
-    let live = screen.getByText(/light theme selected/i);
-    expect(live).toHaveAttribute("aria-live", "polite");
-    expect(button).toHaveTextContent("Dark");
-    expect(button).toHaveAttribute("aria-pressed", "false");
+    const group = screen.getByRole("radiogroup", { name: /theme/i });
+    expect(group).toBeInTheDocument();
 
-    fireEvent.click(button);
+    let light = screen.getByLabelText("Light");
+    let dark = screen.getByLabelText("Dark");
+    let system = screen.getByLabelText("System");
+    let live = screen.getByText(/light theme selected/i);
+
+    expect(live).toHaveAttribute("aria-live", "polite");
+    expect(light).toBeChecked();
+    expect(light).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(dark);
     expect(setTheme).toHaveBeenNthCalledWith(1, "dark");
 
     mockTheme = "dark";
     rerender(<ThemeToggle />);
-    button = screen.getByRole("button", { name: /toggle theme/i });
+    light = screen.getByLabelText("Light");
+    dark = screen.getByLabelText("Dark");
+    system = screen.getByLabelText("System");
     live = screen.getByText(/dark theme selected/i);
-    expect(button).toHaveTextContent("System");
-    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(dark).toBeChecked();
+    expect(dark).toHaveAttribute("aria-checked", "true");
 
-    fireEvent.click(button);
+    fireEvent.click(system);
     expect(setTheme).toHaveBeenNthCalledWith(2, "system");
 
     mockTheme = "system";
     rerender(<ThemeToggle />);
-    button = screen.getByRole("button", { name: /toggle theme/i });
+    light = screen.getByLabelText("Light");
+    dark = screen.getByLabelText("Dark");
+    system = screen.getByLabelText("System");
     live = screen.getByText(/system theme selected/i);
-    expect(button).toHaveTextContent("Light");
-    expect(button).toHaveAttribute("aria-pressed", "mixed");
+    expect(system).toBeChecked();
+    expect(system).toHaveAttribute("aria-checked", "true");
 
-    fireEvent.click(button);
+    fireEvent.click(light);
     expect(setTheme).toHaveBeenNthCalledWith(3, "base");
   });
 });

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTheme, Theme } from "@platform-core/src/contexts/ThemeContext";
+import type { ChangeEvent } from "react";
 
 const themes: Theme[] = ["base", "dark", "system"];
 const labels: Record<Theme, string> = {
@@ -13,29 +14,29 @@ const labels: Record<Theme, string> = {
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
 
-  const currentIndex = themes.indexOf(theme as Theme);
-  const nextTheme = themes[(currentIndex + 1) % themes.length];
-  const ariaPressed: boolean | "mixed" =
-    theme === "dark" ? true : theme === "base" ? false : "mixed";
-
-  const toggleTheme = () => {
-    setTheme(nextTheme);
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTheme(e.target.value as Theme);
   };
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={toggleTheme}
-        className="hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-        aria-label="Toggle theme"
-        aria-pressed={ariaPressed}
-      >
-        {labels[nextTheme]}
-      </button>
+    <div role="radiogroup" aria-label="Theme">
+      {themes.map((t) => (
+        <div key={t} className="flex items-center gap-2">
+          <input
+            type="radio"
+            id={`theme-${t}`}
+            name="theme"
+            value={t}
+            checked={theme === t}
+            onChange={handleChange}
+            aria-checked={theme === t}
+          />
+          <label htmlFor={`theme-${t}`}>{labels[t]}</label>
+        </div>
+      ))}
       <span aria-live="polite" className="sr-only">
         {labels[theme as keyof typeof labels]} theme selected
       </span>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace theme toggle button with radio group offering Light, Dark, and System
- show current theme and announce changes for screen readers
- adjust tests for new selector behavior

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/ThemeToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68989812eb04832faa03e4771b9876e2