### PR TITLE
feat: add page builder guidance

### DIFF
--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -127,7 +127,7 @@ async function main() {
   }
 
   console.log(
-    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Review data/shops/${prefixedId}/shop.json\n  - Run: pnpm --filter @apps/${prefixedId} dev`
+    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Review data/shops/${prefixedId}/shop.json\n  - Use the CMS Page Builder to lay out your pages\n  - Run: pnpm --filter @apps/${prefixedId} dev`
   );
 }
 


### PR DESCRIPTION
## Summary
- guide users to the CMS Page Builder after `pnpm init-shop`

## Testing
- `npx eslint scripts/src/init-shop.ts`
- `pnpm validate-env abc` *(fails: Unknown file extension ".ts" for validate-env.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6899c89447c8832fa984cb248aad7914