### PR TITLE
feat: add durable cart store with redis backend

### DIFF
--- a/apps/cms/src/app/[lang]/checkout/page.tsx
+++ b/apps/cms/src/app/[lang]/checkout/page.tsx
@@ -27,7 +27,7 @@ export default async function CheckoutPage({
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
-  const cart = cartId ? getCart(cartId) : {};
+  const cart = cartId ? await getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",
-    "@prisma/client": "^5.15.1"
+    "@prisma/client": "^5.15.1",
+    "@upstash/redis": "^1.35.3"
   },
   "peerDependencies": {
     "next": "^15.0.0",

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -1,28 +1,87 @@
 import crypto from "crypto";
+import { Redis } from "@upstash/redis";
 
 import type { CartState } from "./cartCookie";
 
-// Simple in-memory cart storage keyed by cart ID.
-const carts = new Map<string, CartState>();
-
-/** Create a new empty cart and return its ID. */
-export function createCart(): string {
-  const id = crypto.randomUUID();
-  carts.set(id, {});
-  return id;
+/** Abstraction for cart storage backends */
+export interface CartStore {
+  createCart(): Promise<string>;
+  getCart(id: string): Promise<CartState>;
+  setCart(id: string, cart: CartState): Promise<void>;
+  deleteCart(id: string): Promise<void>;
 }
 
-/** Retrieve cart by ID, returning empty object if not found. */
-export function getCart(id: string): CartState {
-  return carts.get(id) ?? {};
+const TTL_SECONDS = Number(process.env.CART_TTL ?? 60 * 60 * 24);
+
+class MemoryCartStore implements CartStore {
+  private carts = new Map<string, { cart: CartState; expires: number }>();
+
+  constructor(private ttl: number) {}
+
+  async createCart(): Promise<string> {
+    const id = crypto.randomUUID();
+    await this.setCart(id, {});
+    return id;
+  }
+
+  async getCart(id: string): Promise<CartState> {
+    const entry = this.carts.get(id);
+    if (!entry) return {};
+    if (entry.expires < Date.now()) {
+      this.carts.delete(id);
+      return {};
+    }
+    return entry.cart;
+  }
+
+  async setCart(id: string, cart: CartState): Promise<void> {
+    this.carts.set(id, { cart, expires: Date.now() + this.ttl * 1000 });
+  }
+
+  async deleteCart(id: string): Promise<void> {
+    this.carts.delete(id);
+  }
 }
 
-/** Replace cart contents for given ID. */
-export function setCart(id: string, cart: CartState): void {
-  carts.set(id, cart);
+class RedisCartStore implements CartStore {
+  constructor(private client: Redis, private ttl: number) {}
+
+  async createCart(): Promise<string> {
+    const id = crypto.randomUUID();
+    await this.client.set(id, {}, { ex: this.ttl });
+    return id;
+  }
+
+  async getCart(id: string): Promise<CartState> {
+    return ((await this.client.get(id)) as CartState) ?? {};
+  }
+
+  async setCart(id: string, cart: CartState): Promise<void> {
+    await this.client.set(id, cart, { ex: this.ttl });
+  }
+
+  async deleteCart(id: string): Promise<void> {
+    await this.client.del(id);
+  }
 }
 
-/** Remove cart from storage. */
-export function deleteCart(id: string): void {
-  carts.delete(id);
+let store: CartStore;
+if (
+  process.env.UPSTASH_REDIS_REST_URL &&
+  process.env.UPSTASH_REDIS_REST_TOKEN
+) {
+  const client = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+  });
+  store = new RedisCartStore(client, TTL_SECONDS);
+} else {
+  store = new MemoryCartStore(TTL_SECONDS);
 }
+
+export const createCart = () => store.createCart();
+export const getCart = (id: string) => store.getCart(id);
+export const setCart = (id: string, cart: CartState) =>
+  store.setCart(id, cart);
+export const deleteCart = (id: string) => store.deleteCart(id);
+

--- a/packages/template-app/__tests__/cart.test.ts
+++ b/packages/template-app/__tests__/cart.test.ts
@@ -43,7 +43,8 @@ test("POST adds items and sets cookie", async () => {
   const header = res.headers.get("Set-Cookie")!;
   const encoded = header.split(";")[0].split("=")[1];
   const id = decodeCartCookie(encoded)!;
-  expect(getCart(id)[sku.id].qty).toBe(2);
+  const stored = await getCart(id);
+  expect(stored[sku.id].qty).toBe(2);
 });
 
 test("POST validates body", async () => {
@@ -54,8 +55,8 @@ test("POST validates body", async () => {
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
@@ -67,8 +68,8 @@ test("PATCH updates quantity", async () => {
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
@@ -76,7 +77,7 @@ test("PATCH removes item when qty is 0", async () => {
 });
 
 test("PATCH returns 404 for missing item", async () => {
-  const cartId = createCart();
+  const cartId = await createCart();
   const res = await PATCH(
     createRequest(
       { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", qty: 1 },
@@ -104,8 +105,8 @@ test("POST rejects negative or non-integer quantity", async () => {
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   let res = await PATCH(
     createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cartId))
   );
@@ -119,8 +120,8 @@ test("PATCH rejects negative or non-integer quantity", async () => {
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 2 } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   const req = createRequest({ id: sku.id }, encodeCartCookie(cartId));
   const res = await DELETE(req);
   const body = await res.json();
@@ -130,8 +131,8 @@ test("DELETE removes item", async () => {
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 3 } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   const res = await GET(createRequest({}, encodeCartCookie(cartId)));
   const body = await res.json();
   expect(body.cart).toEqual(cart);

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -44,8 +44,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
   const sku = PRODUCTS[0];
   const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
@@ -69,8 +69,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 test("returns 400 when returnDate is invalid", async () => {
   const sku = PRODUCTS[0];
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const cartId = createCart();
-  setCart(cartId, cart);
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
   const req = createRequest({ returnDate: "invalid" }, cookie);
   const res = await POST(req);

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -38,12 +38,12 @@ export async function POST(req: NextRequest) {
 
   let cartId = decodeCartCookie(req.cookies.get(CART_COOKIE)?.value);
   if (!cartId) {
-    cartId = createCart();
+    cartId = await createCart();
   }
-  const cart = getCart(cartId);
+  const cart = await getCart(cartId);
   const line = cart[sku.id];
   cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
-  setCart(cartId, cart);
+  await setCart(cartId, cart);
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;
@@ -68,7 +68,7 @@ export async function PATCH(req: NextRequest) {
   if (!cartId) {
     return NextResponse.json({ error: "Cart not found" }, { status: 404 });
   }
-  const cart = getCart(cartId);
+  const cart = await getCart(cartId);
   const line = cart[id];
 
   if (!line) {
@@ -80,7 +80,7 @@ export async function PATCH(req: NextRequest) {
   } else {
     cart[id] = { ...line, qty };
   }
-  setCart(cartId, cart);
+  await setCart(cartId, cart);
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;
@@ -105,14 +105,14 @@ export async function DELETE(req: NextRequest) {
   if (!cartId) {
     return NextResponse.json({ error: "Cart not found" }, { status: 404 });
   }
-  const cart = getCart(cartId);
+  const cart = await getCart(cartId);
 
   if (!cart[id]) {
     return NextResponse.json({ error: "Item not in cart" }, { status: 404 });
   }
 
   delete cart[id];
-  setCart(cartId, cart);
+  await setCart(cartId, cart);
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
@@ -125,9 +125,9 @@ export async function DELETE(req: NextRequest) {
 export async function GET(req: NextRequest) {
   let cartId = decodeCartCookie(req.cookies.get(CART_COOKIE)?.value);
   if (!cartId) {
-    cartId = createCart();
+    cartId = await createCart();
   }
-  const cart = getCart(cartId);
+  const cart = await getCart(cartId);
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -107,7 +107,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   /* 1  Decode cart -------------------------------------------------- */
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
   const cartId = decodeCartCookie(rawCookie);
-  const cart = cartId ? (getCart(cartId) as CartState) : {};
+  const cart = cartId ? ((await getCart(cartId)) as CartState) : {};
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -33,7 +33,7 @@ export default async function CheckoutPage({
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
-  const cart = cartId ? getCart(cartId) : {};
+  const cart = cartId ? await getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -23,7 +23,7 @@ export default async function Header({
 }) {
   const cookieStore = await cookies();
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
-  const cart = cartId ? getCart(cartId) : {};
+  const cart = cartId ? await getCart(cartId) : {};
   const initialQty = Object.values(cart).reduce((s, line) => s + line.qty, 0);
   const shopId = process.env.NEXT_PUBLIC_SHOP_ID || "default";
   const shop = await readShop(shopId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       '@prisma/client':
         specifier: ^5.15.1
         version: 5.22.0(prisma@5.22.0)
+      '@upstash/redis':
+        specifier: ^1.35.3
+        version: 1.35.3
       react:
         specifier: ^18
         version: 18.3.1
@@ -3809,6 +3812,9 @@ packages:
     resolution: {integrity: sha512-2v3erKKmmCyIVvvhI2nF15qEbdBpISTq44m9pyd5gfIJB1PN94oePTLWEd82XUbIbvKhv76xTSeUQSCOGesLeg==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/redis@1.35.3':
+    resolution: {integrity: sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==}
 
   '@vercel/blob@1.0.2':
     resolution: {integrity: sha512-Im/KeFH4oPx7UsM+QiteimnE07bIUD7JK6CBafI9Z0jRFogaialTBMiZj8EKk/30ctUYsrpIIyP9iIY1YxWnUQ==}
@@ -9474,6 +9480,9 @@ packages:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -13514,6 +13523,10 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.10.1':
     optional: true
+
+  '@upstash/redis@1.35.3':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vercel/blob@1.0.2':
     dependencies:
@@ -20142,6 +20155,8 @@ snapshots:
       through: 2.3.8
 
   unc-path-regex@0.1.2: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary
- abstract cart storage behind CartStore interface with memory and Redis options
- use Redis with TTL when configured, fallback to in-memory store
- update API routes, pages, and tests to await async cart operations

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '.prisma/client/index-browser')*


------
https://chatgpt.com/codex/tasks/task_e_689911e331bc832fb6d61ced4100222f