### PR TITLE
feat: expose AI product catalogue

### DIFF
--- a/doc/seo.md
+++ b/doc/seo.md
@@ -1,0 +1,20 @@
+# SEO
+
+## AI Product Catalogue
+
+The template app exposes a machine‑readable product feed for AI crawlers at `/api/ai/catalog`.
+It returns paginated JSON with product metadata and honours `If-Modified-Since`.
+
+Example usage:
+
+```bash
+curl -i "https://example.com/api/ai/catalog?limit=10" \
+  -H "Accept: application/json"
+```
+
+To leverage caching:
+
+```bash
+curl -i "https://example.com/api/ai/catalog" \
+  -H "If-Modified-Since: <timestamp>"
+```

--- a/packages/template-app/__tests__/ai-catalog.test.ts
+++ b/packages/template-app/__tests__/ai-catalog.test.ts
@@ -1,0 +1,42 @@
+// packages/template-app/__tests__/ai-catalog.test.ts
+import { GET } from "../src/app/api/ai/catalog/route";
+
+describe("AI catalogue API", () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_SHOP_ID = "abc";
+  });
+
+  function createRequest(url: string, headers: Record<string, string> = {}) {
+    return {
+      nextUrl: new URL(url),
+      headers: new Headers(headers),
+    } as any;
+  }
+
+  test("returns product metadata", async () => {
+    const res = await GET(
+      createRequest("http://localhost/api/ai/catalog?limit=1&page=1")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items.length).toBeLessThanOrEqual(1);
+    const item = body.items[0];
+    expect(item).toHaveProperty("id");
+    expect(item).toHaveProperty("title");
+    expect(item).toHaveProperty("description");
+    expect(item).toHaveProperty("price");
+    expect(item).toHaveProperty("images");
+  });
+
+  test("responds 304 when not modified", async () => {
+    const first = await GET(createRequest("http://localhost/api/ai/catalog"));
+    const lm = first.headers.get("Last-Modified")!;
+    const second = await GET(
+      createRequest("http://localhost/api/ai/catalog", {
+        "If-Modified-Since": lm,
+      })
+    );
+    expect(second.status).toBe(304);
+  });
+});

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getProductById } from "@platform-core/src/products";
+import { readRepo } from "@platform-core/repositories/products.server";
+import type { ProductPublication } from "@types";
+
+export const runtime = "nodejs";
+
+function parseIntOr(val: string | null, def: number): number {
+  const n = Number.parseInt(val ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+export async function GET(req: NextRequest) {
+  const shop = process.env.NEXT_PUBLIC_SHOP_ID || "default";
+  const all = await readRepo<ProductPublication>(shop);
+
+  const lastModifiedDate = all.reduce((max, p) => {
+    const d = p.updated_at ? new Date(p.updated_at) : new Date(0);
+    return d > max ? d : max;
+  }, new Date(0));
+  const lastModified = new Date(lastModifiedDate.toUTCString());
+
+  const ims = req.headers.get("if-modified-since");
+  if (ims) {
+    const imsDate = new Date(ims);
+    if (!Number.isNaN(imsDate.getTime()) && lastModified <= imsDate) {
+      return new NextResponse(null, { status: 304 });
+    }
+  }
+
+  const { searchParams } = req.nextUrl;
+  const page = parseIntOr(searchParams.get("page"), 1);
+  const limit = parseIntOr(searchParams.get("limit"), 50);
+  const start = (page - 1) * limit;
+  const paged = all.slice(start, start + limit);
+
+  const items = paged.map((p) => {
+    const sku = getProductById(p.sku) || {};
+    return {
+      id: p.id,
+      title: p.title,
+      description: p.description,
+      price: p.price ?? (sku as any).price ?? null,
+      images: p.images?.length ? p.images : (sku as any).image ? [(sku as any).image] : [],
+    };
+  });
+
+  return NextResponse.json(
+    { items, page, total: all.length },
+    { headers: { "Last-Modified": lastModified.toUTCString() } }
+  );
+}
+

--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/api/ai/catalog"],
+      },
+    ],
+    sitemap: `${base}/sitemap.xml`,
+    additionalSitemaps: [`${base}/api/ai/catalog`],
+  };
+}

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const now = new Date().toISOString();
+  return [
+    { url: `${base}/`, lastModified: now },
+    { url: `${base}/api/ai/catalog`, lastModified: now },
+  ];
+}


### PR DESCRIPTION
## Summary
- expose paginated JSON product feed for AI crawlers
- advertise the feed via robots.txt and sitemap
- document usage and add tests for feed shape

## Testing
- `pnpm exec jest packages/template-app/__tests__/ai-catalog.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6898f0fe8adc832f813600a8c1183bef