### PR TITLE
feat(cms): dynamic dashboard steps

### DIFF
--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -4,16 +4,10 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/atoms/shadcn";
-import type { WizardState } from "../wizard/schema";
-export type StepStatus = "idle" | "pending" | "success" | "failure";
+import { wizardStateSchema, type WizardState } from "../wizard/schema";
+import { getSteps } from "./steps";
 
-interface StepConfig {
-  id: string;
-  title: string;
-  href: string;
-  required?: boolean;
-  completed: boolean;
-}
+export type StepStatus = "idle" | "pending" | "success" | "failure";
 
 export default function ConfiguratorDashboard() {
   const [state, setState] = useState<WizardState | null>(null);
@@ -31,36 +25,23 @@ export default function ConfiguratorDashboard() {
   useEffect(() => {
     fetch("/cms/api/wizard-progress")
       .then((res) => (res.ok ? res.json() : null))
-      .then((json) => setState(json))
+      .then((json) => {
+        if (!json) return;
+        const parsed = wizardStateSchema.safeParse({
+          ...(json.state ?? json),
+          completed: json.completed ?? {},
+        });
+        if (parsed.success) {
+          setState(parsed.data);
+        }
+      })
       .catch(() => setState(null));
   }, []);
 
-  const steps: StepConfig[] = [
-    {
-      id: "details",
-      title: "Shop Details",
-      href: "/cms/configurator/details",
-      required: true,
-      completed: Boolean(state?.storeName),
-    },
-    {
-      id: "theme",
-      title: "Theme",
-      href: "/cms/configurator/theme",
-      required: true,
-      completed: Boolean(state?.theme),
-    },
-    {
-      id: "products",
-      title: "Products",
-      href: "/cms/configurator/products",
-      required: false,
-      completed: (state?.components?.length ?? 0) > 0,
-    },
-  ];
+  const steps = getSteps();
 
   const allRequiredDone = steps.every(
-    (s) => !s.required || s.completed
+    (s) => !s.required || Boolean(state?.completed?.[s.id])
   );
 
   const launchShop = async () => {
@@ -94,18 +75,24 @@ export default function ConfiguratorDashboard() {
     <div>
       <h2 className="mb-4 text-xl font-semibold">Configuration Steps</h2>
       <ul className="mb-6 space-y-2">
-        {steps.map((step) => (
-          <li key={step.id} className="flex items-center gap-2">
-            {step.completed ? (
-              <CheckCircledIcon className="h-4 w-4 text-green-600" />
-            ) : (
-              <CircleIcon className="h-4 w-4 text-gray-400" />
-            )}
-            <Link href={step.href} className="underline">
-              {step.title}
-            </Link>
-          </li>
-        ))}
+        {steps.map((step) => {
+          const completed = Boolean(state?.completed?.[step.id]);
+          return (
+            <li key={step.id} className="flex items-center gap-2">
+              {completed ? (
+                <CheckCircledIcon className="h-4 w-4 text-green-600" />
+              ) : (
+                <CircleIcon className="h-4 w-4 text-gray-400" />
+              )}
+              <Link
+                href={`/cms/configurator/${step.id}`}
+                className="underline"
+              >
+                {step.label}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
       <Button disabled={!allRequiredDone} onClick={launchShop}>
         Launch Shop

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -162,3 +162,7 @@ export const initialStepStatus: Record<string, StepStatus> = Object.fromEntries(
   stepOrder.map((id) => [id, "pending"])
 );
 
+export function getSteps(): ConfiguratorStep[] {
+  return stepOrder.map((id) => steps[id]);
+}
+


### PR DESCRIPTION
## Summary
- generate configurator step list with `getSteps`
- show completion status and enable launch when all required steps are done

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '@prisma/client' and other modules, 18 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_e_6899c13f93c4832f890826e39a330d7f