### PR TITLE
feat(email): derive plaintext fallback

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -62,6 +62,18 @@ describe("sendCampaignEmail fallback and retry", () => {
     expect(sendgridSendMock).toHaveBeenCalledTimes(1);
     expect(resendSendMock).toHaveBeenCalledTimes(1);
     expect(sendMailMock).not.toHaveBeenCalled();
+    expect(sendgridSendMock).toHaveBeenCalledWith({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      text: "HTML",
+    });
+    expect(resendSendMock).toHaveBeenCalledWith({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      text: "HTML",
+    });
   });
 
   it("retries with exponential backoff on retryable error", async () => {
@@ -90,6 +102,8 @@ describe("sendCampaignEmail fallback and retry", () => {
     await promise;
 
     expect(sendgridSendMock).toHaveBeenCalledTimes(2);
+    expect(sendgridSendMock.mock.calls[0][0].text).toBe("HTML");
+    expect(sendgridSendMock.mock.calls[1][0].text).toBe("HTML");
     expect(resendSendMock).not.toHaveBeenCalled();
     timeoutSpy.mockRestore();
   });

--- a/packages/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/email/src/__tests__/sendCampaignEmail.test.ts
@@ -26,7 +26,7 @@ describe("sendCampaignEmail", () => {
     delete process.env.RESEND_API_KEY;
   });
 
-  it("uses SMTP_URL and CAMPAIGN_FROM env vars and forwards options", async () => {
+  it("uses SMTP_URL and CAMPAIGN_FROM env vars and derives text from HTML", async () => {
     const sendMail = jest.fn().mockResolvedValue(undefined);
     createTransportMock.mockReturnValue({ sendMail });
 
@@ -38,7 +38,6 @@ describe("sendCampaignEmail", () => {
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
-      text: "Text body",
     });
 
     expect(createTransportMock).toHaveBeenCalledWith({ url: "smtp://test" });
@@ -47,7 +46,7 @@ describe("sendCampaignEmail", () => {
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
-      text: "Text body",
+      text: "HTML",
     });
   });
 
@@ -72,6 +71,7 @@ describe("sendCampaignEmail", () => {
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
+      text: "HTML",
     });
   });
 
@@ -96,6 +96,7 @@ describe("sendCampaignEmail", () => {
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
+      text: "HTML",
     });
   });
 });


### PR DESCRIPTION
## Summary
- derive plain text from HTML in `sendCampaignEmail`
- ensure providers always include plaintext
- test fallback behavior

## Testing
- `pnpm --filter @acme/email test -- send.test.ts sendCampaignEmail.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689cb9608f74832f90d539894a403bc8