### PR TITLE
refactor: use fillLocales for translated fields

### DIFF
--- a/apps/cms/__tests__/page-utils.test.ts
+++ b/apps/cms/__tests__/page-utils.test.ts
@@ -1,0 +1,11 @@
+// apps/cms/__tests__/page-utils.test.ts
+import { toPageInfo } from "../src/app/cms/wizard/utils/page-utils";
+
+describe("page utils", () => {
+  it("fills locales for missing fields", () => {
+    const info = toPageInfo({ slug: "test" });
+    expect(Object.keys(info.title)).toEqual(["en", "de", "it"]);
+    expect(Object.keys(info.description)).toEqual(["en", "de", "it"]);
+    expect(Object.keys(info.image)).toEqual(["en", "de", "it"]);
+  });
+});

--- a/apps/cms/__tests__/products.test.ts
+++ b/apps/cms/__tests__/products.test.ts
@@ -51,6 +51,7 @@ describe("product actions", () => {
       expect(draft.status).toBe("draft");
       expect(draft.title.en).toBe("Untitled");
       expect(Object.keys(draft.title)).toEqual(["en", "de", "it"]);
+      expect(Object.keys(draft.description)).toEqual(["en", "de", "it"]);
     });
   });
 

--- a/apps/cms/src/actions/pages/validation.ts
+++ b/apps/cms/src/actions/pages/validation.ts
@@ -1,14 +1,12 @@
 // apps/cms/src/actions/pages/validation.ts
 
 import { LOCALES } from "@acme/i18n";
+import { fillLocales } from "@platform-core/utils";
 import { pageComponentSchema, type Locale } from "@types";
 import { z } from "zod";
 
 export const emptyTranslated = (): Record<Locale, string> =>
-  LOCALES.reduce(
-    (acc, l) => ({ ...acc, [l]: "" }),
-    {} as Record<Locale, string>
-  );
+  fillLocales(undefined, "");
 
 export const componentsField = z
   .string()

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -13,6 +13,7 @@ import {
   updateProductInRepo,
   writeRepo,
 } from "@platform-core/repositories/json.server";
+import { fillLocales } from "@platform-core/utils";
 import type { ProductPublication } from "@platform-core/src/products";
 import * as Sentry from "@sentry/node";
 import type { Locale } from "@types";
