### PR TITLE
feat(cart): key cart lines by sku and size

### DIFF
--- a/apps/shop-abc/__tests__/cartApi.test.ts
+++ b/apps/shop-abc/__tests__/cartApi.test.ts
@@ -8,6 +8,7 @@ import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/app/api/cart/route";
 
 const TEST_SKU = { ...PRODUCTS[0], id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+const TEST_SIZE = PRODUCTS[0].sizes[0];
 
 declare function expectType<T>(value: T): void;
 
@@ -40,13 +41,14 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const req = createRequest({ sku, qty: 2, size: TEST_SIZE });
   const res = await POST(req);
   const body = (await res.json()) as any;
 
-  expect(body.cart[sku.id].qty).toBe(2);
+  expect(body.cart[id].qty).toBe(2);
   const expected = asSetCookieHeader(
-    encodeCartCookie({ [sku.id]: { sku, qty: 2 } })
+    encodeCartCookie({ [id]: { sku, qty: 2, size: TEST_SIZE } })
   );
   expect(res.headers.get("Set-Cookie")).toBe(expected);
 });
@@ -58,28 +60,30 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cart));
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [id]: { sku, qty: 1, size: TEST_SIZE } };
+  const req = createRequest({ id, qty: 5 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[id].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toEqual(body.cart);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cart));
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [id]: { sku, qty: 1, size: TEST_SIZE } };
+  const req = createRequest({ id, qty: 0 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
   const res = await PATCH(
     createRequest(
-      { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", qty: 1 },
+      { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA:SIZE", qty: 1 },
       encodeCartCookie({})
     )
   );
@@ -88,37 +92,44 @@ test("PATCH returns 404 for missing item", async () => {
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku, qty: -1 }));
+  let res = await POST(
+    createRequest({ sku, qty: -1, size: sku.sizes[0] })
+  );
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku, qty: 1.5 }));
+  res = await POST(
+    createRequest({ sku, qty: 1.5, size: sku.sizes[0] })
+  );
   expect(res.status).toBe(400);
 });
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [id]: { sku, qty: 1, size: TEST_SIZE } };
   let res = await PATCH(
-    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cart))
+    createRequest({ id, qty: -2 }, encodeCartCookie(cart))
   );
   expect(res.status).toBe(400);
   res = await PATCH(
-    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cart))
+    createRequest({ id, qty: 1.5 }, encodeCartCookie(cart))
   );
   expect(res.status).toBe(400);
 });
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cart));
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [id]: { sku, qty: 2, size: TEST_SIZE } };
+  const req = createRequest({ id }, encodeCartCookie(cart));
   const res = await DELETE(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 3 } };
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [id]: { sku, qty: 3, size: TEST_SIZE } };
   const res = await GET(createRequest({}, encodeCartCookie(cart)));
   const body = (await res.json()) as any;
   expect(body.cart).toEqual(cart);

--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -42,7 +42,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const id = `${sku.id}:40`;
+  const cart = { [id]: { sku, qty: 2, size: "40" } };
   const cookie = encodeCartCookie(cart);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
@@ -65,7 +66,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
 test("responds with 400 on invalid returnDate", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = `${sku.id}:40`;
+  const cart = { [id]: { sku, qty: 1, size: "40" } };
   const cookie = encodeCartCookie(cart);
   const req = createRequest({ returnDate: "not-a-date" }, cookie);
   const res = await POST(req);

--- a/apps/shop-abc/__tests__/cmsPages.test.tsx
+++ b/apps/shop-abc/__tests__/cmsPages.test.tsx
@@ -65,7 +65,8 @@ test("Checkout page renders CMS components with cart data", async () => {
     { slug: "checkout", status: "published", components },
   ]);
 
-  const cart = { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } };
+  const size = PRODUCTS[0].sizes[0];
+  const cart = { [`${PRODUCTS[0].id}:${size}`]: { sku: PRODUCTS[0], qty: 1, size } };
   (cookies as jest.Mock).mockResolvedValue({
     get: () => ({ value: encodeCartCookie(cart) }),
   });

