### PR TITLE
feat(cms): store shop-specific Sanity config

### DIFF
--- a/apps/cms/__tests__/saveSanityConfig.test.ts
+++ b/apps/cms/__tests__/saveSanityConfig.test.ts
@@ -1,6 +1,8 @@
 import { saveSanityConfig } from "../src/actions/saveSanityConfig";
 import { verifyCredentials } from "@acme/plugin-sanity";
 import { setupSanityBlog } from "../src/actions/setupSanityBlog";
+import { getShopById, updateShopInRepo } from "@platform-core/src/repositories/shop.server";
+import { setSanityConfig } from "@platform-core/src/shops";
 
 jest.mock("../src/actions/common/auth", () => ({
   ensureAuthorized: jest.fn(),
@@ -14,15 +16,13 @@ jest.mock("../src/actions/setupSanityBlog", () => ({
   setupSanityBlog: jest.fn(),
 }));
 
-jest.mock("@platform-core/dataRoot", () => ({
-  resolveDataRoot: jest.fn(() => "/tmp/data/shops"),
+jest.mock("@platform-core/src/repositories/shop.server", () => ({
+  getShopById: jest.fn(),
+  updateShopInRepo: jest.fn(),
 }));
 
-jest.mock("node:fs", () => ({
-  promises: {
-    mkdir: jest.fn().mockResolvedValue(undefined),
-    writeFile: jest.fn().mockResolvedValue(undefined),
-  },
+jest.mock("@platform-core/src/shops", () => ({
+  setSanityConfig: jest.fn(),
 }));
 
 describe("saveSanityConfig", () => {
@@ -33,13 +33,19 @@ describe("saveSanityConfig", () => {
   it("calls setupSanityBlog after verifying credentials", async () => {
     (verifyCredentials as jest.Mock).mockResolvedValue(true);
     (setupSanityBlog as jest.Mock).mockResolvedValue({ success: true });
+    (getShopById as jest.Mock).mockResolvedValue({ id: "shop" });
+    (setSanityConfig as jest.Mock).mockReturnValue({
+      id: "shop",
+      sanityBlog: { projectId: "p", dataset: "d", token: "t" },
+    });
+    (updateShopInRepo as jest.Mock).mockResolvedValue({ id: "shop" });
 
     const fd = new FormData();
     fd.set("projectId", "p");
     fd.set("dataset", "d");
     fd.set("token", "t");
 
-    const res = await saveSanityConfig(fd);
+    const res = await saveSanityConfig("shop", fd);
 
     expect(verifyCredentials).toHaveBeenCalledWith({
       projectId: "p",
@@ -51,7 +57,16 @@ describe("saveSanityConfig", () => {
       dataset: "d",
       token: "t",
     });
-    expect(res).toEqual({});
+    expect(setSanityConfig).toHaveBeenCalledWith({ id: "shop" }, {
+      projectId: "p",
+      dataset: "d",
+      token: "t",
+    });
+    expect(updateShopInRepo).toHaveBeenCalledWith("shop", {
+      id: "shop",
+      sanityBlog: { projectId: "p", dataset: "d", token: "t" },
+    });
+    expect(res).toEqual({ message: "Sanity connected" });
   });
 
   it("returns error when setupSanityBlog fails", async () => {
@@ -66,7 +81,7 @@ describe("saveSanityConfig", () => {
     fd.set("dataset", "d");
     fd.set("token", "t");
 
-    const res = await saveSanityConfig(fd);
+    const res = await saveSanityConfig("shop", fd);
     expect(res).toEqual({ error: "fail" });
   });
 });

--- a/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
@@ -1,0 +1,70 @@
+// apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+"use client";
+
+import { useFormState } from "react-dom";
+import { Button } from "@/components/atoms/shadcn";
+import { Toast } from "@ui";
+import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
+
+interface FormState {
+  message?: string;
+  error?: string;
+}
+
+interface Props {
+  shopId: string;
+}
+
+const initialState: FormState = { message: "", error: "" };
+
+export default function ConnectForm({ shopId }: Props) {
+  const action = saveSanityConfig.bind(null, shopId);
+  const [state, formAction] = useFormState<FormState>(action, initialState);
+  return (
+    <div className="space-y-4 max-w-md">
+      <form action={formAction} className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="projectId">
+            Project ID
+          </label>
+          <input
+            id="projectId"
+            name="projectId"
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="dataset">
+            Dataset
+          </label>
+          <input
+            id="dataset"
+            name="dataset"
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="token">
+            Token
+          </label>
+          <input
+            id="token"
+            name="token"
+            type="password"
+            className="w-full rounded border p-2"
+            required
+          />
+        </div>
+        <Button type="submit" className="bg-primary text-white">
+          Save
+        </Button>
+      </form>
+      <Toast
+        open={Boolean(state.message || state.error)}
+        message={state.message || state.error || ""}
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/sanity/connect/page.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/page.tsx
@@ -1,52 +1,19 @@
 // apps/cms/src/app/cms/blog/sanity/connect/page.tsx
-import { Button } from "@/components/atoms/shadcn";
-import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
+import ConnectForm from "./ConnectForm.client";
 
 export const revalidate = 0;
 
-export default function SanityConnectPage() {
+export default function SanityConnectPage({
+  searchParams,
+}: {
+  searchParams?: { shopId?: string };
+}) {
+  const shopId = searchParams?.shopId;
+  if (!shopId) return <p>No shop selected.</p>;
   return (
     <div className="space-y-6">
       <h2 className="text-xl font-semibold">Connect Sanity</h2>
-      <form action={saveSanityConfig} className="space-y-4 max-w-md">
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="projectId">
-            Project ID
-          </label>
-          <input
-            id="projectId"
-            name="projectId"
-            className="w-full rounded border p-2"
-            required
-          />
-        </div>
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="dataset">
-            Dataset
-          </label>
-          <input
-            id="dataset"
-            name="dataset"
-            className="w-full rounded border p-2"
-            required
-          />
-        </div>
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="token">
-            Token
-          </label>
-          <input
-            id="token"
-            name="token"
-            type="password"
-            className="w-full rounded border p-2"
-            required
-          />
-        </div>
-        <Button type="submit" className="bg-primary text-white">
-          Save
-        </Button>
-      </form>
+      <ConnectForm shopId={shopId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wire Sanity connect form to include selected shop
- persist Sanity credentials on a shop record via platform-core
- return success/failure message and display via Toast

## Testing
- `pnpm --filter @apps/cms test -- __tests__/saveSanityConfig.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898ff32547c832fb39b1d9bacdca52a