### PR TITLE
feat: configure deposit release per shop

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.d.ts
+++ b/packages/platform-machine/src/releaseDepositsService.d.ts
@@ -1,3 +1,7 @@
-export declare function releaseDepositsOnce(): Promise<void>;
-export declare function startDepositReleaseService(intervalMs?: number): () => void;
-//# sourceMappingURL=releaseDepositsService.d.ts.map
+interface DepositReleaseConfig {
+    enabled: boolean;
+    intervalMs: number;
+}
+export declare function releaseDepositsOnce(shop?: string): Promise<void>;
+export declare function startDepositReleaseService(overrides?: Record<string, Partial<DepositReleaseConfig>>): () => void;
+

--- a/packages/platform-machine/src/releaseDepositsService.d.ts.map
+++ b/packages/platform-machine/src/releaseDepositsService.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"releaseDepositsService.d.ts","sourceRoot":"","sources":["releaseDepositsService.ts"],"names":[],"mappings":"AAKA,wBAAsB,mBAAmB,IAAI,OAAO,CAAC,IAAI,CAAC,CA8BzD;AAED,wBAAgB,0BAA0B,CACxC,UAAU,SAAiB,GAC1B,MAAM,IAAI,CAYZ"}

--- a/packages/platform-machine/src/releaseDepositsService.js
+++ b/packages/platform-machine/src/releaseDepositsService.js
@@ -1,12 +1,33 @@
 import { stripe } from "@acme/stripe";
