### PR TITLE
feat: add pricing table block

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -178,6 +178,18 @@ export interface TestimonialsComponent extends PageComponentBase {
   testimonials?: { quote: string; name?: string }[];
 }
 
+export interface PricingTableComponent extends PageComponentBase {
+  type: "PricingTable";
+  plans?: {
+    title: string;
+    price: string;
+    features: string[];
+    ctaLabel: string;
+    ctaHref: string;
+    featured?: boolean;
+  }[];
+}
+
 export interface TextComponent extends PageComponentBase {
   type: "Text";
   text?: string;
@@ -225,6 +237,7 @@ export type PageComponent =
   | CountdownTimerComponent
   | BlogListingComponent
   | TestimonialsComponent
+  | PricingTableComponent
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent
@@ -402,6 +415,22 @@ const testimonialsComponentSchema = baseComponentSchema.extend({
     .optional(),
 });
 
+const pricingTableComponentSchema = baseComponentSchema.extend({
+  type: z.literal("PricingTable"),
+  plans: z
+    .array(
+      z.object({
+        title: z.string(),
+        price: z.string(),
+        features: z.array(z.string()),
+        ctaLabel: z.string(),
+        ctaHref: z.string(),
+        featured: z.boolean().optional(),
+      })
+    )
+    .optional(),
+});
+
 const imageComponentSchema = baseComponentSchema.extend({
   type: z.literal("Image"),
   src: z.string().optional(),
@@ -463,6 +492,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     socialLinksComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
+    pricingTableComponentSchema,
     testimonialSliderComponentSchema,
     imageComponentSchema,
     textComponentSchema,

--- a/packages/ui/src/components/cms/blocks/PricingTable.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/PricingTable.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import PricingTable from "./PricingTable";
+
+const meta: Meta<typeof PricingTable> = {
+  component: PricingTable,
+  args: {
+    plans: [
+      {
+        title: "Basic",
+        price: "$10/mo",
+        features: ["Feature A", "Feature B"],
+        ctaLabel: "Choose Basic",
+        ctaHref: "#",
+      },
+      {
+        title: "Pro",
+        price: "$20/mo",
+        features: ["Feature A", "Feature B", "Feature C"],
+        ctaLabel: "Choose Pro",
+        ctaHref: "#",
+        featured: true,
+      },
+      {
+        title: "Enterprise",
+        price: "$50/mo",
+        features: ["Everything in Pro", "Dedicated Support"],
+        ctaLabel: "Contact Us",
+        ctaHref: "#",
+      },
+    ],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof PricingTable> = {};

--- a/packages/ui/src/components/cms/blocks/PricingTable.tsx
+++ b/packages/ui/src/components/cms/blocks/PricingTable.tsx
@@ -1,0 +1,60 @@
+import { Button } from "../../atoms/shadcn";
+import { cn } from "../../../utils/style/cn";
+
+export interface Plan {
+  title: string;
+  price: string;
+  features: string[];
+  ctaLabel: string;
+  ctaHref: string;
+  featured?: boolean;
+}
+
+interface Props {
+  plans?: Plan[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function PricingTable({
+  plans = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = plans.slice(0, maxItems ?? plans.length);
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+
+  const colClass =
+    {
+      1: "md:grid-cols-1",
+      2: "md:grid-cols-2",
+      3: "md:grid-cols-3",
+      4: "md:grid-cols-4",
+    }[list.length] || "md:grid-cols-3";
+
+  return (
+    <section className={cn("grid grid-cols-1 gap-6", colClass)}>
+      {list.map((plan, i) => (
+        <div
+          key={i}
+          className={cn(
+            "flex flex-col rounded border p-6",
+            plan.featured && "border-primary"
+          )}
+        >
+          <h3 className="text-xl font-semibold">{plan.title}</h3>
+          <p className="mt-2 text-2xl font-bold">{plan.price}</p>
+          <ul className="mt-4 flex-1 space-y-2 text-sm">
+            {plan.features.map((f, idx) => (
+              <li key={idx}>{f}</li>
+            ))}
+          </ul>
+          <Button asChild className="mt-6 self-start">
+            <a href={plan.ctaHref}>{plan.ctaLabel}</a>
+          </Button>
+        </div>
+      ))}
+    </section>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/PricingTable.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/PricingTable.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import PricingTable from "../PricingTable";
+
+describe("PricingTable", () => {
+  it("renders plan details and CTA", () => {
+    render(
+      <PricingTable
+        plans={[
+          {
+            title: "Basic",
+            price: "$10/mo",
+            features: ["Feature A", "Feature B"],
+            ctaLabel: "Choose Basic",
+            ctaHref: "/basic",
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText("Basic")).toBeInTheDocument();
+    expect(screen.getByText("$10/mo")).toBeInTheDocument();
+    expect(screen.getByText("Feature A")).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: "Choose Basic" });
+    expect(cta).toHaveAttribute("href", "/basic");
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -21,6 +21,7 @@ import Footer from "./FooterBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
 import Button from "./Button";
+import PricingTable from "./PricingTable";
 
 export {
   BlogListing,
@@ -46,6 +47,7 @@ export {
   Footer,
   SocialLinks,
   Button,
+  PricingTable,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -16,6 +16,7 @@ import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
+import PricingTable from "./PricingTable";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -36,6 +37,7 @@ export const organismRegistry = {
   FAQBlock,
   CountdownTimer,
   SocialLinks,
+  PricingTable,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -26,6 +26,7 @@ import VideoBlockEditor from "./VideoBlockEditor";
 import FAQBlockEditor from "./FAQBlockEditor";
 import HeaderEditor from "./HeaderEditor";
 import FooterEditor from "./FooterEditor";
+import PricingTableEditor from "./PricingTableEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -65,6 +66,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "Testimonials":
       specific = (
         <TestimonialsEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "PricingTable":
+      specific = (
+        <PricingTableEditor component={component} onChange={onChange} />
       );
       break;
     case "HeroBanner":

--- a/packages/ui/src/components/cms/page-builder/PricingTableEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PricingTableEditor.tsx
@@ -1,0 +1,107 @@
+import type { ChangeEvent } from "react";
+import type { PageComponent } from "@acme/types";
+import { Button, Input, Textarea } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function PricingTableEditor({ component, onChange }: Props) {
+  const plans = ((component as any).plans ?? []) as any[];
+  const min = (component as any).minItems ?? 0;
+  const max = (component as any).maxItems ?? Infinity;
+
+  const update = (idx: number, field: string, value: unknown) => {
+    const next = [...plans];
+    next[idx] = { ...next[idx], [field]: value };
+    onChange({ plans: next } as Partial<PageComponent>);
+  };
+
+  const removePlan = (idx: number) => {
+    onChange({ plans: plans.filter((_, i) => i !== idx) } as Partial<PageComponent>);
+  };
+
+  const addPlan = () => {
+    onChange({
+      plans: [
+        ...plans,
+        { title: "", price: "", features: [], ctaLabel: "", ctaHref: "" },
+      ],
+    } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      {plans.map((plan, i) => (
+        <div key={i} className="space-y-1 rounded border p-2">
+          <Input
+            value={plan.title ?? ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              update(i, "title", e.target.value)
+            }
+            placeholder="title"
+            className="w-full"
+          />
+          <Input
+            value={plan.price ?? ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              update(i, "price", e.target.value)
+            }
+            placeholder="price"
+            className="w-full"
+          />
+          <Textarea
+            value={(plan.features ?? []).join("\n")}
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+              update(
+                i,
+                "features",
+                e.target.value
+                  .split(/\n+/)
+                  .map((f) => f.trim())
+                  .filter(Boolean)
+              )
+            }
+            placeholder="one feature per line"
+            className="w-full"
+          />
+          <Input
+            value={plan.ctaLabel ?? ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              update(i, "ctaLabel", e.target.value)
+            }
+            placeholder="CTA label"
+            className="w-full"
+          />
+          <Input
+            value={plan.ctaHref ?? ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              update(i, "ctaHref", e.target.value)
+            }
+            placeholder="CTA href"
+            className="w-full"
+          />
+          <div className="flex items-center gap-2">
+            <label className="text-sm">Featured</label>
+            <input
+              type="checkbox"
+              checked={plan.featured ?? false}
+              onChange={(e) => update(i, "featured", e.target.checked)}
+            />
+          </div>
+          <Button
+            variant="destructive"
+            onClick={() => removePlan(i)}
+            disabled={plans.length <= min}
+          >
+            Remove Plan
+          </Button>
+        </div>
+      ))}
+      <Button onClick={addPlan} disabled={plans.length >= max}>
+        Add Plan
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -11,6 +11,7 @@ export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as MapBlockEditor } from "./MapBlockEditor";
 export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as FAQBlockEditor } from "./FAQBlockEditor";
+export { default as PricingTableEditor } from "./PricingTableEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add PricingTable block with responsive layout
- add editor support and register block
- include stories and tests

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/PricingTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a5100acd0832f97a853c526a64758