### PR TITLE
feat: sync wizard preview on state changes

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -29,6 +29,7 @@ export default function WizardPreview({ style }: Props): React.JSX.Element {
 
   /* ------------------------------------------------------------------ */
   /*             Sync wizard state from localStorage                    */
+  /*  Re-sync when localStorage changes or when a custom event fires.   */
   /* ------------------------------------------------------------------ */
   useEffect(() => {
     const load = () => {
@@ -46,7 +47,11 @@ export default function WizardPreview({ style }: Props): React.JSX.Element {
 
     load();
     window.addEventListener("storage", load);
-    return () => window.removeEventListener("storage", load);
+    window.addEventListener("wizard:update", load);
+    return () => {
+      window.removeEventListener("storage", load);
+      window.removeEventListener("wizard:update", load);
+    };
   }, []);
 
   /* ------------------------------------------------------------------ */

--- a/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
@@ -24,7 +24,7 @@ export async function resetWizardProgress(): Promise<void> {
 }
 
 /**
- * Loads wizard state from the server and saves it back whenever the step
+ * Loads wizard state from the server and saves it back whenever the state
  * changes. A copy is mirrored to localStorage so the live preview can read it.
  */
 export function useWizardPersistence(
@@ -44,6 +44,7 @@ export function useWizardPersistence(
           setState(parsed.data);
           try {
             localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed.data));
+            window.dispatchEvent(new CustomEvent("wizard:update"));
           } catch {
             /* ignore */
           }
@@ -57,11 +58,12 @@ export function useWizardPersistence(
       });
   }, [setState]);
 
-  /* Persist whenever the step changes */
+  /* Persist whenever the state changes */
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      window.dispatchEvent(new CustomEvent("wizard:update"));
     } catch {
       /* ignore quota */
     }
@@ -72,5 +74,5 @@ export function useWizardPersistence(
     }).catch(() => {
       /* ignore network errors */
     });
-  }, [state.step]);
+  }, [state]);
 }


### PR DESCRIPTION
## Summary
- persist wizard state on any change and notify preview via custom event
- refresh `WizardPreview` when local storage or custom events trigger

## Testing
- `pnpm exec jest apps/cms/__tests__/wizard.test.tsx --runInBand` *(fails: Cannot find module '@/components/atoms')*
- `pnpm lint:apps` *(fails: You are linting "apps/**/*.{ts,tsx}", but all of the files matching the glob pattern are ignored)*

------
https://chatgpt.com/codex/tasks/task_e_6899053ee8c4832fb5f653266d158921