### PR TITLE
feat(cms): move cloudflare provisioning server-side

### DIFF
--- a/apps/cms/src/actions/cloudflare.server.ts
+++ b/apps/cms/src/actions/cloudflare.server.ts
@@ -1,0 +1,70 @@
+// apps/cms/src/actions/cloudflare.server.ts
+"use server";
+
+import { ensureAuthorized } from "./common/auth";
+
+export async function provisionDomain(
+  shopId: string,
+  domain: string
+): Promise<{ status?: string; certificateStatus?: string }> {
+  await ensureAuthorized();
+  const account = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  if (!account || !token) throw new Error("Cloudflare credentials not configured");
+
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  } as const;
+
+  const addRes = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${shopId}/domains`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: domain }),
+    }
+  );
+  const addJson = (await addRes.json()) as any;
+  if (!addRes.ok) {
+    throw new Error(addJson.errors?.[0]?.message ?? "Failed to provision domain");
+  }
+
+  const cnameTarget =
+    addJson.result?.verification_data?.cname_target || `${shopId}.pages.dev`;
+
+  const root = domain.split(".").slice(-2).join(".");
+  const zoneRes = await fetch(`https://api.cloudflare.com/client/v4/zones?name=${root}`, {
+    headers,
+  });
+  const zoneJson = (await zoneRes.json()) as any;
+  const zoneId = zoneJson.result?.[0]?.id as string | undefined;
+  if (zoneId) {
+    await fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/dns_records`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        type: "CNAME",
+        name: domain,
+        content: cnameTarget,
+        ttl: 1,
+      }),
+    }).catch(() => {});
+  }
+
+  const verifyRes = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${shopId}/domains/${domain}/verify`,
+    { method: "POST", headers }
+  );
+  const verifyJson = (await verifyRes.json()) as any;
+  if (!verifyRes.ok) {
+    throw new Error(
+      verifyJson.errors?.[0]?.message ?? "Failed to issue certificate"
+    );
+  }
+
+  return {
+    status: verifyJson.result?.status as string | undefined,
+    certificateStatus: verifyJson.result?.certificate_status as string | undefined,
+  };
+}

--- a/apps/cms/src/app/api/cloudflare/route.ts
+++ b/apps/cms/src/app/api/cloudflare/route.ts
@@ -1,0 +1,22 @@
+import { provisionDomain } from "@cms/actions/cloudflare.server";
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const body = await req.json();
+    const { id, domain } = body as { id: string; domain: string };
+    const res = await provisionDomain(id, domain);
+    return NextResponse.json(res);
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/cms/wizard/services/deployShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/deployShop.ts
@@ -19,78 +19,6 @@ export interface DeployResult {
   error?: string;
 }
 
-async function createCloudflareRecords(
-  shopId: string,
-  domain: string
-): Promise<{ status?: string; certificateStatus?: string }> {
-  const account = process.env.NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_ID;
-  const token = process.env.NEXT_PUBLIC_CLOUDFLARE_API_TOKEN;
-  if (!account || !token) throw new Error("Cloudflare credentials not configured");
-
-  const headers = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  } as const;
-
-  // Add custom domain to project
-  const addRes = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${shopId}/domains`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ name: domain }),
-    }
-  );
-  const addJson = (await addRes.json()) as any;
-  if (!addRes.ok) {
-    throw new Error(addJson.errors?.[0]?.message ?? "Failed to provision domain");
-  }
-
-  const cnameTarget =
-    addJson.result?.verification_data?.cname_target || `${shopId}.pages.dev`;
-
-  // Determine zone for domain and create DNS record
-  const root = domain.split(".").slice(-2).join(".");
-  const zoneRes = await fetch(
-    `https://api.cloudflare.com/client/v4/zones?name=${root}`,
-    { headers }
-  );
-  const zoneJson = (await zoneRes.json()) as any;
-  const zoneId = zoneJson.result?.[0]?.id as string | undefined;
-  if (zoneId) {
-    await fetch(
-      `https://api.cloudflare.com/client/v4/zones/${zoneId}/dns_records`,
-      {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          type: "CNAME",
-          name: domain,
-          content: cnameTarget,
-          ttl: 1,
-        }),
-      }
-    ).catch(() => {});
-  }
-
-  // Verify domain / issue certificate
-  const verifyRes = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${account}/pages/projects/${shopId}/domains/${domain}/verify`,
-    { method: "POST", headers }
-  );
-  const verifyJson = (await verifyRes.json()) as any;
-  if (!verifyRes.ok) {
-    throw new Error(
-      verifyJson.errors?.[0]?.message ?? "Failed to issue certificate"
-    );
-  }
-
-  return {
-    status: verifyJson.result?.status as string | undefined,
-    certificateStatus: verifyJson.result?.certificate_status as string | undefined,
-  };
-}
-
 export async function deployShop(
   shopId: string,
   domain: string
@@ -113,18 +41,30 @@ export async function deployShop(
   const json = (await res.json()) as DeployInfo | { status: "pending"; error?: string };
 
   if (!res.ok) {
-    return { ok: false, error: json.error ?? "Deployment failed" };
+    return { ok: false, error: (json as any).error ?? "Deployment failed" };
   }
 
   let info: DeployInfo = json as DeployInfo;
 
   if (domain) {
     try {
-      const cf = await createCloudflareRecords(shopId, domain);
+      const cfRes = await fetch("/cms/api/cloudflare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: shopId, domain }),
+      });
+      const cfJson = (await cfRes.json()) as {
+        status?: string;
+        certificateStatus?: string;
+        error?: string;
+      };
+      if (!cfRes.ok) {
+        throw new Error(cfJson.error ?? "Failed to provision domain");
+      }
       info = {
         ...(json as DeployInfo),
-        domainStatus: cf.status ?? (json as DeployInfo).domainStatus,
-        certificateStatus: cf.certificateStatus,
+        domainStatus: cfJson.status ?? (json as DeployInfo).domainStatus,
+        certificateStatus: cfJson.certificateStatus,
       };
 
       await fetch("/cms/api/deploy-shop", {
@@ -133,8 +73,8 @@ export async function deployShop(
         body: JSON.stringify({
           id: shopId,
           domain,
-          domainStatus: cf.status,
-          certificateStatus: cf.certificateStatus,
+          domainStatus: cfJson.status,
+          certificateStatus: cfJson.certificateStatus,
         }),
       });
     } catch (err) {
@@ -159,4 +99,3 @@ export async function getDeployStatus(
     | DeployInfo
     | { status: "pending"; error?: string; domainStatus?: string; certificateStatus?: string };
 }
-

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -81,6 +81,7 @@ The wizard scaffolds placeholders for common variables:
 - `CMS_SPACE_URL` / `CMS_ACCESS_TOKEN` – headless CMS credentials
 - `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_WRITE_TOKEN` – Sanity blog configuration
 - `GMAIL_USER`, `GMAIL_PASS` – credentials for email sending
+- `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` – Cloudflare credentials for provisioning custom domains (server-side only)
 
 Leave any value blank if the integration isn't needed. You can update the `.env`
 file later and rerun `pnpm validate-env <id>` to confirm everything is set up.


### PR DESCRIPTION
## Summary
- add server-side Cloudflare provisioning action and API route
- call server Cloudflare endpoint from shop deployment
- document CLOUDFLARE_* env variables

## Testing
- `pnpm test:cms` (fails: Cannot find module '@/components/atoms'...)
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68990545d704832fa0242479ab5d0380