### PR TITLE
feat: enrich stock alert messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Key points:
 
 - Stripe handles deposits via escrow sessions.
 - Inventory lives in JSON files under data/shops/\*/inventory.json.
-- Low-stock alerts email the configured recipient when inventory falls below its threshold.
+- Low-stock alerts email the configured recipient (`STOCK_ALERT_RECIPIENT`) when inventory falls below its threshold.
 - Rental pricing matrix defined in data/rental/pricing.json with duration discounts and damage-fee rules.
 - Return logistics options stored in data/return-logistics.json.
 - RBAC: ShopAdmin currently manages all shops.
@@ -163,7 +163,7 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `CMS_SPACE_URL` – base URL of the CMS API
 - `CMS_ACCESS_TOKEN` – access token for pushing schemas
 - `CHROMATIC_PROJECT_TOKEN` – token for publishing Storybook previews
-- `STOCK_ALERT_RECIPIENT` – email address that receives low stock alerts
+- `STOCK_ALERT_RECIPIENT` – email address that receives low stock alerts; leave unset to disable notifications
 
 The scaffolded `.env` also includes generated placeholders for `NEXTAUTH_SECRET`
 and `PREVIEW_TOKEN_SECRET`. Replace all placeholders with real values or supply

--- a/packages/platform-core/__tests__/inventory.test.ts
+++ b/packages/platform-core/__tests__/inventory.test.ts
@@ -77,6 +77,24 @@ describe("inventory repository", () => {
     });
   });
 
+  it("invokes checkAndAlert after writing", async () => {
+    await withRepo(async (repo, shop) => {
+      const items = [
+        {
+          sku: "sku-1",
+          productId: "p1",
+          variantAttributes: { size: "m" },
+          quantity: 1,
+          lowStockThreshold: 2,
+        },
+      ];
+      const checkAndAlert = jest.fn();
+      jest.doMock("../src/services/stockAlert.server", () => ({ checkAndAlert }));
+      await repo.writeInventory(shop, items);
+      expect(checkAndAlert).toHaveBeenCalledWith(shop, items);
+    });
+  });
+
   it("writeInventory throws on invalid items", async () => {
     await withRepo(async (repo, shop) => {
       const bad = [

--- a/packages/platform-core/__tests__/stockAlert.test.ts
+++ b/packages/platform-core/__tests__/stockAlert.test.ts
@@ -31,11 +31,12 @@ describe("stock alerts", () => {
     ]);
 
     expect(sendEmail).toHaveBeenCalledTimes(1);
-    expect(sendEmail).toHaveBeenCalledWith(
-      "alert@example.com",
-      expect.stringContaining("shop"),
-      expect.stringContaining("sku-1"),
-    );
+    const [to, subject, body] = sendEmail.mock.calls[0];
+    expect(to).toBe("alert@example.com");
+    expect(subject).toContain("shop");
+    expect(body).toContain("sku-1");
+    expect(body).toContain("size: m");
+    expect(body).toContain("threshold 2");
   });
 
   it("does not send when above threshold", async () => {

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -18,12 +18,14 @@ export async function checkAndAlert(
   );
   if (lowItems.length === 0) return;
 
-  const lines = lowItems.map(
-    (i) => `${i.sku} – qty ${i.quantity} (threshold ${i.lowStockThreshold})`,
-  );
-  const body = `The following items in shop ${shop} are low on stock:\n${lines.join(
-    "\n",
-  )}`;
+  const lines = lowItems.map((i) => {
+    const attrs = Object.entries(i.variantAttributes)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(", ");
+    const variant = attrs ? ` (${attrs})` : "";
+    return `${i.sku}${variant} – qty ${i.quantity} (threshold ${i.lowStockThreshold})`;
+  });
+  const body = `The following items in shop ${shop} are low on stock:\n${lines.join("\n")}`;
   const subject = `Low stock alert for ${shop}`;
 
   try {


### PR DESCRIPTION
## Summary
- include variant attributes and thresholds in stock alert emails
- add tests ensuring inventory writes trigger stock alerts
- document STOCK_ALERT_RECIPIENT configuration

## Testing
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/stockAlert.test.ts packages/platform-core/__tests__/inventory.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68990a8181e8832f8e0c4737a1f49035