### PR TITLE
feat(ui): add newsletter signup block

### DIFF
--- a/packages/ui/src/components/cms/blocks/NewsletterSignup.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/NewsletterSignup.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NewsletterSignup from "./NewsletterSignup";
+
+const meta: Meta<typeof NewsletterSignup> = {
+  component: NewsletterSignup,
+  args: {},
+};
+export default meta;
+
+export const Default: StoryObj<typeof NewsletterSignup> = {};

--- a/packages/ui/src/components/cms/blocks/NewsletterSignup.tsx
+++ b/packages/ui/src/components/cms/blocks/NewsletterSignup.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+export default function NewsletterSignup({
+  placeholder = "Enter your email",
+  buttonText = "Subscribe",
+  action = "/api/newsletter",
+}: {
+  placeholder?: string;
+  buttonText?: string;
+  action?: string;
+}) {
+  return (
+    <form className="space-y-2" action={action} method="post">
+      <input
+        type="email"
+        name="email"
+        placeholder={placeholder}
+        className="w-full rounded border p-2"
+      />
+      <button
+        type="submit"
+        className="rounded bg-primary px-4 py-2 text-primary-fg"
+      >
+        {buttonText}
+      </button>
+    </form>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import NewsletterSignup from "../NewsletterSignup";
+
+describe("NewsletterSignup", () => {
+  it("renders provided placeholder, button text, and action", () => {
+    render(
+      <NewsletterSignup
+        placeholder="Email here"
+        buttonText="Join"
+        action="/api/signup"
+      />
+    );
+    const input = screen.getByPlaceholderText("Email here") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    const form = input.closest("form");
+    expect(form).toHaveAttribute("action", "/api/signup");
+    expect(screen.getByRole("button", { name: "Join" })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -21,6 +21,7 @@ import Footer from "./FooterBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
 import Button from "./Button";
+import NewsletterSignup from "./NewsletterSignup";
 
 export {
   BlogListing,
@@ -46,6 +47,7 @@ export {
   Footer,
   SocialLinks,
   Button,
+  NewsletterSignup,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -16,6 +16,7 @@ import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
+import NewsletterSignup from "./NewsletterSignup";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -36,6 +37,7 @@ export const organismRegistry = {
   FAQBlock,
   CountdownTimer,
   SocialLinks,
+  NewsletterSignup,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -26,6 +26,7 @@ import VideoBlockEditor from "./VideoBlockEditor";
 import FAQBlockEditor from "./FAQBlockEditor";
 import HeaderEditor from "./HeaderEditor";
 import FooterEditor from "./FooterEditor";
+import NewsletterSignupEditor from "./NewsletterSignupEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -54,6 +55,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "ContactForm":
       specific = (
         <ContactFormEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "NewsletterSignup":
+      specific = (
+        <NewsletterSignupEditor component={component} onChange={onChange} />
       );
       break;
     case "Gallery":

--- a/packages/ui/src/components/cms/page-builder/NewsletterSignupEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/NewsletterSignupEditor.tsx
@@ -1,0 +1,33 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function NewsletterSignupEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).placeholder ?? ""}
+        onChange={(e) => handleInput("placeholder", e.target.value)}
+        placeholder="placeholder"
+      />
+      <Input
+        value={(component as any).buttonText ?? ""}
+        onChange={(e) => handleInput("buttonText", e.target.value)}
+        placeholder="buttonText"
+      />
+      <Input
+        value={(component as any).action ?? ""}
+        onChange={(e) => handleInput("action", e.target.value)}
+        placeholder="action"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -7,6 +7,7 @@ import HeroBannerEditor from "../HeroBannerEditor";
 import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
 import AnnouncementBarEditor from "../AnnouncementBarEditor";
+import NewsletterSignupEditor from "../NewsletterSignupEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -65,6 +66,17 @@ describe("block editors", () => {
       AnnouncementBarEditor,
       { type: "AnnouncementBar", text: "", link: "" },
       "text",
+    ],
+    [
+      "NewsletterSignupEditor",
+      NewsletterSignupEditor,
+      {
+        type: "NewsletterSignup",
+        placeholder: "",
+        buttonText: "",
+        action: "",
+      },
+      "placeholder",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -11,6 +11,7 @@ export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as MapBlockEditor } from "./MapBlockEditor";
 export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as FAQBlockEditor } from "./FAQBlockEditor";
+export { default as NewsletterSignupEditor } from "./NewsletterSignupEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add `NewsletterSignup` block with customizable placeholder, button text, and API action
- support block configuration via `NewsletterSignupEditor`
- register block in CMS builder and add stories & tests

## Testing
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689a50fcbd74832fba3a0f05fe6dbb64