### PR TITLE
feat: move cart state to server

### DIFF
--- a/apps/cms/src/app/[lang]/checkout/page.tsx
+++ b/apps/cms/src/app/[lang]/checkout/page.tsx
@@ -3,6 +3,7 @@ import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import { getCart } from "@platform-core/src/cartStore";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 
@@ -25,7 +26,8 @@ export default async function CheckoutPage({
 
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
-  const cart = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cart = cartId ? getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/packages/platform-core/__tests__/cartContext.test.tsx
+++ b/packages/platform-core/__tests__/cartContext.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CartProvider, useCart } from "../contexts/CartContext";
 import { PRODUCTS } from "../products";
 
-jest.mock("@/lib/cartCookie", () => jest.requireActual("../cartCookie.ts"));
-
 function TestComponent() {
   const [state, dispatch] = useCart();
   const line = state[PRODUCTS[0].id];
@@ -28,51 +26,49 @@ function TestComponent() {
   );
 }
 
-describe("CartContext reducer", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    document.cookie = "";
+describe("CartContext actions", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
-  it("handles add, setQty and remove actions", () => {
+  it("handles add, setQty and remove actions", async () => {
+    global.fetch = jest
+      .fn()
+      // initial GET
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) })
+      // add
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+      })
+      // setQty
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 3 } } }),
+      })
+      // remove
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });
+
     render(
       <CartProvider>
         <TestComponent />
       </CartProvider>
     );
 
-    const qty = screen.getByTestId("qty");
+    const qty = await screen.findByTestId("qty");
     const add = screen.getByText("add");
     const set = screen.getByText("set");
     const remove = screen.getByText("remove");
 
     fireEvent.click(add);
-    expect(qty.textContent).toBe("1");
-
-    fireEvent.click(add);
-    expect(qty.textContent).toBe("2");
+    await waitFor(() => expect(qty.textContent).toBe("1"));
 
     fireEvent.click(set);
-    expect(qty.textContent).toBe("1");
+    await waitFor(() => expect(qty.textContent).toBe("3"));
 
     fireEvent.click(remove);
-    expect(qty.textContent).toBe("0");
-  });
-
-  it("persists to localStorage and cookies", async () => {
-    render(
-      <CartProvider>
-        <TestComponent />
-      </CartProvider>
-    );
-
-    fireEvent.click(screen.getByText("add"));
-
-    await waitFor(() => {
-      expect(localStorage.getItem("CART_STATE")).toBeTruthy();
-    });
-
-    const encoded = localStorage.getItem("CART_STATE")!;
-    expect(document.cookie).toContain(`CART_STATE=${encoded}`);
+    await waitFor(() => expect(qty.textContent).toBe("0"));
   });
 });

--- a/packages/platform-core/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/__tests__/cartCookie.test.ts
@@ -4,37 +4,18 @@ import {
   CART_COOKIE,
   decodeCartCookie,
   encodeCartCookie,
-  type CartState,
 } from "../src/cartCookie";
 
