### PR TITLE
feat(cms): support sanity acl mode and product refs

### DIFF
--- a/apps/cms/__tests__/saveSanityConfig.test.ts
+++ b/apps/cms/__tests__/saveSanityConfig.test.ts
@@ -44,6 +44,7 @@ describe("saveSanityConfig", () => {
     fd.set("projectId", "p");
     fd.set("dataset", "d");
     fd.set("token", "t");
+    fd.set("aclMode", "public");
 
     const res = await saveSanityConfig("shop", fd);
 
@@ -52,11 +53,14 @@ describe("saveSanityConfig", () => {
       dataset: "d",
       token: "t",
     });
-    expect(setupSanityBlog).toHaveBeenCalledWith({
-      projectId: "p",
-      dataset: "d",
-      token: "t",
-    });
+    expect(setupSanityBlog).toHaveBeenCalledWith(
+      {
+        projectId: "p",
+        dataset: "d",
+        token: "t",
+      },
+      "public",
+    );
     expect(setSanityConfig).toHaveBeenCalledWith({ id: "shop" }, {
       projectId: "p",
       dataset: "d",
@@ -80,6 +84,7 @@ describe("saveSanityConfig", () => {
     fd.set("projectId", "p");
     fd.set("dataset", "d");
     fd.set("token", "t");
+    fd.set("aclMode", "public");
 
     const res = await saveSanityConfig("shop", fd);
     expect(res).toEqual({ error: "fail" });

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -19,6 +19,7 @@ export async function saveSanityConfig(
   const projectId = String(formData.get("projectId") ?? "");
   const dataset = String(formData.get("dataset") ?? "");
   const token = String(formData.get("token") ?? "");
+  const aclMode = String(formData.get("aclMode") ?? "public");
 
   const config = { projectId, dataset, token };
 
@@ -27,7 +28,7 @@ export async function saveSanityConfig(
     return { error: "Invalid Sanity credentials" };
   }
 
-  const setup = await setupSanityBlog(config);
+  const setup = await setupSanityBlog(config, aclMode as "public" | "private");
   if (!setup.success) {
     return { error: setup.error ?? "Failed to setup Sanity blog" };
   }

--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -18,6 +18,7 @@ interface Result {
  */
 export async function setupSanityBlog(
   creds: SanityCredentials,
+  aclMode: "public" | "private" = "public",
 ): Promise<Result> {
   "use server";
   await ensureAuthorized();
@@ -39,7 +40,7 @@ export async function setupSanityBlog(
     const exists = json.datasets?.some((d) => d.name === dataset);
 
     if (!exists) {
-      // create dataset with public read access
+      // create dataset with requested access mode
       const createRes = await fetch(
         `https://api.sanity.io/v1/projects/${projectId}/datasets/${dataset}`,
         {
@@ -48,7 +49,7 @@ export async function setupSanityBlog(
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ aclMode: "public" }),
+          body: JSON.stringify({ aclMode }),
         },
       );
       if (!createRes.ok) {
@@ -69,7 +70,7 @@ export async function setupSanityBlog(
         body: JSON.stringify({
           mutations: [
             {
-              createIfNotExists: {
+              createOrReplace: {
                 _id: "schema-post",
                 _type: "schema",
                 name: "post",
@@ -81,6 +82,13 @@ export async function setupSanityBlog(
                   { name: "excerpt", type: "text", title: "Excerpt" },
                   { name: "body", type: "text", title: "Body" },
                   { name: "published", type: "boolean", title: "Published" },
+                  {
+                    name: "products",
+                    type: "array",
+                    title: "Products",
+                    of: [{ type: "string" }],
+                    description: "Shop product IDs or slugs",
+                  },
                 ],
               },
             },


### PR DESCRIPTION
## Summary
- allow choosing ACL mode when provisioning a Sanity dataset
- update blog schema with product references
- forward ACL mode from CMS config save and refresh schema

## Testing
- `pnpm --filter @apps/cms test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*

------
https://chatgpt.com/codex/tasks/task_e_689a1421b79c832f94cc66bdcffdaf1f