### PR TITLE
Validate deposit release env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `STOCK_ALERT_RECIPIENT` – email address that receives low stock alerts; leave unset to disable notifications
 - `CART_COOKIE_SECRET` – secret used to sign cart cookies (required)
 - `CART_TTL` – cart expiration in seconds (defaults to 30 days)
+- `DEPOSIT_RELEASE_ENABLED`, `DEPOSIT_RELEASE_INTERVAL_MS` – control automatic deposit refunds for rental shops
 
 The scaffolded `.env` also includes generated placeholders for `NEXTAUTH_SECRET`
 and `PREVIEW_TOKEN_SECRET`. Replace all placeholders with real values or supply

--- a/doc/machine.md
+++ b/doc/machine.md
@@ -17,6 +17,11 @@ const stop = startDepositReleaseService();
 
 `startDepositReleaseService(intervalMs)` accepts an optional interval in milliseconds (defaults to one hour) and returns a function to stop the timer. The service subtracts any `damageFee` from the refunded amount and calls `markRefunded` so the order is not processed again.
 
+Environment variables can adjust behavior globally or per shop:
+
+- `DEPOSIT_RELEASE_ENABLED` or `DEPOSIT_RELEASE_ENABLED_<SHOP>` – set to `false` to disable refunds
+- `DEPOSIT_RELEASE_INTERVAL_MS` or `DEPOSIT_RELEASE_INTERVAL_MS_<SHOP>` – override the run interval in milliseconds
+
 Stripe credentials (`STRIPE_SECRET_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`) must be configured in the shop `.env` files. A one-off CLI utility is also available:
 
 ```bash

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -84,6 +84,7 @@ The wizard scaffolds placeholders for common variables:
 - `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_TOKEN` – Sanity blog configuration
 - `GMAIL_USER`, `GMAIL_PASS` – credentials for email sending
 - `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` – Cloudflare credentials for provisioning custom domains (server-side only)
+- `DEPOSIT_RELEASE_ENABLED`, `DEPOSIT_RELEASE_INTERVAL_MS` – control automatic deposit refunds for rental shops
 
 Leave any value blank if the integration isn't needed. You can update the `.env`
 file later and rerun `pnpm validate-env <id>` to confirm everything is set up.
@@ -125,6 +126,11 @@ pnpm release-deposits
 ```
 
 To keep it running on a schedule, import `startDepositReleaseService` from `@acme/platform-machine` and optionally pass a custom interval (defaults to one hour). The service scans every shop under `data/shops/*`, issues Stripe refunds and marks orders as refunded.
+
+Environment variables can adjust the service:
+
+- `DEPOSIT_RELEASE_ENABLED` or `DEPOSIT_RELEASE_ENABLED_<SHOP>` – set to `false` to disable automatic refunds
+- `DEPOSIT_RELEASE_INTERVAL_MS` or `DEPOSIT_RELEASE_INTERVAL_MS_<SHOP>` – override the run interval in milliseconds
 
 See [doc/machine.md](./machine.md#deposit-release-service) for more details and configuration options.
 

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -22,11 +22,15 @@ describe("envSchema", () => {
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
         process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
       CART_COOKIE_SECRET: process.env.CART_COOKIE_SECRET!,
+      DEPOSIT_RELEASE_ENABLED: "true",
+      DEPOSIT_RELEASE_INTERVAL_MS: "60000",
     });
     expect(parsed).toEqual({
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
       CART_COOKIE_SECRET: "secret",
+      DEPOSIT_RELEASE_ENABLED: "true",
+      DEPOSIT_RELEASE_INTERVAL_MS: 60000,
     });
   });
 
