### PR TITLE
chore: unify text color suffix

### DIFF
--- a/packages/design-tokens/index.ts
+++ b/packages/design-tokens/index.ts
@@ -14,7 +14,7 @@ const designTokens = plugin.withOptions(
           muted: "hsl(var(--color-muted))",
         },
         textColor: {
-          "primary-fg": "hsl(var(--color-primary-fg))",
+          "primary-foreground": "hsl(var(--color-primary-fg))",
           "accent-foreground": "hsl(var(--color-accent-fg))",
           "danger-foreground": "hsl(var(--color-danger-fg))",
         },

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -21,7 +21,7 @@ const preset: Config = {
         muted: "hsl(var(--color-muted))",
       },
       textColor: {
-        "primary-fg": "hsl(var(--color-primary-fg))",
+        "primary-foreground": "hsl(var(--color-primary-fg))",
         "accent-foreground": "hsl(var(--color-accent-fg))",
         "danger-foreground": "hsl(var(--color-danger-fg))",
       },

--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -21,7 +21,7 @@ const preset: Partial<Config> = {
         muted: "hsl(var(--color-muted))",
       },
       textColor: {
-        "primary-fg": "hsl(var(--color-primary-fg))",
+        "primary-foreground": "hsl(var(--color-primary-fg))",
         "accent-foreground": "hsl(var(--color-accent-fg))",
         "danger-foreground": "hsl(var(--color-danger-fg))",
       },

--- a/packages/ui/src/components/templates/MarketingEmailTemplate.tsx
+++ b/packages/ui/src/components/templates/MarketingEmailTemplate.tsx
@@ -49,7 +49,7 @@ export function MarketingEmailTemplate({
           <div className="text-center">
             <a
               href={ctaHref}
-              className="bg-primary text-primary-fg inline-block rounded-md px-4 py-2 font-medium"
+              className="bg-primary text-primary-foreground inline-block rounded-md px-4 py-2 font-medium"
             >
               {ctaLabel}
             </a>


### PR DESCRIPTION
## Summary
- standardize tailwind text color utilities on the `-foreground` suffix
- update email template to use `text-primary-foreground`

## Testing
- `pnpm test` *(fails: Cannot find module '.prisma/client/index-browser' from '@prisma/client/index-browser.js')*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6898c615ecb8832f9395e5b3d0d1d274