### PR TITLE
test: expand utility tests

### DIFF
--- a/packages/ui/src/utils/__tests__/utils.test.ts
+++ b/packages/ui/src/utils/__tests__/utils.test.ts
@@ -6,9 +6,17 @@ describe("cn", () => {
       "a b"
     );
   });
+
+  it("returns empty string with no arguments", () => {
+    expect(cn()).toBe("");
+  });
 });
 
 describe("boxProps", () => {
+  it("returns empty classes and style when no props provided", () => {
+    expect(boxProps({})).toEqual({ classes: "", style: {} });
+  });
+
   it("returns classes for tailwind width/height", () => {
     const result = boxProps({
       width: "w-16",
@@ -36,5 +44,12 @@ describe("drawerWidthProps", () => {
     const result = drawerWidthProps(250);
     expect(result.widthClass).toBeUndefined();
     expect(result.style).toEqual({ width: 250 });
+  });
+
+  it("handles percentage width string", () => {
+    expect(drawerWidthProps("50%")).toEqual({
+      widthClass: undefined,
+      style: { width: "50%" },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- expand cn, boxProps, and drawerWidthProps tests

## Testing
- `pnpm --filter @acme/ui exec jest src/utils/__tests__/utils.test.ts --runTestsByPath --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_6899ae677e0c832fb4359313a0f3b08a