### PR TITLE
feat(cms): add token color swatches and reset link

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -12,6 +12,20 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+const HEX_RE = /^#(?:[0-9a-fA-F]{3}){1,2}$/;
+const HSL_RE =
+  /^\d+(?:\.\d+)?\s+\d+(?:\.\d+)?%\s+\d+(?:\.\d+)?%$/;
+
+function isColor(value: string) {
+  return HEX_RE.test(value) || HSL_RE.test(value);
+}
+
+function swatchStyle(value: string) {
+  return {
+    backgroundColor: HSL_RE.test(value) ? `hsl(${value})` : value,
+  } as const;
+}
+
 const ShopEditor = dynamic(() => import("./ShopEditor"));
 void ShopEditor;
 const CurrencyTaxEditor = dynamic(() => import("./CurrencyTaxEditor"));
@@ -75,8 +89,32 @@ export default async function SettingsPage({
               return (
                 <tr key={k} className={changed ? "bg-yellow-50" : undefined}>
                   <td className="pr-4 font-mono">{k}</td>
-                  <td className="pr-4 font-mono">{defaultTokens[k]}</td>
-                  <td className="pr-4 font-mono">{override ?? ""}</td>
+                  <td className="pr-4 font-mono">
+                    {defaultTokens[k]}
+                    {isColor(defaultTokens[k]) && (
+                      <span
+                        className="ml-2 inline-block h-4 w-4 rounded border align-middle"
+                        style={swatchStyle(defaultTokens[k])}
+                      />
+                    )}
+                  </td>
+                  <td className="pr-4 font-mono">
+                    {override ?? ""}
+                    {override && isColor(override) && (
+                      <span
+                        className="ml-2 inline-block h-4 w-4 rounded border align-middle"
+                        style={swatchStyle(override)}
+                      />
+                    )}
+                    {changed && (
+                      <Link
+                        href={`/cms/shop/${shop}/themes#${k}`}
+                        className="ml-2 text-xs text-primary underline"
+                      >
+                        reset override
+                      </Link>
+                    )}
+                  </td>
                 </tr>
               );
             })}


### PR DESCRIPTION
## Summary
- show color swatches for theme token defaults and overrides when values are HSL or hex
- link to theme editor to reset individual token overrides

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689bbbe108f0832fbe83d5fe149db901