### PR TITLE
Add tests for organism components

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/Footer.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/Footer.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { Footer } from "../Footer";
+
+describe("Footer", () => {
+  it("renders children and applies className", () => {
+    render(<Footer className="custom">Content</Footer>);
+    const footer = screen.getByText("Content").closest("footer");
+    expect(footer).toHaveClass("custom");
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/Header.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/Header.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Header } from "../Header";
+import "../../../../../../test/resetNextMocks";
+
+describe("Header", () => {
+  it("renders navigation and handles search suggestions", async () => {
+    const nav = [{ title: "Home", href: "/" }];
+    render(<Header locale="en" nav={nav} searchSuggestions={["apple"]} />);
+
+    expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText("Search…");
+    await userEvent.type(input, "app");
+    expect(screen.getByText("apple")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("apple"));
+    expect(screen.queryByText("apple")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MiniCart } from "../MiniCart.client";
+
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+const mockUseCart = jest.fn();
+jest.mock("@platform-core/src/contexts/CartContext", () => ({
+  useCart: () => mockUseCart(),
+}));
+
+describe("MiniCart", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders empty state when cart has no items", async () => {
+    mockUseCart.mockReturnValue([{}, jest.fn()]);
+    render(<MiniCart trigger={<button>Open Cart</button>} />);
+
+    await userEvent.click(screen.getByText("Open Cart"));
+    expect(await screen.findByText("Cart is empty.")).toBeInTheDocument();
+  });
+
+  it("shows cart items and handles removal", async () => {
+    const dispatch = jest.fn();
+    mockUseCart.mockReturnValue([
+      {
+        sku1: {
+          sku: { id: "sku1", title: "Item", price: 10 },
+          qty: 1,
+        },
+      },
+      dispatch,
+    ]);
+
+    render(<MiniCart trigger={<button>Cart</button>} />);
+    await userEvent.click(screen.getByText("Cart"));
+
+    expect(await screen.findByText("Item")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /remove/i }));
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1" });
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ProductCard, type Product } from "../ProductCard";
+import "../../../../../../test/resetNextMocks";
+
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+describe("ProductCard", () => {
+  const product: Product = {
+    id: "1",
+    title: "Test Product",
+    image: "/img.jpg",
+    price: 9.99,
+  };
+
+  it("renders product info and handles add to cart", () => {
+    const handleAdd = jest.fn();
+    render(<ProductCard product={product} onAddToCart={handleAdd} />);
+
+    expect(screen.getByText("Test Product")).toBeInTheDocument();
+    expect(screen.getByText(/\$9\.99/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /add to cart/i }));
+    expect(handleAdd).toHaveBeenCalledWith(product);
+  });
+});


### PR DESCRIPTION
## Summary
- add ProductCard tests for rendering and add-to-cart callback
- verify Header renders nav and search suggestion interaction
- ensure Footer renders children and custom class
- cover MiniCart empty state and item removal behavior

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6898fc743358832f8f8af25ef821671f