### PR TITLE
feat: share shop config

### DIFF
--- a/apps/shop-abc/next.config.mjs
+++ b/apps/shop-abc/next.config.mjs
@@ -1,32 +1,3 @@
 // apps/shop-abc/next.config.mjs
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { baseConfig, withShopCode } from "@acme/next-config";
-
-/* ------------------------------------------------------------------ */
-/*  ES-module-safe __dirname                                           */
-/* ------------------------------------------------------------------ */
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export default withShopCode(process.env.SHOP_CODE, {
-  /* 1️⃣ ‒ don’t fail the build on lint errors */
-  eslint: { ignoreDuringBuilds: true },
-
-  webpack(config, { isServer }) {
-    if (typeof baseConfig.webpack === "function") {
-      config = baseConfig.webpack(config, { isServer });
-    }
-
-    /* 3️⃣ – same alias set as Template App ------------------------------- */
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      "@": path.resolve(__dirname, "src"),
-      "@i18n": path.resolve(__dirname, "../../packages/i18n"),
-      "node:fs": "fs",
-      "node:path": "path",
-    };
-
-    return config;
-  },
-});
+// Re-export the shared configuration from the Template App
+export { default } from "@acme/template-app/next.config.mjs";

--- a/apps/shop-abc/package.json
+++ b/apps/shop-abc/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
-    "@acme/next-config": "workspace:*"
+    "@acme/next-config": "workspace:*",
+    "@acme/template-app": "workspace:*"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-abc/postcss.config.cjs
+++ b/apps/shop-abc/postcss.config.cjs
@@ -1,1 +1,2 @@
-module.exports = require("../../postcss.config.cjs");
+// apps/shop-abc/postcss.config.cjs
+module.exports = require("@acme/template-app/postcss.config.cjs");

--- a/apps/shop-abc/tailwind.config.mjs
+++ b/apps/shop-abc/tailwind.config.mjs
@@ -1,1 +1,2 @@
-export { default } from "../../tailwind.config";
+// apps/shop-abc/tailwind.config.mjs
+export { default } from "@acme/template-app/tailwind.config.mjs";

--- a/apps/shop-bcd/next.config.mjs
+++ b/apps/shop-bcd/next.config.mjs
@@ -1,32 +1,3 @@
 // apps/shop-bcd/next.config.mjs
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { baseConfig, withShopCode } from "@acme/next-config";
-
-/* ------------------------------------------------------------------ */
-/*  ES-module-safe __dirname                                           */
-/* ------------------------------------------------------------------ */
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export default withShopCode(process.env.SHOP_CODE, {
-  /* 1️⃣ ‒ don’t fail the build on lint errors */
-  eslint: { ignoreDuringBuilds: true },
-
-  webpack(config, { isServer }) {
-    if (typeof baseConfig.webpack === "function") {
-      config = baseConfig.webpack(config, { isServer });
-    }
-
-    /* 3️⃣ – same alias set as Template App ------------------------------- */
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      "@": path.resolve(__dirname, "src"),
-      "@i18n": path.resolve(__dirname, "../../packages/i18n"),
-      "node:fs": "fs",
-      "node:path": "path",
-    };
-
-    return config;
-  },
-});
+// Re-export the shared configuration from the Template App
+export { default } from "@acme/template-app/next.config.mjs";

--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
-    "@acme/next-config": "workspace:*"
+    "@acme/next-config": "workspace:*",
+    "@acme/template-app": "workspace:*"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-bcd/postcss.config.cjs
+++ b/apps/shop-bcd/postcss.config.cjs
@@ -1,1 +1,2 @@
-module.exports = require("../../postcss.config.cjs");
+// apps/shop-bcd/postcss.config.cjs
+module.exports = require("@acme/template-app/postcss.config.cjs");

--- a/apps/shop-bcd/tailwind.config.mjs
+++ b/apps/shop-bcd/tailwind.config.mjs
@@ -1,1 +1,2 @@
-export { default } from "../../tailwind.config";
+// apps/shop-bcd/tailwind.config.mjs
+export { default } from "@acme/template-app/tailwind.config.mjs";

