### PR TITLE
feat: add password reset workflow

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -44,14 +44,18 @@ jest.mock("@platform-core/users", () => ({
 
 let registerPOST: typeof import("../src/app/api/register/route").POST;
 let loginPOST: typeof import("../src/app/login/route").POST;
-let forgotPOST: typeof import("../src/app/forgot-password/route").POST;
-let resetPOST: typeof import("../src/app/api/reset-password/route").POST;
+let requestPOST: typeof import("../src/app/api/account/reset/request/route").POST;
+let completePOST: typeof import("../src/app/api/account/reset/complete/route").POST;
 
 beforeAll(async () => {
   ({ POST: registerPOST } = await import("../src/app/api/register/route"));
   ({ POST: loginPOST } = await import("../src/app/login/route"));
-  ({ POST: forgotPOST } = await import("../src/app/forgot-password/route"));
-  ({ POST: resetPOST } = await import("../src/app/api/reset-password/route"));
+  ({ POST: requestPOST } = await import(
+    "../src/app/api/account/reset/request/route"
+  ));
+  ({ POST: completePOST } = await import(
+    "../src/app/api/account/reset/complete/route"
+  ));
 });
 
 function makeRequest(body: any, headers: Record<string, string> = {}) {
@@ -89,11 +93,11 @@ describe("auth flows", () => {
     );
     expect(res.status).toBe(200);
 
-    await forgotPOST(makeRequest({ email: "test@example.com" }));
+    await requestPOST(makeRequest({ email: "test@example.com" }));
     const { getUserById } = await import("@platform-core/users");
     const token = (await getUserById("cust1"))!.resetToken as string;
 
-    res = await resetPOST(
+    res = await completePOST(
       makeRequest({
         customerId: "cust1",
         token,

--- a/apps/shop-abc/src/app/account/reset/page.tsx
+++ b/apps/shop-abc/src/app/account/reset/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ResetPasswordPage() {
+  const [msg, setMsg] = useState("");
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget.elements as any;
+    const customerId = (form.namedItem("customerId") as HTMLInputElement).value;
+    const token = (form.namedItem("token") as HTMLInputElement).value;
+    const password = (form.namedItem("password") as HTMLInputElement).value;
+    const res = await fetch("/api/account/reset/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ customerId, token, password }),
+    });
+    await res.json().catch(() => ({}));
+    setMsg(res.ok ? "Password updated" : "Error");
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input name="customerId" placeholder="Customer ID" className="border p-1" />
+      <input name="token" placeholder="Token" className="border p-1" />
+      <input
+        name="password"
+        type="password"
+        placeholder="New password"
+        className="border p-1"
+      />
+      <button type="submit" className="border px-2 py-1">
+        Reset password
+      </button>
+      {msg && <p>{msg}</p>}
+    </form>
+  );
+}

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -1,10 +1,10 @@
-// apps/shop-abc/src/app/api/reset-password/route.ts
+// apps/shop-abc/src/app/api/account/reset/complete/route.ts
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 import { getUserById, updatePassword } from "@platform-core/users";
 
-const ResetSchema = z.object({
+const schema = z.object({
   customerId: z.string(),
   token: z.string(),
   password: z.string(),
@@ -12,7 +12,7 @@ const ResetSchema = z.object({
 
 export async function POST(req: Request) {
   const json = await req.json();
-  const parsed = ResetSchema.safeParse(json);
+  const parsed = schema.safeParse(json);
   if (!parsed.success) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, {
       status: 400,

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -1,16 +1,16 @@
-// apps/shop-abc/src/app/forgot-password/route.ts
+// apps/shop-abc/src/app/api/account/reset/request/route.ts
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getUserByEmail, setResetToken } from "@platform-core/users";
 import { sendEmail } from "@lib/email";
 
-const ForgotSchema = z.object({
+const schema = z.object({
   email: z.string().email(),
 });
 
 export async function POST(req: Request) {
   const json = await req.json();
-  const parsed = ForgotSchema.safeParse(json);
+  const parsed = schema.safeParse(json);
   if (!parsed.success) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, {
       status: 400,

--- a/apps/shop-abc/src/app/forgot-password/page.tsx
+++ b/apps/shop-abc/src/app/forgot-password/page.tsx
@@ -8,7 +8,7 @@ export default function ForgotPasswordPage() {
     e.preventDefault();
     const email = (e.currentTarget.elements.namedItem("email") as HTMLInputElement)
       .value;
-    const res = await fetch("/forgot-password", {
+    const res = await fetch("/api/account/reset/request", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email }),


### PR DESCRIPTION
## Summary
- add API endpoints for requesting and completing account password resets
- provide pages for requesting a reset token and setting a new password
- update integration test to exercise full reset flow

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/authFlow.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899c1707ad4832fa8f9b50f075cfc14