### PR TITLE
feat: add discount management and analytics

### DIFF
--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -1,0 +1,145 @@
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { resolveDataRoot } from "@platform-core/dataRoot";
+import { listEvents } from "@platform-core/repositories/analytics.server";
+import { env } from "@acme/config";
+import type { Coupon } from "@acme/types";
+
+interface Discount extends Coupon {
+  active?: boolean;
+}
+
+function getShop(req: NextRequest): string {
+  const { searchParams } = new URL(req.url);
+  return (
+    searchParams.get("shop") || env.NEXT_PUBLIC_DEFAULT_SHOP || "abc"
+  );
+}
+
+function filePath(shop: string): string {
+  return path.join(resolveDataRoot(), shop, "discounts.json");
+}
+
+async function readDiscounts(shop: string): Promise<Discount[]> {
+  try {
+    const buf = await fs.readFile(filePath(shop), "utf8");
+    const parsed = JSON.parse(buf) as Discount[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeDiscounts(shop: string, discounts: Discount[]): Promise<void> {
+  const fp = filePath(shop);
+  await fs.mkdir(path.dirname(fp), { recursive: true });
+  await fs.writeFile(fp, JSON.stringify(discounts, null, 2), "utf8");
+}
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const shop = getShop(req);
+  const [discounts, events] = await Promise.all([
+    readDiscounts(shop),
+    listEvents(shop),
+  ]);
+  const counts: Record<string, number> = {};
+  for (const e of events) {
+    if (e.type === "discount_redeemed" && typeof (e as any).code === "string") {
+      const code = (e as any).code as string;
+      counts[code] = (counts[code] || 0) + 1;
+    }
+  }
+  return NextResponse.json(
+    discounts.map((d) => ({ ...d, redemptions: counts[d.code] || 0 }))
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const forbidden = await requireAdmin();
+  if (forbidden) return forbidden;
+  const shop = getShop(req);
+  try {
+    const { code, description, discountPercent } = (await req.json()) as Discount;
+    if (!code || typeof discountPercent !== "number") {
+      return NextResponse.json({ error: "Invalid" }, { status: 400 });
+    }
+    const discounts = await readDiscounts(shop);
+    const idx = discounts.findIndex(
+      (d) => d.code.toLowerCase() === code.toLowerCase()
+    );
+    const entry: Discount = { code, description, discountPercent, active: true };
+    if (idx >= 0) discounts[idx] = entry;
+    else discounts.push(entry);
+    await writeDiscounts(shop, discounts);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const forbidden = await requireAdmin();
+  if (forbidden) return forbidden;
+  const shop = getShop(req);
+  try {
+    const { code, ...rest } = (await req.json()) as Partial<Discount> & {
+      code: string;
+    };
+    if (!code) {
+      return NextResponse.json({ error: "Missing code" }, { status: 400 });
+    }
+    const discounts = await readDiscounts(shop);
+    const idx = discounts.findIndex(
+      (d) => d.code.toLowerCase() === code.toLowerCase()
+    );
+    if (idx < 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    discounts[idx] = { ...discounts[idx], ...rest };
+    await writeDiscounts(shop, discounts);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const forbidden = await requireAdmin();
+  if (forbidden) return forbidden;
+  const shop = getShop(req);
+  try {
+    const { searchParams } = new URL(req.url);
+    const code = searchParams.get("code");
+    if (!code) {
+      return NextResponse.json({ error: "Missing code" }, { status: 400 });
+    }
+    const discounts = await readDiscounts(shop);
+    const filtered = discounts.filter(
+      (d) => d.code.toLowerCase() !== code.toLowerCase()
+    );
+    await writeDiscounts(shop, filtered);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -38,7 +38,7 @@ export default async function ShopDashboard({
     } else if (e.type === "campaign_sale") {
       const amount = typeof e.amount === "number" ? e.amount : 0;
       campaignSalesByDay[day] = (campaignSalesByDay[day] || 0) + amount;
-    } else if (e.type === "discount_redemption") {
+    } else if (e.type === "discount_redeemed") {
       discountByDay[day] = (discountByDay[day] || 0) + 1;
     }
   }
@@ -50,6 +50,7 @@ export default async function ShopDashboard({
       ...Object.keys(emailOpenByDay),
       ...Object.keys(campaignSalesByDay),
       ...Object.keys(discountByDay),
+      ...Object.keys(aggregates.discount_redeemed),
     ])
   ).sort();
 

--- a/apps/cms/src/app/cms/marketing/discounts/page.tsx
+++ b/apps/cms/src/app/cms/marketing/discounts/page.tsx
@@ -1,12 +1,32 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+interface Discount {
+  code: string;
+  description?: string;
+  discountPercent: number;
+  active?: boolean;
+  redemptions?: number;
+}
 
 export default function DiscountsPage() {
   const [code, setCode] = useState("");
   const [description, setDescription] = useState("");
   const [percent, setPercent] = useState(0);
   const [status, setStatus] = useState<string | null>(null);
+  const [discounts, setDiscounts] = useState<Discount[]>([]);
+
+  async function load() {
+    const res = await fetch("/api/marketing/discounts");
+    if (res.ok) {
+      setDiscounts(await res.json());
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
 
   async function create(e: React.FormEvent) {
     e.preventDefault();
@@ -18,36 +38,103 @@ export default function DiscountsPage() {
         body: JSON.stringify({ code, description, discountPercent: percent }),
       });
       setStatus(res.ok ? "Saved" : "Failed");
+      if (res.ok) await load();
     } catch {
       setStatus("Failed");
     }
   }
 
+  async function toggle(d: Discount) {
+    await fetch("/api/marketing/discounts", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: d.code, active: !d.active }),
+    });
+    await load();
+  }
+
+  async function remove(code: string) {
+    await fetch(`/api/marketing/discounts?code=${encodeURIComponent(code)}`, {
+      method: "DELETE",
+    });
+    await load();
+  }
+
   return (
-    <form onSubmit={create} className="space-y-2 p-4">
-      <input
-        className="border p-2 w-full"
-        placeholder="Code"
-        value={code}
-        onChange={(e) => setCode(e.target.value)}
-      />
-      <input
-        className="border p-2 w-full"
-        placeholder="Description"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-      />
-      <input
-        type="number"
-        className="border p-2 w-full"
-        placeholder="Discount %"
-        value={percent}
-        onChange={(e) => setPercent(Number(e.target.value))}
-      />
-      <button className="border px-4 py-2" type="submit">
-        Create
-      </button>
-      {status && <p>{status}</p>}
-    </form>
+    <div className="p-4 space-y-6">
+      <form onSubmit={create} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Code"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <input
+          type="number"
+          className="border p-2 w-full"
+          placeholder="Discount %"
+          value={percent}
+          onChange={(e) => setPercent(Number(e.target.value))}
+        />
+        <button className="border px-4 py-2" type="submit">
+          Create
+        </button>
+        {status && <p>{status}</p>}
+      </form>
+
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr>
+            <th className="border-b p-2">Code</th>
+            <th className="border-b p-2">Description</th>
+            <th className="border-b p-2">Discount %</th>
+            <th className="border-b p-2">Redemptions</th>
+            <th className="border-b p-2">Status</th>
+            <th className="border-b p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {discounts.map((d) => (
+            <tr key={d.code} className="border-b">
+              <td className="p-2 font-mono">{d.code}</td>
+              <td className="p-2">{d.description}</td>
+              <td className="p-2">{d.discountPercent}</td>
+              <td className="p-2">{d.redemptions ?? 0}</td>
+              <td className="p-2">
+                <button
+                  className="underline"
+                  type="button"
+                  onClick={() => toggle(d)}
+                >
+                  {d.active === false ? "Inactive" : "Active"}
+                </button>
+              </td>
+              <td className="p-2">
+                <button
+                  className="text-red-600 underline"
+                  type="button"
+                  onClick={() => remove(d.code)}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+          {discounts.length === 0 && (
+            <tr>
+              <td className="p-2" colSpan={6}>
+                No discounts.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -12,6 +12,8 @@ import { stripe } from "@acme/stripe";
 import { getCustomerSession } from "@auth";
 import { priceForDays, convertCurrency } from "@platform-core/pricing";
 import { findCoupon } from "@platform-core/coupons";
+import { trackEvent } from "@platform-core/analytics";
+import shop from "../../../../shop.json";
 import { getTaxRate } from "@platform-core/tax";
 
 import { NextRequest, NextResponse } from "next/server";
@@ -126,7 +128,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       currency?: string;
       taxRegion?: string;
     };
-  const couponDef = findCoupon(coupon);
+  const couponDef = await findCoupon(shop.id, coupon);
+  if (couponDef) {
+    await trackEvent(shop.id, { type: "discount_redeemed", code: couponDef.code });
+  }
   const discountRate = couponDef ? couponDef.discountPercent / 100 : 0;
   let rentalDays: number;
   try {

--- a/packages/platform-core/__tests__/analytics.test.ts
+++ b/packages/platform-core/__tests__/analytics.test.ts
@@ -143,6 +143,7 @@ describe("analytics aggregates", () => {
         await analytics.trackPageView("test", "/home");
         await analytics.trackEvent("test", { type: "order", orderId: "o1", amount: 2 });
         await analytics.trackOrder("test", "o2", 5);
+        await analytics.trackEvent("test", { type: "discount_redeemed", code: "SAVE" });
 
         const fp = path.join(
           dir,
@@ -154,6 +155,7 @@ describe("analytics aggregates", () => {
         const agg = JSON.parse(await fs.readFile(fp, "utf8"));
         expect(agg.page_view[now.slice(0, 10)]).toBe(2);
         expect(agg.order[now.slice(0, 10)]).toEqual({ count: 2, amount: 7 });
+        expect(agg.discount_redeemed[now.slice(0, 10)]).toBe(1);
         expect(fetch).not.toHaveBeenCalled();
       },
       { now }

--- a/packages/platform-core/__tests__/coupons.test.ts
+++ b/packages/platform-core/__tests__/coupons.test.ts
@@ -1,19 +1,39 @@
 // packages/platform-core/__tests__/coupons.test.ts
-import { COUPONS, findCoupon } from "@platform-core/src/coupons";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+
+let tmpDir = "";
+
+jest.mock("@platform-core/src/dataRoot", () => ({
+  resolveDataRoot: () => tmpDir,
+}));
+
+import { saveCoupons, findCoupon, type StoredCoupon } from "@platform-core/src/coupons";
+
+const shop = "test";
+const sample: StoredCoupon[] = [
+  { code: "SAVE10", description: "10% off", discountPercent: 10, active: true },
+];
 
 describe("findCoupon", () => {
-  it("matches coupon codes ignoring case", () => {
-    const coupon = findCoupon(COUPONS[0].code.toLowerCase());
-    expect(coupon).toEqual(COUPONS[0]);
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "coupons-"));
+    await saveCoupons(shop, sample);
   });
 
-  it("returns undefined when code is undefined or null", () => {
-    expect(findCoupon(undefined)).toBeUndefined();
+  it("matches coupon codes ignoring case", async () => {
+    const coupon = await findCoupon(shop, sample[0].code.toLowerCase());
+    expect(coupon).toEqual(sample[0]);
+  });
+
+  it("returns undefined when code is undefined or null", async () => {
+    expect(await findCoupon(shop, undefined)).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(findCoupon(null as any)).toBeUndefined();
+    expect(await findCoupon(shop, null as any)).toBeUndefined();
   });
 
-  it("returns undefined for unknown codes", () => {
-    expect(findCoupon("INVALID")).toBeUndefined();
+  it("returns undefined for unknown codes", async () => {
+    expect(await findCoupon(shop, "INVALID")).toBeUndefined();
   });
 });

--- a/packages/platform-core/src/coupons.ts
+++ b/packages/platform-core/src/coupons.ts
@@ -1,17 +1,51 @@
 // packages/platform-core/src/coupons.ts
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 import type { Coupon } from "@acme/types";
+import { resolveDataRoot } from "./dataRoot";
+import { validateShopName } from "./shops";
 
-/** Sample coupons available on the storefront */
-export const COUPONS: readonly Coupon[] = [
-  {
-    code: "SUMMER20",
-    description: "Summer promotion – 20% off",
-    discountPercent: 20,
-  },
-];
+/** Internal helper to compute the JSON file path for a shop. */
+function fileFor(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(resolveDataRoot(), shop, "discounts.json");
+}
 
-/** Lookup a coupon by code (case-insensitive). */
-export function findCoupon(code: string | undefined | null): Coupon | undefined {
+export type StoredCoupon = Coupon & { active?: boolean };
+
+/**
+ * Read all coupons for a shop from disk.
+ */
+export async function listCoupons(shop: string): Promise<StoredCoupon[]> {
+  try {
+    const buf = await fs.readFile(fileFor(shop), "utf8");
+    const parsed = JSON.parse(buf) as StoredCoupon[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist coupon definitions for a shop. */
+export async function saveCoupons(
+  shop: string,
+  coupons: StoredCoupon[],
+): Promise<void> {
+  const fp = fileFor(shop);
+  await fs.mkdir(path.dirname(fp), { recursive: true });
+  await fs.writeFile(fp, JSON.stringify(coupons, null, 2), "utf8");
+}
+
+/**
+ * Lookup a coupon by code (case-insensitive) for the given shop.
+ */
+export async function findCoupon(
+  shop: string,
+  code: string | undefined | null,
+): Promise<StoredCoupon | undefined> {
   if (!code) return undefined;
-  return COUPONS.find((c) => c.code.toLowerCase() === code.toLowerCase());
+  const coupons = await listCoupons(shop);
+  return coupons.find(
+    (c) => c.active !== false && c.code.toLowerCase() === code.toLowerCase(),
+  );
 }

--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -36,7 +36,7 @@ export async function readAggregates(
     const buf = await fs.readFile(aggregatesPath(shop), "utf8");
     return JSON.parse(buf) as AnalyticsAggregates;
   } catch {
-    return { page_view: {}, order: {} };
+    return { page_view: {}, order: {}, discount_redeemed: {} };
   }
 }
 


### PR DESCRIPTION
## Summary
- implement marketing discounts API with persistence and analytics counts
- surface discount codes in CMS with activation and deletion controls
- track `discount_redeemed` events during checkout and dashboard analytics

## Testing
- `pnpm test` *(fails: Cannot find module '@acme/config/env.ts' in @acme/next-config tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b21641208832fa1239cbf08c86941