### PR TITLE
feat: generate sitemap and robots with hreflang

### DIFF
--- a/doc/seo.md
+++ b/doc/seo.md
@@ -18,3 +18,16 @@ To leverage caching:
 curl -i "https://example.com/api/ai/catalog" \
   -H "If-Modified-Since: <timestamp>"
 ```
+
+## Regenerating sitemaps
+
+`sitemap.xml` is generated from the files in `src/app/sitemap.ts`. When products
+or shop settings change, rebuild the app to refresh the sitemap:
+
+```bash
+pnpm --filter @acme/template-app build
+# for a specific shop:
+pnpm --filter @apps/<shop-id> build
+```
+
+During development, requesting `/sitemap.xml` will always serve the latest data.

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -42,6 +42,14 @@ export function writeFiles(
   newData: string
 ): void {
   copyTemplate(templateApp, newApp);
+  cpSync(
+    join(templateApp, "src", "app", "sitemap.ts"),
+    join(newApp, "src", "app", "sitemap.ts")
+  );
+  cpSync(
+    join(templateApp, "src", "app", "robots.ts"),
+    join(newApp, "src", "app", "robots.ts")
+  );
   // ensure PostCSS setup is available in the generated shop
   cpSync("postcss.config.cjs", join(newApp, "postcss.config.cjs"));
   const pkgPath = join(newApp, "package.json");

--- a/packages/template-app/__tests__/sitemap.test.ts
+++ b/packages/template-app/__tests__/sitemap.test.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+
+const getShopSettingsMock = jest.fn().mockResolvedValue({ languages: ["en", "de"] });
+const readRepoMock = jest.fn().mockResolvedValue([
+  { id: "p1", slug: "shoe", updated_at: "2024-01-01T00:00:00Z" },
+]);
+
+jest.mock("@platform-core/src/repositories/settings.server", () => ({
+  getShopSettings: getShopSettingsMock,
+}));
+
+jest.mock("@platform-core/src/repositories/products.server", () => ({
+  readRepo: readRepoMock,
+}));
+
+describe("sitemap generation", () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://example.com";
+    process.env.NEXT_PUBLIC_SHOP_ID = "shop1";
+  });
+
+  it("builds URLs with hreflang alternates", async () => {
+    const { default: sitemap } = await import("../src/app/sitemap");
+    const entries = (await sitemap()) as MetadataRoute.Sitemap;
+    expect(getShopSettingsMock).toHaveBeenCalledWith("shop1");
+    expect(readRepoMock).toHaveBeenCalledWith("shop1");
+    const home = entries.find((e) => e.url === "https://example.com/en");
+    expect(home?.alternates?.languages?.de).toBe("https://example.com/de");
+    const product = entries.find((e) => e.url.endsWith("/product/shoe"));
+    expect(product?.alternates?.languages?.de).toBe(
+      "https://example.com/de/product/shoe"
+    );
+  });
+});
+

--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -4,12 +4,11 @@ export default function robots(): MetadataRoute.Robots {
   const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   return {
     rules: [
-      {
-        userAgent: "*",
-        allow: ["/", "/api/ai/catalog"],
-      },
+      { userAgent: "*", allow: "/" },
+      { userAgent: "GPTBot", allow: "/" },
+      { userAgent: "ClaudeBot", allow: "/" },
     ],
     sitemap: `${base}/sitemap.xml`,
-    additionalSitemaps: [`${base}/api/ai/catalog`],
+    additionalSitemaps: [`${base}/ai-sitemap.xml`],
   };
 }

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -1,10 +1,43 @@
 import type { MetadataRoute } from "next";
+import { getShopSettings } from "@platform-core/src/repositories/settings.server";
+import { readRepo } from "@platform-core/src/repositories/products.server";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const shop = process.env.NEXT_PUBLIC_SHOP_ID || "shop";
   const now = new Date().toISOString();
-  return [
-    { url: `${base}/`, lastModified: now },
-    { url: `${base}/api/ai/catalog`, lastModified: now },
+
+  const [settings, products] = await Promise.all([
+    getShopSettings(shop),
+    readRepo<Record<string, unknown>>(shop),
+  ]);
+  const languages = settings.languages ?? ["en"];
+
+  const buildAlternates = (path: string) => {
+    const map: Record<string, string> = {};
+    for (const lang of languages) {
+      map[lang] = `${base}/${lang}${path}`;
+    }
+    return { languages: map };
+  };
+
+  const entries: MetadataRoute.Sitemap = [
+    {
+      url: `${base}/${languages[0]}`,
+      lastModified: now,
+      alternates: buildAlternates(""),
+    },
   ];
+
+  for (const product of products) {
+    const slug = (product as any).slug || (product as any).id;
+    if (!slug) continue;
+    entries.push({
+      url: `${base}/${languages[0]}/product/${slug}`,
+      lastModified: (product as any).updated_at || now,
+      alternates: buildAlternates(`/product/${slug}`),
+    });
+  }
+
+  return entries;
 }


### PR DESCRIPTION
## Summary
- generate sitemap from shop settings and product data with hreflang alternates
- advertise sitemap and AI-specific rules in robots
- scaffold new shops with sitemap and robots files and document regeneration steps

## Testing
- `pnpm exec jest packages/template-app/__tests__/sitemap.test.ts --config jest.config.cjs`
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_6898f6d55df4832f8b5505f6f3d77716