### PR TITLE
feat: schedule blog posts

### DIFF
--- a/apps/cms/__tests__/blogActions.test.ts
+++ b/apps/cms/__tests__/blogActions.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test, describe, jest } from "@jest/globals";
+
+jest.mock("@platform-core/src/repositories/shop.server", () => ({
+  getShopById: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("@platform-core/src/shops", () => ({
+  getSanityConfig: jest.fn().mockReturnValue({ projectId: "p", dataset: "d", token: "t" }),
+}));
+
+jest.mock("../src/actions/common/auth", () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+describe("blog actions", () => {
+  afterEach(() => {
+    (fetch as jest.Mock | undefined)?.mockClear();
+  });
+
+  test("createPost forwards publishedAt", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ results: [{ id: "1" }] }) }) as any;
+    const { createPost } = await import("../src/actions/blog.server");
+    const fd = new FormData();
+    fd.set("title", "T");
+    fd.set("content", "[]");
+    fd.set("slug", "t");
+    fd.set("excerpt", "");
+    fd.set("publishedAt", "2025-01-01T10:00");
+    await createPost("s", {} as any, fd);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.mutations[0].create.publishedAt).toBe(
+      new Date("2025-01-01T10:00").toISOString(),
+    );
+  });
+
+  test("publishPost uses provided publishedAt", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({}) }) as any;
+    const { publishPost } = await import("../src/actions/blog.server");
+    const fd = new FormData();
+    fd.set("publishedAt", "2025-01-02T12:00");
+    await publishPost("s", "1", {} as any, fd);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.mutations[0].patch.set.publishedAt).toBe(
+      new Date("2025-01-02T12:00").toISOString(),
+    );
+  });
+});

