### PR TITLE
feat(platform-core): add prisma rental order store

### DIFF
--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -23,6 +23,11 @@
     "prisma": "^5.15.1"
   },
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/packages/platform-core/prisma/migrations/20240724000000_add_rental_order/migration.sql
+++ b/packages/platform-core/prisma/migrations/20240724000000_add_rental_order/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "RentalOrder" (
+    "id" TEXT NOT NULL,
+    "shop" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "deposit" INTEGER NOT NULL,
+    "expectedReturnDate" TEXT,
+    "startedAt" TEXT NOT NULL,
+    "returnedAt" TEXT,
+    "refundedAt" TEXT,
+    "damageFee" INTEGER,
+    "customerId" TEXT,
+    CONSTRAINT "RentalOrder_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RentalOrder_shop_sessionId_key" ON "RentalOrder"("shop", "sessionId");
+
+-- CreateIndex
+CREATE INDEX "RentalOrder_customerId_idx" ON "RentalOrder"("customerId");

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -21,3 +21,19 @@ model Page {
   slug   String
   data   Json
 }
+
+model RentalOrder {
+  id                 String @id
+  shop               String
+  sessionId          String
+  deposit            Int
+  expectedReturnDate String?
+  startedAt          String
+  returnedAt         String?
+  refundedAt         String?
+  damageFee          Int?
+  customerId         String?
+
+  @@unique([shop, sessionId])
+  @@index([customerId])
+}

--- a/packages/platform-core/prisma/seed.ts
+++ b/packages/platform-core/prisma/seed.ts
@@ -1,0 +1,25 @@
+import { prisma } from "../src/db";
+
+async function main() {
+  await prisma.rentalOrder.createMany({
+    data: [
+      {
+        id: "seed-order-1",
+        shop: "seed-shop",
+        sessionId: "seed-session",
+        deposit: 0,
+        startedAt: new Date().toISOString(),
+      },
+    ],
+    skipDuplicates: true,
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,3 +1,8 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+const databaseUrl =
+  process.env.DATABASE_URL ?? "file:./packages/platform-core/dev.db";
+
+export const prisma = new PrismaClient({
+  datasources: { db: { url: databaseUrl } },
+});


### PR DESCRIPTION
## Summary
- add RentalOrder model and migration
- persist orders with Prisma client instead of in-memory map
- add seed and migration scripts for orders

## Testing
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms')*
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" pnpm -F @acme/platform-core exec prisma db seed`


------
https://chatgpt.com/codex/tasks/task_e_6899017904cc832f916251b5945993b2