### PR TITLE
feat: enforce strict history state schema

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -308,6 +308,7 @@ export const historyStateSchema: z.ZodType<HistoryState> = z
     present: z.array(pageComponentSchema),
     future: z.array(z.array(pageComponentSchema)),
   })
+  .strict()
   .default({ past: [], present: [], future: [] });
 
 export const pageSchema = z.object({


### PR DESCRIPTION
## Summary
- require exact fields for history state schema to discard unknown keys

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6899041afd54832f88db87914773af6c