### PR TITLE
feat: add configurable sizes to FilterBar

### DIFF
--- a/apps/cms/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/apps/cms/src/app/[lang]/shop/ShopClient.client.tsx
@@ -10,6 +10,10 @@ import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {
   const [filters, setFilters] = useState<Filters>({});
+  const sizes = useMemo(
+    () => Array.from(new Set(skus.flatMap((p) => p.sizes))).sort(),
+    [skus]
+  );
 
   const visible = useMemo(() => {
     if (!filters.size) return skus;
@@ -19,7 +23,7 @@ export default function ShopClient({ skus }: { skus: SKU[] }) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-10">
       <h1 className="mb-4 text-3xl font-bold">Shop</h1>
-      <FilterBar onChange={setFilters} />
+      <FilterBar onChange={setFilters} sizes={sizes} />
       <ProductGrid skus={visible} />
     </div>
   );

--- a/apps/shop-abc/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/ShopClient.client.tsx
@@ -10,6 +10,10 @@ import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {
   const [filters, setFilters] = useState<Filters>({});
+  const sizes = useMemo(
+    () => Array.from(new Set(skus.flatMap((p) => p.sizes))).sort(),
+    [skus]
+  );
 
   const visible = useMemo(() => {
     if (!filters.size) return skus;
@@ -19,7 +23,7 @@ export default function ShopClient({ skus }: { skus: SKU[] }) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-10">
       <h1 className="mb-4 text-3xl font-bold">Shop</h1>
-      <FilterBar onChange={setFilters} />
+      <FilterBar onChange={setFilters} sizes={sizes} />
       <ProductGrid skus={visible} />
     </div>
   );

--- a/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.js
+++ b/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.js
@@ -6,10 +6,11 @@ import { ProductGrid } from "@/components/shop/ProductGrid";
 import { useMemo, useState } from "react";
 export default function ShopClient({ skus }) {
     const [filters, setFilters] = useState({});
+    const sizes = useMemo(() => Array.from(new Set(skus.flatMap((p) => p.sizes))).sort(), [skus]);
     const visible = useMemo(() => {
         if (!filters.size)
             return skus;
         return skus.filter((p) => p.sizes.includes(filters.size));
     }, [filters, skus]);
-    return (_jsxs("div", { className: "mx-auto max-w-6xl px-4 py-10", children: [_jsx("h1", { className: "mb-4 text-3xl font-bold", children: "Shop" }), _jsx(FilterBar, { onChange: setFilters }), _jsx(ProductGrid, { skus: visible })] }));
+    return (_jsxs("div", { className: "mx-auto max-w-6xl px-4 py-10", children: [_jsx("h1", { className: "mb-4 text-3xl font-bold", children: "Shop" }), _jsx(FilterBar, { onChange: setFilters, sizes: sizes }), _jsx(ProductGrid, { skus: visible })] }));
 }

--- a/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/ShopClient.client.tsx
@@ -10,6 +10,10 @@ import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {
   const [filters, setFilters] = useState<Filters>({});
+  const sizes = useMemo(
+    () => Array.from(new Set(skus.flatMap((p) => p.sizes))).sort(),
+    [skus]
+  );
 
   const visible = useMemo(() => {
     if (!filters.size) return skus;
@@ -19,7 +23,7 @@ export default function ShopClient({ skus }: { skus: SKU[] }) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-10">
       <h1 className="mb-4 text-3xl font-bold">Shop</h1>
-      <FilterBar onChange={setFilters} />
+      <FilterBar onChange={setFilters} sizes={sizes} />
       <ProductGrid skus={visible} />
     </div>
   );

--- a/packages/platform-core/__tests__/filterBar.test.tsx
+++ b/packages/platform-core/__tests__/filterBar.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import FilterBar from "../components/shop/FilterBar";
+import FilterBar from "../src/components/shop/FilterBar";
 
 describe("FilterBar", () => {
   it("propagates changes", async () => {
     const onChange = jest.fn();
-    render(<FilterBar onChange={onChange} />);
+    render(<FilterBar onChange={onChange} sizes={["39", "40"]} />);
     const select = screen.getByLabelText(/Size/);
     fireEvent.change(select, { target: { value: "39" } });
     await waitFor(() => {

--- a/packages/platform-core/src/components/shop/FilterBar.tsx
+++ b/packages/platform-core/src/components/shop/FilterBar.tsx
@@ -5,10 +5,14 @@ import { useDeferredValue, useEffect, useState } from "react";
 
 export type Filters = { size?: string };
 
+const defaultSizes = ["36", "37", "38", "39", "40", "41", "42", "43", "44"];
+
 export default function FilterBar({
   onChange,
+  sizes = defaultSizes,
 }: {
   onChange: (f: Filters) => void;
+  sizes?: string[];
 }) {
   const [size, setSize] = useState("");
   const deferredSize = useDeferredValue(size);
@@ -32,7 +36,7 @@ export default function FilterBar({
           className="border rounded px-2 py-1 text-sm"
         >
           <option value="">All</option>
-          {["36", "37", "38", "39", "40", "41", "42", "43", "44"].map((s) => (
+          {sizes.map((s) => (
             <option key={s}>{s}</option>
           ))}
         </select>

--- a/packages/template-app/src/app/[lang]/shop/ShopClient.client.tsx
+++ b/packages/template-app/src/app/[lang]/shop/ShopClient.client.tsx
@@ -10,6 +10,10 @@ import { useMemo, useState } from "react";
 
 export default function ShopClient({ skus }: { skus: SKU[] }) {
   const [filters, setFilters] = useState<Filters>({});
+  const sizes = useMemo(
+    () => Array.from(new Set(skus.flatMap((p) => p.sizes))).sort(),
+    [skus]
+  );
 
   const visible = useMemo(() => {
     if (!filters.size) return skus;
@@ -19,7 +23,7 @@ export default function ShopClient({ skus }: { skus: SKU[] }) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-10">
       <h1 className="mb-4 text-3xl font-bold">Shop</h1>
-      <FilterBar onChange={setFilters} />
+      <FilterBar onChange={setFilters} sizes={sizes} />
       <ProductGrid skus={visible} />
     </div>
   );


### PR DESCRIPTION
## Summary
- allow specifying available sizes via new `sizes` prop on `FilterBar`
- pass shop-specific sizes to `FilterBar` in each `ShopClient`
- adjust FilterBar test to supply sizes

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/filterBar.test.tsx` *(fails: A React Element from an older version of React was rendered)*


------
https://chatgpt.com/codex/tasks/task_e_689b633a3f0c832f9d2ea97c59211a2c