### PR TITLE
Ignore empty env vars during validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Key points:
    `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
    contact email and which theme, template, payment and shipping providers to use. It then
    scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
-   provide real secrets (see [Environment Variables](#environment-variables)). For scripted
+   provide real secrets (see [Environment Variables](#environment-variables)). Lines with empty
+   values are treated as placeholders and ignored by `pnpm validate-env`. For scripted
    setups you can still call `pnpm create-shop <id>` with flags.
 
 2. **Run the app**

--- a/dist-scripts/setup-ci.js
+++ b/dist-scripts/setup-ci.js
@@ -21,6 +21,10 @@ for (const line of envRaw.split(/\n+/)) {
     env[key] = rest.join("=");
 }
 try {
+    for (const [key, value] of Object.entries(env)) {
+        if (value === "")
+            delete env[key];
+    }
     envSchema.parse(env);
 }
 catch (err) {

--- a/dist-scripts/validate-env.js
+++ b/dist-scripts/validate-env.js
@@ -21,6 +21,10 @@ for (const line of envRaw.split(/\n+/)) {
     env[key] = rest.join("=");
 }
 try {
+    for (const [key, value] of Object.entries(env)) {
+        if (value === "")
+            delete env[key];
+    }
     envSchema.parse(env);
     console.log("Environment variables look valid.");
 }

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -52,6 +52,8 @@ Scaffolded apps/shop-demo
 ## 2. Configure environment variables
 
 Edit `apps/shop-<id>/.env` to replace placeholder secrets.
+Lines with empty values or commented out entries are treated as placeholders and ignored by
+`pnpm validate-env` and `pnpm setup-ci`.
 
 ```bash
 pnpm validate-env <id>

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -78,9 +78,9 @@ export function writeFiles(
     }
   }
   envContent += `NEXTAUTH_SECRET=${genSecret()}\n`;
-  envContent += `CMS_SPACE_URL=\n`;
-  envContent += `CMS_ACCESS_TOKEN=\n`;
-  envContent += `CHROMATIC_PROJECT_TOKEN=\n`;
+  envContent += `# CMS_SPACE_URL=\n`;
+  envContent += `# CMS_ACCESS_TOKEN=\n`;
+  envContent += `# CHROMATIC_PROJECT_TOKEN=\n`;
   writeFileSync(join(newApp, ".env"), envContent);
 
   mkdirSync(newData, { recursive: true });

--- a/scripts/__tests__/validate-env.test.ts
+++ b/scripts/__tests__/validate-env.test.ts
@@ -52,6 +52,27 @@ describe("validate-env script", () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  it("strips keys with empty values before validation", async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(
+      "STRIPE_SECRET_KEY=sk\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCMS_ACCESS_TOKEN=\n"
+    );
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+
+    await import("../../dist-scripts/validate-env.js");
+
+    expect(logSpy).toHaveBeenCalledWith("Environment variables look valid.");
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
   it("exits 1 and reports invalid env", async () => {
     existsSyncMock.mockReturnValue(true);
     readFileSyncMock.mockReturnValue("STRIPE_SECRET_KEY=sk\n");

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -81,6 +81,9 @@ async function main() {
       const [key, ...rest] = trimmed.split("=");
       env[key] = rest.join("=");
     }
+    for (const [key, value] of Object.entries(env)) {
+      if (value === "") delete env[key];
+    }
     envSchema.parse(env);
   } catch (err) {
     validationError = err;

--- a/scripts/src/setup-ci.ts
+++ b/scripts/src/setup-ci.ts
@@ -24,6 +24,9 @@ for (const line of envRaw.split(/\n+/)) {
 }
 
 try {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === "") delete env[key];
+  }
   envSchema.parse(env);
 } catch (err) {
   console.error("Invalid environment variables:\n", err);

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -27,6 +27,9 @@ for (const line of envRaw.split(/\n+/)) {
 }
 
 try {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === "") delete env[key];
+  }
   envSchema.parse(env);
   console.log("Environment variables look valid.");
 } catch (err) {


### PR DESCRIPTION
## Summary
- strip empty environment variables in shop scripts before validation
- comment out optional env variables in generated shops
- document that empty env entries are treated as placeholders

## Testing
- `pnpm test` *(fails: @apps/cms:test command finished with error)*
- `pnpm exec jest scripts/__tests__/validate-env.test.ts`
- `pnpm exec eslint scripts/src/init-shop.ts scripts/src/validate-env.ts scripts/src/setup-ci.ts packages/platform-core/src/createShop/fsUtils.ts scripts/__tests__/validate-env.test.ts dist-scripts/validate-env.js dist-scripts/setup-ci.js` *(warn: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6898b603530c832fa32e3597623702fb