### PR TITLE
feat(ui): add icon theme toggle

### DIFF
--- a/packages/ui/__tests__/ThemeToggle.test.tsx
+++ b/packages/ui/__tests__/ThemeToggle.test.tsx
@@ -14,46 +14,38 @@ describe("ThemeToggle", () => {
     mockTheme = "base";
   });
 
-  it("selects themes and updates ARIA attributes", () => {
+  it("cycles through themes and announces changes", () => {
     const { rerender } = render(<ThemeToggle />);
 
-    const group = screen.getByRole("radiogroup", { name: /theme/i });
-    expect(group).toBeInTheDocument();
-
-    let light = screen.getByLabelText("Light");
-    let dark = screen.getByLabelText("Dark");
-    let system = screen.getByLabelText("System");
+    let button = screen.getByRole("button", {
+      name: /switch to dark theme/i,
+    });
     let live = screen.getByText(/light theme selected/i);
-
     expect(live).toHaveAttribute("aria-live", "polite");
-    expect(light).toBeChecked();
-    expect(light).toHaveAttribute("aria-checked", "true");
 
-    fireEvent.click(dark);
+    fireEvent.click(button);
     expect(setTheme).toHaveBeenNthCalledWith(1, "dark");
 
     mockTheme = "dark";
     rerender(<ThemeToggle />);
-    light = screen.getByLabelText("Light");
-    dark = screen.getByLabelText("Dark");
-    system = screen.getByLabelText("System");
-    live = screen.getByText(/dark theme selected/i);
-    expect(dark).toBeChecked();
-    expect(dark).toHaveAttribute("aria-checked", "true");
 
-    fireEvent.click(system);
+    button = screen.getByRole("button", {
+      name: /switch to system theme/i,
+    });
+    live = screen.getByText(/dark theme selected/i);
+
+    fireEvent.keyDown(button, { key: "Enter" });
     expect(setTheme).toHaveBeenNthCalledWith(2, "system");
 
     mockTheme = "system";
     rerender(<ThemeToggle />);
-    light = screen.getByLabelText("Light");
-    dark = screen.getByLabelText("Dark");
-    system = screen.getByLabelText("System");
-    live = screen.getByText(/system theme selected/i);
-    expect(system).toBeChecked();
-    expect(system).toHaveAttribute("aria-checked", "true");
 
-    fireEvent.click(light);
+    button = screen.getByRole("button", {
+      name: /switch to light theme/i,
+    });
+    live = screen.getByText(/system theme selected/i);
+
+    fireEvent.keyDown(button, { key: " " });
     expect(setTheme).toHaveBeenNthCalledWith(3, "base");
   });
 });

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { DesktopIcon, MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { useTheme, Theme } from "@platform-core/src/contexts/ThemeContext";
-import type { ChangeEvent } from "react";
+import type { ComponentType, KeyboardEvent } from "react";
 
 const themes: Theme[] = ["base", "dark", "system"];
+
 const labels: Record<Theme, string> = {
   base: "Light",
   dark: "Dark",
@@ -11,32 +13,46 @@ const labels: Record<Theme, string> = {
   brandx: "BrandX", // unused but satisfy type
 };
 
+const icons: Record<Theme, ComponentType> = {
+  base: SunIcon,
+  dark: MoonIcon,
+  system: DesktopIcon,
+  brandx: SunIcon,
+};
+
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTheme(e.target.value as Theme);
+  const current = theme as Theme;
+  const next = themes[(themes.indexOf(current) + 1) % themes.length];
+  const Icon = icons[current];
+
+  const toggleTheme = () => {
+    setTheme(next);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggleTheme();
+    }
   };
 
   return (
-    <div role="radiogroup" aria-label="Theme">
-      {themes.map((t) => (
-        <div key={t} className="flex items-center gap-2">
-          <input
-            type="radio"
-            id={`theme-${t}`}
-            name="theme"
-            value={t}
-            checked={theme === t}
-            onChange={handleChange}
-            aria-checked={theme === t}
-          />
-          <label htmlFor={`theme-${t}`}>{labels[t]}</label>
-        </div>
-      ))}
+    <div>
+      <button
+        type="button"
+        onClick={toggleTheme}
+        onKeyDown={handleKeyDown}
+        aria-label={`Switch to ${labels[next]} theme`}
+        className="p-2"
+      >
+        <Icon />
+      </button>
       <span aria-live="polite" className="sr-only">
-        {labels[theme as keyof typeof labels]} theme selected
+        {labels[current as keyof typeof labels]} theme selected
       </span>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- replace ThemeToggle radio group with icon-based button that cycles themes
- update ThemeToggle tests for new behavior

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6898b7873e5c832fb684a8c603d125b6