### PR TITLE
Check Sanity config before loading CMS blog posts

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
@@ -1,15 +1,37 @@
 // apps/cms/src/app/cms/blog/posts/[id]/page.tsx
 
+import Link from "next/link";
+import { Button } from "@ui";
 import { notFound } from "next/navigation";
 import PostForm from "../PostForm.client";
 import PublishButton from "../PublishButton.client";
 import { getPost, updatePost } from "@cms/actions/blog.server";
+import { readShop } from "@platform-core/src/repositories/shops.server";
+import { getSanityConfig } from "@platform-core/src/shops";
 
 interface Params {
   params: { id: string };
 }
 
 export default async function EditPostPage({ params }: Params) {
+  const shopId =
+    process.env.NEXT_PUBLIC_SHOP_ID ||
+    process.env.NEXT_PUBLIC_DEFAULT_SHOP ||
+    "shop";
+  const shop = await readShop(shopId);
+  const config = getSanityConfig(shop);
+
+  if (!config) {
+    return (
+      <div className="space-y-4">
+        <p>Sanity is not connected for this shop.</p>
+        <Button asChild>
+          <Link href="/cms/blog/sanity/connect">Connect Sanity</Link>
+        </Button>
+      </div>
+    );
+  }
+
   const post = await getPost(params.id);
   if (!post) return notFound();
   return (

--- a/apps/cms/src/app/cms/blog/posts/new/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/new/page.tsx
@@ -1,9 +1,31 @@
 // apps/cms/src/app/cms/blog/posts/new/page.tsx
 
+import Link from "next/link";
+import { Button } from "@ui";
 import PostForm from "../PostForm.client";
 import { createPost } from "@cms/actions/blog.server";
+import { readShop } from "@platform-core/src/repositories/shops.server";
+import { getSanityConfig } from "@platform-core/src/shops";
 
-export default function NewPostPage() {
+export default async function NewPostPage() {
+  const shopId =
+    process.env.NEXT_PUBLIC_SHOP_ID ||
+    process.env.NEXT_PUBLIC_DEFAULT_SHOP ||
+    "shop";
+  const shop = await readShop(shopId);
+  const config = getSanityConfig(shop);
+
+  if (!config) {
+    return (
+      <div className="space-y-4">
+        <p>Sanity is not connected for this shop.</p>
+        <Button asChild>
+          <Link href="/cms/blog/sanity/connect">Connect Sanity</Link>
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">New Post</h1>

--- a/apps/cms/src/app/cms/blog/posts/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/page.tsx
@@ -3,8 +3,28 @@
 import Link from "next/link";
 import { Button } from "@ui";
 import { getPosts } from "@cms/actions/blog.server";
+import { readShop } from "@platform-core/src/repositories/shops.server";
+import { getSanityConfig } from "@platform-core/src/shops";
 
 export default async function BlogPostsPage() {
+  const shopId =
+    process.env.NEXT_PUBLIC_SHOP_ID ||
+    process.env.NEXT_PUBLIC_DEFAULT_SHOP ||
+    "shop";
+  const shop = await readShop(shopId);
+  const config = getSanityConfig(shop);
+
+  if (!config) {
+    return (
+      <div className="space-y-4">
+        <p>Sanity is not connected for this shop.</p>
+        <Button asChild>
+          <Link href="/cms/blog/sanity/connect">Connect Sanity</Link>
+        </Button>
+      </div>
+    );
+  }
+
   const posts = await getPosts();
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- ensure each CMS blog post page verifies Sanity config for the active shop
- show a "Connect Sanity" link when no configuration is found

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@prisma/client/index-browser.js')*


------
https://chatgpt.com/codex/tasks/task_e_6898fbf8c174832fbbf975d2d2dfcef9