### PR TITLE
Setup Sanity blog when saving config

### DIFF
--- a/apps/cms/__tests__/saveSanityConfig.test.ts
+++ b/apps/cms/__tests__/saveSanityConfig.test.ts
@@ -1,0 +1,72 @@
+import { saveSanityConfig } from "../src/actions/saveSanityConfig";
+import { verifyCredentials } from "@acme/plugin-sanity";
+import { setupSanityBlog } from "../src/actions/setupSanityBlog";
+
+jest.mock("../src/actions/common/auth", () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+jest.mock("@acme/plugin-sanity", () => ({
+  verifyCredentials: jest.fn(),
+}));
+
+jest.mock("../src/actions/setupSanityBlog", () => ({
+  setupSanityBlog: jest.fn(),
+}));
+
+jest.mock("@platform-core/dataRoot", () => ({
+  resolveDataRoot: jest.fn(() => "/tmp/data/shops"),
+}));
+
+jest.mock("node:fs", () => ({
+  promises: {
+    mkdir: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe("saveSanityConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls setupSanityBlog after verifying credentials", async () => {
+    (verifyCredentials as jest.Mock).mockResolvedValue(true);
+    (setupSanityBlog as jest.Mock).mockResolvedValue({ success: true });
+
+    const fd = new FormData();
+    fd.set("projectId", "p");
+    fd.set("dataset", "d");
+    fd.set("token", "t");
+
+    const res = await saveSanityConfig(fd);
+
+    expect(verifyCredentials).toHaveBeenCalledWith({
+      projectId: "p",
+      dataset: "d",
+      token: "t",
+    });
+    expect(setupSanityBlog).toHaveBeenCalledWith({
+      projectId: "p",
+      dataset: "d",
+      token: "t",
+    });
+    expect(res).toEqual({});
+  });
+
+  it("returns error when setupSanityBlog fails", async () => {
+    (verifyCredentials as jest.Mock).mockResolvedValue(true);
+    (setupSanityBlog as jest.Mock).mockResolvedValue({
+      success: false,
+      error: "fail",
+    });
+
+    const fd = new FormData();
+    fd.set("projectId", "p");
+    fd.set("dataset", "d");
+    fd.set("token", "t");
+
+    const res = await saveSanityConfig(fd);
+    expect(res).toEqual({ error: "fail" });
+  });
+});

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -4,6 +4,7 @@
 import { verifyCredentials } from "@acme/plugin-sanity";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { ensureAuthorized } from "./common/auth";
+import { setupSanityBlog } from "./setupSanityBlog";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
@@ -21,6 +22,11 @@ export async function saveSanityConfig(formData: FormData): Promise<{
   const valid = await verifyCredentials(config);
   if (!valid) {
     return { error: "Invalid Sanity credentials" };
+  }
+
+  const setup = await setupSanityBlog(config);
+  if (!setup.success) {
+    return { error: setup.error ?? "Failed to setup Sanity blog" };
   }
 
   const root = path.resolve(resolveDataRoot(), "..", "cms");


### PR DESCRIPTION
## Summary
- call `setupSanityBlog` after verifying Sanity credentials to ensure dataset and schema
- surface setup failures back to the form
- add tests for `saveSanityConfig`

## Testing
- `pnpm --filter @apps/cms test saveSanityConfig.test.ts`
- `pnpm --filter @apps/cms test` *(fails: missing modules such as '@\/components/atoms' and '.prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_6898fbf1ea10832fab958c26b4785e8a