### PR TITLE
feat: add page builder grid snapping

### DIFF
--- a/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
@@ -237,5 +237,84 @@ describe("PageBuilder interactions", () => {
       expect.objectContaining({ left: "100px" })
     );
   });
+
+  it("snaps resizing to grid units when grid is enabled", () => {
+    const component: any = { id: "c1", type: "Image", width: "100px", height: "100px" };
+    const dispatch = jest.fn();
+    const { container } = render(
+      <CanvasItem
+        component={component}
+        index={0}
+        parentId={undefined}
+        selectedId="c1"
+        onSelectId={() => {}}
+        onRemove={() => {}}
+        dispatch={dispatch}
+        locale="en"
+        gridEnabled
+        gridCols={4}
+      />
+    );
+    const el = container.firstChild as HTMLElement;
+    Object.defineProperty(container, "offsetWidth", { value: 400, writable: true });
+    Object.defineProperty(container, "offsetHeight", { value: 400, writable: true });
+    Object.defineProperty(el, "offsetWidth", { value: 100, writable: true });
+    Object.defineProperty(el, "offsetHeight", { value: 100, writable: true });
+    Object.defineProperty(el, "offsetLeft", { value: 0, writable: true });
+    Object.defineProperty(el, "offsetTop", { value: 0, writable: true });
+
+    const handle = el.querySelector(".cursor-nwse-resize") as HTMLElement;
+    fireEvent.pointerDown(handle, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(window, { clientX: 175, clientY: 175 });
+    fireEvent.pointerUp(window);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ width: "200px", height: "200px" })
+    );
+  });
+
+  it("snaps movement to grid units when grid is enabled", () => {
+    const component: any = {
+      id: "c1",
+      type: "Image",
+      width: "100px",
+      height: "100px",
+      position: "absolute",
+      left: "0px",
+      top: "0px",
+    };
+    const dispatch = jest.fn();
+    const { container } = render(
+      <CanvasItem
+        component={component}
+        index={0}
+        parentId={undefined}
+        selectedId="c1"
+        onSelectId={() => {}}
+        onRemove={() => {}}
+        dispatch={dispatch}
+        locale="en"
+        gridEnabled
+        gridCols={4}
+      />
+    );
+
+    const el = container.firstChild as HTMLElement;
+    Object.defineProperty(container, "offsetWidth", { value: 400, writable: true });
+    Object.defineProperty(container, "offsetHeight", { value: 400, writable: true });
+    Object.defineProperty(el, "offsetLeft", { value: 0, writable: true });
+    Object.defineProperty(el, "offsetTop", { value: 0, writable: true });
+    Object.defineProperty(el, "offsetWidth", { value: 100, writable: true });
+    Object.defineProperty(el, "offsetHeight", { value: 100, writable: true });
+
+    const handle = el.querySelector(".cursor-move") as HTMLElement;
+    fireEvent.pointerDown(handle, { clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(window, { clientX: 130, clientY: 130 });
+    fireEvent.pointerUp(window);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ left: "100px", top: "100px" })
+    );
+  });
 });
 

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -12,6 +12,7 @@ import Block from "./Block";
 import MenuBar from "./MenuBar";
 import useTextEditor from "./useTextEditor";
 import useSortableBlock from "./useSortableBlock";
