### PR TITLE
refactor: move fillLocales to i18n package

### DIFF
--- a/apps/cms/src/actions/pages/validation.ts
+++ b/apps/cms/src/actions/pages/validation.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/actions/pages/validation.ts
 
 import { LOCALES } from "@acme/i18n";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import { pageComponentSchema, type Locale } from "@types";
 import { z } from "zod";
 

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -13,7 +13,7 @@ import {
   updateProductInRepo,
   writeRepo,
 } from "@platform-core/repositories/json.server";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { ProductPublication } from "@platform-core/src/products";
 import * as Sentry from "@sentry/node";
 import type { Locale } from "@types";

--- a/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
 
 import { createPage } from "@cms/actions/pages.server";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Page } from "@types";
 import dynamic from "next/dynamic";
 

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/wizard/schema.ts
 import { LOCALES } from "@acme/i18n";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import { pageComponentSchema } from "@types/Page";
 import { localeSchema, type Locale } from "@types";
 import { ulid } from "ulid";

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { LOCALES } from "@acme/i18n";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Locale, Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { useState } from "react";

--- a/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";

--- a/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@types";
 import { historyStateSchema } from "@types";
 import { fetchJson } from "@shared-utils";

--- a/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
@@ -3,7 +3,7 @@
 
 import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ReactNode, useState } from "react";

--- a/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import ProductPageBuilder from "@/components/cms/ProductPageBuilder";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@types";
 import { historyStateSchema } from "@types";
 import { fetchJson } from "@shared-utils";

--- a/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";

--- a/apps/cms/src/app/cms/wizard/utils/page-utils.ts
+++ b/apps/cms/src/app/cms/wizard/utils/page-utils.ts
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/wizard/utils/page.ts
 
-import { fillLocales } from "@platform-core/utils";
+import { fillLocales } from "@i18n/fillLocales";
 import type { PageComponent } from "@types";
 import type { PageInfo } from "../schema";
 

--- a/packages/i18n/__tests__/fillLocales.test.ts
+++ b/packages/i18n/__tests__/fillLocales.test.ts
@@ -1,5 +1,4 @@
-import { fillLocales } from "../string";
-import { LOCALES } from "@i18n/locales";
+import { fillLocales, LOCALES } from "@acme/i18n";
 
 describe("fillLocales", () => {
   it("populates all locales and falls back when missing", () => {
@@ -14,4 +13,3 @@ describe("fillLocales", () => {
     }
   });
 });
-

--- a/packages/i18n/src/fillLocales.ts
+++ b/packages/i18n/src/fillLocales.ts
@@ -1,6 +1,5 @@
-// packages/platform-core/src/utils/locales.ts
-import { LOCALES } from "@i18n/locales";
-import type { Locale } from "@types";
+// packages/i18n/src/fillLocales.ts
+import { LOCALES, type Locale } from "./locales";
 
 /**
  * Ensure all locales have a value, filling in missing entries with a fallback.
@@ -17,4 +16,3 @@ export function fillLocales(
     {} as Record<Locale, string>
   );
 }
-

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -3,3 +3,4 @@
 export * from "./locales";
 export { assertLocales, LOCALES } from "./locales";
 export { default as TranslationsProvider } from "./Translations";
+export { fillLocales } from "./fillLocales";

--- a/packages/platform-core/__tests__/createShopUtils.test.ts
+++ b/packages/platform-core/__tests__/createShopUtils.test.ts
@@ -2,7 +2,7 @@
 import fs from "fs";
 import { copyTemplate } from "../src/createShop/fsUtils";
 import { loadBaseTokens } from "../src/createShop/themeUtils";
-import { fillLocales } from "../src/utils/locales";
+import { fillLocales } from "@i18n/fillLocales";
 
 describe("createShop utils", () => {
   beforeEach(() => {

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -3,7 +3,7 @@ import { localeSchema } from "@types";
 import { pageComponentSchema } from "@types/Page";
 import { z } from "zod";
 import { slugify } from "@shared-utils";
-import { fillLocales } from "../utils/locales";
+import { fillLocales } from "@i18n/fillLocales";
 import { defaultPaymentProviders, type DefaultPaymentProvider } from "./defaultPaymentProviders";
 import { defaultShippingProviders, type DefaultShippingProvider } from "./defaultShippingProviders";
 import { defaultTaxProviders, type DefaultTaxProvider } from "./defaultTaxProviders";

--- a/packages/platform-core/src/utils/README.md
+++ b/packages/platform-core/src/utils/README.md
@@ -4,8 +4,7 @@ Shared helpers for platform-core.
 
 - `getShopFromPath(path)` – extract a shop identifier from a URL path.
 - `replaceShopInPath(path, shop)` – swap the shop identifier in a path.
-- `fillLocales(values, fallback)` – ensure all supported locales have a value,
-  falling back when missing.
+- `initTheme` – initialize the client's theme based on saved preferences.
 
 These utilities are re-exported from the `@acme/platform-core` package root for
 easy consumption. Functions like `slugify` and `genSecret` now live in

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,4 +1,3 @@
 export { getShopFromPath } from "./getShopFromPath";
 export { replaceShopInPath } from "./replaceShopInPath";
-export { fillLocales } from "./locales";
 export { initTheme } from "./initTheme";


### PR DESCRIPTION
## Summary
- move fillLocales to `@acme/i18n`
- update platform-core utils and CMS imports
- add unit test for fillLocales

## Testing
- `pnpm exec jest packages/i18n/__tests__/fillLocales.test.ts packages/platform-core/__tests__/createShopUtils.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6898b9f1c2b8832f8cd848a7f537032d