### PR TITLE
feat(email): add batching with delay

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -23,6 +23,8 @@ export const coreEnvSchema = z.object({
   EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).optional(),
   SENDGRID_API_KEY: z.string().optional(),
   RESEND_API_KEY: z.string().optional(),
+  EMAIL_BATCH_SIZE: z.coerce.number().optional(),
+  EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),
   DATABASE_URL: z.string().optional(),
   SANITY_API_VERSION: z.string().optional(),
   CLOUDFLARE_ACCOUNT_ID: z.string().optional(),


### PR DESCRIPTION
## Summary
- batch campaign emails and delay between chunks
- make batch size and delay configurable via env vars
- test scheduler with large recipient set

## Testing
- `pnpm exec jest packages/email/src/__tests__/scheduler.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689cbfcac238832f9b178f16a22c49fc