### PR TITLE
feat: add theme overrides for shops

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -14,6 +14,7 @@ describe("ShopEditor", () => {
       name: "Test",
       themeId: "base",
       catalogFilters: [],
+      themeOverrides: {},
       themeTokens: {},
       filterMappings: {},
       priceOverrides: {},

--- a/apps/cms/__tests__/inventoryImportExport.test.ts
+++ b/apps/cms/__tests__/inventoryImportExport.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+jest.setTimeout(20000);
+
 // Polyfill Response.json when missing
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: unknown, init?: ResponseInit) =>

--- a/apps/cms/__tests__/publishLocationsRoute.test.ts
+++ b/apps/cms/__tests__/publishLocationsRoute.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+jest.setTimeout(20000);
+
 // NextResponse.json relies on the static Response.json API, which cross-fetch
 // does not provide. Polyfill it when missing.
 if (typeof (Response as any).json !== "function") {

--- a/apps/cms/__tests__/shops.test.ts
+++ b/apps/cms/__tests__/shops.test.ts
@@ -40,7 +40,7 @@ describe("shop actions", () => {
             name: "Seed",
             catalogFilters: [],
             themeId: "base",
-            themeTokens: {},
+            themeOverrides: {},
             filterMappings: {},
             priceOverrides: {},
             localeOverrides: {},

--- a/apps/cms/jest.setup.tsx
+++ b/apps/cms/jest.setup.tsx
@@ -14,6 +14,9 @@ import { TextDecoder, TextEncoder } from "node:util";
 Object.assign(process.env, {
   NODE_ENV: "test", // make it explicit
   NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET ?? "test-secret",
+  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY ?? "sk_test",
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "pk_test",
 });
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/src/actions/schemas.d.ts
+++ b/apps/cms/src/actions/schemas.d.ts
@@ -21,6 +21,7 @@ export declare const shopSchema: z.ZodObject<{
     name: z.ZodString;
     themeId: z.ZodString;
     catalogFilters: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, string[], string | undefined>;
+    themeOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
     themeTokens: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
     filterMappings: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
     priceOverrides: z.ZodEffects<z.ZodDefault<z.ZodOptional<z.ZodString>>, Record<string, unknown>, string | undefined>;
@@ -30,6 +31,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     themeId: string;
     catalogFilters: string[];
+    themeOverrides?: Record<string, unknown>;
     themeTokens?: Record<string, unknown>;
     filterMappings?: Record<string, unknown>;
     priceOverrides?: Record<string, unknown>;
@@ -39,6 +41,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     themeId: string;
     catalogFilters?: string | undefined;
+    themeOverrides?: string | undefined;
     themeTokens?: string | undefined;
     filterMappings?: string | undefined;
     priceOverrides?: string | undefined;

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -41,6 +41,7 @@ export const shopSchema = z
           .map((v) => v.trim())
           .filter(Boolean)
       ),
+    themeOverrides: jsonRecord,
     themeTokens: jsonRecord,
     filterMappings: jsonRecord,
     priceOverrides: jsonRecord,

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -3,7 +3,7 @@
   "name": "abc",
   "catalogFilters": [],
   "themeId": "base",
-  "themeTokens": {},
+  "themeOverrides": {},
   "filterMappings": {},
   "priceOverrides": {},
   "localeOverrides": {},

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -3,7 +3,7 @@
   "name": "bcd",
   "catalogFilters": [],
   "themeId": "base",
-  "themeTokens": {},
+  "themeOverrides": {},
   "filterMappings": {},
   "priceOverrides": {},
   "localeOverrides": {},

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -3,7 +3,7 @@
   "name": "abc",
   "catalogFilters": [],
   "themeId": "base",
-  "themeTokens": {},
+  "themeOverrides": {},
   "filterMappings": {},
   "shippingProviders": ["ups"],
   "taxProviders": ["taxjar"],

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -3,7 +3,7 @@
   "name": "bcd",
   "catalogFilters": [],
   "themeId": "base",
-  "themeTokens": {},
+  "themeOverrides": {},
   "filterMappings": {},
   "shippingProviders": ["dhl"],
   "taxProviders": ["taxjar"],

--- a/packages/platform-core/__tests__/shops.test.ts
+++ b/packages/platform-core/__tests__/shops.test.ts
@@ -18,6 +18,7 @@ describe("sanity blog accessors", () => {
     name: "shop",
     catalogFilters: [],
     themeId: "base",
+    themeOverrides: {},
     themeTokens: {},
     filterMappings: {},
     priceOverrides: {},

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -11,7 +11,6 @@ import {
   type PreparedCreateShopOptions,
 } from "./createShop/schema";
 import { loadTokens } from "./createShop/themeUtils";
-
 /**
  * Create a new shop app and seed data.
  * Paths are resolved relative to the repository root.
@@ -24,14 +23,13 @@ export async function createShop(
   id = validateShopName(id);
 
   const prepared = prepareOptions(id, opts);
-  const themeTokens = loadTokens(prepared.theme);
 
   const shopData = {
     id,
     name: prepared.name,
     catalogFilters: [],
     themeId: prepared.theme,
-    themeTokens,
+    themeOverrides: {},
     filterMappings: {},
     priceOverrides: {},
     localeOverrides: {},

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -36,7 +36,7 @@ export function ensureTemplateExists(theme: string, template: string): string {
 export function writeFiles(
   id: string,
   options: PreparedCreateShopOptions,
-  themeTokens: Record<string, string>,
+  themeOverrides: Record<string, string>,
   templateApp: string,
   newApp: string,
   newData: string
@@ -107,7 +107,7 @@ export function writeFiles(
         contactInfo: options.contactInfo,
         catalogFilters: [],
         themeId: options.theme,
-        themeTokens,
+        themeOverrides,
         filterMappings: { ...defaultFilterMappings },
         type: options.type,
         paymentProviders: options.payment,

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -8,7 +8,7 @@ import { prisma } from "../db";
 import { defaultFilterMappings } from "../defaultFilterMappings";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "../dataRoot";
-import { loadThemeTokens } from "../themeTokens";
+import { loadTokens } from "../createShop";
 export {
   diffHistory,
   getShopSettings,
@@ -31,9 +31,10 @@ export async function readShop(shop: string): Promise<Shop> {
     const rec = await prisma.shop.findUnique({ where: { id: shop } });
     if (rec) {
       const data = shopSchema.parse(rec.data);
-      if (!data.themeTokens || Object.keys(data.themeTokens).length === 0) {
-        data.themeTokens = await loadThemeTokens(data.themeId);
-      }
+      data.themeTokens = {
+        ...loadTokens(data.themeId),
+        ...data.themeOverrides,
+      };
       if (!data.navigation) data.navigation = [];
       return data as Shop;
     }
@@ -44,12 +45,10 @@ export async function readShop(shop: string): Promise<Shop> {
     const buf = await fs.readFile(shopPath(shop), "utf8");
     const parsed = shopSchema.safeParse(JSON.parse(buf));
     if (parsed.success && parsed.data.id) {
-      if (
-        !parsed.data.themeTokens ||
-        Object.keys(parsed.data.themeTokens).length === 0
-      ) {
-        parsed.data.themeTokens = await loadThemeTokens(parsed.data.themeId);
-      }
+      parsed.data.themeTokens = {
+        ...loadTokens(parsed.data.themeId),
+        ...parsed.data.themeOverrides,
+      };
       if (!parsed.data.navigation) parsed.data.navigation = [];
       return parsed.data as Shop;
     }
@@ -63,7 +62,8 @@ export async function readShop(shop: string): Promise<Shop> {
     name: shop,
     catalogFilters: [],
     themeId,
-    themeTokens: await loadThemeTokens(themeId),
+    themeOverrides: {},
+    themeTokens: loadTokens(themeId),
     filterMappings: { ...defaultFilterMappings },
     priceOverrides: {},
     localeOverrides: {},

--- a/packages/platform-core/src/repositories/shops/schema.json
+++ b/packages/platform-core/src/repositories/shops/schema.json
@@ -8,7 +8,7 @@
     "name",
     "catalogFilters",
     "themeId",
-    "themeTokens",
+    "themeOverrides",
     "filterMappings",
     "priceOverrides",
     "localeOverrides"
@@ -21,6 +21,10 @@
       "items": { "type": "string" }
     },
     "themeId": { "type": "string" },
+    "themeOverrides": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
     "themeTokens": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -82,8 +82,10 @@ export declare const shopSchema: z.ZodObject<{
     contactInfo: z.ZodOptional<z.ZodString>;
     catalogFilters: z.ZodArray<z.ZodString, "many">;
     themeId: z.ZodString;
-    /** Mapping of design tokens to theme values */
-    themeTokens: z.ZodRecord<z.ZodString, z.ZodString>;
+    /** Mapping of token overrides to theme values */
+    themeOverrides: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodString>>;
+    /** Mapping of design tokens to theme values (computed) */
+    themeTokens: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodString>>;
     /** Mapping of logical filter keys to catalog attributes */
     filterMappings: z.ZodRecord<z.ZodString, z.ZodString>;
     /** Optional price overrides per locale (minor units) */
@@ -113,6 +115,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     catalogFilters: string[];
     themeId: string;
+    themeOverrides: Record<string, string>;
     themeTokens: Record<string, string>;
     filterMappings: Record<string, string>;
     priceOverrides: Partial<Record<"en" | "de" | "it", number>>;
@@ -136,6 +139,7 @@ export declare const shopSchema: z.ZodObject<{
     name: string;
     catalogFilters: string[];
     themeId: string;
+    themeOverrides: Record<string, string>;
     themeTokens: Record<string, string>;
     filterMappings: Record<string, string>;
     type?: string | undefined;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -50,8 +50,10 @@ export const shopSchema = z.object({
   contactInfo: z.string().optional(),
   catalogFilters: z.array(z.string()),
   themeId: z.string(),
-  /** Mapping of design tokens to theme values */
-  themeTokens: z.record(z.string()),
+  /** Mapping of token overrides to theme values */
+  themeOverrides: z.record(z.string()).default({}),
+  /** Mapping of design tokens to theme values (computed) */
+  themeTokens: z.record(z.string()).default({}),
   /** Mapping of logical filter keys to catalog attributes */
   filterMappings: z.record(z.string()),
   /** Optional price overrides per locale (minor units) */


### PR DESCRIPTION
## Summary
- add `themeOverrides` field to Shop types and schemas
- compute `themeTokens` from theme overrides and base theme tokens
- persist overrides instead of merged token map

## Testing
- `pnpm --filter "@apps/cms" test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*

------
https://chatgpt.com/codex/tasks/task_e_689a2a1dae00832fb5ee708ead8ffcac