### PR TITLE
refactor: infer cart types locally

### DIFF
--- a/apps/shop-abc/src/app/api/cart/route.d.ts
+++ b/apps/shop-abc/src/app/api/cart/route.d.ts
@@ -5,13 +5,13 @@ export declare function POST(req: NextRequest): Promise<
   | NextResponse<Record<string, string[]>>
   | NextResponse<{
       ok: boolean;
-      cart: import("@types").CartState;
+      cart: import("@/lib/cartCookie").CartState;
     }>
 >;
 export declare function PATCH(req: NextRequest): Promise<
   | NextResponse<Record<string, string[]>>
   | NextResponse<{
       ok: boolean;
-      cart: import("@types").CartState;
+      cart: import("@/lib/cartCookie").CartState;
     }>
 >;

--- a/apps/shop-bcd/src/api/cart/route.d.ts
+++ b/apps/shop-bcd/src/api/cart/route.d.ts
@@ -5,11 +5,11 @@ export declare function POST(req: NextRequest): Promise<NextResponse<{
     error: string;
 }> | NextResponse<{
     ok: boolean;
-    cart: import("@types").CartState;
+    cart: import("@/lib/cartCookie").CartState;
 }>>;
 export declare function PATCH(req: NextRequest): Promise<NextResponse<{
     error: string;
 }> | NextResponse<{
     ok: boolean;
-    cart: import("@types").CartState;
+    cart: import("@/lib/cartCookie").CartState;
 }>>;

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -2,9 +2,13 @@
 import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import { Locale, resolveLocale } from "@/i18n/locales";
-import { CART_COOKIE, decodeCartCookie } from "@platform-core/src/cartCookie";
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+  type CartLine,
+  type CartState,
+} from "@platform-core/src/cartCookie";
 import { getProductById } from "@platform-core/src/products";
-import type { CartLine, CartState } from "@types";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
 


### PR DESCRIPTION
## Summary
- expose `CartLine` and `CartState` from cart cookies
- replace `@types` cart imports with `cartCookie` equivalents

## Testing
- `pnpm exec eslint packages/platform-core/src/cartCookie.ts packages/template-app/src/app/[lang]/checkout/page.tsx apps/shop-bcd/src/api/cart/route.d.ts apps/shop-abc/src/app/api/cart/route.d.ts`
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_689904231648832faebaa39893aab6da