### PR TITLE
feat(email): normalize provider analytics

### DIFF
--- a/apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts
+++ b/apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts
@@ -1,14 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "node:crypto";
 import { trackEvent } from "@platform-core/analytics";
-
-const typeMap: Record<string, string> = {
-  "email.delivered": "email_delivered",
-  "email.opened": "email_open",
-  "email.clicked": "email_click",
-  "email.unsubscribed": "email_unsubscribe",
-  "email.bounced": "email_bounce",
-};
+import { mapResendEvent } from "@acme/email/analytics";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
@@ -31,10 +24,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   } catch {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
-  const mapped = typeMap[event.type];
+  const mapped = mapResendEvent(event);
   if (mapped) {
-    const campaign = event.data?.campaign || event.data?.campaign_id;
-    await trackEvent(shop, { type: mapped, ...(campaign ? { campaign } : {}) });
+    await trackEvent(shop, mapped);
   }
   return NextResponse.json({ ok: true });
 }

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./analytics": "./src/analytics.ts"
   },
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"

--- a/packages/email/src/__tests__/analytics.test.ts
+++ b/packages/email/src/__tests__/analytics.test.ts
@@ -1,0 +1,69 @@
+import { mapSendGridEvent, mapResendEvent, mapSendGridStats, mapResendStats } from "../analytics";
+
+describe("analytics mapping", () => {
+  it("normalizes SendGrid webhook events", () => {
+    const ev = {
+      event: "open",
+      sg_message_id: "msg-1",
+      email: "user@example.com",
+      category: ["camp1"],
+    };
+    expect(mapSendGridEvent(ev)).toEqual({
+      type: "email_open",
+      campaign: "camp1",
+      messageId: "msg-1",
+      recipient: "user@example.com",
+    });
+  });
+
+  it("normalizes Resend webhook events", () => {
+    const ev = {
+      type: "email.opened",
+      data: {
+        message_id: "m2",
+        email: "user@example.com",
+        campaign_id: "camp1",
+      },
+    };
+    expect(mapResendEvent(ev)).toEqual({
+      type: "email_open",
+      campaign: "camp1",
+      messageId: "m2",
+      recipient: "user@example.com",
+    });
+  });
+
+  it("maps SendGrid stats", () => {
+    const stats = {
+      delivered: 1,
+      opens: 2,
+      clicks: 3,
+      unsubscribes: 4,
+      bounces: 5,
+    };
+    expect(mapSendGridStats(stats)).toEqual({
+      delivered: 1,
+      opened: 2,
+      clicked: 3,
+      unsubscribed: 4,
+      bounced: 5,
+    });
+  });
+
+  it("maps Resend stats", () => {
+    const stats = {
+      delivered_count: 1,
+      opened_count: 2,
+      clicked_count: 3,
+      unsubscribed_count: 4,
+      bounced_count: 5,
+    };
+    expect(mapResendStats(stats)).toEqual({
+      delivered: 1,
+      opened: 2,
+      clicked: 3,
+      unsubscribed: 4,
+      bounced: 5,
+    });
+  });
+});

--- a/packages/email/src/analytics.ts
+++ b/packages/email/src/analytics.ts
@@ -1,0 +1,102 @@
+export type EmailEventType =
+  | "email_delivered"
+  | "email_open"
+  | "email_click"
+  | "email_unsubscribe"
+  | "email_bounce";
+
+export interface EmailAnalyticsEvent {
+  type: EmailEventType;
+  campaign?: string;
+  messageId?: string;
+  recipient?: string;
+}
+
+export interface CampaignStats {
+  delivered: number;
+  opened: number;
+  clicked: number;
+  unsubscribed: number;
+  bounced: number;
+}
+
+export const emptyStats: CampaignStats = {
+  delivered: 0,
+  opened: 0,
+  clicked: 0,
+  unsubscribed: 0,
+  bounced: 0,
+};
+
+/** Map a SendGrid webhook event to the internal analytics format */
+export function mapSendGridEvent(ev: any): EmailAnalyticsEvent | null {
+  const typeMap: Record<string, EmailEventType> = {
+    delivered: "email_delivered",
+    open: "email_open",
+    click: "email_click",
+    unsubscribe: "email_unsubscribe",
+    bounce: "email_bounce",
+  };
+  const type = typeMap[ev?.event];
+  if (!type) return null;
+  const campaign = Array.isArray(ev?.category) ? ev.category[0] : ev?.category;
+  return {
+    type,
+    campaign: campaign || undefined,
+    messageId: ev?.sg_message_id,
+    recipient: ev?.email,
+  };
+}
+
+/** Map a Resend webhook event to the internal analytics format */
+export function mapResendEvent(ev: any): EmailAnalyticsEvent | null {
+  const typeMap: Record<string, EmailEventType> = {
+    "email.delivered": "email_delivered",
+    "email.opened": "email_open",
+    "email.clicked": "email_click",
+    "email.unsubscribed": "email_unsubscribe",
+    "email.bounced": "email_bounce",
+  };
+  const type = typeMap[ev?.type];
+  if (!type) return null;
+  const data = ev?.data || {};
+  const campaign = data.campaign || data.campaign_id;
+  return {
+    type,
+    campaign: campaign || undefined,
+    messageId: data.message_id,
+    recipient: data.email || data.recipient,
+  };
+}
+
+/** Normalize SendGrid stats response to the common CampaignStats shape */
+export function mapSendGridStats(stats: any): CampaignStats {
+  return {
+    delivered: Number(stats?.delivered) || 0,
+    opened: Number(stats?.opens ?? stats?.opened) || 0,
+    clicked: Number(stats?.clicks ?? stats?.clicked) || 0,
+    unsubscribed: Number(stats?.unsubscribes ?? stats?.unsubscribed) || 0,
+    bounced: Number(stats?.bounces ?? stats?.bounced) || 0,
+  };
+}
+
+/** Normalize Resend stats response to the common CampaignStats shape */
+export function mapResendStats(stats: any): CampaignStats {
+  return {
+    delivered: Number(stats?.delivered ?? stats?.delivered_count) || 0,
+    opened: Number(stats?.opened ?? stats?.opened_count) || 0,
+    clicked: Number(stats?.clicked ?? stats?.clicked_count) || 0,
+    unsubscribed:
+      Number(stats?.unsubscribed ?? stats?.unsubscribed_count) || 0,
+    bounced: Number(stats?.bounced ?? stats?.bounced_count) || 0,
+  };
+}
+
+export function normalizeProviderStats(
+  provider: string,
+  stats: any
+): CampaignStats {
+  if (provider === "sendgrid") return mapSendGridStats(stats);
+  if (provider === "resend") return mapResendStats(stats);
+  return { ...emptyStats };
+}

