### PR TITLE
Refactor configurator steps sequence handling

### DIFF
--- a/apps/cms/__tests__/wizard-flow.integration.test.tsx
+++ b/apps/cms/__tests__/wizard-flow.integration.test.tsx
@@ -26,9 +26,9 @@ jest.mock("@platform-core/src", () => {
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import Wizard from "../src/app/cms/wizard/Wizard";
-import { steps as stepConfig, stepOrder } from "../src/app/cms/configurator/steps";
+import { getSteps } from "../src/app/cms/configurator/steps";
 
-const steps = stepOrder.map((id) => stepConfig[id]);
+const steps = getSteps();
 
 const themes = ["base", "dark"];
 const templates = ["template-app"];

--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -6,7 +6,7 @@ import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/atoms/shadcn";
 import { Toast, Tooltip } from "@/components/atoms";
 import type { WizardState } from "../wizard/schema";
-import { steps, stepOrder } from "./steps";
+import { getSteps } from "./steps";
 export type StepStatus = "idle" | "pending" | "success" | "failure";
 
 export default function ConfiguratorDashboard() {
@@ -34,8 +34,9 @@ export default function ConfiguratorDashboard() {
       .then((json) => setState(json))
       .catch(() => setState(null));
   }, []);
-  const missingRequired = stepOrder.filter(
-    (id) => steps[id].required && !state?.completed?.[id]
+  const stepList = getSteps();
+  const missingRequired = stepList.filter(
+    (s) => !s.optional && !state?.completed?.[s.id]
   );
   const allRequiredDone = missingRequired.length === 0;
 
@@ -45,7 +46,7 @@ export default function ConfiguratorDashboard() {
       setToast({
         open: true,
         message: `Complete required steps: ${missingRequired
-          .map((id) => steps[id].label)
+          .map((s) => s.label)
           .join(", ")}`,
       });
       return;
@@ -79,17 +80,16 @@ export default function ConfiguratorDashboard() {
     <div>
       <h2 className="mb-4 text-xl font-semibold">Configuration Steps</h2>
       <ul className="mb-6 space-y-2">
-        {stepOrder.map((id) => {
-          const step = steps[id];
-          const completed = Boolean(state?.completed?.[id]);
+        {stepList.map((step) => {
+          const completed = Boolean(state?.completed?.[step.id]);
           return (
-            <li key={id} className="flex items-center gap-2">
+            <li key={step.id} className="flex items-center gap-2">
               {completed ? (
                 <CheckCircledIcon className="h-4 w-4 text-green-600" />
               ) : (
                 <CircleIcon className="h-4 w-4 text-gray-400" />
               )}
-              <Link href={`/cms/configurator/${id}`} className="underline">
+              <Link href={`/cms/configurator/${step.id}`} className="underline">
                 {step.label}
               </Link>
             </li>
@@ -101,7 +101,7 @@ export default function ConfiguratorDashboard() {
       ) : (
         <Tooltip
           text={`Complete required steps: ${missingRequired
-            .map((id) => steps[id].label)
+            .map((s) => s.label)
             .join(", ")}`}
         >
           <Button disabled>Launch Shop</Button>

--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { steps, stepOrder } from "../steps";
+import { getSteps } from "../steps";
 
 interface Props {
   stepId: string;
@@ -9,14 +9,15 @@ interface Props {
 
 export default function StepPage({ stepId }: Props) {
   const router = useRouter();
-  const step = steps[stepId];
+  const stepList = getSteps();
+  const index = stepList.findIndex((s) => s.id === stepId);
+  const step = stepList[index];
   if (!step) {
     return null;
   }
   const StepComponent = step.component as React.ComponentType<any>;
-  const index = stepOrder.indexOf(stepId);
-  const nextId = index >= 0 && index < stepOrder.length - 1 ? stepOrder[index + 1] : null;
-  const prevId = index > 0 ? stepOrder[index - 1] : null;
+  const nextId = index >= 0 && index < stepList.length - 1 ? stepList[index + 1].id : null;
+  const prevId = index > 0 ? stepList[index - 1].id : null;
   const goNext = () => {
     if (nextId) router.push(`/cms/configurator/${nextId}`);
   };

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -19,146 +19,32 @@ export interface ConfiguratorStep {
   id: string;
   label: string;
   component: React.ComponentType<any>;
-  required: boolean;
-  prerequisites?: string[];
+  optional?: boolean;
+  order?: number;
 }
 
-export type StepStatus = "pending" | "done";
-
-export const steps: Record<string, ConfiguratorStep> = {
-  "shop-details": {
-    id: "shop-details",
-    label: "Shop Details",
-    component: StepShopDetails,
-    required: true,
-  },
-  theme: {
-    id: "theme",
-    label: "Theme",
-    component: StepTheme,
-    required: true,
-    prerequisites: ["shop-details"],
-  },
-  tokens: {
-    id: "tokens",
-    label: "Tokens",
-    component: StepTokens,
-    required: true,
-    prerequisites: ["theme"],
-  },
-  options: {
-    id: "options",
-    label: "Options",
-    component: StepOptions,
-    required: true,
-    prerequisites: ["tokens"],
-  },
-  navigation: {
-    id: "navigation",
-    label: "Navigation",
-    component: StepNavigation,
-    required: true,
-    prerequisites: ["options"],
-  },
-  layout: {
-    id: "layout",
-    label: "Layout",
-    component: StepLayout,
-    required: true,
-    prerequisites: ["navigation"],
-  },
-  "home-page": {
-    id: "home-page",
-    label: "Home Page",
-    component: StepHomePage,
-    required: true,
-    prerequisites: ["layout"],
-  },
-  "checkout-page": {
-    id: "checkout-page",
-    label: "Checkout Page",
-    component: StepCheckoutPage,
-    required: true,
-    prerequisites: ["home-page"],
-  },
-  "shop-page": {
-    id: "shop-page",
-    label: "Shop Page",
-    component: StepShopPage,
-    required: true,
-    prerequisites: ["checkout-page"],
-  },
-  "product-page": {
-    id: "product-page",
-    label: "Product Page",
-    component: StepProductPage,
-    required: true,
-    prerequisites: ["shop-page"],
-  },
-  "additional-pages": {
-    id: "additional-pages",
-    label: "Additional Pages",
-    component: StepAdditionalPages,
-    required: true,
-    prerequisites: ["product-page"],
-  },
-  "env-vars": {
-    id: "env-vars",
-    label: "Environment Variables",
-    component: StepEnvVars,
-    required: true,
-    prerequisites: ["additional-pages"],
-  },
-  summary: {
-    id: "summary",
-    label: "Summary",
-    component: StepSummary,
-    required: true,
-    prerequisites: ["env-vars"],
-  },
-  "import-data": {
-    id: "import-data",
-    label: "Import Data",
-    component: StepImportData,
-    required: false,
-    prerequisites: ["summary"],
-  },
-  "seed-data": {
-    id: "seed-data",
-    label: "Seed Data",
-    component: StepSeedData,
-    required: false,
-    prerequisites: ["import-data"],
-  },
-  hosting: {
-    id: "hosting",
-    label: "Hosting",
-    component: StepHosting,
-    required: false,
-    prerequisites: ["seed-data"],
-  },
-};
-
-export const stepOrder = [
-  "shop-details",
-  "theme",
-  "tokens",
-  "options",
-  "navigation",
-  "layout",
-  "home-page",
-  "checkout-page",
-  "shop-page",
-  "product-page",
-  "additional-pages",
-  "env-vars",
-  "summary",
-  "import-data",
-  "seed-data",
-  "hosting",
+const stepList: ConfiguratorStep[] = [
+  { id: "shop-details", label: "Shop Details", component: StepShopDetails, order: 1 },
+  { id: "theme", label: "Theme", component: StepTheme, order: 2 },
+  { id: "tokens", label: "Tokens", component: StepTokens, order: 3 },
+  { id: "options", label: "Options", component: StepOptions, order: 4 },
+  { id: "navigation", label: "Navigation", component: StepNavigation, order: 5 },
+  { id: "layout", label: "Layout", component: StepLayout, order: 6 },
+  { id: "home-page", label: "Home Page", component: StepHomePage, order: 7 },
+  { id: "checkout-page", label: "Checkout Page", component: StepCheckoutPage, order: 8 },
+  { id: "shop-page", label: "Shop Page", component: StepShopPage, order: 9 },
+  { id: "product-page", label: "Product Page", component: StepProductPage, order: 10 },
+  { id: "additional-pages", label: "Additional Pages", component: StepAdditionalPages, order: 11 },
+  { id: "env-vars", label: "Environment Variables", component: StepEnvVars, order: 12 },
+  { id: "summary", label: "Summary", component: StepSummary, order: 13 },
+  { id: "import-data", label: "Import Data", component: StepImportData, optional: true, order: 14 },
+  { id: "seed-data", label: "Seed Data", component: StepSeedData, optional: true, order: 15 },
+  { id: "hosting", label: "Hosting", component: StepHosting, optional: true, order: 16 },
 ];
 
-export const initialStepStatus: Record<string, StepStatus> = Object.fromEntries(
-  stepOrder.map((id) => [id, "pending"])
-);
+export const getSteps = (): ConfiguratorStep[] =>
+  [...stepList].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
+export const steps: Record<string, ConfiguratorStep> = Object.fromEntries(
+  getSteps().map((s) => [s.id, s])
+);


### PR DESCRIPTION
## Summary
- remove strict step prerequisites and track optional steps with order metadata
- add getSteps() helper for configurator to reuse across pages
- update dashboard, step pages, and tests to use new step API

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard', Prisma client modules missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6899c8d2bb00832f8e662a4209398949