### PR TITLE
feat: throw on unmatched FSM transitions

### DIFF
--- a/packages/platform-machine/README.md
+++ b/packages/platform-machine/README.md
@@ -1,0 +1,18 @@
+# @acme/platform-machine
+
+Utilities for building platform-specific state machines.
+
+## FSM
+
+The `FSM` helper exposes a `send` method to drive transitions. When no
+transition matches the current state and event, `send` will now throw an
+error. Supply a fallback handler as a second argument to intercept these
+cases and return the next state instead.
+
+```ts
+import { createFSM } from "@acme/platform-machine";
+
+const fsm = createFSM("idle", [{ from: "idle", event: "FETCH", to: "loading" }]);
+
+fsm.send("RESOLVE", (event, state) => state); // fallback invoked instead of throwing
+```

--- a/packages/platform-machine/__tests__/fsm.test.ts
+++ b/packages/platform-machine/__tests__/fsm.test.ts
@@ -15,12 +15,25 @@ describe("createFSM", () => {
     expect(fsm.state).toBe("success");
   });
 
-  it("ignores events with no matching transition", () => {
+  it("throws when no transition matches", () => {
     const fsm = createFSM("idle", [
       { from: "idle", event: "FETCH", to: "loading" },
     ]);
 
-    fsm.send("RESOLVE" as any);
+    expect(() => fsm.send("RESOLVE" as any)).toThrow(
+      "No transition for event RESOLVE from state idle"
+    );
+  });
+
+  it("invokes a fallback when provided", () => {
+    const fsm = createFSM("idle", [
+      { from: "idle", event: "FETCH", to: "loading" },
+    ]);
+
+    const fallback = jest.fn(() => "idle" as const);
+    fsm.send("RESOLVE" as any, fallback);
+
+    expect(fallback).toHaveBeenCalledWith("RESOLVE", "idle");
     expect(fsm.state).toBe("idle");
   });
 });

--- a/packages/platform-machine/src/fsm.ts
+++ b/packages/platform-machine/src/fsm.ts
@@ -17,13 +17,31 @@ export class FSM<State extends string, Event extends string> {
     return this.current;
   }
 
-  send(event: Event): State {
+  /**
+   * Sends an event to the state machine.
+   *
+   * If a matching transition is not found, this method will throw unless a
+   * fallback handler is provided. The fallback receives the event and current
+   * state and must return the next state.
+   */
+  send(
+    event: Event,
+    fallback?: (event: Event, state: State) => State
+  ): State {
     const match = this.transitions.find(
       (t) => t.from === this.current && t.event === event
     );
+
     if (match) {
       this.current = match.to;
+    } else if (fallback) {
+      this.current = fallback(event, this.current);
+    } else {
+      throw new Error(
+        `No transition for event ${event} from state ${this.current}`
+      );
     }
+
     return this.current;
   }
 }


### PR DESCRIPTION
## Summary
- throw error on unknown FSM transitions and allow fallback handler
- document FSM send behavior
- update tests for new no-transition error and fallback

## Testing
- `pnpm --filter @acme/platform-machine test packages/platform-machine/__tests__/fsm.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a3eb47bc4832fae4d5b6079145ff7