### PR TITLE
Add HTML-to-text fallback for campaign emails

### DIFF
--- a/packages/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/email/src/__tests__/sendCampaignEmail.test.ts
@@ -1,5 +1,3 @@
-import nodemailer from "nodemailer";
-
 jest.mock("nodemailer", () => ({
   __esModule: true,
   default: { createTransport: jest.fn() },
@@ -12,8 +10,6 @@ jest.mock("../providers/sendgrid", () => ({
 jest.mock("../providers/resend", () => ({
   ResendProvider: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
 }));
-
-const createTransportMock = nodemailer.createTransport as jest.Mock;
 
 describe("sendCampaignEmail", () => {
   afterEach(() => {
@@ -28,12 +24,14 @@ describe("sendCampaignEmail", () => {
 
   it("uses SMTP_URL and CAMPAIGN_FROM env vars and forwards options", async () => {
     const sendMail = jest.fn().mockResolvedValue(undefined);
+    const nodemailerModule = await import("nodemailer");
+    const createTransportMock = nodemailerModule.default.createTransport as jest.Mock;
     createTransportMock.mockReturnValue({ sendMail });
 
     process.env.SMTP_URL = "smtp://test";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
@@ -51,6 +49,32 @@ describe("sendCampaignEmail", () => {
     });
   });
 
+  it("derives text from HTML when plain text is missing", async () => {
+    const sendMail = jest.fn().mockResolvedValue(undefined);
+    const nodemailerModule = await import("nodemailer");
+    (nodemailerModule.default.createTransport as jest.Mock).mockReturnValue({
+      sendMail,
+    });
+
+    process.env.SMTP_URL = "smtp://test";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+
+    const { sendCampaignEmail } = await import("../send");
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+    });
+
+    expect(sendMail).toHaveBeenCalledWith({
+      from: "campaign@example.com",
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      text: "HTML",
+    });
+  });
+
   it("delegates to SendgridProvider when EMAIL_PROVIDER=sendgrid", async () => {
     const send = jest.fn().mockResolvedValue(undefined);
     const { SendgridProvider } = require("../providers/sendgrid");
@@ -60,7 +84,7 @@ describe("sendCampaignEmail", () => {
     process.env.SENDGRID_API_KEY = "sg";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
@@ -72,6 +96,7 @@ describe("sendCampaignEmail", () => {
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
+      text: "HTML",
     });
   });
 
@@ -84,7 +109,7 @@ describe("sendCampaignEmail", () => {
     process.env.RESEND_API_KEY = "rs";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
@@ -96,6 +121,7 @@ describe("sendCampaignEmail", () => {
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
+      text: "HTML",
     });
   });
 });


### PR DESCRIPTION
## Summary
- derive missing plain text from HTML content before sending
- verify Sendgrid/Resend and SMTP flows always include text bodies

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendCampaignEmail.test.ts packages/email/src/__tests__/sendgrid.test.ts packages/email/src/__tests__/resend.test.ts packages/email/src/__tests__/sendEmail.test.ts packages/email/src/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bbd6994a8832f99c01d0d442d7a28