### PR TITLE
refactor: share account components across shops

### DIFF
--- a/apps/shop-abc/package.json
+++ b/apps/shop-abc/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
-    "@acme/next-config": "workspace:*"
+    "@acme/next-config": "workspace:*",
+    "@acme/ui": "workspace:*"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-abc/src/app/account/orders/page.tsx
+++ b/apps/shop-abc/src/app/account/orders/page.tsx
@@ -1,23 +1,9 @@
 // apps/shop-abc/src/app/account/orders/page.tsx
-import { getCustomerSession } from "@auth";
-import { getOrdersForCustomer } from "@platform-core/orders";
+import { Orders } from "@acme/ui";
 import shop from "../../../../shop.json";
 
 export const metadata = { title: "Orders" };
 
-export default async function OrdersPage() {
-  const session = await getCustomerSession();
-  if (!session) return <p>Please log in to view your orders.</p>;
-  const orders = await getOrdersForCustomer(shop.id, session.customerId);
-  if (!orders.length) return <p className="p-6">No orders yet.</p>;
-  return (
-    <ul className="space-y-2 p-6">
-      {orders.map((o) => (
-        <li key={o.id} className="rounded border p-4">
-          <div>Order: {o.id}</div>
-          {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
-        </li>
-      ))}
-    </ul>
-  );
+export default function OrdersPage() {
+  return <Orders shopId={shop.id} />;
 }

--- a/apps/shop-abc/src/app/account/profile/page.tsx
+++ b/apps/shop-abc/src/app/account/profile/page.tsx
@@ -1,15 +1,6 @@
 // apps/shop-abc/src/app/account/profile/page.tsx
-import { getCustomerSession } from "@auth";
+import { Profile } from "@acme/ui";
 
 export const metadata = { title: "Profile" };
 
-export default async function ProfilePage() {
-  const session = await getCustomerSession();
-  if (!session) return <p>Please log in to view your profile.</p>;
-  return (
-    <div className="p-6">
-      <h1 className="mb-4 text-xl">Profile</h1>
-      <pre className="rounded bg-muted p-4">{JSON.stringify(session, null, 2)}</pre>
-    </div>
-  );
-}
+export default Profile;

--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
-    "@acme/next-config": "workspace:*"
+    "@acme/next-config": "workspace:*",
+    "@acme/ui": "workspace:*"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-bcd/src/app/account/orders/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/page.tsx
@@ -1,23 +1,9 @@
 // apps/shop-bcd/src/app/account/orders/page.tsx
-import { getCustomerSession } from "@auth";
-import { getOrdersForCustomer } from "@platform-core/orders";
+import { Orders } from "@acme/ui";
 import shop from "../../../../shop.json";
 
 export const metadata = { title: "Orders" };
 
-export default async function OrdersPage() {
-  const session = await getCustomerSession();
-  if (!session) return <p>Please log in to view your orders.</p>;
-  const orders = await getOrdersForCustomer(shop.id, session.customerId);
-  if (!orders.length) return <p className="p-6">No orders yet.</p>;
-  return (
-    <ul className="space-y-2 p-6">
-      {orders.map((o) => (
-        <li key={o.id} className="rounded border p-4">
-          <div>Order: {o.id}</div>
-          {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
-        </li>
-      ))}
-    </ul>
-  );
+export default function OrdersPage() {
+  return <Orders shopId={shop.id} />;
 }

--- a/apps/shop-bcd/src/app/account/profile/page.tsx
+++ b/apps/shop-bcd/src/app/account/profile/page.tsx
@@ -1,15 +1,6 @@
 // apps/shop-bcd/src/app/account/profile/page.tsx
-import { getCustomerSession } from "@auth";
+import { Profile } from "@acme/ui";
 
 export const metadata = { title: "Profile" };
 
-export default async function ProfilePage() {
-  const session = await getCustomerSession();
-  if (!session) return <p>Please log in to view your profile.</p>;
-  return (
-    <div className="p-6">
-      <h1 className="mb-4 text-xl">Profile</h1>
-      <pre className="rounded bg-muted p-4">{JSON.stringify(session, null, 2)}</pre>
-    </div>
-  );
-}
+export default Profile;

--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -1,0 +1,34 @@
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
+
+export interface OrdersProps {
+  shopId: string;
+  title?: string;
+  loginMessage?: string;
+  noOrdersMessage?: string;
+}
+
+export async function Orders({
+  shopId,
+  title = "Orders",
+  loginMessage = "Please log in to view your orders.",
+  noOrdersMessage = "No orders yet.",
+}: OrdersProps) {
+  const session = await getCustomerSession();
+  if (!session) return <p>{loginMessage}</p>;
+  const orders = await getOrdersForCustomer(shopId, session.customerId);
+  if (!orders.length) return <p className="p-6">{noOrdersMessage}</p>;
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-xl">{title}</h1>
+      <ul className="space-y-2">
+        {orders.map((o) => (
+          <li key={o.id} className="rounded border p-4">
+            <div>Order: {o.id}</div>
+            {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -1,0 +1,20 @@
+import { getCustomerSession } from "@auth";
+
+export interface ProfileProps {
+  title?: string;
+  loginMessage?: string;
+}
+
+export async function Profile({
+  title = "Profile",
+  loginMessage = "Please log in to view your profile.",
+}: ProfileProps = {}) {
+  const session = await getCustomerSession();
+  if (!session) return <p>{loginMessage}</p>;
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-xl">{title}</h1>
+      <pre className="rounded bg-muted p-4">{JSON.stringify(session, null, 2)}</pre>
+    </div>
+  );
+}

--- a/packages/ui/src/components/account/index.ts
+++ b/packages/ui/src/components/account/index.ts
@@ -1,0 +1,2 @@
+export * from "./Profile";
+export * from "./Orders";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -3,5 +3,6 @@ export * from "./atoms";
 export * from "./molecules";
 export * from "./organisms";
 export * from "./templates";
+export * from "./account";
 export { default as DynamicRenderer } from "./DynamicRenderer";
 export { default as ThemeToggle } from "./ThemeToggle";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       '@acme/next-config':
         specifier: workspace:*
         version: link:../../packages/next-config
+      '@acme/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@themes/base':
         specifier: workspace:*
         version: link:../../packages/themes/base
@@ -327,6 +330,9 @@ importers:
       '@acme/next-config':
         specifier: workspace:*
         version: link:../../packages/next-config
+      '@acme/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@themes/base':
         specifier: workspace:*
         version: link:../../packages/themes/base


### PR DESCRIPTION
## Summary
- extract Profile and Orders components into shared @acme/ui package with customizable messages
- use shared components in shop-abc and shop-bcd routes and add dependency

## Testing
- `pnpm --filter @acme/ui test` (fails: Cannot find module '@/components/atoms')
- `pnpm --filter @apps/shop-abc test` (fails: Cannot find module '@/components/atoms')


------
https://chatgpt.com/codex/tasks/task_e_6898fd21efb8832fb3fe3b94cf048b7f