### PR TITLE
feat(cms): add segment builder and API

### DIFF
--- a/apps/cms/__tests__/marketingEmailApi.test.ts
+++ b/apps/cms/__tests__/marketingEmailApi.test.ts
@@ -20,6 +20,8 @@ jest.doMock(
 process.env.CART_COOKIE_SECRET = "secret";
 process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.RESEND_API_KEY = "re_test";
 
 const ResponseWithJson = Response as unknown as typeof Response & {
   json?: (data: unknown, init?: ResponseInit) => Response;
@@ -40,10 +42,16 @@ describe("marketing email API segments", () => {
 
   test("resolves recipients from segment when list empty", async () => {
     await fs.writeFile(
+      path.join(shopDir, "segments.json"),
+      JSON.stringify([
+        { id: "vip", name: "VIP", filters: [{ field: "type", value: "purchase" }] },
+      ]),
+      "utf8"
+    );
+    await fs.writeFile(
       path.join(shopDir, "analytics.jsonl"),
-      JSON.stringify({ type: "segment:vip", email: "a@example.com" }) + "\n" +
-        JSON.stringify({ type: "segment", segment: "vip", email: "b@example.com" }) +
-        "\n",
+      JSON.stringify({ type: "purchase", email: "a@example.com" }) + "\n" +
+        JSON.stringify({ type: "purchase", email: "b@example.com" }) + "\n",
       "utf8"
     );
 

--- a/apps/cms/__tests__/segmentBuilder.test.tsx
+++ b/apps/cms/__tests__/segmentBuilder.test.tsx
@@ -1,0 +1,42 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import SegmentBuilder from "../src/app/cms/segments/SegmentBuilder";
+
+describe("SegmentBuilder", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+  });
+
+  it("adds filters and submits segment", async () => {
+    render(<SegmentBuilder />);
+
+    expect(screen.getAllByPlaceholderText(/Event type/i)).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: /add filter/i }));
+    expect(screen.getAllByPlaceholderText(/Event type/i)).toHaveLength(2);
+
+    fireEvent.change(screen.getByPlaceholderText(/Shop/i), {
+      target: { value: "shop" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Segment ID/i), {
+      target: { value: "vip" },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText(/Event type/i)[0], {
+      target: { value: "purchase" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/segments",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shop: "shop",
+          id: "vip",
+          filters: [{ field: "type", value: "purchase" }],
+        }),
+      })
+    );
+  });
+});

