### PR TITLE
feat(auth): persist customer sessions

### DIFF
--- a/packages/auth/__tests__/rbac.test.ts
+++ b/packages/auth/__tests__/rbac.test.ts
@@ -1,11 +1,6 @@
 import { z } from "zod";
-import {
-  canRead,
-  canWrite,
-  extendRoles,
-  READ_ROLES,
-  WRITE_ROLES,
-} from "../src";
+import { canRead, canWrite, READ_ROLES, WRITE_ROLES } from "../src/rbac";
+import { extendRoles } from "../src/types/roles";
 import * as roles from "../src/types/roles";
 
 const originalRead = [...READ_ROLES];

--- a/packages/auth/__tests__/session.test.ts
+++ b/packages/auth/__tests__/session.test.ts
@@ -1,6 +1,7 @@
 import {
   createCustomerSession,
   getCustomerSession,
+  destroyCustomerSession,
   CUSTOMER_SESSION_COOKIE,
   CSRF_TOKEN_COOKIE,
 } from "../src/session";
@@ -94,6 +95,22 @@ describe("customer session", () => {
     await createCustomerSession(session);
     const secondToken = store.set.mock.calls[2][1];
     expect(secondToken).not.toBe(firstToken);
+  });
+
+  it("invalidates server-side session on destroy", async () => {
+    const store = createStore();
+    mockCookies.mockResolvedValue(store);
+    const session = { customerId: "abc", role: "customer" as Role };
+
+    await createCustomerSession(session);
+    const token = store.set.mock.calls[0][1];
+
+    await destroyCustomerSession();
+
+    // simulate request with old token
+    store.set(CUSTOMER_SESSION_COOKIE, token);
+
+    await expect(getCustomerSession()).resolves.toBeNull();
   });
 });
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "iron-session": "^6.3.1",
     "otplib": "^12.0.1",
-    "@acme/platform-core": "workspace:*"
+    "@acme/platform-core": "workspace:*",
+    "@upstash/redis": "^1.35.3"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -25,7 +25,106 @@ interface SessionRecord {
   createdAt: Date;
 }
 
