### PR TITLE
feat: use size-aware cart keys

### DIFF
--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -5,6 +5,7 @@ import {
   decodeCartCookie,
   encodeCartCookie,
   type CartState,
+  cartKey,
 } from "@platform-core/src/cartCookie";
 import { createCart, getCart, setCart } from "@platform-core/src/cartStore";
 import { getProductById } from "@/lib/products";
@@ -64,15 +65,19 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku: skuInput, qty } = parsed.data;
+  const { sku: skuInput, qty, size } = parsed.data;
   const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
   if (!sku) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
+  if (sku.sizes.length && !size) {
+    return NextResponse.json({ error: "Size is required" }, { status: 400 });
+  }
 
   const { cartId, cart } = await loadCart(req, true);
-  const line = cart[sku.id];
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  const key = cartKey(sku.id, size);
+  const line = cart[key];
+  cart[key] = { sku, qty: (line?.qty ?? 0) + qty, size };
   await setCart(cartId!, cart);
 
   const res = NextResponse.json({ ok: true, cart });

--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -3,13 +3,15 @@
 import { CartProvider, useCart } from "@/contexts/CartContext";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { PRODUCTS } from "@platform-core/products";
+import { cartKey } from "../src/cartCookie";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 jest.mock("react", () => jest.requireActual("react"));
 jest.mock("react-dom", () => jest.requireActual("react-dom"));
 
 function Qty() {
   const [state] = useCart();
-  return <span data-testid="qty">{state[PRODUCTS[0].id]?.qty ?? 0}</span>;
+  const key = cartKey(PRODUCTS[0].id, "40");
+  return <span data-testid="qty">{state[key]?.qty ?? 0}</span>;
 }
 
 describe("AddToCartButton", () => {
@@ -27,12 +29,20 @@ describe("AddToCartButton", () => {
       // POST
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({
+          cart: {
+            [cartKey(PRODUCTS[0].id, "40")]: {
+              sku: PRODUCTS[0],
+              qty: 1,
+              size: "40",
+            },
+          },
+        }),
       });
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} />
+        <AddToCartButton sku={PRODUCTS[0]} size="40" />
         <Qty />
       </CartProvider>
     );
@@ -60,7 +70,7 @@ describe("AddToCartButton", () => {
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} />
+        <AddToCartButton sku={PRODUCTS[0]} size="40" />
         <Qty />
       </CartProvider>
     );

--- a/packages/platform-core/__tests__/cartContext.test.tsx
+++ b/packages/platform-core/__tests__/cartContext.test.tsx
@@ -2,23 +2,27 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CartProvider, useCart } from "../contexts/CartContext";
 import { PRODUCTS } from "../products";
+import { cartKey } from "../src/cartCookie";
 
 function TestComponent() {
   const [state, dispatch] = useCart();
-  const line = state[PRODUCTS[0].id];
+  const id = cartKey(PRODUCTS[0].id, "40");
+  const line = state[id];
 
   return (
     <div>
       <span data-testid="qty">{line?.qty ?? 0}</span>
 
-      <button onClick={() => dispatch({ type: "add", sku: PRODUCTS[0] })}>
+      <button
+        onClick={() => dispatch({ type: "add", sku: PRODUCTS[0], size: "40" })}
+      >
         add
       </button>
-      <button onClick={() => dispatch({ type: "remove", id: PRODUCTS[0].id })}>
+      <button onClick={() => dispatch({ type: "remove", id })}>
         remove
       </button>
       <button
-        onClick={() => dispatch({ type: "setQty", id: PRODUCTS[0].id, qty: 0 })}
+        onClick={() => dispatch({ type: "setQty", id, qty: 0 })}
       >
         set
       </button>
@@ -41,12 +45,28 @@ describe("CartContext actions", () => {
       // add
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({
+          cart: {
+            [cartKey(PRODUCTS[0].id, "40")]: {
+              sku: PRODUCTS[0],
+              qty: 1,
+              size: "40",
+            },
+          },
+        }),
       })
       // setQty
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 3 } } }),
+        json: async () => ({
+          cart: {
+            [cartKey(PRODUCTS[0].id, "40")]: {
+              sku: PRODUCTS[0],
+              qty: 3,
+              size: "40",
+            },
+          },
+        }),
       })
       // remove
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -32,7 +32,8 @@ export const cartLineSchema = z.object({
 });
 
 /**
- * Schema for the full cart, keyed by SKU ID (string).
+ * Schema for the full cart, keyed by a composite of SKU ID and size
+ * (`id:size`). Items without a size simply use their SKU ID.
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
 
@@ -42,6 +43,11 @@ export type CartState = z.infer<typeof cartStateSchema>;
 /* ------------------------------------------------------------------
  * Helper functions
  * ------------------------------------------------------------------ */
+
+/** Build a stable cart line identifier from SKU ID and optional size. */
+export function cartKey(id: string, size?: string): string {
+  return size ? `${id}:${size}` : id;
+}
 
 /**
  * Serialize a cart ID into a signed cookie value.

--- a/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
+++ b/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
@@ -26,6 +26,11 @@ export default function AddToCartButton({
     if (disabled) return;
     setAdding(true);
     setError(null);
+    if (sku.sizes.length && !size) {
+      setError("Please select a size");
+      setAdding(false);
+      return;
+    }
 
     try {
       await dispatch({ type: "add", sku, size });

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -11,8 +11,8 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
  * ------------------------------------------------------------------ */
 type Action =
   | { type: "add"; sku: SKU; size?: string }
