### PR TITLE
Use minutes for deposit service intervals

### DIFF
--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -262,7 +262,7 @@ export async function updateCurrencyAndTax(
 const depositSchema = z
   .object({
     enabled: z.preprocess((v) => v === "on", z.boolean()),
-    interval: z.coerce.number().int().min(1, "Must be at least 1"),
+    intervalMinutes: z.coerce.number().int().min(1, "Must be at least 1"),
   })
   .strict();
 
@@ -282,7 +282,7 @@ export async function updateDepositService(
     ...current,
     depositService: {
       enabled: parsed.data.enabled,
-      interval: parsed.data.interval,
+      intervalMinutes: parsed.data.intervalMinutes,
     },
   };
   await saveShopSettings(shop, updated);

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
@@ -6,7 +6,7 @@ import { useState, type ChangeEvent, type FormEvent } from "react";
 
 interface Props {
   shop: string;
-  initial: { enabled: boolean; interval: number };
+  initial: { enabled: boolean; intervalMinutes: number };
 }
 
 export default function DepositsEditor({ shop, initial }: Props) {
@@ -49,13 +49,13 @@ export default function DepositsEditor({ shop, initial }: Props) {
         <span>Interval (minutes)</span>
         <Input
           type="number"
-          name="interval"
-          value={state.interval}
+          name="intervalMinutes"
+          value={state.intervalMinutes}
           onChange={handleChange}
         />
-        {errors.interval && (
+        {errors.intervalMinutes && (
           <span className="text-sm text-red-600">
-            {errors.interval.join("; ")}
+            {errors.intervalMinutes.join("; ")}
           </span>
         )}
       </label>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
@@ -21,7 +21,7 @@ export default async function DepositsSettingsPage({
   const settings = await getSettings(shop);
   const depositService = settings.depositService ?? {
     enabled: false,
-    interval: 60,
+    intervalMinutes: 60,
   };
 
   return (

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -5,6 +5,6 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   }
 }

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -5,6 +5,6 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   }
 }

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -5,6 +5,6 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   }
 }

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -4,7 +4,7 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   },
   "languages": [
     "en",

--- a/doc/machine.md
+++ b/doc/machine.md
@@ -15,7 +15,7 @@ const stop = startDepositReleaseService();
 // stop(); // call to clear the interval
 ```
 
-`startDepositReleaseService(intervalMs)` accepts an optional interval in milliseconds (defaults to one hour) and returns a function to stop the timer. The service subtracts any `damageFee` from the refunded amount and calls `markRefunded` so the order is not processed again.
+`startDepositReleaseService()` reads optional per-shop settings where intervals are expressed in minutes (default: 60) and returns a function to stop the timer. The service subtracts any `damageFee` from the refunded amount and calls `markRefunded` so the order is not processed again.
 
 Stripe credentials (`STRIPE_SECRET_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`) must be configured in the shop `.env` files. A one-off CLI utility is also available:
 

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -55,7 +55,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
         ...parsed.data,
         depositService: {
           enabled: false,
-          interval: 60,
+          intervalMinutes: 60,
           ...(parsed.data.depositService ?? {}),
         },
       };
@@ -70,7 +70,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     freezeTranslations: false,
     currency: "EUR",
     taxRegion: "",
-    depositService: { enabled: false, interval: 60 },
+    depositService: { enabled: false, intervalMinutes: 60 },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/platform-machine/__tests__/releaseDepositsService.test.ts
+++ b/packages/platform-machine/__tests__/releaseDepositsService.test.ts
@@ -145,7 +145,7 @@ describe("startDepositReleaseService", () => {
     readOrders.mockResolvedValue([]);
     readFile
       .mockResolvedValueOnce(
-        JSON.stringify({ depositRelease: { enabled: true, intervalMs: 5000 } })
+        JSON.stringify({ depositRelease: { enabled: true, intervalMinutes: 1 } })
       )
       .mockResolvedValueOnce(
         JSON.stringify({ depositRelease: { enabled: true } })
@@ -155,7 +155,7 @@ describe("startDepositReleaseService", () => {
     const setSpy = jest
       .spyOn(global, "setInterval")
       .mockImplementation((fn: any, ms?: number) => {
-        expect(ms).toBe(5000);
+        expect(ms).toBe(60000);
         return 123 as any;
       });
     const clearSpy = jest

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -52,12 +52,12 @@ export async function releaseDepositsOnce(
 
 type DepositReleaseConfig = {
   enabled: boolean;
-  intervalMs: number;
+  intervalMinutes: number;
 };
 
 const DEFAULT_CONFIG: DepositReleaseConfig = {
   enabled: true,
-  intervalMs: 1000 * 60 * 60,
+  intervalMinutes: 60,
 };
 
 function envKey(shop: string, key: string): string {
@@ -81,21 +81,23 @@ async function resolveConfig(
     const cfg = json.depositRelease;
     if (cfg) {
       if (typeof cfg.enabled === "boolean") config.enabled = cfg.enabled;
-      if (typeof cfg.intervalMs === "number") config.intervalMs = cfg.intervalMs;
+      if (typeof cfg.intervalMinutes === "number")
+        config.intervalMinutes = cfg.intervalMinutes;
     }
   } catch {}
 
   const envEnabled = readEnv(shop, "ENABLED");
   if (envEnabled !== undefined) config.enabled = envEnabled !== "false";
 
-  const envInterval = readEnv(shop, "INTERVAL_MS");
+  const envInterval = readEnv(shop, "INTERVAL_MINUTES");
   if (envInterval !== undefined) {
     const num = Number(envInterval);
-    if (!Number.isNaN(num)) config.intervalMs = num;
+    if (!Number.isNaN(num)) config.intervalMinutes = num;
   }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;
-  if (override.intervalMs !== undefined) config.intervalMs = override.intervalMs;
+  if (override.intervalMinutes !== undefined)
+    config.intervalMinutes = override.intervalMinutes;
 
   return config;
 }
@@ -120,7 +122,7 @@ export async function startDepositReleaseService(
     }
 
     await run();
-    timers.push(setInterval(run, cfg.intervalMs));
+    timers.push(setInterval(run, cfg.intervalMinutes * 60_000));
   }
 
   return () => timers.forEach((t) => clearInterval(t));

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -94,13 +94,13 @@ export declare const shopSettingsSchema: z.ZodObject<{
     taxRegion: z.ZodOptional<z.ZodString>;
     depositService: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodBoolean;
-        interval: z.ZodNumber;
+        intervalMinutes: z.ZodNumber;
     }, "strip", z.ZodTypeAny, {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     }, {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     }>>;
     updatedAt: z.ZodString;
     updatedBy: z.ZodString;
@@ -137,7 +137,7 @@ export declare const shopSettingsSchema: z.ZodObject<{
     taxRegion?: string | undefined;
     depositService?: {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     } | undefined;
 }, {
     seo: Partial<Record<"en" | "de" | "it", {
@@ -172,8 +172,8 @@ export declare const shopSettingsSchema: z.ZodObject<{
     taxRegion?: string | undefined;
     depositService?: {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     } | undefined;
-}>;
+}>; 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
 //# sourceMappingURL=ShopSettings.d.ts.map

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -20,7 +20,7 @@ export const shopSettingsSchema = z.object({
   depositService: z
     .object({
       enabled: z.boolean(),
-      interval: z.number().int().positive(),
+      intervalMinutes: z.number().int().positive(),
     })
     .optional(),
   updatedAt: z.string(),


### PR DESCRIPTION
## Summary
- standardize deposit service config to `intervalMinutes`
- convert minutes to milliseconds in `releaseDepositsService`
- update CMS editor, schema and docs to reflect minute-based intervals

## Testing
- `pnpm test` *(fails: Test failed. See above for more details.)*
- `npx jest packages/platform-machine/__tests__/releaseDepositsService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b20356e20832f9926307e02a100b7