### PR TITLE
refactor(ui): use semantic color tokens

### DIFF
--- a/packages/ui/__tests__/Chip.test.tsx
+++ b/packages/ui/__tests__/Chip.test.tsx
@@ -21,7 +21,7 @@ describe("Tag", () => {
   it("applies success variant classes", () => {
     const { container } = render(<Tag variant="success" />);
     const span = container.firstChild as HTMLElement;
-    expect(span.className).toContain("bg-green-500");
-    expect(span.className).toContain("text-white");
+    expect(span.className).toContain("bg-success");
+    expect(span.className).toContain("text-success-fg");
   });
 });

--- a/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
+++ b/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
@@ -44,7 +44,7 @@ describe("ImageUploaderWithOrientationCheck", () => {
     expect(
       screen.getByText("Image orientation is landscape; requirement satisfied.")
     ).toBeInTheDocument();
-    expect(container.querySelector("p")?.className).toContain("text-green-600");
+    expect(container.querySelector("p")?.className).toContain("text-success");
 
     fireEvent.change(input, { target: { files: [secondFile] } });
     expect(
@@ -52,6 +52,6 @@ describe("ImageUploaderWithOrientationCheck", () => {
         "Selected image is portrait; please upload a landscape image."
       )
     ).toBeInTheDocument();
-    expect(container.querySelector("p")?.className).toContain("text-red-600");
+    expect(container.querySelector("p")?.className).toContain("text-danger");
   });
 });

--- a/packages/ui/src/components/atoms/Loader.stories.tsx
+++ b/packages/ui/src/components/atoms/Loader.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Loader> = {
       },
     },
   },
-  args: { size: 32, className: "text-blue-500" },
+  args: { size: 32, className: "text-primary" },
 };
 export default meta;
 

