### PR TITLE
refactor: infer create shop options types

### DIFF
--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -1,11 +1,8 @@
 // apps/cms/src/actions/createShop.ts
 "use server";
 
-import {
-  createShop,
-  type CreateShopOptions,
-  type DeployStatusBase,
-} from "@platform-core/createShop";
+import { createShop, type DeployStatusBase } from "@platform-core/createShop";
+import type { CreateShopOptions } from "@platform-core/createShop/schema";
 import { readRbac, writeRbac } from "../lib/rbacStore";
 import { ensureAuthorized } from "./common/auth";
 

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -7,9 +7,8 @@ import { validateShopName } from "./shops";
 import {
   prepareOptions,
   createShopOptionsSchema as createShopOptionsSchemaInternal,
-  type CreateShopOptions,
-  type PreparedCreateShopOptions,
 } from "./createShop/schema";
+import type { CreateShopOptions } from "./createShop/schema";
 import { loadTokens } from "./createShop/themeUtils";
 
 /**
@@ -163,9 +162,13 @@ export function syncTheme(shop: string, theme: string): Record<string, string> {
   return loadTokens(theme);
 }
 
-export const createShopOptionsSchema = createShopOptionsSchemaInternal.strict();
+export const createShopOptionsSchema =
+  createShopOptionsSchemaInternal.strict();
 export { prepareOptions };
-export type { CreateShopOptions, PreparedCreateShopOptions };
+export type {
+  CreateShopOptions,
+  PreparedCreateShopOptions,
+} from "./createShop/schema";
 export { ensureTemplateExists, writeFiles, copyTemplate } from "./createShop/fsUtils";
 export { loadTokens, loadBaseTokens } from "./createShop/themeUtils";
 export { syncTheme };

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -8,43 +8,45 @@ import { defaultPaymentProviders } from "./defaultPaymentProviders";
 import { defaultShippingProviders } from "./defaultShippingProviders";
 import { defaultTaxProviders } from "./defaultTaxProviders";
 
-export const createShopOptionsSchema = z.object({
-  name: z.string().optional(),
-  logo: z.string().url().optional(),
-  contactInfo: z.string().optional(),
-  type: z.enum(["sale", "rental"]).optional(),
-  theme: z.string().optional(),
-  template: z.string().optional(),
-  payment: z.array(z.enum(defaultPaymentProviders)).default([]),
-  shipping: z.array(z.enum(defaultShippingProviders)).default([]),
-  tax: z.enum(defaultTaxProviders).default("taxjar"),
-  pageTitle: z.record(localeSchema, z.string()).optional(),
-  pageDescription: z.record(localeSchema, z.string()).optional(),
-  socialImage: z.string().url().optional(),
-  analytics: z
-    .object({
-      enabled: z.boolean().optional(),
-      provider: z.string(),
-      id: z.string().optional(),
-    })
-    .optional(),
-  sanityBlog: sanityBlogConfigSchema.optional(),
-  navItems: z
-    .array(z.object({ label: z.string().min(1), url: z.string().min(1) }))
-    .default([]),
-  pages: z
-    .array(
-      z.object({
-        slug: z.string(),
-        title: z.record(localeSchema, z.string()),
-        description: z.record(localeSchema, z.string()).optional(),
-        image: z.record(localeSchema, z.string()).optional(),
-        components: z.array(pageComponentSchema),
+export const createShopOptionsSchema = z
+  .object({
+    name: z.string().optional(),
+    logo: z.string().url().optional(),
+    contactInfo: z.string().optional(),
+    type: z.enum(["sale", "rental"]).optional(),
+    theme: z.string().optional(),
+    template: z.string().optional(),
+    payment: z.array(z.enum(defaultPaymentProviders)).default([]),
+    shipping: z.array(z.enum(defaultShippingProviders)).default([]),
+    tax: z.enum(defaultTaxProviders).default("taxjar"),
+    pageTitle: z.record(localeSchema, z.string()).optional(),
+    pageDescription: z.record(localeSchema, z.string()).optional(),
+    socialImage: z.string().url().optional(),
+    analytics: z
+      .object({
+        enabled: z.boolean().optional(),
+        provider: z.string(),
+        id: z.string().optional(),
       })
-    )
-    .default([]),
-  checkoutPage: z.array(pageComponentSchema).default([]),
-});
+      .optional(),
+    sanityBlog: sanityBlogConfigSchema.optional(),
+    navItems: z
+      .array(z.object({ label: z.string().min(1), url: z.string().min(1) }))
+      .default([]),
+    pages: z
+      .array(
+        z.object({
+          slug: z.string(),
+          title: z.record(localeSchema, z.string()),
+          description: z.record(localeSchema, z.string()).optional(),
+          image: z.record(localeSchema, z.string()).optional(),
+          components: z.array(pageComponentSchema),
+        })
+      )
+      .default([]),
+    checkoutPage: z.array(pageComponentSchema).default([]),
+  })
+  .strict();
 
 export type CreateShopOptions = z.infer<typeof createShopOptionsSchema>;
 


### PR DESCRIPTION
## Summary
- make `createShopOptionsSchema` strict
- derive `CreateShopOptions` and `PreparedCreateShopOptions` from schema
- update CMS create-shop action to import inferred types

## Testing
- `pnpm --filter @acme/platform-core --filter cms lint`
- `pnpm --filter cms test` *(fails: Cannot find module '@/components/atoms')*


------
https://chatgpt.com/codex/tasks/task_e_6899041c103c832f8efb8244ebf14115