### PR TITLE
feat: add csrf protection

### DIFF
--- a/apps/shop-abc/__tests__/accountProfileApi.test.ts
+++ b/apps/shop-abc/__tests__/accountProfileApi.test.ts
@@ -2,6 +2,7 @@
 jest.mock("@auth", () => ({
   __esModule: true,
   getCustomerSession: jest.fn(),
+  verifyCsrfToken: jest.fn(),
 }));
 
 jest.mock("@acme/platform-core/customerProfiles", () => ({
@@ -17,9 +18,12 @@ jest.mock("next/server", () => ({
   },
 }));
 
-import { getCustomerSession } from "@auth";
-import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
-import { GET } from "../src/app/api/account/profile/route";
+import { getCustomerSession, verifyCsrfToken } from "@auth";
+import {
+  getCustomerProfile,
+  updateCustomerProfile,
+} from "@acme/platform-core/customerProfiles";
+import { GET, PUT } from "../src/app/api/account/profile/route";
 
 describe("/api/account/profile GET", () => {
   beforeEach(() => {
@@ -54,6 +58,47 @@ describe("/api/account/profile GET", () => {
     const res = await GET();
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, profile });
+  });
+});
+
+describe("/api/account/profile PUT", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function createRequest(body: any, token?: string) {
+    return {
+      json: async () => body,
+      headers: new Headers(token ? { "x-csrf-token": token } : {}),
+    } as any;
+  }
+
+  it("returns 403 when CSRF token is invalid", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    (verifyCsrfToken as jest.Mock).mockResolvedValue(false);
+    const req = createRequest({ name: "Jane", email: "jane@test.com" }, "bad");
+    const res = await PUT(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("updates profile when CSRF token is valid", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    (verifyCsrfToken as jest.Mock).mockResolvedValue(true);
+    const profile = {
+      customerId: "cust1",
+      name: "Jane",
+      email: "jane@test.com",
+    };
+    (getCustomerProfile as jest.Mock).mockResolvedValue(profile);
+    const req = createRequest({ name: "Jane", email: "jane@test.com" }, "good");
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, profile });
+    expect(updateCustomerProfile).toHaveBeenCalled();
   });
 });
 

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -1,5 +1,5 @@
 // apps/shop-abc/src/app/api/account/profile/route.ts