+import { snapToGrid } from "./usePageBuilderDrag";
 
 const CanvasItem = memo(function CanvasItem({
   component,
@@ -22,6 +23,8 @@ const CanvasItem = memo(function CanvasItem({
   onRemove,
   dispatch,
   locale,
+  gridEnabled = false,
+  gridCols = 12,
 }: {
   component: PageComponent;
   index: number;
@@ -31,6 +34,8 @@ const CanvasItem = memo(function CanvasItem({
   onRemove: () => void;
   dispatch: React.Dispatch<Action>;
   locale: Locale;
+  gridEnabled?: boolean;
+  gridCols?: number;
 }) {
   const selected = selectedId === component.id;
   const {
@@ -122,6 +127,13 @@ const CanvasItem = memo(function CanvasItem({
       });
       const snapW = e.shiftKey || Math.abs(parentW - newW) <= threshold;
       const snapH = e.shiftKey || Math.abs(parentH - newH) <= threshold;
+      if (gridEnabled) {
+        const unit = parent ? parent.offsetWidth / gridCols : null;
+        if (unit) {
+          newW = snapToGrid(newW, unit);
+          newH = snapToGrid(newH, unit);
+        }
+      }
       dispatch({
         type: "resize",
         id: component.id,
@@ -182,6 +194,14 @@ const CanvasItem = memo(function CanvasItem({
           guideY = edge;
         }
       });
+      if (gridEnabled) {
+        const parent = containerRef.current.parentElement;
+        const unit = parent ? parent.offsetWidth / gridCols : null;
+        if (unit) {
+          newL = snapToGrid(newL, unit);
+          newT = snapToGrid(newT, unit);
+        }
+      }
       dispatch({
         type: "resize",
         id: component.id,
@@ -410,6 +430,8 @@ const CanvasItem = memo(function CanvasItem({
                   }
                   dispatch={dispatch}
                   locale={locale}
+                  gridEnabled={gridEnabled}
+                  gridCols={gridCols}
                 />
               )
             )}

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -33,6 +33,7 @@ type ComponentType =
   | keyof typeof layoutRegistry;
 
 const CONTAINER_TYPES = Object.keys(containerRegistry) as ComponentType[];
+const GRID_COLS = 12;
 
 const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   HeroBanner: { minItems: 1, maxItems: 5 },
@@ -144,6 +145,8 @@ const PageBuilder = memo(function PageBuilder({
     open: false,
     message: "",
   });
+  const [showGrid, setShowGrid] = useState(false);
+  const [gridSize, setGridSize] = useState(1);
 
   const {
     onDrop,
@@ -187,6 +190,7 @@ const PageBuilder = memo(function PageBuilder({
     containerTypes: CONTAINER_TYPES,
     setInsertIndex,
     selectId: setSelectedId,
+    gridSize,
   });
 
   const widthMap = useMemo(
@@ -197,6 +201,14 @@ const PageBuilder = memo(function PageBuilder({
     () => ({ width: widthMap[viewport] }),
     [viewport, widthMap]
   );
+
+  useEffect(() => {
+    if (showGrid && canvasRef.current) {
+      setGridSize(canvasRef.current.offsetWidth / GRID_COLS);
+    } else {
+      setGridSize(1);
+    }
+  }, [showGrid, viewport]);
 
   useEffect(() => {
     onChange?.(components);
@@ -264,6 +276,8 @@ const PageBuilder = memo(function PageBuilder({
           locales={locales}
           progress={progress}
           isValid={isValid}
+          showGrid={showGrid}
+          toggleGrid={() => setShowGrid((g) => !g)}
         />
         <div aria-live="polite" role="status" className="sr-only">
           {liveMessage}
@@ -283,6 +297,8 @@ const PageBuilder = memo(function PageBuilder({
           dispatch={dispatch}
           locale={locale}
           containerStyle={containerStyle}
+          showGrid={showGrid}
+          gridCols={GRID_COLS}
         />
         <div className="flex gap-2">
           <Button onClick={() => dispatch({ type: "undo" })} disabled={!state.past.length}>

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -28,6 +28,8 @@ interface Props {
   dispatch: (action: Action) => void;
   locale: Locale;
   containerStyle: CSSProperties;
+  showGrid?: boolean;
+  gridCols?: number;
 }
 
 const PageCanvas = ({
@@ -45,6 +47,8 @@ const PageCanvas = ({
   dispatch,
   locale,
   containerStyle,
+  showGrid = false,
+  gridCols = 12,
 }: Props) => (
   <DndContext
     sensors={sensors}
@@ -70,10 +74,23 @@ const PageCanvas = ({
         onDragLeave={() => setDragOver(false)}
         onDragEnd={() => setDragOver(false)}
         className={cn(
-          "mx-auto flex flex-col gap-4 rounded border",
+          "relative mx-auto flex flex-col gap-4 rounded border",
           dragOver && "ring-2 ring-primary"
         )}
       >
+        {showGrid && (
+          <div
+            className="pointer-events-none absolute inset-0 z-10 grid"
+            style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
+          >
+            {Array.from({ length: gridCols }).map((_, i) => (
+              <div
+                key={i}
+                className="border-l border-dashed border-muted-foreground/40"
+              />
+            ))}
+          </div>
+        )}
         {components.map((c, i) => (
           <Fragment key={c.id}>
             {insertIndex === i && (
@@ -91,6 +108,8 @@ const PageCanvas = ({
               onRemove={() => dispatch({ type: "remove", id: c.id })}
               dispatch={dispatch}
               locale={locale}
+              gridEnabled={showGrid}
+              gridCols={gridCols}
             />
           </Fragment>
         ))}

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -9,6 +9,8 @@ interface Props {
   locales: readonly Locale[];
   progress: { done: number; total: number } | null;
   isValid: boolean | null;
+  showGrid: boolean;
+  toggleGrid: () => void;
 }
 
 const PageToolbar = ({
@@ -19,6 +21,8 @@ const PageToolbar = ({
   locales,
   progress,
   isValid,
+  showGrid,
+  toggleGrid,
 }: Props) => (
   <div className="flex flex-col gap-4">
     <div className="flex justify-end gap-2">
@@ -31,6 +35,14 @@ const PageToolbar = ({
           {v.charAt(0).toUpperCase() + v.slice(1)}
         </Button>
       ))}
+    </div>
+    <div className="flex justify-end">
+      <Button
+        variant={showGrid ? "default" : "outline"}
+        onClick={toggleGrid}
+      >
+        {showGrid ? "Hide grid" : "Show grid"}
+      </Button>
     </div>
     <div className="flex justify-end gap-2">
       {locales.map((l) => (

--- a/packages/ui/src/components/cms/page-builder/usePageBuilderDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/usePageBuilderDrag.ts
@@ -19,7 +19,11 @@ interface Params {
   containerTypes: string[];
   setInsertIndex: (i: number | null) => void;
   selectId: (id: string) => void;
+  gridSize?: number;
 }
+
+export const snapToGrid = (value: number, gridSize: number) =>
+  Math.round(value / gridSize) * gridSize;
 
 export function usePageBuilderDrag({
   components,
@@ -28,6 +32,7 @@ export function usePageBuilderDrag({
   containerTypes,
   setInsertIndex,
   selectId,
+  gridSize = 1,
 }: Params) {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -39,7 +44,8 @@ export function usePageBuilderDrag({
       const { over, delta } = ev;
       if (!over) return;
       const overData = over.data.current as { index?: number };
-      const pointerY = (ev.activatorEvent as any)?.clientY + delta.y;
+      const rawY = (ev.activatorEvent as any)?.clientY + delta.y;
+      const pointerY = snapToGrid(rawY, gridSize);
       if (over.id === "canvas") {
         setInsertIndex(components.length);
         return;
@@ -48,7 +54,7 @@ export function usePageBuilderDrag({
       const index = (overData?.index ?? components.length) + (isBelow ? 1 : 0);
       setInsertIndex(index);
     },
-    [components.length, setInsertIndex]
+    [components.length, setInsertIndex, gridSize]
   );
 
   const handleDragEnd = useCallback(


### PR DESCRIPTION
## Summary
- add optional grid overlay to page canvas
- allow dragging/resizing to snap to grid units
- provide toolbar toggle and tests for grid snapping

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/PageBuilder.drag-resize.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a51023314832f9c38b86e5d40d5e8