### PR TITLE
feat: separate theme overrides

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -14,6 +14,7 @@ describe("ShopEditor", () => {
       name: "Test",
       themeId: "base",
       catalogFilters: [],
+      themeOverrides: {},
       themeTokens: {},
       filterMappings: {},
       priceOverrides: {},

--- a/apps/cms/__tests__/shops.test.ts
+++ b/apps/cms/__tests__/shops.test.ts
@@ -40,6 +40,7 @@ describe("shop actions", () => {
             name: "Seed",
             catalogFilters: [],
             themeId: "base",
+            themeOverrides: {},
             themeTokens: {},
             filterMappings: {},
             priceOverrides: {},

--- a/apps/cms/src/actions/schemas.d.ts
+++ b/apps/cms/src/actions/schemas.d.ts
@@ -21,6 +21,7 @@ export declare const shopSchema: z.ZodObject<{
     name: z.ZodString;
     themeId: z.ZodString;
     catalogFilters: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, string[], string | undefined>;
+    themeOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
     themeTokens: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
     filterMappings: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
     priceOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
@@ -30,6 +31,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     themeId: string;
     catalogFilters: string[];
+    themeOverrides?: Record<string, unknown>;
     themeTokens?: Record<string, unknown>;
     filterMappings?: Record<string, unknown>;
     priceOverrides?: Record<string, unknown>;
@@ -39,6 +41,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     themeId: string;
     catalogFilters?: string | undefined;
+    themeOverrides?: string | undefined;
     themeTokens?: string | undefined;
     filterMappings?: string | undefined;
     priceOverrides?: string | undefined;

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -41,6 +41,7 @@ export const shopSchema = z
           .map((v) => v.trim())
           .filter(Boolean)
       ),
+    themeOverrides: jsonRecord,
     themeTokens: jsonRecord,
     filterMappings: jsonRecord,
     priceOverrides: jsonRecord,

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -11,7 +11,7 @@ import {
   getShopById,
   updateShopInRepo,
 } from "@platform-core/src/repositories/shop.server";
-import { syncTheme } from "@platform-core/src/createShop";
+import { syncTheme, loadTokens } from "@platform-core/src/createShop";
 import {
   localeSchema,
   type Locale,
@@ -48,17 +48,19 @@ export async function updateShop(
 
   const data: ShopForm = parsed.data;
 
-  let themeTokens = data.themeTokens as Record<string, string>;
-  if (current.themeId !== data.themeId) {
-    const defaults = syncTheme(shop, data.themeId);
-    themeTokens = { ...defaults, ...themeTokens };
-  }
+  const overrides = data.themeOverrides as Record<string, string>;
+  const defaults =
+    current.themeId !== data.themeId
+      ? syncTheme(shop, data.themeId)
+      : loadTokens(data.themeId);
+  const themeTokens = { ...defaults, ...overrides };
 
   const patch: Partial<Shop> & { id: string } = {
     id: current.id,
     name: data.name,
     themeId: data.themeId,
     catalogFilters: data.catalogFilters,
+    themeOverrides: overrides,
     themeTokens,
     filterMappings: data.filterMappings as Record<string, string>,
     priceOverrides: data.priceOverrides as Partial<Record<Locale, number>>,

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
@@ -3,7 +3,7 @@
 "use client";
 import { Button, Input } from "@/components/atoms/shadcn";
 import { updateShop } from "@cms/actions/shops.server";
-import { useState, ChangeEvent, FormEvent } from "react";
+import { useState, ChangeEvent, FormEvent, useMemo } from "react";
 
 interface Props {
   shop: string;
@@ -28,6 +28,13 @@ export default function ThemeEditor({
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string[]>>({});
 
+  const overrides = useMemo(() => {
+    const defaults = tokensByTheme[theme] || {};
+    return Object.fromEntries(
+      Object.entries(tokens).filter(([k, v]) => defaults[k] !== v)
+    );
+  }, [tokens, theme, tokensByTheme]);
+
   const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const next = e.target.value;
     setTheme(next);
@@ -46,6 +53,7 @@ export default function ThemeEditor({
     setSaving(true);
     const fd = new FormData(e.currentTarget);
     fd.set("themeTokens", JSON.stringify(tokens));
+    fd.set("themeOverrides", JSON.stringify(overrides));
     const result = await updateShop(shop, fd);
     if (result.errors) {
       setErrors(result.errors);
@@ -59,6 +67,11 @@ export default function ThemeEditor({
     <form onSubmit={onSubmit} className="space-y-4">
       <Input type="hidden" name="id" value={shop} />
       <input type="hidden" name="themeTokens" value={JSON.stringify(tokens)} />
+      <input
+        type="hidden"
+        name="themeOverrides"
+        value={JSON.stringify(overrides)}
+      />
       <label className="flex flex-col gap-1">
         <span>Theme</span>
         <select

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -3,6 +3,7 @@
   "name": "abc",
   "catalogFilters": [],
   "themeId": "base",
+  "themeOverrides": {},
   "themeTokens": {},
   "filterMappings": {},
   "priceOverrides": {},

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -3,6 +3,7 @@
   "name": "bcd",
   "catalogFilters": [],
   "themeId": "base",
+  "themeOverrides": {},
   "themeTokens": {},
   "filterMappings": {},
   "priceOverrides": {},

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -3,6 +3,7 @@
   "name": "abc",
   "catalogFilters": [],
   "themeId": "base",
+  "themeOverrides": {},
   "themeTokens": {},
   "filterMappings": {},
   "shippingProviders": ["ups"],

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -3,6 +3,7 @@
   "name": "bcd",
   "catalogFilters": [],
   "themeId": "base",
+  "themeOverrides": {},
   "themeTokens": {},
   "filterMappings": {},
   "shippingProviders": ["dhl"],

--- a/packages/platform-core/__tests__/shops.test.ts
+++ b/packages/platform-core/__tests__/shops.test.ts
@@ -18,6 +18,7 @@ describe("sanity blog accessors", () => {
     name: "shop",
     catalogFilters: [],
     themeId: "base",
+    themeOverrides: {},
     themeTokens: {},
     filterMappings: {},
     priceOverrides: {},

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -31,6 +31,7 @@ export async function createShop(
     name: prepared.name,
     catalogFilters: [],
     themeId: prepared.theme,
+    themeOverrides: {},
     themeTokens,
     filterMappings: {},
     priceOverrides: {},

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -107,6 +107,7 @@ export function writeFiles(
         contactInfo: options.contactInfo,
         catalogFilters: [],
         themeId: options.theme,
+        themeOverrides: {},
         themeTokens,
         filterMappings: { ...defaultFilterMappings },
         type: options.type,

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -8,7 +8,7 @@ import { prisma } from "../db";
 import { defaultFilterMappings } from "../defaultFilterMappings";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "../dataRoot";
-import { loadThemeTokens } from "../themeTokens";
+import { loadTokens } from "../createShop/themeUtils";
 export {
   diffHistory,
   getShopSettings,
@@ -31,9 +31,9 @@ export async function readShop(shop: string): Promise<Shop> {
     const rec = await prisma.shop.findUnique({ where: { id: shop } });
     if (rec) {
       const data = shopSchema.parse(rec.data);
-      if (!data.themeTokens || Object.keys(data.themeTokens).length === 0) {
-        data.themeTokens = await loadThemeTokens(data.themeId);
-      }
+      data.themeOverrides ||= {};
+      const defaults = loadTokens(data.themeId);
+      data.themeTokens = { ...defaults, ...data.themeOverrides };
       if (!data.navigation) data.navigation = [];
       return data as Shop;
     }
@@ -44,12 +44,12 @@ export async function readShop(shop: string): Promise<Shop> {
     const buf = await fs.readFile(shopPath(shop), "utf8");
     const parsed = shopSchema.safeParse(JSON.parse(buf));
     if (parsed.success && parsed.data.id) {
-      if (
-        !parsed.data.themeTokens ||
-        Object.keys(parsed.data.themeTokens).length === 0
-      ) {
-        parsed.data.themeTokens = await loadThemeTokens(parsed.data.themeId);
-      }
+      parsed.data.themeOverrides ||= {};
+      const defaults = loadTokens(parsed.data.themeId);
+      parsed.data.themeTokens = {
+        ...defaults,
+        ...parsed.data.themeOverrides,
+      };
       if (!parsed.data.navigation) parsed.data.navigation = [];
       return parsed.data as Shop;
     }
@@ -63,7 +63,8 @@ export async function readShop(shop: string): Promise<Shop> {
     name: shop,
     catalogFilters: [],
     themeId,
-    themeTokens: await loadThemeTokens(themeId),
+    themeOverrides: {},
+    themeTokens: loadTokens(themeId),
     filterMappings: { ...defaultFilterMappings },
     priceOverrides: {},
     localeOverrides: {},

--- a/packages/platform-core/src/repositories/shops/schema.json
+++ b/packages/platform-core/src/repositories/shops/schema.json
@@ -8,10 +8,10 @@
     "name",
     "catalogFilters",
     "themeId",
-    "themeTokens",
     "filterMappings",
     "priceOverrides",
-    "localeOverrides"
+    "localeOverrides",
+    "themeOverrides"
   ],
   "properties": {
     "id": { "type": "string" },
@@ -21,6 +21,10 @@
       "items": { "type": "string" }
     },
     "themeId": { "type": "string" },
+    "themeOverrides": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
     "themeTokens": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -82,8 +82,10 @@ export declare const shopSchema: z.ZodObject<{
     contactInfo: z.ZodOptional<z.ZodString>;
     catalogFilters: z.ZodArray<z.ZodString, "many">;
     themeId: z.ZodString;
+    /** Overrides applied to theme tokens */
+    themeOverrides: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodString>>;
     /** Mapping of design tokens to theme values */
-    themeTokens: z.ZodRecord<z.ZodString, z.ZodString>;
+    themeTokens: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodString>>;
     /** Mapping of logical filter keys to catalog attributes */
     filterMappings: z.ZodRecord<z.ZodString, z.ZodString>;
     /** Optional price overrides per locale (minor units) */
@@ -113,6 +115,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     catalogFilters: string[];
     themeId: string;
+    themeOverrides: Record<string, string>;
     themeTokens: Record<string, string>;
     filterMappings: Record<string, string>;
     priceOverrides: Partial<Record<"en" | "de" | "it", number>>;
@@ -136,6 +139,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     catalogFilters: string[];
     themeId: string;
+    themeOverrides: Record<string, string>;
     themeTokens: Record<string, string>;
     filterMappings: Record<string, string>;
     type?: string | undefined;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -50,8 +50,10 @@ export const shopSchema = z.object({
   contactInfo: z.string().optional(),
   catalogFilters: z.array(z.string()),
   themeId: z.string(),
+  /** Overrides applied to theme tokens */
+  themeOverrides: z.record(z.string()).default({}),
   /** Mapping of design tokens to theme values */
-  themeTokens: z.record(z.string()),
+  themeTokens: z.record(z.string()).default({}),
   /** Mapping of logical filter keys to catalog attributes */
   filterMappings: z.record(z.string()),
   /** Optional price overrides per locale (minor units) */


### PR DESCRIPTION
## Summary
- add themeOverrides to Shop schema and DTOs
- merge default tokens with overrides when updating shops
- compute theme tokens from stored overrides on read

## Testing
- `pnpm test` *(fails: env setup)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689a22b99a24832f9ff570166718a545