-import { getCustomerSession } from "@auth";
+import { getCustomerSession, verifyCsrfToken } from "@auth";
 import {
   getCustomerProfile,
   updateCustomerProfile,
@@ -35,6 +35,11 @@ export async function PUT(req: NextRequest) {
   const session = await getCustomerSession();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const csrfHeader = req.headers.get("x-csrf-token");
+  if (!(await verifyCsrfToken(csrfHeader))) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
   const json = await req.json();

--- a/packages/auth/__tests__/session.test.ts
+++ b/packages/auth/__tests__/session.test.ts
@@ -2,6 +2,7 @@ import {
   createCustomerSession,
   getCustomerSession,
   CUSTOMER_SESSION_COOKIE,
+  CSRF_TOKEN_COOKIE,
 } from "../src/session";
 import type { Role } from "../src/types";
 
@@ -57,11 +58,21 @@ describe("customer session", () => {
       maxAge: expect.any(Number),
     });
 
+    const [csrfName, , csrfOpts] = store.set.mock.calls[1];
+    expect(csrfName).toBe(CSRF_TOKEN_COOKIE);
+    expect(csrfOpts).toMatchObject({
+      httpOnly: false,
+      sameSite: "strict",
+      secure: true,
+      path: "/",
+      maxAge: expect.any(Number),
+    });
+
     store.get.mockReturnValue({ value: firstToken });
     await expect(getCustomerSession()).resolves.toEqual(session);
-    const secondToken = store.set.mock.calls[1][1];
+    const secondToken = store.set.mock.calls[2][1];
     expect(secondToken).not.toBe(firstToken);
-    const secondOpts = store.set.mock.calls[1][2];
+    const secondOpts = store.set.mock.calls[2][2];
     expect(secondOpts).toMatchObject({
       httpOnly: true,
       sameSite: "strict",
@@ -80,7 +91,7 @@ describe("customer session", () => {
     const firstToken = store.set.mock.calls[0][1];
 
     await createCustomerSession(session);
-    const secondToken = store.set.mock.calls[1][1];
+    const secondToken = store.set.mock.calls[2][1];
     expect(secondToken).not.toBe(firstToken);
   });
 });

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,8 +5,11 @@ export { extendRoles, isRole } from "./types/roles";
 export type { Role } from "./types";
 export {
   CUSTOMER_SESSION_COOKIE,
+  CSRF_TOKEN_COOKIE,
   getCustomerSession,
   createCustomerSession,
   destroyCustomerSession,
+  verifyCsrfToken,
+  getCsrfToken,
 } from "./session";
 export type { CustomerSession } from "./session";

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import type { Role } from "./types";
 
 export const CUSTOMER_SESSION_COOKIE = "customer_session";
+export const CSRF_TOKEN_COOKIE = "csrf_token";
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7; // one week
 const SESSION_TTL_S = Math.floor(SESSION_TTL_MS / 1000);
 
@@ -20,6 +21,17 @@ interface InternalSession extends CustomerSession {
 function cookieOptions() {
   return {
     httpOnly: true,
+    sameSite: "strict" as const,
+    secure: true,
+    path: "/",
+    maxAge: SESSION_TTL_S,
+    domain: process.env.COOKIE_DOMAIN,
+  };
+}
+
+function csrfCookieOptions() {
+  return {
+    httpOnly: false,
     sameSite: "strict" as const,
     secure: true,
     path: "/",
@@ -69,6 +81,8 @@ export async function createCustomerSession(sessionData: CustomerSession): Promi
     ttl: SESSION_TTL_S,
   });
   store.set(CUSTOMER_SESSION_COOKIE, token, cookieOptions());
+  const csrfToken = randomUUID();
+  store.set(CSRF_TOKEN_COOKIE, csrfToken, csrfCookieOptions());
 }
 
 export async function destroyCustomerSession(): Promise<void> {
@@ -77,4 +91,25 @@ export async function destroyCustomerSession(): Promise<void> {
     path: "/",
     domain: process.env.COOKIE_DOMAIN,
   });
+  store.delete(CSRF_TOKEN_COOKIE, {
+    path: "/",
+    domain: process.env.COOKIE_DOMAIN,
+  });
+}
+
+export async function verifyCsrfToken(token: string | null): Promise<boolean> {
+  if (!token) return false;
+  const store = await cookies();
+  const stored = store.get(CSRF_TOKEN_COOKIE)?.value;
+  return stored === token;
+}
+
+export async function getCsrfToken(): Promise<string> {
+  const store = await cookies();
+  let token = store.get(CSRF_TOKEN_COOKIE)?.value;
+  if (!token) {
+    token = randomUUID();
+    store.set(CSRF_TOKEN_COOKIE, token, csrfCookieOptions());
+  }
+  return token;
 }

--- a/packages/ui/src/components/account/ProfileForm.tsx
+++ b/packages/ui/src/components/account/ProfileForm.tsx
@@ -22,9 +22,16 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
     setStatus("idle");
     setMessage(null);
     try {
+      const csrfToken = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("csrf_token="))
+        ?.split("=")[1];
       const res = await fetch("/api/account/profile", {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken ?? "",
+        },
         body: JSON.stringify(form),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- issue CSRF token alongside customer session
- send CSRF token from ProfileForm and validate on account profile updates
- test CSRF token handling

## Testing
- `npx jest packages/auth/__tests__/session.test.ts apps/shop-abc/__tests__/accountProfileApi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689981d68f78832fb525ef43224a9c43