### PR TITLE
feat: add customer session and account pages

### DIFF
--- a/apps/shop-abc/src/app/account/orders/page.tsx
+++ b/apps/shop-abc/src/app/account/orders/page.tsx
@@ -1,0 +1,23 @@
+// apps/shop-abc/src/app/account/orders/page.tsx
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/repositories/rentalOrdersDb.server";
+import shop from "../../../../shop.json";
+
+export const metadata = { title: "Orders" };
+
+export default async function OrdersPage() {
+  const session = await getCustomerSession();
+  if (!session) return <p>Please log in to view your orders.</p>;
+  const orders = await getOrdersForCustomer(shop.id, session.customerId);
+  if (!orders.length) return <p className="p-6">No orders yet.</p>;
+  return (
+    <ul className="space-y-2 p-6">
+      {orders.map((o) => (
+        <li key={o.id} className="rounded border p-4">
+          <div>Order: {o.id}</div>
+          {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/shop-abc/src/app/account/profile/page.tsx
+++ b/apps/shop-abc/src/app/account/profile/page.tsx
@@ -1,0 +1,15 @@
+// apps/shop-abc/src/app/account/profile/page.tsx
+import { getCustomerSession } from "@auth";
+
+export const metadata = { title: "Profile" };
+
+export default async function ProfilePage() {
+  const session = await getCustomerSession();
+  if (!session) return <p>Please log in to view your profile.</p>;
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-xl">Profile</h1>
+      <pre className="rounded bg-muted p-4">{JSON.stringify(session, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -3,6 +3,7 @@
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
 import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer";
+import { getCustomerSession } from "@auth";
 import { priceForDays } from "@platform-core/pricing";
 
 import type { CartLine, CartState } from "@types";
@@ -121,6 +122,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   );
 
   /* 5️⃣ Create Checkout Session -------------------------------------------- */
+  const customer = await getCustomerSession();
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
     line_items,
@@ -132,6 +134,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         depositTotal: depositTotal.toString(),
         returnDate: returnDate ?? "",
         rentalDays: rentalDays.toString(),
+        customerId: customer?.customerId ?? "",
       },
     },
     metadata: {
@@ -140,6 +143,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       returnDate: returnDate ?? "",
       rentalDays: rentalDays.toString(),
       sizes: sizesMeta,
+      customerId: customer?.customerId ?? "",
     },
     expand: ["payment_intent"],
   });

--- a/apps/shop-abc/src/app/api/stripe-webhook/route.ts
+++ b/apps/shop-abc/src/app/api/stripe-webhook/route.ts
@@ -4,6 +4,9 @@ import {
   addOrder,
   markRefunded,
 } from "@platform-core/repositories/rentalOrders.server";
+import {
+  addOrder as addDbOrder,
+} from "@platform-core/repositories/rentalOrdersDb.server";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
@@ -24,7 +27,9 @@ export async function POST(req: NextRequest) {
       const session = data as Stripe.Checkout.Session;
       const deposit = Number(session.metadata?.depositTotal ?? 0);
       const returnDate = session.metadata?.returnDate || undefined;
-      await addOrder("abc", session.id, deposit, returnDate);
+      const customerId = session.metadata?.customerId || undefined;
+      await addDbOrder("abc", session.id, deposit, returnDate, customerId);
+      await addOrder("abc", session.id, deposit, returnDate, customerId);
       break;
     }
     case "charge.refunded": {

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -3,6 +3,7 @@
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
 import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer.server";
+import { getCustomerSession } from "@auth";
 import { priceForDays } from "@platform-core/pricing";
 import type { CartLine, CartState } from "@types";
 import { NextRequest, NextResponse } from "next/server";
@@ -126,6 +127,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   );
 
   /* 5️⃣  Create Stripe Checkout Session ---------------------------------- */
+  const customer = await getCustomerSession();
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
     line_items,
@@ -137,6 +139,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         depositTotal: depositTotal.toString(),
         returnDate: returnDate ?? "",
         rentalDays: rentalDays.toString(),
+        customerId: customer?.customerId ?? "",
       },
     },
     metadata: {
@@ -145,6 +148,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       returnDate: returnDate ?? "",
       rentalDays: rentalDays.toString(),
       sizes: sizesMeta,
+      customerId: customer?.customerId ?? "",
     },
     expand: ["payment_intent"],
   });