--- a/packages/ui/src/components/atoms/ProductBadge.tsx
+++ b/packages/ui/src/components/atoms/ProductBadge.tsx
@@ -13,8 +13,8 @@ export const ProductBadge = React.forwardRef<
 >(({ label, variant = "default", className, ...props }, ref) => {
   const variants: Record<string, string> = {
       default: "bg-muted text-fg",
-    sale: "bg-red-500 text-white",
-    new: "bg-green-500 text-white",
+    sale: "bg-danger text-danger-foreground",
+    new: "bg-success text-success-fg",
   };
   return (
     <span

--- a/packages/ui/src/components/atoms/StockStatus.tsx
+++ b/packages/ui/src/components/atoms/StockStatus.tsx
@@ -19,7 +19,7 @@ export const StockStatus = React.forwardRef<HTMLSpanElement, StockStatusProps>(
     },
     ref
   ) => {
-    const color = inStock ? "text-green-600" : "text-red-600";
+    const color = inStock ? "text-success" : "text-danger";
     return (
       <span
         ref={ref}

--- a/packages/ui/src/components/atoms/Tag.tsx
+++ b/packages/ui/src/components/atoms/Tag.tsx
@@ -9,9 +9,9 @@ export const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
   ({ className, variant = "default", ...props }, ref) => {
     const variants: Record<string, string> = {
       default: "bg-muted text-fg",
-      success: "bg-green-500 text-white",
-      warning: "bg-yellow-500 text-white",
-      destructive: "bg-red-500 text-white",
+      success: "bg-success text-success-fg",
+      warning: "bg-warning text-warning-fg",
+      destructive: "bg-danger text-danger-foreground",
     };
     return (
       <span

--- a/packages/ui/src/components/atoms/primitives/button.tsx
+++ b/packages/ui/src/components/atoms/primitives/button.tsx
@@ -24,7 +24,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     // Exclude `undefined` from the key type with NonNullable<>
     const variants: Record<NonNullable<ButtonProps["variant"]>, string> = {
-      default: "bg-primary text-white hover:bg-primary/90",
+      default: "bg-primary text-primary-fg hover:bg-primary/90",
       outline:
         "border border-input hover:bg-accent hover:text-accent-foreground",
       ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/packages/ui/src/components/atoms/primitives/dialog.tsx
+++ b/packages/ui/src/components/atoms/primitives/dialog.tsx
@@ -16,7 +16,7 @@ export const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in fixed inset-0 z-50 bg-fg/50 backdrop-blur-sm",
       className
     )}
     {...props}

--- a/packages/ui/src/components/atoms/primitives/input.tsx
+++ b/packages/ui/src/components/atoms/primitives/input.tsx
@@ -128,7 +128,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             />
           </>
         )}
-        {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+        {error && <p className="mt-1 text-sm text-danger">{error}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/atoms/primitives/textarea.tsx
+++ b/packages/ui/src/components/atoms/primitives/textarea.tsx
@@ -113,7 +113,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             />
           </>
         )}
-        {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+        {error && <p className="mt-1 text-sm text-danger">{error}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -113,7 +113,7 @@ function PaymentForm({
         />
       </label>
       <PaymentElement />
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-danger">{error}</p>}
       <button
         type="submit"
         disabled={!stripe || processing}

--- a/packages/ui/src/components/cms/ImageUploaderWithOrientationCheck.tsx
+++ b/packages/ui/src/components/cms/ImageUploaderWithOrientationCheck.tsx
@@ -50,7 +50,7 @@ function ImageUploaderWithOrientationCheckInner({
       {file && isValid !== null && (
         <p
           className={
-            isValid ? "text-sm text-green-600" : "text-sm text-red-600"
+            isValid ? "text-sm text-success" : "text-sm text-danger"
           }
         >
           {isValid

--- a/packages/ui/src/components/cms/MediaFileItem.tsx
+++ b/packages/ui/src/components/cms/MediaFileItem.tsx
@@ -13,7 +13,7 @@ export default function MediaFileItem({ item, onDelete }: Props) {
     <div className="relative h-32 w-full overflow-hidden rounded-md border">
       <button
         onClick={() => onDelete(item.url)}
-        className="absolute top-1 right-1 rounded bg-black/50 px-1.5 text-xs text-white"
+        className="absolute top-1 right-1 rounded bg-fg/50 px-1.5 text-xs text-bg"
       >
         Delete
       </button>
@@ -24,7 +24,7 @@ export default function MediaFileItem({ item, onDelete }: Props) {
         className="object-cover"
       />
       {item.altText && (
-        <p className="absolute bottom-1 left-1 bg-black/50 px-1 text-xs text-white">
+        <p className="absolute bottom-1 left-1 bg-fg/50 px-1 text-xs text-bg">
           {item.altText}
         </p>
       )}

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -110,7 +110,7 @@ function MediaManagerBase({
       </div>
 
       {/* Validation / progress feedback */}
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-danger">{error}</p>}
       {progress && (
         <p className="text-sm text-muted">
           Uploaded {progress.done}/{progress.total}
@@ -120,7 +120,7 @@ function MediaManagerBase({
         <div className="space-y-2">
           <p
             className={
-              isValid ? "text-sm text-green-600" : "text-sm text-red-600"
+              isValid ? "text-sm text-success" : "text-sm text-danger"
             }
           >
             {isValid
@@ -138,7 +138,7 @@ function MediaManagerBase({
               />
               <button
                 onClick={handleUpload}
-                className="rounded bg-blue-600 px-2 text-sm text-white"
+                className="rounded bg-primary px-2 text-sm text-primary-fg"
               >
                 Upload
               </button>

--- a/packages/ui/src/components/cms/PagesTable.client.tsx
+++ b/packages/ui/src/components/cms/PagesTable.client.tsx
@@ -32,7 +32,7 @@ export default function PagesTable({ shop, pages, canWrite = false }: Props) {
       render: (p: Page) => (
         <Link
           href={`/cms/shop/${shop}/pages/${p.slug}/builder`}
-          className="bg-primary hover:bg-primary/90 rounded px-2 py-1 text-xs text-white"
+          className="bg-primary hover:bg-primary/90 rounded px-2 py-1 text-xs text-primary-fg"
         >
           Edit
         </Link>
@@ -45,7 +45,7 @@ export default function PagesTable({ shop, pages, canWrite = false }: Props) {
       {canWrite && (
         <Link
           href={`/cms/shop/${shop}/pages/new/builder`}
-          className="bg-primary hover:bg-primary/90 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm text-white"
+          className="bg-primary hover:bg-primary/90 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm text-primary-fg"
         >
           New Page
         </Link>

--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -49,7 +49,7 @@ export default function ProductEditorForm({
       <CardContent>
         <form onSubmit={handleSubmit} className="@container grid gap-6">
           {Object.keys(errors).length > 0 && (
-            <div className="text-sm text-red-600">
+            <div className="text-sm text-danger">
               {Object.entries(errors).map(([k, v]) => (
                 <p key={k}>{v.join("; ")}</p>
               ))}

--- a/packages/ui/src/components/cms/ShopSelector.tsx
+++ b/packages/ui/src/components/cms/ShopSelector.tsx
@@ -62,7 +62,7 @@ export default function ShopSelector() {
     return <span className="text-sm">Loading shops…</span>;
   if (status === "error")
     return (
-      <span className="text-sm text-red-600">
+      <span className="text-sm text-danger">
         {errorMsg ?? "Failed to load shops"}
       </span>
     );

--- a/packages/ui/src/components/cms/TopBar.client.tsx
+++ b/packages/ui/src/components/cms/TopBar.client.tsx
@@ -42,7 +42,7 @@ function TopBarInner() {
         {showNewProduct && (
           <Link
             href={`/cms/shop/${shop}/products/new`}
-            className="bg-primary hover:bg-primary/90 rounded-md px-3 py-2 text-sm text-white"
+            className="bg-primary hover:bg-primary/90 rounded-md px-3 py-2 text-sm text-primary-fg"
           >
             New product
           </Link>
@@ -50,7 +50,7 @@ function TopBarInner() {
         {showNewPage && (
           <Link
             href={`/cms/shop/${shop}/pages/new/builder`}
-            className="bg-primary hover:bg-primary/90 rounded-md px-3 py-2 text-sm text-white"
+            className="bg-primary hover:bg-primary/90 rounded-md px-3 py-2 text-sm text-primary-fg"
           >
             New page
           </Link>

--- a/packages/ui/src/components/cms/blocks/ContactForm.tsx
+++ b/packages/ui/src/components/cms/blocks/ContactForm.tsx
@@ -28,7 +28,7 @@ export default function ContactForm({
       />
       <button
         type="submit"
-        className="rounded bg-blue-600 px-4 py-2 text-white"
+        className="rounded bg-primary px-4 py-2 text-primary-fg"
       >
         Submit
       </button>

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -40,7 +40,7 @@ export const NewsletterForm = memo(function NewsletterForm({
       />
       <button
         type="submit"
-        className="rounded bg-blue-600 px-4 py-2 text-white"
+        className="rounded bg-primary px-4 py-2 text-primary-fg"
       >
         {label}
       </button>

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -258,26 +258,26 @@ const CanvasItem = memo(function CanvasItem({
         <>
           <div
             onPointerDown={startResize}
-            className="absolute -top-1 -left-1 h-2 w-2 cursor-nwse-resize bg-blue-500"
+            className="absolute -top-1 -left-1 h-2 w-2 cursor-nwse-resize bg-primary"
           />
           <div
             onPointerDown={startResize}
-            className="absolute -top-1 -right-1 h-2 w-2 cursor-nesw-resize bg-blue-500"
+            className="absolute -top-1 -right-1 h-2 w-2 cursor-nesw-resize bg-primary"
           />
           <div
             onPointerDown={startResize}
-            className="absolute -bottom-1 -left-1 h-2 w-2 cursor-nesw-resize bg-blue-500"
+            className="absolute -bottom-1 -left-1 h-2 w-2 cursor-nesw-resize bg-primary"
           />
           <div
             onPointerDown={startResize}
-            className="absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize bg-blue-500"
+            className="absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize bg-primary"
           />
         </>
       )}
       <button
         type="button"
         onClick={onRemove}
-        className="absolute top-1 right-1 rounded bg-red-500 px-2 text-xs text-white"
+        className="absolute top-1 right-1 rounded bg-danger px-2 text-xs text-danger-foreground"
       >
         ×
       </button>

--- a/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
@@ -79,7 +79,7 @@ function ImagePicker({ onSelect, children }: Props) {
               : `Selected image is ${actual}; please upload a landscape image.`}
           </p>
         )}
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-danger">{error}</p>}
         <div className="grid max-h-64 grid-cols-3 gap-2 overflow-auto">
           {media.map((m) => (
             <button

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -49,7 +49,7 @@ const PageToolbar = ({
       </p>
     )}
     {isValid === false && (
-      <p className="text-sm text-orange-600">
+      <p className="text-sm text-warning">
         Wrong orientation (needs landscape)
       </p>
     )}

--- a/packages/ui/src/components/cms/products/ProductRowActions.tsx
+++ b/packages/ui/src/components/cms/products/ProductRowActions.tsx
@@ -21,7 +21,7 @@ export default function ProductRowActions({
     <div className="flex flex-wrap gap-2">
       <Link
         href={`/cms/shop/${shop}/products/${product.id}/edit`}
-        className="bg-primary hover:bg-primary/90 rounded px-2 py-1 text-xs text-white"
+        className="bg-primary hover:bg-primary/90 rounded px-2 py-1 text-xs text-primary-fg"
       >
         Edit
       </Link>

--- a/packages/ui/src/components/home/HeroBanner.client.tsx
+++ b/packages/ui/src/components/home/HeroBanner.client.tsx
@@ -75,9 +75,9 @@ export default function HeroBanner({
         priority
         className="object-cover transition-opacity duration-700"
       />
-      <div className="absolute inset-0 bg-black/40" />
+      <div className="absolute inset-0 bg-fg/40" />
 
-      <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center text-white">
+      <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center text-bg">
         {" "}
         <h2 className="mb-6 max-w-3xl text-4xl font-bold drop-shadow-md md:text-5xl">
           {t(slide.headlineKey)}
@@ -95,14 +95,14 @@ export default function HeroBanner({
       <button
         aria-label="Previous slide"
         onClick={prev}
-        className="absolute top-1/2 left-[var(--space-4)] -translate-y-1/2 rounded-full bg-black/50 p-1 hover:bg-black/70"
+        className="absolute top-1/2 left-[var(--space-4)] -translate-y-1/2 rounded-full bg-fg/50 p-1 hover:bg-fg/70"
       >
         ‹
       </button>
       <button
         aria-label="Next slide"
         onClick={next}
-        className="absolute top-1/2 right-[var(--space-4)] -translate-y-1/2 rounded-full bg-black/50 p-1 hover:bg-black/70"
+        className="absolute top-1/2 right-[var(--space-4)] -translate-y-1/2 rounded-full bg-fg/50 p-1 hover:bg-fg/70"
       >
         ›
       </button>

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -50,7 +50,7 @@ export default function HeaderClient({
         <Link href={`/${lang}/checkout`} className="relative hover:underline">
           Cart
           {qty > 0 && (
-            <span className="absolute -top-2 -right-3 rounded-full bg-red-600 px-1.5 text-xs text-white">
+            <span className="absolute -top-2 -right-3 rounded-full bg-danger px-1.5 text-xs text-danger-foreground">
               {qty}
             </span>
           )}

--- a/packages/ui/src/components/molecules/FormField.tsx
+++ b/packages/ui/src/components/molecules/FormField.tsx
@@ -49,13 +49,13 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
         <label htmlFor={htmlFor} className="text-sm font-medium">
           {label}
           {required && (
-            <span aria-hidden="true" className="text-red-600">
+            <span aria-hidden="true" className="text-danger">
               *
             </span>
           )}
         </label>
         {children}
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-danger">{error}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/organisms/CheckoutStepper.tsx
+++ b/packages/ui/src/components/organisms/CheckoutStepper.tsx
@@ -30,7 +30,7 @@ export function CheckoutStepper({
           <span
             className={cn(
               "grid size-6 place-content-center rounded-full border",
-              idx < currentStep && "bg-primary border-primary text-white",
+              idx < currentStep && "bg-primary border-primary text-primary-fg",
               idx === currentStep && "border-primary",
               idx > currentStep && "text-muted-foreground border-muted"
             )}

--- a/packages/ui/src/components/organisms/FilterSidebar.client.tsx
+++ b/packages/ui/src/components/organisms/FilterSidebar.client.tsx
@@ -44,7 +44,7 @@ export function FilterSidebar({
         <Button variant="outline">Filters</Button>
       </DialogPrimitive.Trigger>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/50" />
+        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-fg/50" />
         <DialogPrimitive.Content
           className={cn(
             widthClass,

--- a/packages/ui/src/components/organisms/ProductCard.stories.tsx
+++ b/packages/ui/src/components/organisms/ProductCard.stories.tsx
@@ -34,7 +34,7 @@ export const OutOfStock: StoryObj<typeof ProductCard> = {
   render: (args) => (
     <div className="relative">
       <ProductCard {...args} />
-      <div className="absolute inset-0 flex items-center justify-center bg-black/60 font-semibold text-white">
+      <div className="absolute inset-0 flex items-center justify-center bg-fg/60 font-semibold text-bg">
         Out of stock
       </div>
     </div>

--- a/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
+++ b/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
@@ -27,7 +27,7 @@ export function StickyAddToCartBar({
   return (
     <div
       className={cn(
-        "sticky right-0 bottom-0 left-0 flex items-center justify-between gap-4 border-t bg-white shadow-md",
+        "sticky right-0 bottom-0 left-0 flex items-center justify-between gap-4 border-t bg-bg shadow-md",
         padding,
         className
       )}

--- a/packages/ui/src/components/templates/AnalyticsDashboardTemplate.tsx
+++ b/packages/ui/src/components/templates/AnalyticsDashboardTemplate.tsx
@@ -26,7 +26,7 @@ export function AnalyticsDashboardTemplate<T>({
         <LineChart
           data={chartData}
           options={chartOptions}
-          className="bg-white"
+          className="bg-bg"
         />
         <DataTable rows={tableRows} columns={tableColumns} />
       </div>

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -73,7 +73,7 @@ export function CartTemplate({
                   <button
                     type="button"
                     onClick={() => onRemove(line.sku.id)}
-                    className="text-red-600 hover:underline"
+                    className="text-danger hover:underline"
                   >
                     Remove
                   </button>

--- a/packages/ui/src/components/templates/CheckoutTemplate.tsx
+++ b/packages/ui/src/components/templates/CheckoutTemplate.tsx
@@ -40,9 +40,9 @@ export function CheckoutTemplate({
               className={cn(
                 "mb-1 flex h-8 w-8 items-center justify-center rounded-full border",
                 idx === step
-                  ? "bg-primary border-primary text-white"
+                  ? "bg-primary border-primary text-primary-fg"
                   : idx < step
-                    ? "bg-primary/80 border-primary/80 text-white"
+                    ? "bg-primary/80 border-primary/80 text-primary-fg"
                     : "bg-muted text-muted-foreground"
               )}
             >

--- a/packages/ui/src/components/templates/LiveShoppingEventTemplate.tsx
+++ b/packages/ui/src/components/templates/LiveShoppingEventTemplate.tsx
@@ -43,12 +43,12 @@ export function LiveShoppingEventTemplate({
   return (
     <div className={cn("grid gap-6 lg:grid-cols-3", className)} {...props}>
       <div className="space-y-4 lg:col-span-2">
-        <div className="aspect-video w-full bg-black">
+        <div className="aspect-video w-full bg-fg">
           <video src={streamUrl} controls className="h-full w-full" />
         </div>
         <div className="space-y-2">
           <h3 className="text-lg font-semibold">Chat</h3>
-          <div className="h-64 space-y-2 overflow-y-auto rounded-md border bg-white p-4">
+          <div className="h-64 space-y-2 overflow-y-auto rounded-md border bg-bg p-4">
             {chatMessages.map((m) => (
               <div key={m.id} className="text-sm">
                 <span className="mr-1 font-medium">{m.user}:</span>

--- a/packages/ui/src/hooks/useMediaUpload.tsx
+++ b/packages/ui/src/hooks/useMediaUpload.tsx
@@ -159,13 +159,13 @@ export function useImageUpload(
       <button
         type="button"
         onClick={openFileDialog}
-        className="bg-primary rounded px-3 py-1 text-white"
+        className="bg-primary rounded px-3 py-1 text-primary-fg"
       >
         Browse…
       </button>
 
       {pendingFile && (
-        <p className="mt-2 text-sm text-gray-500">{pendingFile.name}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{pendingFile.name}</p>
       )}
 
       {progress && (
@@ -174,9 +174,9 @@ export function useImageUpload(
         </p>
       )}
 
-      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      {error && <p className="mt-2 text-sm text-danger">{error}</p>}
       {isValid === false && (
-        <p className="mt-2 text-sm text-orange-600">
+        <p className="mt-2 text-sm text-warning">
           Wrong orientation (needs {requiredOrientation})
         </p>
       )}


### PR DESCRIPTION
## Summary
- replace hard-coded Tailwind color classes in UI package with design tokens
- add success and warning variants using semantic tokens

## Testing
- `pnpm --filter @acme/ui lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' and other missing modules)*
- `pnpm --filter @acme/ui build` *(fails: TS errors and missing build outputs)*

------
https://chatgpt.com/codex/tasks/task_e_6898c610e1f8832f93a21af7d96aa798