### PR TITLE
test: add PriceCluster tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { PriceCluster } from "../PriceCluster";
+
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["EUR", jest.fn()],
+}));
+
+describe("PriceCluster", () => {
+  it("renders price without discount when compare is missing or lower", () => {
+    const { rerender } = render(<PriceCluster price={100} />);
+
+    expect(screen.getByText("€100.00")).toBeInTheDocument();
+    expect(screen.queryByText(/-\d+%/)).toBeNull();
+
+    rerender(<PriceCluster price={100} compare={80} />);
+
+    expect(screen.getByText("€100.00")).toBeInTheDocument();
+    expect(screen.queryByText("€80.00")).toBeNull();
+    expect(screen.queryByText(/-\d+%/)).toBeNull();
+  });
+
+  it("shows compare price and discount badge when compare is greater than price", () => {
+    render(<PriceCluster price={80} compare={100} />);
+
+    expect(screen.getByText("€80.00")).toBeInTheDocument();
+    expect(screen.getByText("€100.00")).toBeInTheDocument();
+    expect(screen.getByText("-20%"))
+      .toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test coverage for PriceCluster molecule

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689899041730832fbccac9dec227d522