### PR TITLE
test: expand resize coverage

### DIFF
--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -3,6 +3,29 @@ import ComponentEditor from "../src/components/cms/page-builder/ComponentEditor"
 import type { PageComponent } from "@types";
 
 describe("ComponentEditor", () => {
+  it("updates width and height", () => {
+    const component: PageComponent = {
+      id: "1",
+      type: "Image",
+    } as PageComponent;
+    const onResize = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <ComponentEditor
+        component={component}
+        onChange={() => {}}
+        onResize={onResize}
+      />
+    );
+    fireEvent.change(getByLabelText("Width"), { target: { value: "200" } });
+    expect(onResize).toHaveBeenCalledWith({ width: "200" });
+    fireEvent.click(getByText("Full width"));
+    expect(onResize).toHaveBeenCalledWith({ width: "100%" });
+    fireEvent.change(getByLabelText("Height"), { target: { value: "300" } });
+    expect(onResize).toHaveBeenCalledWith({ height: "300" });
+    fireEvent.click(getByText("Full height"));
+    expect(onResize).toHaveBeenCalledWith({ height: "100%" });
+  });
+
   it("updates minItems and maxItems", () => {
     const component: PageComponent = {
       id: "1",

--- a/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
@@ -84,6 +84,12 @@ describe("PageBuilder interactions", () => {
     expect(screen.getByTestId("target")).toHaveStyle({ width: "200px" });
     fireEvent.click(screen.getByText("Full width"));
     expect(screen.getByTestId("target")).toHaveStyle({ width: "100%" });
+    fireEvent.change(screen.getByLabelText("Height"), {
+      target: { value: "300" },
+    });
+    expect(screen.getByTestId("target")).toHaveStyle({ height: "300px" });
+    fireEvent.click(screen.getByText("Full height"));
+    expect(screen.getByTestId("target")).toHaveStyle({ height: "100%" });
   });
 
   it("resizes via drag handle and snaps to full size with shift", () => {
@@ -112,10 +118,8 @@ describe("PageBuilder interactions", () => {
 
     // drag without shift to change size
     fireEvent.pointerDown(handle, { clientX: 100, clientY: 100 });
-    window.dispatchEvent(
-      new PointerEvent("pointermove", { clientX: 150, clientY: 150 })
-    );
-    window.dispatchEvent(new PointerEvent("pointerup"));
+    fireEvent.pointerMove(window, { clientX: 150, clientY: 150 });
+    fireEvent.pointerUp(window);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ width: "150px", height: "150px" })
     );
@@ -123,14 +127,12 @@ describe("PageBuilder interactions", () => {
 
     // drag with shift to snap to 100%
     fireEvent.pointerDown(handle, { clientX: 100, clientY: 100 });
-    window.dispatchEvent(
-      new PointerEvent("pointermove", {
-        clientX: 150,
-        clientY: 150,
-        shiftKey: true,
-      })
-    );
-    window.dispatchEvent(new PointerEvent("pointerup"));
+    fireEvent.pointerMove(window, {
+      clientX: 150,
+      clientY: 150,
+      shiftKey: true,
+    });
+    fireEvent.pointerUp(window);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ width: "100%", height: "100%" })
     );


### PR DESCRIPTION
## Summary
- test ComponentEditor width/height resizing via inputs and full-size buttons
- cover drag resize snapping with shift and sidebar height input updates

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/ComponentEditor.test.tsx packages/ui/__tests__/PageBuilder.drag-resize.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68990aba5a6c832faf1b2e210272efdd