### PR TITLE
feat: initialize theme from system preference

### DIFF
--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // apps/cms/src/app/layout.tsx
 import { CartProvider } from "@/contexts/CartContext";
+import { themeInitScript } from "@/contexts/themeInitScript";
 import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
@@ -36,32 +37,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="color-scheme" content="light dark" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                var theme = localStorage.getItem('theme');
-                var classList = document.documentElement.classList;
-                if (theme === 'system') {
-                  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                    classList.add('theme-dark');
-                  } else {
-                    classList.remove('theme-dark');
-                  }
-                } else if (theme === 'dark') {
-                  classList.add('theme-dark');
-                } else {
-                  classList.remove('theme-dark');
-                }
-                if (theme === 'brandx') {
-                  classList.add('theme-brandx');
-                } else {
-                  classList.remove('theme-brandx');
-                }
-              })();
-            `,
-          }}
-        />
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className="antialiased">
         {/* Global providers go here */}

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
+import { themeInitScript } from "@/contexts/themeInitScript";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -31,32 +32,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="color-scheme" content="light dark" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                var theme = localStorage.getItem('theme');
-                var classList = document.documentElement.classList;
-                if (theme === 'system') {
-                  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                    classList.add('theme-dark');
-                  } else {
-                    classList.remove('theme-dark');
-                  }
-                } else if (theme === 'dark') {
-                  classList.add('theme-dark');
-                } else {
-                  classList.remove('theme-dark');
-                }
-                if (theme === 'brandx') {
-                  classList.add('theme-brandx');
-                } else {
-                  classList.remove('theme-brandx');
-                }
-              })();
-            `,
-          }}
-        />
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className="antialiased">
         {/* Global providers go here */}

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
+import { themeInitScript } from "@/contexts/themeInitScript";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -31,20 +32,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="color-scheme" content="light dark" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                var theme = localStorage.getItem('theme');
-                if (theme === 'dark') {
-                  document.documentElement.classList.add('theme-dark');
-                } else {
-                  document.documentElement.classList.remove('theme-dark');
-                }
-              })();
-            `,
-          }}
-        />
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className="antialiased">
         {/* Global providers go here */}

--- a/packages/platform-core/src/contexts/themeInitScript.ts
+++ b/packages/platform-core/src/contexts/themeInitScript.ts
@@ -1,0 +1,22 @@
+export const themeInitScript = `
+(function () {
+  var theme = localStorage.getItem('theme') || 'system';
+  var classList = document.documentElement.classList;
+  if (theme === 'system') {
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      classList.add('theme-dark');
+    } else {
+      classList.remove('theme-dark');
+    }
+  } else if (theme === 'dark') {
+    classList.add('theme-dark');
+  } else {
+    classList.remove('theme-dark');
+  }
+  if (theme === 'brandx') {
+    classList.add('theme-brandx');
+  } else {
+    classList.remove('theme-brandx');
+  }
+})();
+`;


### PR DESCRIPTION
## Summary
- add shared theme initializer that defaults to system when no saved theme
- respect prefers-color-scheme to pre-apply `.theme-dark`
- update app layouts to run the shared theme initializer

## Testing
- `pnpm test` *(fails: @apps/cms#test)*

------
https://chatgpt.com/codex/tasks/task_e_6898a5f85f7c832f8254164116fde27a