### PR TITLE
feat: add login and logout routes

### DIFF
--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -1,0 +1,24 @@
+// apps/shop-abc/src/app/login/route.ts
+import { NextResponse } from "next/server";
+import { createCustomerSession } from "@auth";
+import { RoleSchema } from "@auth/types/roles";
+import { z } from "zod";
+
+const LoginSchema = z.object({
+  customerId: z.string(),
+  role: RoleSchema,
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = LoginSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  await createCustomerSession(parsed.data);
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-abc/src/app/logout/route.ts
+++ b/apps/shop-abc/src/app/logout/route.ts
@@ -1,0 +1,8 @@
+// apps/shop-abc/src/app/logout/route.ts
+import { NextResponse } from "next/server";
+import { destroyCustomerSession } from "@auth";
+
+export async function GET(req: Request) {
+  await destroyCustomerSession();
+  return NextResponse.redirect(new URL("/", req.url));
+}

--- a/apps/shop-bcd/src/app/login/route.ts
+++ b/apps/shop-bcd/src/app/login/route.ts
@@ -1,0 +1,24 @@
+// apps/shop-bcd/src/app/login/route.ts
+import { NextResponse } from "next/server";
+import { createCustomerSession } from "@auth";
+import { RoleSchema } from "@auth/types/roles";
+import { z } from "zod";
+
+const LoginSchema = z.object({
+  customerId: z.string(),
+  role: RoleSchema,
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = LoginSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  await createCustomerSession(parsed.data);
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-bcd/src/app/logout/route.ts
+++ b/apps/shop-bcd/src/app/logout/route.ts
@@ -1,0 +1,8 @@
+// apps/shop-bcd/src/app/logout/route.ts
+import { NextResponse } from "next/server";
+import { destroyCustomerSession } from "@auth";
+
+export async function GET(req: Request) {
+  await destroyCustomerSession();
+  return NextResponse.redirect(new URL("/", req.url));
+}


### PR DESCRIPTION
## Summary
- add login and logout handlers for shop-abc and shop-bcd apps
- create customer session on login and destroy session on logout

## Testing
- `pnpm exec eslint apps/shop-abc/src/app/login/route.ts apps/shop-abc/src/app/logout/route.ts apps/shop-bcd/src/app/login/route.ts apps/shop-bcd/src/app/logout/route.ts`
- `pnpm test --filter @apps/shop-abc --filter @apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_6898fd1cc0f4832f9632ed13534643af