### PR TITLE
test: cover theme overrides

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test.tsx
@@ -1,0 +1,73 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import ThemeEditor from "../src/app/cms/shop/[shop]/themes/ThemeEditor";
+import { updateShop } from "@cms/actions/shops.server";
+
+jest.mock("@cms/actions/shops.server", () => ({
+  updateShop: jest.fn(),
+}));
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => ({
+    Button: (props: any) => <button {...props} />,
+    Input: (props: any) => <input {...props} />,
+  }),
+  { virtual: true }
+);
+
+describe("ThemeEditor", () => {
+  it("shows default and override values", () => {
+    const tokensByTheme = {
+      base: { "--color-bg": "white", "--color-primary": "blue" },
+    };
+    const initialOverrides = { "--color-bg": "hotpink" };
+    render(
+      <ThemeEditor
+        shop="test"
+        themes={["base"]}
+        tokensByTheme={tokensByTheme}
+        initialTheme="base"
+        initialTokens={initialOverrides}
+      />
+    );
+
+    const bgLabel = screen.getByText("--color-bg").closest("label")!;
+    const [bgDefault, bgOverride] = within(bgLabel).getAllByRole("textbox");
+    expect(bgDefault).toHaveValue("white");
+    expect(bgOverride).toHaveValue("hotpink");
+    expect(within(bgLabel).getByRole("button", { name: /reset/i })).toBeInTheDocument();
+
+    const primaryLabel = screen.getByText("--color-primary").closest("label")!;
+    const [primaryDefault, primaryOverride] = within(primaryLabel).getAllByRole("textbox");
+    expect(primaryDefault).toHaveValue("blue");
+    expect(primaryOverride).toHaveValue("");
+    expect(primaryOverride).toHaveAttribute("placeholder", "blue");
+    expect(
+      within(primaryLabel).queryByRole("button", { name: /reset/i })
+    ).toBeNull();
+  });
+
+  it("reset button reverts to default", () => {
+    const tokensByTheme = { base: { "--color-bg": "white" } };
+    const initialOverrides = { "--color-bg": "hotpink" };
+    render(
+      <ThemeEditor
+        shop="test"
+        themes={["base"]}
+        tokensByTheme={tokensByTheme}
+        initialTheme="base"
+        initialTokens={initialOverrides}
+      />
+    );
+
+    const bgLabel = screen.getByText("--color-bg").closest("label")!;
+    const overrideInput = within(bgLabel).getAllByRole("textbox")[1];
+    const resetBtn = within(bgLabel).getByRole("button", { name: /reset/i });
+    fireEvent.click(resetBtn);
+    expect(overrideInput).toHaveValue("");
+    expect(overrideInput).toHaveAttribute("placeholder", "white");
+    expect(
+      within(bgLabel).queryByRole("button", { name: /reset/i })
+    ).toBeNull();
+  });
+});

--- a/packages/platform-core/__tests__/shops.test.ts
+++ b/packages/platform-core/__tests__/shops.test.ts
@@ -1,5 +1,12 @@
 // packages/platform-core/__tests__/shops.test.ts
-import { getSanityConfig, setSanityConfig, validateShopName } from "../shops";
+import {
+  getSanityConfig,
+  setSanityConfig,
+  validateShopName,
+} from "../src/shops";
+import { baseTokens } from "../src/themeTokens";
+import { tokens as abcTokens } from "../../themes/abc/src/tailwind-tokens";
+import { tokens as darkTokens } from "../../themes/dark/src/tailwind-tokens";
 import type { Shop } from "@types";
 
 describe("validateShopName", () => {
@@ -41,5 +48,25 @@ describe("sanity blog accessors", () => {
       dataset: "d",
       token: "t",
     });
+  });
+});
+
+describe("theme overrides", () => {
+  it("merges overrides with base tokens", () => {
+    const overrides = { "--color-bg": "255 0% 50%" };
+    const defaults = { ...baseTokens, ...abcTokens };
+    const merged = { ...defaults, ...overrides };
+    expect(merged["--color-bg"]).toBe("255 0% 50%");
+    // token missing from theme overrides falls back to base token
+    expect(merged["--color-danger"]).toBe(baseTokens["--color-danger"]);
+  });
+
+  it("preserves overrides after theme changes", () => {
+    const overrides = { "--color-bg": "255 0% 50%" };
+    const newDefaults = { ...baseTokens, ...darkTokens };
+    const merged = { ...newDefaults, ...overrides };
+    expect(merged["--color-bg"]).toBe("255 0% 50%");
+    // non-overridden tokens use new theme defaults
+    expect(merged["--color-primary"]).toBe(darkTokens["--color-primary"]);
   });
 });


### PR DESCRIPTION
## Summary
- add theme override merging tests for shops
- verify ThemeEditor shows overrides and reset behavior

## Testing
- `pnpm --filter @acme/platform-core test -- --testPathPattern packages/platform-core/__tests__/shops.test.ts`
- `pnpm --filter @apps/cms test -- --testPathPattern apps/cms/__tests__/ThemeEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a279c9f04832f91d28dcd5f685f50