### PR TITLE
Use server API for cart updates

### DIFF
--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -1,14 +1,16 @@
 // packages/platform-core/__tests__/addToCartButton.test.tsx
 
 import { CartProvider, useCart } from "@/contexts/CartContext";
-import AddToCartButton from "@platform-core/components/shop/AddToCartButton.client";
+import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { PRODUCTS } from "@platform-core/products";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 jest.mock("@/lib/cartCookie", () => jest.requireActual("@/lib/cartCookie"));
 jest.mock("@/contexts/CartContext", () =>
   jest.requireActual("@/contexts/CartContext")
 );
+jest.mock("react", () => jest.requireActual("react"));
+jest.mock("react-dom", () => jest.requireActual("react-dom"));
 
 function Qty() {
   const [state] = useCart();
@@ -16,7 +18,17 @@ function Qty() {
 }
 
 describe("AddToCartButton", () => {
-  it("adds items to the cart", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("adds items to the cart", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => ({ ok: true }) })
+    ) as any;
+
     render(
       <CartProvider>
         <AddToCartButton sku={PRODUCTS[0]} />
@@ -29,6 +41,32 @@ describe("AddToCartButton", () => {
 
     fireEvent.click(btn);
 
-    expect(screen.getByTestId("qty").textContent).toBe("1");
+    await waitFor(() =>
+      expect(screen.getByTestId("qty").textContent).toBe("1")
+    );
+  });
+
+  it("shows an error when the server rejects the request", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        json: async () => ({ error: "Out of stock" }),
+      })
+    ) as any;
+
+    render(
+      <CartProvider>
+        <AddToCartButton sku={PRODUCTS[0]} />
+        <Qty />
+      </CartProvider>
+    );
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() =>
+      expect(screen.getByText("Out of stock")).toBeInTheDocument()
+    );
+    expect(screen.getByTestId("qty").textContent).toBe("0");
   });
 });

--- a/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
+++ b/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
@@ -20,23 +20,50 @@ export default function AddToCartButton({
 }: Props) {
   const [, dispatch] = useCart();
   const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function handleClick() {
     if (disabled) return;
     setAdding(true);
-    dispatch({ type: "add", sku, size });
-    /* fake latency for UX feedback */
-    await new Promise((r) => setTimeout(r, 300));
-    setAdding(false);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/cart", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sku, qty: 1 }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError((data as { error?: string }).error ?? "Unable to add to cart");
+        return;
+      }
+
+      dispatch({ type: "add", sku, size });
+      /* fake latency for UX feedback */
+      await new Promise((r) => setTimeout(r, 300));
+    } catch {
+      setError("Unable to add to cart");
+    } finally {
+      setAdding(false);
+    }
   }
 
   return (
-    <button
-      onClick={handleClick}
-      disabled={adding || disabled}
-      className="mt-auto rounded bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-800 disabled:opacity-50"
-    >
-      {adding ? "✓" : "Add to cart"}
-    </button>
+    <>
+      <button
+        onClick={handleClick}
+        disabled={adding || disabled}
+        className="mt-auto rounded bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-800 disabled:opacity-50"
+      >
+        {adding ? "✓" : "Add to cart"}
+      </button>
+      {error && (
+        <p className="mt-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add server call to `/api/cart` in AddToCartButton and surface errors to the user
- extend AddToCartButton tests for success and failure scenarios

## Testing
- `pnpm exec jest packages/platform-core/__tests__/addToCartButton.test.tsx --config jest.config.cjs` *(fails: A React Element from an older version of React was rendered. This can happen with multiple React versions.)*

------
https://chatgpt.com/codex/tasks/task_e_6898fa0ddb24832fadd80d6df1e5a07a