--- a/apps/cms/src/app/api/segments/route.ts
+++ b/apps/cms/src/app/api/segments/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { validateShopName } from "@acme/lib";
+
+interface SegmentDef {
+  id: string;
+  name: string;
+  filters: { field: string; value: string }[];
+}
+
+function segmentsPath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "segments.json");
+}
+
+async function readSegments(shop: string): Promise<SegmentDef[]> {
+  try {
+    const buf = await fs.readFile(segmentsPath(shop), "utf8");
+    const json = JSON.parse(buf);
+    return Array.isArray(json) ? json : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeSegments(shop: string, items: SegmentDef[]): Promise<void> {
+  await fs.mkdir(path.dirname(segmentsPath(shop)), { recursive: true });
+  await fs.writeFile(segmentsPath(shop), JSON.stringify(items, null, 2), "utf8");
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const shop = req.nextUrl.searchParams.get("shop");
+  if (!shop) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 400 });
+  }
+  const segments = await readSegments(shop);
+  return NextResponse.json({ segments });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { shop, id, name, filters } = (await req.json().catch(() => ({}))) as {
+    shop?: string;
+    id?: string;
+    name?: string;
+    filters?: { field: string; value: string }[];
+  };
+  if (!shop || !id || !Array.isArray(filters)) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  const segments = await readSegments(shop);
+  const def: SegmentDef = { id, name: name || id, filters };
+  const idx = segments.findIndex((s) => s.id === id);
+  if (idx >= 0) segments[idx] = def; else segments.push(def);
+  await writeSegments(shop, segments);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/cms/src/app/cms/marketing/email/page.tsx
+++ b/apps/cms/src/app/cms/marketing/email/page.tsx
@@ -17,6 +17,7 @@ export default function EmailMarketingPage() {
   const [shop, setShop] = useState("");
   const [recipients, setRecipients] = useState("");
   const [segment, setSegment] = useState("");
+  const [segments, setSegments] = useState<{ id: string; name: string }[]>([]);
   const [sendAt, setSendAt] = useState("");
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
@@ -39,7 +40,17 @@ export default function EmailMarketingPage() {
 
   useEffect(() => {
     loadCampaigns(shop);
+    loadSegments(shop);
   }, [shop]);
+
+  async function loadSegments(s: string) {
+    if (!s) return;
+    const res = await fetch(`/api/segments?shop=${encodeURIComponent(s)}`);
+    if (res.ok) {
+      const json = await res.json();
+      setSegments(json.segments || []);
+    }
+  }
 
   async function send(e: React.FormEvent) {
     e.preventDefault();
@@ -90,12 +101,18 @@ export default function EmailMarketingPage() {
           value={recipients}
           onChange={(e) => setRecipients(e.target.value)}
         />
-        <input
+        <select
           className="w-full border p-2"
-          placeholder="Segment"
           value={segment}
           onChange={(e) => setSegment(e.target.value)}
-        />
+        >
+          <option value="">Select segment</option>
+          {segments.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
         <input
           type="datetime-local"
           className="w-full border p-2"

--- a/apps/cms/src/app/cms/segments/SegmentBuilder.tsx
+++ b/apps/cms/src/app/cms/segments/SegmentBuilder.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+interface Filter {
+  value: string;
+}
+
+export default function SegmentBuilder() {
+  const [shop, setShop] = useState("");
+  const [id, setId] = useState("");
+  const [filters, setFilters] = useState<Filter[]>([{ value: "" }]);
+  const [status, setStatus] = useState<string | null>(null);
+
+  function updateFilter(idx: number, value: string) {
+    setFilters((prev) => prev.map((f, i) => (i === idx ? { value } : f)));
+  }
+
+  function addFilter() {
+    setFilters((prev) => [...prev, { value: "" }]);
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus(null);
+    try {
+      const body = {
+        shop,
+        id,
+        filters: filters
+          .filter((f) => f.value)
+          .map((f) => ({ field: "type", value: f.value })),
+      };
+      const res = await fetch("/api/segments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      setStatus(res.ok ? "Saved" : "Failed");
+      if (res.ok) {
+        setId("");
+        setFilters([{ value: "" }]);
+      }
+    } catch {
+      setStatus("Failed");
+    }
+  }
+
+  return (
+    <form onSubmit={save} className="space-y-2">
+      <input
+        className="w-full border p-2"
+        placeholder="Shop"
+        value={shop}
+        onChange={(e) => setShop(e.target.value)}
+      />
+      <input
+        className="w-full border p-2"
+        placeholder="Segment ID"
+        value={id}
+        onChange={(e) => setId(e.target.value)}
+      />
+      {filters.map((f, i) => (
+        <input
+          key={i}
+          className="w-full border p-2"
+          placeholder="Event type"
+          value={f.value}
+          onChange={(e) => updateFilter(i, e.target.value)}
+        />
+      ))}
+      <div className="flex gap-2">
+        <button type="button" className="border px-4 py-2" onClick={addFilter}>
+          Add filter
+        </button>
+        <button type="submit" className="border px-4 py-2">
+          Save
+        </button>
+      </div>
+      {status && <p>{status}</p>}
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/segments/page.tsx
+++ b/apps/cms/src/app/cms/segments/page.tsx
@@ -1,0 +1,9 @@
+import SegmentBuilder from "./SegmentBuilder";
+
+export default function SegmentsPage() {
+  return (
+    <div className="p-4">
+      <SegmentBuilder />
+    </div>
+  );
+}

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -1,28 +1,48 @@
 import { listEvents } from "@platform-core/repositories/analytics.server";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { validateShopName } from "@acme/lib";
+
+interface SegmentDef {
+  id: string;
+  filters: { field: string; value: string }[];
+}
+
+async function readSegments(shop: string): Promise<SegmentDef[]> {
+  shop = validateShopName(shop);
+  const file = path.join(DATA_ROOT, shop, "segments.json");
+  try {
+    const buf = await fs.readFile(file, "utf8");
+    const json = JSON.parse(buf);
+    return Array.isArray(json) ? json : [];
+  } catch {
+    return [];
+  }
+}
 
 /**
- * Resolve a segment identifier to a list of customer email addresses.
- *
- * Segments are represented in analytics events with either the form:
- *  { type: `segment:${id}`, email: "user@example.com" }
- * or
- *  { type: "segment", segment: id, email: "user@example.com" }
+ * Resolve a segment identifier to a list of customer email addresses based on
+ * stored segment definitions.
  */
 export async function resolveSegment(
   shop: string,
   id: string
 ): Promise<string[]> {
+  const segments = await readSegments(shop);
+  const def = segments.find((s) => s.id === id);
+  if (!def) return [];
   const events = await listEvents(shop);
   const emails = new Set<string>();
   for (const e of events) {
-    const type = (e as { type?: string }).type;
-    const seg =
-      type === `segment:${id}`
-        ? id
-        : type === "segment" && (e as any).segment === id
-          ? id
-          : null;
-    if (seg) {
+    let match = true;
+    for (const f of def.filters) {
+      if ((e as any)[f.field] !== f.value) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
       const email = (e as any).email;
       if (typeof email === "string") emails.add(email);
     }


### PR DESCRIPTION
## Summary
- add API to store and list segment definitions
- add CMS segment builder UI and integrate segments into marketing email form
- resolve email segments from stored definitions and add tests

## Testing
- `pnpm --filter @apps/cms test -- marketingEmailApi.test.ts segmentBuilder.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bbd590320832faf5f3b79e4eeb913