--- a/apps/shop-bcd/src/api/stripe-webhook/route.ts
+++ b/apps/shop-bcd/src/api/stripe-webhook/route.ts
@@ -4,6 +4,9 @@ import {
   addOrder,
   markRefunded,
 } from "@platform-core/repositories/rentalOrders.server";
+import {
+  addOrder as addDbOrder,
+} from "@platform-core/repositories/rentalOrdersDb.server";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
@@ -24,7 +27,9 @@ export async function POST(req: NextRequest) {
       const session = data as Stripe.Checkout.Session;
       const deposit = Number(session.metadata?.depositTotal ?? 0);
       const returnDate = session.metadata?.returnDate || undefined;
-      await addOrder("bcd", session.id, deposit, returnDate);
+      const customerId = session.metadata?.customerId || undefined;
+      await addDbOrder("bcd", session.id, deposit, returnDate, customerId);
+      await addOrder("bcd", session.id, deposit, returnDate, customerId);
       break;
     }
     case "charge.refunded": {

--- a/apps/shop-bcd/src/app/account/orders/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/page.tsx
@@ -1,0 +1,23 @@
+// apps/shop-bcd/src/app/account/orders/page.tsx
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/repositories/rentalOrdersDb.server";
+import shop from "../../../../shop.json";
+
+export const metadata = { title: "Orders" };
+
+export default async function OrdersPage() {
+  const session = await getCustomerSession();
+  if (!session) return <p>Please log in to view your orders.</p>;
+  const orders = await getOrdersForCustomer(shop.id, session.customerId);
+  if (!orders.length) return <p className="p-6">No orders yet.</p>;
+  return (
+    <ul className="space-y-2 p-6">
+      {orders.map((o) => (
+        <li key={o.id} className="rounded border p-4">
+          <div>Order: {o.id}</div>
+          {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/shop-bcd/src/app/account/profile/page.tsx
+++ b/apps/shop-bcd/src/app/account/profile/page.tsx
@@ -1,0 +1,15 @@
+// apps/shop-bcd/src/app/account/profile/page.tsx
+import { getCustomerSession } from "@auth";
+
+export const metadata = { title: "Profile" };
+
+export default async function ProfilePage() {
+  const session = await getCustomerSession();
+  if (!session) return <p>Please log in to view your profile.</p>;
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-xl">Profile</h1>
+      <pre className="rounded bg-muted p-4">{JSON.stringify(session, null, 2)}</pre>
+    </div>
+  );
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,3 +3,10 @@
 export { canRead, canWrite, READ_ROLES, WRITE_ROLES } from "./rbac";
 export { extendRoles, isRole } from "./types/roles";
 export type { Role } from "./types";
+export {
+  CUSTOMER_SESSION_COOKIE,
+  getCustomerSession,
+  createCustomerSession,
+  destroyCustomerSession,
+} from "./session";
+export type { CustomerSession } from "./session";

--- a/packages/auth/src/roles.json
+++ b/packages/auth/src/roles.json
@@ -1,4 +1,4 @@
 {
   "write": ["admin", "ShopAdmin", "CatalogManager", "ThemeEditor"],
-  "read": ["viewer"]
+  "read": ["viewer", "customer"]
 }

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -1,0 +1,34 @@
+// packages/auth/src/session.ts
+import { cookies } from "next/headers";
+import type { Role } from "./types";
+
+export const CUSTOMER_SESSION_COOKIE = "customer_session";
+
+export interface CustomerSession {
+  customerId: string;
+  role: Role;
+}
+
+export async function getCustomerSession(): Promise<CustomerSession | null> {
+  const store = await cookies();
+  const raw = store.get(CUSTOMER_SESSION_COOKIE)?.value;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as CustomerSession;
+  } catch {
+    return null;
+  }
+}
+
+export async function createCustomerSession(session: CustomerSession): Promise<void> {
+  const store = await cookies();
+  store.set(CUSTOMER_SESSION_COOKIE, JSON.stringify(session), {
+    httpOnly: true,
+    sameSite: "lax",
+  });
+}
+
+export async function destroyCustomerSession(): Promise<void> {
+  const store = await cookies();
+  store.delete(CUSTOMER_SESSION_COOKIE);
+}

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -46,7 +46,8 @@ export async function addOrder(
   shop: string,
   sessionId: string,
   deposit: number,
-  expectedReturnDate?: string
+  expectedReturnDate?: string,
+  customerId?: string
 ): Promise<RentalOrder> {
   const orders = await readOrders(shop);
   const order: RentalOrder = {
@@ -56,6 +57,7 @@ export async function addOrder(
     deposit,
     expectedReturnDate,
     startedAt: nowIso(),
+    ...(customerId ? { customerId } : {}),
   };
   orders.push(order);
   await writeOrders(shop, orders);

--- a/packages/platform-core/src/repositories/rentalOrdersDb.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrdersDb.server.ts
@@ -1,0 +1,39 @@
+// packages/platform-core/src/repositories/rentalOrdersDb.server.ts
+import "server-only";
+import { ulid } from "ulid";
+import { nowIso } from "@shared/date";
+import type { RentalOrder } from "@types";
+
+export type CustomerOrder = RentalOrder;
+
+const db = new Map<string, CustomerOrder[]>();
+
+export async function addOrder(
+  shop: string,
+  sessionId: string,
+  deposit: number,
+  expectedReturnDate?: string,
+  customerId?: string
+): Promise<CustomerOrder> {
+  const list = db.get(shop) ?? [];
+  const order: CustomerOrder = {
+    id: ulid(),
+    sessionId,
+    shop,
+    deposit,
+    expectedReturnDate,
+    startedAt: nowIso(),
+    ...(customerId ? { customerId } : {}),
+  };
+  list.push(order);
+  db.set(shop, list);
+  return order;
+}
+
+export async function getOrdersForCustomer(
+  shop: string,
+  customerId: string
+): Promise<CustomerOrder[]> {
+  const list = db.get(shop) ?? [];
+  return list.filter((o) => o.customerId === customerId);
+}

--- a/packages/types/src/RentalOrder.d.ts
+++ b/packages/types/src/RentalOrder.d.ts
@@ -10,6 +10,7 @@ export declare const rentalOrderSchema: z.ZodObject<{
     refundedAt: z.ZodOptional<z.ZodString>;
     /** Optional damage fee deducted from the deposit */
     damageFee: z.ZodOptional<z.ZodNumber>;
+    customerId: z.ZodOptional<z.ZodString>;
 }, "strip", z.ZodTypeAny, {
     id: string;
     deposit: number;
@@ -20,6 +21,7 @@ export declare const rentalOrderSchema: z.ZodObject<{
     returnedAt?: string | undefined;
     refundedAt?: string | undefined;
     damageFee?: number | undefined;
+    customerId?: string | undefined;
 }, {
     id: string;
     deposit: number;
@@ -30,6 +32,7 @@ export declare const rentalOrderSchema: z.ZodObject<{
     returnedAt?: string | undefined;
     refundedAt?: string | undefined;
     damageFee?: number | undefined;
+    customerId?: string | undefined;
 }>;
 export type RentalOrder = z.infer<typeof rentalOrderSchema>;
 //# sourceMappingURL=RentalOrder.d.ts.map

--- a/packages/types/src/RentalOrder.ts
+++ b/packages/types/src/RentalOrder.ts
@@ -11,6 +11,7 @@ export const rentalOrderSchema = z.object({
   refundedAt: z.string().optional(),
   /** Optional damage fee deducted from the deposit */
   damageFee: z.number().optional(),
+  customerId: z.string().optional(),
 });
 
 export type RentalOrder = z.infer<typeof rentalOrderSchema>;


### PR DESCRIPTION
## Summary
- add customer session helpers and role
- add customer id to order repositories and schema
- add account profile and order pages for shop apps

## Testing
- `pnpm test --filter @acme/auth --filter @acme/platform-core --filter @types/shared` *(fails: ManagedMessageChannel extends NodeMessageChannel)*
- `pnpm lint --filter @acme/auth --filter @acme/platform-core --filter @types/shared`

------
https://chatgpt.com/codex/tasks/task_e_6898a9673fbc832fa87744987161b459