-const activeSessions = new Map<string, SessionRecord>();
+interface SessionStore {
+  get(id: string): Promise<SessionRecord | null>;
+  set(record: SessionRecord): Promise<void>;
+  delete(id: string): Promise<void>;
+  list(customerId: string): Promise<SessionRecord[]>;
+}
+
+class MemorySessionStore implements SessionStore {
+  private sessions = new Map<string, { record: SessionRecord; expires: number }>();
+
+  constructor(private ttl: number) {}
+
+  async get(id: string): Promise<SessionRecord | null> {
+    const entry = this.sessions.get(id);
+    if (!entry) return null;
+    if (entry.expires < Date.now()) {
+      this.sessions.delete(id);
+      return null;
+    }
+    return entry.record;
+  }
+
+  async set(record: SessionRecord): Promise<void> {
+    this.sessions.set(record.sessionId, {
+      record,
+      expires: Date.now() + this.ttl * 1000,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    this.sessions.delete(id);
+  }
+
+  async list(customerId: string): Promise<SessionRecord[]> {
+    const now = Date.now();
+    return Array.from(this.sessions.values())
+      .filter((s) => s.expires > now && s.record.customerId === customerId)
+      .map((s) => s.record);
+  }
+}
+
+class RedisSessionStore implements SessionStore {
+  constructor(private client: Redis, private ttl: number) {}
+
+  private key(id: string) {
+    return `session:${id}`;
+  }
+
+  private customerKey(customerId: string) {
+    return `customer_sessions:${customerId}`;
+  }
+
+  async get(id: string): Promise<SessionRecord | null> {
+    const data = await this.client.get<Record<string, any>>(this.key(id));
+    if (!data) return null;
+    return { ...data, createdAt: new Date(data.createdAt) } as SessionRecord;
+  }
+
+  async set(record: SessionRecord): Promise<void> {
+    await this.client.set(this.key(record.sessionId), record, { ex: this.ttl });
+    await this.client.sadd(this.customerKey(record.customerId), record.sessionId);
+    await this.client.expire(this.customerKey(record.customerId), this.ttl);
+  }
+
+  async delete(id: string): Promise<void> {
+    const rec = await this.get(id);
+    await this.client.del(this.key(id));
+    if (rec) {
+      await this.client.srem(this.customerKey(rec.customerId), id);
+    }
+  }
+
+  async list(customerId: string): Promise<SessionRecord[]> {
+    const ids = await this.client.smembers<string>(
+      this.customerKey(customerId)
+    );
+    if (!ids || ids.length === 0) return [];
+    const records = await this.client.mget<Record<string, any>>(
+      ...ids.map((id) => this.key(id))
+    );
+    return records
+      .filter((r): r is Record<string, any> => r !== null)
+      .map((r) => ({ ...r, createdAt: new Date(r.createdAt) } as SessionRecord));
+  }
+}
+
+const sessionStorePromise: Promise<SessionStore> = (async () => {
+  if (
+    process.env.UPSTASH_REDIS_REST_URL &&
+    process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    const { Redis } = await import("@upstash/redis");
+    const client = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+    return new RedisSessionStore(client, SESSION_TTL_S);
+  }
+  return new MemorySessionStore(SESSION_TTL_S);
+})();
 
 function cookieOptions() {
   return {
@@ -64,7 +163,9 @@ export async function getCustomerSession(): Promise<CustomerSession | null> {
   } catch {
     return null;
   }
-  if (!activeSessions.has(session.sessionId)) {
+  const sessionStore = await sessionStorePromise;
+  const exists = await sessionStore.get(session.sessionId);
+  if (!exists) {
     return null;
   }
   // rotate on activity
@@ -80,13 +181,13 @@ export async function getCustomerSession(): Promise<CustomerSession | null> {
     store.set(CSRF_TOKEN_COOKIE, csrf, csrfCookieOptions());
   }
   const ua = headers().get("user-agent") ?? "unknown";
-  activeSessions.set(session.sessionId, {
+  await sessionStore.set({
     sessionId: session.sessionId,
     customerId: session.customerId,
     userAgent: ua,
     createdAt: new Date(),
   });
-  activeSessions.delete(oldId);
+  await sessionStore.delete(oldId);
   const { customerId, role } = session;
   return { customerId, role };
 }
@@ -109,7 +210,8 @@ export async function createCustomerSession(sessionData: CustomerSession): Promi
   const csrf = randomUUID();
   store.set(CSRF_TOKEN_COOKIE, csrf, csrfCookieOptions());
   const ua = headers().get("user-agent") ?? "unknown";
-  activeSessions.set(session.sessionId, {
+  const sessionStore = await sessionStorePromise;
+  await sessionStore.set({
     sessionId: session.sessionId,
     customerId: session.customerId,
     userAgent: ua,
@@ -128,7 +230,8 @@ export async function destroyCustomerSession(): Promise<void> {
           password: secret,
           ttl: SESSION_TTL_S,
         });
-        activeSessions.delete(session.sessionId);
+        const sessionStore = await sessionStorePromise;
+        await sessionStore.delete(session.sessionId);
       } catch {}
     }
   }
@@ -142,14 +245,16 @@ export async function destroyCustomerSession(): Promise<void> {
   });
 }
 
-export function listSessions(customerId: string): SessionRecord[] {
-  return Array.from(activeSessions.values()).filter(
-    (s) => s.customerId === customerId
-  );
+export async function listSessions(
+  customerId: string
+): Promise<SessionRecord[]> {
+  const sessionStore = await sessionStorePromise;
+  return sessionStore.list(customerId);
 }
 
-export function revokeSession(sessionId: string): void {
-  activeSessions.delete(sessionId);
+export async function revokeSession(sessionId: string): Promise<void> {
+  const sessionStore = await sessionStorePromise;
+  await sessionStore.delete(sessionId);
 }
 
 export async function validateCsrfToken(token: string | null): Promise<boolean> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       '@acme/platform-core':
         specifier: workspace:*
         version: link:../platform-core
+      '@upstash/redis':
+        specifier: ^1.35.3
+        version: 1.35.3
       iron-session:
         specifier: ^6.3.1
         version: 6.3.1(next@15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))


### PR DESCRIPTION
## Summary
- add memory/Redis-backed session store and dynamic initialization
- validate sessions server-side and purge them on logout
- test session invalidation and adjust RBAC tests

## Testing
- `pnpm --filter @acme/auth test packages/auth/__tests__`


------
https://chatgpt.com/codex/tasks/task_e_6899b37d20a4832f9f84136522ffb7da