### PR TITLE
feat: auto-discover plugins with async init and structured logging

### DIFF
--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { getShopFromPath } from "./getShopFromPath";
 export { replaceShopInPath } from "./replaceShopInPath";
 export { initTheme } from "./initTheme";
+export { logger } from "./logger";

--- a/packages/platform-core/src/utils/logger.ts
+++ b/packages/platform-core/src/utils/logger.ts
@@ -1,0 +1,12 @@
+export interface LogMeta {
+  [key: string]: unknown;
+}
+
+export const logger = {
+  warn(message: string, meta: LogMeta = {}) {
+    console.warn({ level: "warn", message, ...meta });
+  },
+  error(message: string, meta: LogMeta = {}) {
+    console.error({ level: "error", message, ...meta });
+  },
+};


### PR DESCRIPTION
## Summary
- auto-scan `packages/plugins/*` for plugin packages
- add simple logger and report load/config failures
- allow plugins to define async init hook before registration
- test plugin discovery and initialization order

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/plugins.test.ts`
- `pnpm --filter @acme/platform-core lint` *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_689b200d5278832f8b3edf37f6cc1584