### PR TITLE
Automate daily SEO audits and expose results in CMS

### DIFF
--- a/apps/cms/src/app/api/seo/audit/[shop]/route.ts
+++ b/apps/cms/src/app/api/seo/audit/[shop]/route.ts
@@ -1,22 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATA_ROOT } from "@platform-core";
 import { validateShopName } from "@acme/lib";
-import fs from "node:fs/promises";
-import path from "node:path";
 import lighthouse from "lighthouse";
 import chromeLauncher from "chrome-launcher";
+import {
+  appendSeoAudit,
+  readSeoAudits,
+  type SeoAuditEntry,
+} from "@platform-core/repositories/seoAudit.server";
 
-interface AuditRecord {
-  timestamp: string;
-  score: number;
-  issues: number;
-}
-
-function auditFile(shop: string) {
-  return path.join(DATA_ROOT, shop, "seo-audit.json");
-}
-
-async function runLighthouse(url: string): Promise<AuditRecord> {
+async function runLighthouse(url: string): Promise<SeoAuditEntry> {
   const chrome = await chromeLauncher.launch({ chromeFlags: ["--headless"] });
   try {
     const result = await lighthouse(url, {
@@ -25,11 +17,15 @@ async function runLighthouse(url: string): Promise<AuditRecord> {
       preset: "desktop",
     });
     const lhr = result.lhr;
-    const score = lhr.categories?.seo?.score ?? 0;
-    const issues = Object.values(lhr.audits).filter((a) => {
-      return a.score !== 1 && a.score !== null && a.score !== undefined && a.scoreDisplayMode !== "notApplicable";
-    }).length;
-    return { timestamp: new Date().toISOString(), score, issues };
+    const score = Math.round((lhr.categories?.seo?.score ?? 0) * 100);
+    const recommendations = Object.values(lhr.audits)
+      .filter((a) =>
+        a.score !== 1 &&
+        a.scoreDisplayMode !== "notApplicable" &&
+        a.title,
+      )
+      .map((a) => a.title as string);
+    return { timestamp: new Date().toISOString(), score, recommendations };
   } finally {
     await chrome.kill();
   }
@@ -41,12 +37,8 @@ export async function GET(
 ) {
   const { shop } = await context.params;
   const safeShop = validateShopName(shop);
-  try {
-    const buf = await fs.readFile(auditFile(safeShop), "utf8");
-    return NextResponse.json(JSON.parse(buf) as AuditRecord[]);
-  } catch {
-    return NextResponse.json([]);
-  }
+  const audits = await readSeoAudits(safeShop);
+  return NextResponse.json(audits);
 }
 
 export async function POST(
@@ -58,18 +50,6 @@ export async function POST(
   const body = await req.json().catch(() => ({} as { url?: string }));
   const url = body.url || `http://localhost:3000/${safeShop}`;
   const record = await runLighthouse(url);
-
-  const file = auditFile(safeShop);
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  let history: AuditRecord[] = [];
-  try {
-    const buf = await fs.readFile(file, "utf8");
-    history = JSON.parse(buf);
-    if (!Array.isArray(history)) history = [];
-  } catch {
-    /* ignore */
-  }
-  history.push(record);
-  await fs.writeFile(file, JSON.stringify(history, null, 2), "utf8");
+  await appendSeoAudit(safeShop, record);
   return NextResponse.json(record);
 }

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoChart.client.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoChart.client.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+interface Props {
+  labels: string[];
+  scores: number[];
+}
+
+export function SeoChart({ labels, scores }: Props) {
+  return (
+    <Line
+      data={{
+        labels,
+        datasets: [
+          {
+            label: "SEO Score",
+            data: scores,
+            borderColor: "rgb(75, 192, 192)",
+          },
+        ],
+      }}
+    />
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoProgressPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoProgressPanel.tsx
@@ -1,6 +1,6 @@
 import { formatTimestamp } from "@acme/date-utils";
 import { readSeoAudits } from "@platform-core/repositories/seoAudit.server";
-import { listEvents } from "@platform-core/repositories/analytics.server";
+import { SeoChart } from "./SeoChart.client";
 
 interface Props {
   /** Shop identifier */
@@ -9,47 +9,17 @@ interface Props {
 
 export default async function SeoProgressPanel({ shop }: Props) {
   const audits = await readSeoAudits(shop);
-  const events = await listEvents(shop);
 
-  const trafficByDay: Record<string, number> = {};
-  for (const ev of events) {
-    if (ev.type === "page_view" && (ev as { source?: string }).source === "organic") {
-      const day = (ev.timestamp as string).slice(0, 10);
-      trafficByDay[day] = (trafficByDay[day] ?? 0) + 1;
-    }
-  }
-
-  const rows = audits.map((a) => ({
-    timestamp: a.timestamp,
-    score: a.score,
-    traffic: trafficByDay[a.timestamp.slice(0, 10)] ?? 0,
-  }));
-
+  const labels = audits.map((a) => formatTimestamp(a.timestamp));
+  const scores = audits.map((a) => a.score);
   const recs = audits.at(-1)?.recommendations ?? [];
 
   return (
     <div className="space-y-4 text-sm">
-      {rows.length === 0 ? (
+      {audits.length === 0 ? (
         <p className="text-muted-foreground">No SEO data available.</p>
       ) : (
-        <table className="w-full text-left">
-          <thead>
-            <tr>
-              <th className="py-1">Date</th>
-              <th className="py-1">Audit Score</th>
-              <th className="py-1">Organic Views</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r) => (
-              <tr key={r.timestamp} className="border-t">
-                <td className="font-mono py-1">{formatTimestamp(r.timestamp)}</td>
-                <td className="py-1">{r.score}</td>
-                <td className="py-1">{r.traffic}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <SeoChart labels={labels} scores={scores} />
       )}
       {recs.length > 0 && (
         <div className="space-y-2">

--- a/functions/src/seoAudit.ts
+++ b/functions/src/seoAudit.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { runSeoAudit } from "../../scripts/seo-audit";
+
+async function auditShop(shop: string): Promise<void> {
+  const url = `http://localhost:3000/${shop}`;
+  const { score, recommendations } = await runSeoAudit(url);
+  const record = {
+    timestamp: new Date().toISOString(),
+    score,
+    recommendations,
+  };
+  const file = path.join(DATA_ROOT, shop, "seo-audits.jsonl");
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.appendFile(file, JSON.stringify(record) + "\n", "utf8");
+}
+
+export default {
+  async scheduled() {
+    const entries = await fs.readdir(DATA_ROOT, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      try {
+        await auditShop(entry.name);
+      } catch (err) {
+        console.error(`seo audit failed for ${entry.name}`, err);
+      }
+    }
+  },
+};

--- a/packages/platform-core/src/repositories/seoAudit.server.ts
+++ b/packages/platform-core/src/repositories/seoAudit.server.ts
@@ -13,16 +13,27 @@ export interface SeoAuditEntry {
 
 function auditPath(shop: string): string {
   shop = validateShopName(shop);
-  return path.join(DATA_ROOT, shop, "seo-audit.json");
+  return path.join(DATA_ROOT, shop, "seo-audits.jsonl");
 }
 
 export async function readSeoAudits(shop: string): Promise<SeoAuditEntry[]> {
   try {
     const buf = await fs.readFile(auditPath(shop), "utf8");
-    const data = JSON.parse(buf) as SeoAuditEntry[];
-    if (Array.isArray(data)) return data;
+    return buf
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as SeoAuditEntry);
   } catch {
     // ignore file errors
   }
   return [];
+}
+
+export async function appendSeoAudit(
+  shop: string,
+  entry: SeoAuditEntry,
+): Promise<void> {
+  const file = auditPath(shop);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.appendFile(file, JSON.stringify(entry) + "\n", "utf8");
 }


### PR DESCRIPTION
## Summary
- add Cloudflare worker to run SEO audits for each shop and log scores as JSONL
- store and retrieve audit history with recommendations
- visualize SEO score trend and show latest recommendations in CMS

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: PageBuilder interactions › resizes via sidebar inputs; createShopActions missing prisma; env validation)*
- `pnpm --filter @apps/cms test` *(fails: missing Wizard module; env validation)*

------
https://chatgpt.com/codex/tasks/task_e_689b420e7ce8832fa1820ff88800dfd2