### PR TITLE
refactor blog portable text

### DIFF
--- a/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,42 +1,7 @@
-import { PortableText } from "@portabletext/react";
 import { notFound } from "next/navigation";
 import { fetchPostBySlug } from "@acme/sanity";
-import { getProductBySlug } from "@/lib/products";
-import { ProductCard } from "@/components/shop/ProductCard";
+import { BlogPortableText } from "@/components/blog/BlogPortableText";
 import shop from "../../../../../shop.json";
-
-const components = {
-  types: {
-    productReference: ({ value }: any) => {
-      if (typeof value?.slug !== "string") return null;
-      const sku = getProductBySlug(value.slug);
-      return sku ? <ProductCard sku={sku} /> : null;
-    },
-    embed: ({ value }: any) => (
-      <div className="aspect-video">
-        <iframe src={value.url} className="h-full w-full" />
-      </div>
-    ),
-  },
-  marks: {
-    link: ({ children, value }: any) => (
-      <a
-        href={value.href}
-        className="text-blue-600 underline"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {children}
-      </a>
-    ),
-    em: ({ children }: any) => <em>{children}</em>,
-  },
-  block: {
-    h1: ({ children }: any) => <h1>{children}</h1>,
-    h2: ({ children }: any) => <h2>{children}</h2>,
-    h3: ({ children }: any) => <h3>{children}</h3>,
-  },
-};
 
 export default async function BlogPostPage({
   params,
@@ -51,7 +16,7 @@ export default async function BlogPostPage({
       {post.excerpt && <p className="text-muted">{post.excerpt}</p>}
       {Array.isArray(post.body) ? (
         <div className="space-y-4">
-          <PortableText value={post.body} components={components} />
+          <BlogPortableText value={post.body} />
         </div>
       ) : null}
     </article>

--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { fetchPostBySlug } from "@acme/sanity";
+import { BlogPortableText } from "@/components/blog/BlogPortableText";
 import shop from "../../../../../shop.json";
 
 export default async function BlogPostPage({
@@ -14,10 +15,8 @@ export default async function BlogPostPage({
       <h1 className="text-2xl font-bold">{post.title}</h1>
       {post.excerpt && <p className="text-muted">{post.excerpt}</p>}
       {Array.isArray(post.body) ? (
-        <div className="space-y-2">
-          {(post.body as any[]).map((b, i) => (
-            <p key={i}>{b.children?.map((c: any) => c.text).join("")}</p>
-          ))}
+        <div className="space-y-4">
+          <BlogPortableText value={post.body} />
         </div>
       ) : null}
     </article>

--- a/packages/platform-core/src/components/blog/BlogPortableText.tsx
+++ b/packages/platform-core/src/components/blog/BlogPortableText.tsx
@@ -1,0 +1,41 @@
+// src/components/blog/BlogPortableText.tsx
+import { PortableText } from "@portabletext/react";
+import { getProductBySlug } from "@/lib/products";
+import { ProductCard } from "@/components/shop/ProductCard";
+
+const components = {
+  types: {
+    productReference: ({ value }: any) => {
+      if (typeof value?.slug !== "string") return null;
+      const sku = getProductBySlug(value.slug);
+      return sku ? <ProductCard sku={sku} /> : null;
+    },
+    embed: ({ value }: any) => (
+      <div className="aspect-video">
+        <iframe src={value.url} className="h-full w-full" />
+      </div>
+    ),
+  },
+  marks: {
+    link: ({ children, value }: any) => (
+      <a
+        href={value.href}
+        className="text-blue-600 underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    ),
+    em: ({ children }: any) => <em>{children}</em>,
+  },
+  block: {
+    h1: ({ children }: any) => <h1>{children}</h1>,
+    h2: ({ children }: any) => <h2>{children}</h2>,
+    h3: ({ children }: any) => <h3>{children}</h3>,
+  },
+};
+
+export function BlogPortableText({ value }: { value: any[] }) {
+  return <PortableText value={value} components={components} />;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -55,6 +55,7 @@
       /* ─── short '@/…' imports for components & hooks ────────────── */
       "@/components/pdp/*": ["packages/platform-core/src/components/pdp/*"],
       "@/components/shop/*": ["packages/platform-core/src/components/shop/*"],
+      "@/components/blog/*": ["packages/platform-core/src/components/blog/*"],
 
       /* ─── lib helpers (products, cookies, …) ────────────── */
       "@lib/*": ["packages/platform-core/src/*"],


### PR DESCRIPTION
## Summary
- add shared blog PortableText renderer with product card references
- use shared renderer in shop-abc and shop-bcd blog posts
- expose blog components via tsconfig path alias

## Testing
- `pnpm test` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689a50ea4288832fbf2804ab94d87b98