### PR TITLE
feat: make shop deployment optional

### DIFF
--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -92,7 +92,7 @@ describe("createNewShop authorization", () => {
     const res = await createNewShop("shop2", { theme: "base" } as any);
 
     expect(createShop).toHaveBeenCalledTimes(1);
-    expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" });
+    expect(createShop).toHaveBeenCalledWith("shop2", { theme: "base" }, { deploy: false });
     expect(res).toBe(deployResult);
 
     (process.env as Record<string, string>).NODE_ENV = prevEnv;

--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -5,7 +5,7 @@ import { authOptions } from "@cms/auth/options";
 import {
   createShop,
   type CreateShopOptions,
-  type DeployShopResult,
+  type DeployStatusBase,
 } from "@platform-core/createShop";
 import { getServerSession } from "next-auth";
 import { readRbac, writeRbac } from "../lib/rbacStore";
@@ -21,12 +21,12 @@ async function ensureAuthorized() {
 export async function createNewShop(
   id: string,
   options: CreateShopOptions
-): Promise<DeployShopResult> {
+): Promise<DeployStatusBase> {
   const session = await ensureAuthorized();
 
-  let result: DeployShopResult;
+  let result: DeployStatusBase;
   try {
-    result = createShop(id, options);
+    result = createShop(id, options, { deploy: false });
   } catch (err) {
     console.error("createShop failed", err);
     throw err;

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -417,10 +417,16 @@ export default function Wizard({
         analyticsId,
       };
 
-      const { ok, error, fieldErrors } = await submitShop(shopId, payload);
+      const { ok, error, fieldErrors, deployment } = await submitShop(
+        shopId,
+        payload
+      );
 
       if (ok) {
         setResult("Shop created successfully");
+        if (deployment && deployment.status !== "pending") {
+          setDeployInfo(deployment as DeployShopResult);
+        }
         /* Remain on the summary step so the success message is visible;
            navigation to the next step is left to the user. */
         resetWizardProgress();

--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -1,12 +1,13 @@
 // apps/cms/src/app/cms/wizard/services/submitShop.ts
 "use client";
 
-import { createShopOptionsSchema } from "@platform-core/createShop";
+import { createShopOptionsSchema, type DeployStatusBase } from "@platform-core/createShop";
 import { validateShopName } from "@platform-core/src/shops";
 import type { WizardState } from "../schema";
 
 export interface SubmitResult {
   ok: boolean;
+  deployment?: DeployStatusBase;
   error?: string;
   fieldErrors?: Record<string, string[]>;
 }
@@ -83,9 +84,14 @@ export async function submitShop(
     body: JSON.stringify({ id: shopId, ...parsed.data }),
   });
 
-  if (res.ok) return { ok: true };
+  const json = (await res.json().catch(() => ({}))) as {
+    success?: boolean;
+    deployment?: DeployStatusBase;
+    error?: string;
+  };
 
-  const json = (await res.json().catch(() => ({}))) as { error?: string };
+  if (res.ok) return { ok: true, deployment: json.deployment };
+
   return { ok: false, error: json.error ?? "Failed to create shop" };
 }
 

--- a/dist-scripts/create-shop.js
+++ b/dist-scripts/create-shop.js
@@ -73,4 +73,4 @@ async function ensureTheme() {
     }
 }
 await ensureTheme();
-await createShop(shopId, options);
+await createShop(shopId, options, { deploy: true });

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -19,8 +19,9 @@ import { loadTokens } from "./createShop/themeUtils";
  */
 export function createShop(
   id: string,
-  opts: CreateShopOptions = {}
-): DeployShopResult {
+  opts: CreateShopOptions = {},
+  options?: { deploy?: boolean }
+): DeployStatusBase {
   id = validateShopName(id);
   const newApp = join("apps", id);
   const newData = join("data", "shops", id);
@@ -40,6 +41,10 @@ export function createShop(
   const themeTokens = loadTokens(options.theme);
 
   writeFiles(id, options, themeTokens, templateApp, newApp, newData);
+
+  if (options?.deploy === false) {
+    return { status: "pending" };
+  }
 
   return deployShop(id);
 }

--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -291,4 +291,4 @@ await ensureLogo();
 await ensureContact();
 await ensurePayment();
 await ensureShipping();
-await createShop(shopId, options);
+await createShop(shopId, options, { deploy: true });

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -67,7 +67,7 @@ async function main() {
   };
 
   const prefixedId = `shop-${shopId}`;
-  createShop(prefixedId, options);
+  createShop(prefixedId, options, { deploy: true });
 
   let validationError: unknown;
   try {


### PR DESCRIPTION
## Summary
- allow skipping automatic deployment in createShop
- ensure CMS calls createShop without deploy and triggers deployment later
- keep CLI scripts deploying by default

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Zod parsing error in pages.server.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7741c24832f86325e9dea6c47e3