### PR TITLE
feat(cms): validate sanity credentials via internal api

### DIFF
--- a/apps/cms/src/app/api/sanity/verify/route.ts
+++ b/apps/cms/src/app/api/sanity/verify/route.ts
@@ -1,0 +1,50 @@
+import { verifyCredentials } from "@acme/plugin-sanity";
+import { createClient } from "@sanity/client";
+
+interface VerifyRequest {
+  projectId: string;
+  dataset?: string;
+  token: string;
+}
+
+export async function POST(req: Request) {
+  const { projectId, dataset, token } = (await req.json()) as VerifyRequest;
+
+  if (!projectId || !token) {
+    return Response.json(
+      { ok: false, error: "Missing projectId or token", errorCode: "INVALID_CREDENTIALS" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const client = createClient({
+      projectId,
+      dataset: dataset || "production",
+      token,
+      apiVersion: "2023-01-01",
+      useCdn: false,
+    });
+
+    const list = await client.datasets.list();
+    const datasets = list.map((d) => d.name);
+
+    if (dataset) {
+      const valid = await verifyCredentials({ projectId, dataset, token });
+      if (!valid) {
+        return Response.json(
+          { ok: false, error: "Invalid Sanity credentials", errorCode: "INVALID_CREDENTIALS", datasets },
+          { status: 401 },
+        );
+      }
+    }
+
+    return Response.json({ ok: true, datasets });
+  } catch (err) {
+    return Response.json(
+      { ok: false, error: "Failed to list datasets", errorCode: "DATASET_LIST_ERROR" },
+      { status: 500 },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/sanity/verify` endpoint to validate Sanity credentials and list datasets
- update ConnectForm to use new endpoint and surface error codes for user feedback

## Testing
- `pnpm test` *(fails: command exited with error; see logs for missing environment configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bbbed2cc8832f85c7d5e0628cd37f