### PR TITLE
feat(wizard): track step completion

### DIFF
--- a/apps/cms/__tests__/wizard-flow.integration.test.tsx
+++ b/apps/cms/__tests__/wizard-flow.integration.test.tsx
@@ -26,6 +26,7 @@ jest.mock("@platform-core/src", () => {
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import Wizard from "../src/app/cms/wizard/Wizard";
+import steps from "../src/app/cms/configurator/steps";
 
 const themes = ["base", "dark"];
 const templates = ["template-app"];
@@ -82,7 +83,13 @@ afterEach(() => {
 
 describe("Wizard locale flow", () => {
   it("preserves locale fields across navigation and reload", async () => {
-      serverState = { state: { step: 11, shopId: "shop" }, completed: {} };
+      const summaryIndex = steps.findIndex((s) => s.id === "summary");
+      serverState = {
+        state: { shopId: "shop" },
+        completed: Object.fromEntries(
+          steps.slice(0, summaryIndex).map((s) => [s.id, true])
+        ),
+      };
     const { unmount } = render(
       <Wizard themes={themes} templates={templates} />
     );

--- a/apps/cms/__tests__/wizard.test.tsx
+++ b/apps/cms/__tests__/wizard.test.tsx
@@ -283,7 +283,7 @@ describe("Wizard", () => {
   it("uses defaults when fields are missing", async () => {
     server.use(
       rest.get("/cms/api/wizard-progress", (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ step: 1 }))
+        res(ctx.status(200), ctx.json({ state: {}, completed: {} }))
       )
     );
     const { container } = render(

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -212,7 +212,6 @@ export default function Wizard({
 
   /* --- hydrate & persist wizard state via server --- */
   const hydrate = useCallback((data: WizardState) => {
-    setStep(data.step);
     setShopId(data.shopId);
     setStoreName(data.storeName);
     setLogo(data.logo);
@@ -249,11 +248,13 @@ export default function Wizard({
     setEnvVars(data.env);
     setDomain(data.domain);
     setCategoriesText(data.categoriesText);
+    setCompleted(data.completed ?? {});
+    const firstIncomplete = steps.findIndex((s) => !data.completed?.[s.id]);
+    setStep(firstIncomplete === -1 ? steps.length - 1 : firstIncomplete);
   }, []);
 
   useWizardPersistence(
     {
-      step,
       shopId,
       storeName,
       logo,
@@ -289,6 +290,7 @@ export default function Wizard({
       pages,
       domain,
       categoriesText,
+      completed,
     },
     hydrate,
     () => setInvalidStateNotice(true)
@@ -722,6 +724,9 @@ export default function Wizard({
     }
   };
 
+  const progressValue =
+    (Object.values(completed).filter(Boolean).length / steps.length) * 100;
+
   /* ====================================================================== */
   /*  JSX                                                                   */
   /* ====================================================================== */
@@ -730,7 +735,10 @@ export default function Wizard({
     <div className="mx-auto max-w-xl" style={themeStyle}>
       <fieldset disabled={disabled} className="space-y-6">
         <div className="mb-6 flex items-center justify-between">
-          <Progress step={step} total={steps.length} />
+          <Progress
+            value={progressValue}
+            label={`Step ${step + 1} of ${steps.length}`}
+          />
           {shopId && <MediaUploadDialog shop={shopId} />}
         </div>
 

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -70,12 +70,12 @@ export type PageInfo = z.infer<typeof pageInfoSchema>; // <- slug & components *
 
 export const wizardStateSchema = z.object({
   /* ------------ Wizard progress & identity ------------ */
-  step: z.number().optional().default(0),
   shopId: z.string().optional().default(""),
   storeName: z.string().optional().default(""),
   logo: z.string().optional().default(""),
   contactInfo: z.string().optional().default(""),
   type: z.enum(["sale", "rental"]).optional().default("sale"),
+  completed: z.record(z.boolean()).optional().default({}),
 
   /* ---------------- Template / theme ------------------ */
   template: z.string().optional().default(""),

--- a/packages/ui/src/components/atoms/Progress.tsx
+++ b/packages/ui/src/components/atoms/Progress.tsx
@@ -2,24 +2,23 @@ import * as React from "react";
 import { cn } from "../../utils/style";
 
 export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
-  step: number;
-  total?: number;
+  value: number;
+  label?: React.ReactNode;
 }
 
 export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ step, total = 4, className, ...props }, ref) => {
-    const percent = ((step + 1) / total) * 100;
+  ({ value, label, className, ...props }, ref) => {
     return (
       <div ref={ref} className={cn("space-y-1", className)} {...props}>
         <div className="bg-muted h-2 w-full overflow-hidden rounded">
           <div
             className="bg-primary h-full transition-all"
-            style={{ width: `${percent}%` }}
+            style={{ width: `${value}%` }}
           />
         </div>
-        <div className="text-muted-foreground text-right text-sm">
-          Step {step + 1} of {total}
-        </div>
+        {label ? (
+          <div className="text-muted-foreground text-right text-sm">{label}</div>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- switch wizard state to completed record keyed by step ids
- persist completion status and calculate progress percentage
- update Progress component to accept explicit value and label

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@/components/cms/StyleEditor', Cannot find module '.prisma/client/index-browser'...)*

------
https://chatgpt.com/codex/tasks/task_e_6899ae8ab488832fbbcc95e3c48b6a31