### PR TITLE
feat: add map block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -2,209 +2,277 @@ import { z } from "zod";
 import { type Translated } from "./Product";
 export type PageStatus = "draft" | "published";
 export interface SeoMeta {
-    title: Translated;
-    description?: Translated;
-    image?: Translated;
+  title: Translated;
+  description?: Translated;
+  image?: Translated;
 }
 export interface PageComponentBase {
-    id: string;
-    type: string;
-    /**
-     * Width of the rendered component. Can be a pixel value (e.g. "300px")
-     * or a percentage (e.g. "50%").
-     */
-    width?: string;
-    /**
-     * Height of the rendered component. Can be a pixel value or percentage.
-     */
-    height?: string;
-    /**
-     * CSS position property used when rendering the component.
-     */
-    position?: "relative" | "absolute";
-    /**
-     * Offset from the top when position is absolute.
-     */
-    top?: string;
-    /**
-     * Offset from the left when position is absolute.
-     */
-    left?: string;
-    /**
-     * Margin applied to the outer container when rendered.
-     * Accepts any valid CSS margin value or Tailwind class.
-     */
-    margin?: string;
-    /**
-     * Padding applied to the outer container when rendered.
-     * Accepts any valid CSS padding value or Tailwind class.
-     */
-    padding?: string;
-    /** Minimum number of items allowed for list components */
-    minItems?: number;
-    /** Maximum number of items allowed for list components */
-    maxItems?: number;
-    [key: string]: unknown;
+  id: string;
+  type: string;
+  /**
+   * Width of the rendered component. Can be a pixel value (e.g. "300px")
+   * or a percentage (e.g. "50%").
+   */
+  width?: string;
+  /**
+   * Height of the rendered component. Can be a pixel value or percentage.
+   */
+  height?: string;
+  /**
+   * CSS position property used when rendering the component.
+   */
+  position?: "relative" | "absolute";
+  /**
+   * Offset from the top when position is absolute.
+   */
+  top?: string;
+  /**
+   * Offset from the left when position is absolute.
+   */
+  left?: string;
+  /**
+   * Margin applied to the outer container when rendered.
+   * Accepts any valid CSS margin value or Tailwind class.
+   */
+  margin?: string;
+  /**
+   * Padding applied to the outer container when rendered.
+   * Accepts any valid CSS padding value or Tailwind class.
+   */
+  padding?: string;
+  /** Minimum number of items allowed for list components */
+  minItems?: number;
+  /** Maximum number of items allowed for list components */
+  maxItems?: number;
+  [key: string]: unknown;
 }
 export interface AnnouncementBarComponent extends PageComponentBase {
-    type: "AnnouncementBar";
-    text?: string;
-    link?: string;
-    closable?: boolean;
+  type: "AnnouncementBar";
+  text?: string;
+  link?: string;
+  closable?: boolean;
 }
 export interface HeroBannerComponent extends PageComponentBase {
-    type: "HeroBanner";
-    slides?: {
-        src: string;
-        alt?: string;
-        headlineKey: string;
-        ctaKey: string;
-    }[];
+  type: "HeroBanner";
+  slides?: {
+    src: string;
+    alt?: string;
+    headlineKey: string;
+    ctaKey: string;
+  }[];
 }
 export interface ValuePropsComponent extends PageComponentBase {
-    type: "ValueProps";
-    items?: {
-        icon: string;
-        title: string;
-        desc: string;
-    }[];
+  type: "ValueProps";
+  items?: {
+    icon: string;
+    title: string;
+    desc: string;
+  }[];
 }
 /** Carousel of customer reviews. `minItems`/`maxItems` limit visible reviews */
 export interface ReviewsCarouselComponent extends PageComponentBase {
-    type: "ReviewsCarousel";
-    reviews?: {
-        nameKey: string;
-        quoteKey: string;
-    }[];
+  type: "ReviewsCarousel";
+  reviews?: {
+    nameKey: string;
+    quoteKey: string;
+  }[];
 }
 /** Grid of products; `minItems`/`maxItems` clamp the responsive product count */
 export interface ProductGridComponent extends PageComponentBase {
-    type: "ProductGrid";
+  type: "ProductGrid";
 }
 /** Carousel of products; `minItems`/`maxItems` clamp visible products */
 export interface ProductCarouselComponent extends PageComponentBase {
-    type: "ProductCarousel";
+  type: "ProductCarousel";
 }
 /** Carousel of recommended products fetched from an API */
 export interface RecommendationCarouselComponent extends PageComponentBase {
-    type: "RecommendationCarousel";
-    endpoint: string;
+  type: "RecommendationCarousel";
+  endpoint: string;
 }
 export interface GalleryComponent extends PageComponentBase {
-    type: "Gallery";
-    images?: {
-        src: string;
-        alt?: string;
-    }[];
+  type: "Gallery";
+  images?: {
+    src: string;
+    alt?: string;
+  }[];
 }
 export interface ContactFormComponent extends PageComponentBase {
-    type: "ContactForm";
-    action?: string;
-    method?: string;
+  type: "ContactForm";
+  action?: string;
+  method?: string;
 }
 export interface ContactFormWithMapComponent extends PageComponentBase {
-    type: "ContactFormWithMap";
-    mapSrc?: string;
+  type: "ContactFormWithMap";
+  mapSrc?: string;
+}
+export interface MapBlockComponent extends PageComponentBase {
+  type: "MapBlock";
+  lat?: number;
+  lng?: number;
+  zoom?: number;
 }
 export interface ImageComponent extends PageComponentBase {
-    type: "Image";
-    src?: string;
-    alt?: string;
+  type: "Image";
+  src?: string;
+  alt?: string;
 }
 export interface TextComponent extends PageComponentBase {
-    type: "Text";
-    text?: string;
+  type: "Text";
+  text?: string;
 }
 export interface BlogListingComponent extends PageComponentBase {
-    type: "BlogListing";
-    posts?: {
-        title: string;
-        excerpt?: string;
-        url?: string;
-    }[];
+  type: "BlogListing";
+  posts?: {
+    title: string;
+    excerpt?: string;
+    url?: string;
+  }[];
 }
 /** Slider of testimonials. `minItems`/`maxItems` limit visible testimonials */
 export interface TestimonialSliderComponent extends PageComponentBase {
-    type: "TestimonialSlider";
-    testimonials?: {
-        quote: string;
-        name?: string;
-    }[];
+  type: "TestimonialSlider";
+  testimonials?: {
+    quote: string;
+    name?: string;
+  }[];
 }
 export interface TestimonialsComponent extends PageComponentBase {
-    type: "Testimonials";
-    testimonials?: {
-        quote: string;
-        name?: string;
-    }[];
+  type: "Testimonials";
+  testimonials?: {
+    quote: string;
+    name?: string;
+  }[];
 }
 export interface SectionComponent extends PageComponentBase {
-    type: "Section";
-    children?: PageComponent[];
+  type: "Section";
+  children?: PageComponent[];
 }
