### PR TITLE
feat: add custom html block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -149,6 +149,11 @@ export interface TextComponent extends PageComponentBase {
   type: "Text";
   text?: string;
 }
+
+export interface CustomHtmlComponent extends PageComponentBase {
+  type: "CustomHtml";
+  html?: string;
+}
 export interface BlogListingComponent extends PageComponentBase {
   type: "BlogListing";
   posts?: {
@@ -201,6 +206,7 @@ export type PageComponent =
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent
+  | CustomHtmlComponent
   | HeaderComponent
   | FooterComponent
   | SectionComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -174,6 +174,11 @@ export interface TextComponent extends PageComponentBase {
   text?: string;
 }
 
+export interface CustomHtmlComponent extends PageComponentBase {
+  type: "CustomHtml";
+  html?: string;
+}
+
 export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
@@ -206,6 +211,7 @@ export type PageComponent =
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent
+  | CustomHtmlComponent
   | HeaderComponent
   | FooterComponent
   | SectionComponent
@@ -379,6 +385,11 @@ const textComponentSchema = baseComponentSchema.extend({
   text: z.string().optional(),
 });
 
+const customHtmlComponentSchema = baseComponentSchema.extend({
+  type: z.literal("CustomHtml"),
+  html: z.string().optional(),
+});
+
 const sectionComponentSchema: z.ZodType<SectionComponent> =
   baseComponentSchema.extend({
     type: z.literal("Section"),
@@ -416,6 +427,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     testimonialSliderComponentSchema,
     imageComponentSchema,
     textComponentSchema,
+    customHtmlComponentSchema,
     sectionComponentSchema,
     multiColumnComponentSchema,
   ])

--- a/packages/ui/src/components/cms/blocks/CustomHtml.tsx
+++ b/packages/ui/src/components/cms/blocks/CustomHtml.tsx
@@ -1,0 +1,14 @@
+import DOMPurify from "dompurify";
+import { memo } from "react";
+
+interface CustomHtmlProps {
+  html?: string;
+}
+
+function CustomHtml({ html }: CustomHtmlProps) {
+  if (!html) return null;
+  const sanitized = DOMPurify.sanitize(html);
+  return <div dangerouslySetInnerHTML={{ __html: sanitized }} />;
+}
+
+export default memo(CustomHtml);

--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -9,7 +9,8 @@ import React, {
 } from "react";
 import Divider from "./Divider";
 import Spacer from "./Spacer";
-export { Divider, Spacer };
+import CustomHtml from "./CustomHtml";
+export { Divider, Spacer, CustomHtml };
 
 /* ──────────────────────────────────────────────────────────────────────────
  * Shared helpers
@@ -81,6 +82,7 @@ export const atomRegistry = {
   Image,
   Divider,
   Spacer,
+  CustomHtml,
 } as const;
 
 export type AtomBlockType = keyof typeof atomRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback } from "react";
 import {
   Button,
   Input,
+  Textarea,
   Select,
   SelectContent,
   SelectItem,
@@ -123,6 +124,15 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "Footer":
       specific = <FooterEditor component={component} onChange={onChange} />;
+      break;
+    case "CustomHtml":
+      specific = (
+        <Textarea
+          label="HTML"
+          value={(component as any).html ?? ""}
+          onChange={(e) => handleInput("html", e.target.value)}
+        />
+      );
       break;
     default:
       specific = <p className="text-muted text-sm">No editable props</p>;


### PR DESCRIPTION
## Summary
- add `CustomHtml` block that sanitizes and renders arbitrary HTML
- register `CustomHtml` in atom registry and allow editing via textarea
- extend page component types to support `CustomHtml`

## Testing
- `pnpm test --filter=@acme/types`
- `pnpm test packages/ui/__tests__/ComponentEditor.test.tsx`
- `pnpm test --filter=@acme/ui` *(fails: cannot find module '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_689a38175d40832f96c0b775ab925533