### PR TITLE
test: ensure dark theme color contrast meets WCAG AA

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@tanstack/react-query": "^5.81.4",
     "bcryptjs": "^3.0.2",
     "chart.js": "^4.5.0",
+    "identity-obj-proxy": "^3.0.0",
     "next": "15.3.5",
     "next-auth": "4.24.11",
     "next-intl": "^3.5.0",
@@ -82,8 +83,7 @@
     "sharp": "^0.34.2",
     "stripe": "^18.2.1",
     "ulid": "^3.0.1",
-    "zod": "^3.25.67",
-    "identity-obj-proxy": "^3.0.0"
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@acme/tailwind-config": "workspace:*",
@@ -129,6 +129,7 @@
     "nock": "^13.4.0",
     "playwright": "^1.53.1",
     "plop": "^4.0.1",
+    "polished": "^4.3.1",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.13",
     "react-server-dom-webpack": "^19.1.0",

--- a/packages/themes/dark/__tests__/contrast.test.ts
+++ b/packages/themes/dark/__tests__/contrast.test.ts
@@ -1,0 +1,20 @@
+import { getContrast } from 'polished';
+import { tokens } from '../src/tailwind-tokens';
+
+type TokenKey = keyof typeof tokens;
+
+function tokenToHsl(value: string): string {
+  return `hsl(${value})`;
+}
+
+const colorPairs: [TokenKey, TokenKey][] = [
+  ['--color-bg', '--color-fg'],
+  ['--color-primary', '--color-primary-fg'],
+];
+
+describe('dark theme color contrast', () => {
+  test.each(colorPairs)("%s and %s meet WCAG AA", (a, b) => {
+    const ratio = getContrast(tokenToHsl(tokens[a]), tokenToHsl(tokens[b]));
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       plop:
         specifier: ^4.0.1
         version: 4.0.1
+      polished:
+        specifier: ^4.3.1
+        version: 4.3.1
       prettier:
         specifier: ^3.5.3
         version: 3.6.2


### PR DESCRIPTION
## Summary
- add polished for contrast calculations
- add dark theme contrast tests to enforce WCAG AA ratios

## Testing
- `pnpm jest packages/themes/dark/__tests__`


------
https://chatgpt.com/codex/tasks/task_e_689898148ea4832f827da8b9fd102c23