### PR TITLE
test: add fetchJson empty and invalid json tests

### DIFF
--- a/packages/shared-utils/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/__tests__/fetchJson.test.ts
@@ -20,6 +20,24 @@ describe('fetchJson', () => {
       .resolves.toEqual(responseData);
   });
 
+  it('returns undefined when response body is empty', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(''),
+    });
+
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when response body contains invalid JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('not json'),
+    });
+
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+
   it('throws error message from JSON error payload', async () => {
     const errorPayload = { error: 'Bad Request' };
     (global.fetch as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- add tests for fetchJson handling of empty and invalid JSON bodies

## Testing
- `npx jest packages/shared-utils/__tests__/fetchJson.test.ts` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_6899ae5ce178832fa0619348fa9bf791