### PR TITLE
feat: add ai catalog feed configuration

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogSettings.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Button, Checkbox, Input } from "@/components/atoms/shadcn";
+import { updateAiCatalog } from "@cms/actions/shops.server";
+import type { AiCatalogField } from "@acme/types";
+import { useState, type FormEvent } from "react";
+
+const ALL_FIELDS: AiCatalogField[] = [
+  "id",
+  "title",
+  "description",
+  "price",
+  "images",
+];
+
+interface Props {
+  shop: string;
+  initial: { enabled: boolean; fields: AiCatalogField[]; pageSize: number; lastCrawl?: string };
+}
+
+export default function AiCatalogSettings({ shop, initial }: Props) {
+  const [state, setState] = useState(initial);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  const toggleField = (field: AiCatalogField) => {
+    setState((s) => ({
+      ...s,
+      fields: s.fields.includes(field)
+        ? s.fields.filter((f) => f !== field)
+        : [...s.fields, field],
+    }));
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData(e.currentTarget);
+    const result = await updateAiCatalog(shop, fd);
+    if (result.errors) {
+      setErrors(result.errors);
+    } else if (result.settings?.seo?.aiCatalog) {
+      setState((s) => ({
+        ...s,
+        enabled: result.settings!.seo!.aiCatalog!.enabled,
+        fields: result.settings!.seo!.aiCatalog!.fields,
+        pageSize: result.settings!.seo!.aiCatalog!.pageSize,
+      }));
+      setErrors({});
+    }
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="grid max-w-md gap-4">
+      <label className="flex items-center gap-2">
+        <Checkbox
+          name="enabled"
+          checked={state.enabled}
+          onCheckedChange={(v) => setState((s) => ({ ...s, enabled: Boolean(v) }))}
+        />
+        <span>Enable AI catalog feed</span>
+      </label>
+      <div className="flex flex-col gap-2">
+        <span>Fields</span>
+        {ALL_FIELDS.map((f) => (
+          <label key={f} className="flex items-center gap-2">
+            <Checkbox
+              name="fields"
+              value={f}
+              checked={state.fields.includes(f)}
+              onCheckedChange={() => toggleField(f)}
+            />
+            <span>{f}</span>
+          </label>
+        ))}
+        {errors.fields && (
+          <span className="text-sm text-red-600">{errors.fields.join("; ")}</span>
+        )}
+      </div>
+      <label className="flex flex-col gap-1">
+        <span>Page size</span>
+        <Input
+          type="number"
+          name="pageSize"
+          value={state.pageSize}
+          onChange={(e) =>
+            setState((s) => ({ ...s, pageSize: Number(e.target.value) }))
+          }
+        />
+        {errors.pageSize && (
+          <span className="text-sm text-red-600">
+            {errors.pageSize.join("; ")}
+          </span>
+        )}
+      </label>
+      {state.lastCrawl && (
+        <p className="text-sm text-gray-600">
+          Last crawl: {new Date(state.lastCrawl).toLocaleString()}
+        </p>
+      )}
+      <Button className="bg-primary text-white" type="submit" disabled={saving}>
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -6,5 +6,12 @@
   "depositService": {
     "enabled": false,
     "interval": 60
+  },
+  "seo": {
+    "aiCatalog": {
+      "enabled": false,
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
+    }
   }
 }

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -6,5 +6,12 @@
   "depositService": {
     "enabled": false,
     "interval": 60
+  },
+  "seo": {
+    "aiCatalog": {
+      "enabled": false,
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
+    }
   }
 }

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -6,5 +6,12 @@
   "depositService": {
     "enabled": false,
     "interval": 60
+  },
+  "seo": {
+    "aiCatalog": {
+      "enabled": false,
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
+    }
   }
 }

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -16,6 +16,11 @@
       "title": "t",
       "description": "",
       "image": "ftp://bad"
+    },
+    "aiCatalog": {
+      "enabled": false,
+      "fields": ["id", "title", "description", "price", "images"],
+      "pageSize": 50
     }
   },
   "updatedAt": "",

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -62,28 +62,34 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
           interval: 60,
           ...(parsed.data.depositService ?? {}),
         },
