### PR TITLE
feat: secure cart cookie

### DIFF
--- a/packages/platform-core/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/__tests__/cartCookie.test.ts
@@ -41,7 +41,7 @@ describe("cart cookie helpers", () => {
     const encoded = "value";
 
     expect(asSetCookieHeader(encoded)).toBe(
-      `${CART_COOKIE}=${encoded}; Path=/; Max-Age=${60 * 60 * 24 * 30}; SameSite=Lax`
+      `${CART_COOKIE}=${encoded}; Path=/; Max-Age=${60 * 60 * 24 * 30}; SameSite=Lax; Secure; HttpOnly`
     );
   });
 });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -62,5 +62,6 @@ export function decodeCartCookie(raw?: string | null): CartState {
 
 /** Build the Set-Cookie header value for HTTP responses. */
 export function asSetCookieHeader(value: string): string {
-  return `${CART_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE}; SameSite=Lax`;
+  // NOTE: Consider signing or encrypting the cookie value to prevent tampering.
+  return `${CART_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE}; SameSite=Lax; Secure; HttpOnly`;
 }


### PR DESCRIPTION
## Summary
- add Secure and HttpOnly flags to cart cookie header
- mention signing/encryption for tamper protection
- update cookie header tests

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms')*


------
https://chatgpt.com/codex/tasks/task_e_6898fdb9a374832fbe9f217089fd1c4c