--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -2,6 +2,7 @@ import { Resend } from "resend";
 import { coreEnv } from "@acme/config/env/core";
 import type { CampaignOptions } from "../send";
 import type { CampaignProvider } from "./types";
+import { mapResendStats, type CampaignStats } from "../analytics";
 
 export class ResendProvider implements CampaignProvider {
   private client: Resend;
@@ -18,5 +19,19 @@ export class ResendProvider implements CampaignProvider {
       html: options.html,
       text: options.text,
     });
+  }
+
+  async getCampaignStats(id: string): Promise<CampaignStats> {
+    try {
+      const res = await fetch(`https://api.resend.com/campaigns/${id}/stats`, {
+        headers: {
+          Authorization: `Bearer ${coreEnv.RESEND_API_KEY || ""}`,
+        },
+      });
+      const json = await res.json().catch(() => ({}));
+      return mapResendStats(json);
+    } catch {
+      return mapResendStats({});
+    }
   }
 }

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -2,6 +2,7 @@ import sgMail from "@sendgrid/mail";
 import { coreEnv } from "@acme/config/env/core";
 import type { CampaignOptions } from "../send";
 import type { CampaignProvider } from "./types";
+import { mapSendGridStats, type CampaignStats } from "../analytics";
 
 export class SendgridProvider implements CampaignProvider {
   constructor() {
@@ -18,5 +19,23 @@ export class SendgridProvider implements CampaignProvider {
       html: options.html,
       text: options.text,
     });
+  }
+
+  async getCampaignStats(id: string): Promise<CampaignStats> {
+    if (!coreEnv.SENDGRID_API_KEY) return mapSendGridStats({});
+    try {
+      const res = await fetch(
+        `https://api.sendgrid.com/v3/campaigns/${id}/stats`,
+        {
+          headers: {
+            Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+          },
+        }
+      );
+      const json = await res.json().catch(() => ({}));
+      return mapSendGridStats(json);
+    } catch {
+      return mapSendGridStats({});
+    }
   }
 }

--- a/packages/email/src/providers/types.ts
+++ b/packages/email/src/providers/types.ts
@@ -1,5 +1,7 @@
 import type { CampaignOptions } from "../send";
+import type { CampaignStats } from "../analytics";
 
 export interface CampaignProvider {
   send(options: CampaignOptions): Promise<void>;
+  getCampaignStats(campaignId: string): Promise<CampaignStats>;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -91,6 +91,7 @@
 
       /* ─── dedicated utility packages ───────────────────────────── */
       "@acme/email": ["packages/email/src/index.ts"],
+      "@acme/email/analytics": ["packages/email/src/analytics.ts"],
       "@acme/stripe": ["packages/stripe/src/index.ts"],
       "@acme/sanity": ["packages/sanity/src/index.ts"],
       "@acme/date-utils": ["packages/date-utils/src/index.ts"],


### PR DESCRIPTION
## Summary
- add unified email analytics mapping for SendGrid and Resend
- expose provider stats via new getCampaignStats implementations
- drive webhook ingestion through normalized events

## Testing
- `npx jest packages/email/src/__tests__/analytics.test.ts apps/cms/__tests__/emailProviderWebhooks.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689bbd59095c832f9f4484a51e2a524c