### PR TITLE
feat: automate domain provisioning

### DIFF
--- a/apps/cms/src/actions/deployShop.server.ts
+++ b/apps/cms/src/actions/deployShop.server.ts
@@ -2,7 +2,11 @@
 "use server";
 
 import { authOptions } from "@cms/auth/options";
-import { deployShop, type DeployShopResult } from "@platform-core/createShop";
+import {
+  deployShop,
+  type DeployShopResult,
+  type DeployStatusBase,
+} from "@platform-core/createShop";
 import { getServerSession } from "next-auth";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -26,12 +30,113 @@ function resolveRepoRoot(): string {
   return process.cwd();
 }
 
+async function provisionDomain(
+  id: string,
+  domain: string
+): Promise<"pending" | "error"> {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  const zone = process.env.CLOUDFLARE_ZONE_ID;
+  const account = process.env.CLOUDFLARE_ACCOUNT_ID;
+  if (!token || !zone || !account) return "error";
+
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  } as const;
+
+  try {
+    // Associate custom domain with Pages project
+    await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${id}/domains`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ name: domain }),
+      }
+    );
+
+    // Create DNS record pointing to Pages deployment
+    await fetch(
+      `https://api.cloudflare.com/client/v4/zones/${zone}/dns_records`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          type: "CNAME",
+          name: domain,
+          content: `${id}.pages.dev`,
+          ttl: 1,
+          proxied: true,
+        }),
+      }
+    );
+
+    return "pending";
+  } catch (err) {
+    console.error("Cloudflare provisioning failed", err);
+    return "error";
+  }
+}
+
+async function writeDeployStatus(id: string, data: DeployStatusBase): Promise<void> {
+  try {
+    const file = path.join(
+      resolveRepoRoot(),
+      "data",
+      "shops",
+      id,
+      "deploy.json"
+    );
+    await fs.writeFile(file, JSON.stringify(data, null, 2));
+  } catch (err) {
+    console.error("Failed to write deploy status", err);
+  }
+}
+
 export async function deployShopHosting(
   id: string,
   domain?: string
 ): Promise<DeployShopResult> {
   await ensureAuthorized();
-  return deployShop(id, domain);
+  const result = deployShop(id, domain) as DeployShopResult & {
+    domain?: string;
+    domainStatus?: "pending" | "active" | "error";
+  };
+
+  if (domain) {
+    const status = await provisionDomain(id, domain);
+    result.domain = domain;
+    result.domainStatus = status;
+    await writeDeployStatus(id, result);
+  }
+
+  return result;
+}
+
+async function checkDomainStatus(
+  id: string,
+  domain: string
+): Promise<"pending" | "active" | "error" | undefined> {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  const account = process.env.CLOUDFLARE_ACCOUNT_ID;
+  if (!token || !account) return undefined;
+
+  try {
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${id}/domains/${domain}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    if (!res.ok) return undefined;
+    const json = (await res.json()) as {
+      result?: { status?: "pending" | "active" | "error" };
+    };
+    return json.result?.status;
+  } catch (err) {
+    console.error("Failed to check domain status", err);
+    return undefined;
+  }
 }
 
 export async function getDeployStatus(
@@ -47,7 +152,20 @@ export async function getDeployStatus(
       "deploy.json"
     );
     const content = await fs.readFile(file, "utf8");
-    return JSON.parse(content) as DeployShopResult;
+    const data = JSON.parse(content) as DeployShopResult & {
+      domain?: string;
+      domainStatus?: "pending" | "active" | "error";
+    };
+
+    if (data.domain) {
+      const status = await checkDomainStatus(id, data.domain);
+      if (status && status !== data.domainStatus) {
+        data.domainStatus = status;
+        await writeDeployStatus(id, data);
+      }
+    }
+
+    return data;
   } catch (err) {
     console.error("Failed to read deploy status", err);
     return { status: "pending", error: (err as Error).message };

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -762,10 +762,12 @@ export default function Wizard({
       case 14:
         return (
           <StepHosting
+            shopId={shopId}
             domain={domain}
             setDomain={setDomain}
             deployResult={deployResult}
             deployInfo={deployInfo}
+            setDeployInfo={setDeployInfo}
             deploying={deploying}
             deploy={deploy}
             onBack={() => setStep(13)}

--- a/apps/cms/src/app/cms/wizard/services/deployShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/deployShop.ts
@@ -6,7 +6,12 @@ import type { DeployShopResult } from "@platform-core/createShop";
 
 export interface DeployResult {
   ok: boolean;
-  info?: DeployShopResult | { status: "pending"; error?: string };
+  info?:
+    | (DeployShopResult & {
+        domain?: string;
+        domainStatus?: "pending" | "active" | "error";
+      })
+    | { status: "pending"; error?: string };
   error?: string;
 }
 
@@ -33,8 +38,53 @@ export async function deployShop(
     | DeployShopResult
     | { status: "pending"; error?: string };
 
-  if (res.ok) return { ok: true, info: json };
+  if (res.ok) {
+    if (domain) {
+      try {
+        await provisionDns(shopId, domain);
+        (json as any).domain = domain;
+        (json as any).domainStatus = "pending";
+      } catch (err) {
+        console.error("Provisioning DNS failed", err);
+        (json as any).domainStatus = "error";
+      }
+    }
+    return { ok: true, info: json };
+  }
 
   return { ok: false, error: json.error ?? "Deployment failed" };
+}
+
+async function provisionDns(id: string, domain: string): Promise<void> {
+  const token = process.env.NEXT_PUBLIC_CLOUDFLARE_API_TOKEN;
+  const zone = process.env.NEXT_PUBLIC_CLOUDFLARE_ZONE_ID;
+  const account = process.env.NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_ID;
+  if (!token || !zone || !account) return;
+
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  } as const;
+
+  await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${id}/domains`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: domain }),
+    }
+  );
+
+  await fetch(`https://api.cloudflare.com/client/v4/zones/${zone}/dns_records`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      type: "CNAME",
+      name: domain,
+      content: `${id}.pages.dev`,
+      ttl: 1,
+      proxied: true,
+    }),
+  });
 }
 

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -64,6 +64,10 @@ export interface DeployStatusBase {
   previewUrl?: string;
   instructions?: string;
   error?: string;
+  /** Custom domain associated with the deployment */
+  domain?: string;
+  /** Current provisioning status for the custom domain */
+  domainStatus?: "pending" | "active" | "error";
 }
 
 export interface DeployShopResult extends DeployStatusBase {


### PR DESCRIPTION
## Summary
- provision custom domains via Cloudflare when deploying shops
- poll domain verification status in hosting step
- persist deployment/domain info for later visits

## Testing
- `pnpm test` *(fails: apps/cms ShopEditor import not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c3c1cc5c832f883b485717d6e0d6