-  | { type: "remove"; id: SKU["id"] }
-  | { type: "setQty"; id: SKU["id"]; qty: number };
+  | { type: "remove"; id: string }
+  | { type: "setQty"; id: string; qty: number };
 
 /* ------------------------------------------------------------------
  * React context

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -5,8 +5,18 @@ export const postSchema = z
   .object({
     sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
     qty: z.coerce.number().int().min(1).default(1),
+    size: z.string().optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (d) => {
+      if ("sizes" in d.sku && Array.isArray(d.sku.sizes) && d.sku.sizes.length) {
+        return typeof d.size === "string" && d.size.length > 0;
+      }
+      return true;
+    },
+    { path: ["size"], message: "Size is required" }
+  );
 
 export const patchSchema = z
   .object({

--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCart } from "@platform-core/src/contexts/CartContext";
+import { cartKey } from "@/lib/cartCookie";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { drawerWidthProps } from "../../utils/style";
@@ -65,14 +66,16 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
               <ul className="grow space-y-3 overflow-y-auto">
                 {lines.map((line) => (
                   <li
-                    key={line.sku.id}
+                    key={cartKey(line.sku.id, line.size)}
                     className="flex items-center justify-between gap-2"
                   >
                     <span className="text-sm">{line.sku.title}</span>
                     <span className="text-sm">× {line.qty}</span>
                     <Button
                       variant="destructive"
-                      onClick={() => void handleRemove(line.sku.id)}
+                      onClick={() =>
+                        void handleRemove(cartKey(line.sku.id, line.size))
+                      }
                       className="px-2 py-1 text-xs"
                     >
                       Remove

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -1,6 +1,7 @@
 import { CartProvider, useCart } from "@platform-core/src/contexts/CartContext";
 import { type Meta, type StoryObj } from "@storybook/react";
 import type { CartState } from "@/lib/cartCookie";
+import { cartKey } from "@/lib/cartCookie";
 import type { SKU } from "@types";
 import * as React from "react";
 import { Button } from "../atoms/shadcn";
@@ -41,7 +42,11 @@ function CartInitializer({ items }: WrapperProps) {
     Object.values(items).forEach((line) => {
       dispatch({ type: "add", sku: line.sku, size: line.size });
       if (line.qty > 1) {
-        dispatch({ type: "setQty", id: line.sku.id, qty: line.qty });
+        dispatch({
+          type: "setQty",
+          id: cartKey(line.sku.id, line.size),
+          qty: line.qty,
+        });
       }
     });
   }, [items, dispatch]);

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -3,6 +3,7 @@
 
 import { useCart } from "@ui/hooks/useCart";
 import type { CartLine } from "@/lib/cartCookie";
+import { cartKey } from "@/lib/cartCookie";
 import { Price } from "../atoms/Price";
 import React, { useMemo } from "react";
 
@@ -67,7 +68,10 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
       </thead>
       <tbody>
         {lines.map((line) => (
-          <tr key={line.sku.id} className="border-b last:border-0">
+          <tr
+            key={cartKey(line.sku.id, line.size)}
+            className="border-b last:border-0"
+          >
             <td className="py-2">
               {line.sku.title}
               {line.size && (

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -1,4 +1,5 @@
 import type { CartState } from "@/lib/cartCookie";
+import { cartKey } from "@/lib/cartCookie";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";
@@ -43,7 +44,10 @@ export function CartTemplate({
         </thead>
         <tbody>
           {lines.map((line) => (
-            <tr key={line.sku.id} className="border-b last:border-0">
+            <tr
+              key={cartKey(line.sku.id, line.size)}
+              className="border-b last:border-0"
+            >
               <td className="py-2">
                 <div className="flex items-center gap-4">
                   <div className="relative hidden h-12 w-12 sm:block">
@@ -61,7 +65,9 @@ export function CartTemplate({
               <td>
                 <QuantityInput
                   value={line.qty}
-                  onChange={(v) => onQtyChange?.(line.sku.id, v)}
+                  onChange={(v) =>
+                    onQtyChange?.(cartKey(line.sku.id, line.size), v)
+                  }
                   className="justify-center"
                 />
               </td>
@@ -72,7 +78,9 @@ export function CartTemplate({
                 <td className="text-right">
                   <button
                     type="button"
-                    onClick={() => onRemove(line.sku.id)}
+                    onClick={() =>
+                      onRemove(cartKey(line.sku.id, line.size))
+                    }
                     className="text-danger hover:underline"
                   >
                     Remove


### PR DESCRIPTION
## Summary
- key cart lines by composite `sku.id:size`
- enforce size selection and validate on add
- update cart UI and API routes for new key format

## Testing
- `pnpm test` *(fails: ENOENT and module resolution errors in cms tests)*

------
https://chatgpt.com/codex/tasks/task_e_6899b33dabac832f8545da0d9bd9dcc7