### PR TITLE
feat: add tabs block to page builder

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -223,6 +223,12 @@ export interface MultiColumnComponent extends PageComponentBase {
   gap?: string;
   children?: PageComponent[];
 }
+export interface TabsComponent extends PageComponentBase {
+  type: "Tabs";
+  labels?: string[];
+  active?: number;
+  children?: PageComponent[];
+}
 export type PageComponent =
   | AnnouncementBarComponent
   | HeroBannerComponent
@@ -250,7 +256,8 @@ export type PageComponent =
   | SocialLinksComponent
   | SocialFeedComponent
   | SectionComponent
-  | MultiColumnComponent;
+  | MultiColumnComponent
+  | TabsComponent;
 export declare const pageSchema: z.ZodObject<
   {
     id: z.ZodString;

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -247,6 +247,13 @@ export interface MultiColumnComponent extends PageComponentBase {
   children?: PageComponent[];
 }
 
+export interface TabsComponent extends PageComponentBase {
+  type: "Tabs";
+  labels?: string[];
+  active?: number;
+  children?: PageComponent[];
+}
+
 export type PageComponent =
   | AnnouncementBarComponent
   | HeroBannerComponent
@@ -276,7 +283,8 @@ export type PageComponent =
   | SocialLinksComponent
   | SocialFeedComponent
   | SectionComponent
-  | MultiColumnComponent;
+  | MultiColumnComponent
+  | TabsComponent;
 
 const baseComponentSchema = z
   .object({
@@ -518,6 +526,14 @@ const multiColumnComponentSchema: z.ZodType<MultiColumnComponent> =
     children: z.array(z.lazy(() => pageComponentSchema)).default([]),
   });
 
+const tabsComponentSchema: z.ZodType<TabsComponent> =
+  baseComponentSchema.extend({
+    type: z.literal("Tabs"),
+    labels: z.array(z.string()).default([]),
+    active: z.number().optional(),
+    children: z.array(z.lazy(() => pageComponentSchema)).default([]),
+  });
+
 export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
   z.discriminatedUnion("type", [
     announcementBarComponentSchema,
@@ -549,6 +565,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     buttonComponentSchema,
     sectionComponentSchema,
     multiColumnComponentSchema,
+    tabsComponentSchema,
   ])
 );
 

--- a/packages/ui/src/components/cms/blocks/Tabs.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/Tabs.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Tabs from "./Tabs";
+
+const meta: Meta<typeof Tabs> = {
+  component: Tabs,
+  args: {
+    labels: ["Tab 1", "Tab 2"],
+    children: [
+      <div key="1">First tab content</div>,
+      <div key="2">Second tab content</div>,
+    ],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof Tabs> = {};

--- a/packages/ui/src/components/cms/blocks/Tabs.tsx
+++ b/packages/ui/src/components/cms/blocks/Tabs.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useState, type ReactNode } from "react";
+import { cn } from "../../../../utils/style";
+
+export interface TabsBlockProps {
+  /** Labels for each tab */
+  labels?: string[];
+  /** Index of the initially active tab */
+  active?: number;
+  /** Tab contents; each child corresponds to the label at the same index */
+  children?: ReactNode[] | ReactNode;
+  className?: string;
+}
+
+export default function TabsBlock({
+  labels = [],
+  active = 0,
+  children,
+  className,
+}: TabsBlockProps) {
+  const [current, setCurrent] = useState(active);
+  const contents = Array.isArray(children) ? children : [children];
+
+  const safeIndex = Math.min(current, Math.max(contents.length - 1, 0));
+
+  return (
+    <div className={className}>
+      <div className="flex gap-2 border-b pb-2">
+        {labels.map((label, i) => (
+          <button
+            type="button"
+            key={i}
+            onClick={() => setCurrent(i)}
+            className={cn(
+              "border-b-2 px-3 py-1 text-sm",
+              i === safeIndex
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="pt-4">{contents[safeIndex]}</div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -24,6 +24,7 @@ import Button from "./Button";
 import PricingTable from "./PricingTable";
 import SocialFeed from "./SocialFeed";
 import NewsletterSignup from "./NewsletterSignup";
+import Tabs from "./Tabs";
 
 export {
   BlogListing,
@@ -52,6 +53,7 @@ export {
   Button,
   NewsletterSignup,
   PricingTable,
+  Tabs,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -19,6 +19,7 @@ import SocialLinks from "./SocialLinks";
 import SocialFeed from "./SocialFeed";
 import PricingTable from "./PricingTable";
 import NewsletterSignup from "./NewsletterSignup";
+import Tabs from "./Tabs";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -42,6 +43,7 @@ export const organismRegistry = {
   SocialFeed,
   NewsletterSignup,
   PricingTable,
+  Tabs,
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -202,6 +202,64 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
         </>
       );
       break;
+    case "Tabs": {
+      const labels = (component as any).labels ?? [];
+      const active = (component as any).active ?? 0;
+      specific = (
+        <>
+          {labels.map((label: string, i: number) => (
+            <div key={i} className="flex items-end gap-2">
+              <Input
+                label={`Tab ${i + 1} Label`}
+                value={label}
+                onChange={(e) => {
+                  const copy = [...labels];
+                  copy[i] = e.target.value;
+                  onChange({ labels: copy });
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  const copy = labels.filter((_: string, idx: number) => idx !== i);
+                  const patch: Partial<PageComponent> = { labels: copy };
+                  if (active >= copy.length) patch.active = 0;
+                  onChange(patch);
+                }}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onChange({ labels: [...labels, ""] })}
+          >
+            Add Tab
+          </Button>
+          <Select
+            value={String(active)}
+            onValueChange={(v) =>
+              onChange({ active: v === undefined ? undefined : Number(v) })
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Active Tab" />
+            </SelectTrigger>
+            <SelectContent>
+              {labels.map((_, i) => (
+                <SelectItem key={i} value={String(i)}>
+                  {`Tab ${i + 1}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </>
+      );
+      break;
+    }
     case "ProductGrid":
     case "ProductCarousel":
       specific = (


### PR DESCRIPTION
## Summary
- add `TabsBlock` component with labeled tabs and active state
- expose Tabs in block registries and page builder palette
- allow editing tab labels and default active tab in ComponentEditor
- extend page component types to support Tabs

## Testing
- `pnpm lint --filter @acme/types --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: command finished with error: command exited (1))*
- `pnpm test --filter @acme/types`


------
https://chatgpt.com/codex/tasks/task_e_689b2107d89c832fa76b624bb187c8bb