### PR TITLE
refactor: render blog posts with PortableText

### DIFF
--- a/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,8 +1,42 @@
+import { PortableText } from "@portabletext/react";
 import { notFound } from "next/navigation";
 import { fetchPostBySlug } from "@acme/sanity";
 import { getProductBySlug } from "@/lib/products";
 import { ProductCard } from "@/components/shop/ProductCard";
 import shop from "../../../../../shop.json";
+
+const components = {
+  types: {
+    productReference: ({ value }: any) => {
+      if (typeof value?.slug !== "string") return null;
+      const sku = getProductBySlug(value.slug);
+      return sku ? <ProductCard sku={sku} /> : null;
+    },
+    embed: ({ value }: any) => (
+      <div className="aspect-video">
+        <iframe src={value.url} className="h-full w-full" />
+      </div>
+    ),
+  },
+  marks: {
+    link: ({ children, value }: any) => (
+      <a
+        href={value.href}
+        className="text-blue-600 underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    ),
+    em: ({ children }: any) => <em>{children}</em>,
+  },
+  block: {
+    h1: ({ children }: any) => <h1>{children}</h1>,
+    h2: ({ children }: any) => <h2>{children}</h2>,
+    h3: ({ children }: any) => <h3>{children}</h3>,
+  },
+};
 
 export default async function BlogPostPage({
   params,
@@ -17,15 +51,7 @@ export default async function BlogPostPage({
       {post.excerpt && <p className="text-muted">{post.excerpt}</p>}
       {Array.isArray(post.body) ? (
         <div className="space-y-4">
-          {post.body.map((b: any, i: number) => {
-            if (b._type === "productReference" && typeof b.slug === "string") {
-              const sku = getProductBySlug(b.slug);
-              return sku ? <ProductCard key={i} sku={sku} /> : null;
-            }
-            return (
-              <p key={i}>{b.children?.map((c: any) => c.text).join("")}</p>
-            );
-          })}
+          <PortableText value={post.body} components={components} />
         </div>
       ) : null}
     </article>


### PR DESCRIPTION
## Summary
- replace manual block mapping with PortableText
- render `productReference` blocks via `ProductCard`
- support link/emphasis marks and embedded media

## Testing
- `pnpm exec eslint apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx`
- `pnpm test --filter @apps/shop-abc`

------
https://chatgpt.com/codex/tasks/task_e_689a3c64db10832f8696f59078fb8823