### PR TITLE
feat: support size-specific cart items

### DIFF
--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -9,6 +9,7 @@ import { getProductById } from "@/lib/products";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { postSchema, patchSchema } from "@platform-core/schemas/cart";
+import { cartLineKey } from "@platform-core/src/cartStore";
 import { z } from "zod";
 
 export const runtime = "edge";
@@ -25,16 +26,17 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku, qty } = parsed.data;
+  const { sku, qty, size } = parsed.data;
   const skuObj = "title" in sku ? sku : getProductById(sku.id);
   if (!skuObj) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
   const cookie = req.cookies.get(CART_COOKIE)?.value;
   const cart = decodeCartCookie(cookie);
-  const line = cart[skuObj.id];
+  const key = cartLineKey(skuObj.id, size);
+  const line = cart[key];
 
-  cart[skuObj.id] = { sku: skuObj, qty: (line?.qty ?? 0) + qty };
+  cart[key] = { sku: skuObj, qty: (line?.qty ?? 0) + qty, size };
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cart)));

--- a/apps/shop-bcd/__tests__/cart-api.test.ts
+++ b/apps/shop-bcd/__tests__/cart-api.test.ts
@@ -3,6 +3,7 @@ import {
   asSetCookieHeader,
   decodeCartCookie,
   encodeCartCookie,
+  cartLineKey,
 } from "@/lib/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/api/cart/route";
@@ -38,13 +39,15 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const size = "40";
+  const req = createRequest({ sku, qty: 2, size });
   const res = await POST(req);
   const body = (await res.json()) as any;
 
-  expect(body.cart[sku.id].qty).toBe(2);
+  const key = cartLineKey(sku.id, size);
+  expect(body.cart[key].qty).toBe(2);
   const expected = asSetCookieHeader(
-    encodeCartCookie({ [sku.id]: { sku, qty: 2 } })
+    encodeCartCookie({ [key]: { sku, qty: 2, size } })
   );
   expect(res.headers.get("Set-Cookie")).toBe(expected);
 });
