### PR TITLE
test: add PaginationControl navigation tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/PaginationControl.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/PaginationControl.test.tsx
@@ -1,0 +1,56 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { PaginationControl } from "../PaginationControl";
+
+describe("PaginationControl", () => {
+  it("handles first page navigation and boundaries", () => {
+    const onPageChange = jest.fn();
+    render(<PaginationControl page={1} pageCount={10} onPageChange={onPageChange} />);
+
+    const prev = screen.getByRole("button", { name: /prev/i });
+    const next = screen.getByRole("button", { name: /next/i });
+
+    expect(prev).toBeDisabled();
+    expect(next).not.toBeDisabled();
+
+    fireEvent.click(prev);
+    expect(onPageChange).not.toHaveBeenCalled();
+
+    fireEvent.click(next);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it("handles middle page navigation", () => {
+    const onPageChange = jest.fn();
+    render(<PaginationControl page={5} pageCount={10} onPageChange={onPageChange} />);
+
+    const prev = screen.getByRole("button", { name: /prev/i });
+    const next = screen.getByRole("button", { name: /next/i });
+
+    expect(prev).not.toBeDisabled();
+    expect(next).not.toBeDisabled();
+
+    fireEvent.click(prev);
+    fireEvent.click(next);
+
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 4);
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 6);
+  });
+
+  it("handles last page navigation and boundaries", () => {
+    const onPageChange = jest.fn();
+    render(<PaginationControl page={10} pageCount={10} onPageChange={onPageChange} />);
+
+    const prev = screen.getByRole("button", { name: /prev/i });
+    const next = screen.getByRole("button", { name: /next/i });
+
+    expect(prev).not.toBeDisabled();
+    expect(next).toBeDisabled();
+
+    fireEvent.click(next);
+    expect(onPageChange).not.toHaveBeenCalled();
+
+    fireEvent.click(prev);
+    expect(onPageChange).toHaveBeenCalledWith(9);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for PaginationControl navigation and boundary behavior

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/molecules/__tests__/PaginationControl.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689899051d34832f929da301d7a32a81