### PR TITLE
feat: add min/max item controls

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -44,10 +44,6 @@ export interface PageComponentBase {
     minItems?: number;
     /** Maximum number of items allowed for list components */
     maxItems?: number;
-    /** Minimum columns allowed for grid components */
-    minCols?: number;
-    /** Maximum columns allowed for grid components */
-    maxCols?: number;
     [key: string]: unknown;
 }
 export interface HeroBannerComponent extends PageComponentBase {

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -51,10 +51,6 @@ export interface PageComponentBase {
   minItems?: number;
   /** Maximum number of items allowed for components with lists */
   maxItems?: number;
-  /** Minimum columns allowed for grid components */
-  minCols?: number;
-  /** Maximum columns allowed for grid components */
-  maxCols?: number;
   [key: string]: unknown;
 }
 
@@ -160,8 +156,6 @@ const baseComponentSchema = z
     padding: z.string().optional(),
     minItems: z.number().int().min(0).optional(),
     maxItems: z.number().int().min(0).optional(),
-    minCols: z.number().int().min(0).optional(),
-    maxCols: z.number().int().min(0).optional(),
   })
   .passthrough();
 

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -152,8 +152,8 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
               e.target.value === "" ? undefined : Number(e.target.value)
             )
           }
-          min={(component as any).minItems ?? (component as any).minCols}
-          max={(component as any).maxItems ?? (component as any).maxCols}
+          min={(component as any).minItems}
+          max={(component as any).maxItems}
         />
       )}
       <Select

--- a/packages/ui/src/components/organisms/ProductGrid.tsx
+++ b/packages/ui/src/components/organisms/ProductGrid.tsx
@@ -7,13 +7,13 @@ export interface ProductGridProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Explicit number of columns. If omitted, the grid will
    * determine a responsive column count within the
-   * `minCols`/`maxCols` range based on its width.
+   * `minItems`/`maxItems` range based on its width.
    */
   columns?: number;
-  /** Minimum number of columns to show */
-  minCols?: number;
-  /** Maximum number of columns to show */
-  maxCols?: number;
+  /** Minimum number of items to show */
+  minItems?: number;
+  /** Maximum number of items to show */
+  maxItems?: number;
   showImage?: boolean;
   showPrice?: boolean;
   ctaLabel?: string;
