### PR TITLE
feat: add editable inventory table

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { Button, Textarea } from "@/components/atoms/shadcn";
+import {
+  Button,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/atoms/shadcn";
 import { inventoryItemSchema, type InventoryItem } from "@types";
 import { FormEvent, useRef, useState } from "react";
 
@@ -10,18 +19,72 @@ interface Props {
 }
 
 export default function InventoryForm({ shop, initial }: Props) {
-  const [text, setText] = useState(
-    () => JSON.stringify(initial, null, 2)
-  );
+  const [items, setItems] = useState<InventoryItem[]>(() => initial);
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
   const fileInput = useRef<HTMLInputElement>(null);
 
+  const updateItem = (
+    index: number,
+    field: keyof InventoryItem | "variant.size" | "variant.color",
+    value: string
+  ) => {
+    setItems((prev) => {
+      const next = [...prev];
+      const item = { ...next[index] } as InventoryItem;
+      if (field === "variant.size") {
+        item.variant = { ...item.variant, size: value };
+      } else if (field === "variant.color") {
+        item.variant = { ...item.variant, color: value || undefined };
+      } else if (field === "quantity") {
+        item.quantity = Number(value);
+      } else if (field === "lowStockThreshold") {
+        item.lowStockThreshold = value === "" ? undefined : Number(value);
+      } else if (field === "sku") {
+        item.sku = value;
+        item.productId = value;
+      } else {
+        // other top-level fields
+        // @ts-expect-error
+        item[field] = value;
+      }
+      next[index] = item;
+      return next;
+    });
+  };
+
+  const addRow = () => {
+    setItems((prev) => [
+      ...prev,
+      {
+        sku: "",
+        productId: "",
+        variant: { size: "", color: undefined },
+        quantity: 0,
+        lowStockThreshold: undefined,
+      },
+    ]);
+  };
+
+  const deleteRow = (idx: number) => {
+    setItems((prev) => prev.filter((_, i) => i !== idx));
+  };
+
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     try {
-      const json = JSON.parse(text);
-      const parsed = inventoryItemSchema.array().safeParse(json);
+      const normalized = items.map((i) => ({
+        ...i,
+        productId: i.productId || i.sku,
+        variant: {
+          size: i.variant.size,
+          ...(i.variant.color ? { color: i.variant.color } : {}),
+        },
+        ...(i.lowStockThreshold === undefined
+          ? {}
+          : { lowStockThreshold: i.lowStockThreshold }),
+      }));
+      const parsed = inventoryItemSchema.array().safeParse(normalized);
       if (!parsed.success) {
         setStatus("error");
         setError(parsed.error.issues.map((i) => i.message).join(", "));
@@ -63,7 +126,7 @@ export default function InventoryForm({ shop, initial }: Props) {
       if (!res.ok) {
         throw new Error(body.error || "Failed to import");
       }
-      setText(JSON.stringify(body.items, null, 2));
+      setItems(body.items);
       setStatus("saved");
       setError(null);
     } catch (err) {
@@ -74,9 +137,11 @@ export default function InventoryForm({ shop, initial }: Props) {
     }
   };
 
-  const onExport = async () => {
+  const onExport = async (format: "json" | "csv") => {
     try {
-      const res = await fetch(`/api/data/${shop}/inventory/export?format=json`);
+      const res = await fetch(
+        `/api/data/${shop}/inventory/export?format=${format}`
+      );
       if (!res.ok) {
         throw new Error("Failed to export");
       }
@@ -84,11 +149,7 @@ export default function InventoryForm({ shop, initial }: Props) {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = res.headers
-        .get("content-type")
-        ?.includes("json")
-        ? "inventory.json"
-        : "inventory.csv";
+      a.download = format === "json" ? "inventory.json" : "inventory.csv";
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -101,11 +162,72 @@ export default function InventoryForm({ shop, initial }: Props) {
 
   return (
     <form onSubmit={onSubmit} className="space-y-4">
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        rows={10}
-      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>SKU</TableHead>
+            <TableHead>Size</TableHead>
+            <TableHead>Color</TableHead>
+            <TableHead>Quantity</TableHead>
+            <TableHead>Low stock threshold</TableHead>
+            <TableHead></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item, idx) => (
+            <TableRow key={idx}>
+              <TableCell>
+                <Input
+                  value={item.sku}
+                  onChange={(e) => updateItem(idx, "sku", e.target.value)}
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  value={item.variant.size}
+                  onChange={(e) => updateItem(idx, "variant.size", e.target.value)}
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  value={item.variant.color ?? ""}
+                  onChange={(e) =>
+                    updateItem(idx, "variant.color", e.target.value)
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={item.quantity}
+                  onChange={(e) => updateItem(idx, "quantity", e.target.value)}
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={item.lowStockThreshold ?? ""}
+                  onChange={(e) =>
+                    updateItem(idx, "lowStockThreshold", e.target.value)
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <Button
+                  type="button"
+                  onClick={() => deleteRow(idx)}
+                  aria-label="delete-row"
+                >
+                  Delete
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <Button type="button" onClick={addRow}>
+        Add row
+      </Button>
       {status === "saved" && (
         <p className="text-sm text-green-600">Saved!</p>
       )}
@@ -115,10 +237,13 @@ export default function InventoryForm({ shop, initial }: Props) {
       <div className="space-x-2">
         <Button type="submit">Save</Button>
         <Button type="button" onClick={onImport}>
-          Import
+          Import JSON/CSV
         </Button>
-        <Button type="button" onClick={onExport}>
-          Export
+        <Button type="button" onClick={() => onExport("json")}>
+          Export JSON
+        </Button>
+        <Button type="button" onClick={() => onExport("csv")}>
+          Export CSV
         </Button>
       </div>
       <input
@@ -131,3 +256,4 @@ export default function InventoryForm({ shop, initial }: Props) {
     </form>
   );
 }
+

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -1,0 +1,103 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => {
+    const React = require("react");
+    return {
+      __esModule: true,
+      Button: ({ children, ...props }: any) => (
+        <button {...props}>{children}</button>
+      ),
+      Input: ({ ...props }: any) => <input {...props} />,
+      Table: ({ children }: any) => <table>{children}</table>,
+      TableBody: ({ children }: any) => <tbody>{children}</tbody>,
+      TableCell: ({ children, ...props }: any) => <td {...props}>{children}</td>,
+      TableHead: ({ children }: any) => <th>{children}</th>,
+      TableHeader: ({ children }: any) => <thead>{children}</thead>,
+      TableRow: ({ children }: any) => <tr>{children}</tr>,
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock("@types", () => {
+  const { z } = require("zod");
+  const inventoryItemSchema = z.object({
+    sku: z.string(),
+    productId: z.string(),
+    variant: z.object({
+      size: z.string(),
+      color: z.string().optional(),
+    }),
+    quantity: z.number().min(1),
+    lowStockThreshold: z.number().optional(),
+  });
+  return { inventoryItemSchema };
+});
+
+import InventoryForm from "../InventoryForm";
+
+describe("InventoryForm", () => {
+  const initial = [
+    {
+      sku: "sku1",
+      productId: "sku1",
+      variant: { size: "M", color: "red" },
+      quantity: 5,
+      lowStockThreshold: 2,
+    },
+  ];
+
+  beforeEach(() => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+  });
+
+  it("adds and deletes rows", () => {
+    render(<InventoryForm shop="test" initial={initial} />);
+    // header row + 1 data row
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    fireEvent.click(screen.getByText("Add row"));
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    fireEvent.click(screen.getAllByText("Delete")[1]);
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+  });
+
+  it("posts structured data on save", async () => {
+    render(<InventoryForm shop="test" initial={initial} />);
+    fireEvent.change(screen.getByDisplayValue("sku1"), {
+      target: { value: "sku2" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/data/test/inventory",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify([
+          {
+            sku: "sku2",
+            productId: "sku2",
+            variant: { size: "M", color: "red" },
+            quantity: 5,
+            lowStockThreshold: 2,
+          },
+        ]),
+      })
+    );
+  });
+
+  it("shows validation errors", async () => {
+    render(<InventoryForm shop="test" initial={initial} />);
+    fireEvent.change(screen.getByDisplayValue("5"), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await screen.findByText(/greater than or equal to 1/i);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace JSON textarea with editable table for SKU, variant, quantity and low stock threshold
- add row management, import/export controls and schema validation
- cover inventory form with component tests

## Testing
- `pnpm test --filter @apps/cms -- --runTestsByPath "src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx"`

------
https://chatgpt.com/codex/tasks/task_e_689902398574832f979cda24cdd6ab72