### PR TITLE
docs: add permission guide and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Key points:
 - Low-stock alerts email the configured recipient (`STOCK_ALERT_RECIPIENT`) when inventory falls below its threshold.
 - Rental pricing matrix defined in data/rental/pricing.json with duration discounts and damage-fee rules.
 - Return logistics options stored in data/return-logistics.json.
-- RBAC: ShopAdmin currently manages all shops.
+- RBAC: ShopAdmin currently manages all shops. See [doc/permissions.md](doc/permissions.md) for default roles and permissions.
 - Product and recommendation carousels adapt their visible item count to the screen width, clamped between caller-provided `minItems` and `maxItems` values.
   A multilingual, hybrid-rendered e-commerce demo built with **Next.js 15** and **React 19**.
   The full technical roadmap is documented in [./IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md).

--- a/apps/cms/src/app/cms/rbac/page.tsx
+++ b/apps/cms/src/app/cms/rbac/page.tsx
@@ -8,6 +8,7 @@ import {
 import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
 import { getServerSession } from "next-auth";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 export const revalidate = 0;
@@ -41,6 +42,13 @@ export default async function RbacPage() {
   return (
     <div>
       <h2 className="mb-4 text-xl font-semibold">User Roles</h2>
+      <p className="mb-4 text-sm">
+        See the
+        <Link href="/doc/permissions.md" target="_blank" rel="noreferrer" className="underline">
+          permission guide
+        </Link>
+        for default role mappings.
+      </p>
       {users.map((u) => (
         <form key={u.id} action={save} className="mb-4 rounded border p-3">
           <input type="hidden" name="id" value={u.id} />

--- a/doc/cms.md
+++ b/doc/cms.md
@@ -2,6 +2,8 @@
 
 This document describes how to navigate the in-browser CMS and what each link in the sidebar does.
 
+For role and permission details, see the [permission guide](./permissions.md).
+
 ## Sidebar Links
 
 The sidebar inside the CMS provides quick access to different sections:

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -1,0 +1,55 @@
+# Permission Guide
+
+This guide lists built-in permissions and their default role mappings.
+
+## read
+Allows viewing CMS content and APIs.
+
+**Default roles**
+
+- `admin`
+- `ShopAdmin`
+- `CatalogManager`
+- `ThemeEditor`
+- `viewer`
+- `customer`
+
+**Example**
+
+```ts
+import { canRead } from "@acme/auth";
+
+if (!canRead(session.user.role)) {
+  throw new Error("Not authorized to view this resource");
+}
+```
+
+## write
+Allows creating or modifying resources in the CMS.
+
+**Default roles**
+
+- `admin`
+- `ShopAdmin`
+- `CatalogManager`
+- `ThemeEditor`
+
+**Example**
+
+```ts
+import { canWrite } from "@acme/auth";
+
+if (!canWrite(session.user.role)) {
+  throw new Error("Not authorized to change this resource");
+}
+```
+
+## Extending roles
+
+Roles and their permissions can be extended at runtime using `extendRoles` from `@acme/auth`.
+
+```ts
+import { extendRoles } from "@acme/auth";
+
+extendRoles({ write: ["author"], read: ["reader"] });
+```


### PR DESCRIPTION
## Summary
- document read/write permissions and default roles
- link permission guide from README, RBAC page, and CMS onboarding notes

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689b652ca420832f98409087ebf666f9