### PR TITLE
feat: add deposit release configuration

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Button, Checkbox, Input } from "@/components/atoms/shadcn";
+import { updateDepositService } from "@cms/actions/shops.server";
+import { useState, type ChangeEvent, type FormEvent } from "react";
+
+interface Props {
+  shop: string;
+  initial: { enabled: boolean; interval: number };
+}
+
+export default function DepositsEditor({ shop, initial }: Props) {
+  const [state, setState] = useState(initial);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setState((s) => ({ ...s, [name]: Number(value) }));
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData(e.currentTarget);
+    const result = await updateDepositService(shop, fd);
+    if (result.errors) {
+      setErrors(result.errors);
+    } else if (result.settings?.depositService) {
+      setState(result.settings.depositService);
+      setErrors({});
+    }
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="grid max-w-md gap-4">
+      <label className="flex items-center gap-2">
+        <Checkbox
+          name="enabled"
+          checked={state.enabled}
+          onCheckedChange={(v) =>
+            setState((s) => ({ ...s, enabled: Boolean(v) }))
+          }
+        />
+        <span>Enable deposit release service</span>
+      </label>
+      <label className="flex flex-col gap-1">
+        <span>Interval (minutes)</span>
+        <Input
+          type="number"
+          name="interval"
+          value={state.interval}
+          onChange={handleChange}
+        />
+        {errors.interval && (
+          <span className="text-sm text-red-600">
+            {errors.interval.join("; ")}
+          </span>
+        )}
+      </label>
+      <Button className="bg-primary text-white" disabled={saving} type="submit">
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
@@ -1,0 +1,34 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
+
+import { getSettings } from "@cms/actions/shops.server";
+import dynamic from "next/dynamic";
+
+const DepositsEditor = dynamic(() => import("./DepositsEditor"));
+void DepositsEditor;
+
+export const revalidate = 0;
+
+interface Params {
+  shop: string;
+}
+
+export default async function DepositsSettingsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { shop } = await params;
+  const settings = await getSettings(shop);
+  const depositService = settings.depositService ?? {
+    enabled: false,
+    interval: 60,
+  };
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Deposits – {shop}</h2>
+      <DepositsEditor shop={shop} initial={depositService} />
+    </div>
+  );
+}
+

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -2,5 +2,9 @@
   "languages": ["en", "de", "it"],
   "freezeTranslations": false,
   "currency": "EUR",
-  "taxRegion": "EU"
+  "taxRegion": "EU",
+  "depositService": {
+    "enabled": false,
+    "interval": 60
+  }
 }

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -2,5 +2,9 @@
   "languages": ["en", "de", "it"],
   "freezeTranslations": false,
   "currency": "EUR",
-  "taxRegion": "EU"
+  "taxRegion": "EU",
+  "depositService": {
+    "enabled": false,
+    "interval": 60
+  }
 }

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -2,5 +2,9 @@
   "languages": ["en", "de", "it"],
   "freezeTranslations": false,
   "currency": "EUR",
-  "taxRegion": "EU"
+  "taxRegion": "EU",
+  "depositService": {
+    "enabled": false,
+    "interval": 60
+  }
 }

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -2,6 +2,10 @@
   "freezeTranslations": false,
   "currency": "EUR",
   "taxRegion": "EU",
+  "depositService": {
+    "enabled": false,
+    "interval": 60
+  },
   "languages": [
     "en",
     "de",

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -53,6 +53,11 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
         currency: parsed.data.currency ?? "EUR",
         taxRegion: parsed.data.taxRegion ?? "",
         ...parsed.data,
+        depositService: {
+          enabled: false,
+          interval: 60,
+          ...(parsed.data.depositService ?? {}),
+        },
       };
     }
   } catch {
@@ -65,6 +70,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     freezeTranslations: false,
     currency: "EUR",
     taxRegion: "",
+    depositService: { enabled: false, interval: 60 },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -92,6 +92,16 @@ export declare const shopSettingsSchema: z.ZodObject<{
     freezeTranslations: z.ZodOptional<z.ZodBoolean>;
     currency: z.ZodOptional<z.ZodString>;
     taxRegion: z.ZodOptional<z.ZodString>;
+    depositService: z.ZodOptional<z.ZodObject<{
+        enabled: z.ZodBoolean;
+        interval: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        enabled: boolean;
+        interval: number;
+    }, {
+        enabled: boolean;
+        interval: number;
+    }>>;
     updatedAt: z.ZodString;
     updatedBy: z.ZodString;
 }, "strip", z.ZodTypeAny, {
@@ -125,6 +135,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
     freezeTranslations?: boolean | undefined;
     currency?: string | undefined;
     taxRegion?: string | undefined;
+    depositService?: {
+        enabled: boolean;
+        interval: number;
+    } | undefined;
 }, {
     seo: Partial<Record<"en" | "de" | "it", {
         title?: string | undefined;
@@ -156,6 +170,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
     freezeTranslations?: boolean | undefined;
     currency?: string | undefined;
     taxRegion?: string | undefined;
+    depositService?: {
+        enabled: boolean;
+        interval: number;
+    } | undefined;
 }>;
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
 //# sourceMappingURL=ShopSettings.d.ts.map

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -17,6 +17,12 @@ export const shopSettingsSchema = z.object({
   currency: z.string().length(3).optional(),
   /** Region identifier for tax calculations */
   taxRegion: z.string().optional(),
+  depositService: z
+    .object({
+      enabled: z.boolean(),
+      interval: z.number().int().positive(),
+    })
+    .optional(),
   updatedAt: z.string(),
   updatedBy: z.string(),
 });

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -61,6 +61,11 @@ export default function Sidebar({ role }: { role?: string }) {
             label: "SEO",
             icon: "🔍",
           },
+          {
+            href: `/shop/${shop}/settings/deposits`,
+            label: "Deposits",
+            icon: "💰",
+          },
         ]
       : []),
     { href: "/live", label: "Live", icon: "🌐" },


### PR DESCRIPTION
## Summary
- add Deposits link under shop settings
- allow enabling deposit release service and setting run interval
- store deposit release preferences in shop settings

## Testing
- `npx eslint packages/ui/src/components/cms/Sidebar.client.tsx apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx apps/cms/src/actions/shops.server.ts packages/types/src/ShopSettings.ts packages/platform-core/src/repositories/settings.server.ts`
- `npx jest packages/platform-machine/__tests__/depositService.test.ts`
- `npx tsc -p packages/types/tsconfig.json` *(fails: Module './Translations' was resolved to ... but '--jsx' is not set)*

------
https://chatgpt.com/codex/tasks/task_e_689a3bc00eb8832f80c6c8558f433755