### PR TITLE
test: ensure toggleItem handles objects without mutating array

### DIFF
--- a/packages/shared-utils/__tests__/toggleItem.test.ts
+++ b/packages/shared-utils/__tests__/toggleItem.test.ts
@@ -10,4 +10,36 @@ describe('toggleItem', () => {
     items = toggleItem(items, 'b');
     expect(items).toEqual(['b']);
   });
+
+  it("doesn't mutate the original array", () => {
+    const original = ['a'];
+    const withAdded = toggleItem(original, 'b');
+
+    expect(original).toEqual(['a']);
+    expect(withAdded).toEqual(['a', 'b']);
+    expect(withAdded).not.toBe(original);
+
+    const withRemoved = toggleItem(original, 'a');
+    expect(original).toEqual(['a']);
+    expect(withRemoved).toEqual([]);
+    expect(withRemoved).not.toBe(original);
+  });
+
+  it('compares objects using reference identity', () => {
+    const item = { id: 1 };
+    const other = { id: 1 };
+
+    let items: { id: number }[] = [];
+    items = toggleItem(items, item);
+    expect(items).toEqual([item]);
+
+    items = toggleItem(items, other);
+    expect(items).toEqual([item, other]);
+
+    items = toggleItem(items, item);
+    expect(items).toEqual([other]);
+
+    items = toggleItem(items, other);
+    expect(items).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- extend toggleItem tests to confirm original array remains unaltered
- add tests verifying object toggling uses reference equality

## Testing
- `pnpm exec jest __tests__/toggleItem.test.ts --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6899ae5f8b18832fa9bea104fe267fe8