### PR TITLE
Handle session revocation errors

### DIFF
--- a/packages/ui/src/components/account/RevokeSessionButton.tsx
+++ b/packages/ui/src/components/account/RevokeSessionButton.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// packages/ui/src/components/account/RevokeSessionButton.tsx
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { revoke } from "./Sessions";
+
+export interface RevokeSessionButtonProps {
+  sessionId: string;
+}
+
+export default function RevokeSessionButton({ sessionId }: RevokeSessionButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await revoke(sessionId);
+      if (result.success) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to revoke session.");
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-end">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isPending}
+        className="rounded bg-primary px-4 py-2 text-primary-fg"
+      >
+        {isPending ? "Revoking..." : "Revoke"}
+      </button>
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/account/Sessions.tsx
+++ b/packages/ui/src/components/account/Sessions.tsx
@@ -1,6 +1,7 @@
 // packages/ui/src/components/account/Sessions.tsx
 import { getCustomerSession, listSessions, revokeSession } from "@auth";
 import { revalidatePath } from "next/cache";
+import RevokeSessionButton from "./RevokeSessionButton";
 
 export interface SessionsPageProps {
   /** Optional heading override */
@@ -11,8 +12,13 @@ export const metadata = { title: "Sessions" };
 
 export async function revoke(id: string) {
   "use server";
-  await revokeSession(id);
-  revalidatePath("/account/sessions");
+  try {
+    await revokeSession(id);
+    revalidatePath("/account/sessions");
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: "Failed to revoke session." };
+  }
 }
 
 export default async function SessionsPage({ title = "Sessions" }: SessionsPageProps = {}) {
@@ -30,11 +36,7 @@ export default async function SessionsPage({ title = "Sessions" }: SessionsPageP
               <div>{s.userAgent}</div>
               <div className="text-sm text-gray-500">{s.createdAt.toISOString()}</div>
             </div>
-            <form action={revoke.bind(null, s.sessionId)}>
-              <button type="submit" className="rounded bg-primary px-4 py-2 text-primary-fg">
-                Revoke
-              </button>
-            </form>
+            <RevokeSessionButton sessionId={s.sessionId} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add RevokeSessionButton client component to handle session revocation
- wrap `revokeSession` call in try/catch and return status
- surface revocation errors to users

## Testing
- `pnpm test --filter @acme/ui` *(fails: Invalid environment variables)*
- `pnpm lint --filter @acme/ui`


------
https://chatgpt.com/codex/tasks/task_e_6899c8e7c9a4832f838ff1aaefc2fd85