### PR TITLE
feat(auth): add storefront permissions

### DIFF
--- a/packages/auth/__tests__/permissions.test.ts
+++ b/packages/auth/__tests__/permissions.test.ts
@@ -1,0 +1,29 @@
+import { PERMISSIONS, isPermission } from "../src/types/permissions";
+import { hasPermission } from "../src/permissions";
+
+describe("isPermission", () => {
+  for (const perm of PERMISSIONS) {
+    it(`${perm} -> true`, () => {
+      expect(isPermission(perm)).toBe(true);
+    });
+  }
+
+  const invalid: unknown[] = ["bad", null, undefined, 0];
+
+  for (const perm of invalid) {
+    it(`${String(perm)} -> false`, () => {
+      expect(isPermission(perm)).toBe(false);
+    });
+  }
+});
+
+describe("hasPermission", () => {
+  it("viewer can view products but not checkout", () => {
+    expect(hasPermission("viewer", "view_products")).toBe(true);
+    expect(hasPermission("viewer", "add_to_cart")).toBe(false);
+  });
+
+  it("customer can checkout", () => {
+    expect(hasPermission("customer", "checkout")).toBe(true);
+  });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -2,7 +2,8 @@
 
 export { canRead, canWrite, READ_ROLES, WRITE_ROLES } from "./rbac";
 export { extendRoles, isRole } from "./types/roles";
-export type { Role } from "./types";
+export { hasPermission } from "./permissions";
+export type { Role, Permission } from "./types";
 export {
   CUSTOMER_SESSION_COOKIE,
   CSRF_TOKEN_COOKIE,

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -1,0 +1,8 @@
+{
+  "viewer": ["view_products"],
+  "customer": ["view_products", "add_to_cart", "checkout", "manage_profile"],
+  "admin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
+  "ShopAdmin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
+  "CatalogManager": ["view_products", "add_to_cart", "checkout", "manage_profile"],
+  "ThemeEditor": ["view_products", "add_to_cart", "checkout", "manage_profile"]
+}

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -1,0 +1,14 @@
+// packages/auth/src/permissions.ts
+
+import permissionsConfig from "./permissions.json";
+import type { Role } from "./types/roles";
+import type { Permission } from "./types/permissions";
+
+// Role to permission mapping loaded from configuration
+const ROLE_PERMISSIONS: Record<Role, Permission[]> = permissionsConfig as Record<Role, Permission[]>;
+
+export function hasPermission(role: Role, perm: Permission): boolean {
+  return ROLE_PERMISSIONS[role]?.includes(perm) ?? false;
+}
+
+export { ROLE_PERMISSIONS };

--- a/packages/auth/src/types/index.ts
+++ b/packages/auth/src/types/index.ts
@@ -1,3 +1,4 @@
 // packages/auth/src/types/index.ts
 
 export type { Role } from "./roles";
+export type { Permission } from "./permissions";

--- a/packages/auth/src/types/permissions.ts
+++ b/packages/auth/src/types/permissions.ts
@@ -1,0 +1,27 @@
+// packages/auth/src/types/permissions.ts
+
+import permissionsConfig from "../permissions.json";
+import { z } from "zod";
+
+// Permissions configuration maps roles to their permissions
+// We only care about the union of all unique permission strings
+
+type PermissionsConfig = Record<string, readonly string[]>;
+
+const config: PermissionsConfig = permissionsConfig;
+
+const allPermissionsFromConfig = [
+  ...new Set(Object.values(config).flat()),
+] as const;
+
+export type Permission = (typeof allPermissionsFromConfig)[number];
+
+export const PERMISSIONS: Permission[] = [...allPermissionsFromConfig];
+
+const PermissionSchema = z.enum(allPermissionsFromConfig as [Permission, ...Permission[]]);
+
+export function isPermission(permission: unknown): permission is Permission {
+  return PermissionSchema.safeParse(permission).success;
+}
+
+export { PermissionSchema };


### PR DESCRIPTION
## Summary
- define storefront permission mapping
- add Permission type and helper utilities
- implement role-based permission check and re-export

## Testing
- `SESSION_SECRET=test pnpm exec jest packages/auth/__tests__/permissions.test.ts packages/auth/__tests__/rbac.test.ts packages/auth/__tests__/roles.test.ts --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_689b65291ae4832f830067247492c399