### PR TITLE
feat: add social links block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -62,6 +62,15 @@ export interface FooterComponent extends PageComponentBase {
   }[];
   logo?: string;
 }
+
+export interface SocialLinksComponent extends PageComponentBase {
+  type: "SocialLinks";
+  facebook?: string;
+  instagram?: string;
+  x?: string;
+  youtube?: string;
+  linkedin?: string;
+}
 export interface AnnouncementBarComponent extends PageComponentBase {
   type: "AnnouncementBar";
   text?: string;
@@ -203,6 +212,7 @@ export type PageComponent =
   | TextComponent
   | HeaderComponent
   | FooterComponent
+  | SocialLinksComponent
   | SectionComponent
   | MultiColumnComponent;
 export declare const pageSchema: z.ZodObject<

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -66,6 +66,15 @@ export interface FooterComponent extends PageComponentBase {
   logo?: string;
 }
 
+export interface SocialLinksComponent extends PageComponentBase {
+  type: "SocialLinks";
+  facebook?: string;
+  instagram?: string;
+  x?: string;
+  youtube?: string;
+  linkedin?: string;
+}
+
 export interface AnnouncementBarComponent extends PageComponentBase {
   type: "AnnouncementBar";
   text?: string;
@@ -208,6 +217,7 @@ export type PageComponent =
   | TextComponent
   | HeaderComponent
   | FooterComponent
+  | SocialLinksComponent
   | SectionComponent
   | MultiColumnComponent;
 
@@ -341,6 +351,15 @@ const footerComponentSchema = baseComponentSchema.extend({
   logo: z.string().optional(),
 });
 
+const socialLinksComponentSchema = baseComponentSchema.extend({
+  type: z.literal("SocialLinks"),
+  facebook: z.string().optional(),
+  instagram: z.string().optional(),
+  x: z.string().optional(),
+  youtube: z.string().optional(),
+  linkedin: z.string().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -411,6 +430,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     countdownTimerComponentSchema,
     headerComponentSchema,
     footerComponentSchema,
+    socialLinksComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,

--- a/packages/ui/src/components/cms/blocks/SocialLinks.tsx
+++ b/packages/ui/src/components/cms/blocks/SocialLinks.tsx
@@ -1,0 +1,101 @@
+import { cn } from "../../utils/style";
+import React from "react";
+
+export interface SocialLinksProps extends React.HTMLAttributes<HTMLDivElement> {
+  facebook?: string;
+  instagram?: string;
+  x?: string;
+  youtube?: string;
+  linkedin?: string;
+}
+
+const icons = {
+  facebook: (
+    <svg
+      viewBox="0 0 512 512"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <path d="M512 256C512 114.6 397.4 0 256 0S0 114.6 0 256C0 376 82.7 476.8 194.2 504.5V334.2H141.4V256h52.8V222.3c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V172c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V256h83.6l-14.4 78.2H287V510.1C413.8 494.8 512 386.9 512 256z" />
+    </svg>
+  ),
+  instagram: (
+    <svg
+      viewBox="0 0 448 512"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <path d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z" />
+    </svg>
+  ),
+  x: (
+    <svg
+      viewBox="0 0 512 512"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z" />
+    </svg>
+  ),
+  youtube: (
+    <svg
+      viewBox="0 0 576 512"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <path d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zM232.145 337.591V175.185l142.739 81.205-142.739 81.201z" />
+    </svg>
+  ),
+  linkedin: (
+    <svg
+      viewBox="0 0 448 512"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z" />
+    </svg>
+  ),
+} as const;
+
+export default function SocialLinks({
+  facebook,
+  instagram,
+  x,
+  youtube,
+  linkedin,
+  className,
+  ...rest
+}: SocialLinksProps) {
+  const items = [
+    { href: facebook, icon: icons.facebook, name: "facebook" },
+    { href: instagram, icon: icons.instagram, name: "instagram" },
+    { href: x, icon: icons.x, name: "x" },
+    { href: youtube, icon: icons.youtube, name: "youtube" },
+    { href: linkedin, icon: icons.linkedin, name: "linkedin" },
+  ].filter((l) => l.href);
+
+  if (!items.length) return null;
+
+  return (
+    <div className={cn("flex gap-4", className)} {...rest}>
+      {items.map((l) => (
+        <a
+          key={l.name}
+          href={l.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={l.name}
+          className="text-current hover:opacity-80"
+        >
+          {l.icon}
+        </a>
+      ))}
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -19,6 +19,7 @@ import FAQBlock from "./FAQBlock";
 import Header from "./HeaderBlock";
 import Footer from "./FooterBlock";
 import CountdownTimer from "./CountdownTimer";
+import SocialLinks from "./SocialLinks";
 
 export {
   BlogListing,
@@ -42,6 +43,7 @@ export {
   CountdownTimer,
   Header,
   Footer,
+  SocialLinks,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -15,6 +15,7 @@ import MapBlock from "./MapBlock";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import CountdownTimer from "./CountdownTimer";
+import SocialLinks from "./SocialLinks";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -34,6 +35,7 @@ export const organismRegistry = {
   VideoBlock,
   FAQBlock,
   CountdownTimer,
+  SocialLinks,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -118,6 +118,37 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
         </>
       );
       break;
+    case "SocialLinks":
+      specific = (
+        <>
+          <Input
+            label="Facebook URL"
+            value={(component as any).facebook ?? ""}
+            onChange={(e) => handleInput("facebook", e.target.value)}
+          />
+          <Input
+            label="Instagram URL"
+            value={(component as any).instagram ?? ""}
+            onChange={(e) => handleInput("instagram", e.target.value)}
+          />
+          <Input
+            label="X URL"
+            value={(component as any).x ?? ""}
+            onChange={(e) => handleInput("x", e.target.value)}
+          />
+          <Input
+            label="YouTube URL"
+            value={(component as any).youtube ?? ""}
+            onChange={(e) => handleInput("youtube", e.target.value)}
+          />
+          <Input
+            label="LinkedIn URL"
+            value={(component as any).linkedin ?? ""}
+            onChange={(e) => handleInput("linkedin", e.target.value)}
+          />
+        </>
+      );
+      break;
     case "Header":
       specific = <HeaderEditor component={component} onChange={onChange} />;
       break;


### PR DESCRIPTION
## Summary
- add SocialLinks block with configurable URLs and inline SVG icons
- expose SocialLinks through block registry and component editor
- extend page component types and schemas to support SocialLinks

## Testing
- `pnpm test` *(fails: turbo: not found; missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_689a38c5fa9c832fb21747de556c41bb