### PR TITLE
refactor: modularize env configuration

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -2,10 +2,10 @@
 
 import { getSanityConfig } from "@platform-core/src/shops";
 import { getShopById } from "@platform-core/src/repositories/shop.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { ensureAuthorized } from "./common/auth";
 
-const apiVersion = env.SANITY_API_VERSION || "2021-10-21";
+const apiVersion = coreEnv.SANITY_API_VERSION || "2021-10-21";
 
 function collectProductSlugs(content: unknown): string[] {
   const slugs = new Set<string>();

--- a/apps/cms/src/actions/cloudflare.server.ts
+++ b/apps/cms/src/actions/cloudflare.server.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/actions/cloudflare.server.ts
 "use server";
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { ensureAuthorized } from "./common/auth";
 
 export async function provisionDomain(
@@ -9,8 +9,8 @@ export async function provisionDomain(
   domain: string
 ): Promise<{ status?: string; certificateStatus?: string }> {
   await ensureAuthorized();
-  const account = env.CLOUDFLARE_ACCOUNT_ID;
-  const token = env.CLOUDFLARE_API_TOKEN;
+  const account = coreEnv.CLOUDFLARE_ACCOUNT_ID;
+  const token = coreEnv.CLOUDFLARE_API_TOKEN;
   if (!account || !token) throw new Error("Cloudflare credentials not configured");
 
   const headers = {

--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -7,7 +7,7 @@ import { historyStateSchema } from "@acme/types";
 import { ulid } from "ulid";
 import { nowIso } from "@acme/date-utils";
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { ensureAuthorized } from "./common/auth";
 import {
   componentsField,
@@ -49,7 +49,7 @@ export async function createPage(
   );
   if (!parsed.success) {
     const context = { shop, id };
-    if (env.NODE_ENV === "development") {
+    if (coreEnv.NODE_ENV === "development") {
       console.warn("[createPage] validation failed", {
         ...context,
         error: parsed.error,
@@ -189,7 +189,7 @@ export async function updatePage(
   );
   if (!parsed.success) {
     const context = { shop, id: formData.get("id") || undefined };
-    if (env.NODE_ENV === "development") {
+    if (coreEnv.NODE_ENV === "development") {
       console.warn("[updatePage] validation failed", {
         ...context,
         error: parsed.error,

--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -1,5 +1,5 @@
 // apps/cms/src/actions/setupSanityBlog.ts
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { ensureAuthorized } from "./common/auth";
 
 interface SanityCredentials {
@@ -80,7 +80,7 @@ export async function setupSanityBlog(
     }
 
     // Upload a minimal blog schema (post document)
-    const apiVersion = env.SANITY_API_VERSION || "2021-10-21";
+    const apiVersion = coreEnv.SANITY_API_VERSION || "2021-10-21";
     const schemaRes = await fetch(
       `https://${projectId}.api.sanity.io/v${apiVersion}/data/mutate/${dataset}`,
       {

--- a/apps/cms/src/auth/options.js
+++ b/apps/cms/src/auth/options.js
@@ -3,12 +3,12 @@ import bcrypt from "bcryptjs";
 import Credentials from "next-auth/providers/credentials";
 import { readRbac } from "../lib/rbacStore";
 import { authSecret } from "./secret";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 /* -----------------------------------------------------------------
  *  Ensure NEXTAUTH_SECRET is defined outside of development
  * ---------------------------------------------------------------- */
 const secret = authSecret;
-if (env.NODE_ENV !== "development" && !env.NEXTAUTH_SECRET) {
+if (coreEnv.NODE_ENV !== "development" && !coreEnv.NEXTAUTH_SECRET) {
     throw new Error("NEXTAUTH_SECRET must be set when NODE_ENV is not 'development'");
 }
 export const authOptions = {

--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -6,7 +6,7 @@ import type { JWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
 import { readRbac as defaultReadRbac } from "../lib/rbacStore";
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import type { Role } from "./roles";
 import { authSecret } from "./secret";
 
@@ -14,7 +14,7 @@ import { authSecret } from "./secret";
 /*  Secret handling                                                           */
 /* -------------------------------------------------------------------------- */
 
-const NODE_ENV = env.NODE_ENV ?? "development";
+const NODE_ENV = coreEnv.NODE_ENV ?? "development";
 
 /**
  * In tests we default to a dummy secret so Jest doesn't explode.

--- a/apps/cms/src/auth/secret.js
+++ b/apps/cms/src/auth/secret.js
@@ -1,3 +1,3 @@
 // apps/cms/src/auth/secret.ts
-import { env } from "@acme/config";
-export const authSecret = env.NEXTAUTH_SECRET || "dev-secret";
+import { coreEnv } from "@acme/config/env/core";
+export const authSecret = coreEnv.NEXTAUTH_SECRET || "dev-secret";

--- a/apps/cms/src/auth/secret.ts
+++ b/apps/cms/src/auth/secret.ts
@@ -1,5 +1,5 @@
 // apps/cms/src/auth/secret.ts
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-export const authSecret = env.NEXTAUTH_SECRET || "dev-secret";
+export const authSecret = coreEnv.NEXTAUTH_SECRET || "dev-secret";

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -3,7 +3,7 @@ import { getPages } from "@platform-core/repositories/pages/index.server";
 import { readShop } from "@platform-core/repositories/shops.server";
 import Home from "./page.client";
 import { trackPageView } from "@platform-core/analytics";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 async function loadComponents(shopId: string): Promise<PageComponent[]> {
   const pages = await getPages(shopId);
@@ -15,7 +15,7 @@ export default async function Page({
 }: {
   params: { lang: string };
 }) {
-  const shop = await readShop(env.NEXT_PUBLIC_SHOP_ID || "shop-abc");
+  const shop = await readShop(coreEnv.NEXT_PUBLIC_SHOP_ID || "shop-abc");
   const components = await loadComponents(shop.id);
   await trackPageView(shop.id, "home");
   return <Home components={components} locale={params.lang} />;

--- a/apps/shop-abc/src/app/lib/seo.ts
+++ b/apps/shop-abc/src/app/lib/seo.ts
@@ -2,7 +2,7 @@ import type { Locale } from "@i18n/locales";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
 import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {
   canonicalBase?: string;
@@ -20,7 +20,7 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<NextSeoProps> = {}
 ): Promise<NextSeoProps> {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const settings: ShopSettings = await getShopSettings(shop);
   const shopSeo = (settings.seo ?? {}) as Record<string, ExtendedSeoProps>;
   const base: ExtendedSeoProps = shopSeo[locale] ?? {};

--- a/apps/shop-abc/src/middleware.ts
+++ b/apps/shop-abc/src/middleware.ts
@@ -1,7 +1,7 @@
 // apps/shop-abc/src/middleware.ts
 import { NextResponse } from "next/server";
 import { Redis } from "@upstash/redis";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 /** Track login attempts per IP + user */
 interface Attempt {
@@ -19,21 +19,21 @@ const mfaAttempts = new Map<string, Attempt>();
 // local development and unit tests.
 let redis: Redis | null = null;
 if (
-  env.LOGIN_RATE_LIMIT_REDIS_URL &&
-  env.LOGIN_RATE_LIMIT_REDIS_TOKEN
+  coreEnv.LOGIN_RATE_LIMIT_REDIS_URL &&
+  coreEnv.LOGIN_RATE_LIMIT_REDIS_TOKEN
 ) {
   redis = new Redis({
-    url: env.LOGIN_RATE_LIMIT_REDIS_URL,
-    token: env.LOGIN_RATE_LIMIT_REDIS_TOKEN,
+    url: coreEnv.LOGIN_RATE_LIMIT_REDIS_URL,
+    token: coreEnv.LOGIN_RATE_LIMIT_REDIS_TOKEN,
   });
 } else if (
-  env.UPSTASH_REDIS_REST_URL &&
-  env.UPSTASH_REDIS_REST_TOKEN
+  coreEnv.UPSTASH_REDIS_REST_URL &&
+  coreEnv.UPSTASH_REDIS_REST_TOKEN
 ) {
   // Fall back to generic Upstash env vars if provided
   redis = new Redis({
-    url: env.UPSTASH_REDIS_REST_URL,
-    token: env.UPSTASH_REDIS_REST_TOKEN,
+    url: coreEnv.UPSTASH_REDIS_REST_URL,
+    token: coreEnv.UPSTASH_REDIS_REST_TOKEN,
   });
 }
 

--- a/apps/shop-abc/src/routes/preview/[pageId].js
+++ b/apps/shop-abc/src/routes/preview/[pageId].js
@@ -2,8 +2,8 @@
 // apps/shop-abc/src/routes/preview/[pageId].ts
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { env } from "@acme/config";
-const secret = env.PREVIEW_TOKEN_SECRET;
+import { coreEnv } from "@acme/config/env/core";
+const secret = coreEnv.PREVIEW_TOKEN_SECRET;
 function verify(id, token) {
     if (!secret || !token)
         return false;
@@ -21,7 +21,7 @@ export const onRequest = async ({ params, request, }) => {
     if (!verify(pageId, token)) {
         return new Response("Unauthorized", { status: 401 });
     }
-    const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+    const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
     const pages = await getPages(shop);
     const page = pages.find((p) => p.id === pageId);
     if (!page)

--- a/apps/shop-abc/src/routes/preview/[pageId].ts
+++ b/apps/shop-abc/src/routes/preview/[pageId].ts
@@ -4,9 +4,9 @@
 import type { EventContext } from "@cloudflare/workers-types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-const secret = env.PREVIEW_TOKEN_SECRET;
+const secret = coreEnv.PREVIEW_TOKEN_SECRET;
 
 function verify(id: string, token: string | null): boolean {
   if (!secret || !token) return false;
@@ -27,7 +27,7 @@ export const onRequest = async ({
   if (!verify(pageId, token)) {
     return new Response("Unauthorized", { status: 401 });
   }
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const pages = await getPages(shop);
   const page = pages.find((p) => p.id === pageId);
   if (!page) return new Response("Not Found", { status: 404 });

--- a/apps/shop-bcd/src/lib/seo.js
+++ b/apps/shop-bcd/src/lib/seo.js
@@ -1,5 +1,5 @@
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 const fallback = {
     title: "",
     description: "",
@@ -8,7 +8,7 @@ const fallback = {
     twitter: {},
 };
 export async function getSeo(locale, pageSeo = {}) {
-    const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+    const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
     const settings = await getShopSettings(shop);
     const shopSeo = (settings.seo ?? {});
     const base = shopSeo[locale] ?? {};

--- a/apps/shop-bcd/src/lib/seo.ts
+++ b/apps/shop-bcd/src/lib/seo.ts
@@ -2,7 +2,7 @@ import type { Locale } from "@i18n/locales";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {
   canonicalBase?: string;
@@ -20,7 +20,7 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<NextSeoProps> = {}
 ): Promise<NextSeoProps> {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const settings: ShopSettings = await getShopSettings(shop);
   const shopSeo = (settings.seo ?? {}) as Record<string, ExtendedSeoProps>;
   const base: ExtendedSeoProps = shopSeo[locale] ?? {};

--- a/apps/shop-bcd/src/routes/preview/(pageId].ts
+++ b/apps/shop-bcd/src/routes/preview/(pageId].ts
@@ -5,9 +5,9 @@
 import type { EventContext } from "@cloudflare/workers-types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-const secret = env.PREVIEW_TOKEN_SECRET;
+const secret = coreEnv.PREVIEW_TOKEN_SECRET;
 
 function verify(id: string, token: string | null): boolean {
   if (!secret || !token) return false;
@@ -28,7 +28,7 @@ export const onRequest = async ({
   if (!verify(pageId, token)) {
     return new Response("Unauthorized", { status: 401 });
   }
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const pages = await getPages(shop);
   const page = pages.find((p) => p.id === pageId);
   if (!page) return new Response("Not Found", { status: 404 });

--- a/dist-scripts/migrate-cms.js
+++ b/dist-scripts/migrate-cms.js
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/env";
+import { envSchema } from "@acme/config/env";
 import fetch from "cross-fetch";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";

--- a/dist-scripts/setup-ci.js
+++ b/dist-scripts/setup-ci.js
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/env";
+import { envSchema } from "@acme/config/env";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 const shopId = process.argv[2];

--- a/dist-scripts/validate-env.js
+++ b/dist-scripts/validate-env.js
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/env";
+import { envSchema } from "@acme/config/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 const shopId = process.argv[2];

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -85,7 +85,7 @@ module.exports = {
     "^@platform-core/repositories/shopSettings$":
       "<rootDir>/packages/platform-core/src/repositories/settings.server.ts",
     "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
-    "^@acme/config$": "<rootDir>/packages/config/src/env.ts",
+    "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
 
     // context mocks

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -2,7 +2,7 @@
 import { cookies, headers } from "next/headers";
 import { sealData, unsealData } from "iron-session";
 import { randomUUID } from "node:crypto";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import type { Role } from "./types";
 import type { SessionRecord } from "./store";
 import { createSessionStore, SESSION_TTL_S } from "./store";
@@ -28,7 +28,7 @@ function cookieOptions() {
     secure: true,
     path: "/",
     maxAge: SESSION_TTL_S,
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   };
 }
 
@@ -39,12 +39,12 @@ function csrfCookieOptions() {
     secure: true,
     path: "/",
     maxAge: SESSION_TTL_S,
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   };
 }
 
 export async function getCustomerSession(): Promise<CustomerSession | null> {
-  const secret = env.SESSION_SECRET;
+  const secret = coreEnv.SESSION_SECRET;
   if (!secret) return null;
   const store = await cookies();
   const token = store.get(CUSTOMER_SESSION_COOKIE)?.value;
@@ -88,7 +88,7 @@ export async function getCustomerSession(): Promise<CustomerSession | null> {
 }
 
 export async function createCustomerSession(sessionData: CustomerSession): Promise<void> {
-  const secret = env.SESSION_SECRET;
+  const secret = coreEnv.SESSION_SECRET;
   if (!secret) {
     throw new Error("SESSION_SECRET is not set");
   }
@@ -118,7 +118,7 @@ export async function destroyCustomerSession(): Promise<void> {
   const store = await cookies();
   const token = store.get(CUSTOMER_SESSION_COOKIE)?.value;
   if (token) {
-    const secret = env.SESSION_SECRET;
+    const secret = coreEnv.SESSION_SECRET;
     if (secret) {
       try {
         const session = await unsealData<InternalSession>(token, {
@@ -132,11 +132,11 @@ export async function destroyCustomerSession(): Promise<void> {
   }
   store.delete(CUSTOMER_SESSION_COOKIE, {
     path: "/",
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   });
   store.delete(CSRF_TOKEN_COOKIE, {
     path: "/",
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   });
 }
 

--- a/packages/auth/src/store.ts
+++ b/packages/auth/src/store.ts
@@ -1,4 +1,4 @@
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7; // one week
 export const SESSION_TTL_S = Math.floor(SESSION_TTL_MS / 1000);
@@ -30,17 +30,19 @@ export async function createSessionStore(): Promise<SessionStore> {
     return customFactory();
   }
 
-  const storeType = env.SESSION_STORE;
+  const storeType = coreEnv.SESSION_STORE;
 
   if (
     storeType === "redis" ||
-    (!storeType && env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN)
+    (!storeType &&
+      coreEnv.UPSTASH_REDIS_REST_URL &&
+      coreEnv.UPSTASH_REDIS_REST_TOKEN)
   ) {
     const { Redis } = await import("@upstash/redis");
     const { RedisSessionStore } = await import("./redisStore");
     const client = new Redis({
-      url: env.UPSTASH_REDIS_REST_URL!,
-      token: env.UPSTASH_REDIS_REST_TOKEN!,
+      url: coreEnv.UPSTASH_REDIS_REST_URL!,
+      token: coreEnv.UPSTASH_REDIS_REST_TOKEN!,
     });
     return new RedisSessionStore(client, SESSION_TTL_S);
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./env.ts",
-    "./env": "./env.ts"
+    ".": "./env/index.ts",
+    "./env": "./env/index.ts",
+    "./env/core": "./env/core.ts",
+    "./env/payments": "./env/payments.ts",
+    "./env/shipping": "./env/shipping.ts"
   }
 }

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 import { applyFriendlyZodMessages } from "@acme/lib";
 
-export const envSchema = z.object({
-  STRIPE_SECRET_KEY: z.string().min(1),
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
+export const coreEnvSchema = z.object({
   NEXTAUTH_SECRET: z.string().optional(),
   PREVIEW_TOKEN_SECRET: z.string().optional(),
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
@@ -27,9 +25,6 @@ export const envSchema = z.object({
   CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
   CLOUDFLARE_API_TOKEN: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
-  TAXJAR_KEY: z.string().optional(),
-  UPS_KEY: z.string().optional(),
-  DHL_KEY: z.string().optional(),
   SESSION_SECRET: z.string().optional(),
   COOKIE_DOMAIN: z.string().optional(),
   LOGIN_RATE_LIMIT_REDIS_URL: z.string().url().optional(),
@@ -50,11 +45,11 @@ export const envSchema = z.object({
 
 applyFriendlyZodMessages();
 
-const parsed = envSchema.safeParse(process.env);
+const parsed = coreEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  console.error("❌ Invalid environment variables:", parsed.error.format());
+  console.error("\u274c Invalid core environment variables:", parsed.error.format());
   process.exit(1);
 }
 
-export const env = parsed.data;
-export type Env = z.infer<typeof envSchema>;
+export const coreEnv = parsed.data;
+export type CoreEnv = z.infer<typeof coreEnvSchema>;

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { coreEnv, coreEnvSchema } from "./core";
+import { paymentEnv, paymentEnvSchema } from "./payments";
+import { shippingEnv, shippingEnvSchema } from "./shipping";
+
+export const env = { ...coreEnv, ...paymentEnv, ...shippingEnv };
+
+const schemas = {
+  payments: paymentEnvSchema,
+  shipping: shippingEnvSchema,
+} as const;
+
+export type EnvModule = keyof typeof schemas;
+
+export const buildEnvSchema = (modules: EnvModule[] = []) =>
+  modules.reduce((acc, m) => acc.merge(schemas[m]), coreEnvSchema);
+
+export const envSchema = buildEnvSchema(["payments", "shipping"]);
+export type Env = z.infer<typeof envSchema>;

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { applyFriendlyZodMessages } from "@acme/lib";
+
+export const paymentEnvSchema = z.object({
+  STRIPE_SECRET_KEY: z.string().min(1),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
+  TAXJAR_KEY: z.string().optional(),
+});
+
+applyFriendlyZodMessages();
+
+const parsed = paymentEnvSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error("\u274c Invalid payment environment variables:", parsed.error.format());
+  process.exit(1);
+}
+
+export const paymentEnv = parsed.data;
+export type PaymentEnv = z.infer<typeof paymentEnvSchema>;

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { applyFriendlyZodMessages } from "@acme/lib";
+
+export const shippingEnvSchema = z.object({
+  UPS_KEY: z.string().optional(),
+  DHL_KEY: z.string().optional(),
+});
+
+applyFriendlyZodMessages();
+
+const parsed = shippingEnvSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error("\u274c Invalid shipping environment variables:", parsed.error.format());
+  process.exit(1);
+}
+
+export const shippingEnv = parsed.data;
+export type ShippingEnv = z.infer<typeof shippingEnvSchema>;

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,5 +1,5 @@
 import nodemailer from "nodemailer";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export interface CampaignOptions {
   /** Recipient email address */
@@ -20,11 +20,11 @@ export async function sendCampaignEmail(
   options: CampaignOptions
 ): Promise<void> {
   const transport = nodemailer.createTransport({
-    url: env.SMTP_URL,
+    url: coreEnv.SMTP_URL,
   });
 
   await transport.sendMail({
-    from: env.CAMPAIGN_FROM || "no-reply@example.com",
+    from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
     to: options.to,
     subject: options.subject,
     html: options.html,

--- a/packages/email/src/sendEmail.ts
+++ b/packages/email/src/sendEmail.ts
@@ -1,16 +1,16 @@
 // packages/email/src/sendEmail.ts
 
-import { env } from "@config/src/env";
+import { coreEnv } from "@acme/config/env/core";
 import nodemailer from "nodemailer";
 
-const hasCreds = env.GMAIL_USER && env.GMAIL_PASS;
+const hasCreds = coreEnv.GMAIL_USER && coreEnv.GMAIL_PASS;
 
 const transporter = hasCreds
   ? nodemailer.createTransport({
       service: "gmail",
       auth: {
-        user: env.GMAIL_USER,
-        pass: env.GMAIL_PASS,
+        user: coreEnv.GMAIL_USER,
+        pass: coreEnv.GMAIL_PASS,
       },
     })
   : null;
@@ -23,7 +23,7 @@ export async function sendEmail(
   if (transporter) {
     try {
       await transporter.sendMail({
-        from: env.GMAIL_USER,
+        from: coreEnv.GMAIL_USER,
         to,
         subject,
         text: body,

--- a/packages/next-config/index.mjs
+++ b/packages/next-config/index.mjs
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -40,11 +40,11 @@ export const baseConfig = {
   // bundlePagesRouterDependencies: true,
 
   // Keep the existing "static export in CI only" logic
-  ...(env.OUTPUT_EXPORT ? { output: "export" } : {}),
+  ...(coreEnv.OUTPUT_EXPORT ? { output: "export" } : {}),
 
   env: {
-    NEXT_PUBLIC_PHASE: env.NEXT_PUBLIC_PHASE || "demo",
-    NEXT_PUBLIC_DEFAULT_SHOP: env.NEXT_PUBLIC_DEFAULT_SHOP || firstShop,
+    NEXT_PUBLIC_PHASE: coreEnv.NEXT_PUBLIC_PHASE || "demo",
+    NEXT_PUBLIC_DEFAULT_SHOP: coreEnv.NEXT_PUBLIC_DEFAULT_SHOP || firstShop,
   },
 };
 
@@ -54,7 +54,7 @@ export const baseConfig = {
  * @param {import('next').NextConfig} [config={}] - Additional Next.js config.
  * @returns {import('next').NextConfig}
  */
-export function withShopCode(shopCode = env.SHOP_CODE, config = {}) {
+export function withShopCode(shopCode = coreEnv.SHOP_CODE, config = {}) {
   return {
     ...baseConfig,
     ...config,

--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { baseConfig, withShopCode } from "./index.mjs";
 
 /* ------------------------------------------------------------------ */
@@ -9,7 +9,7 @@ import { baseConfig, withShopCode } from "./index.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export default withShopCode(env.SHOP_CODE, {
+export default withShopCode(coreEnv.SHOP_CODE, {
   /* 1️⃣ ‒ keep CI/production green even if ESLint finds issues */
   eslint: { ignoreDuringBuilds: true },
 

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -5,7 +5,7 @@ import { nowIso } from "@acme/date-utils";
 import { DATA_ROOT } from "./dataRoot";
 import { validateShopName } from "./shops";
 import { getShopSettings, readShop } from "./repositories/shops.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export interface AnalyticsEvent {
   type: string;
@@ -101,7 +101,7 @@ async function resolveProvider(shop: string): Promise<AnalyticsProvider> {
   }
   if (analytics.provider === "ga") {
     const measurementId = analytics.id;
-    const apiSecret = env.GA_API_SECRET;
+    const apiSecret = coreEnv.GA_API_SECRET;
     if (measurementId && apiSecret) {
       const p = new GoogleAnalyticsProvider(measurementId, apiSecret);
       providerCache.set(shop, p);

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -2,7 +2,7 @@
 import crypto from "crypto";
 import { z } from "zod";
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { skuSchema } from "@acme/types";
 
 /* ------------------------------------------------------------------
@@ -10,7 +10,7 @@ import { skuSchema } from "@acme/types";
  * ------------------------------------------------------------------ */
 export const CART_COOKIE = "__Host-CART_ID";
 const MAX_AGE = 60 * 60 * 24 * 30; // 30 days
-const SECRET = env.CART_COOKIE_SECRET;
+const SECRET = coreEnv.CART_COOKIE_SECRET;
 
 if (!SECRET) {
   throw new Error("env.CART_COOKIE_SECRET is required");

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { Redis } from "@upstash/redis";
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import type { CartState } from "./cartCookie";
 import type { SKU } from "@acme/types";
 
@@ -22,7 +22,7 @@ export interface CartStore {
 }
 
 // Default cart expiration is 30 days (in seconds)
-const TTL_SECONDS = Number(env.CART_TTL ?? 60 * 60 * 24 * 30);
+const TTL_SECONDS = Number(coreEnv.CART_TTL ?? 60 * 60 * 24 * 30);
 const MAX_REDIS_FAILURES = 3;
 
 class MemoryCartStore implements CartStore {
@@ -311,12 +311,12 @@ class RedisCartStore implements CartStore {
   }
 }
 if (
-  env.UPSTASH_REDIS_REST_URL &&
-  env.UPSTASH_REDIS_REST_TOKEN
+  coreEnv.UPSTASH_REDIS_REST_URL &&
+  coreEnv.UPSTASH_REDIS_REST_TOKEN
 ) {
   const client = new Redis({
-    url: env.UPSTASH_REDIS_REST_URL,
-    token: env.UPSTASH_REDIS_REST_TOKEN,
+    url: coreEnv.UPSTASH_REDIS_REST_URL,
+    token: coreEnv.UPSTASH_REDIS_REST_TOKEN,
   });
   store = new RedisCartStore(client, TTL_SECONDS);
 }

--- a/packages/platform-core/src/configurator.ts
+++ b/packages/platform-core/src/configurator.ts
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/src/env";
+import { envSchema } from "@acme/config/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,8 +1,8 @@
 import { PrismaClient } from "@prisma/client";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 const databaseUrl =
-  env.DATABASE_URL ?? "file:./packages/platform-core/dev.db";
+  coreEnv.DATABASE_URL ?? "file:./packages/platform-core/dev.db";
 
 export const prisma = new PrismaClient({
   datasources: { db: { url: databaseUrl } },

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { env } from "@config/src/env";
+import { coreEnv } from "@acme/config/env/core";
 import { DATA_ROOT } from "../dataRoot";
 import { sendEmail } from "@acme/email";
 import { promises as fs } from "node:fs";
@@ -33,8 +33,9 @@ export async function checkAndAlert(
   shop: string,
   items: InventoryItem[],
 ): Promise<void> {
-  const recipientRaw = env.STOCK_ALERT_RECIPIENTS ?? env.STOCK_ALERT_RECIPIENT;
-  const webhook = env.STOCK_ALERT_WEBHOOK;
+  const recipientRaw =
+    coreEnv.STOCK_ALERT_RECIPIENTS ?? coreEnv.STOCK_ALERT_RECIPIENT;
+  const webhook = coreEnv.STOCK_ALERT_WEBHOOK;
   if (!recipientRaw && !webhook) return;
 
   const recipients = recipientRaw
@@ -50,7 +51,7 @@ export async function checkAndAlert(
       const threshold =
         typeof i.lowStockThreshold === "number"
           ? i.lowStockThreshold
-          : env.STOCK_ALERT_DEFAULT_THRESHOLD;
+          : coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD;
       return typeof threshold === "number" && i.quantity <= threshold;
     })
     .filter((i) => {
@@ -66,7 +67,7 @@ export async function checkAndAlert(
       .join(", ");
     const variant = attrs ? ` (${attrs})` : "";
     const threshold =
-      i.lowStockThreshold ?? env.STOCK_ALERT_DEFAULT_THRESHOLD;
+      i.lowStockThreshold ?? coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD;
     return `${i.sku}${variant} – qty ${i.quantity} (threshold ${threshold})`;
   });
   const body = `The following items in shop ${shop} are low on stock:\n${lines.join("\n")}`;

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -1,6 +1,6 @@
 // packages/platform-core/src/shipping/index.ts
 
-import { env } from "@acme/config";
+import { shippingEnv } from "@acme/config/env/shipping";
 
 export interface ShippingRateRequest {
   provider: "ups" | "dhl";
@@ -19,7 +19,7 @@ export async function getShippingRate({
   toPostalCode,
   weight,
 }: ShippingRateRequest): Promise<unknown> {
-  const apiKey = (env as Record<string, string | undefined>)[
+  const apiKey = (shippingEnv as Record<string, string | undefined>)[
     `${provider.toUpperCase()}_KEY`
   ];
   if (!apiKey) {

--- a/packages/platform-core/src/tax/index.ts
+++ b/packages/platform-core/src/tax/index.ts
@@ -3,7 +3,7 @@
 import "server-only";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { env } from "@acme/config";
+import { paymentEnv } from "@acme/config/env/payments";
 import { resolveDataRoot } from "../dataRoot";
 
 export interface TaxCalculationRequest {
@@ -32,7 +32,7 @@ export async function getTaxRate(region: string): Promise<number> {
  * Calculate taxes using the configured provider API.
  */
 export async function calculateTax({ provider, ...payload }: TaxCalculationRequest): Promise<unknown> {
-  const apiKey = (env as Record<string, string | undefined>)[
+  const apiKey = (paymentEnv as Record<string, string | undefined>)[
     `${provider.toUpperCase()}_KEY`
   ];
   if (!apiKey) {

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,7 +1,7 @@
 // packages/stripe/src/index.ts
 import "server-only";
 
-import { env } from "@config/src/env";
+import { paymentEnv } from "@acme/config/env/payments";
 import Stripe from "stripe";
 
 /**
@@ -15,7 +15,7 @@ import Stripe from "stripe";
  * `apiVersion` line and Stripe will default to the newest version whenever
  * you bump the SDK.
  */
-export const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(paymentEnv.STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
   httpClient: Stripe.createFetchHttpClient(),
 });

--- a/packages/template-app/src/app/AnalyticsScripts.tsx
+++ b/packages/template-app/src/app/AnalyticsScripts.tsx
@@ -2,10 +2,10 @@ import {
   getShopSettings,
   readShop,
 } from "@platform-core/repositories/shops.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export default async function AnalyticsScripts() {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const [settings, shopData] = await Promise.all([
     getShopSettings(shop),
     readShop(shop),

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { getProductById } from "@platform-core/src/products";
 import { readRepo } from "@platform-core/repositories/products.server";
 import type { ProductPublication } from "@acme/types";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export const runtime = "nodejs";
 
@@ -13,7 +13,7 @@ function parseIntOr(val: string | null, def: number): number {
 }
 
 export async function GET(req: NextRequest) {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const all = await readRepo<ProductPublication>(shop);
 
   const lastModifiedDate = all.reduce((max, p) => {

--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -1,8 +1,8 @@
 import type { MetadataRoute } from "next";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export default function robots(): MetadataRoute.Robots {
-  const base = env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   return {
     rules: [
       { userAgent: "*", allow: "/" },

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -1,11 +1,11 @@
 import type { MetadataRoute } from "next";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
 import { readRepo } from "@platform-core/src/repositories/products.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const base = env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "shop";
+  const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
   const now = new Date().toISOString();
 
   const [settings, products] = await Promise.all([

--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -1,7 +1,7 @@
 import { LOCALES, type Locale } from "@i18n/locales";
 import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {
   canonicalBase?: string;
@@ -19,7 +19,7 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<NextSeoProps> = {},
 ): Promise<NextSeoProps> {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const { getShopSettings } = await import(
     "@platform-core/repositories/shops.server"
   );

--- a/packages/template-app/src/routes/preview/[pageId].ts
+++ b/packages/template-app/src/routes/preview/[pageId].ts
@@ -3,9 +3,9 @@
 import type { EventContext } from "@cloudflare/workers-types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-const secret = env.PREVIEW_TOKEN_SECRET;
+const secret = coreEnv.PREVIEW_TOKEN_SECRET;
 
 function verify(id: string, token: string | null): boolean {
   if (!secret || !token) return false;
@@ -26,7 +26,7 @@ export const onRequest = async ({
   if (!verify(pageId, token)) {
     return new Response("Unauthorized", { status: 401 });
   }
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const pages = await getPages(shop);
   const page = pages.find((p) => p.id === pageId);
   if (!page) return new Response("Not Found", { status: 404 });

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useTranslations } from "@/i18n/Translations";
-import { env } from "@config/src/env";
+import { paymentEnv } from "@acme/config/env/payments";
 import {
   Elements,
   PaymentElement,
@@ -17,7 +17,9 @@ import { useForm, UseFormReturn } from "react-hook-form";
 import { isoDateInNDays } from "@acme/date-utils";
 import { useCurrency } from "@platform-core/src/contexts/CurrencyContext";
 
-const stripePromise = loadStripe(env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
+const stripePromise = loadStripe(
+  paymentEnv.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+);
 
 type Props = { locale: "en" | "de" | "it"; taxRegion: string };
 

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -3,9 +3,9 @@
 import { getShopFromPath } from "@platform-core/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-if (env.NODE_ENV === "development") {
+if (coreEnv.NODE_ENV === "development") {
   console.log("sidebar rendered on client");
 }
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ import {
 } from "@platform-core/src/cartCookie";
 import { getCart } from "@platform-core/src/cartStore";
 import { cookies } from "next/headers";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import HeaderClient from "./HeaderClient.client";
 
 /**
@@ -26,7 +26,7 @@ export default async function Header({
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
   const cart = cartId ? await getCart(cartId) : {};
   const initialQty = Object.values(cart).reduce((s, line) => s + line.qty, 0);
-  const shopId = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const shop = await readShop(shopId);
   const nav = shop.navigation ?? [];
 

--- a/scripts/__tests__/setup-ci.test.ts
+++ b/scripts/__tests__/setup-ci.test.ts
@@ -2,7 +2,7 @@
 import fs from "fs";
 import path from "node:path";
 
-jest.mock("@config/src/env", () => ({
+jest.mock("@acme/config/env", () => ({
   envSchema: { parse: jest.fn() },
 }));
 
@@ -20,7 +20,7 @@ describe("setup-ci script", () => {
   });
 
   it("writes workflow using provided shop id", async () => {
-    const { envSchema } = await import("@config/src/env");
+    const { envSchema } = await import("@acme/config/env");
     (envSchema.parse as jest.Mock).mockReturnValue({});
 
     const env = [
@@ -57,7 +57,7 @@ describe("setup-ci script", () => {
   });
 
   it("injects domain env vars when configured", async () => {
-    const { envSchema } = await import("@config/src/env");
+    const { envSchema } = await import("@acme/config/env");
     (envSchema.parse as jest.Mock).mockReturnValue({});
 
     const env = [
@@ -87,7 +87,7 @@ describe("setup-ci script", () => {
   });
 
   it("fails when env file is missing", async () => {
-    const { envSchema } = await import("@config/src/env");
+    const { envSchema } = await import("@acme/config/env");
     (envSchema.parse as jest.Mock).mockReturnValue({});
 
     jest.spyOn(fs, "existsSync").mockReturnValue(false);
@@ -112,7 +112,7 @@ describe("setup-ci script", () => {
   });
 
   it("fails with invalid env vars", async () => {
-    const { envSchema } = await import("@config/src/env");
+    const { envSchema } = await import("@acme/config/env");
     (envSchema.parse as jest.Mock).mockImplementation(() => {
       throw new Error("bad env");
     });

--- a/scripts/generate-meta.ts
+++ b/scripts/generate-meta.ts
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export interface ProductData {
   id: string;
@@ -22,7 +22,7 @@ export interface GeneratedMeta {
  * `public/og/<id>.png` and the returned `image` field is the public path.
  */
 export async function generateMeta(product: ProductData): Promise<GeneratedMeta> {
-  const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+  const client = new OpenAI({ apiKey: coreEnv.OPENAI_API_KEY });
 
   const prompt = `Generate SEO metadata for a product as JSON with keys title, description, alt.\n\nTitle: ${product.title}\nDescription: ${product.description}`;
 

--- a/scripts/src/setup-ci.ts
+++ b/scripts/src/setup-ci.ts
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/src/env";
+import { envSchema } from "@acme/config/env";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/src/env";
+import { envSchema } from "@acme/config/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ZodError } from "zod";

--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -60,7 +60,7 @@ describe('init-shop wizard', () => {
             }),
           };
         }
-        if (p.includes('@config/src/env')) {
+        if (p.includes('@acme/config/env')) {
           return { envSchema: { parse: envParse } };
         }
         if (p.includes('../../packages/platform-core/src/createShop/listProviders')) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -81,9 +81,12 @@
       "@auth/*": ["packages/auth/src/*"],
 
       /* ─── runtime config helper ─────────────────────────────────── */
-      "@config": ["packages/config/src/env.ts"],
+      "@config": ["packages/config/src/env/index.ts"],
       "@config/*": ["packages/config/src/*"],
       "@config/src/*": ["packages/config/src/*"],
+
+      "@acme/config": ["packages/config/src/env/index.ts"],
+      "@acme/config/*": ["packages/config/src/*"],
 
       /* ─── shared utilities ──────────────────────────────────────── */
       "@shared-utils": ["packages/shared-utils/src/index.ts"],


### PR DESCRIPTION
## Summary
- split monolithic env.ts into core, payments, and shipping modules
- add helper to build env schema from selected modules
- refactor imports to use domain-specific env exports

## Testing
- `pnpm test --filter @acme/stripe` *(fails: expect(received).toBe(expected))*
- `npx jest scripts/__tests__/setup-ci.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689b200a2d30832fbf9668ec68e7da87