### PR TITLE
feat: add newsletter signup CMS block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -133,6 +133,13 @@ export interface ContactFormComponent extends PageComponentBase {
   action?: string;
   method?: string;
 }
+export interface NewsletterSignupComponent extends PageComponentBase {
+  type: "NewsletterSignup";
+  text?: string;
+  action?: string;
+  placeholder?: string;
+  submitLabel?: string;
+}
 export interface ContactFormWithMapComponent extends PageComponentBase {
   type: "ContactFormWithMap";
   mapSrc?: string;
@@ -220,6 +227,7 @@ export type PageComponent =
   | RecommendationCarouselComponent
   | GalleryComponent
   | ContactFormComponent
+  | NewsletterSignupComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
   | VideoBlockComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -138,6 +138,14 @@ export interface ContactFormComponent extends PageComponentBase {
   method?: string;
 }
 
+export interface NewsletterSignupComponent extends PageComponentBase {
+  type: "NewsletterSignup";
+  text?: string;
+  action?: string;
+  placeholder?: string;
+  submitLabel?: string;
+}
+
 export interface ContactFormWithMapComponent extends PageComponentBase {
   type: "ContactFormWithMap";
   mapSrc?: string;
@@ -243,6 +251,7 @@ export type PageComponent =
   | RecommendationCarouselComponent
   | GalleryComponent
   | ContactFormComponent
+  | NewsletterSignupComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
   | VideoBlockComponent
@@ -340,6 +349,14 @@ const contactFormComponentSchema = baseComponentSchema.extend({
   type: z.literal("ContactForm"),
   action: z.string().optional(),
   method: z.string().optional(),
+});
+
+const newsletterSignupComponentSchema = baseComponentSchema.extend({
+  type: z.literal("NewsletterSignup"),
+  text: z.string().optional(),
+  action: z.string().optional(),
+  placeholder: z.string().optional(),
+  submitLabel: z.string().optional(),
 });
 
 const contactFormWithMapComponentSchema = baseComponentSchema.extend({
@@ -506,6 +523,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     recommendationCarouselComponentSchema,
     galleryComponentSchema,
     contactFormComponentSchema,
+    newsletterSignupComponentSchema,
     contactFormWithMapComponentSchema,
     mapBlockComponentSchema,
     videoBlockComponentSchema,

--- a/packages/ui/src/components/cms/blocks/NewsletterSignup.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/NewsletterSignup.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NewsletterSignup from "./NewsletterSignup";
+
+const meta: Meta<typeof NewsletterSignup> = {
+  title: "CMS/Blocks/NewsletterSignup",
+  component: NewsletterSignup,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof NewsletterSignup> = {
+  args: {
+    text: "Join our mailing list",
+    action: "/api/subscribe",
+    placeholder: "Email address",
+    submitLabel: "Sign Up",
+  },
+};

--- a/packages/ui/src/components/cms/blocks/NewsletterSignup.tsx
+++ b/packages/ui/src/components/cms/blocks/NewsletterSignup.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { NewsletterForm } from "./molecules";
+
+interface Props {
+  /** API endpoint to submit the email to */
+  action?: string;
+  /** Placeholder text for the email input */
+  placeholder?: string;
+  /** Label for the submit button */
+  submitLabel?: string;
+  /** Optional text displayed above the form */
+  text?: string;
+}
+
+export default function NewsletterSignup({
+  action,
+  placeholder = "Email",
+  submitLabel = "Subscribe",
+  text,
+}: Props) {
+  return (
+    <div className="space-y-2">
+      {text && <p>{text}</p>}
+      <NewsletterForm
+        action={action}
+        placeholder={placeholder}
+        submitLabel={submitLabel}
+      />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import NewsletterSignup from "../NewsletterSignup";
+
+describe("NewsletterSignup", () => {
+  it("renders text and form", () => {
+    render(
+      <NewsletterSignup
+        text="Stay updated"
+        action="/api/newsletter"
+        placeholder="Your email"
+        submitLabel="Join"
+      />
+    );
+    expect(screen.getByText("Stay updated")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Your email")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Join" })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -23,6 +23,7 @@ import SocialLinks from "./SocialLinks";
 import Button from "./Button";
 import PricingTable from "./PricingTable";
 import SocialFeed from "./SocialFeed";
+import NewsletterSignup from "./NewsletterSignup";
 
 export {
   BlogListing,
@@ -49,6 +50,7 @@ export {
   SocialLinks,
   SocialFeed,
   Button,
+  NewsletterSignup,
   PricingTable,
 };
 

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -18,6 +18,7 @@ import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
 import SocialFeed from "./SocialFeed";
 import PricingTable from "./PricingTable";
+import NewsletterSignup from "./NewsletterSignup";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -39,6 +40,7 @@ export const organismRegistry = {
   CountdownTimer,
   SocialLinks,
   SocialFeed,
+  NewsletterSignup,
   PricingTable,
 } as const;
 

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -28,6 +28,7 @@ import FAQBlockEditor from "./FAQBlockEditor";
 import HeaderEditor from "./HeaderEditor";
 import FooterEditor from "./FooterEditor";
 import PricingTableEditor from "./PricingTableEditor";
+import NewsletterSignupEditor from "./NewsletterSignupEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -80,6 +81,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "AnnouncementBar":
       specific = (
         <AnnouncementBarEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "NewsletterSignup":
+      specific = (
+        <NewsletterSignupEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/NewsletterSignupEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/NewsletterSignupEditor.tsx
@@ -1,0 +1,38 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function NewsletterSignupEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).text ?? ""}
+        onChange={(e) => handleInput("text", e.target.value)}
+        placeholder="text"
+      />
+      <Input
+        value={(component as any).action ?? ""}
+        onChange={(e) => handleInput("action", e.target.value)}
+        placeholder="action"
+      />
+      <Input
+        value={(component as any).placeholder ?? ""}
+        onChange={(e) => handleInput("placeholder", e.target.value)}
+        placeholder="placeholder"
+      />
+      <Input
+        value={(component as any).submitLabel ?? ""}
+        onChange={(e) => handleInput("submitLabel", e.target.value)}
+        placeholder="submitLabel"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -8,6 +8,7 @@ import ValuePropsEditor from "../ValuePropsEditor";
 import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
 import AnnouncementBarEditor from "../AnnouncementBarEditor";
 import SocialFeedEditor from "../SocialFeedEditor";
+import NewsletterSignupEditor from "../NewsletterSignupEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -66,6 +67,12 @@ describe("block editors", () => {
       AnnouncementBarEditor,
       { type: "AnnouncementBar", text: "", link: "" },
       "text",
+    ],
+    [
+      "NewsletterSignupEditor",
+      NewsletterSignupEditor,
+      { type: "NewsletterSignup", action: "" },
+      "action",
     ],
     [
       "SocialFeedEditor",

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -12,6 +12,7 @@ export { default as MapBlockEditor } from "./MapBlockEditor";
 export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as PricingTableEditor } from "./PricingTableEditor";
+export { default as NewsletterSignupEditor } from "./NewsletterSignupEditor";
 export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";


### PR DESCRIPTION
## Summary
- add NewsletterSignup block component and editor
- register block in CMS registry and PageBuilder palette
- extend Page types and schemas for NewsletterSignup

## Testing
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx packages/types/__tests__/pageSchema.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b138b7e10832f9f2cf7de2ca95852