### PR TITLE
Refactor plugin system and modularize platform-core exports

### DIFF
--- a/apps/cms/src/app/cms/plugins/PluginList.client.tsx
+++ b/apps/cms/src/app/cms/plugins/PluginList.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState } from "react";
-import type { Plugin } from "@acme/platform-core";
+import type { Plugin } from "@acme/platform-core/plugins";
 
 interface Props {
   plugins: Plugin[];

--- a/apps/cms/src/app/cms/plugins/page.tsx
+++ b/apps/cms/src/app/cms/plugins/page.tsx
@@ -1,10 +1,12 @@
 // apps/cms/src/app/cms/plugins/page.tsx
-import { loadPlugins } from "@acme/platform-core";
+import path from "node:path";
+import { loadPlugins } from "@acme/platform-core/plugins";
 import Link from "next/link";
 import PluginList from "./PluginList.client";
 
 export default async function PluginsPage() {
-  const plugins = await loadPlugins();
+  const pluginsDir = path.resolve(process.cwd(), "packages/plugins");
+  const plugins = await loadPlugins({ directories: [pluginsDir] });
   return (
     <div>
       <h2 className="mb-4 text-xl font-semibold">Plugins</h2>

--- a/apps/shop-abc/__tests__/accountProfileApi.test.ts
+++ b/apps/shop-abc/__tests__/accountProfileApi.test.ts
@@ -4,7 +4,7 @@ jest.mock("@auth", () => ({
   getCustomerSession: jest.fn(),
 }));
 
-jest.mock("@acme/platform-core", () => ({
+jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile: jest.fn(),
   updateCustomerProfile: jest.fn(),
@@ -18,7 +18,7 @@ jest.mock("next/server", () => ({
 }));
 
 import { getCustomerSession } from "@auth";
-import { getCustomerProfile } from "@acme/platform-core";
+import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
 import { GET } from "../src/app/api/account/profile/route";
 
 describe("/api/account/profile GET", () => {

--- a/apps/shop-abc/__tests__/api/accountProfile.test.ts
+++ b/apps/shop-abc/__tests__/api/accountProfile.test.ts
@@ -16,7 +16,7 @@ const updateCustomerProfile = jest.fn(async (id: string, data: any) => {
 const getCustomerProfile = jest.fn(async (id: string) => profile);
 
 jest.mock("@auth", () => ({ __esModule: true, getCustomerSession }));
-jest.mock("@acme/platform-core", () => ({
+jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile,
   updateCustomerProfile,

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -3,7 +3,7 @@ import { getCustomerSession } from "@auth";
 import {
   getCustomerProfile,
   updateCustomerProfile,
-} from "@acme/platform-core";
+} from "@acme/platform-core/customerProfiles";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";

--- a/apps/shop-bcd/__tests__/account-profile-api.test.ts
+++ b/apps/shop-bcd/__tests__/account-profile-api.test.ts
@@ -4,7 +4,7 @@ jest.mock("@auth", () => ({
   getCustomerSession: jest.fn(),
 }));
 
-jest.mock("@acme/platform-core", () => ({
+jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile: jest.fn(),
   updateCustomerProfile: jest.fn(),
@@ -18,7 +18,7 @@ jest.mock("next/server", () => ({
 }));
 
 import { getCustomerSession } from "@auth";
-import { getCustomerProfile } from "@acme/platform-core";
+import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
 import { GET } from "../src/app/api/account/profile/route";
 
 describe("/api/account/profile GET", () => {

--- a/apps/shop-bcd/__tests__/api/accountProfile.test.ts
+++ b/apps/shop-bcd/__tests__/api/accountProfile.test.ts
@@ -16,7 +16,7 @@ const updateCustomerProfile = jest.fn(async (id: string, data: any) => {
 const getCustomerProfile = jest.fn(async (id: string) => profile);
 
 jest.mock("@auth", () => ({ __esModule: true, getCustomerSession }));
-jest.mock("@acme/platform-core", () => ({
+jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile,
   updateCustomerProfile,

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -3,7 +3,7 @@ import { getCustomerSession } from "@auth";
 import {
   getCustomerProfile,
   updateCustomerProfile,
-} from "@acme/platform-core";
+} from "@acme/platform-core/customerProfiles";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,59 @@
+# Plugin Authoring Guide
+
+This platform supports a pluggable architecture for payments, shipping and UI widgets.  
+Plugins are plain npm packages that export a default object implementing the
+`Plugin` interface from `@acme/platform-core/plugins`.
+
+```ts
+import type { Plugin, PaymentRegistry } from "@acme/platform-core/plugins";
+
+const myPlugin: Plugin = {
+  id: "my-plugin",
+  name: "My Plugin",
+  defaultConfig: { enabled: true },
+  registerPayments(registry: PaymentRegistry, config) {
+    // add a payment provider
+    registry.add("my-payment", {/* ... */});
+  },
+};
+
+export default myPlugin;
+```
+
+## Discovery
+
+Plugins are discovered by calling `loadPlugins` and providing either an array of
+plugin package directories or directories that contain multiple plugins:
+
+```ts
+import { loadPlugins } from "@acme/platform-core/plugins";
+import path from "node:path";
+
+const pluginsDir = path.resolve(process.cwd(), "packages/plugins");
+const plugins = await loadPlugins({ directories: [pluginsDir] });
+```
+
+Each plugin directory must include a `package.json` with a `main` or
+`exports` field pointing at the compiled module entry point.
+
+## Initialisation and configuration
+
+`initPlugins` wires discovered plugins into the platform.  Configuration can be
+supplied per plugin using the plugin id:
+
+```ts
+import { initPlugins } from "@acme/platform-core/plugins";
+
+await initPlugins(
+  { payments: paymentRegistry },
+  {
+    directories: [pluginsDir],
+    config: {
+      "my-plugin": { enabled: false },
+    },
+  },
+);
+```
+
+The relevant configuration object (or the plugin's `defaultConfig`) is passed to
+all registration hooks.

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -7,8 +7,9 @@
     ".": "./src/index.ts",
     "./shipping": "./src/shipping/index.ts",
     "./tax": "./src/tax/index.ts",
-    "./orders": "./src/orders.ts",
-    "./customerProfiles": "./src/customerProfiles.ts"
+    "./orders": "./src/orders/index.ts",
+    "./customerProfiles": "./src/customerProfiles/index.ts",
+    "./plugins": "./src/plugins/index.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",

--- a/packages/platform-core/src/customerProfiles/index.ts
+++ b/packages/platform-core/src/customerProfiles/index.ts
@@ -1,0 +1,1 @@
+export * from "../customerProfiles";

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -7,8 +7,3 @@ export * from "./defaultFilterMappings";
 export * from "./themeTokens";
 export * from "./dataRoot";
 export * from "./utils";
-export * from "./shipping";
-export * from "./tax";
-export * from "./plugins";
-export * from "./orders";
-export * from "./customerProfiles";

--- a/packages/platform-core/src/orders/index.ts
+++ b/packages/platform-core/src/orders/index.ts
@@ -1,0 +1,1 @@
+export * from "../orders";

--- a/packages/platform-core/src/plugins/index.ts
+++ b/packages/platform-core/src/plugins/index.ts
@@ -1,0 +1,1 @@
+export * from "../plugins";

--- a/packages/plugins/paypal/index.ts
+++ b/packages/plugins/paypal/index.ts
@@ -1,5 +1,5 @@
 // packages/plugins/paypal/index.ts
-import type { Plugin, PaymentRegistry } from "@acme/platform-core";
+import type { Plugin, PaymentRegistry } from "@acme/platform-core/plugins";
 
 const paypalPlugin: Plugin = {
   id: "paypal",

--- a/packages/plugins/sanity/index.ts
+++ b/packages/plugins/sanity/index.ts
@@ -1,5 +1,5 @@
 // packages/plugins/sanity/index.ts
-import type { Plugin } from "@acme/platform-core";
+import type { Plugin } from "@acme/platform-core/plugins";
 import { createClient, type SanityClient } from "@sanity/client";
 
 interface SanityConfig {


### PR DESCRIPTION
## Summary
- define provider interfaces and generic registries for plugins
- make plugin loading configurable and support per-plugin configs
- modularize platform-core exports and add plugin authoring guide

## Testing
- `pnpm test` *(fails: Cannot find module '.prisma/client/index-browser')*


------
https://chatgpt.com/codex/tasks/task_e_6899103a86dc832f90e0b9d80e5f21aa