### PR TITLE
feat(ui): add FAQ accordion block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -69,6 +69,13 @@ export interface ValuePropsComponent extends PageComponentBase {
     desc: string;
   }[];
 }
+export interface FAQBlockComponent extends PageComponentBase {
+  type: "FAQBlock";
+  faqs?: {
+    question: string;
+    answer: string;
+  }[];
+}
 /** Carousel of customer reviews. `minItems`/`maxItems` limit visible reviews */
 export interface ReviewsCarouselComponent extends PageComponentBase {
   type: "ReviewsCarousel";
@@ -152,6 +159,7 @@ export type PageComponent =
   | AnnouncementBarComponent
   | HeroBannerComponent
   | ValuePropsComponent
+  | FAQBlockComponent
   | ReviewsCarouselComponent
   | ProductGridComponent
   | ProductCarouselComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -71,6 +71,11 @@ export interface ValuePropsComponent extends PageComponentBase {
   items?: { icon: string; title: string; desc: string }[];
 }
 
+export interface FAQBlockComponent extends PageComponentBase {
+  type: "FAQBlock";
+  faqs?: { question: string; answer: string }[];
+}
+
 /** Carousel of customer reviews. `minItems`/`maxItems` limit visible reviews */
 export interface ReviewsCarouselComponent extends PageComponentBase {
   type: "ReviewsCarousel";
@@ -152,6 +157,7 @@ export type PageComponent =
   | AnnouncementBarComponent
   | HeroBannerComponent
   | ValuePropsComponent
+  | FAQBlockComponent
   | ReviewsCarouselComponent
   | ProductGridComponent
   | ProductCarouselComponent
@@ -207,6 +213,15 @@ const valuePropsComponentSchema = baseComponentSchema.extend({
   type: z.literal("ValueProps"),
   items: z
     .array(z.object({ icon: z.string(), title: z.string(), desc: z.string() }))
+    .optional(),
+});
+
+const faqBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("FAQBlock"),
+  faqs: z
+    .array(
+      z.object({ question: z.string(), answer: z.string() })
+    )
     .optional(),
 });
 
@@ -304,6 +319,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     announcementBarComponentSchema,
     heroBannerComponentSchema,
     valuePropsComponentSchema,
+    faqBlockComponentSchema,
     reviewsCarouselComponentSchema,
     productGridComponentSchema,
     productCarouselComponentSchema,

--- a/packages/ui/src/components/cms/blocks/FAQBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FAQBlock.tsx
@@ -1,0 +1,23 @@
+import Accordion from "../../molecules/Accordion";
+
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface Props {
+  faqs?: FAQItem[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function FAQBlock({ faqs = [], minItems, maxItems }: Props) {
+  const list = faqs.slice(0, maxItems ?? faqs.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+
+  return (
+    <Accordion
+      items={list.map((f) => ({ title: f.question, content: f.answer }))}
+    />
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -13,6 +13,7 @@ import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
+import FAQBlock from "./FAQBlock";
 
 export {
   BlogListing,
@@ -30,6 +31,7 @@ export {
   Section,
   AnnouncementBar,
   MapBlock,
+  FAQBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -12,6 +12,7 @@ import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
+import FAQBlock from "./FAQBlock";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -28,6 +29,7 @@ export const organismRegistry = {
   Testimonials,
   TestimonialSlider,
   MapBlock,
+  FAQBlock,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -21,6 +21,7 @@ import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
 import MapBlockEditor from "./MapBlockEditor";
+import FAQBlockEditor from "./FAQBlockEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -80,6 +81,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "MapBlock":
       specific = <MapBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "FAQBlock":
+      specific = <FAQBlockEditor component={component} onChange={onChange} />;
       break;
     default:
       specific = <p className="text-muted text-sm">No editable props</p>;

--- a/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
@@ -1,0 +1,20 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function FAQBlockEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor(
+    "faqs",
+    (component as any).faqs,
+    ["question", "answer"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -7,6 +7,7 @@ import HeroBannerEditor from "../HeroBannerEditor";
 import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
 import AnnouncementBarEditor from "../AnnouncementBarEditor";
+import FAQBlockEditor from "../FAQBlockEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -65,6 +66,12 @@ describe("block editors", () => {
       AnnouncementBarEditor,
       { type: "AnnouncementBar", text: "", link: "" },
       "text",
+    ],
+    [
+      "FAQBlockEditor",
+      FAQBlockEditor,
+      { type: "FAQBlock", faqs: [{ question: "", answer: "" }] },
+      "question",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -9,6 +9,7 @@ export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
 export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as MapBlockEditor } from "./MapBlockEditor";
+export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";

--- a/packages/ui/src/components/molecules/Accordion.tsx
+++ b/packages/ui/src/components/molecules/Accordion.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { cn } from "../../utils/style";
+
+export interface AccordionItem {
+  /** Title displayed in the trigger button */
+  title: React.ReactNode;
+  /** Content shown when the item is expanded */
+  content: React.ReactNode;
+}
+
+export interface AccordionProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /** Collection of accordion items */
+  items: AccordionItem[];
+}
+
+/**
+ * Simple accordion component allowing multiple items to be expanded
+ * simultaneously.
+ */
+export default function Accordion({ items, className, ...props }: AccordionProps) {
+  const [open, setOpen] = React.useState<Set<number>>(new Set());
+
+  const toggle = (idx: number) => {
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  };
+
+  return (
+    <div className={cn("space-y-2", className)} {...props}>
+      {items.map((item, idx) => {
+        const isOpen = open.has(idx);
+        return (
+          <div key={idx} className="rounded border">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between p-4 text-left"
+              onClick={() => toggle(idx)}
+              aria-expanded={isOpen}
+            >
+              <span>{item.title}</span>
+              <span className="ml-2 select-none">{isOpen ? "-" : "+"}</span>
+            </button>
+            {isOpen && <div className="border-t p-4">{item.content}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -12,3 +12,4 @@ export { QuantityInput } from "./QuantityInput";
 export { RatingSummary } from "./RatingSummary";
 export { SearchBar } from "./SearchBar";
 export { SustainabilityBadgeCluster } from "./SustainabilityBadgeCluster";
+export { default as Accordion } from "./Accordion";


### PR DESCRIPTION
## Summary
- add reusable Accordion component for UI
- expose FAQBlock CMS block using accordion for Q&A
- allow editing FAQ lists and register new block in registry

## Testing
- `pnpm --filter @acme/ui test src/components/cms/page-builder/__tests__/BlockEditors.test.tsx __tests__/DynamicRenderer.test.tsx` *(fails: Unknown component type and missing data-testid)*

------
https://chatgpt.com/codex/tasks/task_e_689a21279138832f8bbdb00c9f979d17