### PR TITLE
feat(cart): add size-aware cart keys

### DIFF
--- a/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -29,7 +29,7 @@ export default function PdpClient({ product }: { product: SKU }) {
         </div>
 
         {/* size could be added to cart line later */}
-        <AddToCartButton sku={product} disabled={!size} />
+        <AddToCartButton sku={product} size={size ?? undefined} disabled={!size} />
       </section>
     </div>
   );

--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -43,7 +43,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const size = "40";
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 2, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
@@ -61,14 +62,15 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(args.line_items[0].price_data.unit_amount).toBe(1000);
   expect(args.line_items[1].price_data.unit_amount).toBe(sku.deposit * 100);
   expect(args.metadata.rentalDays).toBe(expectedDays.toString());
-  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: "40" }));
+  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: size }));
   expect(args.metadata.subtotal).toBe("20");
   expect(body.clientSecret).toBe("cs_test");
 });
 
 test("responds with 400 on invalid returnDate", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -64,15 +64,20 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku: skuInput, qty } = parsed.data;
+  const { sku: skuInput, qty, size } = parsed.data;
   const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
   if (!sku) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
 
+  if (sku.sizes.length && !size) {
+    return NextResponse.json({ error: "Size required" }, { status: 400 });
+  }
+
   const { cartId, cart } = await loadCart(req, true);
-  const line = cart[sku.id];
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  const id = size ? `${sku.id}:${size}` : sku.id;
+  const line = cart[id];
+  cart[id] = { sku, size, qty: (line?.qty ?? 0) + qty };
   await setCart(cartId!, cart);
 
   const res = NextResponse.json({ ok: true, cart });

--- a/apps/shop-bcd/__tests__/cart-api.test.ts
+++ b/apps/shop-bcd/__tests__/cart-api.test.ts
@@ -38,13 +38,15 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku: { id: sku.id }, qty: 2 });
+  const size = sku.sizes[0];
+  const id = `${sku.id}:${size}`;
+  const req = createRequest({ sku: { id: sku.id }, qty: 2, size });
   const res = await POST(req);
   const body = (await res.json()) as any;
 
-  expect(body.cart[sku.id].qty).toBe(2);
+  expect(body.cart[id].qty).toBe(2);
   const expected = asSetCookieHeader(
-    encodeCartCookie({ [sku.id]: { sku, qty: 2 } })
+    encodeCartCookie({ [id]: { sku, qty: 2, size } })
   );
   expect(res.headers.get("Set-Cookie")).toBe(expected);
 });
@@ -56,22 +58,26 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cart));
+  const size = sku.sizes[0];
+  const id = `${sku.id}:${size}`;
+  const cart = { [id]: { sku, qty: 1, size } };
+  const req = createRequest({ id, qty: 5 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[id].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toEqual(body.cart);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cart));
+  const size = sku.sizes[0];
+  const id = `${sku.id}:${size}`;
+  const cart = { [id]: { sku, qty: 1, size } };
+  const req = createRequest({ id, qty: 0 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
@@ -86,16 +92,20 @@ test("PATCH returns 404 for missing item", async () => {
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cart));
+  const size = sku.sizes[0];
+  const id = `${sku.id}:${size}`;
+  const cart = { [id]: { sku, qty: 2, size } };
+  const req = createRequest({ id }, encodeCartCookie(cart));
   const res = await DELETE(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 3 } };
+  const size = sku.sizes[0];
+  const id = `${sku.id}:${size}`;
+  const cart = { [id]: { sku, qty: 3, size } };
   const res = await GET(createRequest({}, encodeCartCookie(cart)));
   const body = (await res.json()) as any;
   expect(body.cart).toEqual(cart);

--- a/apps/shop-bcd/__tests__/cartApi.test.ts
+++ b/apps/shop-bcd/__tests__/cartApi.test.ts
@@ -30,19 +30,24 @@ afterEach(() => {
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
+  const size = sku.sizes[0];
+  let res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: -1, size })
+  );
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
+  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5, size }));
   expect(res.status).toBe(400);
 });
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const id = `${sku.id}:${size}`;
+  const cart = { [id]: { sku, qty: 1, size } };
   const cookie = encodeCartCookie(cart);
-  let res = await PATCH(createRequest({ id: sku.id, qty: -2 }, cookie));
+  let res = await PATCH(createRequest({ id, qty: -2 }, cookie));
   expect(res.status).toBe(400);
-  res = await PATCH(createRequest({ id: sku.id, qty: 1.5 }, cookie));
+  res = await PATCH(createRequest({ id, qty: 1.5 }, cookie));
   expect(res.status).toBe(400);
 });
 

