### PR TITLE
feat: support sized cart items

### DIFF
--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -1,5 +1,5 @@
 // apps/shop-abc/__tests__/checkoutSession.test.ts
-import { encodeCartCookie } from "@platform-core/src/cartCookie";
+import { encodeCartCookie, cartLineId } from "@platform-core/src/cartCookie";
 import { createCart, setCart } from "@platform-core/src/cartStore";
 import { PRODUCTS } from "@platform-core/products";
 import { calculateRentalDays } from "@/lib/date";
@@ -43,7 +43,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const id = cartLineId(sku.id, "40");
+  const cart = { [id]: { sku, qty: 2, size: "40" } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
@@ -68,7 +69,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
 test("responds with 400 on invalid returnDate", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id2 = cartLineId(sku.id);
+  const cart = { [id2]: { sku, qty: 1 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -5,6 +5,7 @@ import {
   decodeCartCookie,
   encodeCartCookie,
   type CartState,
+  cartLineId,
 } from "@platform-core/src/cartCookie";
 import { createCart, getCart, setCart } from "@platform-core/src/cartStore";
 import { getProductById } from "@/lib/products";
@@ -64,15 +65,16 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku: skuInput, qty } = parsed.data;
+  const { sku: skuInput, qty, size } = parsed.data;
   const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
   if (!sku) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
 
   const { cartId, cart } = await loadCart(req, true);
-  const line = cart[sku.id];
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  const id = cartLineId(sku.id, size);
+  const line = cart[id];
+  cart[id] = { sku, qty: (line?.qty ?? 0) + qty, size };
   await setCart(cartId!, cart);
 
   const res = NextResponse.json({ ok: true, cart });

--- a/apps/shop-bcd/__tests__/cart-api.test.ts
+++ b/apps/shop-bcd/__tests__/cart-api.test.ts
@@ -3,6 +3,7 @@ import {
   asSetCookieHeader,
   decodeCartCookie,
   encodeCartCookie,
+  cartLineId,
 } from "@/lib/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/api/cart/route";
@@ -38,13 +39,15 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const size = "M";
+  const id = cartLineId(sku.id, size);
+  const req = createRequest({ sku, qty: 2, size });
   const res = await POST(req);
   const body = (await res.json()) as any;
 
-  expect(body.cart[sku.id].qty).toBe(2);
+  expect(body.cart[id].qty).toBe(2);
   const expected = asSetCookieHeader(
-    encodeCartCookie({ [sku.id]: { sku, qty: 2 } })
+    encodeCartCookie({ [id]: { sku, qty: 2, size } })
   );
   expect(res.headers.get("Set-Cookie")).toBe(expected);
 });
@@ -56,28 +59,30 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cart));
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 1 } };
+  const req = createRequest({ id, qty: 5 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[id].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toEqual(body.cart);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cart));
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 1 } };
+  const req = createRequest({ id, qty: 0 }, encodeCartCookie(cart));
   const res = await PATCH(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
   const res = await PATCH(
     createRequest(
-      { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", qty: 1 },
+      { id: cartLineId("01ARZ3NDEKTSV4RRFFQ69G5FAA"), qty: 1 },
       encodeCartCookie({})
     )
   );
@@ -86,16 +91,18 @@ test("PATCH returns 404 for missing item", async () => {
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cart));
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 2 } };
+  const req = createRequest({ id }, encodeCartCookie(cart));
   const res = await DELETE(req);
   const body = (await res.json()) as any;
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 3 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 3 } };
   const res = await GET(createRequest({}, encodeCartCookie(cart)));
   const body = (await res.json()) as any;
   expect(body.cart).toEqual(cart);

--- a/apps/shop-bcd/__tests__/cartApi.test.ts
+++ b/apps/shop-bcd/__tests__/cartApi.test.ts
@@ -1,5 +1,5 @@
 // apps/shop-bcd/__tests__/cartApi.test.ts
-import { encodeCartCookie } from "@/lib/cartCookie";
+import { encodeCartCookie, cartLineId } from "@/lib/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { PATCH, POST } from "../src/api/cart/route";
 
@@ -38,11 +38,12 @@ test("POST rejects negative or non-integer quantity", async () => {
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 1 } };
   const cookie = encodeCartCookie(cart);
-  let res = await PATCH(createRequest({ id: sku.id, qty: -2 }, cookie));
+  let res = await PATCH(createRequest({ id, qty: -2 }, cookie));
   expect(res.status).toBe(400);
