### PR TITLE
feat(email): add analytics hooks

### DIFF
--- a/apps/cms/src/app/api/marketing/email/click/route.ts
+++ b/apps/cms/src/app/api/marketing/email/click/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { trackEvent } from "@platform-core/analytics";
+import { triggerClick } from "@acme/email";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");
   const url = req.nextUrl.searchParams.get("url") || "/";
   if (shop && campaign) {
-    await trackEvent(shop, { type: "email_click", campaign });
+    await triggerClick(shop, { campaign, url });
   }
   return NextResponse.redirect(url);
 }

--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { trackEvent } from "@platform-core/analytics";
+import { triggerOpen } from "@acme/email";
 
 // 1x1 transparent gif
 const pixel = Buffer.from(
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");
   if (shop && campaign) {
-    await trackEvent(shop, { type: "email_open", campaign });
+    await triggerOpen(shop, { campaign });
   }
   return new Response(pixel, {
     headers: {

--- a/apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts
+++ b/apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import crypto from "node:crypto";
 import { trackEvent } from "@platform-core/analytics";
 import { mapResendEvent } from "@acme/email/analytics";
+import { triggerOpen, triggerClick } from "@acme/email";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
@@ -26,7 +27,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
   const mapped = mapResendEvent(event);
   if (mapped) {
-    await trackEvent(shop, mapped);
+    if (mapped.type === "email_open") {
+      await triggerOpen(shop, {
+        campaign: mapped.campaign || "",
+        recipient: mapped.recipient,
+        messageId: mapped.messageId,
+      });
+    } else if (mapped.type === "email_click") {
+      await triggerClick(shop, {
+        campaign: mapped.campaign || "",
+        recipient: mapped.recipient,
+        messageId: mapped.messageId,
+      });
+    } else {
+      await trackEvent(shop, mapped);
+    }
   }
   return NextResponse.json({ ok: true });
 }

--- a/doc/marketing-automation.md
+++ b/doc/marketing-automation.md
@@ -1,0 +1,27 @@
+# Marketing Automation Hooks
+
+The email scheduler exposes lifecycle hooks that allow custom analytics or side
+effects when campaign emails are sent, opened or clicked. Register a listener
+with the `onSend`, `onOpen` or `onClick` functions exported from `@acme/email`:
+
+```ts
+import { onSend, onOpen, onClick } from "@acme/email";
+
+onSend((shop, event) => {
+  console.log("sent", shop, event.campaign);
+});
+
+onOpen((shop, event) => {
+  console.log("opened", shop, event.campaign);
+});
+
+onClick((shop, event) => {
+  console.log("clicked", shop, event.campaign, event.url);
+});
+```
+
+Listeners receive the shop and an event object containing the campaign id and
+additional details such as `url`, `recipient` or `messageId` when available.
+The package registers default listeners that record analytics via
+`trackEvent`; registering a listener lets consumers extend tracking without
+replacing the built‑in behavior.

--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -1,0 +1,69 @@
+import { trackEvent } from "@platform-core/analytics";
+
+export interface SendEvent {
+  campaign: string;
+  recipient?: string;
+}
+
+export interface OpenEvent {
+  campaign: string;
+  recipient?: string;
+  messageId?: string;
+}
+
+export interface ClickEvent {
+  campaign: string;
+  url?: string;
+  recipient?: string;
+  messageId?: string;
+}
+
+export type SendHook = (shop: string, ev: SendEvent) => Promise<void> | void;
+export type OpenHook = (shop: string, ev: OpenEvent) => Promise<void> | void;
+export type ClickHook = (shop: string, ev: ClickEvent) => Promise<void> | void;
+
+const sendHooks: SendHook[] = [];
+const openHooks: OpenHook[] = [];
+const clickHooks: ClickHook[] = [];
+
+export function onSend(h: SendHook): void {
+  sendHooks.push(h);
+}
+
+export function onOpen(h: OpenHook): void {
+  openHooks.push(h);
+}
+
+export function onClick(h: ClickHook): void {
+  clickHooks.push(h);
+}
+
+export async function triggerSend(shop: string, ev: SendEvent): Promise<void> {
+  for (const h of sendHooks) {
+    await h(shop, ev);
+  }
+}
+
+export async function triggerOpen(shop: string, ev: OpenEvent): Promise<void> {
+  for (const h of openHooks) {
+    await h(shop, ev);
+  }
+}
+
+export async function triggerClick(shop: string, ev: ClickEvent): Promise<void> {
+  for (const h of clickHooks) {
+    await h(shop, ev);
+  }
+}
+
+// default analytics listeners
+onSend((shop, ev) =>
+  trackEvent(shop, { ...ev, type: "email_sent" })
+);
+onOpen((shop, ev) =>
+  trackEvent(shop, { ...ev, type: "email_open" })
+);
+onClick((shop, ev) =>
+  trackEvent(shop, { ...ev, type: "email_click" })
+);
+

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -9,3 +9,11 @@ export {
   listCampaigns,
   sendDueCampaigns,
 } from "./scheduler";
+export {
+  onSend,
+  onOpen,
+  onClick,
+  triggerSend,
+  triggerOpen,
+  triggerClick,
+} from "./hooks";

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { sendCampaignEmail, resolveSegment } from "./index";
-import { trackEvent } from "@platform-core/analytics";
+import { triggerSend } from "./hooks";
 import { DATA_ROOT } from "@platform-core/dataRoot";
 import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
@@ -71,7 +71,7 @@ async function deliverCampaign(shop: string, c: Campaign): Promise<void> {
       subject: c.subject,
       html,
     });
-    await trackEvent(shop, { type: "email_sent", campaign: c.id });
+    await triggerSend(shop, { campaign: c.id });
   }
   c.sentAt = new Date().toISOString();
 }


### PR DESCRIPTION
## Summary
- add lifecycle hooks for marketing email events
- expose hook registration and trigger functions from `@acme/email`
- route open/click events through hooks and document usage

## Testing
- `pnpm test --filter @acme/email` *(fails: command exited with code 1)*
- `pnpm test --filter @apps/cms` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689cb84f08e4832f9f7c22f494c2e89a