### PR TITLE
Add cache-busting token to email tracking pixel

### DIFF
--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -8,6 +8,8 @@ const pixel = Buffer.from(
 );
 
 export async function GET(req: NextRequest) {
+  // ignore cache-busting token
+  req.nextUrl.searchParams.get("t");
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");
   if (shop && campaign) {

--- a/apps/cms/src/app/api/marketing/email/route.test.ts
+++ b/apps/cms/src/app/api/marketing/email/route.test.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { NextRequest } from "next/server";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+process.env.CART_COOKIE_SECRET = "secret";
+
+jest.mock("@acme/email", () => ({
+  __esModule: true,
+  sendCampaignEmail: jest.fn().mockResolvedValue(undefined),
+  resolveSegment: jest.fn(),
+}));
+
+jest.mock("@platform-core/analytics", () => ({
+  __esModule: true,
+  trackEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@acme/ui", () => ({ marketingEmailTemplates: [] }), { virtual: true });
+jest.mock("@acme/config", () => ({ env: { NEXT_PUBLIC_BASE_URL: "" } }), {
+  virtual: true,
+});
+
+const { sendCampaignEmail } = require("@acme/email");
+const sendCampaignEmailMock = sendCampaignEmail as jest.Mock;
+
+describe("POST /api/marketing/email", () => {
+  const shop = "routetest";
+  const shopDir = path.join(DATA_ROOT, shop);
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await fs.rm(shopDir, { recursive: true, force: true });
+    await fs.mkdir(shopDir, { recursive: true });
+    process.env.NEXT_PUBLIC_BASE_URL = "";
+  });
+
+  afterAll(async () => {
+    await fs.rm(shopDir, { recursive: true, force: true });
+  });
+
+  it("includes cache-busting token in pixel URL", async () => {
+    const req = new NextRequest("http://localhost/api/marketing/email", {
+      method: "POST",
+      body: JSON.stringify({
+        shop,
+        recipients: ["a@example.com"],
+        subject: "Sub",
+        body: "<p>Hi</p>",
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const { POST } = await import("./route");
+    await POST(req);
+
+    expect(sendCampaignEmailMock).toHaveBeenCalledTimes(1);
+    const args = sendCampaignEmailMock.mock.calls[0][0];
+    expect(args.html).toMatch(/open\?shop=.*&campaign=.*&t=\d+/);
+  });
+});
+

--- a/apps/cms/src/app/api/marketing/email/route.ts
+++ b/apps/cms/src/app/api/marketing/email/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const base = env.NEXT_PUBLIC_BASE_URL || "";
   const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
     shop
-  )}&campaign=${encodeURIComponent(id)}`;
+  )}&campaign=${encodeURIComponent(id)}&t=${Date.now()}`;
   let html = body;
   if (templateId) {
     const variant = marketingEmailTemplates.find((t) => t.id === templateId);

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -56,9 +56,10 @@ describe("sendScheduledCampaigns", () => {
     await sendScheduledCampaigns();
 
     expect(sendCampaignEmailMock).toHaveBeenCalledTimes(1);
-    expect(sendCampaignEmailMock).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "past@example.com", subject: "Past" })
-    );
+    const args = sendCampaignEmailMock.mock.calls[0][0];
+    expect(args.to).toBe("past@example.com");
+    expect(args.subject).toBe("Past");
+    expect(args.html).toMatch(/open\?shop=.*&campaign=.*&t=\d+/);
 
     const updated = JSON.parse(
       await fs.readFile(path.join(shopDir, "campaigns.json"), "utf8")

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -51,7 +51,7 @@ export async function sendScheduledCampaigns(): Promise<void> {
       const base = coreEnv.NEXT_PUBLIC_BASE_URL || "";
       const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
         shop
-      )}&campaign=${encodeURIComponent(c.id)}`;
+      )}&campaign=${encodeURIComponent(c.id)}&t=${Date.now()}`;
       const bodyWithPixel =
         c.body +
         `<img src="${pixelUrl}" alt="" style="display:none" width="1" height="1"/>`;


### PR DESCRIPTION
## Summary
- append timestamp query token to email tracking pixel URLs
- ignore cache-busting token in open tracking endpoint
- cover scheduler and API route with tests for tokenized pixel URLs

## Testing
- `npx jest packages/email/src/__tests__/scheduler.test.ts apps/cms/src/app/api/marketing/email/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bbd6cf4ec832f8a9ccd41e7bbbc32