### PR TITLE
feat: manage role permissions in CMS

### DIFF
--- a/apps/cms/__tests__/rbacStore.test.ts
+++ b/apps/cms/__tests__/rbacStore.test.ts
@@ -22,6 +22,7 @@ describe("rbacStore", () => {
       const db = await readRbac();
       expect(db.users["1"].email).toBe("admin@example.com");
       expect(db.roles["1"]).toBe("admin");
+      expect(db.permissions.admin).toEqual(["read", "write"]);
     });
   });
 
@@ -41,6 +42,19 @@ describe("rbacStore", () => {
         await fs.readFile(path.join(dir, "data", "cms", "users.json"), "utf8")
       );
       expect(stored).toEqual(db);
+    });
+  });
+
+  it("updates permissions for roles", async () => {
+    await withTempDir(async (dir) => {
+      const { readRbac, writeRbac } = await import("../src/lib/rbacStore");
+      const db = await readRbac();
+      db.permissions.admin = ["read"];
+      await writeRbac(db);
+      const stored = JSON.parse(
+        await fs.readFile(path.join(dir, "data", "cms", "users.json"), "utf8")
+      );
+      expect(stored.permissions.admin).toEqual(["read"]);
     });
   });
 });

--- a/apps/cms/src/actions/rbac.server.ts
+++ b/apps/cms/src/actions/rbac.server.ts
@@ -38,3 +38,13 @@ export async function inviteUser(formData: FormData): Promise<void> {
   db.roles[id] = roles.length <= 1 ? (roles[0] as Role) : roles;
   await writeRbac(db);
 }
+
+export async function updateRolePermissions(
+  formData: FormData
+): Promise<void> {
+  const role = String(formData.get("role") ?? "") as Role;
+  const permissions = formData.getAll("permissions") as string[];
+  const db = await readRbac();
+  db.permissions[role] = permissions;
+  await writeRbac(db);
+}

--- a/apps/cms/src/app/cms/rbac/permissions/page.tsx
+++ b/apps/cms/src/app/cms/rbac/permissions/page.tsx
@@ -1,0 +1,60 @@
+// apps/cms/src/app/cms/rbac/permissions/page.tsx
+import { Button } from "@/components/atoms/shadcn";
+import { updateRolePermissions } from "@cms/actions/rbac.server";
+import { authOptions } from "@cms/auth/options";
+import type { Role } from "@cms/auth/roles";
+import { readRbac } from "@cms/lib/rbacStore";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+export const revalidate = 0;
+
+export default async function PermissionsPage() {
+  const session = await getServerSession(authOptions);
+  if (session?.user.role !== "admin") {
+    redirect("/cms");
+  }
+
+  const db = await readRbac();
+
+  async function save(formData: FormData) {
+    "use server";
+    await updateRolePermissions(formData);
+  }
+
+  const roles: Role[] = [
+    "admin",
+    "viewer",
+    "ShopAdmin",
+    "CatalogManager",
+    "ThemeEditor",
+  ];
+
+  const permissions = ["read", "write"];
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Role Permissions</h2>
+      {roles.map((role) => (
+        <form key={role} action={save} className="mb-4 rounded border p-3">
+          <input type="hidden" name="role" value={role} />
+          <p className="font-semibold">{role}</p>
+          <div className="my-2 flex flex-wrap gap-2">
+            {permissions.map((perm) => (
+              <label key={perm} className="flex items-center gap-1 text-sm">
+                <input
+                  type="checkbox"
+                  name="permissions"
+                  value={perm}
+                  defaultChecked={db.permissions[role]?.includes(perm)}
+                />
+                {perm}
+              </label>
+            ))}
+          </div>
+          <Button type="submit">Save</Button>
+        </form>
+      ))}
+    </div>
+  );
+}

--- a/apps/cms/src/lib/rbacStore.d.ts
+++ b/apps/cms/src/lib/rbacStore.d.ts
@@ -3,6 +3,7 @@ import type { Role } from "../auth/roles";
 export interface RbacDB {
     users: Record<string, CmsUser>;
     roles: Record<string, Role | Role[]>;
+    permissions: Record<Role, string[]>;
 }
 export declare function readRbac(): Promise<RbacDB>;
 export declare function writeRbac(db: RbacDB): Promise<void>;

--- a/apps/cms/src/lib/rbacStore.ts
+++ b/apps/cms/src/lib/rbacStore.ts
@@ -9,6 +9,7 @@ import type { Role } from "../auth/roles";
 export interface RbacDB {
   users: Record<string, CmsUser>;
   roles: Record<string, Role | Role[]>;
+  permissions: Record<Role, string[]>;
 }
 
 const DEFAULT_DB: RbacDB = {
@@ -51,6 +52,13 @@ const DEFAULT_DB: RbacDB = {
     "4": "CatalogManager",
     "5": "ThemeEditor",
   },
+  permissions: {
+    admin: ["read", "write"],
+    viewer: [],
+    ShopAdmin: [],
+    CatalogManager: [],
+    ThemeEditor: [],
+  },
 };
 
 function resolveFile(): string {
@@ -73,7 +81,7 @@ export async function readRbac(): Promise<RbacDB> {
   try {
     const buf = await fs.readFile(FILE, "utf8");
     const parsed = JSON.parse(buf) as RbacDB;
-    if (parsed && parsed.users && parsed.roles) return parsed;
+    if (parsed && parsed.users && parsed.roles && parsed.permissions) return parsed;
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- extend RBAC store with role permissions
- add server action and admin-only page to edit role permissions
- test RBAC store permission updates

## Testing
- `pnpm --filter @apps/cms test __tests__/rbacStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b652bdbc0832fb436ac949b7d18cc