### PR TITLE
feat(page-builder): add explicit resize controls

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -23,7 +23,9 @@ import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 interface Props {
   component: PageComponent | null;
   onChange: (patch: Partial<PageComponent>) => void;
-  onResize: (patch: { width?: string; height?: string }) => void;
+  onResize: (
+    patch: { width?: string; height?: string; top?: string; left?: string }
+  ) => void;
 }
 
 function ComponentEditor({ component, onChange, onResize }: Props) {
@@ -73,9 +75,10 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
           label="Width"
           placeholder="e.g. 100px or 50%"
           value={component.width ?? ""}
-          onChange={(e) =>
-            onResize({ width: e.target.value ? e.target.value : undefined })
-          }
+          onChange={(e) => {
+            const v = e.target.value.trim();
+            onResize({ width: v || undefined });
+          }}
         />
         <Button
           type="button"
@@ -90,9 +93,10 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
           label="Height"
           placeholder="e.g. 100px or 50%"
           value={component.height ?? ""}
-          onChange={(e) =>
-            onResize({ height: e.target.value ? e.target.value : undefined })
-          }
+          onChange={(e) => {
+            const v = e.target.value.trim();
+            onResize({ height: v || undefined });
+          }}
         />
         <Button
           type="button"
@@ -189,12 +193,18 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
           <Input
             label="Top"
             value={component.top ?? ""}
-            onChange={(e) => handleInput("top", e.target.value)}
+            onChange={(e) => {
+              const v = e.target.value.trim();
+              onResize({ top: v || undefined });
+            }}
           />
           <Input
             label="Left"
             value={component.left ?? ""}
-            onChange={(e) => handleInput("left", e.target.value)}
+            onChange={(e) => {
+              const v = e.target.value.trim();
+              onResize({ left: v || undefined });
+            }}
           />
         </>
       )}

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -100,6 +100,8 @@ const PageBuilder = memo(function PageBuilder({
         setLiveMessage("Block added");
       } else if (action.type === "move") {
         setLiveMessage("Block moved");
+      } else if (action.type === "resize") {
+        setLiveMessage("Block resized");
       }
     },
     [rawDispatch]

--- a/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
@@ -1,6 +1,7 @@
 import ComponentEditor from "./ComponentEditor";
 import type { PageComponent } from "@types";
 import type { Action } from "./state";
+import { useCallback } from "react";
 
 interface Props {
   components: PageComponent[];
@@ -10,16 +11,25 @@ interface Props {
 
 const PageSidebar = ({ components, selectedId, dispatch }: Props) => {
   if (!selectedId) return null;
+
+  const handleChange = useCallback(
+    (patch: Partial<PageComponent>) =>
+      dispatch({ type: "update", id: selectedId, patch }),
+    [dispatch, selectedId],
+  );
+
+  const handleResize = useCallback(
+    (size: { width?: string; height?: string; top?: string; left?: string }) =>
+      dispatch({ type: "resize", id: selectedId, ...size }),
+    [dispatch, selectedId],
+  );
+
   return (
     <aside className="w-72 shrink-0">
       <ComponentEditor
         component={components.find((c) => c.id === selectedId)!}
-        onChange={(patch) =>
-          dispatch({ type: "update", id: selectedId, patch })
-        }
-        onResize={(size) =>
-          dispatch({ type: "resize", id: selectedId, ...size })
-        }
+        onChange={handleChange}
+        onResize={handleResize}
       />
     </aside>
   );


### PR DESCRIPTION
## Summary
- allow resizing page builder components with width/height inputs and full-size buttons
- route resize events through sidebar and builder to update active component
- handle top/left positioning via resize for absolute components

## Testing
- `pnpm lint --filter=@acme/ui`
- `STRIPE_SECRET_KEY=dummy NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy pnpm test --filter=@acme/ui` *(fails: ManagedMessageChannel in test/polyfills/messageChannel.js)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc595190832fb1bea79c3875af54