### PR TITLE
feat: add theme preview click targeting

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test.tsx
@@ -93,4 +93,30 @@ describe("ThemeEditor", () => {
     fireEvent.click(swatch);
     expect(colorInput).toHaveFocus();
   });
+
+  it("focuses field when preview element clicked", () => {
+    const tokensByTheme = { base: { "--color-primary": "#0000ff" } };
+    render(
+      <ThemeEditor
+        shop="test"
+        themes={["base"]}
+        tokensByTheme={tokensByTheme}
+        initialTheme="base"
+        initialOverrides={{}}
+      />
+    );
+
+    const iframe = screen.getByTitle("preview") as HTMLIFrameElement;
+    const doc = document.implementation.createHTMLDocument();
+    doc.body.innerHTML = '<button data-token="--color-primary">x</button>';
+    Object.defineProperty(iframe, "contentDocument", { value: doc });
+    fireEvent.load(iframe);
+    const previewBtn = doc.querySelector("button")!;
+    previewBtn.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+
+    const colorInput = screen.getByLabelText("--color-primary", {
+      selector: 'input[type="color"]',
+    });
+    expect(colorInput).toHaveFocus();
+  });
 });

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -46,6 +46,7 @@ export default function ThemeToggle() {
         onKeyDown={handleKeyDown}
         aria-label={`Switch to ${labels[next]} theme`}
         className="p-2"
+        data-token="--color-primary"
       >
         <Icon />
       </button>

--- a/packages/ui/src/components/layout/Footer.tsx
+++ b/packages/ui/src/components/layout/Footer.tsx
@@ -12,6 +12,7 @@ const Footer = memo(function Footer({
 }) {
   return (
     <footer
+      data-token="--color-muted"
       className={cn(
         "flex items-center justify-center bg-muted text-sm text-muted",
         height,
@@ -20,11 +21,19 @@ const Footer = memo(function Footer({
     >
       {" "}
       <p className="space-x-4">
-        <Link href="/legal/privacy" className="hover:underline">
+        <Link
+          href="/legal/privacy"
+          className="hover:underline"
+          data-token="--color-fg"
+        >
           Privacy
         </Link>
         <span>&middot;</span>
-        <Link href="/legal/terms" className="hover:underline">
+        <Link
+          href="/legal/terms"
+          className="hover:underline"
+          data-token="--color-fg"
+        >
           Terms
         </Link>
       </p>

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -30,9 +30,14 @@ export default function HeaderClient({
 
   return (
     <header
+      data-token="--color-bg"
       className={cn("flex items-center justify-between", height, padding)}
     >
-      <Link href={`/${lang}`} className="text-xl font-bold">
+      <Link
+        href={`/${lang}`}
+        className="text-xl font-bold"
+        data-token="--color-fg"
+      >
         Base-Shop
       </Link>
 
@@ -41,16 +46,24 @@ export default function HeaderClient({
           <Link
             key={item.url}
             href={item.url.startsWith("/") ? `/${lang}${item.url}` : item.url}
+            data-token="--color-fg"
           >
             {item.label}
           </Link>
         ))}
         <CurrencySwitcher />
         <ThemeToggle />
-        <Link href={`/${lang}/checkout`} className="relative hover:underline">
+        <Link
+          href={`/${lang}/checkout`}
+          className="relative hover:underline"
+          data-token="--color-fg"
+        >
           Cart
           {qty > 0 && (
-            <span className="absolute -top-2 -right-3 rounded-full bg-danger px-1.5 text-xs text-danger-foreground">
+            <span
+              className="absolute -top-2 -right-3 rounded-full bg-danger px-1.5 text-xs text-danger-foreground"
+              data-token="--color-danger"
+            >
               {qty}
             </span>
           )}


### PR DESCRIPTION
## Summary
- annotate header, footer, and theme toggle with theme token markers
- embed shop preview iframe that focuses override inputs on element click
- test preview click mapping to token inputs

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/ThemeEditor.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689a50c58ff8832f9228d48f0398e059