### PR TITLE
feat: add Video block and multi-column container

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -112,6 +112,11 @@ export interface MapBlockComponent extends PageComponentBase {
   lng?: number;
   zoom?: number;
 }
+export interface VideoBlockComponent extends PageComponentBase {
+  type: "VideoBlock";
+  src?: string;
+  autoplay?: boolean;
+}
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -148,6 +153,12 @@ export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
 }
+export interface MultiColumnComponent extends PageComponentBase {
+  type: "MultiColumn";
+  columns?: number;
+  gap?: string;
+  children?: PageComponent[];
+}
 export type PageComponent =
   | AnnouncementBarComponent
   | HeroBannerComponent
@@ -160,12 +171,14 @@ export type PageComponent =
   | ContactFormComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
+  | VideoBlockComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent
-  | SectionComponent;
+  | SectionComponent
+  | MultiColumnComponent;
 export declare const pageSchema: z.ZodObject<
   {
     id: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -116,6 +116,12 @@ export interface MapBlockComponent extends PageComponentBase {
   zoom?: number;
 }
 
+export interface VideoBlockComponent extends PageComponentBase {
+  type: "VideoBlock";
+  src?: string;
+  autoplay?: boolean;
+}
+
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -148,6 +154,13 @@ export interface SectionComponent extends PageComponentBase {
   children?: PageComponent[];
 }
 
+export interface MultiColumnComponent extends PageComponentBase {
+  type: "MultiColumn";
+  columns?: number;
+  gap?: string;
+  children?: PageComponent[];
+}
+
 export type PageComponent =
   | AnnouncementBarComponent
   | HeroBannerComponent
@@ -160,12 +173,14 @@ export type PageComponent =
   | ContactFormComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
+  | VideoBlockComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent
-  | SectionComponent;
+  | SectionComponent
+  | MultiColumnComponent;
 
 const baseComponentSchema = z
   .object({
@@ -255,6 +270,12 @@ const mapBlockComponentSchema = baseComponentSchema.extend({
   zoom: z.number().optional(),
 });
 
+const videoBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("VideoBlock"),
+  src: z.string().optional(),
+  autoplay: z.boolean().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -299,6 +320,14 @@ const sectionComponentSchema: z.ZodType<SectionComponent> =
     children: z.array(z.lazy(() => pageComponentSchema)).default([]),
   });
 
+const multiColumnComponentSchema: z.ZodType<MultiColumnComponent> =
+  baseComponentSchema.extend({
+    type: z.literal("MultiColumn"),
+    columns: z.number().optional(),
+    gap: z.string().optional(),
+    children: z.array(z.lazy(() => pageComponentSchema)).default([]),
+  });
+
 export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
   z.discriminatedUnion("type", [
     announcementBarComponentSchema,
@@ -312,12 +341,14 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     contactFormComponentSchema,
     contactFormWithMapComponentSchema,
     mapBlockComponentSchema,
+    videoBlockComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,
     imageComponentSchema,
     textComponentSchema,
     sectionComponentSchema,
+    multiColumnComponentSchema,
   ])
 );
 

--- a/packages/ui/src/components/cms/blocks/VideoBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/VideoBlock.tsx
@@ -1,0 +1,17 @@
+// packages/ui/src/components/cms/blocks/VideoBlock.tsx
+"use client";
+
+import { VideoPlayer } from "../../atoms/VideoPlayer";
+
+interface Props {
+  /** Source URL of the video */
+  src?: string;
+  /** Whether the video should autoplay */
+  autoplay?: boolean;
+}
+
+/** CMS wrapper for the VideoPlayer atom */
+export default function VideoBlock({ src, autoplay }: Props) {
+  if (!src) return null;
+  return <VideoPlayer src={src} autoPlay={autoplay} muted={autoplay} />;
+}

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -1,7 +1,9 @@
 import Section from "./Section";
