### PR TITLE
feat: add plugin manager and flexible plugin loading

### DIFF
--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -13,24 +13,13 @@ import shop from "../../shop.json";
 // Ensure friendly Zod messages for all validations
 applyFriendlyZodMessages();
 
-const payments = new Map<string, unknown>();
-const shipping = new Map<string, unknown>();
-const widgets = new Map<string, unknown>();
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginsDir = path.resolve(__dirname, "../../../../packages/plugins");
 
-const pluginsReady = initPlugins(
-  {
-    payments: { add: (id: string, provider: unknown) => payments.set(id, provider) },
-    shipping: { add: (id: string, provider: unknown) => shipping.set(id, provider) },
-    widgets: { add: (id: string, component: unknown) => widgets.set(id, component) },
-  },
-  {
-    directories: [pluginsDir],
-    config: (shop as any).plugins,
-  },
-);
+const pluginsReady = initPlugins({
+  directories: [pluginsDir],
+  config: (shop as any).plugins,
+});
 
 const geistSans = Geist({
   subsets: ["latin"],

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -13,24 +13,13 @@ import shop from "../../shop.json";
 // Ensure friendly Zod messages for all validations
 applyFriendlyZodMessages();
 
-const payments = new Map<string, unknown>();
-const shipping = new Map<string, unknown>();
-const widgets = new Map<string, unknown>();
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginsDir = path.resolve(__dirname, "../../../../packages/plugins");
 
-const pluginsReady = initPlugins(
-  {
-    payments: { add: (id: string, provider: unknown) => payments.set(id, provider) },
-    shipping: { add: (id: string, provider: unknown) => shipping.set(id, provider) },
-    widgets: { add: (id: string, component: unknown) => widgets.set(id, component) },
-  },
-  {
-    directories: [pluginsDir],
-    config: (shop as any).plugins,
-  },
-);
+const pluginsReady = initPlugins({
+  directories: [pluginsDir],
+  config: (shop as any).plugins,
+});
 
 const geistSans = Geist({
   subsets: ["latin"],

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -38,21 +38,19 @@ Each plugin directory must include a `package.json` with a `main` or
 
 ## Initialisation and configuration
 
-`initPlugins` wires discovered plugins into the platform.  Configuration can be
-supplied per plugin using the plugin id:
+`initPlugins` wires discovered plugins into the platform and returns a
+`PluginManager` instance that exposes registered providers and metadata. Configuration
+can be supplied per plugin using the plugin id:
 
 ```ts
 import { initPlugins } from "@acme/platform-core/plugins";
 
-await initPlugins(
-  { payments: paymentRegistry },
-  {
-    directories: [pluginsDir],
-    config: {
-      "my-plugin": { enabled: false },
-    },
+const manager = await initPlugins({
+  directories: [pluginsDir],
+  config: {
+    "my-plugin": { enabled: false },
   },
-);
+});
 ```
 
 The relevant configuration object (or the plugin's `defaultConfig`) is passed to

--- a/packages/platform-core/__tests__/plugins.test.ts
+++ b/packages/platform-core/__tests__/plugins.test.ts
@@ -96,25 +96,15 @@ describe("plugins", () => {
     const root = await createPluginsRoot(true);
     jest.spyOn(process, "cwd").mockReturnValue(root);
     const { initPlugins } = await import("../src/plugins");
-    const payments = { add: jest.fn() };
-    const shipping = { add: jest.fn() };
-    const widgets = { add: jest.fn() };
-    const plugins = await initPlugins(
-      {
-        payments,
-        shipping,
-        widgets,
-      },
-      {
-        config: { good: { enabled: false } },
-      },
-    );
-    expect(plugins).toHaveLength(1);
-    const plugin = plugins[0] as any;
+    const manager = await initPlugins({
+      config: { good: { enabled: false } },
+    });
+    expect(manager.listPlugins()).toHaveLength(1);
+    const plugin = manager.getPlugin("good")!.plugin as any;
     const cfg = { enabled: false };
-    expect(plugin.registerPayments).toHaveBeenCalledWith(payments, cfg);
-    expect(plugin.registerShipping).toHaveBeenCalledWith(shipping, cfg);
-    expect(plugin.registerWidgets).toHaveBeenCalledWith(widgets, cfg);
+    expect(plugin.registerPayments).toHaveBeenCalledWith(manager.payments, cfg);
+    expect(plugin.registerShipping).toHaveBeenCalledWith(manager.shipping, cfg);
+    expect(plugin.registerWidgets).toHaveBeenCalledWith(manager.widgets, cfg);
     expect(plugin.init).toHaveBeenCalled();
     expect(plugin.callOrder).toEqual([
       'init',
@@ -128,16 +118,12 @@ describe("plugins", () => {
     const root = await createPluginsRoot(true);
     jest.spyOn(process, "cwd").mockReturnValue(root);
     const { initPlugins } = await import("../src/plugins");
-    const payments = { add: jest.fn() };
-    const plugins = await initPlugins(
-      { payments },
-      {
-        // enabled should be boolean
-        config: { good: { enabled: "oops" as any } },
-      },
-    );
-    expect(plugins).toHaveLength(0);
-    expect(payments.add).not.toHaveBeenCalled();
+    const manager = await initPlugins({
+      // enabled should be boolean
+      config: { good: { enabled: "oops" as any } },
+    });
+    expect(manager.listPlugins()).toHaveLength(0);
+    expect(manager.payments.list()).toHaveLength(0);
   });
 });
 

--- a/packages/platform-core/src/plugins/PluginManager.ts
+++ b/packages/platform-core/src/plugins/PluginManager.ts
@@ -1,0 +1,63 @@
+// packages/platform-core/src/plugins/PluginManager.ts
+export interface RegistryItem<T> {
+  id: string;
+  value: T;
+}
+
+class MapRegistry<T> {
+  private items = new Map<string, T>();
+
+  add(id: string, item: T): void {
+    this.items.set(id, item);
+  }
+
+  get(id: string): T | undefined {
+    return this.items.get(id);
+  }
+
+  list(): RegistryItem<T>[] {
+    return Array.from(this.items.entries()).map(([id, value]) => ({ id, value }));
+  }
+}
+
+export interface PluginMetadata {
+  id: string;
+  name?: string;
+  description?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plugin: any;
+}
+
+export class PluginManager<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  P = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  S = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  W = any,
+> {
+  readonly payments = new MapRegistry<P>();
+  readonly shipping = new MapRegistry<S>();
+  readonly widgets = new MapRegistry<W>();
+  private plugins = new Map<string, PluginMetadata>();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addPlugin(plugin: { id: string; name?: string; description?: string } & any): void {
+    this.plugins.set(plugin.id, {
+      id: plugin.id,
+      name: plugin.name,
+      description: plugin.description,
+      plugin,
+    });
+  }
+
+  getPlugin(id: string): PluginMetadata | undefined {
+    return this.plugins.get(id);
+  }
+
+  listPlugins(): PluginMetadata[] {
+    return Array.from(this.plugins.values());
+  }
+}
+
+export { MapRegistry as Registry };

--- a/packages/platform-core/src/plugins/index.ts
+++ b/packages/platform-core/src/plugins/index.ts
@@ -1,1 +1,2 @@
 export * from "../plugins";
+export * from "./PluginManager";


### PR DESCRIPTION
## Summary
- add `PluginManager` with registries for payments, shipping and widgets
- load plugins from env vars or config file and return manager from `initPlugins`
- update layouts, docs, and tests for new plugin API

## Testing
- `pnpm --filter @acme/platform-core run test -- --runTestsByPath packages/platform-core/__tests__/plugins.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689bae867e08832f9d7ac71090c673ff