### PR TITLE
feat(cms): add Sanity blog connection

### DIFF
--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -1,0 +1,32 @@
+// apps/cms/src/actions/saveSanityConfig.ts
+"use server";
+
+import { verifyCredentials } from "@acme/plugin-sanity";
+import { resolveDataRoot } from "@platform-core/dataRoot";
+import { ensureAuthorized } from "./common/auth";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export async function saveSanityConfig(formData: FormData): Promise<{
+  error?: string;
+}> {
+  await ensureAuthorized();
+
+  const projectId = String(formData.get("projectId") ?? "");
+  const dataset = String(formData.get("dataset") ?? "");
+  const token = String(formData.get("token") ?? "");
+
+  const config = { projectId, dataset, token };
+
+  const valid = await verifyCredentials(config);
+  if (!valid) {
+    return { error: "Invalid Sanity credentials" };
+  }
+
+  const root = path.resolve(resolveDataRoot(), "..", "cms");
+  await fs.mkdir(root, { recursive: true });
+  const file = path.join(root, "sanity.json");
+  await fs.writeFile(file, JSON.stringify(config, null, 2), "utf8");
+
+  return {};
+}

--- a/apps/cms/src/app/cms/blog/sanity/connect/page.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/page.tsx
@@ -1,0 +1,52 @@
+// apps/cms/src/app/cms/blog/sanity/connect/page.tsx
+import { Button } from "@/components/atoms/shadcn";
+import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
+
+export const revalidate = 0;
+
+export default function SanityConnectPage() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold">Connect Sanity</h2>
+      <form action={saveSanityConfig} className="space-y-4 max-w-md">
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="projectId">
+            Project ID
+          </label>
+          <input
+            id="projectId"
+            name="projectId"
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="dataset">
+            Dataset
+          </label>
+          <input
+            id="dataset"
+            name="dataset"
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="token">
+            Token
+          </label>
+          <input
+            id="token"
+            name="token"
+            type="password"
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <Button type="submit" className="bg-primary text-white">
+          Save
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/plugins/page.tsx
+++ b/apps/cms/src/app/cms/plugins/page.tsx
@@ -1,5 +1,6 @@
 // apps/cms/src/app/cms/plugins/page.tsx
 import { loadPlugins } from "@acme/platform-core";
+import Link from "next/link";
 import PluginList from "./PluginList.client";
 
 export default async function PluginsPage() {
@@ -8,6 +9,14 @@ export default async function PluginsPage() {
     <div>
       <h2 className="mb-4 text-xl font-semibold">Plugins</h2>
       <PluginList plugins={plugins} />
+      <div className="mt-6">
+        <Link
+          href="/cms/blog/sanity/connect"
+          className="text-blue-600 hover:underline"
+        >
+          Connect blog (Sanity)
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add server action to save and validate Sanity credentials
- add blog connection page with form for project ID, dataset and token
- link Sanity blog connection from plugin list

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/atoms' / `.prisma/client` and other related errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898f0e14d64832f96308373d5369713