### PR TITLE
feat: add configurator API and env validation

### DIFF
--- a/apps/cms/__tests__/navItemsRoundTrip.test.ts
+++ b/apps/cms/__tests__/navItemsRoundTrip.test.ts
@@ -42,7 +42,7 @@ describe("navigation round-trip", () => {
     });
 
     const fetchMock = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
-      if (typeof input === "string" && input === "/cms/api/create-shop") {
+      if (typeof input === "string" && input === "/cms/api/configurator") {
         const body = JSON.parse(init!.body as string) as any;
         const { createShop } = await import("@platform-core/createShop");
         const { id, ...opts } = body;

--- a/apps/cms/__tests__/wizard.test.tsx
+++ b/apps/cms/__tests__/wizard.test.tsx
@@ -112,7 +112,7 @@ describe("Wizard", () => {
 
     server.use(
       rest.post(
-        "/cms/api/create-shop",
+        "/cms/api/configurator",
         async (
           req: RestRequest,
           res: ResponseComposition,

--- a/apps/cms/src/app/api/configurator/route.ts
+++ b/apps/cms/src/app/api/configurator/route.ts
@@ -1,0 +1,44 @@
+import { createNewShop } from "@cms/actions/createShop.server";
+import { createShopOptionsSchema } from "@platform-core/createShop";
+import { validateShopEnv } from "@platform-core/configurator";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+/**
+ * POST /cms/api/configurator
+ * Body: { id: string; ...CreateShopOptions }
+ * Creates a new shop and validates the generated .env file.
+ */
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const parsed = createShopOptionsSchema
+      .extend({ id: z.string() })
+      .safeParse(body);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((i) => i.message).join(", ");
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    const { id, ...options } = parsed.data;
+    const deployment = await createNewShop(id, options);
+
+    let envError: string | undefined;
+    try {
+      validateShopEnv(id);
+    } catch (err) {
+      envError = (err as Error).message;
+    }
+
+    return NextResponse.json(
+      { success: true, deployment, ...(envError ? { envError } : {}) },
+      { status: 201 }
+    );
+  } catch (err) {
+    console.error("Failed to configure shop", err);
+    const message = (err as Error).message;
+    const status = message === "Forbidden" ? 403 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/apps/cms/src/app/api/configurator/validate-env/[shop]/route.ts
+++ b/apps/cms/src/app/api/configurator/validate-env/[shop]/route.ts
@@ -1,0 +1,24 @@
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse, type NextRequest } from "next/server";
+import { validateShopEnv } from "@platform-core/configurator";
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ shop: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const { shop } = await context.params;
+    validateShopEnv(shop);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -93,7 +93,7 @@ export async function submitShop(
     return { ok: false, fieldErrors: errs };
   }
 
-  const res = await fetch("/cms/api/create-shop", {
+  const res = await fetch("/cms/api/configurator", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id: shopId, ...parsed.data }),
@@ -122,6 +122,18 @@ export async function submitShop(
           errors.push(
             envJson.error ?? "Failed to save environment variables"
           );
+        } else {
+          const valRes = await fetch(
+            `/cms/api/configurator/validate-env/${shopId}`
+          );
+          if (!valRes.ok) {
+            const valJson = (await valRes.json().catch(() => ({}))) as {
+              error?: string;
+            };
+            errors.push(
+              valJson.error ?? "Environment validation failed"
+            );
+          }
         }
       } catch {
         errors.push("Failed to save environment variables");

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -9,7 +9,8 @@
     "./tax": "./src/tax/index.ts",
     "./orders": "./src/orders/index.ts",
     "./customerProfiles": "./src/customerProfiles/index.ts",
-    "./plugins": "./src/plugins/index.ts"
+    "./plugins": "./src/plugins/index.ts",
+    "./configurator": "./src/configurator.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",

--- a/packages/platform-core/src/configurator.ts
+++ b/packages/platform-core/src/configurator.ts
@@ -1,0 +1,31 @@
+import { envSchema } from "@config/src/env";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function readEnvFile(file: string): Record<string, string> {
+  const envRaw = readFileSync(file, "utf8");
+  const env: Record<string, string> = {};
+  for (const line of envRaw.split(/\n+/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const [key, ...rest] = trimmed.split("=");
+    env[key] = rest.join("=");
+  }
+  Object.keys(env).forEach((k) => {
+    if (env[k] === "") delete env[k];
+  });
+  return env;
+}
+
+export function validateEnvFile(file: string): void {
+  if (!existsSync(file)) {
+    throw new Error(`Missing ${file}`);
+  }
+  const env = readEnvFile(file);
+  envSchema.parse(env);
+}
+
+export function validateShopEnv(shop: string): void {
+  const envPath = join("apps", shop, ".env");
+  validateEnvFile(envPath);
+}

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -1,9 +1,7 @@
 import { createShop } from "../../packages/platform-core/src/createShop";
 import { validateShopName } from "../../packages/platform-core/src/shops";
-import { envSchema } from "@config/src/env";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import { spawnSync, execSync } from "node:child_process";
+import { validateShopEnv } from "../../packages/platform-core/src/configurator";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { defaultPaymentProviders } from "../../packages/platform-core/src/createShop/defaultPaymentProviders";
@@ -111,20 +109,7 @@ async function main() {
 
   let validationError: unknown;
   try {
-    const envPath = join("apps", prefixedId, ".env");
-    if (!existsSync(envPath)) throw new Error(`Missing ${envPath}`);
-    const envRaw = readFileSync(envPath, "utf8");
-    const env: Record<string, string> = {};
-    for (const line of envRaw.split(/\n+/)) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-      const [key, ...rest] = trimmed.split("=");
-      env[key] = rest.join("=");
-    }
-    Object.keys(env).forEach((k) => {
-      if (env[k] === "") delete env[k];
-    });
-    envSchema.parse(env);
+    validateShopEnv(prefixedId);
   } catch (err) {
     validationError = err;
   }

--- a/test/e2e/shop-wizard.spec.ts
+++ b/test/e2e/shop-wizard.spec.ts
@@ -4,7 +4,11 @@ describe("Shop wizard", () => {
   const shopId = `cyshop-${Date.now()}`;
 
   it("validates input and creates a shop via the wizard", () => {
-    cy.intercept("POST", "/cms/api/create-shop").as("createShop");
+    cy.intercept("POST", "/cms/api/configurator").as("createShop");
+    cy.intercept("GET", "/cms/api/configurator/validate-env/*", {
+      statusCode: 200,
+      body: { success: true },
+    });
 
     // ensure we land back on the wizard page after signing in
     cy.visit("/login?callbackUrl=/cms/wizard");

--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -13,11 +13,14 @@ import { setupServer } from "msw/node";
  */
 export const handlers = [
   // ⬇️  Example “healthy” default; override as required in tests
-  rest.post("/cms/api/create-shop", (_req, res, ctx) =>
+  rest.post("/cms/api/configurator", (_req, res, ctx) =>
     res(
       ctx.status(200),
       ctx.json({ success: true, message: "default handler: OK" })
     )
+  ),
+  rest.get("/cms/api/configurator/validate-env/:shop", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({ success: true }))
   ),
   rest.get("/cms/api/page-templates", (_req, res, ctx) =>
     res(ctx.status(200), ctx.json([]))

--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -23,6 +23,12 @@ describe('init-shop wizard', () => {
       }
       return env;
     });
+    const validateShopEnv = jest.fn(() =>
+      envParse({
+        STRIPE_SECRET_KEY: '',
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
+      })
+    );
 
     const sandbox: any = {
       exports: {},
@@ -63,6 +69,9 @@ describe('init-shop wizard', () => {
         }
         if (p.includes('../../packages/platform-core/src/createShop')) {
           return { createShop };
+        }
+        if (p.includes('../../packages/platform-core/src/configurator')) {
+          return { validateShopEnv };
         }
         return require(p);
       },


### PR DESCRIPTION
## Summary
- add environment validation helpers to platform-core
- expose shop setup and env check via new `/api/configurator` endpoints
- use configurator API in wizard submission

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/atoms' from 'apps/cms/src/app/cms/wizard/Wizard.tsx')*
- `pnpm jest test/unit/init-shop.spec.ts` *(fails: TypeError: Cannot read properties of undefined (reading 'trim'))*

------
https://chatgpt.com/codex/tasks/task_e_68998219590c832fa99826fc39e398f9