### PR TITLE
test: cover image upload error paths

### DIFF
--- a/packages/ui/src/hooks/__tests__/useImageUpload.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useImageUpload.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, renderHook } from "@testing-library/react";
 import ImageUploaderWithOrientationCheck from "@ui/components/cms/ImageUploaderWithOrientationCheck";
-import { useImageUpload } from "../useImageUpload";
+import { useImageUpload as useLocalImageUpload } from "../useImageUpload";
+import useImageUpload from "../useMediaUpload";
 
 jest.mock("@ui/components/cms/ImageUploaderWithOrientationCheck", () => {
   return {
@@ -10,6 +11,10 @@ jest.mock("@ui/components/cms/ImageUploaderWithOrientationCheck", () => {
     )),
   };
 });
+
+jest.mock("../useImageOrientationValidation.ts", () => ({
+  useImageOrientationValidation: () => ({ actual: "landscape", isValid: true }),
+}));
 
 const mockComponent = ImageUploaderWithOrientationCheck as jest.MockedFunction<
   typeof ImageUploaderWithOrientationCheck
@@ -21,7 +26,7 @@ describe("useImageUpload", () => {
   });
 
   it("updates file state and renders uploader", () => {
-    const { result } = renderHook(() => useImageUpload("landscape"));
+    const { result } = renderHook(() => useLocalImageUpload("landscape"));
 
     const { getByTestId, rerender } = render(result.current.uploader);
     expect(mockComponent).toHaveBeenCalledWith(
@@ -43,5 +48,73 @@ describe("useImageUpload", () => {
       undefined
     );
     expect(getByTestId("uploader").textContent).toBe("test.png");
+  });
+});
+
+describe("useImageUpload upload errors", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  const file = new File(["x"], "x.png", { type: "image/png" });
+
+  it("surfaces error when fetch rejects and skips success callback", async () => {
+    const onUploaded = jest.fn();
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("network"));
+    (global as any).fetch = fetchMock;
+
+    const { result } = renderHook(() =>
+      useImageUpload({ shop: "s", requiredOrientation: "landscape", onUploaded })
+    );
+
+    act(() => {
+      result.current.onFileChange({ target: { files: [file] } } as any);
+      result.current.setAltText("alt");
+    });
+
+    await act(async () => {
+      await result.current.handleUpload();
+    });
+
+    expect(result.current.error).toBe("network");
+    expect(onUploaded).not.toHaveBeenCalled();
+    expect(result.current.pendingFile).toBeNull();
+    expect(result.current.altText).toBe("");
+    expect(result.current.progress).toBeNull();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("surfaces error when fetch returns non-OK and skips success callback", async () => {
+    const onUploaded = jest.fn();
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      statusText: "bad",
+      json: () => Promise.resolve({ error: "bad" }),
+    });
+    (global as any).fetch = fetchMock;
+
+    const { result } = renderHook(() =>
+      useImageUpload({ shop: "s", requiredOrientation: "landscape", onUploaded })
+    );
+
+    act(() => {
+      result.current.onFileChange({ target: { files: [file] } } as any);
+      result.current.setAltText("alt");
+    });
+
+    await act(async () => {
+      await result.current.handleUpload();
+    });
+
+    expect(result.current.error).toBe("bad");
+    expect(onUploaded).not.toHaveBeenCalled();
+    expect(result.current.pendingFile).toBeNull();
+    expect(result.current.altText).toBe("");
+    expect(result.current.progress).toBeNull();
+    expect(fetchMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- test uploaded image error handling when fetch rejects or returns non-OK

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/hooks/__tests__/useImageUpload.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6898a2f81028832f8bfe0741cfce1842