### PR TITLE
feat: add registration and reset routes

### DIFF
--- a/apps/shop-abc/src/app/forgot-password/page.tsx
+++ b/apps/shop-abc/src/app/forgot-password/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ForgotPasswordPage() {
+  const [msg, setMsg] = useState("");
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const email = (e.currentTarget.elements.namedItem("email") as HTMLInputElement)
+      .value;
+    const res = await fetch("/forgot-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    await res.json().catch(() => ({}));
+    setMsg(res.ok ? "If the email exists, a token was sent." : "Error");
+  }
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input name="email" type="email" placeholder="Email" className="border p-1" />
+      <button type="submit" className="border px-2 py-1">Send reset link</button>
+      {msg && <p>{msg}</p>}
+    </form>
+  );
+}

--- a/apps/shop-abc/src/app/forgot-password/route.ts
+++ b/apps/shop-abc/src/app/forgot-password/route.ts
@@ -1,0 +1,29 @@
+// apps/shop-abc/src/app/forgot-password/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { findUserByEmail } from "../userStore";
+import { sendEmail } from "@lib/email";
+
+const ForgotSchema = z.object({
+  email: z.string().email(),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = ForgotSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const match = findUserByEmail(parsed.data.email);
+  if (match) {
+    const [, user] = match;
+    const token = Math.random().toString(36).slice(2);
+    user.resetToken = token;
+    await sendEmail(parsed.data.email, "Password reset", `Your token is ${token}`);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -7,13 +7,7 @@ import {
   checkLoginRateLimit,
   clearLoginAttempts,
 } from "../../middleware";
-
-// Mock customer store. In a real app this would query a database or identity provider.
-const CUSTOMER_STORE: Record<string, { password: string; role: Role }> = {
-  cust1: { password: "pass1", role: "customer" },
-  viewer1: { password: "view", role: "viewer" },
-  admin1: { password: "admin", role: "admin" },
-};
+import { USER_STORE } from "../userStore";
 
 const ALLOWED_ROLES: Role[] = ["customer", "viewer"];
 
@@ -26,7 +20,7 @@ async function validateCredentials(
   customerId: string,
   password: string,
 ): Promise<{ customerId: string; role: Role } | null> {
-  const record = CUSTOMER_STORE[customerId];
+  const record = USER_STORE[customerId];
   if (!record || record.password !== password) {
     return null;
   }

--- a/apps/shop-abc/src/app/register/page.tsx
+++ b/apps/shop-abc/src/app/register/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+export default function RegisterPage() {
+  const [msg, setMsg] = useState("");
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const body = {
+      customerId: (form.elements.namedItem("customerId") as HTMLInputElement).value,
+      email: (form.elements.namedItem("email") as HTMLInputElement).value,
+      password: (form.elements.namedItem("password") as HTMLInputElement).value,
+    };
+    const res = await fetch("/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    setMsg(res.ok ? "Account created" : data.error || "Error");
+  }
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input name="customerId" placeholder="User ID" className="border p-1" />
+      <input name="email" type="email" placeholder="Email" className="border p-1" />
+      <input name="password" type="password" placeholder="Password" className="border p-1" />
+      <button type="submit" className="border px-2 py-1">Register</button>
+      {msg && <p>{msg}</p>}
+    </form>
+  );
+}

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -1,0 +1,31 @@
+// apps/shop-abc/src/app/register/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { addUser, USER_STORE } from "../userStore";
+
+const RegisterSchema = z.object({
+  customerId: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = RegisterSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const { customerId, email, password } = parsed.data;
+  if (USER_STORE[customerId]) {
+    return NextResponse.json({ error: "User already exists" }, { status: 400 });
+  }
+  if (Object.values(USER_STORE).some((u) => u.email === email)) {
+    return NextResponse.json({ error: "Email already registered" }, { status: 400 });
+  }
+
+  addUser(customerId, email, password);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-abc/src/app/userStore.ts
+++ b/apps/shop-abc/src/app/userStore.ts
@@ -1,0 +1,22 @@
+import type { Role } from "@auth/types/roles";
+
+export interface UserRecord {
+  password: string;
+  role: Role;
+  email: string;
+  resetToken?: string;
+}
+
+export const USER_STORE: Record<string, UserRecord> = {
+  cust1: { password: "pass1", role: "customer", email: "cust1@example.com" },
+  viewer1: { password: "view", role: "viewer", email: "viewer1@example.com" },
+  admin1: { password: "admin", role: "admin", email: "admin1@example.com" },
+};
+
+export function addUser(id: string, email: string, password: string) {
+  USER_STORE[id] = { password, role: "customer", email };
+}
+
+export function findUserByEmail(email: string) {
+  return Object.entries(USER_STORE).find(([, u]) => u.email === email);
+}


### PR DESCRIPTION
## Summary
- add shared in-memory user store for mock auth
- create register and forgot-password routes with forms
- send password reset emails via existing email utility

## Testing
- `pnpm test` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_6899ae47c50c832fa62273a92a98ae05