### PR TITLE
chore: rename internal types alias

### DIFF
--- a/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
+++ b/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
@@ -21,7 +21,7 @@ jest.mock(
   { virtual: true }
 );
 
-jest.mock("@types", () => {
+jest.mock("@acme/types", () => {
   const { z } = require("zod");
   const inventoryItemSchema = z.object({
     sku: z.string(),

--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -2,7 +2,7 @@
 "use server";
 
 import { validateShopName } from "@platform-core/src/shops";
-import type { ImageOrientation, MediaItem } from "@types";
+import type { ImageOrientation, MediaItem } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import sharp from "sharp";

--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -2,8 +2,8 @@
 
 import { LOCALES } from "@acme/i18n";
 import * as Sentry from "@sentry/node";
-import type { Locale, Page, HistoryState } from "@types";
-import { historyStateSchema } from "@types";
+import type { Locale, Page, HistoryState } from "@acme/types";
+import { historyStateSchema } from "@acme/types";
 import { ulid } from "ulid";
 import { nowIso } from "@acme/date-utils";
 

--- a/apps/cms/src/actions/pages/service.spec.ts
+++ b/apps/cms/src/actions/pages/service.spec.ts
@@ -1,5 +1,5 @@
 import { getPages, savePage, updatePage, deletePage } from "./service";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 
 jest.mock("@platform-core/repositories/pages/index.server", () => ({
   getPages: jest.fn().mockResolvedValue([]),

--- a/apps/cms/src/actions/pages/service.ts
+++ b/apps/cms/src/actions/pages/service.ts
@@ -6,7 +6,7 @@ import {
   updatePage as repoUpdatePage,
   deletePage as repoDeletePage,
 } from "@platform-core/repositories/pages/index.server";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 
 export function getPages(shop: string) {
   return repoGetPages(shop);

--- a/apps/cms/src/actions/pages/validation.ts
+++ b/apps/cms/src/actions/pages/validation.ts
@@ -2,7 +2,7 @@
 
 import { LOCALES } from "@acme/i18n";
 import { fillLocales } from "@i18n/fillLocales";
-import { pageComponentSchema, type Locale } from "@types";
+import { pageComponentSchema, type Locale } from "@acme/types";
 import { z } from "zod";
 
 export const emptyTranslated = (): Record<Locale, string> =>

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -15,7 +15,7 @@ import {
 import { fillLocales } from "@i18n/fillLocales";
 import type { ProductPublication } from "@platform-core/src/products";
 import * as Sentry from "@sentry/node";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import { ensureAuthorized } from "./common/auth";
 import { redirect } from "next/navigation";
 import { ulid } from "ulid";

--- a/apps/cms/src/actions/schemas.d.ts
+++ b/apps/cms/src/actions/schemas.d.ts
@@ -1,4 +1,4 @@
-import { localeSchema } from "@types";
+import { localeSchema } from "@acme/types";
 import { z } from "zod";
 export declare const productSchema: z.ZodObject<{
     id: z.ZodString;

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -1,6 +1,6 @@
 // apps/cms/src/actions/schemas.ts
 
-import { localeSchema } from "@types";
+import { localeSchema } from "@acme/types";
 import { z } from "zod";
 
 export const productSchema = z

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -18,7 +18,7 @@ import {
   type Shop,
   type ShopSeoFields,
   type ShopSettings,
-} from "@types";
+} from "@acme/types";
 import { z } from "zod";
 import { shopSchema, type ShopForm } from "./schemas";
 import { ensureAuthorized } from "./common/auth";

--- a/apps/cms/src/actions/updateProduct.server.ts
+++ b/apps/cms/src/actions/updateProduct.server.ts
@@ -7,7 +7,7 @@ import {
   getProductById,
   updateProductInRepo,
 } from "@platform-core/repositories/json.server";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 
 /**
  * Server Action: patch an existing product (optimistic locking).

--- a/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -5,7 +5,7 @@ import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { Price } from "@ui/components/atoms/Price";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {

--- a/apps/cms/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/apps/cms/src/app/[lang]/shop/ShopClient.client.tsx
@@ -5,7 +5,7 @@ import FilterBar, {
   Filters,
 } from "@platform-core/src/components/shop/FilterBar";
 import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {

--- a/apps/cms/src/app/[lang]/shop/page.tsx
+++ b/apps/cms/src/app/[lang]/shop/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/[lang]/shop/page.tsx
 import { PRODUCTS } from "@/lib/products";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
 import ShopClient from "./ShopClient.client";
 

--- a/apps/cms/src/app/api/configure-shop/[shop]/route.ts
+++ b/apps/cms/src/app/api/configure-shop/[shop]/route.ts
@@ -1,6 +1,6 @@
 import { authOptions } from "@cms/auth/options";
 import { updateShopInRepo } from "@platform-core/repositories/shop.server";
-import type { Shop } from "@types";
+import type { Shop } from "@acme/types";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { inventoryItemSchema } from "@types";
+import { inventoryItemSchema } from "@acme/types";
 import { writeInventory } from "@platform-core/repositories/inventory.server";
 import { parse } from "fast-csv";
 import { Readable } from "node:stream";

--- a/apps/cms/src/app/api/data/[shop]/inventory/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { inventoryItemSchema } from "@types";
+import { inventoryItemSchema } from "@acme/types";
 import { writeInventory } from "@platform-core/repositories/inventory.server";
 
 export async function POST(

--- a/apps/cms/src/app/api/data/[shop]/rental/pricing/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/rental/pricing/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { pricingSchema } from "@types";
+import { pricingSchema } from "@acme/types";
 import { writePricing } from "@platform-core/repositories/pricing.server";
 
 export async function POST(

--- a/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { returnLogisticsSchema } from "@types";
+import { returnLogisticsSchema } from "@acme/types";
 import { writeReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
 
 export async function POST(

--- a/apps/cms/src/app/api/page/[shop]/route.ts
+++ b/apps/cms/src/app/api/page/[shop]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getPages, updatePage as updatePageInRepo } from "@platform-core/repositories/pages/index.server";
-import { pageComponentSchema, type PageComponent } from "@types";
+import { pageComponentSchema, type PageComponent } from "@acme/types";
 
 export async function POST(
   req: NextRequest,

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -10,7 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/atoms/shadcn";
-import { inventoryItemSchema, type InventoryItem } from "@types";
+import { inventoryItemSchema, type InventoryItem } from "@acme/types";
 import { FormEvent, useRef, useState } from "react";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -21,7 +21,7 @@ jest.mock(
   { virtual: true }
 );
 
-jest.mock("@types", () => {
+jest.mock("@acme/types", () => {
   const { z } = require("zod");
   const inventoryItemSchema = z.object({
     sku: z.string(),

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Textarea } from "@/components/atoms/shadcn";
-import { pricingSchema, type PricingMatrix } from "@types";
+import { pricingSchema, type PricingMatrix } from "@acme/types";
 import { FormEvent, useState } from "react";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Input, Checkbox } from "@/components/atoms/shadcn";
-import { returnLogisticsSchema, type ReturnLogistics } from "@types";
+import { returnLogisticsSchema, type ReturnLogistics } from "@acme/types";
 import { FormEvent, useState } from "react";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/pages/PagesClient.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/PagesClient.tsx
@@ -6,7 +6,7 @@ import {
   QueryClientProvider,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import { PagesTable } from "@ui/components/cms";
 import { fetchJson } from "@shared-utils";
 import { useState } from "react";

--- a/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
@@ -2,7 +2,7 @@
 
 import { createPage } from "@cms/actions/pages.server";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import dynamic from "next/dynamic";
 
 const PageBuilder = dynamic(() => import("@ui/components/cms/PageBuilder"));

--- a/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/ProductEditor.client.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/ProductEditor.client.tsx
@@ -3,7 +3,7 @@
 
 import { updateProduct } from "@cms/actions/products.server";
 import type { ProductPublication } from "@platform-core/products";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import ProductEditorForm from "@ui/components/cms/ProductEditorForm";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -4,7 +4,7 @@
 import { Button, Input, Textarea } from "@/components/atoms/shadcn";
 import { updateShop } from "@cms/actions/shops.server";
 import { shopSchema } from "@cms/actions/schemas";
-import type { Shop } from "@types";
+import type { Shop } from "@acme/types";
 import { ChangeEvent, FormEvent, useState } from "react";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -6,7 +6,7 @@ import {
   readSettings,
   readShop,
 } from "@platform-core/repositories/json.server";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import { getServerSession } from "next-auth";
 import dynamic from "next/dynamic";
 import Link from "next/link";

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditor.tsx
@@ -5,7 +5,7 @@ import {
   setFreezeTranslations,
   updateSeo,
 } from "@cms/actions/shops.server";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import { ChangeEvent, FormEvent, useState } from "react";
 
 interface SeoData {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoForm.client.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoForm.client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/atoms/shadcn";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import SeoLanguageTabs from "./SeoLanguageTabs";
 import type { SeoRecord } from "./useSeoForm";
 import useSeoForm from "./useSeoForm";

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoLanguageTabs.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoLanguageTabs.tsx
@@ -2,7 +2,7 @@
 
 import { Tooltip } from "@/components/atoms";
 import { Input, Textarea } from "@/components/atoms/shadcn";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import { cn } from "@ui/utils/style";
 import type { SeoRecord } from "./useSeoForm";
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/useSeoForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/useSeoForm.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { updateSeo } from "@cms/actions/shops.server";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import { FormEvent, useCallback, useState } from "react";
 
 export interface SeoRecord {

--- a/apps/cms/src/app/cms/wizard/MediaUploadDialog.tsx
+++ b/apps/cms/src/app/cms/wizard/MediaUploadDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/atoms/shadcn";
-import type { MediaItem } from "@types";
+import type { MediaItem } from "@acme/types";
 import MediaManager from "@ui/components/cms/MediaManager";
 import { ReactElement, useCallback, useEffect, useState } from "react";
 

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -8,7 +8,7 @@ import { Footer, Header, SideNav } from "@/components/organisms";
 import { AppShell } from "@/components/templates/AppShell";
 import TranslationsProvider from "@/i18n/Translations";
 import enMessages from "@i18n/en.json";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import React, { useEffect, useRef, useState } from "react";
 import { STORAGE_KEY } from "./hooks/useWizardPersistence";
 

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -1,8 +1,8 @@
 // apps/cms/src/app/cms/wizard/schema.ts
 import { LOCALES } from "@acme/i18n";
 import { fillLocales } from "@i18n/fillLocales";
-import { pageComponentSchema } from "@types/Page";
-import { localeSchema, type Locale } from "@types";
+import { pageComponentSchema } from "@acme/types/Page";
+import { localeSchema, type Locale } from "@acme/types";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { baseTokens } from "./tokenUtils";

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/PageLayoutSelector.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/PageLayoutSelector.tsx
@@ -6,7 +6,7 @@ import {
   SelectValue,
 } from "@/components/atoms/shadcn";
 import { ulid } from "ulid";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/PageMetaForm.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/PageMetaForm.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@/components/atoms/shadcn";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 
 interface Props {
   languages: readonly Locale[];

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/StepAdditionalPages.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { LOCALES } from "@acme/i18n";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Locale, Page, PageComponent } from "@types";
+import type { Locale, Page, PageComponent } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { useState } from "react";
 import { Toast } from "@/components/atoms";

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/useNewPageState.ts
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/useNewPageState.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { Locale, PageComponent } from "@types";
+import type { Locale, PageComponent } from "@acme/types";
 
 export default function useNewPageState(languages: readonly Locale[]) {
   const createEmptyLocaleRecord = () =>

--- a/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/usePagesLoader.ts
+++ b/apps/cms/src/app/cms/wizard/steps/StepAdditionalPages/usePagesLoader.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
-import type { Page, PageComponent } from "@types";
-import { historyStateSchema } from "@types";
+import type { Page, PageComponent } from "@acme/types";
+import { historyStateSchema } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { toPageInfo } from "../utils/page-utils";
 import type { PageInfo } from "../schema";

--- a/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepCheckoutPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@types";
+import type { Page, PageComponent } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
 import { useState } from "react";

--- a/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepHomePage.tsx
@@ -10,8 +10,8 @@ import {
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@types";
-import { historyStateSchema } from "@types";
+import type { Page, PageComponent } from "@acme/types";
+import { historyStateSchema } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
 import { useEffect, useState } from "react";

--- a/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
@@ -4,7 +4,7 @@
 import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@types";
+import type { Page, PageComponent } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { ReactNode, useState } from "react";
 import { Toast } from "@/components/atoms";

--- a/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepProductPage.tsx
@@ -10,8 +10,8 @@ import {
 } from "@/components/atoms/shadcn";
 import ProductPageBuilder from "@/components/cms/ProductPageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@types";
-import { historyStateSchema } from "@types";
+import type { Page, PageComponent } from "@acme/types";
+import { historyStateSchema } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
 import { useEffect, useState } from "react";

--- a/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepShopPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@types";
+import type { Page, PageComponent } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { ulid } from "ulid";
 import { useState } from "react";

--- a/apps/cms/src/app/cms/wizard/steps/StepSummary.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepSummary.tsx
@@ -4,7 +4,7 @@
 
 import { Button, Input } from "@/components/atoms/shadcn";
 import { LOCALES } from "@acme/i18n";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import React from "react";
 import WizardPreview from "../WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";

--- a/apps/cms/src/app/cms/wizard/utils/page-utils.ts
+++ b/apps/cms/src/app/cms/wizard/utils/page-utils.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/wizard/utils/page.ts
 
 import { fillLocales } from "@i18n/fillLocales";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import type { PageInfo } from "../schema";
 
 export function toPageInfo(draft: Partial<PageInfo>): PageInfo {

--- a/apps/cms/src/auth/next-auth.d.ts
+++ b/apps/cms/src/auth/next-auth.d.ts
@@ -1,4 +1,4 @@
-import type { Role } from "@types";
+import type { Role } from "@acme/types";
 import "next-auth";
 import { DefaultSession, DefaultUser } from "next-auth";
 import "next-auth/adapters";

--- a/apps/cms/src/auth/users.ts
+++ b/apps/cms/src/auth/users.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/auth/users.ts
 
-import type { CmsUser } from "@types";
-export type { CmsUser } from "@types";
+import type { CmsUser } from "@acme/types";
+export type { CmsUser } from "@acme/types";
 
 /** Phase-0 in-memory users (replace with DB in Phase-1). */
 export const USERS: Record<string, CmsUser> = {

--- a/apps/cms/src/lib/rbacStore.d.ts
+++ b/apps/cms/src/lib/rbacStore.d.ts
@@ -1,4 +1,4 @@
-import type { CmsUser } from "@types";
+import type { CmsUser } from "@acme/types";
 import type { Role } from "../auth/roles";
 export interface RbacDB {
     users: Record<string, CmsUser>;

--- a/apps/cms/src/lib/rbacStore.ts
+++ b/apps/cms/src/lib/rbacStore.ts
@@ -1,6 +1,6 @@
 // apps/cms/src/lib/rbacStore.ts
 
-import type { CmsUser } from "@types";
+import type { CmsUser } from "@acme/types";
 import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";

--- a/apps/shop-abc/__tests__/cmsPages.test.tsx
+++ b/apps/shop-abc/__tests__/cmsPages.test.tsx
@@ -8,7 +8,7 @@ jest.mock("next/headers", () => ({
   cookies: jest.fn(),
 }));
 
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { cookies } from "next/headers";

--- a/apps/shop-abc/__tests__/homePage.test.tsx
+++ b/apps/shop-abc/__tests__/homePage.test.tsx
@@ -8,7 +8,7 @@ jest.mock("../src/app/[lang]/page.client", () => ({
   default: jest.fn(() => null),
 }));
 
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import Page from "../src/app/[lang]/page";
 import Home from "../src/app/[lang]/page.client";
 import { getPages } from "@platform-core/repositories/pages/index.server";

--- a/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/[...slug]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import type { Locale } from "@/i18n/locales";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import DynamicRenderer from "@ui/components/DynamicRenderer";

--- a/apps/shop-abc/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/checkout/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@platform-core/src/cartCookie";
 import { getCart } from "@platform-core/src/cartStore";
 import { getPages } from "@platform-core/repositories/pages/index.server";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import shop from "../../../../shop.json";

--- a/apps/shop-abc/src/app/[lang]/page.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import type { Locale } from "@/i18n/locales";
 
 export default function Home({

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { readShop } from "@platform-core/repositories/shops.server";
 import Home from "./page.client";

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -5,7 +5,7 @@ import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { Price } from "@ui/components/atoms/Price";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -1,6 +1,6 @@
 // apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
 import { getProductBySlug } from "@/lib/products";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import DynamicRenderer from "@ui/components/DynamicRenderer";

--- a/apps/shop-abc/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/ShopClient.client.tsx
@@ -5,7 +5,7 @@ import FilterBar, {
   Filters,
 } from "@platform-core/src/components/shop/FilterBar";
 import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -1,6 +1,6 @@
 // apps/shop-abc/src/app/[lang]/shop/page.tsx
 import { PRODUCTS } from "@/lib/products";
-import type { SKU, PageComponent } from "@types";
+import type { SKU, PageComponent } from "@acme/types";
 import type { Metadata } from "next";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import { getPages } from "@platform-core/repositories/pages/index.server";

--- a/apps/shop-abc/src/app/lib/seo.ts
+++ b/apps/shop-abc/src/app/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Locale } from "@i18n/locales";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
-import type { ShopSettings } from "@types";
+import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {

--- a/apps/shop-bcd/__tests__/home-page.test.tsx
+++ b/apps/shop-bcd/__tests__/home-page.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../src/app/[lang]/page.client", () => ({
   default: jest.fn(() => null),
 }));
 
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { promises as fs } from "node:fs";
 import Page from "../src/app/[lang]/page";
 import Home from "../src/app/[lang]/page.client";

--- a/apps/shop-bcd/src/app/[lang]/generateStaticParams.js
+++ b/apps/shop-bcd/src/app/[lang]/generateStaticParams.js
@@ -1,5 +1,5 @@
 // apps/shop-bcd/src/app/[lang]/generateStaticParams.ts
-import { LOCALES } from "@types";
+import { LOCALES } from "@acme/types";
 export default function generateStaticParams() {
     /* prerender /en, /de, /it — Next will also serve `/` via default locale */
     return LOCALES.map((lang) => ({ lang }));

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 
 export default function Home({
   components,

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import shop from "../../../shop.json";

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.d.ts
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.d.ts
@@ -1,4 +1,4 @@
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 export default function PdpClient({ product }: {
     product: SKU;
 }): import("react/jsx-runtime").JSX.Element;

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -5,7 +5,7 @@ import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { Price } from "@ui/components/atoms/Price";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.js
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx } from "react/jsx-runtime";
 // apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
 import { getProductBySlug } from "@/lib/products";
-import { LOCALES } from "@types";
+import { LOCALES } from "@acme/types";
 import { notFound } from "next/navigation";
 import PdpClient from "./PdpClient.client";
 export async function generateStaticParams() {

--- a/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.d.ts
+++ b/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.d.ts
@@ -1,4 +1,4 @@
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 export default function ShopClient({ skus }: {
     skus: SKU[];
 }): import("react/jsx-runtime").JSX.Element;

--- a/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.tsx
@@ -5,7 +5,7 @@ import FilterBar, {
   Filters,
 } from "@platform-core/src/components/shop/FilterBar";
 import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -1,6 +1,6 @@
 // apps/shop-bcd/src/app/[lang]/shop/page.tsx
 import { PRODUCTS } from "@/lib/products";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
 import ShopClient from "./ShopClient.client";
 

--- a/apps/shop-bcd/src/lib/seo.ts
+++ b/apps/shop-bcd/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Locale } from "@i18n/locales";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import type { ShopSettings } from "@types";
+import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {

--- a/functions/themes/[theme]/__tests__/cms-storefront-integration.test.ts
+++ b/functions/themes/[theme]/__tests__/cms-storefront-integration.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: unknown, init?: ResponseInit) =>

--- a/packages/platform-core/__tests__/shops.test.ts
+++ b/packages/platform-core/__tests__/shops.test.ts
@@ -7,7 +7,7 @@ import {
 import { baseTokens } from "../src/themeTokens";
 import { tokens as abcTokens } from "../../themes/abc/src/tailwind-tokens";
 import { tokens as darkTokens } from "../../themes/dark/src/tailwind-tokens";
-import type { Shop } from "@types";
+import type { Shop } from "@acme/types";
 
 describe("validateShopName", () => {
   it("trims and accepts safe names", () => {

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -2,7 +2,7 @@
 import crypto from "crypto";
 import { z } from "zod";
 
-import { skuSchema } from "@types";
+import { skuSchema } from "@acme/types";
 
 /* ------------------------------------------------------------------
  * Cookie constants

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { Redis } from "@upstash/redis";
 
 import type { CartState } from "./cartCookie";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 
 /** Abstraction for cart storage backends */
 export interface CartStore {

--- a/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
+++ b/packages/platform-core/src/components/shop/AddToCartButton.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useCart } from "@platform-core/src/contexts/CartContext";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useState } from "react";
 
 type Props = {

--- a/packages/platform-core/src/components/shop/ProductCard.tsx
+++ b/packages/platform-core/src/components/shop/ProductCard.tsx
@@ -1,5 +1,5 @@
 // src/components/shop/ProductCard.tsx
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import Image from "next/image";
 import Link from "next/link";
 import { Price } from "@ui/components/atoms/Price";

--- a/packages/platform-core/src/components/shop/ProductGrid.tsx
+++ b/packages/platform-core/src/components/shop/ProductGrid.tsx
@@ -1,7 +1,7 @@
 // src/components/shop/ProductGrid.tsx
 "use client";
 
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { memo, useMemo, useRef, useState, useEffect } from "react";
 import { ProductCard } from "./ProductCard";
 

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -3,7 +3,7 @@
 
 import { type CartState } from "../cartCookie";
 
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import {
   createContext,
   ReactNode,

--- a/packages/platform-core/src/contexts/__tests__/CartContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/CartContext.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { CartProvider, useCart } from "../CartContext";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 
 type CartState = Record<string, { sku: SKU; qty: number; size?: string }>
 

--- a/packages/platform-core/src/coupons.ts
+++ b/packages/platform-core/src/coupons.ts
@@ -1,5 +1,5 @@
 // packages/platform-core/src/coupons.ts
-import type { Coupon } from "@types";
+import type { Coupon } from "@acme/types";
 
 /** Sample coupons available on the storefront */
 export const COUPONS: readonly Coupon[] = [

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -1,5 +1,5 @@
 import { LOCALES } from "@i18n/locales";
-import type { Locale } from "@types";
+import type { Locale } from "@acme/types";
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { ulid } from "ulid";

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -1,6 +1,6 @@
-import type { PageComponent } from "@types";
-import { localeSchema, sanityBlogConfigSchema } from "@types";
-import { pageComponentSchema } from "@types/Page";
+import type { PageComponent } from "@acme/types";
+import { localeSchema, sanityBlogConfigSchema } from "@acme/types";
+import { pageComponentSchema } from "@acme/types/Page";
 import { z } from "zod";
 import { slugify } from "@shared-utils";
 import { fillLocales } from "@i18n/fillLocales";

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -2,7 +2,7 @@
 import "server-only";
 import { ulid } from "ulid";
 import { nowIso } from "@acme/date-utils";
-import type { RentalOrder } from "@types";
+import type { RentalOrder } from "@acme/types";
 import { trackOrder } from "./analytics";
 import { prisma } from "./db";
 

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import type { PricingMatrix, SKU } from "@types";
-import { pricingSchema } from "@types";
+import type { PricingMatrix, SKU } from "@acme/types";
+import { pricingSchema } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { resolveDataRoot } from "./dataRoot";

--- a/packages/platform-core/src/products.ts
+++ b/packages/platform-core/src/products.ts
@@ -2,7 +2,7 @@
 /* -------------------------------------------------------------------------- */
 /*  Locale helpers                                                            */
 /* -------------------------------------------------------------------------- */
-import { type Locale, type SKU } from "@types";
+import { type Locale, type SKU } from "@acme/types";
 
 /* -------------------------------------------------------------------------- */
 /*  Storefront types & helpers                                                */
@@ -70,7 +70,7 @@ export type {
   ProductCore,
   ProductPublication,
   PublicationStatus,
-} from "@types";
+} from "@acme/types";
 
 /* -------------------------------------------------------------------------- */
 /*  Utility                                                                   */

--- a/packages/platform-core/src/repositories/coupons.server.ts
+++ b/packages/platform-core/src/repositories/coupons.server.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "../dataRoot";
-import type { Coupon } from "@types";
+import type { Coupon } from "@acme/types";
 
 function filePath(shop: string): string {
   shop = validateShopName(shop);

--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -2,7 +2,7 @@
 
 import "server-only";
 
-import { inventoryItemSchema, type InventoryItem } from "@types";
+import { inventoryItemSchema, type InventoryItem } from "@acme/types";
 // InventoryItem uses flexible variantAttributes for SKU differentiation
 import { promises as fs } from "node:fs";
 import * as path from "node:path";

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -2,7 +2,7 @@
 
 import "server-only";
 
-import { pageSchema, type Page } from "@types";
+import { pageSchema, type Page } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { prisma } from "../../db";

--- a/packages/platform-core/src/repositories/pricing.server.ts
+++ b/packages/platform-core/src/repositories/pricing.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { pricingSchema, type PricingMatrix } from "@types";
+import { pricingSchema, type PricingMatrix } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { resolveDataRoot } from "../dataRoot";

--- a/packages/platform-core/src/repositories/returnLogistics.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { returnLogisticsSchema, type ReturnLogistics } from "@types";
+import { returnLogisticsSchema, type ReturnLogistics } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { resolveDataRoot } from "../dataRoot";

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -2,7 +2,7 @@
 import "server-only";
 
 import { LOCALES } from "@i18n/locales";
-import { shopSettingsSchema, type Locale, type ShopSettings } from "@types";
+import { shopSettingsSchema, type Locale, type ShopSettings } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";

--- a/packages/platform-core/src/repositories/shop.server.ts
+++ b/packages/platform-core/src/repositories/shop.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
-import { shopSchema, type Shop } from "@types";
+import { shopSchema, type Shop } from "@acme/types";
 import { prisma } from "../db";
 import { validateShopName } from "../shops";
 

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -1,7 +1,7 @@
 // packages/platform-core/repositories/shops.server.ts
 import "server-only";
 
-import { shopSchema, type Shop } from "@types";
+import { shopSchema, type Shop } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { prisma } from "../db";

--- a/packages/platform-core/src/returnLogistics.ts
+++ b/packages/platform-core/src/returnLogistics.ts
@@ -1,5 +1,5 @@
-import type { ReturnLogistics } from "@types";
-import { returnLogisticsSchema } from "@types";
+import type { ReturnLogistics } from "@acme/types";
+import { returnLogisticsSchema } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { resolveDataRoot } from "./dataRoot";

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { skuSchema } from "@types";
+import { skuSchema } from "@acme/types";
 
 export const postSchema = z
   .object({

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -5,7 +5,7 @@ import { DATA_ROOT } from "../dataRoot";
 import { sendEmail } from "@acme/email";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import type { InventoryItem } from "@types";
+import type { InventoryItem } from "@acme/types";
 
 const LOG_FILE = "stock-alert-log.json";
 const SUPPRESS_HOURS = 24; // suppress repeat alerts for a day

--- a/packages/platform-core/src/services/stockScheduler.server.ts
+++ b/packages/platform-core/src/services/stockScheduler.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import type { InventoryItem } from "@types";
+import type { InventoryItem } from "@acme/types";
 import { checkAndAlert } from "./stockAlert.server";
 
 /**

--- a/packages/platform-core/src/shops.ts
+++ b/packages/platform-core/src/shops.ts
@@ -1,4 +1,4 @@
-import type { Shop, SanityBlogConfig, ShopDomain } from "@types";
+import type { Shop, SanityBlogConfig, ShopDomain } from "@acme/types";
 export { SHOP_NAME_RE, validateShopName } from "../../lib/src/validateShopName";
 
 export function getSanityConfig(shop: Shop): SanityBlogConfig | undefined {

--- a/packages/platform-machine/__tests__/depositService.test.ts
+++ b/packages/platform-machine/__tests__/depositService.test.ts
@@ -1,5 +1,5 @@
 // packages/platform-machine/__tests__/depositService.test.ts
-import type { RentalOrder } from "@types";
+import type { RentalOrder } from "@acme/types";
 
 describe("releaseDepositsOnce", () => {
   const OLD_ENV = process.env;

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { createClient } from "@sanity/client";
 import { getSanityConfig } from "@platform-core/shops";
 import { getShopById } from "@platform-core/repositories/shop.server";
-import type { SanityBlogConfig } from "@types";
+import type { SanityBlogConfig } from "@acme/types";
 
 export interface ProductBlock {
   _type: "productReference";

--- a/packages/template-app/__tests__/preview-route.test.ts
+++ b/packages/template-app/__tests__/preview-route.test.ts
@@ -1,5 +1,5 @@
 import { jest } from "@jest/globals";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import { createHmac } from "node:crypto";
 
 process.env.PREVIEW_TOKEN_SECRET = "testsecret";

--- a/packages/template-app/__tests__/return.test.ts
+++ b/packages/template-app/__tests__/return.test.ts
@@ -1,5 +1,5 @@
 import { jest } from "@jest/globals";
-import type { RentalOrder } from "@types";
+import type { RentalOrder } from "@acme/types";
 import type { NextRequest } from "next/server";
 import type Stripe from "stripe";
 

--- a/packages/template-app/src/app/[lang]/product/[slug]/PdpClient.client.tsx
+++ b/packages/template-app/src/app/[lang]/product/[slug]/PdpClient.client.tsx
@@ -5,7 +5,7 @@ import ImageGallery from "@platform-core/src/components/pdp/ImageGallery";
 import SizeSelector from "@platform-core/src/components/pdp/SizeSelector";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
 import { Price } from "@ui/components/atoms/Price";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useState } from "react";
 
 export default function PdpClient({ product }: { product: SKU }) {

--- a/packages/template-app/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/packages/template-app/src/app/[lang]/shop/ShopClient.client.tsx
@@ -5,7 +5,7 @@ import FilterBar, {
   Filters,
 } from "@platform-core/src/components/shop/FilterBar";
 import { ProductGrid } from "@platform-core/src/components/shop/ProductGrid";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {

--- a/packages/template-app/src/app/[lang]/shop/page.tsx
+++ b/packages/template-app/src/app/[lang]/shop/page.tsx
@@ -1,6 +1,6 @@
 // packages/template-app/src/app/[lang]/shop/page.tsx
 import { PRODUCTS } from "@platform-core/src/products";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
 import ShopClient from "./ShopClient.client";
 import { getStructuredData } from "../../../lib/seo";

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getProductById } from "@platform-core/src/products";
 import { readRepo } from "@platform-core/repositories/products.server";
-import type { ProductPublication } from "@types";
+import type { ProductPublication } from "@acme/types";
 
 export const runtime = "nodejs";
 

--- a/packages/template-app/src/components/DynamicRenderer.tsx
+++ b/packages/template-app/src/components/DynamicRenderer.tsx
@@ -18,7 +18,7 @@ import TestimonialSlider from "@/components/cms/blocks/TestimonialSlider";
 import { Textarea as TextBlock } from "@/components/atoms/primitives/textarea";
 
 import { PRODUCTS } from "@platform-core/src/products";
-import type { PageComponent, SKU } from "@types";
+import type { PageComponent, SKU } from "@acme/types";
 
 /* ------------------------------------------------------------------
  * next/image wrapper usable in CMS blocks

--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -1,5 +1,5 @@
 import { LOCALES, type Locale } from "@i18n/locales";
-import type { ShopSettings } from "@types";
+import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@types/shared",
+  "name": "@acme/types",
   "version": "0.0.1",
   "private": true,
   "main": "dist/index.js",

--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, fireEvent } from "@testing-library/react";
 import ComponentEditor from "../src/components/cms/page-builder/ComponentEditor";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 
 describe("ComponentEditor", () => {
   it("updates width and height", () => {

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import DynamicRenderer from "../src/components/DynamicRenderer";
 import { blockRegistry } from "../src/components/cms/blocks";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 
 describe("DynamicRenderer", () => {
   it("warns on unknown component type", () => {

--- a/packages/ui/__tests__/pageComponentSchema.test.ts
+++ b/packages/ui/__tests__/pageComponentSchema.test.ts
@@ -1,4 +1,4 @@
-import { pageComponentSchema } from "@types/Page";
+import { pageComponentSchema } from "@acme/types/Page";
 
 describe("pageComponentSchema", () => {
   it("rejects unknown component type", () => {

--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -5,7 +5,7 @@
 import { blockRegistry } from "@ui/components/cms/blocks";
 import type { Locale } from "@/i18n/locales";
 import { PRODUCTS } from "@platform-core/src/products";
-import type { PageComponent, SKU } from "@types";
+import type { PageComponent, SKU } from "@acme/types";
 import type { CSSProperties, ReactNode } from "react";
 import type { Product } from "./organisms/ProductCard";
 

--- a/packages/ui/src/components/cms/Breadcrumbs.client.tsx
+++ b/packages/ui/src/components/cms/Breadcrumbs.client.tsx
@@ -3,7 +3,7 @@
 
 import type { ProductPublication } from "@platform-core/src/products";
 import { getShopFromPath } from "@platform-core/utils";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import { usePathname } from "next/navigation";
 import { memo, useEffect, useState } from "react";
 import Breadcrumbs, { BreadcrumbItem } from "../molecules/Breadcrumbs";

--- a/packages/ui/src/components/cms/ImageUploaderWithOrientationCheck.tsx
+++ b/packages/ui/src/components/cms/ImageUploaderWithOrientationCheck.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { Input } from "@ui/components/atoms/shadcn";
-import type { ImageOrientation } from "@types";
+import type { ImageOrientation } from "@acme/types";
 import { useImageOrientationValidation } from "@ui/hooks/useImageOrientationValidation";
 import { memo, useCallback } from "react";
 

--- a/packages/ui/src/components/cms/MediaFileItem.tsx
+++ b/packages/ui/src/components/cms/MediaFileItem.tsx
@@ -1,6 +1,6 @@
 // packages/ui/components/cms/MediaFileItem.tsx
 "use client";
-import type { MediaItem } from "@types";
+import type { MediaItem } from "@acme/types";
 import Image from "next/image";
 
 interface Props {

--- a/packages/ui/src/components/cms/MediaFileList.tsx
+++ b/packages/ui/src/components/cms/MediaFileList.tsx
@@ -1,6 +1,6 @@
 // packages/ui/components/cms/MediaFileList.tsx
 "use client";
-import type { MediaItem } from "@types";
+import type { MediaItem } from "@acme/types";
 import MediaFileItem from "./MediaFileItem";
 
 interface Props {

--- a/packages/ui/src/components/cms/MediaManager.stories.tsx
+++ b/packages/ui/src/components/cms/MediaManager.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type { MediaItem } from "@types";
+import type { MediaItem } from "@acme/types";
 import MediaManager from "./MediaManager";
 
 const files: MediaItem[] = [{ url: "/sample.jpg", altText: "Sample" }];

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { Input } from "@ui/components/atoms/shadcn";
-import type { ImageOrientation, MediaItem } from "@types";
+import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";
 import { memo, ReactElement, useCallback, useState } from "react";
 import MediaFileList from "./MediaFileList";

--- a/packages/ui/src/components/cms/PageBuilder.stories.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import PageBuilder from "./PageBuilder";
 
 const samplePage: Page = {

--- a/packages/ui/src/components/cms/PagesTable.client.tsx
+++ b/packages/ui/src/components/cms/PagesTable.client.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link";
 
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import DataTable, { type Column } from "./DataTable";
 
 interface Props {

--- a/packages/ui/src/components/cms/PagesTable.stories.tsx
+++ b/packages/ui/src/components/cms/PagesTable.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type { Page } from "@types";
+import type { Page } from "@acme/types";
 import PagesTable from "./PagesTable";
 
 const pages: Page[] = [

--- a/packages/ui/src/components/cms/PublishLocationSelector.tsx
+++ b/packages/ui/src/components/cms/PublishLocationSelector.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { Button, Input } from "@ui/components/atoms/shadcn";
-import type { PublishLocation } from "@types";
+import type { PublishLocation } from "@acme/types";
 import { usePublishLocations } from "@ui/hooks/usePublishLocations";
 import { toggleItem } from "@shared-utils";
 import { memo, useCallback } from "react";

--- a/packages/ui/src/components/cms/blocks/ProductGrid.client.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductGrid.client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ProductGrid as BaseGrid } from "@platform-core/src/components/shop/ProductGrid";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 
 export interface ProductGridProps {
   skus: SKU[];

--- a/packages/ui/src/components/cms/page-builder/AnnouncementBarEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/AnnouncementBarEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { Input } from "../../atoms/shadcn";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/Block.tsx
+++ b/packages/ui/src/components/cms/page-builder/Block.tsx
@@ -1,5 +1,5 @@
 import type { Locale } from "@/i18n/locales";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import DOMPurify from "dompurify";
 import { memo } from "react";
 import { blockRegistry } from "../blocks";

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -4,7 +4,7 @@ import type { Locale } from "@/i18n/locales";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { EditorContent } from "@tiptap/react";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import type { Action } from "../PageBuilder";
 import DOMPurify from "dompurify";

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -1,7 +1,7 @@
 // packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
 "use client";
 
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { memo, useCallback } from "react";
 import {
   Button,

--- a/packages/ui/src/components/cms/page-builder/ContactFormEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ContactFormEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { Input } from "../../atoms/shadcn";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FAQBlockEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/GalleryEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/GalleryEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/HeroBannerEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/HeroBannerEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/ImageBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImageBlockEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { Button, Input } from "../../atoms/shadcn";
 import ImagePicker from "./ImagePicker";
 

--- a/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
@@ -1,7 +1,7 @@
 // packages/ui/src/components/cms/page-builder/ImagePicker.tsx
 "use client";
 
-import type { MediaItem } from "@types";
+import type { MediaItem } from "@acme/types";
 import useMediaUpload from "@ui/hooks/useMediaUpload";
 import Image from "next/image";
 import { memo, useEffect, useState } from "react";

--- a/packages/ui/src/components/cms/page-builder/MapBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/MapBlockEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { Input } from "../../atoms/shadcn";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { memo, useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import type { CSSProperties, DragEvent } from "react";
 import { ulid } from "ulid";
-import type { Page, PageComponent, HistoryState, MediaItem } from "@types";
+import type { Page, PageComponent, HistoryState, MediaItem } from "@acme/types";
 import { Button } from "../../atoms/shadcn";
 import { Toast } from "../../atoms";
 import Palette from "./Palette";

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -7,7 +7,7 @@ import {
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import type { CSSProperties, DragEvent } from "react";
 import { Fragment } from "react";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import CanvasItem from "./CanvasItem";
 import type { Locale } from "@/i18n/locales";
 import type { Action } from "./state";

--- a/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
@@ -1,5 +1,5 @@
 import ComponentEditor from "./ComponentEditor";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import type { Action } from "./state";
 import { useCallback } from "react";
 

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -2,7 +2,7 @@
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { memo } from "react";
 import {
   atomRegistry,

--- a/packages/ui/src/components/cms/page-builder/ReviewsCarouselEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ReviewsCarouselEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/TestimonialsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/TestimonialsEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/ValuePropsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ValuePropsEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/VideoBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/VideoBlockEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { Input, Checkbox } from "../../atoms/shadcn";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/__tests__/useTextEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useTextEditor.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import type { Locale } from "@/i18n/locales";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import useTextEditor from "../useTextEditor";
 
 describe("useTextEditor", () => {

--- a/packages/ui/src/components/cms/page-builder/state.test.ts
+++ b/packages/ui/src/components/cms/page-builder/state.test.ts
@@ -1,5 +1,5 @@
 import { historyStateSchema, reducer } from "./state";
-import type { PageComponent, HistoryState } from "@types";
+import type { PageComponent, HistoryState } from "@acme/types";
 
 describe("historyStateSchema", () => {
   it("applies defaults when input is undefined", () => {

--- a/packages/ui/src/components/cms/page-builder/state.ts
+++ b/packages/ui/src/components/cms/page-builder/state.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { pageComponentSchema } from "@types";
-import type { PageComponent, HistoryState } from "@types";
+import { pageComponentSchema } from "@acme/types";
+import type { PageComponent, HistoryState } from "@acme/types";
 
 /* ════════════════ runtime validation (Zod) ════════════════ */
 export const historyStateSchema: z.ZodType<HistoryState> = z

--- a/packages/ui/src/components/cms/page-builder/useArrayEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/useArrayEditor.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent } from "react";
 import { useCallback } from "react";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { Button, Input } from "../../atoms/shadcn";
 import ImagePicker from "./ImagePicker";
 

--- a/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
+++ b/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
@@ -1,5 +1,5 @@
 import { getShopFromPath } from "@platform-core/utils";
-import type { MediaItem } from "@types";
+import type { MediaItem } from "@acme/types";
 import { usePathname } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 

--- a/packages/ui/src/components/cms/page-builder/usePageBuilderDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/usePageBuilderDrag.ts
@@ -9,7 +9,7 @@ import {
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { ulid } from "ulid";
 import { useCallback } from "react";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import type { Action } from "./state";
 
 interface Params {

--- a/packages/ui/src/components/cms/page-builder/useTextEditor.ts
+++ b/packages/ui/src/components/cms/page-builder/useTextEditor.ts
@@ -2,7 +2,7 @@ import Link from "@tiptap/extension-link";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import type { Locale } from "@/i18n/locales";
-import type { PageComponent } from "@types";
+import type { PageComponent } from "@acme/types";
 import { useEffect } from "react";
 
 function getContent(component: PageComponent, locale: Locale) {

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -1,7 +1,7 @@
 import { CartProvider, useCart } from "@platform-core/src/contexts/CartContext";
 import { type Meta, type StoryObj } from "@storybook/react";
 import type { CartState } from "@/lib/cartCookie";
-import type { SKU } from "@types";
+import type { SKU } from "@acme/types";
 import * as React from "react";
 import { Button } from "../atoms/shadcn";
 import { MiniCart } from "./MiniCart.client";

--- a/packages/ui/src/hooks/useImageOrientationValidation.ts
+++ b/packages/ui/src/hooks/useImageOrientationValidation.ts
@@ -1,4 +1,4 @@
-import type { ImageOrientation } from "@types";
+import type { ImageOrientation } from "@acme/types";
 import { useEffect, useState } from "react";
 
 export interface ImageOrientationValidationResult {

--- a/packages/ui/src/hooks/useImageUpload.tsx
+++ b/packages/ui/src/hooks/useImageUpload.tsx
@@ -1,6 +1,6 @@
 // src/hooks/useImageUpload.tsx
 
-import type { ImageOrientation } from "@types";
+import type { ImageOrientation } from "@acme/types";
 import ImageUploaderWithOrientationCheck from "@ui/components/cms/ImageUploaderWithOrientationCheck";
 import type { ReactElement } from "react";
 import { useMemo, useState } from "react";

--- a/packages/ui/src/hooks/useMediaUpload.tsx
+++ b/packages/ui/src/hooks/useMediaUpload.tsx
@@ -9,7 +9,7 @@
 import type { ChangeEvent, DragEvent, ReactElement, RefObject } from "react";
 import { useCallback, useRef, useState } from "react";
 
-import type { ImageOrientation, MediaItem } from "@types";
+import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useImageOrientationValidation } from "./useImageOrientationValidation";
 
 /* ──────────────────────────────────────────────────────────────────────

--- a/packages/ui/src/hooks/usePublishLocations.ts
+++ b/packages/ui/src/hooks/usePublishLocations.ts
@@ -1,6 +1,6 @@
 // packages/ui/hooks/usePublishLocations.ts
 
-import type { PublishLocation } from "@types";
+import type { PublishLocation } from "@acme/types";
 import { fetchJson } from "@shared-utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 

--- a/test/unit/locales-regression.spec.ts
+++ b/test/unit/locales-regression.spec.ts
@@ -2,7 +2,7 @@
 
 import { resolveLocale } from "@i18n/locales";
 import { assertLocale } from "@platform-core/src/products";
-import { LOCALES, type Locale } from "@types";
+import { LOCALES, type Locale } from "@acme/types";
 import { parseMultilingualInput } from "@i18n/parseMultilingualInput";
 import { getSeo } from "../../packages/template-app/src/lib/seo";
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -97,10 +97,10 @@
       "@acme/date-utils": ["packages/date-utils/src/index.ts"],
 
       /* ─── shared runtime types ──────────────────────────────────── */
-      "@types": ["packages/types/src/index.ts"],
-      "@types/*": ["packages/types/src/*"],
-      "@types/root": ["src/types/index.ts"],
-      "@types/root/*": ["src/types/*"],
+      "@acme/types": ["packages/types/src/index.ts"],
+      "@acme/types/*": ["packages/types/src/*"],
+      "@acme/types/root": ["src/types/index.ts"],
+      "@acme/types/root/*": ["src/types/*"],
 
       /* ─── Tailwind preset ───────────────────────────────────────── */
       "@acme/tailwind-config": ["packages/tailwind-config/src/index.ts"]


### PR DESCRIPTION
## Summary
- refactor `@types` path alias to `@acme/types`
- rename internal types package accordingly
- update all internal imports to use new alias

## Testing
- `pnpm test` *(fails: @apps/cms#test)*

------
https://chatgpt.com/codex/tasks/task_e_689a2cdf0e5c832fbee14c5ebdb38157