### PR TITLE
Simplify password reset flow to rely on token

### DIFF
--- a/apps/shop-abc/src/app/account/reset/page.tsx
+++ b/apps/shop-abc/src/app/account/reset/page.tsx
@@ -8,13 +8,12 @@ export default function ResetPasswordPage() {
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget.elements as any;
-    const customerId = (form.namedItem("customerId") as HTMLInputElement).value;
     const token = (form.namedItem("token") as HTMLInputElement).value;
     const password = (form.namedItem("password") as HTMLInputElement).value;
     const res = await fetch("/api/account/reset/complete", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ customerId, token, password }),
+      body: JSON.stringify({ token, password }),
     });
     await res.json().catch(() => ({}));
     setMsg(res.ok ? "Password updated" : "Error");
@@ -22,7 +21,6 @@ export default function ResetPasswordPage() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
-      <input name="customerId" placeholder="Customer ID" className="border p-1" />
       <input name="token" placeholder="Token" className="border p-1" />
       <input
         name="password"

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -2,10 +2,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
-import { getUserById, updatePassword } from "@platform-core/users";
+import { getUserByResetToken, updatePassword } from "@platform-core/users";
 
 const schema = z.object({
-  customerId: z.string(),
   token: z.string(),
   password: z.string(),
 });
@@ -19,13 +18,13 @@ export async function POST(req: Request) {
     });
   }
 
-  const { customerId, token, password } = parsed.data;
-  const user = await getUserById(customerId);
-  if (!user || user.resetToken !== token) {
+  const { token, password } = parsed.data;
+  const user = await getUserByResetToken(token);
+  if (!user) {
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });
   }
 
   const passwordHash = await bcrypt.hash(password, 10);
-  await updatePassword(customerId, passwordHash);
+  await updatePassword(user.id, passwordHash);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- remove customerId field from password reset form
- look up user by reset token in reset completion API

## Testing
- `pnpm exec eslint apps/shop-abc/src/app/account/reset/page.tsx apps/shop-abc/src/app/api/account/reset/complete/route.ts`
- `pnpm test --filter @apps/shop-abc`


------
https://chatgpt.com/codex/tasks/task_e_6899c8e48774832f87a47bf83c274e7a