+import MultiColumn from "./containers/MultiColumn";
 
 export const containerRegistry = {
   Section,
+  MultiColumn,
 } as const;
 
 export type ContainerBlockType = keyof typeof containerRegistry;

--- a/packages/ui/src/components/cms/blocks/containers/MultiColumn.tsx
+++ b/packages/ui/src/components/cms/blocks/containers/MultiColumn.tsx
@@ -1,0 +1,31 @@
+"use client";
+import type { ReactNode } from "react";
+import { cn } from "../../../../utils/style";
+
+export interface MultiColumnProps {
+  children?: ReactNode;
+  /** Number of columns in the grid */
+  columns?: number;
+  /** Gap between columns/rows (any CSS length) */
+  gap?: string;
+  className?: string;
+}
+
+export default function MultiColumn({
+  children,
+  columns = 2,
+  gap = "1rem",
+  className,
+}: MultiColumnProps) {
+  return (
+    <div
+      className={cn("grid", className)}
+      style={{
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        gap,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -13,6 +13,8 @@ import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
+import MultiColumn from "./containers/MultiColumn";
+import VideoBlock from "./VideoBlock";
 
 export {
   BlogListing,
@@ -30,6 +32,8 @@ export {
   Section,
   AnnouncementBar,
   MapBlock,
+  MultiColumn,
+  VideoBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -12,6 +12,7 @@ import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
+import VideoBlock from "./VideoBlock";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -28,6 +29,7 @@ export const organismRegistry = {
   Testimonials,
   TestimonialSlider,
   MapBlock,
+  VideoBlock,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -21,6 +21,7 @@ import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
 import MapBlockEditor from "./MapBlockEditor";
+import VideoBlockEditor from "./VideoBlockEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -80,6 +81,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "MapBlock":
       specific = <MapBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "VideoBlock":
+      specific = <VideoBlockEditor component={component} onChange={onChange} />;
       break;
     default:
       specific = <p className="text-muted text-sm">No editable props</p>;
@@ -191,6 +195,13 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
           }
           min={(component as any).minItems}
           max={(component as any).maxItems}
+        />
+      )}
+      {"gap" in component && (
+        <Input
+          label="Gap"
+          value={(component as any).gap ?? ""}
+          onChange={(e) => handleInput("gap", e.target.value)}
         />
       )}
       <Select

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -42,6 +42,7 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
     left: "0",
     width: "100%",
   },
+  MultiColumn: { columns: 2, gap: "1rem" },
 };
 
 interface Props {
@@ -64,7 +65,11 @@ const PageBuilder = memo(function PageBuilder({
   const storageKey = `page-builder-history-${page.id}`;
   const migrate = useCallback(
     (comps: PageComponent[]): PageComponent[] =>
-      comps.map((c) => (c.type === "Section" ? { ...c, children: c.children ?? [] } : c)),
+      comps.map((c) =>
+        c.type === "Section" || c.type === "MultiColumn"
+          ? { ...c, children: c.children ?? [] }
+          : c
+      ),
     []
   );
 

--- a/packages/ui/src/components/cms/page-builder/VideoBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/VideoBlockEditor.tsx
@@ -1,0 +1,34 @@
+import type { PageComponent } from "@types";
+import { Input, Checkbox } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function VideoBlockEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string | boolean) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        label="Video URL"
+        value={(component as any).src ?? ""}
+        onChange={(e) => handleInput("src", e.target.value)}
+        placeholder="https://..."
+      />
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="autoplay"
+          checked={(component as any).autoplay ?? false}
+          onCheckedChange={(checked) => handleInput("autoplay", Boolean(checked))}
+        />
+        <label htmlFor="autoplay" className="text-sm">
+          Autoplay
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -9,6 +9,7 @@ export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
 export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as MapBlockEditor } from "./MapBlockEditor";
+export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add CMS `VideoBlock` rendering `VideoPlayer` with autoplay option
- introduce `MultiColumn` container for adjustable grid layouts
- allow editing of video and multi-column settings in page builder

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689a222ee560832fb8f8181dd8fb1be0