### PR TITLE
feat: validate plugin configs with schemas

### DIFF
--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -17,7 +17,8 @@
     "@prisma/client": "^5.15.1",
     "@upstash/redis": "^1.35.3",
     "@acme/email": "workspace:*",
-    "@acme/date-utils": "workspace:*"
+    "@acme/date-utils": "workspace:*",
+    "zod": "^3.25.67"
   },
   "peerDependencies": {
     "next": "^15.0.0",

--- a/packages/plugins/paypal/index.ts
+++ b/packages/plugins/paypal/index.ts
@@ -1,12 +1,21 @@
 // packages/plugins/paypal/index.ts
 import type { Plugin, PaymentRegistry } from "@acme/platform-core/plugins";
+import { z } from "zod";
 
-const paypalPlugin: Plugin = {
+const configSchema = z.object({
+  clientId: z.string(),
+  secret: z.string(),
+});
+
+type PayPalConfig = z.infer<typeof configSchema>;
+
+const paypalPlugin: Plugin<any, any, any, PayPalConfig> = {
   id: "paypal",
   name: "PayPal",
   description: "Example PayPal payment provider",
   defaultConfig: { clientId: "", secret: "" },
-  registerPayments(registry: PaymentRegistry) {
+  configSchema,
+  registerPayments(registry: PaymentRegistry, _cfg: PayPalConfig) {
     registry.add("paypal", {
       async processPayment() {
         // placeholder implementation

--- a/packages/plugins/paypal/package.json
+++ b/packages/plugins/paypal/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./index.ts"
+  },
+  "dependencies": {
+    "zod": "^3.25.67"
   }
 }

--- a/packages/plugins/sanity/index.ts
+++ b/packages/plugins/sanity/index.ts
@@ -1,12 +1,15 @@
 // packages/plugins/sanity/index.ts
 import type { Plugin } from "@acme/platform-core/plugins";
 import { createClient, type SanityClient } from "@sanity/client";
+import { z } from "zod";
 
-interface SanityConfig {
-  projectId: string;
-  dataset: string;
-  token: string;
-}
+export const configSchema = z.object({
+  projectId: z.string(),
+  dataset: z.string(),
+  token: z.string(),
+});
+
+export type SanityConfig = z.infer<typeof configSchema>;
 
 export const defaultConfig: SanityConfig = {
   projectId: "",
@@ -42,11 +45,12 @@ export async function publishPost(
   return client.create({ _type: "post", ...post });
 }
 
-const sanityPlugin: Plugin = {
+const sanityPlugin: Plugin<any, any, any, SanityConfig> = {
   id: "sanity",
   name: "Sanity",
   description: "Sanity CMS integration",
   defaultConfig,
+  configSchema,
 };
 
 export default sanityPlugin;

--- a/packages/plugins/sanity/package.json
+++ b/packages/plugins/sanity/package.json
@@ -10,6 +10,7 @@
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../../jest.config.cjs"
   },
   "dependencies": {
-    "@sanity/client": "^6.15.0"
+    "@sanity/client": "^6.15.0",
+    "zod": "^3.25.67"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       eslint-plugin-boundaries:
         specifier: ^5.0.1
         version: 5.0.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-jest:
         specifier: ^29.0.1
         version: 29.0.1(@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(jest@29.7.0(@types/node@20.19.4)(ts-node@10.9.2(@swc/core@1.12.9)(@types/node@20.19.4)(typescript@5.8.3)))(typescript@5.8.3)
@@ -472,6 +475,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.73
     devDependencies:
       next:
         specifier: ^15.3.4
@@ -486,13 +492,20 @@ importers:
         specifier: ^15.3.4
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  packages/plugins/paypal: {}
+  packages/plugins/paypal:
+    dependencies:
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.73
 
   packages/plugins/sanity:
     dependencies:
       '@sanity/client':
         specifier: ^6.15.0
         version: 6.29.1
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.73
 
   packages/sanity:
     dependencies:


### PR DESCRIPTION
## Summary
- allow plugins to declare a zod-based `configSchema` with defaults
- validate and merge plugin config before registration
- provide schemas for existing PayPal and Sanity plugins

## Testing
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/plugins.test.ts`
- `pnpm --filter @acme/plugin-sanity exec jest packages/plugins/sanity/__tests__/sanityPlugin.test.ts --config ../../../jest.config.cjs`
- `pnpm exec eslint packages/platform-core/src/plugins.ts packages/platform-core/__tests__/plugins.test.ts packages/plugins/paypal/index.ts packages/plugins/sanity/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a2ce35320832fba3581b570a93ddd