### PR TITLE
feat: add min/max item support to CMS blocks

### DIFF
--- a/packages/ui/__tests__/TestimonialSlider.test.tsx
+++ b/packages/ui/__tests__/TestimonialSlider.test.tsx
@@ -1,7 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import TestimonialSlider from "../components/cms/blocks/TestimonialSlider";
 
 describe("TestimonialSlider", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("shows first testimonial", () => {
     render(
       <TestimonialSlider
@@ -12,5 +19,29 @@ describe("TestimonialSlider", () => {
       />
     );
     expect(screen.getByText("Great")).toBeInTheDocument();
+  });
+
+  it("returns null when below minItems", () => {
+    const { container } = render(
+      <TestimonialSlider testimonials={[{ quote: "Only" }]} minItems={2} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("clamps testimonials to maxItems", () => {
+    render(
+      <TestimonialSlider
+        testimonials={[
+          { quote: "Great", name: "A" },
+          { quote: "Nice", name: "B" },
+        ]}
+        maxItems={1}
+      />
+    );
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+    expect(screen.getByText("Great")).toBeInTheDocument();
+    expect(screen.queryByText("Nice")).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/__tests__/Testimonials.test.tsx
+++ b/packages/ui/__tests__/Testimonials.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import Testimonials from "../src/components/cms/blocks/Testimonials";
+
+describe("Testimonials", () => {
+  it("clamps to maxItems", () => {
+    render(
+      <Testimonials
+        testimonials={[
+          { quote: "A", name: "A" },
+          { quote: "B", name: "B" },
+        ]}
+        maxItems={1}
+      />
+    );
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.queryByText("B")).not.toBeInTheDocument();
+  });
+
+  it("returns null when below minItems", () => {
+    const { container } = render(
+      <Testimonials testimonials={[{ quote: "A", name: "A" }]} minItems={2} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/HeroBanner.tsx
+++ b/packages/ui/src/components/cms/blocks/HeroBanner.tsx
@@ -1,5 +1,17 @@
 import HeroBanner, { type Slide } from "../../home/HeroBanner.client";
 
-export default function CmsHeroBanner(props: { slides?: Slide[] }) {
-  return <HeroBanner {...props} />;
+interface Props {
+  slides?: Slide[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function CmsHeroBanner({
+  slides = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = slides.slice(0, maxItems ?? slides.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+  return <HeroBanner slides={list} />;
 }

--- a/packages/ui/src/components/cms/blocks/ReviewsCarousel.tsx
+++ b/packages/ui/src/components/cms/blocks/ReviewsCarousel.tsx
@@ -1,5 +1,17 @@
 import ReviewsCarousel, { type Review } from "../../home/ReviewsCarousel";
 
-export default function CmsReviewsCarousel(props: { reviews?: Review[] }) {
-  return <ReviewsCarousel {...props} />;
+interface Props {
+  reviews?: Review[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function CmsReviewsCarousel({
+  reviews = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = reviews.slice(0, maxItems ?? reviews.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+  return <ReviewsCarousel reviews={list} />;
 }

--- a/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
+++ b/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
@@ -5,21 +5,26 @@ export type SliderTestimonial = { quote: string; name?: string };
 
 export default function TestimonialSlider({
   testimonials = [],
+  minItems,
+  maxItems,
 }: {
   testimonials?: SliderTestimonial[];
+  minItems?: number;
+  maxItems?: number;
 }) {
+  const list = testimonials.slice(0, maxItems ?? testimonials.length);
   const [i, setI] = useState(0);
   useEffect(() => {
-    if (!testimonials.length) return;
+    if (!list.length) return;
     const id = setInterval(
-      () => setI((n) => (n + 1) % testimonials.length),
+      () => setI((n) => (n + 1) % list.length),
       5000
     );
     return () => clearInterval(id);
-  }, [testimonials.length]);
+  }, [list.length]);
 
-  if (!testimonials.length) return null;
-  const t = testimonials[i];
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+  const t = list[i % list.length];
   return (
     <section className="space-y-2 text-center">
       <blockquote className="italic">“{t.quote}”</blockquote>

--- a/packages/ui/src/components/cms/blocks/Testimonials.tsx
+++ b/packages/ui/src/components/cms/blocks/Testimonials.tsx
@@ -4,13 +4,18 @@ export type Testimonial = { quote: string; name?: string };
 
 export default function Testimonials({
   testimonials = [],
+  minItems,
+  maxItems,
 }: {
   testimonials?: Testimonial[];
+  minItems?: number;
+  maxItems?: number;
 }) {
-  if (!testimonials.length) return null;
+  const list = testimonials.slice(0, maxItems ?? testimonials.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
   return (
     <section className="space-y-4">
-      {testimonials.map((t, i) => (
+      {list.map((t, i) => (
         <blockquote key={i} className="text-center">
           <p className="mb-2 italic">“{t.quote}”</p>
           {t.name && (

--- a/packages/ui/src/components/cms/blocks/ValueProps.tsx
+++ b/packages/ui/src/components/cms/blocks/ValueProps.tsx
@@ -1,6 +1,18 @@
 // packages/ui/components/cms/blocks/ValueProps.tsx
 import { ValueProps, type ValuePropItem } from "../../home/ValueProps";
 
-export default function CmsValueProps(props: { items?: ValuePropItem[] }) {
-  return <ValueProps {...props} />;
+interface Props {
+  items?: ValuePropItem[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function CmsValueProps({
+  items = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = items.slice(0, maxItems ?? items.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+  return <ValueProps items={list} />;
 }


### PR DESCRIPTION
## Summary
- allow HeroBanner, ValueProps, ReviewsCarousel, Testimonials, and TestimonialSlider blocks to accept `minItems` and `maxItems`
- clamp rendered lists to provided limits and skip rendering when below minimum
- add tests for testimonial blocks

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*
- `pnpm --filter @acme/ui lint` *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_6898f8f95b44832fb824e643fdbd4662