### PR TITLE
feat: store login attempt counters in Redis

### DIFF
--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
   }
 
   const ip = req.headers.get("x-forwarded-for") ?? "unknown";
-  const rateLimited = checkLoginRateLimit(ip, parsed.data.customerId);
+  const rateLimited = await checkLoginRateLimit(ip, parsed.data.customerId);
   if (rateLimited) return rateLimited;
 
   const valid = await validateCredentials(
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
   }
 
   await createCustomerSession(valid);
-  clearLoginAttempts(ip, parsed.data.customerId);
+  await clearLoginAttempts(ip, parsed.data.customerId);
 
   return NextResponse.json({ ok: true });
 }

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -47,7 +47,7 @@ module.exports = {
   },
   transformIgnorePatterns: [
     // transpile ESM-only dependencies that would break under CommonJS
-    "/node_modules/(?!(jose|next-auth|ulid)/)",
+    "/node_modules/(?!(jose|next-auth|ulid|@upstash/redis|uncrypto)/)",
   ],
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- switch login rate limiter to Redis with fallback memory store
- make limiter operations atomic and configurable via LOGIN_RATE_LIMIT_REDIS_* env vars
- update Jest config and tests for Redis-based limiter

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/loginRateLimit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899ae42d5ac832f903b75f7d531bb86