### PR TITLE
feat: add multi-column CMS container

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -109,6 +109,12 @@ export interface TextComponent extends PageComponentBase {
     type: "Text";
     text?: string;
 }
+export interface MultiColumnComponent extends PageComponentBase {
+    type: "MultiColumn";
+    columns?: number;
+    gap?: string;
+    children?: PageComponent[];
+}
 export interface BlogListingComponent extends PageComponentBase {
     type: "BlogListing";
     posts?: {
@@ -136,7 +142,7 @@ export interface SectionComponent extends PageComponentBase {
     type: "Section";
     children?: PageComponent[];
 }
-export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
+export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent | MultiColumnComponent;
 export declare const pageSchema: z.ZodObject<{
     id: z.ZodString;
     slug: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -129,6 +129,13 @@ export interface TextComponent extends PageComponentBase {
   text?: string;
 }
 
+export interface MultiColumnComponent extends PageComponentBase {
+  type: "MultiColumn";
+  columns?: number;
+  gap?: string;
+  children?: PageComponent[];
+}
+
 export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
@@ -149,7 +156,8 @@ export type PageComponent =
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent
-  | SectionComponent;
+  | SectionComponent
+  | MultiColumnComponent;
 
 const baseComponentSchema = z
   .object({
@@ -271,6 +279,14 @@ const textComponentSchema = baseComponentSchema.extend({
   text: z.string().optional(),
 });
 
+const multiColumnComponentSchema: z.ZodType<MultiColumnComponent> =
+  baseComponentSchema.extend({
+    type: z.literal("MultiColumn"),
+    columns: z.number().int().min(1).optional(),
+    gap: z.string().optional(),
+    children: z.array(z.lazy(() => pageComponentSchema)).default([]),
+  });
+
 const sectionComponentSchema: z.ZodType<SectionComponent> = baseComponentSchema.extend({
   type: z.literal("Section"),
   children: z.array(z.lazy(() => pageComponentSchema)).default([]),
@@ -293,6 +309,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     imageComponentSchema,
     textComponentSchema,
     sectionComponentSchema,
+    multiColumnComponentSchema,
   ])
 );
 

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -1,7 +1,9 @@
 import Section from "./Section";
+import MultiColumn from "./containers/MultiColumn";
 
 export const containerRegistry = {
   Section,
+  MultiColumn,
 } as const;
 
 export type ContainerBlockType = keyof typeof containerRegistry;

--- a/packages/ui/src/components/cms/blocks/containers/MultiColumn.tsx
+++ b/packages/ui/src/components/cms/blocks/containers/MultiColumn.tsx
@@ -1,0 +1,27 @@
+"use client";
+import type { CSSProperties, ReactNode } from "react";
+
+export interface MultiColumnProps {
+  children?: ReactNode;
+  columns?: number;
+  gap?: string;
+  className?: string;
+}
+
+export default function MultiColumn({
+  children,
+  columns = 2,
+  gap = "1rem",
+  className,
+}: MultiColumnProps) {
+  const style: CSSProperties = {
+    display: "grid",
+    gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+    gap,
+  };
+  return (
+    <div className={className} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -11,6 +11,7 @@ import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
+import MultiColumn from "./containers/MultiColumn";
 
 export {
   BlogListing,
@@ -26,6 +27,7 @@ export {
   TestimonialSlider,
   ValueProps,
   Section,
+  MultiColumn,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -176,6 +176,15 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
           max={(component as any).maxItems}
         />
       )}
+      {"gap" in component && (
+        <Input
+          label="Gap"
+          value={(component as any).gap ?? ""}
+          onChange={(e) =>
+            handleInput("gap", e.target.value === "" ? undefined : e.target.value)
+          }
+        />
+      )}
       <Select
         value={component.position ?? ""}
         onValueChange={(v) => handleInput("position", v || undefined)}

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -36,6 +36,7 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   RecommendationCarousel: { minItems: 1, maxItems: 4 },
   Testimonials: { minItems: 1, maxItems: 10 },
   TestimonialSlider: { minItems: 1, maxItems: 10 },
+  MultiColumn: { columns: 2, gap: "1rem" },
 };
 
 interface Props {
@@ -58,8 +59,12 @@ const PageBuilder = memo(function PageBuilder({
   const storageKey = `page-builder-history-${page.id}`;
   const migrate = useCallback(
     (comps: PageComponent[]): PageComponent[] =>
-      comps.map((c) => (c.type === "Section" ? { ...c, children: c.children ?? [] } : c)),
-    []
+      comps.map((c) =>
+        CONTAINER_TYPES.includes(c.type as ComponentType)
+          ? { ...c, children: c.children ?? [] }
+          : c,
+      ),
+    [],
   );
 
   const [state, rawDispatch] = useReducer(reducer, undefined, (): HistoryState => {


### PR DESCRIPTION
## Summary
- add `MultiColumn` container with configurable columns and gap
- register container so nested blocks can be arranged in grids
- expose gap field in editor and support container defaults in page builder

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689a126a5618832fa83a22dad630d6a7