### PR TITLE
test: add sendCampaignEmail tests

### DIFF
--- a/packages/lib/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/lib/email/src/__tests__/sendCampaignEmail.test.ts
@@ -1,0 +1,80 @@
+import nodemailer from "nodemailer";
+import { sendCampaignEmail } from "../index";
+
+jest.mock("nodemailer", () => ({
+  __esModule: true,
+  default: { createTransport: jest.fn() },
+}));
+
+const createTransportMock = nodemailer.createTransport as jest.Mock;
+
+describe("sendCampaignEmail", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete process.env.SMTP_URL;
+    delete process.env.CAMPAIGN_FROM;
+  });
+
+  it("uses SMTP_URL and CAMPAIGN_FROM env vars and forwards options", async () => {
+    const sendMail = jest.fn().mockResolvedValue(undefined);
+    createTransportMock.mockReturnValue({ sendMail });
+
+    process.env.SMTP_URL = "smtp://test";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      text: "Text body",
+    });
+
+    expect(createTransportMock).toHaveBeenCalledWith({ url: "smtp://test" });
+    expect(sendMail).toHaveBeenCalledWith({
+      from: "campaign@example.com",
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      text: "Text body",
+    });
+  });
+
+  it("omits text when not provided", async () => {
+    const sendMail = jest.fn().mockResolvedValue(undefined);
+    createTransportMock.mockReturnValue({ sendMail });
+
+    process.env.SMTP_URL = "smtp://test";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+    });
+
+    expect(sendMail).toHaveBeenCalledWith({
+      from: "campaign@example.com",
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      text: undefined,
+    });
+  });
+
+  it("propagates sendMail errors", async () => {
+    const error = new Error("smtp failed");
+    const sendMail = jest.fn().mockRejectedValue(error);
+    createTransportMock.mockReturnValue({ sendMail });
+
+    process.env.SMTP_URL = "smtp://test";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+
+    await expect(
+      sendCampaignEmail({
+        to: "to@example.com",
+        subject: "Subject",
+        html: "<p>HTML</p>",
+      })
+    ).rejects.toThrow(error);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for sendCampaignEmail to mock nodemailer and verify env usage
- ensure text option is passed or omitted and errors from sendMail reject

## Testing
- `pnpm --filter @acme/lib test` *(fails: Cannot find module '@/components/atoms')*


------
https://chatgpt.com/codex/tasks/task_e_6898fc032528832fb22f87ce484dd3de