### PR TITLE
feat: add SEO audit script

### DIFF
--- a/doc/seo.md
+++ b/doc/seo.md
@@ -31,3 +31,14 @@ pnpm --filter @apps/<shop-id> build
 ```
 
 During development, requesting `/sitemap.xml` will always serve the latest data.
+
+## Running SEO audits
+
+Run an automated Lighthouse audit focusing on SEO using the helper script:
+
+```bash
+pnpm run seo:audit http://localhost:3000
+```
+
+The optional first argument is the URL to audit (defaults to `http://localhost:3000`).
+An HTML report is written to `seo-report.html` in the current working directory.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "pages:migrate": "ts-node scripts/src/migrate-pages.ts",
     "deposit-service": "ts-node packages/platform-machine/releaseDepositsService.ts",
     "lh:checkout": "lighthouse http://localhost:3000/en/checkout --chrome-flags=\"--headless\" --only-categories=performance,accessibility,best-practices,seo --preset=desktop",
+    "seo:audit": "tsx scripts/seo-audit.ts",
     "validate-env": "ts-node scripts/src/validate-env.ts",
     "check:locales": "ts-node scripts/src/check-locales.ts",
     "check:tailwind-preset": "tsx scripts/check-tailwind-preset.ts",

--- a/scripts/seo-audit.ts
+++ b/scripts/seo-audit.ts
@@ -1,0 +1,29 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const lighthouseBin = path.resolve(__dirname, '../node_modules/.bin/lighthouse');
+
+const url = process.argv[2] || 'http://localhost:3000';
+const output = process.argv[3] || 'seo-report.html';
+
+const args = [
+  url,
+  '--chrome-flags=--headless',
+  '--only-categories=seo',
+  '--preset=desktop',
+  '--output=html',
+  `--output-path=${output}`,
+];
+
+const child = spawn(lighthouseBin, args, { stdio: 'inherit' });
+
+child.on('exit', (code) => {
+  if (code !== 0) {
+    console.error(`Lighthouse audit failed with code ${code}`);
+    process.exit(code ?? 1);
+  }
+});


### PR DESCRIPTION
## Summary
- add Lighthouse-based `seo:audit` script for automated SEO reports
- document and expose SEO audit helper via `pnpm run seo:audit`

## Testing
- `pnpm exec eslint scripts/seo-audit.ts` (warning: File ignored because no matching configuration was supplied)
- `pnpm exec jest packages/template-app/__tests__/ai-catalog.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689903cc4988832fab6bd58427665683