### PR TITLE
feat: persist role permissions

### DIFF
--- a/apps/cms/__tests__/rbacStore.test.ts
+++ b/apps/cms/__tests__/rbacStore.test.ts
@@ -22,6 +22,7 @@ describe("rbacStore", () => {
       const db = await readRbac();
       expect(db.users["1"].email).toBe("admin@example.com");
       expect(db.roles["1"]).toBe("admin");
+      expect(db.permissions.admin).toEqual([]);
     });
   });
 
@@ -36,6 +37,7 @@ describe("rbacStore", () => {
         password: "pw",
       };
       db.roles["6"] = "viewer";
+      db.permissions.viewer.push("test-perm");
       await writeRbac(db);
       const stored = JSON.parse(
         await fs.readFile(path.join(dir, "data", "cms", "users.json"), "utf8")

--- a/apps/cms/src/lib/rbacStore.d.ts
+++ b/apps/cms/src/lib/rbacStore.d.ts
@@ -1,8 +1,10 @@
 import type { CmsUser } from "@acme/types";
 import type { Role } from "../auth/roles";
+export type Permission = string;
 export interface RbacDB {
     users: Record<string, CmsUser>;
     roles: Record<string, Role | Role[]>;
+    permissions: Record<Role, Permission[]>;
 }
 export declare function readRbac(): Promise<RbacDB>;
 export declare function writeRbac(db: RbacDB): Promise<void>;

--- a/apps/cms/src/lib/rbacStore.js
+++ b/apps/cms/src/lib/rbacStore.js
@@ -41,6 +41,13 @@ const DEFAULT_DB = {
         "4": "CatalogManager",
         "5": "ThemeEditor",
     },
+    permissions: {
+        admin: [],
+        viewer: [],
+        ShopAdmin: [],
+        CatalogManager: [],
+        ThemeEditor: [],
+    },
 };
 function resolveFile() {
     let dir = process.cwd();
@@ -61,8 +68,13 @@ export async function readRbac() {
     try {
         const buf = await fs.readFile(FILE, "utf8");
         const parsed = JSON.parse(buf);
-        if (parsed && parsed.users && parsed.roles)
-            return parsed;
+        if (parsed && parsed.users && parsed.roles) {
+            return {
+                users: parsed.users,
+                roles: parsed.roles,
+                permissions: parsed.permissions ?? { ...DEFAULT_DB.permissions },
+            };
+        }
     }
     catch {
         /* ignore */

--- a/apps/cms/src/lib/rbacStore.ts
+++ b/apps/cms/src/lib/rbacStore.ts
@@ -6,9 +6,12 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import type { Role } from "../auth/roles";
 
+export type Permission = string;
+
 export interface RbacDB {
   users: Record<string, CmsUser>;
   roles: Record<string, Role | Role[]>;
+  permissions: Record<Role, Permission[]>;
 }
 
 const DEFAULT_DB: RbacDB = {
@@ -51,6 +54,13 @@ const DEFAULT_DB: RbacDB = {
     "4": "CatalogManager",
     "5": "ThemeEditor",
   },
+  permissions: {
+    admin: [],
+    viewer: [],
+    ShopAdmin: [],
+    CatalogManager: [],
+    ThemeEditor: [],
+  },
 };
 
 function resolveFile(): string {
@@ -72,8 +82,14 @@ const FILE = resolveFile();
 export async function readRbac(): Promise<RbacDB> {
   try {
     const buf = await fs.readFile(FILE, "utf8");
-    const parsed = JSON.parse(buf) as RbacDB;
-    if (parsed && parsed.users && parsed.roles) return parsed;
+    const parsed = JSON.parse(buf) as Partial<RbacDB>;
+    if (parsed && parsed.users && parsed.roles) {
+      return {
+        users: parsed.users,
+        roles: parsed.roles,
+        permissions: parsed.permissions ?? { ...DEFAULT_DB.permissions },
+      };
+    }
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- track permissions per role in RBAC store
- include permissions in default DB and read/write helpers
- test permissions are persisted when serialized

## Testing
- `pnpm --filter @apps/cms test __tests__/rbacStore.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b652cb580832fab8e11c307efa7c0