### PR TITLE
chore: remove duplicate block exports

### DIFF
--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -11,7 +11,6 @@ import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
-import { NewsletterForm, PromoBanner, CategoryList } from "./molecules";
 
 export {
   BlogListing,
@@ -26,9 +25,6 @@ export {
   Testimonials,
   TestimonialSlider,
   ValueProps,
-  NewsletterForm,
-  PromoBanner,
-  CategoryList,
   Section,
 };
 

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -10,7 +10,6 @@ import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
-import { CategoryList, NewsletterForm, PromoBanner } from "./molecules";
 
 export const organismRegistry = {
   HeroBanner,
@@ -23,9 +22,6 @@ export const organismRegistry = {
   ContactForm,
   ContactFormWithMap,
   BlogListing,
-  NewsletterForm,
-  PromoBanner,
-  CategoryList,
   Testimonials,
   TestimonialSlider,
 } as const;


### PR DESCRIPTION
## Summary
- avoid importing NewsletterForm, PromoBanner, CategoryList into organism registry
- rely on molecule registry for these blocks

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms')*

------
https://chatgpt.com/codex/tasks/task_e_6898f9121874832fa41a9b3e929e0dad