### PR TITLE
Clarify shop wizard env vars and add CMS verification tests

### DIFF
--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -362,7 +362,9 @@ export default function Wizard({
       );
 
       if (ok) {
-        setResult("Shop created successfully");
+        setResult(
+          "Shop created successfully. You now have ShopAdmin access and can manage the shop from the CMS dashboard."
+        );
         if (deployment && deployment.status !== "pending") {
           setDeployInfo(deployment as DeployShopResult);
         }

--- a/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
@@ -41,6 +41,12 @@ export default function StepEnvVars({
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Environment Variables</h2>
+      <p className="text-sm text-muted-foreground">
+        Provide credentials for any services your shop will use. Fields left
+        empty will be written as placeholders so you can update them later.
+        Some providers also require a plugin under <code>packages/plugins</code>
+        – see the setup docs for details.
+      </p>
       {ENV_KEYS.map((key) => (
         <label key={key} className="flex flex-col gap-1">
           <span>{key}</span>

--- a/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
@@ -64,6 +64,11 @@ export default function StepOptions({
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Options</h2>
+      <p className="text-sm text-muted-foreground">
+        Provider integrations require their plugins to be installed under
+        <code>packages/plugins</code>. After connecting you can configure each
+        plugin from <strong>CMS → Plugins</strong>.
+      </p>
       <div>
         <p className="font-medium">Payment Providers</p>
         <div className="flex items-center gap-2 text-sm">

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -71,6 +71,18 @@ pnpm validate-env <id>
 `validate-env` parses the `.env` file and exits with an error if any required variable is missing or malformed.
 Lines that have no value after the equals sign (e.g. `MY_VAR=`) are treated as placeholders and ignored during validation, so you can leave optional variables empty until you have real credentials.
 
+The wizard scaffolds placeholders for common variables:
+
+- `STRIPE_SECRET_KEY` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` – Stripe API keys
+- `NEXTAUTH_SECRET` – session encryption secret used by NextAuth
+- `PREVIEW_TOKEN_SECRET` – token used for preview URLs
+- `CMS_SPACE_URL` / `CMS_ACCESS_TOKEN` – headless CMS credentials
+- `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_WRITE_TOKEN` – Sanity blog configuration
+- `GMAIL_USER`, `GMAIL_PASS` – credentials for email sending
+
+Leave any value blank if the integration isn't needed. You can update the `.env`
+file later and rerun `pnpm validate-env <id>` to confirm everything is set up.
+
 ## 3. (Optional) Setup CI and deploy
 
 ```bash
@@ -84,6 +96,10 @@ This creates `.github/workflows/shop-<id>.yml` which installs dependencies, runs
 Plugins extend the platform with extra payment providers, shipping integrations or storefront widgets. The platform automatically loads any plugin found under `packages/plugins/*`.
 
 To install a plugin, add it to the `packages/plugins` directory (e.g. `packages/plugins/paypal`) and export a default plugin object. After restarting the CMS you can enable and configure the plugin under **CMS → Plugins**.
+
+Some plugins require additional environment variables (for example Stripe API
+keys). Add these to the shop's `.env` file and rerun `pnpm validate-env <id>`
+before using the plugin.
 
 ## 5. Analytics and event tracking
 

--- a/test/e2e/shop-wizard.spec.ts
+++ b/test/e2e/shop-wizard.spec.ts
@@ -78,6 +78,23 @@ describe("Shop wizard", () => {
       .its("0.seo.title.en")
       .should("eq", "My Title");
 
+    // verify new shop appears in CMS list
+    cy.request("/cms/api/shops")
+      .its("body")
+      .then((shops) => {
+        expect(shops).to.include(shopId);
+      });
+
+    // creator should now be a ShopAdmin
+    cy.readFile("data/cms/users.json").then((rbac) => {
+      const roles = rbac.roles["1"];
+      if (Array.isArray(roles)) {
+        expect(roles).to.include("ShopAdmin");
+      } else {
+        expect(roles).to.equal("ShopAdmin");
+      }
+    });
+
     // sign out to reset auth state
     cy.contains("Sign out").click();
     cy.location("pathname").should("eq", "/login");


### PR DESCRIPTION
## Summary
- explain required env vars in setup docs and wizard
- note plugin prerequisites in wizard options and success message
- verify new shop appears in CMS and grants creator ShopAdmin

## Testing
- `pnpm lint`
- `pnpm e2e --spec test/e2e/shop-wizard.spec.ts` *(fails: Cypress could not verify that the server at http://localhost:3006 is running)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc5dd7e4832fbe6699e1ef341de6