@@ -23,8 +23,8 @@ export interface ProductGridProps extends React.HTMLAttributes<HTMLDivElement> {
 export function ProductGrid({
   products,
   columns,
-  minCols = 1,
-  maxCols = 4,
+  minItems = 1,
+  maxItems = 4,
   showImage = true,
   showPrice = true,
   ctaLabel = "Add to cart",
@@ -33,7 +33,7 @@ export function ProductGrid({
   ...props
 }: ProductGridProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const [cols, setCols] = React.useState(columns ?? minCols);
+  const [cols, setCols] = React.useState(columns ?? minItems);
 
   React.useEffect(() => {
     if (columns || typeof ResizeObserver === "undefined" || !containerRef.current)
@@ -43,14 +43,14 @@ export function ProductGrid({
     const update = () => {
       const width = el.clientWidth;
       const ideal = Math.floor(width / ITEM_WIDTH) || 1;
-      const clamped = Math.max(minCols, Math.min(maxCols, ideal));
+      const clamped = Math.max(minItems, Math.min(maxItems, ideal));
       setCols(clamped);
     };
     update();
     const observer = new ResizeObserver(update);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [columns, minCols, maxCols]);
+  }, [columns, minItems, maxItems]);
 
   const style = {
     gridTemplateColumns: `repeat(${columns ?? cols}, minmax(0, 1fr))`,

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.stories.tsx
@@ -10,14 +10,14 @@ const meta: Meta<typeof ProductGalleryTemplate> = {
       { id: "3", title: "Product 3", image: "/placeholder.svg", price: 30 },
     ],
     useCarousel: false,
-    minCols: 1,
-    maxCols: 5,
+    minItems: 1,
+    maxItems: 5,
   },
   argTypes: {
     products: { control: "object" },
     useCarousel: { control: "boolean" },
-    minCols: { control: { type: "number" } },
-    maxCols: { control: { type: "number" } },
+    minItems: { control: { type: "number" } },
+    maxItems: { control: { type: "number" } },
   },
 };
 export default meta;

--- a/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
+++ b/packages/ui/src/components/templates/ProductGalleryTemplate.tsx
@@ -7,10 +7,10 @@ export interface ProductGalleryTemplateProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: Product[];
   useCarousel?: boolean;
-  /** Minimum columns to show per row or slide */
-  minCols?: number;
-  /** Maximum columns to show per row or slide */
-  maxCols?: number;
+  /** Minimum items to show per row or slide */
+  minItems?: number;
+  /** Maximum items to show per row or slide */
+  maxItems?: number;
 }
 
 /**
@@ -19,8 +19,8 @@ export interface ProductGalleryTemplateProps
 export function ProductGalleryTemplate({
   products,
   useCarousel = false,
-  minCols,
-  maxCols,
+  minItems,
+  maxItems,
   className,
   ...props
 }: ProductGalleryTemplateProps) {
@@ -28,8 +28,8 @@ export function ProductGalleryTemplate({
     return (
       <ProductCarousel
         products={products}
-        minItems={minCols}
-        maxItems={maxCols}
+        minItems={minItems}
+        maxItems={maxItems}
         className={className}
         {...props}
       />
@@ -38,8 +38,8 @@ export function ProductGalleryTemplate({
   return (
     <ProductGrid
       products={products}
-      minCols={minCols}
-      maxCols={maxCols}
+      minItems={minItems}
+      maxItems={maxItems}
       className={className}
       {...props}
     />

--- a/packages/ui/src/components/templates/README.md
+++ b/packages/ui/src/components/templates/README.md
@@ -8,7 +8,7 @@ Shared page-level layouts used across apps. Currently includes:
   - `DashboardTemplate` – basic stats overview.
 - `AnalyticsDashboardTemplate` – stats, line chart and table for dashboards.
 - `ProductGalleryTemplate` – grid or carousel listing of products. Supports
-  `minCols` and `maxCols` to control the responsive number of items per row or
+  `minItems` and `maxItems` to control the responsive number of items per row or
   slide.
 - `ProductDetailTemplate` – hero-style view for a single product.
 - `FeaturedProductTemplate` – showcase layout for highlighting a product.
@@ -17,7 +17,7 @@ Shared page-level layouts used across apps. Currently includes:
 - `CartTemplate` – editable list of cart items with totals.
 - `CategoryCollectionTemplate` – grid of category cards.
 - `SearchResultsTemplate` – search bar with paginated product results. Accepts
-  `minCols` and `maxCols` to adjust the responsive product grid.
+  `minItems` and `maxItems` to adjust the responsive product grid.
 - `CheckoutTemplate` – multi-step layout for collecting checkout information.
 - `OrderConfirmationTemplate` – summary of purchased items and totals.
 - `WishlistTemplate` – list of saved items with add-to-cart and remove actions.

--- a/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
@@ -24,6 +24,12 @@ const meta: Meta<typeof SearchResultsTemplate> = {
     results,
     page: 1,
     pageCount: 5,
+    minItems: 1,
+    maxItems: 4,
+  },
+  argTypes: {
+    minItems: { control: { type: "number" } },
+    maxItems: { control: { type: "number" } },
   },
 };
 export default meta;

--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -11,10 +11,10 @@ export interface SearchResultsTemplateProps
   results: Product[];
   page: number;
   pageCount: number;
-  /** Minimum columns to show */
-  minCols?: number;
-  /** Maximum columns to show */
-  maxCols?: number;
+  /** Minimum items to show */
+  minItems?: number;
+  /** Maximum items to show */
+  maxItems?: number;
   onQueryChange?: (query: string) => void;
   onPageChange?: (page: number) => void;
 }
@@ -24,8 +24,8 @@ export function SearchResultsTemplate({
   results,
   page,
   pageCount,
-  minCols,
-  maxCols,
+  minItems,
+  maxItems,
   onQueryChange,
   onPageChange,
   className,
@@ -39,7 +39,7 @@ export function SearchResultsTemplate({
         placeholder="Search products…"
       />
       {results.length > 0 ? (
-        <ProductGrid products={results} minCols={minCols} maxCols={maxCols} />
+        <ProductGrid products={results} minItems={minItems} maxItems={maxItems} />
       ) : (
         <p>No results found.</p>
       )}

--- a/packages/ui/src/components/templates/collection.json
+++ b/packages/ui/src/components/templates/collection.json
@@ -1,7 +1,7 @@
 {
   "name": "Collection Showcase",
   "components": [
-    { "type": "CategoryList", "minCols": 2, "maxCols": 4, "columns": 3 },
+    { "type": "CategoryList", "columns": 3 },
     { "type": "ProductCarousel", "minItems": 1, "maxItems": 10 }
   ]
 }

--- a/packages/ui/src/components/templates/homepage.json
+++ b/packages/ui/src/components/templates/homepage.json
@@ -4,6 +4,6 @@
     { "type": "HeroBanner", "minItems": 1, "maxItems": 5 },
     { "type": "PromoBanner" },
     { "type": "ProductCarousel", "minItems": 1, "maxItems": 10 },
-    { "type": "CategoryList", "minCols": 2, "maxCols": 4, "columns": 3 }
+    { "type": "CategoryList", "columns": 3 }
   ]
 }


### PR DESCRIPTION
## Summary
- normalize product grid API to use `minItems`/`maxItems`
- add min/max item props to templates and page-builder editor
- update docs and stories for new item bounds

## Testing
- `pnpm test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/__tests__/wizard.test.tsx')*
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6898982c4c50832faaf2ed304e652bc7