### PR TITLE
feat: sync shop filters with url

### DIFF
--- a/packages/platform-core/src/components/shop/FilterBar.tsx
+++ b/packages/platform-core/src/components/shop/FilterBar.tsx
@@ -11,15 +11,28 @@ export type Filters = Record<string, string | number | undefined>;
 
 export interface FilterBarProps {
   definitions: FilterDefinition[];
+  /**
+   * Current values for the filters. When provided, the component becomes
+   * controlled and will mirror any external updates. When omitted, an empty
+   * object is assumed.
+   */
+  values?: Filters;
   onChange: (filters: Filters) => void;
 }
 
 export default function FilterBar({
   definitions,
+  values: externalValues = {},
   onChange,
 }: FilterBarProps) {
-  const [values, setValues] = useState<Filters>({});
+  const [values, setValues] = useState<Filters>(externalValues);
   const deferred = useDeferredValue(values);
+
+  // Keep internal state in sync when parent updates its values (e.g. after a
+  // reload where values are read from the URL).
+  useEffect(() => {
+    setValues(externalValues);
+  }, [externalValues]);
 
   useEffect(() => {
     onChange(deferred);

--- a/test/shop-client.integration.spec.tsx
+++ b/test/shop-client.integration.spec.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ShopClient from "../apps/cms/src/app/[lang]/shop/ShopClient.client";
+import type { SKU } from "@acme/types";
+
+// Mock next/navigation hooks used by ShopClient
+const pushMock = jest.fn((url: string) => {
+  window.history.pushState({}, "", url);
+});
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/shop",
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}));
+
+// Lightweight mock of the FilterBar component to avoid React version
+// mismatches in tests. It implements a minimal controlled select/number API
+// sufficient for our integration scenario.
+jest.mock("@platform-core/src/components/shop/FilterBar", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ definitions, values, onChange }: any) => (
+      <form>
+        {definitions.map((def: any) =>
+          def.type === "select" ? (
+            <label key={def.name}>
+              {def.label}:
+              <select
+                value={values[def.name] ?? ""}
+                onChange={(e) =>
+                  onChange({ ...values, [def.name]: e.target.value || undefined })
+                }
+              >
+                <option value="">All</option>
+                {def.options.map((opt: string) => (
+                  <option key={opt}>{opt}</option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <label key={def.name}>
+              {def.label}:
+              <input
+                type="number"
+                value={values[def.name] ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    ...values,
+                    [def.name]:
+                      e.target.value === "" ? undefined : Number(e.target.value),
+                  })
+                }
+              />
+            </label>
+          )
+        )}
+      </form>
+    ),
+  };
+});
+
+jest.mock("@platform-core/src/components/shop/ProductGrid", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    ProductGrid: ({ skus }: any) => (
+      <ul>
+        {skus.map((s: any) => (
+          <li key={s.id}>{s.title}</li>
+        ))}
+      </ul>
+    ),
+  };
+});
+
+const skus: SKU[] = [
+  {
+    id: "1",
+    slug: "red-shirt",
+    title: "Red Shirt",
+    price: 1000,
+    deposit: 0,
+    stock: 10,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: ["S", "M"],
+    description: "",
+  },
+  {
+    id: "2",
+    slug: "blue-shirt",
+    title: "Blue Shirt",
+    price: 1000,
+    deposit: 0,
+    stock: 10,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: ["M", "L"],
+    description: "",
+  },
+];
+
+describe("ShopClient URL state", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    window.history.replaceState({}, "", "/shop");
+  });
+
+  it("persists search query and filter selections across reloads", async () => {
+    const { unmount } = render(<ShopClient skus={skus} />);
+
+    const search = screen.getByLabelText(/search products/i);
+    await userEvent.type(search, "red");
+
+    const color = screen.getByLabelText(/color/i);
+    await userEvent.selectOptions(color, "red");
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("q=red");
+      expect(window.location.search).toContain("color=red");
+    });
+
+    unmount();
+
+    render(<ShopClient skus={skus} />);
+    expect(
+      (screen.getByLabelText(/search products/i) as HTMLInputElement).value
+    ).toBe("red");
+    expect(
+      (screen.getByLabelText(/color/i) as HTMLSelectElement).value
+    ).toBe("red");
+  });
+});
+


### PR DESCRIPTION
## Summary
- sync FilterBar with external values
- persist shop query and filters via URL params
- add integration test for state restore on reload

## Testing
- `pnpm test` *(fails: @acme/next-config cannot find module)*
- `pnpm exec jest test/shop-client.integration.spec.tsx`
- `pnpm e2e` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb8df2ebc832fad0c256ef4bb0b56