### PR TITLE
refactor: remove duplicate createShop utils re-export

### DIFF
--- a/packages/platform-core/src/createShop/utils.ts
+++ b/packages/platform-core/src/createShop/utils.ts
@@ -1,3 +1,0 @@
-// packages/platform-core/src/createShop/utils.ts
-export { copyTemplate } from "./utils/copyTemplate";
-export { loadBaseTokens } from "./utils/loadBaseTokens";


### PR DESCRIPTION
## Summary
- remove redundant `createShop/utils.ts` re-export file so helpers are exported from `createShop/utils/index.ts`

## Testing
- `pnpm --filter @acme/platform-core test -- --runTestsByPath packages/platform-core/__tests__/createShopUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68989a349c6c832fab33be82dd9e5792