### PR TITLE
feat: support theme overrides in shop creation

### DIFF
--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -24,7 +24,7 @@ export async function createShop(
 
   const prepared = prepareOptions(id, opts);
 
-  const themeOverrides: Record<string, string> = {};
+  const themeOverrides: Record<string, string> = prepared.themeOverrides;
   const themeDefaults = loadTokens(prepared.theme);
   const themeTokens = { ...themeDefaults, ...themeOverrides };
 
@@ -167,10 +167,13 @@ export function syncTheme(shop: string, theme: string): Record<string, string> {
   return loadTokens(theme);
 }
 
-export const createShopOptionsSchema =
-  baseCreateShopOptionsSchema.strict();
+export const createShopOptionsSchema = baseCreateShopOptionsSchema.strict();
 export { prepareOptions };
 export type { CreateShopOptions, PreparedCreateShopOptions };
-export { ensureTemplateExists, writeFiles, copyTemplate } from "./createShop/fsUtils";
+export {
+  ensureTemplateExists,
+  writeFiles,
+  copyTemplate,
+} from "./createShop/fsUtils";
 export { loadTokens, loadBaseTokens } from "./createShop/themeUtils";
 export { syncTheme };

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -24,40 +24,41 @@ const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
 
 export const createShopOptionsSchema = z
   .object({
-  name: z.string().optional(),
-  logo: z.string().url().optional(),
-  contactInfo: z.string().optional(),
-  type: z.enum(["sale", "rental"]).optional(),
-  theme: z.string().optional(),
-  template: z.string().optional(),
-  payment: z.array(z.enum(defaultPaymentProviders)).default([]),
-  shipping: z.array(z.enum(defaultShippingProviders)).default([]),
-  tax: z.enum(defaultTaxProviders).default("taxjar"),
-  pageTitle: z.record(localeSchema, z.string()).optional(),
-  pageDescription: z.record(localeSchema, z.string()).optional(),
-  socialImage: z.string().url().optional(),
-  analytics: z
-    .object({
-      enabled: z.boolean().optional(),
-      provider: z.string(),
-      id: z.string().optional(),
-    })
-    .optional(),
-  sanityBlog: sanityBlogConfigSchema.optional(),
-  navItems: z.array(navItemSchema).default([]),
-  pages: z
-    .array(
-      z.object({
-        slug: z.string(),
-        title: z.record(localeSchema, z.string()),
-        description: z.record(localeSchema, z.string()).optional(),
-        image: z.record(localeSchema, z.string()).optional(),
-        components: z.array(pageComponentSchema),
+    name: z.string().optional(),
+    logo: z.string().url().optional(),
+    contactInfo: z.string().optional(),
+    type: z.enum(["sale", "rental"]).optional(),
+    theme: z.string().optional(),
+    themeOverrides: z.record(z.string()).default({}),
+    template: z.string().optional(),
+    payment: z.array(z.enum(defaultPaymentProviders)).default([]),
+    shipping: z.array(z.enum(defaultShippingProviders)).default([]),
+    tax: z.enum(defaultTaxProviders).default("taxjar"),
+    pageTitle: z.record(localeSchema, z.string()).optional(),
+    pageDescription: z.record(localeSchema, z.string()).optional(),
+    socialImage: z.string().url().optional(),
+    analytics: z
+      .object({
+        enabled: z.boolean().optional(),
+        provider: z.string(),
+        id: z.string().optional(),
       })
-    )
-    .default([]),
-  checkoutPage: z.array(pageComponentSchema).default([]),
-})
+      .optional(),
+    sanityBlog: sanityBlogConfigSchema.optional(),
+    navItems: z.array(navItemSchema).default([]),
+    pages: z
+      .array(
+        z.object({
+          slug: z.string(),
+          title: z.record(localeSchema, z.string()),
+          description: z.record(localeSchema, z.string()).optional(),
+          image: z.record(localeSchema, z.string()).optional(),
+          components: z.array(pageComponentSchema),
+        })
+      )
+      .default([]),
+    checkoutPage: z.array(pageComponentSchema).default([]),
+  })
   .strict();
 
 export type CreateShopOptions = z.infer<typeof createShopOptionsSchema>;
@@ -93,13 +94,14 @@ export function prepareOptions(
     type: parsed.type ?? "sale",
     theme: parsed.theme ?? "base",
     template: parsed.template ?? "template-app",
+    themeOverrides: parsed.themeOverrides ?? {},
     payment: parsed.payment,
     shipping: parsed.shipping,
     tax: parsed.tax,
     pageTitle: fillLocales(parsed.pageTitle, "Home"),
     pageDescription: fillLocales(parsed.pageDescription, ""),
     socialImage: parsed.socialImage ?? "",
-  analytics: parsed.analytics
+    analytics: parsed.analytics
       ? {
           enabled: parsed.analytics.enabled !== false,
           provider: parsed.analytics.provider ?? "none",


### PR DESCRIPTION
## Summary
- allow theme overrides via schema and prepareOptions
- compute and submit theme overrides from CMS configurator
- use provided theme overrides when creating shop data

## Testing
- `pnpm test --filter @acme/platform-core --filter @apps/cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm lint --filter @acme/platform-core --filter @apps/cms` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689b428702b4832f8d289be53f81e823