### PR TITLE
feat(email): add provider retry and fallback

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -1,0 +1,96 @@
+import { ProviderError } from "../providers/types";
+
+let sendgridSendMock: jest.Mock;
+let resendSendMock: jest.Mock;
+let sendMailMock: jest.Mock;
+
+jest.mock("nodemailer", () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn(() => ({
+      sendMail: (...args: any[]) => sendMailMock(...args),
+    })),
+  },
+}));
+
+jest.mock("../providers/sendgrid", () => ({
+  SendgridProvider: jest.fn().mockImplementation(() => ({
+    send: (...args: any[]) => sendgridSendMock(...args),
+  })),
+}));
+
+jest.mock("../providers/resend", () => ({
+  ResendProvider: jest.fn().mockImplementation(() => ({
+    send: (...args: any[]) => resendSendMock(...args),
+  })),
+}));
+
+describe("sendCampaignEmail fallback and retry", () => {
+  const setupEnv = () => {
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    process.env.SENDGRID_API_KEY = "sg";
+    process.env.RESEND_API_KEY = "rs";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+  };
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    jest.clearAllTimers();
+    delete process.env.EMAIL_PROVIDER;
+    delete process.env.SENDGRID_API_KEY;
+    delete process.env.RESEND_API_KEY;
+    delete process.env.CAMPAIGN_FROM;
+  });
+
+  it("falls back to alternate provider when primary fails", async () => {
+    sendgridSendMock = jest
+      .fn()
+      .mockRejectedValue(new ProviderError("fail", false));
+    resendSendMock = jest.fn().mockResolvedValue(undefined);
+    sendMailMock = jest.fn();
+
+    setupEnv();
+
+    const { sendCampaignEmail } = await import("../index");
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+    });
+
+    expect(sendgridSendMock).toHaveBeenCalledTimes(1);
+    expect(resendSendMock).toHaveBeenCalledTimes(1);
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it("retries with exponential backoff on retryable error", async () => {
+    const timeoutSpy = jest.spyOn(global, "setTimeout");
+    sendgridSendMock = jest
+      .fn()
+      .mockRejectedValueOnce(new ProviderError("temporary", true))
+      .mockResolvedValueOnce(undefined);
+    resendSendMock = jest.fn();
+    sendMailMock = jest.fn();
+
+    setupEnv();
+
+    const { sendCampaignEmail } = await import("../index");
+
+    const promise = sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+    });
+
+    await Promise.resolve();
+    expect(sendgridSendMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+
+    await promise;
+
+    expect(sendgridSendMock).toHaveBeenCalledTimes(2);
+    expect(resendSendMock).not.toHaveBeenCalled();
+    timeoutSpy.mockRestore();
+  });
+});

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -1,6 +1,7 @@
 import sgMail from "@sendgrid/mail";
 import { coreEnv } from "@acme/config/env/core";
 import type { CampaignOptions } from "../send";
+import { ProviderError } from "./types";
 import type { CampaignProvider } from "./types";
 
 export class SendgridProvider implements CampaignProvider {
@@ -11,12 +12,18 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async send(options: CampaignOptions): Promise<void> {
-    await sgMail.send({
-      to: options.to,
-      from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
-      subject: options.subject,
-      html: options.html,
-      text: options.text,
-    });
+    try {
+      await sgMail.send({
+        to: options.to,
+        from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
+        subject: options.subject,
+        html: options.html,
+        text: options.text,
+      });
+    } catch (error: any) {
+      const status = error?.code ?? error?.response?.statusCode ?? error?.statusCode;
+      const retryable = typeof status !== "number" || status >= 500;
+      throw new ProviderError(error.message, retryable);
+    }
   }
 }

--- a/packages/email/src/providers/types.ts
+++ b/packages/email/src/providers/types.ts
@@ -3,3 +3,16 @@ import type { CampaignOptions } from "../send";
 export interface CampaignProvider {
   send(options: CampaignOptions): Promise<void>;
 }
+
+/**
+ * Error thrown by providers to indicate whether a failure is retryable.
+ */
+export class ProviderError extends Error {
+  retryable: boolean;
+
+  constructor(message: string, retryable = true) {
+    super(message);
+    this.retryable = retryable;
+    this.name = "ProviderError";
+  }
+}


### PR DESCRIPTION
## Summary
- add ProviderError for structured provider failures
- retry sending with exponential backoff and fallback providers
- test provider fallback and retry behaviour

## Testing
- `pnpm --filter @acme/email test -- src/__tests__/send.test.ts src/__tests__/sendCampaignEmail.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689bbc6499fc832f9d1b3e172a7b04b0