### PR TITLE
test: add tailwind preset script coverage

### DIFF
--- a/scripts/__tests__/check-tailwind-preset.test.ts
+++ b/scripts/__tests__/check-tailwind-preset.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+import { expect } from "@jest/globals";
+
+const resolveMock = jest.fn();
+
+jest.mock("node:module", () => ({
+  createRequire: jest.fn(() => ({ resolve: resolveMock })),
+}));
+// ensure TypeScript execution via ts-node like the script's CLI usage
+import "ts-node/register";
+
+describe("check-tailwind-preset script", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    resolveMock.mockReset();
+  });
+
+  it("logs resolved path when preset resolves", async () => {
+    resolveMock.mockReturnValue("/mocked/path.js");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await import("../check-tailwind-preset.ts");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "[tailwind.config] ✅  @acme/tailwind-config resolved → /mocked/path.js"
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "[tailwind.config] ℹ️  preset keys:",
+      expect.any(Array)
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("could NOT be resolved"),
+      expect.anything()
+    );
+  });
+
+  it("logs error when preset cannot be resolved", async () => {
+    const err = Object.assign(new Error("Cannot find module"), {
+      code: "MODULE_NOT_FOUND",
+    });
+    resolveMock.mockImplementation(() => {
+      throw err;
+    });
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await import("../check-tailwind-preset.ts");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[tailwind.config] ❌  @acme/tailwind-config could NOT be resolved.\n" +
+        "Is the package in pnpm-workspace.yaml? Did you run `pnpm install`?",
+      err
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "[tailwind.config] ℹ️  preset keys:",
+      expect.any(Array)
+    );
+  });
+});
+

--- a/scripts/check-tailwind-preset.ts
+++ b/scripts/check-tailwind-preset.ts
@@ -1,11 +1,17 @@
 import { createRequire } from "node:module";
 import preset from "../packages/tailwind-config/src/index.ts";
 
-const require = createRequire(import.meta.url);
+let moduleUrl = "";
+try {
+  moduleUrl = (0, eval)("import.meta.url");
+} catch {
+  moduleUrl = __filename;
+}
+const nodeRequire = createRequire(moduleUrl);
 
 let resolvedPresetPath = "<unresolved>";
 try {
-  resolvedPresetPath = require.resolve("@acme/tailwind-config");
+  resolvedPresetPath = nodeRequire.resolve("@acme/tailwind-config");
   // eslint-disable-next-line no-console
   console.log(
     `[tailwind.config] ✅  @acme/tailwind-config resolved → ${resolvedPresetPath}`


### PR DESCRIPTION
## Summary
- adjust tailwind preset checker to resolve package path in both ESM and CJS contexts
- test tailwind preset checker for both successful and missing preset scenarios

## Testing
- `pnpm exec jest scripts/__tests__/check-tailwind-preset.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898a6bba234832fa8daf4798d7090be