### PR TITLE
feat: add social feed block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -71,6 +71,12 @@ export interface SocialLinksComponent extends PageComponentBase {
   youtube?: string;
   linkedin?: string;
 }
+export interface SocialFeedComponent extends PageComponentBase {
+  type: "SocialFeed";
+  platform?: "twitter" | "instagram";
+  account?: string;
+  hashtag?: string;
+}
 export interface AnnouncementBarComponent extends PageComponentBase {
   type: "AnnouncementBar";
   text?: string;
@@ -228,6 +234,7 @@ export type PageComponent =
   | HeaderComponent
   | FooterComponent
   | SocialLinksComponent
+  | SocialFeedComponent
   | SectionComponent
   | MultiColumnComponent;
 export declare const pageSchema: z.ZodObject<

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -81,6 +81,13 @@ export interface SocialLinksComponent extends PageComponentBase {
   linkedin?: string;
 }
 
+export interface SocialFeedComponent extends PageComponentBase {
+  type: "SocialFeed";
+  platform?: "twitter" | "instagram";
+  account?: string;
+  hashtag?: string;
+}
+
 export interface AnnouncementBarComponent extends PageComponentBase {
   type: "AnnouncementBar";
   text?: string;
@@ -252,6 +259,7 @@ export type PageComponent =
   | HeaderComponent
   | FooterComponent
   | SocialLinksComponent
+  | SocialFeedComponent
   | SectionComponent
   | MultiColumnComponent;
 
@@ -397,6 +405,13 @@ const socialLinksComponentSchema = baseComponentSchema.extend({
   linkedin: z.string().optional(),
 });
 
+const socialFeedComponentSchema = baseComponentSchema.extend({
+  type: z.literal("SocialFeed"),
+  platform: z.enum(["twitter", "instagram"]).optional(),
+  account: z.string().optional(),
+  hashtag: z.string().optional(),
+});
+
 const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
@@ -499,6 +514,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     headerComponentSchema,
     footerComponentSchema,
     socialLinksComponentSchema,
+    socialFeedComponentSchema,
     blogListingComponentSchema,
     testimonialsComponentSchema,
     pricingTableComponentSchema,

--- a/packages/ui/src/components/cms/blocks/SocialFeed.tsx
+++ b/packages/ui/src/components/cms/blocks/SocialFeed.tsx
@@ -1,0 +1,41 @@
+// packages/ui/src/components/cms/blocks/SocialFeed.tsx
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  /** Social platform to embed */
+  platform: "twitter" | "instagram";
+  /** Account handle without @ */
+  account?: string;
+  /** Hashtag without # */
+  hashtag?: string;
+}
+
+/** Embed a social media feed from Twitter or Instagram */
+export default function SocialFeed({ platform, account, hashtag }: Props) {
+  const [failed, setFailed] = useState(false);
+
+  if (!account && !hashtag) return null;
+
+  const src =
+    platform === "twitter"
+      ? account
+        ? `https://twitframe.com/show?url=https://twitter.com/${account}`
+        : `https://twitframe.com/show?url=https://twitter.com/hashtag/${hashtag}`
+      : account
+        ? `https://www.instagram.com/${account}/embed`
+        : `https://www.instagram.com/explore/tags/${hashtag}/embed`;
+
+  if (failed) return <p>Unable to load social feed.</p>;
+
+  return (
+    <iframe
+      title="social-feed"
+      src={src}
+      className="w-full"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/SocialFeed.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/SocialFeed.test.tsx
@@ -1,0 +1,14 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import SocialFeed from "../SocialFeed";
+
+describe("SocialFeed", () => {
+  it("shows fallback when iframe fails", () => {
+    render(<SocialFeed platform="twitter" account="acme" />);
+    const iframe = screen.getByTitle("social-feed");
+    fireEvent.error(iframe);
+    expect(
+      screen.getByText(/unable to load social feed/i)
+    ).toBeInTheDocument();
+  });
+});
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -22,6 +22,7 @@ import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
 import Button from "./Button";
 import PricingTable from "./PricingTable";
+import SocialFeed from "./SocialFeed";
 
 export {
   BlogListing,
@@ -46,6 +47,7 @@ export {
   Header,
   Footer,
   SocialLinks,
+  SocialFeed,
   Button,
   PricingTable,
 };

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -16,6 +16,7 @@ import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
+import SocialFeed from "./SocialFeed";
 import PricingTable from "./PricingTable";
 
 export const organismRegistry = {
@@ -37,6 +38,7 @@ export const organismRegistry = {
   FAQBlock,
   CountdownTimer,
   SocialLinks,
+  SocialFeed,
   PricingTable,
 } as const;
 

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -21,6 +21,7 @@ import HeroBannerEditor from "./HeroBannerEditor";
 import ValuePropsEditor from "./ValuePropsEditor";
 import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
+import SocialFeedEditor from "./SocialFeedEditor";
 import MapBlockEditor from "./MapBlockEditor";
 import VideoBlockEditor from "./VideoBlockEditor";
 import FAQBlockEditor from "./FAQBlockEditor";
@@ -88,6 +89,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = (
         <ReviewsCarouselEditor component={component} onChange={onChange} />
       );
+      break;
+    case "SocialFeed":
+      specific = <SocialFeedEditor component={component} onChange={onChange} />;
       break;
     case "MapBlock":
       specific = <MapBlockEditor component={component} onChange={onChange} />;

--- a/packages/ui/src/components/cms/page-builder/SocialFeedEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/SocialFeedEditor.tsx
@@ -1,0 +1,41 @@
+import type { PageComponent } from "@acme/types";
+import { Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function SocialFeedEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Select
+        value={(component as any).platform ?? ""}
+        onValueChange={(v) => handleInput("platform", v)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="platform" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="twitter">twitter</SelectItem>
+          <SelectItem value="instagram">instagram</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        value={(component as any).account ?? ""}
+        onChange={(e) => handleInput("account", e.target.value)}
+        placeholder="account"
+      />
+      <Input
+        value={(component as any).hashtag ?? ""}
+        onChange={(e) => handleInput("hashtag", e.target.value)}
+        placeholder="hashtag"
+      />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -7,6 +7,7 @@ import HeroBannerEditor from "../HeroBannerEditor";
 import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
 import AnnouncementBarEditor from "../AnnouncementBarEditor";
+import SocialFeedEditor from "../SocialFeedEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -65,6 +66,12 @@ describe("block editors", () => {
       AnnouncementBarEditor,
       { type: "AnnouncementBar", text: "", link: "" },
       "text",
+    ],
+    [
+      "SocialFeedEditor",
+      SocialFeedEditor,
+      { type: "SocialFeed", platform: "twitter", account: "" },
+      "account",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -12,6 +12,7 @@ export { default as MapBlockEditor } from "./MapBlockEditor";
 export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as PricingTableEditor } from "./PricingTableEditor";
+export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add SocialFeed block for Twitter and Instagram embeds with graceful fallback
- enable SocialFeed editing via new SocialFeedEditor
- register SocialFeed block and editor in CMS tooling and types

## Testing
- `pnpm --filter @acme/ui test -- packages/ui` *(fails: Cannot find module '../../utils/style' from 'packages/ui/src/components/cms/blocks/SocialLinks.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689b02273cb0832f9e627bc560b9664a