### PR TITLE
feat(shop-abc): persist user store and hash passwords

### DIFF
--- a/apps/shop-abc/src/app/forgot-password/route.ts
+++ b/apps/shop-abc/src/app/forgot-password/route.ts
@@ -1,7 +1,7 @@
 // apps/shop-abc/src/app/forgot-password/route.ts
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { findUserByEmail } from "../userStore";
+import { findUserByEmail, updateUser } from "../userStore";
 import { sendEmail } from "@lib/email";
 
 const ForgotSchema = z.object({
@@ -17,11 +17,11 @@ export async function POST(req: Request) {
     });
   }
 
-  const match = findUserByEmail(parsed.data.email);
+  const match = await findUserByEmail(parsed.data.email);
   if (match) {
-    const [, user] = match;
+    const [id] = match;
     const token = Math.random().toString(36).slice(2);
-    user.resetToken = token;
+    await updateUser(id, { resetToken: token });
     await sendEmail(parsed.data.email, "Password reset", `Your token is ${token}`);
   }
 

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -7,7 +7,8 @@ import {
   checkLoginRateLimit,
   clearLoginAttempts,
 } from "../../middleware";
-import { USER_STORE } from "../userStore";
+import bcrypt from "bcryptjs";
+import { getUser } from "../userStore";
 
 const ALLOWED_ROLES: Role[] = ["customer", "viewer"];
 
