### PR TITLE
Guard theme helpers against missing browser APIs

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "../ThemeContext";
+
+function ThemeDisplay() {
+  const { theme } = useTheme();
+  return <span data-testid="theme">{theme}</span>;
+}
+
+describe("ThemeProvider fallback", () => {
+  const originalLocalStorage = window.localStorage;
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: originalLocalStorage,
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    document.documentElement.style.colorScheme = "";
+  });
+
+  it("defaults to system/base when APIs are unavailable", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked");
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeDisplay />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("theme").textContent).toBe("system");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+  });
+});

--- a/packages/platform-core/src/utils/__tests__/initTheme.test.ts
+++ b/packages/platform-core/src/utils/__tests__/initTheme.test.ts
@@ -1,0 +1,41 @@
+import { initTheme } from "../initTheme";
+
+describe("initTheme", () => {
+  const originalLocalStorage = window.localStorage;
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: originalLocalStorage,
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    document.documentElement.className = "";
+    document.documentElement.style.colorScheme = "";
+  });
+
+  it("falls back when localStorage and matchMedia are unavailable", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked");
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(() => {
+      // eslint-disable-next-line no-eval
+      eval(initTheme);
+    }).not.toThrow();
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(
+      false
+    );
+  });
+});

--- a/packages/platform-core/src/utils/initTheme.ts
+++ b/packages/platform-core/src/utils/initTheme.ts
@@ -1,10 +1,19 @@
 export const initTheme = `
 (function () {
-  var theme = localStorage.getItem('theme') || 'system';
+  var theme = 'system';
+  try {
+    theme = localStorage.getItem('theme') || 'system';
+  } catch (e) {}
   var classList = document.documentElement.classList;
   var isDark = theme === 'dark';
   if (theme === 'system') {
-    isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    try {
+      isDark =
+        window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+    } catch (e) {
+      isDark = false;
+    }
   }
   if (isDark) {
     classList.add('theme-dark');


### PR DESCRIPTION
## Summary
- protect `ThemeContext` against unavailable `localStorage` or `matchMedia`
- add bootstrap `initTheme` guards for the same APIs
- test theme fallback when browser APIs are blocked

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx packages-platform-core/src/utils/__tests__/initTheme.test.ts --config jest.config.cjs --runTestsByPath` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6898b781ddc0832fb9d1d8b4cb225110