### PR TITLE
feat: verify Stripe webhook signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 
 - `STRIPE_SECRET_KEY` – secret key used by the Stripe server SDK
 - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` – public key for the Stripe client SDK
+- `STRIPE_WEBHOOK_SECRET` – secret used to verify Stripe webhook signatures
 - `CMS_SPACE_URL` – base URL of the CMS API
 - `CMS_ACCESS_TOKEN` – access token for pushing schemas
 - `CHROMATIC_PROJECT_TOKEN` – token for publishing Storybook previews

--- a/apps/cms/src/app/cms/configurator/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepEnvVars.tsx
@@ -7,11 +7,12 @@ import {
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 
-const ENV_KEYS = [
-  "STRIPE_SECRET_KEY",
-  "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
-  "NEXTAUTH_SECRET",
-  "PREVIEW_TOKEN_SECRET",
+  const ENV_KEYS = [
+    "STRIPE_SECRET_KEY",
+    "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "NEXTAUTH_SECRET",
+    "PREVIEW_TOKEN_SECRET",
   "NODE_ENV",
   "OUTPUT_EXPORT",
   "NEXT_PUBLIC_PHASE",

--- a/apps/shop-abc/__tests__/stripe-webhook.test.ts
+++ b/apps/shop-abc/__tests__/stripe-webhook.test.ts
@@ -1,6 +1,7 @@
 // Jest globals are available automatically – no import needed
 process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: unknown, init?: ResponseInit) =>
     new Response(JSON.stringify(data), init);
@@ -8,18 +9,60 @@ if (typeof (Response as any).json !== "function") {
 
 afterEach(() => jest.resetModules());
 
-describe("/api/stripe-webhook", () => {
-  test("forwards events to common handler", async () => {
-    const handleStripeWebhook = jest.fn();
-    jest.doMock("@platform-core/stripe-webhook", () => ({
-      __esModule: true,
-      handleStripeWebhook,
-    }), { virtual: true });
+  describe("/api/stripe-webhook", () => {
+    test("verifies signature and forwards events", async () => {
+      const handleStripeWebhook = jest.fn();
+      jest.doMock(
+        "@platform-core/stripe-webhook",
+        () => ({ __esModule: true, handleStripeWebhook }),
+        { virtual: true }
+      );
+      const payload = {
+        type: "checkout.session.completed",
+        data: { object: {} },
+      } as any;
+      const constructEvent = jest.fn().mockReturnValue(payload);
+      jest.doMock("@acme/stripe", () => ({
+        __esModule: true,
+        stripe: { webhooks: { constructEvent } },
+      }));
 
-    const { POST } = await import("../src/app/api/stripe-webhook/route");
-    const payload = { type: "checkout.session.completed", data: { object: {} } } as any;
-    const res = await POST({ json: async () => payload } as any);
-    expect(handleStripeWebhook).toHaveBeenCalledWith("abc", payload);
-    expect(res.status).toBe(200);
+      const { POST } = await import("../src/app/api/stripe-webhook/route");
+      const body = JSON.stringify(payload);
+      const res = await POST({
+        text: async () => body,
+        headers: new Headers({ "stripe-signature": "sig" }),
+      } as any);
+      expect(constructEvent).toHaveBeenCalledWith(
+        body,
+        "sig",
+        "whsec_test"
+      );
+      expect(handleStripeWebhook).toHaveBeenCalledWith("abc", payload);
+      expect(res.status).toBe(200);
+    });
+
+    test("returns 400 for invalid signature", async () => {
+      const handleStripeWebhook = jest.fn();
+      jest.doMock(
+        "@platform-core/stripe-webhook",
+        () => ({ __esModule: true, handleStripeWebhook }),
+        { virtual: true }
+      );
+      const constructEvent = jest.fn(() => {
+        throw new Error("bad");
+      });
+      jest.doMock("@acme/stripe", () => ({
+        __esModule: true,
+        stripe: { webhooks: { constructEvent } },
+      }));
+
+      const { POST } = await import("../src/app/api/stripe-webhook/route");
+      const res = await POST({
+        text: async () => "{}",
+        headers: new Headers({ "stripe-signature": "sig" }),
+      } as any);
+      expect(res.status).toBe(400);
+      expect(handleStripeWebhook).not.toHaveBeenCalled();
+    });
   });
-});

--- a/apps/shop-abc/src/app/api/stripe-webhook/route.ts
+++ b/apps/shop-abc/src/app/api/stripe-webhook/route.ts
@@ -1,13 +1,26 @@
 // apps/shop-abc/src/app/api/stripe-webhook/route.ts
 
 import { handleStripeWebhook } from "@platform-core/stripe-webhook";
+import { stripe } from "@acme/stripe";
+import { paymentEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
 export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
-  const event = (await req.json()) as Stripe.Event;
+  const body = await req.text();
+  const signature = req.headers.get("stripe-signature") ?? "";
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      paymentEnv.STRIPE_WEBHOOK_SECRET
+    );
+  } catch {
+    return new NextResponse("Invalid signature", { status: 400 });
+  }
   await handleStripeWebhook("abc", event);
   return NextResponse.json({ received: true });
 }

--- a/apps/shop-bcd/src/api/stripe-webhook/route.ts
+++ b/apps/shop-bcd/src/api/stripe-webhook/route.ts
@@ -1,13 +1,26 @@
 // apps/shop-bcd/src/api/stripe-webhook/route.ts
 
 import { handleStripeWebhook } from "@platform-core/stripe-webhook";
+import { stripe } from "@acme/stripe";
+import { paymentEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
 export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
-  const event = (await req.json()) as Stripe.Event;
+  const body = await req.text();
+  const signature = req.headers.get("stripe-signature") ?? "";
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      paymentEnv.STRIPE_WEBHOOK_SECRET
+    );
+  } catch {
+    return new NextResponse("Invalid signature", { status: 400 });
+  }
   await handleStripeWebhook("bcd", event);
   return NextResponse.json({ received: true });
 }

--- a/doc/machine.md
+++ b/doc/machine.md
@@ -32,7 +32,7 @@ Environment variables can be used to configure the service:
 
 Both variables may also be suffixed with a shop ID (e.g. `DEPOSIT_RELEASE_ENABLED_SHOP1`) to override settings per shop.
 
-Stripe credentials (`STRIPE_SECRET_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`) must be configured in the shop `.env` files. A one-off CLI utility is also available:
+Stripe credentials (`STRIPE_SECRET_KEY`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, and `STRIPE_WEBHOOK_SECRET`) must be configured in the shop `.env` files. A one-off CLI utility is also available:
 
 ```bash
 pnpm release-deposits

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -75,7 +75,7 @@ Lines that have no value after the equals sign (e.g. `MY_VAR=`) are treated as p
 
 The wizard scaffolds placeholders for common variables:
 
