### PR TITLE
feat: add ai catalog analytics

### DIFF
--- a/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
@@ -27,8 +27,14 @@ interface Series {
   data: number[];
 }
 
+interface TrafficSeries {
+  labels: string[];
+  pageViews: number[];
+  aiCatalog: number[];
+}
+
 interface ChartsProps {
-  traffic: Series;
+  traffic: TrafficSeries;
   conversion: Series;
   sales: Series;
 }
@@ -44,8 +50,13 @@ export function Charts({ traffic, conversion, sales }: ChartsProps) {
             datasets: [
               {
                 label: "Page views",
-                data: traffic.data,
+                data: traffic.pageViews,
                 borderColor: "rgb(75, 192, 192)",
+              },
+              {
+                label: "AI catalog",
+                data: traffic.aiCatalog,
+                borderColor: "rgb(255, 205, 86)",
               },
             ],
           }}

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -19,12 +19,14 @@ export default async function ShopDashboard({
     new Set([
       ...Object.keys(aggregates.page_view),
       ...Object.keys(aggregates.order),
+      ...Object.keys(aggregates.ai_catalog),
     ])
   ).sort();
 
   const traffic = {
     labels: days,
-    data: days.map((d) => aggregates.page_view[d] || 0),
+    pageViews: days.map((d) => aggregates.page_view[d] || 0),
+    aiCatalog: days.map((d) => aggregates.ai_catalog[d] || 0),
   };
   const sales = {
     labels: days,

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -1,10 +1,17 @@
 {
   "languages": ["en", "de", "it"],
+  "seo": {},
   "freezeTranslations": false,
   "currency": "EUR",
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
     "interval": 60
-  }
+  },
+  "aiCatalog": {
+    "enabled": true,
+    "fields": ["id", "title", "description", "price", "images"]
+  },
+  "updatedAt": "",
+  "updatedBy": ""
 }

--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -36,7 +36,7 @@ export async function readAggregates(
     const buf = await fs.readFile(aggregatesPath(shop), "utf8");
     return JSON.parse(buf) as AnalyticsAggregates;
   } catch {
-    return { page_view: {}, order: {} };
+    return { page_view: {}, order: {}, ai_catalog: {} };
   }
 }
 

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -10,6 +10,13 @@ import { validateShopName } from "../shops";
 import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@acme/date-utils";
 const DEFAULT_LANGUAGES: Locale[] = [...LOCALES];
+const DEFAULT_AI_CATALOG_FIELDS = [
+  "id",
+  "title",
+  "description",
+  "price",
+  "images",
+];
 
 function settingsPath(shop: string): string {
   shop = validateShopName(shop);
@@ -58,6 +65,11 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
           interval: 60,
           ...(parsed.data.depositService ?? {}),
         },
