### PR TITLE
feat: forward client IP to Stripe via header

### DIFF
--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -46,7 +46,9 @@ function createRequest(
   } as any;
 }
 
-test("builds Stripe session with correct items and metadata", async () => {
+test(
+  "builds Stripe session with correct items and metadata and forwards IP",
+  async () => {
   jest.useFakeTimers().setSystemTime(new Date("2025-01-01T00:00:00Z"));
   stripeCreate.mockResolvedValue({
     id: "sess_test",
@@ -85,7 +87,7 @@ test("builds Stripe session with correct items and metadata", async () => {
   const body = await res.json();
 
   expect(stripeCreate).toHaveBeenCalled();
-  const args = stripeCreate.mock.calls[0][0];
+  const [args, options] = stripeCreate.mock.calls[0];
 
   expect(args.line_items).toHaveLength(2);
   expect(args.line_items).toHaveLength(2);
@@ -97,8 +99,7 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(
     args.payment_intent_data.payment_method_options.card.request_three_d_secure
   ).toBe("automatic");
-  expect(args.payment_intent_data.metadata.client_ip).toBe("203.0.113.1");
-  expect(args.metadata.client_ip).toBe("203.0.113.1");
+  expect(options.headers["Stripe-Client-IP"]).toBe("203.0.113.1");
   expect(args.metadata.rentalDays).toBe(expectedDays.toString());
   expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: size }));
   expect(args.metadata.subtotal).toBe("20");

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -204,7 +204,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       currency,
       taxRate: String(taxRate),
       taxAmount: String(taxAmount),
-      ...(clientIp ? { client_ip: clientIp } : {}),
     },
   } as any;
 
@@ -212,28 +211,30 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     (paymentIntentData as any).billing_details = billing_details;
   }
 
-  const session = await stripe.checkout.sessions.create({
-    mode: "payment",
-    customer,
-    line_items,
-    success_url: `${req.nextUrl.origin}/success`,
-    cancel_url: `${req.nextUrl.origin}/cancelled`,
-    payment_intent_data: paymentIntentData,
-    metadata: {
-      subtotal: String(subtotal),
-      depositTotal: String(depositTotal),
-      returnDate: returnDate ?? "",
-      rentalDays: String(rentalDays),
-      sizes: sizesMeta,
-      discount: String(discount),
-      coupon: couponDef?.code ?? "",
-      currency,
-      taxRate: String(taxRate),
-      taxAmount: String(taxAmount),
-      ...(clientIp ? { client_ip: clientIp } : {}),
+  const session = await stripe.checkout.sessions.create(
+    {
+      mode: "payment",
+      customer,
+      line_items,
+      success_url: `${req.nextUrl.origin}/success`,
+      cancel_url: `${req.nextUrl.origin}/cancelled`,
+      payment_intent_data: paymentIntentData,
+      metadata: {
+        subtotal: String(subtotal),
+        depositTotal: String(depositTotal),
+        returnDate: returnDate ?? "",
+        rentalDays: String(rentalDays),
+        sizes: sizesMeta,
+        discount: String(discount),
+        coupon: couponDef?.code ?? "",
+        currency,
+        taxRate: String(taxRate),
+        taxAmount: String(taxAmount),
+      },
+      expand: ["payment_intent"],
     },
-    expand: ["payment_intent"],
-  });
+    { headers: { "Stripe-Client-IP": clientIp } }
+  );
 
   /* 6  Return client credentials ----------------------------------- */
   const clientSecret =


### PR DESCRIPTION
## Summary
- forward client IP to Stripe via `Stripe-Client-IP` header when creating checkout sessions
- drop `client_ip` metadata now that IP is sent via header
- test forwarding of IP header in checkout session creation

## Testing
- `npx jest packages/template-app/__tests__/checkout-session.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bbbc5c80c832f91b80274f57cf136