### PR TITLE
feat: add customer profile persistence

### DIFF
--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -1,5 +1,9 @@
 // apps/shop-abc/src/app/api/account/profile/route.ts
 import { getCustomerSession } from "@auth";
+import {
+  getCustomerProfile,
+  updateCustomerProfile,
+} from "@acme/platform-core";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -25,7 +29,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
   }
 
-  // TODO: persist profile changes
-  return NextResponse.json({ ok: true, profile: parsed.data });
+  await updateCustomerProfile(session.customerId, parsed.data);
+  const profile = await getCustomerProfile(session.customerId);
+  return NextResponse.json({ ok: true, profile });
 }
 

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -1,5 +1,9 @@
 // apps/shop-bcd/src/app/api/account/profile/route.ts
 import { getCustomerSession } from "@auth";
+import {
+  getCustomerProfile,
+  updateCustomerProfile,
+} from "@acme/platform-core";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -25,7 +29,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
   }
 
-  // TODO: persist profile changes
-  return NextResponse.json({ ok: true, profile: parsed.data });
+  await updateCustomerProfile(session.customerId, parsed.data);
+  const profile = await getCustomerProfile(session.customerId);
+  return NextResponse.json({ ok: true, profile });
 }
 

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -7,7 +7,8 @@
     ".": "./src/index.ts",
     "./shipping": "./src/shipping/index.ts",
     "./tax": "./src/tax/index.ts",
-    "./orders": "./src/orders.ts"
+    "./orders": "./src/orders.ts",
+    "./customerProfiles": "./src/customerProfiles.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",

--- a/packages/platform-core/prisma/migrations/20240810000000_add_customer_profile/migration.sql
+++ b/packages/platform-core/prisma/migrations/20240810000000_add_customer_profile/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "CustomerProfile" (
+    "customerId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+
+    CONSTRAINT "CustomerProfile_pkey" PRIMARY KEY ("customerId")
+);

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -37,3 +37,9 @@ model RentalOrder {
   @@unique([shop, sessionId])
   @@index([customerId])
 }
+
+model CustomerProfile {
+  customerId String @id
+  name       String
+  email      String
+}

--- a/packages/platform-core/src/customerProfiles.ts
+++ b/packages/platform-core/src/customerProfiles.ts
@@ -1,0 +1,24 @@
+// packages/platform-core/src/customerProfiles.ts
+import "server-only";
+import { prisma } from "./db";
+
+export interface CustomerProfile {
+  customerId: string;
+  name: string;
+  email: string;
+}
+
+export async function getCustomerProfile(customerId: string): Promise<CustomerProfile | null> {
+  return prisma.customerProfile.findUnique({ where: { customerId } });
+}
+
+export async function updateCustomerProfile(
+  customerId: string,
+  data: { name: string; email: string }
+): Promise<CustomerProfile> {
+  return prisma.customerProfile.upsert({
+    where: { customerId },
+    update: data,
+    create: { customerId, ...data },
+  });
+}

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -11,3 +11,4 @@ export * from "./shipping";
 export * from "./tax";
 export * from "./plugins";
 export * from "./orders";
+export * from "./customerProfiles";


### PR DESCRIPTION
## Summary
- add `CustomerProfile` Prisma model and migration
- expose `getCustomerProfile` and `updateCustomerProfile` helpers
- use helpers in shop profile API routes to persist and return profile data

## Testing
- `pnpm test` *(fails: ENOENT in apps/cms test)*


------
https://chatgpt.com/codex/tasks/task_e_68990aa3eb74832f9a7cf075e929e52a