### PR TITLE
docs: document inventory variant schema and import/export

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,6 +10,9 @@ Payments Stripe Elements v2025-05-28 ✔ – edge-ready client (stripeServer.ts)
 API Edge Routes: /api/cart (stub) · /api/checkout-session (client-secret) NEW
 Tooling TS 5.8 · ESLint/Prettier · Jest/RTL · Playwright 1.53 · Wrangler –
 Inventory via JSON in data/shops/\*/inventory.json
+Inventory items use flexible `variantAttributes` maps with optional `lowStockThreshold`.
+Saving inventory triggers email alerts to `STOCK_ALERT_RECIPIENT` when quantity falls below threshold.
+CMS API supports JSON or CSV import/export; CSV headers map variant attribute keys.
 Rental pricing matrix at data/rental/pricing.json
 Return logistics configured in data/return-logistics.json
 RBAC: ShopAdmin scope = all shops

--- a/README.md
+++ b/README.md
@@ -154,6 +154,62 @@ switching shops and admin-only routes. Newcomers can follow the
 [Page Builder](doc/cms.md#page-builder) section to learn how to add,
 rearrange and publish blocks.
 
+## Inventory Management
+
+### Variant schema
+
+Inventory items live in `data/shops/<shop>/inventory.json` and follow this structure:
+
+```json
+{
+  "sku": "green-sneaker-41",
+  "productId": "green-sneaker",
+  "variantAttributes": { "size": "41", "color": "green" },
+  "quantity": 2,
+  "lowStockThreshold": 1
+}
+```
+
+`variantAttributes` is a free-form map of strings (e.g. `size`, `color`) that differentiates
+variants under the same product. Only the keys present are written to CSV export.
+
+### Stock alerts
+
+Set `STOCK_ALERT_RECIPIENT` in the shop's `.env`. When `writeInventory` persists items and
+an item's `quantity` is less than or equal to its `lowStockThreshold`, an email is sent to the
+configured recipient summarising the affected SKUs.
+
+```bash
+STOCK_ALERT_RECIPIENT=alerts@example.com
+```
+
+### Import / export
+
+Inventory can be round-tripped as JSON or CSV through the CMS API.
+
+Export inventory:
+
+```bash
+curl "http://localhost:3000/cms/api/data/demo/inventory/export?format=csv" -o inventory.csv
+curl "http://localhost:3000/cms/api/data/demo/inventory/export" -o inventory.json
+```
+
+Import inventory:
+
+```bash
+curl -X POST -F "file=@inventory.csv;type=text/csv" http://localhost:3000/cms/api/data/demo/inventory/import
+curl -X POST -F "file=@inventory.json;type=application/json" http://localhost:3000/cms/api/data/demo/inventory/import
+```
+
+CSV files use headers to define variant attributes:
+
+```csv
+sku,productId,size,color,quantity,lowStockThreshold
+green-sneaker-41,green-sneaker,41,green,2,1
+```
+
+JSON import/export is an array of inventory objects matching the schema shown above.
+
 # Environment Variables
 
 After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:


### PR DESCRIPTION
## Summary
- document inventory variant attributes and low stock alerts
- outline CSV and JSON inventory import/export with sample curl commands
- note stock alert configuration and import/export support in implementation plan

## Testing
- `pnpm exec eslint README.md IMPLEMENTATION_PLAN.md` *(warnings: File ignored because no matching configuration was supplied)*
- `pnpm --filter @acme/platform-core test` *(failed: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68990ef21894832fa49291242f3bf9e7