--- a/apps/cms/__tests__/blogPostsPage.test.tsx
+++ b/apps/cms/__tests__/blogPostsPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@cms/actions/blog.server", () => ({
+  getPosts: jest.fn(),
+}));
+
+jest.mock("@platform-core/src/shops", () => ({
+  getSanityConfig: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock("@platform-core/src/repositories/shop.server", () => ({
+  getShopById: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: any; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@ui", () => ({
+  Button: ({ children }: any) => <button>{children}</button>,
+}));
+
+describe("BlogPostsPage", () => {
+  test("shows scheduled status for future posts", async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const { getPosts } = require("@cms/actions/blog.server");
+    getPosts.mockResolvedValue([
+      { _id: "1", title: "Post", published: true, publishedAt: future },
+    ]);
+    const Page = (await import("../src/app/cms/blog/posts/page")).default;
+    render(await Page({ searchParams: { shopId: "s" } }));
+    expect(screen.getByText(/scheduled for/i)).toBeInTheDocument();
+  });
+});

--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -97,6 +97,10 @@ export async function createPost(
   }
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
+  const publishedAtInput = formData.get("publishedAt");
+  const publishedAt = publishedAtInput
+    ? new Date(String(publishedAtInput)).toISOString()
+    : undefined;
   try {
     const res = await mutate(config, {
       mutations: [
@@ -108,6 +112,7 @@ export async function createPost(
             published: false,
             slug: slug ? { current: slug } : undefined,
             excerpt: excerpt || undefined,
+            ...(publishedAt ? { publishedAt } : {}),
           },
         },
       ],
@@ -141,6 +146,10 @@ export async function updatePost(
   }
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
+  const publishedAtInput = formData.get("publishedAt");
+  const publishedAt = publishedAtInput
+    ? new Date(String(publishedAtInput)).toISOString()
+    : undefined;
   try {
     await mutate(config, {
       mutations: [
@@ -152,6 +161,7 @@ export async function updatePost(
               body,
               slug: slug ? { current: slug } : undefined,
               excerpt: excerpt || undefined,
+              ...(publishedAt ? { publishedAt } : {}),
             },
           },
         },
@@ -168,14 +178,18 @@ export async function publishPost(
   shopId: string,
   id: string,
   _prev?: unknown,
-  _formData?: FormData
+  formData?: FormData
 ): Promise<{ message?: string; error?: string }> {
   "use server";
   await ensureAuthorized();
   const config = await getConfig(shopId);
+  const publishedAtInput = formData?.get("publishedAt");
+  const publishedAt = publishedAtInput
+    ? new Date(String(publishedAtInput)).toISOString()
+    : new Date().toISOString();
   try {
     await mutate(config, {
-      mutations: [{ patch: { id, set: { published: true, publishedAt: new Date().toISOString() } } }],
+      mutations: [{ patch: { id, set: { published: true, publishedAt } } }],
     });
     return { message: "Post published" };
   } catch (err) {

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -26,7 +26,14 @@ export interface FormState {
 interface Props {
   action: (_state: FormState, formData: FormData) => Promise<FormState>;
   submitLabel: string;
-  post?: { _id?: string; title?: string; body?: string; slug?: string; excerpt?: string };
+  post?: {
+    _id?: string;
+    title?: string;
+    body?: string;
+    slug?: string;
+    excerpt?: string;
+    publishedAt?: string;
+  };
 }
 
 const schema = defineSchema({
@@ -192,6 +199,9 @@ export default function PostForm({ action, submitLabel, post }: Props) {
   useEffect(() => {
     if (!editSlug) setSlug(slugify(title));
   }, [title, editSlug]);
+  const [publishedAt, setPublishedAt] = useState(
+    post?.publishedAt ? post.publishedAt.slice(0, 16) : "",
+  );
   const [content, setContent] = useState<PortableTextBlock[]>(
     Array.isArray(post?.body)
       ? (post?.body as PortableTextBlock[])
@@ -233,6 +243,13 @@ export default function PostForm({ action, submitLabel, post }: Props) {
           </div>
         </div>
         <Textarea name="excerpt" label="Excerpt" defaultValue={post?.excerpt ?? ""} />
+        <Input
+          type="datetime-local"
+          name="publishedAt"
+          label="Publish at"
+          value={publishedAt}
+          onChange={(e) => setPublishedAt(e.target.value)}
+        />
         <div className="space-y-2">
           <EditorProvider
             initialConfig={{ schemaDefinition: schema, initialValue: content }}
@@ -261,6 +278,12 @@ export default function PostForm({ action, submitLabel, post }: Props) {
         {post?._id && <input type="hidden" name="id" value={post._id} />}
         <Button type="submit">{submitLabel}</Button>
       </form>
+      <input
+        type="hidden"
+        name="publishedAt"
+        form="publish-form"
+        value={publishedAt}
+      />
       <Toast
         open={Boolean(state.message || state.error)}
         message={state.message || state.error || ""}

--- a/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
@@ -19,7 +19,7 @@ export default function PublishButton({ id, shopId }: Props) {
   });
   return (
     <div className="space-y-2">
-      <form action={formAction}>
+      <form id="publish-form" action={formAction}>
         <Button type="submit" variant="outline">
           Publish
         </Button>

--- a/apps/cms/src/app/cms/blog/posts/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/page.tsx
@@ -38,23 +38,27 @@ export default async function BlogPostsPage({
         </Button>
       </div>
       <ul className="space-y-2">
-        {posts.map((post) => (
-          <li key={post._id}>
-            <Link
-              href={`/cms/blog/posts/${post._id}?shopId=${shopId}`}
-              className="text-primary underline"
-            >
-              {post.title || "(untitled)"}
-            </Link>
-            <span className="ml-2 text-sm text-muted-foreground">
-              {post.published
-                ? post.publishedAt && new Date(post.publishedAt) > new Date()
-                  ? `scheduled for ${new Date(post.publishedAt).toLocaleString()}`
-                  : "published"
-                : "draft"}
-            </span>
-          </li>
-        ))}
+        {posts.map((post) => {
+          const status =
+            post.publishedAt && new Date(post.publishedAt) > new Date()
+              ? `scheduled for ${new Date(post.publishedAt).toLocaleString()}`
+              : post.published
+                ? "published"
+                : "draft";
+          return (
+            <li key={post._id}>
+              <Link
+                href={`/cms/blog/posts/${post._id}?shopId=${shopId}`}
+                className="text-primary underline"
+              >
+                {post.title || "(untitled)"}
+              </Link>
+              <span className="ml-2 text-sm text-muted-foreground">
+                {status}
+              </span>
+            </li>
+          );
+        })}
         {posts.length === 0 && <li>No posts found.</li>}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- add publish date field and sync to publish action
- handle publishedAt in blog post server actions
- show scheduled status in post list and add tests

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '.prisma/client/index-browser')*
- `pnpm --filter @apps/cms exec jest __tests__/blogActions.test.ts __tests__/blogPostsPage.test.tsx --runTestsByPath --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689a3c6651cc832fa0a16909e3b81c9f