### PR TITLE
feat: enhance stripe webhook handling

### DIFF
--- a/apps/shop-abc/src/app/api/stripe-webhook/route.js
+++ b/apps/shop-abc/src/app/api/stripe-webhook/route.js
@@ -1,36 +1,9 @@
 // apps/shop-abc/src/app/api/stripe-webhook/route.ts
-import { addOrder, markRefunded, } from "@platform-core/orders";
+import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { NextResponse } from "next/server";
 export const runtime = "edge";
 export async function POST(req) {
-    const payload = (await req.json());
-    const eventType = payload.type;
-    const data = payload.data?.object;
-    switch (eventType) {
-        case "checkout.session.completed": {
-            const session = data;
-            const deposit = Number(session.metadata?.depositTotal ?? 0);
-            const returnDate = session.metadata?.returnDate || undefined;
-            const customerId = session.metadata?.customerId || undefined;
-            await addOrder("abc", session.id, deposit, returnDate, customerId);
-            break;
-        }
-        case "charge.refunded": {
-            const charge = data;
-            const sessionId = (() => {
-                if (typeof charge.payment_intent !== "string" &&
-                    charge.payment_intent) {
-                    const pi = charge.payment_intent;
-                    return pi.charges?.data?.[0]?.invoice || undefined;
-                }
-                return undefined;
-            })();
-            const sid = sessionId || charge.id;
-            await markRefunded("abc", sid);
-            break;
-        }
-        default:
-            break;
-    }
+    const event = await req.json();
+    await handleStripeWebhook("abc", event);
     return NextResponse.json({ received: true });
 }

--- a/apps/shop-abc/src/app/api/stripe-webhook/route.ts
+++ b/apps/shop-abc/src/app/api/stripe-webhook/route.ts
@@ -1,61 +1,13 @@
 // apps/shop-abc/src/app/api/stripe-webhook/route.ts
 
-import { addOrder, markRefunded } from "@platform-core/orders";
+import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import type Stripe from "stripe";
-
-type WebhookData =
-  | Stripe.Checkout.Session
-  | Stripe.Charge
-  | Record<string, unknown>;
-
-const StripeEventSchema = z.object({
-  type: z.string(),
-  data: z.object({ object: z.unknown() }),
-});
 
 export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
-  const result = StripeEventSchema.safeParse(await req.json());
-  if (!result.success) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
-  }
-
-  const { type: eventType, data } = result.data;
-  const webhookData = data.object as WebhookData;
-
-  switch (eventType) {
-    case "checkout.session.completed": {
-      const session = webhookData as Stripe.Checkout.Session;
-      const deposit = Number(session.metadata?.depositTotal ?? 0);
-      const returnDate = session.metadata?.returnDate || undefined;
-      const customerId = session.metadata?.customerId || undefined;
-      await addOrder("abc", session.id, deposit, returnDate, customerId);
-      break;
-    }
-    case "charge.refunded": {
-      const charge = webhookData as Stripe.Charge;
-      const sessionId = (() => {
-        if (
-          typeof charge.payment_intent !== "string" &&
-          charge.payment_intent
-        ) {
-          const pi = charge.payment_intent as Stripe.PaymentIntent & {
-            charges?: { data?: Array<{ invoice?: string | null }> };
-          };
-          return pi.charges?.data?.[0]?.invoice || undefined;
-        }
-        return undefined;
-      })();
-      const sid = sessionId || charge.id;
-      await markRefunded("abc", sid);
-      break;
-    }
-    default:
-      break;
-  }
-
+  const event = (await req.json()) as Stripe.Event;
+  await handleStripeWebhook("abc", event);
   return NextResponse.json({ received: true });
 }

