### PR TITLE
feat(ui): add loading state to search results template

### DIFF
--- a/packages/ui/src/components/templates/README.md
+++ b/packages/ui/src/components/templates/README.md
@@ -18,7 +18,7 @@ Shared page-level layouts used across apps. Currently includes:
 - `CategoryCollectionTemplate` – grid of category cards.
 - `SearchResultsTemplate` – search bar with optional filters and paginated
   product results. Accepts `minItems` and `maxItems` to adjust the responsive
-  product grid.
+  product grid and an `isLoading` prop to display a loading skeleton.
 - `CheckoutTemplate` – multi-step layout for collecting checkout information.
 - `OrderConfirmationTemplate` – summary of purchased items and totals.
 - `WishlistTemplate` – list of saved items with add-to-cart and remove actions.

--- a/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
@@ -27,6 +27,7 @@ const meta: Meta<typeof SearchResultsTemplate> = {
     pageCount: 5,
     minItems: 1,
     maxItems: 4,
+    isLoading: false,
   },
   argTypes: {
     minItems: { control: { type: "number" } },
@@ -41,5 +42,13 @@ export const WithFilters: StoryObj<typeof SearchResultsTemplate> = {
   args: {
     ...meta.args,
     filters: <FilterBar onChange={() => undefined} />,
+  },
+};
+
+export const Loading: StoryObj<typeof SearchResultsTemplate> = {
+  args: {
+    ...meta.args,
+    results: [],
+    isLoading: true,
   },
 };

--- a/packages/ui/src/components/templates/SearchResultsTemplate.test.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.test.tsx
@@ -12,13 +12,13 @@ const results: Product[] = [
   {
     id: "1",
     title: "Product 1",
-    images: [{ url: "/img1.jpg", type: "image" }],
+    media: [{ url: "/img1.jpg", type: "image" }],
     price: 1000,
   },
   {
     id: "2",
     title: "Product 2",
-    images: [{ url: "/img2.jpg", type: "image" }],
+    media: [{ url: "/img2.jpg", type: "image" }],
     price: 1500,
   },
 ];
@@ -50,6 +50,23 @@ describe("SearchResultsTemplate", () => {
     );
 
     expect(screen.getByText("No results found.")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when isLoading is true", () => {
+    render(
+      <SearchResultsTemplate
+        suggestions={[]}
+        results={[]}
+        page={1}
+        pageCount={1}
+        isLoading
+      />
+    );
+
+    expect(
+      screen.getByTestId("search-results-loading")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No results found.")).not.toBeInTheDocument();
   });
 
   it("toggles pagination visibility based on pageCount", () => {

--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -4,6 +4,7 @@ import { PaginationControl } from "../molecules/PaginationControl";
 import { SearchBar } from "../molecules/SearchBar";
 import type { Product } from "../organisms/ProductCard";
 import { ProductGrid } from "../organisms/ProductGrid";
+import { Skeleton } from "../atoms/Skeleton";
 
 export interface SearchResultsTemplateProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "results"> {
@@ -19,6 +20,8 @@ export interface SearchResultsTemplateProps
   onPageChange?: (page: number) => void;
   /** Optional filters to render between the search bar and results */
   filters?: React.ReactNode;
+  /** Show loading state */
+  isLoading?: boolean;
 }
 
 export function SearchResultsTemplate({
@@ -31,6 +34,7 @@ export function SearchResultsTemplate({
   onQueryChange,
   onPageChange,
   filters,
+  isLoading,
   className,
   ...props
 }: SearchResultsTemplateProps) {
@@ -43,7 +47,19 @@ export function SearchResultsTemplate({
         placeholder="Search products…"
       />
       {filters}
-      {results.length > 0 ? (
+      {isLoading ? (
+        <div
+          data-testid="search-results-loading"
+          className="grid gap-6"
+          style={{
+            gridTemplateColumns: `repeat(${maxItems ?? minItems ?? 1}, minmax(0, 1fr))`,
+          }}
+        >
+          {Array.from({ length: maxItems ?? minItems ?? 1 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 w-full" />
+          ))}
+        </div>
+      ) : results.length > 0 ? (
         <ProductGrid products={results} minItems={minItems} maxItems={maxItems} />
       ) : (
         <p>No results found.</p>


### PR DESCRIPTION
## Summary
- add optional `isLoading` prop to `SearchResultsTemplate`
- show skeleton grid during loading
- document and test loading state, and expose storybook example

## Testing
- `pnpm exec jest packages/ui/src/components/templates/SearchResultsTemplate.test.tsx`
- `pnpm exec eslint packages/ui/src/components/templates/SearchResultsTemplate.tsx packages/ui/src/components/templates/SearchResultsTemplate.test.tsx packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx packages/ui/src/components/templates/README.md`

------
https://chatgpt.com/codex/tasks/task_e_689b6bbb9cd4832f97be3ebc4affc4a4