--- a/apps/shop-bcd/__tests__/cartApi.test.ts
+++ b/apps/shop-bcd/__tests__/cartApi.test.ts
@@ -30,19 +30,24 @@ afterEach(() => {
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku, qty: -1 }));
+  let res = await POST(
+    createRequest({ sku, qty: -1, size: sku.sizes[0] })
+  );
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku, qty: 1.5 }));
+  res = await POST(
+    createRequest({ sku, qty: 1.5, size: sku.sizes[0] })
+  );
   expect(res.status).toBe(400);
 });
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = `${sku.id}:${sku.sizes[0]}`;
+  const cart = { [id]: { sku, qty: 1, size: sku.sizes[0] } };
   const cookie = encodeCartCookie(cart);
-  let res = await PATCH(createRequest({ id: sku.id, qty: -2 }, cookie));
+  let res = await PATCH(createRequest({ id, qty: -2 }, cookie));
   expect(res.status).toBe(400);
-  res = await PATCH(createRequest({ id: sku.id, qty: 1.5 }, cookie));
+  res = await PATCH(createRequest({ id, qty: 1.5 }, cookie));
   expect(res.status).toBe(400);
 });
 

--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -46,7 +46,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const id = `${sku.id}:40`;
+  const cart = { [id]: { sku, qty: 2, size: "40" } };
   const cookie = encodeCartCookie(cart);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
@@ -70,7 +71,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
 test("responds with 400 on invalid returnDate", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = `${sku.id}:40`;
+  const cart = { [id]: { sku, qty: 1, size: "40" } };
   const cookie = encodeCartCookie(cart);
   const req = createRequest({ returnDate: "not-a-date", currency: "EUR", taxRegion: "EU" }, cookie);
   const res = await POST(req);

--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -9,7 +9,9 @@ jest.mock("react-dom", () => jest.requireActual("react-dom"));
 
 function Qty() {
   const [state] = useCart();
-  return <span data-testid="qty">{state[PRODUCTS[0].id]?.qty ?? 0}</span>;
+  const size = PRODUCTS[0].sizes[0];
+  const id = `${PRODUCTS[0].id}:${size}`;
+  return <span data-testid="qty">{state[id]?.qty ?? 0}</span>;
 }
 
 describe("AddToCartButton", () => {
@@ -20,6 +22,8 @@ describe("AddToCartButton", () => {
   });
 
   it("adds items to the cart", async () => {
+    const size = PRODUCTS[0].sizes[0];
+    const id = `${PRODUCTS[0].id}:${size}`;
     global.fetch = jest
       .fn()
       // initial GET
@@ -27,12 +31,12 @@ describe("AddToCartButton", () => {
       // POST
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } }),
       });
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} />
+        <AddToCartButton sku={PRODUCTS[0]} size={PRODUCTS[0].sizes[0]} />
         <Qty />
       </CartProvider>
     );
@@ -60,7 +64,7 @@ describe("AddToCartButton", () => {
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} />
+        <AddToCartButton sku={PRODUCTS[0]} size={PRODUCTS[0].sizes[0]} />
         <Qty />
       </CartProvider>
     );

--- a/packages/platform-core/__tests__/cartContext.test.tsx
+++ b/packages/platform-core/__tests__/cartContext.test.tsx
@@ -5,23 +5,21 @@ import { PRODUCTS } from "../products";
 
 function TestComponent() {
   const [state, dispatch] = useCart();
-  const line = state[PRODUCTS[0].id];
+  const size = PRODUCTS[0].sizes[0];
+  const id = `${PRODUCTS[0].id}:${size}`;
+  const line = state[id];
 
   return (
     <div>
       <span data-testid="qty">{line?.qty ?? 0}</span>
 
-      <button onClick={() => dispatch({ type: "add", sku: PRODUCTS[0] })}>
+      <button
+        onClick={() => dispatch({ type: "add", sku: PRODUCTS[0], size })}
+      >
         add
       </button>
-      <button onClick={() => dispatch({ type: "remove", id: PRODUCTS[0].id })}>
-        remove
-      </button>
-      <button
-        onClick={() => dispatch({ type: "setQty", id: PRODUCTS[0].id, qty: 0 })}
-      >
-        set
-      </button>
+      <button onClick={() => dispatch({ type: "remove", id })}>remove</button>
+      <button onClick={() => dispatch({ type: "setQty", id, qty: 0 })}>set</button>
     </div>
   );
 }
