### PR TITLE
test: add sanity client error handling tests

### DIFF
--- a/packages/lib/__tests__/sanity.server.test.ts
+++ b/packages/lib/__tests__/sanity.server.test.ts
@@ -1,0 +1,57 @@
+jest.mock('@sanity/client', () => ({
+  createClient: jest.fn(),
+}));
+
+import { createClient } from '@sanity/client';
+import {
+  fetchPublishedPosts,
+  fetchPostBySlug,
+  getConfig,
+} from '../src/sanity.server';
+
+describe('sanity.server', () => {
+  const OLD_ENV = process.env;
+  const mockCreateClient = createClient as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      SANITY_SHOP_PROJECT_ID: 'pid',
+      SANITY_SHOP_DATASET: 'dataset',
+      SANITY_SHOP_READ_TOKEN: 'token',
+    } as NodeJS.ProcessEnv;
+    mockCreateClient.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('fetchPublishedPosts returns [] on client error', async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error('fail'));
+    mockCreateClient.mockReturnValue({ fetch: fetchMock });
+
+    await expect(fetchPublishedPosts('shop')).resolves.toEqual([]);
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchPostBySlug returns null on client error', async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error('fail'));
+    mockCreateClient.mockReturnValue({ fetch: fetchMock });
+
+    await expect(fetchPostBySlug('shop', 'slug')).resolves.toBeNull();
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('getConfig throws when required env vars are absent', () => {
+    delete process.env.SANITY_SHOP_PROJECT_ID;
+    delete process.env.SANITY_SHOP_DATASET;
+
+    expect(() => getConfig('shop')).toThrow(
+      'Missing Sanity credentials for shop shop',
+    );
+  });
+});

--- a/packages/lib/src/sanity.server.ts
+++ b/packages/lib/src/sanity.server.ts
@@ -8,7 +8,7 @@ export interface BlogPost {
   body?: unknown;
 }
 
-function getConfig(shopId: string) {
+export function getConfig(shopId: string) {
   const prefix = `SANITY_${shopId.toUpperCase()}_`;
   const projectId = process.env[`${prefix}PROJECT_ID`];
   const dataset = process.env[`${prefix}DATASET`];


### PR DESCRIPTION
## Summary
- export and test Sanity `getConfig`
- verify fetch helpers handle client errors

## Testing
- `pnpm --filter @acme/lib test` *(fails: Cannot find module '@/components/atoms')*

------
https://chatgpt.com/codex/tasks/task_e_6898fc6d7684832fa7e3c0a8fc02c1bb