### PR TITLE
feat: add token inspect mode to wizard preview

### DIFF
--- a/apps/cms/src/app/cms/wizard/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepTokens.tsx
@@ -1,23 +1,48 @@
 "use client";
 
 import { Button } from "@/components/atoms/shadcn";
+import StyleEditor from "@/components/cms/StyleEditor";
 import WizardPreview from "../WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { baseTokens, type TokenMap } from "../tokenUtils";
+import { useWizard } from "../WizardContext";
 
 interface Props {
   themeStyle: React.CSSProperties;
 }
 
-export default function StepTokens({
-  themeStyle,
-}: Props): React.JSX.Element {
+export default function StepTokens({ themeStyle }: Props): React.JSX.Element {
   const [, markComplete] = useStepCompletion("tokens");
   const router = useRouter();
+  const { state, update } = useWizard();
+  const [tokens, setTokens] = useState<TokenMap>(state.themeVars);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const handleChange = (next: TokenMap) => {
+    setTokens(next);
+    update("themeVars", next);
+  };
+
+  const previewStyle = { ...themeStyle, ...tokens } as React.CSSProperties;
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Customize Tokens</h2>
-      <WizardPreview style={themeStyle} />
+      <WizardPreview
+        style={previewStyle}
+        inspectMode
+        onTokenSelect={(t) => setSelected(t)}
+      />
+      {selected && (
+        <StyleEditor
+          tokens={tokens}
+          baseTokens={baseTokens}
+          onChange={handleChange}
+          focusToken={selected}
+        />
+      )}
       <div className="flex justify-end">
         <Button
           onClick={() => {

--- a/packages/ui/src/components/atoms/primitives/button.tsx
+++ b/packages/ui/src/components/atoms/primitives/button.tsx
@@ -31,10 +31,16 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     };
 
     const Comp = asChild ? Slot : "button";
+    const tokenMap: Record<NonNullable<ButtonProps["variant"]>, string> = {
+      default: "--color-primary",
+      outline: "--color-accent",
+      ghost: "--color-accent",
+    };
 
     return (
       <Comp
         ref={ref}
+        data-token={tokenMap[variant]}
         className={cn(base, variants[variant], className)}
         {...props}
       />

--- a/packages/ui/src/components/cms/StyleEditor.tsx
+++ b/packages/ui/src/components/cms/StyleEditor.tsx
@@ -14,17 +14,21 @@ import {
   getContrast,
   suggestContrastColor,
 } from "./index";
+import { useEffect, useRef } from "react";
 
 interface StyleEditorProps {
   tokens: TokenMap;
   baseTokens: TokenMap;
   onChange: (tokens: TokenMap) => void;
+  /** Token key to focus when editor opens */
+  focusToken?: string | null;
 }
 
 export default function StyleEditor({
   tokens,
   baseTokens,
   onChange,
+  focusToken,
 }: StyleEditorProps) {
   const {
     colors,
@@ -40,6 +44,27 @@ export default function StyleEditor({
     addCustomFont,
     setGoogleFont,
   } = useTokenEditor(tokens, baseTokens, onChange);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!focusToken) return;
+    const el = containerRef.current?.querySelector(
+      `[data-token-key="${focusToken}"]`
+    ) as HTMLElement | null;
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("ring-2", "ring-blue-500");
+      const input = el.querySelector<HTMLElement>(
+        "input, select, textarea, button"
+      );
+      input?.focus();
+      const t = setTimeout(() => {
+        el.classList.remove("ring-2", "ring-blue-500");
+      }, 2000);
+      return () => clearTimeout(t);
+    }
+  }, [focusToken]);
 
   const renderInput = ({
     key: k,
@@ -73,6 +98,7 @@ export default function StyleEditor({
       return (
         <label
           key={k}
+          data-token-key={k}
           className={`flex flex-col gap-1 text-sm ${
             isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
           }`}
@@ -106,6 +132,7 @@ export default function StyleEditor({
       return (
         <label
           key={k}
+          data-token-key={k}
           className={`flex flex-col gap-1 text-sm ${
             isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
           }`}
@@ -157,6 +184,7 @@ export default function StyleEditor({
       return (
         <label
           key={k}
+          data-token-key={k}
           className={`flex items-center gap-2 text-sm ${
             isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
           }`}
@@ -184,6 +212,7 @@ export default function StyleEditor({
     return (
       <label
         key={k}
+        data-token-key={k}
         className={`flex items-center gap-2 text-sm ${
           isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
         }`}
@@ -209,7 +238,10 @@ export default function StyleEditor({
   };
 
   return (
-    <div className="max-h-64 space-y-4 overflow-y-auto rounded border p-2">
+    <div
+      ref={containerRef}
+      className="max-h-64 space-y-4 overflow-y-auto rounded border p-2"
+    >
       {colors.length > 0 && (
         <div className="space-y-2">
           <p className="font-medium">Colors</p>

--- a/packages/ui/src/components/organisms/Footer.tsx
+++ b/packages/ui/src/components/organisms/Footer.tsx
@@ -7,6 +7,7 @@ export const Footer = React.forwardRef<HTMLDivElement, FooterProps>(
   ({ className, ...props }, ref) => (
     <footer
       ref={ref}
+      data-token="--color-bg"
       className={cn("flex h-14 items-center border-t px-4", className)}
       {...props}
     />

--- a/packages/ui/src/components/organisms/Header.tsx
+++ b/packages/ui/src/components/organisms/Header.tsx
@@ -25,6 +25,7 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
   ({ nav = [], searchSuggestions = [], locale, className, ...props }, ref) => (
     <header
       ref={ref}
+      data-token="--color-bg"
       className={cn("bg-background border-b", className)}
       {...props}
     >
@@ -32,7 +33,11 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
         <nav className="flex gap-6">
           {nav.map((section) => (
             <div key={section.title} className="group relative">
-              <a href={section.href} className="font-medium">
+              <a
+                href={section.href}
+                className="font-medium"
+                data-token="--color-fg"
+              >
                 {section.title}
               </a>
               {section.items && section.items.length > 0 && (
@@ -40,7 +45,11 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
                   <ul className="flex flex-col gap-2">
                     {section.items.map((item) => (
                       <li key={item.title}>
-                        <a href={item.href} className="hover:underline">
+                        <a
+                          href={item.href}
+                          className="hover:underline"
+                          data-token="--color-fg"
+                        >
                           {item.title}
                         </a>
                       </li>

--- a/packages/ui/src/components/organisms/SideNav.tsx
+++ b/packages/ui/src/components/organisms/SideNav.tsx
@@ -10,6 +10,7 @@ export const SideNav = React.forwardRef<HTMLDivElement, SideNavProps>(
   ({ className, width = "w-48", ...props }, ref) => (
     <aside
       ref={ref}
+      data-token="--color-bg"
       className={cn(width, "border-r p-4", className)}
       {...props}
     />

--- a/packages/ui/src/components/templates/AppShell.tsx
+++ b/packages/ui/src/components/templates/AppShell.tsx
@@ -23,7 +23,10 @@ function ShellLayout({
   const { isMobileNavOpen } = useLayout();
 
   return (
-    <div className={cn("flex min-h-screen flex-col", className)}>
+    <div
+      data-token="--color-bg"
+      className={cn("flex min-h-screen flex-col", className)}
+    >
       {header}
       <div className="flex flex-1">
         {isMobileNavOpen && sideNav}


### PR DESCRIPTION
## Summary
- add inspect mode to WizardPreview that highlights elements and emits tokens on click
- open StyleEditor on token selection with focus for chosen token
- annotate UI components with `data-token` attributes for mapping

## Testing
- `pnpm lint --filter @acme/ui --filter @apps/cms`
- `pnpm test --filter @acme/ui --filter @apps/cms` *(fails: Cannot read properties of undefined (reading 'replace'))*


------
https://chatgpt.com/codex/tasks/task_e_689a27785dc0832fb4eb405c3fd56038