-const sku = {
-  id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
-  slug: "sample",
-  title: "Sample",
-  price: 100,
-  deposit: 10,
-  forSale: true,
-  forRental: false,
-  image: "/img.png",
-  sizes: [],
-  description: "",
-};
-
 describe("cart cookie helpers", () => {
-  const state: CartState = {
-    [sku.id]: { sku, qty: 2 },
-  };
-
-  it("encodes and decodes the cart", () => {
-    const encoded = encodeCartCookie(state);
-
-    expect(encoded).toBe(encodeURIComponent(JSON.stringify(state)));
-    expect(decodeCartCookie(encoded)).toEqual(state);
+  it("encodes and decodes the cart id", () => {
+    const id = "test-id";
+    const encoded = encodeCartCookie(id);
+    expect(decodeCartCookie(encoded)).toBe(id);
   });
 
   it("decodeCartCookie handles invalid input", () => {
-    expect(decodeCartCookie("%E0%A4%A")).toEqual({});
-    expect(decodeCartCookie(null)).toEqual({});
+    expect(decodeCartCookie("bad" as any)).toBeNull();
+    expect(decodeCartCookie(null)).toBeNull();
   });
 
   it("formats Set-Cookie header", () => {

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -1,0 +1,28 @@
+import crypto from "crypto";
+
+import type { CartState } from "./cartCookie";
+
+// Simple in-memory cart storage keyed by cart ID.
+const carts = new Map<string, CartState>();
+
+/** Create a new empty cart and return its ID. */
+export function createCart(): string {
+  const id = crypto.randomUUID();
+  carts.set(id, {});
+  return id;
+}
+
+/** Retrieve cart by ID, returning empty object if not found. */
+export function getCart(id: string): CartState {
+  return carts.get(id) ?? {};
+}
+
+/** Replace cart contents for given ID. */
+export function setCart(id: string, cart: CartState): void {
+  carts.set(id, cart);
+}
+
+/** Remove cart from storage. */
+export function deleteCart(id: string): void {
+  carts.delete(id);
+}

--- a/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
+++ b/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
@@ -28,23 +28,11 @@ export default function AddToCartButton({
     setError(null);
 
     try {
-      const res = await fetch("/api/cart", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sku, qty: 1 }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        setError((data as { error?: string }).error ?? "Unable to add to cart");
-        return;
-      }
-
-      dispatch({ type: "add", sku, size });
+      await dispatch({ type: "add", sku, size });
       /* fake latency for UX feedback */
       await new Promise((r) => setTimeout(r, 300));
-    } catch {
-      setError("Unable to add to cart");
+    } catch (err) {
+      setError((err as Error).message ?? "Unable to add to cart");
     } finally {
       setAdding(false);
     }

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -1,5 +1,6 @@
 // packages/template-app/__tests__/checkout-session.test.ts
 import { encodeCartCookie } from "../../platform-core/src/cartCookie";
+import { createCart, setCart } from "../../platform-core/src/cartStore";
 import { PRODUCTS } from "../../platform-core/src/products";
 import { calculateRentalDays } from "../../lib/src/date";
 import { POST } from "../src/api/checkout-session/route";
@@ -43,7 +44,9 @@ test("builds Stripe session with correct items and metadata", async () => {
 
   const sku = PRODUCTS[0];
   const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
-  const cookie = encodeCartCookie(cart);
+  const cartId = createCart();
+  setCart(cartId, cart);
+  const cookie = encodeCartCookie(cartId);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
   const req = createRequest({ returnDate }, cookie);
@@ -66,7 +69,9 @@ test("builds Stripe session with correct items and metadata", async () => {
 test("returns 400 when returnDate is invalid", async () => {
   const sku = PRODUCTS[0];
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const cookie = encodeCartCookie(cart);
+  const cartId = createCart();
+  setCart(cartId, cart);
+  const cookie = encodeCartCookie(cartId);
   const req = createRequest({ returnDate: "invalid" }, cookie);
   const res = await POST(req);
   expect(res.status).toBe(400);

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -1,7 +1,13 @@
 // packages/template-app/src/api/checkout-session/route.ts
 import { stripe } from "@/lib/stripeServer";
 import { calculateRentalDays } from "@/lib/date";
-import { CART_COOKIE, decodeCartCookie } from "@platform-core/src/cartCookie";
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+  type CartLine,
+  type CartState,
+} from "@platform-core/src/cartCookie";
+import { getCart } from "@platform-core/src/cartStore";
 import { priceForDays, convertCurrency } from "@platform-core/src/pricing";
 import { getProductById } from "@platform-core/src/products";
 import { findCoupon } from "@platform-core/src/coupons";
@@ -12,19 +18,7 @@ import type Stripe from "stripe";
 /* ------------------------------------------------------------------
  * Types held in the cart cookie
  * ------------------------------------------------------------------ */
-interface CartSku {
-  id: string;
-  title: string;
-  deposit: number;
-}
-
-interface CartItem {
-  sku: CartSku;
-  qty: number;
-  size?: string;
-}
-
-type Cart = Record<string, CartItem>;
+type Cart = CartState;
 
 /* ------------------------------------------------------------------
  * Helpers
@@ -32,7 +26,7 @@ type Cart = Record<string, CartItem>;
 
 /** Build Stripe line-items for one cart entry */
 async function buildLineItemsForItem(
-  item: CartItem,
+  item: CartLine,
   rentalDays: number,
   discountRate: number,
   currency: string
@@ -72,7 +66,7 @@ async function buildLineItemsForItem(
 
 /** Cart-wide subtotals */
 async function computeTotals(
-  cart: Cart,
+  cart: CartState,
   rentalDays: number,
   discountRate: number,
   currency: string
@@ -112,7 +106,8 @@ export const runtime = "edge";
 export async function POST(req: NextRequest): Promise<NextResponse> {
   /* 1  Decode cart -------------------------------------------------- */
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart = decodeCartCookie(rawCookie) as Cart;
+  const cartId = decodeCartCookie(rawCookie);
+  const cart = cartId ? (getCart(cartId) as CartState) : {};
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -8,6 +8,7 @@ import {
   type CartLine,
   type CartState,
 } from "@platform-core/src/cartCookie";
+import { getCart } from "@platform-core/src/cartStore";
 import { getProductById } from "@platform-core/src/products";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
@@ -31,7 +32,8 @@ export default async function CheckoutPage({
 
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
-  const cart = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cart = cartId ? getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/packages/ui/__tests__/OrderSummary.test.tsx
+++ b/packages/ui/__tests__/OrderSummary.test.tsx
@@ -1,5 +1,4 @@
 import { CartProvider } from "@/contexts/CartContext";
-import { CART_COOKIE, encodeCartCookie } from "@/lib/cartCookie";
 import { render, screen } from "@testing-library/react";
 import type { CartState } from "@/lib/cartCookie";
 import OrderSummary from "../src/components/organisms/OrderSummary";
@@ -38,15 +37,17 @@ const mockCart: CartState = {
 };
 
 describe("OrderSummary", () => {
-  beforeEach(() => {
-    localStorage.setItem(CART_COOKIE, encodeCartCookie(mockCart));
-  });
+  const originalFetch = global.fetch;
 
   afterEach(() => {
-    localStorage.clear();
+    global.fetch = originalFetch;
   });
 
-  it("renders quantities, totals and formatted prices", () => {
+  it("renders quantities, totals and formatted prices", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: mockCart }) });
+
     render(
       <CartProvider>
         <OrderSummary />
@@ -54,7 +55,7 @@ describe("OrderSummary", () => {
     );
 
     // item rows
-    expect(screen.getByText("Product A")).toBeInTheDocument();
+    expect(await screen.findByText("Product A")).toBeInTheDocument();
     expect(screen.getByText("Product B")).toBeInTheDocument();
     expect(screen.getByText("2", { selector: "td" })).toBeInTheDocument();
     expect(screen.getByText("1", { selector: "td" })).toBeInTheDocument();

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1,6 +1,10 @@
 // server component
 import { readShop } from "@platform-core/repositories/json.server";
-import { decodeCartCookie } from "@platform-core/src/cartCookie";
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+} from "@platform-core/src/cartCookie";
+import { getCart } from "@platform-core/src/cartStore";
 import { cookies } from "next/headers";
 import HeaderClient from "./HeaderClient.client";
 
@@ -18,7 +22,8 @@ export default async function Header({
   padding?: string;
 }) {
   const cookieStore = await cookies();
-  const cart = decodeCartCookie(cookieStore.get("CART_STATE")?.value);
+  const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cart = cartId ? getCart(cartId) : {};
   const initialQty = Object.values(cart).reduce((s, line) => s + line.qty, 0);
   const shopId = process.env.NEXT_PUBLIC_SHOP_ID || "default";
   const shop = await readShop(shopId);

--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -58,7 +58,7 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
                   <Button
                     variant="destructive"
                     onClick={() =>
-                      dispatch({ type: "remove", id: line.sku.id })
+                      void dispatch({ type: "remove", id: line.sku.id })
                     }
                     className="px-2 py-1 text-xs"
                   >


### PR DESCRIPTION
## Summary
- store carts server-side and sign cart id cookie
- load and update cart through API in CartContext
- update API routes and server components to use cart storage

## Testing
- `pnpm test --filter @acme/platform-core --filter @acme/ui` *(fails: Cannot read properties of undefined (reading 'replace'))*

------
https://chatgpt.com/codex/tasks/task_e_689907552950832f828a2acb5c6749e7