### PR TITLE
test: add sanity server tests

### DIFF
--- a/packages/lib/__tests__/sanity.server.test.ts
+++ b/packages/lib/__tests__/sanity.server.test.ts
@@ -1,0 +1,55 @@
+jest.mock('@sanity/client', () => ({
+  createClient: jest.fn(),
+}));
+jest.mock('@platform-core/repositories/shop.server', () => ({
+  getShopById: jest.fn(),
+}));
+jest.mock('@platform-core/shops', () => ({
+  getSanityConfig: jest.fn(),
+}));
+
+import { fetchPublishedPosts, fetchPostBySlug, getConfig } from '../src/sanity.server';
+import { createClient } from '@sanity/client';
+import { getShopById } from '@platform-core/repositories/shop.server';
+import { getSanityConfig } from '@platform-core/shops';
+
+describe('sanity.server', () => {
+  const createClientMock = createClient as jest.Mock;
+  const getShopByIdMock = getShopById as jest.Mock;
+  const getSanityConfigMock = getSanityConfig as jest.Mock;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    createClientMock.mockReturnValue({ fetch: fetchMock });
+    getShopByIdMock.mockResolvedValue({ id: 'shop1' });
+    getSanityConfigMock.mockReturnValue({
+      projectId: 'pid',
+      dataset: 'ds',
+      token: 'tkn',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetchPublishedPosts returns empty array on client error', async () => {
+    fetchMock.mockRejectedValue(new Error('fail'));
+    await expect(fetchPublishedPosts('shop1')).resolves.toEqual([]);
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchPostBySlug returns null on client error', async () => {
+    fetchMock.mockRejectedValue(new Error('fail'));
+    await expect(fetchPostBySlug('shop1', 'slug')).resolves.toBeNull();
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('getConfig throws when env vars are missing', async () => {
+    getSanityConfigMock.mockReturnValue(undefined);
+    await expect(getConfig('shop1')).rejects.toThrow('Missing Sanity credentials for shop shop1');
+  });
+});

--- a/packages/lib/src/sanity.server.ts
+++ b/packages/lib/src/sanity.server.ts
@@ -11,7 +11,7 @@ export interface BlogPost {
   body?: unknown;
 }
 
-async function getConfig(shopId: string): Promise<SanityBlogConfig> {
+export async function getConfig(shopId: string): Promise<SanityBlogConfig> {
   const shop = await getShopById(shopId);
   const config = getSanityConfig(shop);
   if (!config) {


### PR DESCRIPTION
## Summary
- export getConfig to enable direct testing
- add sanity server tests covering client errors and missing config

## Testing
- `pnpm test --filter @acme/lib` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_689903320e78832f8e93cc1c6aec2e95