### PR TITLE
feat: expand CMS media support

### DIFF
--- a/packages/ui/__tests__/MediaManager.a11y.test.tsx
+++ b/packages/ui/__tests__/MediaManager.a11y.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import MediaManager from "@ui/components/cms/MediaManager";
 
-jest.mock("@ui/hooks/useFileUpload", () => ({
-  useFileUpload: () => ({
+jest.mock("@ui/hooks/useMediaUpload", () => ({
+  __esModule: true,
+  useMediaUpload: () => ({
     pendingFile: null,
+    thumbnail: null,
     altText: "",
     setAltText: jest.fn(),
     actual: null,
@@ -18,6 +19,9 @@ jest.mock("@ui/hooks/useFileUpload", () => ({
     handleUpload: jest.fn(),
   }),
 }));
+
+
+const MediaManager = require("@ui/components/cms/MediaManager").default;
 
 describe("MediaManager accessibility", () => {
   it("links drop zone to live feedback region", () => {

--- a/packages/ui/__tests__/MediaManager.test.tsx
+++ b/packages/ui/__tests__/MediaManager.test.tsx
@@ -31,6 +31,8 @@ beforeEach(() => {
     ok: true,
     json: async () => ({ url: "/new.png", altText: "a", type: "image" }),
   } as any);
+  global.URL.createObjectURL = jest.fn(() => "blob:url");
+  global.URL.revokeObjectURL = jest.fn();
 });
 
 describe("MediaManager", () => {
@@ -74,7 +76,7 @@ describe("MediaManager", () => {
         shop="s"
         initialFiles={[
           { url: "/a.jpg", altText: "Cat", type: "image" } as any,
-          { url: "/b.jpg", altText: "Dog", type: "image" } as any,
+          { url: "/dog.jpg", altText: "Dog", type: "image" } as any,
         ]}
         onDelete={mockDelete}
       />

--- a/packages/ui/src/components/cms/MediaFileList.tsx
+++ b/packages/ui/src/components/cms/MediaFileList.tsx
@@ -6,14 +6,27 @@ import MediaFileItem from "./MediaFileItem";
 interface Props {
   /** List of files already filtered by the parent component */
   files: MediaItem[];
+  shop: string;
   onDelete: (url: string) => void;
+  onReplace: (oldUrl: string, item: MediaItem) => void;
 }
 
-export default function MediaFileList({ files, onDelete }: Props) {
+export default function MediaFileList({
+  files,
+  shop,
+  onDelete,
+  onReplace,
+}: Props) {
   return (
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
       {files.map((item) => (
-        <MediaFileItem key={item.url} item={item} onDelete={onDelete} />
+        <MediaFileItem
+          key={item.url}
+          item={item}
+          shop={shop}
+          onDelete={onDelete}
+          onReplace={onReplace}
+        />
       ))}
     </div>
   );

--- a/packages/ui/src/hooks/useMediaUpload.tsx
+++ b/packages/ui/src/hooks/useMediaUpload.tsx
@@ -1,4 +1,78 @@
+import { useEffect, useState } from "react";
+import type { UseFileUploadOptions, UseFileUploadResult } from "./useFileUpload";
 import { useFileUpload } from "./useFileUpload";
-export * from "./useFileUpload";
-export { useFileUpload as useMediaUpload } from "./useFileUpload";
-export default useFileUpload;
+
+export interface UseMediaUploadResult extends UseFileUploadResult {
+  /** Data URL for a preview thumbnail of the selected file */
+  thumbnail: string | null;
+}
+
+async function createVideoThumbnail(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.src = URL.createObjectURL(file);
+    video.muted = true;
+    video.playsInline = true;
+
+    const cleanup = () => URL.revokeObjectURL(video.src);
+
+    video.onloadeddata = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        cleanup();
+        resolve(canvas.toDataURL("image/png"));
+      } else {
+        cleanup();
+        resolve(video.src);
+      }
+    };
+    video.onerror = () => {
+      cleanup();
+      resolve(video.src);
+    };
+  });
+}
+
+export function useMediaUpload(
+  options: UseFileUploadOptions
+): UseMediaUploadResult {
+  const base = useFileUpload(options);
+  const [thumbnail, setThumbnail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const file = base.pendingFile;
+    if (!file) {
+      setThumbnail(null);
+      return;
+    }
+
+    if (file.type.startsWith("image/")) {
+      const url = URL.createObjectURL(file);
+      setThumbnail(url);
+      return () => URL.revokeObjectURL(url);
+    }
+
+    if (file.type.startsWith("video/")) {
+      let active = true;
+      createVideoThumbnail(file).then((url) => {
+        if (active) setThumbnail(url);
+      });
+      return () => {
+        active = false;
+      };
+    }
+  }, [base.pendingFile]);
+
+  return { ...base, thumbnail };
+}
+
+export type {
+  UseFileUploadOptions as UseMediaUploadOptions,
+  UseMediaUploadResult,
+};
+export default useMediaUpload;


### PR DESCRIPTION
## Summary
- allow video uploads with generated thumbnails
- add inline alt-text editing for media items
- filter media by filename or tag in manager

## Testing
- `pnpm --filter @acme/ui test __tests__/MediaManager.test.tsx __tests__/MediaManager.a11y.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/drop image or video/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689b691d0030832f8303dca5771f3471