### PR TITLE
feat(cms): add SEO progress panel

### DIFF
--- a/apps/cms/__tests__/seoProgressPanel.test.tsx
+++ b/apps/cms/__tests__/seoProgressPanel.test.tsx
@@ -1,0 +1,52 @@
+// apps/cms/__tests__/seoProgressPanel.test.tsx
+/* eslint-env jest */
+
+const readSeoAuditsMock = jest.fn();
+const listEventsMock = jest.fn();
+
+jest.mock("@platform-core/repositories/seoAudit.server", () => ({
+  readSeoAudits: (...a: unknown[]) => readSeoAuditsMock(...a),
+}));
+
+jest.mock("@platform-core/repositories/analytics.server", () => ({
+  listEvents: (...a: unknown[]) => listEventsMock(...a),
+}));
+
+import { render, screen, within } from "@testing-library/react";
+import SeoProgressPanel from "../src/app/cms/shop/[shop]/settings/seo/SeoProgressPanel";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SeoProgressPanel", () => {
+  it("shows audit scores and recommendations", async () => {
+    readSeoAuditsMock.mockResolvedValueOnce([
+      {
+        timestamp: "2024-01-01T00:00:00Z",
+        score: 92,
+        recommendations: ["Add meta tags"],
+      },
+    ]);
+    listEventsMock.mockResolvedValueOnce([
+      {
+        type: "page_view",
+        timestamp: "2024-01-01T01:00:00Z",
+        source: "organic",
+      },
+      {
+        type: "page_view",
+        timestamp: "2024-01-01T02:00:00Z",
+        source: "organic",
+      },
+    ]);
+
+    const ui = await SeoProgressPanel({ shop: "s1" });
+    render(ui);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("92")).toBeInTheDocument();
+    expect(within(table).getByText("2")).toBeInTheDocument();
+    expect(readSeoAuditsMock).toHaveBeenCalled();
+    expect(screen.getByText("Add meta tags")).toBeInTheDocument();
+  });
+});

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoProgressPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoProgressPanel.tsx
@@ -1,0 +1,66 @@
+import { formatTimestamp } from "@acme/date-utils";
+import { readSeoAudits } from "@platform-core/repositories/seoAudit.server";
+import { listEvents } from "@platform-core/repositories/analytics.server";
+
+interface Props {
+  /** Shop identifier */
+  shop: string;
+}
+
+export default async function SeoProgressPanel({ shop }: Props) {
+  const audits = await readSeoAudits(shop);
+  const events = await listEvents(shop);
+
+  const trafficByDay: Record<string, number> = {};
+  for (const ev of events) {
+    if (ev.type === "page_view" && (ev as { source?: string }).source === "organic") {
+      const day = (ev.timestamp as string).slice(0, 10);
+      trafficByDay[day] = (trafficByDay[day] ?? 0) + 1;
+    }
+  }
+
+  const rows = audits.map((a) => ({
+    timestamp: a.timestamp,
+    score: a.score,
+    traffic: trafficByDay[a.timestamp.slice(0, 10)] ?? 0,
+  }));
+
+  const recs = audits.at(-1)?.recommendations ?? [];
+
+  return (
+    <div className="space-y-4 text-sm">
+      {rows.length === 0 ? (
+        <p className="text-muted-foreground">No SEO data available.</p>
+      ) : (
+        <table className="w-full text-left">
+          <thead>
+            <tr>
+              <th className="py-1">Date</th>
+              <th className="py-1">Audit Score</th>
+              <th className="py-1">Organic Views</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.timestamp} className="border-t">
+                <td className="font-mono py-1">{formatTimestamp(r.timestamp)}</td>
+                <td className="py-1">{r.score}</td>
+                <td className="py-1">{r.traffic}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {recs.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="font-medium">Latest Recommendations</h4>
+          <ul className="list-disc pl-5 space-y-1">
+            {recs.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
@@ -2,6 +2,7 @@
 
 import { getSettings } from "@cms/actions/shops.server";
 import dynamic from "next/dynamic";
+import SeoProgressPanel from "./SeoProgressPanel";
 
 const SeoEditor = dynamic(() => import("./SeoEditor"));
 void SeoEditor;
@@ -24,8 +25,9 @@ export default async function SeoSettingsPage({
   const freeze = settings.freezeTranslations ?? false;
 
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">SEO – {shop}</h2>
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold">SEO – {shop}</h2>
+      <SeoProgressPanel shop={shop} />
       <SeoEditor
         shop={shop}
         languages={languages}

--- a/packages/platform-core/src/repositories/seoAudit.server.ts
+++ b/packages/platform-core/src/repositories/seoAudit.server.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { validateShopName } from "../shops";
+import { DATA_ROOT } from "../dataRoot";
+
+export interface SeoAuditEntry {
+  timestamp: string;
+  score: number;
+  recommendations?: string[];
+}
+
+function auditPath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "seo-audit.json");
+}
+
+export async function readSeoAudits(shop: string): Promise<SeoAuditEntry[]> {
+  try {
+    const buf = await fs.readFile(auditPath(shop), "utf8");
+    const data = JSON.parse(buf) as SeoAuditEntry[];
+    if (Array.isArray(data)) return data;
+  } catch {
+    // ignore file errors
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- add server repo to read SEO audit data
- show SEO progress with audit scores, organic traffic and recommendations
- surface progress panel on the SEO settings page

## Testing
- `pnpm --filter @apps/cms test seoProgressPanel.test.tsx`
- `pnpm --filter @acme/platform-core test resolveDataRoot.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b1c286d10832f8c0960d8bf6b3113