### PR TITLE
feat: use parseJsonBody in API routes

### DIFF
--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "@platform-core/src/shops";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 /**
  * POST /cms/api/configurator/init-shop
@@ -46,11 +47,8 @@ export async function POST(req: Request) {
       })
       .strict();
 
-    const parsed = schema.safeParse(await req.json());
-    if (!parsed.success) {
-      const message = parsed.error.issues.map((i) => i.message).join(", ");
-      return NextResponse.json({ error: message }, { status: 400 });
-    }
+    const parsed = await parseJsonBody(req, schema);
+    if (!parsed.success) return parsed.response;
 
     const { id, csv, categories } = parsed.data;
     const dir = path.join(resolveDataRoot(), id);

--- a/apps/cms/src/app/api/data/[shop]/inventory/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { inventoryItemSchema } from "@acme/types";
 import { writeInventory } from "@platform-core/repositories/inventory.server";
+import { parseJsonBody } from "@shared-utils";
 
 export async function POST(
   req: NextRequest,
@@ -12,15 +13,9 @@ export async function POST(
   if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
+  const parsed = await parseJsonBody(req, inventoryItemSchema.array());
+  if (!parsed.success) return parsed.response;
   try {
-    const body = await req.json();
-    const parsed = inventoryItemSchema.array().safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error.flatten().formErrors.join(", ") },
-        { status: 400 }
-      );
-    }
     const { shop } = await context.params;
     await writeInventory(shop, parsed.data);
     return NextResponse.json({ success: true });

--- a/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { returnLogisticsSchema } from "@acme/types";
 import { writeReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
+import { parseJsonBody } from "@shared-utils";
 
 export async function POST(
   req: NextRequest,
@@ -12,15 +13,9 @@ export async function POST(
   if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
+  const parsed = await parseJsonBody(req, returnLogisticsSchema);
+  if (!parsed.success) return parsed.response;
   try {
-    const body = await req.json();
-    const parsed = returnLogisticsSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error.flatten().formErrors.join(", ") },
-        { status: 400 }
-      );
-    }
     await writeReturnLogistics(parsed.data);
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { z } from "zod";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { setupSanityBlog } from "@cms/actions/setupSanityBlog";
+import { parseJsonBody } from "@shared-utils";
 
 const schema = z.record(z.string(), z.string());
 
@@ -19,12 +20,9 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const body = schema.safeParse(await req.json());
+    const body = await parseJsonBody(req, schema);
     if (!body.success) {
-      return NextResponse.json(
-        { error: body.error.message },
-        { status: 400 }
-      );
+      return body.response;
     }
     const { shopId } = await context.params;
     const dir = path.join(resolveDataRoot(), shopId);

--- a/apps/cms/src/app/api/providers/shop/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/shop/[shop]/route.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 const schema = z
   .object({
@@ -22,12 +23,9 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const parsed = schema.safeParse(await req.json());
+    const parsed = await parseJsonBody(req, schema);
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error.message },
-        { status: 400 }
-      );
+      return parsed.response;
     }
     const { shop } = await context.params;
     const dir = path.join(resolveDataRoot(), shop);

--- a/apps/cms/src/app/api/wizard-progress/route.ts
+++ b/apps/cms/src/app/api/wizard-progress/route.ts
@@ -11,6 +11,7 @@ import {
   type StepStatus,
 } from "@cms/app/cms/wizard/schema";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 interface UserRecord {
   state: unknown;
@@ -90,12 +91,9 @@ export async function PUT(req: Request): Promise<NextResponse> {
   if (!session || !session.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  const parsed = await parseJsonBody(req, putBodySchema);
+  if (!parsed.success) return parsed.response;
   try {
-    const body = await req.json().catch(() => ({}));
-    const parsed = putBodySchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
-    }
     const { stepId, data, completed } = parsed.data;
     const db = await readDb();
     let record: UserRecord = { state: {}, completed: {} };
@@ -132,12 +130,9 @@ export async function PATCH(req: Request): Promise<NextResponse> {
   if (!session || !session.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  const parsed = await parseJsonBody(req, patchBodySchema);
+  if (!parsed.success) return parsed.response;
   try {
-    const body = await req.json().catch(() => ({}));
-    const parsed = patchBodySchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
-    }
     const { stepId, completed } = parsed.data;
     const db = await readDb();
     let record: UserRecord = { state: {}, completed: {} };

--- a/apps/shop-abc/src/app/api/account/change-password/route.ts
+++ b/apps/shop-abc/src/app/api/account/change-password/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 import bcrypt from "bcryptjs";
 import { getCustomerSession, hasPermission, validateCsrfToken } from "@auth";
 import { getUserById, updatePassword } from "@acme/platform-core/users";
@@ -34,11 +35,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
-  const json = await req.json();
-  const parsed = ChangePasswordSchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, ChangePasswordSchema);
+  if (!parsed.success) return parsed.response;
 
   const { currentPassword, newPassword } = parsed.data;
   const user = await getUserById(session.customerId);

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -7,6 +7,7 @@ import {
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -53,11 +54,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
   try {
     await updateCustomerProfile(session.customerId, parsed.data);
   } catch (err) {

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -20,6 +20,7 @@ import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { z } from "zod";
 import { shippingSchema, billingSchema } from "@acme/types";
+import { parseJsonBody } from "@shared-utils";
 
 /* ------------------------------------------------------------------ *
  *  Types
@@ -139,13 +140,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   /* 2️⃣ Parse optional body ------------------------------------------------- */
-  const parsed = schema.safeParse(await req.json().catch(() => undefined));
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten().fieldErrors },
-      { status: 400 }
-    );
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   const {
     returnDate,

--- a/apps/shop-abc/src/app/api/mfa/verify/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/verify/route.ts
@@ -1,6 +1,7 @@
 // apps/shop-abc/src/app/api/mfa/verify/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 import {
   createCustomerSession,
   getCustomerSession,
@@ -25,9 +26,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!valid)
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
 