--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -46,7 +46,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const size = "40";
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 2, size } };
   const cookie = encodeCartCookie(cart);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
@@ -63,14 +64,15 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(args.line_items[1].price_data.unit_amount).toBe(sku.deposit * 100);
   expect(args.line_items[2].price_data.unit_amount).toBe(400);
   expect(args.metadata.rentalDays).toBe(expectedDays.toString());
-  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: "40" }));
+  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: size }));
   expect(args.metadata.subtotal).toBe("20");
   expect(body.clientSecret).toBe("cs_test");
 });
 
 test("responds with 400 on invalid returnDate", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
   const cookie = encodeCartCookie(cart);
   const req = createRequest({ returnDate: "not-a-date", currency: "EUR", taxRegion: "EU" }, cookie);
   const res = await POST(req);

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -31,16 +31,21 @@ export async function POST(req: NextRequest) {
   const {
     sku: { id: skuId },
     qty,
+    size,
   } = parsed.data;
   const sku = getProductById(skuId);
   if (!sku) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
+  if (sku.sizes.length && !size) {
+    return NextResponse.json({ error: "Size required" }, { status: 400 });
+  }
   const cookie = req.cookies.get(CART_COOKIE)?.value;
   const cart = decodeCartCookie(cookie);
-  const line = cart[sku.id];
+  const id = size ? `${sku.id}:${size}` : sku.id;
+  const line = cart[id];
 
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  cart[id] = { sku, size, qty: (line?.qty ?? 0) + qty };
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cart)));

--- a/functions/themes/[theme]/__tests__/cart-checkout-integration.test.ts
+++ b/functions/themes/[theme]/__tests__/cart-checkout-integration.test.ts
@@ -51,7 +51,8 @@ afterEach(() => jest.resetAllMocks());
 
 test("add to cart then create checkout session", async () => {
   const sku = PRODUCTS[0];
-  const res = await CART_POST(cartReq({ sku: { id: sku.id }, qty: 1 }));
+  const size = sku.sizes[0];
+  const res = await CART_POST(cartReq({ sku: { id: sku.id }, qty: 1, size }));
   const header = res.headers.get("Set-Cookie")!;
   const cookie = header.split("=")[1].split(";")[0];
 

--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -9,7 +9,9 @@ jest.mock("react-dom", () => jest.requireActual("react-dom"));
 
 function Qty() {
   const [state] = useCart();
-  return <span data-testid="qty">{state[PRODUCTS[0].id]?.qty ?? 0}</span>;
+  const size = PRODUCTS[0].sizes[0];
+  const id = `${PRODUCTS[0].id}:${size}`;
+  return <span data-testid="qty">{state[id]?.qty ?? 0}</span>;
 }
 
 describe("AddToCartButton", () => {
@@ -20,6 +22,8 @@ describe("AddToCartButton", () => {
   });
 
   it("adds items to the cart", async () => {
+    const size = PRODUCTS[0].sizes[0];
+    const id = `${PRODUCTS[0].id}:${size}`;
     global.fetch = jest
       .fn()
       // initial GET
@@ -27,12 +31,12 @@ describe("AddToCartButton", () => {
       // POST
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } }),
       });
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} />
+        <AddToCartButton sku={PRODUCTS[0]} size={size} />
         <Qty />
       </CartProvider>
     );
@@ -48,6 +52,7 @@ describe("AddToCartButton", () => {
   });
 
   it("shows an error when the server rejects the request", async () => {
+    const size = PRODUCTS[0].sizes[0];
     global.fetch = jest
       .fn()
       // initial GET
@@ -60,7 +65,7 @@ describe("AddToCartButton", () => {
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} />
+        <AddToCartButton sku={PRODUCTS[0]} size={size} />
         <Qty />
       </CartProvider>
     );

--- a/packages/platform-core/__tests__/cartContext.test.tsx
+++ b/packages/platform-core/__tests__/cartContext.test.tsx
@@ -5,20 +5,24 @@ import { PRODUCTS } from "../products";
 
 function TestComponent() {
   const [state, dispatch] = useCart();
-  const line = state[PRODUCTS[0].id];
+  const size = PRODUCTS[0].sizes[0];
+  const id = `${PRODUCTS[0].id}:${size}`;
+  const line = state[id];
 
   return (
     <div>
       <span data-testid="qty">{line?.qty ?? 0}</span>
 
-      <button onClick={() => dispatch({ type: "add", sku: PRODUCTS[0] })}>
+      <button
+        onClick={() => dispatch({ type: "add", sku: PRODUCTS[0], size })}
+      >
         add
       </button>
-      <button onClick={() => dispatch({ type: "remove", id: PRODUCTS[0].id })}>
+      <button onClick={() => dispatch({ type: "remove", id })}>
         remove
       </button>
       <button
-        onClick={() => dispatch({ type: "setQty", id: PRODUCTS[0].id, qty: 0 })}
+        onClick={() => dispatch({ type: "setQty", id, qty: 0 })}
       >
         set
       </button>
@@ -34,6 +38,8 @@ describe("CartContext actions", () => {
   });
 
   it("handles add, setQty and remove actions", async () => {
+    const size = PRODUCTS[0].sizes[0];
+    const id = `${PRODUCTS[0].id}:${size}`;
     global.fetch = jest
       .fn()
       // initial GET
@@ -41,12 +47,12 @@ describe("CartContext actions", () => {
       // add
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } }),
       })
       // setQty
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 3 } } }),
+        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 3, size } } }),
       })
       // remove
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -32,7 +32,7 @@ export const cartLineSchema = z.object({
 });
 
 /**
- * Schema for the full cart, keyed by SKU ID (string).
+ * Schema for the full cart, keyed by `${sku.id}` or `${sku.id}:${size}`.
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
 

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -11,8 +11,8 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
  * ------------------------------------------------------------------ */
 type Action =
   | { type: "add"; sku: SKU; size?: string }
