### PR TITLE
test: cover genSecret defaults

### DIFF
--- a/packages/shared-utils/__tests__/genSecret.test.ts
+++ b/packages/shared-utils/__tests__/genSecret.test.ts
@@ -5,4 +5,14 @@ describe('genSecret', () => {
     const secret = genSecret(8);
     expect(secret).toHaveLength(16);
   });
+
+  it('defaults to 32 characters when no argument is provided', () => {
+    const secret = genSecret();
+    expect(secret).toHaveLength(32);
+  });
+
+  it('returns a hexadecimal string', () => {
+    const secret = genSecret(8);
+    expect(secret).toMatch(/^[0-9a-f]+$/);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for genSecret default length and hex format

## Testing
- `npx jest packages/shared-utils/__tests__/genSecret.test.ts --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_6899ae5e1bf8832fbb05950134f1be88