@@ -56,22 +59,26 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cart));
+  const size = "41";
+  const key = cartLineKey(sku.id, size);
+  const cart = { [key]: { sku, qty: 1, size } };
+  const req = createRequest({ id: key, qty: 5 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[key].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toEqual(body.cart);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cart));
+  const size = "42";
+  const key = cartLineKey(sku.id, size);
+  const cart = { [key]: { sku, qty: 1, size } };
+  const req = createRequest({ id: key, qty: 0 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[key]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
@@ -86,11 +93,13 @@ test("PATCH returns 404 for missing item", async () => {
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cart));
+  const size = "43";
+  const key = cartLineKey(sku.id, size);
+  const cart = { [key]: { sku, qty: 2, size } };
+  const req = createRequest({ id: key }, encodeCartCookie(cart));
   const res = await DELETE(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[key]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {

--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -1,5 +1,5 @@
 // apps/shop-bcd/__tests__/checkout-session.test.ts
-import { encodeCartCookie } from "@/lib/cartCookie";
+import { encodeCartCookie, cartLineKey } from "@/lib/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { calculateRentalDays } from "@/lib/date";
 import { POST } from "../src/api/checkout-session/route";
@@ -46,7 +46,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const key = cartLineKey(sku.id, "40");
+  const cart = { [key]: { sku, qty: 2, size: "40" } };
   const cookie = encodeCartCookie(cart);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -9,6 +9,7 @@ import {
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { postSchema, patchSchema } from "@platform-core/schemas/cart";
+import { cartLineKey } from "@platform-core/src/cartStore";
 import { z } from "zod";
 
 export const runtime = "edge";
@@ -27,12 +28,12 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku, qty } = parsed.data;
+  const { sku, qty, size } = parsed.data;
   const cookie = req.cookies.get(CART_COOKIE)?.value;
   const cart = decodeCartCookie(cookie);
-  const line = cart[sku.id];
-
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  const key = cartLineKey(sku.id, size);
+  const line = cart[key];
+  cart[key] = { sku, qty: (line?.qty ?? 0) + qty, size };
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cart)));

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -32,12 +32,16 @@ export const cartLineSchema = z.object({
 });
 
 /**
- * Schema for the full cart, keyed by SKU ID (string).
+ * Schema for the full cart, keyed by a composite "SKUID[:size]" string.
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
 
 export type CartLine = z.infer<typeof cartLineSchema>;
 export type CartState = z.infer<typeof cartStateSchema>;
+
+/** Build a unique key for a cart line from SKU ID and optional size. */
+export const cartLineKey = (skuId: string, size?: string) =>
+  size ? `${skuId}:${size}` : skuId;
 
 /* ------------------------------------------------------------------
  * Helper functions

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -1,7 +1,9 @@
 import crypto from "crypto";
 import { Redis } from "@upstash/redis";
 
-import type { CartState } from "./cartCookie";
+import { cartLineKey, type CartState } from "./cartCookie";
+
+export { cartLineKey };
 
 /** Abstraction for cart storage backends */
 export interface CartStore {

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -11,8 +11,8 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
  * ------------------------------------------------------------------ */
 type Action =
   | { type: "add"; sku: SKU; size?: string }
-  | { type: "remove"; id: SKU["id"] }
-  | { type: "setQty"; id: SKU["id"]; qty: number };
+  | { type: "remove"; id: string }
+  | { type: "setQty"; id: string; qty: number };
 
 /* ------------------------------------------------------------------
  * React context

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -5,6 +5,7 @@ export const postSchema = z
   .object({
     sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
     qty: z.coerce.number().int().min(1).default(1),
+    size: z.string().optional(),
   })
   .strict();
 

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -1,5 +1,5 @@
 // packages/template-app/__tests__/checkout-session.test.ts
-import { encodeCartCookie } from "../../platform-core/src/cartCookie";
+import { encodeCartCookie, cartLineKey } from "../../platform-core/src/cartCookie";
 import { createCart, setCart } from "../../platform-core/src/cartStore";
 import { PRODUCTS } from "../../platform-core/src/products";
 import { calculateRentalDays } from "../../lib/src/date";
@@ -43,7 +43,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const key = cartLineKey(sku.id, "40");
+  const cart = { [key]: { sku, qty: 2, size: "40" } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -5,7 +5,12 @@ import {
   decodeCartCookie,
   encodeCartCookie,
 } from "@platform-core/src/cartCookie";
-import { createCart, getCart, setCart } from "@platform-core/src/cartStore";
+import {
+  createCart,
+  getCart,
+  setCart,
+  cartLineKey,
+} from "@platform-core/src/cartStore";
 import { getProductById } from "@platform-core/src/products";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -29,7 +34,7 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku: skuInput, qty } = parsed.data;
+  const { sku: skuInput, qty, size } = parsed.data;
   const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
 
   if (!sku) {
@@ -41,8 +46,9 @@ export async function POST(req: NextRequest) {
     cartId = await createCart();
   }
   const cart = await getCart(cartId);
-  const line = cart[sku.id];
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  const key = cartLineKey(sku.id, size);
+  const line = cart[key];
+  cart[key] = { sku, qty: (line?.qty ?? 0) + qty, size };
   await setCart(cartId, cart);
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));

--- a/packages/types/src/Cart.d.ts
+++ b/packages/types/src/Cart.d.ts
@@ -11,12 +11,8 @@ export interface CartLine {
     size?: string;
 }
 /**
- * The entire cart state keyed by SKU ID.
- *
- * `SKU["id"]` is declared as `string | undefined` in the product typings,
- * which violates the constraint that a `Record` key must be a concrete
- * string.  Wrapping it in `NonNullable<>` narrows the key to `string`,
- * preserving type-safety while still documenting intent.
+ * The entire cart state keyed by "SKUID[:size]".
  */
-export type CartState = Record<NonNullable<SKU["id"]>, CartLine>;
+export type CartLineKey = `${NonNullable<SKU["id"]>}${`:${string}` | ""}`;
+export type CartState = Record<CartLineKey, CartLine>;
 //# sourceMappingURL=Cart.d.ts.map

--- a/packages/types/src/Cart.ts
+++ b/packages/types/src/Cart.ts
@@ -14,11 +14,7 @@ export interface CartLine {
 }
 
 /**
- * The entire cart state keyed by SKU ID.
- *
- * `SKU["id"]` is declared as `string | undefined` in the product typings,
- * which violates the constraint that a `Record` key must be a concrete
- * string.  Wrapping it in `NonNullable<>` narrows the key to `string`,
- * preserving type-safety while still documenting intent.
+ * The entire cart state keyed by "SKUID[:size]".
  */
-export type CartState = Record<NonNullable<SKU["id"]>, CartLine>;
+export type CartLineKey = `${NonNullable<SKU["id"]>}${`:${string}` | ""}`;
+export type CartState = Record<CartLineKey, CartLine>;

--- a/packages/ui/__tests__/OrderSummary.test.tsx
+++ b/packages/ui/__tests__/OrderSummary.test.tsx
@@ -4,7 +4,7 @@ import type { CartState } from "@/lib/cartCookie";
 import OrderSummary from "../src/components/organisms/OrderSummary";
 
 const mockCart: CartState = {
-  a: {
+  "a:M": {
     sku: {
       id: "a",
       slug: "a",
@@ -18,6 +18,7 @@ const mockCart: CartState = {
       description: "A",
     },
     qty: 2,
+    size: "M",
   },
   b: {
     sku: {
@@ -56,6 +57,7 @@ describe("OrderSummary", () => {
 
     // item rows
     expect(await screen.findByText("Product A")).toBeInTheDocument();
+    expect(screen.getByText("M")).toBeInTheDocument();
     expect(screen.getByText("Product B")).toBeInTheDocument();
     expect(screen.getByText("2", { selector: "td" })).toBeInTheDocument();
     expect(screen.getByText("1", { selector: "td" })).toBeInTheDocument();

--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -32,8 +32,8 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
   const [toast, setToast] = React.useState<{ open: boolean; message: string }>(
     { open: false, message: "" }
   );
-  const lines = Object.values(cart);
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const entries = Object.entries(cart);
+  const subtotal = entries.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
   const { widthClass, style } = drawerWidthProps(width);
 
   const handleRemove = async (id: string) => {
@@ -58,21 +58,28 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
           )}
         >
           <DialogTitle className="mb-4">Your Cart</DialogTitle>
-          {lines.length === 0 ? (
+          {entries.length === 0 ? (
             <p className="text-muted-foreground text-sm">Cart is empty.</p>
           ) : (
             <div className="flex h-full flex-col gap-4">
               <ul className="grow space-y-3 overflow-y-auto">
-                {lines.map((line) => (
+                {entries.map(([id, line]) => (
                   <li
-                    key={line.sku.id}
+                    key={id}
                     className="flex items-center justify-between gap-2"
                   >
-                    <span className="text-sm">{line.sku.title}</span>
+                    <span className="text-sm">
+                      {line.sku.title}
+                      {line.size && (
+                        <span className="ml-1 text-xs text-muted">
+                          ({line.size})
+                        </span>
+                      )}
+                    </span>
                     <span className="text-sm">× {line.qty}</span>
                     <Button
                       variant="destructive"
-                      onClick={() => void handleRemove(line.sku.id)}
+                      onClick={() => void handleRemove(id)}
                       className="px-2 py-1 text-xs"
                     >
                       Remove

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -38,10 +38,10 @@ interface WrapperProps {
 function CartInitializer({ items }: WrapperProps) {
   const [, dispatch] = useCart();
   React.useEffect(() => {
-    Object.values(items).forEach((line) => {
+    Object.entries(items).forEach(([id, line]) => {
       dispatch({ type: "add", sku: line.sku, size: line.size });
       if (line.qty > 1) {
-        dispatch({ type: "setQty", id: line.sku.id, qty: line.qty });
+        dispatch({ type: "setQty", id, qty: line.qty });
       }
     });
   }, [items, dispatch]);

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -35,18 +35,21 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
   /* ------------------------------------------------------------------
    * Derived values
    * ------------------------------------------------------------------ */
-  const lines = useMemo<CartLine[]>(() => Object.values(cart), [cart]);
+  const entries = useMemo(() => Object.entries(cart), [cart]);
 
   // When totals aren't provided, compute them from the cart lines.
   const computedSubtotal = useMemo(
-    () => lines.reduce((sum, line) => sum + line.sku.price * line.qty, 0),
-    [lines]
+    () => entries.reduce((sum, [, line]) => sum + line.sku.price * line.qty, 0),
+    [entries]
   );
 
   const computedDeposit = useMemo(
     () =>
-      lines.reduce((sum, line) => sum + (line.sku.deposit ?? 0) * line.qty, 0),
-    [lines]
+      entries.reduce(
+        (sum, [, line]) => sum + (line.sku.deposit ?? 0) * line.qty,
+        0
+      ),
+    [entries]
   );
 
   const subtotal = totals?.subtotal ?? computedSubtotal;
@@ -66,8 +69,8 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
         </tr>
       </thead>
       <tbody>
-        {lines.map((line) => (
-          <tr key={line.sku.id} className="border-b last:border-0">
+        {entries.map(([id, line]) => (
+          <tr key={id} className="border-b last:border-0">
             <td className="py-2">
               {line.sku.title}
               {line.size && (

--- a/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
@@ -28,9 +28,10 @@ describe("MiniCart", () => {
     const dispatch = jest.fn();
     mockUseCart.mockReturnValue([
       {
-        sku1: {
-          sku: { id: "sku1", title: "Item", price: 10 },
+        "sku1:M": {
+          sku: { id: "sku1", title: "Item", price: 10 } as any,
           qty: 1,
+          size: "M",
         },
       },
       dispatch,
@@ -39,9 +40,10 @@ describe("MiniCart", () => {
     render(<MiniCart trigger={<button>Cart</button>} />);
     await userEvent.click(screen.getByText("Cart"));
 
-    expect(await screen.findByText("Item")).toBeInTheDocument();
+    expect(await screen.findByText(/Item/)).toBeInTheDocument();
+    expect(screen.getByText(/M/)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /remove/i }));
-    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1" });
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1:M" });
   });
 });

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -19,11 +19,11 @@ export function CartTemplate({
   className,
   ...props
 }: CartTemplateProps) {
-  const lines = Object.values(cart);
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
-  const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
+  const entries = Object.entries(cart);
+  const subtotal = entries.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
+  const deposit = entries.reduce((s, [, l]) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
-  if (!lines.length) {
+  if (!entries.length) {
     return (
       <p className={cn("p-8 text-center", className)}>Your cart is empty.</p>
     );
@@ -42,8 +42,8 @@ export function CartTemplate({
           </tr>
         </thead>
         <tbody>
-          {lines.map((line) => (
-            <tr key={line.sku.id} className="border-b last:border-0">
+          {entries.map(([id, line]) => (
+            <tr key={id} className="border-b last:border-0">
               <td className="py-2">
                 <div className="flex items-center gap-4">
                   <div className="relative hidden h-12 w-12 sm:block">
@@ -55,13 +55,18 @@ export function CartTemplate({
                       className="rounded-md object-cover"
                     />
                   </div>
-                  {line.sku.title}
+                  <div>
+                    {line.sku.title}
+                    {line.size && (
+                      <p className="text-xs text-muted">Size: {line.size}</p>
+                    )}
+                  </div>
                 </div>
               </td>
               <td>
                 <QuantityInput
                   value={line.qty}
-                  onChange={(v) => onQtyChange?.(line.sku.id, v)}
+                  onChange={(v) => onQtyChange?.(id, v)}
                   className="justify-center"
                 />
               </td>
@@ -72,7 +77,7 @@ export function CartTemplate({
                 <td className="text-right">
                   <button
                     type="button"
-                    onClick={() => onRemove(line.sku.id)}
+                    onClick={() => onRemove(id)}
                     className="text-danger hover:underline"
                   >
                     Remove


### PR DESCRIPTION
## Summary
- include optional `size` in cart POST schema
- key cart lines by `skuId[:size]` for unique entries
- persist size in cart APIs and display in UI components

## Testing
- `pnpm --filter platform-core test` *(fails: Cannot find module '@/components/atoms' ...)*
- `npx jest packages/template-app/__tests__/cart.test.ts packages/template-app/__tests__/checkout-session.test.ts packages/ui/__tests__/OrderSummary.test.tsx packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx apps/shop-abc/__tests__/cartApi.test.ts apps/shop-bcd/__tests__/cart-api.test.ts apps/shop-bcd/__tests__/cartApi.test.ts apps/shop-bcd/__tests__/checkout-session.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6899ad9dedd4832f8472061a34f38df8