### PR TITLE
feat: add low stock alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Key points:
 
 - Stripe handles deposits via escrow sessions.
 - Inventory lives in JSON files under data/shops/\*/inventory.json.
+- Setting `STOCK_ALERT_RECIPIENT` enables low-stock email alerts when an item's `quantity` falls below its `lowStockThreshold`.
 - Rental pricing matrix defined in data/rental/pricing.json with duration discounts and damage-fee rules.
 - Return logistics options stored in data/return-logistics.json.
 - RBAC: ShopAdmin currently manages all shops.
@@ -162,6 +163,7 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `CMS_SPACE_URL` – base URL of the CMS API
 - `CMS_ACCESS_TOKEN` – access token for pushing schemas
 - `CHROMATIC_PROJECT_TOKEN` – token for publishing Storybook previews
+- `STOCK_ALERT_RECIPIENT` – address that receives low-stock inventory alerts
 
 The scaffolded `.env` also includes generated placeholders for `NEXTAUTH_SECRET`
 and `PREVIEW_TOKEN_SECRET`. Replace all placeholders with real values or supply

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -16,6 +16,7 @@ export const envSchema = z.object({
   CHROMATIC_PROJECT_TOKEN: z.string().optional(),
   GMAIL_USER: z.string().optional(),
   GMAIL_PASS: z.string().optional(),
+  STOCK_ALERT_RECIPIENT: z.string().email().optional(),
 });
 
 applyFriendlyZodMessages();

--- a/packages/platform-core/__tests__/inventory.test.ts
+++ b/packages/platform-core/__tests__/inventory.test.ts
@@ -16,10 +16,40 @@ async function withRepo(
   const cwd = process.cwd();
   process.chdir(dir);
   jest.resetModules();
+  process.env.STRIPE_SECRET_KEY = "test";
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "test";
 
   const repo = await import("../src/repositories/inventory.server");
   try {
     await cb(repo, "test", dir);
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+async function withAlertRepo(
+  cb: (
+    repo: typeof import("../src/repositories/inventory.server"),
+    shop: string,
+    dir: string,
+    check: jest.Mock
+  ) => Promise<void>
+): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "inv-"));
+  const shopDir = path.join(dir, "data", "shops", "test");
+  await fs.mkdir(shopDir, { recursive: true });
+
+  const cwd = process.cwd();
+  process.chdir(dir);
+  jest.resetModules();
+  process.env.STRIPE_SECRET_KEY = "test";
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "test";
+  const check = jest.fn();
+  jest.doMock("../src/services/stockAlert.server", () => ({ checkAndAlert: check }));
+
+  const repo = await import("../src/repositories/inventory.server");
+  try {
+    await cb(repo, "test", dir, check);
   } finally {
     process.chdir(cwd);
   }
@@ -52,6 +82,16 @@ describe("inventory repository", () => {
         "utf8"
       );
       expect(JSON.parse(buf)).toEqual(items);
+    });
+  });
+
+  it("fires stock alerts after write", async () => {
+    await withAlertRepo(async (repo, shop, _dir, check) => {
+      const items = [
+        { sku: "sku-1", quantity: 1, lowStockThreshold: 2 },
+      ];
+      await repo.writeInventory(shop, items);
+      expect(check).toHaveBeenCalledWith(shop, items);
     });
   });
 });

