### PR TITLE
feat(email): centralize marketing template rendering

### DIFF
--- a/packages/email/src/__tests__/abandonedCart.test.ts
+++ b/packages/email/src/__tests__/abandonedCart.test.ts
@@ -1,6 +1,15 @@
 import { recoverAbandonedCarts, type AbandonedCart } from "../index";
 import { sendCampaignEmail } from "../send";
 
+jest.mock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [],
+  }),
+  { virtual: true }
+);
+
 jest.mock("../send", () => ({
   __esModule: true,
   sendCampaignEmail: jest.fn().mockResolvedValue(undefined),

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -4,6 +4,15 @@ import { DATA_ROOT } from "@platform-core/dataRoot";
 
 process.env.CART_COOKIE_SECRET = "secret";
 
+jest.mock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [],
+  }),
+  { virtual: true }
+);
+
 jest.mock("../index", () => ({
   __esModule: true,
   sendCampaignEmail: jest.fn().mockResolvedValue(undefined),

--- a/packages/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/email/src/__tests__/sendCampaignEmail.test.ts
@@ -5,6 +5,15 @@ jest.mock("nodemailer", () => ({
   default: { createTransport: jest.fn() },
 }));
 
+jest.mock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [],
+  }),
+  { virtual: true }
+);
+
 jest.mock("../providers/sendgrid", () => ({
   SendgridProvider: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
 }));

--- a/packages/email/src/__tests__/templates.test.ts
+++ b/packages/email/src/__tests__/templates.test.ts
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+jest.mock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [
+      {
+        id: "basic",
+        name: "Basic",
+        render: ({ headline, content }: any) =>
+          React.createElement(
+            "div",
+            null,
+            React.createElement("h1", null, headline),
+            content
+          ),
+      },
+    ],
+  }),
+  { virtual: true }
+);
+
+describe("renderTemplate", () => {
+  it("returns original body when template not found", async () => {
+    const { renderTemplate } = await import("../templates");
+    const html = renderTemplate("missing", {
+      subject: "Hello",
+      body: "<p>Hi</p>",
+    });
+    expect(html).toBe("<p>Hi</p>");
+  });
+
+  it("renders template when found", async () => {
+    const { renderTemplate } = await import("../templates");
+    const html = renderTemplate("basic", {
+      subject: "Welcome",
+      body: "<p>Body</p>",
+    });
+    expect(html).toContain("<h1>Welcome</h1>");
+    expect(html).toContain("<p>Body</p>");
+  });
+});

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -5,3 +5,4 @@ export { recoverAbandonedCarts } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
 export { resolveSegment } from "./segments";
 export { sendScheduledCampaigns } from "./scheduler";
+export { renderTemplate } from "./templates";

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { marketingEmailTemplates } from "@acme/ui";
+
+interface RenderParams {
+  subject: string;
+  body: string;
+}
+
+/**
+ * Render a marketing email template by id. When no matching template is found,
+ * the raw body is returned unchanged.
+ */
+export function renderTemplate(
+  id: string | null | undefined,
+  params: RenderParams
+): string {
+  if (!id) return params.body;
+  const variant = marketingEmailTemplates.find((t) => t.id === id);
+  if (!variant) return params.body;
+  return renderToStaticMarkup(
+    variant.render({
+      headline: params.subject,
+      content: React.createElement("div", {
+        dangerouslySetInnerHTML: { __html: params.body },
+      }),
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- add email template renderer and expose via package
- refactor marketing email API and scheduler to reuse template renderer
- test template rendering scenarios

## Testing
- `pnpm exec jest packages/email/src/__tests__/templates.test.ts --runInBand`
- `pnpm test --filter @acme/email --filter @apps/cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*
- `pnpm exec jest packages/email/src/__tests__ --runInBand` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689bbd707ab0832f81c96cef9d96a597