### PR TITLE
feat(cms): support storefront role permissions

### DIFF
--- a/apps/cms/__tests__/rbacPermissions.integration.test.tsx
+++ b/apps/cms/__tests__/rbacPermissions.integration.test.tsx
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+
+process.env.STRIPE_SECRET_KEY = "sk_test_123";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_123";
+process.env.CART_COOKIE_SECRET = "test-secret";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+async function withRepo(cb: () => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "rbac-"));
+  await fs.mkdir(path.join(dir, "data"), { recursive: true });
+  const cwd = process.cwd();
+  process.chdir(dir);
+  jest.resetModules();
+  try {
+    await cb();
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+afterEach(() => jest.resetAllMocks());
+
+describe("PermissionsPage storefront roles", () => {
+  it("renders storefront roles", async () => {
+    await withRepo(async () => {
+      jest.doMock("next-auth", () => ({
+        getServerSession: jest
+          .fn()
+          .mockResolvedValue({ user: { role: "admin" } }),
+      }));
+      jest.doMock("next/navigation", () => ({ redirect: jest.fn() }));
+      jest.doMock(
+        "@/components/atoms/shadcn",
+        () => {
+          const React = require("react");
+          return {
+            __esModule: true,
+            Button: ({ children, ...props }: any) => (
+              <button {...props}>{children}</button>
+            ),
+          };
+        },
+        { virtual: true }
+      );
+
+      const { default: PermissionsPage } = await import(
+        "../src/app/cms/rbac/permissions/page"
+      );
+      const html = renderToStaticMarkup(await PermissionsPage());
+      expect(html).toContain("customer");
+      expect(html).toContain("viewer");
+    });
+  });
+
+  it("updates customer permissions", async () => {
+    await withRepo(async () => {
+      jest.doMock("next-auth", () => ({
+        getServerSession: jest
+          .fn()
+          .mockResolvedValue({ user: { role: "admin" } }),
+      }));
+      jest.doMock("next/navigation", () => ({ redirect: jest.fn() }));
+      jest.doMock(
+        "@/components/atoms/shadcn",
+        () => {
+          const React = require("react");
+          return {
+            __esModule: true,
+            Button: ({ children, ...props }: any) => (
+              <button {...props}>{children}</button>
+            ),
+          };
+        },
+        { virtual: true }
+      );
+
+      const { updateRolePermissions } = await import(
+        "../src/actions/rbac.server"
+      );
+      const { readRbac } = await import("../src/lib/rbacStore");
+
+      const form = new FormData();
+      form.append("role", "customer");
+      form.append("permissions", "view_products");
+
+      await updateRolePermissions(form);
+      const db = await readRbac();
+      expect(db.permissions.customer).toEqual(["view_products"]);
+    });
+  });
+});

--- a/apps/cms/src/app/cms/rbac/permissions/page.tsx
+++ b/apps/cms/src/app/cms/rbac/permissions/page.tsx
@@ -27,6 +27,7 @@ export default async function PermissionsPage() {
   const roles: Role[] = [
     "admin",
     "viewer",
+    "customer",
     "ShopAdmin",
     "CatalogManager",
     "ThemeEditor",

--- a/apps/cms/src/lib/rbacStore.ts
+++ b/apps/cms/src/lib/rbacStore.ts
@@ -77,7 +77,12 @@ export async function readRbac(): Promise<RbacDB> {
   try {
     const buf = await fs.readFile(FILE, "utf8");
     const parsed = JSON.parse(buf) as RbacDB;
-    if (parsed && parsed.users && parsed.roles && parsed.permissions) return parsed;
+    if (parsed && parsed.users && parsed.roles && parsed.permissions)
+      return {
+        ...DEFAULT_DB,
+        ...parsed,
+        permissions: { ...DEFAULT_DB.permissions, ...parsed.permissions },
+      };
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- allow editing storefront roles (customer, viewer) on permissions page
- merge default role permissions when reading RBAC store
- add integration tests for storefront role permission UI

## Testing
- `pnpm --filter cms test -- __tests__/rbacPermissions.integration.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bbc3ba5f0832f911eb916590f9fd7