### PR TITLE
feat(auth): sign customer session cookies

### DIFF
--- a/packages/auth/__tests__/session.test.ts
+++ b/packages/auth/__tests__/session.test.ts
@@ -1,0 +1,65 @@
+import { createCustomerSession, getCustomerSession, CUSTOMER_SESSION_COOKIE } from "../src/session";
+import type { Role } from "../src/types";
+
+const mockCookies = jest.fn();
+jest.mock("next/headers", () => ({
+  cookies: () => mockCookies(),
+}));
+
+describe("customer session", () => {
+  const originalSecret = process.env.SESSION_SECRET;
+  beforeEach(() => {
+    process.env.SESSION_SECRET = "test-secret";
+    mockCookies.mockReset();
+  });
+  afterAll(() => {
+    if (originalSecret !== undefined) {
+      process.env.SESSION_SECRET = originalSecret;
+    } else {
+      delete process.env.SESSION_SECRET;
+    }
+  });
+
+  it("creates and retrieves a valid session", async () => {
+    const store = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
+    mockCookies.mockResolvedValue(store);
+    const session = { customerId: "abc", role: "customer" as Role };
+
+    await createCustomerSession(session);
+    const [name, value, opts] = store.set.mock.calls[0];
+    expect(name).toBe(CUSTOMER_SESSION_COOKIE);
+    expect(opts).toMatchObject({
+      httpOnly: true,
+      sameSite: "lax",
+      secure: true,
+      maxAge: expect.any(Number),
+      expires: expect.any(Date),
+    });
+
+    store.get.mockReturnValue({ value });
+    await expect(getCustomerSession()).resolves.toEqual(session);
+  });
+
+  it("rejects tampered tokens", async () => {
+    const store = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
+    mockCookies.mockResolvedValue(store);
+    const session = { customerId: "abc", role: "customer" as Role };
+    await createCustomerSession(session);
+    const token = store.set.mock.calls[0][1] as string;
+    store.get.mockReturnValue({ value: token + "tamper" });
+    await expect(getCustomerSession()).resolves.toBeNull();
+  });
+
+  it("rejects expired tokens", async () => {
+    const store = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
+    mockCookies.mockResolvedValue(store);
+    const session = { customerId: "abc", role: "customer" as Role };
+    await createCustomerSession(session);
+    const token = store.set.mock.calls[0][1] as string;
+    const payload = JSON.parse(Buffer.from(token.split(".")[0], "base64url").toString("utf8"));
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(payload.exp + 1000);
+    store.get.mockReturnValue({ value: token });
+    await expect(getCustomerSession()).resolves.toBeNull();
+    nowSpy.mockRestore();
+  });
+});

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -1,30 +1,77 @@
 // packages/auth/src/session.ts
 import { cookies } from "next/headers";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import type { Role } from "./types";
 
 export const CUSTOMER_SESSION_COOKIE = "customer_session";
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7; // one week
 
 export interface CustomerSession {
   customerId: string;
   role: Role;
 }
 
+function encode(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+function sign(encoded: string, secret: string): string {
+  return createHmac("sha256", secret).update(encoded).digest("base64url");
+}
+
 export async function getCustomerSession(): Promise<CustomerSession | null> {
   const store = await cookies();
-  const raw = store.get(CUSTOMER_SESSION_COOKIE)?.value;
-  if (!raw) return null;
+  const token = store.get(CUSTOMER_SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) return null;
+
+  const [encoded, signature] = token.split(".");
+  if (!encoded || !signature) return null;
+
+  const expected = sign(encoded, secret);
   try {
-    return JSON.parse(raw) as CustomerSession;
+    if (!timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+      return null;
+    }
   } catch {
     return null;
   }
+
+  let payload: any;
+  try {
+    payload = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+
+  if (typeof payload.exp !== "number" || payload.exp < Date.now()) {
+    return null;
+  }
+
+  const { customerId, role } = payload;
+  return { customerId, role };
 }
 
 export async function createCustomerSession(session: CustomerSession): Promise<void> {
   const store = await cookies();
-  store.set(CUSTOMER_SESSION_COOKIE, JSON.stringify(session), {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET is not set");
+  }
+
+  const exp = Date.now() + SESSION_TTL_MS;
+  const encoded = encode({ ...session, exp });
+  const signature = sign(encoded, secret);
+  const token = `${encoded}.${signature}`;
+
+  store.set(CUSTOMER_SESSION_COOKIE, token, {
     httpOnly: true,
     sameSite: "lax",
+    secure: true,
+    maxAge: Math.floor(SESSION_TTL_MS / 1000),
+    expires: new Date(exp),
   });
 }
 


### PR DESCRIPTION
## Summary
- sign customer session cookies with an HMAC-based token
- add secure cookie options with max-age and expiration
- validate token signature and expiration when reading sessions

## Testing
- `pnpm exec jest packages/auth/__tests__/session.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6898fd1cb398832f9543bd8877b85da2