### PR TITLE
feat(cms): add dataset selection for sanity

### DIFF
--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -20,17 +20,23 @@ export async function saveSanityConfig(
   const dataset = String(formData.get("dataset") ?? "");
   const token = String(formData.get("token") ?? "");
   const aclMode = String(formData.get("aclMode") ?? "public");
+  const createDataset = String(formData.get("createDataset") ?? "false") === "true";
 
   const config = { projectId, dataset, token };
 
-  const valid = await verifyCredentials(config);
-  if (!valid) {
-    return { error: "Invalid Sanity credentials" };
-  }
-
-  const setup = await setupSanityBlog(config, aclMode as "public" | "private");
-  if (!setup.success) {
-    return { error: setup.error ?? "Failed to setup Sanity blog" };
+  if (createDataset) {
+    const setup = await setupSanityBlog(
+      config,
+      aclMode as "public" | "private",
+    );
+    if (!setup.success) {
+      return { error: setup.error ?? "Failed to setup Sanity blog" };
+    }
+  } else {
+    const valid = await verifyCredentials(config);
+    if (!valid) {
+      return { error: "Invalid Sanity credentials" };
+    }
   }
 
   const shop = await getShopById(shopId);


### PR DESCRIPTION
## Summary
- fetch Sanity datasets after verifying project ID and token
- replace dataset input with select and optional creation path
- skip dataset creation when existing dataset is chosen

## Testing
- `pnpm test:cms` *(fails: Cannot find module '.prisma/client/index-browser'; process.exit due to missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689a50e48a54832facb12ba7ff0b5dcf