### PR TITLE
Harden request schemas and centralize validation

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -67,7 +67,7 @@ describe("auth flows", () => {
       makeRequest({
         customerId: "cust1",
         email: "test@example.com",
-        password: "pass1",
+        password: "password1",
       }),
     );
     expect(res.status).toBe(200);
@@ -76,14 +76,14 @@ describe("auth flows", () => {
       makeRequest({
         customerId: "cust2",
         email: "test@example.com",
-        password: "pass2",
+        password: "password2",
       }),
     );
     expect(dup.status).toBe(400);
 
     res = await loginPOST(
       makeRequest(
-        { customerId: "cust1", password: "pass1" },
+        { customerId: "cust1", password: "password1" },
         { "x-forwarded-for": "1.1.1.1" },
       ),
     );
@@ -97,14 +97,14 @@ describe("auth flows", () => {
       makeRequest({
         customerId: "cust1",
         token,
-        password: "newpass",
+        password: "newpass1",
       }),
     );
     expect(res.status).toBe(200);
 
     res = await loginPOST(
       makeRequest(
-        { customerId: "cust1", password: "pass1" },
+        { customerId: "cust1", password: "password1" },
         { "x-forwarded-for": "1.1.1.1" },
       ),
     );
@@ -112,7 +112,7 @@ describe("auth flows", () => {
 
     res = await loginPOST(
       makeRequest(
-        { customerId: "cust1", password: "newpass" },
+        { customerId: "cust1", password: "newpass1" },
         { "x-forwarded-for": "1.1.1.1" },
       ),
     );

--- a/apps/shop-abc/src/app/api/reset-password/route.ts
+++ b/apps/shop-abc/src/app/api/reset-password/route.ts
@@ -3,21 +3,21 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 import { getUserById, updatePassword } from "@platform-core/users";
+import { parseJsonBody } from "@lib/parseJsonBody";
 
-const ResetSchema = z.object({
-  customerId: z.string(),
-  token: z.string(),
-  password: z.string(),
-});
+const ResetSchema = z
+  .object({
+    customerId: z.string(),
+    token: z.string(),
+    password: z.string().min(8),
+  })
+  .strict();
+
+export type ResetPasswordInput = z.infer<typeof ResetSchema>;
 
 export async function POST(req: Request) {
-  const json = await req.json();
-  const parsed = ResetSchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, {
-      status: 400,
-    });
-  }
+  const parsed = await parseJsonBody(req, ResetSchema);
+  if (!parsed.success) return parsed.error;
 
   const { customerId, token, password } = parsed.data;
   const user = await getUserById(customerId);

--- a/apps/shop-abc/src/app/forgot-password/route.ts
+++ b/apps/shop-abc/src/app/forgot-password/route.ts
@@ -3,19 +3,19 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getUserByEmail, setResetToken } from "@platform-core/users";
 import { sendEmail } from "@lib/email";
+import { parseJsonBody } from "@lib/parseJsonBody";
 
-const ForgotSchema = z.object({
-  email: z.string().email(),
-});
+const ForgotSchema = z
+  .object({
+    email: z.string().email(),
+  })
+  .strict();
+
+export type ForgotPasswordInput = z.infer<typeof ForgotSchema>;
 
 export async function POST(req: Request) {
-  const json = await req.json();
-  const parsed = ForgotSchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, {
-      status: 400,
-    });
-  }
+  const parsed = await parseJsonBody(req, ForgotSchema);
+  if (!parsed.success) return parsed.error;
 
   const user = await getUserByEmail(parsed.data.email);
   if (user) {

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
+import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -18,6 +19,9 @@ export const metadata: Metadata = {
   title: "Base-Shop",
   description: "Sustainable footwear built with Next.js 15",
 };
+
+// Ensure friendly Zod messages for all validations
+applyFriendlyZodMessages();
 
 export default function RootLayout({
   children,

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -4,6 +4,7 @@ import { createCustomerSession } from "@auth";
 import type { Role } from "@auth/types/roles";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
+import { parseJsonBody } from "@lib/parseJsonBody";
 import {
   checkLoginRateLimit,
   clearLoginAttempts,
@@ -12,15 +13,19 @@ import { getUserById } from "@platform-core/users";
 
 const ALLOWED_ROLES: Role[] = ["customer", "viewer"];
 
-const LoginSchema = z.object({
-  customerId: z.string(),
-  password: z.string(),
-});
+const LoginSchema = z
+  .object({
+    customerId: z.string(),
+    password: z.string().min(8),
+  })
+  .strict();
 
-async function validateCredentials(
-  customerId: string,
-  password: string,
-): Promise<{ customerId: string; role: Role } | null> {
+export type LoginInput = z.infer<typeof LoginSchema>;
+
+async function validateCredentials({
+  customerId,
+  password,
+}: LoginInput): Promise<{ customerId: string; role: Role } | null> {
   const record = await getUserById(customerId);
   if (!record) return null;
   const match = await bcrypt.compare(password, record.passwordHash);
@@ -29,22 +34,16 @@ async function validateCredentials(
 }
 
 export async function POST(req: Request) {
-  const json = await req.json();
-  const parsed = LoginSchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, {
-      status: 400,
-    });
-  }
+  const parsed = await parseJsonBody(req, LoginSchema);
+  if (!parsed.success) return parsed.error;
+
+  const { customerId, password } = parsed.data;
 
   const ip = req.headers.get("x-forwarded-for") ?? "unknown";
-  const rateLimited = await checkLoginRateLimit(ip, parsed.data.customerId);
+  const rateLimited = await checkLoginRateLimit(ip, customerId);
   if (rateLimited) return rateLimited;
 
-  const valid = await validateCredentials(
-    parsed.data.customerId,
-    parsed.data.password,
-  );
+  const valid = await validateCredentials({ customerId, password });
 
   if (!valid) {
     return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
@@ -56,7 +55,7 @@ export async function POST(req: Request) {
   }
 
   await createCustomerSession(valid);
-  await clearLoginAttempts(ip, parsed.data.customerId);
+  await clearLoginAttempts(ip, customerId);
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
+import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -18,6 +19,9 @@ export const metadata: Metadata = {
   title: "Base-Shop",
   description: "Sustainable footwear built with Next.js 15",
 };
+
+// Ensure friendly Zod messages for all validations
+applyFriendlyZodMessages();
 
 export default function RootLayout({
   children,

--- a/packages/lib/src/parseJsonBody.ts
+++ b/packages/lib/src/parseJsonBody.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import type { z } from "zod";
+
+/**
+ * Parse and validate a JSON request body using the provided Zod schema.
+ * Returns a standardized error response on failure.
+ */
+export async function parseJsonBody<T extends z.ZodTypeAny>(
+  req: Request,
+  schema: T,
+): Promise<
+  | { success: true; data: z.infer<T> }
+  | { success: false; error: NextResponse }
+> {
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return {
+      success: false,
+      error: NextResponse.json({ error: "Invalid JSON" }, { status: 400 }),
+    };
+  }
+
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: NextResponse.json(parsed.error.flatten().fieldErrors, {
+        status: 400,
+      }),
+    };
+  }
+
+  return { success: true, data: parsed.data };
+}

--- a/packages/types/__tests__/pageSchema.test.ts
+++ b/packages/types/__tests__/pageSchema.test.ts
@@ -44,4 +44,19 @@ describe("pageSchema", () => {
     } as any;
     expect(pageSchema.safeParse(invalid).success).toBe(false);
   });
+
+  it("rejects unknown fields", () => {
+    const invalid = {
+      id: "p1",
+      slug: "home",
+      status: "draft",
+      components: [],
+      seo: { title: { en: "Home" } },
+      createdAt: "2024-01-01",
+      updatedAt: "2024-01-01",
+      createdBy: "user",
+      foo: "bar",
+    } as any;
+    expect(pageSchema.safeParse(invalid).success).toBe(false);
+  });
 });

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -311,20 +311,24 @@ export const historyStateSchema: z.ZodType<HistoryState> = z
   .strict()
   .default({ past: [], present: [], future: [] });
 
-export const pageSchema = z.object({
-  id: z.string(),
-  slug: z.string(),
-  status: z.enum(["draft", "published"]),
-  components: z.array(pageComponentSchema).default([]),
-  seo: z.object({
-    title: z.record(localeSchema, z.string()),
-    description: z.record(localeSchema, z.string()).optional(),
-    image: z.record(localeSchema, z.string()).optional(),
-  }),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  createdBy: z.string(),
-  history: historyStateSchema.optional(),
-});
+export const pageSchema = z
+  .object({
+    id: z.string(),
+    slug: z.string(),
+    status: z.enum(["draft", "published"]),
+    components: z.array(pageComponentSchema).default([]),
+    seo: z
+      .object({
+        title: z.record(localeSchema, z.string()),
+        description: z.record(localeSchema, z.string()).optional(),
+        image: z.record(localeSchema, z.string()).optional(),
+      })
+      .strict(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    createdBy: z.string(),
+    history: historyStateSchema.optional(),
+  })
+  .strict();
 
 export type Page = z.infer<typeof pageSchema>;


### PR DESCRIPTION
## Summary
- Enforce strict, typed auth schemas with minimum password length
- Centralize JSON body parsing via `parseJsonBody`
- Apply friendly Zod error mapping across shop apps
- Strict page schema to reject unknown fields

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/authFlow.test.ts apps/shop-abc/__tests__/loginRateLimit.test.ts packages/types/__tests__/pageSchema.test.ts`
- `pnpm exec jest apps/shop-bcd/__tests__/account-profile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899c4fd4304832f800028bc7cdbdd83