### PR TITLE
feat: add persistent user store with password hashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ packages/ui/src/**/*.d.ts.map
 *.pem
 *.tsbuildinfo
 next-env.d.ts
+data/users.json
 
 # ---------------------------
 # Debug logs

--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -17,12 +17,12 @@ jest.mock("@lib/email", () => ({
 
 const store: Record<string, any> = {};
 
-jest.mock("@platform-core/users", () => ({
+jest.mock("../src/app/userStore", () => ({
   getUserById: jest.fn(async (id: string) => store[id] ?? null),
   getUserByEmail: jest.fn(async (email: string) =>
     Object.values(store).find((u: any) => u.email === email) ?? null,
   ),
-  createUser: jest.fn(async ({
+  addUser: jest.fn(async ({
     id,
     email,
     passwordHash,
@@ -35,6 +35,9 @@ jest.mock("@platform-core/users", () => ({
   setResetToken: jest.fn(async (id: string, token: string | null) => {
     if (store[id]) store[id].resetToken = token;
   }),
+  getUserByResetToken: jest.fn(async (token: string) =>
+    Object.values(store).find((u: any) => u.resetToken === token) ?? null,
+  ),
   updatePassword: jest.fn(async (id: string, hash: string) => {
     if (store[id]) {
       store[id].passwordHash = hash;
@@ -95,7 +98,7 @@ describe("auth flows", () => {
     expect(res.status).toBe(200);
 
     await requestPOST(makeRequest({ email: "test@example.com" }));
-    const { getUserById } = await import("@platform-core/users");
+    const { getUserById } = await import("../src/app/userStore");
     const token = (await getUserById("cust1"))!.resetToken as string;
 
     res = await completePOST(

--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -7,7 +7,7 @@ jest.mock("@upstash/redis", () => ({
   Redis: jest.fn(() => ({})),
 }));
 
-jest.mock("@platform-core/users", () => ({
+jest.mock("../src/app/userStore", () => ({
   getUserById: jest.fn(async (id: string) =>
     id === "cust1" ? { passwordHash: "pass1", role: "customer" } : null,
   ),

--- a/apps/shop-abc/__tests__/registerApi.test.ts
+++ b/apps/shop-abc/__tests__/registerApi.test.ts
@@ -1,15 +1,19 @@
 // apps/shop-abc/__tests__/registerApi.test.ts
 const USER_STORE: Record<string, any> = {};
 
-jest.mock("@platform-core/users", () => ({
+jest.mock("../src/app/userStore", () => ({
   __esModule: true,
-  createUser: jest.fn(async ({ id, email, passwordHash }) => {
+  addUser: jest.fn(async ({ id, email, passwordHash }) => {
     USER_STORE[id] = { id, email, passwordHash };
   }),
   getUserById: jest.fn(async (id: string) => USER_STORE[id] ?? null),
   getUserByEmail: jest.fn(async (email: string) =>
     Object.values(USER_STORE).find((u: any) => u.email === email) ?? null,
   ),
+}));
+
+jest.mock("@auth", () => ({
+  validateCsrfToken: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock("@upstash/redis", () => ({
@@ -41,7 +45,7 @@ describe("/register POST", () => {
         email: "user@example.com",
         password: "password",
       }),
-      headers: new Headers(),
+      headers: new Headers({ "x-csrf-token": "tok" }),
     } as any;
     const res = await POST(req);
     expect(res.status).toBe(400);
@@ -56,7 +60,7 @@ describe("/register POST", () => {
         email: "user@example.com",
         password: "Str0ngPass",
       }),
-      headers: new Headers(),
+      headers: new Headers({ "x-csrf-token": "tok" }),
     } as any;
     const res = await POST(req);
     expect(res.status).toBe(200);
@@ -71,7 +75,7 @@ describe("/register POST", () => {
         email: "user@example.com",
         password: "Str0ngPass",
       }),
-      headers: new Headers(),
+      headers: new Headers({ "x-csrf-token": "tok" }),
     } as any;
     const first = await POST(req);
     expect(first.status).toBe(200);

--- a/apps/shop-abc/__tests__/registerRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/registerRateLimit.test.ts
@@ -3,8 +3,8 @@ jest.mock("@upstash/redis", () => ({
   Redis: jest.fn(() => ({})),
 }));
 
-jest.mock("@platform-core/users", () => ({
-  createUser: jest.fn().mockResolvedValue(undefined),
+jest.mock("../src/app/userStore", () => ({
+  addUser: jest.fn().mockResolvedValue(undefined),
   getUserById: jest.fn().mockResolvedValue(null),
   getUserByEmail: jest.fn().mockResolvedValue(null),
 }));
@@ -49,7 +49,7 @@ describe("registration rate limiting", () => {
         makeRequest({
           customerId: `cust${i}`,
           email: `test${i}@example.com`,
-          password: "pw",
+          password: "Str0ngPass",
         }),
       );
       expect(res.status).toBe(200);
@@ -59,7 +59,7 @@ describe("registration rate limiting", () => {
       makeRequest({
         customerId: "cust-final",
         email: "final@example.com",
-        password: "pw",
+        password: "Str0ngPass",
       }),
     );
     expect(locked.status).toBe(429);
@@ -68,7 +68,7 @@ describe("registration rate limiting", () => {
       makeRequest({
         customerId: "cust-other",
         email: "other@example.com",
-        password: "pw",
+        password: "Str0ngPass",
       }),
     );
     expect(stillLocked.status).toBe(429);

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
-import { getUserByResetToken, updatePassword } from "@platform-core/users";
+import { getUserByResetToken, updatePassword } from "../../../../userStore";
 
 const schema = z.object({
   token: z.string(),

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -1,7 +1,7 @@
 // apps/shop-abc/src/app/api/account/reset/request/route.ts
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getUserByEmail, setResetToken } from "@platform-core/users";
+import { getUserByEmail, setResetToken } from "../../../../userStore";
 import { sendEmail } from "@lib/email";
 
 const schema = z.object({

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -2,11 +2,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
-import {
-  createUser,
-  getUserById,
-  getUserByEmail,
-} from "@platform-core/users";
+import { addUser, getUserById, getUserByEmail } from "../../userStore";
 
 const RegisterSchema = z.object({
   customerId: z.string(),
@@ -32,6 +28,6 @@ export async function POST(req: Request) {
   }
 
   const passwordHash = await bcrypt.hash(password, 10);
-  await createUser({ id: customerId, email, passwordHash });
+  await addUser({ id: customerId, email, passwordHash });
   return NextResponse.json({ ok: true });
 }

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -8,7 +8,7 @@ import {
   checkLoginRateLimit,
   clearLoginAttempts,
 } from "../../middleware";
-import { getUserById } from "@platform-core/users";
+import { getUserById } from "../userStore";
 
 const ALLOWED_ROLES: Role[] = ["customer", "viewer"];
 

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 import {
-  createUser,
+  addUser,
   getUserById,
   getUserByEmail,
-} from "@platform-core/users";
+} from "../userStore";
 import { checkRegistrationRateLimit } from "../../middleware";
 import { validateCsrfToken } from "@auth";
 
@@ -49,6 +49,6 @@ export async function POST(req: Request) {
   }
 
   const passwordHash = await bcrypt.hash(password, 10);
-  await createUser({ id: customerId, email, passwordHash });
+  await addUser({ id: customerId, email, passwordHash });
   return NextResponse.json({ ok: true });
 }

--- a/apps/shop-abc/src/app/userStore.ts
+++ b/apps/shop-abc/src/app/userStore.ts
@@ -1,0 +1,81 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export interface User {
+  id: string;
+  email: string;
+  passwordHash: string;
+  role: string;
+  resetToken: string | null;
+}
+
+const DATA_PATH = path.join(process.cwd(), "data", "users.json");
+
+async function readStore(): Promise<Record<string, User>> {
+  try {
+    const data = await fs.readFile(DATA_PATH, "utf8");
+    return JSON.parse(data);
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      return {};
+    }
+    throw err;
+  }
+}
+
+async function writeStore(store: Record<string, User>): Promise<void> {
+  await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
+  await fs.writeFile(DATA_PATH, JSON.stringify(store, null, 2));
+}
+
+export async function addUser({
+  id,
+  email,
+  passwordHash,
+  role = "customer",
+}: {
+  id: string;
+  email: string;
+  passwordHash: string;
+  role?: string;
+}): Promise<User> {
+  const store = await readStore();
+  const user: User = { id, email, passwordHash, role, resetToken: null };
+  store[id] = user;
+  await writeStore(store);
+  return user;
+}
+
+export async function getUserById(id: string): Promise<User | null> {
+  const store = await readStore();
+  return store[id] ?? null;
+}
+
+export async function getUserByEmail(email: string): Promise<User | null> {
+  const store = await readStore();
+  return Object.values(store).find((u) => u.email === email) ?? null;
+}
+
+export async function setResetToken(id: string, token: string | null): Promise<void> {
+  const store = await readStore();
+  const user = store[id];
+  if (user) {
+    user.resetToken = token;
+    await writeStore(store);
+  }
+}
+
+export async function getUserByResetToken(token: string): Promise<User | null> {
+  const store = await readStore();
+  return Object.values(store).find((u) => u.resetToken === token) ?? null;
+}
+
+export async function updatePassword(id: string, passwordHash: string): Promise<void> {
+  const store = await readStore();
+  const user = store[id];
+  if (user) {
+    user.passwordHash = passwordHash;
+    user.resetToken = null;
+    await writeStore(store);
+  }
+}


### PR DESCRIPTION
## Summary
- persist users to data/users.json and support password reset helpers
- hash passwords on registration and verify during login
- update tests for new user store

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/registerApi.test.ts apps/shop-abc/__tests__/registerRateLimit.test.ts apps/shop-abc/__tests__/loginRateLimit.test.ts apps/shop-abc/__tests__/authFlow.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6899cbc20f0c832f8d98e5a5b34435fa