### PR TITLE
feat: add unsubscribe flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ SendGrid and Resend can be configured to POST event webhooks to:
 Both endpoints verify the signatures using the environment variables above and
 map delivered, open, click, unsubscribe and bounce events to internal analytics.
 
+Campaign emails include per-recipient unsubscribe links pointing to
+`/api/marketing/email/unsubscribe`. Visits to this endpoint record an
+`email_unsubscribe` analytics event, ensuring the address is excluded from
+future sends.
+
 The scaffolded `.env` also includes generated placeholders for `NEXTAUTH_SECRET`
 and `PREVIEW_TOKEN_SECRET`. Replace all placeholders with real values or supply
 them via your CI's secret store. Missing variables will cause the CLI to exit

--- a/apps/cms/__tests__/unsubscribeFlow.test.ts
+++ b/apps/cms/__tests__/unsubscribeFlow.test.ts
@@ -1,0 +1,85 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+jest.mock("@platform-core/analytics", () => ({
+  __esModule: true,
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("@acme/email", () => {
+  const actual = jest.requireActual("@acme/email");
+  return {
+    __esModule: true,
+    ...actual,
+    sendCampaignEmail: jest.fn(),
+  };
+});
+jest.mock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [],
+  }),
+  { virtual: true }
+);
+
+process.env.RESEND_API_KEY = "test";
+process.env.CART_COOKIE_SECRET = "secret";
+process.env.STRIPE_SECRET_KEY = "sk_test";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+
+const shop = "unsubshop";
+const shopDir = path.join(DATA_ROOT, shop);
+
+beforeEach(async () => {
+  await fs.rm(shopDir, { recursive: true, force: true });
+  await fs.mkdir(shopDir, { recursive: true });
+  const trackEvent = (await import("@platform-core/analytics")).trackEvent as jest.Mock;
+  trackEvent.mockReset();
+  const { sendCampaignEmail } = await import("@acme/email");
+  (sendCampaignEmail as jest.Mock).mockReset();
+});
+
+test("includes unsubscribe link when sending", async () => {
+  const { POST } = await import("../src/app/api/marketing/email/route");
+  const res = await POST({
+    json: async () => ({
+      shop,
+      recipients: ["user@example.com"],
+      subject: "Hi",
+      body: "<p>Hello</p>",
+      sendAt: new Date().toISOString(),
+    }),
+  } as unknown as NextRequest);
+  expect(res.status).toBe(200);
+  const { sendCampaignEmail } = await import("@acme/email");
+  const html = (sendCampaignEmail as jest.Mock).mock.calls[0][0].html as string;
+  expect(html).toContain("/api/marketing/email/unsubscribe");
+  expect(html).toContain("email=user%40example.com");
+});
+
+test("records unsubscribe requests", async () => {
+  const { GET } = await import(
+    "../src/app/api/marketing/email/unsubscribe/route"
+  );
+  const req = {
+    nextUrl: {
+      searchParams: new URLSearchParams({
+        shop,
+        email: "user@example.com",
+        campaign: "c1",
+      }),
+    },
+  } as unknown as NextRequest;
+  const res = await GET(req);
+  expect(res.status).toBe(200);
+  const trackEvent = (await import("@platform-core/analytics")).trackEvent as jest.Mock;
+  expect(trackEvent).toHaveBeenCalledWith(shop, {
+    type: "email_unsubscribe",
+    email: "user@example.com",
+    campaign: "c1",
+  });
+});

--- a/apps/cms/src/app/api/marketing/email/unsubscribe/route.ts
+++ b/apps/cms/src/app/api/marketing/email/unsubscribe/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { trackEvent } from "@platform-core/analytics";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const shop = req.nextUrl.searchParams.get("shop");
+  const email = req.nextUrl.searchParams.get("email");
+  const campaign = req.nextUrl.searchParams.get("campaign");
+  if (shop && email) {
+    await trackEvent(shop, {
+      type: "email_unsubscribe",
+      email,
+      ...(campaign ? { campaign } : {}),
+    });
+  }
+  return new NextResponse("<p>You have been unsubscribed.</p>", {
+    headers: { "Content-Type": "text/html" },
+  });
+}

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -8,6 +8,11 @@ jest.mock("../index", () => ({
   __esModule: true,
   sendCampaignEmail: jest.fn().mockResolvedValue(undefined),
   resolveSegment: jest.fn(),
+  filterUnsubscribed: jest
+    .fn()
+    .mockImplementation((_shop: string, emails: string[]) =>
+      Promise.resolve(emails)
+    ),
 }));
 
 jest.mock("@platform-core/analytics", () => ({

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -5,3 +5,4 @@ export { recoverAbandonedCarts } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
 export { resolveSegment } from "./segments";
 export { sendScheduledCampaigns } from "./scheduler";
+export { listUnsubscribed, filterUnsubscribed } from "./unsubscribe";

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -14,8 +14,14 @@ export async function resolveSegment(
 ): Promise<string[]> {
   const events = await listEvents(shop);
   const emails = new Set<string>();
+  const unsubscribed = new Set<string>();
   for (const e of events) {
     const type = (e as { type?: string }).type;
+    if (type === "email_unsubscribe") {
+      const email = (e as any).email;
+      if (typeof email === "string") unsubscribed.add(email);
+      continue;
+    }
     const seg =
       type === `segment:${id}`
         ? id
@@ -27,5 +33,5 @@ export async function resolveSegment(
       if (typeof email === "string") emails.add(email);
     }
   }
-  return Array.from(emails);
+  return Array.from(emails).filter((e) => !unsubscribed.has(e));
 }

--- a/packages/email/src/unsubscribe.ts
+++ b/packages/email/src/unsubscribe.ts
@@ -1,0 +1,30 @@
+import { listEvents } from "@platform-core/repositories/analytics.server";
+
+/**
+ * Return a set of email addresses that have unsubscribed for the given shop.
+ */
+export async function listUnsubscribed(shop: string): Promise<Set<string>> {
+  const events = await listEvents(shop);
+  const unsub = new Set<string>();
+  for (const e of events) {
+    if ((e as any).type === "email_unsubscribe") {
+      const email = (e as any).email;
+      if (typeof email === "string") {
+        unsub.add(email);
+      }
+    }
+  }
+  return unsub;
+}
+
+/**
+ * Filter out any email addresses that have unsubscribed.
+ */
+export async function filterUnsubscribed(
+  shop: string,
+  emails: string[]
+): Promise<string[]> {
+  const unsub = await listUnsubscribed(shop);
+  return emails.filter((e) => !unsub.has(e));
+}
+


### PR DESCRIPTION
## Summary
- add unsubscribe helper utilities and segment filtering
- append per-recipient unsubscribe links in campaign emails and scheduler
- handle unsubscribe requests via new API endpoint

## Testing
- `pnpm exec jest packages/email/src/__tests__/scheduler.test.ts apps/cms/__tests__/marketingEmailApi.test.ts apps/cms/__tests__/unsubscribeFlow.test.ts --runInBand --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689bbd5bc950832fb0284a84ecda1190