### PR TITLE
feat: improve theme overrides with color picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ switching shops and admin-only routes. Newcomers can follow the
 [Page Builder](doc/cms.md#page-builder) section to learn how to add,
 rearrange and publish blocks.
 
+### Theme overrides
+
+The CMS theme editor lets admins customize design tokens per shop. Tokens are
+grouped by purpose (Background, Text, Accent) and each color token displays a
+preview swatch. Clicking a swatch focuses its corresponding field, where a color
+picker enables quick overrides. Save the form to persist any changes.
+
 ## Inventory Management
 
 ### Variant schema

--- a/apps/cms/__tests__/ThemeEditor.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test.tsx
@@ -35,10 +35,13 @@ describe("ThemeEditor", () => {
     const [bgDefault, bgOverride] = within(bgLabel).getAllByRole("textbox");
     expect(bgDefault).toHaveValue("white");
     expect(bgOverride).toHaveValue("hotpink");
-    expect(within(bgLabel).getByRole("button", { name: /reset/i })).toBeInTheDocument();
+    expect(
+      within(bgLabel).getByRole("button", { name: /reset/i })
+    ).toBeInTheDocument();
 
     const primaryLabel = screen.getByText("--color-primary").closest("label")!;
-    const [primaryDefault, primaryOverride] = within(primaryLabel).getAllByRole("textbox");
+    const [primaryDefault, primaryOverride] =
+      within(primaryLabel).getAllByRole("textbox");
     expect(primaryDefault).toHaveValue("blue");
     expect(primaryOverride).toHaveValue("");
     expect(primaryOverride).toHaveAttribute("placeholder", "blue");
@@ -69,5 +72,25 @@ describe("ThemeEditor", () => {
     expect(
       within(bgLabel).queryByRole("button", { name: /reset/i })
     ).toBeNull();
+  });
+
+  it("focuses field when swatch clicked", () => {
+    const tokensByTheme = { base: { "--color-bg": "#ffffff" } };
+    render(
+      <ThemeEditor
+        shop="test"
+        themes={["base"]}
+        tokensByTheme={tokensByTheme}
+        initialTheme="base"
+        initialOverrides={{}}
+      />
+    );
+
+    const swatch = screen.getByRole("button", { name: "--color-bg" });
+    const colorInput = screen.getByLabelText("--color-bg", {
+      selector: 'input[type="color"]',
+    });
+    fireEvent.click(swatch);
+    expect(colorInput).toHaveFocus();
   });
 });


### PR DESCRIPTION
## Summary
- group theme tokens and add clickable swatches for quick selection
- show color picker with preview in theme override fields
- document new theme override workflow in CMS guide

## Testing
- `pnpm exec jest apps/cms/__tests__/ThemeEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a3f979bb4832fbfdd4e4680d13be2