### PR TITLE
Use theme overrides in ThemeEditor

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within, waitFor } from "@testing-library/react";
 import ThemeEditor from "../src/app/cms/shop/[shop]/themes/ThemeEditor";
 import { updateShop } from "@cms/actions/shops.server";
 
@@ -92,5 +92,27 @@ describe("ThemeEditor", () => {
     });
     fireEvent.click(swatch);
     expect(colorInput).toHaveFocus();
+  });
+
+  it("does not persist untouched tokens as overrides", async () => {
+    const tokensByTheme = { base: { "--color-bg": "white" } };
+    const mock = updateShop as jest.Mock;
+    mock.mockClear();
+    mock.mockResolvedValue({});
+    render(
+      <ThemeEditor
+        shop="test"
+        themes={["base"]}
+        tokensByTheme={tokensByTheme}
+        initialTheme="base"
+        initialOverrides={{}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(mock).toHaveBeenCalled());
+    const fd = mock.mock.calls[0][1] as FormData;
+    expect(JSON.parse(fd.get("themeOverrides") as string)).toEqual({});
   });
 });

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
@@ -45,6 +45,13 @@ export default function ThemeEditor({
     return groups;
   }, [theme, tokensByTheme]);
 
+  const changedOverrides = useMemo(() => {
+    const tokens = tokensByTheme[theme];
+    return Object.fromEntries(
+      Object.entries(overrides).filter(([k, v]) => tokens[k] !== v)
+    );
+  }, [overrides, tokensByTheme, theme]);
+
   const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const next = e.target.value;
     setTheme(next);
@@ -78,7 +85,7 @@ export default function ThemeEditor({
     e.preventDefault();
     setSaving(true);
     const fd = new FormData(e.currentTarget);
-    fd.set("themeOverrides", JSON.stringify(overrides));
+    fd.set("themeOverrides", JSON.stringify(changedOverrides));
     const result = await updateShop(shop, fd);
     if (result.errors) {
       setErrors(result.errors);
@@ -94,7 +101,7 @@ export default function ThemeEditor({
       <input
         type="hidden"
         name="themeOverrides"
-        value={JSON.stringify(overrides)}
+        value={JSON.stringify(changedOverrides)}
       />
       <label className="flex flex-col gap-1">
         <span>Theme</span>

--- a/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
@@ -23,7 +23,7 @@ export default async function ShopThemePage({
         themes={themes}
         tokensByTheme={tokensByTheme}
         initialTheme={shopData.themeId}
-        initialOverrides={shopData.themeTokens}
+        initialOverrides={shopData.themeOverrides}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- pass shop themeOverrides into ThemeEditor
- filter overrides to submit only changed tokens
- test that untouched tokens are not persisted

## Testing
- `pnpm --filter @apps/cms test -- __tests__/ThemeEditor.test.tsx`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '.prisma/client/index-browser')*


------
https://chatgpt.com/codex/tasks/task_e_689a50d56034832fb574df4ec6a431ae