### PR TITLE
feat: add viewport-specific component sizing

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -14,10 +14,22 @@ export interface PageComponentBase {
    * or a percentage (e.g. "50%").
    */
   width?: string;
+  /** Width on large (desktop) viewports. Overrides `width` when provided. */
+  widthDesktop?: string;
+  /** Width on medium (tablet) viewports. Overrides `width` when provided. */
+  widthTablet?: string;
+  /** Width on small (mobile) viewports. Overrides `width` when provided. */
+  widthMobile?: string;
   /**
    * Height of the rendered component. Can be a pixel value or percentage.
    */
   height?: string;
+  /** Height on large (desktop) viewports. Overrides `height` when provided. */
+  heightDesktop?: string;
+  /** Height on medium (tablet) viewports. Overrides `height` when provided. */
+  heightTablet?: string;
+  /** Height on small (mobile) viewports. Overrides `height` when provided. */
+  heightMobile?: string;
   /**
    * CSS position property used when rendering the component.
    */

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -19,10 +19,40 @@ export interface PageComponentBase {
    */
   width?: string;
   /**
+   * Width of the component on desktop viewports. Overrides `width` when
+   * rendering on large screens.
+   */
+  widthDesktop?: string;
+  /**
+   * Width of the component on tablet viewports. Overrides `width` on medium
+   * screens.
+   */
+  widthTablet?: string;
+  /**
+   * Width of the component on mobile viewports. Overrides `width` on small
+   * screens.
+   */
+  widthMobile?: string;
+  /**
    * Height of the rendered component. Supports any CSS length such as
    * pixels, percentages or viewport units.
    */
   height?: string;
+  /**
+   * Height of the component on desktop viewports. Overrides `height` when
+   * rendering on large screens.
+   */
+  heightDesktop?: string;
+  /**
+   * Height of the component on tablet viewports. Overrides `height` on medium
+   * screens.
+   */
+  heightTablet?: string;
+  /**
+   * Height of the component on mobile viewports. Overrides `height` on small
+   * screens.
+   */
+  heightMobile?: string;
   /**
    * CSS position property used when rendering the component.
    */
@@ -290,7 +320,13 @@ const baseComponentSchema = z
   .object({
     id: z.string(),
     width: z.string().optional(),
+    widthDesktop: z.string().optional(),
+    widthTablet: z.string().optional(),
+    widthMobile: z.string().optional(),
     height: z.string().optional(),
+    heightDesktop: z.string().optional(),
+    heightTablet: z.string().optional(),
+    heightMobile: z.string().optional(),
     position: z.enum(["relative", "absolute"]).optional(),
     top: z.string().optional(),
     left: z.string().optional(),

--- a/packages/ui/__tests__/CanvasItem.test.tsx
+++ b/packages/ui/__tests__/CanvasItem.test.tsx
@@ -25,6 +25,7 @@ describe("CanvasItem", () => {
             locale="en"
             gridEnabled={false}
             gridCols={12}
+            viewport="desktop"
           />
         </SortableContext>
       </DndContext>

--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -9,21 +9,21 @@ describe("ComponentEditor", () => {
       type: "Image",
     } as PageComponent;
     const onResize = jest.fn();
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getAllByText } = render(
       <ComponentEditor
         component={component}
         onChange={() => {}}
         onResize={onResize}
       />
     );
-    fireEvent.change(getByLabelText("Width"), { target: { value: "200" } });
-    expect(onResize).toHaveBeenCalledWith({ width: "200" });
-    fireEvent.click(getByText("Full width"));
-    expect(onResize).toHaveBeenCalledWith({ width: "100%" });
-    fireEvent.change(getByLabelText("Height"), { target: { value: "300" } });
-    expect(onResize).toHaveBeenCalledWith({ height: "300" });
-    fireEvent.click(getByText("Full height"));
-    expect(onResize).toHaveBeenCalledWith({ height: "100%" });
+    fireEvent.change(getByLabelText("Width (Desktop)"), { target: { value: "200" } });
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: "200" });
+    fireEvent.click(getAllByText("Full width")[0]);
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: "100%" });
+    fireEvent.change(getByLabelText("Height (Desktop)"), { target: { value: "300" } });
+    expect(onResize).toHaveBeenCalledWith({ heightDesktop: "300" });
+    fireEvent.click(getAllByText("Full height")[0]);
+    expect(onResize).toHaveBeenCalledWith({ heightDesktop: "100%" });
   });
 
   it("updates minItems and maxItems", () => {

--- a/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.drag-resize.test.tsx
@@ -73,28 +73,36 @@ describe("PageBuilder interactions", () => {
               dispatch({ type: "resize", id: comp.id, ...patch })
             }
           />
-          <div data-testid="target" style={{ width: comp.width, height: comp.height }} />
+          <div
+            data-testid="target"
+            style={{ width: comp.widthDesktop, height: comp.heightDesktop }}
+          />
         </>
       );
     }
 
     render(<Wrapper />);
-    fireEvent.change(screen.getByLabelText("Width"), {
-      target: { value: "200" },
+    fireEvent.change(screen.getByLabelText("Width (Desktop)"), {
+      target: { value: "200px" },
     });
     expect(screen.getByTestId("target")).toHaveStyle({ width: "200px" });
-    fireEvent.click(screen.getByText("Full width"));
+    fireEvent.click(screen.getAllByText("Full width")[0]);
     expect(screen.getByTestId("target")).toHaveStyle({ width: "100%" });
-    fireEvent.change(screen.getByLabelText("Height"), {
-      target: { value: "300" },
+    fireEvent.change(screen.getByLabelText("Height (Desktop)"), {
+      target: { value: "300px" },
     });
     expect(screen.getByTestId("target")).toHaveStyle({ height: "300px" });
-    fireEvent.click(screen.getByText("Full height"));
+    fireEvent.click(screen.getAllByText("Full height")[0]);
     expect(screen.getByTestId("target")).toHaveStyle({ height: "100%" });
   });
 
   it("resizes via drag handle and snaps to full size with shift", () => {
-    const component: any = { id: "c1", type: "Image", width: "100px", height: "100px" };
+    const component: any = {
+      id: "c1",
+      type: "Image",
+      widthDesktop: "100px",
+      heightDesktop: "100px",
+    };
     const dispatch = jest.fn();
     const { container } = render(
       <CanvasItem
@@ -107,6 +115,7 @@ describe("PageBuilder interactions", () => {
         dispatch={dispatch}
         locale="en"
         gridCols={12}
+        viewport="desktop"
       />
     );
 
@@ -123,7 +132,7 @@ describe("PageBuilder interactions", () => {
     fireEvent.pointerMove(window, { clientX: 150, clientY: 150 });
     fireEvent.pointerUp(window);
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ width: "150px", height: "150px" })
+      expect.objectContaining({ widthDesktop: "150px", heightDesktop: "150px" })
     );
     dispatch.mockClear();
 
@@ -136,12 +145,17 @@ describe("PageBuilder interactions", () => {
     });
     fireEvent.pointerUp(window);
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ width: "100%", height: "100%" })
+      expect.objectContaining({ widthDesktop: "100%", heightDesktop: "100%" })
     );
   });
 
   it("snaps to full size when dragged near edge", () => {
-    const component: any = { id: "c1", type: "Image", width: "100px", height: "100px" };
+    const component: any = {
+      id: "c1",
+      type: "Image",
+      widthDesktop: "100px",
+      heightDesktop: "100px",
+    };
     const dispatch = jest.fn();
     const { container } = render(
       <CanvasItem
@@ -154,6 +168,7 @@ describe("PageBuilder interactions", () => {
         dispatch={dispatch}
         locale="en"
         gridCols={12}
+        viewport="desktop"
       />
     );
 
@@ -169,7 +184,7 @@ describe("PageBuilder interactions", () => {
     fireEvent.pointerMove(window, { clientX: 145, clientY: 145 });
     fireEvent.pointerUp(window);
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ width: "100%", height: "100%" })
+      expect.objectContaining({ widthDesktop: "100%", heightDesktop: "100%" })
     );
   });
 
@@ -177,8 +192,8 @@ describe("PageBuilder interactions", () => {
     const c1: any = {
       id: "c1",
       type: "Image",
-      width: "100px",
-      height: "100px",
+      widthDesktop: "100px",
+      heightDesktop: "100px",
       position: "absolute",
       left: "0px",
       top: "0px",
@@ -186,8 +201,8 @@ describe("PageBuilder interactions", () => {
     const c2: any = {
       id: "c2",
       type: "Image",
-      width: "100px",
-      height: "100px",
+      widthDesktop: "100px",
+      heightDesktop: "100px",
       position: "absolute",
       left: "120px",
       top: "0px",
@@ -205,6 +220,7 @@ describe("PageBuilder interactions", () => {
           dispatch={jest.fn()}
           locale="en"
           gridCols={12}
+          viewport="desktop"
         />
         <CanvasItem
           component={c2}
@@ -216,6 +232,7 @@ describe("PageBuilder interactions", () => {
           dispatch={dispatch}
           locale="en"
           gridCols={12}
+          viewport="desktop"
         />
       </div>
     );
@@ -243,7 +260,12 @@ describe("PageBuilder interactions", () => {
   });
 
   it("snaps resizing to grid units when grid is enabled", () => {
-    const component: any = { id: "c1", type: "Image", width: "100px", height: "100px" };
+    const component: any = {
+      id: "c1",
+      type: "Image",
+      widthDesktop: "100px",
+      heightDesktop: "100px",
+    };
     const dispatch = jest.fn();
     const { container } = render(
       <CanvasItem
@@ -257,6 +279,7 @@ describe("PageBuilder interactions", () => {
         locale="en"
         gridEnabled
         gridCols={4}
+        viewport="desktop"
       />
     );
     const el = container.firstChild as HTMLElement;
@@ -273,7 +296,7 @@ describe("PageBuilder interactions", () => {
     fireEvent.pointerUp(window);
 
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ width: "200px", height: "200px" })
+      expect.objectContaining({ widthDesktop: "200px", heightDesktop: "200px" })
     );
   });
 
@@ -281,8 +304,8 @@ describe("PageBuilder interactions", () => {
     const component: any = {
       id: "c1",
       type: "Image",
-      width: "100px",
-      height: "100px",
+      widthDesktop: "100px",
+      heightDesktop: "100px",
       position: "absolute",
       left: "0px",
       top: "0px",
@@ -300,6 +323,7 @@ describe("PageBuilder interactions", () => {
         locale="en"
         gridEnabled
         gridCols={4}
+        viewport="desktop"
       />
     );
 

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -25,6 +25,7 @@ const CanvasItem = memo(function CanvasItem({
   locale,
   gridEnabled = false,
   gridCols,
+  viewport,
 }: {
   component: PageComponent;
   index: number;
@@ -36,6 +37,7 @@ const CanvasItem = memo(function CanvasItem({
   locale: Locale;
   gridEnabled?: boolean;
   gridCols: number;
+  viewport: "desktop" | "tablet" | "mobile";
 }) {
   const selected = selectedId === component.id;
   const {
@@ -70,6 +72,21 @@ const CanvasItem = memo(function CanvasItem({
   const [guides, setGuides] = useState<{ x: number | null; y: number | null }>(
     { x: null, y: null }
   );
+
+  const widthKey =
+    viewport === "desktop"
+      ? "widthDesktop"
+      : viewport === "tablet"
+      ? "widthTablet"
+      : "widthMobile";
+  const heightKey =
+    viewport === "desktop"
+      ? "heightDesktop"
+      : viewport === "tablet"
+      ? "heightTablet"
+      : "heightMobile";
+  const widthVal = (component as any)[widthKey] ?? component.width;
+  const heightVal = (component as any)[heightKey] ?? component.height;
 
   const editor = useTextEditor(component, locale, editing);
 
@@ -137,9 +154,9 @@ const CanvasItem = memo(function CanvasItem({
       dispatch({
         type: "resize",
         id: component.id,
-        width: snapW ? "100%" : `${newW}px`,
-        height: snapH ? "100%" : `${newH}px`,
-      });
+        [widthKey]: snapW ? "100%" : `${newW}px`,
+        [heightKey]: snapH ? "100%" : `${newH}px`,
+      } as any);
       setSnapWidth(snapW || guideX !== null);
       setSnapHeight(snapH || guideY !== null);
       setGuides({
@@ -231,12 +248,10 @@ const CanvasItem = memo(function CanvasItem({
     const el = containerRef.current;
     if (!el) return;
     const startWidth =
-      component.width && component.width.endsWith("px")
-        ? parseFloat(component.width)
-        : el.offsetWidth;
+      widthVal && widthVal.endsWith("px") ? parseFloat(widthVal) : el.offsetWidth;
     const startHeight =
-      component.height && component.height.endsWith("px")
-        ? parseFloat(component.height)
+      heightVal && heightVal.endsWith("px")
+        ? parseFloat(heightVal)
         : el.offsetHeight;
     startRef.current = {
       x: e.clientX,
@@ -292,8 +307,8 @@ const CanvasItem = memo(function CanvasItem({
       tabIndex={0}
       style={{
         transform: CSS.Transform.toString(transform),
-        ...(component.width ? { width: component.width } : {}),
-        ...(component.height ? { height: component.height } : {}),
+        ...(widthVal ? { width: widthVal } : {}),
+        ...(heightVal ? { height: heightVal } : {}),
         ...(component.margin ? { margin: component.margin } : {}),
         ...(component.padding ? { padding: component.padding } : {}),
         ...(component.position ? { position: component.position } : {}),

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -38,6 +38,12 @@ interface Props {
     height?: string;
     top?: string;
     left?: string;
+    widthDesktop?: string;
+    widthTablet?: string;
+    widthMobile?: string;
+    heightDesktop?: string;
+    heightTablet?: string;
+    heightMobile?: string;
   }) => void;
 }
 
@@ -315,42 +321,50 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="flex items-end gap-2">
-        <Input
-          label="Width"
-          placeholder="e.g. 100px or 50%"
-          value={component.width ?? ""}
-          onChange={(e) => {
-            const v = e.target.value.trim();
-            onResize({ width: v || undefined });
-          }}
-        />
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => onResize({ width: "100%" })}
-        >
-          Full width
-        </Button>
-      </div>
-      <div className="flex items-end gap-2">
-        <Input
-          label="Height"
-          placeholder="e.g. 1px or 1rem"
-          value={component.height ?? ""}
-          onChange={(e) => {
-            const v = e.target.value.trim();
-            onResize({ height: v || undefined });
-          }}
-        />
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => onResize({ height: "100%" })}
-        >
-          Full height
-        </Button>
-      </div>
+      {(["Desktop", "Tablet", "Mobile"] as const).map((vp) => (
+        <div key={vp} className="space-y-2">
+          <div className="flex items-end gap-2">
+            <Input
+              label={`Width (${vp})`}
+              placeholder="e.g. 100px or 50%"
+              value={(component as any)[`width${vp}`] ?? ""}
+              onChange={(e) => {
+                const v = e.target.value.trim();
+                onResize({ [`width${vp}`]: v || undefined } as any);
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                onResize({ [`width${vp}`]: "100%" } as any)
+              }
+            >
+              Full width
+            </Button>
+          </div>
+          <div className="flex items-end gap-2">
+            <Input
+              label={`Height (${vp})`}
+              placeholder="e.g. 1px or 1rem"
+              value={(component as any)[`height${vp}`] ?? ""}
+              onChange={(e) => {
+                const v = e.target.value.trim();
+                onResize({ [`height${vp}`]: v || undefined } as any);
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                onResize({ [`height${vp}`]: "100%" } as any)
+              }
+            >
+              Full height
+            </Button>
+          </div>
+        </div>
+      ))}
       <Input
         label="Margin"
         value={component.margin ?? ""}

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -318,6 +318,7 @@ const PageBuilder = memo(function PageBuilder({
           containerStyle={containerStyle}
           showGrid={showGrid}
           gridCols={gridCols}
+          viewport={viewport}
         />
         <div className="flex gap-2">
           <Button onClick={() => dispatch({ type: "undo" })} disabled={!state.past.length}>

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -30,6 +30,7 @@ interface Props {
   containerStyle: CSSProperties;
   showGrid?: boolean;
   gridCols: number;
+  viewport: "desktop" | "tablet" | "mobile";
 }
 
 const PageCanvas = ({
@@ -49,6 +50,7 @@ const PageCanvas = ({
   containerStyle,
   showGrid = false,
   gridCols,
+  viewport,
 }: Props) => (
   <DndContext
     sensors={sensors}
@@ -110,6 +112,7 @@ const PageCanvas = ({
               locale={locale}
               gridEnabled={showGrid}
               gridCols={gridCols}
+              viewport={viewport}
             />
           </Fragment>
         ))}

--- a/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
@@ -19,7 +19,20 @@ const PageSidebar = ({ components, selectedId, dispatch }: Props) => {
   );
 
   const handleResize = useCallback(
-    (size: { width?: string; height?: string; top?: string; left?: string }) =>
+    (
+      size: {
+        width?: string;
+        height?: string;
+        top?: string;
+        left?: string;
+        widthDesktop?: string;
+        widthTablet?: string;
+        widthMobile?: string;
+        heightDesktop?: string;
+        heightTablet?: string;
+        heightMobile?: string;
+      },
+    ) =>
       dispatch({ type: "resize", id: selectedId, ...size }),
     [dispatch, selectedId],
   );

--- a/packages/ui/src/components/cms/page-builder/state.ts
+++ b/packages/ui/src/components/cms/page-builder/state.ts
@@ -35,6 +35,12 @@ export type ChangeAction =
       height?: string;
       left?: string;
       top?: string;
+      widthDesktop?: string;
+      widthTablet?: string;
+      widthMobile?: string;
+      heightDesktop?: string;
+      heightTablet?: string;
+      heightMobile?: string;
     }
   | { type: "set"; components: PageComponent[] };
 
@@ -116,7 +122,18 @@ function updateComponent(
 function resizeComponent(
   list: PageComponent[],
   id: string,
-  patch: { width?: string; height?: string; left?: string; top?: string }
+  patch: {
+    width?: string;
+    height?: string;
+    left?: string;
+    top?: string;
+    widthDesktop?: string;
+    widthTablet?: string;
+    widthMobile?: string;
+    heightDesktop?: string;
+    heightTablet?: string;
+    heightMobile?: string;
+  },
 ): PageComponent[] {
   return list.map((c) => {
     if (c.id === id) return { ...c, ...patch } as PageComponent;


### PR DESCRIPTION
## Summary
- add per-viewport width/height fields to `PageComponent`
- allow editing desktop/tablet/mobile sizes in component editor
- render canvas items using viewport-specific dimensions

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__` *(fails: Cannot find module '../components/templates/AppShell' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b25242f30832f87a2a762278a3701