### PR TITLE
feat(shared-utils): add optional schema validation to fetchJson

### DIFF
--- a/packages/shared-utils/src/fetchJson.ts
+++ b/packages/shared-utils/src/fetchJson.ts
@@ -1,6 +1,9 @@
+import { z } from "zod";
+
 export async function fetchJson<T>(
   input: RequestInfo | URL,
-  init?: RequestInit
+  init?: RequestInit,
+  schema?: z.ZodType<T>,
 ): Promise<T> {
   const res = await fetch(input, init);
   let data: any;
@@ -15,5 +18,5 @@ export async function fetchJson<T>(
       (data && data.error) || res.statusText || `HTTP ${res.status}`;
     throw new Error(message);
   }
-  return data as T;
+  return schema ? schema.parse(data) : (data as T);
 }


### PR DESCRIPTION
## Summary
- allow `fetchJson` to accept optional Zod schema for validation
- test schema validation success and failure paths

## Testing
- `pnpm exec jest packages/shared-utils/__tests__/fetchJson.test.ts --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689a427262e4832f9f80dfd97813a168