-        aiCatalog: {
-          enabled: false,
-          fields: ["id", "title", "description", "price", "images"],
-          ...(parsed.data.aiCatalog ?? {}),
+        seo: {
+          ...(parsed.data.seo ?? {}),
+          aiCatalog: {
+            enabled: false,
+            fields: ["id", "title", "description", "price", "images"],
+            pageSize: 50,
+            ...((parsed.data.seo ?? {}).aiCatalog ?? {}),
+          },
         },
-      };
+      } as ShopSettings;
     }
   } catch {
     // ignore
   }
   return {
     languages: DEFAULT_LANGUAGES,
-    seo: {},
+    seo: {
+      aiCatalog: {
+        enabled: false,
+        fields: ["id", "title", "description", "price", "images"],
+        pageSize: 50,
+      },
+    },
     analytics: undefined,
     freezeTranslations: false,
     currency: "EUR",
     taxRegion: "",
     depositService: { enabled: false, interval: 60 },
-    aiCatalog: {
-      enabled: false,
-      fields: ["id", "title", "description", "price", "images"],
-    },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -20,12 +20,11 @@ function parseIntOr(val: string | null, def: number): number {
 export async function GET(req: NextRequest) {
   const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
   const settings = await getShopSettings(shop);
-  if (!settings.aiCatalog?.enabled) {
+  const ai = settings.seo?.aiCatalog;
+  if (!ai?.enabled) {
     return new NextResponse(null, { status: 404 });
   }
-  const fields = (settings.aiCatalog.fields?.length
-    ? settings.aiCatalog.fields
-    : DEFAULT_FIELDS) as Field[];
+  const fields = (ai.fields?.length ? ai.fields : DEFAULT_FIELDS) as Field[];
   const all = await readRepo<ProductPublication>(shop);
 
   const lastModifiedDate = all.reduce((max, p) => {
@@ -49,7 +48,7 @@ export async function GET(req: NextRequest) {
 
   const { searchParams } = req.nextUrl;
   const page = parseIntOr(searchParams.get("page"), 1);
-  const limit = parseIntOr(searchParams.get("limit"), 50);
+  const limit = parseIntOr(searchParams.get("limit"), ai.pageSize ?? 50);
   const start = (page - 1) * limit;
   const paged = all.slice(start, start + limit);
 

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -13,11 +13,18 @@ export const aiCatalogFieldSchema = z.enum([
 export const aiCatalogConfigSchema = z.object({
   enabled: z.boolean(),
   fields: z.array(aiCatalogFieldSchema),
+  pageSize: z.number().int().positive(),
 });
+
+export const seoSettingsSchema = z
+  .object({
+    aiCatalog: aiCatalogConfigSchema.optional(),
+  })
+  .catchall(shopSeoFieldsSchema);
 
 export const shopSettingsSchema = z.object({
   languages: z.array(localeSchema).readonly(),
-  seo: z.record(localeSchema, shopSeoFieldsSchema),
+  seo: seoSettingsSchema,
   analytics: z
     .object({
       enabled: z.boolean().optional(),
@@ -36,7 +43,6 @@ export const shopSettingsSchema = z.object({
       interval: z.number().int().positive(),
     })
     .optional(),
-  aiCatalog: aiCatalogConfigSchema.optional(),
   updatedAt: z.string(),
   updatedBy: z.string(),
 });


### PR DESCRIPTION
## Summary
- store AI catalog settings under `seo.aiCatalog`
- expose catalog feed configuration in CMS
- respect page size and fields in AI catalog route

## Testing
- `pnpm lint --filter @acme/types --filter @acme/platform-core --filter @acme/template-app --filter @apps/cms` *(fails: Cannot find module '@acme/config/env.ts')*
- `pnpm test --filter @acme/types --filter @acme/platform-core --filter @acme/template-app --filter @apps/cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689b463f552c832f9b35f17571fb60b2