### PR TITLE
feat: add clear filters button

### DIFF
--- a/packages/platform-core/__tests__/filterBar.test.tsx
+++ b/packages/platform-core/__tests__/filterBar.test.tsx
@@ -15,4 +15,19 @@ describe("FilterBar", () => {
       expect(onChange).toHaveBeenLastCalledWith({ size: undefined });
     });
   });
+
+  it("resets filters", async () => {
+    const onChange = jest.fn();
+    render(<FilterBar onChange={onChange} sizes={["39", "40"]} />);
+    const select = screen.getByLabelText(/Size/);
+    fireEvent.change(select, { target: { value: "39" } });
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith({ size: "39" });
+    });
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    await waitFor(() => {
+      expect(select).toHaveValue("");
+      expect(onChange).toHaveBeenLastCalledWith({ size: undefined });
+    });
+  });
 });

--- a/packages/platform-core/src/components/shop/FilterBar.tsx
+++ b/packages/platform-core/src/components/shop/FilterBar.tsx
@@ -22,10 +22,15 @@ export default function FilterBar({
     onChange({ size: deferredSize || undefined } as Filters);
   }, [deferredSize, onChange]);
 
+  function clearFilters() {
+    setSize("");
+    onChange({} as Filters);
+  }
+
   return (
     <form
       aria-label="Filters"
-      className="mb-6 flex gap-4 items-center justify-between flex-wrap"
+      className="mb-6 flex flex-wrap items-center justify-between gap-4"
       onSubmit={(e) => e.preventDefault()}
     >
       <label className="flex items-center gap-2 text-sm">
@@ -33,7 +38,7 @@ export default function FilterBar({
         <select
           value={size}
           onChange={(e) => setSize(e.target.value)}
-          className="border rounded px-2 py-1 text-sm"
+          className="rounded border px-2 py-1 text-sm"
         >
           <option value="">All</option>
           {sizes.map((s) => (
@@ -41,6 +46,13 @@ export default function FilterBar({
           ))}
         </select>
       </label>
+      <button
+        type="button"
+        onClick={clearFilters}
+        className="rounded border px-2 py-1 text-sm"
+      >
+        Clear Filters
+      </button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add Clear Filters button to FilterBar component
- reset filter state and propagate cleared filters on click
- test clearing behavior in FilterBar unit test

## Testing
- `pnpm --filter @acme/platform-core test -- --runTestsByPath packages/platform-core/__tests__/filterBar.test.tsx` *(fails: A React Element from an older version of React was rendered)*

------
https://chatgpt.com/codex/tasks/task_e_689b6bc19234832fba250b062642e954