### PR TITLE
feat: add plugin system

### DIFF
--- a/apps/cms/src/app/cms/plugins/PluginList.client.tsx
+++ b/apps/cms/src/app/cms/plugins/PluginList.client.tsx
@@ -1,0 +1,48 @@
+// apps/cms/src/app/cms/plugins/PluginList.client.tsx
+"use client";
+
+import { useState } from "react";
+import type { Plugin } from "@acme/platform-core";
+
+interface Props {
+  plugins: Plugin[];
+}
+
+export default function PluginList({ plugins }: Props) {
+  const [enabled, setEnabled] = useState<Record<string, boolean>>({});
+  const [configs, setConfigs] = useState<Record<string, string>>(
+    Object.fromEntries(
+      plugins.map((p) => [p.id, JSON.stringify(p.defaultConfig ?? {}, null, 2)])
+    )
+  );
+
+  return (
+    <ul className="space-y-6">
+      {plugins.map((plugin) => (
+        <li key={plugin.id} className="border-b pb-4">
+          <label className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={enabled[plugin.id] ?? false}
+              onChange={(e) =>
+                setEnabled({ ...enabled, [plugin.id]: e.target.checked })
+              }
+            />
+            <span className="font-medium">{plugin.name}</span>
+          </label>
+          {enabled[plugin.id] && (
+            <textarea
+              className="mt-2 w-full rounded border p-2 font-mono text-sm"
+              rows={4}
+              value={configs[plugin.id]}
+              onChange={(e) =>
+                setConfigs({ ...configs, [plugin.id]: e.target.value })
+              }
+            />
+          )}
+        </li>
+      ))}
+      {plugins.length === 0 && <li>No plugins installed.</li>}
+    </ul>
+  );
+}

--- a/apps/cms/src/app/cms/plugins/page.tsx
+++ b/apps/cms/src/app/cms/plugins/page.tsx
@@ -1,0 +1,13 @@
+// apps/cms/src/app/cms/plugins/page.tsx
+import { loadPlugins } from "@acme/platform-core";
+import PluginList from "./PluginList.client";
+
+export default async function PluginsPage() {
+  const plugins = await loadPlugins();
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Plugins</h2>
+      <PluginList plugins={plugins} />
+    </div>
+  );
+}

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -67,6 +67,12 @@ pnpm setup-ci <id>
 
 This creates `.github/workflows/shop-<id>.yml` which installs dependencies, runs lint/tests, builds the app and deploys it to Cloudflare Pages via `@cloudflare/next-on-pages`.
 
+## 4. Install plugins
+
+Plugins extend the platform with extra payment providers, shipping integrations or storefront widgets. The platform automatically loads any plugin found under `packages/plugins/*`.
+
+To install a plugin, add it to the `packages/plugins` directory (e.g. `packages/plugins/paypal`) and export a default plugin object. After restarting the CMS you can enable and configure the plugin under **CMS → Plugins**.
+
 ## Troubleshooting
 
 - **"Theme 'X' not found" or "Template 'Y' not found"** – ensure the names match directories in `packages/themes` or `packages/`.

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./dataRoot";
 export * from "./utils";
 export * from "./shipping";
 export * from "./tax";
+export * from "./plugins";

--- a/packages/platform-core/src/plugins.ts
+++ b/packages/platform-core/src/plugins.ts
@@ -1,0 +1,82 @@
+// packages/platform-core/src/plugins.ts
+import { readdir } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+
+/** Registry for payment providers */
+export interface PaymentRegistry {
+  add(id: string, provider: unknown): void;
+}
+
+/** Registry for shipping providers */
+export interface ShippingRegistry {
+  add(id: string, provider: unknown): void;
+}
+
+/** Registry for widget components */
+export interface WidgetRegistry {
+  add(id: string, component: unknown): void;
+}
+
+export interface PluginOptions {
+  /** Optional name shown in the CMS */
+  name: string;
+  /** Optional description for plugin */
+  description?: string;
+  /** Default configuration values */
+  defaultConfig?: Record<string, unknown>;
+}
+
+export interface Plugin extends PluginOptions {
+  id: string;
+  registerPayments?(registry: PaymentRegistry, config?: Record<string, unknown>): void;
+  registerShipping?(registry: ShippingRegistry, config?: Record<string, unknown>): void;
+  registerWidgets?(registry: WidgetRegistry, config?: Record<string, unknown>): void;
+}
+
+/** Load all plugins from packages/plugins */
+export async function loadPlugins(): Promise<Plugin[]> {
+  const pluginsDir = path.resolve(process.cwd(), "packages", "plugins");
+  let dirs: Dirent[];
+  try {
+    dirs = await readdir(pluginsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const plugins: Plugin[] = [];
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue;
+    const modPath = path.join(pluginsDir, dir.name, "index.ts");
+    try {
+      const mod = await import(modPath);
+      if (mod.default) {
+        plugins.push(mod.default as Plugin);
+      }
+    } catch (err) {
+      console.warn(`Failed to load plugin ${dir.name}`, err);
+    }
+  }
+  return plugins;
+}
+
+/** Load plugins and call their registration hooks */
+export async function initPlugins(registries: {
+  payments?: PaymentRegistry;
+  shipping?: ShippingRegistry;
+  widgets?: WidgetRegistry;
+}): Promise<Plugin[]> {
+  const plugins = await loadPlugins();
+  for (const plugin of plugins) {
+    const cfg = plugin.defaultConfig;
+    if (registries.payments && plugin.registerPayments) {
+      plugin.registerPayments(registries.payments, cfg);
+    }
+    if (registries.shipping && plugin.registerShipping) {
+      plugin.registerShipping(registries.shipping, cfg);
+    }
+    if (registries.widgets && plugin.registerWidgets) {
+      plugin.registerWidgets(registries.widgets, cfg);
+    }
+  }
+  return plugins;
+}

--- a/packages/plugins/paypal/index.ts
+++ b/packages/plugins/paypal/index.ts
@@ -1,0 +1,19 @@
+// packages/plugins/paypal/index.ts
+import type { Plugin, PaymentRegistry } from "@acme/platform-core";
+
+const paypalPlugin: Plugin = {
+  id: "paypal",
+  name: "PayPal",
+  description: "Example PayPal payment provider",
+  defaultConfig: { clientId: "", secret: "" },
+  registerPayments(registry: PaymentRegistry) {
+    registry.add("paypal", {
+      async processPayment() {
+        // placeholder implementation
+        return { success: true };
+      },
+    });
+  },
+};
+
+export default paypalPlugin;

--- a/packages/plugins/paypal/package.json
+++ b/packages/plugins/paypal/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@acme/plugin-paypal",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  }
+}


### PR DESCRIPTION
## Summary
- define plugin interfaces and loader
- add admin UI for managing plugins
- document plugin installation and include example PayPal plugin

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/atoms')*

------
https://chatgpt.com/codex/tasks/task_e_6898b7ca89a8832faf7d58625771f1cd