### PR TITLE
feat: add account verification flow

### DIFF
--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -9,7 +9,9 @@ jest.mock("@upstash/redis", () => ({
 
 jest.mock("../src/app/userStore", () => ({
   getUserById: jest.fn(async (id: string) =>
-    id === "cust1" ? { passwordHash: "pass1", role: "customer" } : null,
+    id === "cust1"
+      ? { passwordHash: "pass1", role: "customer", verified: true }
+      : null,
   ),
 }));
 

--- a/apps/shop-abc/__tests__/registerApi.test.ts
+++ b/apps/shop-abc/__tests__/registerApi.test.ts
@@ -4,8 +4,8 @@ const PROFILE_STORE: Record<string, any> = {};
 
 jest.mock("../src/app/userStore", () => ({
   __esModule: true,
-  addUser: jest.fn(async ({ id, email, passwordHash }) => {
-    USER_STORE[id] = { id, email, passwordHash };
+  addUser: jest.fn(async ({ id, email, passwordHash, verified }) => {
+    USER_STORE[id] = { id, email, passwordHash, verified };
   }),
   getUserById: jest.fn(async (id: string) => USER_STORE[id] ?? null),
   getUserByEmail: jest.fn(async (email: string) =>
@@ -35,6 +35,10 @@ jest.mock("@acme/platform-core/customerProfiles", () => ({
     return PROFILE_STORE[id];
   }),
   getCustomerProfile: jest.fn(async (id: string) => PROFILE_STORE[id] ?? null),
+}));
+
+jest.mock("@acme/email", () => ({
+  sendEmail: jest.fn(),
 }));
 
 jest.mock("next/server", () => ({

--- a/apps/shop-abc/__tests__/registerRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/registerRateLimit.test.ts
@@ -9,6 +9,10 @@ jest.mock("../src/app/userStore", () => ({
   getUserByEmail: jest.fn().mockResolvedValue(null),
 }));
 
+jest.mock("@acme/email", () => ({
+  sendEmail: jest.fn(),
+}));
+
 jest.mock("bcryptjs", () => ({
   hash: jest.fn().mockResolvedValue("hashed"),
 }));

--- a/apps/shop-abc/src/app/api/account/verify/route.ts
+++ b/apps/shop-abc/src/app/api/account/verify/route.ts
@@ -1,0 +1,37 @@
+// apps/shop-abc/src/app/api/account/verify/route.ts
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import crypto from "crypto";
+import { getUserById, verifyUser } from "../../../../userStore";
+import { validateCsrfToken } from "@auth";
+import { parseJsonBody } from "@shared-utils";
+
+export const VerifySchema = z.object({ token: z.string() }).strict();
+export type VerifyInput = z.infer<typeof VerifySchema>;
+
+export async function POST(req: Request) {
+  const parsed = await parseJsonBody<VerifyInput>(req, VerifySchema);
+  if (!parsed.success) return parsed.response;
+
+  const csrfToken = req.headers.get("x-csrf-token");
+  if (!csrfToken || !(await validateCsrfToken(csrfToken))) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
+  }
+
+  const { token } = parsed.data;
+  const [id, sig] = token.split(".");
+  if (!id || !sig)
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+
+  const secret = process.env.SESSION_SECRET ?? "test-secret";
+  const expected = crypto.createHmac("sha256", secret).update(id).digest("hex");
+  if (sig !== expected)
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+
+  const user = await getUserById(id);
+  if (!user)
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  await verifyUser(id);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/shop-abc/src/app/userStore.ts
+++ b/apps/shop-abc/src/app/userStore.ts
@@ -6,6 +6,7 @@ export interface User {
   email: string;
   passwordHash: string;
   role: string;
+  verified: boolean;
   resetTokenHash: string | null;
   resetTokenExpires: number | null;
 }
@@ -34,11 +35,13 @@ export async function addUser({
   email,
   passwordHash,
   role = "customer",
+  verified = false,
 }: {
   id: string;
   email: string;
   passwordHash: string;
   role?: string;
+  verified?: boolean;
 }): Promise<User> {
   const store = await readStore();
   const user: User = {
@@ -46,6 +49,7 @@ export async function addUser({
     email,
     passwordHash,
     role,
+    verified,
     resetTokenHash: null,
     resetTokenExpires: null,
   };
@@ -103,6 +107,15 @@ export async function updatePassword(
     user.passwordHash = passwordHash;
     user.resetTokenHash = null;
     user.resetTokenExpires = null;
+    await writeStore(store);
+  }
+}
+
+export async function verifyUser(id: string): Promise<void> {
+  const store = await readStore();
+  const user = store[id];
+  if (user) {
+    user.verified = true;
     await writeStore(store);
   }
 }

--- a/apps/shop-abc/src/app/verify/page.tsx
+++ b/apps/shop-abc/src/app/verify/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getCsrfToken } from "@shared-utils";
+import type { VerifyInput } from "../api/account/verify/route";
+
+export default function VerifyPage() {
+  const [status, setStatus] = useState("Verifying...");
+  const params = useSearchParams();
+
+  useEffect(() => {
+    const token = params.get("token");
+    async function verify() {
+      if (!token) {
+        setStatus("Missing token");
+        return;
+      }
+      const csrfToken = getCsrfToken();
+      const body: VerifyInput = { token };
+      const res = await fetch("/api/account/verify", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrfToken ?? "",
+        },
+        body: JSON.stringify(body),
+      });
+      setStatus(res.ok ? "Account verified" : "Verification failed");
+    }
+    verify();
+  }, [params]);
+
+  return <p>{status}</p>;
+}


### PR DESCRIPTION
## Summary
- store user verification state and update upon confirmation
- email signed verification link during registration
- block unverified logins until token validation succeeds

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689a4287a5f4832fbb852108e3af620f