### PR TITLE
feat(account): add change password page and api

### DIFF
--- a/apps/shop-abc/src/app/account/change-password/page.tsx
+++ b/apps/shop-abc/src/app/account/change-password/page.tsx
@@ -1,0 +1,58 @@
+import { getCustomerSession } from "@auth";
+import { redirect } from "next/navigation";
+import { useState } from "react";
+import { getCsrfToken } from "@shared-utils";
+
+export default async function ChangePasswordPage() {
+  const session = await getCustomerSession();
+  if (!session) {
+    redirect(`/login?callbackUrl=${encodeURIComponent("/account/change-password")}`);
+  }
+  return <ChangePasswordForm />;
+}
+
+function ChangePasswordForm() {
+  "use client";
+  const [msg, setMsg] = useState("");
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget.elements as any;
+    const currentPassword = (form.namedItem("currentPassword") as HTMLInputElement).value;
+    const newPassword = (form.namedItem("newPassword") as HTMLInputElement).value;
+    const csrfToken = getCsrfToken();
+    const res = await fetch("/api/account/change-password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken ?? "",
+      },
+      body: JSON.stringify({ currentPassword, newPassword }),
+    });
+    await res.json().catch(() => ({}));
+    setMsg(res.ok ? "Password updated" : "Error");
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        name="currentPassword"
+        type="password"
+        placeholder="Current password"
+        className="border p-1"
+      />
+      <input
+        name="newPassword"
+        type="password"
+        placeholder="New password"
+        pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$"
+        title="Password must be at least 8 characters and include uppercase, lowercase, and number"
+        className="border p-1"
+      />
+      <button type="submit" className="border px-2 py-1">
+        Change password
+      </button>
+      {msg && <p>{msg}</p>}
+    </form>
+  );
+}

--- a/apps/shop-abc/src/app/api/account/change-password/route.ts
+++ b/apps/shop-abc/src/app/api/account/change-password/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import { getCustomerSession, validateCsrfToken } from "@auth";
+import { getUserById, updatePassword } from "../../../userStore";
+
+const ChangePasswordSchema = z
+  .object({
+    currentPassword: z.string(),
+    newPassword: z
+      .string()
+      .min(8, "Password must be at least 8 characters long")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
+        "Password must include uppercase, lowercase, and number",
+      ),
+  })
+  .strict();
+
+export type ChangePasswordInput = z.infer<typeof ChangePasswordSchema>;
+
+export async function POST(req: Request) {
+  const session = await getCustomerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = req.headers.get("x-csrf-token");
+  if (!token || !(await validateCsrfToken(token))) {
+    return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
+  }
+
+  const json = await req.json();
+  const parsed = ChangePasswordSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
+  }
+
+  const { currentPassword, newPassword } = parsed.data;
+  const user = await getUserById(session.customerId);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const valid = await bcrypt.compare(currentPassword, user.passwordHash);
+  if (!valid) {
+    return NextResponse.json({ error: "Current password incorrect" }, { status: 400 });
+  }
+
+  const newHash = await bcrypt.hash(newPassword, 10);
+  await updatePassword(user.id, newHash);
+  return NextResponse.json({ ok: true });
+}

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -3,6 +3,7 @@ import { getCustomerSession } from "@auth";
 import { getCustomerProfile } from "@acme/platform-core";
 import ProfileForm from "./ProfileForm";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 
 export interface ProfilePageProps {
   /** Optional heading to allow shop-specific overrides */
@@ -27,6 +28,11 @@ export default async function ProfilePage({
     <div className="p-6">
       <h1 className="mb-4 text-xl">{title}</h1>
       <ProfileForm name={profile?.name} email={profile?.email} />
+      <div className="mt-4">
+        <Link href="/account/change-password" className="text-sm underline">
+          Change password
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add protected change password page with CSRF handling
- implement API route to validate and update password
- link change password from account profile

## Testing
- `pnpm exec jest packages/ui/__tests__/Sessions.test.tsx`
- `pnpm exec jest apps/shop-abc/__tests__/accountProfile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a428aa238832fbdfaa1e45884cbde