### PR TITLE
feat(marketing): schedule email campaigns

### DIFF
--- a/functions/marketing-email-sender.ts
+++ b/functions/marketing-email-sender.ts
@@ -1,0 +1,79 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { sendCampaignEmail } from "@acme/email";
+import { trackEvent } from "@platform-core/analytics";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { env } from "@acme/config";
+
+interface Campaign {
+  id: string;
+  recipients: string[];
+  subject: string;
+  body: string;
+  segment?: string | null;
+  sendAt: string;
+  sentAt?: string;
+}
+
+function campaignsPath(shop: string): string {
+  return path.join(DATA_ROOT, shop, "campaigns.json");
+}
+
+async function readCampaigns(shop: string): Promise<Campaign[]> {
+  try {
+    const buf = await fs.readFile(campaignsPath(shop), "utf8");
+    const json = JSON.parse(buf);
+    if (Array.isArray(json)) return json as Campaign[];
+  } catch {}
+  return [];
+}
+
+async function writeCampaigns(shop: string, items: Campaign[]): Promise<void> {
+  await fs.mkdir(path.dirname(campaignsPath(shop)), { recursive: true });
+  await fs.writeFile(
+    campaignsPath(shop),
+    JSON.stringify(items, null, 2),
+    "utf8"
+  );
+}
+
+export async function sendScheduledCampaigns(): Promise<void> {
+  const shops = await fs.readdir(DATA_ROOT).catch(() => []);
+  const now = new Date();
+  for (const shop of shops) {
+    const campaigns = await readCampaigns(shop);
+    let changed = false;
+    for (const c of campaigns) {
+      if (c.sentAt || new Date(c.sendAt) > now) continue;
+      const base = env.NEXT_PUBLIC_BASE_URL || "";
+      const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
+        shop
+      )}&campaign=${encodeURIComponent(c.id)}`;
+      const bodyWithPixel =
+        c.body +
+        `<img src="${pixelUrl}" alt="" style="display:none" width="1" height="1"/>`;
+      const trackedBody = bodyWithPixel.replace(
+        /href="([^"]+)"/g,
+        (_m, url) =>
+          `href="${base}/api/marketing/email/click?shop=${encodeURIComponent(
+            shop
+          )}&campaign=${encodeURIComponent(c.id)}&url=${encodeURIComponent(url)}"`
+      );
+      for (const r of c.recipients) {
+        await sendCampaignEmail({
+          to: r,
+          subject: c.subject,
+          html: trackedBody,
+        });
+        await trackEvent(shop, { type: "email_sent", campaign: c.id });
+      }
+      c.sentAt = new Date().toISOString();
+      changed = true;
+    }
+    if (changed) await writeCampaigns(shop, campaigns);
+  }
+}
+
+export const onScheduled = async () => {
+  await sendScheduledCampaigns();
+};


### PR DESCRIPTION
## Summary
- expand email campaign API to handle segments, recipients and scheduled send times
- add worker to dispatch scheduled campaigns and track sends
- extend CMS marketing UI with recipient list, segment selector and schedule inputs

## Testing
- `pnpm exec eslint apps/cms/src/app/api/marketing/email/route.ts apps/cms/src/app/cms/marketing/email/page.tsx functions/marketing-email-sender.ts`
- `pnpm test:cms` *(fails: Cannot find module '.prisma/client/index-browser')*


------
https://chatgpt.com/codex/tasks/task_e_689b42104330832f8e7e00abc3ad9477