### PR TITLE
feat: add profile GET endpoints

### DIFF
--- a/apps/shop-abc/__tests__/accountProfileApi.test.ts
+++ b/apps/shop-abc/__tests__/accountProfileApi.test.ts
@@ -1,0 +1,59 @@
+// apps/shop-abc/__tests__/accountProfileApi.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+
+jest.mock("@acme/platform-core", () => ({
+  __esModule: true,
+  getCustomerProfile: jest.fn(),
+  updateCustomerProfile: jest.fn(),
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+import { getCustomerSession } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
+import { GET } from "../src/app/api/account/profile/route";
+
+describe("/api/account/profile GET", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns 401 for unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when profile not found", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    (getCustomerProfile as jest.Mock).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns profile when found", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    const profile = {
+      customerId: "cust1",
+      name: "Jane",
+      email: "jane@test.com",
+    };
+    (getCustomerProfile as jest.Mock).mockResolvedValue(profile);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, profile });
+  });
+});
+

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -17,6 +17,20 @@ const schema = z
   })
   .strict();
 
+export async function GET() {
+  const session = await getCustomerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const profile = await getCustomerProfile(session.customerId);
+  if (!profile) {
+    return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true, profile });
+}
+
 export async function PUT(req: NextRequest) {
   const session = await getCustomerSession();
   if (!session) {

--- a/apps/shop-bcd/__tests__/account-profile-api.test.ts
+++ b/apps/shop-bcd/__tests__/account-profile-api.test.ts
@@ -1,0 +1,59 @@
+// apps/shop-bcd/__tests__/account-profile-api.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+
+jest.mock("@acme/platform-core", () => ({
+  __esModule: true,
+  getCustomerProfile: jest.fn(),
+  updateCustomerProfile: jest.fn(),
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+import { getCustomerSession } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
+import { GET } from "../src/app/api/account/profile/route";
+
+describe("/api/account/profile GET", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns 401 for unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when profile not found", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    (getCustomerProfile as jest.Mock).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns profile when found", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    const profile = {
+      customerId: "cust1",
+      name: "Jane",
+      email: "jane@test.com",
+    };
+    (getCustomerProfile as jest.Mock).mockResolvedValue(profile);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, profile });
+  });
+});
+

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -17,6 +17,20 @@ const schema = z
   })
   .strict();
 
+export async function GET() {
+  const session = await getCustomerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const profile = await getCustomerProfile(session.customerId);
+  if (!profile) {
+    return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true, profile });
+}
+
 export async function PUT(req: NextRequest) {
   const session = await getCustomerSession();
   if (!session) {


### PR DESCRIPTION
## Summary
- add GET handler for account profile API routes
- return 404 when profile missing and include profile on success
- add tests for account profile GET behavior

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/accountProfileApi.test.ts apps/shop-bcd/__tests__/account-profile-api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68990d5c8e6c832fa7d31ed33fffa288