### PR TITLE
refactor(types): infer shop type from schema

### DIFF
--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type Locale, type Translated } from "./Product";
 export declare const shopSeoFieldsSchema: z.ZodObject<{
     canonicalBase: z.ZodOptional<z.ZodString>;
     title: z.ZodOptional<z.ZodString>;
@@ -76,38 +75,6 @@ export declare const shopSeoFieldsSchema: z.ZodObject<{
     structuredData?: string | undefined;
 }>;
 export type ShopSeoFields = z.infer<typeof shopSeoFieldsSchema>;
-export interface Shop {
-    id: string;
-    name: string;
-    logo?: string;
-    contactInfo?: string;
-    catalogFilters: string[];
-    themeId: string;
-    /** Mapping of design tokens to theme values */
-    themeTokens: Record<string, string>;
-    /** Mapping of logical filter keys to catalog attributes */
-    filterMappings: Record<string, string>;
-    /** Optional price overrides per locale (minor units) */
-    priceOverrides: Partial<Record<Locale, number>>;
-    /** Optional redirect overrides for locale detection */
-    localeOverrides: Record<string, Locale>;
-    /** Sale or rental shop type */
-    type?: string;
-    /** Enabled payment provider identifiers */
-    paymentProviders?: string[];
-    /** Enabled shipping provider identifiers */
-    shippingProviders?: string[];
-    /** Enabled tax provider identifiers */
-    taxProviders?: string[];
-    homeTitle?: Translated;
-    homeDescription?: Translated;
-    homeImage?: string;
-    navigation?: {
-        label: string;
-        url: string;
-    }[];
-    analyticsEnabled?: boolean;
-}
 export declare const shopSchema: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
@@ -187,5 +154,8 @@ export declare const shopSchema: z.ZodObject<{
         label: string;
     }[] | undefined;
     analyticsEnabled?: boolean | undefined;
-}>; 
+}>;
+export type Shop = z.infer<typeof shopSchema>;
+
 //# sourceMappingURL=Shop.d.ts.map
+

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { localeSchema, type Locale, type Translated } from "./Product";
+import { localeSchema } from "./Product";
 
 export const shopSeoFieldsSchema = z.object({
   canonicalBase: z.string().url().optional(),
@@ -26,36 +26,6 @@ export const shopSeoFieldsSchema = z.object({
 });
 
 export type ShopSeoFields = z.infer<typeof shopSeoFieldsSchema>;
-
-export interface Shop {
-  id: string;
-  name: string;
-  logo?: string;
-  contactInfo?: string;
-  catalogFilters: string[];
-  themeId: string;
-  /** Mapping of design tokens to theme values */
-  themeTokens: Record<string, string>;
-  /** Mapping of logical filter keys to catalog attributes */
-  filterMappings: Record<string, string>;
-  /** Optional price overrides per locale (minor units) */
-  priceOverrides: Partial<Record<Locale, number>>;
-  /** Optional redirect overrides for locale detection */
-  localeOverrides: Record<string, Locale>;
-  /** Sale or rental shop type */
-  type?: string;
-  /** Enabled payment provider identifiers */
-  paymentProviders?: string[];
-  /** Enabled shipping provider identifiers */
-  shippingProviders?: string[];
-  /** Enabled tax provider identifiers */
-  taxProviders?: string[];
-  homeTitle?: Translated;
-  homeDescription?: Translated;
-  homeImage?: string;
-  navigation?: { label: string; url: string }[];
-  analyticsEnabled?: boolean;
-}
 
 export const shopSchema = z.object({
   id: z.string(),
@@ -86,3 +56,5 @@ export const shopSchema = z.object({
     .optional(),
   analyticsEnabled: z.boolean().optional(),
 });
+
+export type Shop = z.infer<typeof shopSchema>;


### PR DESCRIPTION
## Summary
- derive `Shop` type from `shopSchema`
- drop duplicate `Shop` interface and redundant type imports

## Testing
- `pnpm --filter @types/shared lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm test --filter @types/shared`


------
https://chatgpt.com/codex/tasks/task_e_6898f2155494832fab77dd7ba7d0c81c