### PR TITLE
feat: add shop type prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Key points:
    pnpm setup-ci <id>
    ```
 
-   `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
-   contact email and which theme and template to use. Payment and shipping providers are chosen
-   from guided lists of available providers. It then
+   `init-shop` launches an interactive wizard that asks for the shop ID, display name, shop type
+   (`sale` or `rental`), and which theme and template to use. Payment and shipping providers are
+   chosen from guided lists of available providers. It then
    scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
    provide real secrets (see [Environment Variables](#environment-variables)). For scripted
    setups you can still call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and
@@ -59,8 +59,7 @@ Key points:
 pnpm init-shop
 ? Shop ID … demo
 ? Display name … Demo Shop
-? Logo URL … https://example.com/logo.png
-? Contact email … demo@example.com
+? Shop type (sale or rental) … sale
 ? Theme › base
 ? Template › template-app
 Available payment providers:

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -15,8 +15,7 @@ pnpm init-shop
 
 - shop ID
 - display name
-- logo URL
-- contact email
+- shop type (`sale` or `rental`)
 - theme and template
 - payment and shipping providers (selected from a guided list of available providers)
 
@@ -43,8 +42,7 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 pnpm init-shop
 ? Shop ID … demo
 ? Display name … Demo Shop
-? Logo URL … https://example.com/logo.png
-? Contact email … demo@example.com
+? Shop type (sale or rental) … sale
 ? Theme › base
 ? Template › template-app
 Available payment providers:

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -77,6 +77,8 @@ async function main() {
     process.exit(1);
   }
   const name = await prompt("Display name (optional): ");
+  const typeAns = await prompt("Shop type (sale or rental) [sale]: ", "sale");
+  const type = typeAns.toLowerCase() === "rental" ? "rental" : "sale";
   const theme = await prompt("Theme [base]: ", "base");
   const template = await prompt("Template [template-app]: ", "template-app");
   const payment = await selectProviders(
@@ -91,6 +93,7 @@ async function main() {
 
   const options = {
     ...(name && { name }),
+    type,
     theme,
     template,
     payment,

--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -9,10 +9,11 @@ describe('init-shop wizard', () => {
     const answers = [
       'demo',
       'Demo Shop',
+      '',
       'base',
       'template-app',
-      'stripe,paypal',
-      'dhl',
+      '1,2',
+      '1',
       'n',
     ];
     const createShop = jest.fn();
@@ -54,6 +55,12 @@ describe('init-shop wizard', () => {
         if (p.includes('@config/src/env')) {
           return { envSchema: { parse: envParse } };
         }
+        if (p.includes('../../packages/platform-core/src/createShop/defaultPaymentProviders')) {
+          return { defaultPaymentProviders: ['stripe', 'paypal'] };
+        }
+        if (p.includes('../../packages/platform-core/src/createShop/defaultShippingProviders')) {
+          return { defaultShippingProviders: ['dhl', 'ups'] };
+        }
         if (p.includes('../../packages/platform-core/src/createShop')) {
           return { createShop };
         }
@@ -75,15 +82,17 @@ describe('init-shop wizard', () => {
     expect(questions).toEqual([
       'Shop ID: ',
       'Display name (optional): ',
+      'Shop type (sale or rental) [sale]: ',
       'Theme [base]: ',
       'Template [template-app]: ',
-      'Payment providers (comma-separated): ',
-      'Shipping providers (comma-separated): ',
+      'Select payment providers by number (comma-separated, empty for none): ',
+      'Select shipping providers by number (comma-separated, empty for none): ',
       'Setup CI workflow? (y/N): ',
     ]);
 
     expect(createShop).toHaveBeenCalledWith('shop-demo', {
       name: 'Demo Shop',
+      type: 'sale',
       theme: 'base',
       template: 'template-app',
       payment: ['stripe', 'paypal'],


### PR DESCRIPTION
## Summary
- prompt for shop type (sale or rental) when initializing a shop
- pass selected shop type to `createShop`
- document shop type option and update init-shop tests

## Testing
- `pnpm jest test/unit/init-shop.spec.ts`
- `npx eslint scripts/src/init-shop.ts test/unit/init-shop.spec.ts doc/setup.md README.md >/tmp/eslint.log && tail -n 20 /tmp/eslint.log`


------
https://chatgpt.com/codex/tasks/task_e_6898b9990f10832f83dea945ccfaed42