-  | { type: "remove"; id: SKU["id"] }
-  | { type: "setQty"; id: SKU["id"]; qty: number };
+  | { type: "remove"; id: string }
+  | { type: "setQty"; id: string; qty: number };
 
 /* ------------------------------------------------------------------
  * React context
@@ -45,8 +45,11 @@ export function CartProvider({ children }: { children: ReactNode }) {
     let body: unknown;
     switch (action.type) {
       case "add":
+        if (action.sku.sizes.length && !action.size) {
+          throw new Error("Size is required");
+        }
         method = "POST";
-        body = { sku: { id: action.sku.id }, qty: 1 };
+        body = { sku: { id: action.sku.id }, qty: 1, size: action.size };
         break;
       case "remove":
         method = "DELETE";

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -5,6 +5,7 @@ export const postSchema = z
   .object({
     sku: skuSchema.pick({ id: true }),
     qty: z.coerce.number().int().min(1).default(1),
+    size: z.string().optional(),
   })
   .strict();
 

--- a/packages/template-app/__tests__/cart.test.ts
+++ b/packages/template-app/__tests__/cart.test.ts
@@ -41,17 +41,19 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku: { id: sku.id }, qty: 2 });
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
+  const req = createRequest({ sku: { id: sku.id }, qty: 2, size });
   const res = await POST(req);
   const body = await res.json();
 
-  expect(body.cart[sku.id].qty).toBe(2);
-  expect(body.cart[sku.id].sku).toEqual(sku);
+  expect(body.cart[idKey].qty).toBe(2);
+  expect(body.cart[idKey].sku).toEqual(sku);
   const header = res.headers.get("Set-Cookie")!;
   const encoded = header.split(";")[0].split("=")[1];
   const id = decodeCartCookie(encoded)!;
   const stored = await getCart(id);
-  expect(stored[sku.id].qty).toBe(2);
+  expect(stored[idKey].qty).toBe(2);
 });
 
 test("POST validates body", async () => {
@@ -61,26 +63,30 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
+  const cart = { [idKey]: { sku, qty: 1, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cartId));
+  const req = createRequest({ id: idKey, qty: 5 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[idKey].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toBe(cartId);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
+  const cart = { [idKey]: { sku, qty: 1, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cartId));
+  const req = createRequest({ id: idKey, qty: 0 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[idKey]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
@@ -103,41 +109,50 @@ test("POST returns 404 for unknown SKU", async () => {
 
 test("POST rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  let res = await POST(createRequest({ sku: { id: sku.id }, qty: -1 }));
+  const size = sku.sizes[0];
+  let res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: -1, size })
+  );
   expect(res.status).toBe(400);
-  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5 }));
+  res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5, size }));
   expect(res.status).toBe(400);
 });
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
+  const cart = { [idKey]: { sku, qty: 1, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   let res = await PATCH(
-    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cartId))
+    createRequest({ id: idKey, qty: -2 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
   res = await PATCH(
-    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cartId))
+    createRequest({ id: idKey, qty: 1.5 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
 });
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
+  const cart = { [idKey]: { sku, qty: 2, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cartId));
+  const req = createRequest({ id: idKey }, encodeCartCookie(cartId));
   const res = await DELETE(req);
   const body = await res.json();
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[idKey]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 3 } };
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
+  const cart = { [idKey]: { sku, qty: 3, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const res = await GET(createRequest({}, encodeCartCookie(cartId)));
@@ -147,10 +162,12 @@ test("GET returns cart", async () => {
 
 test("incrementQty handles concurrent updates", async () => {
   const sku = { ...TEST_SKU };
+  const size = sku.sizes[0];
+  const idKey = `${sku.id}:${size}`;
   const cartId = await createCart();
   await Promise.all(
-    Array.from({ length: 20 }, () => incrementQty(cartId, sku, 1))
+    Array.from({ length: 20 }, () => incrementQty(cartId, sku, 1, size))
   );
   const cart = await getCart(cartId);
-  expect(cart[sku.id].qty).toBe(20);
+  expect(cart[idKey].qty).toBe(20);
 });

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -46,7 +46,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const size = "40";
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 2, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
@@ -64,14 +65,15 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(args.line_items[0].price_data.unit_amount).toBe(1000);
   expect(args.line_items[1].price_data.unit_amount).toBe(sku.deposit * 100);
   expect(args.metadata.rentalDays).toBe(expectedDays.toString());
-  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: "40" }));
+  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: size }));
   expect(args.metadata.subtotal).toBe("20");
   expect(body.clientSecret).toBe("cs_test");
 });
 
 test("returns 400 when returnDate is invalid", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: NextRequest) {
   const {
     sku: { id: skuId },
     qty,
+    size,
   } = parsed.data;
   const sku = getProductById(skuId);
 
@@ -45,11 +46,15 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
 
+  if (sku.sizes.length && !size) {
+    return NextResponse.json({ error: "Size required" }, { status: 400 });
+  }
+
   let cartId = decodeCartCookie(req.cookies.get(CART_COOKIE)?.value);
   if (!cartId) {
     cartId = await createCart();
   }
-  const cart = await incrementQty(cartId, sku, qty);
+  const cart = await incrementQty(cartId, sku, qty, size);
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;

--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -32,7 +32,7 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
   const [toast, setToast] = React.useState<{ open: boolean; message: string }>(
     { open: false, message: "" }
   );
-  const lines = Object.values(cart);
+  const lines = Object.entries(cart).map(([id, line]) => ({ id, ...line }));
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
   const { widthClass, style } = drawerWidthProps(width);
 
@@ -65,14 +65,17 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
               <ul className="grow space-y-3 overflow-y-auto">
                 {lines.map((line) => (
                   <li
-                    key={line.sku.id}
+                    key={line.id}
                     className="flex items-center justify-between gap-2"
                   >
-                    <span className="text-sm">{line.sku.title}</span>
+                    <span className="text-sm">
+                      {line.sku.title}
+                      {line.size && <span className="ml-1 text-muted">({line.size})</span>}
+                    </span>
                     <span className="text-sm">× {line.qty}</span>
                     <Button
                       variant="destructive"
-                      onClick={() => void handleRemove(line.sku.id)}
+                      onClick={() => void handleRemove(line.id)}
                       className="px-2 py-1 text-xs"
                     >
                       Remove

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -38,10 +38,10 @@ interface WrapperProps {
 function CartInitializer({ items }: WrapperProps) {
   const [, dispatch] = useCart();
   React.useEffect(() => {
-    Object.values(items).forEach((line) => {
+    Object.entries(items).forEach(([id, line]) => {
       dispatch({ type: "add", sku: line.sku, size: line.size });
       if (line.qty > 1) {
-        dispatch({ type: "setQty", id: line.sku.id, qty: line.qty });
+        dispatch({ type: "setQty", id, qty: line.qty });
       }
     });
   }, [items, dispatch]);

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -35,7 +35,10 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
   /* ------------------------------------------------------------------
    * Derived values
    * ------------------------------------------------------------------ */
