### PR TITLE
feat: extend blog post schema

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -58,6 +58,9 @@ interface SanityPost {
   publishedAt?: string;
   slug?: string;
   excerpt?: string;
+  mainImage?: string;
+  author?: string;
+  categories?: string[];
 }
 async function getConfig(shopId: string): Promise<SanityConfig> {
   const shop = await getShopById(shopId);
@@ -73,7 +76,7 @@ export async function getPosts(shopId: string): Promise<SanityPost[]> {
   const config = await getConfig(shopId);
   const posts = await query<SanityPost[]>(
     config,
-    '*[_type=="post"]{_id,title,body,published,publishedAt,"slug":slug.current,excerpt}',
+    '*[_type=="post"]{_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories}',
   );
   return posts ?? [];
 }
@@ -86,7 +89,7 @@ export async function getPost(
   const config = await getConfig(shopId);
   const post = await query<SanityPost | null>(
     config,
-    `*[_type=="post" && _id=="${id}"][0]{_id,title,body,published,publishedAt,"slug":slug.current,excerpt}`,
+    `*[_type=="post" && _id=="${id}"][0]{_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories}`,
   );
   return post ?? null;
 }
@@ -114,6 +117,13 @@ export async function createPost(
   products = existingSlugs;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
+  const mainImage = String(formData.get("mainImage") ?? "");
+  const author = String(formData.get("author") ?? "");
+  const categoriesInput = String(formData.get("categories") ?? "");
+  const categories = categoriesInput
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
   const publishedAtInput = formData.get("publishedAt");
   const publishedAt = publishedAtInput
     ? new Date(String(publishedAtInput)).toISOString()
@@ -133,6 +143,9 @@ export async function createPost(
             published: false,
             slug: slug ? { current: slug } : undefined,
             excerpt: excerpt || undefined,
+            mainImage: mainImage || undefined,
+            author: author || undefined,
+            ...(categories.length ? { categories } : {}),
             ...(publishedAt ? { publishedAt } : {}),
           },
         },
@@ -171,6 +184,13 @@ export async function updatePost(
   products = existingSlugs;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
+  const mainImage = String(formData.get("mainImage") ?? "");
+  const author = String(formData.get("author") ?? "");
+  const categoriesInput = String(formData.get("categories") ?? "");
+  const categories = categoriesInput
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
   const publishedAtInput = formData.get("publishedAt");
   const publishedAt = publishedAtInput
     ? new Date(String(publishedAtInput)).toISOString()
@@ -190,6 +210,9 @@ export async function updatePost(
               products,
               slug: slug ? { current: slug } : undefined,
               excerpt: excerpt || undefined,
+              mainImage: mainImage || undefined,
+              author: author || undefined,
+              ...(categories.length ? { categories } : {}),
               ...(publishedAt ? { publishedAt } : {}),
             },
           },

--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -102,6 +102,14 @@ export async function setupSanityBlog(
                   { name: "title", type: "string", title: "Title" },
                   { name: "slug", type: "slug", title: "Slug", options: { source: "title" } },
                   { name: "excerpt", type: "text", title: "Excerpt" },
+                  { name: "mainImage", type: "string", title: "Main Image URL" },
+                  { name: "author", type: "string", title: "Author" },
+                  {
+                    name: "categories",
+                    type: "array",
+                    title: "Categories",
+                    of: [{ type: "string" }],
+                  },
                   {
                     name: "body",
                     title: "Body",

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -36,6 +36,9 @@ interface Props {
     slug?: string;
     excerpt?: string;
     publishedAt?: string;
+    mainImage?: string;
+    author?: string;
+    categories?: string[];
   };
 }
 
@@ -416,6 +419,21 @@ export default function PostForm({ action, submitLabel, post }: Props) {
           </div>
         </div>
         <Textarea name="excerpt" label="Excerpt" defaultValue={post?.excerpt ?? ""} />
+        <Input
+          name="mainImage"
+          label="Main image URL"
+          defaultValue={post?.mainImage ?? ""}
+        />
+        <Input
+          name="author"
+          label="Author"
+          defaultValue={post?.author ?? ""}
+        />
+        <Input
+          name="categories"
+          label="Categories (comma separated)"
+          defaultValue={(post?.categories ?? []).join(", ")}
+        />
         <Input
           type="datetime-local"
           name="publishedAt"

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -14,6 +14,9 @@ export interface BlogPost {
   slug: string;
   excerpt?: string;
   body?: (unknown | ProductBlock)[];
+  mainImage?: string;
+  author?: string;
+  categories?: string[];
 }
 
 export async function getConfig(shopId: string): Promise<SanityBlogConfig> {
@@ -39,7 +42,7 @@ async function getClient(shopId: string) {
 export async function fetchPublishedPosts(shopId: string): Promise<BlogPost[]> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && defined(slug.current) && published == true && !(_id in path('drafts.**'))]{title, "slug": slug.current, excerpt}`;
+    const query = `*[_type == "post" && defined(slug.current) && published == true && !(_id in path('drafts.**'))]{title, "slug": slug.current, excerpt, mainImage, author, categories}`;
     const posts = await client.fetch<BlogPost[]>(query);
     return posts;
   } catch {
@@ -53,7 +56,7 @@ export async function fetchPostBySlug(
 ): Promise<BlogPost | null> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, body[]{..., _type == "productReference" => { _type, slug }}}`;
+    const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, mainImage, author, categories, body[]{..., _type == "productReference" => { _type, slug }}}`;
     const post = await client.fetch<BlogPost | null>(query, { slug });
     return post;
   } catch {


### PR DESCRIPTION
## Summary
- add mainImage, author and categories fields to Sanity blog schema
- plumb new fields through fetch helpers and CMS post form

## Testing
- `npx jest packages/sanity/src/__tests__/sanity.test.ts --runInBand`
- `pnpm lint --filter @acme/sanity --filter @apps/cms` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689bbbf31cbc832f8992b11dc3eac129