@@ -34,6 +32,8 @@ describe("CartContext actions", () => {
   });
 
   it("handles add, setQty and remove actions", async () => {
+    const size = PRODUCTS[0].sizes[0];
+    const id = `${PRODUCTS[0].id}:${size}`;
     global.fetch = jest
       .fn()
       // initial GET
@@ -41,12 +41,12 @@ describe("CartContext actions", () => {
       // add
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } }),
       })
       // setQty
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 3 } } }),
+        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 3, size } } }),
       })
       // remove
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -32,7 +32,8 @@ export const cartLineSchema = z.object({
 });
 
 /**
- * Schema for the full cart, keyed by SKU ID (string).
+ * Schema for the full cart, keyed by a composite of SKU ID and size
+ * (e.g. `"sku123:XL"`).
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
 

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -11,8 +11,8 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
  * ------------------------------------------------------------------ */
 type Action =
   | { type: "add"; sku: SKU; size?: string }
-  | { type: "remove"; id: SKU["id"] }
-  | { type: "setQty"; id: SKU["id"]; qty: number };
+  | { type: "remove"; id: string }
+  | { type: "setQty"; id: string; qty: number };
 
 /* ------------------------------------------------------------------
  * React context
@@ -45,6 +45,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
     let body: unknown;
     switch (action.type) {
       case "add":
+        if (action.sku.sizes.length > 0 && !action.size) {
+          throw new Error("Size is required");
+        }
         method = "POST";
         body = { sku: action.sku, qty: 1, size: action.size };
         break;

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -5,6 +5,7 @@ export const postSchema = z
   .object({
     sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
     qty: z.coerce.number().int().min(1).default(1),
+    size: z.string().optional(),
   })
   .strict();
 

--- a/packages/template-app/__tests__/cart.test.ts
+++ b/packages/template-app/__tests__/cart.test.ts
@@ -5,6 +5,7 @@ import { PRODUCTS } from "@platform-core/src/products";
 import { DELETE, GET, PATCH, POST } from "../src/api/cart/route";
 
 const TEST_SKU = { ...PRODUCTS[0], id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+const TEST_SIZE = PRODUCTS[0].sizes[0];
 
 // Minimal NextResponse mock using the native Response class
 jest.mock("next/server", () => ({
@@ -34,17 +35,18 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const id = `${sku.id}:${TEST_SIZE}`;
+  const req = createRequest({ sku, qty: 2, size: TEST_SIZE });
   const res = await POST(req);
   const body = await res.json();
 
-  expect(body.cart[sku.id].qty).toBe(2);
-  expect(body.cart[sku.id].sku).toEqual(sku);
+  expect(body.cart[id].qty).toBe(2);
+  expect(body.cart[id].sku).toEqual(sku);
   const header = res.headers.get("Set-Cookie")!;
   const encoded = header.split(";")[0].split("=")[1];
   const id = decodeCartCookie(encoded)!;
   const stored = await getCart(id);
-  expect(stored[sku.id].qty).toBe(2);
+  expect(stored[`${sku.id}:${TEST_SIZE}`].qty).toBe(2);
 });
 
 test("POST validates body", async () => {
@@ -54,33 +56,35 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const lineId = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [lineId]: { sku, qty: 1, size: TEST_SIZE } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cartId));
+  const req = createRequest({ id: lineId, qty: 5 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[lineId].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toBe(cartId);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const lineId = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [lineId]: { sku, qty: 1, size: TEST_SIZE } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cartId));
+  const req = createRequest({ id: lineId, qty: 0 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[lineId]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
   const cartId = await createCart();
   const res = await PATCH(
     createRequest(
-      { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", qty: 1 },
+      { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA:SIZE", qty: 1 },
       encodeCartCookie(cartId)
     )
   );
@@ -89,48 +93,55 @@ test("PATCH returns 404 for missing item", async () => {
 
 test("POST returns 404 for unknown SKU", async () => {
   const res = await POST(
-    createRequest({ sku: { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA" } })
+    createRequest({ sku: { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA" }, size: TEST_SIZE })
   );
   expect(res.status).toBe(404);
 });
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
+  let res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: -1, size: sku.sizes[0] })
+  );
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
+  res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: 1.5, size: sku.sizes[0] })
+  );
   expect(res.status).toBe(400);
 });
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const lineId = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [lineId]: { sku, qty: 1, size: TEST_SIZE } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   let res = await PATCH(
-    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cartId))
+    createRequest({ id: lineId, qty: -2 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
   res = await PATCH(
-    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cartId))
+    createRequest({ id: lineId, qty: 1.5 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
 });
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
+  const lineId = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [lineId]: { sku, qty: 2, size: TEST_SIZE } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cartId));
+  const req = createRequest({ id: lineId }, encodeCartCookie(cartId));
   const res = await DELETE(req);
   const body = await res.json();
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[lineId]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 3 } };
+  const lineId = `${sku.id}:${TEST_SIZE}`;
+  const cart = { [lineId]: { sku, qty: 3, size: TEST_SIZE } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const res = await GET(createRequest({}, encodeCartCookie(cartId)));

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -43,7 +43,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const id = `${sku.id}:40`;
+  const cart = { [id]: { sku, qty: 2, size: "40" } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
@@ -68,7 +69,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
 test("returns 400 when returnDate is invalid", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = `${sku.id}:40`;
+  const cart = { [id]: { sku, qty: 1, size: "40" } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);

--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -32,8 +32,8 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
   const [toast, setToast] = React.useState<{ open: boolean; message: string }>(
     { open: false, message: "" }
   );
-  const lines = Object.values(cart);
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const lines = Object.entries(cart) as [string, typeof cart[string]][];
+  const subtotal = lines.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
   const { widthClass, style } = drawerWidthProps(width);
 
   const handleRemove = async (id: string) => {
@@ -63,16 +63,16 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
           ) : (
             <div className="flex h-full flex-col gap-4">
               <ul className="grow space-y-3 overflow-y-auto">
-                {lines.map((line) => (
+                {lines.map(([id, line]) => (
                   <li
-                    key={line.sku.id}
+                    key={id}
                     className="flex items-center justify-between gap-2"
                   >
                     <span className="text-sm">{line.sku.title}</span>
                     <span className="text-sm">× {line.qty}</span>
                     <Button
                       variant="destructive"
-                      onClick={() => void handleRemove(line.sku.id)}
+                      onClick={() => void handleRemove(id)}
                       className="px-2 py-1 text-xs"
                     >
                       Remove

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -41,7 +41,8 @@ function CartInitializer({ items }: WrapperProps) {
     Object.values(items).forEach((line) => {
       dispatch({ type: "add", sku: line.sku, size: line.size });
       if (line.qty > 1) {
-        dispatch({ type: "setQty", id: line.sku.id, qty: line.qty });
+        const id = line.size ? `${line.sku.id}:${line.size}` : line.sku.id;
+        dispatch({ type: "setQty", id, qty: line.qty });
       }
     });
   }, [items, dispatch]);

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -35,17 +35,23 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
   /* ------------------------------------------------------------------
    * Derived values
    * ------------------------------------------------------------------ */
