### PR TITLE
fix: await shop creation in init CLI

### DIFF
--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -105,7 +105,7 @@ async function main() {
   };
 
   const prefixedId = `shop-${shopId}`;
-  createShop(prefixedId, options, { deploy: true });
+  await createShop(prefixedId, options, { deploy: true });
 
   let validationError: unknown;
   try {


### PR DESCRIPTION
## Summary
- await shop creation before validating env

## Testing
- `pnpm exec jest test/unit/init-shop.spec.ts` (fails: Cannot read properties of undefined (reading 'trim'))

------
https://chatgpt.com/codex/tasks/task_e_6899c50b7e54832fb6777160a6d523f4