### PR TITLE
feat: add registration rate limiter

### DIFF
--- a/apps/shop-abc/__tests__/registerRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/registerRateLimit.test.ts
@@ -1,0 +1,69 @@
+// apps/shop-abc/__tests__/registerRateLimit.test.ts
+jest.mock("@upstash/redis", () => ({
+  Redis: jest.fn(() => ({})),
+}));
+
+jest.mock("@platform-core/users", () => ({
+  createUser: jest.fn().mockResolvedValue(undefined),
+  getUserById: jest.fn().mockResolvedValue(null),
+  getUserByEmail: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("bcryptjs", () => ({
+  hash: jest.fn().mockResolvedValue("hashed"),
+}));
+
+let POST: typeof import("../src/app/register/route").POST;
+let __resetRegistrationRateLimiter: typeof import("../src/middleware").__resetRegistrationRateLimiter;
+let MAX_REGISTRATION_ATTEMPTS: number;
+
+beforeAll(async () => {
+  ({ __resetRegistrationRateLimiter, MAX_REGISTRATION_ATTEMPTS } = await import(
+    "../src/middleware"
+  ));
+  ({ POST } = await import("../src/app/register/route"));
+});
+
+function makeRequest(body: any, ip = "1.1.1.1") {
+  return {
+    json: async () => body,
+    headers: new Headers({ "x-forwarded-for": ip }),
+  } as any;
+}
+
+afterEach(async () => {
+  await __resetRegistrationRateLimiter();
+});
+
+describe("registration rate limiting", () => {
+  it("returns 429 after too many attempts", async () => {
+    for (let i = 0; i < MAX_REGISTRATION_ATTEMPTS; i++) {
+      const res = await POST(
+        makeRequest({
+          customerId: `cust${i}`,
+          email: `test${i}@example.com`,
+          password: "pw",
+        }),
+      );
+      expect(res.status).toBe(200);
+    }
+
+    const locked = await POST(
+      makeRequest({
+        customerId: "cust-final",
+        email: "final@example.com",
+        password: "pw",
+      }),
+    );
+    expect(locked.status).toBe(429);
+
+    const stillLocked = await POST(
+      makeRequest({
+        customerId: "cust-other",
+        email: "other@example.com",
+        password: "pw",
+      }),
+    );
+    expect(stillLocked.status).toBe(429);
+  });
+});

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -7,6 +7,7 @@ import {
   getUserById,
   getUserByEmail,
 } from "@platform-core/users";
+import { checkRegistrationRateLimit } from "../../middleware";
 
 const RegisterSchema = z.object({
   customerId: z.string(),
@@ -22,6 +23,10 @@ export async function POST(req: Request) {
       status: 400,
     });
   }
+
+  const ip = req.headers.get("x-forwarded-for") ?? "unknown";
+  const rateLimited = await checkRegistrationRateLimit(ip);
+  if (rateLimited) return rateLimited;
 
   const { customerId, email, password } = parsed.data;
   if (await getUserById(customerId)) {


### PR DESCRIPTION
## Summary
- add `checkRegistrationRateLimit` middleware to throttle registration requests
- use registration rate limiter in `/register` route to return 429 when exceeded
- test registration rate limit behavior

## Testing
- `npx jest apps/shop-abc/__tests__/registerRateLimit.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_6899bbc700a4832f85268c0ad89e8a98