--- a/apps/shop-bcd/src/api/stripe-webhook/route.js
+++ b/apps/shop-bcd/src/api/stripe-webhook/route.js
@@ -1,36 +1,9 @@
-// apps/shop-bcd/src/app/api/stripe-webhook/route.ts
-import { addOrder, markRefunded, } from "@platform-core/orders";
+// apps/shop-bcd/src/api/stripe-webhook/route.ts
+import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { NextResponse } from "next/server";
 export const runtime = "edge";
 export async function POST(req) {
-    const payload = (await req.json());
-    const eventType = payload.type;
-    const data = payload.data?.object;
-    switch (eventType) {
-        case "checkout.session.completed": {
-            const session = data;
-            const deposit = Number(session.metadata?.depositTotal ?? 0);
-            const returnDate = session.metadata?.returnDate || undefined;
-            const customerId = session.metadata?.customerId || undefined;
-            await addOrder("bcd", session.id, deposit, returnDate, customerId);
-            break;
-        }
-        case "charge.refunded": {
-            const charge = data;
-            const sessionId = (() => {
-                if (typeof charge.payment_intent !== "string" &&
-                    charge.payment_intent) {
-                    const pi = charge.payment_intent;
-                    return pi.charges?.data?.[0]?.invoice || undefined;
-                }
-                return undefined;
-            })();
-            const sid = sessionId || charge.id;
-            await markRefunded("bcd", sid);
-            break;
-        }
-        default:
-            break;
-    }
+    const event = await req.json();
+    await handleStripeWebhook("bcd", event);
     return NextResponse.json({ received: true });
 }

--- a/apps/shop-bcd/src/api/stripe-webhook/route.ts
+++ b/apps/shop-bcd/src/api/stripe-webhook/route.ts
@@ -1,61 +1,13 @@
-// apps/shop-bcd/src/app/api/stripe-webhook/route.ts
+// apps/shop-bcd/src/api/stripe-webhook/route.ts
 
-import { addOrder, markRefunded } from "@platform-core/orders";
+import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import type Stripe from "stripe";
-
-type WebhookData =
-  | Stripe.Checkout.Session
-  | Stripe.Charge
-  | Record<string, unknown>;
-
-const StripeEventSchema = z.object({
-  type: z.string(),
-  data: z.object({ object: z.unknown() }),
-});
 
 export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
-  const result = StripeEventSchema.safeParse(await req.json());
-  if (!result.success) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
-  }
-
-  const { type: eventType, data } = result.data;
-  const webhookData = data.object as WebhookData;
-
-  switch (eventType) {
-    case "checkout.session.completed": {
-      const session = webhookData as Stripe.Checkout.Session;
-      const deposit = Number(session.metadata?.depositTotal ?? 0);
-      const returnDate = session.metadata?.returnDate || undefined;
-      const customerId = session.metadata?.customerId || undefined;
-      await addOrder("bcd", session.id, deposit, returnDate, customerId);
-      break;
-    }
-    case "charge.refunded": {
-      const charge = webhookData as Stripe.Charge;
-      const sessionId = (() => {
-        if (
-          typeof charge.payment_intent !== "string" &&
-          charge.payment_intent
-        ) {
-          const pi = charge.payment_intent as Stripe.PaymentIntent & {
-            charges?: { data?: Array<{ invoice?: string | null }> };
-          };
-          return pi.charges?.data?.[0]?.invoice || undefined;
-        }
-        return undefined;
-      })();
-      const sid = sessionId || charge.id;
-      await markRefunded("bcd", sid);
-      break;
-    }
-    default:
-      break;
-  }
-
+  const event = (await req.json()) as Stripe.Event;
+  await handleStripeWebhook("bcd", event);
   return NextResponse.json({ received: true });
 }