@@ -43,6 +47,27 @@ describe("envSchema", () => {
     const invalid = {
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+    } as Record<string, string>;
+
+    expect(() => envSchema.parse(invalid)).toThrow();
+  });
+
+  it("throws for invalid deposit release values", async () => {
+    process.env = {
+      ...OLD_ENV,
+      STRIPE_SECRET_KEY: "sk",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      CART_COOKIE_SECRET: "secret",
+    } as NodeJS.ProcessEnv;
+
+    const { envSchema } = await import("../src/env");
+
+    const invalid = {
+      STRIPE_SECRET_KEY: "sk",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      CART_COOKIE_SECRET: "secret",
+      DEPOSIT_RELEASE_ENABLED: "maybe",
+      DEPOSIT_RELEASE_INTERVAL_MS: "abc",
     } as Record<string, string>;
 
     expect(() => envSchema.parse(invalid)).toThrow();

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -46,6 +46,8 @@ export const envSchema = z.object({
   SESSION_STORE: z.enum(["memory", "redis"]).optional(),
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+  DEPOSIT_RELEASE_ENABLED: z.enum(["true", "false"]).optional(),
+  DEPOSIT_RELEASE_INTERVAL_MS: z.coerce.number().int().positive().optional(),
 });
 
 applyFriendlyZodMessages();

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -104,6 +104,8 @@ export function writeFiles(
   envContent += `GMAIL_PASS=\n`;
   envContent += `CLOUDFLARE_ACCOUNT_ID=\n`;
   envContent += `CLOUDFLARE_API_TOKEN=\n`;
+  envContent += `DEPOSIT_RELEASE_ENABLED=\n`;
+  envContent += `DEPOSIT_RELEASE_INTERVAL_MS=\n`;
   writeFileSync(join(newApp, ".env"), envContent);
 
   mkdirSync(newData, { recursive: true });

--- a/scripts/__tests__/validate-env.test.ts
+++ b/scripts/__tests__/validate-env.test.ts
@@ -70,7 +70,9 @@ describe("validate-env script", () => {
     await import("../../dist-scripts/validate-env.js").catch(() => {});
 
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(errorSpy.mock.calls[0][0]).toBe("Invalid environment variables:\n");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY is required"
+    );
     expect(logSpy).not.toHaveBeenCalled();
   });
 
@@ -89,6 +91,29 @@ describe("validate-env script", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errorSpy).toHaveBeenCalledWith("Missing apps/shop-abc/.env");
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid deposit release values", async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(
+      "STRIPE_SECRET_KEY=sk\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCART_COOKIE_SECRET=secret\nDEPOSIT_RELEASE_ENABLED_SHOP2=maybe\n"
+    );
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+
+    await import("../../dist-scripts/validate-env.js").catch(() => {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'DEPOSIT_RELEASE_ENABLED_SHOP2 must be "true" or "false"'
+    );
     expect(logSpy).not.toHaveBeenCalled();
   });
 });

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -31,6 +31,26 @@ try {
     if (env[k] === "") delete env[k];
   });
   envSchema.parse(env);
+
+  const depositErrors: string[] = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith("DEPOSIT_RELEASE_ENABLED")) {
+      if (value !== "true" && value !== "false") {
+        depositErrors.push(`${key} must be \"true\" or \"false\"`);
+      }
+    }
+    if (key.startsWith("DEPOSIT_RELEASE_INTERVAL_MS")) {
+      if (Number.isNaN(Number(value))) {
+        depositErrors.push(`${key} must be a number`);
+      }
+    }
+  }
+
+  if (depositErrors.length) {
+    depositErrors.forEach((e) => console.error(e));
+    process.exit(1);
+  }
+
   console.log("Environment variables look valid.");
 } catch (err) {
   if (err instanceof ZodError) {


### PR DESCRIPTION
## Summary
- add schema entries for `DEPOSIT_RELEASE_*`
- validate deposit release env vars in `validate-env` script
- document deposit release env keys and scaffold them in new shops

## Testing
- `STRIPE_SECRET_KEY=sk NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk CART_COOKIE_SECRET=secret pnpm exec jest packages/config/__tests__/env.test.ts scripts/__tests__/validate-env.test.ts packages/platform-core/__tests__/createShop.test.ts packages/platform-core/__tests__/createShopHelpers.test.ts packages/platform-core/__tests__/createShopUtils.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_689b20355cd8832fa6b5b0dbaa14541c