### PR TITLE
feat(cms): guard blog post pages when Sanity missing

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
@@ -1,9 +1,12 @@
 // apps/cms/src/app/cms/blog/posts/[id]/page.tsx
 
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import PostForm from "../PostForm.client";
 import PublishButton from "../PublishButton.client";
 import { getPost, updatePost } from "@cms/actions/blog.server";
+import { getSanityConfig } from "@platform-core/src/shops";
+import { getShopById } from "@platform-core/src/repositories/shop.server";
 
 interface Params {
   params: { id: string };
@@ -16,6 +19,21 @@ export default async function EditPostPage({
 }: Params) {
   const shopId = searchParams?.shopId;
   if (!shopId) return notFound();
+  const shop = await getShopById(shopId);
+  const sanity = getSanityConfig(shop);
+  if (!sanity) {
+    return (
+      <p>
+        Sanity is not connected.{" "}
+        <Link
+          href={`/cms/blog/sanity/connect?shopId=${shopId}`}
+          className="text-primary underline"
+        >
+          Connect Sanity
+        </Link>
+      </p>
+    );
+  }
   const post = await getPost(shopId, params.id);
   if (!post) return notFound();
   return (

--- a/apps/cms/src/app/cms/blog/posts/new/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/new/page.tsx
@@ -1,15 +1,33 @@
 // apps/cms/src/app/cms/blog/posts/new/page.tsx
 
+import Link from "next/link";
 import PostForm from "../PostForm.client";
 import { createPost } from "@cms/actions/blog.server";
+import { getSanityConfig } from "@platform-core/src/shops";
+import { getShopById } from "@platform-core/src/repositories/shop.server";
 
-export default function NewPostPage({
+export default async function NewPostPage({
   searchParams,
 }: {
   searchParams?: { shopId?: string };
 }) {
   const shopId = searchParams?.shopId;
   if (!shopId) return <p>No shop selected.</p>;
+  const shop = await getShopById(shopId);
+  const sanity = getSanityConfig(shop);
+  if (!sanity) {
+    return (
+      <p>
+        Sanity is not connected.{" "}
+        <Link
+          href={`/cms/blog/sanity/connect?shopId=${shopId}`}
+          className="text-primary underline"
+        >
+          Connect Sanity
+        </Link>
+      </p>
+    );
+  }
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">New Post</h1>

--- a/apps/cms/src/app/cms/blog/posts/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { Button } from "@ui";
 import { getPosts } from "@cms/actions/blog.server";
+import { getSanityConfig } from "@platform-core/src/shops";
+import { getShopById } from "@platform-core/src/repositories/shop.server";
 
 export default async function BlogPostsPage({
   searchParams,
@@ -11,6 +13,21 @@ export default async function BlogPostsPage({
 }) {
   const shopId = searchParams?.shopId;
   if (!shopId) return <p>No shop selected.</p>;
+  const shop = await getShopById(shopId);
+  const sanity = getSanityConfig(shop);
+  if (!sanity) {
+    return (
+      <p>
+        Sanity is not connected.{" "}
+        <Link
+          href={`/cms/blog/sanity/connect?shopId=${shopId}`}
+          className="text-primary underline"
+        >
+          Connect Sanity
+        </Link>
+      </p>
+    );
+  }
   const posts = await getPosts(shopId);
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- check for Sanity config on blog post list, new, and edit pages
- prompt user to connect Sanity when missing instead of loading content

## Testing
- `pnpm lint --filter @apps/cms`
- `pnpm test --filter @apps/cms` *(fails: Cannot find module '@/components/atoms')*


------
https://chatgpt.com/codex/tasks/task_e_689902f584c8832fa26ce1b096f6600f