### PR TITLE
feat: add FAQ block and accordion component

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -131,6 +131,11 @@ export interface TestimonialsComponent extends PageComponentBase {
   testimonials?: { quote: string; name?: string }[];
 }
 
+export interface FAQBlockComponent extends PageComponentBase {
+  type: "FAQBlock";
+  faqs?: { question: string; answer: string }[];
+}
+
 export interface TextComponent extends PageComponentBase {
   type: "Text";
   text?: string;
@@ -155,6 +160,7 @@ export type PageComponent =
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
+  | FAQBlockComponent
   | ImageComponent
   | TextComponent
   | SectionComponent;
@@ -275,6 +281,15 @@ const testimonialsComponentSchema = baseComponentSchema.extend({
     .optional(),
 });
 
+const faqBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("FAQBlock"),
+  faqs: z
+    .array(
+      z.object({ question: z.string(), answer: z.string() })
+    )
+    .optional(),
+});
+
 const imageComponentSchema = baseComponentSchema.extend({
   type: z.literal("Image"),
   src: z.string().optional(),
@@ -306,6 +321,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,
+    faqBlockComponentSchema,
     imageComponentSchema,
     textComponentSchema,
     sectionComponentSchema,

--- a/packages/ui/src/components/cms/blocks/FAQBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FAQBlock.tsx
@@ -1,0 +1,29 @@
+import Accordion, { type AccordionItem } from "../../molecules/Accordion";
+
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface Props {
+  faqs?: FAQItem[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function FAQBlock({
+  faqs = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = faqs.slice(0, maxItems ?? faqs.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+
+  const items: AccordionItem[] = list.map((f) => ({
+    title: f.question,
+    content: f.answer,
+  }));
+
+  return <Accordion items={items} />;
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -12,6 +12,7 @@ import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
 import AnnouncementBar from "./AnnouncementBarBlock";
+import FAQBlock from "./FAQBlock";
 
 export {
   BlogListing,
@@ -28,6 +29,7 @@ export {
   ValueProps,
   Section,
   AnnouncementBar,
+  FAQBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -11,6 +11,7 @@ import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import AnnouncementBar from "./AnnouncementBarBlock";
+import FAQBlock from "./FAQBlock";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -26,6 +27,7 @@ export const organismRegistry = {
   BlogListing,
   Testimonials,
   TestimonialSlider,
+  FAQBlock,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -20,6 +20,7 @@ import HeroBannerEditor from "./HeroBannerEditor";
 import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
+import FAQBlockEditor from "./FAQBlockEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -69,6 +70,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = (
         <ReviewsCarouselEditor component={component} onChange={onChange} />
       );
+      break;
+    case "FAQBlock":
+      specific = <FAQBlockEditor component={component} onChange={onChange} />;
       break;
     default:
       specific = <p className="text-sm text-muted">No editable props</p>;

--- a/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
@@ -1,0 +1,21 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function FAQBlockEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor(
+    "faqs",
+    (component as any).faqs,
+    ["question", "answer"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -7,6 +7,7 @@ import HeroBannerEditor from "../HeroBannerEditor";
 import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
 import AnnouncementBarEditor from "../AnnouncementBarEditor";
+import FAQBlockEditor from "../FAQBlockEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -65,6 +66,12 @@ describe("block editors", () => {
       AnnouncementBarEditor,
       { type: "AnnouncementBar", text: "", link: "" },
       "text",
+    ],
+    [
+      "FAQBlockEditor",
+      FAQBlockEditor,
+      { type: "FAQBlock", faqs: [{ question: "", answer: "" }] },
+      "question",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -8,6 +8,7 @@ export { default as HeroBannerEditor } from "./HeroBannerEditor";
 export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
 export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
+export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";

--- a/packages/ui/src/components/molecules/Accordion.tsx
+++ b/packages/ui/src/components/molecules/Accordion.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+export interface AccordionItem {
+  /** Heading shown in the accordion summary */
+  title: React.ReactNode;
+  /** Content revealed when the item is expanded */
+  content: React.ReactNode;
+}
+
+export interface AccordionProps {
+  /** Collection of accordion items to render */
+  items: AccordionItem[];
+}
+
+/**
+ * Simple accordion component rendering a list of expandable items.
+ * Uses native `<details>` / `<summary>` elements for accessibility.
+ */
+export default function Accordion({ items }: AccordionProps) {
+  if (!items?.length) return null;
+  return (
+    <div className="divide-y rounded border">
+      {items.map((item, idx) => (
+        <details key={idx} className="group">
+          <summary className="cursor-pointer select-none p-4 font-medium focus:outline-none focus-visible:ring">
+            {item.title}
+          </summary>
+          <div className="p-4 pt-0">{item.content}</div>
+        </details>
+      ))}
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -12,3 +12,4 @@ export { QuantityInput } from "./QuantityInput";
 export { RatingSummary } from "./RatingSummary";
 export { SearchBar } from "./SearchBar";
 export { SustainabilityBadgeCluster } from "./SustainabilityBadgeCluster";
+export { default as Accordion } from "./Accordion";


### PR DESCRIPTION
## Summary
- add reusable Accordion component
- create FAQBlock with CMS editor and registry entries
- include FAQBlock in page-component types

## Testing
- `pnpm --filter @types/shared test` *(no tests found)*
- `cd packages/ui && npx jest src/components/cms/page-builder/__tests__/BlockEditors.test.tsx --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689a15e08e58832f8900772b92560e19