### PR TITLE
Validate env API input with zod

### DIFF
--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -4,8 +4,11 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { setupSanityBlog } from "@cms/actions/setupSanityBlog";
+
+const schema = z.record(z.string(), z.string());
 
 export async function POST(
   req: NextRequest,
@@ -16,23 +19,29 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const body = (await req.json()) as Record<string, string>;
+    const body = schema.safeParse(await req.json());
+    if (!body.success) {
+      return NextResponse.json(
+        { error: body.error.message },
+        { status: 400 }
+      );
+    }
     const { shopId } = await context.params;
     const dir = path.join(resolveDataRoot(), shopId);
     await fs.mkdir(dir, { recursive: true });
-    const lines = Object.entries(body)
+    const lines = Object.entries(body.data)
       .map(([k, v]) => `${k}=${String(v)}`)
       .join("\n");
     await fs.writeFile(path.join(dir, ".env"), lines, "utf8");
     if (
-      body.SANITY_PROJECT_ID &&
-      body.SANITY_DATASET &&
-      body.SANITY_TOKEN
+      body.data.SANITY_PROJECT_ID &&
+      body.data.SANITY_DATASET &&
+      body.data.SANITY_TOKEN
     ) {
       await setupSanityBlog({
-        projectId: body.SANITY_PROJECT_ID,
-        dataset: body.SANITY_DATASET,
-        token: body.SANITY_TOKEN,
+        projectId: body.data.SANITY_PROJECT_ID,
+        dataset: body.data.SANITY_DATASET,
+        token: body.data.SANITY_TOKEN,
       }).catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });


### PR DESCRIPTION
## Summary
- validate env API payloads with a zod record schema
- return a 400 response when request body fails validation

## Testing
- `pnpm --filter "@apps/cms" lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env.ts')*
- `pnpm --filter "@apps/cms" test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689a42737994832f87ea09b6c7aa6c5f