### PR TITLE
feat: add csrf protection to auth forms

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -3,6 +3,7 @@ import { jest } from "@jest/globals";
 
 jest.mock("@auth", () => ({
   createCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock("../src/middleware", () => ({
@@ -54,12 +55,12 @@ beforeAll(async () => {
   ({ POST: resetPOST } = await import("../src/app/api/reset-password/route"));
 });
 
-function makeRequest(body: any, headers: Record<string, string> = {}) {
-  return {
-    json: async () => body,
-    headers: new Headers(headers),
-  } as any;
-}
+  function makeRequest(body: any, headers: Record<string, string> = {}) {
+    return {
+      json: async () => body,
+      headers: new Headers({ "x-csrf-token": "tok", ...headers }),
+    } as any;
+  }
 
 describe("auth flows", () => {
   it("allows sign-up, login and password reset", async () => {

--- a/apps/shop-abc/__tests__/registerRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/registerRateLimit.test.ts
@@ -13,6 +13,10 @@ jest.mock("bcryptjs", () => ({
   hash: jest.fn().mockResolvedValue("hashed"),
 }));
 
+jest.mock("@auth", () => ({
+  validateCsrfToken: jest.fn().mockResolvedValue(true),
+}));
+
 let POST: typeof import("../src/app/register/route").POST;
 let __resetRegistrationRateLimiter: typeof import("../src/middleware").__resetRegistrationRateLimiter;
 let MAX_REGISTRATION_ATTEMPTS: number;
@@ -25,10 +29,13 @@ beforeAll(async () => {
 });
 
 function makeRequest(body: any, ip = "1.1.1.1") {
-  return {
-    json: async () => body,
-    headers: new Headers({ "x-forwarded-for": ip }),
-  } as any;
+    return {
+      json: async () => body,
+      headers: new Headers({
+        "x-forwarded-for": ip,
+        "x-csrf-token": "tok",
+      }),
+    } as any;
 }
 
 afterEach(async () => {

--- a/apps/shop-abc/src/app/login/page.tsx
+++ b/apps/shop-abc/src/app/login/page.tsx
@@ -2,14 +2,13 @@
 
 import { useState } from "react";
 
-export default function RegisterPage() {
+export default function LoginPage() {
   const [msg, setMsg] = useState("");
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
     const body = {
       customerId: (form.elements.namedItem("customerId") as HTMLInputElement).value,
-      email: (form.elements.namedItem("email") as HTMLInputElement).value,
       password: (form.elements.namedItem("password") as HTMLInputElement).value,
     };
     let csrfToken =
@@ -25,7 +24,7 @@ export default function RegisterPage() {
         location.protocol === "https:" ? "; secure" : ""
       }`;
     }
-    const res = await fetch("/register", {
+    const res = await fetch("/login", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -34,14 +33,13 @@ export default function RegisterPage() {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
-    setMsg(res.ok ? "Account created" : data.error || "Error");
+    setMsg(res.ok ? "Logged in" : data.error || "Error");
   }
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <input name="customerId" placeholder="User ID" className="border p-1" />
-      <input name="email" type="email" placeholder="Email" className="border p-1" />
       <input name="password" type="password" placeholder="Password" className="border p-1" />
-      <button type="submit" className="border px-2 py-1">Register</button>
+      <button type="submit" className="border px-2 py-1">Login</button>
       {msg && <p>{msg}</p>}
     </form>
   );

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -1,6 +1,6 @@
 // apps/shop-abc/src/app/login/route.ts
 import { NextResponse } from "next/server";
-import { createCustomerSession } from "@auth";
+import { createCustomerSession, validateCsrfToken } from "@auth";
 import type { Role } from "@auth/types/roles";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
@@ -35,6 +35,11 @@ export async function POST(req: Request) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, {
       status: 400,
     });
+  }
+
+  const csrfToken = req.headers.get("x-csrf-token");
+  if (!csrfToken || !(await validateCsrfToken(csrfToken))) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
   const ip = req.headers.get("x-forwarded-for") ?? "unknown";

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -8,6 +8,7 @@ import {
   getUserByEmail,
 } from "@platform-core/users";
 import { checkRegistrationRateLimit } from "../../middleware";
+import { validateCsrfToken } from "@auth";
 
 const RegisterSchema = z.object({
   customerId: z.string(),
@@ -22,6 +23,11 @@ export async function POST(req: Request) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, {
       status: 400,
     });
+  }
+
+  const csrfToken = req.headers.get("x-csrf-token");
+  if (!csrfToken || !(await validateCsrfToken(csrfToken))) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
   const ip = req.headers.get("x-forwarded-for") ?? "unknown";

--- a/apps/shop-bcd/src/app/login/page.tsx
+++ b/apps/shop-bcd/src/app/login/page.tsx
@@ -2,14 +2,13 @@
 
 import { useState } from "react";
 
-export default function RegisterPage() {
+export default function LoginPage() {
   const [msg, setMsg] = useState("");
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
     const body = {
       customerId: (form.elements.namedItem("customerId") as HTMLInputElement).value,
-      email: (form.elements.namedItem("email") as HTMLInputElement).value,
       password: (form.elements.namedItem("password") as HTMLInputElement).value,
     };
     let csrfToken =
@@ -21,11 +20,11 @@ export default function RegisterPage() {
         : undefined;
     if (typeof document !== "undefined" && !csrfToken) {
       csrfToken = crypto.randomUUID();
-      document.cookie = `csrf_token=${csrfToken}; path=/; SameSite=Strict${
-        location.protocol === "https:" ? "; secure" : ""
-      }`;
+        document.cookie = `csrf_token=${csrfToken}; path=/; SameSite=Strict${
+          location.protocol === "https:" ? "; secure" : ""
+        }`;
     }
-    const res = await fetch("/register", {
+    const res = await fetch("/login", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -34,14 +33,13 @@ export default function RegisterPage() {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
-    setMsg(res.ok ? "Account created" : data.error || "Error");
+    setMsg(res.ok ? "Logged in" : data.error || "Error");
   }
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <input name="customerId" placeholder="User ID" className="border p-1" />
-      <input name="email" type="email" placeholder="Email" className="border p-1" />
       <input name="password" type="password" placeholder="Password" className="border p-1" />
-      <button type="submit" className="border px-2 py-1">Register</button>
+      <button type="submit" className="border px-2 py-1">Login</button>
       {msg && <p>{msg}</p>}
     </form>
   );

--- a/apps/shop-bcd/src/app/login/route.ts
+++ b/apps/shop-bcd/src/app/login/route.ts
@@ -1,6 +1,6 @@
 // apps/shop-bcd/src/app/login/route.ts
 import { NextResponse } from "next/server";
-import { createCustomerSession } from "@auth";
+import { createCustomerSession, validateCsrfToken } from "@auth";
 import type { Role } from "@auth/types/roles";
 import { z } from "zod";
 
@@ -36,6 +36,11 @@ export async function POST(req: Request) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, {
       status: 400,
     });
+  }
+
+  const csrfToken = req.headers.get("x-csrf-token");
+  if (!csrfToken || !(await validateCsrfToken(csrfToken))) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
   const valid = await validateCredentials(


### PR DESCRIPTION
## Summary
- ensure login and registration requests include a CSRF token
- validate CSRF tokens on login and registration routes across shops
- add login forms with client-side CSRF token generation

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/loginRateLimit.test.ts apps/shop-abc/__tests__/registerRateLimit.test.ts apps/shop-abc/__tests__/authFlow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899c02cfb60832fab27d8c8062597e1