### PR TITLE
feat: add abandoned cart recovery workflow

### DIFF
--- a/packages/lib/email/src/__tests__/abandonedCart.test.ts
+++ b/packages/lib/email/src/__tests__/abandonedCart.test.ts
@@ -1,0 +1,49 @@
+import { recoverAbandonedCarts, type AbandonedCart } from "../index";
+import { sendCampaignEmail } from "../send";
+
+jest.mock("../send", () => ({
+  __esModule: true,
+  sendCampaignEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+const sendCampaignEmailMock = sendCampaignEmail as jest.Mock;
+
+describe("recoverAbandonedCarts", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("sends emails for carts older than a day and marks them as reminded", async () => {
+    const now = Date.now();
+    const carts: AbandonedCart[] = [
+      {
+        email: "old@example.com",
+        cart: {},
+        updatedAt: now - 25 * 60 * 60 * 1000,
+      },
+      {
+        email: "fresh@example.com",
+        cart: {},
+        updatedAt: now - 2 * 60 * 60 * 1000,
+      },
+      {
+        email: "already@example.com",
+        cart: {},
+        updatedAt: now - 26 * 60 * 60 * 1000,
+        reminded: true,
+      },
+    ];
+
+    await recoverAbandonedCarts(carts, now);
+
+    expect(sendCampaignEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendCampaignEmailMock).toHaveBeenCalledWith({
+      to: "old@example.com",
+      subject: "You left items in your cart",
+      html: "<p>You left items in your cart.</p>",
+    });
+    expect(carts[0].reminded).toBe(true);
+    expect(carts[1].reminded).toBeUndefined();
+    expect(carts[2].reminded).toBe(true);
+  });
+});

--- a/packages/lib/email/src/abandonedCart.ts
+++ b/packages/lib/email/src/abandonedCart.ts
@@ -1,0 +1,36 @@
+import { sendCampaignEmail } from "./send";
+
+export interface AbandonedCart {
+  /** Customer's email address */
+  email: string;
+  /** Arbitrary cart payload */
+  cart: unknown;
+  /** Last time the cart was updated */
+  updatedAt: number;
+  /** Whether a reminder email has already been sent */
+  reminded?: boolean;
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+/**
+ * Send reminder emails for carts that have been inactive for at least a day.
+ * Carts with `reminded` set to true are ignored. When an email is sent, the
+ * record's `reminded` flag is set to true.
+ */
+export async function recoverAbandonedCarts(
+  carts: AbandonedCart[],
+  now: number = Date.now()
+): Promise<void> {
+  for (const record of carts) {
+    if (record.reminded) continue;
+    if (now - record.updatedAt < DAY_MS) continue;
+
+    await sendCampaignEmail({
+      to: record.email,
+      subject: "You left items in your cart",
+      html: "<p>You left items in your cart.</p>",
+    });
+    record.reminded = true;
+  }
+}

--- a/packages/lib/email/src/index.ts
+++ b/packages/lib/email/src/index.ts
@@ -1,30 +1,4 @@
-import nodemailer from "nodemailer";
-
-export interface CampaignOptions {
-  /** Recipient email address */
-  to: string;
-  /** Email subject line */
-  subject: string;
-  /** HTML body */
-  html: string;
-  /** Optional plain-text body */
-  text?: string;
-}
-
-/**
- * Send a campaign email using Nodemailer. Transport configuration is taken
- * from the SMTP_URL environment variable.
- */
-export async function sendCampaignEmail(options: CampaignOptions): Promise<void> {
-  const transport = nodemailer.createTransport({
-    url: process.env.SMTP_URL,
-  });
-
-  await transport.sendMail({
-    from: process.env.CAMPAIGN_FROM || "no-reply@example.com",
-    to: options.to,
-    subject: options.subject,
-    html: options.html,
-    text: options.text,
-  });
-}
+export type { CampaignOptions } from "./send";
+export { sendCampaignEmail } from "./send";
+export type { AbandonedCart } from "./abandonedCart";
+export { recoverAbandonedCarts } from "./abandonedCart";

--- a/packages/lib/email/src/send.ts
+++ b/packages/lib/email/src/send.ts
@@ -1,0 +1,32 @@
+import nodemailer from "nodemailer";
+
+export interface CampaignOptions {
+  /** Recipient email address */
+  to: string;
+  /** Email subject line */
+  subject: string;
+  /** HTML body */
+  html: string;
+  /** Optional plain-text body */
+  text?: string;
+}
+
+/**
+ * Send a campaign email using Nodemailer. Transport configuration is taken
+ * from the SMTP_URL environment variable.
+ */
+export async function sendCampaignEmail(
+  options: CampaignOptions
+): Promise<void> {
+  const transport = nodemailer.createTransport({
+    url: process.env.SMTP_URL,
+  });
+
+  await transport.sendMail({
+    from: process.env.CAMPAIGN_FROM || "no-reply@example.com",
+    to: options.to,
+    subject: options.subject,
+    html: options.html,
+    text: options.text,
+  });
+}


### PR DESCRIPTION
## Summary
- add helper to send campaign emails
- implement abandoned-cart recovery workflow with reminder handling
- test abandoned cart reminders are only sent once

## Testing
- `npx jest packages/lib/email/src/__tests__/abandonedCart.test.ts packages/lib/email/src/__tests__/sendCampaignEmail.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689903a204fc832fbe5d94bd52901d0e