-export type PageComponent = AnnouncementBarComponent | HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
-export declare const pageSchema: z.ZodObject<{
+export type PageComponent =
+  | AnnouncementBarComponent
+  | HeroBannerComponent
+  | ValuePropsComponent
+  | ReviewsCarouselComponent
+  | ProductGridComponent
+  | ProductCarouselComponent
+  | RecommendationCarouselComponent
+  | GalleryComponent
+  | ContactFormComponent
+  | ContactFormWithMapComponent
+  | MapBlockComponent
+  | BlogListingComponent
+  | TestimonialsComponent
+  | TestimonialSliderComponent
+  | ImageComponent
+  | TextComponent
+  | SectionComponent;
+export declare const pageSchema: z.ZodObject<
+  {
     id: z.ZodString;
     slug: z.ZodString;
     status: z.ZodEnum<["draft", "published"]>;
-    components: z.ZodDefault<z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        type: z.ZodString;
-    }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-        id: z.ZodString;
-        type: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-        id: z.ZodString;
-        type: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">>, "many">>;
-    seo: z.ZodObject<{
+    components: z.ZodDefault<
+      z.ZodArray<
+        z.ZodObject<
+          {
+            id: z.ZodString;
+            type: z.ZodString;
+          },
+          "passthrough",
+          z.ZodTypeAny,
+          z.objectOutputType<
+            {
+              id: z.ZodString;
+              type: z.ZodString;
+            },
+            z.ZodTypeAny,
+            "passthrough"
+          >,
+          z.objectInputType<
+            {
+              id: z.ZodString;
+              type: z.ZodString;
+            },
+            z.ZodTypeAny,
+            "passthrough"
+          >
+        >,
+        "many"
+      >
+    >;
+    seo: z.ZodObject<
+      {
         title: z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>;
-        description: z.ZodOptional<z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>>;
-        image: z.ZodOptional<z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>>;
-    }, "strip", z.ZodTypeAny, {
+        description: z.ZodOptional<
+          z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>
+        >;
+        image: z.ZodOptional<
+          z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodString>
+        >;
+      },
+      "strip",
+      z.ZodTypeAny,
+      {
         title: Partial<Record<"en" | "de" | "it", string>>;
         image?: Partial<Record<"en" | "de" | "it", string>> | undefined;
         description?: Partial<Record<"en" | "de" | "it", string>> | undefined;
-    }, {
+      },
+      {
         title: Partial<Record<"en" | "de" | "it", string>>;
         image?: Partial<Record<"en" | "de" | "it", string>> | undefined;
         description?: Partial<Record<"en" | "de" | "it", string>> | undefined;
-    }>;
+      }
+    >;
     createdAt: z.ZodString;
     updatedAt: z.ZodString;
     createdBy: z.ZodString;
-}, "strip", z.ZodTypeAny, {
+  },
+  "strip",
+  z.ZodTypeAny,
+  {
     id: string;
     slug: string;
     status: "draft" | "published";
-    components: z.objectOutputType<{
+    components: z.objectOutputType<
+      {
         id: z.ZodString;
         type: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">[];
+      },
+      z.ZodTypeAny,
+      "passthrough"
+    >[];
     seo: {
-        title: Partial<Record<"en" | "de" | "it", string>>;
-        image?: Partial<Record<"en" | "de" | "it", string>> | undefined;
-        description?: Partial<Record<"en" | "de" | "it", string>> | undefined;
+      title: Partial<Record<"en" | "de" | "it", string>>;
+      image?: Partial<Record<"en" | "de" | "it", string>> | undefined;
+      description?: Partial<Record<"en" | "de" | "it", string>> | undefined;
     };
     createdAt: string;
     updatedAt: string;
     createdBy: string;
-}, {
+  },
+  {
     id: string;
     slug: string;
     status: "draft" | "published";
     seo: {
-        title: Partial<Record<"en" | "de" | "it", string>>;
-        image?: Partial<Record<"en" | "de" | "it", string>> | undefined;
-        description?: Partial<Record<"en" | "de" | "it", string>> | undefined;
+      title: Partial<Record<"en" | "de" | "it", string>>;
+      image?: Partial<Record<"en" | "de" | "it", string>> | undefined;
+      description?: Partial<Record<"en" | "de" | "it", string>> | undefined;
     };
     createdAt: string;
     updatedAt: string;
     createdBy: string;
-    components?: z.objectInputType<{
-        id: z.ZodString;
-        type: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">[] | undefined;
-}>;
+    components?:
+      | z.objectInputType<
+          {
+            id: z.ZodString;
+            type: z.ZodString;
+          },
+          z.ZodTypeAny,
+          "passthrough"
+        >[]
+      | undefined;
+  }
+>;
 export type Page = z.infer<typeof pageSchema>;
 //# sourceMappingURL=Page.d.ts.map

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -109,6 +109,13 @@ export interface ContactFormWithMapComponent extends PageComponentBase {
   mapSrc?: string;
 }
 
+export interface MapBlockComponent extends PageComponentBase {
+  type: "MapBlock";
+  lat?: number;
+  lng?: number;
+  zoom?: number;
+}
+
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -152,6 +159,7 @@ export type PageComponent =
   | GalleryComponent
   | ContactFormComponent
   | ContactFormWithMapComponent
+  | MapBlockComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
@@ -198,18 +206,14 @@ const announcementBarComponentSchema = baseComponentSchema.extend({
 const valuePropsComponentSchema = baseComponentSchema.extend({
   type: z.literal("ValueProps"),
   items: z
-    .array(
-      z.object({ icon: z.string(), title: z.string(), desc: z.string() })
-    )
+    .array(z.object({ icon: z.string(), title: z.string(), desc: z.string() }))
     .optional(),
 });
 
 const reviewsCarouselComponentSchema = baseComponentSchema.extend({
   type: z.literal("ReviewsCarousel"),
   reviews: z
-    .array(
-      z.object({ nameKey: z.string(), quoteKey: z.string() })
-    )
+    .array(z.object({ nameKey: z.string(), quoteKey: z.string() }))
     .optional(),
 });
 
@@ -244,6 +248,13 @@ const contactFormWithMapComponentSchema = baseComponentSchema.extend({
   mapSrc: z.string().optional(),
 });
 
+const mapBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("MapBlock"),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
+  zoom: z.number().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -260,18 +271,14 @@ const blogListingComponentSchema = baseComponentSchema.extend({
 const testimonialSliderComponentSchema = baseComponentSchema.extend({
   type: z.literal("TestimonialSlider"),
   testimonials: z
-    .array(
-      z.object({ quote: z.string(), name: z.string().optional() })
-    )
+    .array(z.object({ quote: z.string(), name: z.string().optional() }))
     .optional(),
 });
 
 const testimonialsComponentSchema = baseComponentSchema.extend({
   type: z.literal("Testimonials"),
   testimonials: z
-    .array(
-      z.object({ quote: z.string(), name: z.string().optional() })
-    )
+    .array(z.object({ quote: z.string(), name: z.string().optional() }))
     .optional(),
 });
 
@@ -286,10 +293,11 @@ const textComponentSchema = baseComponentSchema.extend({
   text: z.string().optional(),
 });
 
-const sectionComponentSchema: z.ZodType<SectionComponent> = baseComponentSchema.extend({
-  type: z.literal("Section"),
-  children: z.array(z.lazy(() => pageComponentSchema)).default([]),
-});
+const sectionComponentSchema: z.ZodType<SectionComponent> =
+  baseComponentSchema.extend({
+    type: z.literal("Section"),
+    children: z.array(z.lazy(() => pageComponentSchema)).default([]),
+  });
 
 export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
   z.discriminatedUnion("type", [
@@ -303,6 +311,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     galleryComponentSchema,
     contactFormComponentSchema,
     contactFormWithMapComponentSchema,
+    mapBlockComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,

--- a/packages/ui/src/components/cms/blocks/MapBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/MapBlock.tsx
@@ -1,0 +1,25 @@
+// packages/ui/src/components/cms/blocks/MapBlock.tsx
+"use client";
+
+import { StoreLocatorMap } from "../../organisms/StoreLocatorMap";
+
+interface Props {
+  /** Latitude for the map centre */
+  lat?: number;
+  /** Longitude for the map centre */
+  lng?: number;
+  /** Initial zoom level */
+  zoom?: number;
+}
+
+/** CMS wrapper for the StoreLocatorMap organism */
+export default function MapBlock({ lat, lng, zoom }: Props) {
+  if (typeof lat !== "number" || typeof lng !== "number") return null;
+  return (
+    <StoreLocatorMap
+      locations={[{ lat, lng }]}
+      zoom={zoom}
+      heightClass="h-full"
+    />
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -12,6 +12,7 @@ import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
 import AnnouncementBar from "./AnnouncementBarBlock";
+import MapBlock from "./MapBlock";
 
 export {
   BlogListing,
@@ -28,6 +29,7 @@ export {
   ValueProps,
   Section,
   AnnouncementBar,
+  MapBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -11,6 +11,7 @@ import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import AnnouncementBar from "./AnnouncementBarBlock";
+import MapBlock from "./MapBlock";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -26,6 +27,7 @@ export const organismRegistry = {
   BlogListing,
   Testimonials,
   TestimonialSlider,
+  MapBlock,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -20,13 +20,17 @@ import HeroBannerEditor from "./HeroBannerEditor";
 import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
+import MapBlockEditor from "./MapBlockEditor";
 
 interface Props {
   component: PageComponent | null;
   onChange: (patch: Partial<PageComponent>) => void;
-  onResize: (
-    patch: { width?: string; height?: string; top?: string; left?: string }
-  ) => void;
+  onResize: (patch: {
+    width?: string;
+    height?: string;
+    top?: string;
+    left?: string;
+  }) => void;
 }
 
 function ComponentEditor({ component, onChange, onResize }: Props) {
@@ -36,14 +40,16 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     (field: string, value: string | number | undefined) => {
       onChange({ [field]: value } as Partial<PageComponent>);
     },
-    [onChange],
+    [onChange]
   );
 
   let specific: React.ReactNode = null;
 
   switch (component.type) {
     case "ContactForm":
-      specific = <ContactFormEditor component={component} onChange={onChange} />;
+      specific = (
+        <ContactFormEditor component={component} onChange={onChange} />
+      );
       break;
     case "Gallery":
       specific = <GalleryEditor component={component} onChange={onChange} />;
@@ -52,7 +58,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = <ImageBlockEditor component={component} onChange={onChange} />;
       break;
     case "Testimonials":
-      specific = <TestimonialsEditor component={component} onChange={onChange} />;
+      specific = (
+        <TestimonialsEditor component={component} onChange={onChange} />
+      );
       break;
     case "HeroBanner":
       specific = <HeroBannerEditor component={component} onChange={onChange} />;
@@ -70,8 +78,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
         <ReviewsCarouselEditor component={component} onChange={onChange} />
       );
       break;
+    case "MapBlock":
+      specific = <MapBlockEditor component={component} onChange={onChange} />;
+      break;
     default:
-      specific = <p className="text-sm text-muted">No editable props</p>;
+      specific = <p className="text-muted text-sm">No editable props</p>;
   }
 
   return (

--- a/packages/ui/src/components/cms/page-builder/MapBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/MapBlockEditor.tsx
@@ -1,0 +1,37 @@
+import type { PageComponent } from "@types";
+import { Input } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function MapBlockEditor({ component, onChange }: Props) {
+  const handleNumber = (field: string, value: string) => {
+    const num = value === "" ? undefined : Number(value);
+    onChange({ [field]: num } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        label="Latitude"
+        type="number"
+        value={(component as any).lat ?? ""}
+        onChange={(e) => handleNumber("lat", e.target.value)}
+      />
+      <Input
+        label="Longitude"
+        type="number"
+        value={(component as any).lng ?? ""}
+        onChange={(e) => handleNumber("lng", e.target.value)}
+      />
+      <Input
+        label="Zoom"
+        type="number"
+        value={(component as any).zoom ?? ""}
+        onChange={(e) => handleNumber("zoom", e.target.value)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -8,6 +8,7 @@ export { default as HeroBannerEditor } from "./HeroBannerEditor";
 export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
 export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
+export { default as MapBlockEditor } from "./MapBlockEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add MapBlock that wraps StoreLocatorMap
- allow editing map latitude, longitude, and zoom in page builder
- extend page schema and block registry for MapBlock

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: command finished with error)*
- `pnpm test --filter @types/shared`


------
https://chatgpt.com/codex/tasks/task_e_689a16d3b468832fba92e46b401df5f0