### PR TITLE
test: ensure ProfileForm renders for authenticated profile pages

### DIFF
--- a/apps/shop-abc/__tests__/accountProfile.test.tsx
+++ b/apps/shop-abc/__tests__/accountProfile.test.tsx
@@ -6,6 +6,7 @@ jest.mock("@auth", () => ({
 
 import { getCustomerSession } from "@auth";
 import ProfilePage from "../src/app/account/profile/page";
+import ProfileForm from "../src/app/account/profile/ProfileForm";
 
 describe("/account/profile", () => {
   beforeEach(() => {
@@ -20,29 +21,14 @@ describe("/account/profile", () => {
     expect(element.props.children).toBe("Please log in to view your profile.");
   });
 
-  it("renders profile for authenticated users", async () => {
+  it("renders ProfileForm for authenticated users", async () => {
     const session = { customerId: "cust1", role: "user" };
     (getCustomerSession as jest.Mock).mockResolvedValue(session);
     const element = await ProfilePage();
-    expect(element.type).toBe("div");
-    expect(element.props.children[1].props.children).toBe(
-      JSON.stringify(session, null, 2)
-    );
-  });
-
-  it("updates displayed profile after session changes", async () => {
-    const session1 = { customerId: "cust1", role: "user" };
-    (getCustomerSession as jest.Mock).mockResolvedValue(session1);
-    let element = await ProfilePage();
-    expect(element.props.children[1].props.children).toBe(
-      JSON.stringify(session1, null, 2)
-    );
-
-    const session2 = { customerId: "cust2", role: "admin" };
-    (getCustomerSession as jest.Mock).mockResolvedValue(session2);
-    element = await ProfilePage();
-    expect(element.props.children[1].props.children).toBe(
-      JSON.stringify(session2, null, 2)
-    );
+    const form = element.props.children[1];
+    expect(form.type).toBe(ProfileForm);
+    expect(form.props.name).toBeUndefined();
+    expect(form.props.email).toBeUndefined();
+    // TODO: expect prefilled values once profile retrieval is implemented
   });
 });

--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -6,6 +6,7 @@ jest.mock("@auth", () => ({
 
 import { getCustomerSession } from "@auth";
 import ProfilePage from "../src/app/account/profile/page";
+import ProfileForm from "../src/app/account/profile/ProfileForm";
 
 describe("/account/profile", () => {
   beforeEach(() => {
@@ -20,29 +21,14 @@ describe("/account/profile", () => {
     expect(element.props.children).toBe("Please log in to view your profile.");
   });
 
-  it("renders profile for authenticated users", async () => {
+  it("renders ProfileForm for authenticated users", async () => {
     const session = { customerId: "cust1", role: "user" };
     (getCustomerSession as jest.Mock).mockResolvedValue(session);
     const element = await ProfilePage();
-    expect(element.type).toBe("div");
-    expect(element.props.children[1].props.children).toBe(
-      JSON.stringify(session, null, 2)
-    );
-  });
-
-  it("updates displayed profile after session changes", async () => {
-    const session1 = { customerId: "cust1", role: "user" };
-    (getCustomerSession as jest.Mock).mockResolvedValue(session1);
-    let element = await ProfilePage();
-    expect(element.props.children[1].props.children).toBe(
-      JSON.stringify(session1, null, 2)
-    );
-
-    const session2 = { customerId: "cust2", role: "admin" };
-    (getCustomerSession as jest.Mock).mockResolvedValue(session2);
-    element = await ProfilePage();
-    expect(element.props.children[1].props.children).toBe(
-      JSON.stringify(session2, null, 2)
-    );
+    const form = element.props.children[1];
+    expect(form.type).toBe(ProfileForm);
+    expect(form.props.name).toBeUndefined();
+    expect(form.props.email).toBeUndefined();
+    // TODO: expect prefilled values once profile retrieval is implemented
   });
 });


### PR DESCRIPTION
## Summary
- verify unauthenticated profile access shows login prompt
- ensure profile pages render ProfileForm when authenticated
- note future expectations for prefilled profile values

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/accountProfile.test.tsx apps/shop-bcd/__tests__/account-profile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68990aaa2510832fa4eb9e4cded099f9