### PR TITLE
refactor: centralize i18n parsing

### DIFF
--- a/packages/i18n/__tests__/parseMultilingualInput.test.ts
+++ b/packages/i18n/__tests__/parseMultilingualInput.test.ts
@@ -1,0 +1,20 @@
+import { parseMultilingualInput } from "@acme/i18n";
+
+describe("parseMultilingualInput", () => {
+  const locales = ["en", "de", "it"] as const;
+
+  it("detects field and locale from name", () => {
+    expect(parseMultilingualInput("title_en", locales)).toEqual({
+      field: "title",
+      locale: "en",
+    });
+    expect(parseMultilingualInput("desc_de", locales)).toEqual({
+      field: "desc",
+      locale: "de",
+    });
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseMultilingualInput("foo_en", locales)).toBeNull();
+  });
+});

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -4,3 +4,4 @@ export * from "./locales";
 export { assertLocales, LOCALES } from "./locales";
 export { default as TranslationsProvider } from "./Translations";
 export { fillLocales } from "./fillLocales";
+export { parseMultilingualInput, type MultilingualField } from "./parseMultilingualInput";

--- a/packages/i18n/src/parseMultilingualInput.ts
+++ b/packages/i18n/src/parseMultilingualInput.ts
@@ -1,4 +1,5 @@
-import type { Locale } from "@i18n/locales";
+// packages/i18n/src/parseMultilingualInput.ts
+import type { Locale } from "./locales";
 
 export interface MultilingualField {
   field: "title" | "desc";

--- a/packages/ui/src/hooks/useProductEditorFormState.tsx
+++ b/packages/ui/src/hooks/useProductEditorFormState.tsx
@@ -2,7 +2,7 @@
 import type { Locale, ProductPublication } from "@platform-core/src/products";
 import { useImageUpload } from "@ui/hooks/useImageUpload";
 import { usePublishLocations } from "@ui/hooks/usePublishLocations";
-import { parseMultilingualInput } from "@ui/utils/i18n";
+import { parseMultilingualInput } from "@i18n/parseMultilingualInput";
 import {
   useCallback,
   useMemo,

--- a/packages/ui/src/utils/__tests__/utils.test.ts
+++ b/packages/ui/src/utils/__tests__/utils.test.ts
@@ -1,5 +1,4 @@
 import { boxProps, cn, drawerWidthProps } from "../style";
-import { parseMultilingualInput } from "../i18n";
 
 describe("cn", () => {
   it("filters out falsey values", () => {
@@ -37,23 +36,5 @@ describe("drawerWidthProps", () => {
     const result = drawerWidthProps(250);
     expect(result.widthClass).toBeUndefined();
     expect(result.style).toEqual({ width: 250 });
-  });
-});
-
-describe("parseMultilingualInput", () => {
-  const locales = ["en", "de", "it"] as const;
-  it("detects field and locale from name", () => {
-    expect(parseMultilingualInput("title_en", locales)).toEqual({
-      field: "title",
-      locale: "en",
-    });
-    expect(parseMultilingualInput("desc_de", locales)).toEqual({
-      field: "desc",
-      locale: "de",
-    });
-  });
-
-  it("returns null for invalid input", () => {
-    expect(parseMultilingualInput("foo_en", locales)).toBeNull();
   });
 });

--- a/packages/ui/src/utils/i18n/index.ts
+++ b/packages/ui/src/utils/i18n/index.ts
@@ -1,1 +1,0 @@
-export * from './multilingual';

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,2 +1,1 @@
 export * from './style';
-export * from './i18n';

--- a/test/unit/locales-regression.spec.ts
+++ b/test/unit/locales-regression.spec.ts
@@ -3,7 +3,7 @@
 import { resolveLocale } from "@i18n/locales";
 import { assertLocale } from "@platform-core/src/products";
 import { LOCALES, type Locale } from "@types";
-import { parseMultilingualInput } from "@ui/utils/i18n";
+import { parseMultilingualInput } from "@i18n/parseMultilingualInput";
 import { getSeo } from "../../packages/template-app/src/lib/seo";
 
 jest.mock("@platform-core/repositories/shops.server", () => ({


### PR DESCRIPTION
## Summary
- move `parseMultilingualInput` from UI utilities into the `i18n` package
- update consumers and tests to use `@i18n/parseMultilingualInput`
- clean up old UI test exports

## Testing
- `pnpm --filter @acme/i18n test` *(fails: Cannot find module '@/components/atoms')*
- `npx jest test/unit/locales-regression.spec.ts` *(fails: TypeError: Cannot read properties of undefined (reading 'forEach'))*


------
https://chatgpt.com/codex/tasks/task_e_6898f14672b0832f96b5ba375592d3ef