### PR TITLE
feat: add video block and editor

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -105,6 +105,11 @@ export interface ImageComponent extends PageComponentBase {
     src?: string;
     alt?: string;
 }
+export interface VideoBlockComponent extends PageComponentBase {
+    type: "VideoBlock";
+    src?: string;
+    autoplay?: boolean;
+}
 export interface TextComponent extends PageComponentBase {
     type: "Text";
     text?: string;
@@ -136,7 +141,7 @@ export interface SectionComponent extends PageComponentBase {
     type: "Section";
     children?: PageComponent[];
 }
-export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | TextComponent | SectionComponent;
+export type PageComponent = HeroBannerComponent | ValuePropsComponent | ReviewsCarouselComponent | ProductGridComponent | ProductCarouselComponent | RecommendationCarouselComponent | GalleryComponent | ContactFormComponent | ContactFormWithMapComponent | BlogListingComponent | TestimonialsComponent | TestimonialSliderComponent | ImageComponent | VideoBlockComponent | TextComponent | SectionComponent;
 export declare const pageSchema: z.ZodObject<{
     id: z.ZodString;
     slug: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -108,6 +108,12 @@ export interface ImageComponent extends PageComponentBase {
   alt?: string;
 }
 
+export interface VideoBlockComponent extends PageComponentBase {
+  type: "VideoBlock";
+  src?: string;
+  autoplay?: boolean;
+}
+
 export interface BlogListingComponent extends PageComponentBase {
   type: "BlogListing";
   posts?: { title: string; excerpt?: string; url?: string }[];
@@ -148,6 +154,7 @@ export type PageComponent =
   | TestimonialsComponent
   | TestimonialSliderComponent
   | ImageComponent
+  | VideoBlockComponent
   | TextComponent
   | SectionComponent;
 
@@ -266,6 +273,12 @@ const imageComponentSchema = baseComponentSchema.extend({
   alt: z.string().optional(),
 });
 
+const videoBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("VideoBlock"),
+  src: z.string().optional(),
+  autoplay: z.boolean().optional(),
+});
+
 const textComponentSchema = baseComponentSchema.extend({
   type: z.literal("Text"),
   text: z.string().optional(),
@@ -291,6 +304,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,
     imageComponentSchema,
+    videoBlockComponentSchema,
     textComponentSchema,
     sectionComponentSchema,
   ])

--- a/packages/ui/src/components/cms/blocks/VideoBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/VideoBlock.tsx
@@ -1,0 +1,13 @@
+"use client";
+import React from "react";
+import { VideoPlayer } from "../../atoms/VideoPlayer";
+
+export interface VideoBlockProps {
+  src?: string;
+  autoplay?: boolean;
+}
+
+export default function VideoBlock({ src, autoplay = false }: VideoBlockProps) {
+  if (!src) return null;
+  return <VideoPlayer src={src} autoPlay={autoplay} className="w-full" />;
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -11,6 +11,7 @@ import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
+import VideoBlock from "./VideoBlock";
 
 export {
   BlogListing,
@@ -26,6 +27,7 @@ export {
   TestimonialSlider,
   ValueProps,
   Section,
+  VideoBlock,
 };
 
 export * from "./atoms";
@@ -45,6 +47,7 @@ export const blockRegistry = {
   ...atomRegistry,
   ...moleculeRegistry,
   ...organismRegistry,
+  VideoBlock,
 } as const;
 
 export type BlockType = keyof typeof blockRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -19,6 +19,7 @@ import TestimonialsEditor from "./TestimonialsEditor";
 import HeroBannerEditor from "./HeroBannerEditor";
 import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
+import VideoBlockEditor from "./VideoBlockEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -49,6 +50,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "Image":
       specific = <ImageBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "VideoBlock":
+      specific = <VideoBlockEditor component={component} onChange={onChange} />;
       break;
     case "Testimonials":
       specific = <TestimonialsEditor component={component} onChange={onChange} />;

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -18,7 +18,12 @@ const palette = {
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })
   ),
-  atoms: (Object.keys(atomRegistry) as PageComponent["type"][]).map((t) => ({
+  atoms: (
+    [
+      ...Object.keys(atomRegistry),
+      "VideoBlock",
+    ] as PageComponent["type"][]
+  ).map((t) => ({
     type: t,
     label: t.replace(/([A-Z])/g, " $1").trim(),
   })),

--- a/packages/ui/src/components/cms/page-builder/VideoBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/VideoBlockEditor.tsx
@@ -1,0 +1,33 @@
+import type { PageComponent } from "@types";
+import { Input } from "../../atoms/shadcn";
+import { Switch } from "../../atoms/Switch";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function VideoBlockEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: any) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  const data = component as any;
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={data.src ?? ""}
+        onChange={(e) => handleInput("src", e.target.value)}
+        placeholder="Video URL"
+      />
+      <label className="flex items-center gap-2 text-sm">
+        <Switch
+          checked={data.autoplay ?? false}
+          onChange={(e) => handleInput("autoplay", e.target.checked)}
+        />
+        Autoplay
+      </label>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -6,6 +6,7 @@ import TestimonialsEditor from "../TestimonialsEditor";
 import HeroBannerEditor from "../HeroBannerEditor";
 import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
+import VideoBlockEditor from "../VideoBlockEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -58,6 +59,12 @@ describe("block editors", () => {
       ReviewsCarouselEditor,
       { type: "ReviewsCarousel", reviews: [{ nameKey: "", quoteKey: "" }] },
       "nameKey",
+    ],
+    [
+      "VideoBlockEditor",
+      VideoBlockEditor,
+      { type: "VideoBlock", src: "", autoplay: false },
+      "Video URL",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -7,6 +7,7 @@ export { default as TestimonialsEditor } from "./TestimonialsEditor";
 export { default as HeroBannerEditor } from "./HeroBannerEditor";
 export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
+export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add VideoBlock component wrapping VideoPlayer with configurable source and autoplay
- add VideoBlockEditor to edit video URL and autoplay flag
- register VideoBlock in block registry and page-builder palette

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689a1261d13c832fad10fc76a4f5c737