### PR TITLE
refactor: clarify deposit interval units

### DIFF
--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -267,7 +267,7 @@ export async function updateCurrencyAndTax(
 const depositSchema = z
   .object({
     enabled: z.preprocess((v) => v === "on", z.boolean()),
-    interval: z.coerce.number().int().min(1, "Must be at least 1"),
+    intervalMinutes: z.coerce.number().int().min(1, "Must be at least 1"),
   })
   .strict();
 
@@ -287,7 +287,7 @@ export async function updateDepositService(
     ...current,
     depositService: {
       enabled: parsed.data.enabled,
-      interval: parsed.data.interval,
+      intervalMinutes: parsed.data.intervalMinutes,
     },
   };
   await saveShopSettings(shop, updated);

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
@@ -6,7 +6,7 @@ import { useState, type ChangeEvent, type FormEvent } from "react";
 
 interface Props {
   shop: string;
-  initial: { enabled: boolean; interval: number };
+  initial: { enabled: boolean; intervalMinutes: number };
 }
 
 export default function DepositsEditor({ shop, initial }: Props) {
@@ -49,13 +49,13 @@ export default function DepositsEditor({ shop, initial }: Props) {
         <span>Interval (minutes)</span>
         <Input
           type="number"
-          name="interval"
-          value={state.interval}
+          name="intervalMinutes"
+          value={state.intervalMinutes}
           onChange={handleChange}
         />
-        {errors.interval && (
+        {errors.intervalMinutes && (
           <span className="text-sm text-red-600">
-            {errors.interval.join("; ")}
+            {errors.intervalMinutes.join("; ")}
           </span>
         )}
       </label>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/page.tsx
@@ -21,7 +21,7 @@ export default async function DepositsSettingsPage({
   const settings = await getSettings(shop);
   const depositService = settings.depositService ?? {
     enabled: false,
-    interval: 60,
+    intervalMinutes: 60,
   };
 
   return (

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -5,7 +5,7 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   },
   "seo": {
     "aiCatalog": {

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -5,7 +5,7 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   },
   "seo": {
     "aiCatalog": {

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -5,7 +5,7 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   },
   "seo": {
     "aiCatalog": {

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -4,7 +4,7 @@
   "taxRegion": "EU",
   "depositService": {
     "enabled": false,
-    "interval": 60
+    "intervalMinutes": 60
   },
   "languages": [
     "en",

--- a/doc/machine.md
+++ b/doc/machine.md
@@ -19,11 +19,11 @@ Each shop configures the service in `data/shops/<id>/settings.json` under the `d
 
 ```json
 {
-  "depositService": { "enabled": true, "interval": 60 }
+  "depositService": { "enabled": true, "intervalMinutes": 60 }
 }
 ```
 
-The `interval` value is specified in minutes and converted to milliseconds internally. The service subtracts any `damageFee` from the refunded amount and calls `markRefunded` so the order is not processed again.
+The `intervalMinutes` value is specified in minutes and converted to milliseconds internally. The service subtracts any `damageFee` from the refunded amount and calls `markRefunded` so the order is not processed again.
 
 Environment variables can be used to configure the service:
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -125,7 +125,7 @@ Rental shops that collect deposits can automate refunds when items are returned.
 pnpm release-deposits
 ```
 
-When a shop is scaffolded, `data/<id>/settings.json` includes a `depositService` block with `enabled: false` and `interval: 60` (minutes).
+When a shop is scaffolded, `data/<id>/settings.json` includes a `depositService` block with `enabled: false` and `intervalMinutes: 60` (minutes).
 The generated `.env` file also contains `DEPOSIT_RELEASE_ENABLED` and `DEPOSIT_RELEASE_INTERVAL_MS` placeholders for the background service.
 
 To keep it running on a schedule, import `startDepositReleaseService` from `@acme/platform-machine` and optionally pass a custom interval (defaults to one hour). The service scans every shop under `data/shops/*`, issues Stripe refunds and marks orders as refunded.

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -115,7 +115,7 @@ export function writeFiles(
       {
         languages: [...LOCALES],
         analytics: options.analytics,
-        depositService: { enabled: false, interval: 60 },
+        depositService: { enabled: false, intervalMinutes: 60 },
       },
       null,
       2

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -59,7 +59,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
         ...parsed.data,
         depositService: {
           enabled: false,
-          interval: 60,
+          intervalMinutes: 60,
           ...(parsed.data.depositService ?? {}),
         },
         seo: {
@@ -89,7 +89,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     freezeTranslations: false,
     currency: "EUR",
     taxRegion: "",
-    depositService: { enabled: false, interval: 60 },
+    depositService: { enabled: false, intervalMinutes: 60 },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/platform-machine/__tests__/releaseDepositsService.test.ts
+++ b/packages/platform-machine/__tests__/releaseDepositsService.test.ts
@@ -149,10 +149,14 @@ describe("startDepositReleaseService", () => {
     readOrders.mockResolvedValue([]);
     readFile
       .mockResolvedValueOnce(
-        JSON.stringify({ depositService: { enabled: true, interval: 1 } })
+        JSON.stringify({
+          depositService: { enabled: true, intervalMinutes: 1 },
+        }),
       )
       .mockResolvedValueOnce(
-        JSON.stringify({ depositService: { enabled: true, interval: 1 } })
+        JSON.stringify({
+          depositService: { enabled: true, intervalMinutes: 1 },
+        }),
       );
     process.env.DEPOSIT_RELEASE_ENABLED_SHOP2 = "false";
 

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -53,12 +53,13 @@ export async function releaseDepositsOnce(
 
 type DepositReleaseConfig = {
   enabled: boolean;
-  intervalMs: number;
+  /** Interval in minutes between service runs */
+  intervalMinutes: number;
 };
 
 const DEFAULT_CONFIG: DepositReleaseConfig = {
   enabled: false,
-  intervalMs: 1000 * 60 * 60,
+  intervalMinutes: 60,
 };
 
 function envKey(shop: string, key: string): string {
@@ -78,8 +79,8 @@ async function resolveConfig(
     const cfg = json.depositService;
     if (cfg) {
       if (typeof cfg.enabled === "boolean") config.enabled = cfg.enabled;
-      if (typeof cfg.interval === "number")
-        config.intervalMs = cfg.interval * 60 * 1000;
+      if (typeof cfg.intervalMinutes === "number")
+        config.intervalMinutes = cfg.intervalMinutes;
     }
   } catch {}
 
@@ -93,13 +94,14 @@ async function resolveConfig(
   const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
   if (envInterval !== undefined) {
     const num = Number(envInterval);
-    if (!Number.isNaN(num)) config.intervalMs = num;
+    if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
   } else if (coreEnv.DEPOSIT_RELEASE_INTERVAL_MS !== undefined) {
-    config.intervalMs = coreEnv.DEPOSIT_RELEASE_INTERVAL_MS;
+    config.intervalMinutes = Math.round(coreEnv.DEPOSIT_RELEASE_INTERVAL_MS / 60000);
   }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;
-  if (override.intervalMs !== undefined) config.intervalMs = override.intervalMs;
+  if (override.intervalMinutes !== undefined)
+    config.intervalMinutes = override.intervalMinutes;
 
   return config;
 }
@@ -125,7 +127,7 @@ export async function startDepositReleaseService(
       }
 
       await run();
-      timers.push(setInterval(run, cfg.intervalMs));
+      timers.push(setInterval(run, cfg.intervalMinutes * 60 * 1000));
     }),
   );
 

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -94,13 +94,13 @@ export declare const shopSettingsSchema: z.ZodObject<{
     taxRegion: z.ZodOptional<z.ZodString>;
     depositService: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodBoolean;
-        interval: z.ZodNumber;
+        intervalMinutes: z.ZodNumber;
     }, "strip", z.ZodTypeAny, {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     }, {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     }>>;
     updatedAt: z.ZodString;
     updatedBy: z.ZodString;
@@ -137,7 +137,7 @@ export declare const shopSettingsSchema: z.ZodObject<{
     taxRegion?: string | undefined;
     depositService?: {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     } | undefined;
 }, {
     seo: Partial<Record<"en" | "de" | "it", {
@@ -172,8 +172,8 @@ export declare const shopSettingsSchema: z.ZodObject<{
     taxRegion?: string | undefined;
     depositService?: {
         enabled: boolean;
-        interval: number;
+        intervalMinutes: number;
     } | undefined;
-}>;
+}>; 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
 //# sourceMappingURL=ShopSettings.d.ts.map

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -40,7 +40,8 @@ export const shopSettingsSchema = z.object({
   depositService: z
     .object({
       enabled: z.boolean(),
-      interval: z.number().int().positive(),
+      /** Interval in minutes between deposit release checks */
+      intervalMinutes: z.number().int().positive(),
     })
     .optional(),
   updatedAt: z.string(),


### PR DESCRIPTION
## Summary
- standardize deposit release interval on minutes (`intervalMinutes`)
- update CMS editor and shop settings schema to use minutes
- convert environment-configured milliseconds to minutes in deposit release service

## Testing
- `pnpm --filter @acme/platform-machine test` *(fails: PageBuilder interactions › resizes via sidebar inputs)*
- `pnpm --filter @acme/platform-core test` *(fails: PageBuilder interactions › resizes via sidebar inputs)*

------
https://chatgpt.com/codex/tasks/task_e_689b4be875d4832fa783f4dc3a8a5dd3