### PR TITLE
feat: add countdown timer block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -124,6 +124,13 @@ export interface FAQBlockComponent extends PageComponentBase {
     answer: string;
   }[];
 }
+export interface CountdownTimerComponent extends PageComponentBase {
+  type: "CountdownTimer";
+  targetDate?: string;
+  timeZone?: string;
+  completionText?: string;
+  className?: string;
+}
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -180,6 +187,7 @@ export type PageComponent =
   | MapBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
+  | CountdownTimerComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -127,6 +127,14 @@ export interface FAQBlockComponent extends PageComponentBase {
   items?: { question: string; answer: string }[];
 }
 
+export interface CountdownTimerComponent extends PageComponentBase {
+  type: "CountdownTimer";
+  targetDate?: string;
+  timeZone?: string;
+  completionText?: string;
+  className?: string;
+}
+
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -180,6 +188,7 @@ export type PageComponent =
   | MapBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
+  | CountdownTimerComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
@@ -294,6 +303,14 @@ const faqBlockComponentSchema = baseComponentSchema.extend({
     .optional(),
 });
 
+const countdownTimerComponentSchema = baseComponentSchema.extend({
+  type: z.literal("CountdownTimer"),
+  targetDate: z.string().optional(),
+  timeZone: z.string().optional(),
+  completionText: z.string().optional(),
+  className: z.string().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -361,6 +378,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     mapBlockComponentSchema,
     videoBlockComponentSchema,
     faqBlockComponentSchema,
+    countdownTimerComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,

--- a/packages/ui/src/components/cms/blocks/CountdownTimer.tsx
+++ b/packages/ui/src/components/cms/blocks/CountdownTimer.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { parseIsoDate } from "@acme/date-utils";
+
+interface Props {
+  /** ISO target date/time string */
+  targetDate?: string;
+  /** IANA timezone for the target date */
+  timeZone?: string;
+  /** Text displayed once countdown completes */
+  completionText?: string;
+  /** Optional className for styling */
+  className?: string;
+}
+
+export default function CountdownTimer({
+  targetDate,
+  timeZone,
+  completionText,
+  className,
+}: Props) {
+  const createTarget = () => {
+    if (!targetDate) return null;
+    const parsed = parseIsoDate(targetDate);
+    if (!parsed) return null;
+    if (timeZone) {
+      const tzDate = new Date(
+        parsed.toLocaleString("en-US", { timeZone })
+      );
+      return tzDate;
+    }
+    return parsed;
+  };
+
+  const [remaining, setRemaining] = useState<string | null>(() => {
+    const t = createTarget();
+    if (!t) return null;
+    return formatRemaining(t.getTime() - Date.now());
+  });
+
+  useEffect(() => {
+    const target = createTarget();
+    if (!target) return;
+    const tick = () => {
+      const diff = target.getTime() - Date.now();
+      if (diff <= 0) {
+        setRemaining(null);
+        clearInterval(id);
+      } else {
+        setRemaining(formatRemaining(diff));
+      }
+    };
+    const id = setInterval(tick, 1000);
+    tick();
+    return () => clearInterval(id);
+  }, [targetDate, timeZone]);
+
+  if (!targetDate) return null;
+  if (remaining === null) {
+    return completionText ? (
+      <span className={className}>{completionText}</span>
+    ) : null;
+  }
+  return <span className={className}>{remaining}</span>;
+}
+
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${days}d ${hours}h ${minutes}m ${seconds}s`;
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -16,6 +16,7 @@ import MapBlock from "./MapBlock";
 import MultiColumn from "./containers/MultiColumn";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
+import CountdownTimer from "./CountdownTimer";
 
 export {
   BlogListing,
@@ -36,6 +37,7 @@ export {
   MultiColumn,
   VideoBlock,
   FAQBlock,
+  CountdownTimer,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -14,6 +14,7 @@ import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
+import CountdownTimer from "./CountdownTimer";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -32,6 +33,7 @@ export const organismRegistry = {
   MapBlock,
   VideoBlock,
   FAQBlock,
+  CountdownTimer,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -89,6 +89,35 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "FAQBlock":
       specific = <FAQBlockEditor component={component} onChange={onChange} />;
       break;
+    case "CountdownTimer":
+      specific = (
+        <div className="space-y-2">
+          <Input
+            label="Target Date"
+            type="datetime-local"
+            value={(component as any).targetDate ?? ""}
+            onChange={(e) => handleInput("targetDate", e.target.value)}
+          />
+          <Input
+            label="Timezone"
+            value={(component as any).timeZone ?? ""}
+            onChange={(e) => handleInput("timeZone", e.target.value)}
+            placeholder="e.g. America/New_York"
+          />
+          <Input
+            label="Completion Text"
+            value={(component as any).completionText ?? ""}
+            onChange={(e) => handleInput("completionText", e.target.value)}
+          />
+          <Input
+            label="Class Name"
+            value={(component as any).className ?? ""}
+            onChange={(e) => handleInput("className", e.target.value)}
+            placeholder="optional styles"
+          />
+        </div>
+      );
+      break;
     default:
       specific = <p className="text-muted text-sm">No editable props</p>;
   }


### PR DESCRIPTION
## Summary
- add CountdownTimer block with target date, optional timezone, and completion text
- register CountdownTimer in block registry and palette
- allow editing CountdownTimer properties in page builder editor

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter @types/shared test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_689a2ba060d8832f8bd97c42baf10e56