### PR TITLE
Refactor cart API to cart ID workflow

### DIFF
--- a/apps/shop-abc/__tests__/cartApi.test.ts
+++ b/apps/shop-abc/__tests__/cartApi.test.ts
@@ -1,15 +1,13 @@
 // apps/shop-abc/__tests__/cartApi.test.ts
 import {
-  asSetCookieHeader,
   decodeCartCookie,
   encodeCartCookie,
-} from "@/lib/cartCookie";
+} from "@platform-core/src/cartCookie";
+import { createCart, getCart, setCart } from "@platform-core/src/cartStore";
 import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/app/api/cart/route";
 
 const TEST_SKU = { ...PRODUCTS[0], id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
-
-declare function expectType<T>(value: T): void;
 
 // Minimal NextResponse mock using the native Response class
 jest.mock("next/server", () => ({
@@ -19,7 +17,6 @@ jest.mock("next/server", () => ({
   },
 }));
 
-// Helper to build a minimal NextRequest-like object
 function createRequest(
   body: any,
   cookie?: string,
@@ -42,13 +39,14 @@ test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
   const req = createRequest({ sku, qty: 2 });
   const res = await POST(req);
-  const body = (await res.json()) as any;
+  const body = await res.json();
 
   expect(body.cart[sku.id].qty).toBe(2);
-  const expected = asSetCookieHeader(
-    encodeCartCookie({ [sku.id]: { sku, qty: 2 } })
-  );
-  expect(res.headers.get("Set-Cookie")).toBe(expected);
+  const header = res.headers.get("Set-Cookie")!;
+  const encoded = header.split(";")[0].split("=")[1];
+  const id = decodeCartCookie(encoded)!;
+  const stored = await getCart(id);
+  expect(stored[sku.id].qty).toBe(2);
 });
 
 test("POST validates body", async () => {
@@ -59,50 +57,64 @@ test("POST validates body", async () => {
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cart));
+  const cartId = await createCart();
+  await setCart(cartId, cart);
+  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
-  const body = (await res.json()) as any;
+  const body = await res.json();
   expect(body.cart[sku.id].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
-  expect(decodeCartCookie(encoded)).toEqual(body.cart);
+  expect(decodeCartCookie(encoded)).toBe(cartId);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cart));
+  const cartId = await createCart();
+  await setCart(cartId, cart);
+  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
-  const body = (await res.json()) as any;
+  const body = await res.json();
   expect(body.cart[sku.id]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
+  const cartId = await createCart();
   const res = await PATCH(
     createRequest(
       { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", qty: 1 },
-      encodeCartCookie({})
+      encodeCartCookie(cartId)
     )
+  );
+  expect(res.status).toBe(404);
+});
+
+test("POST returns 404 for unknown SKU", async () => {
+  const res = await POST(
+    createRequest({ sku: { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA" } })
   );
   expect(res.status).toBe(404);
 });
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku, qty: -1 }));
+  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku, qty: 1.5 }));
+  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
   expect(res.status).toBe(400);
 });
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 1 } };
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   let res = await PATCH(
-    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cart))
+    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
   res = await PATCH(
-    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cart))
+    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
 });
@@ -110,16 +122,20 @@ test("PATCH rejects negative or non-integer quantity", async () => {
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 2 } };
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cart));
+  const cartId = await createCart();
+  await setCart(cartId, cart);
+  const req = createRequest({ id: sku.id }, encodeCartCookie(cartId));
   const res = await DELETE(req);
-  const body = (await res.json()) as any;
+  const body = await res.json();
   expect(body.cart[sku.id]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
   const cart = { [sku.id]: { sku, qty: 3 } };
-  const res = await GET(createRequest({}, encodeCartCookie(cart)));
-  const body = (await res.json()) as any;
+  const cartId = await createCart();
+  await setCart(cartId, cart);
+  const res = await GET(createRequest({}, encodeCartCookie(cartId)));
+  const body = await res.json();
   expect(body.cart).toEqual(cart);
 });

--- a/apps/shop-abc/__tests__/cmsPages.test.tsx
+++ b/apps/shop-abc/__tests__/cmsPages.test.tsx
@@ -12,7 +12,8 @@ import type { PageComponent } from "@types";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { cookies } from "next/headers";
-import { encodeCartCookie } from "@/lib/cartCookie";
+import { encodeCartCookie } from "@platform-core/src/cartCookie";
+import { createCart, setCart } from "@platform-core/src/cartStore";
 import { PRODUCTS } from "@platform-core/products";
 
 import ShopPage from "../src/app/[lang]/shop/page";
@@ -66,8 +67,10 @@ test("Checkout page renders CMS components with cart data", async () => {
   ]);
 
   const cart = { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } };
+  const cartId = await createCart();
+  await setCart(cartId, cart);
   (cookies as jest.Mock).mockResolvedValue({
-    get: () => ({ value: encodeCartCookie(cart) }),
+    get: () => ({ value: encodeCartCookie(cartId) }),
   });
 
   const element = await CheckoutPage({

--- a/apps/shop-abc/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/checkout/page.tsx
@@ -4,7 +4,11 @@ import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import { Locale, resolveLocale } from "@/i18n/locales";
-import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+} from "@platform-core/src/cartCookie";
+import { getCart } from "@platform-core/src/cartStore";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import type { PageComponent } from "@types";
 import { cookies } from "next/headers";
@@ -38,7 +42,8 @@ export default async function CheckoutPage({
 
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
-  const cart = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cart = cartId ? await getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -5,7 +5,8 @@ import {
   decodeCartCookie,
   type CartLine,
   type CartState,
-} from "@/lib/cartCookie";
+} from "@platform-core/src/cartCookie";
+import { getCart } from "@platform-core/src/cartStore";
 import { calculateRentalDays } from "@/lib/date";
 import { stripe } from "@lib/stripeServer";
 import { getCustomerSession } from "@auth";
@@ -110,7 +111,8 @@ export const runtime = "edge";
 export async function POST(req: NextRequest): Promise<NextResponse> {
   /* 1️⃣ Decode cart cookie -------------------------------------------------- */
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart = decodeCartCookie(rawCookie);
+  const cartId = decodeCartCookie(rawCookie);
+  const cart: CartState = cartId ? await getCart(cartId) : {};
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });


### PR DESCRIPTION
## Summary
- migrate cart API to cart ID workflow with create/get/set and legacy cookie migration
- update checkout session API and checkout page to consume cart IDs
- adjust tests to use cart IDs instead of serialized cart objects

## Testing
- `npx jest apps/shop-abc/__tests__/cartApi.test.ts apps/shop-abc/__tests__/checkoutSession.test.ts apps/shop-abc/__tests__/cmsPages.test.tsx` *(fails: SyntaxError: Unexpected token 'export')*


------
https://chatgpt.com/codex/tasks/task_e_6899ae54252c832fa3d3466a2266774f