### PR TITLE
feat(email): cache segments with TTL

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, afterEach, jest } from '@jest/globals';
+
+describe('resolveSegment caching', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('uses cache within TTL', async () => {
+    const listEventsMock = jest.fn().mockResolvedValue([
+      { type: 'segment:promo', email: 'a@example.com' },
+    ]);
+    const statMock = jest.fn().mockResolvedValue({ mtimeMs: 1 });
+    jest.doMock('@platform-core/repositories/analytics.server', () => ({ listEvents: listEventsMock }));
+    jest.doMock('node:fs/promises', () => ({ stat: statMock }));
+    const { resolveSegment } = await import('../segments');
+    const first = await resolveSegment('shop', 'promo', 1000);
+    const second = await resolveSegment('shop', 'promo', 1000);
+    expect(first).toEqual(['a@example.com']);
+    expect(second).toEqual(['a@example.com']);
+    expect(listEventsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates cache when analytics file changes', async () => {
+    const listEventsMock = jest
+      .fn()
+      .mockResolvedValueOnce([{ type: 'segment:promo', email: 'a@example.com' }])
+      .mockResolvedValueOnce([
+        { type: 'segment:promo', email: 'a@example.com' },
+        { type: 'segment:promo', email: 'b@example.com' },
+      ]);
+    const statMock = jest
+      .fn()
+      .mockResolvedValueOnce({ mtimeMs: 1 })
+      .mockResolvedValueOnce({ mtimeMs: 2 });
+    jest.doMock('@platform-core/repositories/analytics.server', () => ({ listEvents: listEventsMock }));
+    jest.doMock('node:fs/promises', () => ({ stat: statMock }));
+    const { resolveSegment } = await import('../segments');
+    const first = await resolveSegment('shop', 'promo', 1000);
+    const second = await resolveSegment('shop', 'promo', 1000);
+    expect(first).toEqual(['a@example.com']);
+    expect(second).toEqual(['a@example.com', 'b@example.com']);
+    expect(listEventsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('expires cache after TTL', async () => {
+    jest.useFakeTimers();
+    const listEventsMock = jest.fn().mockResolvedValue([
+      { type: 'segment:promo', email: 'a@example.com' },
+    ]);
+    const statMock = jest.fn().mockResolvedValue({ mtimeMs: 1 });
+    jest.doMock('@platform-core/repositories/analytics.server', () => ({ listEvents: listEventsMock }));
+    jest.doMock('node:fs/promises', () => ({ stat: statMock }));
+    const { resolveSegment } = await import('../segments');
+    await resolveSegment('shop', 'promo', 50);
+    jest.advanceTimersByTime(60);
+    await resolveSegment('shop', 'promo', 50);
+    expect(listEventsMock).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+});

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -1,4 +1,21 @@
 import { listEvents } from "@platform-core/repositories/analytics.server";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { validateShopName } from "@platform-core/shops";
+import { stat } from "node:fs/promises";
+import * as path from "node:path";
+
+type CacheEntry = {
+  emails: string[];
+  expiresAt: number;
+  mtimeMs: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+function analyticsPath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "analytics.jsonl");
+}
 
 /**
  * Resolve a segment identifier to a list of customer email addresses.
@@ -10,8 +27,17 @@ import { listEvents } from "@platform-core/repositories/analytics.server";
  */
 export async function resolveSegment(
   shop: string,
-  id: string
+  id: string,
+  ttlMs = 60_000
 ): Promise<string[]> {
+  const key = `${shop}:${id}`;
+  const now = Date.now();
+  const { mtimeMs } = await stat(analyticsPath(shop)).catch(() => ({ mtimeMs: 0 }));
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > now && cached.mtimeMs === mtimeMs) {
+    return cached.emails;
+  }
+
   const events = await listEvents(shop);
   const emails = new Set<string>();
   for (const e of events) {
@@ -27,5 +53,7 @@ export async function resolveSegment(
       if (typeof email === "string") emails.add(email);
     }
   }
-  return Array.from(emails);
+  const result = Array.from(emails);
+  cache.set(key, { emails: result, expiresAt: now + ttlMs, mtimeMs });
+  return result;
 }


### PR DESCRIPTION
## Summary
- cache segment resolution with configurable TTL
- invalidate cache on new analytics events
- cover caching logic with unit tests

## Testing
- `pnpm --filter @acme/email test -- packages/email/src/__tests__/segments.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689bbd60aa90832f9abbcc345c1af9fa