### PR TITLE
feat(cms): add acl mode to sanity connect

### DIFF
--- a/apps/cms/__tests__/sanityActions.test.ts
+++ b/apps/cms/__tests__/sanityActions.test.ts
@@ -13,6 +13,7 @@ describe("sanity server actions", () => {
     fd.set("projectId", "p");
     fd.set("dataset", "d");
     fd.set("token", "t");
+    fd.set("aclMode", "public");
     const res = await connectSanity(fd);
     expect(res).toBe(true);
     expect(verifyCredentials).toHaveBeenCalledWith({

--- a/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
@@ -34,6 +34,7 @@ export default function ConnectForm({ shopId, initial }: Props) {
   const [projectId, setProjectId] = useState(initial?.projectId ?? "");
   const [dataset, setDataset] = useState(initial?.dataset ?? "");
   const [token, setToken] = useState(initial?.token ?? "");
+  const [aclMode, setAclMode] = useState<"public" | "private">("public");
   const [verifyStatus, setVerifyStatus] = useState<
     "idle" | "loading" | "success" | "error"
   >("idle");
@@ -120,6 +121,24 @@ export default function ConnectForm({ shopId, initial }: Props) {
           {verifyStatus === "error" && (
             <p className="text-xs text-red-600">Invalid credentials</p>
           )}
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="aclMode">
+            Access level
+          </label>
+          <select
+            id="aclMode"
+            name="aclMode"
+            className="w-full rounded border p-2"
+            value={aclMode}
+            onChange={(e) => setAclMode(e.target.value as "public" | "private")}
+          >
+            <option value="public">Public</option>
+            <option value="private">Private</option>
+          </select>
+          <p className="text-xs text-muted-foreground">
+            Public datasets are readable by anyone; private require auth.
+          </p>
         </div>
         <SubmitButton />
       </form>

--- a/doc/sanity-blog.md
+++ b/doc/sanity-blog.md
@@ -5,7 +5,7 @@ Shop owners can connect a Sanity project to manage blog posts alongside the shop
 ## Connect your Sanity project
 
 1. Obtain your **project ID**, **dataset**, and an API **token** from the Sanity dashboard.
-2. In the CMS go to **Settings → Blog** and enter the credentials.
+2. In the CMS go to **Settings → Blog** and enter the credentials, then choose whether the dataset should be **public** or **private**.
 3. The CMS uses the values to verify access via the `verifyCredentials` helper from the plugin.
 4. On success the connection is stored with the shop settings.
 


### PR DESCRIPTION
## Summary
- add ACL mode select to Sanity connect form
- include ACL mode in Sanity connection tests
- document choosing public/private dataset when connecting

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: Test Suites: 18 failed, 27 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c612f18832fb131ad4847cd2921