--- a/packages/platform-core/__tests__/stripe-webhook.test.ts
+++ b/packages/platform-core/__tests__/stripe-webhook.test.ts
@@ -1,0 +1,50 @@
+import { jest } from "@jest/globals";
+import type Stripe from "stripe";
+
+const addOrder = jest.fn();
+const markRefunded = jest.fn();
+const updateRisk = jest.fn();
+
+jest.mock("../src/orders", () => ({
+  addOrder,
+  markRefunded,
+  updateRisk,
+}));
+
+describe("handleStripeWebhook", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("charge.succeeded persists risk details", async () => {
+    const { handleStripeWebhook } = await import("../src/stripe-webhook");
+    const event: Stripe.Event = {
+      type: "charge.succeeded",
+      data: {
+        object: {
+          id: "ch_1",
+          outcome: { risk_level: "elevated", risk_score: 42 },
+        },
+      },
+    } as any;
+    await handleStripeWebhook("test", event);
+    expect(updateRisk).toHaveBeenCalledWith("test", "ch_1", "elevated", 42);
+  });
+
+  test("early fraud warning cancels high risk", async () => {
+    const { handleStripeWebhook } = await import("../src/stripe-webhook");
+    const event: Stripe.Event = {
+      type: "radar.early_fraud_warning.created",
+      data: {
+        object: {
+          charge: "ch_2",
+          risk_level: "highest",
+          risk_score: 90,
+        },
+      },
+    } as any;
+    await handleStripeWebhook("test", event);
+    expect(updateRisk).toHaveBeenCalledWith("test", "ch_2", "highest", 90, true);
+    expect(markRefunded).toHaveBeenCalledWith("test", "ch_2");
+  });
+});

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -11,7 +11,8 @@
     "./customerProfiles": "./src/customerProfiles/index.ts",
     "./plugins": "./src/plugins/index.ts",
     "./configurator": "./src/configurator.ts",
