### PR TITLE
feat: add live feedback region for media uploads

### DIFF
--- a/packages/ui/__tests__/MediaManager.a11y.test.tsx
+++ b/packages/ui/__tests__/MediaManager.a11y.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import MediaManager from "@ui/components/cms/MediaManager";
+
+jest.mock("@ui/hooks/useMediaUpload", () => ({
+  useMediaUpload: () => ({
+    pendingFile: null,
+    altText: "",
+    setAltText: jest.fn(),
+    actual: null,
+    isValid: null,
+    progress: null,
+    error: "Upload failed",
+    inputRef: { current: null },
+    openFileDialog: jest.fn(),
+    onDrop: jest.fn(),
+    onFileChange: jest.fn(),
+    handleUpload: jest.fn(),
+  }),
+}));
+
+describe("MediaManager accessibility", () => {
+  it("links drop zone to live feedback region", () => {
+    render(<MediaManager shop="s" initialFiles={[]} onDelete={jest.fn()} />);
+    const dropzone = screen.getByRole("button", { name: /drop image/i });
+    const status = screen.getByRole("status");
+    expect(dropzone).toHaveAttribute("aria-describedby", status.id);
+    expect(status).toHaveTextContent("Upload failed");
+  });
+});

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -33,6 +33,7 @@ function MediaManagerBase({
 }: Props): ReactElement {
   const [files, setFiles] = useState<MediaItem[]>(initialFiles);
   const [dragActive, setDragActive] = useState(false);
+  const feedbackId = "media-manager-feedback";
 
   /* ---------------------------------------------------------------------- */
   /*  Delete handler (stable)                                               */
@@ -80,6 +81,7 @@ function MediaManagerBase({
         tabIndex={0}
         role="button"
         aria-label="Drop image here or press Enter to browse"
+        aria-describedby={feedbackId}
         onDrop={(e) => {
           onDrop(e);
           setDragActive(false);
@@ -110,42 +112,44 @@ function MediaManagerBase({
       </div>
 
       {/* Validation / progress feedback */}
-      {error && <p className="text-sm text-danger">{error}</p>}
-      {progress && (
-        <p className="text-sm text-muted">
-          Uploaded {progress.done}/{progress.total}
-        </p>
-      )}
-      {pendingFile && isValid !== null && (
-        <div className="space-y-2">
-          <p
-            className={
-              isValid ? "text-sm text-success" : "text-sm text-danger"
-            }
-          >
-            {isValid
-              ? `Image orientation is ${actual}; requirement satisfied.`
-              : `Selected image is ${actual}; please upload a ${REQUIRED_ORIENTATION} image.`}
+      <div id={feedbackId} role="status" aria-live="polite" className="space-y-2">
+        {error && <p className="text-sm text-danger">{error}</p>}
+        {progress && (
+          <p className="text-sm text-muted">
+            Uploaded {progress.done}/{progress.total}
           </p>
-          {isValid && (
-            <div className="flex gap-2">
-              <Input
-                type="text"
-                value={altText}
-                onChange={(e) => setAltText(e.target.value)}
-                placeholder="Alt text"
-                className="flex-1"
-              />
-              <button
-                onClick={handleUpload}
-                className="rounded bg-primary px-2 text-sm text-primary-fg"
-              >
-                Upload
-              </button>
-            </div>
-          )}
-        </div>
-      )}
+        )}
+        {pendingFile && isValid !== null && (
+          <div className="space-y-2">
+            <p
+              className={
+                isValid ? "text-sm text-success" : "text-sm text-danger"
+              }
+            >
+              {isValid
+                ? `Image orientation is ${actual}; requirement satisfied.`
+                : `Selected image is ${actual}; please upload a ${REQUIRED_ORIENTATION} image.`}
+            </p>
+            {isValid && (
+              <div className="flex gap-2">
+                <Input
+                  type="text"
+                  value={altText}
+                  onChange={(e) => setAltText(e.target.value)}
+                  placeholder="Alt text"
+                  className="flex-1"
+                />
+                <button
+                  onClick={handleUpload}
+                  className="rounded bg-primary px-2 text-sm text-primary-fg"
+                >
+                  Upload
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* File list */}
       {files.length > 0 && (

--- a/packages/ui/src/hooks/useMediaUpload.tsx
+++ b/packages/ui/src/hooks/useMediaUpload.tsx
@@ -71,6 +71,7 @@ export function useImageUpload(
   const [error, setError] = useState<string>();
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
+  const feedbackId = "uploader-feedback";
 
   /* ---------- orientation check ----------------------------------- */
   const { actual, isValid } = useImageOrientationValidation(
@@ -132,6 +133,7 @@ export function useImageUpload(
       tabIndex={0}
       role="button"
       aria-label="Drop image here or press Enter to browse"
+      aria-describedby={feedbackId}
       onDragOver={(e) => e.preventDefault()}
       onDragEnter={() => setDragActive(true)}
       onDragLeave={() => setDragActive(false)}
@@ -164,22 +166,24 @@ export function useImageUpload(
         Browse…
       </button>
 
-      {pendingFile && (
-        <p className="mt-2 text-sm text-muted-foreground">{pendingFile.name}</p>
-      )}
+      <div id={feedbackId} role="status" aria-live="polite">
+        {pendingFile && (
+          <p className="mt-2 text-sm text-muted-foreground">{pendingFile.name}</p>
+        )}
 
-      {progress && (
-        <p className="mt-2 text-sm">
-          Uploading… {progress.done}/{progress.total}
-        </p>
-      )}
+        {progress && (
+          <p className="mt-2 text-sm">
+            Uploading… {progress.done}/{progress.total}
+          </p>
+        )}
 
-      {error && <p className="mt-2 text-sm text-danger">{error}</p>}
-      {isValid === false && (
-        <p className="mt-2 text-sm text-warning">
-          Wrong orientation (needs {requiredOrientation})
-        </p>
-      )}
+        {error && <p className="mt-2 text-sm text-danger">{error}</p>}
+        {isValid === false && (
+          <p className="mt-2 text-sm text-warning">
+            Wrong orientation (needs {requiredOrientation})
+          </p>
+        )}
+      </div>
     </div>
   );
 


### PR DESCRIPTION
## Summary
- add `aria-live` status region to MediaManager's upload drop zone
- wire up built-in media uploader with descriptive feedback
- cover association with a11y test

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@\components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6898f23b057c832faeaaee4b1e1097cd