### PR TITLE
Handle cart action failures in MiniCart

### DIFF
--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -6,6 +6,7 @@ import { cn } from "../../utils/style";
 import { drawerWidthProps } from "../../utils/style";
 import { Button } from "../atoms/shadcn";
 import { Price } from "../atoms/Price";
+import { Toast } from "../atoms/Toast";
 import {
   Dialog,
   DialogContent,
@@ -28,54 +29,72 @@ export interface MiniCartProps {
 
 export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
   const [cart, dispatch] = useCart();
+  const [toast, setToast] = React.useState<{ open: boolean; message: string }>(
+    { open: false, message: "" }
+  );
   const lines = Object.values(cart);
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
   const { widthClass, style } = drawerWidthProps(width);
 
+  const handleRemove = async (id: string) => {
+    try {
+      await dispatch({ type: "remove", id });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to update cart";
+      setToast({ open: true, message });
+    }
+  };
+
   return (
-    <Dialog>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent
-        style={style}
-        className={cn(
-          "bg-background fixed top-0 right-0 h-full max-w-full rounded-none border-l p-6 shadow-lg",
-          widthClass
-        )}
-      >
-        <DialogTitle className="mb-4">Your Cart</DialogTitle>
-        {lines.length === 0 ? (
-          <p className="text-muted-foreground text-sm">Cart is empty.</p>
-        ) : (
-          <div className="flex h-full flex-col gap-4">
-            <ul className="grow space-y-3 overflow-y-auto">
-              {lines.map((line) => (
-                <li
-                  key={line.sku.id}
-                  className="flex items-center justify-between gap-2"
-                >
-                  <span className="text-sm">{line.sku.title}</span>
-                  <span className="text-sm">× {line.qty}</span>
-                  <Button
-                    variant="destructive"
-                    onClick={() =>
-                      void dispatch({ type: "remove", id: line.sku.id })
-                    }
-                    className="px-2 py-1 text-xs"
+    <>
+      <Dialog>
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <DialogContent
+          style={style}
+          className={cn(
+            "bg-background fixed top-0 right-0 h-full max-w-full rounded-none border-l p-6 shadow-lg",
+            widthClass
+          )}
+        >
+          <DialogTitle className="mb-4">Your Cart</DialogTitle>
+          {lines.length === 0 ? (
+            <p className="text-muted-foreground text-sm">Cart is empty.</p>
+          ) : (
+            <div className="flex h-full flex-col gap-4">
+              <ul className="grow space-y-3 overflow-y-auto">
+                {lines.map((line) => (
+                  <li
+                    key={line.sku.id}
+                    className="flex items-center justify-between gap-2"
                   >
-                    Remove
-                  </Button>
-                </li>
-              ))}
-            </ul>
-            <div className="border-t pt-4 text-sm">
-              <div className="flex justify-between font-semibold">
-                <span>Subtotal</span>
-                <Price amount={subtotal} />
+                    <span className="text-sm">{line.sku.title}</span>
+                    <span className="text-sm">× {line.qty}</span>
+                    <Button
+                      variant="destructive"
+                      onClick={() => void handleRemove(line.sku.id)}
+                      className="px-2 py-1 text-xs"
+                    >
+                      Remove
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+              <div className="border-t pt-4 text-sm">
+                <div className="flex justify-between font-semibold">
+                  <span>Subtotal</span>
+                  <Price amount={subtotal} />
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </DialogContent>
-    </Dialog>
+          )}
+        </DialogContent>
+      </Dialog>
+      <Toast
+        open={toast.open}
+        onClose={() => setToast((t) => ({ ...t, open: false }))}
+        message={toast.message}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- catch errors when dispatching cart actions in MiniCart
- show a Toast message if cart updates fail

## Testing
- `pnpm --filter @acme/ui test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL, Exit status 1)*
- `pnpm --filter @acme/ui lint` *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_689911e464bc832faabda0b753fe99ef