@@ -20,10 +21,10 @@ async function validateCredentials(
   customerId: string,
   password: string,
 ): Promise<{ customerId: string; role: Role } | null> {
-  const record = USER_STORE[customerId];
-  if (!record || record.password !== password) {
-    return null;
-  }
+  const record = await getUser(customerId);
+  if (!record) return null;
+  const ok = await bcrypt.compare(password, record.password);
+  if (!ok) return null;
   return { customerId, role: record.role };
 }
 

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -1,7 +1,8 @@
 // apps/shop-abc/src/app/register/route.ts
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { addUser, USER_STORE } from "../userStore";
+import bcrypt from "bcryptjs";
+import { addUser, findUserByEmail, getUser } from "../userStore";
 
 const RegisterSchema = z.object({
   customerId: z.string(),
@@ -19,13 +20,16 @@ export async function POST(req: Request) {
   }
 
   const { customerId, email, password } = parsed.data;
-  if (USER_STORE[customerId]) {
+
+  if (await getUser(customerId)) {
     return NextResponse.json({ error: "User already exists" }, { status: 400 });
   }
-  if (Object.values(USER_STORE).some((u) => u.email === email)) {
+
+  if (await findUserByEmail(email)) {
     return NextResponse.json({ error: "Email already registered" }, { status: 400 });
   }
 
-  addUser(customerId, email, password);
+  const hashed = await bcrypt.hash(password, 10);
+  await addUser(customerId, email, hashed);
   return NextResponse.json({ ok: true });
 }

--- a/apps/shop-abc/src/app/userStore.ts
+++ b/apps/shop-abc/src/app/userStore.ts
@@ -1,4 +1,7 @@
 import type { Role } from "@auth/types/roles";
+import * as fsSync from "node:fs";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 
 export interface UserRecord {
   password: string;
@@ -7,16 +10,87 @@ export interface UserRecord {
   resetToken?: string;
 }
 
-export const USER_STORE: Record<string, UserRecord> = {
-  cust1: { password: "pass1", role: "customer", email: "cust1@example.com" },
-  viewer1: { password: "view", role: "viewer", email: "viewer1@example.com" },
-  admin1: { password: "admin", role: "admin", email: "admin1@example.com" },
+const DEFAULT_USERS: Record<string, UserRecord> = {
+  cust1: {
+    password: "$2b$10$vxwDn1x/rWxGtaGnpWNQbuLNHqnnVyzmTb.9wQ6/t8zsPqP5VM/XG",
+    role: "customer",
+    email: "cust1@example.com",
+  },
+  viewer1: {
+    password: "$2b$10$ch.MKZ4DOiWY/Ad6oVPUKuV.WJisqMU8D0EQIdeUm2sqY7IiW3DLC",
+    role: "viewer",
+    email: "viewer1@example.com",
+  },
+  admin1: {
+    password: "$2b$10$I9IVpZpVTfUrLnyh33tQO.85L7bmrhSLnkeS2oZWL8r2AzJTdglSq",
+    role: "admin",
+    email: "admin1@example.com",
+  },
 };
 
-export function addUser(id: string, email: string, password: string) {
-  USER_STORE[id] = { password, role: "customer", email };
+function resolveFile(): string {
+  let dir = process.cwd();
+  while (true) {
+    const candidate = path.join(dir, "data", "shops", "abc");
+    if (fsSync.existsSync(candidate)) {
+      return path.join(candidate, "users.json");
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(process.cwd(), "data", "shops", "abc", "users.json");
 }
 
-export function findUserByEmail(email: string) {
-  return Object.entries(USER_STORE).find(([, u]) => u.email === email);
+const FILE = resolveFile();
+
+async function readUsers(): Promise<Record<string, UserRecord>> {
+  try {
+    const buf = await fs.readFile(FILE, "utf8");
+    const parsed = JSON.parse(buf) as Record<string, UserRecord>;
+    if (parsed) return parsed;
+  } catch {
+    /* ignore */
+  }
+  return { ...DEFAULT_USERS };
 }
+
+async function writeUsers(db: Record<string, UserRecord>): Promise<void> {
+  await fs.mkdir(path.dirname(FILE), { recursive: true });
+  const tmp = `${FILE}.${Date.now()}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(db, null, 2), "utf8");
+  await fs.rename(tmp, FILE);
+}
+
+export async function getUser(id: string): Promise<UserRecord | undefined> {
+  const users = await readUsers();
+  return users[id];
+}
+
+export async function addUser(
+  id: string,
+  email: string,
+  password: string,
+): Promise<void> {
+  const users = await readUsers();
+  users[id] = { password, role: "customer", email };
+  await writeUsers(users);
+}
+
+export async function findUserByEmail(
+  email: string,
+): Promise<[string, UserRecord] | undefined> {
+  const users = await readUsers();
+  return Object.entries(users).find(([, u]) => u.email === email);
+}
+
+export async function updateUser(
+  id: string,
+  patch: Partial<UserRecord>,
+): Promise<void> {
+  const users = await readUsers();
+  if (!users[id]) return;
+  users[id] = { ...users[id], ...patch };
+  await writeUsers(users);
+}
+

--- a/data/shops/abc/users.json
+++ b/data/shops/abc/users.json
@@ -1,0 +1,17 @@
+{
+  "cust1": {
+    "password": "$2b$10$vxwDn1x/rWxGtaGnpWNQbuLNHqnnVyzmTb.9wQ6/t8zsPqP5VM/XG",
+    "role": "customer",
+    "email": "cust1@example.com"
+  },
+  "viewer1": {
+    "password": "$2b$10$ch.MKZ4DOiWY/Ad6oVPUKuV.WJisqMU8D0EQIdeUm2sqY7IiW3DLC",
+    "role": "viewer",
+    "email": "viewer1@example.com"
+  },
+  "admin1": {
+    "password": "$2b$10$I9IVpZpVTfUrLnyh33tQO.85L7bmrhSLnkeS2oZWL8r2AzJTdglSq",
+    "role": "admin",
+    "email": "admin1@example.com"
+  }
+}


### PR DESCRIPTION
## Summary
- replace in-memory USER_STORE with file-backed store storing hashed passwords
- hash passwords on registration and verify hashes during login
- persist password reset tokens in user database

## Testing
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_6899b980c92c832f9996439cce5b9bd7