### PR TITLE
feat: add SocialLinks CMS block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -124,6 +124,13 @@ export interface FAQBlockComponent extends PageComponentBase {
     answer: string;
   }[];
 }
+export interface SocialLinksComponent extends PageComponentBase {
+  type: "SocialLinks";
+  instagram?: string;
+  facebook?: string;
+  x?: string;
+  linkedin?: string;
+}
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -180,6 +187,7 @@ export type PageComponent =
   | MapBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
+  | SocialLinksComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -127,6 +127,14 @@ export interface FAQBlockComponent extends PageComponentBase {
   items?: { question: string; answer: string }[];
 }
 
+export interface SocialLinksComponent extends PageComponentBase {
+  type: "SocialLinks";
+  instagram?: string;
+  facebook?: string;
+  x?: string;
+  linkedin?: string;
+}
+
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -180,6 +188,7 @@ export type PageComponent =
   | MapBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
+  | SocialLinksComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
@@ -294,6 +303,14 @@ const faqBlockComponentSchema = baseComponentSchema.extend({
     .optional(),
 });
 
+const socialLinksComponentSchema = baseComponentSchema.extend({
+  type: z.literal("SocialLinks"),
+  instagram: z.string().optional(),
+  facebook: z.string().optional(),
+  x: z.string().optional(),
+  linkedin: z.string().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -361,6 +378,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     mapBlockComponentSchema,
     videoBlockComponentSchema,
     faqBlockComponentSchema,
+    socialLinksComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,

--- a/packages/ui/src/components/cms/blocks/SocialLinks.tsx
+++ b/packages/ui/src/components/cms/blocks/SocialLinks.tsx
@@ -1,0 +1,49 @@
+import { InstagramLogoIcon, TwitterLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
+import type { SVGProps } from "react";
+
+function FacebookIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M22 12a10 10 0 1 0-11.5 9.95v-7.05h-2.3V12h2.3V9.8c0-2.27 1.35-3.53 3.42-3.53.99 0 2.03.17 2.03.17v2.24h-1.14c-1.12 0-1.47.7-1.47 1.42V12h2.5l-.4 2.9h-2.1v7.05A10 10 0 0 0 22 12Z" />
+    </svg>
+  );
+}
+
+const icons = {
+  instagram: InstagramLogoIcon,
+  facebook: FacebookIcon,
+  x: TwitterLogoIcon,
+  linkedin: LinkedInLogoIcon,
+} as const;
+
+export interface SocialLinksProps {
+  instagram?: string;
+  facebook?: string;
+  x?: string;
+  linkedin?: string;
+}
+
+export default function SocialLinks({ instagram, facebook, x, linkedin }: SocialLinksProps) {
+  const entries = [
+    { key: "instagram", href: instagram },
+    { key: "facebook", href: facebook },
+    { key: "x", href: x },
+    { key: "linkedin", href: linkedin },
+  ].filter((e) => e.href);
+
+  if (!entries.length) return null;
+
+  return (
+    <div className="flex gap-2">
+      {entries.map(({ key, href }) => {
+        const Icon = icons[key as keyof typeof icons];
+        return (
+          <a key={key} href={href} target="_blank" rel="noopener noreferrer">
+            <Icon className="h-5 w-5" />
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -16,6 +16,7 @@ import MapBlock from "./MapBlock";
 import MultiColumn from "./containers/MultiColumn";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
+import SocialLinks from "./SocialLinks";
 
 export {
   BlogListing,
@@ -36,6 +37,7 @@ export {
   MultiColumn,
   VideoBlock,
   FAQBlock,
+  SocialLinks,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -5,6 +5,7 @@ import type { Locale } from "@/i18n/locales";
 import { memo } from "react";
 import type { CategoryCollectionTemplateProps } from "../../templates/CategoryCollectionTemplate";
 import { CategoryCollectionTemplate } from "../../templates/CategoryCollectionTemplate";
+import SocialLinks from "./SocialLinks";
 
 /* ──────────────────────────────────────────────────────────────────────────
  * NewsletterForm
@@ -101,6 +102,7 @@ export const moleculeRegistry = {
   NewsletterForm,
   PromoBanner,
   CategoryList,
+  SocialLinks,
 } as const;
 
 export type MoleculeBlockType = keyof typeof moleculeRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -89,6 +89,32 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "FAQBlock":
       specific = <FAQBlockEditor component={component} onChange={onChange} />;
       break;
+    case "SocialLinks":
+      specific = (
+        <>
+          <Input
+            label="Instagram URL"
+            value={(component as any).instagram ?? ""}
+            onChange={(e) => handleInput("instagram", e.target.value)}
+          />
+          <Input
+            label="Facebook URL"
+            value={(component as any).facebook ?? ""}
+            onChange={(e) => handleInput("facebook", e.target.value)}
+          />
+          <Input
+            label="X URL"
+            value={(component as any).x ?? ""}
+            onChange={(e) => handleInput("x", e.target.value)}
+          />
+          <Input
+            label="LinkedIn URL"
+            value={(component as any).linkedin ?? ""}
+            onChange={(e) => handleInput("linkedin", e.target.value)}
+          />
+        </>
+      );
+      break;
     default:
       specific = <p className="text-muted text-sm">No editable props</p>;
   }


### PR DESCRIPTION
## Summary
- add SocialLinks CMS block with default icons and configurable URLs
- register SocialLinks in block registry and editor
- extend page component types and schema for SocialLinks links

## Testing
- `pnpm --filter @acme/ui lint` (fails: None of the selected packages has a "lint" script)
- `pnpm --filter @acme/ui test` (fails: Cannot find module '.prisma/client/index-browser')
- `pnpm --filter @types/shared build` (fails: test suite failed to run)


------
https://chatgpt.com/codex/tasks/task_e_689a2b9d3f68832f9196e08821a16f4f