### PR TITLE
feat: track email campaign metrics

### DIFF
--- a/apps/cms/src/app/api/marketing/email/click/route.ts
+++ b/apps/cms/src/app/api/marketing/email/click/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { trackEvent } from "@platform-core/analytics";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const shop = req.nextUrl.searchParams.get("shop");
+  const campaign = req.nextUrl.searchParams.get("campaign");
+  const url = req.nextUrl.searchParams.get("url") || "/";
+  if (shop && campaign) {
+    await trackEvent(shop, { type: "email_click", campaign });
+  }
+  return NextResponse.redirect(url);
+}

--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from "next/server";
+import { trackEvent } from "@platform-core/analytics";
+
+// 1x1 transparent gif
+const pixel = Buffer.from(
+  "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
+  "base64"
+);
+
+export async function GET(req: NextRequest) {
+  const shop = req.nextUrl.searchParams.get("shop");
+  const campaign = req.nextUrl.searchParams.get("campaign");
+  if (shop && campaign) {
+    await trackEvent(shop, { type: "email_open", campaign });
+  }
+  return new Response(pixel, {
+    headers: {
+      "Content-Type": "image/gif",
+      "Cache-Control": "no-store, max-age=0",
+    },
+  });
+}

--- a/apps/cms/src/app/api/marketing/email/route.ts
+++ b/apps/cms/src/app/api/marketing/email/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { sendCampaignEmail } from "@acme/email";
+import { trackEvent } from "@platform-core/analytics";
+import { listEvents } from "@platform-core/repositories/analytics.server";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { validateShopName } from "@acme/lib";
+import { env } from "@acme/config";
+
+interface Campaign {
+  id: string;
+  to: string;
+  subject: string;
+  body: string;
+  sentAt: string;
+}
+
+function campaignsPath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "campaigns.json");
+}
+
+async function readCampaigns(shop: string): Promise<Campaign[]> {
+  try {
+    const buf = await fs.readFile(campaignsPath(shop), "utf8");
+    const json = JSON.parse(buf);
+    if (Array.isArray(json)) return json as Campaign[];
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeCampaigns(shop: string, items: Campaign[]): Promise<void> {
+  await fs.mkdir(path.dirname(campaignsPath(shop)), { recursive: true });
+  await fs.writeFile(campaignsPath(shop), JSON.stringify(items, null, 2), "utf8");
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const shop = req.nextUrl.searchParams.get("shop");
+  if (!shop) return NextResponse.json({ error: "Missing shop" }, { status: 400 });
+  const campaigns = await readCampaigns(shop);
+  const events = await listEvents(shop);
+  const withMetrics = campaigns.map((c) => {
+    const metrics = { sent: 0, opened: 0, clicked: 0 };
+    for (const e of events) {
+      if (e.campaign !== c.id) continue;
+      if (e.type === "email_sent") metrics.sent += 1;
+      else if (e.type === "email_open") metrics.opened += 1;
+      else if (e.type === "email_click") metrics.clicked += 1;
+    }
+    return { ...c, metrics };
+  });
+  return NextResponse.json({ campaigns: withMetrics });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { shop, to, subject, body } = (await req.json().catch(() => ({}))) as {
+    shop?: string;
+    to?: string;
+    subject?: string;
+    body?: string;
+  };
+  if (!shop || !to || !subject || !body) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  const id = Date.now().toString(36);
+  const sentAt = new Date().toISOString();
+  const base = env.NEXT_PUBLIC_BASE_URL || "";
+  const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
+    shop
+  )}&campaign=${encodeURIComponent(id)}`;
+  const bodyWithPixel =
+    body +
+    `<img src="${pixelUrl}" alt="" style="display:none" width="1" height="1"/>`;
+  const trackedBody = bodyWithPixel.replace(
+    /href="([^"]+)"/g,
+    (_m, url) =>
+      `href="${base}/api/marketing/email/click?shop=${encodeURIComponent(
+        shop
+      )}&campaign=${encodeURIComponent(id)}&url=${encodeURIComponent(url)}"`
+  );
+  try {
+    await sendCampaignEmail({ to, subject, html: trackedBody });
+    await trackEvent(shop, { type: "email_sent", campaign: id });
+  } catch {
+    return NextResponse.json({ error: "Failed to send" }, { status: 500 });
+  }
+  const campaigns = await readCampaigns(shop);
+  campaigns.push({ id, to, subject, body, sentAt });
+  await writeCampaigns(shop, campaigns);
+  return NextResponse.json({ ok: true, id });
+}