+        aiCatalog: {
+          enabled: false,
+          fields: DEFAULT_AI_CATALOG_FIELDS,
+          ...(parsed.data.aiCatalog ?? {}),
+        },
       };
     }
   } catch {
@@ -71,6 +83,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     currency: "EUR",
     taxRegion: "",
     depositService: { enabled: false, interval: 60 },
+    aiCatalog: { enabled: false, fields: DEFAULT_AI_CATALOG_FIELDS },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/template-app/__tests__/ai-catalog.test.ts
+++ b/packages/template-app/__tests__/ai-catalog.test.ts
@@ -1,5 +1,11 @@
 // packages/template-app/__tests__/ai-catalog.test.ts
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import { GET } from "../src/app/api/ai/catalog/route";
+jest.mock("@platform-core/src/analytics", () => ({
+  trackEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@acme/config", () => ({ env: { NEXT_PUBLIC_SHOP_ID: "abc" } }));
 
 describe("AI catalogue API", () => {
   beforeAll(() => {
@@ -27,6 +33,33 @@ describe("AI catalogue API", () => {
     expect(item).toHaveProperty("description");
     expect(item).toHaveProperty("price");
     expect(item).toHaveProperty("images");
+  });
+
+  test("respects field list", async () => {
+    const settingsPath = path.join(
+      process.cwd(),
+      "data",
+      "shops",
+      "abc",
+      "settings.json"
+    );
+    const orig = await fs.readFile(settingsPath, "utf8");
+    const cfg = JSON.parse(orig);
+    cfg.aiCatalog.fields = ["id", "title"];
+    await fs.writeFile(settingsPath, JSON.stringify(cfg, null, 2), "utf8");
+    try {
+      const res = await GET(createRequest("http://localhost/api/ai/catalog"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const item = body.items[0];
+      expect(item).toHaveProperty("id");
+      expect(item).toHaveProperty("title");
+      expect(item).not.toHaveProperty("description");
+      expect(item).not.toHaveProperty("price");
+      expect(item).not.toHaveProperty("images");
+    } finally {
+      await fs.writeFile(settingsPath, orig, "utf8");
+    }
   });
 
   test("responds 304 when not modified", async () => {

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+export declare const aiCatalogFieldSchema: z.ZodEnum<["id", "title", "description", "price", "images"]>;
 export declare const shopSettingsSchema: z.ZodObject<{
     languages: z.ZodReadonly<z.ZodArray<z.ZodEnum<["en", "de", "it"]>, "many">>;
     seo: z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodObject<{
@@ -89,6 +90,16 @@ export declare const shopSettingsSchema: z.ZodObject<{
         provider: string;
         id?: string | undefined;
     }>>;
+    aiCatalog: z.ZodOptional<z.ZodObject<{
+        enabled: z.ZodBoolean;
+        fields: z.ZodArray<z.ZodEnum<["id", "title", "description", "price", "images"]>, "many">;
+    }, "strip", z.ZodTypeAny, {
+        enabled: boolean;
+        fields: ("id" | "title" | "description" | "price" | "images")[];
+    }, {
+        enabled: boolean;
+        fields: ("id" | "title" | "description" | "price" | "images")[];
+    }>>;
     freezeTranslations: z.ZodOptional<z.ZodBoolean>;
     currency: z.ZodOptional<z.ZodString>;
     taxRegion: z.ZodOptional<z.ZodString>;
@@ -132,6 +143,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
         provider: string;
         id?: string | undefined;
     } | undefined;
+    aiCatalog?: {
+        enabled: boolean;
+        fields: ("id" | "title" | "description" | "price" | "images")[];
+    } | undefined;
     freezeTranslations?: boolean | undefined;
     currency?: string | undefined;
     taxRegion?: string | undefined;
@@ -167,6 +182,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
         provider: string;
         id?: string | undefined;
     } | undefined;
+    aiCatalog?: {
+        enabled: boolean;
+        fields: ("id" | "title" | "description" | "price" | "images")[];
+    } | undefined;
     freezeTranslations?: boolean | undefined;
     currency?: string | undefined;
     taxRegion?: string | undefined;
@@ -176,4 +195,5 @@ export declare const shopSettingsSchema: z.ZodObject<{
     } | undefined;
 }>;
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
+export type AiCatalogField = z.infer<typeof aiCatalogFieldSchema>;
 //# sourceMappingURL=ShopSettings.d.ts.map

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -2,6 +2,14 @@ import { z } from "zod";
 import { localeSchema } from "./Product";
 import { shopSeoFieldsSchema } from "./Shop";
 
+const aiCatalogFieldSchema = z.enum([
+  "id",
+  "title",
+  "description",
+  "price",
+  "images",
+]);
+
 export const shopSettingsSchema = z.object({
   languages: z.array(localeSchema).readonly(),
   seo: z.record(localeSchema, shopSeoFieldsSchema),
@@ -10,6 +18,12 @@ export const shopSettingsSchema = z.object({
       enabled: z.boolean().optional(),
       provider: z.string(),
       id: z.string().optional(),
+    })
+    .optional(),
+  aiCatalog: z
+    .object({
+      enabled: z.boolean(),
+      fields: z.array(aiCatalogFieldSchema),
     })
     .optional(),
   freezeTranslations: z.boolean().optional(),
@@ -28,3 +42,4 @@ export const shopSettingsSchema = z.object({
 });
 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
+export type AiCatalogField = z.infer<typeof aiCatalogFieldSchema>;


### PR DESCRIPTION
## Summary
- add `aiCatalog` config to shop settings
- track and aggregate `ai_catalog` feed requests
- surface AI catalog traffic on the CMS dashboard

## Testing
- `npx jest packages/platform-core/__tests__/analytics.test.ts`
- `npx jest packages/template-app/__tests__/ai-catalog.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b1c2271f4832f9fb1c618e0f4e20a