### PR TITLE
feat(email): configurable abandoned cart delay

### DIFF
--- a/packages/email/src/__tests__/abandonedCart.test.ts
+++ b/packages/email/src/__tests__/abandonedCart.test.ts
@@ -1,4 +1,11 @@
-import { recoverAbandonedCarts, type AbandonedCart } from "../index";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import {
+  recoverAbandonedCarts,
+  resolveAbandonedCartDelay,
+} from "../abandonedCart";
+import type { AbandonedCart } from "../abandonedCart";
+import { DATA_ROOT } from "@platform-core/dataRoot";
 import { sendCampaignEmail } from "../send";
 
 jest.mock("../send", () => ({
@@ -45,5 +52,62 @@ describe("recoverAbandonedCarts", () => {
     expect(carts[0].reminded).toBe(true);
     expect(carts[1].reminded).toBeUndefined();
     expect(carts[2].reminded).toBe(true);
+  });
+
+  it("honors a custom delay", async () => {
+    const delay = 6 * 60 * 60 * 1000; // 6 hours
+    const now = Date.now();
+    const carts: AbandonedCart[] = [
+      {
+        email: "old@example.com",
+        cart: {},
+        updatedAt: now - delay - 1000,
+      },
+      {
+        email: "fresh@example.com",
+        cart: {},
+        updatedAt: now - delay + 1000,
+      },
+    ];
+
+    await recoverAbandonedCarts(carts, now, delay);
+
+    expect(sendCampaignEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendCampaignEmailMock).toHaveBeenCalledWith({
+      to: "old@example.com",
+      subject: "You left items in your cart",
+      html: "<p>You left items in your cart.</p>",
+    });
+    expect(carts[0].reminded).toBe(true);
+    expect(carts[1].reminded).toBeUndefined();
+  });
+});
+
+describe("resolveAbandonedCartDelay", () => {
+  const shop = "abandonedtest";
+  const shopDir = path.join(DATA_ROOT, shop);
+
+  beforeEach(async () => {
+    await fs.rm(shopDir, { recursive: true, force: true });
+    await fs.mkdir(shopDir, { recursive: true });
+    delete process.env[`ABANDONED_CART_DELAY_MS_${shop.toUpperCase()}`];
+    delete process.env.ABANDONED_CART_DELAY_MS;
+  });
+
+  it("reads delay from settings file", async () => {
+    await fs.writeFile(
+      path.join(shopDir, "settings.json"),
+      JSON.stringify({ abandonedCart: { delayMs: 12345 } }, null, 2),
+      "utf8",
+    );
+    const delay = await resolveAbandonedCartDelay(shop);
+    expect(delay).toBe(12345);
+  });
+
+  it("uses per-shop env override", async () => {
+    const key = `ABANDONED_CART_DELAY_MS_${shop.toUpperCase()}`;
+    process.env[key] = "54321";
+    const delay = await resolveAbandonedCartDelay(shop);
+    expect(delay).toBe(54321);
   });
 });

--- a/packages/email/src/abandonedCart.ts
+++ b/packages/email/src/abandonedCart.ts
@@ -1,4 +1,44 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import { sendCampaignEmail } from "./send";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+const DEFAULT_DELAY_MS = 1000 * 60 * 60 * 24;
+
+function envKey(shop: string): string {
+  return `ABANDONED_CART_DELAY_MS_${shop
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "_")}`;
+}
+
+/** Resolve reminder delay for a shop (default: one day). */
+export async function resolveAbandonedCartDelay(
+  shop: string,
+  dataRoot: string = DATA_ROOT,
+): Promise<number> {
+  let delay = DEFAULT_DELAY_MS;
+
+  try {
+    const file = path.join(dataRoot, shop, "settings.json");
+    const json = JSON.parse(await fs.readFile(file, "utf8"));
+    const cfg = json.abandonedCart?.delayMs ?? json.abandonedCartDelayMs;
+    if (typeof cfg === "number") delay = cfg;
+  } catch {}
+
+  const envDelay = process.env[envKey(shop)];
+  if (envDelay !== undefined) {
+    const num = Number(envDelay);
+    if (!Number.isNaN(num)) return num;
+  }
+
+  const globalEnv = process.env.ABANDONED_CART_DELAY_MS;
+  if (globalEnv !== undefined) {
+    const num = Number(globalEnv);
+    if (!Number.isNaN(num)) return num;
+  }
+
+  return delay;
+}
 
 export interface AbandonedCart {
   /** Customer's email address */
@@ -11,20 +51,19 @@ export interface AbandonedCart {
   reminded?: boolean;
 }
 
-const DAY_MS = 1000 * 60 * 60 * 24;
-
 /**
- * Send reminder emails for carts that have been inactive for at least a day.
+ * Send reminder emails for carts that have been inactive for at least a given delay.
  * Carts with `reminded` set to true are ignored. When an email is sent, the
  * record's `reminded` flag is set to true.
  */
 export async function recoverAbandonedCarts(
   carts: AbandonedCart[],
-  now: number = Date.now()
+  now: number = Date.now(),
+  delayMs: number = DEFAULT_DELAY_MS,
 ): Promise<void> {
   for (const record of carts) {
     if (record.reminded) continue;
-    if (now - record.updatedAt < DAY_MS) continue;
+    if (now - record.updatedAt < delayMs) continue;
 
     await sendCampaignEmail({
       to: record.email,

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,7 +1,7 @@
 export type { CampaignOptions } from "./send";
 export { sendCampaignEmail } from "./send";
 export type { AbandonedCart } from "./abandonedCart";
-export { recoverAbandonedCarts } from "./abandonedCart";
+export { recoverAbandonedCarts, resolveAbandonedCartDelay } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
 export { resolveSegment } from "./segments";
 export { sendScheduledCampaigns } from "./scheduler";


### PR DESCRIPTION
## Summary
- allow configuring abandoned cart reminder delay
- support per-shop delay via settings file or env vars
- test custom delays and overrides

## Testing
- `pnpm --filter "@acme/email" test -- packages/email/src/__tests__/abandonedCart.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bbd6a4778832fa978e36cf6c62373