### PR TITLE
Add CSRF protection to login and registration

### DIFF
--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -1,6 +1,7 @@
 // apps/shop-abc/__tests__/loginRateLimit.test.ts
 jest.mock("@auth", () => ({
   createCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn().mockResolvedValue(true),
 }));
 jest.mock("@upstash/redis", () => ({
   Redis: jest.fn(() => ({})),

--- a/apps/shop-abc/src/app/login/page.tsx
+++ b/apps/shop-abc/src/app/login/page.tsx
@@ -3,22 +3,23 @@
 import { useState, useEffect } from "react";
 import { getCsrfToken } from "@auth";
 
-export default function RegisterPage() {
+export default function LoginPage() {
   const [msg, setMsg] = useState("");
   const [csrf, setCsrf] = useState("");
+
   useEffect(() => {
     setCsrf(getCsrfToken());
   }, []);
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
     const body = {
       customerId: (form.elements.namedItem("customerId") as HTMLInputElement).value,
-      email: (form.elements.namedItem("email") as HTMLInputElement).value,
       password: (form.elements.namedItem("password") as HTMLInputElement).value,
     };
     const csrfToken = (form.elements.namedItem("csrfToken") as HTMLInputElement).value;
-    const res = await fetch("/register", {
+    const res = await fetch("/login", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -27,15 +28,15 @@ export default function RegisterPage() {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
-    setMsg(res.ok ? "Account created" : data.error || "Error");
+    setMsg(res.ok ? "Logged in" : data.error || "Error");
   }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <input name="customerId" placeholder="User ID" className="border p-1" />
-      <input name="email" type="email" placeholder="Email" className="border p-1" />
       <input name="password" type="password" placeholder="Password" className="border p-1" />
       <input type="hidden" name="csrfToken" value={csrf} />
-      <button type="submit" className="border px-2 py-1">Register</button>
+      <button type="submit" className="border px-2 py-1">Login</button>
       {msg && <p>{msg}</p>}
     </form>
   );

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -1,6 +1,6 @@
 // apps/shop-abc/src/app/login/route.ts
 import { NextResponse } from "next/server";
-import { createCustomerSession } from "@auth";
+import { createCustomerSession, validateCsrfToken } from "@auth";
 import type { Role } from "@auth/types/roles";
 import { z } from "zod";
 import {
@@ -28,6 +28,11 @@ async function validateCredentials(
 }
 
 export async function POST(req: Request) {
+  const headerToken = req.headers.get("x-csrf-token");
+  const validToken = await validateCsrfToken(headerToken);
+  if (!validToken) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
+  }
   const json = await req.json();
   const parsed = LoginSchema.safeParse(json);
   if (!parsed.success) {

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { addUser, USER_STORE } from "../userStore";
+import { validateCsrfToken } from "@auth";
 
 const RegisterSchema = z.object({
   customerId: z.string(),
@@ -10,6 +11,11 @@ const RegisterSchema = z.object({
 });
 
 export async function POST(req: Request) {
+  const headerToken = req.headers.get("x-csrf-token");
+  const validToken = await validateCsrfToken(headerToken);
+  if (!validToken) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
+  }
   const json = await req.json();
   const parsed = RegisterSchema.safeParse(json);
   if (!parsed.success) {

--- a/apps/shop-bcd/src/app/login/page.tsx
+++ b/apps/shop-bcd/src/app/login/page.tsx
@@ -3,22 +3,23 @@
 import { useState, useEffect } from "react";
 import { getCsrfToken } from "@auth";
 
-export default function RegisterPage() {
+export default function LoginPage() {
   const [msg, setMsg] = useState("");
   const [csrf, setCsrf] = useState("");
+
   useEffect(() => {
     setCsrf(getCsrfToken());
   }, []);
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
     const body = {
       customerId: (form.elements.namedItem("customerId") as HTMLInputElement).value,
-      email: (form.elements.namedItem("email") as HTMLInputElement).value,
       password: (form.elements.namedItem("password") as HTMLInputElement).value,
     };
     const csrfToken = (form.elements.namedItem("csrfToken") as HTMLInputElement).value;
-    const res = await fetch("/register", {
+    const res = await fetch("/login", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -27,15 +28,15 @@ export default function RegisterPage() {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
-    setMsg(res.ok ? "Account created" : data.error || "Error");
+    setMsg(res.ok ? "Logged in" : data.error || "Error");
   }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <input name="customerId" placeholder="User ID" className="border p-1" />
-      <input name="email" type="email" placeholder="Email" className="border p-1" />
       <input name="password" type="password" placeholder="Password" className="border p-1" />
       <input type="hidden" name="csrfToken" value={csrf} />
-      <button type="submit" className="border px-2 py-1">Register</button>
+      <button type="submit" className="border px-2 py-1">Login</button>
       {msg && <p>{msg}</p>}
     </form>
   );

--- a/apps/shop-bcd/src/app/login/route.ts
+++ b/apps/shop-bcd/src/app/login/route.ts
@@ -1,6 +1,6 @@
 // apps/shop-bcd/src/app/login/route.ts
 import { NextResponse } from "next/server";
-import { createCustomerSession } from "@auth";
+import { createCustomerSession, validateCsrfToken } from "@auth";
 import type { Role } from "@auth/types/roles";
 import { z } from "zod";
 
@@ -30,6 +30,11 @@ async function validateCredentials(
 }
 
 export async function POST(req: Request) {
+  const headerToken = req.headers.get("x-csrf-token");
+  const validToken = await validateCsrfToken(headerToken);
+  if (!validToken) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
+  }
   const json = await req.json();
   const parsed = LoginSchema.safeParse(json);
   if (!parsed.success) {

--- a/packages/auth/src/csrf.ts
+++ b/packages/auth/src/csrf.ts
@@ -1,0 +1,9 @@
+'use client';
+
+export function getCsrfToken(): string {
+  const match = document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);
+  if (match) return decodeURIComponent(match[1]);
+  const token = (globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2));
+  document.cookie = `csrf_token=${token}; path=/; SameSite=Strict`;
+  return token;
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -13,6 +13,7 @@ export {
   revokeSession,
   validateCsrfToken,
 } from "./session";
+export { getCsrfToken } from "./csrf";
 export type { CustomerSession } from "./session";
 
 export {


### PR DESCRIPTION
## Summary
- add client helper to generate CSRF tokens
- include CSRF tokens on login and registration forms
- validate CSRF tokens on auth routes across shops

## Testing
- `pnpm --filter @acme/auth test` *(fails: Cannot find module '@/components/cms/StyleEditor')*

------
https://chatgpt.com/codex/tasks/task_e_6899b9815ecc832f8e584d71e22b7ca4