### PR TITLE
Handle invalid JSON in page components field

### DIFF
--- a/apps/cms/src/actions/pages/validation.ts
+++ b/apps/cms/src/actions/pages/validation.ts
@@ -11,7 +11,17 @@ export const emptyTranslated = (): Record<Locale, string> =>
 export const componentsField = z
   .string()
   .default("[]")
-  .transform((val) => JSON.parse(val))
+  .transform((val, ctx) => {
+    try {
+      return JSON.parse(val);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Invalid JSON",
+      });
+      return [];
+    }
+  })
   .pipe(z.array(pageComponentSchema));
 
 export type PageComponents = z.infer<typeof componentsField>;


### PR DESCRIPTION
## Summary
- validate CMS page components by parsing JSON with error handling and returning a clear "Invalid JSON" issue

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test src/actions/pages/validation.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898f212e7c4832fbcbabf8050960f7e