### PR TITLE
feat: add cart offline fallback

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/CartContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/CartContext.test.tsx
@@ -1,0 +1,89 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { CartProvider, useCart } from "../CartContext";
+import type { SKU } from "@types";
+
+type CartState = Record<string, { sku: SKU; qty: number; size?: string }>
+
+function CartDisplay() {
+  const [cart] = useCart();
+  return <span data-testid="count">{Object.keys(cart).length}</span>;
+}
+
+describe("CartProvider offline fallback", () => {
+  const sku: SKU = {
+    id: "sku1",
+    slug: "sku1",
+    title: "Test",
+    price: 100,
+    deposit: 0,
+    forSale: true,
+    forRental: false,
+    image: "img",
+    sizes: [],
+    description: "desc",
+  };
+  const mockCart: CartState = {
+    sku1: { sku, qty: 1 },
+  };
+
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    // @ts-expect-error override
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    // @ts-expect-error restore
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("loads cached cart when initial fetch fails", async () => {
+    window.localStorage.setItem("cart", JSON.stringify(mockCart));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("offline"));
+
+    render(
+      <CartProvider>
+        <CartDisplay />
+      </CartProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("count").textContent).toBe("1")
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("syncs cached cart to server when back online", async () => {
+    window.localStorage.setItem("cart", JSON.stringify(mockCart));
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ cart: mockCart }) });
+
+    render(
+      <CartProvider>
+        <CartDisplay />
+      </CartProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("count").textContent).toBe("1")
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/cart",
+        expect.objectContaining({ method: "POST" })
+      )
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- surface cart fetch failures and cache cart state in localStorage
- sync cached cart to server once back online
- add tests for offline cart scenarios

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/src/contexts/__tests__/CartContext.test.tsx` *(fails: A React Element from an older version of React was rendered)*

------
https://chatgpt.com/codex/tasks/task_e_689a123ff668832fbbef098a696b8a28