### PR TITLE
feat: add clear filters control to FilterBar

### DIFF
--- a/packages/platform-core/__tests__/filterBar.test.tsx
+++ b/packages/platform-core/__tests__/filterBar.test.tsx
@@ -33,5 +33,28 @@ describe("FilterBar", () => {
       expect(onChange).toHaveBeenLastCalledWith({ size: undefined, maxPrice: undefined });
     });
   });
+
+  it("resets all filters when cleared", async () => {
+    const onChange = jest.fn();
+    const defs: FilterDefinition[] = [
+      { name: "size", label: "Size", type: "select", options: ["39", "40"] },
+      { name: "maxPrice", label: "Max Price", type: "number" },
+    ];
+    render(<FilterBar definitions={defs} onChange={onChange} />);
+    const select = screen.getByLabelText(/Size/);
+    const price = screen.getByLabelText(/Max Price/);
+    fireEvent.change(select, { target: { value: "39" } });
+    fireEvent.change(price, { target: { value: "100" } });
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith({ size: "39", maxPrice: 100 });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Clear Filters/i }));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith({});
+    });
+    expect((select as HTMLSelectElement).value).toBe("");
+    expect((price as HTMLInputElement).value).toBe("");
+  });
 });
 

--- a/packages/platform-core/src/components/shop/FilterBar.tsx
+++ b/packages/platform-core/src/components/shop/FilterBar.tsx
@@ -37,6 +37,10 @@ export default function FilterBar({
     }));
   }
 
+  function handleClear() {
+    setValues({});
+  }
+
   return (
     <form
       aria-label="Filters"
@@ -74,6 +78,13 @@ export default function FilterBar({
           </label>
         )
       )}
+      <button
+        type="button"
+        onClick={handleClear}
+        className="text-sm underline"
+      >
+        Clear Filters
+      </button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add clear button to `FilterBar` to reset all filters
- test that clicking the button clears state and fires `onChange`

## Testing
- `npx eslint packages/platform-core/src/components/shop/FilterBar.tsx packages/platform-core/__tests__/filterBar.test.tsx`
- `pnpm --filter @acme/platform-core test __tests__/filterBar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bba7a31f0832f878ea42d740a2a60