-  const lines = useMemo<CartLine[]>(() => Object.values(cart), [cart]);
+  const lines = useMemo<[string, CartLine][]>(
+    () => Object.entries(cart),
+    [cart]
+  );
 
   // When totals aren't provided, compute them from the cart lines.
   const computedSubtotal = useMemo(
-    () => lines.reduce((sum, line) => sum + line.sku.price * line.qty, 0),
+    () => lines.reduce((sum, [, line]) => sum + line.sku.price * line.qty, 0),
     [lines]
   );
 
   const computedDeposit = useMemo(
     () =>
-      lines.reduce((sum, line) => sum + (line.sku.deposit ?? 0) * line.qty, 0),
+      lines.reduce(
+        (sum, [, line]) => sum + (line.sku.deposit ?? 0) * line.qty,
+        0
+      ),
     [lines]
   );
 
@@ -66,8 +72,8 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
         </tr>
       </thead>
       <tbody>
-        {lines.map((line) => (
-          <tr key={line.sku.id} className="border-b last:border-0">
+        {lines.map(([id, line]) => (
+          <tr key={id} className="border-b last:border-0">
             <td className="py-2">
               {line.sku.title}
               {line.size && (

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -19,9 +19,9 @@ export function CartTemplate({
   className,
   ...props
 }: CartTemplateProps) {
-  const lines = Object.values(cart);
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
-  const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
+  const lines = Object.entries(cart) as [string, CartState[string]][];
+  const subtotal = lines.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
+  const deposit = lines.reduce((s, [, l]) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
   if (!lines.length) {
     return (
@@ -42,8 +42,8 @@ export function CartTemplate({
           </tr>
         </thead>
         <tbody>
-          {lines.map((line) => (
-            <tr key={line.sku.id} className="border-b last:border-0">
+          {lines.map(([id, line]) => (
+            <tr key={id} className="border-b last:border-0">
               <td className="py-2">
                 <div className="flex items-center gap-4">
                   <div className="relative hidden h-12 w-12 sm:block">
@@ -61,7 +61,7 @@ export function CartTemplate({
               <td>
                 <QuantityInput
                   value={line.qty}
-                  onChange={(v) => onQtyChange?.(line.sku.id, v)}
+                  onChange={(v) => onQtyChange?.(id, v)}
                   className="justify-center"
                 />
               </td>
@@ -72,7 +72,7 @@ export function CartTemplate({
                 <td className="text-right">
                   <button
                     type="button"
-                    onClick={() => onRemove(line.sku.id)}
+                    onClick={() => onRemove(id)}
                     className="text-danger hover:underline"
                   >
                     Remove

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -15,12 +15,10 @@ export function OrderConfirmationTemplate({
   className,
   ...props
 }: OrderConfirmationTemplateProps) {
-  const subtotal = Object.values(cart).reduce(
-    (s, l) => s + l.sku.price * l.qty,
-    0
-  );
-  const deposit = Object.values(cart).reduce(
-    (s, l) => s + (l.sku.deposit ?? 0) * l.qty,
+  const entries = Object.entries(cart);
+  const subtotal = entries.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
+  const deposit = entries.reduce(
+    (s, [, l]) => s + (l.sku.deposit ?? 0) * l.qty,
     0
   );
 
@@ -40,8 +38,8 @@ export function OrderConfirmationTemplate({
           </tr>
         </thead>
         <tbody>
-          {Object.values(cart).map((l) => (
-            <tr key={l.sku.id} className="border-b last:border-0">
+          {entries.map(([id, l]) => (
+            <tr key={id} className="border-b last:border-0">
               <td className="py-2">{l.sku.title}</td>
               <td>{l.qty}</td>
               <td className="text-right">


### PR DESCRIPTION
## Summary
- track cart lines using composite `sku:size` keys
- validate required sizes when adding items
- update cart UI components to handle size-scoped keys

## Testing
- `pnpm test` *(fails: command @apps/cms#test exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_6899ae5091a4832fb471bc4392249f10