### PR TITLE
feat(auth): expand granular permissions

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -44,6 +44,17 @@ if (!canWrite(session.user.role)) {
 }
 ```
 
+## Granular permissions
+
+In addition to the broad `read`/`write` flags, roles can have more specific permissions:
+
+- `view_orders` – view order history. Roles: `customer`, `admin`, `ShopAdmin`
+- `manage_orders` – create or modify orders. Roles: `admin`, `ShopAdmin`
+- `manage_sessions` – manage active user sessions. Roles: `admin`, `ShopAdmin`
+- `change_password` – change the user's password. Roles: `customer`, `admin`, `ShopAdmin`, `CatalogManager`, `ThemeEditor`
+
+Use `hasPermission(role, permission)` from `@acme/auth` to check them.
+
 ## Extending roles
 
 Roles and their permissions can be extended at runtime using `extendRoles` from `@acme/auth`.

--- a/packages/auth/__tests__/permissions.test.ts
+++ b/packages/auth/__tests__/permissions.test.ts
@@ -26,4 +26,16 @@ describe("hasPermission", () => {
   it("customer can checkout", () => {
     expect(hasPermission("customer", "checkout")).toBe(true);
   });
+
+  it("customer can view orders and change password but not manage orders or sessions", () => {
+    expect(hasPermission("customer", "view_orders")).toBe(true);
+    expect(hasPermission("customer", "change_password")).toBe(true);
+    expect(hasPermission("customer", "manage_orders")).toBe(false);
+    expect(hasPermission("customer", "manage_sessions")).toBe(false);
+  });
+
+  it("admin can manage orders and sessions", () => {
+    expect(hasPermission("admin", "manage_orders")).toBe(true);
+    expect(hasPermission("admin", "manage_sessions")).toBe(true);
+  });
 });

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -1,8 +1,45 @@
 {
   "viewer": ["view_products"],
-  "customer": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "admin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "ShopAdmin": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "CatalogManager": ["view_products", "add_to_cart", "checkout", "manage_profile"],
-  "ThemeEditor": ["view_products", "add_to_cart", "checkout", "manage_profile"]
+  "customer": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "view_orders",
+    "change_password"
+  ],
+  "admin": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "view_orders",
+    "manage_orders",
+    "manage_sessions",
+    "change_password"
+  ],
+  "ShopAdmin": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "view_orders",
+    "manage_orders",
+    "manage_sessions",
+    "change_password"
+  ],
+  "CatalogManager": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "change_password"
+  ],
+  "ThemeEditor": [
+    "view_products",
+    "add_to_cart",
+    "checkout",
+    "manage_profile",
+    "change_password"
+  ]
 }

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -4,8 +4,11 @@ import permissionsConfig from "./permissions.json";
 import type { Role } from "./types/roles";
 import type { Permission } from "./types/permissions";
 
-// Role to permission mapping loaded from configuration
-const ROLE_PERMISSIONS: Record<Role, Permission[]> = permissionsConfig as Record<Role, Permission[]>;
+// Role to permission mapping loaded from configuration.
+// Permissions include granular actions like "view_orders",
+// "manage_orders", "manage_sessions", and "change_password".
+const ROLE_PERMISSIONS: Record<Role, Permission[]> =
+  permissionsConfig as Record<Role, Permission[]>;
 
 export function hasPermission(role: Role, perm: Permission): boolean {
   return ROLE_PERMISSIONS[role]?.includes(perm) ?? false;


### PR DESCRIPTION
## Summary
- add view_orders, manage_orders, manage_sessions, and change_password permissions
- document new granular permissions and role assignments
- test role permission checks for new capabilities

## Testing
- `cd packages/auth && pnpm test __tests__/permissions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bbc3fbab0832f8e3730be0742ca47