### PR TITLE
chore: secure cart cookie

### DIFF
--- a/packages/platform-core/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/__tests__/cartCookie.test.ts
@@ -22,7 +22,7 @@ describe("cart cookie helpers", () => {
     const encoded = "value";
 
     expect(asSetCookieHeader(encoded)).toBe(
-      `${CART_COOKIE}=${encoded}; Path=/; Max-Age=${60 * 60 * 24 * 30}; SameSite=Lax; Secure; HttpOnly`
+      `${CART_COOKIE}=${encoded}; Path=/; Max-Age=${60 * 60 * 24 * 30}; SameSite=Strict; Secure; HttpOnly`
     );
   });
 });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -7,7 +7,7 @@ import { skuSchema } from "@types";
 /* ------------------------------------------------------------------
  * Cookie constants
  * ------------------------------------------------------------------ */
-export const CART_COOKIE = "CART_ID";
+export const CART_COOKIE = "__Host-CART_ID";
 const MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 const SECRET = process.env.CART_COOKIE_SECRET;
 
@@ -76,6 +76,5 @@ export function decodeCartCookie(raw?: string | null): string | null {
 
 /** Build the Set-Cookie header value for HTTP responses. */
 export function asSetCookieHeader(value: string): string {
-  // NOTE: Consider signing or encrypting the cookie value to prevent tampering.
-  return `${CART_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE}; SameSite=Lax; Secure; HttpOnly`;
+  return `${CART_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE}; SameSite=Strict; Secure; HttpOnly`;
 }


### PR DESCRIPTION
## Summary
- use __Host-CART_ID for cart cookie
- set cart cookie with SameSite=Strict, Secure, HttpOnly
- ensure cart API routes set cookie with helper

## Testing
- `pnpm exec jest packages/platform-core/__tests__/cartCookie.test.ts --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_689a2a56f3a4832fb004162907467006