### PR TITLE
feat: secure password reset token

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -17,26 +17,27 @@ jest.mock("@lib/email", () => ({
 
 const store: Record<string, any> = {};
 
+let sendEmail: jest.Mock;
+
 jest.mock("../src/app/userStore", () => ({
   getUserById: jest.fn(async (id: string) => store[id] ?? null),
-  getUserByEmail: jest.fn(async (email: string) =>
-    Object.values(store).find((u: any) => u.email === email) ?? null,
+  getUserByEmail: jest.fn(
+    async (email: string) =>
+      Object.values(store).find((u: any) => u.email === email) ?? null
   ),
-  addUser: jest.fn(async ({
-    id,
-    email,
-    passwordHash,
-    role = "customer",
-  }: any) => {
-    const user = { id, email, passwordHash, role, resetToken: null };
-    store[id] = user;
-    return user;
-  }),
+  addUser: jest.fn(
+    async ({ id, email, passwordHash, role = "customer" }: any) => {
+      const user = { id, email, passwordHash, role, resetToken: null };
+      store[id] = user;
+      return user;
+    }
+  ),
   setResetToken: jest.fn(async (id: string, token: string | null) => {
     if (store[id]) store[id].resetToken = token;
   }),
-  getUserByResetToken: jest.fn(async (token: string) =>
-    Object.values(store).find((u: any) => u.resetToken === token) ?? null,
+  getUserByResetToken: jest.fn(
+    async (token: string) =>
+      Object.values(store).find((u: any) => u.resetToken === token) ?? null
   ),
   updatePassword: jest.fn(async (id: string, hash: string) => {
     if (store[id]) {
@@ -60,18 +61,20 @@ beforeAll(async () => {
   ({ POST: completePOST } = await import(
     "../src/app/api/account/reset/complete/route"
   ));
+  ({ sendEmail } = await import("@lib/email"));
 });
 
-  function makeRequest(body: any, headers: Record<string, string> = {}) {
-    return {
-      json: async () => body,
-      headers: new Headers({ "x-csrf-token": "tok", ...headers }),
-    } as any;
-  }
+function makeRequest(body: any, headers: Record<string, string> = {}) {
+  return {
+    json: async () => body,
+    headers: new Headers({ "x-csrf-token": "tok", ...headers }),
+  } as any;
+}
 
 describe("auth flows", () => {
   beforeEach(() => {
     for (const key in store) delete store[key];
+    sendEmail.mockClear();
   });
 
   it("allows sign-up, login and password reset", async () => {
@@ -80,7 +83,7 @@ describe("auth flows", () => {
         customerId: "cust1",
         email: "test@example.com",
         password: "Str0ngPass1",
-      }),
+      })
     );
     expect(res.status).toBe(200);
 
@@ -89,44 +92,44 @@ describe("auth flows", () => {
         customerId: "cust2",
         email: "test@example.com",
         password: "An0therPass1",
-      }),
+      })
     );
     expect(dup.status).toBe(400);
 
     res = await loginPOST(
       makeRequest(
         { customerId: "cust1", password: "Str0ngPass1" },
-        { "x-forwarded-for": "1.1.1.1" },
-      ),
+        { "x-forwarded-for": "1.1.1.1" }
+      )
     );
     expect(res.status).toBe(200);
 
     await requestPOST(makeRequest({ email: "test@example.com" }));
-    const { getUserById } = await import("../src/app/userStore");
-    const token = (await getUserById("cust1"))!.resetToken as string;
+    const tokenEmail = sendEmail.mock.calls[0][2] as string;
+    const token = tokenEmail.replace("Your token is ", "");
 
     res = await completePOST(
       makeRequest({
         customerId: "cust1",
         token,
         password: "NewStr0ng1",
-      }),
+      })
     );
     expect(res.status).toBe(200);
 
     res = await loginPOST(
       makeRequest(
         { customerId: "cust1", password: "Str0ngPass1" },
-        { "x-forwarded-for": "1.1.1.1" },
-      ),
+        { "x-forwarded-for": "1.1.1.1" }
+      )
     );
     expect(res.status).toBe(401);
 
     res = await loginPOST(
       makeRequest(
         { customerId: "cust1", password: "NewStr0ng1" },
-        { "x-forwarded-for": "1.1.1.1" },
-      ),
+        { "x-forwarded-for": "1.1.1.1" }
+      )
     );
     expect(res.status).toBe(200);
   });
@@ -137,19 +140,19 @@ describe("auth flows", () => {
         customerId: "cust1",
         email: "test@example.com",
         password: "Str0ngPass1",
-      }),
+      })
     );
 
     await requestPOST(makeRequest({ email: "test@example.com" }));
-    const { getUserById } = await import("../src/app/userStore");
-    const token = (await getUserById("cust1"))!.resetToken as string;
+    const tokenEmail = sendEmail.mock.calls[0][2] as string;
+    const token = tokenEmail.replace("Your token is ", "");
 
     const res = await completePOST(
       makeRequest({
         customerId: "cust1",
         token,
         password: "weakpass",
-      }),
+      })
     );
     expect(res.status).toBe(400);
   });

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
+import crypto from "crypto";
 import { getUserByResetToken, updatePassword } from "../../../../userStore";
 import { validateCsrfToken } from "@auth";
 
@@ -12,7 +13,7 @@ const schema = z.object({
     .min(8, "Password must be at least 8 characters long")
     .regex(
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
-      "Password must include uppercase, lowercase, and number",
+      "Password must include uppercase, lowercase, and number"
     ),
 });
 
@@ -31,7 +32,8 @@ export async function POST(req: Request) {
   }
 
   const { token, password } = parsed.data;
-  const user = await getUserByResetToken(token);
+  const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+  const user = await getUserByResetToken(hashedToken);
   if (!user) {
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- generate password reset tokens using crypto for stronger randomness
- hash reset tokens before storage and verification
- adjust auth flow tests to read tokens from email

## Testing
- `pnpm test` *(fails: apps/cms#test)*
- `pnpm exec jest apps/shop-abc/__tests__/authFlow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a16e19818832fbac98a156a8fa155