### PR TITLE
Add account page access tests

### DIFF
--- a/apps/shop-abc/__tests__/accountOrders.test.tsx
+++ b/apps/shop-abc/__tests__/accountOrders.test.tsx
@@ -1,0 +1,64 @@
+// apps/shop-abc/__tests__/accountOrders.test.tsx
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+jest.mock("@platform-core/orders", () => ({
+  __esModule: true,
+  getOrdersForCustomer: jest.fn(),
+}));
+
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
+import OrdersPage from "../src/app/account/orders/page";
+import shop from "../shop.json";
+
+describe("/account/orders", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("redirects unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const element = await OrdersPage();
+    expect(getCustomerSession).toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Please log in to view your orders.");
+  });
+
+  it("shows empty state when no orders", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    (getOrdersForCustomer as jest.Mock).mockResolvedValue([]);
+    const element = await OrdersPage();
+    expect(getOrdersForCustomer).toHaveBeenCalledWith(
+      shop.id,
+      session.customerId
+    );
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("No orders yet.");
+  });
+
+  it("lists customer orders", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    const orders = [
+      { id: "o1", expectedReturnDate: "2024-01-01" },
+      { id: "o2" },
+    ];
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    (getOrdersForCustomer as jest.Mock).mockResolvedValue(orders);
+    const element = await OrdersPage();
+    expect(getOrdersForCustomer).toHaveBeenCalledWith(
+      shop.id,
+      session.customerId
+    );
+    expect(element.type).toBe("ul");
+    expect(element.props.children).toHaveLength(2);
+    expect(
+      element.props.children.map((li: any) => {
+        const child = li.props.children[0].props.children;
+        return Array.isArray(child) ? child.join("") : child;
+      })
+    ).toEqual(["Order: o1", "Order: o2"]);
+  });
+});

--- a/apps/shop-abc/__tests__/accountProfile.test.tsx
+++ b/apps/shop-abc/__tests__/accountProfile.test.tsx
@@ -1,0 +1,48 @@
+// apps/shop-abc/__tests__/accountProfile.test.tsx
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+
+import { getCustomerSession } from "@auth";
+import ProfilePage from "../src/app/account/profile/page";
+
+describe("/account/profile", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("redirects unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const element = await ProfilePage();
+    expect(getCustomerSession).toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Please log in to view your profile.");
+  });
+
+  it("renders profile for authenticated users", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    const element = await ProfilePage();
+    expect(element.type).toBe("div");
+    expect(element.props.children[1].props.children).toBe(
+      JSON.stringify(session, null, 2)
+    );
+  });
+
+  it("updates displayed profile after session changes", async () => {
+    const session1 = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session1);
+    let element = await ProfilePage();
+    expect(element.props.children[1].props.children).toBe(
+      JSON.stringify(session1, null, 2)
+    );
+
+    const session2 = { customerId: "cust2", role: "admin" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session2);
+    element = await ProfilePage();
+    expect(element.props.children[1].props.children).toBe(
+      JSON.stringify(session2, null, 2)
+    );
+  });
+});

--- a/apps/shop-bcd/__tests__/account-orders.test.tsx
+++ b/apps/shop-bcd/__tests__/account-orders.test.tsx
@@ -1,0 +1,64 @@
+// apps/shop-bcd/__tests__/account-orders.test.tsx
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+jest.mock("@platform-core/orders", () => ({
+  __esModule: true,
+  getOrdersForCustomer: jest.fn(),
+}));
+
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
+import OrdersPage from "../src/app/account/orders/page";
+import shop from "../shop.json";
+
+describe("/account/orders", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("redirects unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const element = await OrdersPage();
+    expect(getCustomerSession).toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Please log in to view your orders.");
+  });
+
+  it("shows empty state when no orders", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    (getOrdersForCustomer as jest.Mock).mockResolvedValue([]);
+    const element = await OrdersPage();
+    expect(getOrdersForCustomer).toHaveBeenCalledWith(
+      shop.id,
+      session.customerId
+    );
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("No orders yet.");
+  });
+
+  it("lists customer orders", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    const orders = [
+      { id: "o1", expectedReturnDate: "2024-01-01" },
+      { id: "o2" },
+    ];
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    (getOrdersForCustomer as jest.Mock).mockResolvedValue(orders);
+    const element = await OrdersPage();
+    expect(getOrdersForCustomer).toHaveBeenCalledWith(
+      shop.id,
+      session.customerId
+    );
+    expect(element.type).toBe("ul");
+    expect(element.props.children).toHaveLength(2);
+    expect(
+      element.props.children.map((li: any) => {
+        const child = li.props.children[0].props.children;
+        return Array.isArray(child) ? child.join("") : child;
+      })
+    ).toEqual(["Order: o1", "Order: o2"]);
+  });
+});

--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -1,0 +1,48 @@
+// apps/shop-bcd/__tests__/account-profile.test.tsx
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+
+import { getCustomerSession } from "@auth";
+import ProfilePage from "../src/app/account/profile/page";
+
+describe("/account/profile", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("redirects unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const element = await ProfilePage();
+    expect(getCustomerSession).toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Please log in to view your profile.");
+  });
+
+  it("renders profile for authenticated users", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    const element = await ProfilePage();
+    expect(element.type).toBe("div");
+    expect(element.props.children[1].props.children).toBe(
+      JSON.stringify(session, null, 2)
+    );
+  });
+
+  it("updates displayed profile after session changes", async () => {
+    const session1 = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session1);
+    let element = await ProfilePage();
+    expect(element.props.children[1].props.children).toBe(
+      JSON.stringify(session1, null, 2)
+    );
+
+    const session2 = { customerId: "cust2", role: "admin" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session2);
+    element = await ProfilePage();
+    expect(element.props.children[1].props.children).toBe(
+      JSON.stringify(session2, null, 2)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `/account/profile` tests for auth and profile updates
- add `/account/orders` tests for auth checks and order listings

## Testing
- `pnpm test:cms` *(fails: Cannot find module '.prisma/client/index-browser.js')*

------
https://chatgpt.com/codex/tasks/task_e_6898fd2319d4832fa6d609c400005380