### PR TITLE
chore: use shared aliases for date and email utilities

### DIFF
--- a/apps/cms/__tests__/accounts.test.ts
+++ b/apps/cms/__tests__/accounts.test.ts
@@ -84,7 +84,7 @@ describe("account actions", () => {
     await withRepo(async () => {
       /* stub email sending so the test doesn't talk to SMTP */
       const sendEmail = jest.fn();
-      jest.doMock("../../../src/lib/email", () => ({
+      jest.doMock("@lib/email", () => ({
         __esModule: true,
         sendEmail,
       }));
@@ -112,7 +112,7 @@ describe("account actions", () => {
   it("approveAccount throws for unknown ID", async () => {
     await withRepo(async () => {
       const sendEmail = jest.fn();
-      jest.doMock("../../../src/lib/email", () => ({
+      jest.doMock("@lib/email", () => ({
         __esModule: true,
         sendEmail,
       }));

--- a/apps/cms/__tests__/pages.test.ts
+++ b/apps/cms/__tests__/pages.test.ts
@@ -31,7 +31,7 @@ describe("page actions", () => {
   it("createPage stores new page", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const { createPage } = await import("../src/actions/pages.server");
 
@@ -57,7 +57,7 @@ describe("page actions", () => {
   it("updatePage modifies page data", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
         "../../../packages/platform-core/src/repositories/pages/index.server"
@@ -96,7 +96,7 @@ describe("page actions", () => {
   it("updatePage persists history", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
         "../../../packages/platform-core/src/repositories/pages/index.server"
@@ -140,7 +140,7 @@ describe("page actions", () => {
   it("deletePage removes page from repo", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
         "../../../packages/platform-core/src/repositories/pages/index.server"
@@ -168,7 +168,7 @@ describe("page actions", () => {
   it("createPage returns validation error for bad components", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       mockAuth();
       const { createPage } = await import("../src/actions/pages.server");
       const fd = new FormData();

--- a/apps/cms/__tests__/products.test.ts
+++ b/apps/cms/__tests__/products.test.ts
@@ -42,7 +42,7 @@ describe("product actions", () => {
   it("createDraftRecord creates placeholders", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       const { createDraftRecord } = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -58,7 +58,7 @@ describe("product actions", () => {
   it("updateProduct merges form data and bumps version", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -84,7 +84,7 @@ describe("product actions", () => {
   it("rejects invalid product payloads", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -116,7 +116,7 @@ describe("product actions", () => {
   it("duplicateProduct copies a product", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");
@@ -143,7 +143,7 @@ describe("product actions", () => {
   it("deleteProduct removes product and redirects", async () => {
     await withRepo(async () => {
       const now = "2024-01-01T00:00:00.000Z";
-      jest.doMock("../../../packages/shared/date", () => ({ nowIso: () => now }));
+      jest.doMock("@shared/date", () => ({ nowIso: () => now }));
       const actions = (await import(
         "../src/actions/products.server"
       )) as typeof import("../src/actions/products.server");

--- a/apps/cms/src/actions/accounts.server.ts
+++ b/apps/cms/src/actions/accounts.server.ts
@@ -6,7 +6,7 @@ import type { Role } from "@cms/auth/roles";
 import type { CmsUser } from "@cms/auth/users";
 import bcrypt from "bcryptjs";
 import { ulid } from "ulid";
-import { sendEmail } from "../../../../src/lib/email";
+import { sendEmail } from "@lib/email";
 import { readRbac, writeRbac } from "../lib/rbacStore";
 
 export interface PendingUser {

--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -5,7 +5,7 @@ import * as Sentry from "@sentry/node";
 import type { Locale, Page, HistoryState } from "@types";
 import { historyStateSchema } from "@types";
 import { ulid } from "ulid";
-import { nowIso } from "../../../../packages/shared/date";
+import { nowIso } from "@shared/date";
 
 import { ensureAuthorized } from "./common/auth";
 import {

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -20,7 +20,7 @@ import type { Locale } from "@types";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { ulid } from "ulid";
-import { nowIso } from "../../../../packages/shared/date";
+import { nowIso } from "@shared/date";
 
 /* -------------------------------------------------------------------------- */
 /*  Helpers                                                                    */

--- a/packages/lib/src/email.ts
+++ b/packages/lib/src/email.ts
@@ -1,4 +1,4 @@
-// src/lib/email.ts
+// packages/lib/src/email.ts
 
 import { env } from "@config/src/env";
 import nodemailer from "nodemailer";

--- a/test/unit/email.spec.ts
+++ b/test/unit/email.spec.ts
@@ -22,7 +22,7 @@ describe("sendEmail", () => {
       createTransport: () => ({ sendMail }),
     }));
 
-    const { sendEmail } = await import("../../src/lib/email");
+    const { sendEmail } = await import("@lib/email");
     await sendEmail("a@b.com", "Hello", "World");
     expect(sendMail).toHaveBeenCalledWith({
       from: "test@example.com",
@@ -50,7 +50,7 @@ describe("sendEmail", () => {
     }));
 
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    const { sendEmail } = await import("../../src/lib/email");
+    const { sendEmail } = await import("@lib/email");
     await expect(
       sendEmail("a@b.com", "Hello", "World")
     ).rejects.toThrow("failure");
@@ -71,7 +71,7 @@ describe("sendEmail", () => {
       createTransport: jest.fn(),
     }));
 
-    const { sendEmail } = await import("../../src/lib/email");
+    const { sendEmail } = await import("@lib/email");
     await sendEmail("a@b.com", "Hi", "There");
     expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -59,10 +59,12 @@
       /* ─── lib helpers (stripe, products, cookies, …) ────────────── */
       "@lib/stripeServer": ["packages/lib/src/stripeServer.server.ts"],
       "@lib/stripeServer.server": ["packages/lib/src/stripeServer.server.ts"],
+      "@lib/email": ["packages/lib/src/email.ts"],
       "@lib/*": ["packages/platform-core/src/*", "packages/lib/src/*"],
 
       "@/lib/stripeServer": ["packages/lib/src/stripeServer.server.ts"],
       "@/lib/stripeServer.server": ["packages/lib/src/stripeServer.server.ts"],
+      "@/lib/email": ["packages/lib/src/email.ts"],
       "@/lib/products": ["packages/platform-core/src/products.ts"],
       "@/lib/cartCookie": ["packages/platform-core/src/cartCookie.ts"],
       "@/lib/*": ["packages/platform-core/src/*", "packages/lib/src/*"],


### PR DESCRIPTION
## Summary
- use `@shared/date` alias in CMS product and page actions
- move `email.ts` into `packages/lib` and expose as `@lib/email`
- update accounts action and tests to use `@lib/email`

## Testing
- `pnpm test --filter @acme/lib` *(fails: Cannot find module '../components/atoms/shadcn' from 'packages/ui/__tests__/Input.test.tsx')*
- `pnpm test --filter @apps/cms` *(fails: Cannot find module '@types' from 'apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx')*
- `pnpm exec jest test/unit/email.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6898c61f2270832f8d1c98a7a10ec550