### PR TITLE
feat(ui): configure recommendation carousel item counts

### DIFF
--- a/packages/ui/src/components/cms/blocks/RecommendationCarousel.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/RecommendationCarousel.stories.tsx
@@ -12,3 +12,7 @@ export const Default: StoryObj<typeof RecommendationCarousel> = {};
 export const Bounded: StoryObj<typeof RecommendationCarousel> = {
   args: { minItems: 2, maxItems: 4 },
 };
+
+export const Responsive: StoryObj<typeof RecommendationCarousel> = {
+  args: { desktopItems: 4, tabletItems: 2, mobileItems: 1 },
+};

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -32,6 +32,7 @@ import NewsletterSignupEditor from "./NewsletterSignupEditor";
 import ImageSliderEditor from "./ImageSliderEditor";
 import CollectionListEditor from "./CollectionListEditor";
 import SearchBarEditor from "./SearchBarEditor";
+import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -108,6 +109,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "CollectionList":
       specific = (
         <CollectionListEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "RecommendationCarousel":
+      specific = (
+        <RecommendationCarouselEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/RecommendationCarouselEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/RecommendationCarouselEditor.tsx
@@ -1,0 +1,42 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function RecommendationCarouselEditor({ component, onChange }: Props) {
+  const handleNum = (field: string, value: string) => {
+    const num = value ? Number(value) : undefined;
+    onChange({ [field]: isNaN(num!) ? undefined : num } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        label="Endpoint"
+        value={(component as any).endpoint ?? ""}
+        onChange={(e) => onChange({ endpoint: e.target.value } as Partial<PageComponent>)}
+      />
+      <Input
+        label="Desktop Items"
+        type="number"
+        value={(component as any).desktopItems ?? ""}
+        onChange={(e) => handleNum("desktopItems", e.target.value)}
+      />
+      <Input
+        label="Tablet Items"
+        type="number"
+        value={(component as any).tabletItems ?? ""}
+        onChange={(e) => handleNum("tabletItems", e.target.value)}
+      />
+      <Input
+        label="Mobile Items"
+        type="number"
+        value={(component as any).mobileItems ?? ""}
+        onChange={(e) => handleNum("mobileItems", e.target.value)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -16,6 +16,7 @@ export { default as NewsletterSignupEditor } from "./NewsletterSignupEditor";
 export { default as ImageSliderEditor } from "./ImageSliderEditor";
 export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as SearchBarEditor } from "./SearchBarEditor";
+export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";

--- a/packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx
+++ b/packages/ui/src/components/organisms/RecommendationCarousel.stories.tsx
@@ -20,3 +20,7 @@ export const Bounded: StoryObj<typeof RecommendationCarousel> = {
 export const Mobile: StoryObj<typeof RecommendationCarousel> = {
   parameters: { viewport: { defaultViewport: "mobile1" } },
 };
+
+export const Responsive: StoryObj<typeof RecommendationCarousel> = {
+  args: { desktopItems: 4, tabletItems: 2, mobileItems: 1 },
+};

--- a/packages/ui/src/components/organisms/RecommendationCarousel.tsx
+++ b/packages/ui/src/components/organisms/RecommendationCarousel.tsx
@@ -12,6 +12,12 @@ export interface RecommendationCarouselProps
   minItems?: number;
   /** Maximum number of items visible per slide. */
   maxItems?: number;
+  /** Items shown on desktop viewports */
+  desktopItems?: number;
+  /** Items shown on tablet viewports */
+  tabletItems?: number;
+  /** Items shown on mobile viewports */
+  mobileItems?: number;
   /** Tailwind class controlling gap between slides */
   gapClassName?: string;
   /** Function to calculate individual slide width */
@@ -28,17 +34,32 @@ export function RecommendationCarousel({
   endpoint,
   minItems = 1,
   maxItems = 4,
+  desktopItems,
+  tabletItems,
+  mobileItems,
   gapClassName = "gap-4",
   getSlideWidth = (n) => `${100 / n}%`,
   className,
   ...props
 }: RecommendationCarouselProps) {
   const [products, setProducts] = React.useState<Product[]>([]);
-  const [itemsPerSlide, setItemsPerSlide] = React.useState(minItems);
+  const [itemsPerSlide, setItemsPerSlide] = React.useState(
+    desktopItems ?? minItems
+  );
 
   React.useEffect(() => {
     const calculateItems = () => {
       const width = window.innerWidth;
+      if (desktopItems || tabletItems || mobileItems) {
+        const chosen =
+          width >= 1024
+            ? desktopItems
+            : width >= 768
+            ? tabletItems
+            : mobileItems;
+        setItemsPerSlide(chosen ?? minItems);
+        return;
+      }
       const approxItemWidth = 320;
       const count = Math.floor(width / approxItemWidth);
       setItemsPerSlide(
@@ -48,7 +69,13 @@ export function RecommendationCarousel({
     calculateItems();
     window.addEventListener("resize", calculateItems);
     return () => window.removeEventListener("resize", calculateItems);
-  }, [minItems, maxItems]);
+  }, [
+    minItems,
+    maxItems,
+    desktopItems,
+    tabletItems,
+    mobileItems,
+  ]);
 
   React.useEffect(() => {
     const load = async () => {

--- a/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
@@ -1,0 +1,46 @@
+import { render, waitFor } from "@testing-library/react";
+import { RecommendationCarousel } from "../RecommendationCarousel";
+import type { Product } from "../ProductCard";
+
+jest.mock("../ProductCard", () => ({
+  ProductCard: ({ product }: { product: Product }) => (
+    <div data-testid={`product-${product.id}`} />
+  ),
+}));
+
+const products: Product[] = [
+  { id: "1", title: "A", images: [{ url: "", type: "image" }], price: 1 },
+  { id: "2", title: "B", images: [{ url: "", type: "image" }], price: 2 },
+];
+
+describe("RecommendationCarousel responsive counts", () => {
+  beforeEach(() => {
+    // @ts-expect-error mock fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => products,
+    });
+  });
+
+  function setWidth(width: number) {
+    Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+  }
+
+  it("uses desktopItems for wide viewports", async () => {
+    setWidth(1200);
+    const { container } = render(
+      <RecommendationCarousel
+        endpoint="/api"
+        desktopItems={4}
+        tabletItems={2}
+        mobileItems={1}
+      />
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(container.querySelector(".snap-start")).toBeTruthy()
+    );
+    const slide = container.querySelector(".snap-start") as HTMLElement;
+    expect(slide.style.flex).toBe("0 0 25%");
+  });
+});


### PR DESCRIPTION
## Summary
- add desktop/tablet/mobile item props to `RecommendationCarousel`
- expose new props in page builder via `RecommendationCarouselEditor`
- document responsive counts in stories and tests

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx packages/ui/__tests__/RecommendationCarousel.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689b5d0b4aac832f87684f2168bee66e