### PR TITLE
test: add RatingSummary component tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/RatingSummary.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/RatingSummary.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { RatingSummary } from "../RatingSummary";
+
+const mockRatingStars = jest.fn((props: any) => <div data-testid="rating-stars" />);
+
+jest.mock("../../atoms/RatingStars", () => ({
+  RatingStars: (props: any) => mockRatingStars(props),
+}));
+
+describe("RatingSummary", () => {
+  afterEach(() => {
+    mockRatingStars.mockClear();
+  });
+
+  it("displays rounded rating and review count when provided", () => {
+    render(<RatingSummary rating={4.26} count={7} />);
+    expect(screen.getByText("4.3")).toBeInTheDocument();
+    expect(screen.getByText("(7)")).toBeInTheDocument();
+  });
+
+  it("omits review count when count is undefined", () => {
+    render(<RatingSummary rating={4.26} />);
+    expect(screen.queryByText(/\(\d+\)/)).not.toBeInTheDocument();
+  });
+
+  it("passes rating to RatingStars", () => {
+    render(<RatingSummary rating={3.7} />);
+    expect(mockRatingStars).toHaveBeenCalled();
+    expect(mockRatingStars.mock.calls[0][0].rating).toBe(3.7);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for RatingSummary component
- check rating is rounded and count shown/hidden
- ensure RatingStars receives correct rating prop

## Testing
- `pnpm --filter @acme/ui test src/components/molecules/__tests__/RatingSummary.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68989907c008832f89f7cfd055c78f8d