### PR TITLE
Send password reset link and auto-fill token

### DIFF
--- a/apps/shop-abc/src/app/account/reset/page.tsx
+++ b/apps/shop-abc/src/app/account/reset/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { getCsrfToken } from "@shared-utils";
 import type { ResetCompleteInput } from "../../api/account/reset/complete/route";
 
 export default function ResetPasswordPage() {
   const [msg, setMsg] = useState("");
+  const searchParams = useSearchParams();
+  const tokenParam = searchParams.get("token") ?? "";
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -28,7 +31,7 @@ export default function ResetPasswordPage() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
-      <input name="token" placeholder="Token" className="border p-1" />
+      <input type="hidden" name="token" value={tokenParam} />
       <input
         name="password"
         type="password"

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -40,10 +40,11 @@ export async function POST(req: Request) {
       .digest("hex");
     const expires = Date.now() + 1000 * 60 * 60; // 1 hour
     await setResetToken(user.id, hashedToken, expires);
+    const resetUrl = `/account/reset?token=${token}`;
     await sendEmail(
       parsed.data.email,
       "Password reset",
-      `Your token is ${token}`,
+      `Reset your password: ${resetUrl}`,
     );
   }
 

--- a/apps/shop-abc/src/app/forgot-password/page.tsx
+++ b/apps/shop-abc/src/app/forgot-password/page.tsx
@@ -22,7 +22,7 @@ export default function ForgotPasswordPage() {
       body: JSON.stringify(body),
     });
     await res.json().catch(() => ({}));
-    setMsg(res.ok ? "If the email exists, a token was sent." : "Error");
+    setMsg(res.ok ? "If the email exists, a reset link was sent." : "Error");
   }
   return (
     <form onSubmit={handleSubmit} className="space-y-2">


### PR DESCRIPTION
## Summary
- email password reset link instead of raw token
- auto-fill reset token from query string
- clarify forgot password messaging

## Testing
- `pnpm test` *(fails: Cannot find module '@acme/config/env.ts' in @acme/next-config)*

------
https://chatgpt.com/codex/tasks/task_e_689a42898148832f81575d71c9bd282a