### PR TITLE
feat(platform-core): persist rental orders via Prisma

### DIFF
--- a/packages/platform-core/__tests__/rentalOrders.test.ts
+++ b/packages/platform-core/__tests__/rentalOrders.test.ts
@@ -1,3 +1,34 @@
+import { jest } from "@jest/globals";
+
+const mockOrders: any[] = [];
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    rentalOrder: {
+      findMany: jest.fn(async ({ where }: any) =>
+        mockOrders.filter(
+          (o) =>
+            o.shopId === where.shopId &&
+            (!where.customerId || o.customerId === where.customerId)
+        )
+      ),
+      create: jest.fn(async ({ data }: any) => {
+        mockOrders.push(data);
+        return data;
+      }),
+      findUnique: jest.fn(async ({ where }: any) =>
+        mockOrders.find((o) => o.sessionId === where.sessionId) || null
+      ),
+      update: jest.fn(async ({ where, data }: any) => {
+        const idx = mockOrders.findIndex((o) => o.id === where.id);
+        if (idx === -1) throw new Error("not found");
+        mockOrders[idx] = { ...mockOrders[idx], ...data };
+        return mockOrders[idx];
+      }),
+    },
+  },
+}));
+
 import * as repo from "../src/repositories/rentalOrders.server";
 
 describe("rental order repository", () => {

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -23,6 +23,11 @@
     "prisma": "^5.15.1"
   },
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "db:push": "prisma db push",
+    "db:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -8,10 +8,11 @@ datasource db {
 }
 
 model Shop {
-  id   String @id
+  id     String @id
   /// @type {import("../../types/src/Shop").Shop}
-  data Json
-  pages Page[]
+  data   Json
+  pages  Page[]
+  orders RentalOrder[]
 }
 
 model Page {
@@ -20,4 +21,13 @@ model Page {
   shopId String
   slug   String
   data   Json
+}
+
+model RentalOrder {
+  id         String @id
+  sessionId  String @unique
+  shop       Shop   @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  shopId     String
+  customerId String?
+  data       Json
 }

--- a/packages/platform-core/prisma/seed.ts
+++ b/packages/platform-core/prisma/seed.ts
@@ -1,0 +1,37 @@
+import { prisma } from "../src/db";
+import { ulid } from "ulid";
+
+async function main() {
+  const shopId = "demo-shop";
+
+  await prisma.shop.upsert({
+    where: { id: shopId },
+    update: {},
+    create: { id: shopId, data: {} },
+  });
+
+  const id = ulid();
+  await prisma.rentalOrder.create({
+    data: {
+      id,
+      shopId,
+      sessionId: "seed-session",
+      data: {
+        id,
+        sessionId: "seed-session",
+        shop: shopId,
+        deposit: 0,
+        startedAt: new Date().toISOString(),
+      },
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add `RentalOrder` model and seed script
- refactor order APIs to perform CRUD via Prisma
- mock Prisma client in rental order tests and expose DB helper scripts

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6898fd206068832f8323d791f50daf6c