### PR TITLE
feat: add image slider block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -146,6 +146,16 @@ export interface GalleryComponent extends PageComponentBase {
     alt?: string;
   }[];
 }
+export interface ImageSliderComponent extends PageComponentBase {
+  type: "ImageSlider";
+  slides?: {
+    src: string;
+    alt?: string;
+    caption?: string;
+  }[];
+  minItems?: number;
+  maxItems?: number;
+}
 export interface ContactFormComponent extends PageComponentBase {
   type: "ContactForm";
   action?: string;
@@ -250,6 +260,7 @@ export type PageComponent =
   | ProductCarouselComponent
   | RecommendationCarouselComponent
   | GalleryComponent
+  | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
   | ContactFormWithMapComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -168,6 +168,13 @@ export interface GalleryComponent extends PageComponentBase {
   images?: { src: string; alt?: string }[];
 }
 
+export interface ImageSliderComponent extends PageComponentBase {
+  type: "ImageSlider";
+  slides?: { src: string; alt?: string; caption?: string }[];
+  minItems?: number;
+  maxItems?: number;
+}
+
 export interface ContactFormComponent extends PageComponentBase {
   type: "ContactForm";
   action?: string;
@@ -293,6 +300,7 @@ export type PageComponent =
   | ProductCarouselComponent
   | RecommendationCarouselComponent
   | GalleryComponent
+  | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
   | ContactFormWithMapComponent

--- a/packages/ui/src/components/cms/blocks/ImageSlider.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/ImageSlider.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ImageSlider from "./ImageSlider";
+
+const meta: Meta<typeof ImageSlider> = {
+  component: ImageSlider,
+  args: {
+    slides: [
+      { src: "/hero/slide-1.jpg", alt: "Slide 1", caption: "Caption 1" },
+      { src: "/hero/slide-2.jpg", alt: "Slide 2", caption: "Caption 2" },
+    ],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ImageSlider> = {};

--- a/packages/ui/src/components/cms/blocks/ImageSlider.tsx
+++ b/packages/ui/src/components/cms/blocks/ImageSlider.tsx
@@ -1,0 +1,78 @@
+"use client";
+import { useState } from "react";
+
+export type ImageSlide = {
+  src: string;
+  alt?: string;
+  caption?: string;
+};
+
+interface Props {
+  slides?: ImageSlide[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export default function ImageSlider({
+  slides = [],
+  minItems,
+  maxItems,
+}: Props) {
+  const list = slides.slice(0, maxItems ?? slides.length);
+  const [index, setIndex] = useState(0);
+
+  if (!list.length || list.length < (minItems ?? 0)) return null;
+
+  const next = () => setIndex((i) => (i + 1) % list.length);
+  const prev = () => setIndex((i) => (i - 1 + list.length) % list.length);
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowRight") next();
+    else if (e.key === "ArrowLeft") prev();
+  };
+
+  return (
+    <div
+      className="relative"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Image Slider"
+      tabIndex={0}
+      onKeyDown={handleKey}
+    >
+      {list.map((img, i) => (
+        <figure
+          key={img.src}
+          className={i === index ? "block" : "hidden"}
+          aria-hidden={i !== index}
+        >
+          <img src={img.src} alt={img.alt ?? ""} className="w-full object-cover" />
+          {img.caption && (
+            <figcaption className="text-center text-sm" aria-live="polite">
+              {img.caption}
+            </figcaption>
+          )}
+        </figure>
+      ))}
+      {list.length > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={prev}
+            aria-label="Previous slide"
+            className="absolute left-2 top-1/2 -translate-y-1/2 rounded bg-black/50 p-2 text-white"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            aria-label="Next slide"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded bg-black/50 p-2 text-white"
+          >
+            ›
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/__tests__/ImageSlider.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ImageSlider.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import ImageSlider from "../ImageSlider";
+
+describe("ImageSlider", () => {
+  it("renders first slide", () => {
+    render(
+      <ImageSlider
+        slides={[
+          { src: "/a.jpg", alt: "a" },
+          { src: "/b.jpg", alt: "b" },
+        ]}
+      />
+    );
+    expect(screen.getByAltText("a")).toBeInTheDocument();
+  });
+
+  it("advances to next slide", () => {
+    render(
+      <ImageSlider
+        slides={[
+          { src: "/a.jpg", alt: "a" },
+          { src: "/b.jpg", alt: "b" },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /next slide/i }));
+    expect(screen.getByAltText("b")).toBeInTheDocument();
+  });
+
+  it("returns null when below minItems", () => {
+    const { container } = render(
+      <ImageSlider slides={[{ src: "/a.jpg" }]} minItems={2} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -25,6 +25,7 @@ import PricingTable from "./PricingTable";
 import SocialFeed from "./SocialFeed";
 import NewsletterSignup from "./NewsletterSignup";
 import Tabs from "./Tabs";
+import ImageSlider from "./ImageSlider";
 
 export {
   BlogListing,
@@ -52,6 +53,7 @@ export {
   SocialFeed,
   Button,
   NewsletterSignup,
+  ImageSlider,
   PricingTable,
   Tabs,
 };

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -20,6 +20,7 @@ import SocialFeed from "./SocialFeed";
 import PricingTable from "./PricingTable";
 import NewsletterSignup from "./NewsletterSignup";
 import Tabs from "./Tabs";
+import ImageSlider from "./ImageSlider";
 
 export const organismRegistry = {
   AnnouncementBar,
@@ -29,6 +30,7 @@ export const organismRegistry = {
   ProductGrid,
   ProductCarousel,
   RecommendationCarousel,
+  ImageSlider,
   Gallery,
   ContactForm,
   ContactFormWithMap,

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -29,6 +29,7 @@ import HeaderEditor from "./HeaderEditor";
 import FooterEditor from "./FooterEditor";
 import PricingTableEditor from "./PricingTableEditor";
 import NewsletterSignupEditor from "./NewsletterSignupEditor";
+import ImageSliderEditor from "./ImageSliderEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -93,6 +94,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = (
         <NewsletterSignupEditor component={component} onChange={onChange} />
       );
+      break;
+    case "ImageSlider":
+      specific = <ImageSliderEditor component={component} onChange={onChange} />;
       break;
     case "ValueProps":
       specific = <ValuePropsEditor component={component} onChange={onChange} />;

--- a/packages/ui/src/components/cms/page-builder/ImageSliderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImageSliderEditor.tsx
@@ -1,0 +1,89 @@
+import type { PageComponent } from "@acme/types";
+import { Button, Input } from "../../atoms/shadcn";
+import ImagePicker from "./ImagePicker";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ImageSliderEditor({ component, onChange }: Props) {
+  const slides = ((component as any).slides ?? []) as any[];
+  const min = (component as any).minItems ?? 0;
+  const max = (component as any).maxItems ?? Infinity;
+
+  const update = (idx: number, field: string, value: string) => {
+    const next = [...slides];
+    next[idx] = { ...next[idx], [field]: value };
+    onChange({ slides: next } as Partial<PageComponent>);
+  };
+
+  const move = (from: number, to: number) => {
+    const next = [...slides];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    onChange({ slides: next } as Partial<PageComponent>);
+  };
+
+  const remove = (idx: number) => {
+    const next = slides.filter((_: unknown, i: number) => i !== idx);
+    onChange({ slides: next } as Partial<PageComponent>);
+  };
+
+  const add = () => {
+    onChange({ slides: [...slides, { src: "", alt: "", caption: "" }] } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      {slides.map((s, idx) => (
+        <div key={idx} className="space-y-1 rounded border p-2">
+          <div className="flex items-start gap-2">
+            <Input
+              value={s.src ?? ""}
+              onChange={(e) => update(idx, "src", e.target.value)}
+              placeholder="src"
+              className="flex-1"
+            />
+            <ImagePicker onSelect={(url) => update(idx, "src", url)}>
+              <Button type="button" variant="outline">Pick</Button>
+            </ImagePicker>
+          </div>
+          <Input
+            value={s.alt ?? ""}
+            onChange={(e) => update(idx, "alt", e.target.value)}
+            placeholder="alt"
+          />
+          <Input
+            value={s.caption ?? ""}
+            onChange={(e) => update(idx, "caption", e.target.value)}
+            placeholder="caption"
+          />
+          <div className="flex gap-2">
+            <Button type="button" onClick={() => move(idx, idx - 1)} disabled={idx === 0}>
+              Up
+            </Button>
+            <Button
+              type="button"
+              onClick={() => move(idx, idx + 1)}
+              disabled={idx === slides.length - 1}
+            >
+              Down
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => remove(idx)}
+              disabled={slides.length <= min}
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ))}
+      <Button onClick={add} disabled={slides.length >= max}>
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -57,6 +57,7 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   RecommendationCarousel: { minItems: 1, maxItems: 4 },
   Testimonials: { minItems: 1, maxItems: 10 },
   TestimonialSlider: { minItems: 1, maxItems: 10 },
+  ImageSlider: { minItems: 1, maxItems: 10 },
   AnnouncementBar: {
     position: "absolute",
     top: "0",

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -13,6 +13,7 @@ export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as PricingTableEditor } from "./PricingTableEditor";
 export { default as NewsletterSignupEditor } from "./NewsletterSignupEditor";
+export { default as ImageSliderEditor } from "./ImageSliderEditor";
 export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";


### PR DESCRIPTION
## Summary
- add accessible ImageSlider carousel component
- integrate ImageSlider editor and register block in CMS
- add Storybook story, tests, and type definitions

## Testing
- `pnpm test src/components/cms/blocks/__tests__/ImageSlider.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689b427814b4832fb26a5b2a84564e78