### PR TITLE
Add CSRF-protected MFA enrollment and verification pages

### DIFF
--- a/apps/shop-abc/__tests__/mfaApi.test.ts
+++ b/apps/shop-abc/__tests__/mfaApi.test.ts
@@ -1,0 +1,79 @@
+// apps/shop-abc/__tests__/mfaApi.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn(),
+  enrollMfa: jest.fn(),
+  verifyMfa: jest.fn(),
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+import {
+  getCustomerSession,
+  validateCsrfToken,
+  enrollMfa,
+  verifyMfa,
+} from "@auth";
+import { POST as enrollPost } from "../src/app/api/mfa/enroll/route";
+import { POST as verifyPost } from "../src/app/api/mfa/verify/route";
+
+describe("/api/mfa/enroll POST", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("rejects requests without valid CSRF token", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    (validateCsrfToken as jest.Mock).mockResolvedValue(false);
+    const req = { headers: new Headers() } as any;
+    const res = await enrollPost(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns enrollment data", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+    const enrollment = { secret: "abc", otpauth: "otpauth://..." };
+    (enrollMfa as jest.Mock).mockResolvedValue(enrollment);
+    const req = { headers: new Headers({ "x-csrf-token": "tok" }) } as any;
+    const res = await enrollPost(req);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(enrollment);
+  });
+});
+
+describe("/api/mfa/verify POST", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("rejects requests without valid CSRF token", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    (validateCsrfToken as jest.Mock).mockResolvedValue(false);
+    const req = {
+      headers: new Headers(),
+      json: async () => ({ token: "123" }),
+    } as any;
+    const res = await verifyPost(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns verification result", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust1" });
+    (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+    (verifyMfa as jest.Mock).mockResolvedValue(true);
+    const req = {
+      headers: new Headers({ "x-csrf-token": "tok" }),
+      json: async () => ({ token: "123" }),
+    } as any;
+    const res = await verifyPost(req);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified: true });
+  });
+});

--- a/apps/shop-abc/src/app/account/mfa/enroll/page.tsx
+++ b/apps/shop-abc/src/app/account/mfa/enroll/page.tsx
@@ -1,0 +1,8 @@
+// apps/shop-abc/src/app/account/mfa/enroll/page.tsx
+import MfaSetup from "@ui/components/account/MfaSetup";
+
+export const metadata = { title: "MFA Enrollment" };
+
+export default function Page() {
+  return <MfaSetup />;
+}

--- a/apps/shop-abc/src/app/account/mfa/verify/page.tsx
+++ b/apps/shop-abc/src/app/account/mfa/verify/page.tsx
@@ -1,0 +1,8 @@
+// apps/shop-abc/src/app/account/mfa/verify/page.tsx
+import MfaChallenge from "@ui/components/account/MfaChallenge";
+
+export const metadata = { title: "MFA Verification" };
+
+export default function Page() {
+  return <MfaChallenge />;
+}

--- a/apps/shop-abc/src/app/api/mfa/enroll/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/enroll/route.ts
@@ -1,10 +1,14 @@
 // apps/shop-abc/src/app/api/mfa/enroll/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getCustomerSession, enrollMfa } from "@auth";
+import { getCustomerSession, validateCsrfToken, enrollMfa } from "@auth";
 
-export async function POST(_req: NextRequest): Promise<NextResponse> {
+export async function POST(req: NextRequest): Promise<NextResponse> {
   const session = await getCustomerSession();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const headerToken = req.headers.get("x-csrf-token");
+  const valid = await validateCsrfToken(headerToken);
+  if (!valid)
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   const enrollment = await enrollMfa(session.customerId);
   return NextResponse.json(enrollment);
 }

--- a/apps/shop-abc/src/app/api/mfa/verify/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/verify/route.ts
@@ -1,10 +1,14 @@
 // apps/shop-abc/src/app/api/mfa/verify/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getCustomerSession, verifyMfa } from "@auth";
+import { getCustomerSession, validateCsrfToken, verifyMfa } from "@auth";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const session = await getCustomerSession();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const headerToken = req.headers.get("x-csrf-token");
+  const valid = await validateCsrfToken(headerToken);
+  if (!valid)
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   const { token } = await req.json();
   if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });
   const ok = await verifyMfa(session.customerId, token);

--- a/packages/ui/src/components/account/MfaChallenge.tsx
+++ b/packages/ui/src/components/account/MfaChallenge.tsx
@@ -13,9 +13,19 @@ export default function MfaChallenge({ onSuccess }: MfaChallengeProps) {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const csrfToken =
+      typeof document !== "undefined"
+        ? document.cookie
+            .split("; ")
+            .find((row) => row.startsWith("csrf_token="))
+            ?.split("=")[1]
+        : undefined;
     const res = await fetch("/api/mfa/verify", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken ?? "",
+      },
       body: JSON.stringify({ token }),
     });
     const data = await res.json();


### PR DESCRIPTION
## Summary
- secure MFA enroll and verify API routes with CSRF checks
- expose enrollment QR code & token verification UI and add verification page
- test MFA APIs including CSRF validation

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/mfaApi.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899bbf68f5c832f8def487bf89d76d5