### PR TITLE
feat: add FAQ block with accordion

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -117,6 +117,13 @@ export interface VideoBlockComponent extends PageComponentBase {
   src?: string;
   autoplay?: boolean;
 }
+export interface FAQBlockComponent extends PageComponentBase {
+  type: "FAQBlock";
+  items?: {
+    question: string;
+    answer: string;
+  }[];
+}
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -172,6 +179,7 @@ export type PageComponent =
   | ContactFormWithMapComponent
   | MapBlockComponent
   | VideoBlockComponent
+  | FAQBlockComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -122,6 +122,11 @@ export interface VideoBlockComponent extends PageComponentBase {
   autoplay?: boolean;
 }
 
+export interface FAQBlockComponent extends PageComponentBase {
+  type: "FAQBlock";
+  items?: { question: string; answer: string }[];
+}
+
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -174,6 +179,7 @@ export type PageComponent =
   | ContactFormWithMapComponent
   | MapBlockComponent
   | VideoBlockComponent
+  | FAQBlockComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
@@ -276,6 +282,18 @@ const videoBlockComponentSchema = baseComponentSchema.extend({
   autoplay: z.boolean().optional(),
 });
 
+const faqBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("FAQBlock"),
+  items: z
+    .array(
+      z.object({
+        question: z.string(),
+        answer: z.string(),
+      })
+    )
+    .optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -342,6 +360,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     contactFormWithMapComponentSchema,
     mapBlockComponentSchema,
     videoBlockComponentSchema,
+    faqBlockComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,

--- a/packages/ui/src/components/cms/blocks/FAQBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FAQBlock.tsx
@@ -1,0 +1,27 @@
+// packages/ui/components/cms/blocks/FAQBlock.tsx
+import { Accordion, type AccordionItem } from "../../molecules/Accordion";
+
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface Props {
+  items?: FAQItem[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function FAQBlock({
+  items = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = items.slice(0, maxItems ?? items.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+  const accItems: AccordionItem[] = list.map(({ question, answer }) => ({
+    title: question,
+    content: answer,
+  }));
+  return <Accordion items={accItems} />;
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -15,6 +15,7 @@ import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
 import MultiColumn from "./containers/MultiColumn";
 import VideoBlock from "./VideoBlock";
+import FAQBlock from "./FAQBlock";
 
 export {
   BlogListing,
@@ -34,6 +35,7 @@ export {
   MapBlock,
   MultiColumn,
   VideoBlock,
+  FAQBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -13,6 +13,7 @@ import RecommendationCarousel from "./RecommendationCarousel";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
 import VideoBlock from "./VideoBlock";
+import FAQBlock from "./FAQBlock";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -30,6 +31,7 @@ export const organismRegistry = {
   TestimonialSlider,
   MapBlock,
   VideoBlock,
+  FAQBlock,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -22,6 +22,7 @@ import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
 import MapBlockEditor from "./MapBlockEditor";
 import VideoBlockEditor from "./VideoBlockEditor";
+import FAQBlockEditor from "./FAQBlockEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -84,6 +85,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "VideoBlock":
       specific = <VideoBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "FAQBlock":
+      specific = <FAQBlockEditor component={component} onChange={onChange} />;
       break;
     default:
       specific = <p className="text-muted text-sm">No editable props</p>;

--- a/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
@@ -1,0 +1,20 @@
+import type { PageComponent } from "@types";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function FAQBlockEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return arrayEditor(
+    "items",
+    (component as any).items,
+    ["question", "answer"],
+    {
+      minItems: (component as any).minItems,
+      maxItems: (component as any).maxItems,
+    }
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -10,6 +10,7 @@ export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
 export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as MapBlockEditor } from "./MapBlockEditor";
 export { default as VideoBlockEditor } from "./VideoBlockEditor";
+export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";

--- a/packages/ui/src/components/molecules/Accordion.tsx
+++ b/packages/ui/src/components/molecules/Accordion.tsx
@@ -1,0 +1,44 @@
+import { useState, type ReactNode } from "react";
+
+export interface AccordionItem {
+  title: ReactNode;
+  content: ReactNode;
+}
+
+export interface AccordionProps {
+  items: AccordionItem[];
+}
+
+export function Accordion({ items }: AccordionProps) {
+  const [open, setOpen] = useState<number[]>([]);
+
+  const toggle = (idx: number) => {
+    setOpen((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      {items.map((item, idx) => {
+        const isOpen = open.includes(idx);
+        return (
+          <div key={idx} className="rounded border">
+            <button
+              type="button"
+              aria-expanded={isOpen}
+              onClick={() => toggle(idx)}
+              className="flex w-full items-center justify-between p-2 text-left"
+            >
+              <span>{item.title}</span>
+              <span>{isOpen ? "-" : "+"}</span>
+            </button>
+            {isOpen && <div className="border-t p-2">{item.content}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default Accordion;

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -12,3 +12,4 @@ export { QuantityInput } from "./QuantityInput";
 export { RatingSummary } from "./RatingSummary";
 export { SearchBar } from "./SearchBar";
 export { SustainabilityBadgeCluster } from "./SustainabilityBadgeCluster";
+export { Accordion } from "./Accordion";


### PR DESCRIPTION
## Summary
- add reusable Accordion component
- add FAQBlock and editor for question/answer pairs
- register FAQBlock in block registry and types

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689a2670a290832fb581f87269bcc75e