### PR TITLE
feat(stock): enhance stock alerts

### DIFF
--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -16,6 +16,13 @@ export const envSchema = z.object({
   CHROMATIC_PROJECT_TOKEN: z.string().optional(),
   GMAIL_USER: z.string().optional(),
   GMAIL_PASS: z.string().optional(),
+  // Comma separated list of email recipients for stock alerts
+  STOCK_ALERT_RECIPIENTS: z.string().optional(),
+  // Optional webhook URL for stock alerts
+  STOCK_ALERT_WEBHOOK: z.string().url().optional(),
+  // Default low stock threshold if an item does not specify one
+  STOCK_ALERT_DEFAULT_THRESHOLD: z.coerce.number().optional(),
+  // Legacy single-recipient support
   STOCK_ALERT_RECIPIENT: z.string().email().optional(),
 });
 

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -1,21 +1,60 @@
 import "server-only";
 
 import { env } from "@config/src/env";
+import { DATA_ROOT } from "../dataRoot";
 import { sendEmail } from "@lib/email";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 import type { InventoryItem } from "@types";
+
+const LOG_FILE = "stock-alert-log.json";
+const SUPPRESS_HOURS = 24; // suppress repeat alerts for a day
+
+async function readLog(shop: string): Promise<Record<string, number>> {
+  try {
+    const p = path.join(DATA_ROOT, shop, LOG_FILE);
+    const buf = await fs.readFile(p, "utf8");
+    return JSON.parse(buf) as Record<string, number>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeLog(shop: string, log: Record<string, number>): Promise<void> {
+  const p = path.join(DATA_ROOT, shop, LOG_FILE);
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, JSON.stringify(log, null, 2), "utf8");
+}
 
 export async function checkAndAlert(
   shop: string,
   items: InventoryItem[],
 ): Promise<void> {
-  const recipient = env.STOCK_ALERT_RECIPIENT;
-  if (!recipient) return;
+  const recipientRaw = env.STOCK_ALERT_RECIPIENTS ?? env.STOCK_ALERT_RECIPIENT;
+  const webhook = env.STOCK_ALERT_WEBHOOK;
+  if (!recipientRaw && !webhook) return;
 
-  const lowItems = items.filter(
-    (i) =>
-      typeof i.lowStockThreshold === "number" &&
-      i.quantity <= i.lowStockThreshold,
-  );
+  const recipients = recipientRaw
+    ? recipientRaw.split(",").map((r) => r.trim()).filter(Boolean)
+    : [];
+
+  const log = await readLog(shop);
+  const now = Date.now();
+  const suppressBefore = now - SUPPRESS_HOURS * 60 * 60 * 1000;
+
+  const lowItems = items
+    .filter((i) => {
+      const threshold =
+        typeof i.lowStockThreshold === "number"
+          ? i.lowStockThreshold
+          : env.STOCK_ALERT_DEFAULT_THRESHOLD;
+      return typeof threshold === "number" && i.quantity <= threshold;
+    })
+    .filter((i) => {
+      const last = log[i.sku];
+      return !last || last < suppressBefore;
+    });
+
   if (lowItems.length === 0) return;
 
   const lines = lowItems.map((i) => {
@@ -23,14 +62,35 @@ export async function checkAndAlert(
       .map(([k, v]) => `${k}: ${v}`)
       .join(", ");
     const variant = attrs ? ` (${attrs})` : "";
-    return `${i.sku}${variant} – qty ${i.quantity} (threshold ${i.lowStockThreshold})`;
+    const threshold =
+      i.lowStockThreshold ?? env.STOCK_ALERT_DEFAULT_THRESHOLD;
+    return `${i.sku}${variant} – qty ${i.quantity} (threshold ${threshold})`;
   });
   const body = `The following items in shop ${shop} are low on stock:\n${lines.join("\n")}`;
   const subject = `Low stock alert for ${shop}`;
 
-  try {
-    await sendEmail(recipient, subject, body);
-  } catch (err) {
-    console.error("Failed to send stock alert", err);
+  for (const r of recipients) {
+    try {
+      await sendEmail(r, subject, body);
+    } catch (err) {
+      console.error("Failed to send stock alert", err);
+    }
   }
+
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ shop, items: lowItems, subject, body }),
+      });
+    } catch (err) {
+      console.error("Failed to send stock alert webhook", err);
+    }
+  }
+
+  for (const item of lowItems) {
+    log[item.sku] = now;
+  }
+  await writeLog(shop, log);
 }

--- a/packages/platform-core/src/services/stockScheduler.server.ts
+++ b/packages/platform-core/src/services/stockScheduler.server.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import type { InventoryItem } from "@types";
+import { checkAndAlert } from "./stockAlert.server";
+
+/**
+ * Periodically runs {@link checkAndAlert} for a shop.
+ * @param shop The shop identifier.
+ * @param getItems Function returning the latest inventory items.
+ * @param intervalMs Interval in milliseconds between checks (default 1h).
+ */
+export function scheduleStockChecks(
+  shop: string,
+  getItems: () => Promise<InventoryItem[]>,
+  intervalMs = 60 * 60 * 1000,
+): void {
+  setInterval(async () => {
+    try {
+      const items = await getItems();
+      await checkAndAlert(shop, items);
+    } catch (err) {
+      console.error("Scheduled stock check failed", err);
+    }
+  }, intervalMs);
+}


### PR DESCRIPTION
## Summary
- add configurable stock alert recipients, webhook, and default threshold
- log alerts to avoid repeats and schedule periodic checks

## Testing
- `pnpm test --filter @acme/platform-core` *(fails: Expected substring: "--color-bg")*

------
https://chatgpt.com/codex/tasks/task_e_6899c77c7150832fbd1ee843f32a4a72