### PR TITLE
feat: add shop context to blog actions

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
@@ -8,11 +8,15 @@ import type { FormState } from "./PostForm.client";
 
 interface Props {
   id: string;
+  shopId: string;
 }
 
-export default function PublishButton({ id }: Props) {
-  const action = publishPost.bind(null, id);
-  const [state, formAction] = useFormState<FormState>(action, { message: "", error: "" });
+export default function PublishButton({ id, shopId }: Props) {
+  const action = publishPost.bind(null, shopId, id);
+  const [state, formAction] = useFormState<FormState>(action, {
+    message: "",
+    error: "",
+  });
   return (
     <div className="space-y-2">
       <form action={formAction}>
@@ -20,7 +24,10 @@ export default function PublishButton({ id }: Props) {
           Publish
         </Button>
       </form>
-      <Toast open={Boolean(state.message || state.error)} message={state.message || state.error || ""} />
+      <Toast
+        open={Boolean(state.message || state.error)}
+        message={state.message || state.error || ""}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
@@ -7,16 +7,26 @@ import { getPost, updatePost } from "@cms/actions/blog.server";
 
 interface Params {
   params: { id: string };
+  searchParams?: { shopId?: string };
 }
 
-export default async function EditPostPage({ params }: Params) {
-  const post = await getPost(params.id);
+export default async function EditPostPage({
+  params,
+  searchParams,
+}: Params) {
+  const shopId = searchParams?.shopId;
+  if (!shopId) return notFound();
+  const post = await getPost(shopId, params.id);
   if (!post) return notFound();
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Edit Post</h1>
-      <PostForm action={updatePost} submitLabel="Save" post={post} />
-      <PublishButton id={post._id} />
+      <PostForm
+        action={updatePost.bind(null, shopId)}
+        submitLabel="Save"
+        post={post}
+      />
+      <PublishButton id={post._id} shopId={shopId} />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/blog/posts/new/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/new/page.tsx
@@ -3,11 +3,20 @@
 import PostForm from "../PostForm.client";
 import { createPost } from "@cms/actions/blog.server";
 
-export default function NewPostPage() {
+export default function NewPostPage({
+  searchParams,
+}: {
+  searchParams?: { shopId?: string };
+}) {
+  const shopId = searchParams?.shopId;
+  if (!shopId) return <p>No shop selected.</p>;
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">New Post</h1>
-      <PostForm action={createPost} submitLabel="Create" />
+      <PostForm
+        action={createPost.bind(null, shopId)}
+        submitLabel="Create"
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/blog/posts/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/page.tsx
@@ -4,21 +4,27 @@ import Link from "next/link";
 import { Button } from "@ui";
 import { getPosts } from "@cms/actions/blog.server";
 
-export default async function BlogPostsPage() {
-  const posts = await getPosts();
+export default async function BlogPostsPage({
+  searchParams,
+}: {
+  searchParams?: { shopId?: string };
+}) {
+  const shopId = searchParams?.shopId;
+  if (!shopId) return <p>No shop selected.</p>;
+  const posts = await getPosts(shopId);
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Blog Posts</h1>
         <Button asChild>
-          <Link href="/cms/blog/posts/new">New Post</Link>
+          <Link href={`/cms/blog/posts/new?shopId=${shopId}`}>New Post</Link>
         </Button>
       </div>
       <ul className="space-y-2">
         {posts.map((post) => (
           <li key={post._id}>
             <Link
-              href={`/cms/blog/posts/${post._id}`}
+              href={`/cms/blog/posts/${post._id}?shopId=${shopId}`}
               className="text-primary underline"
             >
               {post.title || "(untitled)"}


### PR DESCRIPTION
## Summary
- load Sanity blog config per shop and add shopId parameter to blog actions
- wire CMS blog pages and publish button to pass the current shopId

## Testing
- `pnpm test:cms` *(fails: Cannot find module '@prisma/client' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_6898fbf33f40832fb3bfa2992418d133