### PR TITLE
feat: add social feed block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -71,6 +71,12 @@ export interface SocialLinksComponent extends PageComponentBase {
   youtube?: string;
   linkedin?: string;
 }
+export interface SocialFeedComponent extends PageComponentBase {
+  type: "SocialFeed";
+  provider: "instagram" | "twitter";
+  account?: string;
+  hashtag?: string;
+}
 export interface AnnouncementBarComponent extends PageComponentBase {
   type: "AnnouncementBar";
   text?: string;
@@ -228,6 +234,7 @@ export type PageComponent =
   | HeaderComponent
   | FooterComponent
   | SocialLinksComponent
+  | SocialFeedComponent
   | SectionComponent
   | MultiColumnComponent;
 export declare const pageSchema: z.ZodObject<

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -75,6 +75,13 @@ export interface SocialLinksComponent extends PageComponentBase {
   linkedin?: string;
 }
 
+export interface SocialFeedComponent extends PageComponentBase {
+  type: "SocialFeed";
+  provider: "instagram" | "twitter";
+  account?: string;
+  hashtag?: string;
+}
+
 export interface AnnouncementBarComponent extends PageComponentBase {
   type: "AnnouncementBar";
   text?: string;
@@ -233,6 +240,7 @@ export type PageComponent =
   | HeaderComponent
   | FooterComponent
   | SocialLinksComponent
+  | SocialFeedComponent
   | SectionComponent
   | MultiColumnComponent;
 
@@ -375,6 +383,13 @@ const socialLinksComponentSchema = baseComponentSchema.extend({
   linkedin: z.string().optional(),
 });
 
+const socialFeedComponentSchema = baseComponentSchema.extend({
+  type: z.literal("SocialFeed"),
+  provider: z.union([z.literal("instagram"), z.literal("twitter")]),
+  account: z.string().optional(),
+  hashtag: z.string().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -461,6 +476,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     headerComponentSchema,
     footerComponentSchema,
     socialLinksComponentSchema,
+    socialFeedComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     testimonialSliderComponentSchema,

--- a/packages/ui/__tests__/SocialFeed.test.tsx
+++ b/packages/ui/__tests__/SocialFeed.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import SocialFeed from "../src/components/cms/blocks/SocialFeed";
+
+describe("SocialFeed", () => {
+  const originalCreate = document.createElement.bind(document);
+
+  afterEach(() => {
+    document.createElement = originalCreate;
+  });
+
+  it("shows fallback on script failure", async () => {
+    document.createElement = ((tagName: string) => {
+      const el = originalCreate(tagName);
+      if (tagName === "script") {
+        setTimeout(() => {
+          el.onerror?.(new Event("error"));
+        }, 0);
+      }
+      return el;
+    }) as any;
+
+    render(<SocialFeed provider="twitter" account="test" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Unable to load social feed/i)
+      ).toBeInTheDocument()
+    );
+  });
+});
+

--- a/packages/ui/src/components/cms/blocks/SocialFeed.tsx
+++ b/packages/ui/src/components/cms/blocks/SocialFeed.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface SocialFeedProps {
+  provider: "instagram" | "twitter";
+  account?: string;
+  hashtag?: string;
+}
+
+export default function SocialFeed({
+  provider,
+  account,
+  hashtag,
+}: SocialFeedProps) {
+  const [error, setError] = useState(false);
+
+  const href = provider === "twitter"
+    ? account
+      ? `https://twitter.com/${account}`
+      : hashtag
+      ? `https://twitter.com/hashtag/${encodeURIComponent(hashtag)}`
+      : undefined
+    : account
+    ? `https://www.instagram.com/${account}`
+    : hashtag
+    ? `https://www.instagram.com/explore/tags/${encodeURIComponent(hashtag)}`
+    : undefined;
+
+  useEffect(() => {
+    if (!href) return;
+    const script = document.createElement("script");
+    script.async = true;
+    script.src =
+      provider === "twitter"
+        ? "https://platform.twitter.com/widgets.js"
+        : "https://www.instagram.com/embed.js";
+    script.onerror = () => setError(true);
+    script.onload = () => {
+      if (provider === "twitter") {
+        (window as any).twttr?.widgets.load();
+      } else {
+        (window as any).instgrm?.Embeds.process();
+      }
+    };
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, [provider, href]);
+
+  if (!href) return null;
+  if (error) {
+    return <p>Unable to load social feed.</p>;
+  }
+
+  if (provider === "twitter") {
+    return (
+      <blockquote className="twitter-timeline">
+        <a href={href}>Tweets by {account || `#${hashtag}`}</a>
+      </blockquote>
+    );
+  }
+
+  return (
+    <blockquote
+      className="instagram-media"
+      data-instgrm-permalink={href}
+      data-instgrm-version="14"
+    >
+      <a href={href}>Instagram</a>
+    </blockquote>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -21,6 +21,7 @@ import Footer from "./FooterBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
 import Button from "./Button";
+import SocialFeed from "./SocialFeed";
 
 export {
   BlogListing,
@@ -45,6 +46,7 @@ export {
   Header,
   Footer,
   SocialLinks,
+  SocialFeed,
   Button,
 };
 

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -16,6 +16,7 @@ import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
+import SocialFeed from "./SocialFeed";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -36,6 +37,7 @@ export const organismRegistry = {
   FAQBlock,
   CountdownTimer,
   SocialLinks,
+  SocialFeed,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -26,6 +26,7 @@ import VideoBlockEditor from "./VideoBlockEditor";
 import FAQBlockEditor from "./FAQBlockEditor";
 import HeaderEditor from "./HeaderEditor";
 import FooterEditor from "./FooterEditor";
+import SocialFeedEditor from "./SocialFeedEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -117,6 +118,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
             onChange={(e) => handleInput("styles", e.target.value)}
           />
         </>
+      );
+      break;
+    case "SocialFeed":
+      specific = (
+        <SocialFeedEditor component={component} onChange={onChange} />
       );
       break;
     case "SocialLinks":

--- a/packages/ui/src/components/cms/page-builder/SocialFeedEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/SocialFeedEditor.tsx
@@ -1,0 +1,48 @@
+import type { PageComponent } from "@acme/types";
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function SocialFeedEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value || undefined } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Select
+        value={(component as any).provider ?? ""}
+        onValueChange={(v) => handleInput("provider", v)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Provider" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="instagram">Instagram</SelectItem>
+          <SelectItem value="twitter">Twitter</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        label="Account"
+        value={(component as any).account ?? ""}
+        onChange={(e) => handleInput("account", e.target.value)}
+      />
+      <Input
+        label="Hashtag"
+        value={(component as any).hashtag ?? ""}
+        onChange={(e) => handleInput("hashtag", e.target.value)}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add SocialFeed block with Instagram and Twitter embeds and fallback message
- allow selecting provider/account/hashtag in new editor
- register SocialFeed in block registry and add unit tests

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/SocialFeed.test.tsx`
- `pnpm --filter @acme/ui test packages/ui/__tests__/pageComponentSchema.test.ts`
- `pnpm --filter @acme/ui test` (fails: Cannot find module '.prisma/client/index-browser')

------
https://chatgpt.com/codex/tasks/task_e_689a50fecd34832f8dc2046743f9e0be