### PR TITLE
feat: add shop deployment adapter

### DIFF
--- a/doc/deployment-adapters.md
+++ b/doc/deployment-adapters.md
@@ -1,0 +1,37 @@
+# Deployment adapters
+
+`ShopDeploymentAdapter` abstracts how shop applications are scaffolded and
+deployed.  The core `createShop` logic delegates to an adapter, allowing
+different environments to provide their own deployment pipelines.
+
+## Interface
+
+Adapters implement three methods:
+
+```ts
+interface ShopDeploymentAdapter {
+  scaffold(appPath: string): void;
+  deploy(id: string, domain?: string): DeployShopResult;
+  writeDeployInfo(id: string, info: DeployShopResult): void;
+}
+```
+
+The default `CloudflareDeploymentAdapter` reproduces the existing behaviour by
+invoking `npx create-cloudflare` and writing `deploy.json` in the shop data
+directory.  Custom adapters can override these steps to target different hosts
+or deployment workflows without touching `createShop` itself.
+
+## Usage
+
+`createShop` and `deployShop` accept an optional adapter parameter.  When no
+adapter is provided, the Cloudflare implementation is used:
+
+```ts
+import { createShop, CloudflareDeploymentAdapter } from "@platform-core/createShop";
+
+await createShop("my-shop", options, { deploy: true }, new CloudflareDeploymentAdapter());
+```
+
+To provide an alternative deployment pipeline, implement the interface and pass
+your adapter instance to `createShop`/`deployShop`.
+

--- a/packages/platform-core/__tests__/deployShop.test.ts
+++ b/packages/platform-core/__tests__/deployShop.test.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
-import { deployShop } from "../createShop";
 
 jest.mock("fs");
 jest.mock("child_process", () => ({
   spawnSync: jest.fn(() => ({ status: 0 })),
 }));
+jest.mock("../src/db", () => ({ prisma: {} }));
 
 const fsMock = fs as jest.Mocked<typeof fs>;
 
@@ -13,7 +13,8 @@ describe("deployShop", () => {
     jest.resetAllMocks();
   });
 
-  it("writes deploy.json and returns preview url", () => {
+  it("writes deploy.json and returns preview url", async () => {
+    const { deployShop } = await import("../src/createShop");
     const result = deployShop("shopx", "shop.example.com");
     expect(fsMock.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining("data/shops/shopx/deploy.json"),

--- a/packages/platform-core/src/createShop/deployTypes.ts
+++ b/packages/platform-core/src/createShop/deployTypes.ts
@@ -1,0 +1,14 @@
+// packages/platform-core/src/createShop/deployTypes.ts
+
+export interface DeployStatusBase {
+  status: "pending" | "success" | "error";
+  previewUrl?: string;
+  instructions?: string;
+  error?: string;
+}
+
+export interface DeployShopResult extends DeployStatusBase {
+  status: "success" | "error";
+  previewUrl: string;
+}
+

--- a/packages/platform-core/src/createShop/deploymentAdapter.ts
+++ b/packages/platform-core/src/createShop/deploymentAdapter.ts
@@ -1,0 +1,50 @@
+// packages/platform-core/src/createShop/deploymentAdapter.ts
+
+import { spawnSync } from "child_process";
+import { join } from "path";
+import { writeFileSync } from "fs";
+
+import type { DeployShopResult } from "./deployTypes";
+
+export interface ShopDeploymentAdapter {
+  scaffold(appPath: string): void;
+  deploy(id: string, domain?: string): DeployShopResult;
+  writeDeployInfo(id: string, info: DeployShopResult): void;
+}
+
+export class CloudflareDeploymentAdapter implements ShopDeploymentAdapter {
+  scaffold(appPath: string): void {
+    const result = spawnSync("npx", ["--yes", "create-cloudflare", appPath], {
+      stdio: "inherit",
+    });
+
+    if (result.status !== 0) {
+      throw new Error("C3 process failed or not available. Skipping.");
+    }
+  }
+
+  deploy(id: string, domain?: string): DeployShopResult {
+    const previewUrl = `https://${id}.pages.dev`;
+    const instructions = domain
+      ? `Add a CNAME record for ${domain} pointing to ${id}.pages.dev`
+      : undefined;
+
+    return {
+      status: "success",
+      previewUrl,
+      instructions,
+    };
+  }
+
+  writeDeployInfo(id: string, info: DeployShopResult): void {
+    try {
+      const file = join("data", "shops", id, "deploy.json");
+      writeFileSync(file, JSON.stringify(info, null, 2));
+    } catch {
+      // ignore write errors
+    }
+  }
+}
+
+export const defaultDeploymentAdapter = new CloudflareDeploymentAdapter();
+


### PR DESCRIPTION
## Summary
- abstract deployment logic behind `ShopDeploymentAdapter`
- default to Cloudflare deployment and inject adapter into `createShop`/`deployShop`
- document how to provide custom deployment adapters

## Testing
- `pnpm exec jest packages/platform-core/__tests__/deployShop.test.ts --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689bae87dbf4832faae3e60c506b40dd