### PR TITLE
test: cover init-shop prompts

### DIFF
--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { runInNewContext } from 'vm';
+
+describe('init-shop wizard', () => {
+  it('collects user input and validates environment', async () => {
+    const questions: string[] = [];
+    const answers = [
+      'demo',
+      'Demo Shop',
+      'base',
+      'template-app',
+      'stripe,paypal',
+      'dhl',
+      'n',
+    ];
+    const createShop = jest.fn();
+    const envParse = jest.fn((env: Record<string, string>) => {
+      if (!env.STRIPE_SECRET_KEY || !env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {
+        throw new Error('invalid env');
+      }
+      return env;
+    });
+
+    const sandbox: any = {
+      exports: {},
+      module: { exports: {} },
+      process: { version: 'v20.0.0', exit: jest.fn() },
+      console: { log: jest.fn(), error: jest.fn() },
+      require: (p: string) => {
+        if (p === 'node:fs') {
+          return {
+            existsSync: () => true,
+            readFileSync: () =>
+              'STRIPE_SECRET_KEY=\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=\n',
+          };
+        }
+        if (p === 'node:path') return require('node:path');
+        if (p === 'node:child_process') {
+          return { spawnSync: jest.fn(), execSync: () => '10.0.0' };
+        }
+        if (p === 'node:readline/promises') {
+          return {
+            createInterface: () => ({
+              question: (q: string) => {
+                questions.push(q);
+                return Promise.resolve(answers.shift()!);
+              },
+              close: () => undefined,
+            }),
+          };
+        }
+        if (p.includes('@config/src/env')) {
+          return { envSchema: { parse: envParse } };
+        }
+        if (p.includes('../../packages/platform-core/src/createShop')) {
+          return { createShop };
+        }
+        return require(p);
+      },
+    };
+
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../scripts/src/init-shop.ts'),
+      'utf8'
+    );
+    const transpiled = ts.transpileModule(src, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, esModuleInterop: true },
+    }).outputText;
+
+    const promise = runInNewContext(transpiled, sandbox);
+    await promise;
+
+    expect(questions).toEqual([
+      'Shop ID: ',
+      'Display name (optional): ',
+      'Theme [base]: ',
+      'Template [template-app]: ',
+      'Payment providers (comma-separated): ',
+      'Shipping providers (comma-separated): ',
+      'Setup CI workflow? (y/N): ',
+    ]);
+
+    expect(createShop).toHaveBeenCalledWith('shop-demo', {
+      name: 'Demo Shop',
+      theme: 'base',
+      template: 'template-app',
+      payment: ['stripe', 'paypal'],
+      shipping: ['dhl'],
+    });
+
+    expect(envParse).toHaveBeenCalledWith({
+      STRIPE_SECRET_KEY: '',
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
+    });
+
+    expect(sandbox.console.error).toHaveBeenCalled();
+    expect(sandbox.console.error.mock.calls[0][0]).toContain(
+      'Environment validation failed'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test for `init-shop` wizard verifying prompts
- ensure createShop called with collected options and env placeholders fail validation

## Testing
- `npx jest test/unit/init-shop.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898b609ae04832f845f5451f8366285