### PR TITLE
feat: centralize shop configs

### DIFF
--- a/apps/shop-abc/next.config.mjs
+++ b/apps/shop-abc/next.config.mjs
@@ -1,3 +1,3 @@
 // apps/shop-abc/next.config.mjs
-// Re-export the shared configuration from the Template App
-export { default } from "@acme/template-app/next.config.mjs";
+// Re-export shared Next.js configuration
+export { default } from "@acme/next-config/next.config.mjs";

--- a/apps/shop-abc/package.json
+++ b/apps/shop-abc/package.json
@@ -10,6 +10,7 @@
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
     "@acme/next-config": "workspace:*",
+    "@acme/tailwind-config": "workspace:*",
     "@acme/template-app": "workspace:*",
     "@acme/email": "workspace:*",
     "@acme/stripe": "workspace:*",

--- a/apps/shop-abc/tailwind.config.mjs
+++ b/apps/shop-abc/tailwind.config.mjs
@@ -1,2 +1,3 @@
 // apps/shop-abc/tailwind.config.mjs
-export { default } from "@acme/template-app/tailwind.config.mjs";
+// Re-export shared Tailwind configuration
+export { default } from "@acme/tailwind-config/tailwind.config.mjs";

--- a/apps/shop-bcd/next.config.mjs
+++ b/apps/shop-bcd/next.config.mjs
@@ -1,3 +1,3 @@
 // apps/shop-bcd/next.config.mjs
-// Re-export the shared configuration from the Template App
-export { default } from "@acme/template-app/next.config.mjs";
+// Re-export shared Next.js configuration
+export { default } from "@acme/next-config/next.config.mjs";

--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -10,6 +10,7 @@
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
     "@acme/next-config": "workspace:*",
+    "@acme/tailwind-config": "workspace:*",
     "@acme/template-app": "workspace:*",
     "@acme/stripe": "workspace:*",
     "@acme/date-utils": "workspace:*",

--- a/apps/shop-bcd/tailwind.config.mjs
+++ b/apps/shop-bcd/tailwind.config.mjs
@@ -1,2 +1,3 @@
 // apps/shop-bcd/tailwind.config.mjs
-export { default } from "@acme/template-app/tailwind.config.mjs";
+// Re-export shared Tailwind configuration
+export { default } from "@acme/tailwind-config/tailwind.config.mjs";

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "format": "prettier --write .",
     "create-shop": "ts-node scripts/create-shop.ts",
     "init-shop": "ts-node scripts/src/init-shop.ts",
+    "generate-shop": "ts-node scripts/src/generate-shop.ts",
     "setup-ci": "ts-node scripts/setup-ci.ts",
     "gen": "plop --plopfile plopfile.ts",
     "plop": "pnpm gen",

--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { baseConfig, withShopCode } from "./index.mjs";
+
+/* ------------------------------------------------------------------ */
+/*  ES-module-safe __dirname                                           */
+/* ------------------------------------------------------------------ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default withShopCode(process.env.SHOP_CODE, {
+  /* 1️⃣ ‒ keep CI/production green even if ESLint finds issues */
+  eslint: { ignoreDuringBuilds: true },
+
+  webpack(config, { isServer }) {
+    // 2️⃣ – preserve any tweaks from the base config
+    if (typeof baseConfig.webpack === "function") {
+      config = baseConfig.webpack(config, { isServer });
+    }
+
+    /* 3️⃣ – extra aliases -------------------------------------------------- */
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@": path.resolve(__dirname, "../template-app/src"),
+      "@i18n": path.resolve(__dirname, "../i18n"),
+      "node:fs": "fs",
+      "node:path": "path",
+    };
+
+    return config;
+  },
+});

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./index.mjs"
+    ".": "./index.mjs",
+    "./next.config.mjs": "./next.config.mjs"
   },
   "scripts": {
     "test": "node --test"

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -5,7 +5,8 @@
   "type": "commonjs",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./tailwind.config.mjs": "./tailwind.config.mjs"
   },
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/tailwind-config/tailwind.config.mjs
+++ b/packages/tailwind-config/tailwind.config.mjs
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import tokens from "../design-tokens/index.ts";
+import preset from "./src/index.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..", "..");
+
+/** @type {import('tailwindcss').Config} */
+const config = {
+  presets: [tokens, preset],
+  darkMode: ["class", ".theme-dark"],
+  content: [
+    path.join(rootDir, "apps/**/*.{ts,tsx,mdx}"),
+    path.join(
+      rootDir,
+      "packages/{ui,platform-core,platform-machine,i18n,themes}/**/*.{ts,tsx,mdx}"
+    ),
+    path.join(rootDir, ".storybook/**/*.{ts,tsx,mdx}"),
+    "!**/node_modules",
+    "!**/dist",
+    "!**/.next",
+  ],
+  plugins: [
+    require("@tailwindcss/forms"),
+    require("@tailwindcss/container-queries"),
+  ],
+};
+
+export default config;

