### PR TITLE
feat(register): enforce strict schema

### DIFF
--- a/apps/shop-abc/__tests__/registerApi.test.ts
+++ b/apps/shop-abc/__tests__/registerApi.test.ts
@@ -85,6 +85,20 @@ describe("/register POST", () => {
     expect(data.ok).toBe(true);
   });
 
+  it("rejects unknown properties", async () => {
+    const req = {
+      json: async () => ({
+        customerId: "newuser",
+        email: "user@example.com",
+        password: "Str0ngPass",
+        extra: "nope",
+      }),
+      headers: new Headers({ "x-csrf-token": "tok" }),
+    } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
   it("rejects duplicate user IDs", async () => {
     const req = {
       json: async () => ({

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -11,17 +11,19 @@ import { checkRegistrationRateLimit } from "../../middleware";
 import { validateCsrfToken } from "@auth";
 import { updateCustomerProfile } from "@acme/platform-core/customerProfiles";
 
-const RegisterSchema = z.object({
-  customerId: z.string(),
-  email: z.string().email(),
-  password: z
-    .string()
-    .min(8, "Password must be at least 8 characters long")
-    .regex(
-      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
-      "Password must include uppercase, lowercase, and number",
-    ),
-});
+const RegisterSchema = z
+  .object({
+    customerId: z.string(),
+    email: z.string().email(),
+    password: z
+      .string()
+      .min(8, "Password must be at least 8 characters long")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
+        "Password must include uppercase, lowercase, and number",
+      ),
+  })
+  .strict();
 
 export async function POST(req: Request) {
   const json = await req.json();


### PR DESCRIPTION
## Summary
- reject unknown properties in `RegisterSchema`
- test registration rejection of unknown properties

## Testing
- `npx jest apps/shop-abc/__tests__/registerApi.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_689a427b2128832fab627be0de0c42de