-    "./users": "./src/users.ts"
+    "./users": "./src/users.ts",
+    "./stripe-webhook": "./src/stripe-webhook.ts"
   },
   "dependencies": {
     "@acme/shared-utils": "workspace:*",

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -33,6 +33,9 @@ model RentalOrder {
   refundedAt         String?
   damageFee          Int?
   customerId         String?
+  riskLevel          String?
+  riskScore          Int?
+  flaggedForReview   Boolean? @default(false)
 
   @@unique([shop, sessionId])
   @@index([customerId])

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -69,6 +69,30 @@ export async function markRefunded(
   }
 }
 
+export async function updateRisk(
+  shop: string,
+  sessionId: string,
+  riskLevel?: string,
+  riskScore?: number,
+  flaggedForReview?: boolean
+): Promise<Order | null> {
+  try {
+    const order = await prisma.rentalOrder.update({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: {
+        ...(riskLevel ? { riskLevel } : {}),
+        ...(typeof riskScore === "number" ? { riskScore } : {}),
+        ...(typeof flaggedForReview === "boolean"
+          ? { flaggedForReview }
+          : {}),
+      },
+    });
+    return order as Order;
+  } catch {
+    return null;
+  }
+}
+
 export async function getOrdersForCustomer(
   shop: string,
   customerId: string

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -6,4 +6,5 @@ export {
   addOrder,
   markReturned,
   markRefunded,
+  updateRisk,
 } from "../orders";

--- a/packages/platform-core/src/stripe-webhook.ts
+++ b/packages/platform-core/src/stripe-webhook.ts
@@ -1,0 +1,81 @@
+// packages/platform-core/src/stripe-webhook.ts
+import type Stripe from "stripe";
+import { addOrder, markRefunded, updateRisk } from "./orders";
+
+function extractSessionIdFromCharge(charge: Stripe.Charge): string | undefined {
+  if (charge.invoice) return charge.invoice as string;
+  if (typeof charge.payment_intent !== "string" && charge.payment_intent) {
+    const pi = charge.payment_intent as Stripe.PaymentIntent & {
+      charges?: { data?: Array<{ invoice?: string | null }> };
+    };
+    return pi.charges?.data?.[0]?.invoice || undefined;
+  }
+  return undefined;
+}
+
+async function persistRiskFromCharge(shop: string, charge: Stripe.Charge) {
+  const sessionId = extractSessionIdFromCharge(charge) || charge.id;
+  const riskLevel = charge.outcome?.risk_level;
+  const riskScore = charge.outcome?.risk_score;
+  await updateRisk(
+    shop,
+    sessionId,
+    riskLevel,
+    typeof riskScore === "number" ? riskScore : undefined
+  );
+}
+
+export async function handleStripeWebhook(
+  shop: string,
+  event: Stripe.Event
+): Promise<void> {
+  const { type, data } = event;
+  switch (type) {
+    case "checkout.session.completed": {
+      const session = data.object as Stripe.Checkout.Session;
+      const deposit = Number(session.metadata?.depositTotal ?? 0);
+      const returnDate = session.metadata?.returnDate || undefined;
+      const customerId = session.metadata?.customerId || undefined;
+      await addOrder(shop, session.id, deposit, returnDate, customerId);
+      break;
+    }
+    case "charge.refunded": {
+      const charge = data.object as Stripe.Charge;
+      const sessionId = extractSessionIdFromCharge(charge) || charge.id;
+      await markRefunded(shop, sessionId);
+      break;
+    }
+    case "payment_intent.succeeded": {
+      const pi = data.object as Stripe.PaymentIntent;
+      const charge = pi.charges?.data?.[0];
+      if (charge) {
+        await persistRiskFromCharge(shop, charge);
+      }
+      break;
+    }
+    case "charge.succeeded": {
+      const charge = data.object as Stripe.Charge;
+      await persistRiskFromCharge(shop, charge);
+      break;
+    }
+    default: {
+      if (type.startsWith("radar.early_fraud_warning.")) {
+        const warning = data.object as any; // Stripe.Radar.EarlyFraudWarning
+        const chargeId =
+          typeof warning.charge === "string" ? warning.charge : warning.charge?.id;
+        if (chargeId) {
+          const riskLevel = warning.risk_level as string | undefined;
+          const riskScore = warning.risk_score as number | undefined;
+          await updateRisk(shop, chargeId, riskLevel, riskScore, true);
+          if (
+            riskLevel === "highest" ||
+            (typeof riskScore === "number" && riskScore > 75)
+          ) {
+            await markRefunded(shop, chargeId);
+          }
+        }
+      }
+      break;
+    }
+  }
+}

--- a/packages/template-app/__tests__/stripe-webhook.test.ts
+++ b/packages/template-app/__tests__/stripe-webhook.test.ts
@@ -9,59 +9,17 @@ if (typeof (Response as any).json !== "function") {
 afterEach(() => jest.resetModules());
 
 describe("/api/stripe-webhook", () => {
-  test("checkout.session.completed creates an order", async () => {
-    const addOrder = jest.fn();
-    jest.doMock(
-      "@platform-core/repositories/rentalOrders.server",
-      () => ({
-        __esModule: true,
-        addOrder,
-        markRefunded: jest.fn(),
-      }),
-      { virtual: true }
-    );
+  test("forwards events to common handler", async () => {
+    const handleStripeWebhook = jest.fn();
+    jest.doMock("@platform-core/stripe-webhook", () => ({
+      __esModule: true,
+      handleStripeWebhook,
+    }), { virtual: true });
 
     const { POST } = await import("../src/api/stripe-webhook/route");
-    const payload = {
-      type: "checkout.session.completed",
-      data: {
-        object: {
-          id: "sess",
-          metadata: { depositTotal: "10", returnDate: "2030-05-05" },
-        },
-      },
-    } as any;
+    const payload = { type: "checkout.session.completed", data: { object: {} } } as any;
     const res = await POST({ json: async () => payload } as any);
-    expect(addOrder).toHaveBeenCalledWith("bcd", "sess", 10, "2030-05-05");
-    expect(res.status).toBe(200);
-  });
-
-  test("charge.refunded marks order refunded", async () => {
-    const markRefunded = jest.fn();
-    jest.doMock(
-      "@platform-core/repositories/rentalOrders.server",
-      () => ({
-        __esModule: true,
-        addOrder: jest.fn(),
-        markRefunded,
-      }),
-      { virtual: true }
-    );
-
-    const { POST } = await import("../src/api/stripe-webhook/route");
-    const payload = {
-      type: "charge.refunded",
-      data: {
-        object: {
-          id: "ch_1",
-          payment_intent: {
-            charges: { data: [{ invoice: "sess_2" }] },
-          },
-        },
-      },
-    } as any;
-    const res = await POST({ json: async () => payload } as any);
-    expect(markRefunded).toHaveBeenCalledWith("bcd", "sess_2");
+    expect(handleStripeWebhook).toHaveBeenCalledWith("bcd", payload);
     expect(res.status).toBe(200);
   });
 });

--- a/packages/template-app/src/api/stripe-webhook/route.ts
+++ b/packages/template-app/src/api/stripe-webhook/route.ts
@@ -1,53 +1,13 @@
 // packages/template-app/src/api/stripe-webhook/route.ts
 
-import {
-  addOrder,
-  markRefunded,
-} from "@platform-core/repositories/rentalOrders.server";
+import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
-
-type WebhookData =
-  | Stripe.Checkout.Session
-  | Stripe.Charge
-  | Record<string, unknown>;
 
 export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
-  const payload = (await req.json()) as Stripe.Event;
-  const eventType = payload.type;
-  const data = payload.data?.object as WebhookData;
-
-  switch (eventType) {
-    case "checkout.session.completed": {
-      const session = data as Stripe.Checkout.Session;
-      const deposit = Number(session.metadata?.depositTotal ?? 0);
-      const returnDate = session.metadata?.returnDate || undefined;
-      await addOrder("bcd", session.id, deposit, returnDate);
-      break;
-    }
-    case "charge.refunded": {
-      const charge = data as Stripe.Charge;
-      const sessionId = (() => {
-        if (
-          typeof charge.payment_intent !== "string" &&
-          charge.payment_intent
-        ) {
-          const pi = charge.payment_intent as Stripe.PaymentIntent & {
-            charges?: { data?: Array<{ invoice?: string | null }> };
-          };
-          return pi.charges?.data?.[0]?.invoice || undefined;
-        }
-        return undefined;
-      })();
-      const sid = sessionId || charge.id;
-      await markRefunded("bcd", sid);
-      break;
-    }
-    default:
-      break;
-  }
-
+  const event = (await req.json()) as Stripe.Event;
+  await handleStripeWebhook("bcd", event);
   return NextResponse.json({ received: true });
 }

--- a/packages/types/src/RentalOrder.d.ts
+++ b/packages/types/src/RentalOrder.d.ts
@@ -11,6 +11,9 @@ export declare const rentalOrderSchema: z.ZodObject<{
     /** Optional damage fee deducted from the deposit */
     damageFee: z.ZodOptional<z.ZodNumber>;
     customerId: z.ZodOptional<z.ZodString>;
+    riskLevel: z.ZodOptional<z.ZodString>;
+    riskScore: z.ZodOptional<z.ZodNumber>;
+    flaggedForReview: z.ZodOptional<z.ZodBoolean>;
 }, "strip", z.ZodTypeAny, {
     id: string;
     deposit: number;
@@ -22,6 +25,9 @@ export declare const rentalOrderSchema: z.ZodObject<{
     refundedAt?: string | undefined;
     damageFee?: number | undefined;
     customerId?: string | undefined;
+    riskLevel?: string | undefined;
+    riskScore?: number | undefined;
+    flaggedForReview?: boolean | undefined;
 }, {
     id: string;
     deposit: number;
@@ -33,6 +39,9 @@ export declare const rentalOrderSchema: z.ZodObject<{
     refundedAt?: string | undefined;
     damageFee?: number | undefined;
     customerId?: string | undefined;
+    riskLevel?: string | undefined;
+    riskScore?: number | undefined;
+    flaggedForReview?: boolean | undefined;
 }>;
 export type RentalOrder = z.infer<typeof rentalOrderSchema>;
 //# sourceMappingURL=RentalOrder.d.ts.map

--- a/packages/types/src/RentalOrder.ts
+++ b/packages/types/src/RentalOrder.ts
@@ -12,6 +12,9 @@ export const rentalOrderSchema = z.object({
   /** Optional damage fee deducted from the deposit */
   damageFee: z.number().optional(),
   customerId: z.string().optional(),
+  riskLevel: z.string().optional(),
+  riskScore: z.number().optional(),
+  flaggedForReview: z.boolean().optional(),
 });
 
 export type RentalOrder = z.infer<typeof rentalOrderSchema>;


### PR DESCRIPTION
## Summary
- add risk-level fields to rental orders and API
- centralize Stripe webhook handling with risk scoring and fraud warning logic
- update shop apps and template to use shared handler

## Testing
- `pnpm exec jest packages/platform-core/__tests__/stripe-webhook.test.ts apps/shop-abc/__tests__/stripe-webhook.test.ts packages/template-app/__tests__/stripe-webhook.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b6411c5a0832f9aed8f63764ee9e3