### PR TITLE
refactor: modularize env schema

### DIFF
--- a/functions/marketing-email-sender.ts
+++ b/functions/marketing-email-sender.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { sendCampaignEmail } from "@acme/email";
 import { trackEvent } from "@platform-core/analytics";
 import { DATA_ROOT } from "@platform-core/dataRoot";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 interface Campaign {
   id: string;
@@ -45,7 +45,7 @@ export async function sendScheduledCampaigns(): Promise<void> {
     let changed = false;
     for (const c of campaigns) {
       if (c.sentAt || new Date(c.sendAt) > now) continue;
-      const base = env.NEXT_PUBLIC_BASE_URL || "";
+      const base = coreEnv.NEXT_PUBLIC_BASE_URL || "";
       const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
         shop
       )}&campaign=${encodeURIComponent(c.id)}`;

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -85,7 +85,7 @@ module.exports = {
     "^@platform-core/repositories/shopSettings$":
       "<rootDir>/packages/platform-core/src/repositories/settings.server.ts",
     "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
-    "^@acme/config$": "<rootDir>/packages/config/src/env.ts",
+    "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
 
     // context mocks

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -2,7 +2,7 @@
 import { cookies, headers } from "next/headers";
 import { sealData, unsealData } from "iron-session";
 import { randomUUID } from "node:crypto";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import type { Role } from "./types";
 import type { SessionRecord } from "./store";
 import { createSessionStore, SESSION_TTL_S } from "./store";
@@ -28,7 +28,7 @@ function cookieOptions() {
     secure: true,
     path: "/",
     maxAge: SESSION_TTL_S,
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   };
 }
 
@@ -39,12 +39,12 @@ function csrfCookieOptions() {
     secure: true,
     path: "/",
     maxAge: SESSION_TTL_S,
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   };
 }
 
 export async function getCustomerSession(): Promise<CustomerSession | null> {
-  const secret = env.SESSION_SECRET;
+  const secret = coreEnv.SESSION_SECRET;
   if (!secret) return null;
   const store = await cookies();
   const token = store.get(CUSTOMER_SESSION_COOKIE)?.value;
@@ -118,7 +118,7 @@ export async function destroyCustomerSession(): Promise<void> {
   const store = await cookies();
   const token = store.get(CUSTOMER_SESSION_COOKIE)?.value;
   if (token) {
-    const secret = env.SESSION_SECRET;
+    const secret = coreEnv.SESSION_SECRET;
     if (secret) {
       try {
         const session = await unsealData<InternalSession>(token, {
@@ -132,11 +132,11 @@ export async function destroyCustomerSession(): Promise<void> {
   }
   store.delete(CUSTOMER_SESSION_COOKIE, {
     path: "/",
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   });
   store.delete(CSRF_TOKEN_COOKIE, {
     path: "/",
-    domain: env.COOKIE_DOMAIN,
+    domain: coreEnv.COOKIE_DOMAIN,
   });
 }
 

--- a/packages/auth/src/store.ts
+++ b/packages/auth/src/store.ts
@@ -1,4 +1,4 @@
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7; // one week
 export const SESSION_TTL_S = Math.floor(SESSION_TTL_MS / 1000);
@@ -30,17 +30,19 @@ export async function createSessionStore(): Promise<SessionStore> {
     return customFactory();
   }
 
-  const storeType = env.SESSION_STORE;
+  const storeType = coreEnv.SESSION_STORE;
 
   if (
     storeType === "redis" ||
-    (!storeType && env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN)
+    (!storeType &&
+      coreEnv.UPSTASH_REDIS_REST_URL &&
+      coreEnv.UPSTASH_REDIS_REST_TOKEN)
   ) {
     const { Redis } = await import("@upstash/redis");
     const { RedisSessionStore } = await import("./redisStore");
     const client = new Redis({
-      url: env.UPSTASH_REDIS_REST_URL!,
-      token: env.UPSTASH_REDIS_REST_TOKEN!,
+      url: coreEnv.UPSTASH_REDIS_REST_URL!,
+      token: coreEnv.UPSTASH_REDIS_REST_TOKEN!,
     });
     return new RedisSessionStore(client, SESSION_TTL_S);
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./env.ts",
-    "./env": "./env.ts",
+    ".": "./env/index.ts",
+    "./env": "./env/index.ts",
+    "./env/core": "./env/core.ts",
+    "./env/payments": "./env/payments.ts",
+    "./env/shipping": "./env/shipping.ts",
     "./tsconfig.app.json": "./tsconfig.app.json",
     "./jest.preset.cjs": "./jest.preset.cjs"
   }

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 import { applyFriendlyZodMessages } from "@acme/lib";
 
-export const envSchema = z.object({
-  STRIPE_SECRET_KEY: z.string().min(1),
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
+export const coreEnvSchema = z.object({
   NEXTAUTH_SECRET: z.string().optional(),
   PREVIEW_TOKEN_SECRET: z.string().optional(),
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
@@ -26,39 +24,30 @@ export const envSchema = z.object({
   SANITY_API_VERSION: z.string().optional(),
   CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
   CLOUDFLARE_API_TOKEN: z.string().optional(),
-  DEPOSIT_RELEASE_ENABLED: z.enum(["true", "false"]).optional(),
+  DEPOSIT_RELEASE_ENABLED: z.coerce.boolean().optional(),
   DEPOSIT_RELEASE_INTERVAL_MS: z.coerce.number().optional(),
   OPENAI_API_KEY: z.string().optional(),
-  TAXJAR_KEY: z.string().optional(),
-  UPS_KEY: z.string().optional(),
-  DHL_KEY: z.string().optional(),
   SESSION_SECRET: z.string().optional(),
   COOKIE_DOMAIN: z.string().optional(),
   LOGIN_RATE_LIMIT_REDIS_URL: z.string().url().optional(),
   LOGIN_RATE_LIMIT_REDIS_TOKEN: z.string().optional(),
   NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
-  // Comma separated list of email recipients for stock alerts
   STOCK_ALERT_RECIPIENTS: z.string().optional(),
-  // Optional webhook URL for stock alerts
   STOCK_ALERT_WEBHOOK: z.string().url().optional(),
-  // Default low stock threshold if an item does not specify one
   STOCK_ALERT_DEFAULT_THRESHOLD: z.coerce.number().optional(),
-  // Legacy single-recipient support
   STOCK_ALERT_RECIPIENT: z.string().email().optional(),
   SESSION_STORE: z.enum(["memory", "redis"]).optional(),
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
-  DEPOSIT_RELEASE_ENABLED: z.coerce.boolean().optional(),
-  DEPOSIT_RELEASE_INTERVAL_MS: z.coerce.number().optional(),
 });
 
 applyFriendlyZodMessages();
 
-const parsed = envSchema.safeParse(process.env);
+const parsed = coreEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  console.error("❌ Invalid environment variables:", parsed.error.format());
+  console.error("❌ Invalid core environment variables:", parsed.error.format());
   process.exit(1);
 }
 
-export const env = parsed.data;
-export type Env = z.infer<typeof envSchema>;
+export const coreEnv = parsed.data;
+export type CoreEnv = z.infer<typeof coreEnvSchema>;

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { applyFriendlyZodMessages } from "@acme/lib";
+import { coreEnvSchema } from "./core";
+import { paymentEnvSchema } from "./payments";
+import { shippingEnvSchema } from "./shipping";
+
+export const mergeEnvSchemas = (
+  ...schemas: z.ZodObject<any, any, any, any, any>[]
+) => schemas.reduce((acc, s) => acc.merge(s), z.object({}));
+
+export const envSchema = mergeEnvSchemas(
+  coreEnvSchema,
+  paymentEnvSchema,
+  shippingEnvSchema,
+);
+
+applyFriendlyZodMessages();
+
+const parsed = envSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error("❌ Invalid environment variables:", parsed.error.format());
+  process.exit(1);
+}
+
+export const env = parsed.data;
+export type Env = z.infer<typeof envSchema>;
+
+export * from "./core";
+export * from "./payments";
+export * from "./shipping";

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { applyFriendlyZodMessages } from "@acme/lib";
+
+export const paymentEnvSchema = z.object({
+  STRIPE_SECRET_KEY: z.string().min(1),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
+});
+
+applyFriendlyZodMessages();
+
+const parsed = paymentEnvSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error(
+    "❌ Invalid payment environment variables:",
+    parsed.error.format(),
+  );
+  process.exit(1);
+}
+
+export const paymentEnv = parsed.data;
+export type PaymentEnv = z.infer<typeof paymentEnvSchema>;

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { applyFriendlyZodMessages } from "@acme/lib";
+
+export const shippingEnvSchema = z.object({
+  TAXJAR_KEY: z.string().optional(),
+  UPS_KEY: z.string().optional(),
+  DHL_KEY: z.string().optional(),
+});
+
+applyFriendlyZodMessages();
+
+const parsed = shippingEnvSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error(
+    "❌ Invalid shipping environment variables:",
+    parsed.error.format(),
+  );
+  process.exit(1);
+}
+
+export const shippingEnv = parsed.data;
+export type ShippingEnv = z.infer<typeof shippingEnvSchema>;

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,5 +1,5 @@
 import nodemailer from "nodemailer";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export interface CampaignOptions {
   /** Recipient email address */
@@ -20,11 +20,11 @@ export async function sendCampaignEmail(
   options: CampaignOptions
 ): Promise<void> {
   const transport = nodemailer.createTransport({
-    url: env.SMTP_URL,
+    url: coreEnv.SMTP_URL,
   });
 
   await transport.sendMail({
-    from: env.CAMPAIGN_FROM || "no-reply@example.com",
+    from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
     to: options.to,
     subject: options.subject,
     html: options.html,

--- a/packages/email/src/sendEmail.ts
+++ b/packages/email/src/sendEmail.ts
@@ -1,16 +1,16 @@
 // packages/email/src/sendEmail.ts
 
-import { env } from "@config/src/env";
+import { coreEnv } from "@acme/config/env/core";
 import nodemailer from "nodemailer";
 
-const hasCreds = env.GMAIL_USER && env.GMAIL_PASS;
+const hasCreds = coreEnv.GMAIL_USER && coreEnv.GMAIL_PASS;
 
 const transporter = hasCreds
   ? nodemailer.createTransport({
       service: "gmail",
       auth: {
-        user: env.GMAIL_USER,
-        pass: env.GMAIL_PASS,
+        user: coreEnv.GMAIL_USER,
+        pass: coreEnv.GMAIL_PASS,
       },
     })
   : null;
@@ -23,7 +23,7 @@ export async function sendEmail(
   if (transporter) {
     try {
       await transporter.sendMail({
-        from: env.GMAIL_USER,
+        from: coreEnv.GMAIL_USER,
         to,
         subject,
         text: body,

--- a/packages/next-config/index.mjs
+++ b/packages/next-config/index.mjs
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -40,11 +40,11 @@ export const baseConfig = {
   // bundlePagesRouterDependencies: true,
 
   // Keep the existing "static export in CI only" logic
-  ...(env.OUTPUT_EXPORT ? { output: "export" } : {}),
+  ...(coreEnv.OUTPUT_EXPORT ? { output: "export" } : {}),
 
   env: {
-    NEXT_PUBLIC_PHASE: env.NEXT_PUBLIC_PHASE || "demo",
-    NEXT_PUBLIC_DEFAULT_SHOP: env.NEXT_PUBLIC_DEFAULT_SHOP || firstShop,
+    NEXT_PUBLIC_PHASE: coreEnv.NEXT_PUBLIC_PHASE || "demo",
+    NEXT_PUBLIC_DEFAULT_SHOP: coreEnv.NEXT_PUBLIC_DEFAULT_SHOP || firstShop,
   },
 };
 
@@ -54,7 +54,7 @@ export const baseConfig = {
  * @param {import('next').NextConfig} [config={}] - Additional Next.js config.
  * @returns {import('next').NextConfig}
  */
-export function withShopCode(shopCode = env.SHOP_CODE, config = {}) {
+export function withShopCode(shopCode = coreEnv.SHOP_CODE, config = {}) {
   return {
     ...baseConfig,
     ...config,

--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { baseConfig, withShopCode } from "./index.mjs";
 
 /* ------------------------------------------------------------------ */
@@ -9,7 +9,7 @@ import { baseConfig, withShopCode } from "./index.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export default withShopCode(env.SHOP_CODE, {
+export default withShopCode(coreEnv.SHOP_CODE, {
   /* 1️⃣ ‒ keep CI/production green even if ESLint finds issues */
   eslint: { ignoreDuringBuilds: true },
 

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -5,7 +5,7 @@ import { nowIso } from "@acme/date-utils";
 import { DATA_ROOT } from "./dataRoot";
 import { validateShopName } from "./shops";
 import { getShopSettings, readShop } from "./repositories/shops.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export interface AnalyticsEvent {
   type: string;
@@ -101,7 +101,7 @@ async function resolveProvider(shop: string): Promise<AnalyticsProvider> {
   }
   if (analytics.provider === "ga") {
     const measurementId = analytics.id;
-    const apiSecret = env.GA_API_SECRET;
+    const apiSecret = coreEnv.GA_API_SECRET;
     if (measurementId && apiSecret) {
       const p = new GoogleAnalyticsProvider(measurementId, apiSecret);
       providerCache.set(shop, p);

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -2,7 +2,7 @@
 import crypto from "crypto";
 import { z } from "zod";
 
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { skuSchema } from "@acme/types";
 
 /* ------------------------------------------------------------------
@@ -10,7 +10,7 @@ import { skuSchema } from "@acme/types";
  * ------------------------------------------------------------------ */
 export const CART_COOKIE = "__Host-CART_ID";
 const MAX_AGE = 60 * 60 * 24 * 30; // 30 days
-const SECRET = env.CART_COOKIE_SECRET;
+const SECRET = coreEnv.CART_COOKIE_SECRET;
 
 if (!SECRET) {
   throw new Error("env.CART_COOKIE_SECRET is required");

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -1,5 +1,5 @@
 import { Redis } from "@upstash/redis";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import type { CartState } from "./cartCookie";
 import type { SKU } from "@acme/types";
 import { MemoryCartStore } from "./cartStore/memoryStore";
@@ -41,21 +41,21 @@ export function createRedisCartStore(
 }
 
 export function createCartStore(options: CartStoreOptions = {}): CartStore {
-  const ttl = options.ttlSeconds ?? Number(env.CART_TTL ?? DEFAULT_TTL);
+  const ttl = options.ttlSeconds ?? Number(coreEnv.CART_TTL ?? DEFAULT_TTL);
   const backend =
     options.backend ??
-    env.SESSION_STORE ??
-    (env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
+    coreEnv.SESSION_STORE ??
+    (coreEnv.UPSTASH_REDIS_REST_URL && coreEnv.UPSTASH_REDIS_REST_TOKEN
       ? "redis"
       : "memory");
 
   if (backend === "redis") {
     const client =
       options.redis ??
-      (env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
+      (coreEnv.UPSTASH_REDIS_REST_URL && coreEnv.UPSTASH_REDIS_REST_TOKEN
         ? new Redis({
-            url: env.UPSTASH_REDIS_REST_URL,
-            token: env.UPSTASH_REDIS_REST_TOKEN,
+            url: coreEnv.UPSTASH_REDIS_REST_URL,
+            token: coreEnv.UPSTASH_REDIS_REST_TOKEN,
           })
         : undefined);
     if (client) {

--- a/packages/platform-core/src/configurator.ts
+++ b/packages/platform-core/src/configurator.ts
@@ -1,4 +1,4 @@
-import { envSchema } from "@config/src/env";
+import { envSchema } from "@acme/config/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,8 +1,8 @@
 import { PrismaClient } from "@prisma/client";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 const databaseUrl =
-  env.DATABASE_URL ?? "file:./packages/platform-core/dev.db";
+  coreEnv.DATABASE_URL ?? "file:./packages/platform-core/dev.db";
 
 export const prisma = new PrismaClient({
   datasources: { db: { url: databaseUrl } },

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { env } from "@config/src/env";
+import { coreEnv } from "@acme/config/env/core";
 import { DATA_ROOT } from "../dataRoot";
 import { sendEmail } from "@acme/email";
 import { promises as fs } from "node:fs";
@@ -33,8 +33,9 @@ export async function checkAndAlert(
   shop: string,
   items: InventoryItem[],
 ): Promise<void> {
-  const recipientRaw = env.STOCK_ALERT_RECIPIENTS ?? env.STOCK_ALERT_RECIPIENT;
-  const webhook = env.STOCK_ALERT_WEBHOOK;
+  const recipientRaw =
+    coreEnv.STOCK_ALERT_RECIPIENTS ?? coreEnv.STOCK_ALERT_RECIPIENT;
+  const webhook = coreEnv.STOCK_ALERT_WEBHOOK;
   if (!recipientRaw && !webhook) return;
 
   const recipients = recipientRaw
@@ -50,7 +51,7 @@ export async function checkAndAlert(
       const threshold =
         typeof i.lowStockThreshold === "number"
           ? i.lowStockThreshold
-          : env.STOCK_ALERT_DEFAULT_THRESHOLD;
+          : coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD;
       return typeof threshold === "number" && i.quantity <= threshold;
     })
     .filter((i) => {
@@ -66,7 +67,7 @@ export async function checkAndAlert(
       .join(", ");
     const variant = attrs ? ` (${attrs})` : "";
     const threshold =
-      i.lowStockThreshold ?? env.STOCK_ALERT_DEFAULT_THRESHOLD;
+      i.lowStockThreshold ?? coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD;
     return `${i.sku}${variant} – qty ${i.quantity} (threshold ${threshold})`;
   });
   const body = `The following items in shop ${shop} are low on stock:\n${lines.join("\n")}`;

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -1,6 +1,6 @@
 // packages/platform-core/src/shipping/index.ts
 
-import { env } from "@acme/config";
+import { shippingEnv } from "@acme/config/env/shipping";
 
 export interface ShippingRateRequest {
   provider: "ups" | "dhl";
@@ -19,7 +19,7 @@ export async function getShippingRate({
   toPostalCode,
   weight,
 }: ShippingRateRequest): Promise<unknown> {
-  const apiKey = (env as Record<string, string | undefined>)[
+  const apiKey = (shippingEnv as Record<string, string | undefined>)[
     `${provider.toUpperCase()}_KEY`
   ];
   if (!apiKey) {

--- a/packages/platform-core/src/tax/index.ts
+++ b/packages/platform-core/src/tax/index.ts
@@ -3,7 +3,7 @@
 import "server-only";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { env } from "@acme/config";
+import { shippingEnv } from "@acme/config/env/shipping";
 import { resolveDataRoot } from "../dataRoot";
 
 export interface TaxCalculationRequest {
@@ -32,7 +32,7 @@ export async function getTaxRate(region: string): Promise<number> {
  * Calculate taxes using the configured provider API.
  */
 export async function calculateTax({ provider, ...payload }: TaxCalculationRequest): Promise<unknown> {
-  const apiKey = (env as Record<string, string | undefined>)[
+  const apiKey = (shippingEnv as Record<string, string | undefined>)[
     `${provider.toUpperCase()}_KEY`
   ];
   if (!apiKey) {

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -1,4 +1,4 @@
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { stripe } from "@acme/stripe";
 import {
   markRefunded,
@@ -86,16 +86,16 @@ async function resolveConfig(
   const envEnabled = process.env[envKey(shop, "ENABLED")];
   if (envEnabled !== undefined) {
     config.enabled = envEnabled !== "false";
-  } else if (env.DEPOSIT_RELEASE_ENABLED !== undefined) {
-    config.enabled = env.DEPOSIT_RELEASE_ENABLED;
+  } else if (coreEnv.DEPOSIT_RELEASE_ENABLED !== undefined) {
+    config.enabled = coreEnv.DEPOSIT_RELEASE_ENABLED;
   }
 
   const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
   if (envInterval !== undefined) {
     const num = Number(envInterval);
     if (!Number.isNaN(num)) config.intervalMs = num;
-  } else if (env.DEPOSIT_RELEASE_INTERVAL_MS !== undefined) {
-    config.intervalMs = env.DEPOSIT_RELEASE_INTERVAL_MS;
+  } else if (coreEnv.DEPOSIT_RELEASE_INTERVAL_MS !== undefined) {
+    config.intervalMs = coreEnv.DEPOSIT_RELEASE_INTERVAL_MS;
   }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;

--- a/packages/stripe/src/__tests__/stripe.test.ts
+++ b/packages/stripe/src/__tests__/stripe.test.ts
@@ -20,6 +20,7 @@ describe("stripe client", () => {
     process.env = {
       ...OLD_ENV,
       STRIPE_SECRET_KEY: "sk_test_123",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_123",
     } as NodeJS.ProcessEnv;
   });
 

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,7 +1,7 @@
 // packages/stripe/src/index.ts
 import "server-only";
 
-import { env } from "@config/src/env";
+import { paymentEnv } from "@acme/config/env/payments";
 import Stripe from "stripe";
 
 /**
@@ -15,7 +15,7 @@ import Stripe from "stripe";
  * `apiVersion` line and Stripe will default to the newest version whenever
  * you bump the SDK.
  */
-export const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(paymentEnv.STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
   httpClient: Stripe.createFetchHttpClient(),
 });

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -12,7 +12,7 @@ import { priceForDays, convertCurrency } from "@platform-core/src/pricing";
 import { getProductById } from "@platform-core/src/products";
 import { findCoupon } from "@platform-core/src/coupons";
 import { trackEvent } from "@platform-core/src/analytics";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import { getTaxRate } from "@platform-core/src/tax";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
@@ -127,7 +127,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       currency?: string;
       taxRegion?: string;
     };
-  const shop = env.NEXT_PUBLIC_DEFAULT_SHOP || "shop";
+  const shop = coreEnv.NEXT_PUBLIC_DEFAULT_SHOP || "shop";
   const couponDef = await findCoupon(shop, coupon);
   if (couponDef) {
     await trackEvent(shop, { type: "discount_redeemed", code: couponDef.code });

--- a/packages/template-app/src/app/AnalyticsScripts.tsx
+++ b/packages/template-app/src/app/AnalyticsScripts.tsx
@@ -2,10 +2,10 @@ import {
   getShopSettings,
   readShop,
 } from "@platform-core/repositories/shops.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export default async function AnalyticsScripts() {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const [settings, shopData] = await Promise.all([
     getShopSettings(shop),
     readShop(shop),

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -5,7 +5,7 @@ import { readRepo } from "@platform-core/repositories/products.server";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import { trackEvent } from "@platform-core/src/analytics";
 import type { ProductPublication } from "@acme/types";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 const DEFAULT_FIELDS = ["id", "title", "description", "price", "images"] as const;
 type Field = (typeof DEFAULT_FIELDS)[number];
@@ -18,7 +18,7 @@ function parseIntOr(val: string | null, def: number): number {
 }
 
 export async function GET(req: NextRequest) {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const settings = await getShopSettings(shop);
   if (!settings.aiCatalog?.enabled) {
     return new NextResponse(null, { status: 404 });

--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -1,8 +1,8 @@
 import type { MetadataRoute } from "next";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export default function robots(): MetadataRoute.Robots {
-  const base = env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   return {
     rules: [
       { userAgent: "*", allow: "/" },

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -1,11 +1,11 @@
 import type { MetadataRoute } from "next";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
 import { readRepo } from "@platform-core/src/repositories/products.server";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const base = env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "shop";
+  const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
   const now = new Date().toISOString();
 
   const [settings, products] = await Promise.all([

--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -1,7 +1,7 @@
 import { LOCALES, type Locale } from "@i18n/locales";
 import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
 interface ExtendedSeoProps extends Partial<NextSeoProps> {
   canonicalBase?: string;
@@ -19,7 +19,7 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<NextSeoProps> = {},
 ): Promise<NextSeoProps> {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const { getShopSettings } = await import(
     "@platform-core/repositories/shops.server"
   );

--- a/packages/template-app/src/routes/preview/[pageId].ts
+++ b/packages/template-app/src/routes/preview/[pageId].ts
@@ -3,9 +3,9 @@
 import type { EventContext } from "@cloudflare/workers-types";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-const secret = env.PREVIEW_TOKEN_SECRET;
+const secret = coreEnv.PREVIEW_TOKEN_SECRET;
 
 function verify(id: string, token: string | null): boolean {
   if (!secret || !token) return false;
@@ -26,7 +26,7 @@ export const onRequest = async ({
   if (!verify(pageId, token)) {
     return new Response("Unauthorized", { status: 401 });
   }
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const pages = await getPages(shop);
   const page = pages.find((p) => p.id === pageId);
   if (!page) return new Response("Not Found", { status: 404 });

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useTranslations } from "@/i18n/Translations";
-import { env } from "@config/src/env";
+import { paymentEnv } from "@acme/config/env/payments";
 import {
   Elements,
   PaymentElement,
@@ -17,7 +17,9 @@ import { useForm, UseFormReturn } from "react-hook-form";
 import { isoDateInNDays } from "@acme/date-utils";
 import { useCurrency } from "@platform-core/src/contexts/CurrencyContext";
 
-const stripePromise = loadStripe(env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
+const stripePromise = loadStripe(
+  paymentEnv.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+);
 
 type Props = { locale: "en" | "de" | "it"; taxRegion: string };
 

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -3,9 +3,9 @@
 import { getShopFromPath } from "@platform-core/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 
-if (env.NODE_ENV === "development") {
+if (coreEnv.NODE_ENV === "development") {
   console.log("sidebar rendered on client");
 }
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ import {
 } from "@platform-core/src/cartCookie";
 import { getCart } from "@platform-core/src/cartStore";
 import { cookies } from "next/headers";
-import { env } from "@acme/config";
+import { coreEnv } from "@acme/config/env/core";
 import HeaderClient from "./HeaderClient.client";
 
 /**
@@ -26,7 +26,7 @@ export default async function Header({
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
   const cart = cartId ? await getCart(cartId) : {};
   const initialQty = Object.values(cart).reduce((s, line) => s + line.qty, 0);
-  const shopId = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const shop = await readShop(shopId);
   const nav = shop.navigation ?? [];
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -81,9 +81,9 @@
       "@auth/*": ["packages/auth/src/*"],
 
       /* ─── runtime config helper ─────────────────────────────────── */
-      "@config": ["packages/config/src/env.ts"],
-      "@config/*": ["packages/config/src/*"],
-      "@config/src/*": ["packages/config/src/*"],
+      "@config": ["packages/config/src/env/index.ts"],
+      "@config/*": ["packages/config/src/env/*"],
+      "@config/src/*": ["packages/config/src/env/*"],
 
       /* ─── shared utilities ──────────────────────────────────────── */
       "@shared-utils": ["packages/shared-utils/src/index.ts"],


### PR DESCRIPTION
## Summary
- split env config into core and optional payment/shipping modules
- add helper to merge env schemas and export domain-specific envs
- update packages to consume scoped env modules

## Testing
- `pnpm exec jest packages/config/__tests__/env.test.ts`
- `pnpm exec jest packages/stripe/src/__tests__/stripe.test.ts` *(fails: An error occurred with our connection to Stripe)*

------
https://chatgpt.com/codex/tasks/task_e_689b45fd8528832fae6a91b1dac5f51c