### PR TITLE
feat: add shipping and tax modules

### DIFF
--- a/apps/shop-abc/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-abc/src/app/api/shipping-rate/route.ts
@@ -1,0 +1,34 @@
+// apps/shop-abc/src/app/api/shipping-rate/route.ts
+import { getShippingRate } from "@acme/platform-core/shipping";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "edge";
+
+const schema = z
+  .object({
+    provider: z.enum(["ups", "dhl"]),
+    fromPostalCode: z.string(),
+    toPostalCode: z.string(),
+    weight: z.number(),
+  })
+  .strict();
+
+export async function POST(req: NextRequest) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  try {
+    const rate = await getShippingRate(parsed.data);
+    return NextResponse.json({ rate });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/shop-abc/src/app/api/tax/route.ts
+++ b/apps/shop-abc/src/app/api/tax/route.ts
@@ -1,0 +1,34 @@
+// apps/shop-abc/src/app/api/tax/route.ts
+import { calculateTax } from "@acme/platform-core/tax";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "edge";
+
+const schema = z
+  .object({
+    provider: z.enum(["taxjar"]).default("taxjar"),
+    amount: z.number(),
+    toCountry: z.string(),
+    toPostalCode: z.string().optional(),
+  })
+  .strict();
+
+export async function POST(req: NextRequest) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  try {
+    const tax = await calculateTax(parsed.data);
+    return NextResponse.json({ tax });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -1,0 +1,34 @@
+// apps/shop-bcd/src/app/api/shipping-rate/route.ts
+import { getShippingRate } from "@acme/platform-core/shipping";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "edge";
+
+const schema = z
+  .object({
+    provider: z.enum(["ups", "dhl"]),
+    fromPostalCode: z.string(),
+    toPostalCode: z.string(),
+    weight: z.number(),
+  })
+  .strict();
+
+export async function POST(req: NextRequest) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  try {
+    const rate = await getShippingRate(parsed.data);
+    return NextResponse.json({ rate });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -1,0 +1,34 @@
+// apps/shop-bcd/src/app/api/tax/route.ts
+import { calculateTax } from "@acme/platform-core/tax";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "edge";
+
+const schema = z
+  .object({
+    provider: z.enum(["taxjar"]).default("taxjar"),
+    amount: z.number(),
+    toCountry: z.string(),
+    toPostalCode: z.string().optional(),
+  })
+  .strict();
+
+export async function POST(req: NextRequest) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  try {
+    const tax = await calculateTax(parsed.data);
+    return NextResponse.json({ tax });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -5,6 +5,8 @@
   "themeId": "base",
   "themeTokens": {},
   "filterMappings": {},
+  "shippingProviders": ["ups"],
+  "taxProviders": ["taxjar"],
   "priceOverrides": {},
   "localeOverrides": {}
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -5,6 +5,8 @@
   "themeId": "base",
   "themeTokens": {},
   "filterMappings": {},
+  "shippingProviders": ["dhl"],
+  "taxProviders": ["taxjar"],
   "priceOverrides": {},
   "localeOverrides": {}
 }

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": "./src/index.ts",
+    "./shipping": "./src/shipping/index.ts",
+    "./tax": "./src/tax/index.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*"

--- a/packages/platform-core/src/createShop/defaultTaxProviders.ts
+++ b/packages/platform-core/src/createShop/defaultTaxProviders.ts
@@ -1,0 +1,6 @@
+// packages/platform-core/createShop/defaultTaxProviders.ts
+
+/** Supported tax provider identifiers */
+export const defaultTaxProviders = ["taxjar"] as const;
+
+export type DefaultTaxProvider = (typeof defaultTaxProviders)[number];

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -67,7 +67,7 @@ export function writeFiles(
 
   let envContent = `NEXT_PUBLIC_SHOP_ID=${id}\n`;
   envContent += `PREVIEW_TOKEN_SECRET=${genSecret()}\n`;
-  const envVars = [...options.payment, ...options.shipping];
+  const envVars = [...options.payment, ...options.shipping, options.tax];
   if (envVars.length === 0) envVars.push("stripe");
   for (const provider of envVars) {
     if (provider === "stripe") {
@@ -104,6 +104,7 @@ export function writeFiles(
         type: options.type,
         paymentProviders: options.payment,
         shippingProviders: options.shipping,
+        taxProviders: [options.tax],
         priceOverrides: {},
         localeOverrides: {},
         homeTitle: options.pageTitle,

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -6,6 +6,7 @@ import { slugify } from "@shared-utils";
 import { fillLocales } from "../utils/locales";
 import { defaultPaymentProviders, type DefaultPaymentProvider } from "./defaultPaymentProviders";
 import { defaultShippingProviders, type DefaultShippingProvider } from "./defaultShippingProviders";
+import { defaultTaxProviders, type DefaultTaxProvider } from "./defaultTaxProviders";
 
 export const createShopOptionsSchema = z.object({
   name: z.string().optional(),
@@ -16,6 +17,7 @@ export const createShopOptionsSchema = z.object({
   template: z.string().optional(),
   payment: z.array(z.enum(defaultPaymentProviders)).default([]),
   shipping: z.array(z.enum(defaultShippingProviders)).default([]),
+  tax: z.enum(defaultTaxProviders).default("taxjar"),
   pageTitle: z.record(localeSchema, z.string()).optional(),
   pageDescription: z.record(localeSchema, z.string()).optional(),
   socialImage: z.string().url().optional(),
@@ -51,6 +53,7 @@ export interface CreateShopOptions {
   template?: string;
   payment?: DefaultPaymentProvider[];
   shipping?: DefaultShippingProvider[];
+  tax?: DefaultTaxProvider;
   pageTitle?: Partial<Record<Locale, string>>;
   pageDescription?: Partial<Record<Locale, string>>;
   socialImage?: string;
@@ -91,6 +94,7 @@ export function prepareOptions(
     template: parsed.template ?? "template-app",
     payment: parsed.payment,
     shipping: parsed.shipping,
+    tax: parsed.tax,
     pageTitle: fillLocales(parsed.pageTitle, "Home"),
     pageDescription: fillLocales(parsed.pageDescription, ""),
     socialImage: parsed.socialImage ?? "",

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -7,3 +7,5 @@ export * from "./defaultFilterMappings";
 export * from "./themeTokens";
 export * from "./dataRoot";
 export * from "./utils";
+export * from "./shipping";
+export * from "./tax";

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -1,0 +1,44 @@
+// packages/platform-core/src/shipping/index.ts
+
+export interface ShippingRateRequest {
+  provider: "ups" | "dhl";
+  fromPostalCode: string;
+  toPostalCode: string;
+  weight: number;
+}
+
+/**
+ * Fetch a shipping rate from the configured provider.
+ * The underlying provider API is called using the respective API key.
+ */
+export async function getShippingRate({
+  provider,
+  fromPostalCode,
+  toPostalCode,
+  weight,
+}: ShippingRateRequest): Promise<unknown> {
+  const apiKey = process.env[`${provider.toUpperCase()}_KEY`];
+  if (!apiKey) {
+    throw new Error(`Missing ${provider.toUpperCase()}_KEY`);
+  }
+
+  const url =
+    provider === "ups"
+      ? "https://onlinetools.ups.com/ship/v1/rating/Rate"
+      : "https://api.dhl.com/rates";
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ fromPostalCode, toPostalCode, weight }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch rate from ${provider}`);
+  }
+
+  return res.json();
+}

--- a/packages/platform-core/src/tax/index.ts
+++ b/packages/platform-core/src/tax/index.ts
@@ -1,0 +1,35 @@
+// packages/platform-core/src/tax/index.ts
+
+export interface TaxCalculationRequest {
+  provider: "taxjar";
+  amount: number;
+  toCountry: string;
+  toPostalCode?: string;
+}
+
+/**
+ * Calculate taxes using the configured provider API.
+ */
+export async function calculateTax({ provider, ...payload }: TaxCalculationRequest): Promise<unknown> {
+  const apiKey = process.env[`${provider.toUpperCase()}_KEY`];
+  if (!apiKey) {
+    throw new Error(`Missing ${provider.toUpperCase()}_KEY`);
+  }
+
+  const url = "https://api.taxjar.com/v2/taxes";
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to calculate tax with ${provider}`);
+  }
+
+  return res.json();
+}

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -97,6 +97,8 @@ export interface Shop {
     paymentProviders?: string[];
     /** Enabled shipping provider identifiers */
     shippingProviders?: string[];
+    /** Enabled tax provider identifiers */
+    taxProviders?: string[];
     homeTitle?: Translated;
     homeDescription?: Translated;
     homeImage?: string;
@@ -123,6 +125,7 @@ export declare const shopSchema: z.ZodObject<{
     type: z.ZodOptional<z.ZodString>;
     paymentProviders: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     shippingProviders: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    taxProviders: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     homeTitle: z.ZodOptional<z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>>;
     homeDescription: z.ZodOptional<z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>>;
     homeImage: z.ZodOptional<z.ZodString>;
@@ -150,6 +153,7 @@ export declare const shopSchema: z.ZodObject<{
     contactInfo?: string | undefined;
     paymentProviders?: string[] | undefined;
     shippingProviders?: string[] | undefined;
+    taxProviders?: string[] | undefined;
     homeTitle?: Partial<Record<"en" | "de" | "it", string>> | undefined;
     homeDescription?: Partial<Record<"en" | "de" | "it", string>> | undefined;
     homeImage?: string | undefined;
@@ -171,6 +175,7 @@ export declare const shopSchema: z.ZodObject<{
     localeOverrides?: Record<string, "en" | "de" | "it"> | undefined;
     paymentProviders?: string[] | undefined;
     shippingProviders?: string[] | undefined;
+    taxProviders?: string[] | undefined;
     homeTitle?: Partial<Record<"en" | "de" | "it", string>> | undefined;
     homeDescription?: Partial<Record<"en" | "de" | "it", string>> | undefined;
     homeImage?: string | undefined;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -48,6 +48,8 @@ export interface Shop {
   paymentProviders?: string[];
   /** Enabled shipping provider identifiers */
   shippingProviders?: string[];
+  /** Enabled tax provider identifiers */
+  taxProviders?: string[];
   homeTitle?: Translated;
   homeDescription?: Translated;
   homeImage?: string;
@@ -74,6 +76,7 @@ export const shopSchema = z.object({
   type: z.string().optional(),
   paymentProviders: z.array(z.string()).optional(),
   shippingProviders: z.array(z.string()).optional(),
+  taxProviders: z.array(z.string()).optional(),
   homeTitle: z.record(localeSchema, z.string()).optional(),
   homeDescription: z.record(localeSchema, z.string()).optional(),
   homeImage: z.string().optional(),


### PR DESCRIPTION
## Summary
- add shipping/tax provider modules to platform core
- store provider credentials when scaffolding shops
- expose shipping-rate and tax API endpoints in each shop app

## Testing
- `pnpm lint --filter @acme/platform-core --filter @apps/shop-abc --filter @apps/shop-bcd`
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms')*

------
https://chatgpt.com/codex/tasks/task_e_6898ae0288b0832f81466b2ca3dc7aec