### PR TITLE
test: add PaymentMethodSelector interactions

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/PaymentMethodSelector.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/PaymentMethodSelector.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { PaymentMethodSelector, type PaymentMethod } from "../PaymentMethodSelector";
+
+describe("PaymentMethodSelector", () => {
+  const methods: PaymentMethod[] = [
+    { value: "card", label: "Credit Card", icon: <svg data-testid="card-icon" /> },
+    { value: "paypal", label: "PayPal", icon: <svg data-testid="paypal-icon" /> },
+  ];
+
+  function Wrapper({ onChange }: { onChange: (value: string) => void }) {
+    const [value, setValue] = useState("card");
+    return (
+      <PaymentMethodSelector
+        methods={methods}
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          onChange(v);
+        }}
+      />
+    );
+  }
+
+  it("fires onChange with the selected value and renders icons", () => {
+    const handle = jest.fn();
+    render(<Wrapper onChange={handle} />);
+
+    expect(screen.getByTestId("card-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("paypal-icon")).toBeInTheDocument();
+
+    const paypalRadio = screen.getByLabelText("PayPal") as HTMLInputElement;
+    fireEvent.click(paypalRadio);
+
+    expect(handle).toHaveBeenCalledWith("paypal");
+    expect(paypalRadio.checked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for PaymentMethodSelector covering multiple methods and icon rendering

## Testing
- `pnpm exec jest packages/ui/src/components/molecules/__tests__/PaymentMethodSelector.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68989908b33c832f821e7eab54796b1f