### PR TITLE
feat: require cart cookie secret

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -76,7 +76,7 @@ Lines that have no value after the equals sign (e.g. `MY_VAR=`) are treated as p
 The wizard scaffolds placeholders for common variables:
 
 - `STRIPE_SECRET_KEY` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` – Stripe API keys
-- `CART_COOKIE_SECRET` – secret for signing cart cookies
+- `CART_COOKIE_SECRET` – secret for signing cart cookies (required)
 - `CART_TTL` – cart expiration in seconds (default 30 days)
 - `NEXTAUTH_SECRET` – session encryption secret used by NextAuth
 - `PREVIEW_TOKEN_SECRET` – token used for preview URLs

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -13,6 +13,7 @@ describe("envSchema", () => {
       ...OLD_ENV,
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      CART_COOKIE_SECRET: "secret",
     } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");
@@ -20,10 +21,12 @@ describe("envSchema", () => {
       STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY!,
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
         process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
+      CART_COOKIE_SECRET: process.env.CART_COOKIE_SECRET!,
     });
     expect(parsed).toEqual({
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      CART_COOKIE_SECRET: "secret",
     });
   });
 
@@ -32,12 +35,14 @@ describe("envSchema", () => {
       ...OLD_ENV,
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      CART_COOKIE_SECRET: "secret",
     } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");
 
     const invalid = {
       STRIPE_SECRET_KEY: "sk",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
     } as Record<string, string>;
 
     expect(() => envSchema.parse(invalid)).toThrow();

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -12,7 +12,7 @@ export const envSchema = z.object({
   NEXT_PUBLIC_DEFAULT_SHOP: z.string().optional(),
   NEXT_PUBLIC_SHOP_ID: z.string().optional(),
   SHOP_CODE: z.string().optional(),
-  CART_COOKIE_SECRET: z.string().min(1).optional(),
+  CART_COOKIE_SECRET: z.string().min(1),
   CART_TTL: z.coerce.number().optional(),
   CMS_SPACE_URL: z.string().url().optional(),
   CMS_ACCESS_TOKEN: z.string().optional(),

--- a/packages/configurator/__tests__/cli.test.ts
+++ b/packages/configurator/__tests__/cli.test.ts
@@ -16,6 +16,7 @@ describe("configurator CLI", () => {
 
     process.env.STRIPE_SECRET_KEY = "sk";
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
+    process.env.CART_COOKIE_SECRET = "secret";
   });
 
   afterEach(() => {

--- a/scripts/__tests__/validate-env.test.ts
+++ b/scripts/__tests__/validate-env.test.ts
@@ -20,6 +20,7 @@ describe("validate-env script", () => {
     process.argv = ["node", "validate-env", "abc"];
     process.env.STRIPE_SECRET_KEY = "sk";
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
+    process.env.CART_COOKIE_SECRET = "secret";
     existsSyncMock = require("node:fs").existsSync as jest.Mock;
     readFileSyncMock = require("node:fs").readFileSync as jest.Mock;
     existsSyncMock.mockReset();
@@ -34,7 +35,7 @@ describe("validate-env script", () => {
   it("exits 0 and logs success for valid env", async () => {
     existsSyncMock.mockReturnValue(true);
     readFileSyncMock.mockReturnValue(
-      "STRIPE_SECRET_KEY=sk\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\n"
+      "STRIPE_SECRET_KEY=sk\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCART_COOKIE_SECRET=secret\n"
     );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
@@ -54,7 +55,9 @@ describe("validate-env script", () => {
 
   it("exits 1 and reports invalid env", async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue("STRIPE_SECRET_KEY=sk\n");
+    readFileSyncMock.mockReturnValue(
+      "STRIPE_SECRET_KEY=sk\nCART_COOKIE_SECRET=secret\n"
+    );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- require `CART_COOKIE_SECRET` in env schema
- update tests and scripts to provide the cookie secret
- document `CART_COOKIE_SECRET` as required

## Testing
- `pnpm exec jest packages/config/__tests__/env.test.ts scripts/__tests__/validate-env.test.ts packages/configurator/__tests__/cli.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a4d1b714c832f80e00be179a6a2ca