### PR TITLE
feat(email): add segment-based recipients

### DIFF
--- a/apps/cms/__tests__/marketingEmailApi.test.ts
+++ b/apps/cms/__tests__/marketingEmailApi.test.ts
@@ -1,0 +1,94 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+jest.doMock("@platform-core/analytics", () => ({
+  __esModule: true,
+  trackEvent: jest.fn(),
+}));
+jest.doMock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [],
+  }),
+  { virtual: true }
+);
+
+process.env.CART_COOKIE_SECRET = "secret";
+process.env.STRIPE_SECRET_KEY = "sk_test";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+
+const ResponseWithJson = Response as unknown as typeof Response & {
+  json?: (data: unknown, init?: ResponseInit) => Response;
+};
+if (typeof ResponseWithJson.json !== "function") {
+  ResponseWithJson.json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+describe("marketing email API segments", () => {
+  const shop = "segshop";
+  const shopDir = path.join(DATA_ROOT, shop);
+
+  beforeEach(async () => {
+    await fs.rm(shopDir, { recursive: true, force: true });
+    await fs.mkdir(shopDir, { recursive: true });
+  });
+
+  test("resolves recipients from segment when list empty", async () => {
+    await fs.writeFile(
+      path.join(shopDir, "analytics.jsonl"),
+      JSON.stringify({ type: "segment:vip", email: "a@example.com" }) + "\n" +
+        JSON.stringify({ type: "segment", segment: "vip", email: "b@example.com" }) +
+        "\n",
+      "utf8"
+    );
+
+    const { POST } = await import("../src/app/api/marketing/email/route");
+
+    const res = await POST({
+      json: async () => ({
+        shop,
+        recipients: [],
+        subject: "Hello",
+        body: "<p>Hi</p>",
+        segment: "vip",
+        sendAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+      }),
+    } as unknown as NextRequest);
+
+    expect(res.status).toBe(200);
+    const campaigns = JSON.parse(
+      await fs.readFile(path.join(shopDir, "campaigns.json"), "utf8")
+    );
+    expect(campaigns[0].recipients.sort()).toEqual(
+      ["a@example.com", "b@example.com"].sort()
+    );
+  });
+
+  test("falls back to manual recipients when provided", async () => {
+    await fs.writeFile(path.join(shopDir, "analytics.jsonl"), "", "utf8");
+
+    const { POST } = await import("../src/app/api/marketing/email/route");
+
+    const res = await POST({
+      json: async () => ({
+        shop,
+        recipients: ["manual@example.com"],
+        subject: "Hello",
+        body: "<p>Hi</p>",
+        segment: "vip",
+        sendAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+      }),
+    } as unknown as NextRequest);
+
+    expect(res.status).toBe(200);
+    const campaigns = JSON.parse(
+      await fs.readFile(path.join(shopDir, "campaigns.json"), "utf8")
+    );
+    expect(campaigns[0].recipients).toEqual(["manual@example.com"]);
+  });
+});

--- a/functions/__tests__/marketing-email-sender.test.ts
+++ b/functions/__tests__/marketing-email-sender.test.ts
@@ -1,0 +1,84 @@
+import { jest } from "@jest/globals";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+process.env.CART_COOKIE_SECRET = "secret";
+
+jest.mock("@acme/email", () => {
+  const actual = jest.requireActual("@acme/email") as Record<string, any>;
+  return { __esModule: true, ...actual, sendCampaignEmail: jest.fn() };
+});
+
+jest.mock("@platform-core/analytics", () => ({
+  __esModule: true,
+  trackEvent: jest.fn(),
+}));
+
+let sendCampaignEmail: jest.Mock;
+beforeAll(async () => {
+  ({ sendCampaignEmail } = (await import("@acme/email")) as any);
+});
+
+describe("sendScheduledCampaigns", () => {
+  const shop = "segshop2";
+  const shopDir = path.join(DATA_ROOT, shop);
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await fs.rm(shopDir, { recursive: true, force: true });
+    await fs.mkdir(shopDir, { recursive: true });
+  });
+
+  test("refreshes segment recipients at send time and uses manual list otherwise", async () => {
+    await fs.writeFile(
+      path.join(shopDir, "analytics.jsonl"),
+      JSON.stringify({ type: "segment:vip", email: "new@example.com" }) + "\n",
+      "utf8"
+    );
+    const past = new Date(Date.now() - 1000).toISOString();
+    const campaigns = [
+      {
+        id: "c1",
+        recipients: ["old@example.com"],
+        subject: "Seg",
+        body: "<p>Seg</p>",
+        segment: "vip",
+        sendAt: past,
+      },
+      {
+        id: "c2",
+        recipients: ["manual@example.com"],
+        subject: "Man",
+        body: "<p>Man</p>",
+        segment: null,
+        sendAt: past,
+      },
+    ];
+    await fs.writeFile(
+      path.join(shopDir, "campaigns.json"),
+      JSON.stringify(campaigns, null, 2),
+      "utf8"
+    );
+
+    const { sendScheduledCampaigns } = await import("../marketing-email-sender");
+    await sendScheduledCampaigns();
+
+    expect(sendCampaignEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "new@example.com", subject: "Seg" })
+    );
+    expect(sendCampaignEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "manual@example.com", subject: "Man" })
+    );
+
+    const updated = JSON.parse(
+      await fs.readFile(path.join(shopDir, "campaigns.json"), "utf8")
+    );
+    const seg = updated.find((c: any) => c.id === "c1");
+    const man = updated.find((c: any) => c.id === "c2");
+    expect(seg.recipients).toEqual(["new@example.com"]);
+    expect(seg.sentAt).toBeDefined();
+    expect(man.recipients).toEqual(["manual@example.com"]);
+    expect(man.sentAt).toBeDefined();
+  });
+});

