### PR TITLE
Return deploy result from shop creation

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -14,7 +14,8 @@ describe("create-shop API", () => {
   it("creates shop when authorized", async () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
-    const createNewShop = jest.fn();
+    const deployment = { status: "success", previewUrl: "https://new.pages.dev" };
+    const createNewShop = jest.fn().mockResolvedValue(deployment);
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
@@ -33,6 +34,7 @@ describe("create-shop API", () => {
       payment: [],
       shipping: [],
     });
+    await expect(res.json()).resolves.toEqual({ success: true, deployment });
     (process.env as Record<string, string>).NODE_ENV = prevEnv as string;
   });
 

--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -74,7 +74,8 @@ describe("createNewShop authorization", () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
 
-    const createShop = jest.fn();
+    const deployResult = { status: "success", previewUrl: "https://shop2.pages.dev" };
+    const createShop = jest.fn().mockReturnValue(deployResult);
     jest.doMock("@platform-core/createShop", () => ({
       __esModule: true,
       createShop,
@@ -88,10 +89,11 @@ describe("createNewShop authorization", () => {
     const { createNewShop } = await import(
       /* webpackIgnore: true */ "../src/actions/createShop.server.ts"
     );
-    await createNewShop("shop2", { theme: "base" } as any);
+    const res = await createNewShop("shop2", { theme: "base" } as any);
 
     expect(createShop).toHaveBeenCalledTimes(1);
     expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" });
+    expect(res).toBe(deployResult);
 
     (process.env as Record<string, string>).NODE_ENV = prevEnv;
   });

--- a/apps/cms/src/app/api/create-shop/route.ts
+++ b/apps/cms/src/app/api/create-shop/route.ts
@@ -33,12 +33,12 @@ export async function POST(req: Request) {
 
     const { id, ...options } = parsed.data;
 
-    await createNewShop(id, options);
+    const deployment = await createNewShop(id, options);
 
     /* --------------------------------------------------------------
      *  Success → 201 Created
      * ------------------------------------------------------------ */
-    return NextResponse.json({ success: true }, { status: 201 });
+    return NextResponse.json({ success: true, deployment }, { status: 201 });
   } catch (err) {
     /* --------------------------------------------------------------
      *  Forbidden or bad request

--- a/packages/platform-core/__tests__/createShopRoute.test.ts
+++ b/packages/platform-core/__tests__/createShopRoute.test.ts
@@ -30,7 +30,8 @@ describe("POST /api/create-shop", () => {
   });
 
   it("calls createNewShop and returns success", async () => {
-    const createNewShop = jest.fn();
+    const deployment = { status: "success", previewUrl: "https://shop1.pages.dev" };
+    const createNewShop = jest.fn().mockResolvedValue(deployment);
     jest.doMock("@cms/actions/createShop.server", () => ({
       __esModule: true,
       createNewShop,
@@ -54,7 +55,7 @@ describe("POST /api/create-shop", () => {
       checkoutPage: [],
     });
     expect(res.status).toBe(201);
-    await expect(res.json()).resolves.toEqual({ success: true });
+    await expect(res.json()).resolves.toEqual({ success: true, deployment });
   });
 
   it("returns 400 when action throws", async () => {

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -315,7 +315,10 @@ export function writeFiles(
  * Create a new shop app and seed data.
  * Paths are resolved relative to the repository root.
  */
-export function createShop(id: string, opts: CreateShopOptions = {}): void {
+export function createShop(
+  id: string,
+  opts: CreateShopOptions = {}
+): DeployShopResult {
   id = validateShopName(id);
   const newApp = join("apps", id);
   const newData = join("data", "shops", id);
@@ -335,7 +338,7 @@ export function createShop(id: string, opts: CreateShopOptions = {}): void {
 
   writeFiles(id, options, templateApp, newApp, newData);
 
-  deployShop(id);
+  return deployShop(id);
 }
 
 export interface DeployStatusBase {


### PR DESCRIPTION
## Summary
- return deployment info from `createShop`
- expose deploy result in `createNewShop` and `/api/create-shop` route
- update related tests

## Testing
- `pnpm test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6898a68c5984832f9959bcf3530605e7