### PR TITLE
feat: fetch customer profile on profile page

### DIFF
--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -1,11 +1,13 @@
 // apps/shop-bcd/__tests__/account-profile.test.tsx
-jest.mock("@auth", () => ({
-  __esModule: true,
-  getCustomerSession: jest.fn(),
-}));
+import { jest } from "@jest/globals";
 
-import { getCustomerSession } from "@auth";
-import ProfilePage from "../src/app/account/profile/page";
+const getCustomerSession = jest.fn();
+const getCustomerProfile = jest.fn();
+
+jest.unstable_mockModule("@auth", () => ({ getCustomerSession }));
+jest.unstable_mockModule("@acme/platform-core", () => ({ getCustomerProfile }));
+
+const { default: ProfilePage } = await import("../src/app/account/profile/page");
 
 describe("/account/profile", () => {
   beforeEach(() => {
@@ -13,7 +15,7 @@ describe("/account/profile", () => {
   });
 
   it("redirects unauthenticated users", async () => {
-    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    getCustomerSession.mockResolvedValue(null);
     const element = await ProfilePage();
     expect(getCustomerSession).toHaveBeenCalled();
     expect(element.type).toBe("p");
@@ -21,10 +23,17 @@ describe("/account/profile", () => {
   });
 
   it("renders profile form for authenticated users", async () => {
-    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    getCustomerSession.mockResolvedValue({ customerId: "cust1" });
+    getCustomerProfile.mockResolvedValue({
+      name: "Jane",
+      email: "jane@example.com",
+      customerId: "cust1",
+    });
     const element = await ProfilePage();
+    expect(getCustomerProfile).toHaveBeenCalledWith("cust1");
     expect(element.type).toBe("div");
     expect(element.props.children[0].props.children).toBe("Profile");
-    expect(element.props.children[1].type.name).toBe("ProfileForm");
+    expect(element.props.children[1].props.name).toBe("Jane");
+    expect(element.props.children[1].props.email).toBe("jane@example.com");
   });
 });

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -1,5 +1,6 @@
 // packages/ui/src/components/account/Profile.tsx
 import { getCustomerSession } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
 import ProfileForm from "./ProfileForm";
 
 export interface ProfilePageProps {
@@ -12,10 +13,11 @@ export const metadata = { title: "Profile" };
 export default async function ProfilePage({ title = "Profile" }: ProfilePageProps) {
   const session = await getCustomerSession();
   if (!session) return <p>Please log in to view your profile.</p>;
+  const profile = await getCustomerProfile(session.customerId);
   return (
     <div className="p-6">
       <h1 className="mb-4 text-xl">{title}</h1>
-      <ProfileForm />
+      <ProfileForm name={profile?.name} email={profile?.email} />
     </div>
   );
 }

--- a/packages/ui/src/components/account/ProfileForm.tsx
+++ b/packages/ui/src/components/account/ProfileForm.tsx
@@ -8,8 +8,8 @@ export interface ProfileFormProps {
   email?: string;
 }
 
-export default function ProfileForm({ name = "", email = "" }: ProfileFormProps) {
-  const [form, setForm] = useState({ name, email });
+export default function ProfileForm({ name, email }: ProfileFormProps) {
+  const [form, setForm] = useState({ name: name ?? "", email: email ?? "" });
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
 


### PR DESCRIPTION
## Summary
- fetch customer profile in ProfilePage and pass name/email to ProfileForm
- allow ProfileForm to handle undefined name and email
- add tests for both shops ensuring profile data flows to form

## Testing
- `pnpm test` *(fails: @apps/cms#test exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68990df7904c832fadba5a9bf5d01d3f