### PR TITLE
Improve env validation error reporting

### DIFF
--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -1,6 +1,7 @@
 import { envSchema } from "@config/src/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { ZodError } from "zod";
 
 const shopId = process.argv[2];
 
@@ -29,6 +30,14 @@ try {
   envSchema.parse(env);
   console.log("Environment variables look valid.");
 } catch (err) {
-  console.error("Invalid environment variables:\n", err);
+  if (err instanceof ZodError) {
+    for (const issue of err.issues) {
+      const name = issue.path.join(".");
+      const message = issue.message === "Required" ? "is required" : issue.message;
+      console.error(`${name} ${message}`);
+    }
+  } else {
+    console.error(err);
+  }
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- handle ZodError from env validation to show human-readable messages for each variable issue

## Testing
- `pnpm lint`
- `pnpm test` *(fails: @apps/cms:test command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68989ea64e90832f9ecf76e9458c9239