### PR TITLE
Add Sanity blog config to shop data

### DIFF
--- a/packages/platform-core/__tests__/shops.test.ts
+++ b/packages/platform-core/__tests__/shops.test.ts
@@ -1,5 +1,6 @@
 // packages/platform-core/__tests__/shops.test.ts
-import { validateShopName } from "../shops";
+import { getSanityConfig, setSanityConfig, validateShopName } from "../shops";
+import type { Shop } from "@types";
 
 describe("validateShopName", () => {
   it("trims and accepts safe names", () => {
@@ -8,5 +9,37 @@ describe("validateShopName", () => {
 
   it("throws for invalid characters", () => {
     expect(() => validateShopName("bad/name")).toThrow("Invalid shop name");
+  });
+});
+
+describe("sanity blog accessors", () => {
+  const baseShop: Shop = {
+    id: "shop",
+    name: "shop",
+    catalogFilters: [],
+    themeId: "base",
+    themeTokens: {},
+    filterMappings: {},
+    priceOverrides: {},
+    localeOverrides: {},
+    navigation: [],
+    analyticsEnabled: false,
+  };
+
+  it("gets undefined when not set", () => {
+    expect(getSanityConfig(baseShop)).toBeUndefined();
+  });
+
+  it("sets and retrieves config", () => {
+    const updated = setSanityConfig(baseShop, {
+      projectId: "p",
+      dataset: "d",
+      token: "t",
+    });
+    expect(getSanityConfig(updated)).toEqual({
+      projectId: "p",
+      dataset: "d",
+      token: "t",
+    });
   });
 });

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -9,6 +9,7 @@ datasource db {
 
 model Shop {
   id   String @id
+  /// @type {import("../../types/src/Shop").Shop}
   data Json
   pages Page[]
 }

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -38,6 +38,7 @@ export async function createShop(
     shippingProviders: prepared.shipping,
     taxProviders: [prepared.tax],
     paymentProviders: prepared.payment,
+    sanityBlog: prepared.sanityBlog,
   };
 
   await prisma.shop.create({ data: { id, data: shopData } });

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -1,5 +1,5 @@
-import type { Locale, PageComponent } from "@types";
-import { localeSchema } from "@types";
+import type { Locale, PageComponent, SanityBlogConfig } from "@types";
+import { localeSchema, sanityBlogConfigSchema } from "@types";
 import { pageComponentSchema } from "@types/Page";
 import { z } from "zod";
 import { slugify } from "@shared-utils";
@@ -28,6 +28,7 @@ export const createShopOptionsSchema = z.object({
       id: z.string().optional(),
     })
     .optional(),
+  sanityBlog: sanityBlogConfigSchema.optional(),
   navItems: z
     .array(z.object({ label: z.string().min(1), url: z.string().min(1) }))
     .default([]),
@@ -72,12 +73,14 @@ export interface CreateShopOptions {
     components: PageComponent[];
   }[];
   checkoutPage?: PageComponent[];
+  sanityBlog?: SanityBlogConfig;
 }
 
 export interface PreparedCreateShopOptions extends Required<
-  Omit<CreateShopOptions, "analytics" | "checkoutPage">
+  Omit<CreateShopOptions, "analytics" | "checkoutPage" | "sanityBlog">
 > {
   analytics?: CreateShopOptions["analytics"];
+  sanityBlog?: CreateShopOptions["sanityBlog"];
   checkoutPage: PageComponent[];
 }
 
@@ -120,5 +123,6 @@ export function prepareOptions(
       components: p.components ?? [],
     })),
     checkoutPage: parsed.checkoutPage,
+    sanityBlog: parsed.sanityBlog,
   };
 }

--- a/packages/platform-core/src/shops.ts
+++ b/packages/platform-core/src/shops.ts
@@ -1,1 +1,21 @@
+import type { Shop, SanityBlogConfig } from "@types";
 export { SHOP_NAME_RE, validateShopName } from "../../lib/src/validateShopName";
+
+export function getSanityConfig(shop: Shop): SanityBlogConfig | undefined {
+  return shop.sanityBlog;
+}
+
+export function setSanityConfig(
+  shop: Shop,
+  config: SanityBlogConfig | undefined
+): Shop {
+  const next = { ...shop } as Shop & { sanityBlog?: SanityBlogConfig };
+  if (config) {
+    next.sanityBlog = config;
+  } else {
+    delete next.sanityBlog;
+  }
+  return next;
+}
+
+export type { SanityBlogConfig };

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -27,6 +27,14 @@ export const shopSeoFieldsSchema = z.object({
 
 export type ShopSeoFields = z.infer<typeof shopSeoFieldsSchema>;
 
+export const sanityBlogConfigSchema = z.object({
+  projectId: z.string(),
+  dataset: z.string(),
+  token: z.string(),
+});
+
+export type SanityBlogConfig = z.infer<typeof sanityBlogConfigSchema>;
+
 export interface Shop {
   id: string;
   name: string;
@@ -54,6 +62,7 @@ export interface Shop {
   homeDescription?: Translated;
   homeImage?: string;
   navigation?: { label: string; url: string }[];
+  sanityBlog?: SanityBlogConfig;
   analyticsEnabled?: boolean;
 }
 
@@ -84,5 +93,6 @@ export const shopSchema = z.object({
   navigation: z
     .array(z.object({ label: z.string(), url: z.string() }))
     .optional(),
+  sanityBlog: sanityBlogConfigSchema.optional(),
   analyticsEnabled: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
- extend Shop data model with Sanity blog credentials
- add helpers to read/write Sanity blog config
- wire Sanity config through shop creation and Prisma types

## Testing
- `npx prisma generate --schema packages/platform-core/prisma/schema.prisma` *(fails: prisma: not found)*
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms')*


------
https://chatgpt.com/codex/tasks/task_e_6898f0e08ce0832f8dd118397c6ba5c7