### PR TITLE
refactor(configurator): remove step order and prerequisites

### DIFF
--- a/apps/cms/__tests__/dashboardRecommendations.integration.test.tsx
+++ b/apps/cms/__tests__/dashboardRecommendations.integration.test.tsx
@@ -1,4 +1,4 @@
-/* apps/cms/__tests__/dashboardPrerequisites.integration.test.tsx */
+/* apps/cms/__tests__/dashboardRecommendations.integration.test.tsx */
 /* eslint-env jest */
 
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -39,14 +39,12 @@ jest.mock("../src/app/cms/configurator/steps", () => {
       id: "a",
       label: "Step A",
       component: () => null,
-      order: 1,
     },
     {
       id: "b",
       label: "Step B",
       component: () => null,
-      order: 2,
-      prerequisites: ["a"],
+      recommended: ["a"],
     },
   ];
   return {
@@ -98,12 +96,15 @@ afterEach(() => {
   window.addEventListener = originalAddEventListener;
 });
 
-test("shows prerequisites message when launching step with unmet requirements", async () => {
-  render(<ConfiguratorDashboard />);
-  const link = await screen.findByRole("link", { name: /step b/i });
-  fireEvent.click(link);
-  const alert = await screen.findByRole("alert");
-  expect(alert).toHaveTextContent(/step a/i);
-  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
-  expect(stored.completed?.b).toBeFalsy();
-});
+test(
+  "shows recommendation message when launching step with suggested steps",
+  async () => {
+    render(<ConfiguratorDashboard />);
+    const link = await screen.findByRole("link", { name: /step b/i });
+    fireEvent.click(link);
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/step a/i);
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    expect(stored.completed?.b).toBeFalsy();
+  }
+);

--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -5,7 +5,6 @@ import {
   useEffect,
   useMemo,
   useState,
-  type MouseEvent,
 } from "react";
 import Link from "next/link";
 import { CheckCircledIcon, CircleIcon } from "@radix-ui/react-icons";
@@ -76,17 +75,14 @@ export default function ConfiguratorDashboard() {
   const skipStep = (stepId: string) => markStepComplete(stepId, "skipped");
   const resetStep = (stepId: string) => markStepComplete(stepId, "pending");
 
-  const handleStepClick = (step: ConfiguratorStep) => (
-    e: MouseEvent<HTMLAnchorElement>
-  ) => {
-    const missing = (step.prerequisites ?? []).filter(
+  const handleStepClick = (step: ConfiguratorStep) => () => {
+    const missing = (step.recommended ?? []).filter(
       (id) => !state?.completed?.[id]
     );
     if (missing.length > 0) {
-      e.preventDefault();
       setToast({
         open: true,
-        message: `Complete prerequisite steps: ${missing
+        message: `Recommended to complete: ${missing
           .map((id) => configuratorSteps[id]?.label ?? id)
           .join(", ")}`,
       });

--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -1,35 +1,15 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { steps } from "../steps";
-import { useWizard } from "../../wizard/WizardContext";
 
 interface Props {
   stepId: string;
 }
 
 export default function StepPage({ stepId }: Props) {
-  const router = useRouter();
-  const { state } = useWizard();
   const step = steps[stepId];
   if (!step) {
     return null;
-  }
-
-  const prerequisites = step.prerequisites ?? [];
-  const missingPrereq = prerequisites.find(
-    (id) => state.completed[id] !== "complete"
-  );
-
-  useEffect(() => {
-    if (missingPrereq) {
-      router.push(`/cms/configurator/${missingPrereq}`);
-    }
-  }, [missingPrereq, router]);
-
-  if (missingPrereq) {
-    return <div>Please complete prerequisite steps first.</div>;
   }
 
   const StepComponent = step.component as React.ComponentType<any>;

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -20,86 +20,75 @@ export interface ConfiguratorStep {
   label: string;
   component: React.ComponentType<any>;
   optional?: boolean;
-  /** IDs of steps that must be completed before this step */
-  prerequisites?: string[];
-  order?: number;
+  /** IDs of steps that are recommended to complete before this step */
+  recommended?: string[];
 }
 
 const stepList: ConfiguratorStep[] = [
-  { id: "shop-details", label: "Shop Details", component: StepShopDetails, order: 1 },
-  { id: "theme", label: "Theme", component: StepTheme, order: 2 },
-  { id: "tokens", label: "Tokens", component: StepTokens, order: 3 },
-  { id: "options", label: "Options", component: StepOptions, order: 4 },
-  { id: "navigation", label: "Navigation", component: StepNavigation, order: 5 },
+  { id: "shop-details", label: "Shop Details", component: StepShopDetails },
+  { id: "theme", label: "Theme", component: StepTheme },
+  { id: "tokens", label: "Tokens", component: StepTokens },
+  { id: "options", label: "Options", component: StepOptions },
+  { id: "navigation", label: "Navigation", component: StepNavigation },
   {
     id: "layout",
     label: "Layout",
     component: StepLayout,
-    order: 6,
-    prerequisites: ["navigation"],
+    recommended: ["navigation"],
   },
   {
     id: "home-page",
     label: "Home Page",
     component: StepHomePage,
-    order: 7,
-    prerequisites: ["layout"],
+    recommended: ["layout"],
   },
   {
     id: "checkout-page",
     label: "Checkout Page",
     component: StepCheckoutPage,
-    order: 8,
-    prerequisites: ["layout"],
+    recommended: ["layout"],
   },
   {
     id: "shop-page",
     label: "Shop Page",
     component: StepShopPage,
-    order: 9,
-    prerequisites: ["layout"],
+    recommended: ["layout"],
   },
   {
     id: "product-page",
     label: "Product Page",
     component: StepProductPage,
-    order: 10,
-    prerequisites: ["shop-page"],
+    recommended: ["shop-page"],
   },
   {
     id: "additional-pages",
     label: "Additional Pages",
     component: StepAdditionalPages,
-    order: 11,
-    prerequisites: ["layout"],
+    recommended: ["layout"],
   },
-  { id: "env-vars", label: "Environment Variables", component: StepEnvVars, order: 12 },
-  { id: "summary", label: "Summary", component: StepSummary, order: 13 },
+  { id: "env-vars", label: "Environment Variables", component: StepEnvVars },
+  { id: "summary", label: "Summary", component: StepSummary },
   {
     id: "import-data",
     label: "Import Data",
     component: StepImportData,
     optional: true,
-    order: 14,
   },
   {
     id: "seed-data",
     label: "Seed Data",
     component: StepSeedData,
     optional: true,
-    order: 15,
   },
   {
     id: "hosting",
     label: "Hosting",
     component: StepHosting,
     optional: true,
-    order: 16,
   },
 ];
 
-export const getSteps = (): ConfiguratorStep[] =>
-  [...stepList].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+export const getSteps = (): ConfiguratorStep[] => [...stepList];
 
 export const getRequiredSteps = (): ConfiguratorStep[] =>
   getSteps().filter((s) => !s.optional);


### PR DESCRIPTION
## Summary
- drop `order` field from configurator steps and keep default list order
- convert hard prerequisites into optional recommendations
- stop dashboard and step pages from blocking navigation on unmet prerequisites

## Testing
- `pnpm --filter cms test apps/cms/__tests__/dashboardRecommendations.integration.test.tsx`
- `pnpm --filter cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter cms lint` *(fails: Cannot find module '@acme/config/env.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689b1c1487e8832fabdf9c0fb242282f