### PR TITLE
feat: add user auth routes

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -1,0 +1,114 @@
+// apps/shop-abc/__tests__/authFlow.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  createCustomerSession: jest.fn(),
+}));
+jest.mock("@acme/platform-core/users", () => {
+  const store = new Map<string, any>();
+  return {
+    __esModule: true,
+    getUser: (id: string) => Promise.resolve(store.get(id) ?? null),
+    getUserByEmail: (email: string) =>
+      Promise.resolve(
+        [...store.values()].find((u) => u.email === email) ?? null,
+      ),
+    createUser: (data: any) => {
+      store.set(data.customerId, data);
+      return Promise.resolve(data);
+    },
+    updateUserPassword: (id: string, passwordHash: string) => {
+      const user = store.get(id);
+      if (user) {
+        user.passwordHash = passwordHash;
+        store.set(id, user);
+      }
+      return Promise.resolve(user);
+    },
+    __reset: () => store.clear(),
+  };
+});
+
+import { POST as register } from "../src/app/api/register/route";
+import { POST as login } from "../src/app/login/route";
+import { POST as reset } from "../src/app/api/password-reset/route";
+import * as usersModule from "@acme/platform-core/users";
+const __resetUsers = (usersModule as any).__reset as () => void;
+
+function makeRequest(body: any, ip = "1.1.1.1") {
+  return {
+    json: async () => body,
+    headers: new Headers({ "x-forwarded-for": ip }),
+  } as any;
+}
+
+beforeEach(() => {
+  __resetUsers();
+});
+
+beforeAll(() => {
+  process.env.SESSION_SECRET = "test";
+});
+
+afterAll(() => {
+  delete process.env.SESSION_SECRET;
+});
+
+describe("auth flows", () => {
+  it("allows sign-up and login", async () => {
+    let res = await register(
+      makeRequest({
+        customerId: "cust1",
+        email: "cust1@test.com",
+        password: "pass1",
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    res = await login(makeRequest({ customerId: "cust1", password: "pass1" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects duplicate emails", async () => {
+    await register(
+      makeRequest({
+        customerId: "cust2",
+        email: "cust2@test.com",
+        password: "pass1",
+      }),
+    );
+    const dup = await register(
+      makeRequest({
+        customerId: "cust3",
+        email: "cust2@test.com",
+        password: "pass2",
+      }),
+    );
+    expect(dup.status).toBe(409);
+  });
+
+  it("resets password and logs in with new password", async () => {
+    await register(
+      makeRequest({
+        customerId: "cust4",
+        email: "cust4@test.com",
+        password: "oldpass",
+      }),
+    );
+
+    let res = await reset(
+      makeRequest({ email: "cust4@test.com", password: "newpass" }),
+    );
+    expect(res.status).toBe(200);
+
+    const oldLogin = await login(
+      makeRequest({ customerId: "cust4", password: "oldpass" }),
+    );
+    expect(oldLogin.status).toBe(401);
+
+    const newLogin = await login(
+      makeRequest({ customerId: "cust4", password: "newpass" }),
+    );
+    expect(newLogin.status).toBe(200);
+  });
+});
+

--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -1,9 +1,41 @@
 // apps/shop-abc/__tests__/loginRateLimit.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  createCustomerSession: jest.fn(),
+}));
+jest.mock("@acme/platform-core/users", () => {
+  const store = new Map<string, any>();
+  return {
+    __esModule: true,
+    getUser: (id: string) => Promise.resolve(store.get(id) ?? null),
+    getUserByEmail: (email: string) =>
+      Promise.resolve(
+        [...store.values()].find((u) => u.email === email) ?? null,
+      ),
+    createUser: (data: any) => {
+      store.set(data.customerId, data);
+      return Promise.resolve(data);
+    },
+    updateUserPassword: (id: string, passwordHash: string) => {
+      const user = store.get(id);
+      if (user) {
+        user.passwordHash = passwordHash;
+        store.set(id, user);
+      }
+      return Promise.resolve(user);
+    },
+    __reset: () => store.clear(),
+  };
+});
+
 import { POST } from "../src/app/login/route";
 import {
   __resetLoginRateLimiter,
   MAX_ATTEMPTS,
 } from "../src/middleware";
+import { POST as register } from "../src/app/api/register/route";
+import * as usersModule from "@acme/platform-core/users";
+const __resetUsers = (usersModule as any).__reset as () => void;
 
 function makeRequest(body: any, ip = "1.1.1.1") {
   return {
@@ -12,7 +44,22 @@ function makeRequest(body: any, ip = "1.1.1.1") {
   } as any;
 }
 
-afterEach(() => __resetLoginRateLimiter());
+beforeEach(async () => {
+  __resetUsers();
+  __resetLoginRateLimiter();
+  await register(
+    makeRequest({
+      customerId: "cust1",
+      email: "cust1@test.com",
+      password: "pass1",
+    }),
+  );
+});
+
+afterEach(() => {
+  __resetLoginRateLimiter();
+  __resetUsers();
+});
 
 describe("login rate limiting", () => {
   it("returns 429 after too many attempts", async () => {

--- a/apps/shop-abc/src/app/api/password-reset/route.ts
+++ b/apps/shop-abc/src/app/api/password-reset/route.ts
@@ -1,0 +1,38 @@
+// apps/shop-abc/src/app/api/password-reset/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import {
+  getUserByEmail,
+  updateUserPassword,
+} from "@acme/platform-core/users";
+
+const schema = z
+  .object({
+    email: z.string().email(),
+    password: z.string(),
+  })
+  .strict();
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const user = await getUserByEmail(parsed.data.email);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, {
+      status: 404,
+    });
+  }
+
+  const passwordHash = await bcrypt.hash(parsed.data.password, 10);
+  await updateUserPassword(user.customerId, passwordHash);
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -1,0 +1,44 @@
+// apps/shop-abc/src/app/api/register/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import {
+  createUser,
+  getUserByEmail,
+} from "@acme/platform-core/users";
+
+const schema = z
+  .object({
+    customerId: z.string(),
+    email: z.string().email(),
+    password: z.string(),
+  })
+  .strict();
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const existing = await getUserByEmail(parsed.data.email);
+  if (existing) {
+    return NextResponse.json({ error: "Email already in use" }, {
+      status: 409,
+    });
+  }
+
+  const passwordHash = await bcrypt.hash(parsed.data.password, 10);
+  await createUser({
+    customerId: parsed.data.customerId,
+    email: parsed.data.email,
+    passwordHash,
+    role: "customer",
+  });
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -9,7 +9,8 @@
     "./tax": "./src/tax/index.ts",
     "./orders": "./src/orders/index.ts",
     "./customerProfiles": "./src/customerProfiles/index.ts",
-    "./plugins": "./src/plugins/index.ts"
+    "./plugins": "./src/plugins/index.ts",
+    "./users": "./src/users/index.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",

--- a/packages/platform-core/prisma/migrations/20240912000000_add_users_table/migration.sql
+++ b/packages/platform-core/prisma/migrations/20240912000000_add_users_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "customerId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("customerId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -49,3 +49,10 @@ model CustomerMfa {
   secret     String
   enabled    Boolean @default(false)
 }
+
+model User {
+  customerId  String @id
+  email       String @unique
+  passwordHash String
+  role        String
+}

--- a/packages/platform-core/src/users.ts
+++ b/packages/platform-core/src/users.ts
@@ -1,0 +1,38 @@
+// packages/platform-core/src/users.ts
+import "server-only";
+import { prisma } from "./db";
+
+export interface User {
+  customerId: string;
+  email: string;
+  passwordHash: string;
+  role: string;
+}
+
+export async function getUser(customerId: string): Promise<User | null> {
+  return prisma.user.findUnique({ where: { customerId } });
+}
+
+export async function getUserByEmail(email: string): Promise<User | null> {
+  return prisma.user.findUnique({ where: { email } });
+}
+
+export async function createUser(data: {
+  customerId: string;
+  email: string;
+  passwordHash: string;
+  role: string;
+}): Promise<User> {
+  return prisma.user.create({ data });
+}
+
+export async function updateUserPassword(
+  customerId: string,
+  passwordHash: string,
+): Promise<User> {
+  return prisma.user.update({
+    where: { customerId },
+    data: { passwordHash },
+  });
+}
+

--- a/packages/platform-core/src/users/index.ts
+++ b/packages/platform-core/src/users/index.ts
@@ -1,0 +1,2 @@
+export * from "../users";
+


### PR DESCRIPTION
## Summary
- add Prisma user model and helpers
- implement register, login, and password reset APIs with bcrypt
- cover auth flows and rate limiting with integration tests

## Testing
- `npx jest apps/shop-abc/__tests__/authFlow.test.ts apps/shop-abc/__tests__/loginRateLimit.test.ts --runTestsByPath --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_6899adda2d74832fae036c1a76d187a1