### PR TITLE
feat: make AI catalog feed configurable

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogForm.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Button, Input } from "@/components/atoms/shadcn";
+import { formatTimestamp } from "@acme/date-utils";
+import { updateAiCatalog } from "@cms/actions/shops.server";
+import { FormEvent, useState } from "react";
+
+const ALL_FIELDS = ["id", "title", "description", "price", "images"] as const;
+
+interface Props {
+  shop: string;
+  initialFields: string[];
+  initialPageSize: number;
+  lastCrawl?: string;
+}
+
+export default function AiCatalogForm({
+  shop,
+  initialFields,
+  initialPageSize,
+  lastCrawl,
+}: Props) {
+  const [fields, setFields] = useState<string[]>(initialFields);
+  const [pageSize, setPageSize] = useState(initialPageSize);
+  const [saving, setSaving] = useState(false);
+
+  const toggle = (f: string) => {
+    setFields((prev) =>
+      prev.includes(f) ? prev.filter((x) => x !== f) : [...prev, f]
+    );
+  };
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData();
+    fd.append("fields", fields.join(","));
+    fd.append("pageSize", String(pageSize));
+    await updateAiCatalog(shop, fd);
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <h3 className="text-lg font-medium">AI Catalog Feed</h3>
+      <p className="text-sm text-muted-foreground">
+        Last crawl: {lastCrawl ? formatTimestamp(lastCrawl) : "Never"}
+      </p>
+      <div className="space-y-2">
+        {ALL_FIELDS.map((f) => (
+          <label key={f} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={fields.includes(f)}
+              onChange={() => toggle(f)}
+            />
+            <span>{f}</span>
+          </label>
+        ))}
+      </div>
+      <label className="flex flex-col gap-1">
+        <span>Page Size</span>
+        <Input
+          type="number"
+          value={pageSize}
+          onChange={(e) => setPageSize(Number(e.target.value))}
+        />
+      </label>
+      <Button type="submit" disabled={saving}>
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
@@ -3,11 +3,14 @@
 import { getSettings } from "@cms/actions/shops.server";
 import dynamic from "next/dynamic";
 import SeoProgressPanel from "./SeoProgressPanel";
+import { listEvents } from "@platform-core/repositories/analytics.server";
 
 const SeoEditor = dynamic(() => import("./SeoEditor"));
 const SeoAuditPanel = dynamic(() => import("./SeoAuditPanel"));
+const AiCatalogForm = dynamic(() => import("./AiCatalogForm"));
 void SeoEditor;
 void SeoAuditPanel;
+void AiCatalogForm;
 
 export const revalidate = 0;
 
@@ -24,7 +27,14 @@ export default async function SeoSettingsPage({
   const settings = await getSettings(shop);
   const languages = settings.languages;
   const seo = settings.seo ?? {};
+  const ai = seo.aiCatalog ?? { fields: ["id", "title", "description", "price", "images"], pageSize: 50 };
   const freeze = settings.freezeTranslations ?? false;
+  const events = await listEvents(shop);
+  const lastCrawl = events
+    .filter((e) => e.type === "ai_catalog_crawl" && e.timestamp)
+    .map((e) => e.timestamp as string)
+    .sort()
+    .at(-1);
 
   return (
     <div className="space-y-6">
@@ -35,6 +45,12 @@ export default async function SeoSettingsPage({
         languages={languages}
         initialSeo={seo}
         initialFreeze={freeze}
+      />
+      <AiCatalogForm
+        shop={shop}
+        initialFields={ai.fields}
+        initialPageSize={ai.pageSize ?? 50}
+        lastCrawl={lastCrawl}
       />
       <SeoAuditPanel shop={shop} />
     </div>

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -6,5 +6,13 @@
   "depositService": {
     "enabled": false,
     "interval": 60
-  }
+  },
+  "seo": {
+    "aiCatalog": {
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
+    }
+  },
+  "updatedAt": "",
+  "updatedBy": ""
 }

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -6,5 +6,13 @@
   "depositService": {
     "enabled": false,
     "interval": 60
-  }
+  },
+  "seo": {
+    "aiCatalog": {
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
+    }
+  },
+  "updatedAt": "",
+  "updatedBy": ""
 }

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -6,5 +6,13 @@
   "depositService": {
     "enabled": false,
     "interval": 60
-  }
+  },
+  "seo": {
+    "aiCatalog": {
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
+    }
+  },
+  "updatedAt": "",
+  "updatedBy": ""
 }

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -16,6 +16,10 @@
       "title": "t",
       "description": "",
       "image": "ftp://bad"
