### PR TITLE
feat(shop-bcd): validate return API input

### DIFF
--- a/apps/shop-bcd/__tests__/return-api.test.ts
+++ b/apps/shop-bcd/__tests__/return-api.test.ts
@@ -149,6 +149,7 @@ describe("/api/return", () => {
 
   test("returns 400 for invalid request body", async () => {
     const { POST } = await import("../src/api/return/route");
-    await expect(POST({ json: async () => null } as any)).rejects.toThrow();
+    const res = await POST({ json: async () => null } as any);
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/shop-bcd/src/api/return/route.d.ts
+++ b/apps/shop-bcd/src/api/return/route.d.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 export declare const runtime = "edge";
-export declare function POST(req: NextRequest): Promise<NextResponse<{
-    error: string;
-}> | NextResponse<{
-    ok: boolean;
-}>>;
+export declare function POST(req: NextRequest): Promise<
+  | NextResponse<{ errors: unknown }>
+  | NextResponse<{ error: string }>
+  | NextResponse<{ ok: boolean; message?: string }>
+>; 

--- a/apps/shop-bcd/src/api/return/route.js
+++ b/apps/shop-bcd/src/api/return/route.js
@@ -2,12 +2,16 @@ import { stripe } from "@acme/stripe";
 import { computeDamageFee } from "@platform-core/pricing";
 import { markRefunded, markReturned, } from "@platform-core/repositories/rentalOrders.server";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 export const runtime = "edge";
+const schema = z.object({ sessionId: z.string(), damage: z.union([z.string(), z.number()]).optional(), });
 export async function POST(req) {
-    const { sessionId, damage } = (await req.json());
-    if (!sessionId) {
-        return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
+    var _a, _b, _c;
+    const parsed = schema.safeParse(await req.json());
+    if (!parsed.success) {
+        return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
     }
+    const { sessionId, damage } = parsed.data;
     const order = await markReturned("bcd", sessionId);
     if (!order) {
         return NextResponse.json({ error: "Order not found" }, { status: 404 });
@@ -15,10 +19,10 @@ export async function POST(req) {
     const session = await stripe.checkout.sessions.retrieve(sessionId, {
         expand: ["payment_intent"],
     });
-    const deposit = Number(session.metadata?.depositTotal ?? 0);
+    const deposit = Number((_b = (_a = session.metadata) === null || _a === void 0 ? void 0 : _a.depositTotal) !== null && _b !== void 0 ? _b : 0);
     const pi = typeof session.payment_intent === "string"
         ? session.payment_intent
-        : session.payment_intent?.id;
+        : (_c = session.payment_intent) === null || _c === void 0 ? void 0 : _c.id;
     if (!deposit || !pi) {
         return NextResponse.json({ ok: false, message: "No deposit found" });
     }


### PR DESCRIPTION
## Summary
- validate return API payload with a Zod schema and use parsed data
- handle invalid request bodies by returning 400 with validation errors
- adjust return API tests for new error handling

## Testing
- `pnpm exec eslint apps/shop-bcd/src/api/return/route.ts apps/shop-bcd/src/api/return/route.js apps/shop-bcd/__tests__/return-api.test.ts`
- `pnpm exec jest apps/shop-bcd/__tests__/return-api.test.ts -c apps/shop-bcd/jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689b47ee75b8832face759bc63479cfe