### PR TITLE
Handle shop creation authorization in createNewShop

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import type { Session } from "next-auth";
 
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: any, init?: ResponseInit) =>
@@ -16,13 +15,6 @@ describe("create-shop API", () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
     const createNewShop = jest.fn();
-    const session: Session = {
-      user: { role: "admin", email: "a" },
-      expires: "",
-    } as any;
-    jest.doMock("next-auth", () => ({
-      getServerSession: jest.fn(() => Promise.resolve(session)),
-    }));
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
@@ -41,13 +33,14 @@ describe("create-shop API", () => {
   it("returns 403 when unauthorized", async () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
-    jest.doMock("next-auth", () => ({
-      getServerSession: jest.fn(() =>
-        Promise.resolve({ user: { role: "viewer" } })
-      ),
+    const createNewShop = jest.fn().mockRejectedValue(new Error("Forbidden"));
+    jest.doMock("@cms/actions/createShop.server", () => ({
+      __esModule: true,
+      createNewShop,
     }));
     const { POST } = await import("../src/app/api/create-shop/route");
-    const res = await POST({ json: async () => ({}) } as Request);
+    const req = { json: async () => ({ id: "shop1" }) } as Request;
+    const res = await POST(req);
     expect(res.status).toBe(403);
     (process.env as Record<string, string>).NODE_ENV = prevEnv as string;
   });

--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -3,24 +3,23 @@
 
 import { authOptions } from "@cms/auth/options";
 import { createShop, type CreateShopOptions } from "@platform-core/createShop";
+import type { Session } from "next-auth";
 import { getServerSession } from "next-auth";
 import { readRbac, writeRbac } from "../lib/rbacStore";
 
-async function ensureAuthorized(): Promise<void> {
+async function getAuthorizedSession(): Promise<Session> {
   const session = await getServerSession(authOptions);
   if (!session || !["admin", "ShopAdmin"].includes(session.user?.role ?? "")) {
     throw new Error("Forbidden");
   }
+  return session;
 }
 
 export async function createNewShop(
   id: string,
   options: CreateShopOptions
 ): Promise<void> {
-  await ensureAuthorized();
-
-  const session = await getServerSession(authOptions);
-  if (!session) throw new Error("Forbidden");
+  const session = await getAuthorizedSession();
 
   try {
     await createShop(id, options);

--- a/apps/cms/src/app/api/create-shop/route.ts
+++ b/apps/cms/src/app/api/create-shop/route.ts
@@ -1,8 +1,6 @@
 // apps/cms/src/app/api/create-shop/route.ts
 import { createNewShop } from "@cms/actions/createShop.server";
-import { authOptions } from "@cms/auth/options";
 import type { CreateShopOptions } from "@platform-core/createShop";
-import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 
 /**
@@ -16,15 +14,6 @@ import { NextResponse } from "next/server";
  * • Returns **400** with an error message on validation / runtime errors.
  */
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions);
-
-  /* ------------------------------------------------------------------
-   *  Only admins and existing ShopAdmins may create new shops
-   * ---------------------------------------------------------------- */
-  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
   /* ------------------------------------------------------------------
    *  Parse request and delegate to the server action
    * ---------------------------------------------------------------- */
@@ -42,6 +31,10 @@ export async function POST(req: Request) {
      * ------------------------------------------------------------ */
     return NextResponse.json({ success: true }, { status: 201 });
   } catch (err) {
+    if ((err as Error).message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     /* --------------------------------------------------------------
      *  Bad request or runtime failure → 400
      * ------------------------------------------------------------ */

--- a/packages/platform-core/__tests__/createShopRoute.test.ts
+++ b/packages/platform-core/__tests__/createShopRoute.test.ts
@@ -8,11 +8,10 @@ describe("POST /api/create-shop", () => {
     jest.resetModules();
   });
 
-  it("returns 403 when session is missing", async () => {
-    jest.doMock("next-auth", () => ({
-      getServerSession: jest.fn().mockResolvedValue(null),
-    }));
-    const createNewShop = jest.fn();
+  it("returns 403 when action denies access", async () => {
+    const createNewShop = jest
+      .fn()
+      .mockRejectedValue(new Error("Forbidden"));
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
@@ -23,10 +22,11 @@ describe("POST /api/create-shop", () => {
     );
     const req = new Request("http://localhost/api/create-shop", {
       method: "POST",
+      body: JSON.stringify({ id: "shop1" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(403);
-    expect(createNewShop).not.toHaveBeenCalled();
+    expect(createNewShop).toHaveBeenCalledTimes(1);
   });
 
   it("calls createNewShop and returns success", async () => {
@@ -34,11 +34,6 @@ describe("POST /api/create-shop", () => {
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
-    }));
-    jest.doMock("next-auth", () => ({
-      getServerSession: jest
-        .fn()
-        .mockResolvedValue({ user: { role: "admin" } }),
     }));
 
     const { POST } = await import(
@@ -60,11 +55,6 @@ describe("POST /api/create-shop", () => {
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
-    }));
-    jest.doMock("next-auth", () => ({
-      getServerSession: jest
-        .fn()
-        .mockResolvedValue({ user: { role: "admin" } }),
     }));
 
     const { POST } = await import(


### PR DESCRIPTION
## Summary
- centralize session-based role check within `createNewShop`
- simplify `create-shop` route to rely on action for authorization
- update tests for new authorization flow

## Testing
- `pnpm test` *(fails: Cannot find module '@/components/atoms/shadcn')*
- `pnpm --filter @apps/cms test __tests__/api.create-shop.test.ts`
- `pnpm --filter @acme/platform-core test __tests__/createShopRoute.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68989ec0e0dc832fa3558abea0537e7a