### PR TITLE
chore: use single SANITY_TOKEN env variable

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -5,7 +5,7 @@ import { ensureAuthorized } from "./common/auth";
 const projectId = process.env.SANITY_PROJECT_ID as string;
 const dataset = process.env.SANITY_DATASET as string;
 const apiVersion = process.env.SANITY_API_VERSION || "2021-10-21";
-const token = process.env.SANITY_WRITE_TOKEN;
+const token = process.env.SANITY_TOKEN;
 
 interface SanityPost {
   _id: string;

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -27,12 +27,12 @@ export async function POST(
     if (
       body.SANITY_PROJECT_ID &&
       body.SANITY_DATASET &&
-      body.SANITY_WRITE_TOKEN
+      body.SANITY_TOKEN
     ) {
       await setupSanityBlog({
         projectId: body.SANITY_PROJECT_ID,
         dataset: body.SANITY_DATASET,
-        token: body.SANITY_WRITE_TOKEN,
+        token: body.SANITY_TOKEN,
       }).catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });

--- a/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
@@ -22,7 +22,7 @@ const ENV_KEYS = [
   "GMAIL_PASS",
   "SANITY_PROJECT_ID",
   "SANITY_DATASET",
-  "SANITY_WRITE_TOKEN",
+  "SANITY_TOKEN",
 ] as const;
 
 interface Props {

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -77,7 +77,7 @@ The wizard scaffolds placeholders for common variables:
 - `NEXTAUTH_SECRET` – session encryption secret used by NextAuth
 - `PREVIEW_TOKEN_SECRET` – token used for preview URLs
 - `CMS_SPACE_URL` / `CMS_ACCESS_TOKEN` – headless CMS credentials
-- `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_WRITE_TOKEN` – Sanity blog configuration
+- `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_TOKEN` – Sanity blog configuration
 - `GMAIL_USER`, `GMAIL_PASS` – credentials for email sending
 
 Leave any value blank if the integration isn't needed. You can update the `.env`

--- a/packages/lib/src/sanity.server.ts
+++ b/packages/lib/src/sanity.server.ts
@@ -21,11 +21,12 @@ async function getConfig(shopId: string): Promise<SanityBlogConfig> {
 }
 
 async function getClient(shopId: string) {
-  const { projectId, dataset, token } = await getConfig(shopId);
+  const { projectId, dataset, token: sanityToken } = await getConfig(shopId);
+  // sanityToken is sourced from the SANITY_TOKEN environment variable per shop
   return createClient({
     projectId,
     dataset,
-    token,
+    token: sanityToken,
     apiVersion: "2023-01-01",
     useCdn: true,
   });


### PR DESCRIPTION
## Summary
- replace SANITY_WRITE_TOKEN with SANITY_TOKEN
- document new SANITY_TOKEN env var
- clarify Sanity client token usage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '@/components/atoms/shadcn' from 'apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6898fed21eb0832fa215d80663136dc8