### PR TITLE
feat: add stock validation

### DIFF
--- a/apps/shop-abc/__tests__/cartApi.test.ts
+++ b/apps/shop-abc/__tests__/cartApi.test.ts
@@ -118,6 +118,26 @@ test("POST rejects negative or non-integer quantity", async () => {
   expect(res.status).toBe(400);
 });
 
+test("POST rejects out-of-stock items", async () => {
+  const sku = { ...TEST_SKU, id: "01ARZ3NDEKTSV4RRFFQ69G5FAA", stock: 0 };
+  jest.spyOn(productLib, "getProductById").mockReturnValue(undefined as any);
+  const size = sku.sizes[0];
+  const res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: 1, size })
+  );
+  expect(res.status).toBe(404);
+});
+
+test("POST rejects when requested quantity exceeds stock", async () => {
+  const sku = { ...TEST_SKU, id: "01ARZ3NDEKTSV4RRFFQ69G5FAB", stock: 2 };
+  jest.spyOn(productLib, "getProductById").mockReturnValue(sku as any);
+  const size = sku.sizes[0];
+  const res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: sku.stock + 1, size })
+  );
+  expect(res.status).toBe(409);
+});
+
 test("PATCH rejects negative or non-integer quantity", async () => {
   const sku = { ...TEST_SKU };
   const size = sku.sizes[0];

--- a/packages/platform-core/src/cartApi.ts
+++ b/packages/platform-core/src/cartApi.ts
@@ -12,7 +12,7 @@ import {
   setQty,
   removeItem,
 } from "@platform-core/src/cartStore";
-import { getProductById } from "@platform-core/src/products";
+import { getProductById, PRODUCTS } from "@platform-core/src/products";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { postSchema, patchSchema } from "@platform-core/schemas/cart";
@@ -41,9 +41,11 @@ export async function POST(req: NextRequest) {
     size,
   } = parsed.data;
   const sku = getProductById(skuId);
-
   if (!sku) {
-    return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    const exists = PRODUCTS.some((p) => p.id === skuId);
+    const status = exists ? 409 : 404;
+    const error = exists ? "Out of stock" : "Item not found";
+    return NextResponse.json({ error }, { status });
   }
 
   if (sku.sizes.length && !size) {
@@ -54,8 +56,15 @@ export async function POST(req: NextRequest) {
   if (!cartId) {
     cartId = await createCart();
   }
-  const cart = await incrementQty(cartId, sku, qty, size);
-  const res = NextResponse.json({ ok: true, cart });
+  const cart = await getCart(cartId);
+  const id = size ? `${sku.id}:${size}` : sku.id;
+  const line = cart[id];
+  const newQty = (line?.qty ?? 0) + qty;
+  if (newQty > sku.stock) {
+    return NextResponse.json({ error: "Insufficient stock" }, { status: 409 });
+  }
+  const updated = await incrementQty(cartId, sku, qty, size);
+  const res = NextResponse.json({ ok: true, cart: updated });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;
 }

--- a/packages/platform-core/src/products.ts
+++ b/packages/platform-core/src/products.ts
@@ -16,6 +16,7 @@ export const PRODUCTS: readonly SKU[] = [
     title: "Eco Runner — Green",
     price: 119,
     deposit: 50,
+    stock: 5,
     forSale: true,
     forRental: false,
     image: "/shop/green.jpg",
@@ -29,6 +30,7 @@ export const PRODUCTS: readonly SKU[] = [
     title: "Eco Runner — Sand",
     price: 119,
     deposit: 50,
+    stock: 2,
     forSale: true,
     forRental: false,
     image: "/shop/sand.jpg",
@@ -42,6 +44,7 @@ export const PRODUCTS: readonly SKU[] = [
     title: "Eco Runner — Black",
     price: 119,
     deposit: 50,
+    stock: 0,
     forSale: true,
     forRental: false,
     image: "/shop/black.jpg",
@@ -58,7 +61,8 @@ export function getProductBySlug(slug: string): SKU | undefined {
 
 /** Lookup a product by SKU id */
 export function getProductById(id: string): SKU | undefined {
-  return PRODUCTS.find((p) => p.id === id);
+  const sku = PRODUCTS.find((p) => p.id === id);
+  return sku && sku.stock > 0 ? sku : undefined;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/types/src/Product.d.ts
+++ b/packages/types/src/Product.d.ts
@@ -11,6 +11,8 @@ export declare const skuSchema: z.ZodObject<{
     price: z.ZodNumber;
     /** Refundable deposit, required by business rules */
     deposit: z.ZodNumber;
+    /** Available stock count */
+    stock: z.ZodNumber;
     /** Item can be sold */
     forSale: z.ZodDefault<z.ZodBoolean>;
     /** Item can be rented */
@@ -41,6 +43,7 @@ export declare const skuSchema: z.ZodObject<{
     title: string;
     price: number;
     deposit: number;
+    stock: number;
     forSale: boolean;
     forRental: boolean;
     image: string;
@@ -59,6 +62,7 @@ export declare const skuSchema: z.ZodObject<{
     title: string;
     price: number;
     deposit: number;
+    stock: number;
     image: string;
     sizes: string[];
     description: string;

--- a/packages/types/src/Product.ts
+++ b/packages/types/src/Product.ts
@@ -14,6 +14,8 @@ export const skuSchema = z.object({
   price: z.number().int().nonnegative(),
   /** Refundable deposit, required by business rules */
   deposit: z.number().int().nonnegative(),
+  /** Available stock count */
+  stock: z.number().int().nonnegative(),
   /** Item can be sold */
   forSale: z.boolean().default(true),
   /** Item can be rented */


### PR DESCRIPTION
## Summary
- include stock in SKU type and sample products
- enforce stock checks in product lookup and cart API
- test out-of-stock and insufficient stock scenarios

## Testing
- `npx jest apps/shop-abc/__tests__/cartApi.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a37dca3fc832fb68e2f5c732ef585