### PR TITLE
Send shop fields directly when creating shops

### DIFF
--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -441,7 +441,7 @@ export default function Wizard({
       const res = await fetch("/cms/api/create-shop", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: shopId, options: parsed.data }),
+        body: JSON.stringify({ id: shopId, ...parsed.data }),
       });
 
       if (res.ok) {

--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -80,7 +80,7 @@ export async function submitShop(
   const res = await fetch("/cms/api/create-shop", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id: shopId, options: parsed.data }),
+    body: JSON.stringify({ id: shopId, ...parsed.data }),
   });
 
   if (res.ok) return { ok: true };


### PR DESCRIPTION
## Summary
- send shop options directly in `submitShop` service request
- update wizard submit handler to match body shape

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/atoms' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898af585410832faa4c5ded3bd08235