### PR TITLE
feat(cms): validate product slugs

### DIFF
--- a/apps/cms/__tests__/blogActions.test.ts
+++ b/apps/cms/__tests__/blogActions.test.ts
@@ -27,7 +27,7 @@ describe("blog actions", () => {
     fd.set("excerpt", "");
     fd.set("publishedAt", "2025-01-01T10:00");
     await createPost("s", {} as any, fd);
-    const body = JSON.parse((fetch as jest.Mock).mock.calls[1][1].body);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
     expect(body.mutations[0].create.publishedAt).toBe(
       new Date("2025-01-01T10:00").toISOString(),
     );
@@ -39,14 +39,18 @@ describe("blog actions", () => {
     const fd = new FormData();
     fd.set("publishedAt", "2025-01-02T12:00");
     await publishPost("s", "1", {} as any, fd);
-    const body = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
     expect(body.mutations[0].patch.set.publishedAt).toBe(
       new Date("2025-01-02T12:00").toISOString(),
     );
   });
 
   test("createPost collects product slugs", async () => {
-    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ results: [{ id: "1" }] }) }) as any;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ json: async () => ({ result: null }) })
+      .mockResolvedValueOnce({ json: async () => ({ results: [{ id: "1" }] }) }) as any;
     const { createPost } = await import("../src/actions/blog.server");
     const fd = new FormData();
     fd.set("title", "T");
@@ -57,12 +61,17 @@ describe("blog actions", () => {
     fd.set("slug", "t");
     fd.set("excerpt", "");
     await createPost("s", {} as any, fd);
-    const body = JSON.parse((fetch as jest.Mock).mock.calls[1][1].body);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
     expect(body.mutations[0].create.products).toEqual(["foo"]);
   });
 
   test("updatePost collects product slugs", async () => {
-    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({}) }) as any;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ json: async () => ({ result: null }) })
+      .mockResolvedValueOnce({ json: async () => ({}) }) as any;
     const { updatePost } = await import("../src/actions/blog.server");
     const fd = new FormData();
     fd.set("id", "1");
@@ -77,7 +86,48 @@ describe("blog actions", () => {
     fd.set("slug", "t");
     fd.set("excerpt", "");
     await updatePost("s", {} as any, fd);
-    const body = JSON.parse((fetch as jest.Mock).mock.calls[1][1].body);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
     expect(body.mutations[0].patch.set.products).toEqual(["foo", "bar"]);
+  });
+
+  test("createPost filters invalid product slugs", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ json: async () => ({ result: null }) })
+      .mockResolvedValueOnce({ json: async () => ({ results: [{ id: "1" }] }) }) as any;
+    const { createPost } = await import("../src/actions/blog.server");
+    const fd = new FormData();
+    fd.set("title", "T");
+    fd.set(
+      "content",
+      JSON.stringify([{ _type: "productReference", slug: "foo" }]),
+    );
+    fd.set("slug", "t");
+    fd.set("excerpt", "");
+    await createPost("s", {} as any, fd);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
+    expect(body.mutations[0].create.products).toEqual([]);
+  });
+
+  test("updatePost filters invalid product slugs", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ json: async () => ({ result: null }) })
+      .mockResolvedValueOnce({ json: async () => ({}) }) as any;
+    const { updatePost } = await import("../src/actions/blog.server");
+    const fd = new FormData();
+    fd.set("id", "1");
+    fd.set("title", "T");
+    fd.set(
+      "content",
+      JSON.stringify([{ _type: "productReference", slug: "foo" }]),
+    );
+    fd.set("slug", "t");
+    fd.set("excerpt", "");
+    await updatePost("s", {} as any, fd);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
+    expect(body.mutations[0].patch.set.products).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- check blog post product references against `/api/products`
- skip invalid product slugs when saving
- add unit tests for slug validation

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689a50e84258832f8c128b5bb2385b03