### PR TITLE
refactor: use structured logging for deposit release

### DIFF
--- a/packages/platform-core/src/utils/logger.ts
+++ b/packages/platform-core/src/utils/logger.ts
@@ -3,6 +3,9 @@ export interface LogMeta {
 }
 
 export const logger = {
+  info(message: string, meta: LogMeta = {}) {
+    console.info({ level: "info", message, ...meta });
+  },
   warn(message: string, meta: LogMeta = {}) {
     console.warn({ level: "warn", message, ...meta });
   },

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -5,6 +5,7 @@ import {
   readOrders,
 } from "@platform-core/repositories/rentalOrders.server";
 import { resolveDataRoot } from "@platform-core/dataRoot";
+import { logger } from "@platform-core/utils";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -39,12 +40,16 @@ export async function releaseDepositsOnce(
             });
           }
           await markRefunded(shop, order.sessionId);
-          console.log(`refunded deposit for ${order.sessionId} (${shop})`);
+          logger.info("refunded deposit", {
+            shopId: shop,
+            sessionId: order.sessionId,
+          });
         } catch (err) {
-          console.error(
-            `failed to release deposit for ${order.sessionId} (${shop})`,
-            err
-          );
+          logger.error("failed to release deposit", {
+            shopId: shop,
+            sessionId: order.sessionId,
+            err,
+          });
         }
       }
     }
@@ -120,7 +125,7 @@ export async function startDepositReleaseService(
         try {
           await releaseDepositsOnce(shop, dataRoot);
         } catch (err) {
-          console.error("deposit release failed", err);
+          logger.error("deposit release failed", { shopId: shop, err });
         }
       }
 


### PR DESCRIPTION
## Summary
- log refunded deposits with structured logger metadata
- log deposit release failures using logger.error
- expose `info` method on core logger

## Testing
- `pnpm --filter @acme/platform-core test -- --passWithNoTests`
- `pnpm --filter @acme/platform-machine test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b4290a1c4832fb56ab28226a7ed82