### PR TITLE
Check configurator step prerequisites before rendering

### DIFF
--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getSteps } from "../steps";
+import { getSteps, steps } from "../steps";
+import { useWizard } from "../../wizard/WizardContext";
 
 interface Props {
   stepId: string;
@@ -9,14 +11,30 @@ interface Props {
 
 export default function StepPage({ stepId }: Props) {
   const router = useRouter();
+  const { state } = useWizard();
   const stepList = getSteps();
   const index = stepList.findIndex((s) => s.id === stepId);
   const step = stepList[index];
   if (!step) {
     return null;
   }
+
+  const prerequisites = steps[stepId]?.prerequisites ?? [];
+  const missingPrereq = prerequisites.find((id) => !state.completed[id]);
+
+  useEffect(() => {
+    if (missingPrereq) {
+      router.push(`/cms/configurator/${missingPrereq}`);
+    }
+  }, [missingPrereq, router]);
+
+  if (missingPrereq) {
+    return <div>Please complete prerequisite steps first.</div>;
+  }
+
   const StepComponent = step.component as React.ComponentType<any>;
-  const nextId = index >= 0 && index < stepList.length - 1 ? stepList[index + 1].id : null;
+  const nextId =
+    index >= 0 && index < stepList.length - 1 ? stepList[index + 1].id : null;
   const prevId = index > 0 ? stepList[index - 1].id : null;
   const goNext = () => {
     if (nextId) router.push(`/cms/configurator/${nextId}`);

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -20,6 +20,8 @@ export interface ConfiguratorStep {
   label: string;
   component: React.ComponentType<any>;
   optional?: boolean;
+  /** IDs of steps that must be completed before this step */
+  prerequisites?: string[];
   order?: number;
 }
 


### PR DESCRIPTION
## Summary
- add `prerequisites` field to configurator steps
- redirect to first incomplete prerequisite before rendering step

## Testing
- `pnpm lint`
- `pnpm test` (fails: ts-jest configuration warning and run failed)


------
https://chatgpt.com/codex/tasks/task_e_689a1078c0b8832fb6cec9535e266e39