### PR TITLE
feat(platform-core): add log level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `CART_TTL` – cart expiration in seconds (defaults to 30 days)
 - `DEPOSIT_RELEASE_ENABLED` – `true` or `false` to toggle automated deposit refunds
 - `DEPOSIT_RELEASE_INTERVAL_MS` – interval in milliseconds for running the refund service
+- `LOG_LEVEL` – controls logging output (`error`, `warn`, `info`, `debug`; defaults to `info`)
 
 The scaffolded `.env` also includes generated placeholders for `NEXTAUTH_SECRET`
 and `PREVIEW_TOKEN_SECRET`. Replace all placeholders with real values or supply

--- a/packages/platform-core/src/utils/README.md
+++ b/packages/platform-core/src/utils/README.md
@@ -5,6 +5,7 @@ Shared helpers for platform-core.
 - `getShopFromPath(path)` – extract a shop identifier from a URL path.
 - `replaceShopInPath(path, shop)` – swap the shop identifier in a path.
 - `initTheme` – initialize the client's theme based on saved preferences.
+- `logger` – structured console logger; set `LOG_LEVEL` (`error`, `warn`, `info`, `debug`) to control output (defaults to `info`).
 
 These utilities are re-exported from the `@acme/platform-core` package root for
 easy consumption. Functions like `slugify` and `genSecret` now live in

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -2,3 +2,4 @@ export { getShopFromPath } from "./getShopFromPath";
 export { replaceShopInPath } from "./replaceShopInPath";
 export { initTheme } from "./initTheme";
 export { logger } from "./logger";
+export type { LogMeta } from "./logger";

--- a/packages/platform-core/src/utils/logger.ts
+++ b/packages/platform-core/src/utils/logger.ts
@@ -2,14 +2,48 @@ export interface LogMeta {
   [key: string]: unknown;
 }
 
+type LogLevel = "error" | "warn" | "info" | "debug";
+
+const levelPriority: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+const envLevel = process.env.LOG_LEVEL as LogLevel | undefined;
+const currentLevel = levelPriority[envLevel ?? "info"] ?? levelPriority.info;
+
+function log(level: LogLevel, message: string, meta: LogMeta = {}) {
+  if (levelPriority[level] <= currentLevel) {
+    const output = { level, message, ...meta };
+    switch (level) {
+      case "error":
+        console.error(output);
+        break;
+      case "warn":
+        console.warn(output);
+        break;
+      case "debug":
+        console.debug(output);
+        break;
+      default:
+        console.info(output);
+    }
+  }
+}
+
 export const logger = {
-  info(message: string, meta: LogMeta = {}) {
-    console.info({ level: "info", message, ...meta });
+  error(message: string, meta: LogMeta = {}) {
+    log("error", message, meta);
   },
   warn(message: string, meta: LogMeta = {}) {
-    console.warn({ level: "warn", message, ...meta });
+    log("warn", message, meta);
   },
-  error(message: string, meta: LogMeta = {}) {
-    console.error({ level: "error", message, ...meta });
+  info(message: string, meta: LogMeta = {}) {
+    log("info", message, meta);
+  },
+  debug(message: string, meta: LogMeta = {}) {
+    log("debug", message, meta);
   },
 };


### PR DESCRIPTION
## Summary
- add centralized logger helper honoring LOG_LEVEL
- expose LogMeta and document LOG_LEVEL

## Testing
- `pnpm lint --filter @acme/platform-core`
- `pnpm --filter @acme/platform-core test` *(fails: PageBuilder interactions › resizes via sidebar inputs)*

------
https://chatgpt.com/codex/tasks/task_e_689b5886c9e4832fb016dd1c13e55075