### PR TITLE
refactor: expose initTheme from utils

### DIFF
--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/layout.tsx
 import { CartProvider } from "@/contexts/CartContext";
-import { initTheme } from "@platform-core/src/utils/initTheme";
+import { initTheme } from "@platform-core/utils";
 import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { initTheme } from "@platform-core/src/utils/initTheme";
+import { initTheme } from "@platform-core/utils";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { initTheme } from "@platform-core/src/utils/initTheme";
+import { initTheme } from "@platform-core/utils";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { getShopFromPath } from "./getShopFromPath";
 export { replaceShopInPath } from "./replaceShopInPath";
 export { fillLocales } from "./locales";
+export { initTheme } from "./initTheme";


### PR DESCRIPTION
## Summary
- re-export initTheme from `@platform-core/utils`
- update apps to import initTheme from the barrel

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms')*

------
https://chatgpt.com/codex/tasks/task_e_6898b5e53bf4832fbcd72c244ec57107