### PR TITLE
feat: granular wizard progress updates

### DIFF
--- a/apps/cms/__tests__/wizard.test.tsx
+++ b/apps/cms/__tests__/wizard.test.tsx
@@ -226,7 +226,11 @@ describe("Wizard", () => {
     });
 
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
-    expect(fetchSpy.mock.calls[0][0]).toContain("/cms/api/page-draft/shop");
+    expect(
+      fetchSpy.mock.calls.some((c) =>
+        String(c[0]).includes("/cms/api/page-draft/shop")
+      )
+    ).toBe(true);
   });
 
   it("calls save endpoint for additional pages", async () => {
@@ -295,3 +299,18 @@ describe("Wizard", () => {
     });
   });
 });
+
+jest.mock(
+  "@/components/atoms",
+  () => ({
+    Progress: () => null,
+    Toast: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock("@/components/cms/PageBuilder", () => () => null, {
+  virtual: true,
+});
+
+jest.mock("@/components/atoms/shadcn", () => ({}), { virtual: true });

--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -23,9 +23,12 @@ export const handlers = [
     res(ctx.status(200), ctx.json([]))
   ),
   rest.get("/cms/api/wizard-progress", (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json({}))
+    res(ctx.status(200), ctx.json({ state: {}, completed: {} }))
   ),
   rest.put("/cms/api/wizard-progress", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({}))
+  ),
+  rest.patch("/cms/api/wizard-progress", (_req, res, ctx) =>
     res(ctx.status(200), ctx.json({}))
   ),
 ];


### PR DESCRIPTION
## Summary
- merge wizard step updates on PUT and add completion PATCH API
- persist step-level wizard state and completion flags from hook
- adjust wizard tests and mocks for new progress API

## Testing
- `pnpm test:cms apps/cms/__tests__/wizard.test.tsx apps/cms/__tests__/wizard-flow.integration.test.tsx apps/cms/__tests__/storageUtils.test.ts` (fails: Cannot find module '../utils/page-utils')

------
https://chatgpt.com/codex/tasks/task_e_689982105ae4832f9963d5b3860d116f