### PR TITLE
feat: enforce profile permissions

### DIFF
--- a/apps/shop-abc/__tests__/changePasswordApi.test.ts
+++ b/apps/shop-abc/__tests__/changePasswordApi.test.ts
@@ -1,0 +1,70 @@
+// apps/shop-abc/__tests__/changePasswordApi.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn(),
+  hasPermission: jest.requireActual("@auth/permissions").hasPermission,
+}));
+
+jest.mock("@acme/platform-core/users", () => ({
+  __esModule: true,
+  getUserById: jest.fn(),
+  updatePassword: jest.fn(),
+}));
+
+jest.mock("bcryptjs", () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+import { getCustomerSession, validateCsrfToken } from "@auth";
+import { getUserById, updatePassword } from "@acme/platform-core/users";
+import bcrypt from "bcryptjs";
+import { POST } from "../src/app/api/account/change-password/route";
+
+describe("/api/account/change-password POST", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns 403 when lacking change_password permission", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+      role: "viewer",
+    });
+    const req = { headers: new Headers(), json: async () => ({}) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("changes password for authorized user", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+      role: "customer",
+    });
+    (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+    (getUserById as jest.Mock).mockResolvedValue({
+      id: "cust1",
+      passwordHash: "old",
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    (bcrypt.hash as jest.Mock).mockResolvedValue("newhash");
+    const req = {
+      headers: new Headers({ "x-csrf-token": "tok" }),
+      json: async () => ({
+        currentPassword: "Oldpass1",
+        newPassword: "Newpass1",
+      }),
+    } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(updatePassword).toHaveBeenCalledWith("cust1", "newhash");
+  });
+});

--- a/apps/shop-abc/src/app/api/account/change-password/route.ts
+++ b/apps/shop-abc/src/app/api/account/change-password/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
-import { getCustomerSession, validateCsrfToken } from "@auth";
+import { getCustomerSession, validateCsrfToken, hasPermission } from "@auth";
 import { getUserById, updatePassword } from "@acme/platform-core/users";
 
 const ChangePasswordSchema = z
@@ -23,6 +23,10 @@ export async function POST(req: Request) {
   const session = await getCustomerSession();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!hasPermission(session.role, "change_password")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const token = req.headers.get("x-csrf-token");

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -1,5 +1,5 @@
 // apps/shop-abc/src/app/api/account/profile/route.ts
-import { getCustomerSession, validateCsrfToken } from "@auth";
+import { getCustomerSession, validateCsrfToken, hasPermission } from "@auth";
 import {
   getCustomerProfile,
   updateCustomerProfile,
@@ -23,6 +23,10 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  if (!hasPermission(session.role, "view_profile")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const profile = await getCustomerProfile(session.customerId);
   if (!profile) {
     return NextResponse.json({
@@ -38,6 +42,10 @@ export async function PUT(req: NextRequest) {
   const session = await getCustomerSession();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!hasPermission(session.role, "manage_profile")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const token = req.headers.get("x-csrf-token");

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -1,8 +1,43 @@
 {
   "viewer": ["view_products"],
-  "customer": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "admin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "ShopAdmin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "CatalogManager": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "ThemeEditor": ["view_products", "add_to_cart", "checkout", "manage_profile"]
+  "customer": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "view_profile",
+    "manage_profile",
+    "change_password"
+  ],
+  "admin": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "view_profile",
+    "manage_profile",
+    "change_password"
+  ],
+  "ShopAdmin": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "view_profile",
+    "manage_profile",
+    "change_password"
+  ],
+  "CatalogManager": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "view_profile",
+    "manage_profile",
+    "change_password"
+  ],
+  "ThemeEditor": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "view_profile",
+    "manage_profile",
+    "change_password"
+  ]
 }


### PR DESCRIPTION
## Summary
- require `view_profile` or `manage_profile` for account profile operations
- protect change password route behind `change_password` permission
- add tests for unauthorized roles on profile and password routes

## Testing
- `pnpm exec jest packages/auth/__tests__/permissions.test.ts --config jest.config.cjs`
- `pnpm exec jest apps/shop-abc/__tests__/accountProfileApi.test.ts apps/shop-abc/__tests__/api/accountProfile.test.ts apps/shop-abc/__tests__/changePasswordApi.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689bbc3cfa54832fa3574f3e61ee7bff