### PR TITLE
feat: add analytics logging and dashboards

### DIFF
--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -1,0 +1,58 @@
+import { listEvents } from "@platform-core/repositories/analytics.server";
+import { readOrders } from "@platform-core/repositories/rentalOrders.server";
+
+function groupByDay<T>(items: T[], getDate: (item: T) => string | undefined) {
+  const map: Record<string, number> = {};
+  for (const item of items) {
+    const d = getDate(item)?.slice(0, 10);
+    if (!d) continue;
+    map[d] = (map[d] || 0) + 1;
+  }
+  return map;
+}
+
+export default async function ShopDashboard({
+  params,
+}: {
+  params: { shop: string };
+}) {
+  const shop = params.shop;
+  const [events, orders] = await Promise.all([
+    listEvents(shop),
+    readOrders(shop),
+  ]);
+
+  const views = groupByDay(
+    events.filter((e) => e.type === "page_view"),
+    (e) => e.timestamp as string
+  );
+  const sales = groupByDay(orders, (o) => o.startedAt);
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Dashboard: {shop}</h2>
+      <section className="mb-6">
+        <h3 className="font-semibold">Sales</h3>
+        <ul>
+          {Object.entries(sales).map(([day, count]) => (
+            <li key={day}>
+              {day}: {count}
+            </li>
+          ))}
+          {Object.keys(sales).length === 0 && <li>No orders</li>}
+        </ul>
+      </section>
+      <section>
+        <h3 className="font-semibold">Traffic</h3>
+        <ul>
+          {Object.entries(views).map(([day, count]) => (
+            <li key={day}>
+              {day}: {count}
+            </li>
+          ))}
+          {Object.keys(views).length === 0 && <li>No page views</li>}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/dashboard/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { listShops } from "../listShops";
+
+export default async function DashboardIndexPage() {
+  const shops = await listShops();
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Choose a shop</h2>
+      <ul className="space-y-2">
+        {shops.map((shop) => (
+          <li key={shop}>
+            <Link
+              href={`/cms/dashboard/${shop}`}
+              className="text-primary underline"
+            >
+              {shop}
+            </Link>
+          </li>
+        ))}
+        {shops.length === 0 && <li>No shops found.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -6,5 +6,6 @@
   "themeTokens": {},
   "filterMappings": {},
   "priceOverrides": {},
-  "localeOverrides": {}
+  "localeOverrides": {},
+  "analyticsEnabled": true
 }

--- a/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Locale } from "@/i18n/locales";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import shop from "../../../../shop.json";
+import { trackPageView } from "@platform-core/analytics";
 
 async function loadComponents(slug: string): Promise<PageComponent[] | null> {
   const pages = await getPages(shop.id);
@@ -19,6 +20,7 @@ export default async function Page({
   const slug = params.slug.join("/");
   const components = await loadComponents(slug);
   if (!components) notFound();
+  await trackPageView(shop.id, slug);
   return <DynamicRenderer components={components} locale={params.lang} />;
 }
 

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -2,6 +2,7 @@ import type { PageComponent } from "@types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import shop from "../../../shop.json";
 import Home from "./page.client";
+import { trackPageView } from "@platform-core/analytics";
 
 async function loadComponents(): Promise<PageComponent[]> {
   const pages = await getPages(shop.id);
@@ -14,5 +15,6 @@ export default async function Page({
   params: { lang: string };
 }) {
   const components = await loadComponents();
+  await trackPageView(shop.id, "home");
   return <Home components={components} locale={params.lang} />;
 }

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { getPages } from "@platform-core/repositories/pages/index.server";
 import { LOCALES } from "@acme/i18n";
 import shop from "../../../../../shop.json";
 import PdpClient from "./PdpClient.client";
+import { trackPageView } from "@platform-core/analytics";
 
 async function loadComponents(slug: string): Promise<PageComponent[] | null> {
   const pages = await getPages(shop.id);
@@ -48,6 +49,7 @@ export default async function ProductDetailPage({
   if (!product) return notFound();
 
   const components = await loadComponents(params.slug);
+  await trackPageView(shop.id, `product/${params.slug}`);
   if (components && components.length) {
     return (
       <DynamicRenderer
@@ -57,7 +59,6 @@ export default async function ProductDetailPage({
       />
     );
   }
-
   return <PdpClient product={product} />;
 }
 

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -6,6 +6,7 @@ import DynamicRenderer from "@ui/components/DynamicRenderer";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import shop from "../../../../shop.json";
 import ShopClient from "./ShopClient.client";
+import { trackPageView } from "@platform-core/analytics";
 
 async function loadComponents(): Promise<PageComponent[] | null> {
   const pages = await getPages(shop.id);
@@ -25,6 +26,7 @@ export default async function ShopIndexPage({
   params: { lang: string };
 }) {
   const components = await loadComponents();
+  await trackPageView(shop.id, "shop");
   if (components && components.length) {
     return <DynamicRenderer components={components} locale={params.lang} />;
   }

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -6,5 +6,6 @@
   "themeTokens": {},
   "filterMappings": {},
   "priceOverrides": {},
-  "localeOverrides": {}
+  "localeOverrides": {},
+  "analyticsEnabled": false
 }

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -1,0 +1,96 @@
+import "server-only";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { nowIso } from "@shared/date";
+import { DATA_ROOT } from "./dataRoot";
+import { validateShopName } from "./shops";
+import { getShopSettings, readShop } from "./repositories/shops.server";
+
+export interface AnalyticsEvent {
+  type: string;
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+export interface AnalyticsProvider {
+  track(event: AnalyticsEvent): Promise<void> | void;
+}
+
+class NoopProvider implements AnalyticsProvider {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async track(_event: AnalyticsEvent): Promise<void> {}
+}
+
+class ConsoleProvider implements AnalyticsProvider {
+  async track(event: AnalyticsEvent): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.log("analytics", event);
+  }
+}
+
+class FileProvider implements AnalyticsProvider {
+  constructor(private shop: string) {}
+
+  private filePath(): string {
+    const shop = validateShopName(this.shop);
+    return path.join(DATA_ROOT, shop, "analytics.jsonl");
+  }
+
+  async track(event: AnalyticsEvent): Promise<void> {
+    const fp = this.filePath();
+    await fs.mkdir(path.dirname(fp), { recursive: true });
+    await fs.appendFile(fp, JSON.stringify(event) + "\n", "utf8");
+  }
+}
+
+const providerCache = new Map<string, AnalyticsProvider>();
+
+async function resolveProvider(shop: string): Promise<AnalyticsProvider> {
+  if (providerCache.has(shop)) return providerCache.get(shop)!;
+  const shopInfo = await readShop(shop);
+  if (!shopInfo.analyticsEnabled) {
+    const p = new NoopProvider();
+    providerCache.set(shop, p);
+    return p;
+  }
+  const settings = await getShopSettings(shop);
+  const analytics = settings.analytics;
+  if (!analytics || analytics.enabled === false || analytics.provider === "none") {
+    const p = new NoopProvider();
+    providerCache.set(shop, p);
+    return p;
+  }
+  if (analytics.provider === "console") {
+    const p = new ConsoleProvider();
+    providerCache.set(shop, p);
+    return p;
+  }
+  const p = new FileProvider(shop);
+  providerCache.set(shop, p);
+  return p;
+}
+
+export async function trackEvent(
+  shop: string,
+  event: AnalyticsEvent
+): Promise<void> {
+  const provider = await resolveProvider(shop);
+  const withTs = { timestamp: nowIso(), ...event };
+  await provider.track(withTs);
+}
+
+export async function trackPageView(
+  shop: string,
+  page: string
+): Promise<void> {
+  await trackEvent(shop, { type: "page_view", page });
+}
+
+export async function trackOrder(
+  shop: string,
+  orderId: string,
+  amount?: number
+): Promise<void> {
+  await trackEvent(shop, { type: "order", orderId, amount });
+}
+

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -106,6 +106,7 @@ export function writeFiles(
         shippingProviders: options.shipping,
         priceOverrides: {},
         localeOverrides: {},
+        analyticsEnabled: options.analytics.enabled,
         homeTitle: options.pageTitle,
         homeDescription: options.pageDescription,
         homeImage: options.socialImage,

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -21,6 +21,7 @@ export const createShopOptionsSchema = z.object({
   socialImage: z.string().url().optional(),
   analytics: z
     .object({
+      enabled: z.boolean().optional(),
       provider: z.string(),
       id: z.string().optional(),
     })
@@ -55,6 +56,7 @@ export interface CreateShopOptions {
   pageDescription?: Partial<Record<Locale, string>>;
   socialImage?: string;
   analytics?: {
+    enabled?: boolean;
     provider: string;
     id?: string;
   };
@@ -94,9 +96,13 @@ export function prepareOptions(
     pageTitle: fillLocales(parsed.pageTitle, "Home"),
     pageDescription: fillLocales(parsed.pageDescription, ""),
     socialImage: parsed.socialImage ?? "",
-    analytics: parsed.analytics
-      ? { provider: parsed.analytics.provider ?? "none", id: parsed.analytics.id }
-      : { provider: "none" },
+  analytics: parsed.analytics
+      ? {
+          enabled: parsed.analytics.enabled !== false,
+          provider: parsed.analytics.provider ?? "none",
+          id: parsed.analytics.id,
+        }
+      : { enabled: false, provider: "none" },
     navItems:
       parsed.navItems?.map((n) => ({
         label: n.label ?? "—",

--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { validateShopName } from "../shops";
+import { DATA_ROOT } from "../dataRoot";
+import type { AnalyticsEvent } from "../analytics";
+
+function analyticsPath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "analytics.jsonl");
+}
+
+export async function listEvents(shop: string): Promise<AnalyticsEvent[]> {
+  try {
+    const buf = await fs.readFile(analyticsPath(shop), "utf8");
+    return buf
+      .trim()
+      .split(/\n+/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as AnalyticsEvent);
+  } catch {
+    return [];
+  }
+}
+

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -9,6 +9,7 @@ import { ulid } from "ulid";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@shared/date";
+import { trackOrder } from "../analytics";
 
 function ordersPath(shop: string): string {
   shop = validateShopName(shop);
@@ -59,6 +60,7 @@ export async function addOrder(
   };
   orders.push(order);
   await writeOrders(shop, orders);
+  await trackOrder(shop, order.id, deposit);
   return order;
 }
 

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -54,5 +54,6 @@ export async function readShop(shop: string): Promise<Shop> {
     priceOverrides: {},
     localeOverrides: {},
     navigation: [],
+    analyticsEnabled: false,
   };
 }

--- a/packages/template-app/src/app/AnalyticsScripts.tsx
+++ b/packages/template-app/src/app/AnalyticsScripts.tsx
@@ -1,10 +1,17 @@
-import { getShopSettings } from "@platform-core/repositories/shops.server";
+import {
+  getShopSettings,
+  readShop,
+} from "@platform-core/repositories/shops.server";
 
 export default async function AnalyticsScripts() {
   const shop = process.env.NEXT_PUBLIC_SHOP_ID || "default";
-  const settings = await getShopSettings(shop);
+  const [settings, shopData] = await Promise.all([
+    getShopSettings(shop),
+    readShop(shop),
+  ]);
+  if (!shopData.analyticsEnabled) return null;
   const analytics = settings.analytics;
-  if (!analytics || !analytics.provider) return null;
+  if (!analytics || analytics.enabled === false || !analytics.provider) return null;
   if (analytics.provider === "ga" && analytics.id) {
     return (
       <>

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -104,6 +104,7 @@ export interface Shop {
         label: string;
         url: string;
     }[];
+    analyticsEnabled?: boolean;
 }
 export declare const shopSchema: z.ZodObject<{
     id: z.ZodString;
@@ -136,6 +137,7 @@ export declare const shopSchema: z.ZodObject<{
         url: string;
         label: string;
     }>, "many">>;
+    analyticsEnabled: z.ZodOptional<z.ZodBoolean>;
 }, "strip", z.ZodTypeAny, {
     id: string;
     name: string;
@@ -157,6 +159,7 @@ export declare const shopSchema: z.ZodObject<{
         url: string;
         label: string;
     }[] | undefined;
+    analyticsEnabled?: boolean | undefined;
 }, {
     id: string;
     name: string;
@@ -178,5 +181,6 @@ export declare const shopSchema: z.ZodObject<{
         url: string;
         label: string;
     }[] | undefined;
-}>;
+    analyticsEnabled?: boolean | undefined;
+}>; 
 //# sourceMappingURL=Shop.d.ts.map

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -52,6 +52,7 @@ export interface Shop {
   homeDescription?: Translated;
   homeImage?: string;
   navigation?: { label: string; url: string }[];
+  analyticsEnabled?: boolean;
 }
 
 export const shopSchema = z.object({
@@ -80,4 +81,5 @@ export const shopSchema = z.object({
   navigation: z
     .array(z.object({ label: z.string(), url: z.string() }))
     .optional(),
+  analyticsEnabled: z.boolean().optional(),
 });

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -77,12 +77,15 @@ export declare const shopSettingsSchema: z.ZodObject<{
         structuredData?: string | undefined;
     }>>;
     analytics: z.ZodOptional<z.ZodObject<{
+        enabled: z.ZodOptional<z.ZodBoolean>;
         provider: z.ZodString;
         id: z.ZodOptional<z.ZodString>;
     }, "strip", z.ZodTypeAny, {
+        enabled?: boolean | undefined;
         provider: string;
         id?: string | undefined;
     }, {
+        enabled?: boolean | undefined;
         provider: string;
         id?: string | undefined;
     }>>;
@@ -113,6 +116,7 @@ export declare const shopSettingsSchema: z.ZodObject<{
     languages: readonly ("en" | "de" | "it")[];
     updatedBy: string;
     analytics?: {
+        enabled?: boolean | undefined;
         provider: string;
         id?: string | undefined;
     } | undefined;
@@ -141,6 +145,7 @@ export declare const shopSettingsSchema: z.ZodObject<{
     languages: readonly ("en" | "de" | "it")[];
     updatedBy: string;
     analytics?: {
+        enabled?: boolean | undefined;
         provider: string;
         id?: string | undefined;
     } | undefined;

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -7,6 +7,7 @@ export const shopSettingsSchema = z.object({
   seo: z.record(localeSchema, shopSeoFieldsSchema),
   analytics: z
     .object({
+      enabled: z.boolean().optional(),
       provider: z.string(),
       id: z.string().optional(),
     })


### PR DESCRIPTION
## Summary
- add pluggable analytics with file/console providers and tracking helpers
- log rental orders and page views to analytics provider
- CMS dashboard pages chart sales and traffic per shop
- allow enabling analytics per shop via `analyticsEnabled` in shop.json

## Testing
- `pnpm test` *(fails: ENOENT in media action)*

------
https://chatgpt.com/codex/tasks/task_e_6898ad2ee82c832fa16b1a155cb30191