### PR TITLE
feat: validate wizard steps

### DIFF
--- a/apps/cms/__tests__/stepValidators.test.ts
+++ b/apps/cms/__tests__/stepValidators.test.ts
@@ -1,0 +1,86 @@
+import { validators } from "../src/app/cms/wizard/hooks/useStepCompletion";
+import { wizardStateSchema } from "../src/app/cms/wizard/schema";
+import { fillLocales } from "@i18n/fillLocales";
+
+describe("step validators", () => {
+  const base = wizardStateSchema.parse({});
+
+  it("shop-details requires id and name", () => {
+    expect(validators["shop-details"](base)).toBe(false);
+  });
+
+  it("theme requires selection", () => {
+    expect(validators.theme(base)).toBe(false);
+  });
+
+  it("tokens require theme variables", () => {
+    const state = { ...base, themeVars: {} };
+    expect(validators.tokens(state)).toBe(false);
+  });
+
+  it("options require analytics id when provider set", () => {
+    const state = { ...base, analyticsProvider: "ga", analyticsId: "" };
+    expect(validators.options(state)).toBe(false);
+  });
+
+  it("navigation requires items", () => {
+    const state = { ...base, navItems: [] };
+    expect(validators.navigation(state)).toBe(false);
+  });
+
+  it("layout requires header and footer", () => {
+    expect(validators.layout(base)).toBe(false);
+  });
+
+  it("home page requires id", () => {
+    expect(validators["home-page"](base)).toBe(false);
+  });
+
+  it("checkout page requires id", () => {
+    expect(validators["checkout-page"](base)).toBe(false);
+  });
+
+  it("shop page requires id", () => {
+    expect(validators["shop-page"](base)).toBe(false);
+  });
+
+  it("product page requires id", () => {
+    expect(validators["product-page"](base)).toBe(false);
+  });
+
+  it("additional pages require slugs", () => {
+    const state = {
+      ...base,
+      pages: [
+        {
+          slug: "",
+          title: fillLocales(undefined, ""),
+          description: fillLocales(undefined, ""),
+          image: fillLocales(undefined, ""),
+          components: [],
+        },
+      ],
+    };
+    expect(validators["additional-pages"](state)).toBe(false);
+  });
+
+  it("env vars require values", () => {
+    expect(validators["env-vars"](base)).toBe(false);
+  });
+
+  it("summary requires title and description", () => {
+    expect(validators.summary(base)).toBe(false);
+  });
+
+  it("import data requires categories", () => {
+    expect(validators["import-data"](base)).toBe(false);
+  });
+
+  it("seed data requires categories", () => {
+    expect(validators["seed-data"](base)).toBe(false);
+  });
+
+  it("hosting requires domain", () => {
+    expect(validators.hosting(base)).toBe(false);
+  });
+});

--- a/apps/cms/src/app/cms/wizard/hooks/useStepCompletion.ts
+++ b/apps/cms/src/app/cms/wizard/hooks/useStepCompletion.ts
@@ -3,9 +3,26 @@ import type { WizardState } from "../schema";
 
 type Validator = (state: WizardState) => boolean;
 
