### PR TITLE
fix: use trusted product data for deposit totals

### DIFF
--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -86,10 +86,14 @@ async function computeTotals(
   const subtotalBase = lineTotals.reduce((s, n) => s + n.discounted, 0);
   const originalBase = lineTotals.reduce((s, n) => s + n.base, 0);
   const discountBase = originalBase - subtotalBase;
-  const depositBase = Object.values(cart).reduce(
-    (s, item) => s + item.sku.deposit * item.qty,
-    0
-  );
+  const depositBase = Object.values(cart).reduce((s, item) => {
+    const deposit = getProductById(item.sku.id)?.deposit;
+    if (deposit === undefined) {
+      console.warn(`Deposit lookup failed for SKU ${item.sku.id}`);
+      return s;
+    }
+    return s + deposit * item.qty;
+  }, 0);
 
   return {
     subtotal: await convertCurrency(subtotalBase, currency),


### PR DESCRIPTION
## Summary
- fetch deposit amounts from trusted products in checkout session totals
- warn and skip deposit calculation if SKU lookup fails

## Testing
- `pnpm lint --filter @acme/template-app`
- `pnpm test --filter @acme/template-app`


------
https://chatgpt.com/codex/tasks/task_e_6899ae4fb288832faf9c7a25aafb9f43