### PR TITLE
feat: handle cleared filter

### DIFF
--- a/packages/platform-core/__tests__/filterBar.test.tsx
+++ b/packages/platform-core/__tests__/filterBar.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import FilterBar from "../components/shop/FilterBar";
+import FilterBar from "../src/components/shop/FilterBar";
 
 describe("FilterBar", () => {
   it("propagates changes", async () => {
@@ -12,7 +12,7 @@ describe("FilterBar", () => {
     });
     fireEvent.change(select, { target: { value: "" } });
     await waitFor(() => {
-      expect(onChange).toHaveBeenLastCalledWith({ size: "" });
+      expect(onChange).toHaveBeenLastCalledWith({ size: undefined });
     });
   });
 });

--- a/packages/platform-core/src/components/shop/FilterBar.tsx
+++ b/packages/platform-core/src/components/shop/FilterBar.tsx
@@ -15,7 +15,7 @@ export default function FilterBar({
 
   // propagate filters when typing settles
   useEffect(() => {
-    onChange({ size: deferredSize ?? undefined } as Filters);
+    onChange({ size: deferredSize || undefined } as Filters);
   }, [deferredSize, onChange]);
 
   return (


### PR DESCRIPTION
## Summary
- treat empty size in FilterBar as undefined when notifying changes
- update FilterBar tests for undefined size on clear

## Testing
- `pnpm exec eslint packages/platform-core/src/components/shop/FilterBar.tsx packages/platform-core/__tests__/filterBar.test.tsx`
- `pnpm --filter @acme/platform-core test __tests__/filterBar.test.tsx` *(fails: A React Element from an older version of React was rendered)*

------
https://chatgpt.com/codex/tasks/task_e_689b6338f978832fb3a7ce3c34f25aed