### PR TITLE
feat: check for duplicate post slugs

### DIFF
--- a/apps/cms/__tests__/blog.server.test.ts
+++ b/apps/cms/__tests__/blog.server.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+import { createPost, updatePost } from "../src/actions/blog.server";
+
+jest.mock("../src/actions/common/auth", () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+jest.mock("@platform-core/src/repositories/shop.server", () => ({
+  getShopById: jest.fn().mockResolvedValue({ id: "shop" }),
+}));
+
+jest.mock("@platform-core/src/shops", () => ({
+  getSanityConfig: jest.fn().mockReturnValue({
+    projectId: "p",
+    dataset: "d",
+    token: "t",
+  }),
+}));
+
+describe("blog post slug conflicts", () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    (global.fetch as any) = realFetch;
+    jest.clearAllMocks();
+  });
+
+  it("returns error when slug already exists on create", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({ result: [{ _id: "existing" }] }),
+    });
+    (global.fetch as any) = fetchMock;
+
+    const fd = new FormData();
+    fd.set("title", "Title");
+    fd.set("content", "[]");
+    fd.set("slug", "dup");
+
+    const res = await createPost("shop", {} as any, fd);
+    expect(res).toEqual({ error: "Slug already exists" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns error when slug already exists on update", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({ result: [{ _id: "other" }] }),
+    });
+    (global.fetch as any) = fetchMock;
+
+    const fd = new FormData();
+    fd.set("id", "current");
+    fd.set("title", "Title");
+    fd.set("content", "[]");
+    fd.set("slug", "dup");
+
+    const res = await updatePost("shop", {} as any, fd);
+    expect(res).toEqual({ error: "Slug already exists" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- query Sanity for existing posts with matching slug before creating or updating
- return error when slug conflict occurs
- add tests covering slug conflicts on create and update

## Testing
- `pnpm test:cms apps/cms/__tests__/blog.server.test.ts`
- `pnpm eslint apps/cms/src/actions/blog.server.ts apps/cms/__tests__/blog.server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a3c647770832fae25dbfdbb4c47e8