### PR TITLE
feat: add countdown timer block

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -139,6 +139,14 @@ export interface FAQBlockComponent extends PageComponentBase {
   items?: { question: string; answer: string }[];
 }
 
+export interface CountdownTimerComponent extends PageComponentBase {
+  type: "CountdownTimer";
+  targetDate?: string;
+  timezone?: string;
+  completionText?: string;
+  styles?: string;
+}
+
 export interface ImageComponent extends PageComponentBase {
   type: "Image";
   src?: string;
@@ -192,6 +200,7 @@ export type PageComponent =
   | MapBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
+  | CountdownTimerComponent
   | BlogListingComponent
   | TestimonialsComponent
   | TestimonialSliderComponent
@@ -308,6 +317,14 @@ const faqBlockComponentSchema = baseComponentSchema.extend({
     .optional(),
 });
 
+const countdownTimerComponentSchema = baseComponentSchema.extend({
+  type: z.literal("CountdownTimer"),
+  targetDate: z.string().optional(),
+  timezone: z.string().optional(),
+  completionText: z.string().optional(),
+  styles: z.string().optional(),
+});
+
 const headerComponentSchema = baseComponentSchema.extend({
   type: z.literal("Header"),
   nav: z
@@ -391,6 +408,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     mapBlockComponentSchema,
     videoBlockComponentSchema,
     faqBlockComponentSchema,
+    countdownTimerComponentSchema,
     headerComponentSchema,
     footerComponentSchema,
     blogListingComponentSchema,

--- a/packages/ui/src/components/cms/blocks/CountdownTimer.tsx
+++ b/packages/ui/src/components/cms/blocks/CountdownTimer.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+interface Props {
+  targetDate?: string;
+  timezone?: string;
+  completionText?: string;
+  styles?: string;
+  children?: React.ReactNode;
+}
+
+function getTargetDate(targetDate?: string, timezone?: string) {
+  if (!targetDate) return null;
+  const date = new Date(targetDate);
+  if (Number.isNaN(date.getTime())) return null;
+  if (timezone) {
+    const localized = new Date(date.toLocaleString("en-US", { timeZone: timezone }));
+    return localized;
+  }
+  return date;
+}
+
+export default function CountdownTimer({
+  targetDate,
+  timezone,
+  completionText,
+  styles,
+}: Props) {
+  const target = getTargetDate(targetDate, timezone);
+  const [remaining, setRemaining] = useState(() =>
+    target ? target.getTime() - Date.now() : 0
+  );
+
+  useEffect(() => {
+    if (!target) return;
+    const tick = () => {
+      setRemaining(target.getTime() - Date.now());
+    };
+    const id = setInterval(tick, 1000);
+    tick();
+    return () => clearInterval(id);
+  }, [targetDate, timezone]);
+
+  if (!target) return null;
+
+  if (remaining <= 0) {
+    return completionText ? <div className={styles}>{completionText}</div> : null;
+  }
+
+  const totalSeconds = Math.floor(remaining / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts = [] as string[];
+  if (days) parts.push(`${days}d`);
+  if (days || hours) parts.push(`${hours}h`);
+  if (days || hours || minutes) parts.push(`${minutes}m`);
+  parts.push(`${seconds}s`);
+
+  return <div className={styles}>{parts.join(" ")}</div>;
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -18,6 +18,7 @@ import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import Header from "./HeaderBlock";
 import Footer from "./FooterBlock";
+import CountdownTimer from "./CountdownTimer";
 
 export {
   BlogListing,
@@ -38,6 +39,7 @@ export {
   MultiColumn,
   VideoBlock,
   FAQBlock,
+  CountdownTimer,
   Header,
   Footer,
 };

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -14,6 +14,7 @@ import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
+import CountdownTimer from "./CountdownTimer";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -32,6 +33,7 @@ export const organismRegistry = {
   MapBlock,
   VideoBlock,
   FAQBlock,
+  CountdownTimer,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -91,6 +91,33 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "FAQBlock":
       specific = <FAQBlockEditor component={component} onChange={onChange} />;
       break;
+    case "CountdownTimer":
+      specific = (
+        <>
+          <Input
+            label="Target Date"
+            type="datetime-local"
+            value={(component as any).targetDate ?? ""}
+            onChange={(e) => handleInput("targetDate", e.target.value)}
+          />
+          <Input
+            label="Timezone"
+            value={(component as any).timezone ?? ""}
+            onChange={(e) => handleInput("timezone", e.target.value)}
+          />
+          <Input
+            label="Completion Text"
+            value={(component as any).completionText ?? ""}
+            onChange={(e) => handleInput("completionText", e.target.value)}
+          />
+          <Input
+            label="Styles"
+            value={(component as any).styles ?? ""}
+            onChange={(e) => handleInput("styles", e.target.value)}
+          />
+        </>
+      );
+      break;
     case "Header":
       specific = <HeaderEditor component={component} onChange={onChange} />;
       break;


### PR DESCRIPTION
## Summary
- add CountdownTimer block with target date, timezone and completion text
- expose timer in block registry and palette
- allow editing timer properties in ComponentEditor

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689a349c5494832f9f7caa9042272474