### PR TITLE
feat: allow skipping deployment when creating shops

### DIFF
--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -74,8 +74,8 @@ describe("createNewShop authorization", () => {
     const prevEnv = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
 
-    const deployResult = { status: "success", previewUrl: "https://shop2.pages.dev" };
-    const createShop = jest.fn().mockReturnValue(deployResult);
+    const deployment = { status: "pending" };
+    const createShop = jest.fn().mockReturnValue(deployment);
     jest.doMock("@platform-core/createShop", () => ({
       __esModule: true,
       createShop,
@@ -92,8 +92,8 @@ describe("createNewShop authorization", () => {
     const res = await createNewShop("shop2", { theme: "base" } as any);
 
     expect(createShop).toHaveBeenCalledTimes(1);
-    expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" });
-    expect(res).toBe(deployResult);
+    expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" }, { deploy: false });
+    expect(res).toBe(deployment);
 
     (process.env as Record<string, string>).NODE_ENV = prevEnv;
   });

--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -5,7 +5,7 @@ import { authOptions } from "@cms/auth/options";
 import {
   createShop,
   type CreateShopOptions,
-  type DeployShopResult,
+  type DeployStatusBase,
 } from "@platform-core/createShop";
 import { getServerSession } from "next-auth";
 import { readRbac, writeRbac } from "../lib/rbacStore";
@@ -21,12 +21,12 @@ async function ensureAuthorized() {
 export async function createNewShop(
   id: string,
   options: CreateShopOptions
-): Promise<DeployShopResult> {
+): Promise<DeployStatusBase> {
   const session = await ensureAuthorized();
 
-  let result: DeployShopResult;
+  let result: DeployStatusBase;
   try {
-    result = createShop(id, options);
+    result = createShop(id, options, { deploy: false });
   } catch (err) {
     console.error("createShop failed", err);
     throw err;

--- a/apps/cms/src/app/cms/wizard/services/deployShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/deployShop.ts
@@ -2,11 +2,11 @@
 "use client";
 
 import { validateShopName } from "@platform-core/src/shops";
-import type { DeployShopResult } from "@platform-core/createShop";
+import type { DeployStatusBase } from "@platform-core/createShop";
 
 export interface DeployResult {
   ok: boolean;
-  info?: DeployShopResult | { status: "pending"; error?: string };
+  info?: DeployStatusBase;
   error?: string;
 }
 
@@ -26,12 +26,10 @@ export async function deployShop(
   const res = await fetch("/cms/api/deploy-shop", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id: shopId, domain }),
+    body: JSON.stringify(domain ? { id: shopId, domain } : { id: shopId }),
   });
 
-  const json = (await res.json()) as
-    | DeployShopResult
-    | { status: "pending"; error?: string };
+  const json = (await res.json()) as DeployStatusBase;
 
   if (res.ok) return { ok: true, info: json };
 

--- a/dist-scripts/create-shop.js
+++ b/dist-scripts/create-shop.js
@@ -73,4 +73,4 @@ async function ensureTheme() {
     }
 }
 await ensureTheme();
-await createShop(shopId, options);
+await createShop(shopId, options, { deploy: true });

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -19,8 +19,9 @@ import { loadTokens } from "./createShop/themeUtils";
  */
 export function createShop(
   id: string,
-  opts: CreateShopOptions = {}
-): DeployShopResult {
+  opts: CreateShopOptions = {},
+  { deploy = true }: { deploy?: boolean } = {}
+): DeployStatusBase {
   id = validateShopName(id);
   const newApp = join("apps", id);
   const newData = join("data", "shops", id);
@@ -40,6 +41,10 @@ export function createShop(
   const themeTokens = loadTokens(options.theme);
 
   writeFiles(id, options, themeTokens, templateApp, newApp, newData);
+
+  if (!deploy) {
+    return { status: "pending" };
+  }
 
   return deployShop(id);
 }

--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -291,4 +291,4 @@ await ensureLogo();
 await ensureContact();
 await ensurePayment();
 await ensureShipping();
-await createShop(shopId, options);
+await createShop(shopId, options, { deploy: true });

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -67,7 +67,7 @@ async function main() {
   };
 
   const prefixedId = `shop-${shopId}`;
-  createShop(prefixedId, options);
+  createShop(prefixedId, options, { deploy: true });
 
   let validationError: unknown;
   try {

--- a/test/unit/create-shop-cli.spec.ts
+++ b/test/unit/create-shop-cli.spec.ts
@@ -15,7 +15,7 @@ function loadParseArgs() {
   const sandbox: any = {
     exports: {},
     module: { exports: {} },
-    process: { exit: jest.fn() },
+    process: { exit: jest.fn(), version: "v20.0.0" },
     console: { error: jest.fn() },
     require,
   };
@@ -95,7 +95,7 @@ function runCli(args: string[]) {
   const sandbox: any = {
     exports: {},
     module: { exports: {} },
-    process: { argv: ["node", "script", ...args], exit: jest.fn() },
+    process: { argv: ["node", "script", ...args], exit: jest.fn(), version: "v20.0.0" },
     console: { error: jest.fn() },
     require: (p: string) => {
       if (p.includes("packages/platform-core/src/createShop")) {


### PR DESCRIPTION
## Summary
- add optional deploy flag to `createShop` and return pending status when disabled
- call `createShop` without deployment in CMS actions and auto-deploy via wizard API
- ensure CLI utilities trigger deployment explicitly

## Testing
- `pnpm --filter @acme/platform-core test` (fails: Cannot find module '@/components/atoms' from 'Wizard.tsx'; page action validation errors)
- `pnpm --filter @apps/cms test` (fails: Cannot find module '@/components/atoms' from 'Wizard.tsx')


------
https://chatgpt.com/codex/tasks/task_e_6898af596810832f96e2d56aeb7b53db