### PR TITLE
feat: refresh configurator dashboard on wizard update

### DIFF
--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/atoms/shadcn";
@@ -28,12 +28,22 @@ export default function ConfiguratorDashboard() {
     }
   );
 
-  useEffect(() => {
+  const fetchState = useCallback(() => {
     fetch("/cms/api/wizard-progress")
       .then((res) => (res.ok ? res.json() : null))
       .then((json) => setState(json))
       .catch(() => setState(null));
   }, []);
+
+  useEffect(() => {
+    fetchState();
+  }, [fetchState]);
+
+  useEffect(() => {
+    const handler = () => fetchState();
+    window.addEventListener("wizard:update", handler);
+    return () => window.removeEventListener("wizard:update", handler);
+  }, [fetchState]);
   const stepList = getSteps();
   const missingRequired = stepList.filter(
     (s) => !s.optional && !state?.completed?.[s.id]


### PR DESCRIPTION
## Summary
- refetch configurator wizard state when `wizard:update` fires so step list stays current

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/configurator/Dashboard.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_689a10797b5c832fa71c896bce929081