-  res = await PATCH(createRequest({ id: sku.id, qty: 1.5 }, cookie));
+  res = await PATCH(createRequest({ id, qty: 1.5 }, cookie));
   expect(res.status).toBe(400);
 });
 

--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -1,5 +1,5 @@
 // apps/shop-bcd/__tests__/checkout-session.test.ts
-import { encodeCartCookie } from "@/lib/cartCookie";
+import { encodeCartCookie, cartLineId } from "@/lib/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { calculateRentalDays } from "@/lib/date";
 import { POST } from "../src/api/checkout-session/route";
@@ -46,7 +46,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const id = cartLineId(sku.id, "40");
+  const cart = { [id]: { sku, qty: 2, size: "40" } };
   const cookie = encodeCartCookie(cart);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
@@ -70,7 +71,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
 test("responds with 400 on invalid returnDate", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id2 = cartLineId(sku.id);
+  const cart = { [id2]: { sku, qty: 1 } };
   const cookie = encodeCartCookie(cart);
   const req = createRequest({ returnDate: "not-a-date", currency: "EUR", taxRegion: "EU" }, cookie);
   const res = await POST(req);

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -5,6 +5,7 @@ import {
   CART_COOKIE,
   decodeCartCookie,
   encodeCartCookie,
+  cartLineId,
 } from "@/lib/cartCookie";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -27,12 +28,13 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku, qty } = parsed.data;
+  const { sku, qty, size } = parsed.data;
   const cookie = req.cookies.get(CART_COOKIE)?.value;
   const cart = decodeCartCookie(cookie);
-  const line = cart[sku.id];
+  const id = cartLineId(sku.id, size);
+  const line = cart[id];
 
-  cart[sku.id] = { sku, qty: (line?.qty ?? 0) + qty };
+  cart[id] = { sku, qty: (line?.qty ?? 0) + qty, size };
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cart)));

--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -3,13 +3,15 @@
 import { CartProvider, useCart } from "@/contexts/CartContext";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { PRODUCTS } from "@platform-core/products";
+import { cartLineId } from "@platform-core/src/cartCookie";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 jest.mock("react", () => jest.requireActual("react"));
 jest.mock("react-dom", () => jest.requireActual("react-dom"));
 
 function Qty() {
   const [state] = useCart();
-  return <span data-testid="qty">{state[PRODUCTS[0].id]?.qty ?? 0}</span>;
+  const id = cartLineId(PRODUCTS[0].id);
+  return <span data-testid="qty">{state[id]?.qty ?? 0}</span>;
 }
 
 describe("AddToCartButton", () => {
@@ -27,7 +29,9 @@ describe("AddToCartButton", () => {
       // POST
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({
+          cart: { [cartLineId(PRODUCTS[0].id)]: { sku: PRODUCTS[0], qty: 1 } },
+        }),
       });
 
     render(

--- a/packages/platform-core/__tests__/cartContext.test.tsx
+++ b/packages/platform-core/__tests__/cartContext.test.tsx
@@ -1,11 +1,13 @@
 // packages/platform-core/__tests__/cartContext.test.tsx
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CartProvider, useCart } from "../contexts/CartContext";
+import { cartLineId } from "../cartCookie";
 import { PRODUCTS } from "../products";
 
 function TestComponent() {
   const [state, dispatch] = useCart();
-  const line = state[PRODUCTS[0].id];
+  const id = cartLineId(PRODUCTS[0].id);
+  const line = state[id];
 
   return (
     <div>
@@ -14,11 +16,11 @@ function TestComponent() {
       <button onClick={() => dispatch({ type: "add", sku: PRODUCTS[0] })}>
         add
       </button>
-      <button onClick={() => dispatch({ type: "remove", id: PRODUCTS[0].id })}>
+      <button onClick={() => dispatch({ type: "remove", id })}>
         remove
       </button>
       <button
-        onClick={() => dispatch({ type: "setQty", id: PRODUCTS[0].id, qty: 0 })}
+        onClick={() => dispatch({ type: "setQty", id, qty: 0 })}
       >
         set
       </button>
@@ -41,12 +43,16 @@ describe("CartContext actions", () => {
       // add
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 1 } } }),
+        json: async () => ({
+          cart: { [cartLineId(PRODUCTS[0].id)]: { sku: PRODUCTS[0], qty: 1 } },
+        }),
       })
       // setQty
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [PRODUCTS[0].id]: { sku: PRODUCTS[0], qty: 3 } } }),
+        json: async () => ({
+          cart: { [cartLineId(PRODUCTS[0].id)]: { sku: PRODUCTS[0], qty: 3 } },
+        }),
       })
       // remove
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -32,7 +32,8 @@ export const cartLineSchema = z.object({
 });
 
 /**
- * Schema for the full cart, keyed by SKU ID (string).
+ * Schema for the full cart, keyed by cart line identifier
+ * (SKU ID plus optional size).
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
 
@@ -42,6 +43,14 @@ export type CartState = z.infer<typeof cartStateSchema>;
 /* ------------------------------------------------------------------
  * Helper functions
  * ------------------------------------------------------------------ */
