### PR TITLE
chore: use SANITY_TOKEN across app

### DIFF
--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -27,12 +27,12 @@ export async function POST(
     if (
       body.SANITY_PROJECT_ID &&
       body.SANITY_DATASET &&
-      body.SANITY_WRITE_TOKEN
+      body.SANITY_TOKEN
     ) {
       await setupSanityBlog({
         projectId: body.SANITY_PROJECT_ID,
         dataset: body.SANITY_DATASET,
-        token: body.SANITY_WRITE_TOKEN,
+        token: body.SANITY_TOKEN,
       }).catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });

--- a/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
@@ -22,7 +22,7 @@ const ENV_KEYS = [
   "GMAIL_PASS",
   "SANITY_PROJECT_ID",
   "SANITY_DATASET",
-  "SANITY_WRITE_TOKEN",
+  "SANITY_TOKEN",
 ] as const;
 
 interface Props {

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -77,7 +77,7 @@ The wizard scaffolds placeholders for common variables:
 - `NEXTAUTH_SECRET` – session encryption secret used by NextAuth
 - `PREVIEW_TOKEN_SECRET` – token used for preview URLs
 - `CMS_SPACE_URL` / `CMS_ACCESS_TOKEN` – headless CMS credentials
-- `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_WRITE_TOKEN` – Sanity blog configuration
+- `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_TOKEN` – Sanity blog configuration
 - `GMAIL_USER`, `GMAIL_PASS` – credentials for email sending
 
 Leave any value blank if the integration isn't needed. You can update the `.env`

--- a/packages/lib/src/sanity.server.ts
+++ b/packages/lib/src/sanity.server.ts
@@ -21,11 +21,11 @@ async function getConfig(shopId: string): Promise<SanityBlogConfig> {
 }
 
 async function getClient(shopId: string) {
-  const { projectId, dataset, token } = await getConfig(shopId);
+  const { projectId, dataset, token: sanityToken } = await getConfig(shopId);
   return createClient({
     projectId,
     dataset,
-    token,
+    token: sanityToken,
     apiVersion: "2023-01-01",
     useCdn: true,
   });


### PR DESCRIPTION
## Summary
- switch CMS env route to SANITY_TOKEN
- expose SANITY_TOKEN in setup wizard
- document SANITY_TOKEN in setup guide

## Testing
- `pnpm test` *(fails: Cannot find module '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_689902b65ab4832fbba899b5bf149b13