### PR TITLE
feat: enforce permissions on account components

### DIFF
--- a/packages/ui/__tests__/Orders.test.tsx
+++ b/packages/ui/__tests__/Orders.test.tsx
@@ -1,0 +1,61 @@
+// packages/ui/__tests__/Orders.test.tsx
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+  hasPermission: jest.fn(),
+}));
+
+jest.mock("@platform-core/orders", () => ({
+  __esModule: true,
+  getOrdersForCustomer: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  redirect: jest.fn(),
+}));
+
+import { getCustomerSession, hasPermission } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
+import OrdersPage from "../src/components/account/Orders";
+import { redirect } from "next/navigation";
+
+describe("OrdersPage permissions", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const shopId = "shop1";
+
+  it("redirects unauthenticated users", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    await OrdersPage({ shopId });
+    expect(redirect).toHaveBeenCalled();
+  });
+
+  it("hides orders when lacking permission", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+      role: "viewer",
+    });
+    (hasPermission as jest.Mock).mockReturnValue(false);
+    const element = await OrdersPage({ shopId });
+    expect(getOrdersForCustomer).not.toHaveBeenCalled();
+    expect(element.type).toBe("p");
+    expect(element.props.children).toBe("Not authorized.");
+  });
+
+  it("shows orders when permitted", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+      role: "customer",
+    });
+    (hasPermission as jest.Mock).mockReturnValue(true);
+    (getOrdersForCustomer as jest.Mock).mockResolvedValue([
+      { id: "o1" },
+    ]);
+    const element = await OrdersPage({ shopId });
+    const list = element.props.children[1];
+    expect(list.type).toBe("ul");
+  });
+});

--- a/packages/ui/__tests__/Profile.test.tsx
+++ b/packages/ui/__tests__/Profile.test.tsx
@@ -1,0 +1,47 @@
+// packages/ui/__tests__/Profile.test.tsx
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+  hasPermission: jest.fn(),
+}));
+
+jest.mock("@acme/platform-core", () => ({
+  __esModule: true,
+  getCustomerProfile: jest.fn(),
+}));
+
+import { getCustomerSession, hasPermission } from "@auth";
+import { getCustomerProfile } from "@acme/platform-core";
+import ProfilePage from "../src/components/account/Profile";
+
+describe("ProfilePage permissions", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("hides change password link without permission", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+      role: "viewer",
+    });
+    (hasPermission as jest.Mock).mockReturnValue(false);
+    (getCustomerProfile as jest.Mock).mockResolvedValue({ name: "Jane" });
+    const element = await ProfilePage({});
+    expect(hasPermission).toHaveBeenCalledWith("viewer", "manage_profile");
+    expect(element.props.children[2]).toBeFalsy();
+  });
+
+  it("shows change password link with permission", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+      role: "customer",
+    });
+    (hasPermission as jest.Mock).mockReturnValue(true);
+    (getCustomerProfile as jest.Mock).mockResolvedValue({ name: "Jane" });
+    const element = await ProfilePage({});
+    const linkWrapper = element.props.children[2];
+    expect(linkWrapper.props.children.props.href).toBe(
+      "/account/change-password",
+    );
+  });
+});

--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -1,5 +1,5 @@
 // packages/ui/src/components/account/Orders.tsx
-import { getCustomerSession } from "@auth";
+import { getCustomerSession, hasPermission } from "@auth";
 import { getOrdersForCustomer } from "@platform-core/orders";
 import { redirect } from "next/navigation";
 
@@ -23,6 +23,9 @@ export default async function OrdersPage({
   if (!session) {
     redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
     return null as never;
+  }
+  if (!hasPermission(session.role, "manage_profile")) {
+    return <p className="p-6">Not authorized.</p>;
   }
   const orders = await getOrdersForCustomer(shopId, session.customerId);
   if (!orders.length) return <p className="p-6">No orders yet.</p>;

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -1,5 +1,5 @@
 // packages/ui/src/components/account/Profile.tsx
-import { getCustomerSession } from "@auth";
+import { getCustomerSession, hasPermission } from "@auth";
 import { getCustomerProfile } from "@acme/platform-core";
 import ProfileForm from "./ProfileForm";
 import { redirect } from "next/navigation";
@@ -24,15 +24,18 @@ export default async function ProfilePage({
     return null as never;
   }
   const profile = await getCustomerProfile(session.customerId);
+  const canManageProfile = hasPermission(session.role, "manage_profile");
   return (
     <div className="p-6">
       <h1 className="mb-4 text-xl">{title}</h1>
       <ProfileForm name={profile?.name} email={profile?.email} />
-      <div className="mt-4">
-        <Link href="/account/change-password" className="text-sm underline">
-          Change password
-        </Link>
-      </div>
+      {canManageProfile && (
+        <div className="mt-4">
+          <Link href="/account/change-password" className="text-sm underline">
+            Change password
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/account/Sessions.tsx
+++ b/packages/ui/src/components/account/Sessions.tsx
@@ -15,10 +15,10 @@ export const metadata = { title: "Sessions" };
 
 export async function revoke(id: string) {
   "use server";
-  const { getCustomerSession, listSessions } = await import("@auth");
+  const { getCustomerSession, listSessions, hasPermission } = await import("@auth");
   try {
     const session = await getCustomerSession();
-    if (!session) {
+    if (!session || !hasPermission(session.role, "manage_profile")) {
       return { success: false, error: "Failed to revoke session." };
     }
     const sessions = await listSessions(session.customerId);
@@ -37,11 +37,14 @@ export default async function SessionsPage({
   title = "Sessions",
   callbackUrl = "/account/sessions",
 }: SessionsPageProps = {}) {
-  const { getCustomerSession, listSessions } = await import("@auth");
+  const { getCustomerSession, listSessions, hasPermission } = await import("@auth");
   const session = await getCustomerSession();
   if (!session) {
     redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
     return null as never;
+  }
+  if (!hasPermission(session.role, "manage_profile")) {
+    return <p className="p-6">Not authorized.</p>;
   }
   const sessions = await listSessions(session.customerId);
   if (!sessions.length) return <p className="p-6">No active sessions.</p>;


### PR DESCRIPTION
## Summary
- gate profile password link, orders, and sessions pages behind manage_profile permission
- add tests verifying unauthorized roles don't see account controls

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/Profile.test.tsx packages/ui/__tests__/Orders.test.tsx packages/ui/__tests__/Sessions.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bbc3d5a6c832f8f914c4960a16f4f