### PR TITLE
feat(ui): add divider and spacer blocks

### DIFF
--- a/packages/ui/src/components/cms/blocks/Divider.tsx
+++ b/packages/ui/src/components/cms/blocks/Divider.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  /** Thickness of the divider */
+  height?: string;
+}
+
+export default function Divider({ height = "1px" }: Props) {
+  return (
+    <div
+      aria-hidden="true"
+      className="w-full bg-border"
+      style={{ height }}
+    />
+  );
+}

--- a/packages/ui/src/components/cms/blocks/Spacer.tsx
+++ b/packages/ui/src/components/cms/blocks/Spacer.tsx
@@ -1,0 +1,8 @@
+interface Props {
+  /** Amount of vertical space */
+  height?: string;
+}
+
+export default function Spacer({ height = "1rem" }: Props) {
+  return <div aria-hidden="true" style={{ height }} />;
+}

--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -7,6 +7,9 @@ import React, {
   type JSXElementConstructor,
   type JSX as ReactJSX,
 } from "react";
+import Divider from "./Divider";
+import Spacer from "./Spacer";
+export { Divider, Spacer };
 
 /* ──────────────────────────────────────────────────────────────────────────
  * Shared helpers
@@ -76,6 +79,8 @@ export const Image = memo(function Image({
 export const atomRegistry = {
   Text,
   Image,
+  Divider,
+  Spacer,
 } as const;
 
 export type AtomBlockType = keyof typeof atomRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -116,7 +116,7 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       <div className="flex items-end gap-2">
         <Input
           label="Height"
-          placeholder="e.g. 100px or 50%"
+          placeholder="e.g. 1px or 1rem"
           value={component.height ?? ""}
           onChange={(e) => {
             const v = e.target.value.trim();

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -43,6 +43,8 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
     width: "100%",
   },
   MultiColumn: { columns: 2, gap: "1rem" },
+  Divider: { width: "100%", height: "1px" },
+  Spacer: { width: "100%", height: "1rem" },
 };
 
 interface Props {


### PR DESCRIPTION
## Summary
- add simple Divider and Spacer CMS blocks
- register new blocks in atom registry, block defaults, and palette
- support editing thickness/spacing via height input

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689a2b9caa98832f9a6ca4024d8f3474