### PR TITLE
feat: add danger semantic tokens

### DIFF
--- a/packages/design-tokens/index.ts
+++ b/packages/design-tokens/index.ts
@@ -10,11 +10,13 @@ const designTokens = plugin.withOptions(
           fg: "hsl(var(--color-fg))",
           primary: "hsl(var(--color-primary))",
           accent: "hsl(var(--color-accent))",
+          danger: "hsl(var(--color-danger))",
           muted: "hsl(var(--color-muted))",
         },
         textColor: {
           "primary-fg": "hsl(var(--color-primary-fg))",
           "accent-foreground": "hsl(var(--color-accent-fg))",
+          "danger-foreground": "hsl(var(--color-danger-fg))",
         },
         fontFamily: {
           sans: "var(--font-sans)",

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -17,11 +17,13 @@ const preset: Config = {
         fg: "hsl(var(--color-fg))",
         primary: "hsl(var(--color-primary))",
         accent: "hsl(var(--color-accent))",
+        danger: "hsl(var(--color-danger))",
         muted: "hsl(var(--color-muted))",
       },
       textColor: {
         "primary-fg": "hsl(var(--color-primary-fg))",
         "accent-foreground": "hsl(var(--color-accent-fg))",
+        "danger-foreground": "hsl(var(--color-danger-fg))",
       },
       fontFamily: {
         sans: "var(--font-sans)",

--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -17,11 +17,13 @@ const preset: Partial<Config> = {
         fg: "hsl(var(--color-fg))",
         primary: "hsl(var(--color-primary))",
         accent: "hsl(var(--color-accent))",
+        danger: "hsl(var(--color-danger))",
         muted: "hsl(var(--color-muted))",
       },
       textColor: {
         "primary-fg": "hsl(var(--color-primary-fg))",
         "accent-foreground": "hsl(var(--color-accent-fg))",
+        "danger-foreground": "hsl(var(--color-danger-fg))",
       },
       fontFamily: {
         sans: "var(--font-sans)",

--- a/packages/themes/base/__tests__/__snapshots__/tokens.test.ts.snap
+++ b/packages/themes/base/__tests__/__snapshots__/tokens.test.ts.snap
@@ -14,6 +14,14 @@ exports[`base theme tokens tokens snapshot 1`] = `
     "dark": "0 0% 4%",
     "light": "0 0% 100%",
   },
+  "--color-danger": {
+    "dark": "0 63% 31%",
+    "light": "0 86% 97%",
+  },
+  "--color-danger-fg": {
+    "dark": "0 93% 94%",
+    "light": "0 74% 42%",
+  },
   "--color-fg": {
     "dark": "0 0% 93%",
     "light": "0 0% 10%",

--- a/packages/themes/base/__tests__/tokens.test.ts
+++ b/packages/themes/base/__tests__/tokens.test.ts
@@ -9,6 +9,8 @@ const expectedKeys = [
   '--color-primary-fg',
   '--color-accent',
   '--color-accent-fg',
+  '--color-danger',
+  '--color-danger-fg',
   '--color-muted',
   '--font-sans',
   '--font-mono',

--- a/packages/themes/base/src/tokens.css
+++ b/packages/themes/base/src/tokens.css
@@ -13,6 +13,8 @@
   --color-primary-fg: 0 0% 100%;
   --color-accent: 260 83% 70%;
   --color-accent-fg: 0 0% 10%;
+  --color-danger: 0 86% 97%;
+  --color-danger-fg: 0 74% 42%;
   --color-muted: 0 0% 88%;
 
   --color-bg-dark: 0 0% 4%;
@@ -21,6 +23,8 @@
   --color-primary-fg-dark: 0 0% 10%;
   --color-accent-dark: 260 83% 70%;
   --color-accent-fg-dark: 0 0% 10%;
+  --color-danger-dark: 0 63% 31%;
+  --color-danger-fg-dark: 0 93% 94%;
   --color-muted-dark: 0 0% 60%;
 
   /* typography */
@@ -47,6 +51,8 @@
     --color-primary-fg: var(--color-primary-fg-dark);
     --color-accent: var(--color-accent-dark);
     --color-accent-fg: var(--color-accent-fg-dark);
+    --color-danger: var(--color-danger-dark);
+    --color-danger-fg: var(--color-danger-fg-dark);
     --color-muted: var(--color-muted-dark);
   }
 }
@@ -58,5 +64,7 @@ html.theme-dark {
   --color-primary-fg: var(--color-primary-fg-dark);
   --color-accent: var(--color-accent-dark);
   --color-accent-fg: var(--color-accent-fg-dark);
+  --color-danger: var(--color-danger-dark);
+  --color-danger-fg: var(--color-danger-fg-dark);
   --color-muted: var(--color-muted-dark);
 }

--- a/packages/themes/base/src/tokens.dynamic.css
+++ b/packages/themes/base/src/tokens.dynamic.css
@@ -13,6 +13,10 @@
   --color-accent-dark: var(--token-color-accent-dark, 260 83% 70%);
   --color-accent-fg: var(--token-color-accent-fg, 0 0% 10%);
   --color-accent-fg-dark: var(--token-color-accent-fg-dark, 0 0% 10%);
+  --color-danger: var(--token-color-danger, 0 86% 97%);
+  --color-danger-dark: var(--token-color-danger-dark, 0 63% 31%);
+  --color-danger-fg: var(--token-color-danger-fg, 0 74% 42%);
+  --color-danger-fg-dark: var(--token-color-danger-fg-dark, 0 93% 94%);
   --color-muted: var(--token-color-muted, 0 0% 88%);
   --color-muted-dark: var(--token-color-muted-dark, 0 0% 60%);
   --font-sans: var(--token-font-sans, "Geist Sans", system-ui, sans-serif);
@@ -37,6 +41,8 @@
     --color-primary-fg: var(--color-primary-fg-dark);
     --color-accent: var(--color-accent-dark);
     --color-accent-fg: var(--color-accent-fg-dark);
+    --color-danger: var(--color-danger-dark);
+    --color-danger-fg: var(--color-danger-fg-dark);
     --color-muted: var(--color-muted-dark);
   }
 }
@@ -48,5 +54,7 @@ html.theme-dark {
   --color-primary-fg: var(--color-primary-fg-dark);
   --color-accent: var(--color-accent-dark);
   --color-accent-fg: var(--color-accent-fg-dark);
+  --color-danger: var(--color-danger-dark);
+  --color-danger-fg: var(--color-danger-fg-dark);
   --color-muted: var(--color-muted-dark);
 }

--- a/packages/themes/base/src/tokens.static.css
+++ b/packages/themes/base/src/tokens.static.css
@@ -13,6 +13,10 @@
   --color-accent-dark: 260 83% 70%;
   --color-accent-fg: 0 0% 10%;
   --color-accent-fg-dark: 0 0% 10%;
+  --color-danger: 0 86% 97%;
+  --color-danger-dark: 0 63% 31%;
+  --color-danger-fg: 0 74% 42%;
+  --color-danger-fg-dark: 0 93% 94%;
   --color-muted: 0 0% 88%;
   --color-muted-dark: 0 0% 60%;
   --font-sans: "Geist Sans", system-ui, sans-serif;
@@ -37,6 +41,8 @@
     --color-primary-fg: var(--color-primary-fg-dark);
     --color-accent: var(--color-accent-dark);
     --color-accent-fg: var(--color-accent-fg-dark);
+    --color-danger: var(--color-danger-dark);
+    --color-danger-fg: var(--color-danger-fg-dark);
     --color-muted: var(--color-muted-dark);
   }
 }
@@ -48,5 +54,7 @@ html.theme-dark {
   --color-primary-fg: var(--color-primary-fg-dark);
   --color-accent: var(--color-accent-dark);
   --color-accent-fg: var(--color-accent-fg-dark);
+  --color-danger: var(--color-danger-dark);
+  --color-danger-fg: var(--color-danger-fg-dark);
   --color-muted: var(--color-muted-dark);
 }

--- a/packages/themes/base/src/tokens.ts
+++ b/packages/themes/base/src/tokens.ts
@@ -21,6 +21,8 @@ export const tokens = {
   "--color-primary-fg": { light: "0 0% 100%", dark: "0 0% 10%" },
   "--color-accent": { light: "260 83% 70%", dark: "260 83% 70%" },
   "--color-accent-fg": { light: "0 0% 10%", dark: "0 0% 10%" },
+  "--color-danger": { light: "0 86% 97%", dark: "0 63% 31%" },
+  "--color-danger-fg": { light: "0 74% 42%", dark: "0 93% 94%" },
   "--color-muted": { light: "0 0% 88%", dark: "0 0% 60%" },
   "--font-sans": { light: '"Geist Sans", system-ui, sans-serif' },
   "--font-mono": { light: '"Geist Mono", ui-monospace, monospace' },

--- a/packages/themes/base/tokens.js
+++ b/packages/themes/base/tokens.js
@@ -5,6 +5,8 @@ export const tokens = {
   "--color-primary-fg": { light: "0 0% 100%", dark: "0 0% 10%" },
   "--color-accent": { light: "260 83% 70%", dark: "260 83% 70%" },
   "--color-accent-fg": { light: "0 0% 10%", dark: "0 0% 10%" },
+  "--color-danger": { light: "0 86% 97%", dark: "0 63% 31%" },
+  "--color-danger-fg": { light: "0 74% 42%", dark: "0 93% 94%" },
   "--color-muted": { light: "0 0% 88%", dark: "0 0% 60%" },
   "--font-sans": { light: '"Geist Sans", system-ui, sans-serif' },
   "--font-mono": { light: '"Geist Mono", ui-monospace, monospace' },

--- a/packages/ui/src/components/cms/products/ProductRowActions.tsx
+++ b/packages/ui/src/components/cms/products/ProductRowActions.tsx
@@ -41,7 +41,7 @@ export default function ProductRowActions({
       <Button
         onClick={() => onDelete(product.id)}
         variant="outline"
-        className="px-2 py-1 text-xs hover:bg-red-50 dark:hover:bg-red-900"
+        className="px-2 py-1 text-xs hover:bg-danger hover:text-danger-foreground"
       >
         Delete
       </Button>


### PR DESCRIPTION
## Summary
- add `--color-danger` semantic tokens and styles
- expose `bg-danger` and `text-danger-foreground` through Tailwind presets
- use the new classes in `ProductRowActions`

## Testing
- `pnpm build:tokens`
- `npx jest packages/themes/base/__tests__/tokens.test.ts --updateSnapshot`
- `npx jest packages/design-tokens/__tests__/preset.test.ts`
- `npx jest packages/themes/base/__tests__/tokens.test.ts`
- `npx jest packages/ui` *(fails: Cannot find module '../useMediaUpload.ts' from 'useMediaUpload.test.ts')*
- `npx eslint packages/themes/base/src/tokens.ts packages/themes/base/__tests__/tokens.test.ts packages/design-tokens/index.ts packages/design-tokens/src/index.ts packages/tailwind-config/src/index.ts packages/ui/src/components/cms/products/ProductRowActions.tsx` *(files ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6898a5f6b4ac832f984ef6329f1d02e6