### PR TITLE
feat: add shop type prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Key points:
    pnpm setup-ci <id>
    ```
 
-   `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
-   contact email and which theme, template, payment and shipping providers to use. It then
+   `init-shop` launches an interactive wizard that asks for the shop ID, type (sale or rental),
+   display name, logo URL, contact email and which theme, template, payment and shipping providers
+   to use. Selecting `rental` scaffolds the shop for rentals; otherwise the shop defaults to
+   standard sales. It then
    scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
    provide real secrets (see [Environment Variables](#environment-variables)). For scripted
    setups you can still call `pnpm create-shop <id>` with flags.
@@ -52,6 +54,7 @@ Key points:
 pnpm init-shop
 ? Shop ID … demo
 ? Display name … Demo Shop
+? Shop type … sale
 ? Logo URL … https://example.com/logo.png
 ? Contact email … demo@example.com
 ? Theme › base

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -17,6 +17,7 @@ pnpm init-shop
 - display name
 - logo URL
 - contact email
+- shop type (sale or rental; defaults to sale)
 - theme and template
 - payment and shipping providers
 
@@ -40,6 +41,7 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 pnpm init-shop
 ? Shop ID … demo
 ? Display name … Demo Shop
+? Shop type … sale
 ? Logo URL … https://example.com/logo.png
 ? Contact email … demo@example.com
 ? Theme › base

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -52,6 +52,8 @@ async function main() {
     process.exit(1);
   }
   const name = await prompt("Display name (optional): ");
+  const typeAns = await prompt("Shop type [sale|rental]: ", "sale");
+  const type = typeAns === "rental" ? "rental" : "sale";
   const theme = await prompt("Theme [base]: ", "base");
   const template = await prompt("Template [template-app]: ", "template-app");
   const paymentAns = await prompt("Payment providers (comma-separated): ");
@@ -60,6 +62,7 @@ async function main() {
 
   const options = {
     ...(name && { name }),
+    type,
     theme,
     template,
     payment: paymentAns.split(",").map((s) => s.trim()).filter(Boolean),


### PR DESCRIPTION
## Summary
- ask for shop type when running `pnpm init-shop`
- include selected type in `createShop` options
- document shop type prompt and examples

## Testing
- `pnpm lint`
- `pnpm test` *(fails: @apps/cms#test)*

------
https://chatgpt.com/codex/tasks/task_e_6898b606d9d8832f9878deef2519ffd9