### PR TITLE
feat: add Cloudflare DNS provisioning and domain polling

### DIFF
--- a/apps/cms/src/actions/deployShop.server.ts
+++ b/apps/cms/src/actions/deployShop.server.ts
@@ -45,3 +45,26 @@ export async function getDeployStatus(
     return { status: "pending", error: (err as Error).message };
   }
 }
+
+export async function updateDeployStatus(
+  id: string,
+  data: Partial<DeployShopResult> & { domainStatus?: string }
+): Promise<void> {
+  await ensureAuthorized();
+  const file = path.join(
+    resolveRepoRoot(),
+    "data",
+    "shops",
+    id,
+    "deploy.json"
+  );
+  try {
+    const existing = await fs.readFile(file, "utf8").catch(() => "{}");
+    const parsed = JSON.parse(existing) as Record<string, unknown>;
+    const updated = { ...parsed, ...data };
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, JSON.stringify(updated, null, 2), "utf8");
+  } catch (err) {
+    console.error("Failed to write deploy status", err);
+  }
+}

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -763,10 +763,12 @@ export default function Wizard({
       case 14:
         return (
           <StepHosting
+            shopId={shopId}
             domain={domain}
             setDomain={setDomain}
             deployResult={deployResult}
             deployInfo={deployInfo}
+            setDeployInfo={setDeployInfo}
             deploying={deploying}
             deploy={deploy}
             onBack={() => setStep(13)}

--- a/apps/cms/src/app/cms/wizard/services/deployShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/deployShop.ts
@@ -4,10 +4,46 @@
 import { validateShopName } from "@platform-core/src/shops";
 import type { DeployShopResult } from "@platform-core/createShop";
 
+export interface DeployInfo
+  extends Partial<DeployShopResult> {
+  domainStatus?: string;
+  error?: string;
+}
+
 export interface DeployResult {
   ok: boolean;
-  info?: DeployShopResult | { status: "pending"; error?: string };
+  info?: DeployInfo | { status: "pending"; error?: string; domainStatus?: string };
   error?: string;
+}
+
+async function createCloudflareRecords(
+  shopId: string,
+  domain: string
+): Promise<{ status?: string; cnameTarget?: string }> {
+  const account = process.env.NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_ID;
+  const token = process.env.NEXT_PUBLIC_CLOUDFLARE_API_TOKEN;
+  if (!account || !token) throw new Error("Cloudflare credentials not configured");
+
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${shopId}/domains`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ name: domain }),
+    }
+  );
+
+  const json = (await res.json()) as any;
+  if (!res.ok) {
+    throw new Error(json.errors?.[0]?.message ?? "Failed to provision domain");
+  }
+  return {
+    status: json.result?.status as string | undefined,
+    cnameTarget: json.result?.verification_data?.cname_target as string | undefined,
+  };
 }
 
 export async function deployShop(
@@ -29,12 +65,46 @@ export async function deployShop(
     body: JSON.stringify({ id: shopId, domain }),
   });
 
-  const json = (await res.json()) as
-    | DeployShopResult
-    | { status: "pending"; error?: string };
+  const json = (await res.json()) as DeployInfo | { status: "pending"; error?: string };
 
-  if (res.ok) return { ok: true, info: json };
+  if (!res.ok) {
+    return { ok: false, error: json.error ?? "Deployment failed" };
+  }
 
-  return { ok: false, error: json.error ?? "Deployment failed" };
+  let info: DeployInfo = json as DeployInfo;
+
+  if (domain) {
+    try {
+      const cf = await createCloudflareRecords(shopId, domain);
+      info = {
+        ...(json as DeployInfo),
+        domainStatus: cf.status ?? (json as DeployInfo).domainStatus,
+        instructions:
+          cf.cnameTarget
+            ? `Add a CNAME record for ${domain} pointing to ${cf.cnameTarget}`
+            : (json as DeployInfo).instructions,
+      };
+
+      await fetch("/cms/api/deploy-shop", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: shopId, ...info }),
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  return { ok: true, info };
+}
+
+export async function getDeployStatus(
+  shopId: string
+): Promise<DeployInfo | { status: "pending"; error?: string; domainStatus?: string }> {
+  const res = await fetch(`/cms/api/deploy-shop?id=${shopId}`);
+  return (await res.json()) as DeployInfo | { status: "pending"; error?: string; domainStatus?: string };
 }
 

--- a/apps/cms/src/app/cms/wizard/steps/StepHosting.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepHosting.tsx
@@ -2,26 +2,61 @@
 
 import { Button, Input } from "@/components/atoms/shadcn";
 import type { DeployStatusBase } from "@platform-core/createShop";
+import { useEffect } from "react";
+import { getDeployStatus, type DeployInfo } from "../services/deployShop";
 
 interface Props {
+  shopId: string;
   domain: string;
   setDomain: (v: string) => void;
   deployResult: string | null;
-  deployInfo: DeployStatusBase | null;
+  deployInfo: (DeployStatusBase & { domainStatus?: string }) | null;
+  setDeployInfo: (
+    info: (DeployStatusBase & { domainStatus?: string }) | null
+  ) => void;
   deploying: boolean;
   onBack: () => void;
   deploy: () => void;
 }
 
 export default function StepHosting({
+  shopId,
   domain,
   setDomain,
   deployResult,
   deployInfo,
+  setDeployInfo,
   deploying,
   onBack,
   deploy,
 }: Props): React.JSX.Element {
+  useEffect(() => {
+    if (!shopId || !deployInfo) return;
+    if (
+      deployInfo.status !== "pending" &&
+      deployInfo.domainStatus !== "pending"
+    ) {
+      return;
+    }
+    let timer: NodeJS.Timeout;
+    const poll = async () => {
+      try {
+        const status = await getDeployStatus(shopId);
+        setDeployInfo(status as DeployInfo);
+        if (
+          status.status === "pending" ||
+          (status as DeployInfo).domainStatus === "pending"
+        ) {
+          timer = setTimeout(poll, 5000);
+        }
+      } catch {
+        timer = setTimeout(poll, 5000);
+      }
+    };
+    poll();
+    return () => clearTimeout(timer);
+  }, [shopId, deployInfo, setDeployInfo]);
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Hosting</h2>
@@ -49,6 +84,9 @@ export default function StepHosting({
       )}
       {deployInfo?.instructions && (
         <p className="text-sm">{deployInfo.instructions}</p>
+      )}
+      {deployInfo?.domainStatus === "pending" && (
+        <p className="text-sm">Waiting for domain verification…</p>
       )}
       {deployInfo?.status === "success" && (
         <p className="text-sm text-green-600">Deployment complete</p>


### PR DESCRIPTION
## Summary
- provision DNS/CNAME records via Cloudflare when deploying a shop
- poll hosting status in wizard step to verify domain and show required actions
- persist deployment status so domain state is available on later visits

## Testing
- `pnpm test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6898f18dcda0832f93e11e8ac9e203bc