### PR TITLE
feat: make grid columns configurable

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -532,6 +532,7 @@ export interface HistoryState {
   past: PageComponent[][];
   present: PageComponent[];
   future: PageComponent[][];
+  gridCols: number;
 }
 
 export const historyStateSchema: z.ZodType<HistoryState> = z
@@ -539,9 +540,10 @@ export const historyStateSchema: z.ZodType<HistoryState> = z
     past: z.array(z.array(pageComponentSchema)),
     present: z.array(pageComponentSchema),
     future: z.array(z.array(pageComponentSchema)),
+    gridCols: z.number().int().min(1).max(24).default(12),
   })
   .strict()
-  .default({ past: [], present: [], future: [] });
+  .default({ past: [], present: [], future: [], gridCols: 12 });
 
 export const pageSchema = z
   .object({

--- a/packages/ui/__tests__/CanvasItem.test.tsx
+++ b/packages/ui/__tests__/CanvasItem.test.tsx
@@ -17,11 +17,14 @@ describe("CanvasItem", () => {
           <CanvasItem
             component={component}
             index={0}
+            parentId={undefined}
+            selectedId={null}
+            onSelectId={() => {}}
             onRemove={() => {}}
-            selected={false}
-            onSelect={() => {}}
             dispatch={() => {}}
             locale="en"
+            gridEnabled={false}
+            gridCols={12}
           />
         </SortableContext>
       </DndContext>

--- a/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
@@ -106,6 +106,7 @@ describe("PageBuilder interactions", () => {
         onRemove={() => {}}
         dispatch={dispatch}
         locale="en"
+        gridCols={12}
       />
     );
 
@@ -152,6 +153,7 @@ describe("PageBuilder interactions", () => {
         onRemove={() => {}}
         dispatch={dispatch}
         locale="en"
+        gridCols={12}
       />
     );
 
@@ -202,6 +204,7 @@ describe("PageBuilder interactions", () => {
           onRemove={() => {}}
           dispatch={jest.fn()}
           locale="en"
+          gridCols={12}
         />
         <CanvasItem
           component={c2}
@@ -212,6 +215,7 @@ describe("PageBuilder interactions", () => {
           onRemove={() => {}}
           dispatch={dispatch}
           locale="en"
+          gridCols={12}
         />
       </div>
     );

--- a/packages/ui/__tests__/PageBuilder.highlight.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.highlight.test.tsx
@@ -71,6 +71,7 @@ describe("PageBuilder drag highlight", () => {
         onRemove={() => {}}
         dispatch={() => {}}
         locale="en"
+        gridCols={12}
       />
     );
     expect(queryByTestId("drop-placeholder")).toBeInTheDocument();
@@ -85,6 +86,7 @@ describe("PageBuilder drag highlight", () => {
         onRemove={() => {}}
         dispatch={() => {}}
         locale="en"
+        gridCols={12}
       />
     );
     expect(queryByTestId("drop-placeholder")).toBeNull();

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -24,7 +24,7 @@ const CanvasItem = memo(function CanvasItem({
   dispatch,
   locale,
   gridEnabled = false,
-  gridCols = 12,
+  gridCols,
 }: {
   component: PageComponent;
   index: number;
@@ -35,7 +35,7 @@ const CanvasItem = memo(function CanvasItem({
   dispatch: React.Dispatch<Action>;
   locale: Locale;
   gridEnabled?: boolean;
-  gridCols?: number;
+  gridCols: number;
 }) {
   const selected = selectedId === component.id;
   const {

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -33,7 +33,6 @@ type ComponentType =
   | keyof typeof layoutRegistry;
 
 const CONTAINER_TYPES = Object.keys(containerRegistry) as ComponentType[];
-const GRID_COLS = 12;
 
 const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   HeroBanner: { minItems: 1, maxItems: 5 },
@@ -104,10 +103,10 @@ const PageBuilder = memo(function PageBuilder({
             const valid = historyStateSchema.parse(fromServer);
             return { ...valid, present: migrate(valid.present) };
           } catch {
-            return { past: [], present: initial, future: [] };
+            return { past: [], present: initial, future: [], gridCols: 12 };
           }
         })()
-      : { past: [], present: initial, future: [] };
+      : { past: [], present: initial, future: [], gridCols: 12 };
 
     if (typeof window === "undefined") {
       return parsedServer;
@@ -124,6 +123,7 @@ const PageBuilder = memo(function PageBuilder({
   });
 
   const components = state.present;
+  const [gridCols, setGridCols] = useState(state.gridCols);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState("");
   const dispatch = useCallback(
@@ -216,11 +216,11 @@ const PageBuilder = memo(function PageBuilder({
 
   useEffect(() => {
     if (showGrid && canvasRef.current) {
-      setGridSize(canvasRef.current.offsetWidth / GRID_COLS);
+      setGridSize(canvasRef.current.offsetWidth / gridCols);
     } else {
       setGridSize(1);
     }
-  }, [showGrid, viewport]);
+  }, [showGrid, viewport, gridCols]);
 
   useEffect(() => {
     onChange?.(components);
@@ -286,11 +286,16 @@ const PageBuilder = memo(function PageBuilder({
           locale={locale}
           setLocale={setLocale}
           locales={locales}
-          progress={progress}
-          isValid={isValid}
-          showGrid={showGrid}
-          toggleGrid={() => setShowGrid((g) => !g)}
-        />
+        progress={progress}
+        isValid={isValid}
+        showGrid={showGrid}
+        toggleGrid={() => setShowGrid((g) => !g)}
+        gridCols={gridCols}
+        setGridCols={(n) => {
+          setGridCols(n);
+          dispatch({ type: "set-grid-cols", gridCols: n });
+        }}
+      />
         <div aria-live="polite" role="status" className="sr-only">
           {liveMessage}
         </div>
@@ -310,7 +315,7 @@ const PageBuilder = memo(function PageBuilder({
           locale={locale}
           containerStyle={containerStyle}
           showGrid={showGrid}
-          gridCols={GRID_COLS}
+          gridCols={gridCols}
         />
         <div className="flex gap-2">
           <Button onClick={() => dispatch({ type: "undo" })} disabled={!state.past.length}>

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -29,7 +29,7 @@ interface Props {
   locale: Locale;
   containerStyle: CSSProperties;
   showGrid?: boolean;
-  gridCols?: number;
+  gridCols: number;
 }
 
 const PageCanvas = ({
@@ -48,7 +48,7 @@ const PageCanvas = ({
   locale,
   containerStyle,
   showGrid = false,
-  gridCols = 12,
+  gridCols,
 }: Props) => (
   <DndContext
     sensors={sensors}

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -1,5 +1,5 @@
 import type { Locale } from "@/i18n/locales";
-import { Button } from "../../atoms/shadcn";
+import { Button, Input } from "../../atoms/shadcn";
 
 interface Props {
   viewport: "desktop" | "tablet" | "mobile";
@@ -11,6 +11,8 @@ interface Props {
   isValid: boolean | null;
   showGrid: boolean;
   toggleGrid: () => void;
+  gridCols: number;
+  setGridCols: (n: number) => void;
 }
 
 const PageToolbar = ({
@@ -23,6 +25,8 @@ const PageToolbar = ({
   isValid,
   showGrid,
   toggleGrid,
+  gridCols,
+  setGridCols,
 }: Props) => (
   <div className="flex flex-col gap-4">
     <div className="flex justify-end gap-2">
@@ -36,13 +40,21 @@ const PageToolbar = ({
         </Button>
       ))}
     </div>
-    <div className="flex justify-end">
+    <div className="flex items-center justify-end gap-2">
       <Button
         variant={showGrid ? "default" : "outline"}
         onClick={toggleGrid}
       >
         {showGrid ? "Hide grid" : "Show grid"}
       </Button>
+      <Input
+        type="number"
+        min={1}
+        max={24}
+        value={gridCols}
+        onChange={(e) => setGridCols(Number(e.target.value))}
+        className="w-16"
+      />
     </div>
     <div className="flex justify-end gap-2">
       {locales.map((l) => (

--- a/packages/ui/src/components/cms/page-builder/state.test.ts
+++ b/packages/ui/src/components/cms/page-builder/state.test.ts
@@ -7,6 +7,7 @@ describe("historyStateSchema", () => {
       past: [],
       present: [],
       future: [],
+      gridCols: 12,
     });
   });
 });
@@ -14,7 +15,7 @@ describe("historyStateSchema", () => {
 describe("state reducer", () => {
   const a = { id: "a", type: "Text" } as PageComponent;
   const b = { id: "b", type: "Image" } as PageComponent;
-  const init: HistoryState = { past: [], present: [], future: [] };
+  const init: HistoryState = { past: [], present: [], future: [], gridCols: 12 };
 
   it("adds components", () => {
     const state = reducer(init, { type: "add", component: a });

--- a/packages/ui/src/components/cms/page-builder/state.ts
+++ b/packages/ui/src/components/cms/page-builder/state.ts
@@ -8,9 +8,10 @@ export const historyStateSchema: z.ZodType<HistoryState> = z
     past: z.array(z.array(pageComponentSchema)),
     present: z.array(pageComponentSchema),
     future: z.array(z.array(pageComponentSchema)),
+    gridCols: z.number().int().min(1).max(24).default(12),
   })
   .strict()
-  .default({ past: [], present: [], future: [] });
+  .default({ past: [], present: [], future: [], gridCols: 12 });
 
 /* ════════════════ reducers ════════════════ */
 export type ChangeAction =
@@ -37,7 +38,11 @@ export type ChangeAction =
     }
   | { type: "set"; components: PageComponent[] };
 
-export type Action = ChangeAction | { type: "undo" } | { type: "redo" };
+export type Action =
+  | ChangeAction
+  | { type: "undo" }
+  | { type: "redo" }
+  | { type: "set-grid-cols"; gridCols: number };
 
 function addAt(list: PageComponent[], index: number, item: PageComponent) {
   return [...list.slice(0, index), item, ...list.slice(index)];
@@ -215,6 +220,7 @@ export function reducer(state: HistoryState, action: Action): HistoryState {
         past: state.past.slice(0, -1),
         present: previous,
         future: [state.present, ...state.future],
+        gridCols: state.gridCols,
       };
     }
     case "redo": {
@@ -224,7 +230,11 @@ export function reducer(state: HistoryState, action: Action): HistoryState {
         past: [...state.past, state.present],
         present: next,
         future: state.future.slice(1),
+        gridCols: state.gridCols,
       };
+    }
+    case "set-grid-cols": {
+      return { ...state, gridCols: action.gridCols };
     }
     default: {
       const next = componentsReducer(state.present, action as ChangeAction);
@@ -233,6 +243,7 @@ export function reducer(state: HistoryState, action: Action): HistoryState {
         past: [...state.past, state.present],
         present: next,
         future: [],
+        gridCols: state.gridCols,
       };
     }
   }


### PR DESCRIPTION
## Summary
- add toolbar input to adjust grid columns
- persist selected column count in page history
- honor dynamic column count in grid and snapping

## Testing
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/src/components/cms/page-builder/state.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b1c044014832f9e6f969b28c123d4