### PR TITLE
feat: add login rate limiting middleware

### DIFF
--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -1,0 +1,36 @@
+// apps/shop-abc/__tests__/loginRateLimit.test.ts
+import { POST } from "../src/app/login/route";
+import {
+  __resetLoginRateLimiter,
+  MAX_ATTEMPTS,
+} from "../src/middleware";
+
+function makeRequest(body: any, ip = "1.1.1.1") {
+  return {
+    json: async () => body,
+    headers: new Headers({ "x-forwarded-for": ip }),
+  } as any;
+}
+
+afterEach(() => __resetLoginRateLimiter());
+
+describe("login rate limiting", () => {
+  it("returns 429 after too many attempts", async () => {
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      const res = await POST(
+        makeRequest({ customerId: "cust1", password: "wrong" }),
+      );
+      expect(res.status).toBe(401);
+    }
+
+    const locked = await POST(
+      makeRequest({ customerId: "cust1", password: "wrong" }),
+    );
+    expect(locked.status).toBe(429);
+
+    const stillLocked = await POST(
+      makeRequest({ customerId: "cust1", password: "pass1" }),
+    );
+    expect(stillLocked.status).toBe(429);
+  });
+});

--- a/apps/shop-abc/src/middleware.ts
+++ b/apps/shop-abc/src/middleware.ts
@@ -1,0 +1,65 @@
+// apps/shop-abc/src/middleware.ts
+import { NextResponse } from "next/server";
+
+/** Track login attempts per IP + user */
+interface Attempt {
+  count: number;
+  lockedUntil: number;
+}
+
+const attempts = new Map<string, Attempt>();
+
+export const MAX_ATTEMPTS = 3;
+const LOCK_MS = 5 * 60 * 1000; // 5 minutes
+
+function key(ip: string, user: string) {
+  return `${ip}:${user}`;
+}
+
+/**
+ * Check rate limit for login attempts.
+ * Returns a 429 response if the account is locked or limit exceeded.
+ */
+export function checkLoginRateLimit(ip: string, user: string) {
+  const k = key(ip, user);
+  const now = Date.now();
+  const record = attempts.get(k) ?? { count: 0, lockedUntil: 0 };
+
+  if (record.lockedUntil > now) {
+    console.warn(`[login] locked out ${k}`);
+    return NextResponse.json(
+      { error: "Too many login attempts. Try again later." },
+      { status: 429 },
+    );
+  }
+
+  if (record.lockedUntil && record.lockedUntil <= now) {
+    record.count = 0;
+    record.lockedUntil = 0;
+  }
+
+  record.count += 1;
+
+  if (record.count > MAX_ATTEMPTS) {
+    record.lockedUntil = now + LOCK_MS;
+    attempts.set(k, record);
+    console.warn(`[login] lockout ${k}`);
+    return NextResponse.json(
+      { error: "Too many login attempts. Try again later." },
+      { status: 429 },
+    );
+  }
+
+  attempts.set(k, record);
+  return null;
+}
+
+/** Clear attempts after successful login */
+export function clearLoginAttempts(ip: string, user: string) {
+  attempts.delete(key(ip, user));
+}
+
+/** Test helper to reset store */
+export function __resetLoginRateLimiter() {
+  attempts.clear();
+}


### PR DESCRIPTION
## Summary
- add login rate limiter that tracks attempts by IP and user
- record rate limiting and lockout events
- test login rate limiting

## Testing
- `npx jest apps/shop-abc/__tests__/loginRateLimit.test.ts --config jest.config.cjs`
- `npx jest apps/shop-abc/__tests__/middleware.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689911d2dee8832fb0e52b51caad0ad9