### PR TITLE
feat(email): add marketing campaign CLI

### DIFF
--- a/doc/marketing-automation.md
+++ b/doc/marketing-automation.md
@@ -1,0 +1,27 @@
+# Marketing automation
+
+The `@acme/email` package ships with a small CLI for managing email marketing campaigns.
+
+## Create a campaign
+
+```bash
+pnpm --filter @acme/email exec email campaign create <shop> \
+  --subject "Launch" \
+  --body "<p>Hello world</p>" \
+  --recipients "user@example.com" \
+  --send-at 2025-01-01T00:00:00Z
+```
+
+## List campaigns
+
+```bash
+pnpm --filter @acme/email exec email campaign list <shop>
+```
+
+## Send due campaigns
+
+```bash
+pnpm --filter @acme/email exec email campaign send
+```
+
+The scheduler will deliver any campaigns whose `sendAt` timestamp has passed.

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -6,11 +6,15 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "bin": {
+    "email": "./src/cli.ts"
+  },
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "dependencies": {
     "@acme/config": "workspace:*",
+    "commander": "^11.1.0",
     "@sendgrid/mail": "^8.1.5",
     "nodemailer": "^6.10.1",
     "resend": "^3.5.0"

--- a/packages/email/src/cli.ts
+++ b/packages/email/src/cli.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env tsx
+import { Command } from "commander";
+import { promises as fs } from "node:fs";
+import * as fsSync from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { sendScheduledCampaigns } from "../../../functions/marketing-email-sender.ts";
+
+interface Campaign {
+  id: string;
+  recipients: string[];
+  subject: string;
+  body: string;
+  segment?: string | null;
+  sendAt: string;
+  sentAt?: string;
+}
+
+function resolveDataRoot(): string {
+  let dir = process.cwd();
+  while (true) {
+    const candidate = path.join(dir, "data", "shops");
+    if (fsSync.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(process.cwd(), "data", "shops");
+}
+
+const DATA_ROOT = resolveDataRoot();
+
+function campaignsPath(shop: string): string {
+  return path.join(DATA_ROOT, shop, "campaigns.json");
+}
+
+async function readCampaigns(shop: string): Promise<Campaign[]> {
+  try {
+    const buf = await fs.readFile(campaignsPath(shop), "utf8");
+    const json = JSON.parse(buf);
+    if (Array.isArray(json)) return json as Campaign[];
+  } catch {}
+  return [];
+}
+
+async function writeCampaigns(shop: string, items: Campaign[]): Promise<void> {
+  await fs.mkdir(path.dirname(campaignsPath(shop)), { recursive: true });
+  await fs.writeFile(campaignsPath(shop), JSON.stringify(items, null, 2), "utf8");
+}
+
+const program = new Command();
+program.name("email").description("Email marketing CLI");
+
+const campaign = program.command("campaign").description("Manage campaigns");
+
+campaign
+  .command("create")
+  .argument("<shop>")
+  .requiredOption("--subject <subject>", "Email subject")
+  .requiredOption("--body <html>", "HTML body")
+  .option("--recipients <emails>", "Comma separated recipient emails")
+  .option("--segment <segment>", "Recipient segment name")
+  .option("--send-at <date>", "ISO send time", () => new Date().toISOString())
+  .action(async (shop, options) => {
+    const campaigns = await readCampaigns(shop);
+    const recipients = options.recipients
+      ? String(options.recipients)
+          .split(",")
+          .map((e: string) => e.trim())
+          .filter(Boolean)
+      : [];
+    const item: Campaign = {
+      id: randomUUID(),
+      recipients,
+      subject: options.subject,
+      body: options.body,
+      segment: options.segment ?? null,
+      sendAt: new Date(options.sendAt).toISOString(),
+    };
+    campaigns.push(item);
+    await writeCampaigns(shop, campaigns);
+    console.log(`Created campaign ${item.id}`);
+  });
+
+campaign
+  .command("list")
+  .argument("<shop>")
+  .action(async (shop) => {
+    const campaigns = await readCampaigns(shop);
+    console.log(JSON.stringify(campaigns, null, 2));
+  });
+
+campaign
+  .command("send")
+  .description("Send due campaigns")
+  .action(async () => {
+    await sendScheduledCampaigns();
+    console.log("Sent due campaigns");
+  });
+
+program.parseAsync(process.argv);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,9 @@ importers:
       '@sendgrid/mail':
         specifier: ^8.1.5
         version: 8.1.5
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
       nodemailer:
         specifier: ^6.10.1
         version: 6.10.1


### PR DESCRIPTION
## Summary
- add commander-based email campaign CLI
- document marketing automation usage

## Testing
- `pnpm exec jest packages/email/src/__tests__/*.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bbc62e2cc832f982cfe40ef813a12