-import { readdir } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { markRefunded, readOrders } from "./repositories/rentalOrders.server";
-export async function releaseDepositsOnce() {
+const defaultConfig = {
+    enabled: process.env.DEPOSIT_RELEASE_ENABLED ? process.env.DEPOSIT_RELEASE_ENABLED !== "false" : true,
+    intervalMs: process.env.DEPOSIT_RELEASE_INTERVAL_MS ? Number(process.env.DEPOSIT_RELEASE_INTERVAL_MS) : 1000 * 60 * 60,
+};
+async function readConfig(shop) {
+    try {
+        const buf = await readFile(join(process.cwd(), "data", "shops", shop, "shop.json"), "utf8");
+        const json = JSON.parse(buf);
+        const cfg = json.depositRelease || {};
+        return {
+            enabled: typeof cfg.enabled === "boolean" ? cfg.enabled : defaultConfig.enabled,
+            intervalMs: typeof cfg.intervalMs === "number" ? cfg.intervalMs : defaultConfig.intervalMs,
+        };
+    }
+    catch {
+        return { ...defaultConfig };
+    }
+}
+export async function releaseDepositsOnce(shop) {
     const shopsDir = join(process.cwd(), "data", "shops");
-    const shops = await readdir(shopsDir);
-    for (const shop of shops) {
-        const orders = await readOrders(shop);
+    const shops = shop ? [shop] : await readdir(shopsDir);
+    for (const s of shops) {
+        const cfg = await readConfig(s);
+        if (!cfg.enabled)
+            continue;
+        const orders = await readOrders(s);
         for (const order of orders) {
             if (order.returnedAt && !order.refundedAt && order.deposit > 0) {
                 const session = await stripe.checkout.sessions.retrieve(order.sessionId, {
@@ -24,22 +45,39 @@ export async function releaseDepositsOnce() {
                         amount: refund * 100,
                     });
                 }
-                await markRefunded(shop, order.sessionId);
-                console.log(`refunded deposit for ${order.sessionId} (${shop})`);
+                await markRefunded(s, order.sessionId);
+                console.log(`refunded deposit for ${order.sessionId} (${s})`);
             }
         }
     }
 }
-export function startDepositReleaseService(intervalMs = 1000 * 60 * 60) {
-    async function run() {
-        try {
-            await releaseDepositsOnce();
+export function startDepositReleaseService(overrides = {}) {
+    const timers = [];
+    (async () => {
+        const shopsDir = join(process.cwd(), "data", "shops");
+        const shops = await readdir(shopsDir);
+        for (const shop of shops) {
+            const base = await readConfig(shop);
+            const cfg = {
+                enabled: (overrides[shop]?.enabled) ?? base.enabled,
+                intervalMs: (overrides[shop]?.intervalMs) ?? base.intervalMs,
+            };
+            if (!cfg.enabled)
+                continue;
+            async function run() {
+                try {
+                    await releaseDepositsOnce(shop);
+                }
+                catch (err) {
+                    console.error("deposit release failed", err);
+                }
+            }
+            run();
+            timers.push(setInterval(run, cfg.intervalMs));
         }
-        catch (err) {
-            console.error("deposit release failed", err);
-        }
-    }
-    run();
-    const id = setInterval(run, intervalMs);
-    return () => clearInterval(id);
+    })();
+    return () => {
+        for (const t of timers)
+            clearInterval(t);
+    };
 }

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -3,14 +3,50 @@ import {
   markRefunded,
   readOrders,
 } from "@platform-core/repositories/rentalOrders.server";
-import { readdir } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-export async function releaseDepositsOnce(): Promise<void> {
+interface DepositReleaseConfig {
+  enabled: boolean;
+  intervalMs: number;
+}
+
+const defaultConfig: DepositReleaseConfig = {
+  enabled: process.env.DEPOSIT_RELEASE_ENABLED
+    ? process.env.DEPOSIT_RELEASE_ENABLED !== "false"
+    : true,
+  intervalMs: process.env.DEPOSIT_RELEASE_INTERVAL_MS
+    ? Number(process.env.DEPOSIT_RELEASE_INTERVAL_MS)
+    : 1000 * 60 * 60,
+};
+
+async function readConfig(shop: string): Promise<DepositReleaseConfig> {
+  try {
+    const buf = await readFile(
+      join(process.cwd(), "data", "shops", shop, "shop.json"),
+      "utf8"
+    );
+    const json = JSON.parse(buf);
+    const cfg = json.depositRelease || {};
+    return {
+      enabled:
+        typeof cfg.enabled === "boolean" ? cfg.enabled : defaultConfig.enabled,
+      intervalMs:
+        typeof cfg.intervalMs === "number"
+          ? cfg.intervalMs
+          : defaultConfig.intervalMs,
+    };
+  } catch {
+    return { ...defaultConfig };
+  }
+}
+export async function releaseDepositsOnce(shop?: string): Promise<void> {
   const shopsDir = join(process.cwd(), "data", "shops");
-  const shops = await readdir(shopsDir);
-  for (const shop of shops) {
-    const orders = await readOrders(shop);
+  const shops = shop ? [shop] : await readdir(shopsDir);
+  for (const s of shops) {
+    const cfg = await readConfig(s);
+    if (!cfg.enabled) continue;
+    const orders = await readOrders(s);
     for (const order of orders) {
       if (order.returnedAt && !order.refundedAt && order.deposit > 0) {
         const session = await stripe.checkout.sessions.retrieve(
@@ -31,25 +67,43 @@ export async function releaseDepositsOnce(): Promise<void> {
             amount: refund * 100,
           });
         }
-        await markRefunded(shop, order.sessionId);
-        console.log(`refunded deposit for ${order.sessionId} (${shop})`);
+        await markRefunded(s, order.sessionId);
+        console.log(`refunded deposit for ${order.sessionId} (${s})`);
       }
     }
   }
 }
 
 export function startDepositReleaseService(
-  intervalMs = 1000 * 60 * 60
+  overrides: Record<string, Partial<DepositReleaseConfig>> = {}
 ): () => void {
-  async function run() {
-    try {
-      await releaseDepositsOnce();
-    } catch (err) {
-      console.error("deposit release failed", err);
-    }
-  }
+  const timers: NodeJS.Timeout[] = [];
 
-  run();
-  const id = setInterval(run, intervalMs);
-  return () => clearInterval(id);
+  (async () => {
+    const shopsDir = join(process.cwd(), "data", "shops");
+    const shops = await readdir(shopsDir);
+    for (const shop of shops) {
+      const base = await readConfig(shop);
+      const cfg: DepositReleaseConfig = {
+        enabled: overrides[shop]?.enabled ?? base.enabled,
+        intervalMs: overrides[shop]?.intervalMs ?? base.intervalMs,
+      };
+      if (!cfg.enabled) continue;
+
+      async function run() {
+        try {
+          await releaseDepositsOnce(shop);
+        } catch (err) {
+          console.error("deposit release failed", err);
+        }
+      }
+
+      run();
+      timers.push(setInterval(run, cfg.intervalMs));
+    }
+  })();
+
+  return () => {
+    for (const t of timers) clearInterval(t);
+  };
 }


### PR DESCRIPTION
## Summary
- allow deposit release interval and enabling per shop from env or shop.json
- support per-shop deposit release scheduling

## Testing
- `pnpm --filter @acme/platform-machine test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `npx jest packages/platform-machine/__tests__/releaseDepositsService.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_689a3bbf6b1c832faa497196e6b6e04d