### PR TITLE
feat(auth): add registration and password reset API routes

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -1,0 +1,121 @@
+// apps/shop-abc/__tests__/authFlow.test.ts
+import { jest } from "@jest/globals";
+
+jest.mock("@auth", () => ({
+  createCustomerSession: jest.fn(),
+}));
+
+jest.mock("../src/middleware", () => ({
+  checkLoginRateLimit: jest.fn(async () => null),
+  clearLoginAttempts: jest.fn(),
+}));
+
+jest.mock("@lib/email", () => ({
+  sendEmail: jest.fn(),
+}));
+
+const store: Record<string, any> = {};
+
+jest.mock("@platform-core/users", () => ({
+  getUserById: jest.fn(async (id: string) => store[id] ?? null),
+  getUserByEmail: jest.fn(async (email: string) =>
+    Object.values(store).find((u: any) => u.email === email) ?? null,
+  ),
+  createUser: jest.fn(async ({
+    id,
+    email,
+    passwordHash,
+    role = "customer",
+  }: any) => {
+    const user = { id, email, passwordHash, role, resetToken: null };
+    store[id] = user;
+    return user;
+  }),
+  setResetToken: jest.fn(async (id: string, token: string | null) => {
+    if (store[id]) store[id].resetToken = token;
+  }),
+  updatePassword: jest.fn(async (id: string, hash: string) => {
+    if (store[id]) {
+      store[id].passwordHash = hash;
+      store[id].resetToken = null;
+    }
+  }),
+}));
+
+let registerPOST: typeof import("../src/app/api/register/route").POST;
+let loginPOST: typeof import("../src/app/login/route").POST;
+let forgotPOST: typeof import("../src/app/forgot-password/route").POST;
+let resetPOST: typeof import("../src/app/api/reset-password/route").POST;
+
+beforeAll(async () => {
+  ({ POST: registerPOST } = await import("../src/app/api/register/route"));
+  ({ POST: loginPOST } = await import("../src/app/login/route"));
+  ({ POST: forgotPOST } = await import("../src/app/forgot-password/route"));
+  ({ POST: resetPOST } = await import("../src/app/api/reset-password/route"));
+});
+
+function makeRequest(body: any, headers: Record<string, string> = {}) {
+  return {
+    json: async () => body,
+    headers: new Headers(headers),
+  } as any;
+}
+
+describe("auth flows", () => {
+  it("allows sign-up, login and password reset", async () => {
+    let res = await registerPOST(
+      makeRequest({
+        customerId: "cust1",
+        email: "test@example.com",
+        password: "pass1",
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const dup = await registerPOST(
+      makeRequest({
+        customerId: "cust2",
+        email: "test@example.com",
+        password: "pass2",
+      }),
+    );
+    expect(dup.status).toBe(400);
+
+    res = await loginPOST(
+      makeRequest(
+        { customerId: "cust1", password: "pass1" },
+        { "x-forwarded-for": "1.1.1.1" },
+      ),
+    );
+    expect(res.status).toBe(200);
+
+    await forgotPOST(makeRequest({ email: "test@example.com" }));
+    const { getUserById } = await import("@platform-core/users");
+    const token = (await getUserById("cust1"))!.resetToken as string;
+
+    res = await resetPOST(
+      makeRequest({
+        customerId: "cust1",
+        token,
+        password: "newpass",
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    res = await loginPOST(
+      makeRequest(
+        { customerId: "cust1", password: "pass1" },
+        { "x-forwarded-for": "1.1.1.1" },
+      ),
+    );
+    expect(res.status).toBe(401);
+
+    res = await loginPOST(
+      makeRequest(
+        { customerId: "cust1", password: "newpass" },
+        { "x-forwarded-for": "1.1.1.1" },
+      ),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -1,0 +1,37 @@
+// apps/shop-abc/src/app/api/register/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import {
+  createUser,
+  getUserById,
+  getUserByEmail,
+} from "@platform-core/users";
+
+const RegisterSchema = z.object({
+  customerId: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = RegisterSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const { customerId, email, password } = parsed.data;
+  if (await getUserById(customerId)) {
+    return NextResponse.json({ error: "User already exists" }, { status: 400 });
+  }
+  if (await getUserByEmail(email)) {
+    return NextResponse.json({ error: "Email already registered" }, { status: 400 });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  await createUser({ id: customerId, email, passwordHash });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-abc/src/app/api/reset-password/route.ts
+++ b/apps/shop-abc/src/app/api/reset-password/route.ts
@@ -1,0 +1,31 @@
+// apps/shop-abc/src/app/api/reset-password/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import { getUserById, updatePassword } from "@platform-core/users";
+
+const ResetSchema = z.object({
+  customerId: z.string(),
+  token: z.string(),
+  password: z.string(),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json();
+  const parsed = ResetSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, {
+      status: 400,
+    });
+  }
+
+  const { customerId, token, password } = parsed.data;
+  const user = await getUserById(customerId);
+  if (!user || user.resetToken !== token) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  await updatePassword(customerId, passwordHash);
+  return NextResponse.json({ ok: true });
+}

--- a/packages/platform-core/src/users.ts
+++ b/packages/platform-core/src/users.ts
@@ -37,3 +37,19 @@ export async function createUser({
 export async function setResetToken(id: string, token: string | null): Promise<void> {
   await prisma.user.update({ where: { id }, data: { resetToken: token } });
 }
+
+export async function getUserByResetToken(
+  token: string,
+): Promise<User | null> {
+  return prisma.user.findFirst({ where: { resetToken: token } });
+}
+
+export async function updatePassword(
+  id: string,
+  passwordHash: string,
+): Promise<void> {
+  await prisma.user.update({
+    where: { id },
+    data: { passwordHash, resetToken: null },
+  });
+}


### PR DESCRIPTION
## Summary
- add user helper functions for reset tokens and password updates
- create register and reset-password API routes with bcrypt verification
- add integration test covering sign-up, login, and password reset

## Testing
- `npx jest apps/shop-abc/__tests__/authFlow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899bbc4aaec832fb9d0ac434cef22e4