-  const lines = useMemo<CartLine[]>(() => Object.values(cart), [cart]);
+  const lines = useMemo<(CartLine & { id: string })[]>(
+    () => Object.entries(cart).map(([id, line]) => ({ id, ...line })),
+    [cart]
+  );
 
   // When totals aren't provided, compute them from the cart lines.
   const computedSubtotal = useMemo(
@@ -67,7 +70,7 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
       </thead>
       <tbody>
         {lines.map((line) => (
-          <tr key={line.sku.id} className="border-b last:border-0">
+          <tr key={line.id} className="border-b last:border-0">
             <td className="py-2">
               {line.sku.title}
               {line.size && (

--- a/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
@@ -28,9 +28,10 @@ describe("MiniCart", () => {
     const dispatch = jest.fn();
     mockUseCart.mockReturnValue([
       {
-        sku1: {
-          sku: { id: "sku1", title: "Item", price: 10 },
+        "sku1:m": {
+          sku: { id: "sku1", title: "Item", price: 10, sizes: [] },
           qty: 1,
+          size: "m",
         },
       },
       dispatch,
@@ -42,6 +43,6 @@ describe("MiniCart", () => {
     expect(await screen.findByText("Item")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /remove/i }));
-    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1" });
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1:m" });
   });
 });

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -19,7 +19,7 @@ export function CartTemplate({
   className,
   ...props
 }: CartTemplateProps) {
-  const lines = Object.values(cart);
+  const lines = Object.entries(cart).map(([id, line]) => ({ id, ...line }));
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
@@ -43,7 +43,7 @@ export function CartTemplate({
         </thead>
         <tbody>
           {lines.map((line) => (
-            <tr key={line.sku.id} className="border-b last:border-0">
+            <tr key={line.id} className="border-b last:border-0">
               <td className="py-2">
                 <div className="flex items-center gap-4">
                   <div className="relative hidden h-12 w-12 sm:block">
@@ -56,12 +56,15 @@ export function CartTemplate({
                     />
                   </div>
                   {line.sku.title}
+                  {line.size && (
+                    <span className="ml-1 text-xs text-muted">({line.size})</span>
+                  )}
                 </div>
               </td>
               <td>
                 <QuantityInput
                   value={line.qty}
-                  onChange={(v) => onQtyChange?.(line.sku.id, v)}
+                  onChange={(v) => onQtyChange?.(line.id, v)}
                   className="justify-center"
                 />
               </td>
@@ -72,7 +75,7 @@ export function CartTemplate({
                 <td className="text-right">
                   <button
                     type="button"
-                    onClick={() => onRemove(line.sku.id)}
+                    onClick={() => onRemove(line.id)}
                     className="text-danger hover:underline"
                   >
                     Remove

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -15,14 +15,9 @@ export function OrderConfirmationTemplate({
   className,
   ...props
 }: OrderConfirmationTemplateProps) {
-  const subtotal = Object.values(cart).reduce(
-    (s, l) => s + l.sku.price * l.qty,
-    0
-  );
-  const deposit = Object.values(cart).reduce(
-    (s, l) => s + (l.sku.deposit ?? 0) * l.qty,
-    0
-  );
+  const lines = Object.entries(cart).map(([id, line]) => ({ id, ...line }));
+  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
   return (
     <div className={cn("space-y-6", className)} {...props}>
@@ -40,9 +35,14 @@ export function OrderConfirmationTemplate({
           </tr>
         </thead>
         <tbody>
-          {Object.values(cart).map((l) => (
-            <tr key={l.sku.id} className="border-b last:border-0">
-              <td className="py-2">{l.sku.title}</td>
+          {lines.map((l) => (
+            <tr key={l.id} className="border-b last:border-0">
+              <td className="py-2">
+                {l.sku.title}
+                {l.size && (
+                  <span className="ml-1 text-xs text-muted">({l.size})</span>
+                )}
+              </td>
               <td>{l.qty}</td>
               <td className="text-right">
                 <Price amount={l.sku.price * l.qty} />


### PR DESCRIPTION
## Summary
- support `${sku.id}:${size}` line keys and require a size when needed
- adjust cart APIs and client components to handle composite cart keys
- validate size selection and surface it throughout UI

## Testing
- `pnpm exec jest packages/platform-core/__tests__/cartContext.test.tsx packages-platform-core/__tests__/addToCartButton.test.tsx packages/ui/__tests__/OrderSummary.test.tsx packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx packages/template-app/__tests__/cart.test.ts packages-template-app/__tests__/checkout-session.test.ts functions/themes/[theme]/__tests__/cart-checkout-integration.test.ts apps/shop-abc/__tests__/cartApi.test.ts apps/shop-abc/__tests__/checkoutSession.test.ts apps/shop-bcd/__tests__/cart-api.test.ts apps-shop-bcd/__tests__/cartApi.test.ts apps-shop-bcd/__tests__/checkout-session.test.ts` *(failed: Jest encountered an unexpected token; missing Prisma client, module transform issues, invalid hook calls)*

------
https://chatgpt.com/codex/tasks/task_e_6899b77d3f28832fbce6d52d06e7fe0d