### PR TITLE
feat(ui): add tabs block for page builder

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -200,6 +200,12 @@ export interface TestimonialsComponent extends PageComponentBase {
     name?: string;
   }[];
 }
+export interface TabsComponent extends PageComponentBase {
+  type: "Tabs";
+  tabs?: { label: string }[];
+  activeTab?: number;
+  children?: PageComponent[];
+}
 export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
@@ -235,6 +241,7 @@ export type PageComponent =
   | FooterComponent
   | SocialLinksComponent
   | SocialFeedComponent
+  | TabsComponent
   | SectionComponent
   | MultiColumnComponent;
 export declare const pageSchema: z.ZodObject<

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -221,6 +221,13 @@ export interface ButtonComponent extends PageComponentBase {
   size?: "sm" | "md" | "lg";
 }
 
+export interface TabsComponent extends PageComponentBase {
+  type: "Tabs";
+  tabs?: { label: string }[];
+  activeTab?: number;
+  children?: PageComponent[];
+}
+
 export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
@@ -260,6 +267,7 @@ export type PageComponent =
   | FooterComponent
   | SocialLinksComponent
   | SocialFeedComponent
+  | TabsComponent
   | SectionComponent
   | MultiColumnComponent;
 
@@ -481,6 +489,13 @@ const buttonComponentSchema = baseComponentSchema.extend({
   size: z.enum(["sm", "md", "lg"]).optional(),
 });
 
+const tabsComponentSchema: any = baseComponentSchema.extend({
+  type: z.literal("Tabs"),
+  tabs: z.array(z.object({ label: z.string() })).optional(),
+  activeTab: z.number().int().nonnegative().optional(),
+  children: z.array(z.lazy(() => pageComponentSchema as any)).default([]),
+});
+
 const sectionComponentSchema: z.ZodType<SectionComponent> =
   baseComponentSchema.extend({
     type: z.literal("Section"),
@@ -523,6 +538,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     textComponentSchema,
     customHtmlComponentSchema,
     buttonComponentSchema,
+    tabsComponentSchema,
     sectionComponentSchema,
     multiColumnComponentSchema,
   ])

--- a/packages/ui/src/components/cms/blocks/Tabs.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/Tabs.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TabsBlock from "./Tabs";
+
+const meta: Meta<typeof TabsBlock> = {
+  component: TabsBlock,
+  args: {
+    tabs: [{ label: "Tab 1" }, { label: "Tab 2" }],
+    activeTab: 0,
+    children: [<div key="1">Content 1</div>, <div key="2">Content 2</div>],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof TabsBlock> = {};

--- a/packages/ui/src/components/cms/blocks/Tabs.tsx
+++ b/packages/ui/src/components/cms/blocks/Tabs.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+interface Tab {
+  label: string;
+}
+
+interface Props {
+  tabs?: Tab[];
+  activeTab?: number;
+  children?: ReactNode[];
+}
+
+export default function TabsBlock({ tabs = [], activeTab = 0, children = [] }: Props) {
+  const [current, setCurrent] = useState(activeTab);
+  if (!tabs.length) return null;
+  return (
+    <div>
+      <div className="flex border-b">
+        {tabs.map((tab, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => setCurrent(i)}
+            className={`px-4 py-2 ${current === i ? "border-b-2 border-primary" : ""}`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="p-4">
+        {Array.isArray(children) ? children[current] : children}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -10,6 +10,7 @@ import TestimonialSlider from "./TestimonialSlider";
 import Testimonials from "./Testimonials";
 import ValueProps from "./ValueProps";
 import RecommendationCarousel from "./RecommendationCarousel";
+import Tabs from "./Tabs";
 import Section from "./Section";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
@@ -37,6 +38,7 @@ export {
   Testimonials,
   TestimonialSlider,
   ValueProps,
+  Tabs,
   Section,
   AnnouncementBar,
   MapBlock,

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -18,6 +18,7 @@ import CountdownTimer from "./CountdownTimer";
 import SocialLinks from "./SocialLinks";
 import SocialFeed from "./SocialFeed";
 import PricingTable from "./PricingTable";
+import Tabs from "./Tabs";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -40,6 +41,7 @@ export const organismRegistry = {
   SocialLinks,
   SocialFeed,
   PricingTable,
+  Tabs,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -28,6 +28,7 @@ import FAQBlockEditor from "./FAQBlockEditor";
 import HeaderEditor from "./HeaderEditor";
 import FooterEditor from "./FooterEditor";
 import PricingTableEditor from "./PricingTableEditor";
+import { useArrayEditor } from "./useArrayEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -49,6 +50,8 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     },
     [onChange]
   );
+
+  const arrayEditor = useArrayEditor(onChange);
 
   let specific: React.ReactNode = null;
 
@@ -72,6 +75,26 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "PricingTable":
       specific = (
         <PricingTableEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "Tabs":
+      specific = (
+        <>
+          {arrayEditor("tabs", (component as any).tabs, ["label"])}
+          <Input
+            label="Active Tab"
+            type="number"
+            value={(component as any).activeTab ?? 0}
+            onChange={(e) =>
+              handleInput(
+                "activeTab",
+                e.target.value === "" ? undefined : Number(e.target.value)
+              )
+            }
+            min={0}
+            max={((component as any).tabs?.length ?? 1) - 1}
+          />
+        </>
       );
       break;
     case "HeroBanner":


### PR DESCRIPTION
## Summary
- add TabsBlock component and story for CMS blocks
- expose Tabs in block registry and organism palette
- allow editing tab labels and active tab in ComponentEditor
- extend types to include TabsComponent

## Testing
- `pnpm test --filter @acme/types`
- `pnpm test --filter @acme/ui` *(fails: packages/ui tests exited with env configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_689b1c046050832f96075bddfdfe88f4