### PR TITLE
feat: centralize cart schemas

### DIFF
--- a/apps/shop-abc/src/app/api/cart/route.d.ts
+++ b/apps/shop-abc/src/app/api/cart/route.d.ts
@@ -1,15 +1,17 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 export declare const runtime = "edge";
-export declare function POST(req: NextRequest): Promise<NextResponse<{
-    error: string;
-}> | NextResponse<{
-    ok: boolean;
-    cart: import("@types").CartState;
-}>>;
-export declare function PATCH(req: NextRequest): Promise<NextResponse<{
-    error: string;
-}> | NextResponse<{
-    ok: boolean;
-    cart: import("@types").CartState;
-}>>;
+export declare function POST(req: NextRequest): Promise<
+  | NextResponse<Record<string, string[]>>
+  | NextResponse<{
+      ok: boolean;
+      cart: import("@types").CartState;
+    }>
+>;
+export declare function PATCH(req: NextRequest): Promise<
+  | NextResponse<Record<string, string[]>>
+  | NextResponse<{
+      ok: boolean;
+      cart: import("@types").CartState;
+    }>
+>;

--- a/apps/shop-abc/src/app/api/cart/route.js
+++ b/apps/shop-abc/src/app/api/cart/route.js
@@ -1,23 +1,14 @@
 // apps/shop-abc/src/app/api/cart/route.ts
 import { asSetCookieHeader, CART_COOKIE, decodeCartCookie, encodeCartCookie, } from "@/lib/cartCookie";
 import { getProductById } from "@/lib/products";
-import { skuSchema } from "@types";
 import { NextResponse } from "next/server";
-import { z } from "zod";
+import { postSchema, patchSchema } from "@platform-core/schemas/cart";
 export const runtime = "edge";
-const postSchema = z.object({
-    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
-    qty: z.number().int().positive().optional(),
-});
-const patchSchema = z.object({
-    id: z.string(),
-    qty: z.number().int().positive(),
-});
 export async function POST(req) {
     const json = await req.json();
     const parsed = postSchema.safeParse(json);
     if (!parsed.success) {
-        return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+        return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
     }
     const { sku, qty = 1 } = parsed.data;
     const skuObj = "title" in sku ? sku : getProductById(sku.id);
@@ -36,7 +27,7 @@ export async function PATCH(req) {
     const json = await req.json();
     const parsed = patchSchema.safeParse(json);
     if (!parsed.success) {
-        return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+        return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
     }
     const { id, qty } = parsed.data;
     const cookie = req.cookies.get(CART_COOKIE)?.value;

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -6,35 +6,22 @@ import {
   decodeCartCookie,
   encodeCartCookie,
 } from "@/lib/cartCookie";
-import { skuSchema } from "@types";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { z } from "zod";
+import { postSchema, patchSchema } from "@platform-core/schemas/cart";
 
 export const runtime = "edge";
 
 // This simple handler echoes back the posted body and status 200.
 // Stripe / KV integration will extend this in Sprint 5.
 
-const postSchema = z
-  .object({
-    sku: skuSchema,
-    qty: z.coerce.number().int().min(1).default(1),
-  })
-  .strict();
-
-const patchSchema = z
-  .object({
-    id: z.string(),
-    qty: z.coerce.number().int().min(1),
-  })
-  .strict();
-
 export async function POST(req: NextRequest) {
   const json = await req.json();
   const parsed = postSchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
   }
 
   const { sku, qty } = parsed.data;
@@ -53,7 +40,9 @@ export async function PATCH(req: NextRequest) {
   const json = await req.json();
   const parsed = patchSchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
   }
 
   const { id, qty } = parsed.data;

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { skuSchema } from "@types";
+
+export const postSchema = z
+  .object({
+    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
+    qty: z.coerce.number().int().min(1).default(1),
+  })
+  .strict();
+
+export const patchSchema = z
+  .object({
+    id: z.string(),
+    qty: z.coerce.number().int().min(1),
+  })
+  .strict();
+


### PR DESCRIPTION
## Summary
- centralize cart schemas in platform core
- reuse shared cart schemas across apps
- return validation field errors when schema parsing fails

## Testing
- `pnpm test` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_6898f21ab11c832f848fcb224a28152a