### PR TITLE
feat: allow optional shop deployment

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -33,6 +33,7 @@ describe("create-shop API", () => {
       pages: [],
       payment: [],
       shipping: [],
+      tax: "taxjar",
     });
     await expect(res.json()).resolves.toEqual({ success: true, deployment });
     (process.env as Record<string, string>).NODE_ENV = prevEnv as string;

--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -92,7 +92,7 @@ describe("createNewShop authorization", () => {
     const res = await createNewShop("shop2", { theme: "base" } as any);
 
     expect(createShop).toHaveBeenCalledTimes(1);
-    expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" });
+    expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" }, { deploy: false });
     expect(res).toBe(deployResult);
 
     (process.env as Record<string, string>).NODE_ENV = prevEnv;

--- a/apps/cms/__tests__/wizard.test.tsx
+++ b/apps/cms/__tests__/wizard.test.tsx
@@ -120,8 +120,21 @@ describe("Wizard", () => {
           ctx: RestContext
         ) => {
           capturedBody = await req.json();
-          return res(ctx.status(200), ctx.json({ success: true }));
+          return res(
+            ctx.status(200),
+            ctx.json({ success: true, deployment: { status: "pending" } })
+          );
         }
+      ),
+      rest.post(
+        "/cms/api/deploy-shop",
+        (_req: RestRequest, res: ResponseComposition, ctx: RestContext) =>
+          res(ctx.status(200), ctx.json({ status: "pending" }))
+      ),
+      rest.get(
+        "/cms/api/deploy-shop",
+        (_req: RestRequest, res: ResponseComposition, ctx: RestContext) =>
+          res(ctx.status(200), ctx.json({ status: "success", previewUrl: "" }))
       )
     );
 

--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -6,6 +6,7 @@ import {
   createShop,
   type CreateShopOptions,
   type DeployShopResult,
+  type DeployStatusBase,
 } from "@platform-core/createShop";
 import { getServerSession } from "next-auth";
 import { readRbac, writeRbac } from "../lib/rbacStore";
@@ -21,12 +22,12 @@ async function ensureAuthorized() {
 export async function createNewShop(
   id: string,
   options: CreateShopOptions
-): Promise<DeployShopResult> {
+): Promise<DeployShopResult | DeployStatusBase> {
   const session = await ensureAuthorized();
 
-  let result: DeployShopResult;
+  let result: DeployShopResult | DeployStatusBase;
   try {
-    result = createShop(id, options);
+    result = createShop(id, options, { deploy: false });
   } catch (err) {
     console.error("createShop failed", err);
     throw err;

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -398,7 +398,7 @@ export default function Wizard({
     setResult(null);
     setFieldErrors({});
     try {
-      const { ok, error, fieldErrors } = await submitShop(shopId, {
+      const { ok, error, fieldErrors, deployment } = await submitShop(shopId, {
         storeName,
         logo,
         contactInfo,
@@ -418,6 +418,13 @@ export default function Wizard({
 
       if (ok) {
         setResult("Shop created successfully");
+        if (deployment) {
+          if (deployment.status === "pending") {
+            deploy();
+          } else {
+            setDeployInfo(deployment);
+          }
+        }
         /* Remain on the summary step so the success message is visible;
            navigation to the next step is left to the user. */
         resetWizardProgress();

--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -1,7 +1,11 @@
 // apps/cms/src/app/cms/wizard/services/submitShop.ts
 "use client";
 
-import { createShopOptionsSchema } from "@platform-core/createShop";
+import {
+  createShopOptionsSchema,
+  type DeployShopResult,
+  type DeployStatusBase,
+} from "@platform-core/createShop";
 import { validateShopName } from "@platform-core/src/shops";
 import type { WizardState } from "../schema";
 
@@ -9,6 +13,7 @@ export interface SubmitResult {
   ok: boolean;
   error?: string;
   fieldErrors?: Record<string, string[]>;
+  deployment?: DeployShopResult | DeployStatusBase;
 }
 
 export async function submitShop(
@@ -83,9 +88,14 @@ export async function submitShop(
     body: JSON.stringify({ id: shopId, options: parsed.data }),
   });
 
-  if (res.ok) return { ok: true };
+  const json = (await res.json().catch(() => ({}))) as
+    | { success: true; deployment?: DeployShopResult | DeployStatusBase }
+    | { error?: string };
 
-  const json = (await res.json().catch(() => ({}))) as { error?: string };
+  if (res.ok) {
+    return { ok: true, deployment: json.deployment };
+  }
+
   return { ok: false, error: json.error ?? "Failed to create shop" };
 }
 

--- a/packages/platform-core/__tests__/createShop.test.ts
+++ b/packages/platform-core/__tests__/createShop.test.ts
@@ -37,7 +37,7 @@ describe("createShop", () => {
   });
 
   it("copies template directory", () => {
-    createShop("shop1", { template: "template-app" });
+    createShop("shop1", { template: "template-app" }, { deploy: false });
     expect(fsMock.cpSync).toHaveBeenCalledWith(
       expect.stringContaining("packages/template-app"),
       expect.stringContaining("apps/shop1"),
@@ -55,7 +55,7 @@ describe("createShop", () => {
   });
 
   it("writes .env with generated secrets", () => {
-    createShop("shop2", {});
+    createShop("shop2", {}, { deploy: false });
     const call = fsMock.writeFileSync.mock.calls.find((c) =>
       String(c[0]).includes(".env")
     );
@@ -73,7 +73,9 @@ describe("createShop", () => {
       if (path.includes("apps/")) return false;
       return !path.includes("missing-template");
     });
-    expect(() => createShop("id", { template: "missing-template" })).toThrow(
+    expect(() =>
+      createShop("id", { template: "missing-template" }, { deploy: false })
+    ).toThrow(
       "Template 'missing-template'"
     );
   });
@@ -85,13 +87,13 @@ describe("createShop", () => {
       if (path.includes("data/shops")) return false;
       return true;
     });
-    expect(() => createShop("existing", {})).toThrow(
+    expect(() => createShop("existing", {}, { deploy: false })).toThrow(
       "Pick a different ID or remove the existing folder"
     );
   });
 
   it("validates and trims shop ID", () => {
-    createShop("  new_shop  ", {});
+    createShop("  new_shop  ", {}, { deploy: false });
     expect(fsMock.cpSync).toHaveBeenCalledWith(
       expect.stringContaining("packages/template-app"),
       expect.stringContaining("apps/new_shop"),
@@ -100,6 +102,8 @@ describe("createShop", () => {
   });
 
   it("throws on invalid shop ID", () => {
-    expect(() => createShop("bad/id", {})).toThrow("Invalid shop name");
+    expect(() => createShop("bad/id", {}, { deploy: false })).toThrow(
+      "Invalid shop name"
+    );
   });
 });

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -19,8 +19,9 @@ import { loadTokens } from "./createShop/themeUtils";
  */
 export function createShop(
   id: string,
-  opts: CreateShopOptions = {}
-): DeployShopResult {
+  opts: CreateShopOptions = {},
+  { deploy = true }: { deploy?: boolean } = {}
+): DeployShopResult | DeployStatusBase {
   id = validateShopName(id);
   const newApp = join("apps", id);
   const newData = join("data", "shops", id);
@@ -40,6 +41,17 @@ export function createShop(
   const themeTokens = loadTokens(options.theme);
 
   writeFiles(id, options, themeTokens, templateApp, newApp, newData);
+
+  if (!deploy) {
+    const result: DeployStatusBase = { status: "pending" };
+    try {
+      const file = join("data", "shops", id, "deploy.json");
+      writeFileSync(file, JSON.stringify(result, null, 2));
+    } catch {
+      // ignore write errors
+    }
+    return result;
+  }
 
   return deployShop(id);
 }
@@ -102,6 +114,6 @@ export function listThemes(): string[] {
     .map((d) => d.name);
 }
 
-export { prepareOptions } from "./createShop/schema";
+export { prepareOptions, createShopOptionsSchema } from "./createShop/schema";
 export { ensureTemplateExists, writeFiles, copyTemplate } from "./createShop/fsUtils";
 export { loadTokens, loadBaseTokens } from "./createShop/themeUtils";

--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -291,4 +291,4 @@ await ensureLogo();
 await ensureContact();
 await ensurePayment();
 await ensureShipping();
-await createShop(shopId, options);
+await createShop(shopId, options, { deploy: true });

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -67,7 +67,7 @@ async function main() {
   };
 
   const prefixedId = `shop-${shopId}`;
-  createShop(prefixedId, options);
+  createShop(prefixedId, options, { deploy: true });
 
   let validationError: unknown;
   try {


### PR DESCRIPTION
## Summary
- allow createShop to skip deploy
- update CMS action and wizard to handle deferred deployment
- keep CLI scripts deploying by default and adjust tests

## Testing
- `pnpm lint --filter @acme/platform-core --filter @apps/cms`
- `pnpm --filter @apps/cms test __tests__/api.create-shop.test.ts`
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/createShop.test.ts`
- `pnpm test --filter @apps/cms --filter @acme/platform-core` *(fails: Cannot find module '@/components/atoms/shadcn', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898b3623024832f86d450f09e0f294f