### PR TITLE
Add LanguageSwitcher tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/LanguageSwitcher.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import LanguageSwitcher from "../LanguageSwitcher";
+import { locales } from "@/i18n/locales";
+import "../../../../../../test/resetNextMocks";
+
+describe("LanguageSwitcher", () => {
+  it("highlights the current locale", () => {
+    render(<LanguageSwitcher current="de" />);
+    const active = screen.getByRole("link", { name: "DE" });
+    expect(active).toHaveClass("font-semibold");
+    expect(active).toHaveClass("underline");
+
+    const inactive = screen.getByRole("link", { name: "EN" });
+    expect(inactive).toHaveClass("text-muted");
+    expect(inactive).not.toHaveClass("font-semibold");
+  });
+
+  it("renders a link for each locale", () => {
+    render(<LanguageSwitcher current="en" />);
+    locales.forEach((locale) => {
+      const link = screen.getByRole("link", { name: locale.toUpperCase() });
+      expect(link).toHaveAttribute("href", `/${locale}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for the LanguageSwitcher component to ensure active locale styling and rendering of locale links

## Testing
- `npx jest packages/ui/src/components/molecules/__tests__/LanguageSwitcher.test.tsx --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68989906e40c832f89a8e26290a7a6d0