### PR TITLE
feat: enhance CMS Sanity blog management

### DIFF
--- a/apps/cms/src/actions/deleteSanityConfig.ts
+++ b/apps/cms/src/actions/deleteSanityConfig.ts
@@ -1,0 +1,21 @@
+// apps/cms/src/actions/deleteSanityConfig.ts
+"use server";
+
+import { getShopById, updateShopInRepo } from "@platform-core/src/repositories/shop.server";
+import { setSanityConfig } from "@platform-core/src/shops";
+import { ensureAuthorized } from "./common/auth";
+
+export async function deleteSanityConfig(
+  shopId: string,
+): Promise<{ message?: string; error?: string }> {
+  await ensureAuthorized();
+  try {
+    const shop = await getShopById(shopId);
+    const updated = setSanityConfig(shop, undefined);
+    await updateShopInRepo(shopId, updated);
+    return { message: "Sanity disconnected" };
+  } catch (err) {
+    console.error("Failed to disconnect Sanity", err);
+    return { error: "Failed to disconnect Sanity" };
+  }
+}

--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -77,6 +77,8 @@ export async function setupSanityBlog(
                 type: "document",
                 fields: [
                   { name: "title", type: "string", title: "Title" },
+                  { name: "slug", type: "slug", title: "Slug", options: { source: "title" } },
+                  { name: "excerpt", type: "text", title: "Excerpt" },
                   { name: "body", type: "text", title: "Body" },
                   { name: "published", type: "boolean", title: "Published" },
                 ],

--- a/apps/cms/src/app/cms/blog/posts/DeleteButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/DeleteButton.client.tsx
@@ -1,0 +1,33 @@
+// apps/cms/src/app/cms/blog/posts/DeleteButton.client.tsx
+"use client";
+
+import { useFormState } from "react-dom";
+import { Button, Toast } from "@ui";
+import { deletePost } from "@cms/actions/blog.server";
+import type { FormState } from "./PostForm.client";
+
+interface Props {
+  id: string;
+  shopId: string;
+}
+
+export default function DeleteButton({ id, shopId }: Props) {
+  const action = deletePost.bind(null, shopId, id);
+  const [state, formAction] = useFormState<FormState>(action, {
+    message: "",
+    error: "",
+  });
+  return (
+    <div className="space-y-2">
+      <form action={formAction}>
+        <Button type="submit" variant="destructive">
+          Delete
+        </Button>
+      </form>
+      <Toast
+        open={Boolean(state.message || state.error)}
+        message={state.message || state.error || ""}
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -13,7 +13,7 @@ export interface FormState {
 interface Props {
   action: (_state: FormState, formData: FormData) => Promise<FormState>;
   submitLabel: string;
-  post?: { _id?: string; title?: string; body?: string };
+  post?: { _id?: string; title?: string; body?: string; slug?: string; excerpt?: string };
 }
 
 export default function PostForm({ action, submitLabel, post }: Props) {
@@ -22,6 +22,8 @@ export default function PostForm({ action, submitLabel, post }: Props) {
     <div className="space-y-4">
       <form action={formAction} className="space-y-4 max-w-xl">
         <Input name="title" label="Title" defaultValue={post?.title ?? ""} required />
+        <Input name="slug" label="Slug" defaultValue={post?.slug ?? ""} required />
+        <Textarea name="excerpt" label="Excerpt" defaultValue={post?.excerpt ?? ""} />
         <Textarea
           name="content"
           label="Content"

--- a/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import PostForm from "../PostForm.client";
 import PublishButton from "../PublishButton.client";
+import DeleteButton from "../DeleteButton.client";
 import { getPost, updatePost } from "@cms/actions/blog.server";
 import { getSanityConfig } from "@platform-core/src/shops";
 import { getShopById } from "@platform-core/src/repositories/shop.server";
@@ -44,7 +45,10 @@ export default async function EditPostPage({
         submitLabel="Save"
         post={post}
       />
-      <PublishButton id={post._id} shopId={shopId} />
+      <div className="flex items-center space-x-4">
+        <PublishButton id={post._id} shopId={shopId} />
+        <DeleteButton id={post._id} shopId={shopId} />
+      </div>
     </div>
   );
 }

--- a/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
@@ -5,6 +5,7 @@ import { useFormState } from "react-dom";
 import { Button } from "@/components/atoms/shadcn";
 import { Toast } from "@ui";
 import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
+import { deleteSanityConfig } from "@cms/actions/deleteSanityConfig";
 
 interface FormState {
   message?: string;
@@ -13,13 +14,22 @@ interface FormState {
 
 interface Props {
   shopId: string;
+  initial?: { projectId: string; dataset: string; token?: string };
 }
 
 const initialState: FormState = { message: "", error: "" };
 
-export default function ConnectForm({ shopId }: Props) {
-  const action = saveSanityConfig.bind(null, shopId);
-  const [state, formAction] = useFormState<FormState>(action, initialState);
+export default function ConnectForm({ shopId, initial }: Props) {
+  const saveAction = saveSanityConfig.bind(null, shopId);
+  const [state, formAction] = useFormState<FormState>(saveAction, initialState);
+
+  const disconnectAction = deleteSanityConfig.bind(null, shopId);
+  const [disconnectState, disconnectFormAction] = useFormState<FormState>(
+    disconnectAction,
+    initialState,
+  );
+  const message = state.message || disconnectState.message;
+  const error = state.error || disconnectState.error;
   return (
     <div className="space-y-4 max-w-md">
       <form action={formAction} className="space-y-4">
@@ -31,6 +41,7 @@ export default function ConnectForm({ shopId }: Props) {
             id="projectId"
             name="projectId"
             className="w-full rounded border p-2"
+            defaultValue={initial?.projectId ?? ""}
             required
           />
         </div>
@@ -42,6 +53,7 @@ export default function ConnectForm({ shopId }: Props) {
             id="dataset"
             name="dataset"
             className="w-full rounded border p-2"
+            defaultValue={initial?.dataset ?? ""}
             required
           />
         </div>
@@ -54,6 +66,7 @@ export default function ConnectForm({ shopId }: Props) {
             name="token"
             type="password"
             className="w-full rounded border p-2"
+            defaultValue={initial?.token ?? ""}
             required
           />
         </div>
@@ -61,10 +74,14 @@ export default function ConnectForm({ shopId }: Props) {
           Save
         </Button>
       </form>
-      <Toast
-        open={Boolean(state.message || state.error)}
-        message={state.message || state.error || ""}
-      />
+      {initial && (
+        <form action={disconnectFormAction}>
+          <Button type="submit" variant="destructive">
+            Disconnect
+          </Button>
+        </form>
+      )}
+      <Toast open={Boolean(message || error)} message={message || error || ""} />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/blog/sanity/connect/page.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/page.tsx
@@ -1,19 +1,23 @@
 // apps/cms/src/app/cms/blog/sanity/connect/page.tsx
 import ConnectForm from "./ConnectForm.client";
+import { getShopById } from "@platform-core/src/repositories/shop.server";
+import { getSanityConfig } from "@platform-core/src/shops";
 
 export const revalidate = 0;
 
-export default function SanityConnectPage({
+export default async function SanityConnectPage({
   searchParams,
 }: {
   searchParams?: { shopId?: string };
 }) {
   const shopId = searchParams?.shopId;
   if (!shopId) return <p>No shop selected.</p>;
+  const shop = await getShopById(shopId);
+  const sanity = getSanityConfig(shop);
   return (
     <div className="space-y-6">
       <h2 className="text-xl font-semibold">Connect Sanity</h2>
-      <ConnectForm shopId={shopId} />
+      <ConnectForm shopId={shopId} initial={sanity} />
     </div>
   );
 }

--- a/packages/lib/src/sanity.server.ts
+++ b/packages/lib/src/sanity.server.ts
@@ -34,7 +34,7 @@ async function getClient(shopId: string) {
 export async function fetchPublishedPosts(shopId: string): Promise<BlogPost[]> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && defined(slug.current) && !(_id in path('drafts.**'))]{title, "slug": slug.current, excerpt}`;
+    const query = `*[_type == "post" && defined(slug.current) && published == true && !(_id in path('drafts.**'))]{title, "slug": slug.current, excerpt}`;
     const posts = await client.fetch<BlogPost[]>(query);
     return posts;
   } catch {
@@ -48,7 +48,7 @@ export async function fetchPostBySlug(
 ): Promise<BlogPost | null> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, excerpt, body}`;
+    const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, body}`;
     const post = await client.fetch<BlogPost | null>(query, { slug });
     return post;
   } catch {


### PR DESCRIPTION
## Summary
- add slug and excerpt fields when setting up Sanity blog
- expose slug/excerpt in CMS forms and actions, including post deletion
- allow updating or disconnecting Sanity credentials and filter storefront posts by published flag

## Testing
- `pnpm --filter @apps/cms test` (fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)
- `pnpm --filter @acme/lib test` (fails: unhandled requests and missing modules)


------
https://chatgpt.com/codex/tasks/task_e_68990f249138832f8896c6c23b7975ad