### PR TITLE
docs: add init-shop wizard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,19 @@ Key points:
 
 ## Getting Started
 
-1. **Create a shop**
+1. **Initialize a shop**
 
    ```bash
-   pnpm create-shop <id> [--name="My Shop"] [--logo=https://example.com/logo.png] [--contact="support@example.com"]
+   pnpm init-shop
    # optionally generate a GitHub Actions workflow
    pnpm setup-ci <id>
    ```
 
-   This scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app.
-   `--name`, `--logo`, and `--contact` seed the shop's display name, logo URL, and contact information.
-   Edit the `.env` file to provide real secrets (see [Environment Variables](#environment-variables)).
+   `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
+   contact email and which theme, template, payment and shipping providers to use. It then
+   scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
+   provide real secrets (see [Environment Variables](#environment-variables)). For scripted
+   setups you can still call `pnpm create-shop <id>` with flags.
 
 2. **Run the app**
 
@@ -47,7 +49,17 @@ Key points:
 ### Example
 
 ```bash
-pnpm create-shop demo
+pnpm init-shop
+? Shop ID … demo
+? Display name … Demo Shop
+? Logo URL … https://example.com/logo.png
+? Contact email … demo@example.com
+? Theme › base
+? Template › template-app
+? Payment providers › stripe
+? Shipping providers › ups
+Scaffolded apps/shop-demo
+
 pnpm setup-ci demo  # optional
 pnpm validate-env demo
 cd apps/shop-demo

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -8,6 +8,23 @@
 ## 1. Create a shop
 
 ```bash
+pnpm init-shop
+```
+
+`init-shop` launches an interactive wizard that collects:
+
+- shop ID
+- display name
+- logo URL
+- contact email
+- theme and template
+- payment and shipping providers
+
+After answering the prompts the wizard scaffolds `apps/shop-<id>` and generates an `.env` file inside the new app.
+
+For automated scripts you can still call `pnpm create-shop <id>` with flags:
+
+```bash
 pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--payment=p1,p2] [--shipping=s1,s2]
 ```
 
@@ -17,7 +34,20 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 - `--payment` – comma‑separated payment providers to configure.
 - `--shipping` – comma‑separated shipping providers to configure.
 
-The command scaffolds `apps/shop-<id>` and generates an `.env` file inside the new app.
+### Example wizard run
+
+```bash
+pnpm init-shop
+? Shop ID … demo
+? Display name … Demo Shop
+? Logo URL … https://example.com/logo.png
+? Contact email … demo@example.com
+? Theme › base
+? Template › template-app
+? Payment providers › stripe
+? Shipping providers › ups
+Scaffolded apps/shop-demo
+```
 
 ## 2. Configure environment variables
 
@@ -42,4 +72,3 @@ This creates `.github/workflows/shop-<id>.yml` which installs dependencies, runs
 - **"Theme 'X' not found" or "Template 'Y' not found"** – ensure the names match directories in `packages/themes` or `packages/`.
 - **`validate-env` fails** – verify `apps/shop-<id>/.env` contains all variables listed in the error. Missing values will stop the script.
 - **Node or pnpm version errors** – check you are running Node.js ≥20 and pnpm 10.x. Version mismatches can cause dependency resolution issues.
-


### PR DESCRIPTION
## Summary
- document new `pnpm init-shop` interactive wizard
- show example prompts for shop metadata
- mention init-shop in setup docs and README

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68989ea85874832fb3026456f938642d