### PR TITLE
feat: support quantity for cart items

### DIFF
--- a/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {
   const [size, setSize] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
 
   return (
     <div className="mx-auto max-w-6xl p-6 lg:grid lg:grid-cols-2 lg:gap-10">
@@ -27,9 +28,27 @@ export default function PdpClient({ product }: { product: SKU }) {
         <div className="text-2xl font-semibold">
           <Price amount={product.price} />
         </div>
+        <div>
+          <label className="mb-2 block font-medium" htmlFor="qty">
+            Quantity:
+          </label>
+          <input
+            id="qty"
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+            className="w-20 rounded border p-2"
+          />
+        </div>
 
         {/* size could be added to cart line later */}
-        <AddToCartButton sku={product} size={size ?? undefined} disabled={!size} />
+        <AddToCartButton
+          sku={product}
+          size={size ?? undefined}
+          disabled={!size}
+          quantity={quantity}
+        />
       </section>
     </div>
   );

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {
   const [size, setSize] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
 
   return (
     <div className="mx-auto max-w-6xl p-6 lg:grid lg:grid-cols-2 lg:gap-10">
@@ -25,11 +26,25 @@ export default function PdpClient({ product }: { product: SKU }) {
         <div className="text-2xl font-semibold">
           <Price amount={product.price} />
         </div>
+        <div>
+          <label className="mb-2 block font-medium" htmlFor="qty">
+            Quantity:
+          </label>
+          <input
+            id="qty"
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+            className="w-20 rounded border p-2"
+          />
+        </div>
         {/* size could be added to cart line later */}
         <AddToCartButton
           sku={product}
           size={size ?? undefined}
           disabled={!size}
+          quantity={quantity}
         />{" "}
       </section>
     </div>

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {
   const [size, setSize] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
 
   return (
     <div className="mx-auto max-w-6xl p-6 lg:grid lg:grid-cols-2 lg:gap-10">
@@ -27,12 +28,26 @@ export default function PdpClient({ product }: { product: SKU }) {
         <div className="text-2xl font-semibold">
           <Price amount={product.price} />
         </div>
+        <div>
+          <label className="mb-2 block font-medium" htmlFor="qty">
+            Quantity:
+          </label>
+          <input
+            id="qty"
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+            className="w-20 rounded border p-2"
+          />
+        </div>
 
         {/* size could be added to cart line later */}
         <AddToCartButton
           sku={product}
           size={size ?? undefined}
           disabled={!size}
+          quantity={quantity}
         />
       </section>
     </div>

--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -24,6 +24,7 @@ describe("AddToCartButton", () => {
   it("adds items to the cart", async () => {
     const size = PRODUCTS[0].sizes[0];
     const id = `${PRODUCTS[0].id}:${size}`;
+    const quantity = 2;
     global.fetch = jest
       .fn()
       // initial GET
@@ -31,12 +32,14 @@ describe("AddToCartButton", () => {
       // POST
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } }),
+        json: async () => ({
+          cart: { [id]: { sku: PRODUCTS[0], qty: quantity, size } },
+        }),
       });
 
     render(
       <CartProvider>
-        <AddToCartButton sku={PRODUCTS[0]} size={size} />
+        <AddToCartButton sku={PRODUCTS[0]} size={size} quantity={quantity} />
         <Qty />
       </CartProvider>
     );
@@ -47,7 +50,9 @@ describe("AddToCartButton", () => {
     fireEvent.click(btn);
 
     await waitFor(() =>
-      expect(screen.getByTestId("qty").textContent).toBe("1")
+      expect(screen.getByTestId("qty").textContent).toBe(
+        quantity.toString()
+      )
     );
   });
 

--- a/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
+++ b/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
@@ -11,12 +11,15 @@ type Props = {
   size?: string;
   /** Disable button until prerequisites are met (e.g. size chosen) */
   disabled?: boolean;
+  /** Number of items to add */
+  quantity?: number;
 };
 
 export default function AddToCartButton({
   sku,
   size,
   disabled = false,
+  quantity = 1,
 }: Props) {
   const [, dispatch] = useCart();
   const [adding, setAdding] = useState(false);
@@ -28,7 +31,7 @@ export default function AddToCartButton({
     setError(null);
 
     try {
-      await dispatch({ type: "add", sku, size });
+      await dispatch({ type: "add", sku, size, qty: quantity });
     } catch (err) {
       setError((err as Error).message ?? "Unable to add to cart");
     } finally {

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -10,7 +10,7 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
  * Action types
  * ------------------------------------------------------------------ */
 type Action =
-  | { type: "add"; sku: SKU; size?: string }
+  | { type: "add"; sku: SKU; size?: string; qty?: number }
   | { type: "remove"; id: string }
   | { type: "setQty"; id: string; qty: number };
 
@@ -49,7 +49,11 @@ export function CartProvider({ children }: { children: ReactNode }) {
           throw new Error("Size is required");
         }
         method = "POST";
-        body = { sku: { id: action.sku.id }, qty: 1, size: action.size };
+        body = {
+          sku: { id: action.sku.id },
+          qty: action.qty ?? 1,
+          size: action.size,
+        };
         break;
       case "remove":
         method = "DELETE";

--- a/packages/template-app/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/packages/template-app/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {
   const [size, setSize] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
 
   return (
     <div className="mx-auto max-w-6xl p-6 lg:grid lg:grid-cols-2 lg:gap-10">
@@ -27,12 +28,26 @@ export default function PdpClient({ product }: { product: SKU }) {
         <div className="text-2xl font-semibold">
           <Price amount={product.price} />
         </div>
+        <div>
+          <label className="mb-2 block font-medium" htmlFor="qty">
+            Quantity:
+          </label>
+          <input
+            id="qty"
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+            className="w-20 rounded border p-2"
+          />
+        </div>
 
         {/* size could be added to cart line later */}
         <AddToCartButton
           sku={product}
           size={size ?? undefined}
           disabled={!size}
+          quantity={quantity}
         />
       </section>
     </div>


### PR DESCRIPTION
## Summary
- allow specifying quantity in AddToCartButton and cart context
- add quantity selector on product pages and wire to AddToCartButton
- expand add-to-cart tests for quantity

## Testing
- `pnpm exec jest packages/platform-core/__tests__/addToCartButton.test.tsx` *(fails: React Element from older version rendered)*

------
https://chatgpt.com/codex/tasks/task_e_689a1242bdf8832fa62d4d42789df2b1