--- a/packages/template-app/next.config.mjs
+++ b/packages/template-app/next.config.mjs
@@ -1,37 +1,3 @@
 // packages/template-app/next.config.mjs
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { baseConfig, withShopCode } from "@acme/next-config";
-
-/* ------------------------------------------------------------------ */
-/*  ES-module-safe __dirname                                           */
-/* ------------------------------------------------------------------ */
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export default withShopCode(process.env.SHOP_CODE, {
-  /* 1️⃣ ‒ keep CI/production green even if ESLint finds issues */
-  eslint: { ignoreDuringBuilds: true },
-
-  webpack(config, { isServer }) {
-    // 2️⃣ – preserve any tweaks from the base config
-    if (typeof baseConfig.webpack === "function") {
-      config = baseConfig.webpack(config, { isServer });
-    }
-
-    /* 3️⃣ – extra aliases -------------------------------------------------- */
-    config.resolve.alias = {
-      ...config.resolve.alias,
-
-      /* path-based imports --------------------------- */
-      "@": path.resolve(__dirname, "src"),
-      "@i18n": path.resolve(__dirname, "../../packages/i18n"),
-
-      /* allow “node:fs” / “node:path” in shared libs */
-      "node:fs": "fs",
-      "node:path": "path",
-    };
-
-    return config;
-  },
-});
+// Re-export shared Next.js configuration
+export { default } from "@acme/next-config/next.config.mjs";

--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -16,6 +16,7 @@
     "@themes/base": "workspace:*",
     "@acme/i18n": "workspace:*",
     "@acme/next-config": "workspace:*",
+    "@acme/tailwind-config": "workspace:*",
     "@acme/stripe": "workspace:*",
     "@acme/date-utils": "workspace:*"
   },

--- a/packages/template-app/tailwind.config.mjs
+++ b/packages/template-app/tailwind.config.mjs
@@ -1,34 +1,3 @@
 // packages/template-app/tailwind.config.mjs
