### PR TITLE
feat(platform-machine): resolve data root

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.d.ts
+++ b/packages/platform-machine/src/releaseDepositsService.d.ts
@@ -1,3 +1,3 @@
-export declare function releaseDepositsOnce(): Promise<void>;
-export declare function startDepositReleaseService(intervalMs?: number): () => void;
+export declare function releaseDepositsOnce(shopsDir?: string): Promise<void>;
+export declare function startDepositReleaseService(intervalMs?: number, shopsDir?: string): () => void;
 //# sourceMappingURL=releaseDepositsService.d.ts.map

--- a/packages/platform-machine/src/releaseDepositsService.d.ts.map
+++ b/packages/platform-machine/src/releaseDepositsService.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"releaseDepositsService.d.ts","sourceRoot":"","sources":["releaseDepositsService.ts"],"names":[],"mappings":"AAKA,wBAAsB,mBAAmB,IAAI,OAAO,CAAC,IAAI,CAAC,CA8BzD;AAED,wBAAgB,0BAA0B,CACxC,UAAU,SAAiB,GAC1B,MAAM,IAAI,CAYZ"}
+{"version":3,"file":"releaseDepositsService.d.ts","sourceRoot":"","sources":["releaseDepositsService.ts"],"names":[],"mappings":"AAQA,wBAAsB,mBAAmB,CACvC,QAAQ,GAAE,MAA0B,GACnC,OAAO,CAAC,IAAI,CAAC,CA6Bf;AAED,wBAAgB,0BAA0B,CACxC,UAAU,SAAiB,EAC3B,QAAQ,GAAE,MAA0B,GACnC,MAAM,IAAI,CAYZ"}

--- a/packages/platform-machine/src/releaseDepositsService.js
+++ b/packages/platform-machine/src/releaseDepositsService.js
@@ -1,9 +1,8 @@
 import { stripe } from "@acme/stripe";
+import { markRefunded, readOrders, } from "@platform-core/repositories/rentalOrders.server";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 import { readdir } from "node:fs/promises";
-import { join } from "node:path";
-import { markRefunded, readOrders } from "./repositories/rentalOrders.server";
-export async function releaseDepositsOnce() {
-    const shopsDir = join(process.cwd(), "data", "shops");
+export async function releaseDepositsOnce(shopsDir = resolveDataRoot()) {
     const shops = await readdir(shopsDir);
     for (const shop of shops) {
         const orders = await readOrders(shop);
@@ -30,10 +29,10 @@ export async function releaseDepositsOnce() {
         }
     }
 }
-export function startDepositReleaseService(intervalMs = 1000 * 60 * 60) {
+export function startDepositReleaseService(intervalMs = 1000 * 60 * 60, shopsDir = resolveDataRoot()) {
     async function run() {
         try {
-            await releaseDepositsOnce();
+            await releaseDepositsOnce(shopsDir);
         }
         catch (err) {
             console.error("deposit release failed", err);

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -3,11 +3,12 @@ import {
   markRefunded,
   readOrders,
 } from "@platform-core/repositories/rentalOrders.server";
+import { resolveDataRoot } from "@platform-core/dataRoot";
 import { readdir } from "node:fs/promises";
-import { join } from "node:path";
 
-export async function releaseDepositsOnce(): Promise<void> {
-  const shopsDir = join(process.cwd(), "data", "shops");
+export async function releaseDepositsOnce(
+  shopsDir: string = resolveDataRoot()
+): Promise<void> {
   const shops = await readdir(shopsDir);
   for (const shop of shops) {
     const orders = await readOrders(shop);
@@ -39,11 +40,12 @@ export async function releaseDepositsOnce(): Promise<void> {
 }
 
 export function startDepositReleaseService(
-  intervalMs = 1000 * 60 * 60
+  intervalMs = 1000 * 60 * 60,
+  shopsDir: string = resolveDataRoot()
 ): () => void {
   async function run() {
     try {
-      await releaseDepositsOnce();
+      await releaseDepositsOnce(shopsDir);
     } catch (err) {
       console.error("deposit release failed", err);
     }


### PR DESCRIPTION
## Summary
- use resolveDataRoot to locate shops directory
- allow overriding data path when starting deposit release service

## Testing
- `pnpm exec jest packages/platform-machine/__tests__/releaseDepositsService.test.ts packages/platform-machine/__tests__/depositService.test.ts --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_689a3bbec5c8832f900666f7dbc9157f