### PR TITLE
feat: add init-shop helper script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "preview": "wrangler pages dev",
     "format": "prettier --write .",
     "create-shop": "ts-node scripts/create-shop.ts",
+    "init-shop": "ts-node scripts/src/init-shop.ts",
     "setup-ci": "ts-node scripts/setup-ci.ts",
     "gen": "plop --plopfile plopfile.ts",
     "plop": "pnpm gen",

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -1,0 +1,78 @@
+import { createShop } from "../../packages/platform-core/src/createShop";
+import { validateShopName } from "../../packages/platform-core/src/shops";
+import { envSchema } from "@config/src/env";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+async function prompt(question: string, def = ""): Promise<string> {
+  const rl = readline.createInterface({ input, output });
+  const answer = (await rl.question(question)).trim();
+  rl.close();
+  return answer || def;
+}
+
+async function main() {
+  const rawId = await prompt("Shop ID: ");
+  let shopId: string;
+  try {
+    shopId = validateShopName(rawId);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+  const name = await prompt("Display name (optional): ");
+  const theme = await prompt("Theme [base]: ", "base");
+  const template = await prompt("Template [template-app]: ", "template-app");
+  const paymentAns = await prompt("Payment providers (comma-separated): ");
+  const shippingAns = await prompt("Shipping providers (comma-separated): ");
+  const ciAns = await prompt("Setup CI workflow? (y/N): ");
+
+  const options = {
+    ...(name && { name }),
+    theme,
+    template,
+    payment: paymentAns.split(",").map((s) => s.trim()).filter(Boolean),
+    shipping: shippingAns.split(",").map((s) => s.trim()).filter(Boolean),
+  };
+
+  const prefixedId = `shop-${shopId}`;
+  createShop(prefixedId, options);
+
+  let validationError: unknown;
+  try {
+    const envPath = join("apps", prefixedId, ".env");
+    if (!existsSync(envPath)) throw new Error(`Missing ${envPath}`);
+    const envRaw = readFileSync(envPath, "utf8");
+    const env: Record<string, string> = {};
+    for (const line of envRaw.split(/\n+/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const [key, ...rest] = trimmed.split("=");
+      env[key] = rest.join("=");
+    }
+    envSchema.parse(env);
+  } catch (err) {
+    validationError = err;
+  }
+
+  if (ciAns.toLowerCase().startsWith("y")) {
+    spawnSync("pnpm", ["ts-node", "scripts/src/setup-ci.ts", shopId], {
+      stdio: "inherit",
+    });
+  }
+
+  if (validationError) {
+    console.error("\nEnvironment validation failed:\n", validationError);
+  } else {
+    console.log("\nEnvironment variables look valid.");
+  }
+
+  console.log(
+    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Run: pnpm --filter @apps/${prefixedId} dev`
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- add an interactive `init-shop` script that scaffolds a shop, validates env, and optionally sets up CI
- expose the script via `pnpm init-shop`

## Testing
- `pnpm exec eslint scripts/src/init-shop.ts` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68989ea4b7d4832f9beb7e0f0d717706