+    },
+    "aiCatalog": {
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
     }
   },
   "updatedAt": "",

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -3,7 +3,11 @@ import type { NextRequest } from "next/server";
 import { getProductById } from "@platform-core/src/products";
 import { readRepo } from "@platform-core/repositories/products.server";
 import type { ProductPublication } from "@acme/types";
-import { env } from "@acme/config";
+import { getShopSettings } from "@platform-core/src/repositories/settings.server";
+import { DATA_ROOT } from "@platform-core/src/dataRoot";
+import { validateShopName } from "@platform-core/src/shops";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 
 export const runtime = "nodejs";
 
@@ -13,7 +17,11 @@ function parseIntOr(val: string | null, def: number): number {
 }
 
 export async function GET(req: NextRequest) {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = process.env.NEXT_PUBLIC_SHOP_ID || "default";
+  const settings = await getShopSettings(shop);
+  const ai = settings.seo?.aiCatalog;
+  const fields = ai?.fields ?? ["id", "title", "description", "price", "images"];
+  const defaultPageSize = ai?.pageSize ?? 50;
   const all = await readRepo<ProductPublication>(shop);
 
   const lastModifiedDate = all.reduce((max, p) => {
@@ -32,20 +40,41 @@ export async function GET(req: NextRequest) {
 
   const { searchParams } = req.nextUrl;
   const page = parseIntOr(searchParams.get("page"), 1);
-  const limit = parseIntOr(searchParams.get("limit"), 50);
+  const limit = parseIntOr(searchParams.get("limit"), defaultPageSize);
   const start = (page - 1) * limit;
   const paged = all.slice(start, start + limit);
 
   const items = paged.map((p) => {
     const sku = getProductById(p.sku) || {};
-    return {
+    const base: Record<string, unknown> = {
       id: p.id,
       title: p.title,
       description: p.description,
       price: p.price ?? (sku as any).price ?? null,
       images: p.images?.length ? p.images : (sku as any).image ? [(sku as any).image] : [],
     };
+    const filtered: Record<string, unknown> = {};
+    for (const f of fields) {
+      if (f in base) filtered[f] = base[f];
+    }
+    return filtered;
   });
+
+  try {
+    const logPath = path.join(
+      DATA_ROOT,
+      validateShopName(shop),
+      "analytics.jsonl",
+    );
+    const entry = JSON.stringify({
+      type: "ai_catalog_crawl",
+      timestamp: new Date().toISOString(),
+    });
+    await fs.mkdir(path.dirname(logPath), { recursive: true });
+    await fs.appendFile(logPath, entry + "\n", "utf8");
+  } catch {
+    // ignore logging errors
+  }
 
   return NextResponse.json(
     { items, page, total: all.length },

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -1,7 +1,18 @@
 import { z } from "zod";
 export declare const shopSettingsSchema: z.ZodObject<{
     languages: z.ZodReadonly<z.ZodArray<z.ZodEnum<["en", "de", "it"]>, "many">>;
-    seo: z.ZodRecord<z.ZodEnum<["en", "de", "it"]>, z.ZodObject<{
+    seo: z.ZodObject<{
+        aiCatalog: z.ZodOptional<z.ZodObject<{
+            fields: z.ZodArray<z.ZodString, "many">;
+            pageSize: z.ZodOptional<z.ZodNumber>;
+        }, "strip", z.ZodTypeAny, {
+            fields?: string[];
+            pageSize?: number;
+        }, {
+            fields?: string[];
+            pageSize?: number;
+        }>>;
+    }, "strip", z.ZodObject<{
         canonicalBase: z.ZodOptional<z.ZodString>;
         title: z.ZodOptional<z.ZodString>;
         description: z.ZodOptional<z.ZodString>;
@@ -12,15 +23,15 @@ export declare const shopSettingsSchema: z.ZodObject<{
             url: z.ZodOptional<z.ZodString>;
             image: z.ZodOptional<z.ZodString>;
         }, "strip", z.ZodTypeAny, {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            url?: string | undefined;
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
         }, {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            url?: string | undefined;
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
         }>>;
         twitter: z.ZodOptional<z.ZodObject<{
             card: z.ZodOptional<z.ZodString>;
@@ -28,152 +39,337 @@ export declare const shopSettingsSchema: z.ZodObject<{
             description: z.ZodOptional<z.ZodString>;
             image: z.ZodOptional<z.ZodString>;
         }, "strip", z.ZodTypeAny, {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            card?: string | undefined;
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
         }, {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            card?: string | undefined;
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
         }>>;
         structuredData: z.ZodOptional<z.ZodString>;
     }, "strip", z.ZodTypeAny, {
-        title?: string | undefined;
-        image?: string | undefined;
-        description?: string | undefined;
-        canonicalBase?: string | undefined;
+        title?: string;
+        image?: string;
+        description?: string;
+        canonicalBase?: string;
         openGraph?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            url?: string | undefined;
-        } | undefined;
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        };
         twitter?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            card?: string | undefined;
-        } | undefined;
-        structuredData?: string | undefined;
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        };
+        structuredData?: string;
     }, {
-        title?: string | undefined;
-        image?: string | undefined;
-        description?: string | undefined;
-        canonicalBase?: string | undefined;
+        title?: string;
+        image?: string;
+        description?: string;
+        canonicalBase?: string;
         openGraph?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            url?: string | undefined;
-        } | undefined;
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        };
         twitter?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            card?: string | undefined;
-        } | undefined;
-        structuredData?: string | undefined;
-    }>>;
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        };
+        structuredData?: string;
+    }>, z.objectOutputType<{
+        aiCatalog: z.ZodOptional<z.ZodObject<{
+            fields: z.ZodArray<z.ZodString, "many">;
+            pageSize: z.ZodOptional<z.ZodNumber>;
+        }, "strip", z.ZodTypeAny, {
+            fields?: string[];
+            pageSize?: number;
+        }, {
+            fields?: string[];
+            pageSize?: number;
+        }>>;
+    }, z.ZodObject<{
+        canonicalBase: z.ZodOptional<z.ZodString>;
+        title: z.ZodOptional<z.ZodString>;
+        description: z.ZodOptional<z.ZodString>;
+        image: z.ZodOptional<z.ZodString>;
+        openGraph: z.ZodOptional<z.ZodObject<{
+            title: z.ZodOptional<z.ZodString>;
+            description: z.ZodOptional<z.ZodString>;
+            url: z.ZodOptional<z.ZodString>;
+            image: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        }, {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        }>>;
+        twitter: z.ZodOptional<z.ZodObject<{
+            card: z.ZodOptional<z.ZodString>;
+            title: z.ZodOptional<z.ZodString>;
+            description: z.ZodOptional<z.ZodString>;
+            image: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        }, {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        }>>;
+        structuredData: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        title?: string;
+        image?: string;
+        description?: string;
+        canonicalBase?: string;
+        openGraph?: {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        };
+        twitter?: {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        };
+        structuredData?: string;
+    }, {
+        title?: string;
+        image?: string;
+        description?: string;
+        canonicalBase?: string;
+        openGraph?: {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        };
+        twitter?: {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        };
+        structuredData?: string;
+    }>, "strip">, z.objectInputType<{
+        aiCatalog: z.ZodOptional<z.ZodObject<{
+            fields: z.ZodArray<z.ZodString, "many">;
+            pageSize: z.ZodOptional<z.ZodNumber>;
+        }, "strip", z.ZodTypeAny, {
+            fields?: string[];
+            pageSize?: number;
+        }, {
+            fields?: string[];
+            pageSize?: number;
+        }>>;
+    }, z.ZodObject<{
+        canonicalBase: z.ZodOptional<z.ZodString>;
+        title: z.ZodOptional<z.ZodString>;
+        description: z.ZodOptional<z.ZodString>;
+        image: z.ZodOptional<z.ZodString>;
+        openGraph: z.ZodOptional<z.ZodObject<{
+            title: z.ZodOptional<z.ZodString>;
+            description: z.ZodOptional<z.ZodString>;
+            url: z.ZodOptional<z.ZodString>;
+            image: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        }, {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        }>>;
+        twitter: z.ZodOptional<z.ZodObject<{
+            card: z.ZodOptional<z.ZodString>;
+            title: z.ZodOptional<z.ZodString>;
+            description: z.ZodOptional<z.ZodString>;
+            image: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        }, {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        }>>;
+        structuredData: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        title?: string;
+        image?: string;
+        description?: string;
+        canonicalBase?: string;
+        openGraph?: {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        };
+        twitter?: {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        };
+        structuredData?: string;
+    }, {
+        title?: string;
+        image?: string;
+        description?: string;
+        canonicalBase?: string;
+        openGraph?: {
+            url?: string;
+            title?: string;
+            image?: string;
+            description?: string;
+        };
+        twitter?: {
+            title?: string;
+            image?: string;
+            description?: string;
+            card?: string;
+        };
+        structuredData?: string;
+    }>, "strip">>;
     analytics: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodOptional<z.ZodBoolean>;
         provider: z.ZodString;
         id: z.ZodOptional<z.ZodString>;
     }, "strip", z.ZodTypeAny, {
-        enabled?: boolean | undefined;
-        provider: string;
-        id?: string | undefined;
+        id?: string;
+        enabled?: boolean;
+        provider?: string;
     }, {
-        enabled?: boolean | undefined;
-        provider: string;
-        id?: string | undefined;
+        id?: string;
+        enabled?: boolean;
+        provider?: string;
     }>>;
     freezeTranslations: z.ZodOptional<z.ZodBoolean>;
