### PR TITLE
feat(ui): add client validation to profile form

### DIFF
--- a/packages/ui/__tests__/ProfileForm.test.tsx
+++ b/packages/ui/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ProfileForm from "../src/components/account/ProfileForm";
+
+describe("ProfileForm", () => {
+  it("marks fields as required", () => {
+    render(<ProfileForm />);
+    expect(screen.getByLabelText("Name")).toBeRequired();
+    expect(screen.getByLabelText("Email")).toBeRequired();
+  });
+
+  it("shows client-side validation errors", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({} as any);
+    render(<ProfileForm />);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await screen.findByText("Name is required.")).toBeInTheDocument();
+    expect(await screen.findByText("Email is required.")).toBeInTheDocument();
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/components/account/ProfileForm.tsx
+++ b/packages/ui/src/components/account/ProfileForm.tsx
@@ -30,6 +30,15 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
     setStatus("idle");
     setMessage(null);
     setErrors({});
+    const newErrors: Record<string, string> = {};
+    if (!form.name) newErrors.name = "Name is required.";
+    if (!form.email) newErrors.email = "Email is required.";
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors);
+      setStatus("error");
+      setMessage("Please fix the errors below.");
+      return;
+    }
     try {
       const csrfToken =
         typeof document !== "undefined"
@@ -83,6 +92,7 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
           value={form.name}
           onChange={handleChange}
           className="rounded border p-2"
+          required
         />
         {errors.name && <p className="text-red-600 text-sm">{errors.name}</p>}
       </div>
@@ -95,6 +105,7 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
           value={form.email}
           onChange={handleChange}
           className="rounded border p-2"
+          required
         />
         {errors.email && <p className="text-red-600 text-sm">{errors.email}</p>}
       </div>


### PR DESCRIPTION
## Summary
- require name and email inputs and validate on the client
- test profile form client-side validation

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_689a122ad7bc832fa8d554c91f782452