### PR TITLE
refactor: centralize create shop auth

### DIFF
--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -6,21 +6,19 @@ import { createShop, type CreateShopOptions } from "@platform-core/createShop";
 import { getServerSession } from "next-auth";
 import { readRbac, writeRbac } from "../lib/rbacStore";
 
-async function ensureAuthorized(): Promise<void> {
+async function ensureAuthorized() {
   const session = await getServerSession(authOptions);
   if (!session || !["admin", "ShopAdmin"].includes(session.user?.role ?? "")) {
     throw new Error("Forbidden");
   }
+  return session;
 }
 
 export async function createNewShop(
   id: string,
   options: CreateShopOptions
 ): Promise<void> {
-  await ensureAuthorized();
-
-  const session = await getServerSession(authOptions);
-  if (!session) throw new Error("Forbidden");
+  const session = await ensureAuthorized();
 
   try {
     await createShop(id, options);


### PR DESCRIPTION
## Summary
- move authorization and session management into createNewShop
- rely on createNewShop for permissions in the create-shop API route

## Testing
- `pnpm --filter=@apps/cms test __tests__/api.create-shop.test.ts __tests__/createShopActions.test.tsx`
- `pnpm --filter=@acme/platform-core test __tests__/createShopRoute.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898a24590e8832fb3a4b32c1d29d2b4