### PR TITLE
Add FormField component tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/FormField.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/FormField.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { FormField } from "../FormField";
+
+describe("FormField", () => {
+  it("renders the provided label", () => {
+    render(
+      <FormField label="Username">
+        <input id="username" />
+      </FormField>
+    );
+
+    expect(screen.getByText("Username")).toBeInTheDocument();
+  });
+
+  it("shows a required asterisk when required", () => {
+    render(
+      <FormField label="Email" htmlFor="email" required>
+        <input id="email" />
+      </FormField>
+    );
+
+    const asterisk = screen.getByText("*");
+    expect(asterisk).toBeInTheDocument();
+    expect(asterisk).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("displays an error message when provided", () => {
+    render(
+      <FormField label="Password" error="Required field">
+        <input id="password" />
+      </FormField>
+    );
+
+    expect(screen.getByText("Required field")).toBeInTheDocument();
+  });
+
+  it("applies boxProps to class names and styles", () => {
+    const { container } = render(
+      <FormField
+        label="Styled"
+        width={200}
+        height="h-5"
+        padding="p-3"
+        margin="m-4"
+      >
+        <input />
+      </FormField>
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass("flex", "flex-col", "gap-1", "h-5", "p-3", "m-4");
+    expect(wrapper).toHaveStyle({ width: "200px" });
+  });
+});


### PR DESCRIPTION
## Summary
- add FormField component unit tests for label, required indicator, error message, and boxProps class/style

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/molecules/__tests__/FormField.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68989902e66c832f94594bb8a889c17a