### PR TITLE
feat: use price component for currency formatting

### DIFF
--- a/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -4,6 +4,7 @@
 import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
+import { Price } from "@ui/components/atoms/Price";
 import type { SKU } from "@types";
 import { useState } from "react";
 
@@ -23,7 +24,9 @@ export default function PdpClient({ product }: { product: SKU }) {
           <SizeSelector sizes={product.sizes} onSelect={setSize} />
         </div>
 
-        <div className="text-2xl font-semibold">€{product.price}</div>
+        <div className="text-2xl font-semibold">
+          <Price amount={product.price} />
+        </div>
 
         {/* size could be added to cart line later */}
         <AddToCartButton sku={product} disabled={!size} />

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -4,6 +4,7 @@
 import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
+import { Price } from "@ui/components/atoms/Price";
 import type { SKU } from "@types";
 import { useState } from "react";
 
@@ -21,7 +22,9 @@ export default function PdpClient({ product }: { product: SKU }) {
           <div className="mb-2 font-medium">Select size:</div>
           <SizeSelector sizes={product.sizes} onSelect={setSize} />
         </div>
-        <div className="text-2xl font-semibold">€{product.price}</div>
+        <div className="text-2xl font-semibold">
+          <Price amount={product.price} />
+        </div>
         {/* size could be added to cart line later */}
         <AddToCartButton
           sku={product}

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -4,6 +4,7 @@
 import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
+import { Price } from "@ui/components/atoms/Price";
 import type { SKU } from "@types";
 import { useState } from "react";
 
@@ -23,7 +24,9 @@ export default function PdpClient({ product }: { product: SKU }) {
           <SizeSelector sizes={product.sizes} onSelect={setSize} />
         </div>
 
-        <div className="text-2xl font-semibold">€{product.price}</div>
+        <div className="text-2xl font-semibold">
+          <Price amount={product.price} />
+        </div>
 
         {/* size could be added to cart line later */}
         <AddToCartButton

--- a/packages/platform-core/src/components/shop/ProductCard.tsx
+++ b/packages/platform-core/src/components/shop/ProductCard.tsx
@@ -2,6 +2,7 @@
 import type { SKU } from "@types";
 import Image from "next/image";
 import Link from "next/link";
+import { Price } from "@ui/components/atoms/Price";
 import { memo } from "react";
 import AddToCartButton from "./AddToCartButton.client";
 
@@ -22,7 +23,9 @@ function ProductCardInner({ sku }: { sku: SKU }) {
         />
       </Link>
       <h3 className="font-medium">{sku.title}</h3>
-      <div className="font-semibold text-gray-900">€{sku.price}</div>
+      <div className="font-semibold text-gray-900">
+        <Price amount={sku.price} />
+      </div>
       <AddToCartButton sku={sku} />
     </article>
   );

--- a/packages/template-app/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/packages/template-app/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -4,6 +4,7 @@
 import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
+import { Price } from "@ui/components/atoms/Price";
 import type { SKU } from "@types";
 import { useState } from "react";
 
@@ -23,7 +24,9 @@ export default function PdpClient({ product }: { product: SKU }) {
           <SizeSelector sizes={product.sizes} onSelect={setSize} />
         </div>
 
-        <div className="text-2xl font-semibold">€{product.price}</div>
+        <div className="text-2xl font-semibold">
+          <Price amount={product.price} />
+        </div>
 
         {/* size could be added to cart line later */}
         <AddToCartButton

--- a/packages/ui/src/components/organisms/OrderSummary.stories.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.stories.tsx
@@ -3,6 +3,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 
 import OrderSummary from "./OrderSummary";
+import { Price } from "../atoms/Price";
 
 /* ------------------------------------------------------------------ *
  *  Storybook meta
@@ -31,17 +32,23 @@ export const Default: StoryObj<typeof OrderSummary> = {
           <tr>
             <td />
             <td className="py-2">Shipping</td>
-            <td className="text-right">€5</td>
+            <td className="text-right">
+              <Price amount={5} />
+            </td>
           </tr>
           <tr>
             <td />
             <td className="py-2">Tax</td>
-            <td className="text-right">€3</td>
+            <td className="text-right">
+              <Price amount={3} />
+            </td>
           </tr>
           <tr>
             <td />
             <td className="py-2">Discount</td>
-            <td className="text-right">-€2</td>
+            <td className="text-right">
+              <Price amount={-2} />
+            </td>
           </tr>
         </tbody>
       </table>

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -3,6 +3,7 @@
 
 import { useCart } from "@ui/hooks/useCart";
 import type { CartLine } from "@/lib/cartCookie";
+import { Price } from "../atoms/Price";
 import React, { useMemo } from "react";
 
 type Totals = {
@@ -76,7 +77,9 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
               )}
             </td>
             <td>{line.qty}</td>
-            <td className="text-right">€{line.sku.price * line.qty}</td>
+            <td className="text-right">
+              <Price amount={line.sku.price * line.qty} />
+            </td>
           </tr>
         ))}
       </tbody>
@@ -84,12 +87,16 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
         <tr>
           <td />
           <td className="py-2">Deposit</td>
-          <td className="text-right">€{deposit}</td>
+          <td className="text-right">
+            <Price amount={deposit} />
+          </td>
         </tr>
         <tr>
           <td />
           <td className="py-2 font-semibold">Total</td>
-          <td className="text-right font-semibold">€{total}</td>
+          <td className="text-right font-semibold">
+            <Price amount={total} />
+          </td>
         </tr>
       </tfoot>
     </table>


### PR DESCRIPTION
## Summary
- use `<Price>` in `OrderSummary` for line items, deposit, and total
- update cart/checkout and product components to rely on `Price`

## Testing
- `pnpm test --filter @acme/ui` *(fails: Invalid environment variables)*
- `pnpm test --filter @acme/platform-core` *(fails: Invalid environment variables)*
- `pnpm test --filter @apps/cms --filter @apps/shop-abc --filter @apps/shop-bcd --filter @acme/template-app` *(fails: missing module errors)*

------
https://chatgpt.com/codex/tasks/task_e_689911e234a8832f87cebdf07a916207