--- a/functions/marketing-email-sender.ts
+++ b/functions/marketing-email-sender.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { sendCampaignEmail } from "@acme/email";
+import { sendCampaignEmail, resolveSegment } from "@acme/email";
 import { trackEvent } from "@platform-core/analytics";
 import { DATA_ROOT } from "@platform-core/dataRoot";
 import { coreEnv } from "@acme/config/env/core";
@@ -59,7 +59,12 @@ export async function sendScheduledCampaigns(): Promise<void> {
             shop
           )}&campaign=${encodeURIComponent(c.id)}&url=${encodeURIComponent(url)}"`
       );
-      for (const r of c.recipients) {
+      let recipients = c.recipients;
+      if (c.segment) {
+        recipients = await resolveSegment(shop, c.segment);
+        c.recipients = recipients;
+      }
+      for (const r of recipients) {
         await sendCampaignEmail({
           to: r,
           subject: c.subject,

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -3,3 +3,4 @@ export { sendCampaignEmail } from "./send";
 export type { AbandonedCart } from "./abandonedCart";
 export { recoverAbandonedCarts } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
+export { resolveSegment } from "./segments";

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -1,0 +1,31 @@
+import { listEvents } from "@platform-core/repositories/analytics.server";
+
+/**
+ * Resolve a segment identifier to a list of customer email addresses.
+ *
+ * Segments are represented in analytics events with either the form:
+ *  { type: `segment:${id}`, email: "user@example.com" }
+ * or
+ *  { type: "segment", segment: id, email: "user@example.com" }
+ */
+export async function resolveSegment(
+  shop: string,
+  id: string
+): Promise<string[]> {
+  const events = await listEvents(shop);
+  const emails = new Set<string>();
+  for (const e of events) {
+    const type = (e as { type?: string }).type;
+    const seg =
+      type === `segment:${id}`
+        ? id
+        : type === "segment" && (e as any).segment === id
+          ? id
+          : null;
+    if (seg) {
+      const email = (e as any).email;
+      if (typeof email === "string") emails.add(email);
+    }
+  }
+  return Array.from(emails);
+}


### PR DESCRIPTION
## Summary
- add segments service to resolve segment IDs to customer emails via analytics
- use segment recipient lists in CMS marketing email API and scheduled sender
- test segment resolution and manual recipient fallbacks end-to-end

## Testing
- `pnpm exec jest apps/cms/__tests__/marketingEmailApi.test.ts functions/__tests__/marketing-email-sender.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b644e1568832fb663a0dacca9f42d