-const validators: Record<string, Validator> = {
+export const validators: Record<string, Validator> = {
   "shop-details": (s) => Boolean(s.shopId && s.storeName),
   theme: (s) => Boolean(s.theme),
+  tokens: (s) => Object.keys(s.themeVars ?? {}).length > 0,
+  options: (s) =>
+    s.analyticsProvider !== "ga" || Boolean(s.analyticsId),
+  navigation: (s) => s.navItems.length > 0,
+  layout: (s) => Boolean(s.headerPageId && s.footerPageId),
+  "home-page": (s) => Boolean(s.homePageId),
+  "checkout-page": (s) => Boolean(s.checkoutPageId),
+  "shop-page": (s) => Boolean(s.shopPageId),
+  "product-page": (s) => Boolean(s.productPageId),
+  "additional-pages": (s) => s.pages.every((p) => Boolean(p.slug)),
+  "env-vars": (s) => Object.values(s.env).some(Boolean),
+  summary: (s) =>
+    Object.values(s.pageTitle).some(Boolean) &&
+    Object.values(s.pageDescription).some(Boolean),
+  "import-data": (s) => Boolean(s.categoriesText),
+  "seed-data": (s) => Boolean(s.categoriesText),
+  hosting: (s) => Boolean(s.domain),
 };
 
 export function useStepCompletion(stepId: string): [boolean, (v: boolean) => void] {

--- a/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepLayout.tsx
@@ -10,55 +10,30 @@ import { ReactNode, useState } from "react";
 import { Toast } from "@/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
+import { useWizard } from "../WizardContext";
+import { useThemeLoader } from "../hooks/useThemeLoader";
 
 interface Props {
-  currentStep: number;
-  stepIndex: number;
-
-  /** Header */
-  headerComponents: PageComponent[];
-  setHeaderComponents: (v: PageComponent[]) => void;
-  headerPageId: string | null;
-  setHeaderPageId: (v: string | null) => void;
-
-  /** Footer */
-  footerComponents: PageComponent[];
-  setFooterComponents: (v: PageComponent[]) => void;
-  footerPageId: string | null;
-  setFooterPageId: (v: string | null) => void;
-
-  /** Context */
-  shopId: string;
-  themeStyle: React.CSSProperties;
-
   /** Optional inner content for the step */
   children?: ReactNode;
 }
 
 const emptyTranslated = () => fillLocales(undefined, "");
 
-export default function StepLayout({
-  currentStep,
-  stepIndex,
-  headerComponents,
-  setHeaderComponents,
-  headerPageId,
-  setHeaderPageId,
-  footerComponents,
-  setFooterComponents,
-  footerPageId,
-  setFooterPageId,
-  shopId,
-  themeStyle,
-  children,
-}: Props): React.JSX.Element | null {
-  /**
-   * Render **nothing at all** for inactive steps so the DOM
-   * contains only a single set of navigation buttons.
-   * This keeps Testing-Library queries (and screen-reader focus)
-   * unambiguous.
-   */
-  if (stepIndex !== currentStep) return null;
+export default function StepLayout({ children }: Props): React.JSX.Element {
+  const { state, update } = useWizard();
+  const {
+    headerComponents,
+    headerPageId,
+    footerComponents,
+    footerPageId,
+    shopId,
+  } = state;
+  const themeStyle = useThemeLoader();
+  const setHeaderComponents = (v: PageComponent[]) => update("headerComponents", v);
+  const setHeaderPageId = (v: string | null) => update("headerPageId", v);
+  const setFooterComponents = (v: PageComponent[]) => update("footerComponents", v);
+  const setFooterPageId = (v: string | null) => update("footerPageId", v);
 
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,

--- a/apps/cms/src/app/cms/wizard/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepNavigation.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/atoms/shadcn";
 import NavigationEditor from "@/components/cms/NavigationEditor";
+import { useWizard } from "../WizardContext";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 
@@ -12,15 +13,10 @@ interface NavItem {
   children?: NavItem[];
 }
 
-interface Props {
-  navItems: NavItem[];
-  setNavItems: (v: NavItem[]) => void;
-}
-
-export default function StepNavigation({
-  navItems,
-  setNavItems,
-}: Props): React.JSX.Element {
+export default function StepNavigation(): React.JSX.Element {
+  const { state, update } = useWizard();
+  const navItems = state.navItems;
+  const setNavItems = (items: NavItem[]) => update("navItems", items);
   const [, markComplete] = useStepCompletion("navigation");
   const router = useRouter();
   return (

--- a/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/wizard/steps/StepOptions.tsx
@@ -11,31 +11,23 @@ import {
 } from "@/components/atoms/shadcn";
 import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useWizard } from "../WizardContext";
 import useStepCompletion from "../hooks/useStepCompletion";
 
-interface Props {
-  shopId: string;
-  payment: string[];
-  setPayment: React.Dispatch<React.SetStateAction<string[]>>;
-  shipping: string[];
-  setShipping: React.Dispatch<React.SetStateAction<string[]>>;
-  analyticsProvider: string;
-  setAnalyticsProvider: (v: string) => void;
-  analyticsId: string;
-  setAnalyticsId: (v: string) => void;
-}
+export default function StepOptions(): React.JSX.Element {
+  const { state, update } = useWizard();
+  const {
+    shopId,
+    payment,
+    shipping,
+    analyticsProvider,
+    analyticsId,
+  } = state;
+  const setPayment = (v: string[]) => update("payment", v);
+  const setShipping = (v: string[]) => update("shipping", v);
+  const setAnalyticsProvider = (v: string) => update("analyticsProvider", v);
+  const setAnalyticsId = (v: string) => update("analyticsId", v);
 
-export default function StepOptions({
-  shopId,
-  payment,
-  setPayment,
-  shipping,
-  setShipping,
-  analyticsProvider,
-  setAnalyticsProvider,
-  analyticsId,
-  setAnalyticsId,
-}: Props): React.JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [, markComplete] = useStepCompletion("options");
@@ -45,14 +37,14 @@ export default function StepOptions({
     if (!provider) return;
 
     if (["stripe", "paypal"].includes(provider) && !payment.includes(provider)) {
-      setPayment((l) => [...l, provider]);
+      setPayment([...payment, provider]);
     }
     if (["dhl", "ups"].includes(provider) && !shipping.includes(provider)) {
-      setShipping((l) => [...l, provider]);
+      setShipping([...shipping, provider]);
     }
 
     router.replace("/cms/wizard");
-  }, [searchParams, payment, shipping, router, setPayment, setShipping]);
+  }, [searchParams, payment, shipping, router]);
 
   function connect(provider: string) {
     const url = `/cms/api/providers/${provider}?shop=${encodeURIComponent(shopId)}`;


### PR DESCRIPTION
## Summary
- validate configurator wizard steps using state-driven validators
- hook navigation, options, and layout steps into wizard state
- test step validators against invalid wizard state

## Testing
- `pnpm test:cms apps/cms/__tests__/stepValidators.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b1c12e4ac832f89603b63ff4b436a