### PR TITLE
feat: prompt for logo and contact email

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ Key points:
 
    `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
    contact email and which theme, template, payment and shipping providers to use. It then
-   scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
-   provide real secrets (see [Environment Variables](#environment-variables)). For scripted
-   setups you can still call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and
-   `--contact` to skip those prompts.
+   scaffolds `apps/shop-<id>`, writes an `.env` file inside the new app and stores the provided
+   logo and contact email in `data/shops/shop-<id>/shop.json`. Edit the `.env` file to provide
+   real secrets (see [Environment Variables](#environment-variables)). For scripted setups you
+   can still call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and `--contact`
+   to skip those prompts.
 
    ```bash
    pnpm create-shop <id> --name="Demo Shop" --logo=https://example.com/logo.png \

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -20,7 +20,8 @@ pnpm init-shop
 - theme and template
 - payment and shipping providers
 
-After answering the prompts the wizard scaffolds `apps/shop-<id>` and generates an `.env` file inside the new app.
+After answering the prompts the wizard scaffolds `apps/shop-<id>`, generates an `.env` file inside the new app and saves the
+provided logo and contact email in `data/shops/shop-<id>/shop.json`.
 
 For automated scripts you can still call `pnpm create-shop <id>` with flags:
 
@@ -54,7 +55,8 @@ Scaffolded apps/shop-demo
 
 ## 2. Configure environment variables
 
-Edit `apps/shop-<id>/.env` to replace placeholder secrets.
+Edit `apps/shop-<id>/.env` to replace placeholder secrets and review
+`data/shops/shop-<id>/shop.json` for the stored logo and contact details.
 
 ```bash
 pnpm validate-env <id>

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -52,6 +52,8 @@ async function main() {
     process.exit(1);
   }
   const name = await prompt("Display name (optional): ");
+  const logo = await prompt("Logo URL (optional): ");
+  const contactInfo = await prompt("Contact email (optional): ");
   const theme = await prompt("Theme [base]: ", "base");
   const template = await prompt("Template [template-app]: ", "template-app");
   const paymentAns = await prompt("Payment providers (comma-separated): ");
@@ -60,6 +62,8 @@ async function main() {
 
   const options = {
     ...(name && { name }),
+    ...(logo && { logo }),
+    ...(contactInfo && { contactInfo }),
     theme,
     template,
     payment: paymentAns.split(",").map((s) => s.trim()).filter(Boolean),
@@ -99,7 +103,7 @@ async function main() {
   }
 
   console.log(
-    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Run: pnpm --filter @apps/${prefixedId} dev`
+    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Review data/shops/${prefixedId}/shop.json\n  - Run: pnpm --filter @apps/${prefixedId} dev`
   );
 }
 


### PR DESCRIPTION
## Summary
- prompt for shop logo URL and contact email when running `init-shop`
- pass logo and contact info to `createShop` and update next steps
- document the new prompts and shop.json updates in README and setup guide

## Testing
- `pnpm lint`
- `pnpm test` *(fails: command exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_6898b90298c4832f8f1e33c54498b977