### PR TITLE
Add variant inventory tests and stock alert coverage

### DIFF
--- a/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
+++ b/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
@@ -1,0 +1,78 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => {
+    const React = require("react");
+    return {
+      __esModule: true,
+      Button: ({ children, ...props }: any) => (
+        <button {...props}>{children}</button>
+      ),
+      Input: ({ ...props }: any) => <input {...props} />,
+      Table: ({ children }: any) => <table>{children}</table>,
+      TableBody: ({ children }: any) => <tbody>{children}</tbody>,
+      TableCell: ({ children, ...props }: any) => <td {...props}>{children}</td>,
+      TableHead: ({ children }: any) => <th>{children}</th>,
+      TableHeader: ({ children }: any) => <thead>{children}</thead>,
+      TableRow: ({ children }: any) => <tr>{children}</tr>,
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock("@types", () => {
+  const { z } = require("zod");
+  const inventoryItemSchema = z.object({
+    sku: z.string(),
+    productId: z.string(),
+    variant: z.object({
+      size: z.string(),
+      color: z.string().optional(),
+    }),
+    quantity: z.number().min(1),
+    lowStockThreshold: z.number().optional(),
+  });
+  return { inventoryItemSchema };
+});
+
+import InventoryForm from "../src/app/cms/shop/[shop]/data/inventory/InventoryForm";
+
+describe("InventoryForm integration", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+  });
+
+  it("submits multiple rows with variant attributes", async () => {
+    const initial = [
+      {
+        sku: "sku1",
+        productId: "sku1",
+        variant: { size: "M", color: "red" },
+        quantity: 5,
+        lowStockThreshold: 2,
+      },
+      {
+        sku: "sku2",
+        productId: "sku2",
+        variant: { size: "L", color: "blue" },
+        quantity: 3,
+        lowStockThreshold: 1,
+      },
+    ];
+    render(<InventoryForm shop="test" initial={initial} />);
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/data/test/inventory",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(initial),
+      })
+    );
+  });
+});
+

--- a/apps/cms/src/app/api/data/[shop]/inventory/export/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/export/route.ts
@@ -24,7 +24,17 @@ export async function GET(
           .on("error", reject)
           .on("data", (c) => chunks.push(c.toString()))
           .on("end", () => resolve(chunks.join("")));
-        items.forEach((i) => stream.write(i));
+        items.forEach((i) => {
+          stream.write({
+            sku: i.sku,
+            productId: i.productId,
+            ...i.variantAttributes,
+            quantity: i.quantity,
+            ...(i.lowStockThreshold !== undefined
+              ? { lowStockThreshold: i.lowStockThreshold }
+              : {}),
+          });
+        });
         stream.end();
       });
       return new Response(csv, {

--- a/packages/platform-core/__tests__/stockAlert.test.ts
+++ b/packages/platform-core/__tests__/stockAlert.test.ts
@@ -38,6 +38,38 @@ describe("stock alerts", () => {
     );
   });
 
+  it("handles items with multiple variant attributes", async () => {
+    const sendEmail = jest.fn();
+    jest.doMock("@lib/email", () => ({ sendEmail }));
+
+    const { checkAndAlert } = await import(
+      "../src/services/stockAlert.server"
+    );
+    await checkAndAlert("shop", [
+      {
+        sku: "sku-1",
+        productId: "p1",
+        variantAttributes: { size: "m", color: "red" },
+        quantity: 1,
+        lowStockThreshold: 2,
+      },
+      {
+        sku: "sku-2",
+        productId: "p2",
+        variantAttributes: { size: "l", color: "blue" },
+        quantity: 5,
+        lowStockThreshold: 2,
+      },
+    ]);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail).toHaveBeenCalledWith(
+      "alert@example.com",
+      expect.any(String),
+      expect.stringContaining("sku-1"),
+    );
+  });
+
   it("does not send when above threshold", async () => {
     const sendEmail = jest.fn();
     jest.doMock("@lib/email", () => ({ sendEmail }));


### PR DESCRIPTION
## Summary
- add integration test for inventory form submitting multiple variants
- test stock alert emails when multiple variant attributes included
- cover inventory JSON/CSV import/export with variant data and update routes

## Testing
- `pnpm --filter @apps/cms test -- apps/cms/__tests__/inventoryImportExport.test.ts apps/cms/__tests__/inventoryFormVariants.integration.test.tsx`
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/stockAlert.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68990a84c234832fb13da274dc8bc6ce