### PR TITLE
feat(theme): add color transition

### DIFF
--- a/packages/themes/base/src/tokens.css
+++ b/packages/themes/base/src/tokens.css
@@ -39,6 +39,20 @@
   --radius-lg: 12px;
 }
 
+html,
+body {
+  transition-property: background-color, color, border-color;
+  transition-duration: 250ms;
+  transition-timing-function: ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html,
+  body {
+    transition: none;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: var(--color-bg-dark);


### PR DESCRIPTION
## Summary
- animate `background-color`, `color`, and `border-color` on `html, body`
- disable color transitions when `prefers-reduced-motion`

## Testing
- `pnpm lint --filter @themes/base`
- `pnpm test --filter @themes/base`


------
https://chatgpt.com/codex/tasks/task_e_6898a5f7acfc832f8f0336c13f628ed4