### PR TITLE
Persist wizard completion map

### DIFF
--- a/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
@@ -15,7 +15,7 @@ export async function resetWizardProgress(): Promise<void> {
       await fetch("/cms/api/wizard-progress", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ stepId: null, data: {} }),
+        body: JSON.stringify({ stepId: null, data: {}, completed: {} }),
       });
     } catch {
       /* ignore network errors */
@@ -74,7 +74,7 @@ export function useWizardPersistence(
     fetch("/cms/api/wizard-progress", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ stepId: "wizard", data }),
+      body: JSON.stringify({ stepId: "wizard", data, completed }),
     }).catch(() => {
       /* ignore network errors */
     });


### PR DESCRIPTION
## Summary
- include `completed` map when resetting wizard progress and persisting state

## Testing
- `pnpm test:cms` *(fails: Cannot find module '@/components/cms/StyleEditor')*

------
https://chatgpt.com/codex/tasks/task_e_6899b27a0320832f90b6288b5a5384a0