### PR TITLE
feat(ui): use shared Locale type

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "shadcn-ui": "^0.9.5",
+    "@acme/i18n": "workspace:*",
     "@acme/shared-utils": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/ui/src/utils/i18n/multilingual.ts
+++ b/packages/ui/src/utils/i18n/multilingual.ts
@@ -1,4 +1,4 @@
-import type { Locale } from "@platform-core/src/products";
+import type { Locale } from "@i18n/locales";
 
 export interface MultilingualField {
   field: "title" | "desc";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@acme/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@acme/shared-utils':
         specifier: workspace:*
         version: link:../shared-utils


### PR DESCRIPTION
## Summary
- import Locale from shared `@i18n/locales` utilities
- add `@acme/i18n` dependency to UI package

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx'; timeout in apps/cms/__tests__/products.test.ts; SyntaxError in apps/cms/__tests__/pages.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6898b5e14800832f889aeb5054dcf8d4