### PR TITLE
chore: enforce strict zod schemas

### DIFF
--- a/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
+++ b/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
@@ -23,16 +23,20 @@ jest.mock(
 
 jest.mock("@acme/types", () => {
   const { z } = require("zod");
-  const inventoryItemSchema = z.object({
-    sku: z.string(),
-    productId: z.string(),
-    variant: z.object({
-      size: z.string(),
-      color: z.string().optional(),
-    }),
-    quantity: z.number().min(1),
-    lowStockThreshold: z.number().optional(),
-  });
+  const inventoryItemSchema = z
+    .object({
+      sku: z.string(),
+      productId: z.string(),
+      variant: z
+        .object({
+          size: z.string(),
+          color: z.string().optional(),
+        })
+        .strict(),
+      quantity: z.number().min(1),
+      lowStockThreshold: z.number().optional(),
+    })
+    .strict();
   return { inventoryItemSchema };
 });
 

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -3,12 +3,14 @@
 import { localeSchema } from "@acme/types";
 import { z } from "zod";
 
-const mediaItemSchema = z.object({
-  url: z.string(),
-  title: z.string().optional(),
-  altText: z.string().optional(),
-  type: z.enum(["image", "video"]),
-});
+const mediaItemSchema = z
+  .object({
+    url: z.string(),
+    title: z.string().optional(),
+    altText: z.string().optional(),
+    type: z.enum(["image", "video"]),
+  })
+  .strict();
 
 export const productSchema = z
   .object({

--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -19,30 +19,32 @@ export async function POST(req: Request) {
   }
 
   try {
-    const schema = z.object({
-      id: z
-        .string()
-        .transform((s) => validateShopName(s)),
-      csv: z
-        .string()
-        .optional()
-        .transform((s) => s.replace(/\s+/g, ""))
-        .refine(
-          (val) => {
-            if (!val) return true;
-            try {
-              return (
-                Buffer.from(val, "base64").toString("base64").replace(/=+$/, "") ===
-                val.replace(/=+$/, "")
-              );
-            } catch {
-              return false;
-            }
-          },
-          { message: "Invalid CSV encoding" }
-        ),
-      categories: z.array(z.string()).optional(),
-    });
+    const schema = z
+      .object({
+        id: z
+          .string()
+          .transform((s) => validateShopName(s)),
+        csv: z
+          .string()
+          .optional()
+          .transform((s) => s.replace(/\s+/g, ""))
+          .refine(
+            (val) => {
+              if (!val) return true;
+              try {
+                return (
+                  Buffer.from(val, "base64").toString("base64").replace(/=+$/, "") ===
+                  val.replace(/=+$/, "")
+                );
+              } catch {
+                return false;
+              }
+            },
+            { message: "Invalid CSV encoding" }
+          ),
+        categories: z.array(z.string()).optional(),
+      })
+      .strict();
 
     const parsed = schema.safeParse(await req.json());
     if (!parsed.success) {

--- a/apps/cms/src/app/api/products/[shop]/[id]/route.ts
+++ b/apps/cms/src/app/api/products/[shop]/[id]/route.ts
@@ -4,7 +4,9 @@ import { getProductById } from "@platform-core/repositories/json.server";
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
-const ParamsSchema = z.object({ shop: z.string(), id: z.string() });
+const ParamsSchema = z
+  .object({ shop: z.string(), id: z.string() })
+  .strict();
 
 export async function GET(
   _req: NextRequest,

--- a/apps/cms/src/app/api/products/route.ts
+++ b/apps/cms/src/app/api/products/route.ts
@@ -8,11 +8,13 @@ import type {
   ProductPublication,
 } from "@platform-core/src/products";
 
-const searchSchema = z.object({
-  q: z.string().optional(),
-  slug: z.string().optional(),
-  shop: z.string().default("abc"),
-});
+const searchSchema = z
+  .object({
+    q: z.string().optional(),
+    slug: z.string().optional(),
+    shop: z.string().default("abc"),
+  })
+  .strict();
 
 const paramsToObject = (params: URLSearchParams) =>
   Object.fromEntries(params.entries());

--- a/apps/cms/src/app/api/providers/[provider]/route.ts
+++ b/apps/cms/src/app/api/providers/[provider]/route.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { z } from "zod";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 
-const ParamsSchema = z.object({ shop: z.string(), code: z.string().optional() });
+const ParamsSchema = z
+  .object({ shop: z.string(), code: z.string().optional() })
+  .strict();
 
 export async function GET(
   req: NextRequest,

--- a/apps/cms/src/app/api/wizard-progress/route.ts
+++ b/apps/cms/src/app/api/wizard-progress/route.ts
@@ -21,18 +21,22 @@ interface DB {
   [userId: string]: UserRecord | unknown;
 }
 
-const putBodySchema = z.object({
-  stepId: z.string().nullish(),
-  data: wizardStateSchema.partial().optional(),
-  completed: z
-    .union([stepStatusSchema, z.record(stepStatusSchema)])
-    .optional(),
-});
+const putBodySchema = z
+  .object({
+    stepId: z.string().nullish(),
+    data: wizardStateSchema.partial().optional(),
+    completed: z
+      .union([stepStatusSchema, z.record(stepStatusSchema)])
+      .optional(),
+  })
+  .strict();
 
-const patchBodySchema = z.object({
-  stepId: z.string(),
-  completed: stepStatusSchema,
-});
+const patchBodySchema = z
+  .object({
+    stepId: z.string(),
+    completed: stepStatusSchema,
+  })
+  .strict();
 
 function resolveFile(): string {
   let dir = process.cwd();

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -23,13 +23,15 @@ jest.mock(
 
 jest.mock("@acme/types", () => {
   const { z } = require("zod");
-  const inventoryItemSchema = z.object({
-    sku: z.string(),
-    productId: z.string(),
-    variantAttributes: z.record(z.string()),
-    quantity: z.number().min(1),
-    lowStockThreshold: z.number().optional(),
-  });
+  const inventoryItemSchema = z
+    .object({
+      sku: z.string(),
+      productId: z.string(),
+      variantAttributes: z.record(z.string()),
+      quantity: z.number().min(1),
+      lowStockThreshold: z.number().optional(),
+    })
+    .strict();
   return { inventoryItemSchema };
 });
 

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -36,12 +36,14 @@ export interface NavItem {
 }
 
 export const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
-  z.object({
-    id: z.string(),
-    label: z.string(),
-    url: z.string().url(),
-    children: z.array(navItemSchema).optional(),
-  })
+  z
+    .object({
+      id: z.string(),
+      label: z.string(),
+      url: z.string().url(),
+      children: z.array(navItemSchema).optional(),
+    })
+    .strict()
 );
 
 /* -------------------------------------------------------------------------- */

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -8,11 +8,13 @@ import {
   getUserByEmail,
 } from "@acme/platform-core/users";
 
-const RegisterSchema = z.object({
-  customerId: z.string(),
-  email: z.string().email(),
-  password: z.string(),
-});
+const RegisterSchema = z
+  .object({
+    customerId: z.string(),
+    email: z.string().email(),
+    password: z.string(),
+  })
+  .strict();
 
 export async function POST(req: Request) {
   const json = await req.json();

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -17,6 +17,7 @@ import { getTaxRate } from "@platform-core/tax";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { z } from "zod";
+import { shippingSchema, billingSchema } from "@acme/types";
 
 /* ------------------------------------------------------------------ *
  *  Domain types
@@ -34,28 +35,6 @@ type Cart = CartState;
  * ------------------------------------------------------------------ */
 
 export const runtime = "edge";
-
-const addressSchema = z.object({
-  line1: z.string(),
-  line2: z.string().optional(),
-  city: z.string(),
-  postal_code: z.string(),
-  country: z.string(),
-  state: z.string().optional(),
-});
-
-const shippingSchema = z.object({
-  name: z.string(),
-  address: addressSchema,
-  phone: z.string().optional(),
-});
-
-const billingSchema = z.object({
-  name: z.string(),
-  email: z.string().email(),
-  address: addressSchema,
-  phone: z.string().optional(),
-});
 
 const schema = z
   .object({

--- a/apps/shop-bcd/src/api/return/route.ts
+++ b/apps/shop-bcd/src/api/return/route.ts
@@ -10,10 +10,12 @@ import { z } from "zod";
 
 export const runtime = "edge";
 
-const schema = z.object({
-  sessionId: z.string(),
-  damage: z.union([z.string(), z.number()]).optional(),
-});
+const schema = z
+  .object({
+    sessionId: z.string(),
+    damage: z.union([z.string(), z.number()]).optional(),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const parsed = schema.safeParse(await req.json());

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -26,11 +26,13 @@ if (!SECRET) {
  * `CartLine` / `CartState` so the rest of the codebase stays strongly
  * typed without running into “required vs optional” variance issues.
  */
-export const cartLineSchema = z.object({
-  sku: skuSchema, // full SKU object
-  qty: z.number().int().min(0), // quantity validated by API schemas
-  size: z.string().optional(),
-});
+export const cartLineSchema = z
+  .object({
+    sku: skuSchema, // full SKU object
+    qty: z.number().int().min(0), // quantity validated by API schemas
+    size: z.string().optional(),
+  })
+  .strict();
 
 /**
  * Schema for the full cart, keyed by `${sku.id}` or `${sku.id}:${size}`.

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -15,11 +15,13 @@ interface NavItem {
 }
 
 const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
-  z.object({
-    label: z.string().min(1),
-    url: z.string().min(1),
-    children: z.array(navItemSchema).optional(),
-  })
+  z
+    .object({
+      label: z.string().min(1),
+      url: z.string().min(1),
+      children: z.array(navItemSchema).optional(),
+    })
+    .strict()
 );
 
 export const createShopOptionsSchema = z

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -121,10 +121,12 @@ export interface SettingsDiffEntry {
   diff: Partial<ShopSettings>;
 }
 
-const entrySchema = z.object({
-  timestamp: z.string().datetime(),
-  diff: shopSettingsSchema.partial(),
-});
+const entrySchema = z
+  .object({
+    timestamp: z.string().datetime(),
+    diff: shopSettingsSchema.partial(),
+  })
+  .strict();
 
 export async function diffHistory(shop: string): Promise<SettingsDiffEntry[]> {
   try {

--- a/packages/plugins/paypal/index.ts
+++ b/packages/plugins/paypal/index.ts
@@ -2,10 +2,12 @@
 import type { Plugin, PaymentRegistry } from "@acme/platform-core/plugins";
 import { z } from "zod";
 
-const configSchema = z.object({
-  clientId: z.string(),
-  secret: z.string(),
-});
+const configSchema = z
+  .object({
+    clientId: z.string(),
+    secret: z.string(),
+  })
+  .strict();
 
 type PayPalConfig = z.infer<typeof configSchema>;
 

--- a/packages/plugins/sanity/index.ts
+++ b/packages/plugins/sanity/index.ts
@@ -3,11 +3,13 @@ import type { Plugin } from "@acme/platform-core/plugins";
 import { createClient, type SanityClient } from "@sanity/client";
 import { z } from "zod";
 
-export const configSchema = z.object({
-  projectId: z.string(),
-  dataset: z.string(),
-  token: z.string(),
-});
+export const configSchema = z
+  .object({
+    projectId: z.string(),
+    dataset: z.string(),
+    token: z.string(),
+  })
+  .strict();
 
 export type SanityConfig = z.infer<typeof configSchema>;
 

--- a/packages/shared-utils/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/__tests__/fetchJson.test.ts
@@ -81,7 +81,7 @@ describe('fetchJson', () => {
       text: jest.fn().mockResolvedValue(JSON.stringify(responseData)),
     });
 
-    const schema = z.object({ message: z.string() });
+    const schema = z.object({ message: z.string() }).strict();
 
     await expect(
       fetchJson('https://example.com', undefined, schema),
@@ -95,7 +95,7 @@ describe('fetchJson', () => {
       text: jest.fn().mockResolvedValue(JSON.stringify(responseData)),
     });
 
-    const schema = z.object({ count: z.number() });
+    const schema = z.object({ count: z.number() }).strict();
 
     await expect(
       fetchJson('https://example.com', undefined, schema),

--- a/packages/types/src/Checkout.ts
+++ b/packages/types/src/Checkout.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const addressSchema = z
+  .object({
+    line1: z.string(),
+    line2: z.string().optional(),
+    city: z.string(),
+    postal_code: z.string(),
+    country: z.string(),
+    state: z.string().optional(),
+  })
+  .strict();
+
+export const shippingSchema = z
+  .object({
+    name: z.string(),
+    address: addressSchema,
+    phone: z.string().optional(),
+  })
+  .strict();
+
+export const billingSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().email(),
+    address: addressSchema,
+    phone: z.string().optional(),
+  })
+  .strict();
+
+export type Address = z.infer<typeof addressSchema>;
+export type Shipping = z.infer<typeof shippingSchema>;
+export type Billing = z.infer<typeof billingSchema>;

--- a/packages/types/src/Coupon.ts
+++ b/packages/types/src/Coupon.ts
@@ -1,17 +1,19 @@
 import { z } from "zod";
 
 /** Basic coupon definition */
-export const couponSchema = z.object({
-  /** Case-insensitive coupon code */
-  code: z.string(),
-  /** Optional description shown in CMS */
-  description: z.string().optional(),
-  /** Percentage discount to apply (0–100) */
-  discountPercent: z.number().int().min(0).max(100),
-  /** ISO date when the coupon becomes valid */
-  validFrom: z.string().optional(),
-  /** ISO date when the coupon expires */
-  validTo: z.string().optional(),
-});
+export const couponSchema = z
+  .object({
+    /** Case-insensitive coupon code */
+    code: z.string(),
+    /** Optional description shown in CMS */
+    description: z.string().optional(),
+    /** Percentage discount to apply (0–100) */
+    discountPercent: z.number().int().min(0).max(100),
+    /** ISO date when the coupon becomes valid */
+    validFrom: z.string().optional(),
+    /** ISO date when the coupon expires */
+    validTo: z.string().optional(),
+  })
+  .strict();
 
 export type Coupon = z.infer<typeof couponSchema>;

--- a/packages/types/src/InventoryItem.ts
+++ b/packages/types/src/InventoryItem.ts
@@ -3,14 +3,16 @@ import { z } from "zod";
 // Flexible map of variant attributes (e.g. size, color)
 export const variantAttributesSchema = z.record(z.string());
 
-export const inventoryItemSchema = z.object({
-  sku: z.string(),
-  productId: z.string(),
-  quantity: z.number(),
-  // Each variant attribute is a free-form key/value string pair
-  variantAttributes: variantAttributesSchema,
-  lowStockThreshold: z.number().optional(),
-});
+export const inventoryItemSchema = z
+  .object({
+    sku: z.string(),
+    productId: z.string(),
+    quantity: z.number(),
+    // Each variant attribute is a free-form key/value string pair
+    variantAttributes: variantAttributesSchema,
+    lowStockThreshold: z.number().optional(),
+  })
+  .strict();
 
 export type VariantAttributes = z.infer<typeof variantAttributesSchema>;
 export type InventoryItem = z.infer<typeof inventoryItemSchema>;

--- a/packages/types/src/Pricing.ts
+++ b/packages/types/src/Pricing.ts
@@ -7,15 +7,19 @@ import { z } from "zod";
  * - `durationDiscounts` contains rate multipliers applied when `minDays` is met.
  * - `damageFees` maps damage codes to a fixed amount or the string `"deposit"`.
  */
-export const pricingSchema = z.object({
-  baseDailyRate: z.number(),
-  durationDiscounts: z.array(
-    z.object({
-      minDays: z.number(),
-      rate: z.number(),
-    })
-  ),
-  damageFees: z.record(z.union([z.number(), z.literal("deposit")])),
-});
+export const pricingSchema = z
+  .object({
+    baseDailyRate: z.number(),
+    durationDiscounts: z.array(
+      z
+        .object({
+          minDays: z.number(),
+          rate: z.number(),
+        })
+        .strict()
+    ),
+    damageFees: z.record(z.union([z.number(), z.literal("deposit")])),
+  })
+  .strict();
 
 export type PricingMatrix = z.infer<typeof pricingSchema>;

--- a/packages/types/src/Product.ts
+++ b/packages/types/src/Product.ts
@@ -7,42 +7,46 @@ export type { Locale } from "@acme/i18n";
 export const localeSchema = z.enum(LOCALES);
 
 /** Runtime validator + compile-time source of truth */
-const mediaItemSchema = z.object({
-  url: z.string(),
-  title: z.string().optional(),
-  altText: z.string().optional(),
-  type: z.enum(["image", "video"]),
-});
+const mediaItemSchema = z
+  .object({
+    url: z.string(),
+    title: z.string().optional(),
+    altText: z.string().optional(),
+    type: z.enum(["image", "video"]),
+  })
+  .strict();
 
-export const skuSchema = z.object({
-  id: z.string().ulid(),
-  slug: z.string(),
-  title: z.string(),
-  /** Unit price in minor currency units (e.g. cents) */
-  price: z.number().int().nonnegative(),
-  /** Refundable deposit, required by business rules */
-  deposit: z.number().int().nonnegative(),
-  /** Available stock count */
-  stock: z.number().int().nonnegative(),
-  /** Item can be sold */
-  forSale: z.boolean().default(true),
-  /** Item can be rented */
-  forRental: z.boolean().default(false),
-  /** daily rental rate in minor currency units */
-  dailyRate: z.number().int().nonnegative().optional(),
-  /** weekly rental rate in minor currency units */
-  weeklyRate: z.number().int().nonnegative().optional(),
-  /** monthly rental rate in minor currency units */
-  monthlyRate: z.number().int().nonnegative().optional(),
-  /** availability windows as ISO timestamps */
-  availability: z
-    .array(z.object({ from: z.string(), to: z.string() }))
-    .optional(),
-  /** Ordered media gallery for the product */
-  media: z.array(mediaItemSchema),
-  sizes: z.array(z.string()),
-  description: z.string(),
-});
+export const skuSchema = z
+  .object({
+    id: z.string().ulid(),
+    slug: z.string(),
+    title: z.string(),
+    /** Unit price in minor currency units (e.g. cents) */
+    price: z.number().int().nonnegative(),
+    /** Refundable deposit, required by business rules */
+    deposit: z.number().int().nonnegative(),
+    /** Available stock count */
+    stock: z.number().int().nonnegative(),
+    /** Item can be sold */
+    forSale: z.boolean().default(true),
+    /** Item can be rented */
+    forRental: z.boolean().default(false),
+    /** daily rental rate in minor currency units */
+    dailyRate: z.number().int().nonnegative().optional(),
+    /** weekly rental rate in minor currency units */
+    weeklyRate: z.number().int().nonnegative().optional(),
+    /** monthly rental rate in minor currency units */
+    monthlyRate: z.number().int().nonnegative().optional(),
+    /** availability windows as ISO timestamps */
+    availability: z
+      .array(z.object({ from: z.string(), to: z.string() }).strict())
+      .optional(),
+    /** Ordered media gallery for the product */
+    media: z.array(mediaItemSchema),
+    sizes: z.array(z.string()),
+    description: z.string(),
+  })
+  .strict();
 
 export type SKU = z.infer<typeof skuSchema>;
 

--- a/packages/types/src/PublishLocation.ts
+++ b/packages/types/src/PublishLocation.ts
@@ -3,22 +3,23 @@ import { imageOrientationSchema } from "./ImageOrientation";
 /**
  * Definition of a publish-to location within the shop-front.
  */
-export const publishLocationSchema = z.object({
-  /** Unique, stable identifier (e.g. slug or UUID). */
-  id: z.string(),
+export const publishLocationSchema = z
+  .object({
+    /** Unique, stable identifier (e.g. slug or UUID). */
+    id: z.string(),
 
-  /** Human-readable name shown to content editors. */
-  name: z.string(),
+    /** Human-readable name shown to content editors. */
+    name: z.string(),
 
-  /** Optional richer description for tooltips or secondary text. */
-  description: z.string().optional(),
+    /** Optional richer description for tooltips or secondary text. */
+    description: z.string().optional(),
 
-  /** Hierarchical path (e.g. "homepage/hero", "product/:id/upsell"). */
-  path: z.string(),
+    /** Hierarchical path (e.g. "homepage/hero", "product/:id/upsell"). */
+    path: z.string(),
 
-  /** Required orientation for images displayed at this location. */
-
-  requiredOrientation: imageOrientationSchema,
-});
+    /** Required orientation for images displayed at this location. */
+    requiredOrientation: imageOrientationSchema,
+  })
+  .strict();
 
 export type PublishLocation = z.infer<typeof publishLocationSchema>;

--- a/packages/types/src/RentalOrder.ts
+++ b/packages/types/src/RentalOrder.ts
@@ -1,20 +1,22 @@
 import { z } from "zod";
 
-export const rentalOrderSchema = z.object({
-  id: z.string(),
-  sessionId: z.string(),
-  shop: z.string(),
-  deposit: z.number(),
-  expectedReturnDate: z.string().optional(),
-  startedAt: z.string(),
-  returnedAt: z.string().optional(),
-  refundedAt: z.string().optional(),
-  /** Optional damage fee deducted from the deposit */
-  damageFee: z.number().optional(),
-  customerId: z.string().optional(),
-  riskLevel: z.string().optional(),
-  riskScore: z.number().optional(),
-  flaggedForReview: z.boolean().optional(),
-});
+export const rentalOrderSchema = z
+  .object({
+    id: z.string(),
+    sessionId: z.string(),
+    shop: z.string(),
+    deposit: z.number(),
+    expectedReturnDate: z.string().optional(),
+    startedAt: z.string(),
+    returnedAt: z.string().optional(),
+    refundedAt: z.string().optional(),
+    /** Optional damage fee deducted from the deposit */
+    damageFee: z.number().optional(),
+    customerId: z.string().optional(),
+    riskLevel: z.string().optional(),
+    riskScore: z.number().optional(),
+    flaggedForReview: z.boolean().optional(),
+  })
+  .strict();
 
 export type RentalOrder = z.infer<typeof rentalOrderSchema>;

--- a/packages/types/src/ReturnLogistics.ts
+++ b/packages/types/src/ReturnLogistics.ts
@@ -6,9 +6,11 @@ import { z } from "zod";
  * - `labelService` specifies the provider used to create return shipping labels.
  * - `inStore` toggles whether items can be dropped off in store.
  */
-export const returnLogisticsSchema = z.object({
-  labelService: z.string(),
-  inStore: z.boolean(),
-});
+export const returnLogisticsSchema = z
+  .object({
+    labelService: z.string(),
+    inStore: z.boolean(),
+  })
+  .strict();
 
 export type ReturnLogistics = z.infer<typeof returnLogisticsSchema>;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -1,83 +1,93 @@
 import { z } from "zod";
 import { localeSchema } from "./Product";
 
-export const shopSeoFieldsSchema = z.object({
-  canonicalBase: z.string().url().optional(),
-  title: z.string().optional(),
-  description: z.string().optional(),
-  image: z.string().url().optional(),
-  alt: z.string().optional(),
-  openGraph: z
-    .object({
-      title: z.string().optional(),
-      description: z.string().optional(),
-      url: z.string().url().optional(),
-      image: z.string().url().optional(),
-    })
-    .optional(),
-  twitter: z
-    .object({
-      card: z.string().optional(),
-      title: z.string().optional(),
-      description: z.string().optional(),
-      image: z.string().url().optional(),
-    })
-    .optional(),
-  structuredData: z.string().optional(),
-});
+export const shopSeoFieldsSchema = z
+  .object({
+    canonicalBase: z.string().url().optional(),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    image: z.string().url().optional(),
+    alt: z.string().optional(),
+    openGraph: z
+      .object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+        url: z.string().url().optional(),
+        image: z.string().url().optional(),
+      })
+      .strict()
+      .optional(),
+    twitter: z
+      .object({
+        card: z.string().optional(),
+        title: z.string().optional(),
+        description: z.string().optional(),
+        image: z.string().url().optional(),
+      })
+      .strict()
+      .optional(),
+    structuredData: z.string().optional(),
+  })
+  .strict();
 
 export type ShopSeoFields = z.infer<typeof shopSeoFieldsSchema>;
 
-export const sanityBlogConfigSchema = z.object({
-  projectId: z.string(),
-  dataset: z.string(),
-  token: z.string(),
-});
+export const sanityBlogConfigSchema = z
+  .object({
+    projectId: z.string(),
+    dataset: z.string(),
+    token: z.string(),
+  })
+  .strict();
 
 export type SanityBlogConfig = z.infer<typeof sanityBlogConfigSchema>;
 
-export const shopDomainSchema = z.object({
-  name: z.string(),
-  status: z.string().optional(),
-  certificateStatus: z.string().optional(),
-});
+export const shopDomainSchema = z
+  .object({
+    name: z.string(),
+    status: z.string().optional(),
+    certificateStatus: z.string().optional(),
+  })
+  .strict();
 
 export type ShopDomain = z.infer<typeof shopDomainSchema>;
 
-export const shopSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  logo: z.string().optional(),
-  contactInfo: z.string().optional(),
-  catalogFilters: z.array(z.string()),
-  themeId: z.string(),
-  /** Mapping of design tokens to original theme values */
-  themeDefaults: z.record(z.string()).default({}),
-  /** Mapping of token overrides to theme values */
-  themeOverrides: z.record(z.string()).default({}),
-  /** Mapping of design tokens to theme values (defaults merged with overrides) */
-  themeTokens: z.record(z.string()).default({}),
-  /** Mapping of logical filter keys to catalog attributes */
-  filterMappings: z.record(z.string()),
-  /** Optional price overrides per locale (minor units) */
-  priceOverrides: z
-    .record(localeSchema, z.number().int().nonnegative())
-    .default({}),
-  /** Optional redirect overrides for locale detection */
-  localeOverrides: z.record(z.string(), localeSchema).default({}),
-  type: z.string().optional(),
-  paymentProviders: z.array(z.string()).optional(),
-  shippingProviders: z.array(z.string()).optional(),
-  taxProviders: z.array(z.string()).optional(),
-  homeTitle: z.record(localeSchema, z.string()).optional(),
-  homeDescription: z.record(localeSchema, z.string()).optional(),
-  homeImage: z.string().optional(),
-  navigation: z
-    .array(z.object({ label: z.string(), url: z.string() }))
-    .optional(),
-  sanityBlog: sanityBlogConfigSchema.optional(),
-  domain: shopDomainSchema.optional(),
-  analyticsEnabled: z.boolean().optional(),
-});
+export const shopSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    logo: z.string().optional(),
+    contactInfo: z.string().optional(),
+    catalogFilters: z.array(z.string()),
+    themeId: z.string(),
+    /** Mapping of design tokens to original theme values */
+    themeDefaults: z.record(z.string()).default({}),
+    /** Mapping of token overrides to theme values */
+    themeOverrides: z.record(z.string()).default({}),
+    /** Mapping of design tokens to theme values (defaults merged with overrides) */
+    themeTokens: z.record(z.string()).default({}),
+    /** Mapping of logical filter keys to catalog attributes */
+    filterMappings: z.record(z.string()),
+    /** Optional price overrides per locale (minor units) */
+    priceOverrides: z
+      .record(localeSchema, z.number().int().nonnegative())
+      .default({}),
+    /** Optional redirect overrides for locale detection */
+    localeOverrides: z.record(z.string(), localeSchema).default({}),
+    type: z.string().optional(),
+    paymentProviders: z.array(z.string()).optional(),
+    shippingProviders: z.array(z.string()).optional(),
+    taxProviders: z.array(z.string()).optional(),
+    homeTitle: z.record(localeSchema, z.string()).optional(),
+    homeDescription: z.record(localeSchema, z.string()).optional(),
+    homeImage: z.string().optional(),
+    navigation: z
+      .array(z.object({ label: z.string(), url: z.string() }).strict())
+      .optional(),
+    sanityBlog: sanityBlogConfigSchema.optional(),
+    domain: shopDomainSchema.optional(),
+    analyticsEnabled: z.boolean().optional(),
+  })
+  .strict();
 
 export type Shop = z.infer<typeof shopSchema>;

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -10,11 +10,13 @@ export const aiCatalogFieldSchema = z.enum([
   "images",
 ]);
 
-export const aiCatalogConfigSchema = z.object({
-  enabled: z.boolean(),
-  fields: z.array(aiCatalogFieldSchema),
-  pageSize: z.number().int().positive(),
-});
+export const aiCatalogConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    fields: z.array(aiCatalogFieldSchema),
+    pageSize: z.number().int().positive(),
+  })
+  .strict();
 
 export const seoSettingsSchema = z
   .object({
@@ -22,31 +24,35 @@ export const seoSettingsSchema = z
   })
   .catchall(shopSeoFieldsSchema);
 
-export const shopSettingsSchema = z.object({
-  languages: z.array(localeSchema).readonly(),
-  seo: seoSettingsSchema,
-  analytics: z
-    .object({
-      enabled: z.boolean().optional(),
-      provider: z.string(),
-      id: z.string().optional(),
-    })
-    .optional(),
-  freezeTranslations: z.boolean().optional(),
-  /** ISO currency code used as the shop's base currency */
-  currency: z.string().length(3).optional(),
-  /** Region identifier for tax calculations */
-  taxRegion: z.string().optional(),
-  depositService: z
-    .object({
-      enabled: z.boolean(),
-      /** Interval in minutes between deposit release checks */
-      intervalMinutes: z.number().int().positive(),
-    })
-    .optional(),
-  updatedAt: z.string(),
-  updatedBy: z.string(),
-});
+export const shopSettingsSchema = z
+  .object({
+    languages: z.array(localeSchema).readonly(),
+    seo: seoSettingsSchema,
+    analytics: z
+      .object({
+        enabled: z.boolean().optional(),
+        provider: z.string(),
+        id: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    freezeTranslations: z.boolean().optional(),
+    /** ISO currency code used as the shop's base currency */
+    currency: z.string().length(3).optional(),
+    /** Region identifier for tax calculations */
+    taxRegion: z.string().optional(),
+    depositService: z
+      .object({
+        enabled: z.boolean(),
+        /** Interval in minutes between deposit release checks */
+        intervalMinutes: z.number().int().positive(),
+      })
+      .strict()
+      .optional(),
+    updatedAt: z.string(),
+    updatedBy: z.string(),
+  })
+  .strict();
 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
 export type AiCatalogConfig = z.infer<typeof aiCatalogConfigSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,3 +14,4 @@ export * from "./ReturnLogistics";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";
+export * from "./Checkout";


### PR DESCRIPTION
## Summary
- centralize checkout-session schemas and enforce strict parsing
- tighten plugin and core schemas with `z.strict`
- apply strict validation to numerous app and package schemas

## Testing
- `pnpm test` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*
- `pnpm lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689bbbd40b78832fb887a2c3c523c65a