### PR TITLE
Support variant attributes in inventory import/export

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/inventory/export/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/export/route.ts
@@ -17,14 +17,36 @@ export async function GET(
     const items = await readInventory(shop);
     const format = new URL(req.url).searchParams.get("format");
     if (format === "csv") {
+      const variantKeys = new Set<string>();
+      items.forEach((i) => {
+        Object.keys(i.variantAttributes || {}).forEach((k) => variantKeys.add(k));
+      });
+      const headers = [
+        "sku",
+        "productId",
+        "quantity",
+        "lowStockThreshold",
+        ...Array.from(variantKeys).sort().map((k) => `variant.${k}`),
+      ];
       const csv = await new Promise<string>((resolve, reject) => {
         const chunks: string[] = [];
-        const stream = formatCsv({ headers: true });
+        const stream = formatCsv({ headers, writeHeaders: true });
         stream
           .on("error", reject)
           .on("data", (c) => chunks.push(c.toString()))
           .on("end", () => resolve(chunks.join("")));
-        items.forEach((i) => stream.write(i));
+        items.forEach((i) => {
+          const row: Record<string, unknown> = {
+            sku: i.sku,
+            productId: i.productId,
+            quantity: i.quantity,
+            lowStockThreshold: i.lowStockThreshold ?? "",
+          };
+          Object.entries(i.variantAttributes || {}).forEach(([k, v]) => {
+            row[`variant.${k}`] = v;
+          });
+          stream.write(row);
+        });
         stream.end();
       });
       return new Response(csv, {


### PR DESCRIPTION
## Summary
- parse `productId`, `lowStockThreshold`, and `variant.*` columns when importing inventory
- include these fields in exported CSV
- test JSON/CSV round trip for variant attributes and thresholds

## Testing
- `pnpm --filter @apps/cms test -- inventoryImportExport.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68990a80d2e4832f85255f2605497311