### PR TITLE
Strip empty env vars before validation

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -67,6 +67,7 @@ pnpm validate-env <id>
 ```
 
 `validate-env` parses the `.env` file and exits with an error if any required variable is missing or malformed.
+Lines that have no value after the equals sign (e.g. `MY_VAR=`) are treated as placeholders and ignored during validation, so you can leave optional variables empty until you have real credentials.
 
 ## 3. (Optional) Setup CI and deploy
 

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -78,9 +78,9 @@ export function writeFiles(
     }
   }
   envContent += `NEXTAUTH_SECRET=${genSecret()}\n`;
-  envContent += `CMS_SPACE_URL=\n`;
-  envContent += `CMS_ACCESS_TOKEN=\n`;
-  envContent += `CHROMATIC_PROJECT_TOKEN=\n`;
+  envContent += `# CMS_SPACE_URL=\n`;
+  envContent += `# CMS_ACCESS_TOKEN=\n`;
+  envContent += `# CHROMATIC_PROJECT_TOKEN=\n`;
   writeFileSync(join(newApp, ".env"), envContent);
 
   mkdirSync(newData, { recursive: true });

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -112,6 +112,9 @@ async function main() {
       const [key, ...rest] = trimmed.split("=");
       env[key] = rest.join("=");
     }
+    Object.keys(env).forEach((k) => {
+      if (env[k] === "") delete env[k];
+    });
     envSchema.parse(env);
   } catch (err) {
     validationError = err;

--- a/scripts/src/setup-ci.ts
+++ b/scripts/src/setup-ci.ts
@@ -24,6 +24,9 @@ for (const line of envRaw.split(/\n+/)) {
 }
 
 try {
+  Object.keys(env).forEach((k) => {
+    if (env[k] === "") delete env[k];
+  });
   envSchema.parse(env);
 } catch (err) {
   console.error("Invalid environment variables:\n", err);

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -27,6 +27,9 @@ for (const line of envRaw.split(/\n+/)) {
 }
 
 try {
+  Object.keys(env).forEach((k) => {
+    if (env[k] === "") delete env[k];
+  });
   envSchema.parse(env);
   console.log("Environment variables look valid.");
 } catch (err) {


### PR DESCRIPTION
## Summary
- ignore empty environment variable values in setup scripts before schema validation
- comment out optional CMS and Chromatic entries in generated `.env`
- document that blank env values are treated as placeholders

## Testing
- `pnpm eslint scripts/src/init-shop.ts scripts/src/validate-env.ts scripts/src/setup-ci.ts packages/platform-core/src/createShop/fsUtils.ts`
- `pnpm test --filter @acme/platform-core` *(fails: Cannot find module '@/components/checkout/CheckoutForm' from 'apps/shop-abc/src/app/[lang]/checkout/page.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6898b95e9100832f9805f88c1893c713