### PR TITLE
Validate create-shop API input

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -29,12 +29,18 @@ describe("create-shop API", () => {
     }));
 
     const { POST } = await import("../src/app/api/create-shop/route");
-    const body = { id: "new", options: {} };
+    const body = { id: "new" };
     const req = { json: () => Promise.resolve(body) } as Request;
     const res = await POST(req);
     expect(res.status).toBe(201);
     expect(createNewShop).toHaveBeenCalledTimes(1);
-    expect(createNewShop).toHaveBeenCalledWith("new", {});
+    expect(createNewShop).toHaveBeenCalledWith("new", {
+      checkoutPage: [],
+      navItems: [],
+      pages: [],
+      payment: [],
+      shipping: [],
+    });
     (process.env as Record<string, string>).NODE_ENV = prevEnv as string;
   });
 


### PR DESCRIPTION
## Summary
- use `createShopOptionsSchema` to validate `create-shop` API requests
- reject invalid input with JSON error response
- update API test for default option values

## Testing
- `pnpm test:cms apps/cms/__tests__/api.create-shop.test.ts`
- `pnpm test:cms` *(fails: Cannot find module '@/components/atoms' from apps/cms/src/app/cms/wizard/Wizard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68989ebe6188832fa3f018d105510b6f