### PR TITLE
feat: secure cart cookie

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -18,6 +18,7 @@ const mutableEnv = process.env as unknown as Record<string, string>;
 
 mutableEnv.NODE_ENV ||= "development"; // relax “edge” runtime checks
 mutableEnv.NEXTAUTH_SECRET ||= "test-secret"; // dummy secret for Next-Auth
+mutableEnv.CART_COOKIE_SECRET ||= "test-secret"; // dummy secret for cart cookie signing
 
 /* -------------------------------------------------------------------------- */
 /* 2.  Polyfills missing from the JSDOM / Node test runtime                    */


### PR DESCRIPTION
## Summary
- append `Secure` and `HttpOnly` flags to cart cookie headers
- sign cart cookie values to prevent tampering
- add tests for signed cart cookies and update test setup

## Testing
- `npx jest --config jest.config.cjs packages/platform-core/__tests__/cartCookie.test.ts --runTestsByPath`
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '.prisma/client/index-browser.js')*

------
https://chatgpt.com/codex/tasks/task_e_6898fa0bdc5c832f92511828ac86f568