### PR TITLE
test: cover registration and security flows

### DIFF
--- a/apps/shop-abc/__tests__/csrf.test.ts
+++ b/apps/shop-abc/__tests__/csrf.test.ts
@@ -1,0 +1,34 @@
+// apps/shop-abc/__tests__/csrf.test.ts
+import { CSRF_TOKEN_COOKIE, validateCsrfToken } from "../../../packages/auth/src/session";
+
+const jar = new Map<string, string>();
+
+jest.mock("next/headers", () => ({
+  cookies: () => ({
+    get: (name: string) =>
+      jar.has(name) ? { value: jar.get(name)! } : undefined,
+    set: (name: string, value: string) => {
+      jar.set(name, value);
+    },
+    delete: (name: string) => {
+      jar.delete(name);
+    },
+  }),
+}));
+
+describe("validateCsrfToken", () => {
+  beforeEach(() => {
+    jar.clear();
+  });
+
+  it("accepts matching token", async () => {
+    jar.set(CSRF_TOKEN_COOKIE, "abc");
+    await expect(validateCsrfToken("abc")).resolves.toBe(true);
+  });
+
+  it("rejects missing or mismatched token", async () => {
+    jar.set(CSRF_TOKEN_COOKIE, "abc");
+    await expect(validateCsrfToken("wrong")).resolves.toBe(false);
+    await expect(validateCsrfToken(null)).resolves.toBe(false);
+  });
+});

--- a/apps/shop-abc/__tests__/mfa.test.ts
+++ b/apps/shop-abc/__tests__/mfa.test.ts
@@ -1,0 +1,72 @@
+// apps/shop-abc/__tests__/mfa.test.ts
+import { POST as enrollPOST } from "../src/app/api/mfa/enroll/route";
+import { POST as verifyPOST } from "../src/app/api/mfa/verify/route";
+import { getCustomerSession, enrollMfa, verifyMfa } from "@auth";
+
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+  enrollMfa: jest.fn(),
+  verifyMfa: jest.fn(),
+}));
+
+describe("MFA enroll", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("requires authentication", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const res = await enrollPOST({} as any);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns enrollment when authenticated", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1" });
+    (enrollMfa as jest.Mock).mockResolvedValue({ secret: "s" });
+    const res = await enrollPOST({} as any);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ secret: "s" });
+  });
+});
+
+describe("MFA verify", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function makeReq(body: any) {
+    return {
+      json: async () => body,
+      headers: new Headers(),
+    } as any;
+  }
+
+  it("requires authentication", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const res = await verifyPOST(makeReq({ token: "123" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects missing token", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1" });
+    const res = await verifyPOST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("verifies token", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1" });
+    (verifyMfa as jest.Mock).mockResolvedValue(true);
+    const res = await verifyPOST(makeReq({ token: "123" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified: true });
+  });
+
+  it("returns false for invalid token", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1" });
+    (verifyMfa as jest.Mock).mockResolvedValue(false);
+    const res = await verifyPOST(makeReq({ token: "bad" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified: false });
+  });
+});

--- a/apps/shop-abc/__tests__/register.test.ts
+++ b/apps/shop-abc/__tests__/register.test.ts
@@ -1,0 +1,76 @@
+// apps/shop-abc/__tests__/register.test.ts
+import { POST } from "../src/app/register/route";
+import { createUser, getUserById, getUserByEmail } from "@platform-core/users";
+import { validateCsrfToken } from "@auth";
+
+jest.mock("@platform-core/users", () => ({
+  __esModule: true,
+  createUser: jest.fn(),
+  getUserById: jest.fn(),
+  getUserByEmail: jest.fn(),
+}));
+
+jest.mock("@auth", () => ({
+  __esModule: true,
+  validateCsrfToken: jest.fn(),
+}));
+
+describe("/register POST", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function makeReq(body: any, token = "token") {
+    return {
+      json: async () => body,
+      headers: new Headers({ "x-csrf-token": token }),
+    } as any;
+  }
+
+  it("registers a new user", async () => {
+    (getUserById as jest.Mock).mockResolvedValue(null);
+    (getUserByEmail as jest.Mock).mockResolvedValue(null);
+    (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+
+    const res = await POST(
+      makeReq({
+        customerId: "c1",
+        email: "a@b.com",
+        password: "Password1",
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(createUser).toHaveBeenCalled();
+  });
+
+  it("rejects weak passwords", async () => {
+    (getUserById as jest.Mock).mockResolvedValue(null);
+    (getUserByEmail as jest.Mock).mockResolvedValue(null);
+    (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+
+    const res = await POST(
+      makeReq({
+        customerId: "c1",
+        email: "a@b.com",
+        password: "short",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid CSRF token", async () => {
+    (getUserById as jest.Mock).mockResolvedValue(null);
+    (getUserByEmail as jest.Mock).mockResolvedValue(null);
+    (validateCsrfToken as jest.Mock).mockResolvedValue(false);
+
+    const res = await POST(
+      makeReq({
+        customerId: "c1",
+        email: "a@b.com",
+        password: "Password1",
+      }, "bad")
+    );
+    expect(res.status).toBe(403);
+  });
+});
+

--- a/apps/shop-abc/__tests__/sessions.test.ts
+++ b/apps/shop-abc/__tests__/sessions.test.ts
@@ -1,0 +1,44 @@
+// apps/shop-abc/__tests__/sessions.test.ts
+import {
+  createCustomerSession,
+  listSessions,
+  revokeSession,
+} from "../../../packages/auth/src/session";
+
+const jar = new Map<string, string>();
+
+jest.mock("next/headers", () => ({
+  cookies: () => ({
+    get: (name: string) =>
+      jar.has(name) ? { value: jar.get(name)! } : undefined,
+    set: (name: string, value: string) => {
+      jar.set(name, value);
+    },
+    delete: (name: string) => {
+      jar.delete(name);
+    },
+  }),
+  headers: () => new Headers({ "user-agent": "jest" }),
+}));
+
+describe("session listing and revocation", () => {
+  beforeEach(() => {
+    jar.clear();
+    process.env.SESSION_SECRET = "0123456789abcdef0123456789abcdef";
+  });
+
+  it("lists and revokes sessions", async () => {
+    await createCustomerSession({ customerId: "cust", role: "customer" as any });
+    let sessions = await listSessions("cust");
+    expect(sessions).toHaveLength(1);
+    await revokeSession(sessions[0].sessionId);
+    sessions = await listSessions("cust");
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("handles missing sessions gracefully", async () => {
+    let sessions = await listSessions("none");
+    expect(sessions).toHaveLength(0);
+    await expect(revokeSession("nosuch")).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add password complexity and CSRF validation to registration route
- add tests for registration, CSRF token checks, session management, and MFA flows

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/register.test.ts apps/shop-abc/__tests__/sessions.test.ts apps/shop-abc/__tests__/csrf.test.ts apps/shop-abc/__tests__/mfa.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899bbf81598832f8020f9748f19e328