### PR TITLE
Handle invalid JSON lines in settings history

### DIFF
--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -104,13 +104,21 @@ const entrySchema = z.object({
 export async function diffHistory(shop: string): Promise<SettingsDiffEntry[]> {
   try {
     const buf = await fs.readFile(historyPath(shop), "utf8");
-    return buf
-      .trim()
-      .split(/\n+/)
-      .filter(Boolean)
-      .map((line) => entrySchema.safeParse(JSON.parse(line)))
-      .filter((r) => r.success)
-      .map((r) => (r as z.SafeParseSuccess<SettingsDiffEntry>).data);
+      return buf
+        .trim()
+        .split(/\n+/)
+        .filter(Boolean)
+        .map((line) => {
+          try {
+            return JSON.parse(line);
+          } catch {
+            return undefined;
+          }
+        })
+        .filter((parsed): parsed is unknown => parsed !== undefined)
+        .map((parsed) => entrySchema.safeParse(parsed))
+        .filter((r) => r.success)
+        .map((r) => (r as z.SafeParseSuccess<SettingsDiffEntry>).data);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Safely parse settings history lines and skip invalid JSON entries

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_6898f218b610832f99daf7529bbd3cf1