### PR TITLE
feat: add step status tracking

### DIFF
--- a/apps/cms/__tests__/dashboardSkip.integration.test.tsx
+++ b/apps/cms/__tests__/dashboardSkip.integration.test.tsx
@@ -57,7 +57,7 @@ declare global {
   var fetch: jest.Mock;
 }
 
-let serverState: { state: any; completed: Record<string, boolean> };
+let serverState: { state: any; completed: Record<string, string> };
 let originalAddEventListener: any;
 
 beforeEach(() => {
@@ -66,7 +66,7 @@ beforeEach(() => {
   const required = getRequiredSteps();
   serverState = {
     state: { shopId: "shop" },
-    completed: Object.fromEntries(required.map((s) => [s.id, true])),
+    completed: Object.fromEntries(required.map((s) => [s.id, "complete"])),
   };
   global.fetch = jest.fn((url: string, init?: RequestInit) => {
     if (url === "/cms/api/wizard-progress") {
@@ -108,12 +108,12 @@ test("skipped optional steps do not block Launch Shop", async () => {
   stepLabel = await screen.findByText(optional.label);
   const resetBtn = within(stepLabel.closest("li")!).getByRole("button", { name: /reset/i });
   const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
-  expect(stored.completed?.[optional.id]).toBe(true);
+  expect(stored.completed?.[optional.id]).toBe("skipped");
   expect(launchBtn).toBeEnabled();
 
   fireEvent.click(resetBtn);
   await screen.findByRole("button", { name: /skip/i });
   const stored2 = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
-  expect(stored2.completed?.[optional.id]).toBe(false);
+  expect(stored2.completed?.[optional.id]).toBe("pending");
   expect(launchBtn).toBeEnabled();
 });

--- a/apps/cms/__tests__/wizard-flow.integration.test.tsx
+++ b/apps/cms/__tests__/wizard-flow.integration.test.tsx
@@ -89,7 +89,7 @@ describe("Wizard locale flow", () => {
       serverState = {
         state: { shopId: "shop" },
         completed: Object.fromEntries(
-          steps.slice(0, summaryIndex).map((s) => [s.id, true])
+          steps.slice(0, summaryIndex).map((s) => [s.id, "complete"])
         ),
       };
     const { unmount } = render(

--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -53,7 +53,7 @@ export default function ConfiguratorDashboard() {
   const markStepComplete = useWizardPersistence(state, setState);
   const stepList = useMemo(() => getSteps(), []);
   const missingRequired = getRequiredSteps().filter(
-    (s) => !state?.completed?.[s.id]
+    (s) => state?.completed?.[s.id] !== "complete"
   );
   const allRequiredDone = missingRequired.length === 0;
   const tooltipText = allRequiredDone
@@ -62,8 +62,8 @@ export default function ConfiguratorDashboard() {
         .map((s) => s.label)
         .join(", ")}`;
 
-  const skipStep = (stepId: string) => markStepComplete(stepId, true);
-  const resetStep = (stepId: string) => markStepComplete(stepId, false);
+  const skipStep = (stepId: string) => markStepComplete(stepId, "skipped");
+  const resetStep = (stepId: string) => markStepComplete(stepId, "pending");
 
   const launchShop = async () => {
     if (!state?.shopId) return;
@@ -127,7 +127,8 @@ export default function ConfiguratorDashboard() {
         {stepList
           .filter((s) => !s.optional)
           .map((step) => {
-            const completed = Boolean(state?.completed?.[step.id]);
+            const status = state?.completed?.[step.id];
+            const completed = status === "complete";
             return (
               <li key={step.id} className="flex items-center gap-2">
                 {completed ? (
@@ -166,7 +167,9 @@ export default function ConfiguratorDashboard() {
             {stepList
               .filter((s) => s.optional)
               .map((step) => {
-                const completed = Boolean(state?.completed?.[step.id]);
+                const status = state?.completed?.[step.id];
+                const completed = status === "complete";
+                const skipped = status === "skipped";
                 return (
                   <li key={step.id} className="flex items-center gap-2">
                     {completed ? (
@@ -186,9 +189,9 @@ export default function ConfiguratorDashboard() {
                       </span>
                     </div>
                     <span className="text-xs text-gray-500">
-                      {completed ? "Done" : "Pending"}
+                      {completed ? "Done" : skipped ? "Skipped" : "Pending"}
                     </span>
-                    {completed ? (
+                    {completed || skipped ? (
                       <button
                         type="button"
                         onClick={() => resetStep(step.id)}

--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -18,7 +18,9 @@ export default function StepPage({ stepId }: Props) {
   }
 
   const prerequisites = step.prerequisites ?? [];
-  const missingPrereq = prerequisites.find((id) => !state.completed[id]);
+  const missingPrereq = prerequisites.find(
+    (id) => state.completed[id] !== "complete"
+  );
 
   useEffect(() => {
     if (missingPrereq) {

--- a/apps/cms/src/app/cms/wizard/WizardContext.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardContext.tsx
@@ -2,14 +2,18 @@
 "use client";
 
 import React, { createContext, useContext, useState } from "react";
-import { wizardStateSchema, type WizardState } from "./schema";
+import {
+  wizardStateSchema,
+  type WizardState,
+  type StepStatus,
+} from "./schema";
 import { useWizardPersistence } from "./hooks/useWizardPersistence";
 
 interface WizardContextValue {
   state: WizardState;
   setState: React.Dispatch<React.SetStateAction<WizardState>>;
   update: <K extends keyof WizardState>(key: K, value: WizardState[K]) => void;
-  markStepComplete: (stepId: string, status: boolean) => void;
+  markStepComplete: (stepId: string, status: StepStatus) => void;
 }
 
 const WizardContext = createContext<WizardContextValue | null>(null);

--- a/apps/cms/src/app/cms/wizard/hooks/useStepCompletion.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useStepCompletion.ts
@@ -11,10 +11,10 @@ const validators: Record<string, Validator> = {
 export function useStepCompletion(stepId: string): [boolean, (v: boolean) => void] {
   const { state, markStepComplete } = useWizard();
   const validate = validators[stepId] ?? (() => true);
-  const completed = (state.completed[stepId] ?? false) && validate(state);
+  const completed = state.completed[stepId] === "complete" && validate(state);
   const setCompleted = (v: boolean) => {
     if (v && !validate(state)) return;
-    markStepComplete(stepId, v);
+    markStepComplete(stepId, v ? "complete" : "pending");
   };
   return [completed, setCompleted];
 }

--- a/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts
@@ -2,7 +2,11 @@
 "use client";
 
 import { useEffect } from "react";
-import { wizardStateSchema, type WizardState } from "../schema";
+import {
+  wizardStateSchema,
+  type WizardState,
+  type StepStatus,
+} from "../schema";
 
 /** Key used to mirror wizard progress in localStorage for preview components. */
 export const STORAGE_KEY = "cms-wizard-progress";
@@ -31,7 +35,7 @@ export function useWizardPersistence(
   state: WizardState,
   setState: (s: WizardState) => void,
   onInvalid?: () => void
-): (stepId: string, status: boolean) => void {
+): (stepId: string, status: StepStatus) => void {
   /* Load persisted state on mount */
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -81,7 +85,7 @@ export function useWizardPersistence(
   }, [state]);
 
   /* Expose completion helper */
-  const markStepComplete = (stepId: string, status: boolean) => {
+  const markStepComplete = (stepId: string, status: StepStatus) => {
     let updated: WizardState | null = null;
     setState((prev) => {
       updated = {

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -68,6 +68,9 @@ export type PageInfo = z.infer<typeof pageInfoSchema>; // <- slug & components *
 /*  Wizard‑state schema                                                       */
 /* -------------------------------------------------------------------------- */
 
+export const stepStatusSchema = z.enum(["pending", "complete", "skipped"]);
+export type StepStatus = z.infer<typeof stepStatusSchema>;
+
 export const wizardStateSchema = z.object({
   /* ------------ Wizard progress & identity ------------ */
   shopId: z.string().optional().default(""),
@@ -75,7 +78,7 @@ export const wizardStateSchema = z.object({
   logo: z.string().optional().default(""),
   contactInfo: z.string().optional().default(""),
   type: z.enum(["sale", "rental"]).optional().default("sale"),
-  completed: z.record(z.boolean()).optional().default({}),
+  completed: z.record(stepStatusSchema).optional().default({}),
 
   /* ---------------- Template / theme ------------------ */
   template: z.string().optional().default(""),


### PR DESCRIPTION
## Summary
- track wizard progress using explicit step statuses
- persist step status through API and adjust dashboard logic
- update tests for new status shape

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/wizard/hooks/useWizardPersistence.ts apps/cms/src/app/api/wizard-progress/route.ts`
- `pnpm test:cms` *(fails: Cannot find module '.prisma/client/index-browser' from '@prisma/client/index-browser.js')*


------
https://chatgpt.com/codex/tasks/task_e_689a376a60e0832f863ea702d34d2eb5