### PR TITLE
feat: add orders database

### DIFF
--- a/apps/cms/src/app/cms/orders/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/orders/[shop]/page.tsx
@@ -1,0 +1,55 @@
+import { listOrders, setRefunded, setReturned } from "@platform-core/orders";
+
+async function markReturned(formData: FormData) {
+  "use server";
+  const shop = String(formData.get("shop"));
+  const sessionId = String(formData.get("sessionId"));
+  await setReturned(shop, sessionId);
+}
+
+async function markRefunded(formData: FormData) {
+  "use server";
+  const shop = String(formData.get("shop"));
+  const sessionId = String(formData.get("sessionId"));
+  await setRefunded(shop, sessionId);
+}
+
+export default async function OrdersPage({ params }: { params: { shop: string } }) {
+  const shop = params.shop;
+  const orders = await listOrders(shop);
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Orders for {shop}</h2>
+      <ul className="space-y-4">
+        {orders.map((o) => (
+          <li key={o.id} className="rounded border p-4">
+            <div className="mb-2">Order: {o.id}</div>
+            {o.returnedAt ? (
+              <div className="text-sm text-gray-600">Returned: {o.returnedAt}</div>
+            ) : (
+              <form action={markReturned} className="mb-2">
+                <input type="hidden" name="shop" value={shop} />
+                <input type="hidden" name="sessionId" value={o.sessionId} />
+                <button className="rounded bg-blue-600 px-2 py-1 text-white">
+                  Mark Returned
+                </button>
+              </form>
+            )}
+            {o.refundedAt ? (
+              <div className="text-sm text-gray-600">Refunded: {o.refundedAt}</div>
+            ) : (
+              <form action={markRefunded}>
+                <input type="hidden" name="shop" value={shop} />
+                <input type="hidden" name="sessionId" value={o.sessionId} />
+                <button className="rounded bg-green-600 px-2 py-1 text-white">
+                  Mark Refunded
+                </button>
+              </form>
+            )}
+          </li>
+        ))}
+        {orders.length === 0 && <li>No orders</li>}
+      </ul>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/orders/page.tsx
+++ b/apps/cms/src/app/cms/orders/page.tsx
@@ -1,0 +1,17 @@
+import listShops from "../listShops";
+import Link from "next/link";
+
+export default async function OrdersIndex() {
+  const shops = await listShops();
+  return (
+    <ul className="space-y-2">
+      {shops.map((s) => (
+        <li key={s.id}>
+          <Link href={`/cms/orders/${s.id}`} className="text-blue-600 underline">
+            {s.id} orders
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/shop-abc/src/app/account/orders/page.tsx
+++ b/apps/shop-abc/src/app/account/orders/page.tsx
@@ -1,6 +1,6 @@
 // apps/shop-abc/src/app/account/orders/page.tsx
 import { getCustomerSession } from "@auth";
-import { getOrdersForCustomer } from "@platform-core/repositories/rentalOrdersDb.server";
+import { getOrdersForCustomer } from "@platform-core/orders";
 import shop from "../../../../shop.json";
 
 export const metadata = { title: "Orders" };

--- a/apps/shop-bcd/src/app/account/orders/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/page.tsx
@@ -1,6 +1,6 @@
 // apps/shop-bcd/src/app/account/orders/page.tsx
 import { getCustomerSession } from "@auth";
-import { getOrdersForCustomer } from "@platform-core/repositories/rentalOrdersDb.server";
+import { getOrdersForCustomer } from "@platform-core/orders";
 import shop from "../../../../shop.json";
 
 export const metadata = { title: "Orders" };

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@stripe/stripe-js": "^7.3.1",
     "@tanstack/react-query": "^5.81.4",
     "bcryptjs": "^3.0.2",
+    "better-sqlite3": "^12.2.0",
     "chart.js": "^4.5.0",
     "identity-obj-proxy": "^3.0.0",
     "next": "15.3.5",

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./dataRoot";
 export * from "./utils";
 export * from "./shipping";
 export * from "./tax";
+export * from "./orders";

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -1,0 +1,95 @@
+import Database from "better-sqlite3";
+import path from "node:path";
+import { DATA_ROOT } from "./dataRoot";
+import { ulid } from "ulid";
+import { nowIso } from "@shared/date";
+import type { RentalOrder } from "@types";
+import { trackOrder } from "./analytics";
+
+const dbPath = path.join(DATA_ROOT, "..", "orders.sqlite");
+const db = new Database(dbPath);
+
+// Ensure table exists
+// id: ulid, sessionId: string, shop: string, deposit: number, expectedReturnDate: string?,
+// customerId: string?, startedAt, returnedAt?, refundedAt?, damageFee?
+db.exec(`CREATE TABLE IF NOT EXISTS orders (
+  id TEXT PRIMARY KEY,
+  sessionId TEXT NOT NULL,
+  shop TEXT NOT NULL,
+  deposit REAL NOT NULL,
+  expectedReturnDate TEXT,
+  customerId TEXT,
+  startedAt TEXT NOT NULL,
+  returnedAt TEXT,
+  refundedAt TEXT,
+  damageFee REAL
+)`);
+
+export async function createOrder(
+  shop: string,
+  sessionId: string,
+  deposit: number,
+  expectedReturnDate?: string,
+  customerId?: string
+): Promise<RentalOrder> {
+  const order: RentalOrder = {
+    id: ulid(),
+    sessionId,
+    shop,
+    deposit,
+    expectedReturnDate,
+    startedAt: nowIso(),
+    ...(customerId ? { customerId } : {}),
+  };
+  const stmt = db.prepare(
+    `INSERT INTO orders (id, sessionId, shop, deposit, expectedReturnDate, customerId, startedAt)
+     VALUES (@id, @sessionId, @shop, @deposit, @expectedReturnDate, @customerId, @startedAt)`
+  );
+  stmt.run(order);
+  await trackOrder(shop, order.id, deposit);
+  return order;
+}
+
+export async function listOrders(shop: string): Promise<RentalOrder[]> {
+  const stmt = db.prepare(`SELECT * FROM orders WHERE shop = ? ORDER BY startedAt DESC`);
+  return stmt.all(shop) as RentalOrder[];
+}
+
+export async function getOrdersForCustomer(
+  shop: string,
+  customerId: string
+): Promise<RentalOrder[]> {
+  const stmt = db.prepare(
+    `SELECT * FROM orders WHERE shop = ? AND customerId = ? ORDER BY startedAt DESC`
+  );
+  return stmt.all(shop, customerId) as RentalOrder[];
+}
+
+export async function setReturned(
+  shop: string,
+  sessionId: string,
+  damageFee?: number
+): Promise<RentalOrder | null> {
+  const order = db.prepare(
+    `SELECT * FROM orders WHERE shop = ? AND sessionId = ?`
+  ).get(shop, sessionId) as RentalOrder | undefined;
+  if (!order) return null;
+  const returnedAt = nowIso();
+  db.prepare(
+    `UPDATE orders SET returnedAt = ?, damageFee = COALESCE(?, damageFee) WHERE id = ?`
+  ).run(returnedAt, damageFee, order.id);
+  return { ...order, returnedAt, damageFee: damageFee ?? order.damageFee };
+}
+
+export async function setRefunded(
+  shop: string,
+  sessionId: string
+): Promise<RentalOrder | null> {
+  const order = db.prepare(
+    `SELECT * FROM orders WHERE shop = ? AND sessionId = ?`
+  ).get(shop, sessionId) as RentalOrder | undefined;
+  if (!order) return null;
+  const refundedAt = nowIso();
+  db.prepare(`UPDATE orders SET refundedAt = ? WHERE id = ?`).run(refundedAt, order.id);
+  return { ...order, refundedAt };
+}

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -2,45 +2,18 @@
 
 import "server-only";
 
-import { rentalOrderSchema, type RentalOrder } from "@types";
-import { promises as fs } from "node:fs";
-import * as path from "node:path";
-import { ulid } from "ulid";
+import type { RentalOrder } from "@types";
 import { validateShopName } from "../shops";
-import { DATA_ROOT } from "../dataRoot";
-import { nowIso } from "@shared/date";
-import { trackOrder } from "../analytics";
-
-function ordersPath(shop: string): string {
-  shop = validateShopName(shop);
-
-  return path.join(DATA_ROOT, shop, "rental_orders.json");
-}
-
-async function ensureDir(shop: string): Promise<void> {
-  shop = validateShopName(shop);
-
-  await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
-}
+import {
+  createOrder,
+  listOrders,
+  setRefunded,
+  setReturned,
+} from "../orders";
 
 export async function readOrders(shop: string): Promise<RentalOrder[]> {
-  try {
-    const buf = await fs.readFile(ordersPath(shop), "utf8");
-    const parsed = rentalOrderSchema.array().safeParse(JSON.parse(buf));
-    return parsed.success ? parsed.data : [];
-  } catch {
-    return [];
-  }
-}
-
-export async function writeOrders(
-  shop: string,
-  orders: RentalOrder[]
-): Promise<void> {
-  await ensureDir(shop);
-  const tmp = `${ordersPath(shop)}.${Date.now()}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(orders, null, 2), "utf8");
-  await fs.rename(tmp, ordersPath(shop));
+  shop = validateShopName(shop);
+  return listOrders(shop);
 }
 
 export async function addOrder(
@@ -50,20 +23,8 @@ export async function addOrder(
   expectedReturnDate?: string,
   customerId?: string
 ): Promise<RentalOrder> {
-  const orders = await readOrders(shop);
-  const order: RentalOrder = {
-    id: ulid(),
-    sessionId,
-    shop,
-    deposit,
-    expectedReturnDate,
-    startedAt: nowIso(),
-    ...(customerId ? { customerId } : {}),
-  };
-  orders.push(order);
-  await writeOrders(shop, orders);
-  await trackOrder(shop, order.id, deposit);
-  return order;
+  shop = validateShopName(shop);
+  return createOrder(shop, sessionId, deposit, expectedReturnDate, customerId);
 }
 
 export async function markReturned(
@@ -71,25 +32,14 @@ export async function markReturned(
   sessionId: string,
   damageFee?: number
 ): Promise<RentalOrder | null> {
-  const orders = await readOrders(shop);
-  const idx = orders.findIndex((o) => o.sessionId === sessionId);
-  if (idx === -1) return null;
-  orders[idx].returnedAt = nowIso();
-  if (typeof damageFee === "number") {
-    orders[idx].damageFee = damageFee;
-  }
-  await writeOrders(shop, orders);
-  return orders[idx];
+  shop = validateShopName(shop);
+  return setReturned(shop, sessionId, damageFee);
 }
 
 export async function markRefunded(
   shop: string,
   sessionId: string
 ): Promise<RentalOrder | null> {
-  const orders = await readOrders(shop);
-  const idx = orders.findIndex((o) => o.sessionId === sessionId);
-  if (idx === -1) return null;
-  orders[idx].refundedAt = nowIso();
-  await writeOrders(shop, orders);
-  return orders[idx];
+  shop = validateShopName(shop);
+  return setRefunded(shop, sessionId);
 }

--- a/packages/platform-core/src/repositories/rentalOrdersDb.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrdersDb.server.ts
@@ -1,12 +1,9 @@
 // packages/platform-core/src/repositories/rentalOrdersDb.server.ts
 import "server-only";
-import { ulid } from "ulid";
-import { nowIso } from "@shared/date";
 import type { RentalOrder } from "@types";
+import { createOrder, getOrdersForCustomer as getOrdersForCustomerDb } from "../orders";
 
 export type CustomerOrder = RentalOrder;
-
-const db = new Map<string, CustomerOrder[]>();
 
 export async function addOrder(
   shop: string,
@@ -15,25 +12,12 @@ export async function addOrder(
   expectedReturnDate?: string,
   customerId?: string
 ): Promise<CustomerOrder> {
-  const list = db.get(shop) ?? [];
-  const order: CustomerOrder = {
-    id: ulid(),
-    sessionId,
-    shop,
-    deposit,
-    expectedReturnDate,
-    startedAt: nowIso(),
-    ...(customerId ? { customerId } : {}),
-  };
-  list.push(order);
-  db.set(shop, list);
-  return order;
+  return createOrder(shop, sessionId, deposit, expectedReturnDate, customerId);
 }
 
 export async function getOrdersForCustomer(
   shop: string,
   customerId: string
 ): Promise<CustomerOrder[]> {
-  const list = db.get(shop) ?? [];
-  return list.filter((o) => o.customerId === customerId);
+  return getOrdersForCustomerDb(shop, customerId);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
+      better-sqlite3:
+        specifier: ^12.2.0
+        version: 12.2.0
       chart.js:
         specifier: ^4.5.0
         version: 4.5.0
@@ -4286,6 +4289,10 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  better-sqlite3@12.2.0:
+    resolution: {integrity: sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -4489,6 +4496,9 @@ packages:
   chokidar@4.0.0:
     resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4913,6 +4923,10 @@ packages:
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
 
@@ -4927,6 +4941,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -5723,6 +5741,10 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expand-tilde@1.2.2:
     resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
     engines: {node: '>=0.10.0'}
@@ -5930,6 +5952,9 @@ packages:
   fromentries@1.3.2:
     resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-exists-sync@0.1.0:
     resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
     engines: {node: '>=0.10.0'}
@@ -6035,6 +6060,9 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -7238,6 +7266,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -7299,6 +7331,9 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -7353,6 +7388,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   napi-postinstall@0.3.0:
     resolution: {integrity: sha512-M7NqKyhODKV1gRLdkwE7pDsZP2/SC2a2vHkOYh9MCpKMbWVfyVfUw5MaH83Fv6XMjxr5jryUp3IDDL9rlxsTeA==}
@@ -7427,6 +7465,10 @@ packages:
   nock@13.5.6:
     resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
+
+  node-abi@3.75.0:
+    resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
+    engines: {node: '>=10'}
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -7947,6 +7989,11 @@ packages:
   preact@10.26.9:
     resolution: {integrity: sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -8191,6 +8238,10 @@ packages:
   raw-body@2.4.1:
     resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
     engines: {node: '>= 0.8'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-chartjs-2@5.3.0:
     resolution: {integrity: sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==}
@@ -8636,6 +8687,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
@@ -8860,6 +8917,10 @@ packages:
     resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
     engines: {node: '>=12'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -8939,8 +9000,15 @@ packages:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.3:
+    resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
+
   tar-fs@3.1.0:
     resolution: {integrity: sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -13994,6 +14062,11 @@ snapshots:
     dependencies:
       open: 8.4.2
 
+  better-sqlite3@12.2.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
@@ -14238,6 +14311,8 @@ snapshots:
   chokidar@4.0.0:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   chownr@2.0.0: {}
 
@@ -14680,11 +14755,17 @@ snapshots:
 
   decimal.js@10.5.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@0.7.0: {}
 
   dedent@1.6.0: {}
 
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -15598,6 +15679,8 @@ snapshots:
 
   exit@0.1.2: {}
 
+  expand-template@2.0.3: {}
+
   expand-tilde@1.2.2:
     dependencies:
       os-homedir: 1.0.2
@@ -15832,6 +15915,8 @@ snapshots:
 
   fromentries@1.3.2: {}
 
+  fs-constants@1.0.0: {}
+
   fs-exists-sync@0.1.0: {}
 
   fs-extra@10.1.0:
@@ -15946,6 +16031,8 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -17431,6 +17518,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   mini-svg-data-uri@1.4.4: {}
@@ -17507,6 +17596,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
 
   mkdirp@3.0.1: {}
@@ -17557,6 +17648,8 @@ snapshots:
   mute-stream@1.0.0: {}
 
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.3.0: {}
 
@@ -17665,6 +17758,10 @@ snapshots:
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  node-abi@3.75.0:
+    dependencies:
+      semver: 7.7.2
 
   node-abort-controller@3.1.1: {}
 
@@ -18245,6 +18342,21 @@ snapshots:
 
   preact@10.26.9: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.0.4
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.75.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.3
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-tailwindcss@0.6.13(prettier@3.6.2):
@@ -18493,6 +18605,13 @@ snapshots:
       http-errors: 1.7.3
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-chartjs-2@5.3.0(chart.js@4.5.0)(react@19.1.0):
     dependencies:
@@ -19033,6 +19152,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -19325,6 +19452,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   stripe@18.3.0(@types/node@20.19.4):
@@ -19397,6 +19526,13 @@ snapshots:
 
   tapable@2.2.2: {}
 
+  tar-fs@2.1.3:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
   tar-fs@3.1.0:
     dependencies:
       pump: 3.0.3
@@ -19406,6 +19542,14 @@ snapshots:
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-buffer
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar-stream@3.1.7:
     dependencies:


### PR DESCRIPTION
## Summary
- add SQLite-backed orders module with CRUD APIs
- route rental order repository through DB
- expose CMS order management pages and update storefront account pages

## Testing
- `pnpm test` *(fails: apps/cms#test)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7b647f8832f94e6564587cef2ef