### PR TITLE
feat(cms): dynamic configurator steps

### DIFF
--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -6,17 +6,17 @@ import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/atoms/shadcn";
 import { Toast, Tooltip } from "@/components/atoms";
 import type { WizardState } from "../wizard/schema";
-import { steps, stepOrder } from "./steps";
-export type StepStatus = "idle" | "pending" | "success" | "failure";
+import { getSteps } from "./steps";
+export type LaunchStatus = "idle" | "pending" | "success" | "failure";
 
 export default function ConfiguratorDashboard() {
   const [state, setState] = useState<WizardState | null>(null);
   const [launchStatus, setLaunchStatus] = useState<
     | {
-        create: StepStatus;
-        init: StepStatus;
-        deploy: StepStatus;
-        seed?: StepStatus;
+        create: LaunchStatus;
+        init: LaunchStatus;
+        deploy: LaunchStatus;
+        seed?: LaunchStatus;
       }
     | null
   >(null);
@@ -34,8 +34,9 @@ export default function ConfiguratorDashboard() {
       .then((json) => setState(json))
       .catch(() => setState(null));
   }, []);
-  const missingRequired = stepOrder.filter(
-    (id) => steps[id].required && !state?.completed?.[id]
+  const stepList = getSteps();
+  const missingRequired = stepList.filter(
+    (s) => s.required && !state?.completed?.[s.id]
   );
   const allRequiredDone = missingRequired.length === 0;
 
@@ -45,7 +46,7 @@ export default function ConfiguratorDashboard() {
       setToast({
         open: true,
         message: `Complete required steps: ${missingRequired
-          .map((id) => steps[id].label)
+          .map((s) => s.label)
           .join(", ")}`,
       });
       return;
@@ -56,7 +57,7 @@ export default function ConfiguratorDashboard() {
       create: "pending",
       init: "pending",
       deploy: "pending",
-      ...(seed ? { seed: "pending" as StepStatus } : {}),
+      ...(seed ? { seed: "pending" as LaunchStatus } : {}),
     });
     const res = await fetch("/cms/api/launch-shop", {
       method: "POST",
@@ -64,7 +65,7 @@ export default function ConfiguratorDashboard() {
       body: JSON.stringify({ shopId: state.shopId, state, seed }),
     });
     const json = (await res.json().catch(() => ({}))) as {
-      statuses?: Record<string, StepStatus>;
+      statuses?: Record<string, LaunchStatus>;
       error?: string;
     };
     if (json.statuses) {
@@ -79,19 +80,23 @@ export default function ConfiguratorDashboard() {
     <div>
       <h2 className="mb-4 text-xl font-semibold">Configuration Steps</h2>
       <ul className="mb-6 space-y-2">
-        {stepOrder.map((id) => {
-          const step = steps[id];
-          const completed = Boolean(state?.completed?.[id]);
+        {stepList.map((step) => {
+          const completed = Boolean(state?.completed?.[step.id]);
+          const status = completed ? "done" : "pending";
           return (
-            <li key={id} className="flex items-center gap-2">
+            <li key={step.id} className="flex items-center gap-2">
               {completed ? (
                 <CheckCircledIcon className="h-4 w-4 text-green-600" />
               ) : (
                 <CircleIcon className="h-4 w-4 text-gray-400" />
               )}
-              <Link href={`/cms/configurator/${id}`} className="underline">
+              <Link
+                href={`/cms/configurator/${step.id}`}
+                className="underline"
+              >
                 {step.label}
               </Link>
+              <span className="text-sm text-gray-500">({status})</span>
             </li>
           );
         })}
@@ -101,7 +106,7 @@ export default function ConfiguratorDashboard() {
       ) : (
         <Tooltip
           text={`Complete required steps: ${missingRequired
-            .map((id) => steps[id].label)
+            .map((s) => s.label)
             .join(", ")}`}
         >
           <Button disabled>Launch Shop</Button>

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -25,6 +25,8 @@ export interface ConfiguratorStep {
 
 export type StepStatus = "pending" | "done";
 
+export type StepMeta = Omit<ConfiguratorStep, "component">;
+
 export const steps: Record<string, ConfiguratorStep> = {
   "shop-details": {
     id: "shop-details",
@@ -161,4 +163,11 @@ export const stepOrder = [
 export const initialStepStatus: Record<string, StepStatus> = Object.fromEntries(
   stepOrder.map((id) => [id, "pending"])
 );
+
+export function getSteps(): StepMeta[] {
+  return stepOrder.map((id) => {
+    const { component, ...meta } = steps[id];
+    return meta;
+  });
+}
 


### PR DESCRIPTION
## Summary
- derive step metadata through `getSteps()` and expose `StepMeta`
- render configurator dashboard with dynamic step list and completion status
- enable launch button only once all required steps are done

## Testing
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' and other missing Prisma modules)*

------
https://chatgpt.com/codex/tasks/task_e_6899c98eb0b0832f878bf1783cf73818