+    /** ISO currency code used as the shop's base currency */
     currency: z.ZodOptional<z.ZodString>;
+    /** Region identifier for tax calculations */
     taxRegion: z.ZodOptional<z.ZodString>;
     depositService: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodBoolean;
         interval: z.ZodNumber;
     }, "strip", z.ZodTypeAny, {
-        enabled: boolean;
-        interval: number;
+        interval?: number;
+        enabled?: boolean;
     }, {
-        enabled: boolean;
-        interval: number;
+        interval?: number;
+        enabled?: boolean;
     }>>;
     updatedAt: z.ZodString;
     updatedBy: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    seo: Partial<Record<"en" | "de" | "it", {
-        title?: string | undefined;
-        image?: string | undefined;
-        description?: string | undefined;
-        canonicalBase?: string | undefined;
-        openGraph?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            url?: string | undefined;
-        } | undefined;
-        twitter?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            card?: string | undefined;
-        } | undefined;
-        structuredData?: string | undefined;
-    }>>;
-    updatedAt: string;
-    languages: readonly ("en" | "de" | "it")[];
-    updatedBy: string;
+    currency?: string;
+    languages?: readonly ("en" | "de" | "it")[];
+    seo?: {
+        aiCatalog?: {
+            fields?: string[];
+            pageSize?: number;
+        };
+    } & {
+        [k: string]: {
+            title?: string;
+            image?: string;
+            description?: string;
+            canonicalBase?: string;
+            openGraph?: {
+                url?: string;
+                title?: string;
+                image?: string;
+                description?: string;
+            };
+            twitter?: {
+                title?: string;
+                image?: string;
+                description?: string;
+                card?: string;
+            };
+            structuredData?: string;
+        };
+    };
     analytics?: {
-        enabled?: boolean | undefined;
-        provider: string;
-        id?: string | undefined;
-    } | undefined;
-    freezeTranslations?: boolean | undefined;
-    currency?: string | undefined;
-    taxRegion?: string | undefined;
+        id?: string;
+        enabled?: boolean;
+        provider?: string;
+    };
+    freezeTranslations?: boolean;
+    taxRegion?: string;
     depositService?: {
-        enabled: boolean;
-        interval: number;
-    } | undefined;
+        interval?: number;
+        enabled?: boolean;
+    };
+    updatedAt?: string;
+    updatedBy?: string;
 }, {
-    seo: Partial<Record<"en" | "de" | "it", {
-        title?: string | undefined;
-        image?: string | undefined;
-        description?: string | undefined;
-        canonicalBase?: string | undefined;
-        openGraph?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            url?: string | undefined;
-        } | undefined;
-        twitter?: {
-            title?: string | undefined;
-            image?: string | undefined;
-            description?: string | undefined;
-            card?: string | undefined;
-        } | undefined;
-        structuredData?: string | undefined;
-    }>>;
-    updatedAt: string;
-    languages: readonly ("en" | "de" | "it")[];
-    updatedBy: string;
+    currency?: string;
+    languages?: readonly ("en" | "de" | "it")[];
+    seo?: {
+        aiCatalog?: {
+            fields?: string[];
+            pageSize?: number;
+        };
+    } & {
+        [k: string]: {
+            title?: string;
+            image?: string;
+            description?: string;
+            canonicalBase?: string;
+            openGraph?: {
+                url?: string;
+                title?: string;
+                image?: string;
+                description?: string;
+            };
+            twitter?: {
+                title?: string;
+                image?: string;
+                description?: string;
+                card?: string;
+            };
+            structuredData?: string;
+        };
+    };
     analytics?: {
-        enabled?: boolean | undefined;
-        provider: string;
-        id?: string | undefined;
-    } | undefined;
-    freezeTranslations?: boolean | undefined;
-    currency?: string | undefined;
-    taxRegion?: string | undefined;
+        id?: string;
+        enabled?: boolean;
+        provider?: string;
+    };
+    freezeTranslations?: boolean;
+    taxRegion?: string;
     depositService?: {
-        enabled: boolean;
-        interval: number;
-    } | undefined;
+        interval?: number;
+        enabled?: boolean;
+    };
+    updatedAt?: string;
+    updatedBy?: string;
 }>;
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
-//# sourceMappingURL=ShopSettings.d.ts.map

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -2,9 +2,18 @@ import { z } from "zod";
 import { localeSchema } from "./Product";
 import { shopSeoFieldsSchema } from "./Shop";
 
+const aiCatalogSchema = z.object({
+  fields: z.array(z.string()),
+  pageSize: z.number().int().positive().optional(),
+});
+
 export const shopSettingsSchema = z.object({
   languages: z.array(localeSchema).readonly(),
-  seo: z.record(localeSchema, shopSeoFieldsSchema),
+  seo: z
+    .object({
+      aiCatalog: aiCatalogSchema.optional(),
+    })
+    .catchall(shopSeoFieldsSchema),
   analytics: z
     .object({
       enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- add aiCatalog settings per shop for feed fields and pagination
- expose API catalog feed respecting settings and logging crawl events
- allow CMS owners to configure fields, page size, and view last crawl

## Testing
- `STRIPE_SECRET_KEY=1 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=1 CART_COOKIE_SECRET=1 pnpm jest packages/template-app/__tests__/ai-catalog.test.ts apps/cms/__tests__/seoProgressPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689b420f3210832fa85e25a2ea4feea4