### PR TITLE
feat: add guided provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Key points:
    ```
 
    `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
-   contact email and which theme, template, payment and shipping providers to use. It then
+   contact email and which theme and template to use. Payment and shipping providers are chosen
+   from guided lists of available providers. It then
    scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
    provide real secrets (see [Environment Variables](#environment-variables)). For scripted
    setups you can still call `pnpm create-shop <id>` with flags.
@@ -56,8 +57,14 @@ pnpm init-shop
 ? Contact email … demo@example.com
 ? Theme › base
 ? Template › template-app
-? Payment providers › stripe
-? Shipping providers › ups
+Available payment providers:
+  1) stripe
+  2) paypal
+Select payment providers by number (comma-separated, empty for none): 1
+Available shipping providers:
+  1) dhl
+  2) ups
+Select shipping providers by number (comma-separated, empty for none): 2
 Scaffolded apps/shop-demo
 
 pnpm setup-ci demo  # optional

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -18,7 +18,7 @@ pnpm init-shop
 - logo URL
 - contact email
 - theme and template
-- payment and shipping providers
+- payment and shipping providers (selected from a guided list of available providers)
 
 After answering the prompts the wizard scaffolds `apps/shop-<id>` and generates an `.env` file inside the new app.
 
@@ -44,8 +44,14 @@ pnpm init-shop
 ? Contact email … demo@example.com
 ? Theme › base
 ? Template › template-app
-? Payment providers › stripe
-? Shipping providers › ups
+Available payment providers:
+  1) stripe
+  2) paypal
+Select payment providers by number (comma-separated, empty for none): 1
+Available shipping providers:
+  1) dhl
+  2) ups
+Select shipping providers by number (comma-separated, empty for none): 2
 Scaffolded apps/shop-demo
 ```
 


### PR DESCRIPTION
## Summary
- guide `init-shop` users through choosing payment and shipping providers
- document provider menus in setup guide and README

## Testing
- `npx eslint scripts/src/init-shop.ts doc/setup.md README.md` (files ignored: no matching configuration)
- `pnpm test` *(fails: @apps/cms#test exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6898b5ff4be0832fae165b14e3237ef0