### PR TITLE
Validate rental and return API request bodies

### DIFF
--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -6,17 +6,19 @@ import {
   markReturned,
 } from "@platform-core/repositories/rentalOrders.server";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
+const ReturnSchema = z
+  .object({ sessionId: z.string(), damageFee: z.number().optional() })
+  .strict();
+
 export async function POST(req: NextRequest) {
-  const { sessionId, damageFee } = (await req.json()) as {
-    sessionId?: string;
-    damageFee?: number;
-  };
-  if (!sessionId) {
-    return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, ReturnSchema);
+  if (!parsed.success) return parsed.response;
+  const { sessionId, damageFee } = parsed.data;
 
   const order = await markReturned("abc", sessionId, damageFee);
   if (!order) {


### PR DESCRIPTION
## Summary
- validate rental create/update requests with Zod schemas
- validate return request bodies and handle invalid payloads

## Testing
- `pnpm exec eslint apps/shop-abc/src/app/api/rental/route.ts apps/shop-abc/src/app/api/return/route.ts`
- `pnpm test --filter @apps/shop-abc`


------
https://chatgpt.com/codex/tasks/task_e_689bbbd32214832fb7690dbce1d0a703