### PR TITLE
feat: add SEO audit endpoint and panel

### DIFF
--- a/apps/cms/src/app/api/seo/audit/[shop]/route.ts
+++ b/apps/cms/src/app/api/seo/audit/[shop]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { DATA_ROOT } from "@platform-core";
+import { validateShopName } from "@acme/lib";
+import fs from "node:fs/promises";
+import path from "node:path";
+import lighthouse from "lighthouse";
+import chromeLauncher from "chrome-launcher";
+
+interface AuditRecord {
+  timestamp: string;
+  score: number;
+  issues: number;
+}
+
+function auditFile(shop: string) {
+  return path.join(DATA_ROOT, shop, "seo-audit.json");
+}
+
+async function runLighthouse(url: string): Promise<AuditRecord> {
+  const chrome = await chromeLauncher.launch({ chromeFlags: ["--headless"] });
+  try {
+    const result = await lighthouse(url, {
+      port: chrome.port,
+      onlyCategories: ["seo"],
+      preset: "desktop",
+    });
+    const lhr = result.lhr;
+    const score = lhr.categories?.seo?.score ?? 0;
+    const issues = Object.values(lhr.audits).filter((a) => {
+      return a.score !== 1 && a.score !== null && a.score !== undefined && a.scoreDisplayMode !== "notApplicable";
+    }).length;
+    return { timestamp: new Date().toISOString(), score, issues };
+  } finally {
+    await chrome.kill();
+  }
+}
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ shop: string }> }
+) {
+  const { shop } = await context.params;
+  const safeShop = validateShopName(shop);
+  try {
+    const buf = await fs.readFile(auditFile(safeShop), "utf8");
+    return NextResponse.json(JSON.parse(buf) as AuditRecord[]);
+  } catch {
+    return NextResponse.json([]);
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ shop: string }> }
+) {
+  const { shop } = await context.params;
+  const safeShop = validateShopName(shop);
+  const body = await req.json().catch(() => ({} as { url?: string }));
+  const url = body.url || `http://localhost:3000/${safeShop}`;
+  const record = await runLighthouse(url);
+
+  const file = auditFile(safeShop);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  let history: AuditRecord[] = [];
+  try {
+    const buf = await fs.readFile(file, "utf8");
+    history = JSON.parse(buf);
+    if (!Array.isArray(history)) history = [];
+  } catch {
+    /* ignore */
+  }
+  history.push(record);
+  await fs.writeFile(file, JSON.stringify(history, null, 2), "utf8");
+  return NextResponse.json(record);
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoAuditPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoAuditPanel.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/atoms/shadcn";
+
+interface AuditRecord {
+  timestamp: string;
+  score: number;
+  issues: number;
+}
+
+export default function SeoAuditPanel({ shop }: { shop: string }) {
+  const [history, setHistory] = useState<AuditRecord[]>([]);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/seo/audit/${shop}`);
+        const data: AuditRecord[] = await res.json();
+        setHistory(data);
+      } catch {
+        // ignore
+      }
+    };
+    void load();
+  }, [shop]);
+
+  const runAudit = async () => {
+    setRunning(true);
+    try {
+      const res = await fetch(`/api/seo/audit/${shop}`, { method: "POST" });
+      const record: AuditRecord = await res.json();
+      setHistory((prev) => [...prev, record]);
+    } catch {
+      // ignore
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const last = history[history.length - 1];
+
+  return (
+    <div className="mt-8 border-t pt-4">
+      <h3 className="mb-2 text-lg font-medium">SEO Audit</h3>
+      <Button onClick={runAudit} disabled={running} className="bg-primary text-white">
+        {running ? "Running…" : "Run audit"}
+      </Button>
+      {running && <p className="mt-2 text-sm">Audit in progress…</p>}
+      {last && (
+        <div className="mt-4 text-sm">
+          <p>Last run: {new Date(last.timestamp).toLocaleString()}</p>
+          <p>Score: {Math.round(last.score * 100)}</p>
+          <p>Issues found: {last.issues}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
@@ -4,7 +4,9 @@ import { getSettings } from "@cms/actions/shops.server";
 import dynamic from "next/dynamic";
 
 const SeoEditor = dynamic(() => import("./SeoEditor"));
+const SeoAuditPanel = dynamic(() => import("./SeoAuditPanel"));
 void SeoEditor;
+void SeoAuditPanel;
 
 export const revalidate = 0;
 
@@ -32,6 +34,7 @@ export default async function SeoSettingsPage({
         initialSeo={seo}
         initialFreeze={freeze}
       />
+      <SeoAuditPanel shop={shop} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add API route to run lighthouse SEO audit and persist results
- add client SEO audit panel with trigger and summary
- display audit panel in shop SEO settings page

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '@acme/config/env.ts')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689b1c216fe4832f888cdfead5861e4f