### PR TITLE
feat: add inventory table editing

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -1,26 +1,102 @@
 "use client";
 
-import { Button, Textarea } from "@/components/atoms/shadcn";
+import { Button, Input } from "@/components/atoms/shadcn";
 import { inventoryItemSchema, type InventoryItem } from "@types";
-import { FormEvent, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 
 interface Props {
   shop: string;
   initial: InventoryItem[];
 }
 
+interface RowState {
+  sku: string;
+  variantAttributes: string;
+  quantity: number;
+  lowStockThreshold: number;
+}
+
 export default function InventoryForm({ shop, initial }: Props) {
-  const [text, setText] = useState(
-    () => JSON.stringify(initial, null, 2)
-  );
+  const mapItemToRow = (item: InventoryItem): RowState => ({
+    sku: item.sku,
+    variantAttributes: JSON.stringify((item as any).variantAttributes || {}),
+    quantity: item.quantity,
+    lowStockThreshold: (item as any).lowStockThreshold ?? 0,
+  });
+
+  const [rows, setRows] = useState<RowState[]>(() => initial.map(mapItemToRow));
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const updateRow = (
+    index: number,
+    field: keyof RowState,
+    value: string
+  ) => {
+    setRows((prev) => {
+      const next = [...prev];
+      (next[index] as any)[field] =
+        field === "quantity" || field === "lowStockThreshold"
+          ? Number(value)
+          : value;
+      return next;
+    });
+  };
+
+  const addRow = () => {
+    setRows((prev) => [
+      ...prev,
+      { sku: "", variantAttributes: "{}", quantity: 0, lowStockThreshold: 0 },
+    ]);
+  };
+
+  const deleteRow = (index: number) => {
+    setRows((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleImport = (format: "json" | "csv") => {
+    const input = fileInputRef.current;
+    if (!input) return;
+    input.accept = format === "json" ? "application/json" : ".csv,text/csv";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const body = new FormData();
+      body.append("file", file);
+      try {
+        const res = await fetch(
+          `/api/data/${shop}/inventory/import?format=${format}`,
+          {
+            method: "POST",
+            body,
+          }
+        );
+        const data = await res.json().catch(() => null);
+        if (res.ok && Array.isArray(data)) {
+          setRows(data.map(mapItemToRow));
+        }
+      } finally {
+        input.value = "";
+      }
+    };
+    input.click();
+  };
+
+  const handleExport = (format: "json" | "csv") => {
+    window.location.href = `/api/data/${shop}/inventory/export?format=${format}`;
+  };
 
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     try {
-      const json = JSON.parse(text);
-      const parsed = inventoryItemSchema.array().safeParse(json);
+      const toSubmit = rows.map((r) => ({
+        sku: r.sku,
+        variantAttributes: JSON.parse(r.variantAttributes || "{}"),
+        quantity: Number(r.quantity),
+        lowStockThreshold: Number(r.lowStockThreshold),
+      }));
+      const parsed = inventoryItemSchema.array().safeParse(toSubmit);
       if (!parsed.success) {
         setStatus("error");
         setError(parsed.error.issues.map((i) => i.message).join(", "));
@@ -46,11 +122,85 @@ export default function InventoryForm({ shop, initial }: Props) {
 
   return (
     <form onSubmit={onSubmit} className="space-y-4">
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        rows={10}
-      />
+      <input type="file" ref={fileInputRef} className="hidden" />
+      <table className="min-w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">SKU</th>
+            <th className="border px-2 py-1 text-left">Variant Attributes</th>
+            <th className="border px-2 py-1 text-left">Quantity</th>
+            <th className="border px-2 py-1 text-left">Low Stock Threshold</th>
+            <th className="border px-2 py-1" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i}>
+              <td className="border px-2 py-1">
+                <Input
+                  aria-label="sku"
+                  value={row.sku}
+                  onChange={(e) => updateRow(i, "sku", e.target.value)}
+                />
+              </td>
+              <td className="border px-2 py-1">
+                <Input
+                  aria-label="variant attributes"
+                  value={row.variantAttributes}
+                  onChange={(e) =>
+                    updateRow(i, "variantAttributes", e.target.value)
+                  }
+                />
+              </td>
+              <td className="border px-2 py-1">
+                <Input
+                  aria-label="quantity"
+                  type="number"
+                  value={row.quantity}
+                  onChange={(e) => updateRow(i, "quantity", e.target.value)}
+                />
+              </td>
+              <td className="border px-2 py-1">
+                <Input
+                  aria-label="low stock threshold"
+                  type="number"
+                  value={row.lowStockThreshold}
+                  onChange={(e) =>
+                    updateRow(i, "lowStockThreshold", e.target.value)
+                  }
+                />
+              </td>
+              <td className="border px-2 py-1 text-center">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  aria-label="delete row"
+                  onClick={() => deleteRow(i)}
+                >
+                  Delete
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" onClick={addRow}>
+          Add row
+        </Button>
+        <Button type="button" onClick={() => handleImport("json")}>
+          Import JSON
+        </Button>
+        <Button type="button" onClick={() => handleImport("csv")}>
+          Import CSV
+        </Button>
+        <Button type="button" onClick={() => handleExport("json")}>
+          Export JSON
+        </Button>
+        <Button type="button" onClick={() => handleExport("csv")}>
+          Export CSV
+        </Button>
+      </div>
       {status === "saved" && (
         <p className="text-sm text-green-600">Saved!</p>
       )}

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import InventoryForm from "../InventoryForm";
+
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => {
+    const React = require("react");
+    return {
+      __esModule: true,
+      Button: React.forwardRef((props: any, ref: any) => (
+        <button ref={ref} {...props} />
+      )),
+      Input: React.forwardRef((props: any, ref: any) => (
+        <input ref={ref} {...props} />
+      )),
+    };
+  },
+  { virtual: true }
+);
+
+describe("InventoryForm", () => {
+  const initial = [
+    {
+      sku: "sku1",
+      variantAttributes: { color: "red" },
+      quantity: 1,
+      lowStockThreshold: 0,
+    },
+  ];
+
+  it("allows adding and deleting rows", () => {
+    render(<InventoryForm shop="shop" initial={initial} />);
+    expect(screen.getAllByLabelText(/sku/i)).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: /add row/i }));
+    expect(screen.getAllByLabelText(/sku/i)).toHaveLength(2);
+    fireEvent.click(screen.getAllByRole("button", { name: /delete row/i })[1]);
+    expect(screen.getAllByLabelText(/sku/i)).toHaveLength(1);
+  });
+
+  it("shows error for invalid variant JSON and prevents submission", async () => {
+    const fetchMock = jest.fn();
+    (global as any).fetch = fetchMock;
+    render(<InventoryForm shop="shop" initial={initial} />);
+    fireEvent.change(screen.getByLabelText(/variant attributes/i), {
+      target: { value: "{bad" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(
+      await screen.findByText(/position 1/i)
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("submits structured data", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    (global as any).fetch = fetchMock;
+    render(<InventoryForm shop="shop" initial={initial} />);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/data/shop/inventory",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify([
+          {
+            sku: "sku1",
+            variantAttributes: { color: "red" },
+            quantity: 1,
+            lowStockThreshold: 0,
+          },
+        ]),
+      })
+    );
+  });
+});

--- a/packages/types/src/InventoryItem.d.ts
+++ b/packages/types/src/InventoryItem.d.ts
@@ -1,13 +1,19 @@
 import { z } from "zod";
 export declare const inventoryItemSchema: z.ZodObject<{
     sku: z.ZodString;
+    variantAttributes: z.ZodRecord<z.ZodString, z.ZodString>;
     quantity: z.ZodNumber;
+    lowStockThreshold: z.ZodNumber;
 }, "strip", z.ZodTypeAny, {
     sku: string;
+    variantAttributes: Record<string, string>;
     quantity: number;
+    lowStockThreshold: number;
 }, {
     sku: string;
+    variantAttributes: Record<string, string>;
     quantity: number;
+    lowStockThreshold: number;
 }>;
 export type InventoryItem = z.infer<typeof inventoryItemSchema>;
 //# sourceMappingURL=InventoryItem.d.ts.map

--- a/packages/types/src/InventoryItem.d.ts.map
+++ b/packages/types/src/InventoryItem.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"InventoryItem.d.ts","sourceRoot":"","sources":["InventoryItem.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,CAAC,EAAE,MAAM,KAAK,CAAC;AAExB,eAAO,MAAM,mBAAmB;;;;;;;;;EAG9B,CAAC;AAEH,MAAM,MAAM,aAAa,GAAG,CAAC,CAAC,KAAK,CAAC,OAAO,mBAAmB,CAAC,CAAC"}
+{"version":3,"file":"InventoryItem.d.ts","sourceRoot":"","sources":["InventoryItem.ts"],"names":[],"mappings":""}

--- a/packages/types/src/InventoryItem.ts
+++ b/packages/types/src/InventoryItem.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 export const inventoryItemSchema = z.object({
   sku: z.string(),
+  variantAttributes: z.record(z.string()),
   quantity: z.number(),
+  lowStockThreshold: z.number(),
 });
 
 export type InventoryItem = z.infer<typeof inventoryItemSchema>;


### PR DESCRIPTION
## Summary
- replace inventory textarea with row-based table editor
- support JSON/CSV import-export and validation
- add component tests for inventory grid

## Testing
- `pnpm --filter @types/shared test`
- `pnpm --filter @apps/cms test -- -t InventoryForm`


------
https://chatgpt.com/codex/tasks/task_e_6898fe89a33c832fa0574dba1f218258