### PR TITLE
feat(cms): add blog post management

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -1,0 +1,111 @@
+// apps/cms/src/actions/blog.server.ts
+
+import { ensureAuthorized } from "./common/auth";
+
+const projectId = process.env.SANITY_PROJECT_ID as string;
+const dataset = process.env.SANITY_DATASET as string;
+const apiVersion = process.env.SANITY_API_VERSION || "2021-10-21";
+const token = process.env.SANITY_WRITE_TOKEN;
+
+interface SanityPost {
+  _id: string;
+  title?: string;
+  body?: string;
+  published?: boolean;
+}
+
+function queryUrl(query: string) {
+  return `https://${projectId}.api.sanity.io/v${apiVersion}/data/query/${dataset}?query=${encodeURIComponent(query)}`;
+}
+
+async function mutate(body: unknown) {
+  const url = `https://${projectId}.api.sanity.io/v${apiVersion}/data/mutate/${dataset}`;
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getPosts(): Promise<SanityPost[]> {
+  await ensureAuthorized();
+  const res = await fetch(queryUrl('*[_type=="post"]{_id,title,body,published}'), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  const json = await res.json();
+  return json.result ?? [];
+}
+
+export async function getPost(id: string): Promise<SanityPost | null> {
+  await ensureAuthorized();
+  const res = await fetch(queryUrl(`*[_type=="post" && _id=="${id}"][0]{_id,title,body,published}`), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  const json = await res.json();
+  return json.result ?? null;
+}
+
+export async function createPost(
+  _prev: unknown,
+  formData: FormData
+): Promise<{ message?: string; error?: string; id?: string }> {
+  "use server";
+  await ensureAuthorized();
+  const title = String(formData.get("title") ?? "");
+  const content = String(formData.get("content") ?? "");
+  try {
+    const res = await mutate({
+      mutations: [{ create: { _type: "post", title, body: content, published: false } }],
+      returnIds: true,
+    });
+    const json = await res.json();
+    const id = json?.results?.[0]?.id as string | undefined;
+    return { message: "Post created", id };
+  } catch (err) {
+    console.error("Failed to create post", err);
+    return { error: "Failed to create post" };
+  }
+}
+
+export async function updatePost(
+  _prev: unknown,
+  formData: FormData
+): Promise<{ message?: string; error?: string }> {
+  "use server";
+  await ensureAuthorized();
+  const id = String(formData.get("id") ?? "");
+  const title = String(formData.get("title") ?? "");
+  const content = String(formData.get("content") ?? "");
+  try {
+    await mutate({
+      mutations: [{ patch: { id, set: { title, body: content } } }],
+    });
+    return { message: "Post updated" };
+  } catch (err) {
+    console.error("Failed to update post", err);
+    return { error: "Failed to update post" };
+  }
+}
+
+export async function publishPost(
+  id: string,
+  _prev?: unknown,
+  _formData?: FormData
+): Promise<{ message?: string; error?: string }> {
+  "use server";
+  await ensureAuthorized();
+  try {
+    await mutate({
+      mutations: [{ patch: { id, set: { published: true } } }],
+    });
+    return { message: "Post published" };
+  } catch (err) {
+    console.error("Failed to publish post", err);
+    return { error: "Failed to publish post" };
+  }
+}
+
+export type { SanityPost };

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -1,0 +1,37 @@
+// apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+"use client";
+
+import { useFormState } from "react-dom";
+import { Button, Input, Textarea, Toast } from "@ui";
+
+export interface FormState {
+  message?: string;
+  error?: string;
+  id?: string;
+}
+
+interface Props {
+  action: (_state: FormState, formData: FormData) => Promise<FormState>;
+  submitLabel: string;
+  post?: { _id?: string; title?: string; body?: string };
+}
+
+export default function PostForm({ action, submitLabel, post }: Props) {
+  const [state, formAction] = useFormState(action, { message: "", error: "" });
+  return (
+    <div className="space-y-4">
+      <form action={formAction} className="space-y-4 max-w-xl">
+        <Input name="title" label="Title" defaultValue={post?.title ?? ""} required />
+        <Textarea
+          name="content"
+          label="Content"
+          defaultValue={post?.body ?? ""}
+          className="min-h-[200px]"
+        />
+        {post?._id && <input type="hidden" name="id" value={post._id} />}
+        <Button type="submit">{submitLabel}</Button>
+      </form>
+      <Toast open={Boolean(state.message || state.error)} message={state.message || state.error || ""} />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
@@ -1,0 +1,26 @@
+// apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
+"use client";
+
+import { useFormState } from "react-dom";
+import { Button, Toast } from "@ui";
+import { publishPost } from "@cms/actions/blog.server";
+import type { FormState } from "./PostForm.client";
+
+interface Props {
+  id: string;
+}
+
+export default function PublishButton({ id }: Props) {
+  const action = publishPost.bind(null, id);
+  const [state, formAction] = useFormState<FormState>(action, { message: "", error: "" });
+  return (
+    <div className="space-y-2">
+      <form action={formAction}>
+        <Button type="submit" variant="outline">
+          Publish
+        </Button>
+      </form>
+      <Toast open={Boolean(state.message || state.error)} message={state.message || state.error || ""} />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
@@ -1,0 +1,22 @@
+// apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+
+import { notFound } from "next/navigation";
+import PostForm from "../PostForm.client";
+import PublishButton from "../PublishButton.client";
+import { getPost, updatePost } from "@cms/actions/blog.server";
+
+interface Params {
+  params: { id: string };
+}
+
+export default async function EditPostPage({ params }: Params) {
+  const post = await getPost(params.id);
+  if (!post) return notFound();
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Edit Post</h1>
+      <PostForm action={updatePost} submitLabel="Save" post={post} />
+      <PublishButton id={post._id} />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/new/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/new/page.tsx
@@ -1,0 +1,13 @@
+// apps/cms/src/app/cms/blog/posts/new/page.tsx
+
+import PostForm from "../PostForm.client";
+import { createPost } from "@cms/actions/blog.server";
+
+export default function NewPostPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">New Post</h1>
+      <PostForm action={createPost} submitLabel="Create" />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/page.tsx
@@ -1,0 +1,35 @@
+// apps/cms/src/app/cms/blog/posts/page.tsx
+
+import Link from "next/link";
+import { Button } from "@ui";
+import { getPosts } from "@cms/actions/blog.server";
+
+export default async function BlogPostsPage() {
+  const posts = await getPosts();
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Blog Posts</h1>
+        <Button asChild>
+          <Link href="/cms/blog/posts/new">New Post</Link>
+        </Button>
+      </div>
+      <ul className="space-y-2">
+        {posts.map((post) => (
+          <li key={post._id}>
+            <Link
+              href={`/cms/blog/posts/${post._id}`}
+              className="text-primary underline"
+            >
+              {post.title || "(untitled)"}
+            </Link>
+            {post.published && (
+              <span className="ml-2 text-sm text-muted-foreground">published</span>
+            )}
+          </li>
+        ))}
+        {posts.length === 0 && <li>No posts found.</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add server actions for Sanity blog posts (create/update/publish)
- implement CMS routes for blog post listing, creation and editing
- reuse shared UI components for forms and notifications

## Testing
- `pnpm test --filter @apps/cms` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*
- `pnpm lint --filter @apps/cms`

------
https://chatgpt.com/codex/tasks/task_e_6898f0ea6ffc832faa270d32c2a191dd