### PR TITLE
feat: add announcement bar block and editor

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -46,6 +46,12 @@ export interface PageComponentBase {
     maxItems?: number;
     [key: string]: unknown;
 }
+export interface AnnouncementBarComponent extends PageComponentBase {
+    type: "AnnouncementBar";
+    text?: string;
+    link?: string;
+    closable?: boolean;
+}
 export interface HeroBannerComponent extends PageComponentBase {
     type: "HeroBanner";
     slides?: {
@@ -136,7 +142,7 @@ export interface SectionComponent extends PageComponentBase {
     type: "Section";
     children?: PageComponent[];
 }
-export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
+export type PageComponent = AnnouncementBarComponent | HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
 export declare const pageSchema: z.ZodObject<{
     id: z.ZodString;
     slug: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -54,6 +54,13 @@ export interface PageComponentBase {
   [key: string]: unknown;
 }
 
+export interface AnnouncementBarComponent extends PageComponentBase {
+  type: "AnnouncementBar";
+  text?: string;
+  link?: string;
+  closable?: boolean;
+}
+
 export interface HeroBannerComponent extends PageComponentBase {
   type: "HeroBanner";
   slides?: { src: string; alt?: string; headlineKey: string; ctaKey: string }[];
@@ -135,6 +142,7 @@ export interface SectionComponent extends PageComponentBase {
 }
 
 export type PageComponent =
+  | AnnouncementBarComponent
   | HeroBannerComponent
   | ValuePropsComponent
   | ReviewsCarouselComponent
@@ -178,6 +186,13 @@ const heroBannerComponentSchema = baseComponentSchema.extend({
       })
     )
     .optional(),
+});
+
+const announcementBarComponentSchema = baseComponentSchema.extend({
+  type: z.literal("AnnouncementBar"),
+  text: z.string().optional(),
+  link: z.string().optional(),
+  closable: z.boolean().optional(),
 });
 
 const valuePropsComponentSchema = baseComponentSchema.extend({
@@ -278,6 +293,7 @@ const sectionComponentSchema: z.ZodType<SectionComponent> = baseComponentSchema.
 
 export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
   z.discriminatedUnion("type", [
+    announcementBarComponentSchema,
     heroBannerComponentSchema,
     valuePropsComponentSchema,
     reviewsCarouselComponentSchema,

--- a/packages/ui/src/components/cms/blocks/AnnouncementBarBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/AnnouncementBarBlock.tsx
@@ -1,0 +1,13 @@
+import AnnouncementBar from "../../organisms/AnnouncementBar";
+
+interface Props {
+  text?: string;
+  link?: string;
+  closable?: boolean;
+}
+
+/** CMS wrapper for the AnnouncementBar organism */
+export default function AnnouncementBarBlock({ text, link, closable }: Props) {
+  if (!text) return null;
+  return <AnnouncementBar text={text} href={link} closable={closable} />;
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -11,6 +11,7 @@ import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
+import AnnouncementBar from "./AnnouncementBarBlock";
 
 export {
   BlogListing,
@@ -26,6 +27,7 @@ export {
   TestimonialSlider,
   ValueProps,
   Section,
+  AnnouncementBar,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -10,8 +10,10 @@ import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
+import AnnouncementBar from "./AnnouncementBarBlock";
 
 export const organismRegistry = {
+  AnnouncementBar,
   HeroBanner,
   ValueProps,
   ReviewsCarousel,

--- a/packages/ui/src/components/cms/page-builder/AnnouncementBarEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/AnnouncementBarEditor.tsx
@@ -1,0 +1,28 @@
+import type { PageComponent } from "@types";
+import { Input } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function AnnouncementBarEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).text ?? ""}
+        onChange={(e) => handleInput("text", e.target.value)}
+        placeholder="text"
+      />
+      <Input
+        value={(component as any).link ?? ""}
+        onChange={(e) => handleInput("link", e.target.value)}
+        placeholder="link"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -19,6 +19,7 @@ import TestimonialsEditor from "./TestimonialsEditor";
 import HeroBannerEditor from "./HeroBannerEditor";
 import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
+import AnnouncementBarEditor from "./AnnouncementBarEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -55,6 +56,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "HeroBanner":
       specific = <HeroBannerEditor component={component} onChange={onChange} />;
+      break;
+    case "AnnouncementBar":
+      specific = (
+        <AnnouncementBarEditor component={component} onChange={onChange} />
+      );
       break;
     case "ValueProps":
       specific = <ValuePropsEditor component={component} onChange={onChange} />;

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -36,6 +36,12 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   RecommendationCarousel: { minItems: 1, maxItems: 4 },
   Testimonials: { minItems: 1, maxItems: 10 },
   TestimonialSlider: { minItems: 1, maxItems: 10 },
+  AnnouncementBar: {
+    position: "absolute",
+    top: "0",
+    left: "0",
+    width: "100%",
+  },
 };
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -6,6 +6,7 @@ import TestimonialsEditor from "../TestimonialsEditor";
 import HeroBannerEditor from "../HeroBannerEditor";
 import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
+import AnnouncementBarEditor from "../AnnouncementBarEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -58,6 +59,12 @@ describe("block editors", () => {
       ReviewsCarouselEditor,
       { type: "ReviewsCarousel", reviews: [{ nameKey: "", quoteKey: "" }] },
       "nameKey",
+    ],
+    [
+      "AnnouncementBarEditor",
+      AnnouncementBarEditor,
+      { type: "AnnouncementBar", text: "", link: "" },
+      "text",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -7,6 +7,7 @@ export { default as TestimonialsEditor } from "./TestimonialsEditor";
 export { default as HeroBannerEditor } from "./HeroBannerEditor";
 export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
+export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";

--- a/packages/ui/src/components/organisms/AnnouncementBar.tsx
+++ b/packages/ui/src/components/organisms/AnnouncementBar.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { cn } from "../../utils/style";
+
+export interface AnnouncementBarProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /** Message text displayed in the bar */
+  text?: string;
+  /** Optional URL the bar links to */
+  href?: string;
+  /** Whether to show a close button */
+  closable?: boolean;
+}
+
+/**
+ * Simple announcement bar that can display a message with an optional link
+ * and close button. When `href` is provided the entire bar becomes a link.
+ */
+export default function AnnouncementBar({
+  text,
+  href,
+  closable = false,
+  className,
+  ...props
+}: AnnouncementBarProps) {
+  const [open, setOpen] = React.useState(true);
+  if (!open || !text) return null;
+
+  const content = (
+    <div
+      className={cn(
+        "flex w-full items-center justify-center gap-2 bg-primary px-4 py-2 text-sm text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <span>{text}</span>
+      {closable && (
+        <button
+          type="button"
+          aria-label="Close announcement"
+          onClick={() => setOpen(false)}
+          className="ml-2 text-primary-foreground/70 hover:text-primary-foreground"
+        >
+          &times;
+        </button>
+      )}
+    </div>
+  );
+
+  return href ? (
+    <a href={href} className="block w-full">
+      {content}
+    </a>
+  ) : (
+    content
+  );
+}

--- a/packages/ui/src/components/organisms/index.ts
+++ b/packages/ui/src/components/organisms/index.ts
@@ -30,3 +30,4 @@ export { StatsGrid } from "./StatsGrid";
 export { StickyAddToCartBar } from "./StickyAddToCartBar";
 export { StoreLocatorMap } from "./StoreLocatorMap";
 export { WishlistDrawer } from "./WishlistDrawer";
+export { default as AnnouncementBar } from "./AnnouncementBar";


### PR DESCRIPTION
## Summary
- add `AnnouncementBar` organism with optional close button
- provide CMS block and editor for announcement text and link
- register announcement bar in block registry and page builder defaults

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/ComponentEditor.test.tsx packages/ui/__tests__/DynamicRenderer.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx` *(fails: Unknown component type: Text)*

------
https://chatgpt.com/codex/tasks/task_e_689a1267cb5c832f82efd0238c6d517a