### PR TITLE
feat: add configurator step routing

### DIFF
--- a/apps/cms/src/app/cms/configurator/[stepId]/page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import steps from "../steps";
+import { WizardProvider } from "../../wizard/WizardContext";
+import useStepCompletion from "../../wizard/hooks/useStepCompletion";
+
+interface PageProps {
+  params: { stepId: string };
+}
+
+function StepContent({ stepId }: { stepId: string }) {
+  const step = steps.find((s) => s.id === stepId);
+  if (!step) {
+    return null;
+  }
+  const StepComponent = step.component as React.ComponentType<any>;
+  const [, setCompleted] = useStepCompletion(step.id);
+  return (
+    <StepComponent
+      onComplete={() => setCompleted(true)}
+      onNext={() => {}}
+      onBack={() => {}}
+    />
+  );
+}
+
+export default function ConfiguratorStepPage({ params }: PageProps) {
+  return (
+    <WizardProvider>
+      <StepContent stepId={params.stepId} />
+    </WizardProvider>
+  );
+}

--- a/apps/cms/src/app/cms/wizard/hooks/useStepCompletion.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useStepCompletion.ts
@@ -1,0 +1,12 @@
+import { useWizard } from "../WizardContext";
+
+export function useStepCompletion(stepId: string): [boolean, (v: boolean) => void] {
+  const { state, update } = useWizard();
+  const completed = state.completed[stepId] ?? false;
+  const setCompleted = (v: boolean) => {
+    update("completed", { ...state.completed, [stepId]: v });
+  };
+  return [completed, setCompleted];
+}
+
+export default useStepCompletion;


### PR DESCRIPTION
## Summary
- add hook for reading/updating wizard step completion
- add dynamic configurator step page that loads step components by id

## Testing
- `pnpm test:cms` *(fails: Cannot find module '@\/components\/cms\/StyleEditor')*


------
https://chatgpt.com/codex/tasks/task_e_6899b27c5120832fb944f73a55010ff8