### PR TITLE
Export cart state types from cartCookie

### DIFF
--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -1,6 +1,11 @@
 // apps/shop-abc/src/app/api/checkout-session/route.ts
 
-import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+  type CartLine,
+  type CartState,
+} from "@/lib/cartCookie";
 import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer";
 import { getCustomerSession } from "@auth";
@@ -8,7 +13,6 @@ import { priceForDays, convertCurrency } from "@platform-core/pricing";
 import { findCoupon } from "@platform-core/coupons";
 import { getTaxRate } from "@platform-core/tax";
 
-import type { CartLine, CartState } from "@types";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -1,13 +1,17 @@
 // apps/shop-bcd/src/app/api/checkout-session/route.ts
 
-import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+  type CartLine,
+  type CartState,
+} from "@/lib/cartCookie";
 import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer.server";
 import { getCustomerSession } from "@auth";
 import { priceForDays, convertCurrency } from "@platform-core/pricing";
 import { findCoupon } from "@platform-core/coupons";
 import { getTaxRate } from "@platform-core/tax";
-import type { CartLine, CartState } from "@types";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 

--- a/packages/platform-core/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/__tests__/cartCookie.test.ts
@@ -1,16 +1,28 @@
 // packages/platform-core/__tests__/cartCookie.test.ts
-import type { CartState } from "@types";
 import {
   asSetCookieHeader,
   CART_COOKIE,
   decodeCartCookie,
   encodeCartCookie,
-} from "../cartCookie";
-import { PRODUCTS } from "../products";
+  type CartState,
+} from "../src/cartCookie";
+
+const sku = {
+  id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  slug: "sample",
+  title: "Sample",
+  price: 100,
+  deposit: 10,
+  forSale: true,
+  forRental: false,
+  image: "/img.png",
+  sizes: [],
+  description: "",
+};
 
 describe("cart cookie helpers", () => {
   const state: CartState = {
-    [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 2 },
+    [sku.id]: { sku, qty: 2 },
   };
 
   it("encodes and decodes the cart", () => {

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -1,7 +1,6 @@
 // packages/platform-core/src/cartCookie.ts
 import { z } from "zod";
 
-import type { CartState } from "@types";
 import { skuSchema } from "@types";
 
 /* ------------------------------------------------------------------
@@ -30,6 +29,9 @@ export const cartLineSchema = z.object({
  * Schema for the full cart, keyed by SKU ID (string).
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
+
+export type CartLine = z.infer<typeof cartLineSchema>;
+export type CartState = z.infer<typeof cartStateSchema>;
 
 /* ------------------------------------------------------------------
  * Helper functions

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -6,9 +6,10 @@ import {
   CART_COOKIE,
   decodeCartCookie,
   encodeCartCookie,
+  type CartState,
 } from "../cartCookie";
 
-import type { CartState, SKU } from "@types";
+import type { SKU } from "@types";
 import {
   createContext,
   ReactNode,

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1,4 +1,5 @@
-export type { Locale } from "@acme/i18n";
+export const LOCALES = ["en", "de", "it"] as const;
+export type Locale = (typeof LOCALES)[number];
 
 export const ROLES = [
   "admin",

--- a/packages/ui/__tests__/OrderSummary.test.tsx
+++ b/packages/ui/__tests__/OrderSummary.test.tsx
@@ -1,8 +1,8 @@
 import { CartProvider } from "@/contexts/CartContext";
 import { CART_COOKIE, encodeCartCookie } from "@/lib/cartCookie";
 import { render, screen } from "@testing-library/react";
-import type { CartState } from "@types";
-import OrderSummary from "../components/organisms/OrderSummary";
+import type { CartState } from "@/lib/cartCookie";
+import OrderSummary from "../src/components/organisms/OrderSummary";
 
 const mockCart: CartState = {
   a: {

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -1,6 +1,7 @@
 import { CartProvider, useCart } from "@platform-core/src/contexts/CartContext";
 import { type Meta, type StoryObj } from "@storybook/react";
-import type { CartState, SKU } from "@types";
+import type { CartState } from "@/lib/cartCookie";
+import type { SKU } from "@types";
 import * as React from "react";
 import { Button } from "../atoms/shadcn";
 import { MiniCart } from "./MiniCart.client";

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useCart } from "@ui/hooks/useCart";
-import type { CartLine } from "@types";
+import type { CartLine } from "@/lib/cartCookie";
 import React, { useMemo } from "react";
 
 /**

--- a/packages/ui/src/components/templates/CartTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from "@storybook/react";
-import type { CartState } from "@types";
+import type { CartState } from "@/lib/cartCookie";
 import { CartTemplate } from "./CartTemplate";
 
 const cart: CartState = {

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -1,4 +1,4 @@
-import type { CartState } from "@types";
+import type { CartState } from "@/lib/cartCookie";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from "@storybook/react";
-import type { CartState } from "@types";
+import type { CartState } from "@/lib/cartCookie";
 import { OrderConfirmationTemplate } from "./OrderConfirmationTemplate";
 
 const cart: CartState = {

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -1,4 +1,4 @@
-import type { CartState } from "@types";
+import type { CartState } from "@/lib/cartCookie";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Price } from "../atoms/Price";


### PR DESCRIPTION
## Summary
- expose CartLine and CartState in cartCookie using zod inference
- switch consumers to import cart types from cartCookie instead of @types
- define LOCALES constant in types package for tests

## Testing
- `npx jest packages/platform-core/__tests__/cartCookie.test.ts` (passed)
- `npx jest packages/ui/__tests__/OrderSummary.test.tsx` (failed: Invalid hook call - useReducer)`

------
https://chatgpt.com/codex/tasks/task_e_6898f21bf45c832f9f5f27bb7e35ff87