-  const parsed = schema.safeParse(await req.json());
-  if (!parsed.success)
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
   const { token, customerId } = parsed.data;
   if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });
 

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -7,6 +7,7 @@ import {
   getUserById,
   getUserByEmail,
 } from "@acme/platform-core/users";
+import { parseJsonBody } from "@shared-utils";
 
 const RegisterSchema = z
   .object({
@@ -17,13 +18,8 @@ const RegisterSchema = z
   .strict();
 
 export async function POST(req: Request) {
-  const json = await req.json();
-  const parsed = RegisterSchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, {
-      status: 400,
-    });
-  }
+  const parsed = await parseJsonBody(req, RegisterSchema);
+  if (!parsed.success) return parsed.response;
 
   const { customerId, email, password } = parsed.data;
   if (await getUserById(customerId)) {

--- a/apps/shop-abc/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-abc/src/app/api/shipping-rate/route.ts
@@ -3,6 +3,7 @@ import { getShippingRate } from "@acme/platform-core/shipping";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const rate = await getShippingRate(parsed.data);

--- a/apps/shop-abc/src/app/api/tax/route.ts
+++ b/apps/shop-abc/src/app/api/tax/route.ts
@@ -3,6 +3,7 @@ import { calculateTax } from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const tax = await calculateTax(parsed.data);

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -7,6 +7,7 @@ import {
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -37,11 +38,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   await updateCustomerProfile(session.customerId, parsed.data);
   const profile = await getCustomerProfile(session.customerId);

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -3,6 +3,7 @@ import { getShippingRate } from "@acme/platform-core/shipping";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const rate = await getShippingRate(parsed.data);

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -3,6 +3,7 @@ import { calculateTax } from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const tax = await calculateTax(parsed.data);


### PR DESCRIPTION
## Summary
- use `parseJsonBody` for JSON validation in shop and CMS API routes
- standardize error responses across endpoints

## Testing
- `pnpm test` *(fails: @acme/next-config tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cc11286f0832f9497e90bc43785f8