+
+/**
+ * Compute the cart line identifier from SKU ID and optional size.
+ * The returned string is used as the key in {@link CartState}.
+ */
+export function cartLineId(skuId: string, size?: string): string {
+  return size ? `${skuId}:${size}` : skuId;
+}
 
 /**
  * Serialize a cart ID into a signed cookie value.

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -11,8 +11,8 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
  * ------------------------------------------------------------------ */
 type Action =
   | { type: "add"; sku: SKU; size?: string }
-  | { type: "remove"; id: SKU["id"] }
-  | { type: "setQty"; id: SKU["id"]; qty: number };
+  | { type: "remove"; id: string }
+  | { type: "setQty"; id: string; qty: number };
 
 /* ------------------------------------------------------------------
  * React context

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -5,6 +5,7 @@ export const postSchema = z
   .object({
     sku: z.union([skuSchema, skuSchema.pick({ id: true })]),
     qty: z.coerce.number().int().min(1).default(1),
+    size: z.string().optional(),
   })
   .strict();
 

--- a/packages/template-app/__tests__/cart.test.ts
+++ b/packages/template-app/__tests__/cart.test.ts
@@ -1,5 +1,9 @@
 // packages/template-app/__tests__/cart.test.ts
-import { decodeCartCookie, encodeCartCookie } from "@platform-core/src/cartCookie";
+import {
+  decodeCartCookie,
+  encodeCartCookie,
+  cartLineId,
+} from "@platform-core/src/cartCookie";
 import {
   createCart,
   getCart,
@@ -41,17 +45,21 @@ afterEach(() => {
 
 test("POST adds items and sets cookie", async () => {
   const sku = { ...TEST_SKU };
-  const req = createRequest({ sku, qty: 2 });
+  const size = "M";
+  const lineId = cartLineId(sku.id, size);
+  const req = createRequest({ sku, qty: 2, size });
   const res = await POST(req);
   const body = await res.json();
 
-  expect(body.cart[sku.id].qty).toBe(2);
-  expect(body.cart[sku.id].sku).toEqual(sku);
+  expect(body.cart[lineId].qty).toBe(2);
+  expect(body.cart[lineId].sku).toEqual(sku);
+  expect(body.cart[lineId].size).toBe(size);
   const header = res.headers.get("Set-Cookie")!;
   const encoded = header.split(";")[0].split("=")[1];
   const id = decodeCartCookie(encoded)!;
   const stored = await getCart(id);
-  expect(stored[sku.id].qty).toBe(2);
+  expect(stored[lineId].qty).toBe(2);
+  expect(stored[lineId].size).toBe(size);
 });
 
 test("POST validates body", async () => {
@@ -61,33 +69,35 @@ test("POST validates body", async () => {
 
 test("PATCH updates quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 1 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id, qty: 5 }, encodeCartCookie(cartId));
+  const req = createRequest({ id, qty: 5 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
-  expect(body.cart[sku.id].qty).toBe(5);
+  expect(body.cart[id].qty).toBe(5);
   const encoded = res.headers.get("Set-Cookie")!.split(";")[0].split("=")[1];
   expect(decodeCartCookie(encoded)).toBe(cartId);
 });
 
 test("PATCH removes item when qty is 0", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 1 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id, qty: 0 }, encodeCartCookie(cartId));
+  const req = createRequest({ id, qty: 0 }, encodeCartCookie(cartId));
   const res = await PATCH(req);
   const body = await res.json();
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("PATCH returns 404 for missing item", async () => {
   const cartId = await createCart();
   const res = await PATCH(
     createRequest(
-      { id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", qty: 1 },
+      { id: cartLineId("01ARZ3NDEKTSV4RRFFQ69G5FAA"), qty: 1 },
       encodeCartCookie(cartId)
     )
   );
@@ -111,33 +121,36 @@ test("POST rejects negative or non-integer quantity", async () => {
 
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 1 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   let res = await PATCH(
-    createRequest({ id: sku.id, qty: -2 }, encodeCartCookie(cartId))
+    createRequest({ id, qty: -2 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
   res = await PATCH(
-    createRequest({ id: sku.id, qty: 1.5 }, encodeCartCookie(cartId))
+    createRequest({ id, qty: 1.5 }, encodeCartCookie(cartId))
   );
   expect(res.status).toBe(400);
 });
 
 test("DELETE removes item", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 2 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 2 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
-  const req = createRequest({ id: sku.id }, encodeCartCookie(cartId));
+  const req = createRequest({ id }, encodeCartCookie(cartId));
   const res = await DELETE(req);
   const body = await res.json();
-  expect(body.cart[sku.id]).toBeUndefined();
+  expect(body.cart[id]).toBeUndefined();
 });
 
 test("GET returns cart", async () => {
   const sku = { ...TEST_SKU };
-  const cart = { [sku.id]: { sku, qty: 3 } };
+  const id = cartLineId(sku.id);
+  const cart = { [id]: { sku, qty: 3 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const res = await GET(createRequest({}, encodeCartCookie(cartId)));
@@ -147,10 +160,11 @@ test("GET returns cart", async () => {
 
 test("incrementQty handles concurrent updates", async () => {
   const sku = { ...TEST_SKU };
+  const id = cartLineId(sku.id);
   const cartId = await createCart();
   await Promise.all(
     Array.from({ length: 20 }, () => incrementQty(cartId, sku, 1))
   );
   const cart = await getCart(cartId);
-  expect(cart[sku.id].qty).toBe(20);
+  expect(cart[id].qty).toBe(20);
 });

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -1,5 +1,5 @@
 // packages/template-app/__tests__/checkout-session.test.ts
-import { encodeCartCookie } from "../../platform-core/src/cartCookie";
+import { encodeCartCookie, cartLineId } from "../../platform-core/src/cartCookie";
 import { createCart, setCart } from "../../platform-core/src/cartStore";
 import { PRODUCTS } from "../../platform-core/src/products";
 import { calculateRentalDays } from "../../lib/src/date";
@@ -46,7 +46,8 @@ test("builds Stripe session with correct items and metadata", async () => {
   });
 
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 2, size: "40" } };
+  const id = cartLineId(sku.id, "40");
+  const cart = { [id]: { sku, qty: 2, size: "40" } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);
@@ -71,7 +72,8 @@ test("builds Stripe session with correct items and metadata", async () => {
 
 test("returns 400 when returnDate is invalid", async () => {
   const sku = PRODUCTS[0];
-  const cart = { [sku.id]: { sku, qty: 1 } };
+  const id2 = cartLineId(sku.id);
+  const cart = { [id2]: { sku, qty: 1 } };
   const cartId = await createCart();
   await setCart(cartId, cart);
   const cookie = encodeCartCookie(cartId);

--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const { sku: skuInput, qty } = parsed.data;
+  const { sku: skuInput, qty, size } = parsed.data;
   const sku = "title" in skuInput ? skuInput : getProductById(skuInput.id);
 
   if (!sku) {
@@ -46,7 +46,7 @@ export async function POST(req: NextRequest) {
   if (!cartId) {
     cartId = await createCart();
   }
-  const cart = await incrementQty(cartId, sku, qty);
+  const cart = await incrementQty(cartId, sku, qty, size);
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;

--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -32,8 +32,8 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
   const [toast, setToast] = React.useState<{ open: boolean; message: string }>(
     { open: false, message: "" }
   );
-  const lines = Object.values(cart);
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const lines = Object.entries(cart);
+  const subtotal = lines.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
   const { widthClass, style } = drawerWidthProps(width);
 
   const handleRemove = async (id: string) => {
@@ -63,16 +63,23 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
           ) : (
             <div className="flex h-full flex-col gap-4">
               <ul className="grow space-y-3 overflow-y-auto">
-                {lines.map((line) => (
+                {lines.map(([id, line]) => (
                   <li
-                    key={line.sku.id}
+                    key={id}
                     className="flex items-center justify-between gap-2"
                   >
-                    <span className="text-sm">{line.sku.title}</span>
+                    <span className="text-sm">
+                      {line.sku.title}
+                      {line.size && (
+                        <span className="ml-1 text-xs text-muted-foreground">
+                          ({line.size})
+                        </span>
+                      )}
+                    </span>
                     <span className="text-sm">× {line.qty}</span>
                     <Button
                       variant="destructive"
-                      onClick={() => void handleRemove(line.sku.id)}
+                      onClick={() => void handleRemove(id)}
                       className="px-2 py-1 text-xs"
                     >
                       Remove

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -1,6 +1,7 @@
 import { CartProvider, useCart } from "@platform-core/src/contexts/CartContext";
 import { type Meta, type StoryObj } from "@storybook/react";
 import type { CartState } from "@/lib/cartCookie";
+import { cartLineId } from "@/lib/cartCookie";
 import type { SKU } from "@types";
 import * as React from "react";
 import { Button } from "../atoms/shadcn";
@@ -38,10 +39,10 @@ interface WrapperProps {
 function CartInitializer({ items }: WrapperProps) {
   const [, dispatch] = useCart();
   React.useEffect(() => {
-    Object.values(items).forEach((line) => {
+    Object.entries(items).forEach(([id, line]) => {
       dispatch({ type: "add", sku: line.sku, size: line.size });
       if (line.qty > 1) {
-        dispatch({ type: "setQty", id: line.sku.id, qty: line.qty });
+        dispatch({ type: "setQty", id, qty: line.qty });
       }
     });
   }, [items, dispatch]);
@@ -70,8 +71,8 @@ export const Empty: StoryObj<typeof MiniCartWrapper> = {};
 export const Filled: StoryObj<typeof MiniCartWrapper> = {
   args: {
     items: {
-      [sku1.id]: { sku: sku1, qty: 2 },
-      [sku2.id]: { sku: sku2, qty: 1 },
+      [cartLineId(sku1.id, "M")]: { sku: sku1, qty: 2, size: "M" },
+      [cartLineId(sku2.id)]: { sku: sku2, qty: 1 },
     },
   },
 };

--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -35,17 +35,17 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
   /* ------------------------------------------------------------------
    * Derived values
    * ------------------------------------------------------------------ */
