### PR TITLE
feat(cms): display order risk metrics for manual review

### DIFF
--- a/apps/cms/src/app/cms/orders/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/orders/[shop]/page.tsx
@@ -1,5 +1,6 @@
 // apps/cms/src/app/cms/orders/[shop]/page.tsx
 import { readOrders, markReturned, markRefunded } from "@platform-core/orders";
+import type { RentalOrder } from "@acme/types";
 
 export default async function ShopOrdersPage({
   params,
@@ -7,7 +8,7 @@ export default async function ShopOrdersPage({
   params: { shop: string };
 }) {
   const shop = params.shop;
-  const orders = await readOrders(shop);
+  const orders: RentalOrder[] = await readOrders(shop);
 
   async function returnAction(formData: FormData) {
     "use server";
@@ -30,11 +31,28 @@ export default async function ShopOrdersPage({
       <h2 className="mb-4 text-xl font-semibold">Orders for {shop}</h2>
       <ul className="space-y-2">
         {orders.map((o) => (
-          <li key={o.id} className="space-y-2 rounded border p-4">
-            <div>Order: {o.id}</div>
+          <li
+            key={o.id}
+            className={`space-y-2 rounded border p-4 ${
+              o.flaggedForReview ? "border-red-500 bg-red-50" : ""
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <div>Order: {o.id}</div>
+              {o.flaggedForReview && (
+                <span className="rounded bg-red-100 px-2 py-1 text-xs font-semibold text-red-800">
+                  Flagged
+                </span>
+              )}
+            </div>
             {o.expectedReturnDate && (
               <div>Return: {o.expectedReturnDate}</div>
             )}
+            <div>Risk Level: {o.riskLevel ?? "Unknown"}</div>
+            <div>
+              Risk Score: {typeof o.riskScore === "number" ? o.riskScore : "N/A"}
+            </div>
+            <div>Flagged for Review: {o.flaggedForReview ? "Yes" : "No"}</div>
             <form action={returnAction}>
               <input type="hidden" name="sessionId" value={o.sessionId} />
               <button type="submit" className="text-sm text-primary underline">


### PR DESCRIPTION
## Summary
- show risk level, score, and flagged status on CMS order list
- highlight flagged orders with badge and red styling for quick review
- annotate orders with RentalOrder type to include risk fields

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689bbbc8f4c0832f8e4b9a99e11d263c