@@ -46,13 +47,9 @@ export async function createDraftRecord(
 
   const now = nowIso();
   const locales = await getLocales(shop);
-  const blank: Record<string, string> = {};
-  locales.forEach((l) => {
-    blank[l] = "";
-  });
   const first = locales[0] ?? "en";
-  const title = { ...blank, [first]: "Untitled" } as Record<Locale, string>;
-  const description = { ...blank } as Record<Locale, string>;
+  const title = fillLocales({ [first]: "Untitled" }, "");
+  const description = fillLocales(undefined, "");
 
   const draft: ProductPublication = {
     id: ulid(),

--- a/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
@@ -1,6 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
 
 import { createPage } from "@cms/actions/pages.server";
+import { fillLocales } from "@platform-core/utils";
 import type { Page } from "@types";
 import dynamic from "next/dynamic";
 
@@ -26,9 +27,9 @@ export default async function NewPageBuilderRoute({
     status: "draft",
     components: [],
     seo: {
-      title: { en: "", de: "", it: "" },
-      description: { en: "", de: "", it: "" },
-      image: { en: "", de: "", it: "" },
+      title: fillLocales(undefined, ""),
+      description: fillLocales(undefined, ""),
+      image: fillLocales(undefined, ""),
     },
     createdAt: "",
     updatedAt: "",

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -1,5 +1,6 @@
 // apps/cms/src/app/cms/wizard/schema.ts
 import { LOCALES } from "@acme/i18n";
+import { fillLocales } from "@platform-core/utils";
 import { pageComponentSchema } from "@types/Page";
 import { localeSchema, type Locale } from "@types";
 import { ulid } from "ulid";
@@ -14,13 +15,11 @@ import { baseTokens } from "./tokenUtils";
 function defaultLocaleRecord(
   first: string | null = null
 ): Record<Locale, string> {
-  return LOCALES.reduce<Record<Locale, string>>(
-    (acc, l, i) => {
-      acc[l] = i === 0 && first !== null ? first : "";
-      return acc;
-    },
-    {} as Record<Locale, string>
-  );
+  const record = fillLocales(undefined, "");
+  if (first !== null) {
+    record[LOCALES[0]] = first;
+  }
+  return record;
 }
 
 const localeRecordSchema = z.record(localeSchema, z.string());

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { LOCALES } from "@acme/i18n";
+import { fillLocales } from "@platform-core/utils";
 import type { Locale, Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { useState } from "react";
@@ -61,7 +62,6 @@ export default function StepAdditionalPages({
 
   usePagesLoader({
     shopId,
-    languages,
     setPages,
     adding,
     draftId: newDraftId,
@@ -106,18 +106,9 @@ export default function StepAdditionalPages({
                 status: "draft",
                 components: newComponents,
                 seo: {
-                  title: LOCALES.reduce(
-                    (acc, l) => ({ ...acc, [l]: "" }),
-                    {} as Record<Locale, string>
-                  ),
-                  description: LOCALES.reduce(
-                    (acc, l) => ({ ...acc, [l]: "" }),
-                    {} as Record<Locale, string>
-                  ),
-                  image: LOCALES.reduce(
-                    (acc, l) => ({ ...acc, [l]: "" }),
-                    {} as Record<Locale, string>
-                  ),
+                  title: fillLocales(undefined, ""),
+                  description: fillLocales(undefined, ""),
+                  image: fillLocales(undefined, ""),
                 },
                 createdAt: "",
                 updatedAt: "",
@@ -157,17 +148,14 @@ export default function StepAdditionalPages({
               onClick={() => {
                 setPages([
                   ...pages,
-                  toPageInfo(
-                    {
-                      id: newDraftId ?? undefined,
-                      slug: newSlug,
-                      title: newTitle,
-                      description: newDesc,
-                      image: newImage,
-                      components: newComponents,
-                    },
-                    languages
-                  ),
+                  toPageInfo({
+                    id: newDraftId ?? undefined,
+                    slug: newSlug,
+                    title: newTitle,
+                    description: newDesc,
+                    image: newImage,
+                    components: newComponents,
+                  }),
                 ]);
                 resetFields();
                 setAdding(false);

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/usePagesLoader.ts
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/usePagesLoader.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import type { Locale, Page, PageComponent } from "@types";
+import type { Page, PageComponent } from "@types";
 import { historyStateSchema } from "@types";
 import { fetchJson } from "@shared-utils";
 import { toPageInfo } from "../utils/page-utils";
@@ -7,7 +7,6 @@ import type { PageInfo } from "../schema";
 
 interface Params {
   shopId: string;
-  languages: readonly Locale[];
   setPages: (v: PageInfo[]) => void;
   adding: boolean;
   draftId: string | null;
@@ -17,7 +16,6 @@ interface Params {
 
 export default function usePagesLoader({
   shopId,
-  languages,
   setPages,
   adding,
   draftId,
@@ -29,7 +27,7 @@ export default function usePagesLoader({
     (async () => {
       try {
         const loaded = await fetchJson<Page[]>(`/cms/api/pages/${shopId}`);
-        setPages(loaded.map((p) => toPageInfo(p, languages)));
+        setPages(loaded.map((p) => toPageInfo(p)));
         if (typeof window !== "undefined") {
           loaded.forEach((p) => {
             localStorage.setItem(
@@ -50,7 +48,7 @@ export default function usePagesLoader({
         setToast({ open: true, message: "Failed to load pages" });
       }
     })();
-  }, [shopId, languages, setPages, setToast]);
+  }, [shopId, setPages, setToast]);
 
   useEffect(() => {
     if (!adding || !draftId || !shopId) return;

--- a/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
@@ -9,8 +9,8 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { LOCALES } from "@acme/i18n";
-import type { Locale, Page, PageComponent } from "@types";
+import { fillLocales } from "@platform-core/utils";
+import type { Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
 import { useState } from "react";
@@ -86,15 +86,9 @@ export default function StepCheckoutPage({
             status: "draft",
             components: checkoutComponents,
             seo: {
-              title: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              description: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              image: "",
+              title: fillLocales(undefined, ""),
+              description: fillLocales(undefined, ""),
+              image: fillLocales(undefined, ""),
             },
             createdAt: "",
             updatedAt: "",

--- a/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
@@ -9,8 +9,8 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { LOCALES } from "@acme/i18n";
-import type { Locale, Page, PageComponent } from "@types";
+import { fillLocales } from "@platform-core/utils";
+import type { Page, PageComponent } from "@types";
 import { historyStateSchema } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
@@ -116,15 +116,9 @@ export default function StepHomePage({
             status: "draft",
             components,
             seo: {
-              title: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              description: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              image: "",
+              title: fillLocales(undefined, ""),
+              description: fillLocales(undefined, ""),
+              image: fillLocales(undefined, ""),
             },
             createdAt: "",
             updatedAt: "",

--- a/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
@@ -3,8 +3,8 @@
 
 import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { LOCALES } from "@acme/i18n";
-import type { Locale, Page, PageComponent } from "@types";
+import { fillLocales } from "@platform-core/utils";
+import type { Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ReactNode, useState } from "react";
 import { Toast } from "@/components/atoms";
@@ -37,11 +37,7 @@ interface Props {
   children?: ReactNode;
 }
 
-const emptyTranslated = (): Record<Locale, string> =>
-  LOCALES.reduce(
-    (acc, l) => ({ ...acc, [l]: "" }),
-    {} as Record<Locale, string>
-  );
+const emptyTranslated = () => fillLocales(undefined, "");
 
 export default function StepLayout({
   currentStep,

--- a/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
@@ -9,8 +9,8 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import ProductPageBuilder from "@/components/cms/ProductPageBuilder";
-import { LOCALES } from "@acme/i18n";
-import type { Locale, Page, PageComponent } from "@types";
+import { fillLocales } from "@platform-core/utils";
+import type { Page, PageComponent } from "@types";
 import { historyStateSchema } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
@@ -118,15 +118,9 @@ export default function StepProductPage({
             status: "draft",
             components: productComponents,
             seo: {
-              title: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              description: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              image: "",
+              title: fillLocales(undefined, ""),
+              description: fillLocales(undefined, ""),
+              image: fillLocales(undefined, ""),
             },
             createdAt: "",
             updatedAt: "",

--- a/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
@@ -9,8 +9,8 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { LOCALES } from "@acme/i18n";
-import type { Locale, Page, PageComponent } from "@types";
+import { fillLocales } from "@platform-core/utils";
+import type { Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
 import { useState } from "react";
@@ -86,15 +86,9 @@ export default function StepShopPage({
             status: "draft",
             components: shopComponents,
             seo: {
-              title: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              description: LOCALES.reduce(
-                (acc, l) => ({ ...acc, [l]: "" }),
-                {} as Record<Locale, string>
-              ),
-              image: "",
+              title: fillLocales(undefined, ""),
+              description: fillLocales(undefined, ""),
+              image: fillLocales(undefined, ""),
             },
             createdAt: "",
             updatedAt: "",

--- a/apps/cms/src/app/cms/wizard/utils/page-utils.ts
+++ b/apps/cms/src/app/cms/wizard/utils/page-utils.ts
@@ -1,23 +1,16 @@
 // apps/cms/src/app/cms/wizard/utils/page.ts
 
-import type { Locale, PageComponent } from "@types";
+import { fillLocales } from "@platform-core/utils";
+import type { PageComponent } from "@types";
 import type { PageInfo } from "../schema";
 
-export function toPageInfo(
-  draft: Partial<PageInfo>,
-  locales: readonly Locale[]
-): PageInfo {
-  const blank = Object.fromEntries(locales.map((l) => [l, ""])) as Record<
-    Locale,
-    string
-  >;
-
+export function toPageInfo(draft: Partial<PageInfo>): PageInfo {
   return {
     id: draft.id,
     slug: draft.slug ?? "",
-    title: { ...blank, ...draft.title },
-    description: { ...blank, ...draft.description },
-    image: { ...blank, ...draft.image },
+    title: fillLocales(draft.title, ""),
+    description: fillLocales(draft.description, ""),
+    image: fillLocales(draft.image, ""),
     components: draft.components ?? ([] as PageComponent[]),
   };
 }


### PR DESCRIPTION
## Summary
- replace manual locale defaults with `fillLocales` in product drafts and page utilities
- rely on `fillLocales` across wizard page builders and layout helpers
- test that localized fields are fully populated

## Testing
- `pnpm --filter @apps/cms test __tests__/products.test.ts __tests__/page-utils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6898b5e7a9e4832fb5eec824e426533a