### PR TITLE
feat: enforce storefront API permissions

### DIFF
--- a/apps/shop-abc/__tests__/cartPermission.test.ts
+++ b/apps/shop-abc/__tests__/cartPermission.test.ts
@@ -1,0 +1,41 @@
+// apps/shop-abc/__tests__/cartPermission.test.ts
+import { GET } from "../src/app/api/cart/route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+  },
+}));
+
+jest.mock("@upstash/redis", () => ({ Redis: class {} }));
+
+jest.mock("@auth", () => {
+  const { hasPermission } = require("../../../packages/auth/src/permissions");
+  return { getCustomerSession: jest.fn(), hasPermission };
+});
+import { getCustomerSession } from "@auth";
+
+function createRequest(): Parameters<typeof GET>[0] {
+  const url = "http://localhost/api/cart";
+  return {
+    json: async () => ({}),
+    cookies: { get: () => undefined },
+    nextUrl: Object.assign(new URL(url), { clone: () => new URL(url) }),
+  } as any;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("denies access without manage_cart permission", async () => {
+  (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1", role: "viewer" });
+  const res = await GET(createRequest());
+  expect(res.status).toBe(403);
+});
+
+test("allows access with manage_cart permission", async () => {
+  (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1", role: "customer" });
+  const res = await GET(createRequest());
+  expect(res.status).toBe(200);
+});

--- a/apps/shop-abc/__tests__/checkoutPermission.test.ts
+++ b/apps/shop-abc/__tests__/checkoutPermission.test.ts
@@ -1,0 +1,64 @@
+// apps/shop-abc/__tests__/checkoutPermission.test.ts
+import { encodeCartCookie } from "@platform-core/src/cartCookie";
+import { PRODUCTS } from "@platform-core/products";
+import { POST } from "../src/app/api/checkout-session/route";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+  },
+}));
+
+jest.mock("@acme/stripe", () => ({
+  stripe: { checkout: { sessions: { create: jest.fn(async () => ({ id: "s", payment_intent: { client_secret: "cs" } })) } } },
+}));
+
+jest.mock("@platform-core/pricing", () => ({
+  priceForDays: jest.fn(async () => 1),
+  convertCurrency: jest.fn(async (n: number) => n),
+}));
+
+jest.mock("@platform-core/analytics", () => ({ trackEvent: jest.fn() }));
+jest.mock("@upstash/redis", () => ({ Redis: class {} }));
+let mockCart: any;
+jest.mock("@platform-core/src/cartStore", () => ({
+  getCart: jest.fn(async () => mockCart),
+}));
+
+jest.mock("@auth", () => {
+  const { hasPermission } = require("../../../packages/auth/src/permissions");
+  return { getCustomerSession: jest.fn(), hasPermission };
+});
+import { getCustomerSession } from "@auth";
+
+function createRequest(cookie: string): Parameters<typeof POST>[0] {
+  const url = "http://localhost/api/checkout-session";
+  return {
+    json: async () => ({}),
+    cookies: { get: () => ({ name: "", value: cookie }) },
+    nextUrl: Object.assign(new URL(url), { clone: () => new URL(url) }),
+    headers: { get: () => null },
+  } as any;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("denies checkout without permission", async () => {
+  const sku = PRODUCTS[0];
+  mockCart = { [sku.id]: { sku, qty: 1 } };
+  const cookie = encodeCartCookie("test");
+  (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1", role: "viewer" });
+  const res = await POST(createRequest(cookie));
+  expect(res.status).toBe(403);
+});
+
+test("allows checkout with permission", async () => {
+  const sku = PRODUCTS[0];
+  mockCart = { [sku.id]: { sku, qty: 1 } };
+  const cookie = encodeCartCookie("test");
+  (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "c1", role: "customer" });
+  const res = await POST(createRequest(cookie));
+  expect(res.status).toBe(200);
+});

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -1,2 +1,29 @@
 // apps/shop-abc/src/app/api/cart/route.ts
-export { runtime, DELETE, GET, PATCH, POST, PUT } from "@platform-core/src/cartApi";
+import { getCustomerSession, hasPermission } from "@auth";
+import {
+  runtime,
+  DELETE as coreDELETE,
+  GET as coreGET,
+  PATCH as corePATCH,
+  POST as corePOST,
+  PUT as corePUT,
+} from "@platform-core/src/cartApi";
+import { NextResponse, type NextRequest } from "next/server";
+
+async function guard(
+  req: NextRequest,
+  handler: (req: NextRequest) => Promise<NextResponse>
+): Promise<NextResponse> {
+  const session = await getCustomerSession();
+  if (!session || !hasPermission(session.role, "manage_cart")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return handler(req);
+}
+
+export { runtime };
+export const GET = (req: NextRequest) => guard(req, coreGET);
+export const POST = (req: NextRequest) => guard(req, corePOST);
+export const PATCH = (req: NextRequest) => guard(req, corePATCH);
+export const PUT = (req: NextRequest) => guard(req, corePUT);
+export const DELETE = (req: NextRequest) => guard(req, coreDELETE);

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -1,8 +1,38 @@
 {
   "viewer": ["view_products"],
-  "customer": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "admin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "ShopAdmin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "CatalogManager": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "ThemeEditor": ["view_products", "add_to_cart", "checkout", "manage_profile"]
+  "customer": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "manage_cart"
+  ],
+  "admin": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "manage_cart"
+  ],
+  "ShopAdmin": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "manage_cart"
+  ],
+  "CatalogManager": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "manage_cart"
+  ],
+  "ThemeEditor": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "manage_cart"
+  ]
 }


### PR DESCRIPTION
## Summary
- gate cart API routes by manage_cart permission
- require checkout permission for checkout session creation
- add tests verifying allowed and denied API access

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/cartPermission.test.ts apps/shop-abc/__tests__/checkoutPermission.test.ts --config apps/shop-abc/jest.config.cjs --runInBand`
- `pnpm --filter @acme/auth exec jest packages/auth/__tests__/permissions.test.ts --config ../../jest.config.cjs --runInBand --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_689bb9af3898832f9610a5e3e520a317