### PR TITLE
feat(cms): loosen configurator step ordering

### DIFF
--- a/apps/cms/__tests__/wizard-flow.integration.test.tsx
+++ b/apps/cms/__tests__/wizard-flow.integration.test.tsx
@@ -26,9 +26,9 @@ jest.mock("@platform-core/src", () => {
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import Wizard from "../src/app/cms/wizard/Wizard";
-import { steps as stepConfig, stepOrder } from "../src/app/cms/configurator/steps";
+import { getSteps } from "../src/app/cms/configurator/steps";
 
-const steps = stepOrder.map((id) => stepConfig[id]);
+const steps = getSteps();
 
 const themes = ["base", "dark"];
 const templates = ["template-app"];

--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/atoms/shadcn";
 import type { WizardState } from "../wizard/schema";
+import { getSteps } from "./steps";
 export type StepStatus = "idle" | "pending" | "success" | "failure";
 
 interface StepConfig {
@@ -35,29 +36,13 @@ export default function ConfiguratorDashboard() {
       .catch(() => setState(null));
   }, []);
 
-  const steps: StepConfig[] = [
-    {
-      id: "details",
-      title: "Shop Details",
-      href: "/cms/configurator/details",
-      required: true,
-      completed: Boolean(state?.storeName),
-    },
-    {
-      id: "theme",
-      title: "Theme",
-      href: "/cms/configurator/theme",
-      required: true,
-      completed: Boolean(state?.theme),
-    },
-    {
-      id: "products",
-      title: "Products",
-      href: "/cms/configurator/products",
-      required: false,
-      completed: (state?.components?.length ?? 0) > 0,
-    },
-  ];
+  const steps: StepConfig[] = getSteps().map((s) => ({
+    id: s.id,
+    title: s.label,
+    href: `/cms/configurator/${s.id}`,
+    required: s.required && !s.optional,
+    completed: Boolean((state as any)?.completed?.[s.id]),
+  }));
 
   const allRequiredDone = steps.every(
     (s) => !s.required || s.completed

--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { steps, stepOrder } from "../steps";
+import { steps, getSteps } from "../steps";
 import useStepCompletion from "../../wizard/hooks/useStepCompletion";
 
 interface Props {
@@ -16,9 +16,10 @@ export default function StepPage({ stepId }: Props) {
   }
   const StepComponent = step.component as React.ComponentType<any>;
   const [, setCompleted] = useStepCompletion(stepId);
-  const index = stepOrder.indexOf(stepId);
-  const nextId = index >= 0 && index < stepOrder.length - 1 ? stepOrder[index + 1] : null;
-  const prevId = index > 0 ? stepOrder[index - 1] : null;
+  const ordered = getSteps();
+  const index = ordered.findIndex((s) => s.id === stepId);
+  const nextId = index >= 0 && index < ordered.length - 1 ? ordered[index + 1].id : null;
+  const prevId = index > 0 ? ordered[index - 1].id : null;
   const goNext = () => {
     if (nextId) router.push(`/cms/configurator/${nextId}`);
   };

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -20,7 +20,10 @@ export interface ConfiguratorStep {
   label: string;
   component: React.ComponentType<any>;
   required: boolean;
-  prerequisites?: string[];
+  /** Marks whether the step can be skipped */
+  optional?: boolean;
+  /** Default display order */
+  order?: number;
 }
 
 export type StepStatus = "pending" | "done";
@@ -31,134 +34,125 @@ export const steps: Record<string, ConfiguratorStep> = {
     label: "Shop Details",
     component: StepShopDetails,
     required: true,
+    order: 1,
   },
   theme: {
     id: "theme",
     label: "Theme",
     component: StepTheme,
     required: true,
-    prerequisites: ["shop-details"],
+    order: 2,
   },
   tokens: {
     id: "tokens",
     label: "Tokens",
     component: StepTokens,
     required: true,
-    prerequisites: ["theme"],
+    order: 3,
   },
   options: {
     id: "options",
     label: "Options",
     component: StepOptions,
     required: true,
-    prerequisites: ["tokens"],
+    order: 4,
   },
   navigation: {
     id: "navigation",
     label: "Navigation",
     component: StepNavigation,
     required: true,
-    prerequisites: ["options"],
+    order: 5,
   },
   layout: {
     id: "layout",
     label: "Layout",
     component: StepLayout,
     required: true,
-    prerequisites: ["navigation"],
+    order: 6,
   },
   "home-page": {
     id: "home-page",
     label: "Home Page",
     component: StepHomePage,
     required: true,
-    prerequisites: ["layout"],
+    order: 7,
   },
   "checkout-page": {
     id: "checkout-page",
     label: "Checkout Page",
     component: StepCheckoutPage,
     required: true,
-    prerequisites: ["home-page"],
+    order: 8,
   },
   "shop-page": {
     id: "shop-page",
     label: "Shop Page",
     component: StepShopPage,
     required: true,
-    prerequisites: ["checkout-page"],
+    order: 9,
   },
   "product-page": {
     id: "product-page",
     label: "Product Page",
     component: StepProductPage,
     required: true,
-    prerequisites: ["shop-page"],
+    order: 10,
   },
   "additional-pages": {
     id: "additional-pages",
     label: "Additional Pages",
     component: StepAdditionalPages,
     required: true,
-    prerequisites: ["product-page"],
+    order: 11,
   },
   "env-vars": {
     id: "env-vars",
     label: "Environment Variables",
     component: StepEnvVars,
     required: true,
-    prerequisites: ["additional-pages"],
+    order: 12,
   },
   summary: {
     id: "summary",
     label: "Summary",
     component: StepSummary,
     required: true,
-    prerequisites: ["env-vars"],
+    order: 13,
   },
   "import-data": {
     id: "import-data",
     label: "Import Data",
     component: StepImportData,
     required: false,
-    prerequisites: ["summary"],
+    optional: true,
+    order: 14,
   },
   "seed-data": {
     id: "seed-data",
     label: "Seed Data",
     component: StepSeedData,
     required: false,
-    prerequisites: ["import-data"],
+    optional: true,
+    order: 15,
   },
   hosting: {
     id: "hosting",
     label: "Hosting",
     component: StepHosting,
     required: false,
-    prerequisites: ["seed-data"],
+    optional: true,
+    order: 16,
   },
 };
 
-export const stepOrder = [
-  "shop-details",
-  "theme",
-  "tokens",
-  "options",
-  "navigation",
-  "layout",
-  "home-page",
-  "checkout-page",
-  "shop-page",
-  "product-page",
-  "additional-pages",
-  "env-vars",
-  "summary",
-  "import-data",
-  "seed-data",
-  "hosting",
-];
+export function getSteps(): ConfiguratorStep[] {
+  return Object.values(steps).sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0)
+  );
+}
 
 export const initialStepStatus: Record<string, StepStatus> = Object.fromEntries(
-  stepOrder.map((id) => [id, "pending"])
+  getSteps().map((step) => [step.id, "pending"])
 );
 


### PR DESCRIPTION
## Summary
- allow optional configurator steps with display order metadata
- share configurator step list via `getSteps()` helper
- consume new helper in dashboard and step pages

## Testing
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6899c1c644ac832f88a14d7c56129577