### PR TITLE
feat(ui): improve SearchBar accessibility and keyboard navigation

### DIFF
--- a/packages/ui/src/components/molecules/SearchBar.tsx
+++ b/packages/ui/src/components/molecules/SearchBar.tsx
@@ -24,6 +24,7 @@ export function SearchBar({
   const [matches, setMatches] = useState<string[]>([]);
   const [isSelecting, setIsSelecting] = useState(false);
   const [focused, setFocused] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
 
   useEffect(() => {
     if (isSelecting || !focused) {
@@ -38,13 +39,16 @@ export function SearchBar({
     setMatches(
       suggestions.filter((s) => s.toLowerCase().includes(q)).slice(0, 5)
     );
+    setActiveIndex(-1);
   }, [query, suggestions, isSelecting, focused]);
 
   const handleSelect = (value: string) => {
     setIsSelecting(true);
     setQuery(value);
     setMatches([]);
+    setActiveIndex(-1);
     onSelect?.(value);
+    setTimeout(() => setIsSelecting(false), 0);
   };
 
   return (
@@ -52,11 +56,26 @@ export function SearchBar({
       <Input
         type="search"
         value={query}
+        aria-activedescendant={
+          activeIndex >= 0 ? `search-option-${activeIndex}` : undefined
+        }
+        aria-controls={matches.length > 0 ? "search-options" : undefined}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            setMatches([]);
-            onSearch?.(query);
+          if (e.key === "ArrowDown" && matches.length > 0) {
+            e.preventDefault();
+            setActiveIndex((i) => (i + 1) % matches.length);
+          } else if (e.key === "ArrowUp" && matches.length > 0) {
+            e.preventDefault();
+            setActiveIndex((i) => (i - 1 + matches.length) % matches.length);
+          } else if (e.key === "Enter") {
+            if (activeIndex >= 0 && matches[activeIndex]) {
+              e.preventDefault();
+              handleSelect(matches[activeIndex]);
+            } else {
+              setMatches([]);
+              onSearch?.(query);
+            }
           }
         }}
         onFocus={() => setFocused(true)}
@@ -73,12 +92,21 @@ export function SearchBar({
       />
       <MagnifyingGlassIcon className="text-muted-foreground pointer-events-none absolute top-2 right-2 h-4 w-4" />
       {matches.length > 0 && (
-        <ul className="bg-background absolute z-10 mt-1 w-full rounded-md border shadow">
-          {matches.map((m) => (
+        <ul
+          id="search-options"
+          role="listbox"
+          className="bg-background absolute z-10 mt-1 w-full rounded-md border shadow"
+        >
+          {matches.map((m, idx) => (
             <li
+              id={`search-option-${idx}`}
+              role="option"
+              aria-selected={idx === activeIndex}
               key={m}
               onMouseDown={() => handleSelect(m)}
-              className="text-fg hover:bg-accent hover:text-accent-foreground cursor-pointer px-3 py-1"
+              className={`text-fg cursor-pointer px-3 py-1 hover:bg-accent hover:text-accent-foreground ${
+                idx === activeIndex ? "bg-accent text-accent-foreground" : ""
+              }`}
             >
               {m}
             </li>

--- a/packages/ui/src/components/molecules/__tests__/SearchBar.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/SearchBar.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SearchBar } from "../SearchBar";
 
@@ -19,5 +19,46 @@ describe("SearchBar", () => {
     await userEvent.type(input, "world");
     fireEvent.blur(input);
     expect(onSearch).toHaveBeenCalledWith("world");
+  });
+
+  it("navigates suggestions with keyboard and selects with Enter", async () => {
+    const onSelect = jest.fn();
+    render(
+      <SearchBar
+        suggestions={["Alpha", "Beta", "Gamma"]}
+        onSelect={onSelect}
+      />
+    );
+    const input = screen.getByRole("searchbox");
+    await userEvent.type(input, "a");
+
+    const listbox = screen.getByRole("listbox");
+    const options = within(listbox).getAllByRole("option");
+    expect(options).toHaveLength(3);
+
+    await userEvent.keyboard("{ArrowDown}");
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+
+    await userEvent.keyboard("{ArrowDown}");
+    expect(options[0]).toHaveAttribute("aria-selected", "false");
+    expect(options[1]).toHaveAttribute("aria-selected", "true");
+
+    await userEvent.keyboard("{ArrowUp}");
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    expect(options[1]).toHaveAttribute("aria-selected", "false");
+
+    await userEvent.keyboard("{Enter}");
+    expect(onSelect).toHaveBeenCalledWith("Alpha");
+    expect(input).toHaveValue("Alpha");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("renders suggestions with ARIA roles", async () => {
+    render(<SearchBar suggestions={["One", "Two"]} />);
+    const input = screen.getByRole("searchbox");
+    await userEvent.type(input, "o");
+    const listbox = screen.getByRole("listbox");
+    const options = within(listbox).getAllByRole("option");
+    expect(options).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- add ARIA roles to SearchBar suggestions
- implement arrow key navigation and Enter to select a suggestion
- test SearchBar keyboard interactions and ARIA attributes

## Testing
- `pnpm --filter @acme/ui test src/components/molecules/__tests__/SearchBar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689b6bbdff98832f8b92837abd6de3bf