### PR TITLE
Use SKU ID for cart API requests

### DIFF
--- a/apps/shop-abc/__tests__/cartApi.test.ts
+++ b/apps/shop-abc/__tests__/cartApi.test.ts
@@ -7,7 +7,7 @@ import {
 import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/app/api/cart/route";
 
-const TEST_SKU = { ...PRODUCTS[0], id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+const TEST_SKU = PRODUCTS[0];
 
 declare function expectType<T>(value: T): void;
 
@@ -40,7 +40,7 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const req = createRequest({ sku: { id: sku.id }, qty: 2 });
   const res = await POST(req);
   const body = (await res.json()) as any;
 
@@ -88,9 +88,9 @@ test("PATCH returns 404 for missing item", async () => {
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku, qty: -1 }));
+  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku, qty: 1.5 }));
+  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
   expect(res.status).toBe(400);
 });
 

--- a/apps/shop-bcd/__tests__/cart-api.test.ts
+++ b/apps/shop-bcd/__tests__/cart-api.test.ts
@@ -7,7 +7,7 @@ import {
 import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/api/cart/route";
 
-const TEST_SKU = { ...PRODUCTS[0], id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+const TEST_SKU = PRODUCTS[0];
 
 declare function expectType<T>(value: T): void;
 
@@ -38,7 +38,7 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const req = createRequest({ sku: { id: sku.id }, qty: 2 });
   const res = await POST(req);
   const body = (await res.json()) as any;
 

--- a/apps/shop-bcd/__tests__/cartApi.test.ts
+++ b/apps/shop-bcd/__tests__/cartApi.test.ts
@@ -30,9 +30,9 @@ afterEach(() => {
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku, qty: -1 }));
+  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku, qty: 1.5 }));
+  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
   expect(res.status).toBe(400);
 });
 

--- a/apps/shop-bcd/src/api/cart/route.js
+++ b/apps/shop-bcd/src/api/cart/route.js
@@ -1,5 +1,6 @@
 // apps/shop-abc/src/app/api/cart/route.ts
 import { asSetCookieHeader, CART_COOKIE, decodeCartCookie, encodeCartCookie, } from "@/lib/cartCookie";
+import { getProductById } from "@/lib/products";
 import { NextResponse } from "next/server";
 import { postSchema, patchSchema } from "@platform-core/schemas/cart";
 import { z } from "zod";
@@ -13,7 +14,11 @@ export async function POST(req) {
     if (!parsed.success) {
         return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
     }
-    const { sku, qty = 1 } = parsed.data;
+    const { sku: { id: skuId }, qty } = parsed.data;
+    const sku = getProductById(skuId);
+    if (!sku) {
+        return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    }
     const cookie = req.cookies.get(CART_COOKIE)?.value;
     const cart = decodeCartCookie(cookie);
     const line = cart[sku.id];

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -6,6 +6,7 @@ import {
   decodeCartCookie,
   encodeCartCookie,
 } from "@/lib/cartCookie";
+import { getProductById } from "@/lib/products";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { postSchema, patchSchema } from "@platform-core/schemas/cart";
@@ -27,7 +28,14 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku, qty } = parsed.data;
+  const {
+    sku: { id: skuId },
+    qty,
+  } = parsed.data;
+  const sku = getProductById(skuId);
+  if (!sku) {
+    return NextResponse.json({ error: "Item not found" }, { status: 404 });
+  }
   const cookie = req.cookies.get(CART_COOKIE)?.value;
   const cart = decodeCartCookie(cookie);
   const line = cart[sku.id];

--- a/functions/themes/[theme]/__tests__/cart-checkout-integration.test.ts
+++ b/functions/themes/[theme]/__tests__/cart-checkout-integration.test.ts
@@ -51,7 +51,7 @@ afterEach(() => jest.resetAllMocks());
 
 test("add to cart then create checkout session", async () => {
   const sku = PRODUCTS[0];
-  const res = await CART_POST(cartReq({ sku, qty: 1 }));
+  const res = await CART_POST(cartReq({ sku: { id: sku.id }, qty: 1 }));
   const header = res.headers.get("Set-Cookie")!;
   const cookie = header.split("=")[1].split(";")[0];
 

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -46,7 +46,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
     switch (action.type) {
       case "add":
         method = "POST";
-        body = { sku: action.sku, qty: 1, size: action.size };
+        body = { sku: { id: action.sku.id }, qty: 1 };
         break;
       case "remove":
         method = "DELETE";

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -3,7 +3,7 @@ import { skuSchema } from "@types";
 
 export const postSchema = z
   .object({
-    sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
+    sku: skuSchema.pick({ id: true }),
     qty: z.coerce.number().int().min(1).default(1),
   })
   .strict();

--- a/packages/template-app/__tests__/cart.test.ts
+++ b/packages/template-app/__tests__/cart.test.ts
@@ -4,7 +4,7 @@ import { createCart, getCart, setCart } from "@platform-core/src/cartStore";
 import { PRODUCTS } from "@platform-core/src/products";
 import { DELETE, GET, PATCH, POST } from "../src/api/cart/route";
 
-const TEST_SKU = { ...PRODUCTS[0], id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+const TEST_SKU = PRODUCTS[0];
 
 // Minimal NextResponse mock using the native Response class
 jest.mock("next/server", () => ({
@@ -34,7 +34,7 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const req = createRequest({ sku: { id: sku.id }, qty: 2 });
   const res = await POST(req);
   const body = await res.json();
 

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -29,8 +29,11 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku: skuInput, qty } = parsed.data;
-  const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
+  const {
+    sku: { id: skuId },
+    qty,
+  } = parsed.data;
+  const sku = getProductById(skuId);
 
   if (!sku) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });

--- a/test/e2e/rental-return-flow.spec.ts
+++ b/test/e2e/rental-return-flow.spec.ts
@@ -48,7 +48,7 @@ describe("Rental return flow", () => {
 
   it("records refunded rental order", () => {
     // 1️⃣ create rental cart
-    cy.request("POST", "/api/cart", { sku, qty: 1 });
+    cy.request("POST", "/api/cart", { sku: { id: sku.id }, qty: 1 });
 
     // 2️⃣ checkout
     cy.visit("/en/checkout");


### PR DESCRIPTION
## Summary
- require only SKU ID in cart post schema
- fetch cart item details server-side by SKU ID
- update client context and tests to send SKU IDs

## Testing
- `pnpm test` *(fails: command exited with code 1: @apps/cms#test)*

------
https://chatgpt.com/codex/tasks/task_e_6899ae4ec8bc832fbe00568d368dc2f2