### PR TITLE
Use provider enums in createShop and rely on schema validation

### DIFF
--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -16,6 +16,14 @@ import { fillLocales } from "./utils/locales";
 import { loadThemeTokensNode } from "./themeTokens";
 import { nowIso } from "@shared/date";
 import { defaultFilterMappings } from "./defaultFilterMappings";
+import {
+  defaultPaymentProviders,
+  type DefaultPaymentProvider,
+} from "./createShop/defaultPaymentProviders";
+import {
+  defaultShippingProviders,
+  type DefaultShippingProvider,
+} from "./createShop/defaultShippingProviders";
 
 export const createShopOptionsSchema = z.object({
   name: z.string().optional(),
@@ -24,8 +32,8 @@ export const createShopOptionsSchema = z.object({
   type: z.enum(["sale", "rental"]).optional(),
   theme: z.string().optional(),
   template: z.string().optional(),
-  payment: z.array(z.string()).default([]),
-  shipping: z.array(z.string()).default([]),
+  payment: z.array(z.enum(defaultPaymentProviders)).default([]),
+  shipping: z.array(z.enum(defaultShippingProviders)).default([]),
   pageTitle: z.record(localeSchema, z.string()).optional(),
   pageDescription: z.record(localeSchema, z.string()).optional(),
   socialImage: z.string().url().optional(),
@@ -59,8 +67,8 @@ export interface CreateShopOptions {
   type?: "sale" | "rental";
   theme?: string;
   template?: string;
-  payment?: string[];
-  shipping?: string[];
+  payment?: DefaultPaymentProvider[];
+  shipping?: DefaultShippingProvider[];
   pageTitle?: Partial<Record<Locale, string>>;
   pageDescription?: Partial<Record<Locale, string>>;
   socialImage?: string;

--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -114,29 +114,6 @@ if (templateProvided) {
   }
 }
 
-if (options.payment.length) {
-  const invalid = options.payment.filter(
-    (p) => !defaultPaymentProviders.includes(p)
-  );
-  if (invalid.length) {
-    console.error(
-      `Unsupported payment providers: ${invalid.join(", ")}. Supported: ${defaultPaymentProviders.join(", ")}`
-    );
-    process.exit(1);
-  }
-}
-
-if (options.shipping.length) {
-  const invalid = options.shipping.filter(
-    (p) => !defaultShippingProviders.includes(p)
-  );
-  if (invalid.length) {
-    console.error(
-      `Unsupported shipping providers: ${invalid.join(", ")}. Supported: ${defaultShippingProviders.join(", ")}`
-    );
-    process.exit(1);
-  }
-}
 
 /** Prompt for theme when none is provided on the command line. */
 async function ensureTheme() {

--- a/test/unit/create-shop-cli.spec.ts
+++ b/test/unit/create-shop-cli.spec.ts
@@ -121,16 +121,16 @@ describe("CLI", () => {
     expect(sandbox.process.exit).toHaveBeenCalledWith(1);
   });
 
-  it("exits when payment provider is unsupported", () => {
+  it("passes payment providers through for validation", () => {
     const sandbox = runCli(["shop", "--payment=foo"]);
-    expect(sandbox.console.error).toHaveBeenCalled();
-    expect(sandbox.process.exit).toHaveBeenCalledWith(1);
+    expect(sandbox.process.exit).not.toHaveBeenCalled();
+    expect(sandbox.console.error).not.toHaveBeenCalled();
   });
 
-  it("exits when shipping provider is unsupported", () => {
+  it("passes shipping providers through for validation", () => {
     const sandbox = runCli(["shop", "--shipping=bar"]);
-    expect(sandbox.console.error).toHaveBeenCalled();
-    expect(sandbox.process.exit).toHaveBeenCalledWith(1);
+    expect(sandbox.process.exit).not.toHaveBeenCalled();
+    expect(sandbox.console.error).not.toHaveBeenCalled();
   });
 
   it("exits when shop name is invalid", () => {


### PR DESCRIPTION
## Summary
- validate payment and shipping providers using enums from default provider lists
- drop redundant provider checks in the create-shop CLI
- update CLI tests for new validation behavior

## Testing
- `pnpm exec jest test/unit/create-shop-cli.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68989ec446a8832f844bc0de33485bfb