### PR TITLE
Return deployment result from shop creation

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -15,7 +15,11 @@ describe("create-shop API", () => {
   it("creates shop when authorized", async () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
-    const createNewShop = jest.fn();
+    const deployResult = {
+      status: "success",
+      previewUrl: "https://new.pages.dev",
+    };
+    const createNewShop = jest.fn().mockResolvedValue(deployResult);
     const session: Session = {
       user: { role: "admin", email: "a" },
       expires: "",
@@ -40,6 +44,10 @@ describe("create-shop API", () => {
       pages: [],
       payment: [],
       shipping: [],
+    });
+    await expect(res.json()).resolves.toEqual({
+      success: true,
+      deployment: deployResult,
     });
     (process.env as Record<string, string>).NODE_ENV = prevEnv as string;
   });

--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -74,7 +74,8 @@ describe("createNewShop authorization", () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
 
-    const createShop = jest.fn();
+    const deployResult = { status: "success", previewUrl: "https://shop2.pages.dev" };
+    const createShop = jest.fn().mockReturnValue(deployResult);
     jest.doMock("@platform-core/createShop", () => ({
       __esModule: true,
       createShop,
@@ -88,7 +89,9 @@ describe("createNewShop authorization", () => {
     const { createNewShop } = await import(
       /* webpackIgnore: true */ "../src/actions/createShop.server.ts"
     );
-    await createNewShop("shop2", { theme: "base" } as any);
+    await expect(
+      createNewShop("shop2", { theme: "base" } as any)
+    ).resolves.toEqual(deployResult);
 
     expect(createShop).toHaveBeenCalledTimes(1);
     expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" });

--- a/apps/cms/src/app/api/create-shop/route.ts
+++ b/apps/cms/src/app/api/create-shop/route.ts
@@ -44,12 +44,12 @@ export async function POST(req: Request) {
 
     const { id, ...options } = parsed.data;
 
-    await createNewShop(id, options);
+    const deployment = await createNewShop(id, options);
 
     /* --------------------------------------------------------------
      *  Success → 201 Created
      * ------------------------------------------------------------ */
-    return NextResponse.json({ success: true }, { status: 201 });
+    return NextResponse.json({ success: true, deployment }, { status: 201 });
   } catch (err) {
     /* --------------------------------------------------------------
      *  Bad request or runtime failure → 400

--- a/packages/platform-core/__tests__/createShopRoute.test.ts
+++ b/packages/platform-core/__tests__/createShopRoute.test.ts
@@ -30,7 +30,8 @@ describe("POST /api/create-shop", () => {
   });
 
   it("calls createNewShop and returns success", async () => {
-    const createNewShop = jest.fn();
+    const deployResult = { status: "success", previewUrl: "https://shop1.pages.dev" };
+    const createNewShop = jest.fn().mockResolvedValue(deployResult);
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
@@ -46,13 +47,20 @@ describe("POST /api/create-shop", () => {
     );
     const req = new Request("http://localhost/api/create-shop", {
       method: "POST",
-      body: JSON.stringify({ id: "shop1", options: { theme: "base" } }),
+      body: JSON.stringify({ id: "shop1", theme: "base" }),
     });
     const res = await POST(req);
     expect(createNewShop).toHaveBeenCalledTimes(1);
-    expect(createNewShop).toHaveBeenCalledWith("shop1", { theme: "base" });
+    expect(createNewShop).toHaveBeenCalledWith("shop1", {
+      theme: "base",
+      payment: [],
+      shipping: [],
+      pages: [],
+      navItems: [],
+      checkoutPage: [],
+    });
     expect(res.status).toBe(201);
-    await expect(res.json()).resolves.toEqual({ success: true });
+    await expect(res.json()).resolves.toEqual({ success: true, deployment: deployResult });
   });
 
   it("returns 400 when action throws", async () => {

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -316,7 +316,10 @@ export function writeFiles(
  * Create a new shop app and seed data.
  * Paths are resolved relative to the repository root.
  */
-export function createShop(id: string, opts: CreateShopOptions = {}): void {
+export function createShop(
+  id: string,
+  opts: CreateShopOptions = {}
+): DeployShopResult {
   id = validateShopName(id);
   const newApp = join("apps", id);
   const newData = join("data", "shops", id);
@@ -336,7 +339,7 @@ export function createShop(id: string, opts: CreateShopOptions = {}): void {
 
   writeFiles(id, options, templateApp, newApp, newData);
 
-  deployShop(id);
+  return deployShop(id);
 }
 
 export interface DeployStatusBase {


### PR DESCRIPTION
## Summary
- return `DeployShopResult` from `createShop`
- forward deployment info through `createNewShop`
- include deployment status and preview URL in create-shop API response

## Testing
- `pnpm exec jest packages/platform-core/__tests__/createShopRoute.test.ts apps/cms/__tests__/api.create-shop.test.ts apps/cms/__tests__/createShopActions.test.tsx`
- `pnpm exec eslint apps/cms/src/actions/createShop.server.ts apps/cms/src/app/api/create-shop/route.ts packages/platform-core/src/createShop.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898a2693940832fadd8dffa8a5756a0