### PR TITLE
feat(cms): add configurator dashboard

### DIFF
--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
+import { Button } from "@/components/atoms/shadcn";
+import type { WizardState } from "../wizard/schema";
+
+interface StepConfig {
+  id: string;
+  title: string;
+  href: string;
+  required?: boolean;
+  completed: boolean;
+}
+
+export default function ConfiguratorDashboard() {
+  const [state, setState] = useState<WizardState | null>(null);
+
+  useEffect(() => {
+    fetch("/cms/api/wizard-progress")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => setState(json))
+      .catch(() => setState(null));
+  }, []);
+
+  const steps: StepConfig[] = [
+    {
+      id: "details",
+      title: "Shop Details",
+      href: "/cms/configurator/details",
+      required: true,
+      completed: Boolean(state?.storeName),
+    },
+    {
+      id: "theme",
+      title: "Theme",
+      href: "/cms/configurator/theme",
+      required: true,
+      completed: Boolean(state?.theme),
+    },
+    {
+      id: "products",
+      title: "Products",
+      href: "/cms/configurator/products",
+      required: false,
+      completed: (state?.components?.length ?? 0) > 0,
+    },
+  ];
+
+  const allRequiredDone = steps.every(
+    (s) => !s.required || s.completed
+  );
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Configuration Steps</h2>
+      <ul className="mb-6 space-y-2">
+        {steps.map((step) => (
+          <li key={step.id} className="flex items-center gap-2">
+            {step.completed ? (
+              <CheckCircledIcon className="h-4 w-4 text-green-600" />
+            ) : (
+              <CircleIcon className="h-4 w-4 text-gray-400" />
+            )}
+            <Link href={step.href} className="underline">
+              {step.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <Button disabled={!allRequiredDone}>Launch Shop</Button>
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/configurator/page.tsx
+++ b/apps/cms/src/app/cms/configurator/page.tsx
@@ -1,0 +1,6 @@
+import ConfiguratorDashboard from "./Dashboard";
+
+export default function ConfiguratorPage() {
+  return <ConfiguratorDashboard />;
+}
+


### PR DESCRIPTION
## Summary
- add configurator dashboard that lists setup steps with status icons
- add `/cms/configurator` route rendering the dashboard
- enable Launch Shop button once required steps are complete

## Testing
- `pnpm --filter=@apps/cms lint`
- `pnpm --filter=@apps/cms test` *(fails: Cannot find module '@/components/atoms' and Prisma client)*

------
https://chatgpt.com/codex/tasks/task_e_6899820ad8d8832fabc73b73b6e73830