### PR TITLE
test: add coupon lookup tests

### DIFF
--- a/packages/platform-core/__tests__/coupons.test.ts
+++ b/packages/platform-core/__tests__/coupons.test.ts
@@ -1,0 +1,19 @@
+// packages/platform-core/__tests__/coupons.test.ts
+import { COUPONS, findCoupon } from "@platform-core/src/coupons";
+
+describe("findCoupon", () => {
+  it("matches coupon codes ignoring case", () => {
+    const coupon = findCoupon(COUPONS[0].code.toLowerCase());
+    expect(coupon).toEqual(COUPONS[0]);
+  });
+
+  it("returns undefined when code is undefined or null", () => {
+    expect(findCoupon(undefined)).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(findCoupon(null as any)).toBeUndefined();
+  });
+
+  it("returns undefined for unknown codes", () => {
+    expect(findCoupon("INVALID")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `findCoupon` covering case-insensitive match, undefined/null, and missing codes

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/coupons.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899ae646a30832fb3542f9398df4b84