### PR TITLE
Refactor createShop option types with zod inference

### DIFF
--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -4,10 +4,7 @@ import { readdirSync } from "fs";
 import { join } from "path";
 import { prisma } from "./db";
 import { validateShopName } from "./shops";
-import {
-  prepareOptions,
-  type CreateShopOptions,
-} from "./createShop/schema";
+import { prepareOptions, type CreateShopOptions } from "./createShop/schema";
 import { loadTokens } from "./createShop/themeUtils";
 
 /**
@@ -161,6 +158,7 @@ export function syncTheme(shop: string, theme: string): Record<string, string> {
 }
 
 export { prepareOptions, createShopOptionsSchema } from "./createShop/schema";
+export type { CreateShopOptions, PreparedCreateShopOptions } from "./createShop/schema";
 export { ensureTemplateExists, writeFiles, copyTemplate } from "./createShop/fsUtils";
 export { loadTokens, loadBaseTokens } from "./createShop/themeUtils";
 export { syncTheme };

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -1,12 +1,11 @@
-import type { Locale, PageComponent } from "@types";
 import { localeSchema } from "@types";
 import { pageComponentSchema } from "@types/Page";
 import { z } from "zod";
 import { slugify } from "@shared-utils";
 import { fillLocales } from "@i18n/fillLocales";
-import { defaultPaymentProviders, type DefaultPaymentProvider } from "./defaultPaymentProviders";
-import { defaultShippingProviders, type DefaultShippingProvider } from "./defaultShippingProviders";
-import { defaultTaxProviders, type DefaultTaxProvider } from "./defaultTaxProviders";
+import { defaultPaymentProviders } from "./defaultPaymentProviders";
+import { defaultShippingProviders } from "./defaultShippingProviders";
+import { defaultTaxProviders } from "./defaultTaxProviders";
 
 export const createShopOptionsSchema = z.object({
   name: z.string().optional(),
@@ -43,43 +42,15 @@ export const createShopOptionsSchema = z.object({
     )
     .default([]),
   checkoutPage: z.array(pageComponentSchema).default([]),
-});
+}).strict();
+export type CreateShopOptions = z.infer<typeof createShopOptionsSchema>;
 
-export interface CreateShopOptions {
-  name?: string;
-  logo?: string;
-  contactInfo?: string;
-  type?: "sale" | "rental";
-  theme?: string;
-  template?: string;
-  payment?: DefaultPaymentProvider[];
-  shipping?: DefaultShippingProvider[];
-  tax?: DefaultTaxProvider;
-  pageTitle?: Partial<Record<Locale, string>>;
-  pageDescription?: Partial<Record<Locale, string>>;
-  socialImage?: string;
-  analytics?: {
-    enabled?: boolean;
-    provider: string;
-    id?: string;
-  };
-  navItems?: { label: string; url: string }[];
-  pages?: {
-    slug: string;
-    title: Partial<Record<Locale, string>>;
-    description?: Partial<Record<Locale, string>>;
-    image?: Partial<Record<Locale, string>>;
-    components: PageComponent[];
-  }[];
-  checkoutPage?: PageComponent[];
-}
-
-export interface PreparedCreateShopOptions extends Required<
+export type PreparedCreateShopOptions = Required<
   Omit<CreateShopOptions, "analytics" | "checkoutPage">
-> {
+> & {
   analytics?: CreateShopOptions["analytics"];
-  checkoutPage: PageComponent[];
-}
+  checkoutPage: Required<CreateShopOptions>["checkoutPage"];
+};
 
 /** Parse and populate option defaults. */
 export function prepareOptions(


### PR DESCRIPTION
## Summary
- enforce strict validation on `createShopOptionsSchema`
- derive `CreateShopOptions` and `PreparedCreateShopOptions` from schema
- re-export inferred option types for consumers

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6898f2143f04832f8399482b7169da90