### PR TITLE
test: add setup-ci script tests

### DIFF
--- a/scripts/__tests__/setup-ci.test.ts
+++ b/scripts/__tests__/setup-ci.test.ts
@@ -1,0 +1,106 @@
+// scripts/__tests__/setup-ci.test.ts
+import fs from "fs";
+import path from "node:path";
+
+jest.mock("@config/src/env", () => ({
+  envSchema: { parse: jest.fn() },
+}));
+
+describe("setup-ci script", () => {
+  const ORIGINAL_ARGV = process.argv;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.argv = [...ORIGINAL_ARGV];
+  });
+
+  afterEach(() => {
+    process.argv = ORIGINAL_ARGV;
+    jest.restoreAllMocks();
+  });
+
+  it("writes workflow using provided shop id", async () => {
+    const { envSchema } = await import("@config/src/env");
+    (envSchema.parse as jest.Mock).mockReturnValue({});
+
+    const existsMock = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    const env = [
+      "STRIPE_SECRET_KEY=sk",
+      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk",
+    ].join("\n");
+    const readMock = jest.spyOn(fs, "readFileSync").mockReturnValue(env);
+    const writeMock = jest
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+
+    process.argv = ["node", "setup-ci", "abc"];
+
+    await import("../src/setup-ci");
+
+    expect(existsMock).toHaveBeenCalled();
+    expect(readMock).toHaveBeenCalled();
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    const [wfPath, content] = writeMock.mock.calls[0];
+    expect(wfPath).toBe(path.join(".github", "workflows", "shop-abc.yml"));
+    expect(content).toContain("shop-abc");
+    expect(exitMock).not.toHaveBeenCalled();
+  });
+
+  it("fails when env file is missing", async () => {
+    const { envSchema } = await import("@config/src/env");
+    (envSchema.parse as jest.Mock).mockReturnValue({});
+
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    const writeMock = jest
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+
+    process.argv = ["node", "setup-ci", "abc"];
+
+    await expect(import("../src/setup-ci")).rejects.toThrow("EXIT:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Missing ${path.join("apps", "shop-abc", ".env")}`
+    );
+    expect(writeMock).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it("fails with invalid env vars", async () => {
+    const { envSchema } = await import("@config/src/env");
+    (envSchema.parse as jest.Mock).mockImplementation(() => {
+      throw new Error("bad env");
+    });
+
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue("STRIPE_SECRET_KEY=sk");
+    const writeMock = jest
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+
+    process.argv = ["node", "setup-ci", "abc"];
+
+    await expect(import("../src/setup-ci")).rejects.toThrow("EXIT:1");
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0][0]).toContain("Invalid environment variables");
+    expect(writeMock).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for setup-ci script validating workflow generation and error paths

## Testing
- `npx jest scripts/__tests__/setup-ci.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68989900b914832fb46845d4d295f154