### PR TITLE
refactor: use @acme/lib package

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/page.tsx
@@ -1,4 +1,4 @@
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import { readInventory } from "@platform-core/repositories/inventory.server";
 import { notFound } from "next/navigation";
 import InventoryForm from "./InventoryForm";

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/page.tsx
@@ -1,4 +1,4 @@
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import { readPricing } from "@platform-core/repositories/pricing.server";
 import { notFound } from "next/navigation";
 import PricingForm from "./PricingForm";

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
@@ -1,4 +1,4 @@
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import { readReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
 import { notFound } from "next/navigation";
 import ReturnLogisticsForm from "./ReturnLogisticsForm";

--- a/apps/cms/src/app/cms/shop/[shop]/media/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/media/page.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/media/page.tsx
 
 import { deleteMedia, listMedia } from "@cms/actions/media.server";
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import MediaManager from "@ui/components/cms/MediaManager";
 import { notFound } from "next/navigation";
 

--- a/apps/cms/src/app/cms/shop/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/shop/[shop]/page.tsx
 
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 

--- a/apps/cms/src/app/cms/shop/[shop]/pages/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/page.tsx
@@ -2,7 +2,7 @@
 
 import { canWrite } from "@auth";
 import { authOptions } from "@cms/auth/options";
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { getServerSession } from "next-auth";
 import { notFound } from "next/navigation";

--- a/apps/cms/src/app/cms/shop/[shop]/products/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/products/page.tsx
@@ -7,7 +7,7 @@ import {
   duplicateProduct,
 } from "@cms/actions/products.server";
 import { authOptions } from "@cms/auth/options";
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import type { ProductPublication } from "@platform-core/products";
 import { readRepo } from "@platform-core/repositories/json.server";
 import ProductsTable from "@ui/components/cms/ProductsTable.client";

--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
 
 import { authOptions } from "@cms/auth/options";
-import { checkShopExists } from "@lib/checkShopExists.server";
+import { checkShopExists } from "@acme/lib";
 import {
   readSettings,
   readShop,

--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/layout.tsx
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
-import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
+import { applyFriendlyZodMessages } from "@acme/lib";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 

--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -82,7 +82,7 @@ beforeAll(async () => {
   ({ POST: completePOST } = await import(
     "../src/app/api/account/reset/complete/route"
   ));
-  ({ sendEmail } = await import("@lib/email"));
+  ({ sendEmail } = await import("@acme/email"));
 });
 
 function makeRequest(body: any, headers: Record<string, string> = {}) {

--- a/apps/shop-abc/src/app/layout.js
+++ b/apps/shop-abc/src/app/layout.js
@@ -2,7 +2,7 @@ import { jsx as _jsx } from "react/jsx-runtime";
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
+import { applyFriendlyZodMessages } from "@acme/lib";
 import { Geist, Geist_Mono } from "next/font/google";
 applyFriendlyZodMessages();
 const geistSans = Geist({

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -2,7 +2,7 @@
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
-import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
+import { applyFriendlyZodMessages } from "@acme/lib";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 

--- a/apps/shop-bcd/src/app/layout.js
+++ b/apps/shop-bcd/src/app/layout.js
@@ -2,7 +2,7 @@ import { jsx as _jsx } from "react/jsx-runtime";
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
+import { applyFriendlyZodMessages } from "@acme/lib";
 import { Geist, Geist_Mono } from "next/font/google";
 applyFriendlyZodMessages();
 const geistSans = Geist({

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -2,7 +2,7 @@
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
-import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
+import { applyFriendlyZodMessages } from "@acme/lib";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { applyFriendlyZodMessages } from "@lib/zodErrorMap";
+import { applyFriendlyZodMessages } from "@acme/lib";
 
 export const envSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -3,6 +3,12 @@
   "private": true,
   "type": "module",
   "version": "0.0.0",
+  "exports": {
+    ".": "./src/index.ts",
+    "./validateShopName": "./src/validateShopName.ts",
+    "./checkShopExists.server": "./src/checkShopExists.server.ts",
+    "./zodErrorMap": "./src/zodErrorMap.ts"
+  },
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,0 +1,3 @@
+export { SHOP_NAME_RE, validateShopName } from "./validateShopName";
+export { checkShopExists } from "./checkShopExists.server";
+export { applyFriendlyZodMessages, friendlyErrorMap } from "./zodErrorMap";

--- a/packages/platform-core/src/shops.ts
+++ b/packages/platform-core/src/shops.ts
@@ -1,5 +1,5 @@
 import type { Shop, SanityBlogConfig, ShopDomain } from "@acme/types";
-export { SHOP_NAME_RE, validateShopName } from "../../lib/src/validateShopName";
+export { SHOP_NAME_RE, validateShopName } from "@acme/lib";
 
 export function getSanityConfig(shop: Shop): SanityBlogConfig | undefined {
   return shop.sanityBlog;

--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -34,7 +34,8 @@
       "@platform-core/*": ["packages/platform-core/src/*"],
 
       /* shared lib utilities */
-      "@lib/*": ["packages/lib/*"]
+      "@acme/lib": ["packages/lib/src/index.ts"],
+      "@acme/lib/*": ["packages/lib/src/*"]
     }
   },
 

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -10,7 +10,7 @@ if (!shopId) {
   process.exit(1);
 }
 
-const envPath = join("apps", `shop-${shopId}", ".env");
+const envPath = join("apps", `shop-${shopId}`, ".env");
 
 if (!existsSync(envPath)) {
   console.error(`Missing ${envPath}`);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -57,21 +57,19 @@
       "@/components/shop/*": ["packages/platform-core/src/components/shop/*"],
 
       /* ─── lib helpers (products, cookies, …) ────────────── */
-      "@lib/*": ["packages/platform-core/src/*", "packages/lib/src/*"],
+      "@lib/*": ["packages/platform-core/src/*"],
 
       "@/lib/products": ["packages/platform-core/src/products.ts"],
       "@/lib/cartCookie": ["packages/platform-core/src/cartCookie.ts"],
-      "@/lib/*": ["packages/platform-core/src/*", "packages/lib/src/*"],
+      "@/lib/*": ["packages/platform-core/src/*"],
 
       /* ─── shared contexts ───────────────────────────────────────── */
-      "@contexts/*": [
-        "packages/platform-core/src/contexts/*",
-        "packages/lib/src/contexts/*"
-      ],
-      "@/contexts/*": [
-        "packages/platform-core/src/contexts/*",
-        "packages/lib/src/contexts/*"
-      ],
+      "@contexts/*": ["packages/platform-core/src/contexts/*"],
+      "@/contexts/*": ["packages/platform-core/src/contexts/*"],
+
+      /* ─── shared lib package ─────────────────────────────────────── */
+      "@acme/lib": ["packages/lib/src/index.ts"],
+      "@acme/lib/*": ["packages/lib/src/*"],
 
       /* ─── i18n ──────────────────────────────────────────────────── */
       "@i18n/*": ["packages/i18n/src/*"],

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -15,7 +15,6 @@
     { "path": "packages/platform-core" },
     { "path": "packages/platform-machine" },
     { "path": "packages/lib" },
-    { "path": "packages/lib/email" },
     { "path": "packages/themes/base" },
     { "path": "packages/themes/abc" },
     { "path": "packages/themes/bcd" },


### PR DESCRIPTION
## Summary
- export shared helpers from @acme/lib via index and package.json exports
- replace relative @lib imports with @acme/lib package imports
- add TypeScript path aliases for @acme/lib

## Testing
- `pnpm run typecheck` *(fails: File '/workspace/base-shop/packages/shared-utils/src/parseJsonBody.ts' is not under 'rootDir' '/workspace/base-shop/apps/shop-bcd'...)*

------
https://chatgpt.com/codex/tasks/task_e_689a35b39654832faf20aedcf0d5ca41