### PR TITLE
feat: generate locale-specific canonical and hreflang links

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditor.tsx
@@ -52,11 +52,11 @@ export default function SeoEditor({
   const handleLocaleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const l = e.target.value as Locale;
     setLocale(l);
+    setCanonicalBase(initialSeo[l]?.canonicalBase ?? "");
     if (!freeze) {
       setTitle(initialSeo[l]?.title ?? "");
       setDescription(initialSeo[l]?.description ?? "");
       setImage(initialSeo[l]?.image ?? "");
-      setCanonicalBase(initialSeo[l]?.canonicalBase ?? "");
       setOgUrl(initialSeo[l]?.ogUrl ?? "");
       setTwitterCard(initialSeo[l]?.twitterCard ?? "");
     }

--- a/packages/template-app/src/app/[lang]/checkout/layout.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/layout.tsx
@@ -33,7 +33,7 @@ export default async function LocaleLayout({
 
   return (
     <TranslationsProvider messages={messages}>
-      <DefaultSeo {...seo} />
+      <DefaultSeo {...seo} additionalLinkTags={seo.additionalLinkTags} />
       <Header lang={lang} />
       <main className="min-h-[calc(100vh-8rem)]">{children}</main>
       <Footer />


### PR DESCRIPTION
## Summary
- compute canonical URL variants and hreflang alternates for all locales
- expose hreflang links in layout via next-seo
- allow editing canonicalBase per locale even when translations are frozen
- cover getSeo canonical and hreflang behavior with tests

## Testing
- `npx jest test/unit/seo-validation.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6898f9f5c220832f9a0e5f13be749c05