### PR TITLE
Use shared deposit release helper

### DIFF
--- a/dist-scripts/release-deposits.d.ts.map
+++ b/dist-scripts/release-deposits.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"release-deposits.d.ts","sourceRoot":"","sources":["../scripts/release-deposits.ts"],"names":[],"mappings":""}
+{"version":3,"file":"release-deposits.d.ts","sourceRoot":"","sources":["../scripts/src/release-deposits.ts"],"names":[],"mappings":""}

--- a/dist-scripts/release-deposits.js
+++ b/dist-scripts/release-deposits.js
@@ -1,39 +1,6 @@
-import { stripe } from "@acme/stripe";
-import { markRefunded, readOrders, } from "@platform-core/repositories/rentalOrders.server";
-import { readdir } from "node:fs/promises";
-import { join } from "node:path";
-async function processShop(shop) {
-    var _a, _b;
-    const orders = await readOrders(shop);
-    for (const order of orders) {
-        const deposit = (_a = order.deposit) !== null && _a !== void 0 ? _a : 0;
-        const sessionId = order.sessionId;
-        if (order.returnedAt && !order.refundedAt && deposit > 0 && sessionId) {
-            const session = await stripe.checkout.sessions.retrieve(sessionId, {
-                expand: ["payment_intent"],
-            });
-            const pi = typeof session.payment_intent === "string"
-                ? session.payment_intent
-                : (_b = session.payment_intent) === null || _b === void 0 ? void 0 : _b.id;
-            if (!pi)
-                continue;
-            await stripe.refunds.create({
-                payment_intent: pi,
-                amount: deposit * 100,
-            });
-            await markRefunded(shop, sessionId);
-            console.log(`refunded deposit for ${sessionId} (${shop})`);
-        }
-    }
-}
-async function main() {
-    const shopsDir = join(process.cwd(), "data", "shops");
-    const shops = await readdir(shopsDir);
-    for (const shop of shops) {
-        await processShop(shop);
-    }
-}
-main().catch((err) => {
-    console.error(err);
-    process.exit(1);
+import { releaseDepositsOnce } from "@acme/platform-machine";
+
+releaseDepositsOnce().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });

--- a/scripts/src/release-deposits.ts
+++ b/scripts/src/release-deposits.ts
@@ -1,46 +1,8 @@
 // scripts/src/release-deposits.ts
 
-import { readdir } from "node:fs/promises";
-import { join } from "node:path";
-import { stripe } from "@acme/stripe";
-import {
-  markRefunded,
-  readOrders,
-} from "../../packages/platform-core/src/repositories/rentalOrders.server";
+import { releaseDepositsOnce } from "@acme/platform-machine";
 
-async function processShop(shop: string): Promise<void> {
-  const orders = await readOrders(shop);
-  for (const order of orders) {
-    const deposit = order.deposit ?? 0;
-    const sessionId = order.sessionId;
-    if (order.returnedAt && !order.refundedAt && deposit > 0 && sessionId) {
-      const session = await stripe.checkout.sessions.retrieve(sessionId, {
-        expand: ["payment_intent"],
-      });
-      const pi =
-        typeof session.payment_intent === "string"
-          ? session.payment_intent
-          : session.payment_intent?.id;
-      if (!pi) continue;
-      await stripe.refunds.create({
-        payment_intent: pi,
-        amount: deposit * 100,
-      });
-      await markRefunded(shop, sessionId);
-      console.log(`refunded deposit for ${sessionId} (${shop})`);
-    }
-  }
-}
-
-async function main(): Promise<void> {
-  const shopsDir = join(process.cwd(), "data", "shops");
-  const shops = await readdir(shopsDir);
-  for (const shop of shops) {
-    await processShop(shop);
-  }
-}
-
-main().catch((err) => {
+releaseDepositsOnce().catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/test/unit/release-deposits.spec.ts
+++ b/test/unit/release-deposits.spec.ts
@@ -1,54 +1,20 @@
-jest.mock('node:fs/promises', () => ({
-  readdir: jest.fn(),
-}));
+const releaseMock = jest.fn();
 
-let readdirMock = require('node:fs/promises').readdir as jest.Mock;
-
-const retrieveMock = jest.fn();
-const refundMock = jest.fn();
-
-jest.mock('@acme/stripe', () => ({
-  stripe: {
-    checkout: { sessions: { retrieve: retrieveMock } },
-    refunds: { create: refundMock },
-  },
-}));
-
-const readOrdersMock = jest.fn();
-const markRefundedMock = jest.fn();
-
-jest.mock('@platform-core/repositories/rentalOrders.server', () => ({
-  readOrders: (...args: any[]) => readOrdersMock(...args),
-  markRefunded: (...args: any[]) => markRefundedMock(...args),
+jest.mock('@acme/platform-machine', () => ({
+  releaseDepositsOnce: (...args: any[]) => releaseMock(...args),
 }));
 
 describe('scripts/release-deposits', () => {
   beforeEach(() => {
     jest.resetModules();
-    readdirMock = require('node:fs/promises').readdir as jest.Mock;
-    readdirMock.mockReset();
-    retrieveMock.mockReset();
-    refundMock.mockReset();
-    readOrdersMock.mockReset();
-    markRefundedMock.mockReset();
-    process.env.STRIPE_SECRET_KEY = 'sk';
-    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk';
+    releaseMock.mockReset();
     process.exit = jest.fn() as any;
   });
 
-  it('refunds returned deposits', async () => {
-    readdirMock.mockResolvedValue(['shop1']);
-    readOrdersMock.mockResolvedValue([
-      { deposit: 10, sessionId: 'sess1', returnedAt: 'now', refundedAt: undefined },
-    ]);
-    retrieveMock.mockResolvedValue({ payment_intent: 'pi_1' });
-    refundMock.mockResolvedValue({});
-
-    await import('../../scripts/release-deposits');
+  it('calls releaseDepositsOnce', async () => {
+    releaseMock.mockResolvedValue(undefined);
+    await import('../../scripts/src/release-deposits');
     await new Promise(process.nextTick);
-
-    expect(retrieveMock).toHaveBeenCalledWith('sess1', { expand: ['payment_intent'] });
-    expect(refundMock).toHaveBeenCalledWith({ payment_intent: 'pi_1', amount: 1000 });
-    expect(markRefundedMock).toHaveBeenCalledWith('shop1', 'sess1');
+    expect(releaseMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- replace custom Stripe refund logic in `release-deposits` script with shared `releaseDepositsOnce`
- mock `releaseDepositsOnce` in unit test

## Testing
- `pnpm exec jest test/unit/release-deposits.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b202db3a4832f8a8b8694639a8434