### PR TITLE
feat(cms): refine Sanity setup error handling

### DIFF
--- a/apps/cms/__tests__/saveSanityConfig.test.ts
+++ b/apps/cms/__tests__/saveSanityConfig.test.ts
@@ -109,6 +109,7 @@ describe("saveSanityConfig", () => {
     (setupSanityBlog as jest.Mock).mockResolvedValue({
       success: false,
       error: "fail",
+      code: "DATASET_CREATE_ERROR",
     });
 
     const fd = new FormData();
@@ -119,6 +120,6 @@ describe("saveSanityConfig", () => {
     fd.set("createDataset", "true");
 
     const res = await saveSanityConfig("shop", fd);
-    expect(res).toEqual({ error: "fail" });
+    expect(res).toEqual({ error: "fail", errorCode: "DATASET_CREATE_ERROR" });
   });
 });

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -13,6 +13,7 @@ export async function saveSanityConfig(
 ): Promise<{
   error?: string;
   message?: string;
+  errorCode?: string;
 }> {
   await ensureAuthorized();
 
@@ -30,12 +31,15 @@ export async function saveSanityConfig(
       aclMode as "public" | "private",
     );
     if (!setup.success) {
-      return { error: setup.error ?? "Failed to setup Sanity blog" };
+      return {
+        error: setup.error ?? "Failed to setup Sanity blog",
+        errorCode: setup.code,
+      };
     }
   } else {
     const valid = await verifyCredentials(config);
     if (!valid) {
-      return { error: "Invalid Sanity credentials" };
+      return { error: "Invalid Sanity credentials", errorCode: "INVALID_CREDENTIALS" };
     }
   }
 

--- a/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
@@ -11,6 +11,7 @@ import { deleteSanityConfig } from "@cms/actions/deleteSanityConfig";
 interface FormState {
   message?: string;
   error?: string;
+  errorCode?: string;
 }
 
 interface Props {
@@ -18,7 +19,7 @@ interface Props {
   initial?: { projectId: string; dataset: string; token?: string };
 }
 
-const initialState: FormState = { message: "", error: "" };
+const initialState: FormState = { message: "", error: "", errorCode: "" };
 
 export default function ConnectForm({ shopId, initial }: Props) {
   const saveAction = saveSanityConfig.bind(null, shopId);


### PR DESCRIPTION
## Summary
- add specific error codes for Sanity dataset listing, creation, and schema upload
- propagate Sanity setup error codes through saveSanityConfig and ConnectForm state
- cover failure propagation in saveSanityConfig tests

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/saveSanityConfig.test.ts`
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '.prisma/client/index-browser')*
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689b13ab7960832f91ef2d62f719bf36