### PR TITLE
chore: enforce runtime versions in shop scripts

### DIFF
--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -2,6 +2,7 @@
 // Import directly to avoid relying on tsconfig path aliases when using ts-node.
 import { readdirSync } from "fs";
 import readline from "node:readline";
+import { execSync } from "node:child_process";
 import { join } from "path";
 import {
   createShop,
@@ -10,6 +11,34 @@ import {
 import { validateShopName } from "../../packages/platform-core/src/shops";
 import { defaultPaymentProviders } from "../../packages/platform-core/src/createShop/defaultPaymentProviders";
 import { defaultShippingProviders } from "../../packages/platform-core/src/createShop/defaultShippingProviders";
+
+function ensureRuntime() {
+  const nodeMajor = Number(process.version.replace(/^v/, "").split(".")[0]);
+  if (nodeMajor < 20) {
+    console.error(
+      `Node.js v20 or later is required. Current version: ${process.version}`
+    );
+    process.exit(1);
+  }
+
+  let pnpmVersion: string;
+  try {
+    pnpmVersion = execSync("pnpm --version", { encoding: "utf8" }).trim();
+  } catch {
+    console.error("Failed to determine pnpm version. pnpm v10 or later is required.");
+    process.exit(1);
+  }
+
+  const pnpmMajor = Number(pnpmVersion.split(".")[0]);
+  if (pnpmMajor < 10) {
+    console.error(
+      `pnpm v10 or later is required. Current version: ${pnpmVersion}`
+    );
+    process.exit(1);
+  }
+}
+
+ensureRuntime();
 
 /* ────────────────────────────────────────────────────────── *
  * Command-line parsing                                       *

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -3,9 +3,37 @@ import { validateShopName } from "../../packages/platform-core/src/shops";
 import { envSchema } from "@config/src/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync, execSync } from "node:child_process";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
+
+function ensureRuntime() {
+  const nodeMajor = Number(process.version.replace(/^v/, "").split(".")[0]);
+  if (nodeMajor < 20) {
+    console.error(
+      `Node.js v20 or later is required. Current version: ${process.version}`
+    );
+    process.exit(1);
+  }
+
+  let pnpmVersion: string;
+  try {
+    pnpmVersion = execSync("pnpm --version", { encoding: "utf8" }).trim();
+  } catch {
+    console.error("Failed to determine pnpm version. pnpm v10 or later is required.");
+    process.exit(1);
+  }
+
+  const pnpmMajor = Number(pnpmVersion.split(".")[0]);
+  if (pnpmMajor < 10) {
+    console.error(
+      `pnpm v10 or later is required. Current version: ${pnpmVersion}`
+    );
+    process.exit(1);
+  }
+}
+
+ensureRuntime();
 
 async function prompt(question: string, def = ""): Promise<string> {
   const rl = readline.createInterface({ input, output });


### PR DESCRIPTION
## Summary
- validate Node.js >= 20 and pnpm >= 10 before running `create-shop`
- validate Node.js >= 20 and pnpm >= 10 before running `init-shop`

## Testing
- `pnpm test` *(fails: command /root/.nvm/versions/node/v20.19.4/bin/pnpm run test exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_6898a64a5b50832fb4fc4f4225d4bc2e