-// Shared TailwindCSS configuration for shop apps
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-// Import workspaces directly to avoid requiring built packages
-import tokens from "../design-tokens/index.ts";
-import preset from "../tailwind-config/src/index.ts";
-
-// Resolve absolute paths so content globs work when re-exported
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const rootDir = path.resolve(__dirname, "../..");
-
-/** @type {import('tailwindcss').Config} */
-const config = {
-  presets: [tokens, preset],
-  darkMode: ["class", ".theme-dark"],
-  content: [
-    path.join(rootDir, "apps/**/*.{ts,tsx,mdx}"),
-    path.join(rootDir, "packages/{ui,platform-core,platform-machine,i18n,themes}/**/*.{ts,tsx,mdx}"),
-    path.join(rootDir, ".storybook/**/*.{ts,tsx,mdx}"),
-    "!**/node_modules",
-    "!**/dist",
-    "!**/.next",
-  ],
-  plugins: [
-    require("@tailwindcss/forms"),
-    require("@tailwindcss/container-queries"),
-  ],
-};
-
-export default config;
-
+// Re-export shared Tailwind configuration
+export { default } from "@acme/tailwind-config/tailwind.config.mjs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       eslint-plugin-boundaries:
         specifier: ^5.0.1
         version: 5.0.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-jest:
         specifier: ^29.0.1
         version: 29.0.1(@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(jest@29.7.0(@types/node@20.19.4)(ts-node@10.9.2(@swc/core@1.12.9)(@types/node@20.19.4)(typescript@5.8.3)))(typescript@5.8.3)
@@ -344,6 +347,9 @@ importers:
       '@acme/stripe':
         specifier: workspace:*
         version: link:../../packages/stripe
+      '@acme/tailwind-config':
+        specifier: workspace:*
+        version: link:../../packages/tailwind-config
       '@acme/template-app':
         specifier: workspace:*
         version: link:../../packages/template-app
@@ -372,6 +378,9 @@ importers:
       '@acme/stripe':
         specifier: workspace:*
         version: link:../../packages/stripe
+      '@acme/tailwind-config':
+        specifier: workspace:*
+        version: link:../../packages/tailwind-config
       '@acme/template-app':
         specifier: workspace:*
         version: link:../../packages/template-app
@@ -534,6 +543,9 @@ importers:
       '@acme/stripe':
         specifier: workspace:*
         version: link:../stripe
+      '@acme/tailwind-config':
+        specifier: workspace:*
+        version: link:../tailwind-config
       '@themes/base':
         specifier: workspace:*
         version: link:../themes/base

--- a/scripts/src/generate-shop.ts
+++ b/scripts/src/generate-shop.ts
@@ -1,0 +1,50 @@
+import { cpSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const slug = process.argv[2];
+if (!slug) {
+  console.error("Usage: pnpm ts-node scripts/src/generate-shop.ts <shop-slug>");
+  process.exit(1);
+}
+
+const shopId = slug.startsWith("shop-") ? slug : `shop-${slug}`;
+const rootDir = path.resolve(__dirname, "..", "..");
+const templateDir = path.join(rootDir, "packages", "template-app");
+const targetDir = path.join(rootDir, "apps", shopId);
+
+if (existsSync(targetDir)) {
+  console.error(`Shop app already exists: ${targetDir}`);
+  process.exit(1);
+}
+
+// Copy template app contents
+cpSync(templateDir, targetDir, {
+  recursive: true,
+  filter: (src) => {
+    const rel = path.relative(templateDir, src);
+    return !rel.startsWith("node_modules") && !rel.includes("dist");
+  },
+});
+
+// Update package.json
+const pkgPath = path.join(targetDir, "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+pkg.name = `@apps/${shopId}`;
+pkg.dependencies = {
+  ...pkg.dependencies,
+  "@acme/next-config": "workspace:*",
+  "@acme/tailwind-config": "workspace:*",
+};
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+// Link shared configs
+writeFileSync(
+  path.join(targetDir, "next.config.mjs"),
+  'export { default } from "@acme/next-config/next.config.mjs";\n'
+);
+writeFileSync(
+  path.join(targetDir, "tailwind.config.mjs"),
+  'export { default } from "@acme/tailwind-config/tailwind.config.mjs";\n'
+);
+
+console.log(`Created shop ${shopId} in apps/`);


### PR DESCRIPTION
## Summary
- share Next.js configuration via `@acme/next-config`
- expose Tailwind preset through `@acme/tailwind-config`
- add generator script to scaffold new shop apps with shared configs

## Testing
- `pnpm test --filter @acme/next-config`
- `pnpm exec jest packages/tailwind-config/__tests__/preset.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a2ce00078832fb661352ea903e50d