### PR TITLE
feat: add ai catalog analytics

### DIFF
--- a/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/Charts.client.tsx
@@ -35,6 +35,7 @@ interface ChartsProps {
   emailClicks: Series;
   campaignSales: Series;
   discountRedemptions: Series;
+  aiCatalog: Series;
 }
 
 export function Charts({
@@ -45,6 +46,7 @@ export function Charts({
   emailClicks,
   campaignSales,
   discountRedemptions,
+  aiCatalog,
 }: ChartsProps) {
   return (
     <div className="space-y-8">
@@ -148,6 +150,21 @@ export function Charts({
                 label: "Discount redemptions",
                 data: discountRedemptions.data,
                 borderColor: "rgb(201, 203, 207)",
+              },
+            ],
+          }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 font-semibold">AI Catalog Requests</h3>
+        <Line
+          data={{
+            labels: aiCatalog.labels,
+            datasets: [
+              {
+                label: "AI catalog requests",
+                data: aiCatalog.data,
+                borderColor: "rgb(99, 132, 255)",
               },
             ],
           }}

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -55,6 +55,7 @@ export default async function ShopDashboard({
       ...Object.keys(campaignSalesByDay),
       ...Object.keys(discountByDay),
       ...Object.keys(aggregates.discount_redeemed),
+      ...Object.keys(aggregates.ai_catalog),
     ])
   ).sort();
 
@@ -90,18 +91,24 @@ export default async function ShopDashboard({
     labels: days,
     data: days.map((d) => discountByDay[d] || 0),
   };
+  const aiCatalog = {
+    labels: days,
+    data: days.map((d) => aggregates.ai_catalog[d] || 0),
+  };
 
   const totals = {
     emailOpens: emailOpens.data.reduce((a, b) => a + b, 0),
     emailClicks: emailClicks.data.reduce((a, b) => a + b, 0),
     campaignSales: campaignSales.data.reduce((a, b) => a + b, 0),
     discountRedemptions: discountRedemptions.data.reduce((a, b) => a + b, 0),
+    aiCatalog: aiCatalog.data.reduce((a, b) => a + b, 0),
   };
   const maxTotal = Math.max(
     totals.emailOpens,
     totals.emailClicks,
     totals.campaignSales,
     totals.discountRedemptions,
+    totals.aiCatalog,
     1,
   );
 
@@ -130,6 +137,7 @@ export default async function ShopDashboard({
         emailClicks={emailClicks}
         campaignSales={campaignSales}
         discountRedemptions={discountRedemptions}
+        aiCatalog={aiCatalog}
       />
       <div className="mt-8 space-y-4">
         <h3 className="text-lg font-semibold">Progress</h3>
@@ -161,6 +169,15 @@ export default async function ShopDashboard({
           <Progress
             value={(totals.discountRedemptions / maxTotal) * 100}
             label={String(totals.discountRedemptions)}
+          />
+        </div>
+        <div>
+          <span className="mb-1 block text-sm font-medium">
+            AI catalog requests
+          </span>
+          <Progress
+            value={(totals.aiCatalog / maxTotal) * 100}
+            label={String(totals.aiCatalog)}
           />
         </div>
       </div>

--- a/packages/platform-core/__tests__/analytics.test.ts
+++ b/packages/platform-core/__tests__/analytics.test.ts
@@ -144,6 +144,7 @@ describe("analytics aggregates", () => {
         await analytics.trackEvent("test", { type: "order", orderId: "o1", amount: 2 });
         await analytics.trackOrder("test", "o2", 5);
         await analytics.trackEvent("test", { type: "discount_redeemed", code: "SAVE" });
+        await analytics.trackEvent("test", { type: "ai_catalog" });
 
         const fp = path.join(
           dir,
@@ -156,6 +157,7 @@ describe("analytics aggregates", () => {
         expect(agg.page_view[now.slice(0, 10)]).toBe(2);
         expect(agg.order[now.slice(0, 10)]).toEqual({ count: 2, amount: 7 });
         expect(agg.discount_redeemed[now.slice(0, 10)]).toBe(1);
+        expect(agg.ai_catalog[now.slice(0, 10)]).toBe(1);
         expect(fetch).not.toHaveBeenCalled();
       },
       { now }

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -142,6 +142,7 @@ interface Aggregates {
   page_view: Record<string, number>;
   order: Record<string, { count: number; amount: number }>;
   discount_redeemed: Record<string, number>;
+  ai_catalog: Record<string, number>;
 }
 
 async function updateAggregates(
@@ -150,7 +151,12 @@ async function updateAggregates(
 ): Promise<void> {
   const fp = path.join(DATA_ROOT, validateShopName(shop), "analytics-aggregates.json");
   const day = (event.timestamp as string).slice(0, 10);
-  let agg: Aggregates = { page_view: {}, order: {}, discount_redeemed: {} };
+  let agg: Aggregates = {
+    page_view: {},
+    order: {},
+    discount_redeemed: {},
+    ai_catalog: {},
+  };
   try {
     const buf = await fs.readFile(fp, "utf8");
     agg = JSON.parse(buf) as Aggregates;
@@ -167,6 +173,8 @@ async function updateAggregates(
     agg.order[day] = entry;
   } else if (event.type === "discount_redeemed") {
     agg.discount_redeemed[day] = (agg.discount_redeemed[day] || 0) + 1;
+  } else if (event.type === "ai_catalog") {
+    agg.ai_catalog[day] = (agg.ai_catalog[day] || 0) + 1;
   }
   await fs.mkdir(path.dirname(fp), { recursive: true });
   await fs.writeFile(fp, JSON.stringify(agg), "utf8");

--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -36,7 +36,7 @@ export async function readAggregates(
     const buf = await fs.readFile(aggregatesPath(shop), "utf8");
     return JSON.parse(buf) as AnalyticsAggregates;
   } catch {
-    return { page_view: {}, order: {}, discount_redeemed: {} };
+    return { page_view: {}, order: {}, discount_redeemed: {}, ai_catalog: {} };
   }
 }
 

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -2,7 +2,11 @@
 import "server-only";
 
 import { LOCALES } from "@i18n/locales";
-import { shopSettingsSchema, type Locale, type ShopSettings } from "@acme/types";
+import {
+  shopSettingsSchema,
+  type Locale,
+  type ShopSettings,
+} from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
@@ -58,6 +62,11 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
           interval: 60,
           ...(parsed.data.depositService ?? {}),
         },
+        aiCatalog: {
+          enabled: false,
+          fields: ["id", "title", "description", "price", "images"],
+          ...(parsed.data.aiCatalog ?? {}),
+        },
       };
     }
   } catch {
@@ -71,6 +80,10 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     currency: "EUR",
     taxRegion: "",
     depositService: { enabled: false, interval: 60 },
+    aiCatalog: {
+      enabled: false,
+      fields: ["id", "title", "description", "price", "images"],
+    },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -2,6 +2,19 @@ import { z } from "zod";
 import { localeSchema } from "./Product";
 import { shopSeoFieldsSchema } from "./Shop";
 
+export const aiCatalogFieldSchema = z.enum([
+  "id",
+  "title",
+  "description",
+  "price",
+  "images",
+]);
+
+export const aiCatalogConfigSchema = z.object({
+  enabled: z.boolean(),
+  fields: z.array(aiCatalogFieldSchema),
+});
+
 export const shopSettingsSchema = z.object({
   languages: z.array(localeSchema).readonly(),
   seo: z.record(localeSchema, shopSeoFieldsSchema),
@@ -23,8 +36,11 @@ export const shopSettingsSchema = z.object({
       interval: z.number().int().positive(),
     })
     .optional(),
+  aiCatalog: aiCatalogConfigSchema.optional(),
   updatedAt: z.string(),
   updatedBy: z.string(),
 });
 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
+export type AiCatalogConfig = z.infer<typeof aiCatalogConfigSchema>;
+export type AiCatalogField = z.infer<typeof aiCatalogFieldSchema>;


### PR DESCRIPTION
## Summary
- add aiCatalog config to shop settings
- expose AI catalog requests in analytics and dashboard
- filter AI catalog feed fields based on shop settings

## Testing
- `pnpm test --filter "@acme/template-app"`
- `pnpm test --filter "@apps/cms"` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*
- `pnpm test --filter "@acme/platform-core"` *(fails: Cannot find module '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_689b3fb53c80832f922489328c393a68