### PR TITLE
feat(email): add provider mocks for tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -95,6 +95,10 @@ module.exports = {
     "^@platform-core/src/contexts/CurrencyContext$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
 
+    // email provider client mocks
+    "^resend$": "<rootDir>/packages/email/src/providers/__mocks__/resend.ts",
+    "^@sendgrid/mail$": "<rootDir>/packages/email/src/providers/__mocks__/@sendgrid/mail.ts",
+
     // component stubs – structure isn’t under test
     "^@ui/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@ui/atoms/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",

--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -1,10 +1,4 @@
-jest.mock("resend", () => ({
-  Resend: jest.fn(),
-}));
-
-const { Resend } = require("resend");
-const sendMock = jest.fn();
-(Resend as jest.Mock).mockImplementation(() => ({ emails: { send: sendMock } }));
+const { Resend, send } = require("resend");
 
 describe("ResendProvider", () => {
   afterEach(() => {
@@ -29,7 +23,7 @@ describe("ResendProvider", () => {
     });
 
     expect(Resend).toHaveBeenCalledWith("rs");
-    expect(sendMock).toHaveBeenCalledWith({
+    expect(send).toHaveBeenCalledWith({
       from: "campaign@example.com",
       to: "to@example.com",
       subject: "Subject",

--- a/packages/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/email/src/__tests__/sendCampaignEmail.test.ts
@@ -5,14 +5,6 @@ jest.mock("nodemailer", () => ({
   default: { createTransport: jest.fn() },
 }));
 
-jest.mock("../providers/sendgrid", () => ({
-  SendgridProvider: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
-}));
-
-jest.mock("../providers/resend", () => ({
-  ResendProvider: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
-}));
-
 const createTransportMock = nodemailer.createTransport as jest.Mock;
 
 describe("sendCampaignEmail", () => {
@@ -33,7 +25,7 @@ describe("sendCampaignEmail", () => {
     process.env.SMTP_URL = "smtp://test";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
@@ -52,47 +44,43 @@ describe("sendCampaignEmail", () => {
   });
 
   it("delegates to SendgridProvider when EMAIL_PROVIDER=sendgrid", async () => {
-    const send = jest.fn().mockResolvedValue(undefined);
-    const { SendgridProvider } = require("../providers/sendgrid");
-    (SendgridProvider as jest.Mock).mockImplementation(() => ({ send }));
-
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.SENDGRID_API_KEY = "sg";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
     });
 
-    expect(SendgridProvider).toHaveBeenCalled();
-    expect(send).toHaveBeenCalledWith({
+    const sgMail = require("@sendgrid/mail").default;
+    expect(sgMail.setApiKey).toHaveBeenCalledWith("sg");
+    expect(sgMail.send).toHaveBeenCalledWith({
       to: "to@example.com",
+      from: "campaign@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
     });
   });
 
   it("delegates to ResendProvider when EMAIL_PROVIDER=resend", async () => {
-    const send = jest.fn().mockResolvedValue(undefined);
-    const { ResendProvider } = require("../providers/resend");
-    (ResendProvider as jest.Mock).mockImplementation(() => ({ send }));
-
     process.env.EMAIL_PROVIDER = "resend";
     process.env.RESEND_API_KEY = "rs";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
     });
 
-    expect(ResendProvider).toHaveBeenCalled();
+    const { Resend, send } = require("resend");
+    expect(Resend).toHaveBeenCalledWith("rs");
     expect(send).toHaveBeenCalledWith({
+      from: "campaign@example.com",
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",

--- a/packages/email/src/__tests__/sendgrid.test.ts
+++ b/packages/email/src/__tests__/sendgrid.test.ts
@@ -1,11 +1,3 @@
-jest.mock("@sendgrid/mail", () => ({
-  __esModule: true,
-  default: {
-    setApiKey: jest.fn(),
-    send: jest.fn(),
-  },
-}));
-
 const sgMail = require("@sendgrid/mail").default;
 
 describe("SendgridProvider", () => {

--- a/packages/email/src/providers/__mocks__/@sendgrid/mail.ts
+++ b/packages/email/src/providers/__mocks__/@sendgrid/mail.ts
@@ -1,0 +1,4 @@
+export const setApiKey = jest.fn();
+export const send = jest.fn();
+
+export default { setApiKey, send };

--- a/packages/email/src/providers/__mocks__/resend.ts
+++ b/packages/email/src/providers/__mocks__/resend.ts
@@ -1,0 +1,5 @@
+export const send = jest.fn();
+
+export const Resend = jest.fn().mockImplementation(() => ({
+  emails: { send },
+}));


### PR DESCRIPTION
## Summary
- add jest mocks for Resend and Sendgrid provider clients
- map provider client mocks in Jest config
- simplify email provider tests to rely on automatic mocks

## Testing
- `pnpm exec jest packages/email/src/__tests__/resend.test.ts packages/email/src/__tests__/sendgrid.test.ts packages/email/src/__tests__/sendCampaignEmail.test.ts --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_689bbd65efe0832fa8b3b45b8fa961a4