### PR TITLE
refactor: unify Sanity token

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -5,7 +5,7 @@ import { ensureAuthorized } from "./common/auth";
 const projectId = process.env.SANITY_PROJECT_ID as string;
 const dataset = process.env.SANITY_DATASET as string;
 const apiVersion = process.env.SANITY_API_VERSION || "2021-10-21";
-const token = process.env.SANITY_WRITE_TOKEN;
+const token = process.env.SANITY_TOKEN;
 
 interface SanityPost {
   _id: string;

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -27,12 +27,12 @@ export async function POST(
     if (
       body.SANITY_PROJECT_ID &&
       body.SANITY_DATASET &&
-      body.SANITY_WRITE_TOKEN
+      body.SANITY_TOKEN
     ) {
       await setupSanityBlog({
         projectId: body.SANITY_PROJECT_ID,
         dataset: body.SANITY_DATASET,
-        token: body.SANITY_WRITE_TOKEN,
+        token: body.SANITY_TOKEN,
       }).catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });

--- a/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
@@ -22,7 +22,7 @@ const ENV_KEYS = [
   "GMAIL_PASS",
   "SANITY_PROJECT_ID",
   "SANITY_DATASET",
-  "SANITY_WRITE_TOKEN",
+  "SANITY_TOKEN",
 ] as const;
 
 interface Props {

--- a/packages/lib/src/sanity.server.ts
+++ b/packages/lib/src/sanity.server.ts
@@ -12,7 +12,7 @@ function getConfig(shopId: string) {
   const prefix = `SANITY_${shopId.toUpperCase()}_`;
   const projectId = process.env[`${prefix}PROJECT_ID`];
   const dataset = process.env[`${prefix}DATASET`];
-  const token = process.env[`${prefix}READ_TOKEN`];
+  const token = process.env[`${prefix}TOKEN`];
   if (!projectId || !dataset) {
     throw new Error(`Missing Sanity credentials for shop ${shopId}`);
   }


### PR DESCRIPTION
## Summary
- unify Sanity auth to single `SANITY_TOKEN`
- update CMS env API to provision `SANITY_TOKEN`
- list `SANITY_TOKEN` in CMS env wizard

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/atoms'...)*
- `pnpm --filter @acme/lib lint` *(no script)
- `pnpm --filter @acme/lib test` *(fails: Cannot find module '.prisma/client/index-browser.js')*

------
https://chatgpt.com/codex/tasks/task_e_6898fbf5daf0832f8ece61c276987cd2