### PR TITLE
Hash password reset tokens with expiry

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -27,22 +27,39 @@ jest.mock("../src/app/userStore", () => ({
   ),
   addUser: jest.fn(
     async ({ id, email, passwordHash, role = "customer" }: any) => {
-      const user = { id, email, passwordHash, role, resetToken: null };
+      const user = {
+        id,
+        email,
+        passwordHash,
+        role,
+        resetTokenHash: null,
+        resetTokenExpires: null,
+      };
       store[id] = user;
       return user;
     }
   ),
-  setResetToken: jest.fn(async (id: string, token: string | null) => {
-    if (store[id]) store[id].resetToken = token;
-  }),
-  getUserByResetToken: jest.fn(
-    async (token: string) =>
-      Object.values(store).find((u: any) => u.resetToken === token) ?? null
+  setResetToken: jest.fn(
+    async (id: string, tokenHash: string | null, expires: number | null) => {
+      if (store[id]) {
+        store[id].resetTokenHash = tokenHash;
+        store[id].resetTokenExpires = expires;
+      }
+    }
+  ),
+  getUserByResetToken: jest.fn(async (tokenHash: string) =>
+    Object.values(store).find(
+      (u: any) =>
+        u.resetTokenHash === tokenHash &&
+        u.resetTokenExpires !== null &&
+        u.resetTokenExpires > Date.now(),
+    ) ?? null,
   ),
   updatePassword: jest.fn(async (id: string, hash: string) => {
     if (store[id]) {
       store[id].passwordHash = hash;
-      store[id].resetToken = null;
+      store[id].resetTokenHash = null;
+      store[id].resetTokenExpires = null;
     }
   }),
 }));

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -34,8 +34,15 @@ export async function POST(req: Request) {
   const { token, password } = parsed.data;
   const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
   const user = await getUserByResetToken(hashedToken);
-  if (!user) {
-    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+  if (
+    !user ||
+    user.resetTokenExpires === null ||
+    user.resetTokenExpires < Date.now()
+  ) {
+    return NextResponse.json(
+      { error: "Invalid or expired token" },
+      { status: 400 },
+    );
   }
 
   const passwordHash = await bcrypt.hash(password, 10);

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -31,13 +31,17 @@ export async function POST(req: Request) {
 
   const user = await getUserByEmail(parsed.data.email);
   if (user) {
-    const token = crypto.randomBytes(32).toString("hex");
-    const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
-    await setResetToken(user.id, hashedToken);
+    const token = crypto.randomUUID();
+    const hashedToken = crypto
+      .createHash("sha256")
+      .update(token)
+      .digest("hex");
+    const expires = Date.now() + 1000 * 60 * 60; // 1 hour
+    await setResetToken(user.id, hashedToken, expires);
     await sendEmail(
       parsed.data.email,
       "Password reset",
-      `Your token is ${token}`
+      `Your token is ${token}`,
     );
   }
 

--- a/apps/shop-abc/src/app/userStore.ts
+++ b/apps/shop-abc/src/app/userStore.ts
@@ -6,7 +6,8 @@ export interface User {
   email: string;
   passwordHash: string;
   role: string;
-  resetToken: string | null;
+  resetTokenHash: string | null;
+  resetTokenExpires: number | null;
 }
 
 const DATA_PATH = path.join(process.cwd(), "data", "users.json");
@@ -40,7 +41,14 @@ export async function addUser({
   role?: string;
 }): Promise<User> {
   const store = await readStore();
-  const user: User = { id, email, passwordHash, role, resetToken: null };
+  const user: User = {
+    id,
+    email,
+    passwordHash,
+    role,
+    resetTokenHash: null,
+    resetTokenExpires: null,
+  };
   store[id] = user;
   await writeStore(store);
   return user;
@@ -56,26 +64,45 @@ export async function getUserByEmail(email: string): Promise<User | null> {
   return Object.values(store).find((u) => u.email === email) ?? null;
 }
 
-export async function setResetToken(id: string, token: string | null): Promise<void> {
+export async function setResetToken(
+  id: string,
+  tokenHash: string | null,
+  expires: number | null,
+): Promise<void> {
   const store = await readStore();
   const user = store[id];
   if (user) {
-    user.resetToken = token;
+    user.resetTokenHash = tokenHash;
+    user.resetTokenExpires = expires;
     await writeStore(store);
   }
 }
 
-export async function getUserByResetToken(token: string): Promise<User | null> {
+export async function getUserByResetToken(
+  tokenHash: string,
+): Promise<User | null> {
   const store = await readStore();
-  return Object.values(store).find((u) => u.resetToken === token) ?? null;
+  const now = Date.now();
+  return (
+    Object.values(store).find(
+      (u) =>
+        u.resetTokenHash === tokenHash &&
+        u.resetTokenExpires !== null &&
+        u.resetTokenExpires > now,
+    ) ?? null
+  );
 }
 
-export async function updatePassword(id: string, passwordHash: string): Promise<void> {
+export async function updatePassword(
+  id: string,
+  passwordHash: string,
+): Promise<void> {
   const store = await readStore();
   const user = store[id];
   if (user) {
     user.passwordHash = passwordHash;
-    user.resetToken = null;
+    user.resetTokenHash = null;
+    user.resetTokenExpires = null;
     await writeStore(store);
   }
 }


### PR DESCRIPTION
## Summary
- Store password reset tokens as hashed values with expiration time
- Use crypto UUID tokens and send plain token via email
- Validate hashed tokens and expiry before resetting password

## Testing
- `pnpm --filter @apps/shop-abc exec jest apps/shop-abc/__tests__/authFlow.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a21e28ba4832f8c2fe9f24091ef1b