### PR TITLE
Redirect unauthenticated profile access to login

### DIFF
--- a/apps/shop-abc/__tests__/accountProfile.test.tsx
+++ b/apps/shop-abc/__tests__/accountProfile.test.tsx
@@ -9,10 +9,16 @@ jest.mock("@acme/platform-core", () => ({
   getCustomerProfile: jest.fn(),
 }));
 
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  redirect: jest.fn(),
+}));
+
 import { getCustomerSession } from "@auth";
 import { getCustomerProfile } from "@acme/platform-core";
 import ProfilePage from "@ui/src/components/account/Profile";
 import ProfileForm from "@ui/src/components/account/ProfileForm";
+import { redirect } from "next/navigation";
 
 describe("/account/profile", () => {
   beforeEach(() => {
@@ -21,10 +27,11 @@ describe("/account/profile", () => {
 
   it("redirects unauthenticated users", async () => {
     (getCustomerSession as jest.Mock).mockResolvedValue(null);
-    const element = await ProfilePage({});
+    await ProfilePage({});
     expect(getCustomerSession).toHaveBeenCalled();
-    expect(element.type).toBe("p");
-    expect(element.props.children).toBe("Please log in to view your profile.");
+    expect(redirect).toHaveBeenCalledWith(
+      "/login?callbackUrl=%2Faccount%2Fprofile",
+    );
     expect(getCustomerProfile).not.toHaveBeenCalled();
   });
 
@@ -37,6 +44,7 @@ describe("/account/profile", () => {
     const element = await ProfilePage({});
     expect(getCustomerSession).toHaveBeenCalled();
     expect(getCustomerProfile).toHaveBeenCalledWith("cust1");
+    expect(redirect).not.toHaveBeenCalled();
     expect(element.type).toBe("div");
     expect(element.props.children[0].props.children).toBe("Profile");
     const form = element.props.children[1];

--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -9,10 +9,16 @@ jest.mock("@acme/platform-core", () => ({
   getCustomerProfile: jest.fn(),
 }));
 
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  redirect: jest.fn(),
+}));
+
 import { getCustomerSession } from "@auth";
 import { getCustomerProfile } from "@acme/platform-core";
 import ProfilePage from "@ui/src/components/account/Profile";
 import ProfileForm from "@ui/src/components/account/ProfileForm";
+import { redirect } from "next/navigation";
 
 describe("/account/profile", () => {
   beforeEach(() => {
@@ -21,10 +27,11 @@ describe("/account/profile", () => {
 
   it("redirects unauthenticated users", async () => {
     (getCustomerSession as jest.Mock).mockResolvedValue(null);
-    const element = await ProfilePage({});
+    await ProfilePage({});
     expect(getCustomerSession).toHaveBeenCalled();
-    expect(element.type).toBe("p");
-    expect(element.props.children).toBe("Please log in to view your profile.");
+    expect(redirect).toHaveBeenCalledWith(
+      "/login?callbackUrl=%2Faccount%2Fprofile",
+    );
     expect(getCustomerProfile).not.toHaveBeenCalled();
   });
 
@@ -37,6 +44,7 @@ describe("/account/profile", () => {
     const element = await ProfilePage({});
     expect(getCustomerSession).toHaveBeenCalled();
     expect(getCustomerProfile).toHaveBeenCalledWith("cust1");
+    expect(redirect).not.toHaveBeenCalled();
     expect(element.type).toBe("div");
     expect(element.props.children[0].props.children).toBe("Profile");
     const form = element.props.children[1];

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -2,17 +2,26 @@
 import { getCustomerSession } from "@auth";
 import { getCustomerProfile } from "@acme/platform-core";
 import ProfileForm from "./ProfileForm";
+import { redirect } from "next/navigation";
 
 export interface ProfilePageProps {
   /** Optional heading to allow shop-specific overrides */
   title?: string;
+  /** Destination to return to after login */
+  callbackUrl?: string;
 }
 
 export const metadata = { title: "Profile" };
 
-export default async function ProfilePage({ title = "Profile" }: ProfilePageProps) {
+export default async function ProfilePage({
+  title = "Profile",
+  callbackUrl = "/account/profile",
+}: ProfilePageProps) {
   const session = await getCustomerSession();
-  if (!session) return <p>Please log in to view your profile.</p>;
+  if (!session) {
+    redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+    return null as never;
+  }
   const profile = await getCustomerProfile(session.customerId);
   return (
     <div className="p-6">


### PR DESCRIPTION
## Summary
- redirect unauthenticated profile views to `/login`
- include callback URL to return to profile after login
- update account profile tests for redirect behavior

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/accountProfile.test.tsx apps/shop-bcd/__tests__/account-profile.test.tsx --runInBand`
- `pnpm exec eslint packages/ui/src/components/account/Profile.tsx apps/shop-abc/__tests__/accountProfile.test.tsx apps/shop-bcd/__tests__/account-profile.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899ae456720832f889a41b1bcfb1df4