### PR TITLE
feat(ui): pass query through search results template

### DIFF
--- a/packages/ui/src/components/molecules/SearchBar.tsx
+++ b/packages/ui/src/components/molecules/SearchBar.tsx
@@ -14,6 +14,8 @@ export interface SearchBarProps {
   placeholder?: string;
   /** Accessible label for the search input */
   label: string;
+  /** Optional search query to display */
+  query?: string;
 }
 
 export function SearchBar({
@@ -22,12 +24,17 @@ export function SearchBar({
   onSearch,
   placeholder = "Search…",
   label,
+  query: initialQuery = "",
 }: SearchBarProps) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(initialQuery);
   const [matches, setMatches] = useState<string[]>([]);
   const [isSelecting, setIsSelecting] = useState(false);
   const [focused, setFocused] = useState(false);
   const inputId = useId();
+
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
 
   useEffect(() => {
     if (isSelecting || !focused) {

--- a/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof SearchResultsTemplate> = {
     minItems: 1,
     maxItems: 4,
     isLoading: false,
+    query: "",
   },
   argTypes: {
     minItems: { control: { type: "number" } },

--- a/packages/ui/src/components/templates/SearchResultsTemplate.test.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.test.tsx
@@ -31,6 +31,7 @@ describe("SearchResultsTemplate", () => {
         results={results}
         page={1}
         pageCount={1}
+        query=""
       />
     );
 
@@ -46,6 +47,7 @@ describe("SearchResultsTemplate", () => {
         results={[]}
         page={1}
         pageCount={1}
+        query=""
       />
     );
 
@@ -60,6 +62,7 @@ describe("SearchResultsTemplate", () => {
         page={1}
         pageCount={1}
         isLoading
+        query=""
       />
     );
 
@@ -76,6 +79,7 @@ describe("SearchResultsTemplate", () => {
         results={results}
         page={1}
         pageCount={3}
+        query=""
       />
     );
 
@@ -87,6 +91,7 @@ describe("SearchResultsTemplate", () => {
         results={results}
         page={1}
         pageCount={1}
+        query=""
       />
     );
 
@@ -102,6 +107,7 @@ describe("SearchResultsTemplate", () => {
         page={1}
         pageCount={1}
         onQueryChange={onQueryChange}
+        query=""
       />
     );
 

--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -16,6 +16,8 @@ export interface SearchResultsTemplateProps
   minItems?: number;
   /** Maximum items to show */
   maxItems?: number;
+  /** Optional search query to display */
+  query?: string;
   onQueryChange?: (query: string) => void;
   onPageChange?: (page: number) => void;
   /** Optional filters to render between the search bar and results */
@@ -31,6 +33,7 @@ export function SearchResultsTemplate({
   pageCount,
   minItems,
   maxItems,
+  query,
   onQueryChange,
   onPageChange,
   filters,
@@ -41,6 +44,7 @@ export function SearchResultsTemplate({
   return (
     <div className={cn("space-y-6", className)} {...props}>
       <SearchBar
+        query={query}
         suggestions={suggestions}
         onSelect={onQueryChange}
         onSearch={onQueryChange}


### PR DESCRIPTION
## Summary
- support optional `query` prop in `SearchResultsTemplate` and forward to `SearchBar`
- allow `SearchBar` to receive initial query value
- update stories and tests to provide `query`

## Testing
- `pnpm exec jest packages/ui/src/components/templates/SearchResultsTemplate.test.tsx packages/ui/src/components/molecules/__tests__/SearchBar.test.tsx`
- `pnpm exec eslint -c eslint.config.mjs packages/ui/src/components/molecules/SearchBar.tsx packages/ui/src/components/templates/SearchResultsTemplate.tsx packages/ui/src/components/templates/SearchResultsTemplate.stories.tsx packages/ui/src/components/templates/SearchResultsTemplate.test.tsx` *(fails: ConfigError: Cannot redefine plugin "import")*

------
https://chatgpt.com/codex/tasks/task_e_689bbab38ac8832f94adff0dbdff7a78