### PR TITLE
refactor wizard to use step config

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -1,0 +1,45 @@
+import StepShopDetails from "../wizard/steps/StepShopDetails";
+import StepTheme from "../wizard/steps/StepTheme";
+import StepTokens from "../wizard/steps/StepTokens";
+import StepOptions from "../wizard/steps/StepOptions";
+import StepNavigation from "../wizard/steps/StepNavigation";
+import StepLayout from "../wizard/steps/StepLayout";
+import StepHomePage from "../wizard/steps/StepHomePage";
+import StepCheckoutPage from "../wizard/steps/StepCheckoutPage";
+import StepShopPage from "../wizard/steps/StepShopPage";
+import StepProductPage from "../wizard/steps/StepProductPage";
+import StepAdditionalPages from "../wizard/steps/StepAdditionalPages";
+import StepEnvVars from "../wizard/steps/StepEnvVars";
+import StepSummary from "../wizard/steps/StepSummary";
+import StepImportData from "../wizard/steps/StepImportData";
+import StepSeedData from "../wizard/steps/StepSeedData";
+import StepHosting from "../wizard/steps/StepHosting";
+
+export interface ConfiguratorStep {
+  id: string;
+  label: string;
+  component: React.ComponentType<any>;
+  required: boolean;
+  deps: string[];
+}
+
+export const steps: ConfiguratorStep[] = [
+  { id: "shop-details", label: "Shop Details", component: StepShopDetails, required: true, deps: [] },
+  { id: "theme", label: "Theme", component: StepTheme, required: true, deps: ["shop-details"] },
+  { id: "tokens", label: "Tokens", component: StepTokens, required: true, deps: ["theme"] },
+  { id: "options", label: "Options", component: StepOptions, required: true, deps: ["tokens"] },
+  { id: "navigation", label: "Navigation", component: StepNavigation, required: true, deps: ["options"] },
+  { id: "layout", label: "Layout", component: StepLayout, required: true, deps: ["navigation"] },
+  { id: "home-page", label: "Home Page", component: StepHomePage, required: true, deps: ["layout"] },
+  { id: "checkout-page", label: "Checkout Page", component: StepCheckoutPage, required: true, deps: ["home-page"] },
+  { id: "shop-page", label: "Shop Page", component: StepShopPage, required: true, deps: ["checkout-page"] },
+  { id: "product-page", label: "Product Page", component: StepProductPage, required: true, deps: ["shop-page"] },
+  { id: "additional-pages", label: "Additional Pages", component: StepAdditionalPages, required: true, deps: ["product-page"] },
+  { id: "env-vars", label: "Environment Variables", component: StepEnvVars, required: true, deps: ["additional-pages"] },
+  { id: "summary", label: "Summary", component: StepSummary, required: true, deps: ["env-vars"] },
+  { id: "import-data", label: "Import Data", component: StepImportData, required: false, deps: ["summary"] },
+  { id: "seed-data", label: "Seed Data", component: StepSeedData, required: false, deps: ["import-data"] },
+  { id: "hosting", label: "Hosting", component: StepHosting, required: false, deps: ["seed-data"] },
+];
+
+export default steps;

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -13,22 +13,7 @@ import { ulid } from "ulid";
 /*  Wizard step views                                                         */
 /* -------------------------------------------------------------------------- */
 import MediaUploadDialog from "./MediaUploadDialog";
-import StepAdditionalPages from "./steps/StepAdditionalPages";
-import StepCheckoutPage from "./steps/StepCheckoutPage";
-import StepHomePage from "./steps/StepHomePage";
-import StepHosting from "./steps/StepHosting";
-import StepImportData from "./steps/StepImportData";
-import StepLayout from "./steps/StepLayout";
-import StepNavigation from "./steps/StepNavigation";
-import StepOptions from "./steps/StepOptions";
-import StepProductPage from "./steps/StepProductPage";
-import StepSeedData from "./steps/StepSeedData";
-import StepEnvVars from "./steps/StepEnvVars";
-import StepShopDetails from "./steps/StepShopDetails";
-import StepShopPage from "./steps/StepShopPage";
-import StepSummary from "./steps/StepSummary";
-import StepTheme from "./steps/StepTheme";
-import StepTokens from "./steps/StepTokens";
+import steps from "../configurator/steps";
 
 /* -------------------------------------------------------------------------- */
 /*  Schema / utils                                                            */