--- a/packages/platform-core/__tests__/stockAlert.test.ts
+++ b/packages/platform-core/__tests__/stockAlert.test.ts
@@ -1,0 +1,39 @@
+import { sendEmail } from "@lib/email";
+
+jest.mock("@lib/email", () => ({
+  sendEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+async function loadService() {
+  jest.resetModules();
+   process.env.STRIPE_SECRET_KEY = "test";
+   process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "test";
+  const mod = await import("../src/services/stockAlert.server");
+  return { ...mod, sendEmail: (await import("@lib/email")).sendEmail as jest.Mock };
+}
+
+describe("stock alert service", () => {
+  it("sends emails when quantities fall below threshold", async () => {
+    process.env.STOCK_ALERT_RECIPIENT = "alerts@example.com";
+    const { checkAndAlert, sendEmail } = await loadService();
+    await checkAndAlert("shop", [
+      { sku: "a", quantity: 1, lowStockThreshold: 2 },
+      { sku: "b", quantity: 5, lowStockThreshold: 2 },
+    ]);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail).toHaveBeenCalledWith(
+      "alerts@example.com",
+      "[shop] Low stock for a",
+      expect.any(String)
+    );
+  });
+
+  it("skips when recipient missing", async () => {
+    delete process.env.STOCK_ALERT_RECIPIENT;
+    const { checkAndAlert, sendEmail } = await loadService();
+    await checkAndAlert("shop", [
+      { sku: "a", quantity: 0, lowStockThreshold: 1 },
+    ]);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { validateShopName } from "../shops";
 
 import { DATA_ROOT } from "../dataRoot";
+import { checkAndAlert } from "../services/stockAlert.server";
 
 function inventoryPath(shop: string): string {
   shop = validateShopName(shop);
@@ -41,4 +42,5 @@ export async function writeInventory(
   const tmp = `${inventoryPath(shop)}.${Date.now()}.tmp`;
   await fs.writeFile(tmp, JSON.stringify(items, null, 2), "utf8");
   await fs.rename(tmp, inventoryPath(shop));
+  await checkAndAlert(shop, items);
 }

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import { sendEmail } from "@lib/email";
+import { env } from "@config/src/env";
+import type { InventoryItem } from "@types";
+
+export async function checkAndAlert(
+  shop: string,
+  items: InventoryItem[],
+): Promise<void> {
+  const recipient = env.STOCK_ALERT_RECIPIENT;
+  if (!recipient) return;
+  for (const item of items) {
+    if (
+      typeof item.lowStockThreshold === "number" &&
+      item.quantity <= item.lowStockThreshold
+    ) {
+      await sendEmail(
+        recipient,
+        `[${shop}] Low stock for ${item.sku}`,
+        `Item ${item.sku} has quantity ${item.quantity} (threshold ${item.lowStockThreshold}).`,
+      );
+    }
+  }
+}

--- a/packages/types/src/InventoryItem.d.ts
+++ b/packages/types/src/InventoryItem.d.ts
@@ -2,12 +2,15 @@ import { z } from "zod";
 export declare const inventoryItemSchema: z.ZodObject<{
     sku: z.ZodString;
     quantity: z.ZodNumber;
+    lowStockThreshold: z.ZodOptional<z.ZodNumber>;
 }, "strip", z.ZodTypeAny, {
     sku: string;
     quantity: number;
+    lowStockThreshold?: number | undefined;
 }, {
     sku: string;
     quantity: number;
+    lowStockThreshold?: number | undefined;
 }>;
 export type InventoryItem = z.infer<typeof inventoryItemSchema>;
 //# sourceMappingURL=InventoryItem.d.ts.map

--- a/packages/types/src/InventoryItem.d.ts.map
+++ b/packages/types/src/InventoryItem.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"InventoryItem.d.ts","sourceRoot":"","sources":["InventoryItem.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,CAAC,EAAE,MAAM,KAAK,CAAC;AAExB,eAAO,MAAM,mBAAmB;;;;;;;;;EAG9B,CAAC;AAEH,MAAM,MAAM,aAAa,GAAG,CAAC,CAAC,KAAK,CAAC,OAAO,mBAAmB,CAAC,CAAC"}

--- a/packages/types/src/InventoryItem.ts
+++ b/packages/types/src/InventoryItem.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const inventoryItemSchema = z.object({
   sku: z.string(),
   quantity: z.number(),
+  lowStockThreshold: z.number().optional(),
 });
 
 export type InventoryItem = z.infer<typeof inventoryItemSchema>;


### PR DESCRIPTION
## Summary
- add stock alert service to send emails when inventory is low
- hook inventory writes to trigger low stock alerts
- document STOCK_ALERT_RECIPIENT environment variable

## Testing
- `pnpm exec jest --runTestsByPath packages/platform-core/__tests__/inventory.test.ts packages/platform-core/__tests__/stockAlert.test.ts --silent`


------
https://chatgpt.com/codex/tasks/task_e_6898fe8b3380832f86296b0711503bec