### PR TITLE
feat(cms): persist role permissions in RBAC store

### DIFF
--- a/apps/cms/__tests__/authOptions.test.ts
+++ b/apps/cms/__tests__/authOptions.test.ts
@@ -7,6 +7,7 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const rbacStorePath = require.resolve("../src/lib/rbacStore");
+const { ROLE_PERMISSIONS } = require("@auth/permissions");
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 jest.doMock(rbacStorePath, () => ({
@@ -15,8 +16,11 @@ jest.doMock(rbacStorePath, () => ({
       "1": { id: "1", email: "admin@example.com", password: "admin" },
     },
     roles: { "1": "admin" },
+    permissions: ROLE_PERMISSIONS,
   }),
 }));
+
+process.env.CART_COOKIE_SECRET = "test";
 
 /* -------------------------------------------------------------------------- */
 /* 2.  Imports                                                                */

--- a/apps/cms/__tests__/rbacStore.test.ts
+++ b/apps/cms/__tests__/rbacStore.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { ROLE_PERMISSIONS } from "@auth/permissions";
+import { PERMISSIONS } from "@auth/types/permissions";
 
 async function withTempDir(cb: (dir: string) => Promise<void>): Promise<void> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "rbac-"));
@@ -22,7 +24,7 @@ describe("rbacStore", () => {
       const db = await readRbac();
       expect(db.users["1"].email).toBe("admin@example.com");
       expect(db.roles["1"]).toBe("admin");
-      expect(db.permissions.admin).toEqual(["read", "write"]);
+      expect(db.permissions.admin).toEqual(ROLE_PERMISSIONS.admin);
     });
   });
 
@@ -49,12 +51,12 @@ describe("rbacStore", () => {
     await withTempDir(async (dir) => {
       const { readRbac, writeRbac } = await import("../src/lib/rbacStore");
       const db = await readRbac();
-      db.permissions.admin = ["read"];
+      db.permissions.admin = [PERMISSIONS[0]];
       await writeRbac(db);
       const stored = JSON.parse(
         await fs.readFile(path.join(dir, "data", "cms", "users.json"), "utf8")
       );
-      expect(stored.permissions.admin).toEqual(["read"]);
+      expect(stored.permissions.admin).toEqual([PERMISSIONS[0]]);
     });
   });
 });

--- a/apps/cms/src/actions/rbac.server.ts
+++ b/apps/cms/src/actions/rbac.server.ts
@@ -3,6 +3,7 @@
 
 import type { Role } from "@cms/auth/roles";
 import type { CmsUser } from "@cms/auth/users";
+import type { Permission } from "@auth";
 import bcrypt from "bcryptjs";
 import { ulid } from "ulid";
 import { readRbac, writeRbac } from "../lib/rbacStore";
@@ -43,7 +44,7 @@ export async function updateRolePermissions(
   formData: FormData
 ): Promise<void> {
   const role = String(formData.get("role") ?? "") as Role;
-  const permissions = formData.getAll("permissions") as string[];
+  const permissions = formData.getAll("permissions") as Permission[];
   const db = await readRbac();
   db.permissions[role] = permissions;
   await writeRbac(db);

--- a/apps/cms/src/app/cms/rbac/permissions/page.tsx
+++ b/apps/cms/src/app/cms/rbac/permissions/page.tsx
@@ -3,6 +3,8 @@ import { Button } from "@/components/atoms/shadcn";
 import { updateRolePermissions } from "@cms/actions/rbac.server";
 import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
+import type { Permission } from "@auth";
+import { PERMISSIONS } from "@auth/types/permissions";
 import { readRbac } from "@cms/lib/rbacStore";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -30,7 +32,7 @@ export default async function PermissionsPage() {
     "ThemeEditor",
   ];
 
-  const permissions = ["read", "write"];
+  const permissions: Permission[] = PERMISSIONS;
 
   return (
     <div>

--- a/apps/cms/src/lib/rbacStore.d.ts
+++ b/apps/cms/src/lib/rbacStore.d.ts
@@ -1,9 +1,10 @@
 import type { CmsUser } from "@acme/types";
+import type { Permission } from "@auth";
 import type { Role } from "../auth/roles";
 export interface RbacDB {
     users: Record<string, CmsUser>;
     roles: Record<string, Role | Role[]>;
-    permissions: Record<Role, string[]>;
+    permissions: Record<Role, Permission[]>;
 }
 export declare function readRbac(): Promise<RbacDB>;
 export declare function writeRbac(db: RbacDB): Promise<void>;

--- a/apps/cms/src/lib/rbacStore.js
+++ b/apps/cms/src/lib/rbacStore.js
@@ -1,3 +1,4 @@
+import { ROLE_PERMISSIONS } from "@auth/permissions";
 import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
@@ -41,6 +42,7 @@ const DEFAULT_DB = {
         "4": "CatalogManager",
         "5": "ThemeEditor",
     },
+    permissions: { ...ROLE_PERMISSIONS },
 };
 function resolveFile() {
     let dir = process.cwd();
@@ -61,7 +63,7 @@ export async function readRbac() {
     try {
         const buf = await fs.readFile(FILE, "utf8");
         const parsed = JSON.parse(buf);
-        if (parsed && parsed.users && parsed.roles)
+        if (parsed && parsed.users && parsed.roles && parsed.permissions)
             return parsed;
     }
     catch {

--- a/apps/cms/src/lib/rbacStore.ts
+++ b/apps/cms/src/lib/rbacStore.ts
@@ -1,6 +1,8 @@
 // apps/cms/src/lib/rbacStore.ts
 
 import type { CmsUser } from "@acme/types";
+import type { Permission } from "@auth";
+import { ROLE_PERMISSIONS } from "@auth/permissions";
 import * as fsSync from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
@@ -9,7 +11,7 @@ import type { Role } from "../auth/roles";
 export interface RbacDB {
   users: Record<string, CmsUser>;
   roles: Record<string, Role | Role[]>;
-  permissions: Record<Role, string[]>;
+  permissions: Record<Role, Permission[]>;
 }
 
 const DEFAULT_DB: RbacDB = {
@@ -52,13 +54,7 @@ const DEFAULT_DB: RbacDB = {
     "4": "CatalogManager",
     "5": "ThemeEditor",
   },
-  permissions: {
-    admin: ["read", "write"],
-    viewer: [],
-    ShopAdmin: [],
-    CatalogManager: [],
-    ThemeEditor: [],
-  },
+  permissions: { ...ROLE_PERMISSIONS },
 };
 
 function resolveFile(): string {


### PR DESCRIPTION
## Summary
- include typed role permissions in CMS RBAC store
- expose default permission mapping via ROLE_PERMISSIONS
- test RBAC read/write with permission serialization

## Testing
- `pnpm --filter @apps/cms test __tests__/rbacStore.test.ts __tests__/authOptions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b6a9a9f4c832fb630e149f2bf2999