### PR TITLE
feat: add filters slot to SearchResultsTemplate

### DIFF
--- a/packages/ui/src/components/templates/README.md
+++ b/packages/ui/src/components/templates/README.md
@@ -16,8 +16,9 @@ Shared page-level layouts used across apps. Currently includes:
 - `HomepageTemplate` – layout with hero and recommendation slots.
 - `CartTemplate` – editable list of cart items with totals.
 - `CategoryCollectionTemplate` – grid of category cards.
-- `SearchResultsTemplate` – search bar with paginated product results. Accepts
-  `minItems` and `maxItems` to adjust the responsive product grid.
+- `SearchResultsTemplate` – search bar with optional filters and paginated
+  product results. Accepts `minItems` and `maxItems` to adjust the responsive
+  product grid.
 - `CheckoutTemplate` – multi-step layout for collecting checkout information.
 - `OrderConfirmationTemplate` – summary of purchased items and totals.
 - `WishlistTemplate` – list of saved items with add-to-cart and remove actions.

--- a/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from "@storybook/react";
+import FilterBar from "@platform-core/src/components/shop/FilterBar";
 import type { Product } from "../organisms/ProductCard";
 import { SearchResultsTemplate } from "./SearchResultsTemplate";
 
@@ -35,3 +36,10 @@ const meta: Meta<typeof SearchResultsTemplate> = {
 export default meta;
 
 export const Default: StoryObj<typeof SearchResultsTemplate> = {};
+
+export const WithFilters: StoryObj<typeof SearchResultsTemplate> = {
+  args: {
+    ...meta.args,
+    filters: <FilterBar onChange={() => undefined} />,
+  },
+};

--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -17,6 +17,8 @@ export interface SearchResultsTemplateProps
   maxItems?: number;
   onQueryChange?: (query: string) => void;
   onPageChange?: (page: number) => void;
+  /** Optional filters to render between the search bar and results */
+  filters?: React.ReactNode;
 }
 
 export function SearchResultsTemplate({
@@ -28,6 +30,7 @@ export function SearchResultsTemplate({
   maxItems,
   onQueryChange,
   onPageChange,
+  filters,
   className,
   ...props
 }: SearchResultsTemplateProps) {
@@ -38,6 +41,7 @@ export function SearchResultsTemplate({
         onSelect={onQueryChange}
         placeholder="Search products…"
       />
+      {filters}
       {results.length > 0 ? (
         <ProductGrid products={results} minItems={minItems} maxItems={maxItems} />
       ) : (


### PR DESCRIPTION
## Summary
- allow SearchResultsTemplate to accept optional `filters` slot
- demo SearchResultsTemplate composed with `FilterBar` story
- document filters slot in templates README

## Testing
- `pnpm --filter @acme/ui test` *(fails: PageBuilder.drag-resize.test.tsx expectation mismatch; apps/cms wizard.test.tsx missing module; process.exit called in payments env)*

------
https://chatgpt.com/codex/tasks/task_e_689b633ae9b4832f90a9100b651dcdae