-- `STRIPE_SECRET_KEY` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` – Stripe API keys
+- `STRIPE_SECRET_KEY` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` / `STRIPE_WEBHOOK_SECRET` – Stripe API keys and webhook signature secret
 - `CART_COOKIE_SECRET` – secret for signing cart cookies (required)
 - `CART_TTL` – cart expiration in seconds (default 30 days)
 - `NEXTAUTH_SECRET` – session encryption secret used by NextAuth

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -82,9 +82,10 @@ module.exports = {
     // specific rules that must override tsconfig-derived ones
     "^@platform-core/src/(.*)$": "<rootDir>/packages/platform-core/src/$1",
     "^@ui/src/(.*)$": "<rootDir>/packages/ui/src/$1",
-    "^@platform-core/repositories/shopSettings$":
-      "<rootDir>/packages/platform-core/src/repositories/settings.server.ts",
-    "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
+      "^@platform-core/repositories/shopSettings$":
+        "<rootDir>/packages/platform-core/src/repositories/settings.server.ts",
+      "^@config/src/env$": "<rootDir>/packages/config/src/env/index.ts",
+      "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
     "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -19,6 +19,7 @@ const mutableEnv = process.env as unknown as Record<string, string>;
 mutableEnv.NODE_ENV ||= "development"; // relax “edge” runtime checks
 mutableEnv.NEXTAUTH_SECRET ||= "test-secret"; // dummy secret for Next-Auth
 mutableEnv.CART_COOKIE_SECRET ||= "test-cart-secret"; // cart cookie signing
+mutableEnv.STRIPE_WEBHOOK_SECRET ||= "whsec_test"; // dummy Stripe webhook secret
 
 /* -------------------------------------------------------------------------- */
 /* 2.  Polyfills missing from the JSDOM / Node test runtime                    */

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -9,25 +9,28 @@ describe("envSchema", () => {
   });
 
   it("parses when required variables are present", async () => {
-    process.env = {
-      ...OLD_ENV,
-      STRIPE_SECRET_KEY: "sk",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
-      CART_COOKIE_SECRET: "secret",
-    } as NodeJS.ProcessEnv;
+      process.env = {
+        ...OLD_ENV,
+        STRIPE_SECRET_KEY: "sk",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+        CART_COOKIE_SECRET: "secret",
+        STRIPE_WEBHOOK_SECRET: "whsec",
+      } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");
-    const parsed = envSchema.parse({
-      STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY!,
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
-        process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
-      CART_COOKIE_SECRET: process.env.CART_COOKIE_SECRET!,
-    });
-    expect(parsed).toEqual({
-      STRIPE_SECRET_KEY: "sk",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
-      CART_COOKIE_SECRET: "secret",
-    });
+      const parsed = envSchema.parse({
+        STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY!,
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+          process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
+        CART_COOKIE_SECRET: process.env.CART_COOKIE_SECRET!,
+        STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET!,
+      });
+      expect(parsed).toEqual({
+        STRIPE_SECRET_KEY: "sk",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+        CART_COOKIE_SECRET: "secret",
+        STRIPE_WEBHOOK_SECRET: "whsec",
+      });
   });
 
   it("throws when variables are missing", async () => {

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -4,6 +4,7 @@ import { applyFriendlyZodMessages } from "@acme/lib";
 export const paymentEnvSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
+  STRIPE_WEBHOOK_SECRET: z.string().min(1),
 });
 
 applyFriendlyZodMessages();

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -83,14 +83,15 @@ export function writeFiles(
   let envContent = `NEXT_PUBLIC_SHOP_ID=${id}\n`;
   const envVars = [...options.payment, ...options.shipping, options.tax];
   if (envVars.length === 0) envVars.push("stripe");
-  for (const provider of envVars) {
-    if (provider === "stripe") {
-      envContent += `STRIPE_SECRET_KEY=\n`;
-      envContent += `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=\n`;
-    } else {
-      envContent += `${provider.toUpperCase()}_KEY=\n`;
+    for (const provider of envVars) {
+      if (provider === "stripe") {
+        envContent += `STRIPE_SECRET_KEY=\n`;
+        envContent += `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=\n`;
+        envContent += `STRIPE_WEBHOOK_SECRET=\n`;
+      } else {
+        envContent += `${provider.toUpperCase()}_KEY=\n`;
+      }
     }
-  }
   envContent += `CART_COOKIE_SECRET=${genSecret()}\n`;
   envContent += `CART_TTL=\n`;
   envContent += `NEXTAUTH_SECRET=${genSecret()}\n`;

--- a/packages/template-app/__tests__/stripe-webhook.test.ts
+++ b/packages/template-app/__tests__/stripe-webhook.test.ts
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: unknown, init?: ResponseInit) =>
     new Response(JSON.stringify(data), init);
@@ -8,18 +9,60 @@ if (typeof (Response as any).json !== "function") {
 
 afterEach(() => jest.resetModules());
 
-describe("/api/stripe-webhook", () => {
-  test("forwards events to common handler", async () => {
-    const handleStripeWebhook = jest.fn();
-    jest.doMock("@platform-core/stripe-webhook", () => ({
-      __esModule: true,
-      handleStripeWebhook,
-    }), { virtual: true });
+  describe("/api/stripe-webhook", () => {
+    test("verifies signature and forwards events", async () => {
+      const handleStripeWebhook = jest.fn();
+      jest.doMock(
+        "@platform-core/stripe-webhook",
+        () => ({ __esModule: true, handleStripeWebhook }),
+        { virtual: true }
+      );
+      const payload = {
+        type: "checkout.session.completed",
+        data: { object: {} },
+      } as any;
+      const constructEvent = jest.fn().mockReturnValue(payload);
+      jest.doMock("@acme/stripe", () => ({
+        __esModule: true,
+        stripe: { webhooks: { constructEvent } },
+      }));
 
-    const { POST } = await import("../src/api/stripe-webhook/route");
-    const payload = { type: "checkout.session.completed", data: { object: {} } } as any;
-    const res = await POST({ json: async () => payload } as any);
-    expect(handleStripeWebhook).toHaveBeenCalledWith("bcd", payload);
-    expect(res.status).toBe(200);
+      const { POST } = await import("../src/api/stripe-webhook/route");
+      const body = JSON.stringify(payload);
+      const res = await POST({
+        text: async () => body,
+        headers: new Headers({ "stripe-signature": "sig" }),
+      } as any);
+      expect(constructEvent).toHaveBeenCalledWith(
+        body,
+        "sig",
+        "whsec_test"
+      );
+      expect(handleStripeWebhook).toHaveBeenCalledWith("bcd", payload);
+      expect(res.status).toBe(200);
+    });
+
+    test("returns 400 for invalid signature", async () => {
+      const handleStripeWebhook = jest.fn();
+      jest.doMock(
+        "@platform-core/stripe-webhook",
+        () => ({ __esModule: true, handleStripeWebhook }),
+        { virtual: true }
+      );
+      const constructEvent = jest.fn(() => {
+        throw new Error("bad");
+      });
+      jest.doMock("@acme/stripe", () => ({
+        __esModule: true,
+        stripe: { webhooks: { constructEvent } },
+      }));
+
+      const { POST } = await import("../src/api/stripe-webhook/route");
+      const res = await POST({
+        text: async () => "{}",
+        headers: new Headers({ "stripe-signature": "sig" }),
+      } as any);
+      expect(res.status).toBe(400);
+      expect(handleStripeWebhook).not.toHaveBeenCalled();
+    });
   });
-});

--- a/packages/template-app/src/api/stripe-webhook/route.ts
+++ b/packages/template-app/src/api/stripe-webhook/route.ts
@@ -1,13 +1,26 @@
 // packages/template-app/src/api/stripe-webhook/route.ts
 
 import { handleStripeWebhook } from "@platform-core/stripe-webhook";
+import { stripe } from "@acme/stripe";
+import { paymentEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
 export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
-  const event = (await req.json()) as Stripe.Event;
+  const body = await req.text();
+  const signature = req.headers.get("stripe-signature") ?? "";
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      paymentEnv.STRIPE_WEBHOOK_SECRET
+    );
+  } catch {
+    return new NextResponse("Invalid signature", { status: 400 });
+  }
   await handleStripeWebhook("bcd", event);
   return NextResponse.json({ received: true });
 }

--- a/scripts/__tests__/setup-ci.test.ts
+++ b/scripts/__tests__/setup-ci.test.ts
@@ -23,10 +23,11 @@ describe("setup-ci script", () => {
     const { envSchema } = await import("@config/src/env");
     (envSchema.parse as jest.Mock).mockReturnValue({});
 
-    const env = [
-      "STRIPE_SECRET_KEY=sk",
-      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk",
-    ].join("\n");
+      const env = [
+        "STRIPE_SECRET_KEY=sk",
+        "STRIPE_WEBHOOK_SECRET=whsec",
+        "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk",
+      ].join("\n");
     const existsMock = jest
       .spyOn(fs, "existsSync")
       .mockImplementation((p) => p.toString().endsWith(".env"));
@@ -51,19 +52,21 @@ describe("setup-ci script", () => {
     expect(writeMock).toHaveBeenCalledTimes(1);
     const [wfPath, content] = writeMock.mock.calls[0];
     expect(wfPath).toBe(path.join(".github", "workflows", "shop-abc.yml"));
-    expect(content).toContain("shop-abc");
-    expect(content).toContain("STRIPE_SECRET_KEY: sk");
-    expect(exitMock).not.toHaveBeenCalled();
+      expect(content).toContain("shop-abc");
+      expect(content).toContain("STRIPE_SECRET_KEY: sk");
+      expect(content).toContain("STRIPE_WEBHOOK_SECRET: whsec");
+      expect(exitMock).not.toHaveBeenCalled();
   });
 
   it("injects domain env vars when configured", async () => {
     const { envSchema } = await import("@config/src/env");
     (envSchema.parse as jest.Mock).mockReturnValue({});
 
-    const env = [
-      "STRIPE_SECRET_KEY=sk",
-      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk",
-    ].join("\n");
+      const env = [
+        "STRIPE_SECRET_KEY=sk",
+        "STRIPE_WEBHOOK_SECRET=whsec",
+        "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk",
+      ].join("\n");
     jest
       .spyOn(fs, "existsSync")
       .mockImplementation((p) => true);

--- a/scripts/__tests__/validate-env.test.ts
+++ b/scripts/__tests__/validate-env.test.ts
@@ -15,17 +15,18 @@ let readFileSyncMock = require("node:fs").readFileSync as jest.Mock;
 describe("validate-env script", () => {
   const ORIGINAL_ARGV = process.argv;
 
-  beforeEach(() => {
-    jest.resetModules();
-    process.argv = ["node", "validate-env", "abc"];
-    process.env.STRIPE_SECRET_KEY = "sk";
-    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
-    process.env.CART_COOKIE_SECRET = "secret";
-    existsSyncMock = require("node:fs").existsSync as jest.Mock;
-    readFileSyncMock = require("node:fs").readFileSync as jest.Mock;
-    existsSyncMock.mockReset();
-    readFileSyncMock.mockReset();
-  });
+    beforeEach(() => {
+      jest.resetModules();
+      process.argv = ["node", "validate-env", "abc"];
+      process.env.STRIPE_SECRET_KEY = "sk";
+      process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
+      process.env.CART_COOKIE_SECRET = "secret";
+      process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+      existsSyncMock = require("node:fs").existsSync as jest.Mock;
+      readFileSyncMock = require("node:fs").readFileSync as jest.Mock;
+      existsSyncMock.mockReset();
+      readFileSyncMock.mockReset();
+    });
 
   afterEach(() => {
     process.argv = ORIGINAL_ARGV;
@@ -34,9 +35,9 @@ describe("validate-env script", () => {
 
   it("exits 0 and logs success for valid env", async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(
-      "STRIPE_SECRET_KEY=sk\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCART_COOKIE_SECRET=secret\n"
-    );
+      readFileSyncMock.mockReturnValue(
+        "STRIPE_SECRET_KEY=sk\nSTRIPE_WEBHOOK_SECRET=whsec\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCART_COOKIE_SECRET=secret\n"
+      );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -55,9 +56,9 @@ describe("validate-env script", () => {
 
   it("exits 1 and reports invalid env", async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(
-      "STRIPE_SECRET_KEY=sk\nCART_COOKIE_SECRET=secret\n"
-    );
+      readFileSyncMock.mockReturnValue(
+        "STRIPE_SECRET_KEY=sk\nSTRIPE_WEBHOOK_SECRET=whsec\nCART_COOKIE_SECRET=secret\n"
+      );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -96,9 +97,9 @@ describe("validate-env script", () => {
 
   it("exits 1 for invalid DEPOSIT_RELEASE values", async () => {
     existsSyncMock.mockReturnValue(true);
-    readFileSyncMock.mockReturnValue(
-      "STRIPE_SECRET_KEY=sk\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCART_COOKIE_SECRET=secret\nDEPOSIT_RELEASE_ENABLED=maybe\nDEPOSIT_RELEASE_INTERVAL_MS=foo\n",
-    );
+      readFileSyncMock.mockReturnValue(
+        "STRIPE_SECRET_KEY=sk\nSTRIPE_WEBHOOK_SECRET=whsec\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk\nCART_COOKIE_SECRET=secret\nDEPOSIT_RELEASE_ENABLED=maybe\nDEPOSIT_RELEASE_INTERVAL_MS=foo\n",
+      );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -19,18 +19,23 @@ describe('init-shop wizard', () => {
       'n',
     ];
     const createShop = jest.fn();
-    const envParse = jest.fn((env: Record<string, string>) => {
-      if (!env.STRIPE_SECRET_KEY || !env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {
-        throw new Error('invalid env');
-      }
-      return env;
-    });
-    const validateShopEnv = jest.fn(() =>
-      envParse({
-        STRIPE_SECRET_KEY: '',
-        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
-      })
-    );
+      const envParse = jest.fn((env: Record<string, string>) => {
+        if (
+          !env.STRIPE_SECRET_KEY ||
+          !env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+          !env.STRIPE_WEBHOOK_SECRET
+        ) {
+          throw new Error('invalid env');
+        }
+        return env;
+      });
+      const validateShopEnv = jest.fn(() =>
+        envParse({
+          STRIPE_SECRET_KEY: '',
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
+          STRIPE_WEBHOOK_SECRET: '',
+        })
+      );
 
     const sandbox: any = {
       exports: {},
@@ -41,8 +46,8 @@ describe('init-shop wizard', () => {
         if (p === 'node:fs') {
           return {
             existsSync: () => true,
-            readFileSync: () =>
-              'STRIPE_SECRET_KEY=\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=\n',
+              readFileSync: () =>
+                'STRIPE_SECRET_KEY=\nNEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=\nSTRIPE_WEBHOOK_SECRET=\n',
           };
         }
         if (p === 'node:path') return require('node:path');
@@ -123,10 +128,11 @@ describe('init-shop wizard', () => {
       { deploy: true }
     );
 
-    expect(envParse).toHaveBeenCalledWith({
-      STRIPE_SECRET_KEY: '',
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
-    });
+      expect(envParse).toHaveBeenCalledWith({
+        STRIPE_SECRET_KEY: '',
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
+        STRIPE_WEBHOOK_SECRET: '',
+      });
 
     expect(sandbox.console.error).toHaveBeenCalled();
     expect(sandbox.console.error.mock.calls[0][0]).toContain(


### PR DESCRIPTION
## Summary
- validate Stripe webhooks using `stripe.webhooks.constructEvent`
- add STRIPE_WEBHOOK_SECRET to payment env config and docs
- scaffold STRIPE_WEBHOOK_SECRET in new shop env files

## Testing
- `pnpm exec jest packages/template-app/__tests__/stripe-webhook.test.ts apps/shop-abc/__tests__/stripe-webhook.test.ts packages/config/__tests__/env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b6ac189cc832f965ed7dd79457bba