### PR TITLE
Handle polling failures in deployment status

### DIFF
--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -111,6 +111,7 @@ export default function Wizard({
     DeployShopResult | { status: "pending"; error?: string } | null
   >(null);
   const pollRef = useRef<NodeJS.Timeout | null>(null);
+  const pollRetries = useRef(0);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
 
   /* ---------------------------------------------------------------------- */
@@ -385,7 +386,7 @@ export default function Wizard({
   /* --- clear polling timer when unmounting --- */
   useEffect(() => {
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      if (pollRef.current) clearTimeout(pollRef.current);
     };
   }, []);
 
@@ -522,25 +523,57 @@ export default function Wizard({
   }
 
   function startPolling() {
-    if (pollRef.current) clearInterval(pollRef.current);
+    if (pollRef.current) clearTimeout(pollRef.current);
+    pollRetries.current = 0;
 
-    pollRef.current = setInterval(async () => {
+    const poll = async () => {
       try {
         const res = await fetch(`/cms/api/deploy-shop?id=${shopId}`);
-        const status = (await res.json()) as
-          | DeployShopResult
-          | { status: "pending"; error?: string };
+        if (!res.ok) {
+          console.error(
+            `Polling deploy status failed: ${res.status} ${res.statusText}`,
+          );
+          pollRetries.current += 1;
+          if (pollRetries.current >= 3) {
+            setDeployInfo({
+              status: "error",
+              error: `Polling failed with status ${res.status}`,
+            });
+            pollRef.current = null;
+            return;
+          }
+        } else {
+          const status = (await res.json()) as
+            | DeployShopResult
+            | { status: "pending"; error?: string };
 
-        setDeployInfo(status);
+          setDeployInfo(status);
 
-        if (status.status !== "pending") {
-          if (pollRef.current) clearInterval(pollRef.current);
-          pollRef.current = null;
+          if (status.status !== "pending") {
+            pollRef.current = null;
+            return;
+          }
+
+          pollRetries.current = 0;
         }
       } catch (err) {
         console.error("Polling deploy status failed", err);
+        pollRetries.current += 1;
+        if (pollRetries.current >= 3) {
+          setDeployInfo({
+            status: "error",
+            error: "Polling failed due to network error",
+          });
+          pollRef.current = null;
+          return;
+        }
       }
-    }, 3000);
+
+      const delay = Math.min(3000 * 2 ** pollRetries.current, 30000);
+      pollRef.current = setTimeout(poll, delay);
+    };
+
+    poll();
   }
 
   /* ====================================================================== */


### PR DESCRIPTION
## Summary
- Check `fetch` response when polling shop deployment
- Log non-OK responses and stop polling with error feedback
- Add simple retry with exponential backoff for transient polling errors

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/atoms')*

------
https://chatgpt.com/codex/tasks/task_e_6898b2a5cda0832fb4c7f8650c331840