### PR TITLE
feat: manage theme overrides in editor

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test.tsx
@@ -27,7 +27,7 @@ describe("ThemeEditor", () => {
         themes={["base"]}
         tokensByTheme={tokensByTheme}
         initialTheme="base"
-        initialTokens={initialOverrides}
+        initialOverrides={initialOverrides}
       />
     );
 
@@ -56,7 +56,7 @@ describe("ThemeEditor", () => {
         themes={["base"]}
         tokensByTheme={tokensByTheme}
         initialTheme="base"
-        initialTokens={initialOverrides}
+        initialOverrides={initialOverrides}
       />
     );
 

--- a/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
@@ -23,7 +23,7 @@ export default async function ShopThemePage({
         themes={themes}
         tokensByTheme={tokensByTheme}
         initialTheme={shopData.themeId}
-        initialTokens={shopData.themeTokens}
+        initialOverrides={shopData.themeTokens}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- store only explicit theme overrides and submit via `themeOverrides`
- hide reset button unless an override exists
- use a color picker for hex token overrides

## Testing
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689a3c5472b4832faeb1001d64b1d287