### PR TITLE
feat: add campaign analytics

### DIFF
--- a/apps/cms/src/app/cms/dashboard/[shop]/CampaignFilter.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/CampaignFilter.client.tsx
@@ -6,25 +6,24 @@ export function CampaignFilter({ campaigns }: { campaigns: string[] }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const selected = searchParams.get("campaign") ?? "";
+  const selected = searchParams.getAll("campaign");
 
   return (
     <select
+      multiple
       className="mb-4 rounded border p-1"
       value={selected}
       onChange={(e) => {
         const params = new URLSearchParams(searchParams.toString());
-        const value = e.target.value;
-        if (value) {
-          params.set("campaign", value);
-        } else {
-          params.delete("campaign");
+        params.delete("campaign");
+        const values = Array.from(e.target.selectedOptions).map((o) => o.value);
+        for (const v of values) {
+          if (v) params.append("campaign", v);
         }
         const query = params.toString();
         router.push(query ? `${pathname}?${query}` : pathname);
       }}
     >
-      <option value="">All campaigns</option>
       {campaigns.map((c) => (
         <option key={c} value={c}>
           {c}

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -6,32 +6,27 @@ import { readShop } from "@platform-core/repositories/shops.server";
 import { Progress } from "@acme/ui";
 import { CampaignFilter } from "./CampaignFilter.client";
 import { Charts } from "./Charts.client";
+import type {
+  AnalyticsAggregates,
+  AnalyticsEvent,
+} from "@platform-core/analytics";
 
-export default async function ShopDashboard({
-  params,
-  searchParams,
-}: {
-  params: { shop: string };
-  searchParams: { campaign?: string };
-}) {
-  const shop = params.shop;
-  const campaign = searchParams?.campaign;
-  const [events, aggregates, shopData] = await Promise.all([
-    listEvents(shop),
-    readAggregates(shop),
-    readShop(shop),
-  ]);
-  const domain = shopData.domain?.name;
-  const domainStatus = shopData.domain?.status;
-  const filteredEvents = campaign
-    ? events.filter((e) => e.campaign === campaign)
-    : events;
+interface Series {
+  labels: string[];
+  data: number[];
+}
 
+function buildMetrics(
+  events: AnalyticsEvent[],
+  aggregates?: AnalyticsAggregates,
+) {
   const emailOpenByDay: Record<string, number> = {};
   const emailClickByDay: Record<string, number> = {};
   const campaignSalesByDay: Record<string, number> = {};
+  const campaignSalesCountByDay: Record<string, number> = {};
   const discountByDay: Record<string, number> = {};
-  for (const e of filteredEvents) {
+
+  for (const e of events) {
     const day = (e.timestamp || "").slice(0, 10);
     if (!day) continue;
     if (e.type === "email_open") {
@@ -41,6 +36,8 @@ export default async function ShopDashboard({
     } else if (e.type === "campaign_sale") {
       const amount = typeof e.amount === "number" ? e.amount : 0;
       campaignSalesByDay[day] = (campaignSalesByDay[day] || 0) + amount;
+      campaignSalesCountByDay[day] =
+        (campaignSalesCountByDay[day] || 0) + 1;
     } else if (e.type === "discount_redeemed") {
       discountByDay[day] = (discountByDay[day] || 0) + 1;
     }
@@ -48,61 +45,85 @@ export default async function ShopDashboard({
 
   const days = Array.from(
     new Set([
-      ...Object.keys(aggregates.page_view),
-      ...Object.keys(aggregates.order),
+      ...(aggregates ? Object.keys(aggregates.page_view) : []),
+      ...(aggregates ? Object.keys(aggregates.order) : []),
       ...Object.keys(emailOpenByDay),
       ...Object.keys(emailClickByDay),
       ...Object.keys(campaignSalesByDay),
       ...Object.keys(discountByDay),
-      ...Object.keys(aggregates.discount_redeemed),
-      ...Object.keys(aggregates.ai_catalog),
-    ])
+      ...(aggregates ? Object.keys(aggregates.discount_redeemed) : []),
+      ...(aggregates ? Object.keys(aggregates.ai_catalog) : []),
+    ]),
   ).sort();
 
-  const traffic = {
+  const traffic: Series = {
     labels: days,
-    data: days.map((d) => aggregates.page_view[d] || 0),
+    data: aggregates
+      ? days.map((d) => aggregates.page_view[d] || 0)
+      : days.map((d) => emailClickByDay[d] || 0),
   };
-  const sales = {
+
+  const sales: Series = {
     labels: days,
-    data: days.map((d) => aggregates.order[d]?.amount ?? 0),
+    data: aggregates
+      ? days.map((d) => aggregates.order[d]?.amount ?? 0)
+      : days.map((d) => campaignSalesByDay[d] || 0),
   };
-  const conversion = {
+
+  const conversion: Series = {
     labels: days,
-    data: days.map((d) => {
-      const views = aggregates.page_view[d] || 0;
-      const orders = aggregates.order[d]?.count || 0;
-      return views > 0 ? (orders / views) * 100 : 0;
-    }),
+    data: aggregates
+      ? days.map((d) => {
+          const views = aggregates.page_view[d] || 0;
+          const orders = aggregates.order[d]?.count || 0;
+          return views > 0 ? (orders / views) * 100 : 0;
+        })
+      : days.map((d) => {
+          const clicks = emailClickByDay[d] || 0;
+          const salesCount = campaignSalesCountByDay[d] || 0;
+          return clicks > 0 ? (salesCount / clicks) * 100 : 0;
+        }),
   };
-  const emailOpens = {
+
+  const emailOpens: Series = {
     labels: days,
     data: days.map((d) => emailOpenByDay[d] || 0),
   };
-  const emailClicks = {
+
+  const emailClicks: Series = {
     labels: days,
     data: days.map((d) => emailClickByDay[d] || 0),
   };
-  const campaignSales = {
+
+  const campaignSales: Series = {
     labels: days,
     data: days.map((d) => campaignSalesByDay[d] || 0),
   };
-  const discountRedemptions = {
+
+  const discountRedemptions: Series = {
     labels: days,
     data: days.map((d) => discountByDay[d] || 0),
   };
-  const aiCatalog = {
+
+  const aiCatalog: Series = {
     labels: days,
-    data: days.map((d) => aggregates.ai_catalog[d] || 0),
+    data: aggregates
+      ? days.map((d) => aggregates.ai_catalog[d] || 0)
+      : days.map(() => 0),
   };
 
   const totals = {
     emailOpens: emailOpens.data.reduce((a, b) => a + b, 0),
     emailClicks: emailClicks.data.reduce((a, b) => a + b, 0),
     campaignSales: campaignSales.data.reduce((a, b) => a + b, 0),
+    campaignSaleCount: Object.values(campaignSalesCountByDay).reduce(
+      (a, b) => a + b,
+      0,
+    ),
     discountRedemptions: discountRedemptions.data.reduce((a, b) => a + b, 0),
     aiCatalog: aiCatalog.data.reduce((a, b) => a + b, 0),
   };
+
   const maxTotal = Math.max(
     totals.emailOpens,
     totals.emailClicks,
@@ -112,6 +133,37 @@ export default async function ShopDashboard({
     1,
   );
 
+  return {
+    traffic,
+    sales,
+    conversion,
+    emailOpens,
+    emailClicks,
+    campaignSales,
+    discountRedemptions,
+    aiCatalog,
+    totals,
+    maxTotal,
+  };
+}
+
+export default async function ShopDashboard({
+  params,
+  searchParams,
+}: {
+  params: { shop: string };
+  searchParams: { campaign?: string | string[] };
+}) {
+  const shop = params.shop;
+  const [events, aggregates, shopData] = await Promise.all([
+    listEvents(shop),
+    readAggregates(shop),
+    readShop(shop),
+  ]);
+
+  const domain = shopData.domain?.name;
+  const domainStatus = shopData.domain?.status;
+
   const campaigns = Array.from(
     new Set(
       events
@@ -120,8 +172,114 @@ export default async function ShopDashboard({
     ),
   );
 
+  const selected = searchParams?.campaign;
+  const selectedCampaigns = Array.isArray(selected)
+    ? selected
+    : selected
+      ? [selected]
+      : [];
+
+  const content =
+    selectedCampaigns.length === 0
+      ? (() => {
+          const metrics = buildMetrics(events, aggregates);
+          return (
+            <>
+              <Charts
+                traffic={metrics.traffic}
+                sales={metrics.sales}
+                conversion={metrics.conversion}
+                emailOpens={metrics.emailOpens}
+                emailClicks={metrics.emailClicks}
+                campaignSales={metrics.campaignSales}
+                discountRedemptions={metrics.discountRedemptions}
+                aiCatalog={metrics.aiCatalog}
+              />
+              <div className="mt-8 space-y-4">
+                <h3 className="text-lg font-semibold">Progress</h3>
+                <div>
+                  <span className="mb-1 block text-sm font-medium">
+                    Email opens
+                  </span>
+                  <Progress
+                    value={(metrics.totals.emailOpens / metrics.maxTotal) * 100}
+                    label={String(metrics.totals.emailOpens)}
+                  />
+                </div>
+                <div>
+                  <span className="mb-1 block text-sm font-medium">
+                    Email clicks
+                  </span>
+                  <Progress
+                    value={(metrics.totals.emailClicks / metrics.maxTotal) * 100}
+                    label={String(metrics.totals.emailClicks)}
+                  />
+                </div>
+                <div>
+                  <span className="mb-1 block text-sm font-medium">
+                    Campaign sales
+                  </span>
+                  <Progress
+                    value={(metrics.totals.campaignSales / metrics.maxTotal) * 100}
+                    label={String(metrics.totals.campaignSales)}
+                  />
+                </div>
+                <div>
+                  <span className="mb-1 block text-sm font-medium">
+                    Discount redemptions
+                  </span>
+                  <Progress
+                    value={
+                      (metrics.totals.discountRedemptions / metrics.maxTotal) *
+                      100
+                    }
+                    label={String(metrics.totals.discountRedemptions)}
+                  />
+                </div>
+                <div>
+                  <span className="mb-1 block text-sm font-medium">
+                    AI catalog requests
+                  </span>
+                  <Progress
+                    value={(metrics.totals.aiCatalog / metrics.maxTotal) * 100}
+                    label={String(metrics.totals.aiCatalog)}
+                  />
+                </div>
+              </div>
+            </>
+          );
+        })()
+      : selectedCampaigns.map((c) => {
+          const metrics = buildMetrics(events.filter((e) => e.campaign === c));
+          const totalTraffic = metrics.totals.emailClicks;
+          const totalRevenue = metrics.totals.campaignSales;
+          const conversionRate =
+            totalTraffic > 0
+              ? (metrics.totals.campaignSaleCount / totalTraffic) * 100
+              : 0;
+          return (
+            <div key={c} className="mb-8">
+              <h3 className="text-lg font-semibold">Campaign: {c}</h3>
+              <p className="mb-2 text-sm">
+                Traffic: {totalTraffic} • Revenue: {totalRevenue.toFixed(2)} •
+                Conversion: {conversionRate.toFixed(2)}%
+              </p>
+              <Charts
+                traffic={metrics.traffic}
+                sales={metrics.sales}
+                conversion={metrics.conversion}
+                emailOpens={metrics.emailOpens}
+                emailClicks={metrics.emailClicks}
+                campaignSales={metrics.campaignSales}
+                discountRedemptions={metrics.discountRedemptions}
+                aiCatalog={metrics.aiCatalog}
+              />
+            </div>
+          );
+        });
+
   return (
-    <div>
+  <div>
       <h2 className="mb-4 text-xl font-semibold">Dashboard: {shop}</h2>
       {domain && (
         <p className="mb-2 text-sm text-gray-600">
@@ -129,58 +287,8 @@ export default async function ShopDashboard({
         </p>
       )}
       {campaigns.length > 0 && <CampaignFilter campaigns={campaigns} />}
-      <Charts
-        traffic={traffic}
-        sales={sales}
-        conversion={conversion}
-        emailOpens={emailOpens}
-        emailClicks={emailClicks}
-        campaignSales={campaignSales}
-        discountRedemptions={discountRedemptions}
-        aiCatalog={aiCatalog}
-      />
-      <div className="mt-8 space-y-4">
-        <h3 className="text-lg font-semibold">Progress</h3>
-        <div>
-          <span className="mb-1 block text-sm font-medium">Email opens</span>
-          <Progress
-            value={(totals.emailOpens / maxTotal) * 100}
-            label={String(totals.emailOpens)}
-          />
-        </div>
-        <div>
-          <span className="mb-1 block text-sm font-medium">Email clicks</span>
-          <Progress
-            value={(totals.emailClicks / maxTotal) * 100}
-            label={String(totals.emailClicks)}
-          />
-        </div>
-        <div>
-          <span className="mb-1 block text-sm font-medium">Campaign sales</span>
-          <Progress
-            value={(totals.campaignSales / maxTotal) * 100}
-            label={String(totals.campaignSales)}
-          />
-        </div>
-        <div>
-          <span className="mb-1 block text-sm font-medium">
-            Discount redemptions
-          </span>
-          <Progress
-            value={(totals.discountRedemptions / maxTotal) * 100}
-            label={String(totals.discountRedemptions)}
-          />
-        </div>
-        <div>
-          <span className="mb-1 block text-sm font-medium">
-            AI catalog requests
-          </span>
-          <Progress
-            value={(totals.aiCatalog / maxTotal) * 100}
-            label={String(totals.aiCatalog)}
-          />
-        </div>
-      </div>
+      {content}
     </div>
   );
 }
+

--- a/apps/cms/src/app/cms/marketing/page.tsx
+++ b/apps/cms/src/app/cms/marketing/page.tsx
@@ -1,6 +1,22 @@
 import Link from "next/link";
+import { listShops } from "../listShops";
+import { listEvents } from "@platform-core/repositories/analytics.server";
 
-export default function MarketingPage() {
+export default async function MarketingPage() {
+  const shops = await listShops();
+  const campaignsByShop: Record<string, string[]> = {};
+  for (const shop of shops) {
+    const events = await listEvents(shop);
+    const campaigns = Array.from(
+      new Set(
+        events
+          .map((e) => (typeof e.campaign === "string" ? e.campaign : null))
+          .filter(Boolean) as string[],
+      ),
+    );
+    if (campaigns.length > 0) campaignsByShop[shop] = campaigns;
+  }
+
   return (
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-semibold">Marketing Tools</h2>
@@ -12,6 +28,30 @@ export default function MarketingPage() {
           <Link href="/cms/marketing/discounts">Discount Codes</Link>
         </li>
       </ul>
+      {Object.keys(campaignsByShop).length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Campaign Analytics</h3>
+          {Object.entries(campaignsByShop).map(([shop, campaigns]) => (
+            <div key={shop}>
+              <h4 className="font-medium">{shop}</h4>
+              <ul className="list-disc pl-6">
+                {campaigns.map((c) => (
+                  <li key={c}>
+                    <Link
+                      href={`/cms/dashboard/${shop}?campaign=${encodeURIComponent(
+                        c,
+                      )}`}
+                      className="text-primary underline"
+                    >
+                      {c}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- support selecting multiple campaigns on dashboard
- show traffic, revenue, and conversion stats for each campaign
- add campaign drill-down links from marketing page

## Testing
- `pnpm lint --filter @apps/cms` *(fails: ERR_MODULE_NOT_FOUND: file:///workspace/base-shop/packages/next-config/node_modules/@acme/config/env.ts)*
- `pnpm test --filter @apps/cms` *(fails: Test failed. See above for more details.)*


------
https://chatgpt.com/codex/tasks/task_e_689b459d295c832f895085e77aae5bc6