-  const lines = useMemo<CartLine[]>(() => Object.values(cart), [cart]);
+  const lines = useMemo<[string, CartLine][]>(() => Object.entries(cart), [cart]);
 
   // When totals aren't provided, compute them from the cart lines.
   const computedSubtotal = useMemo(
-    () => lines.reduce((sum, line) => sum + line.sku.price * line.qty, 0),
+    () => lines.reduce((sum, [, line]) => sum + line.sku.price * line.qty, 0),
     [lines]
   );
 
   const computedDeposit = useMemo(
     () =>
-      lines.reduce((sum, line) => sum + (line.sku.deposit ?? 0) * line.qty, 0),
+      lines.reduce((sum, [, line]) => sum + (line.sku.deposit ?? 0) * line.qty, 0),
     [lines]
   );
 
@@ -66,8 +66,8 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
         </tr>
       </thead>
       <tbody>
-        {lines.map((line) => (
-          <tr key={line.sku.id} className="border-b last:border-0">
+        {lines.map(([id, line]) => (
+          <tr key={id} className="border-b last:border-0">
             <td className="py-2">
               {line.sku.title}
               {line.size && (

--- a/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { cartLineId } from "@/lib/cartCookie";
 import { MiniCart } from "../MiniCart.client";
 
 jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
@@ -26,11 +27,13 @@ describe("MiniCart", () => {
 
   it("shows cart items and handles removal", async () => {
     const dispatch = jest.fn();
+    const id = cartLineId("sku1", "L");
     mockUseCart.mockReturnValue([
       {
-        sku1: {
+        [id]: {
           sku: { id: "sku1", title: "Item", price: 10 },
           qty: 1,
+          size: "L",
         },
       },
       dispatch,
@@ -39,9 +42,10 @@ describe("MiniCart", () => {
     render(<MiniCart trigger={<button>Cart</button>} />);
     await userEvent.click(screen.getByText("Cart"));
 
-    expect(await screen.findByText("Item")).toBeInTheDocument();
+    expect(await screen.findByText("Item"));
+    expect(screen.getByText(/\(L\)/)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /remove/i }));
-    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1" });
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id });
   });
 });

--- a/packages/ui/src/components/templates/CartTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.stories.tsx
@@ -1,9 +1,10 @@
 import { type Meta, type StoryObj } from "@storybook/react";
 import type { CartState } from "@/lib/cartCookie";
+import { cartLineId } from "@/lib/cartCookie";
 import { CartTemplate } from "./CartTemplate";
 
 const cart: CartState = {
-  sku1: {
+  [cartLineId("sku1", "L")]: {
     sku: {
       id: "sku1",
       slug: "prod-1",
@@ -17,6 +18,7 @@ const cart: CartState = {
       description: "",
     },
     qty: 1,
+    size: "L",
   },
 };
 

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -19,9 +19,12 @@ export function CartTemplate({
   className,
   ...props
 }: CartTemplateProps) {
-  const lines = Object.values(cart);
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
-  const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
+  const lines = Object.entries(cart);
+  const subtotal = lines.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
+  const deposit = lines.reduce(
+    (s, [, l]) => s + (l.sku.deposit ?? 0) * l.qty,
+    0
+  );
 
   if (!lines.length) {
     return (
@@ -42,8 +45,8 @@ export function CartTemplate({
           </tr>
         </thead>
         <tbody>
-          {lines.map((line) => (
-            <tr key={line.sku.id} className="border-b last:border-0">
+          {lines.map(([id, line]) => (
+            <tr key={id} className="border-b last:border-0">
               <td className="py-2">
                 <div className="flex items-center gap-4">
                   <div className="relative hidden h-12 w-12 sm:block">
@@ -56,12 +59,17 @@ export function CartTemplate({
                     />
                   </div>
                   {line.sku.title}
+                  {line.size && (
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      ({line.size})
+                    </span>
+                  )}
                 </div>
               </td>
               <td>
                 <QuantityInput
                   value={line.qty}
-                  onChange={(v) => onQtyChange?.(line.sku.id, v)}
+                  onChange={(v) => onQtyChange?.(id, v)}
                   className="justify-center"
                 />
               </td>
@@ -72,7 +80,7 @@ export function CartTemplate({
                 <td className="text-right">
                   <button
                     type="button"
-                    onClick={() => onRemove(line.sku.id)}
+                    onClick={() => onRemove(id)}
                     className="text-danger hover:underline"
                   >
                     Remove

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.stories.tsx
@@ -1,9 +1,10 @@
 import { type Meta, type StoryObj } from "@storybook/react";
 import type { CartState } from "@/lib/cartCookie";
+import { cartLineId } from "@/lib/cartCookie";
 import { OrderConfirmationTemplate } from "./OrderConfirmationTemplate";
 
 const cart: CartState = {
-  sku1: {
+  [cartLineId("sku1", "L")]: {
     sku: {
       id: "sku1",
       slug: "prod-1",
@@ -17,6 +18,7 @@ const cart: CartState = {
       description: "",
     },
     qty: 1,
+    size: "L",
   },
 };
 

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -15,12 +15,10 @@ export function OrderConfirmationTemplate({
   className,
   ...props
 }: OrderConfirmationTemplateProps) {
-  const subtotal = Object.values(cart).reduce(
-    (s, l) => s + l.sku.price * l.qty,
-    0
-  );
-  const deposit = Object.values(cart).reduce(
-    (s, l) => s + (l.sku.deposit ?? 0) * l.qty,
+  const lines = Object.entries(cart);
+  const subtotal = lines.reduce((s, [, l]) => s + l.sku.price * l.qty, 0);
+  const deposit = lines.reduce(
+    (s, [, l]) => s + (l.sku.deposit ?? 0) * l.qty,
     0
   );
 
@@ -40,9 +38,14 @@ export function OrderConfirmationTemplate({
           </tr>
         </thead>
         <tbody>
-          {Object.values(cart).map((l) => (
-            <tr key={l.sku.id} className="border-b last:border-0">
-              <td className="py-2">{l.sku.title}</td>
+          {lines.map(([id, l]) => (
+            <tr key={id} className="border-b last:border-0">
+              <td className="py-2">
+                {l.sku.title}
+                {l.size && (
+                  <span className="ml-1 text-xs text-muted">({l.size})</span>
+                )}
+              </td>
               <td>{l.qty}</td>
               <td className="text-right">
                 <Price amount={l.sku.price * l.qty} />


### PR DESCRIPTION
## Summary
- allow cart POST to include optional size
- key cart lines by sku and size
- surface selected size in cart UI

## Testing
- `STRIPE_SECRET_KEY=1 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=1 pnpm test --filter @acme/platform-core --filter @acme/ui --filter @acme/template-app --filter @apps/shop-abc --filter @apps/shop-bcd` *(failed: ManagedMessageChannel error)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5413ea4832f9c39a10ad1ffc607