### PR TITLE
feat(email): add campaign analytics sync

### DIFF
--- a/packages/email/src/__tests__/analytics.test.ts
+++ b/packages/email/src/__tests__/analytics.test.ts
@@ -1,0 +1,26 @@
+jest.mock("@platform-core/analytics", () => ({ trackEvent: jest.fn() }));
+
+import { trackEvent } from "@platform-core/analytics";
+import { syncCampaignStats } from "../analytics";
+import type { CampaignProvider } from "../providers/types";
+
+describe("syncCampaignStats", () => {
+  it("forwards stats to analytics provider", async () => {
+    const provider: CampaignProvider = {
+      send: jest.fn(),
+      getCampaignStats: jest.fn().mockResolvedValue([
+        { id: "cmp1", delivered: 10, opened: 5 },
+      ]),
+    };
+
+    await syncCampaignStats("shop1", provider);
+
+    expect(provider.getCampaignStats).toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledWith("shop1", {
+      type: "email_campaign_stats",
+      campaign: "cmp1",
+      delivered: 10,
+      opened: 5,
+    });
+  });
+});

--- a/packages/email/src/analytics.ts
+++ b/packages/email/src/analytics.ts
@@ -1,0 +1,34 @@
+import { coreEnv } from "@acme/config/env/core";
+import type { CampaignProvider, CampaignStat } from "./providers/types";
+import { ResendProvider } from "./providers/resend";
+import { SendgridProvider } from "./providers/sendgrid";
+
+function resolveProvider(override?: CampaignProvider): CampaignProvider | undefined {
+  if (override) return override;
+  const key = coreEnv.EMAIL_PROVIDER ?? "";
+  if (key === "sendgrid") return new SendgridProvider();
+  if (key === "resend") return new ResendProvider();
+  return undefined;
+}
+
+/**
+ * Fetch campaign stats from the selected provider and forward them to the
+ * platform analytics system.
+ */
+export async function syncCampaignStats(
+  shop: string,
+  override?: CampaignProvider,
+): Promise<void> {
+  const provider = resolveProvider(override);
+  if (!provider) return;
+  const { trackEvent } = await import("@platform-core/analytics");
+  const stats: CampaignStat[] = await provider.getCampaignStats();
+  for (const stat of stats) {
+    const { id, ...metrics } = stat;
+    await trackEvent(shop, {
+      type: "email_campaign_stats",
+      campaign: id,
+      ...metrics,
+    });
+  }
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -4,3 +4,5 @@ export type { AbandonedCart } from "./abandonedCart";
 export { recoverAbandonedCarts } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
 export { resolveSegment } from "./segments";
+export { syncCampaignStats } from "./analytics";
+export { scheduleAnalyticsSync } from "./scheduler";

--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -1,7 +1,7 @@
 import { Resend } from "resend";
 import { coreEnv } from "@acme/config/env/core";
 import type { CampaignOptions } from "../send";
-import type { CampaignProvider } from "./types";
+import type { CampaignProvider, CampaignStat } from "./types";
 
 export class ResendProvider implements CampaignProvider {
   private client: Resend;
@@ -18,5 +18,10 @@ export class ResendProvider implements CampaignProvider {
       html: options.html,
       text: options.text,
     });
+  }
+
+  async getCampaignStats(): Promise<CampaignStat[]> {
+    // Resend currently lacks a public stats API; return empty metrics.
+    return [];
   }
 }

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -1,7 +1,7 @@
 import sgMail from "@sendgrid/mail";
 import { coreEnv } from "@acme/config/env/core";
 import type { CampaignOptions } from "../send";
-import type { CampaignProvider } from "./types";
+import type { CampaignProvider, CampaignStat } from "./types";
 
 export class SendgridProvider implements CampaignProvider {
   constructor() {
@@ -18,5 +18,10 @@ export class SendgridProvider implements CampaignProvider {
       html: options.html,
       text: options.text,
     });
+  }
+
+  async getCampaignStats(): Promise<CampaignStat[]> {
+    // Sendgrid stats are not fetched in tests; return empty metrics.
+    return [];
   }
 }

--- a/packages/email/src/providers/types.ts
+++ b/packages/email/src/providers/types.ts
@@ -1,5 +1,13 @@
 import type { CampaignOptions } from "../send";
 
+export interface CampaignStat {
+  /** Identifier of the campaign */
+  id: string;
+  /** Additional metric fields provided by the vendor */
+  [key: string]: string | number;
+}
+
 export interface CampaignProvider {
   send(options: CampaignOptions): Promise<void>;
+  getCampaignStats(): Promise<CampaignStat[]>;
 }

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -1,0 +1,22 @@
+import { syncCampaignStats } from "./analytics";
+
+/**
+ * Starts a periodic job that syncs campaign analytics.
+ * @returns timer identifier that can be cleared to stop the job.
+ */
+export function scheduleAnalyticsSync(
+  shop: string,
+  intervalMs = 60 * 60 * 1000,
+): NodeJS.Timeout {
+  async function run(): Promise<void> {
+    try {
+      await syncCampaignStats(shop);
+    } catch (err) {
+      console.error("Analytics sync failed", err);
+    }
+  }
+
+  // run immediately then schedule
+  void run();
+  return setInterval(run, intervalMs);
+}


### PR DESCRIPTION
## Summary
- add campaign analytics interfaces and provider stubs
- implement analytics sync and scheduler
- cover campaign analytics with tests

## Testing
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__ --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689bbc5cf498832f8f67479fd72ce67d