### PR TITLE
Handle order fetch errors

### DIFF
--- a/apps/shop-abc/__tests__/accountOrders.test.tsx
+++ b/apps/shop-abc/__tests__/accountOrders.test.tsx
@@ -39,6 +39,25 @@ describe("/account/orders", () => {
     expect(element.props.children).toBe("No orders yet.");
   });
 
+  it("shows message when orders fetch fails", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    const error = new Error("boom");
+    (getOrdersForCustomer as jest.Mock).mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const element = await OrdersPage();
+    expect(getOrdersForCustomer).toHaveBeenCalledWith(
+      shop.id,
+      session.customerId
+    );
+    expect(consoleError).toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Unable to load orders.");
+    consoleError.mockRestore();
+  });
+
   it("lists customer orders", async () => {
     const session = { customerId: "cust1", role: "user" };
     const orders = [

--- a/apps/shop-abc/src/app/account/orders/page.tsx
+++ b/apps/shop-abc/src/app/account/orders/page.tsx
@@ -1,9 +1,31 @@
 // apps/shop-abc/src/app/account/orders/page.tsx
-import OrdersPage, { metadata } from "@ui/components/account/Orders";
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
 import shop from "../../../../shop.json";
 
-export { metadata };
+export const metadata = { title: "Orders" };
 
-export default function Page() {
-  return OrdersPage({ shopId: shop.id });
+export default async function Page() {
+  const session = await getCustomerSession();
+  if (!session) return <p>Please log in to view your orders.</p>;
+  try {
+    const orders = await getOrdersForCustomer(shop.id, session.customerId);
+    if (!orders.length) return <p className="p-6">No orders yet.</p>;
+    return (
+      <>
+        <h1 className="p-6 text-xl">Orders</h1>
+        <ul className="space-y-2 p-6">
+          {orders.map((o) => (
+            <li key={o.id} className="rounded border p-4">
+              <div>Order: {o.id}</div>
+              {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
+            </li>
+          ))}
+        </ul>
+      </>
+    );
+  } catch (err) {
+    console.error("Failed to load orders", err);
+    return <p className="p-6">Unable to load orders.</p>;
+  }
 }

--- a/apps/shop-bcd/__tests__/account-orders.test.tsx
+++ b/apps/shop-bcd/__tests__/account-orders.test.tsx
@@ -39,6 +39,25 @@ describe("/account/orders", () => {
     expect(element.props.children).toBe("No orders yet.");
   });
 
+  it("shows message when orders fetch fails", async () => {
+    const session = { customerId: "cust1", role: "user" };
+    (getCustomerSession as jest.Mock).mockResolvedValue(session);
+    const error = new Error("boom");
+    (getOrdersForCustomer as jest.Mock).mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const element = await OrdersPage();
+    expect(getOrdersForCustomer).toHaveBeenCalledWith(
+      shop.id,
+      session.customerId
+    );
+    expect(consoleError).toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Unable to load orders.");
+    consoleError.mockRestore();
+  });
+
   it("lists customer orders", async () => {
     const session = { customerId: "cust1", role: "user" };
     const orders = [

--- a/apps/shop-bcd/src/app/account/orders/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/page.tsx
@@ -1,9 +1,31 @@
 // apps/shop-bcd/src/app/account/orders/page.tsx
-import OrdersPage, { metadata } from "@ui/components/account/Orders";
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
 import shop from "../../../../shop.json";
 
-export { metadata };
+export const metadata = { title: "Orders" };
 
-export default function Page() {
-  return OrdersPage({ shopId: shop.id });
+export default async function Page() {
+  const session = await getCustomerSession();
+  if (!session) return <p>Please log in to view your orders.</p>;
+  try {
+    const orders = await getOrdersForCustomer(shop.id, session.customerId);
+    if (!orders.length) return <p className="p-6">No orders yet.</p>;
+    return (
+      <>
+        <h1 className="p-6 text-xl">Orders</h1>
+        <ul className="space-y-2 p-6">
+          {orders.map((o) => (
+            <li key={o.id} className="rounded border p-4">
+              <div>Order: {o.id}</div>
+              {o.expectedReturnDate && <div>Return: {o.expectedReturnDate}</div>}
+            </li>
+          ))}
+        </ul>
+      </>
+    );
+  } catch (err) {
+    console.error("Failed to load orders", err);
+    return <p className="p-6">Unable to load orders.</p>;
+  }
 }


### PR DESCRIPTION
## Summary
- handle getOrdersForCustomer failures on account orders pages
- show friendly message when orders can't load
- test error handling in account orders pages

## Testing
- `npx eslint apps/shop-abc/src/app/account/orders/page.tsx apps/shop-bcd/src/app/account/orders/page.tsx apps/shop-abc/__tests__/accountOrders.test.tsx apps/shop-bcd/__tests__/account-orders.test.tsx`
- `npx jest apps/shop-abc/__tests__/accountOrders.test.tsx apps/shop-bcd/__tests__/account-orders.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68990e3f26ac832fb79e0c56158eba25