### PR TITLE
feat: merge theme defaults and overrides for tokens

### DIFF
--- a/apps/cms/__tests__/stepValidators.test.ts
+++ b/apps/cms/__tests__/stepValidators.test.ts
@@ -13,8 +13,8 @@ describe("step validators", () => {
     expect(validators.theme(base)).toBe(false);
   });
 
-  it("tokens require theme variables", () => {
-    const state = { ...base, themeVars: {} };
+  it("tokens require theme defaults", () => {
+    const state = { ...base, themeDefaults: {} };
     expect(validators.tokens(state)).toBe(false);
   });
 

--- a/apps/cms/src/app/cms/configurator/hooks/useStepCompletion.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/useStepCompletion.ts
@@ -6,7 +6,7 @@ type Validator = (state: WizardState) => boolean;
 export const validators: Record<string, Validator> = {
   "shop-details": (s) => Boolean(s.shopId && s.storeName),
   theme: (s) => Boolean(s.theme),
-  tokens: (s) => Object.keys(s.themeVars ?? {}).length > 0,
+  tokens: (s) => Object.keys(s.themeDefaults ?? {}).length > 0,
   options: (s) =>
     s.analyticsProvider !== "ga" || Boolean(s.analyticsId),
   navigation: (s) => s.navItems.length > 0,

--- a/apps/cms/src/app/cms/configurator/hooks/useThemeLoader.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/useThemeLoader.ts
@@ -11,24 +11,30 @@ import { useConfigurator } from "../ConfiguratorContext";
  */
 export function useThemeLoader(): React.CSSProperties {
   const { state, setState } = useConfigurator();
-  const { theme, themeVars } = state;
+  const { theme, themeDefaults, themeOverrides } = state;
 
   /* On initial mount ensure base tokens exist */
   useEffect(() => {
-    if (!themeVars || Object.keys(themeVars).length === 0) {
-      setState((prev) => ({ ...prev, themeVars: baseTokens }));
+    if (!themeDefaults || Object.keys(themeDefaults).length === 0) {
+      setState((prev) => ({
+        ...prev,
+        themeDefaults: baseTokens,
+        themeOverrides: {},
+      }));
     }
   }, []);
 
   /* Load tokens for selected theme */
   useEffect(() => {
     loadThemeTokens(theme).then((tv) => {
-      setState((prev) => ({ ...prev, themeVars: tv }));
+      setState((prev) => ({
+        ...prev,
+        themeDefaults: tv,
+        themeOverrides: {},
+      }));
     });
   }, [theme, setState]);
 
-  return Object.fromEntries(
-    Object.entries(themeVars ?? {}).map(([k, v]) => [k, v])
-  ) as React.CSSProperties;
+  return { ...themeDefaults, ...themeOverrides } as React.CSSProperties;
 }
 

--- a/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
@@ -5,40 +5,47 @@ import StyleEditor from "@/components/cms/StyleEditor";
 import WizardPreview from "../../wizard/WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { baseTokens, type TokenMap } from "../../wizard/tokenUtils";
+import { useMemo, useState } from "react";
+import { type TokenMap } from "../../wizard/tokenUtils";
 import { useConfigurator } from "../ConfiguratorContext";
 
-interface Props {
-  themeStyle: React.CSSProperties;
-}
-
-export default function StepTokens({ themeStyle }: Props): React.JSX.Element {
+export default function StepTokens(): React.JSX.Element {
   const [, markComplete] = useStepCompletion("tokens");
   const router = useRouter();
   const { state, update } = useConfigurator();
-  const [tokens, setTokens] = useState<TokenMap>(state.themeVars);
+  const { themeDefaults, themeOverrides } = state;
+
+  const [overrides, setOverrides] = useState<TokenMap>(themeOverrides);
   const [selected, setSelected] = useState<string | null>(null);
 
-  const handleChange = (next: TokenMap) => {
-    setTokens(next);
-    update("themeVars", next);
-  };
+  const tokens = useMemo(
+    () => ({ ...themeDefaults, ...overrides }),
+    [themeDefaults, overrides]
+  );
 
-  const previewStyle = { ...themeStyle, ...tokens } as React.CSSProperties;
+  const handleChange = (next: TokenMap) => {
+    const nextOverrides: TokenMap = {};
+    Object.entries(next).forEach(([k, v]) => {
+      if (themeDefaults[k as keyof TokenMap] !== v) {
+        nextOverrides[k as keyof TokenMap] = v;
+      }
+    });
+    setOverrides(nextOverrides);
+    update("themeOverrides", nextOverrides);
+  };
 
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Customize Tokens</h2>
       <WizardPreview
-        style={previewStyle}
+        style={tokens as React.CSSProperties}
         inspectMode
         onTokenSelect={(t) => setSelected(t)}
       />
       {selected && (
         <StyleEditor
           tokens={tokens}
-          baseTokens={baseTokens}
+          baseTokens={themeDefaults}
           onChange={handleChange}
           focusToken={selected}
         />

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -83,7 +83,8 @@ export const wizardStateSchema = z.object({
   /* ---------------- Template / theme ------------------ */
   template: z.string().optional().default(""),
   theme: z.string().optional().default(""),
-  themeVars: z.record(z.string()).optional().default(baseTokens),
+  themeDefaults: z.record(z.string()).optional().default(baseTokens),
+  themeOverrides: z.record(z.string()).optional().default({}),
 
   /* -------------- Commerce settings ------------------- */
   payment: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary
- merge themeDefaults and themeOverrides to compute tokens in StepTokens
- load themeDefaults in useThemeLoader and track overrides separately
- update token validator and schema to use theme defaults

## Testing
- `pnpm --filter @apps/cms test stepValidators.test.ts`
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689b42884d1c832f8305080575d82069