### PR TITLE
refactor: infer create shop option types with strict schema

### DIFF
--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -6,7 +6,7 @@ import { prisma } from "./db";
 import { validateShopName } from "./shops";
 import {
   prepareOptions,
-  createShopOptionsSchema as createShopOptionsSchemaInternal,
+  createShopOptionsSchema as baseCreateShopOptionsSchema,
   type CreateShopOptions,
   type PreparedCreateShopOptions,
 } from "./createShop/schema";
@@ -163,7 +163,8 @@ export function syncTheme(shop: string, theme: string): Record<string, string> {
   return loadTokens(theme);
 }
 
-export const createShopOptionsSchema = createShopOptionsSchemaInternal.strict();
+export const createShopOptionsSchema =
+  baseCreateShopOptionsSchema.strict();
 export { prepareOptions };
 export type { CreateShopOptions, PreparedCreateShopOptions };
 export { ensureTemplateExists, writeFiles, copyTemplate } from "./createShop/fsUtils";

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -22,7 +22,8 @@ const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
   })
 );
 
-export const createShopOptionsSchema = z.object({
+export const createShopOptionsSchema = z
+  .object({
   name: z.string().optional(),
   logo: z.string().url().optional(),
   contactInfo: z.string().optional(),
@@ -56,7 +57,8 @@ export const createShopOptionsSchema = z.object({
     )
     .default([]),
   checkoutPage: z.array(pageComponentSchema).default([]),
-});
+})
+  .strict();
 
 export type CreateShopOptions = z.infer<typeof createShopOptionsSchema>;
 


### PR DESCRIPTION
## Summary
- ensure createShopOptionsSchema is strict when exported
- reuse inferred types for CreateShopOptions and PreparedCreateShopOptions

## Testing
- `pnpm --filter platform-core test` *(fails: Cannot find module '@/components/atoms', Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68990cef4bdc832f8433486982a0f757