### PR TITLE
test: add campaign integration tests

### DIFF
--- a/packages/email/src/__tests__/campaign-integration.test.ts
+++ b/packages/email/src/__tests__/campaign-integration.test.ts
@@ -1,0 +1,142 @@
+import { jest } from "@jest/globals";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+jest.mock("@platform-core/analytics", () => ({
+  __esModule: true,
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("@sendgrid/mail", () => ({
+  __esModule: true,
+  default: {
+    setApiKey: jest.fn(),
+    send: jest.fn(),
+  },
+}));
+
+const resendSendMock = jest.fn();
+jest.mock("resend", () => ({
+  __esModule: true,
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send: resendSendMock },
+  })),
+}));
+
+let trackEvent: jest.Mock;
+
+const shop = "intshop";
+const shopDir = path.join(DATA_ROOT, shop);
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  await fs.rm(shopDir, { recursive: true, force: true });
+  await fs.mkdir(shopDir, { recursive: true });
+  ({ trackEvent } = require("@platform-core/analytics"));
+  process.env.CART_COOKIE_SECRET = "secret";
+  process.env.CAMPAIGN_FROM = "campaign@example.com";
+  process.env.NEXT_PUBLIC_BASE_URL = "http://example.com";
+});
+
+afterEach(() => {
+  delete process.env.EMAIL_PROVIDER;
+  delete process.env.SENDGRID_API_KEY;
+  delete process.env.RESEND_API_KEY;
+  delete process.env.CAMPAIGN_FROM;
+  delete process.env.NEXT_PUBLIC_BASE_URL;
+});
+
+describe("campaign integration", () => {
+  test("creates and sends scheduled campaign via SendGrid with analytics sync", async () => {
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    process.env.SENDGRID_API_KEY = "sg";
+
+    await fs.writeFile(
+      path.join(shopDir, "analytics.jsonl"),
+      JSON.stringify({ type: "segment:vip", email: "a@example.com" }) + "\n" +
+        JSON.stringify({ type: "segment", segment: "vip", email: "b@example.com" }) +
+        "\n",
+      "utf8"
+    );
+    const past = new Date(Date.now() - 1000).toISOString();
+    const campaigns = [
+      {
+        id: "c1",
+        recipients: [],
+        subject: "Seg",
+        body: "<p>Seg</p>",
+        segment: "vip",
+        sendAt: past,
+      },
+    ];
+    await fs.writeFile(
+      path.join(shopDir, "campaigns.json"),
+      JSON.stringify(campaigns, null, 2),
+      "utf8"
+    );
+
+    const { sendScheduledCampaigns } = await import("../../../../functions/marketing-email-sender");
+    const sgMail = require("@sendgrid/mail").default;
+    await sendScheduledCampaigns();
+
+    expect(sgMail.send).toHaveBeenCalledTimes(2);
+    expect(sgMail.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "a@example.com", subject: "Seg" })
+    );
+    expect(sgMail.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "b@example.com", subject: "Seg" })
+    );
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+    expect(trackEvent).toHaveBeenCalledWith(shop, {
+      type: "email_sent",
+      campaign: "c1",
+    });
+    const updated = JSON.parse(
+      await fs.readFile(path.join(shopDir, "campaigns.json"), "utf8")
+    );
+    expect(updated[0].recipients.sort()).toEqual(
+      ["a@example.com", "b@example.com"].sort()
+    );
+    expect(updated[0].sentAt).toBeDefined();
+  });
+
+  test("creates and sends scheduled campaign via Resend with analytics sync", async () => {
+    process.env.EMAIL_PROVIDER = "resend";
+    process.env.RESEND_API_KEY = "rs";
+
+    await fs.writeFile(path.join(shopDir, "analytics.jsonl"), "", "utf8");
+    const past = new Date(Date.now() - 1000).toISOString();
+    const campaigns = [
+      {
+        id: "c2",
+        recipients: ["manual@example.com"],
+        subject: "Man",
+        body: "<p>Man</p>",
+        segment: null,
+        sendAt: past,
+      },
+    ];
+    await fs.writeFile(
+      path.join(shopDir, "campaigns.json"),
+      JSON.stringify(campaigns, null, 2),
+      "utf8"
+    );
+
+    const { sendScheduledCampaigns } = await import("../../../../functions/marketing-email-sender");
+    await sendScheduledCampaigns();
+
+    expect(resendSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "manual@example.com", subject: "Man" })
+    );
+    expect(trackEvent).toHaveBeenCalledWith(shop, {
+      type: "email_sent",
+      campaign: "c2",
+    });
+    const updated = JSON.parse(
+      await fs.readFile(path.join(shopDir, "campaigns.json"), "utf8")
+    );
+    expect(updated[0].sentAt).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests for campaign creation, scheduling, provider sending, and analytics sync
- mock SendGrid and Resend APIs to verify delivery and tracking

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/campaign-integration.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689bbc609d1c832fb9e80897fbe37125