### PR TITLE
Fetch profile data in ProfilePage

### DIFF
--- a/apps/shop-abc/__tests__/accountProfile.test.tsx
+++ b/apps/shop-abc/__tests__/accountProfile.test.tsx
@@ -4,7 +4,13 @@ jest.mock("@auth", () => ({
   getCustomerSession: jest.fn(),
 }));
 
+jest.mock("@acme/platform-core", () => ({
+  __esModule: true,
+  getCustomerProfile: jest.fn(),
+}));
+
 import { getCustomerSession } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
 import ProfilePage from "@ui/src/components/account/Profile";
 import ProfileForm from "@ui/src/components/account/ProfileForm";
 
@@ -19,17 +25,25 @@ describe("/account/profile", () => {
     expect(getCustomerSession).toHaveBeenCalled();
     expect(element.type).toBe("p");
     expect(element.props.children).toBe("Please log in to view your profile.");
+    expect(getCustomerProfile).not.toHaveBeenCalled();
   });
 
   it("renders profile form for authenticated users", async () => {
     (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    (getCustomerProfile as jest.Mock).mockResolvedValue({
+      name: "Jane Doe",
+      email: "jane@example.com",
+    });
     const element = await ProfilePage({});
     expect(getCustomerSession).toHaveBeenCalled();
+    expect(getCustomerProfile).toHaveBeenCalledWith("cust1");
     expect(element.type).toBe("div");
     expect(element.props.children[0].props.children).toBe("Profile");
     const form = element.props.children[1];
     expect(form.type).toBe(ProfileForm);
-    // TODO: once profile retrieval is implemented, assert default values
-    // expect(form.props).toMatchObject({ name: "Jane Doe", email: "jane@example.com" });
+    expect(form.props).toMatchObject({
+      name: "Jane Doe",
+      email: "jane@example.com",
+    });
   });
 });

--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -4,7 +4,13 @@ jest.mock("@auth", () => ({
   getCustomerSession: jest.fn(),
 }));
 
+jest.mock("@acme/platform-core", () => ({
+  __esModule: true,
+  getCustomerProfile: jest.fn(),
+}));
+
 import { getCustomerSession } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
 import ProfilePage from "@ui/src/components/account/Profile";
 import ProfileForm from "@ui/src/components/account/ProfileForm";
 
@@ -19,17 +25,25 @@ describe("/account/profile", () => {
     expect(getCustomerSession).toHaveBeenCalled();
     expect(element.type).toBe("p");
     expect(element.props.children).toBe("Please log in to view your profile.");
+    expect(getCustomerProfile).not.toHaveBeenCalled();
   });
 
   it("renders profile form for authenticated users", async () => {
     (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    (getCustomerProfile as jest.Mock).mockResolvedValue({
+      name: "Jane Doe",
+      email: "jane@example.com",
+    });
     const element = await ProfilePage({});
     expect(getCustomerSession).toHaveBeenCalled();
+    expect(getCustomerProfile).toHaveBeenCalledWith("cust1");
     expect(element.type).toBe("div");
     expect(element.props.children[0].props.children).toBe("Profile");
     const form = element.props.children[1];
     expect(form.type).toBe(ProfileForm);
-    // TODO: once profile retrieval is implemented, assert default values
-    // expect(form.props).toMatchObject({ name: "Jane Doe", email: "jane@example.com" });
+    expect(form.props).toMatchObject({
+      name: "Jane Doe",
+      email: "jane@example.com",
+    });
   });
 });

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -1,5 +1,6 @@
 // packages/ui/src/components/account/Profile.tsx
 import { getCustomerSession } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
 import ProfileForm from "./ProfileForm";
 
 export interface ProfilePageProps {
@@ -12,10 +13,11 @@ export const metadata = { title: "Profile" };
 export default async function ProfilePage({ title = "Profile" }: ProfilePageProps) {
   const session = await getCustomerSession();
   if (!session) return <p>Please log in to view your profile.</p>;
+  const profile = await getCustomerProfile(session.customerId);
   return (
     <div className="p-6">
       <h1 className="mb-4 text-xl">{title}</h1>
-      <ProfileForm />
+      <ProfileForm name={profile?.name} email={profile?.email} />
     </div>
   );
 }

--- a/packages/ui/src/components/account/ProfileForm.tsx
+++ b/packages/ui/src/components/account/ProfileForm.tsx
@@ -4,8 +4,10 @@
 import { useState } from "react";
 
 export interface ProfileFormProps {
-  name?: string;
-  email?: string;
+  /** Pre-filled name value; may be undefined if profile data is missing */
+  name?: string | undefined;
+  /** Pre-filled email value; may be undefined if profile data is missing */
+  email?: string | undefined;
 }
 
 export default function ProfileForm({ name = "", email = "" }: ProfileFormProps) {


### PR DESCRIPTION
## Summary
- fetch customer profile in ProfilePage and pass name/email to form
- allow undefined values in ProfileForm props
- add tests for profile retrieval in both shops

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6899120ad708832fb1cb37b57bae4260