### PR TITLE
refactor: use platform core util imports

### DIFF
--- a/packages/ui/src/components/cms/Breadcrumbs.client.tsx
+++ b/packages/ui/src/components/cms/Breadcrumbs.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { ProductPublication } from "@platform-core/src/products";
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
+import { getShopFromPath } from "@platform-core/utils";
 import type { Page } from "@types";
 import { usePathname } from "next/navigation";
 import { memo, useEffect, useState } from "react";

--- a/packages/ui/src/components/cms/ShopSelector.tsx
+++ b/packages/ui/src/components/cms/ShopSelector.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
-import { replaceShopInPath } from "@platform-core/src/utils/replaceShopInPath";
+import { getShopFromPath, replaceShopInPath } from "@platform-core/utils";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import {

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -1,6 +1,6 @@
 // packages/ui/components/cms/Sidebar.tsx
 "use client";
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
+import { getShopFromPath } from "@platform-core/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 

--- a/packages/ui/src/components/cms/TopBar.client.tsx
+++ b/packages/ui/src/components/cms/TopBar.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useLayout } from "@platform-core/src/contexts/LayoutContext";
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
+import { getShopFromPath } from "@platform-core/utils";
 import { signOut } from "next-auth/react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -10,7 +10,7 @@ import { Button } from "../../atoms/shadcn";
 import { Toast } from "../../atoms";
 import Palette from "./Palette";
 import { atomRegistry, moleculeRegistry, organismRegistry, containerRegistry } from "../blocks";
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
+import { getShopFromPath } from "@platform-core/utils";
 import useMediaUpload from "@ui/hooks/useMediaUpload";
 import { historyStateSchema, reducer, type Action } from "./state";
 import usePageBuilderDrag from "./usePageBuilderDrag";

--- a/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
+++ b/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
@@ -1,4 +1,4 @@
-import { getShopFromPath } from "@platform-core/src/utils/getShopFromPath";
+import { getShopFromPath } from "@platform-core/utils";
 import type { MediaItem } from "@types";
 import { usePathname } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";


### PR DESCRIPTION
## Summary
- replace deep platform-core util imports with top-level `@platform-core/utils`

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6898b8a729a0832f9c071dcd4a8cd286