@@ -118,6 +103,8 @@ export default function Wizard({
   const pollRef = useRef<NodeJS.Timeout | null>(null);
   const pollRetries = useRef(0);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+  const [completed, setCompleted] = useState<Record<string, boolean>>({});
 
   /* ---------------------------------------------------------------------- */
   /*  SEO fields                                                            */
@@ -415,7 +402,6 @@ export default function Wizard({
 
       if (ok) {
         setSeedResult("Data saved");
-        setStep(10);
       } else {
         setSeedResult(error ?? "Failed to save data");
       }
@@ -460,7 +446,6 @@ export default function Wizard({
       }
 
       setImportResult("Saved");
-      setStep(9);
     } catch (err) {
       console.error("Error importing data", err);
       setImportResult(
@@ -549,263 +534,191 @@ export default function Wizard({
     }
   }
 
-  /** Returns the JSX for the current step—only that step is mounted. */
-  const renderStep = () => {
-    switch (step) {
-      case 0:
-        return (
-          <StepShopDetails
-            shopId={shopId}
-            setShopId={setShopId}
-            storeName={storeName}
-            setStoreName={setStoreName}
-            logo={logo}
-            setLogo={setLogo}
-            contactInfo={contactInfo}
-            setContactInfo={setContactInfo}
-            type={type}
-            setType={setType}
-            template={template}
-            setTemplate={setTemplate}
-            templates={templates}
-            onNext={handleIdStepNext}
-            errors={fieldErrors}
-          />
-        );
+  const layoutIndex = steps.findIndex((s) => s.id === "layout");
 
-      case 1:
-        return (
-          <StepTheme
-            themes={themes}
-            theme={theme}
-            setTheme={setTheme}
-            themeVars={themeVars}
-            setThemeVars={setThemeVars}
-            themeStyle={themeStyle}
-            onBack={() => setStep(0)}
-            onNext={() => setStep(2)}
-          />
-        );
+  const stepProps: Record<string, any> = {
+    "shop-details": {
+      shopId,
+      setShopId,
+      storeName,
+      setStoreName,
+      logo,
+      setLogo,
+      contactInfo,
+      setContactInfo,
+      type,
+      setType,
+      template,
+      setTemplate,
+      templates,
+      errors: fieldErrors,
+    },
+    theme: {
+      themes,
+      theme,
+      setTheme,
+      themeVars,
+      setThemeVars,
+      themeStyle,
+    },
+    tokens: { themeStyle },
+    options: {
+      shopId,
+      payment,
+      setPayment,
+      shipping,
+      setShipping,
+      analyticsProvider,
+      setAnalyticsProvider,
+      analyticsId,
+      setAnalyticsId,
+    },
+    navigation: { navItems, setNavItems },
+    layout: {
+      currentStep: step,
+      stepIndex: layoutIndex,
+      headerComponents,
+      setHeaderComponents,
+      headerPageId,
+      setHeaderPageId,
+      footerComponents,
+      setFooterComponents,
+      footerPageId,
+      setFooterPageId,
+      shopId,
+      themeStyle,
+    },
+    "home-page": {
+      pageTemplates,
+      homeLayout,
+      setHomeLayout,
+      components,
+      setComponents,
+      homePageId,
+      setHomePageId,
+      shopId,
+      themeStyle,
+    },
+    "checkout-page": {
+      pageTemplates,
+      checkoutLayout,
+      setCheckoutLayout,
+      checkoutComponents,
+      setCheckoutComponents,
+      checkoutPageId,
+      setCheckoutPageId,
+      shopId,
+      themeStyle,
+    },
+    "shop-page": {
+      pageTemplates,
+      shopLayout,
+      setShopLayout,
+      shopComponents,
+      setShopComponents,
+      shopPageId,
+      setShopPageId,
+      shopId,
+      themeStyle,
+    },
+    "product-page": {
+      pageTemplates,
+      productLayout,
+      setProductLayout,
+      productComponents,
+      setProductComponents,
+      productPageId,
+      setProductPageId,
+      shopId,
+      themeStyle,
+    },
+    "additional-pages": {
+      pageTemplates,
+      pages,
+      setPages,
+      shopId,
+      themeStyle,
+    },
+    "env-vars": { env: envVars, setEnv },
+    summary: {
+      shopId,
+      name: storeName,
+      logo,
+      contactInfo,
+      type,
+      template,
+      theme,
+      payment,
+      shipping,
+      analyticsProvider,
+      pageTitle,
+      setPageTitle,
+      pageDescription,
+      setPageDescription,
+      socialImage,
+      setSocialImage,
+      result,
+      themeStyle,
+      creating,
+      submit,
+      errors: fieldErrors,
+    },
+    "import-data": {
+      setCsvFile,
+      categoriesText,
+      setCategoriesText,
+      importResult,
+      importing,
+      saveData,
+    },
+    "seed-data": {
+      setCsvFile,
+      categoriesText,
+      setCategoriesText,
+      seedResult,
+      seeding,
+      seed,
+    },
+    hosting: {
+      shopId,
+      domain,
+      setDomain,
+      deployResult,
+      deployInfo,
+      setDeployInfo,
+      deploying,
+      deploy,
+    },
+  };
 
-      case 2:
-        return (
-          <StepTokens
-            themeStyle={themeStyle}
-            onBack={() => setStep(1)}
-            onNext={() => setStep(3)}
-          />
-        );
+  const stepsWithNext = new Set([
+    "shop-details",
+    "theme",
+    "tokens",
+    "options",
+    "navigation",
+    "layout",
+    "home-page",
+    "checkout-page",
+    "shop-page",
+    "product-page",
+    "additional-pages",
+    "env-vars",
+    "summary",
+  ]);
 
-      case 3:
-        return (
-          <StepOptions
-            shopId={shopId}
-            payment={payment}
-            setPayment={setPayment}
-            shipping={shipping}
-            setShipping={setShipping}
-            analyticsProvider={analyticsProvider}
-            setAnalyticsProvider={setAnalyticsProvider}
-            analyticsId={analyticsId}
-            setAnalyticsId={setAnalyticsId}
-            onBack={() => setStep(2)}
-            onNext={() => setStep(4)}
-          />
-        );
+  const currentStepDef = steps[step];
+  const StepComponent = currentStepDef.component as any;
+  const hasNext = stepsWithNext.has(currentStepDef.id);
+  const onNext =
+    currentStepDef.id === "shop-details"
+      ? handleIdStepNext
+      : () => setStep(step + 1);
 
-      case 4:
-        return (
-          <StepNavigation
-            navItems={navItems}
-            setNavItems={setNavItems}
-            onBack={() => setStep(3)}
-            onNext={() => setStep(5)}
-          />
-        );
-
-      case 5:
-        return (
-          <StepLayout
-            currentStep={step}
-            stepIndex={5}
-            headerComponents={headerComponents}
-            setHeaderComponents={setHeaderComponents}
-            headerPageId={headerPageId}
-            setHeaderPageId={setHeaderPageId}
-            footerComponents={footerComponents}
-            setFooterComponents={setFooterComponents}
-            footerPageId={footerPageId}
-            setFooterPageId={setFooterPageId}
-            shopId={shopId}
-            themeStyle={themeStyle}
-            onBack={() => setStep(4)}
-            onNext={() => setStep(6)}
-          />
-        );
-
-      case 6:
-        return (
-          <StepHomePage
-            pageTemplates={pageTemplates}
-            homeLayout={homeLayout}
-            setHomeLayout={setHomeLayout}
-            components={components}
-            setComponents={setComponents}
-            homePageId={homePageId}
-            setHomePageId={setHomePageId}
-            shopId={shopId}
-            themeStyle={themeStyle}
-            onBack={() => setStep(5)}
-            onNext={() => setStep(7)}
-          />
-        );
-
-      case 7:
-        return (
-          <StepCheckoutPage
-            pageTemplates={pageTemplates}
-            checkoutLayout={checkoutLayout}
-            setCheckoutLayout={setCheckoutLayout}
-            checkoutComponents={checkoutComponents}
-            setCheckoutComponents={setCheckoutComponents}
-            checkoutPageId={checkoutPageId}
-            setCheckoutPageId={setCheckoutPageId}
-            shopId={shopId}
-            themeStyle={themeStyle}
-            onBack={() => setStep(6)}
-            onNext={() => setStep(8)}
-          />
-        );
-
-      case 8:
-        return (
-          <StepShopPage
-            pageTemplates={pageTemplates}
-            shopLayout={shopLayout}
-            setShopLayout={setShopLayout}
-            shopComponents={shopComponents}
-            setShopComponents={setShopComponents}
-            shopPageId={shopPageId}
-            setShopPageId={setShopPageId}
-            shopId={shopId}
-            themeStyle={themeStyle}
-            onBack={() => setStep(7)}
-            onNext={() => setStep(9)}
-          />
-        );
-
-      case 9:
-        return (
-          <StepProductPage
-            pageTemplates={pageTemplates}
-            productLayout={productLayout}
-            setProductLayout={setProductLayout}
-            productComponents={productComponents}
-            setProductComponents={setProductComponents}
-            productPageId={productPageId}
-            setProductPageId={setProductPageId}
-            shopId={shopId}
-            themeStyle={themeStyle}
-            onBack={() => setStep(8)}
-            onNext={() => setStep(10)}
-          />
-        );
-
-      case 10:
-        return (
-          <StepAdditionalPages
-            pageTemplates={pageTemplates}
-            pages={pages}
-            setPages={setPages}
-            shopId={shopId}
-            themeStyle={themeStyle}
-            onBack={() => setStep(9)}
-            onNext={() => setStep(11)}
-          />
-        );
-
-      case 11:
-        return (
-          <StepEnvVars
-            env={envVars}
-            setEnv={setEnv}
-            onBack={() => setStep(10)}
-            onNext={() => setStep(12)}
-          />
-        );
-
-      case 12:
-        return (
-          <StepSummary
-            shopId={shopId}
-            name={storeName}
-            logo={logo}
-            contactInfo={contactInfo}
-            type={type}
-            template={template}
-            theme={theme}
-            payment={payment}
-            shipping={shipping}
-            analyticsProvider={analyticsProvider}
-            pageTitle={pageTitle}
-            setPageTitle={setPageTitle}
-            pageDescription={pageDescription}
-            setPageDescription={setPageDescription}
-            socialImage={socialImage}
-            setSocialImage={setSocialImage}
-            result={result}
-            themeStyle={themeStyle}
-            creating={creating}
-            submit={submit}
-            onBack={() => setStep(11)}
-            onNext={() => setStep(13)}
-            errors={fieldErrors}
-          />
-        );
-
-      case 13:
-        return (
-          <StepImportData
-            setCsvFile={setCsvFile}
-            categoriesText={categoriesText}
-            setCategoriesText={setCategoriesText}
-            importResult={importResult}
-            importing={importing}
-            saveData={saveData}
-            onBack={() => setStep(12)}
-          />
-        );
-
-      case 14:
-        return (
-          <StepSeedData
-            setCsvFile={setCsvFile}
-            categoriesText={categoriesText}
-            setCategoriesText={setCategoriesText}
-            seedResult={seedResult}
-            seeding={seeding}
-            seed={seed}
-            onBack={() => setStep(13)}
-          />
-        );
-
-      case 15:
-        return (
-          <StepHosting
-            shopId={shopId}
-            domain={domain}
-            setDomain={setDomain}
-            deployResult={deployResult}
-            deployInfo={deployInfo}
-            setDeployInfo={setDeployInfo}
-            deploying={deploying}
-            deploy={deploy}
-            onBack={() => setStep(14)}
-          />
-        );
-
-      default:
-        return null;
+  const handleComplete = () => {
+    setCompleted((prev) => ({ ...prev, [currentStepDef.id]: true }));
+    if (!hasNext) {
+      setStep(step + 1);
     }
   };
 
@@ -817,12 +730,16 @@ export default function Wizard({
     <div className="mx-auto max-w-xl" style={themeStyle}>
       <fieldset disabled={disabled} className="space-y-6">
         <div className="mb-6 flex items-center justify-between">
-          <Progress step={step} total={16} />
+          <Progress step={step} total={steps.length} />
           {shopId && <MediaUploadDialog shop={shopId} />}
         </div>
 
-        {/* Only the active step is rendered */}
-        {renderStep()}
+        <StepComponent
+          {...stepProps[currentStepDef.id]}
+          {...(step > 0 ? { onBack: () => setStep(step - 1) } : {})}
+          {...(hasNext ? { onNext } : {})}
+          onComplete={handleComplete}
+        />
       </fieldset>
 
       <Toast

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
@@ -23,6 +23,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepAdditionalPages({
@@ -33,6 +34,7 @@ export default function StepAdditionalPages({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const languages = LOCALES as readonly Locale[];
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
@@ -174,7 +176,14 @@ export default function StepAdditionalPages({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
@@ -28,6 +28,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepCheckoutPage({
@@ -42,6 +43,7 @@ export default function StepCheckoutPage({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -121,7 +123,14 @@ export default function StepCheckoutPage({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepEnvVars.tsx
@@ -30,6 +30,7 @@ interface Props {
   setEnv: (key: string, value: string) => void;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepEnvVars({
@@ -37,6 +38,7 @@ export default function StepEnvVars({
   setEnv,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   return (
     <div className="space-y-4">
@@ -62,7 +64,14 @@ export default function StepEnvVars({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );

--- a/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
@@ -29,6 +29,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepHomePage({
@@ -43,6 +44,7 @@ export default function StepHomePage({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -166,7 +168,14 @@ export default function StepHomePage({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/wizard/steps/StepHosting.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepHosting.tsx
@@ -16,7 +16,8 @@ interface Props {
   ) => void;
   deploying: boolean;
   onBack: () => void;
-  deploy: () => void;
+  deploy: () => Promise<void> | void;
+  onComplete: () => void;
 }
 
 export default function StepHosting({
@@ -29,6 +30,7 @@ export default function StepHosting({
   deploying,
   onBack,
   deploy,
+  onComplete,
 }: Props): React.JSX.Element {
   useEffect(() => {
     if (!shopId || !deployInfo) return;
@@ -98,7 +100,13 @@ export default function StepHosting({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button disabled={deploying} onClick={deploy}>
+        <Button
+          disabled={deploying}
+          onClick={async () => {
+            await deploy();
+            onComplete();
+          }}
+        >
           {deploying ? "Deploying…" : "Deploy"}
         </Button>
       </div>

--- a/apps/cms/src/app/cms/wizard/steps/StepImportData.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepImportData.tsx
@@ -9,7 +9,8 @@ interface Props {
   importResult: string | null;
   importing: boolean;
   onBack: () => void;
-  saveData: () => void;
+  saveData: () => Promise<void> | void;
+  onComplete: () => void;
 }
 
 export default function StepImportData({
@@ -20,6 +21,7 @@ export default function StepImportData({
   importing,
   onBack,
   saveData,
+  onComplete,
 }: Props): React.JSX.Element {
   return (
     <div className="space-y-4">
@@ -43,7 +45,13 @@ export default function StepImportData({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button disabled={importing} onClick={saveData}>
+        <Button
+          disabled={importing}
+          onClick={async () => {
+            await saveData();
+            onComplete();
+          }}
+        >
           {importing ? "Saving…" : "Save & Continue"}
         </Button>
       </div>

--- a/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
@@ -32,6 +32,7 @@ interface Props {
   /** Navigation */
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 
   /** Optional inner content for the step */
   children?: ReactNode;
@@ -54,6 +55,7 @@ export default function StepLayout({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
   children,
 }: Props): React.JSX.Element | null {
   /**
@@ -169,7 +171,14 @@ export default function StepLayout({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/wizard/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepNavigation.tsx
@@ -15,6 +15,7 @@ interface Props {
   setNavItems: (v: NavItem[]) => void;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepNavigation({
@@ -22,6 +23,7 @@ export default function StepNavigation({
   setNavItems,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   return (
     <div className="space-y-4">
@@ -31,7 +33,14 @@ export default function StepNavigation({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );

--- a/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
@@ -24,6 +24,7 @@ interface Props {
   setAnalyticsId: (v: string) => void;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepOptions({
@@ -38,6 +39,7 @@ export default function StepOptions({
   setAnalyticsId,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -134,7 +136,14 @@ export default function StepOptions({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );

--- a/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
@@ -29,6 +29,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepProductPage({
@@ -43,6 +44,7 @@ export default function StepProductPage({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -168,7 +170,14 @@ export default function StepProductPage({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/wizard/steps/StepSeedData.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepSeedData.tsx
@@ -9,7 +9,8 @@ interface Props {
   seedResult: string | null;
   seeding: boolean;
   onBack: () => void;
-  seed: () => void;
+  seed: () => Promise<void> | void;
+  onComplete: () => void;
 }
 
 export default function StepSeedData({
@@ -20,6 +21,7 @@ export default function StepSeedData({
   seeding,
   onBack,
   seed,
+  onComplete,
 }: Props): React.JSX.Element {
   return (
     <div className="space-y-4">
@@ -44,7 +46,13 @@ export default function StepSeedData({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button disabled={seeding} onClick={seed}>
+        <Button
+          disabled={seeding}
+          onClick={async () => {
+            await seed();
+            onComplete();
+          }}
+        >
           {seeding ? "Saving…" : "Save & Continue"}
         </Button>
       </div>

--- a/apps/cms/src/app/cms/wizard/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepShopDetails.tsx
@@ -25,6 +25,7 @@ interface Props {
   setTemplate: (v: string) => void;
   templates: string[];
   onNext: () => void;
+  onComplete: () => void;
   errors?: Record<string, string[]>;
 }
 
@@ -43,6 +44,7 @@ export default function StepShopDetails({
   setTemplate,
   templates,
   onNext,
+  onComplete,
   errors = {},
 }: Props): React.JSX.Element {
   return (
@@ -123,7 +125,13 @@ export default function StepShopDetails({
         </Select>
       </label>
       <div className="flex justify-end gap-2">
-        <Button disabled={!shopId} onClick={onNext}>
+        <Button
+          disabled={!shopId}
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
           Next
         </Button>
       </div>

--- a/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
@@ -28,6 +28,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepShopPage({
@@ -42,6 +43,7 @@ export default function StepShopPage({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -136,7 +138,14 @@ export default function StepShopPage({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/wizard/steps/StepSummary.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepSummary.tsx
@@ -29,6 +29,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
   creating: boolean;
   submit: () => void;
   errors?: Record<string, string[]>;
@@ -55,6 +56,7 @@ export default function StepSummary({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
   creating,
   submit,
   errors = {},
@@ -160,7 +162,14 @@ export default function StepSummary({
         <Button disabled={creating} onClick={submit} className="ml-auto">
           {creating ? "Creating…" : "Create Shop"}
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );

--- a/apps/cms/src/app/cms/wizard/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepTheme.tsx
@@ -60,6 +60,7 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepTheme({
@@ -71,6 +72,7 @@ export default function StepTheme({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   const [palette, setPalette] = useState(colorPalettes[0].name);
 
@@ -128,7 +130,14 @@ export default function StepTheme({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );

--- a/apps/cms/src/app/cms/wizard/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepTokens.tsx
@@ -7,12 +7,14 @@ interface Props {
   themeStyle: React.CSSProperties;
   onBack: () => void;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 export default function StepTokens({
   themeStyle,
   onBack,
   onNext,
+  onComplete,
 }: Props): React.JSX.Element {
   return (
     <div className="space-y-4">
@@ -22,7 +24,14 @@ export default function StepTokens({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onNext}>Next</Button>
+        <Button
+          onClick={() => {
+            onComplete();
+            onNext();
+          }}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- centralize wizard step metadata in configurator/steps
- drive wizard rendering from shared step list and add completion tracking
- expose `onComplete` callback in each wizard step component

## Testing
- `pnpm --filter cms lint`
- `pnpm --filter cms test` *(fails: Cannot find module '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_689982017fb0832fbefff26a6ed3c8f7