### PR TITLE
feat(init-shop): prompt for logo and contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Key points:
    pnpm setup-ci <id>
    ```
 
-   `init-shop` launches an interactive wizard that asks for the shop ID, display name, shop type
-   (`sale` or `rental`), and which theme and template to use. Payment and shipping providers are
-   chosen from guided lists of available providers. It then
+   `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
+   contact email, shop type (`sale` or `rental`), and which theme and template to use. Payment and
+   shipping providers are chosen from guided lists of available providers. It then
    scaffolds `apps/shop-<id>` and writes an `.env` file inside the new app. Edit the `.env` file to
    provide real secrets (see [Environment Variables](#environment-variables)). For scripted
    setups you can still call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and
@@ -59,6 +59,8 @@ Key points:
 pnpm init-shop
 ? Shop ID … demo
 ? Display name … Demo Shop
+? Logo URL … https://example.com/logo.png
+? Contact email … demo@example.com
 ? Shop type (sale or rental) … sale
 ? Theme › base
 ? Template › template-app

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -15,6 +15,8 @@ pnpm init-shop
 
 - shop ID
 - display name
+- logo URL
+- contact email
 - shop type (`sale` or `rental`)
 - theme and template
 - payment and shipping providers (selected from a guided list of available providers)
@@ -42,6 +44,8 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 pnpm init-shop
 ? Shop ID … demo
 ? Display name … Demo Shop
+? Logo URL … https://example.com/logo.png
+? Contact email … demo@example.com
 ? Shop type (sale or rental) … sale
 ? Theme › base
 ? Template › template-app

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -22,7 +22,9 @@ function ensureRuntime() {
   try {
     pnpmVersion = execSync("pnpm --version", { encoding: "utf8" }).trim();
   } catch {
-    console.error("Failed to determine pnpm version. pnpm v10 or later is required.");
+    console.error(
+      "Failed to determine pnpm version. pnpm v10 or later is required."
+    );
     process.exit(1);
   }
 
@@ -77,6 +79,8 @@ async function main() {
     process.exit(1);
   }
   const name = await prompt("Display name (optional): ");
+  const logo = await prompt("Logo URL (optional): ");
+  const contact = await prompt("Contact email (optional): ");
   const typeAns = await prompt("Shop type (sale or rental) [sale]: ", "sale");
   const type = typeAns.toLowerCase() === "rental" ? "rental" : "sale";
   const theme = await prompt("Theme [base]: ", "base");
@@ -93,6 +97,8 @@ async function main() {
 
   const options = {
     ...(name && { name }),
+    ...(logo && { logo }),
+    ...(contact && { contactInfo: contact }),
     type,
     theme,
     template,
@@ -136,7 +142,7 @@ async function main() {
   }
 
   console.log(
-    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Run: pnpm --filter @apps/${prefixedId} dev`
+    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Review data/shops/${prefixedId}/shop.json\n  - Run: pnpm --filter @apps/${prefixedId} dev`
   );
 }
 


### PR DESCRIPTION
## Summary
- ask for logo URL and contact email when initializing a shop
- pass logo/contact to `createShop` and show `shop.json` review instructions
- document new prompts in README and setup guide

## Testing
- `npx prettier -w scripts/src/init-shop.ts README.md doc/setup.md`
- `npx eslint scripts/src/init-shop.ts` *(warn: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_6898c45a593c832fb3337e24ad74cef4