### PR TITLE
feat: add user authentication flow

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -1,0 +1,96 @@
+// apps/shop-abc/__tests__/authFlow.test.ts
+import bcrypt from "bcryptjs";
+
+const mockDb: Record<string, { email: string; passwordHash: string; role: string }> = {};
+
+jest.mock("@acme/platform-core/users", () => ({
+  __esModule: true,
+  createUser: jest.fn(
+    (email: string, passwordHash: string, role: string) => {
+      mockDb[email] = { email, passwordHash, role };
+      return Promise.resolve();
+    },
+  ),
+  getUserByEmail: jest.fn((email: string) =>
+    Promise.resolve(mockDb[email] ?? null),
+  ),
+  updateUserPassword: jest.fn(
+    (email: string, passwordHash: string) => {
+      if (mockDb[email]) {
+        mockDb[email].passwordHash = passwordHash;
+      }
+      return Promise.resolve();
+    },
+  ),
+}));
+
+jest.mock("@auth", () => ({
+  __esModule: true,
+  createCustomerSession: jest.fn(),
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+import { POST as registerPOST } from "../src/app/api/register/route";
+import { POST as loginPOST } from "../src/app/login/route";
+import { POST as resetPOST } from "../src/app/api/password-reset/route";
+import { createCustomerSession } from "@auth";
+
+describe("auth flow", () => {
+  beforeEach(() => {
+    for (const k in mockDb) delete mockDb[k];
+    jest.clearAllMocks();
+  });
+
+  test("sign-up, login and password reset", async () => {
+    const email = "user@example.com";
+    const password = "secret123";
+    const newPassword = "newSecret123";
+
+    const resSignup = await registerPOST({
+      json: async () => ({ email, password }),
+    } as any);
+    expect(resSignup.status).toBe(200);
+    expect(mockDb[email]).toBeDefined();
+    expect(await bcrypt.compare(password, mockDb[email].passwordHash)).toBe(
+      true,
+    );
+
+    const resLogin = await loginPOST({
+      json: async () => ({ email, password }),
+    } as any);
+    expect(resLogin.status).toBe(200);
+    expect(createCustomerSession).toHaveBeenCalledWith({
+      customerId: email,
+      role: "customer",
+    });
+
+    const resReset = await resetPOST({
+      json: async () => ({ email, newPassword }),
+    } as any);
+    expect(resReset.status).toBe(200);
+    expect(
+      await bcrypt.compare(newPassword, mockDb[email].passwordHash),
+    ).toBe(true);
+
+    const resOldLogin = await loginPOST({
+      json: async () => ({ email, password }),
+    } as any);
+    expect(resOldLogin.status).toBe(401);
+
+    const resNewLogin = await loginPOST({
+      json: async () => ({ email, password: newPassword }),
+    } as any);
+    expect(resNewLogin.status).toBe(200);
+  });
+});

--- a/apps/shop-abc/src/app/api/password-reset/route.ts
+++ b/apps/shop-abc/src/app/api/password-reset/route.ts
@@ -1,0 +1,33 @@
+// apps/shop-abc/src/app/api/password-reset/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import {
+  getUserByEmail,
+  updateUserPassword,
+} from "@acme/platform-core/users";
+
+const schema = z.object({
+  email: z.string().email(),
+  newPassword: z.string().min(6),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const user = await getUserByEmail(parsed.data.email);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const hash = await bcrypt.hash(parsed.data.newPassword, 10);
+  await updateUserPassword(parsed.data.email, hash);
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -1,0 +1,36 @@
+// apps/shop-abc/src/app/api/register/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import {
+  createUser,
+  getUserByEmail,
+} from "@acme/platform-core/users";
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const existing = await getUserByEmail(parsed.data.email);
+  if (existing) {
+    return NextResponse.json(
+      { error: "Email already registered" },
+      { status: 409 },
+    );
+  }
+
+  const hash = await bcrypt.hash(parsed.data.password, 10);
+  await createUser(parsed.data.email, hash, "customer");
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -8,7 +8,8 @@
     "./shipping": "./src/shipping/index.ts",
     "./tax": "./src/tax/index.ts",
     "./orders": "./src/orders.ts",
-    "./customerProfiles": "./src/customerProfiles.ts"
+    "./customerProfiles": "./src/customerProfiles.ts",
+    "./users": "./src/users.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",

--- a/packages/platform-core/prisma/migrations/20240820000000_add_users_table/migration.sql
+++ b/packages/platform-core/prisma/migrations/20240820000000_add_users_table/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("email")
+);
+

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -43,3 +43,9 @@ model CustomerProfile {
   name       String
   email      String
 }
+
+model User {
+  email        String @id
+  passwordHash String
+  role         String
+}

--- a/packages/platform-core/src/users.ts
+++ b/packages/platform-core/src/users.ts
@@ -1,0 +1,27 @@
+// packages/platform-core/src/users.ts
+import { prisma } from "./db";
+
+export interface User {
+  email: string;
+  passwordHash: string;
+  role: string;
+}
+
+export async function getUserByEmail(email: string): Promise<User | null> {
+  return prisma.user.findUnique({ where: { email } });
+}
+
+export async function createUser(
+  email: string,
+  passwordHash: string,
+  role: string,
+): Promise<void> {
+  await prisma.user.create({ data: { email, passwordHash, role } });
+}
+
+export async function updateUserPassword(
+  email: string,
+  passwordHash: string,
+): Promise<void> {
+  await prisma.user.update({ where: { email }, data: { passwordHash } });
+}


### PR DESCRIPTION
## Summary
- define `User` model with hashed password and role
- support user lookup and management in platform core
- add registration, login and password reset routes with bcrypt
- cover auth flow with integration test

## Testing
- `npx jest apps/shop-abc/__tests__/authFlow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689911d1de3c832facbe85e70111baf5