### PR TITLE
feat: handle duplicate emails in profile update

### DIFF
--- a/apps/shop-abc/__tests__/accountProfileApi.test.ts
+++ b/apps/shop-abc/__tests__/accountProfileApi.test.ts
@@ -95,5 +95,22 @@ describe("/api/account/profile PUT", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, profile });
   });
+
+  it("returns 409 when email already exists", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+    (updateCustomerProfile as jest.Mock).mockRejectedValue(
+      new Error("Conflict: email already in use")
+    );
+    const req = {
+      headers: new Headers({ "x-csrf-token": "tok" }),
+      json: async () => ({ name: "Jane", email: "jane@test.com" }),
+    } as any;
+    const res = await PUT(req);
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "email already in use" });
+  });
 });
 

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -47,8 +47,17 @@ export async function PUT(req: NextRequest) {
   if (!parsed.success) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
   }
-
-  await updateCustomerProfile(session.customerId, parsed.data);
+  try {
+    await updateCustomerProfile(session.customerId, parsed.data);
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Conflict:")) {
+      return NextResponse.json(
+        { error: err.message.replace("Conflict: ", "") },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json({ error: "Update failed" }, { status: 400 });
+  }
   const profile = await getCustomerProfile(session.customerId);
   return NextResponse.json({ ok: true, profile });
 }

--- a/packages/platform-core/src/customerProfiles.ts
+++ b/packages/platform-core/src/customerProfiles.ts
@@ -16,6 +16,15 @@ export async function updateCustomerProfile(
   customerId: string,
   data: { name: string; email: string }
 ): Promise<CustomerProfile> {
+  const existing = await prisma.customerProfile.findFirst({
+    where: {
+      email: data.email,
+      NOT: { customerId },
+    },
+  });
+  if (existing) {
+    throw new Error("Conflict: email already in use");
+  }
   return prisma.customerProfile.upsert({
     where: { customerId },
     update: data,

--- a/packages/ui/src/components/account/ProfileForm.tsx
+++ b/packages/ui/src/components/account/ProfileForm.tsx
@@ -52,7 +52,10 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
       if (!res.ok) {
         const data = await res.json();
         setStatus("error");
-        if (res.status === 400 && data && typeof data === "object" && !("error" in data)) {
+        if (res.status === 409) {
+          setErrors({ email: data.error ?? "Email already in use" });
+          setMessage(data.error ?? "Email already in use");
+        } else if (res.status === 400 && data && typeof data === "object" && !("error" in data)) {
           const fieldErrors = data as Record<string, string[]>;
           setErrors(
             Object.fromEntries(


### PR DESCRIPTION
## Summary
- check for existing email before updating customer profile
- return 409 on duplicate email updates
- show friendly error when email already in use

## Testing
- `pnpm test --filter @acme/platform-core` *(fails: process.exit(1) due to invalid environment variables)*
- `pnpm test --filter @acme/ui` *(fails: process.exit(1) due to invalid environment variables)*
- `pnpm exec jest apps/shop-abc/__tests__/api/accountProfile.test.ts apps/shop-abc/__tests__/accountProfileApi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a122bd064832fbdb237fe7dd10016