### PR TITLE
feat: require mfa challenge on login

### DIFF
--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -3,6 +3,9 @@ jest.mock("@auth", () => ({
   createCustomerSession: jest.fn(),
   validateCsrfToken: jest.fn().mockResolvedValue(true),
 }));
+jest.mock("@auth/mfa", () => ({
+  isMfaEnabled: jest.fn().mockResolvedValue(false),
+}));
 jest.mock("@upstash/redis", () => ({
   Redis: jest.fn(() => ({})),
 }));

--- a/apps/shop-abc/__tests__/mfaApi.test.ts
+++ b/apps/shop-abc/__tests__/mfaApi.test.ts
@@ -5,6 +5,7 @@ jest.mock("@auth", () => ({
   validateCsrfToken: jest.fn(),
   enrollMfa: jest.fn(),
   verifyMfa: jest.fn(),
+  createCustomerSession: jest.fn(),
 }));
 
 jest.mock("next/server", () => ({

--- a/apps/shop-abc/src/app/api/mfa/verify/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/verify/route.ts
@@ -1,16 +1,53 @@
 // apps/shop-abc/src/app/api/mfa/verify/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getCustomerSession, validateCsrfToken, verifyMfa } from "@auth";
+import {
+  getCustomerSession,
+  validateCsrfToken,
+  verifyMfa,
+  createCustomerSession,
+} from "@auth";
+import type { Role } from "@auth/types/roles";
+import { getUserById } from "../../../userStore";
+import { clearLoginAttempts } from "../../../../middleware";
+
+const ALLOWED_ROLES: Role[] = ["customer", "viewer"];
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { token, customerId } = await req.json();
   const session = await getCustomerSession();
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session && !customerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const headerToken = req.headers.get("x-csrf-token");
   const valid = await validateCsrfToken(headerToken);
   if (!valid)
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
-  const { token } = await req.json();
+
   if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });
-  const ok = await verifyMfa(session.customerId, token);
-  return NextResponse.json({ verified: ok });
+
+  if (session) {
+    const ok = await verifyMfa(session.customerId, token);
+    return NextResponse.json({ verified: ok });
+  }
+
+  if (!customerId)
+    return NextResponse.json({ error: "Customer ID required" }, { status: 400 });
+
+  const ok = await verifyMfa(customerId, token);
+  if (!ok) return NextResponse.json({ verified: false });
+
+  const user = await getUserById(customerId);
+  if (!user)
+    return NextResponse.json({ error: "Invalid user" }, { status: 400 });
+  const role = user.role as Role;
+  if (!ALLOWED_ROLES.includes(role)) {
+    return NextResponse.json({ error: "Unauthorized role" }, { status: 403 });
+  }
+
+  await createCustomerSession({ customerId, role });
+  const ip = req.headers.get("x-forwarded-for") ?? "unknown";
+  await clearLoginAttempts(ip, customerId);
+
+  return NextResponse.json({ verified: true });
 }

--- a/apps/shop-abc/src/app/login/page.tsx
+++ b/apps/shop-abc/src/app/login/page.tsx
@@ -3,9 +3,12 @@
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getCsrfToken } from "@shared-utils";
+import MfaChallenge from "@ui/components/account/MfaChallenge";
 
 export default function LoginPage() {
   const [msg, setMsg] = useState("");
+  const [mfaRequired, setMfaRequired] = useState(false);
+  const [customerId, setCustomerId] = useState("");
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl");
 
@@ -27,12 +30,25 @@ export default function LoginPage() {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
+    if (res.ok && data.mfaRequired) {
+      setCustomerId(body.customerId);
+      setMfaRequired(true);
+      setMsg("");
+      return;
+    }
     if (res.ok) {
       window.location.href = callbackUrl ?? "/account";
       return;
     }
     setMsg(data.error || "Error");
   }
+  if (mfaRequired) {
+    const onSuccess = () => {
+      window.location.href = callbackUrl ?? "/account";
+    };
+    return <MfaChallenge customerId={customerId} onSuccess={onSuccess} />;
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <input name="customerId" placeholder="User ID" className="border p-1" />

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -1,6 +1,7 @@
 // apps/shop-abc/src/app/login/route.ts
 import { NextResponse } from "next/server";
 import { createCustomerSession, validateCsrfToken } from "@auth";
+import { isMfaEnabled } from "@auth/mfa";
 import type { Role } from "@auth/types/roles";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
@@ -58,6 +59,11 @@ export async function POST(req: Request) {
   if (!ALLOWED_ROLES.includes(valid.role)) {
     // Ignore elevated roles by rejecting them
     return NextResponse.json({ error: "Unauthorized role" }, { status: 403 });
+  }
+
+  const mfaEnabled = await isMfaEnabled(valid.customerId);
+  if (mfaEnabled) {
+    return NextResponse.json({ mfaRequired: true });
   }
 
   await createCustomerSession(valid);

--- a/packages/ui/src/components/account/MfaChallenge.tsx
+++ b/packages/ui/src/components/account/MfaChallenge.tsx
@@ -5,10 +5,11 @@ import { useState } from "react";
 import { getCsrfToken } from "@shared-utils";
 
 export interface MfaChallengeProps {
+  customerId?: string;
   onSuccess?: () => void;
 }
 
-export default function MfaChallenge({ onSuccess }: MfaChallengeProps) {
+export default function MfaChallenge({ customerId, onSuccess }: MfaChallengeProps) {
   const [token, setToken] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +22,7 @@ export default function MfaChallenge({ onSuccess }: MfaChallengeProps) {
         "Content-Type": "application/json",
         "x-csrf-token": csrfToken ?? "",
       },
-      body: JSON.stringify({ token }),
+      body: JSON.stringify({ token, customerId }),
     });
     const data = await res.json();
     if (data.verified) {


### PR DESCRIPTION
## Summary
- check for MFA during login and prompt for challenge when enabled
- verify MFA token before creating session
- show MFA challenge UI on login when needed

## Testing
- `pnpm exec jest --runTestsByPath apps/shop-abc/__tests__/authFlow.test.ts apps/shop-abc/__tests__/loginRateLimit.test.ts apps/shop-abc/__tests__/mfaApi.test.ts` *(fails: Jest encountered an unexpected token in @upstash/redis)*

------
https://chatgpt.com/codex/tasks/task_e_689a12307878832fafdeb41c44f7f8bc