### PR TITLE
feat: add recommendation carousel block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -79,6 +79,11 @@ export interface ProductGridComponent extends PageComponentBase {
 export interface ProductCarouselComponent extends PageComponentBase {
     type: "ProductCarousel";
 }
+/** Carousel of recommended products fetched from an API */
+export interface RecommendationCarouselComponent extends PageComponentBase {
+    type: "RecommendationCarousel";
+    endpoint: string;
+}
 export interface GalleryComponent extends PageComponentBase {
     type: "Gallery";
     images?: {
@@ -131,7 +136,7 @@ export interface SectionComponent extends PageComponentBase {
     type: "Section";
     children?: PageComponent[];
 }
-export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
+export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
 export declare const pageSchema: z.ZodObject<{
     id: z.ZodString;
     slug: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -80,6 +80,12 @@ export interface ProductCarouselComponent extends PageComponentBase {
   type: "ProductCarousel";
 }
 
+/** Carousel of recommended products fetched from an API */
+export interface RecommendationCarouselComponent extends PageComponentBase {
+  type: "RecommendationCarousel";
+  endpoint: string;
+}
+
 export interface GalleryComponent extends PageComponentBase {
   type: "Gallery";
   images?: { src: string; alt?: string }[];
@@ -134,6 +140,7 @@ export type PageComponent =
   | ReviewsCarouselComponent
   | ProductGridComponent
   | ProductCarouselComponent
+  | RecommendationCarouselComponent
   | GalleryComponent
   | ContactFormComponent
   | ContactFormWithMapComponent
@@ -197,6 +204,11 @@ const productGridComponentSchema = baseComponentSchema.extend({
 
 const productCarouselComponentSchema = baseComponentSchema.extend({
   type: z.literal("ProductCarousel"),
+});
+
+const recommendationCarouselComponentSchema = baseComponentSchema.extend({
+  type: z.literal("RecommendationCarousel"),
+  endpoint: z.string(),
 });
 
 const galleryComponentSchema = baseComponentSchema.extend({
@@ -271,6 +283,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     reviewsCarouselComponentSchema,
     productGridComponentSchema,
     productCarouselComponentSchema,
+    recommendationCarouselComponentSchema,
     galleryComponentSchema,
     contactFormComponentSchema,
     contactFormWithMapComponentSchema,

--- a/packages/ui/src/components/cms/blocks/RecommendationCarousel.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/RecommendationCarousel.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import RecommendationCarousel from "./RecommendationCarousel";
+
+const meta: Meta<typeof RecommendationCarousel> = {
+  component: RecommendationCarousel,
+  args: { endpoint: "/api/products" },
+};
+export default meta;
+
+export const Default: StoryObj<typeof RecommendationCarousel> = {};
+
+export const Bounded: StoryObj<typeof RecommendationCarousel> = {
+  args: { minItems: 2, maxItems: 4 },
+};

--- a/packages/ui/src/components/cms/blocks/RecommendationCarousel.tsx
+++ b/packages/ui/src/components/cms/blocks/RecommendationCarousel.tsx
@@ -1,0 +1,14 @@
+import {
+  RecommendationCarousel as BaseCarousel,
+  type RecommendationCarouselProps,
+} from "../../organisms/RecommendationCarousel";
+
+export default function CmsRecommendationCarousel({
+  minItems,
+  maxItems,
+  ...rest
+}: RecommendationCarouselProps) {
+  return (
+    <BaseCarousel minItems={minItems} maxItems={maxItems} {...rest} />
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -9,6 +9,7 @@ import ReviewsCarousel from "./ReviewsCarousel";
 import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
+import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
 import { NewsletterForm, PromoBanner, CategoryList } from "./molecules";
 
@@ -20,6 +21,7 @@ export {
   HeroBanner,
   ProductCarousel,
   ProductGrid,
+  RecommendationCarousel,
   ReviewsCarousel,
   Testimonials,
   TestimonialSlider,

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -9,6 +9,7 @@ import ReviewsCarousel from "./ReviewsCarousel";
 import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
+import RecommendationCarousel from "./RecommendationCarousel";
 import { CategoryList, NewsletterForm, PromoBanner } from "./molecules";
 
 export const organismRegistry = {
@@ -17,6 +18,7 @@ export const organismRegistry = {
   ReviewsCarousel,
   ProductGrid,
   ProductCarousel,
+  RecommendationCarousel,
   Gallery,
   ContactForm,
   ContactFormWithMap,

--- a/packages/ui/src/components/organisms/README.md
+++ b/packages/ui/src/components/organisms/README.md
@@ -35,8 +35,9 @@ Current components:
 - `ProductGallery`
 - `OrderSummary`
 
-## Responsive Carousels
+## Responsive Product Displays
 
-`ProductCarousel` and `RecommendationCarousel` automatically adjust their
-visible item count based on screen width. The `minItems` and `maxItems` props
-allow callers to bound how many products appear at once.
+`ProductGrid`, `ProductCarousel` and `RecommendationCarousel` automatically
+adjust how many products are shown based on available width. Use `minItems`
+and `maxItems` to constrain the number of visible items so layouts remain
+attractive across screen sizes.


### PR DESCRIPTION
## Summary
- add CMS block wrapper for RecommendationCarousel and register it in block registry
- support RecommendationCarousel in Page type definitions
- document min/max item behavior for product displays

## Testing
- `pnpm test` *(fails: ENOENT: no such file or directory, scandir '/tmp/media-Cy6gxH/public/uploads/shop1')*

------
https://chatgpt.com/codex/tasks/task_e_6898b3826710832fb09645ff643de7df