--- a/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
@@ -32,6 +32,7 @@ interface ChartsProps {
   conversion: Series;
   sales: Series;
   emailOpens: Series;
+  emailClicks: Series;
   campaignSales: Series;
   discountRedemptions: Series;
 }
@@ -41,6 +42,7 @@ export function Charts({
   conversion,
   sales,
   emailOpens,
+  emailClicks,
   campaignSales,
   discountRedemptions,
 }: ChartsProps) {
@@ -101,6 +103,21 @@ export function Charts({
                 label: "Email opens",
                 data: emailOpens.data,
                 borderColor: "rgb(54, 162, 235)",
+              },
+            ],
+          }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 font-semibold">Email Clicks</h3>
+        <Line
+          data={{
+            labels: emailClicks.labels,
+            datasets: [
+              {
+                label: "Email clicks",
+                data: emailClicks.data,
+                borderColor: "rgb(255, 205, 86)",
               },
             ],
           }}

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -28,6 +28,7 @@ export default async function ShopDashboard({
     : events;
 
   const emailOpenByDay: Record<string, number> = {};
+  const emailClickByDay: Record<string, number> = {};
   const campaignSalesByDay: Record<string, number> = {};
   const discountByDay: Record<string, number> = {};
   for (const e of filteredEvents) {
@@ -35,6 +36,8 @@ export default async function ShopDashboard({
     if (!day) continue;
     if (e.type === "email_open") {
       emailOpenByDay[day] = (emailOpenByDay[day] || 0) + 1;
+    } else if (e.type === "email_click") {
+      emailClickByDay[day] = (emailClickByDay[day] || 0) + 1;
     } else if (e.type === "campaign_sale") {
       const amount = typeof e.amount === "number" ? e.amount : 0;
       campaignSalesByDay[day] = (campaignSalesByDay[day] || 0) + amount;
@@ -48,6 +51,7 @@ export default async function ShopDashboard({
       ...Object.keys(aggregates.page_view),
       ...Object.keys(aggregates.order),
       ...Object.keys(emailOpenByDay),
+      ...Object.keys(emailClickByDay),
       ...Object.keys(campaignSalesByDay),
       ...Object.keys(discountByDay),
     ])
@@ -73,6 +77,10 @@ export default async function ShopDashboard({
     labels: days,
     data: days.map((d) => emailOpenByDay[d] || 0),
   };
+  const emailClicks = {
+    labels: days,
+    data: days.map((d) => emailClickByDay[d] || 0),
+  };
   const campaignSales = {
     labels: days,
     data: days.map((d) => campaignSalesByDay[d] || 0),
@@ -84,11 +92,13 @@ export default async function ShopDashboard({
 
   const totals = {
     emailOpens: emailOpens.data.reduce((a, b) => a + b, 0),
+    emailClicks: emailClicks.data.reduce((a, b) => a + b, 0),
     campaignSales: campaignSales.data.reduce((a, b) => a + b, 0),
     discountRedemptions: discountRedemptions.data.reduce((a, b) => a + b, 0),
   };
   const maxTotal = Math.max(
     totals.emailOpens,
+    totals.emailClicks,
     totals.campaignSales,
     totals.discountRedemptions,
     1,
@@ -116,6 +126,7 @@ export default async function ShopDashboard({
         sales={sales}
         conversion={conversion}
         emailOpens={emailOpens}
+        emailClicks={emailClicks}
         campaignSales={campaignSales}
         discountRedemptions={discountRedemptions}
       />
@@ -126,6 +137,13 @@ export default async function ShopDashboard({
           <Progress
             value={(totals.emailOpens / maxTotal) * 100}
             label={String(totals.emailOpens)}
+          />
+        </div>
+        <div>
+          <span className="mb-1 block text-sm font-medium">Email clicks</span>
+          <Progress
+            value={(totals.emailClicks / maxTotal) * 100}
+            label={String(totals.emailClicks)}
           />
         </div>
         <div>

--- a/apps/cms/src/app/cms/marketing/email/page.tsx
+++ b/apps/cms/src/app/cms/marketing/email/page.tsx
@@ -1,12 +1,35 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+interface Campaign {
+  id: string;
+  to: string;
+  subject: string;
+  sentAt: string;
+  metrics: { sent: number; opened: number; clicked: number };
+}
 
 export default function EmailMarketingPage() {
+  const [shop, setShop] = useState("");
   const [to, setTo] = useState("");
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
   const [status, setStatus] = useState<string | null>(null);
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+
+  async function loadCampaigns(s: string) {
+    if (!s) return;
+    const res = await fetch(`/api/marketing/email?shop=${encodeURIComponent(s)}`);
+    if (res.ok) {
+      const json = await res.json();
+      setCampaigns(json.campaigns || []);
+    }
+  }
+
+  useEffect(() => {
+    loadCampaigns(shop);
+  }, [shop]);
 
   async function send(e: React.FormEvent) {
     e.preventDefault();
@@ -15,38 +38,80 @@ export default function EmailMarketingPage() {
       const res = await fetch("/api/marketing/email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ to, subject, body }),
+        body: JSON.stringify({ shop, to, subject, body }),
       });
       setStatus(res.ok ? "Sent" : "Failed");
+      if (res.ok) {
+        setTo("");
+        setSubject("");
+        setBody("");
+        await loadCampaigns(shop);
+      }
     } catch {
       setStatus("Failed");
     }
   }
 
   return (
-    <form onSubmit={send} className="space-y-2 p-4">
-      <input
-        className="border p-2 w-full"
-        placeholder="Recipient"
-        value={to}
-        onChange={(e) => setTo(e.target.value)}
-      />
-      <input
-        className="border p-2 w-full"
-        placeholder="Subject"
-        value={subject}
-        onChange={(e) => setSubject(e.target.value)}
-      />
-      <textarea
-        className="border p-2 w-full h-40"
-        placeholder="HTML body"
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-      />
-      <button className="border px-4 py-2" type="submit">
-        Send
-      </button>
-      {status && <p>{status}</p>}
-    </form>
+    <div className="space-y-4 p-4">
+      <form onSubmit={send} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Shop"
+          value={shop}
+          onChange={(e) => setShop(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Recipient"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Subject"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        />
+        <textarea
+          className="border p-2 w-full h-40"
+          placeholder="HTML body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+        />
+        <button className="border px-4 py-2" type="submit">
+          Send
+        </button>
+        {status && <p>{status}</p>}
+      </form>
+      {campaigns.length > 0 && (
+        <table className="mt-4 w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border px-2 py-1 text-left">Subject</th>
+              <th className="border px-2 py-1 text-left">To</th>
+              <th className="border px-2 py-1">Sent At</th>
+              <th className="border px-2 py-1">Sent</th>
+              <th className="border px-2 py-1">Opened</th>
+              <th className="border px-2 py-1">Clicked</th>
+            </tr>
+          </thead>
+          <tbody>
+            {campaigns.map((c) => (
+              <tr key={c.id}>
+                <td className="border px-2 py-1">{c.subject}</td>
+                <td className="border px-2 py-1">{c.to}</td>
+                <td className="border px-2 py-1 text-center">
+                  {new Date(c.sentAt).toLocaleString()}
+                </td>
+                <td className="border px-2 py-1 text-center">{c.metrics.sent}</td>
+                <td className="border px-2 py-1 text-center">{c.metrics.opened}</td>
+                <td className="border px-2 py-1 text-center">{c.metrics.clicked}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add email campaign API with persistent storage and event tracking
- show campaign metrics in CMS and chart email clicks on dashboard
- track email open/click events via API endpoints

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689b1f89066c832f94f86c6562c64b26