--- a/packages/template-app/README.md
+++ b/packages/template-app/README.md
@@ -1,0 +1,57 @@
+# Template App Configuration
+
+The Template App exposes shared configuration for Next.js, Tailwind CSS and
+PostCSS so that individual shop applications don’t need to copy these files.
+
+## Usage
+
+In a shop application you can simply re-export the config files:
+
+```js
+// next.config.mjs
+export { default } from "@acme/template-app/next.config.mjs";
+
+// tailwind.config.mjs
+export { default } from "@acme/template-app/tailwind.config.mjs";
+
+// postcss.config.cjs
+module.exports = require("@acme/template-app/postcss.config.cjs");
+```
+
+## Extending
+
+If a shop needs to customise these settings, import the base config and extend
+it instead of copying the entire file:
+
+```js
+// Example: extend Next.js config
+import baseConfig from "@acme/template-app/next.config.mjs";
+
+export default {
+  ...baseConfig,
+  // overrides here
+};
+
+// Example: extend Tailwind config
+import tailwind from "@acme/template-app/tailwind.config.mjs";
+
+export default {
+  ...tailwind,
+  content: [...tailwind.content, "./src/extra/**/*.{ts,tsx}"],
+};
+
+// Example: extend PostCSS config
+const postcss = require("@acme/template-app/postcss.config.cjs");
+
+module.exports = {
+  ...postcss,
+  plugins: {
+    ...postcss.plugins,
+    // add additional plugins here
+  },
+};
+```
+
+This pattern keeps configuration logic in one place while still allowing each
+shop to override pieces as needed.
+

--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@acme/template-app",
   "private": true,
+  "type": "module",
+  "exports": {
+    "./next.config.mjs": "./next.config.mjs",
+    "./tailwind.config.mjs": "./tailwind.config.mjs",
+    "./postcss.config.cjs": "./postcss.config.cjs"
+  },
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",

--- a/packages/template-app/postcss.config.cjs
+++ b/packages/template-app/postcss.config.cjs
@@ -1,1 +1,8 @@
-module.exports = require("../../postcss.config.cjs");
+/* packages/template-app/postcss.config.cjs
+   Shared PostCSS configuration for all shop apps */
+module.exports = {
+  plugins: {
+    // TailwindCSS v4 bundles autoprefixer & postcss-import
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/packages/template-app/tailwind.config.mjs
+++ b/packages/template-app/tailwind.config.mjs
@@ -1,0 +1,34 @@
+// packages/template-app/tailwind.config.mjs
+// Shared TailwindCSS configuration for shop apps
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Import workspaces directly to avoid requiring built packages
+import tokens from "../design-tokens/index.ts";
+import preset from "../tailwind-config/src/index.ts";
+
+// Resolve absolute paths so content globs work when re-exported
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "../..");
+
+/** @type {import('tailwindcss').Config} */
+const config = {
+  presets: [tokens, preset],
+  darkMode: ["class", ".theme-dark"],
+  content: [
+    path.join(rootDir, "apps/**/*.{ts,tsx,mdx}"),
+    path.join(rootDir, "packages/{ui,platform-core,platform-machine,i18n,themes}/**/*.{ts,tsx,mdx}"),
+    path.join(rootDir, ".storybook/**/*.{ts,tsx,mdx}"),
+    "!**/node_modules",
+    "!**/dist",
+    "!**/.next",
+  ],
+  plugins: [
+    require("@tailwindcss/forms"),
+    require("@tailwindcss/container-queries"),
+  ],
+};
+
+export default config;
+

--- a/packages/template-app/tailwind.config.ts
+++ b/packages/template-app/tailwind.config.ts
@@ -1,1 +1,0 @@
-export { default } from "../../tailwind.config";


### PR DESCRIPTION
## Summary
- centralize Next.js, Tailwind, and PostCSS configs in `@acme/template-app`
- expose minimal wrappers in `shop-abc` and `shop-bcd`
- document how to extend shared configs

## Testing
- `pnpm test --filter @acme/template-app --filter @apps/shop-abc --filter @apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_689a124ee784832f969292bab50b4d7e