### PR TITLE
feat(ui): add search bar labels

### DIFF
--- a/packages/ui/src/components/molecules/SearchBar.stories.tsx
+++ b/packages/ui/src/components/molecules/SearchBar.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof SearchBar> = {
   args: {
     suggestions: ["Apple", "Banana", "Cherry", "Date"],
     placeholder: "Search…",
+    label: "Search",
   },
   argTypes: {
     onSelect: { action: "select" },

--- a/packages/ui/src/components/molecules/SearchBar.tsx
+++ b/packages/ui/src/components/molecules/SearchBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Input } from "../atoms/shadcn";
 
 export interface SearchBarProps {
@@ -12,6 +12,8 @@ export interface SearchBarProps {
   /** Callback when a search is manually submitted */
   onSearch?(value: string): void;
   placeholder?: string;
+  /** Accessible label for the search input */
+  label: string;
 }
 
 export function SearchBar({
@@ -19,11 +21,13 @@ export function SearchBar({
   onSelect,
   onSearch,
   placeholder = "Search…",
+  label,
 }: SearchBarProps) {
   const [query, setQuery] = useState("");
   const [matches, setMatches] = useState<string[]>([]);
   const [isSelecting, setIsSelecting] = useState(false);
   const [focused, setFocused] = useState(false);
+  const inputId = useId();
 
   useEffect(() => {
     if (isSelecting || !focused) {
@@ -49,8 +53,13 @@ export function SearchBar({
 
   return (
     <div className="relative w-full max-w-sm">
+      <label htmlFor={inputId} className="sr-only">
+        {label}
+      </label>
       <Input
+        id={inputId}
         type="search"
+        aria-label={label}
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={(e) => {

--- a/packages/ui/src/components/molecules/__tests__/SearchBar.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/SearchBar.test.tsx
@@ -6,18 +6,24 @@ import { SearchBar } from "../SearchBar";
 describe("SearchBar", () => {
   it("calls onSearch when pressing Enter", async () => {
     const onSearch = jest.fn();
-    render(<SearchBar suggestions={[]} onSearch={onSearch} />);
-    const input = screen.getByRole("searchbox");
+    render(<SearchBar suggestions={[]} onSearch={onSearch} label="Search" />);
+    const input = screen.getByRole("searchbox", { name: "Search" });
     await userEvent.type(input, "hello{enter}");
     expect(onSearch).toHaveBeenCalledWith("hello");
   });
 
   it("calls onSearch when input loses focus", async () => {
     const onSearch = jest.fn();
-    render(<SearchBar suggestions={[]} onSearch={onSearch} />);
-    const input = screen.getByRole("searchbox");
+    render(<SearchBar suggestions={[]} onSearch={onSearch} label="Search" />);
+    const input = screen.getByRole("searchbox", { name: "Search" });
     await userEvent.type(input, "world");
     fireEvent.blur(input);
     expect(onSearch).toHaveBeenCalledWith("world");
+  });
+
+  it("applies an accessible label", () => {
+    render(<SearchBar suggestions={[]} label="Search products" />);
+    const input = screen.getByRole("searchbox", { name: "Search products" });
+    expect(input).toHaveAttribute("aria-label", "Search products");
   });
 });

--- a/packages/ui/src/components/organisms/Header.tsx
+++ b/packages/ui/src/components/organisms/Header.tsx
@@ -75,7 +75,7 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
 
         <div className="flex flex-1 justify-end gap-4">
           <div className="max-w-xs flex-1">
-            <SearchBar suggestions={searchSuggestions} />
+            <SearchBar suggestions={searchSuggestions} label="Search products" />
           </div>
           <LanguageSwitcher current={locale} />
         </div>

--- a/packages/ui/src/components/organisms/__tests__/Header.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/Header.test.tsx
@@ -10,7 +10,7 @@ describe("Header", () => {
 
     expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
 
-    const input = screen.getByPlaceholderText("Search…");
+    const input = screen.getByRole("searchbox", { name: "Search products" });
     await userEvent.type(input, "app");
     expect(screen.getByText("apple")).toBeInTheDocument();
 

--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -41,6 +41,7 @@ export function SearchResultsTemplate({
         onSelect={onQueryChange}
         onSearch={onQueryChange}
         placeholder="Search products…"
+        label="Search products"
       />
       {filters}
       {results.length > 0 ? (


### PR DESCRIPTION
## Summary
- add required `label` prop to SearchBar and expose it via hidden label and `aria-label`
- give SearchResultsTemplate and Header accessible labels
- test SearchBar and Header for labeled search inputs

## Testing
- `pnpm exec jest src/components/molecules/__tests__/SearchBar.test.tsx src/components/organisms/__tests__/Header.test.tsx --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689b6991a6d4832f9357cf770b6a4a36