### PR TITLE
feat(email): add provider segmentation methods

### DIFF
--- a/packages/email/src/__tests__/providers.test.ts
+++ b/packages/email/src/__tests__/providers.test.ts
@@ -1,0 +1,100 @@
+jest.mock("resend", () => ({
+  Resend: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock("@sendgrid/mail", () => ({
+  __esModule: true,
+  default: { setApiKey: jest.fn(), send: jest.fn() },
+}));
+
+describe("Campaign providers segmentation", () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({}) })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.SENDGRID_API_KEY;
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("sendgrid segmentation methods call API", async () => {
+    process.env.SENDGRID_API_KEY = "sg";
+    const { SendgridProvider } = await import("../providers/sendgrid");
+    const provider = new SendgridProvider();
+
+    // createContact
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ persisted_recipients: ["c1"] }),
+    });
+    const id = await provider.createContact!("user@example.com");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.sendgrid.com/v3/marketing/contacts",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({ Authorization: "Bearer sg" }),
+      })
+    );
+    expect(id).toBe("c1");
+
+    // addToList
+    (fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+    await provider.addToList!("c1", "l1");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.sendgrid.com/v3/marketing/lists/l1/contacts",
+      expect.objectContaining({ method: "PUT" })
+    );
+
+    // listSegments
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ result: [{ id: "s1", name: "Seg" }] }),
+    });
+    const segs = await provider.listSegments!();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.sendgrid.com/v3/marketing/segments",
+      expect.any(Object)
+    );
+    expect(segs).toEqual([{ id: "s1", name: "Seg" }]);
+  });
+
+  it("resend segmentation methods call API", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+
+    // createContact
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ id: "c2" }),
+    });
+    const id = await provider.createContact!("user@example.com");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.resend.com/contacts",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(id).toBe("c2");
+
+    // addToList
+    (fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+    await provider.addToList!("c2", "l2");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.resend.com/segments/l2/contacts",
+      expect.objectContaining({ method: "POST" })
+    );
+
+    // listSegments
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: [{ id: "s2", name: "Seg2" }] }),
+    });
+    const segs = await provider.listSegments!();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.resend.com/segments",
+      expect.any(Object)
+    );
+    expect(segs).toEqual([{ id: "s2", name: "Seg2" }]);
+  });
+});
+

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -3,7 +3,7 @@ export { sendCampaignEmail } from "./send";
 export type { AbandonedCart } from "./abandonedCart";
 export { recoverAbandonedCarts } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
-export { resolveSegment } from "./segments";
+export { resolveSegment, createContact, addToList, listSegments } from "./segments";
 export {
   createCampaign,
   listCampaigns,

--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -41,4 +41,47 @@ export class ResendProvider implements CampaignProvider {
       return mapResendStats({});
     }
   }
+
+  async createContact(email: string): Promise<string> {
+    try {
+      const res = await fetch("https://api.resend.com/contacts", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${coreEnv.RESEND_API_KEY || ""}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+      const json = await res.json().catch(() => ({}));
+      return json?.id || "";
+    } catch {
+      return "";
+    }
+  }
+
+  async addToList(contactId: string, listId: string): Promise<void> {
+    await fetch(`https://api.resend.com/segments/${listId}/contacts`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${coreEnv.RESEND_API_KEY || ""}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ contact_id: contactId }),
+    }).catch(() => undefined);
+  }
+
+  async listSegments(): Promise<{ id: string; name?: string }[]> {
+    try {
+      const res = await fetch("https://api.resend.com/segments", {
+        headers: { Authorization: `Bearer ${coreEnv.RESEND_API_KEY || ""}` },
+      });
+      const json = await res.json().catch(() => ({}));
+      const segments = Array.isArray(json?.data ?? json?.segments)
+        ? json.data ?? json.segments
+        : [];
+      return segments.map((s: any) => ({ id: s.id, name: s.name }));
+    } catch {
+      return [];
+    }
+  }
 }

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -45,4 +45,49 @@ export class SendgridProvider implements CampaignProvider {
       return mapSendGridStats({});
     }
   }
+
+  async createContact(email: string): Promise<string> {
+    if (!coreEnv.SENDGRID_API_KEY) return "";
+    try {
+      const res = await fetch("https://api.sendgrid.com/v3/marketing/contacts", {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ contacts: [{ email }] }),
+      });
+      const json = await res.json().catch(() => ({}));
+      const ids = json?.persisted_recipients;
+      return Array.isArray(ids) ? ids[0] || "" : "";
+    } catch {
+      return "";
+    }
+  }
+
+  async addToList(contactId: string, listId: string): Promise<void> {
+    if (!coreEnv.SENDGRID_API_KEY) return;
+    await fetch(`https://api.sendgrid.com/v3/marketing/lists/${listId}/contacts`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ contact_ids: [contactId] }),
+    }).catch(() => undefined);
+  }
+
+  async listSegments(): Promise<{ id: string; name?: string }[]> {
+    if (!coreEnv.SENDGRID_API_KEY) return [];
+    try {
+      const res = await fetch("https://api.sendgrid.com/v3/marketing/segments", {
+        headers: { Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}` },
+      });
+      const json = await res.json().catch(() => ({}));
+      const segments = Array.isArray(json?.result) ? json.result : [];
+      return segments.map((s: any) => ({ id: s.id, name: s.name }));
+    } catch {
+      return [];
+    }
+  }
 }

--- a/packages/email/src/providers/types.ts
+++ b/packages/email/src/providers/types.ts
@@ -4,6 +4,19 @@ import type { CampaignStats } from "../analytics";
 export interface CampaignProvider {
   send(options: CampaignOptions): Promise<void>;
   getCampaignStats(campaignId: string): Promise<CampaignStats>;
+  /**
+   * Optionally create or upsert a contact with the given email address and
+   * return the provider-specific identifier for the contact.
+   */
+  createContact?(email: string): Promise<string>;
+  /**
+   * Optionally associate a contact with a list/segment on the provider.
+   */
+  addToList?(contactId: string, listId: string): Promise<void>;
+  /**
+   * Optionally list available segments from the provider.
+   */
+  listSegments?(): Promise<{ id: string; name?: string }[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add optional segmentation methods to campaign provider interface
- implement contact and segment operations for SendGrid and Resend providers
- expose segmentation helpers and tests

## Testing
- `pnpm --filter @acme/email test -- packages/email/src/__tests__/providers.test.ts packages/email/src/__tests__/sendgrid.test.ts packages/email/src/__tests__/resend.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cb8a0f3c4832faf0b3bf01ecd0785