### PR TITLE
feat: persist CMS wizard progress on server

### DIFF
--- a/apps/cms/__tests__/storageUtils.test.ts
+++ b/apps/cms/__tests__/storageUtils.test.ts
@@ -8,16 +8,27 @@ import {
 
 describe("storageUtils", () => {
   beforeEach(() => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    );
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockReset();
   });
 
   it("uses a consistent storage key", () => {
     expect(STORAGE_KEY).toBe("cms-wizard-progress");
   });
 
-  it("clears wizard progress from localStorage", () => {
+  it("clears wizard progress from localStorage", async () => {
     localStorage.setItem(STORAGE_KEY, "data");
-    resetWizardProgress();
+    await resetWizardProgress();
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/cms/api/wizard-progress",
+      expect.objectContaining({ method: "PUT" })
+    );
   });
 });

--- a/apps/cms/src/app/api/wizard-progress/route.ts
+++ b/apps/cms/src/app/api/wizard-progress/route.ts
@@ -1,0 +1,79 @@
+// apps/cms/src/app/api/wizard-progress/route.ts
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { promises as fs } from "node:fs";
+import * as fsSync from "node:fs";
+import path from "node:path";
+import { wizardStateSchema } from "@cms/app/cms/wizard/schema";
+
+interface DB {
+  [userId: string]: unknown;
+}
+
+function resolveFile(): string {
+  let dir = process.cwd();
+  while (true) {
+    const candidateDir = path.join(dir, "data", "cms");
+    if (fsSync.existsSync(candidateDir)) {
+      return path.join(candidateDir, "wizard-progress.json");
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(process.cwd(), "data", "cms", "wizard-progress.json");
+}
+
+const FILE = resolveFile();
+
+async function readDb(): Promise<DB> {
+  try {
+    const buf = await fs.readFile(FILE, "utf8");
+    const parsed = JSON.parse(buf) as DB;
+    if (parsed && typeof parsed === "object") return parsed;
+  } catch {
+    /* ignore */
+  }
+  return {};
+}
+
+async function writeDb(db: DB): Promise<void> {
+  await fs.mkdir(path.dirname(FILE), { recursive: true });
+  const tmp = `${FILE}.${Date.now()}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(db, null, 2), "utf8");
+  await fs.rename(tmp, FILE);
+}
+
+export async function GET(): Promise<NextResponse> {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({}, { status: 401 });
+  }
+  const db = await readDb();
+  const data = db[session.user.id] ?? {};
+  return NextResponse.json(data);
+}
+
+export async function PUT(req: Request): Promise<NextResponse> {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const body = await req.json().catch(() => ({}));
+    const parsed = wizardStateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid state" }, { status: 400 });
+    }
+    const db = await readDb();
+    db[session.user.id] = parsed.data;
+    await writeDb(db);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
@@ -4,52 +4,73 @@
 import { useEffect } from "react";
 import { wizardStateSchema, type WizardState } from "../schema";
 
-/** Key used to persist wizard progress in localStorage. */
+/** Key used to mirror wizard progress in localStorage for preview components. */
 export const STORAGE_KEY = "cms-wizard-progress";
 
-/** Removes any persisted wizard progress from localStorage. */
-export function resetWizardProgress(): void {
+/** Clears persisted wizard progress on the server and localStorage. */
+export async function resetWizardProgress(): Promise<void> {
   if (typeof window !== "undefined") {
     localStorage.removeItem(STORAGE_KEY);
+    try {
+      await fetch("/cms/api/wizard-progress", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+    } catch {
+      /* ignore network errors */
+    }
   }
 }
 
 /**
- * Handles loading & persisting wizard state to localStorage.
- *
- * @param state - Current wizard state
- * @param setState - Setter to update wizard state when rehydrating
+ * Loads wizard state from the server and saves it back whenever the step
+ * changes. A copy is mirrored to localStorage so the live preview can read it.
  */
 export function useWizardPersistence(
   state: WizardState,
-  setState: (s: WizardState) => void
+  setState: (s: WizardState) => void,
+  onInvalid?: () => void
 ): void {
   /* Load persisted state on mount */
   useEffect(() => {
     if (typeof window === "undefined") return;
-    try {
-      const json = localStorage.getItem(STORAGE_KEY);
-      if (json) {
-        const parsed = wizardStateSchema.safeParse(JSON.parse(json));
+    fetch("/cms/api/wizard-progress")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (!json) return;
+        const parsed = wizardStateSchema.safeParse(json);
         if (parsed.success) {
           setState(parsed.data);
+          try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed.data));
+          } catch {
+            /* ignore */
+          }
         } else {
           resetWizardProgress();
+          onInvalid?.();
         }
-      }
-    } catch {
-      /* ignore */
-    }
+      })
+      .catch(() => {
+        /* ignore */
+      });
   }, [setState]);
 
-  /* Persist whenever state changes */
+  /* Persist whenever the step changes */
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     } catch {
-      /* ignore */
+      /* ignore quota */
     }
-  }, [state]);
+    fetch("/cms/api/wizard-progress", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(state),
+    }).catch(() => {
+      /* ignore network errors */
+    });
+  }, [state.step]);
 }
-

--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -22,6 +22,12 @@ export const handlers = [
   rest.get("/cms/api/page-templates", (_req, res, ctx) =>
     res(ctx.status(200), ctx.json([]))
   ),
+  rest.get("/cms/api/wizard-progress", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({}))
+  ),
+  rest.put("/cms/api/wizard-progress", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({}))
+  ),
 ];
 
 export const server = setupServer(...handlers);


### PR DESCRIPTION
## Summary
- add `/cms/api/wizard-progress` GET/PUT endpoints storing per-user wizard state
- replace localStorage persistence with server calls in `useWizardPersistence`
- hydrate and save wizard progress from `Wizard` on step changes

## Testing
- `pnpm test:cms` *(fails: Cannot find module '@/components/atoms' from Wizard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6898be0eb44c832f88effe31c1feb49f