### PR TITLE
test: cover logo and contact prompts in init-shop

### DIFF
--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -9,8 +9,8 @@ describe('init-shop wizard', () => {
     const answers = [
       'demo',
       'Demo Shop',
-      '',
-      '',
+      'https://example.com/logo.png',
+      'contact@example.com',
       '',
       'base',
       'template-app',
@@ -112,6 +112,8 @@ describe('init-shop wizard', () => {
       'shop-demo',
       {
         name: 'Demo Shop',
+        logo: 'https://example.com/logo.png',
+        contactInfo: 'contact@example.com',
         type: 'sale',
         theme: 'base',
         template: 'template-app',


### PR DESCRIPTION
## Summary
- include logo URL and contact email prompts in init-shop test
- expect createShop to receive logo and contactInfo
- keep env validation failure reporting check

## Testing
- `pnpm exec jest test/unit/init-shop.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b14fa107c832f95a0bbf5e29281b1