### PR TITLE
feat: centralize theme initialization

### DIFF
--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/layout.tsx
 import { CartProvider } from "@/contexts/CartContext";
-import { themeInitScript } from "@/contexts/themeInitScript";
+import { initTheme } from "@platform-core/src/utils/initTheme";
 import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
@@ -37,7 +37,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="color-scheme" content="light dark" />
-        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        <script dangerouslySetInnerHTML={{ __html: initTheme }} />
       </head>
       <body className="antialiased">
         {/* Global providers go here */}

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { themeInitScript } from "@/contexts/themeInitScript";
+import { initTheme } from "@platform-core/src/utils/initTheme";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -32,7 +32,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="color-scheme" content="light dark" />
-        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        <script dangerouslySetInnerHTML={{ __html: initTheme }} />
       </head>
       <body className="antialiased">
         {/* Global providers go here */}

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { themeInitScript } from "@/contexts/themeInitScript";
+import { initTheme } from "@platform-core/src/utils/initTheme";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -32,7 +32,7 @@ export default function RootLayout({
     >
       <head>
         <meta name="color-scheme" content="light dark" />
-        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        <script dangerouslySetInnerHTML={{ __html: initTheme }} />
       </head>
       <body className="antialiased">
         {/* Global providers go here */}

--- a/packages/platform-core/src/utils/initTheme.ts
+++ b/packages/platform-core/src/utils/initTheme.ts
@@ -1,17 +1,17 @@
-export const themeInitScript = `
+export const initTheme = `
 (function () {
   var theme = localStorage.getItem('theme') || 'system';
   var classList = document.documentElement.classList;
+  var isDark = theme === 'dark';
   if (theme === 'system') {
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      classList.add('theme-dark');
-    } else {
-      classList.remove('theme-dark');
-    }
-  } else if (theme === 'dark') {
+    isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  if (isDark) {
     classList.add('theme-dark');
+    document.documentElement.style.colorScheme = 'dark';
   } else {
     classList.remove('theme-dark');
+    document.documentElement.style.colorScheme = 'light';
   }
   if (theme === 'brandx') {
     classList.add('theme-brandx');


### PR DESCRIPTION
## Summary
- add `initTheme` helper to set dark/light mode and brand class from localStorage
- inline theme initializer script in shop-abc, shop-bcd, and cms layouts
- remove legacy `themeInitScript`

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*
- `pnpm exec eslint apps/shop-abc/src/app/layout.tsx apps/shop-bcd/src/app/layout.tsx apps/cms/src/app/layout.tsx packages/platform-core/src/utils/initTheme.ts`

------
https://chatgpt.com/codex/tasks/task_e_6898aab75c3c832f8f422067dee718cf