### PR TITLE
feat(dashboard): add campaign analytics

### DIFF
--- a/apps/cms/src/app/cms/dashboard/[shop]/CampaignFilter.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/CampaignFilter.client.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export function CampaignFilter({ campaigns }: { campaigns: string[] }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const selected = searchParams.get("campaign") ?? "";
+
+  return (
+    <select
+      className="mb-4 rounded border p-1"
+      value={selected}
+      onChange={(e) => {
+        const params = new URLSearchParams(searchParams.toString());
+        const value = e.target.value;
+        if (value) {
+          params.set("campaign", value);
+        } else {
+          params.delete("campaign");
+        }
+        const query = params.toString();
+        router.push(query ? `${pathname}?${query}` : pathname);
+      }}
+    >
+      <option value="">All campaigns</option>
+      {campaigns.map((c) => (
+        <option key={c} value={c}>
+          {c}
+        </option>
+      ))}
+    </select>
+  );
+}
+

--- a/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
@@ -31,9 +31,19 @@ interface ChartsProps {
   traffic: Series;
   conversion: Series;
   sales: Series;
+  emailOpens: Series;
+  campaignSales: Series;
+  discountRedemptions: Series;
 }
 
-export function Charts({ traffic, conversion, sales }: ChartsProps) {
+export function Charts({
+  traffic,
+  conversion,
+  sales,
+  emailOpens,
+  campaignSales,
+  discountRedemptions,
+}: ChartsProps) {
   return (
     <div className="space-y-8">
       <div>
@@ -76,6 +86,51 @@ export function Charts({ traffic, conversion, sales }: ChartsProps) {
                 label: "Sales",
                 data: sales.data,
                 borderColor: "rgb(255, 99, 132)",
+              },
+            ],
+          }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 font-semibold">Email Opens</h3>
+        <Line
+          data={{
+            labels: emailOpens.labels,
+            datasets: [
+              {
+                label: "Email opens",
+                data: emailOpens.data,
+                borderColor: "rgb(54, 162, 235)",
+              },
+            ],
+          }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 font-semibold">Campaign Sales</h3>
+        <Line
+          data={{
+            labels: campaignSales.labels,
+            datasets: [
+              {
+                label: "Campaign sales",
+                data: campaignSales.data,
+                borderColor: "rgb(255, 159, 64)",
+              },
+            ],
+          }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 font-semibold">Discount Redemptions</h3>
+        <Line
+          data={{
+            labels: discountRedemptions.labels,
+            datasets: [
+              {
+                label: "Discount redemptions",
+                data: discountRedemptions.data,
+                borderColor: "rgb(201, 203, 207)",
               },
             ],
           }}

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -1,24 +1,55 @@
-import { readAggregates } from "@platform-core/repositories/analytics.server";
+import {
+  listEvents,
+  readAggregates,
+} from "@platform-core/repositories/analytics.server";
 import { readShop } from "@platform-core/repositories/shops.server";
+import { Progress } from "@acme/ui";
+import { CampaignFilter } from "./CampaignFilter.client";
 import { Charts } from "./Charts.client";
 
 export default async function ShopDashboard({
   params,
+  searchParams,
 }: {
   params: { shop: string };
+  searchParams: { campaign?: string };
 }) {
   const shop = params.shop;
-  const [aggregates, shopData] = await Promise.all([
+  const campaign = searchParams?.campaign;
+  const [events, aggregates, shopData] = await Promise.all([
+    listEvents(shop),
     readAggregates(shop),
     readShop(shop),
   ]);
   const domain = shopData.domain?.name;
   const domainStatus = shopData.domain?.status;
+  const filteredEvents = campaign
+    ? events.filter((e) => e.campaign === campaign)
+    : events;
+
+  const emailOpenByDay: Record<string, number> = {};
+  const campaignSalesByDay: Record<string, number> = {};
+  const discountByDay: Record<string, number> = {};
+  for (const e of filteredEvents) {
+    const day = (e.timestamp || "").slice(0, 10);
+    if (!day) continue;
+    if (e.type === "email_open") {
+      emailOpenByDay[day] = (emailOpenByDay[day] || 0) + 1;
+    } else if (e.type === "campaign_sale") {
+      const amount = typeof e.amount === "number" ? e.amount : 0;
+      campaignSalesByDay[day] = (campaignSalesByDay[day] || 0) + amount;
+    } else if (e.type === "discount_redemption") {
+      discountByDay[day] = (discountByDay[day] || 0) + 1;
+    }
+  }
 
   const days = Array.from(
     new Set([
       ...Object.keys(aggregates.page_view),
       ...Object.keys(aggregates.order),
+      ...Object.keys(emailOpenByDay),
+      ...Object.keys(campaignSalesByDay),
+      ...Object.keys(discountByDay),
     ])
   ).sort();
 
@@ -28,7 +59,7 @@ export default async function ShopDashboard({
   };
   const sales = {
     labels: days,
-    data: days.map((d) => (aggregates.order[d]?.amount ?? 0)),
+    data: days.map((d) => aggregates.order[d]?.amount ?? 0),
   };
   const conversion = {
     labels: days,
@@ -38,6 +69,38 @@ export default async function ShopDashboard({
       return views > 0 ? (orders / views) * 100 : 0;
     }),
   };
+  const emailOpens = {
+    labels: days,
+    data: days.map((d) => emailOpenByDay[d] || 0),
+  };
+  const campaignSales = {
+    labels: days,
+    data: days.map((d) => campaignSalesByDay[d] || 0),
+  };
+  const discountRedemptions = {
+    labels: days,
+    data: days.map((d) => discountByDay[d] || 0),
+  };
+
+  const totals = {
+    emailOpens: emailOpens.data.reduce((a, b) => a + b, 0),
+    campaignSales: campaignSales.data.reduce((a, b) => a + b, 0),
+    discountRedemptions: discountRedemptions.data.reduce((a, b) => a + b, 0),
+  };
+  const maxTotal = Math.max(
+    totals.emailOpens,
+    totals.campaignSales,
+    totals.discountRedemptions,
+    1,
+  );
+
+  const campaigns = Array.from(
+    new Set(
+      events
+        .map((e) => (typeof e.campaign === "string" ? e.campaign : null))
+        .filter(Boolean) as string[],
+    ),
+  );
 
   return (
     <div>
@@ -47,7 +110,41 @@ export default async function ShopDashboard({
           Domain: {domain} {domainStatus ? `(${domainStatus})` : ""}
         </p>
       )}
-      <Charts traffic={traffic} sales={sales} conversion={conversion} />
+      {campaigns.length > 0 && <CampaignFilter campaigns={campaigns} />}
+      <Charts
+        traffic={traffic}
+        sales={sales}
+        conversion={conversion}
+        emailOpens={emailOpens}
+        campaignSales={campaignSales}
+        discountRedemptions={discountRedemptions}
+      />
+      <div className="mt-8 space-y-4">
+        <h3 className="text-lg font-semibold">Progress</h3>
+        <div>
+          <span className="mb-1 block text-sm font-medium">Email opens</span>
+          <Progress
+            value={(totals.emailOpens / maxTotal) * 100}
+            label={String(totals.emailOpens)}
+          />
+        </div>
+        <div>
+          <span className="mb-1 block text-sm font-medium">Campaign sales</span>
+          <Progress
+            value={(totals.campaignSales / maxTotal) * 100}
+            label={String(totals.campaignSales)}
+          />
+        </div>
+        <div>
+          <span className="mb-1 block text-sm font-medium">
+            Discount redemptions
+          </span>
+          <Progress
+            value={(totals.discountRedemptions / maxTotal) * 100}
+            label={String(totals.discountRedemptions)}
+          />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add email, campaign sales, and discount redemption series to dashboard charts
- aggregate analytics events with campaign filter and progress indicators
- provide client-side campaign filter selector

## Testing
- `npx eslint apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx apps/cms/src/app/cms/dashboard/[shop]/page.tsx apps/cms/src/app/cms/dashboard/[shop]/CampaignFilter.client.tsx`
- `pnpm test` *(fails: command /root/.nvm/versions/node/v20.19.4/bin/pnpm run test exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_689b1c27b05c832fa655f91ae464c1ec