### PR TITLE
Hash and expire password reset tokens

### DIFF
--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
+import crypto from "node:crypto";
 import { getUserByResetToken, updatePassword } from "../../../../userStore";
 
 const schema = z.object({
@@ -19,9 +20,13 @@ export async function POST(req: Request) {
   }
 
   const { token, password } = parsed.data;
-  const user = await getUserByResetToken(token);
+  const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
+  const user = await getUserByResetToken(tokenHash);
   if (!user) {
-    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid or expired token" },
+      { status: 400 },
+    );
   }
 
   const passwordHash = await bcrypt.hash(password, 10);


### PR DESCRIPTION
## Summary
- Generate UUID reset tokens, hash them, and email the plain token
- Extend in-memory user store to persist hashed tokens with expiry
- Validate hashed tokens and expiration before updating passwords

## Testing
- `pnpm test:cms apps/shop-abc/__tests__/authFlow.test.ts`
- `pnpm lint --filter=@apps/shop-abc` *(no tasks)*

------
https://chatgpt.com/codex/tasks/task_e_689a1234c260832f92dd1eed5e2d8008