### PR TITLE
Validate deposit release environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `STOCK_ALERT_RECIPIENT` – email address that receives low stock alerts; leave unset to disable notifications
 - `CART_COOKIE_SECRET` – secret used to sign cart cookies (required)
 - `CART_TTL` – cart expiration in seconds (defaults to 30 days)
+- `DEPOSIT_RELEASE_ENABLED` – `true` or `false` to toggle automated deposit refunds
+- `DEPOSIT_RELEASE_INTERVAL_MS` – interval in milliseconds for running the refund service
 
 The scaffolded `.env` also includes generated placeholders for `NEXTAUTH_SECRET`
 and `PREVIEW_TOKEN_SECRET`. Replace all placeholders with real values or supply

--- a/dist-scripts/validate-env.js
+++ b/dist-scripts/validate-env.js
@@ -1,6 +1,7 @@
-import { envSchema } from "@config/env";
+import { envSchema } from "@config/src/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { ZodError } from "zod";
 const shopId = process.argv[2];
 if (!shopId) {
     console.error("Usage: pnpm validate-env <shopId>");
@@ -20,11 +21,44 @@ for (const line of envRaw.split(/\n+/)) {
     const [key, ...rest] = trimmed.split("=");
     env[key] = rest.join("=");
 }
+Object.keys(env).forEach((k) => {
+    if (env[k] === "")
+        delete env[k];
+});
+const depositErrors = [];
+for (const [key, value] of Object.entries(env)) {
+    if (!key.startsWith("DEPOSIT_RELEASE_"))
+        continue;
+    if (key.includes("ENABLED")) {
+        if (value !== "true" && value !== "false") {
+            depositErrors.push(`${key} must be true or false`);
+        }
+    }
+    else if (key.includes("INTERVAL_MS")) {
+        if (Number.isNaN(Number(value))) {
+            depositErrors.push(`${key} must be a number`);
+        }
+    }
+}
+if (depositErrors.length) {
+    for (const err of depositErrors)
+        console.error(err);
+    process.exit(1);
+}
 try {
     envSchema.parse(env);
     console.log("Environment variables look valid.");
 }
 catch (err) {
-    console.error("Invalid environment variables:\n", err);
+    if (err instanceof ZodError) {
+        for (const issue of err.issues) {
+            const name = issue.path.join(".");
+            const message = issue.message === "Required" ? "is required" : issue.message;
+            console.error(`${name} ${message}`);
+        }
+    }
+    else {
+        console.error(err);
+    }
     process.exit(1);
 }

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -84,7 +84,7 @@ The wizard scaffolds placeholders for common variables:
 - `SANITY_PROJECT_ID`, `SANITY_DATASET`, `SANITY_TOKEN` – Sanity blog configuration
 - `GMAIL_USER`, `GMAIL_PASS` – credentials for email sending
 - `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` – Cloudflare credentials for provisioning custom domains (server-side only)
-- `DEPOSIT_RELEASE_ENABLED`, `DEPOSIT_RELEASE_INTERVAL_MS` – control automated deposit refunds (default disabled, 60 minutes)
+- `DEPOSIT_RELEASE_ENABLED`, `DEPOSIT_RELEASE_INTERVAL_MS` – control automated deposit refunds (`true`/`false` to enable, interval in milliseconds; default disabled, 60 minutes)
 
 Leave any value blank if the integration isn't needed. You can update the `.env`
 file later and rerun `pnpm validate-env <id>` to confirm everything is set up.

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -26,6 +26,8 @@ export const envSchema = z.object({
   SANITY_API_VERSION: z.string().optional(),
   CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
   CLOUDFLARE_API_TOKEN: z.string().optional(),
+  DEPOSIT_RELEASE_ENABLED: z.enum(["true", "false"]).optional(),
+  DEPOSIT_RELEASE_INTERVAL_MS: z.coerce.number().optional(),
   OPENAI_API_KEY: z.string().optional(),
   TAXJAR_KEY: z.string().optional(),
   UPS_KEY: z.string().optional(),

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -26,10 +26,30 @@ for (const line of envRaw.split(/\n+/)) {
   env[key] = rest.join("=");
 }
 
+Object.keys(env).forEach((k) => {
+  if (env[k] === "") delete env[k];
+});
+
+const depositErrors: string[] = [];
+for (const [key, value] of Object.entries(env)) {
+  if (!key.startsWith("DEPOSIT_RELEASE_")) continue;
+  if (key.includes("ENABLED")) {
+    if (value !== "true" && value !== "false") {
+      depositErrors.push(`${key} must be true or false`);
+    }
+  } else if (key.includes("INTERVAL_MS")) {
+    if (Number.isNaN(Number(value))) {
+      depositErrors.push(`${key} must be a number`);
+    }
+  }
+}
+
+if (depositErrors.length) {
+  for (const err of depositErrors) console.error(err);
+  process.exit(1);
+}
+
 try {
-  Object.keys(env).forEach((k) => {
-    if (env[k] === "") delete env[k];
-  });
   envSchema.parse(env);
   console.log("Environment variables look valid.");
 } catch (err) {


### PR DESCRIPTION
## Summary
- validate DEPOSIT_RELEASE env vars with strict schema entries
- surface errors for malformed DEPOSIT_RELEASE values in `validate-env`
- document deposit release env keys in setup docs and README

## Testing
- `pnpm exec jest packages/config/__tests__/env.test.ts`
- `pnpm exec jest scripts/__tests__/validate-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b2591cd30832f993728c63d68fbee