### PR TITLE
feat(email): centralize marketing template rendering

### DIFF
--- a/apps/cms/src/app/api/marketing/email/route.ts
+++ b/apps/cms/src/app/api/marketing/email/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-import { createCampaign, listCampaigns } from "@acme/email";
+import { createCampaign, listCampaigns, renderTemplate } from "@acme/email";
 import { listEvents } from "@platform-core/repositories/analytics.server";
-import { marketingEmailTemplates } from "@acme/ui";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
@@ -50,20 +47,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!shop || !subject || !body || (list.length === 0 && !segment)) {
     return NextResponse.json({ error: "Missing fields" }, { status: 400 });
   }
-  let html = body;
-  if (templateId) {
-    const variant = marketingEmailTemplates.find((t) => t.id === templateId);
-    if (variant) {
-      html = renderToStaticMarkup(
-        variant.render({
-          headline: subject,
-          content: React.createElement("div", {
-            dangerouslySetInnerHTML: { __html: body },
-          }),
-        })
-      );
-    }
-  }
+  const html = templateId
+    ? renderTemplate(templateId, { subject, body })
+    : body;
   try {
     const id = await createCampaign({
       shop,

--- a/packages/email/src/__tests__/templates.test.ts
+++ b/packages/email/src/__tests__/templates.test.ts
@@ -1,0 +1,37 @@
+import { renderTemplate } from "../templates";
+
+jest.mock(
+  "@acme/ui",
+  () => {
+    const React = require("react");
+    return {
+      __esModule: true,
+      marketingEmailTemplates: [
+        {
+          id: "basic",
+          name: "Basic",
+          render: ({ headline, content }: any) =>
+            React.createElement("div", null, [
+              React.createElement("h1", { key: "h" }, headline),
+              React.createElement("div", { key: "c" }, content),
+            ]),
+        },
+      ],
+    };
+  },
+  { virtual: true }
+);
+
+describe("renderTemplate", () => {
+  it("renders known template", () => {
+    const html = renderTemplate("basic", { subject: "Hi", body: "<p>Body</p>" });
+    expect(html).toContain("<!--template:basic-->");
+    expect(html).toContain("<h1>Hi</h1>");
+    expect(html).toContain("<p>Body</p>");
+  });
+
+  it("returns body when template missing", () => {
+    const html = renderTemplate("missing", { subject: "Hi", body: "<p>Body</p>" });
+    expect(html).toBe("<p>Body</p>");
+  });
+});

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -11,3 +11,5 @@ export {
 } from "./scheduler";
 export { setCampaignStore, fsCampaignStore } from "./storage";
 export type { CampaignStore, Campaign } from "./storage";
+export { renderTemplate } from "./templates";
+export type { TemplateParams } from "./templates";

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -1,4 +1,5 @@
 import { sendCampaignEmail } from "./send";
+import { renderTemplate } from "./templates";
 import { resolveSegment } from "./segments";
 import { trackEvent } from "@platform-core/analytics";
 import { coreEnv } from "@acme/config/env/core";
@@ -25,7 +26,14 @@ function trackedBody(shop: string, id: string, body: string): string {
 
 async function deliverCampaign(shop: string, c: Campaign): Promise<void> {
   shop = validateShopName(shop);
-  const html = trackedBody(shop, c.id, c.body);
+  let rendered = c.body;
+  if (c.templateId && !c.body.startsWith("<!--template:")) {
+    rendered = renderTemplate(c.templateId, {
+      subject: c.subject,
+      body: c.body,
+    });
+  }
+  const html = trackedBody(shop, c.id, rendered);
   let recipients = c.recipients;
   if (c.segment) {
     recipients = await resolveSegment(shop, c.segment);

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { marketingEmailTemplates } from "@acme/ui";
+
+export interface TemplateParams {
+  subject: string;
+  body: string;
+  logoSrc?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  footer?: string;
+}
+
+/**
+ * Render a marketing email template by id. If the template id is not found,
+ * the original body string is returned. A marker comment is prefixed to the
+ * returned HTML so that callers can detect if rendering has already been
+ * applied.
+ */
+export function renderTemplate(id: string, params: TemplateParams): string {
+  const variant = marketingEmailTemplates.find((t) => t.id === id);
+  if (!variant) return params.body;
+  const { subject, body, ...rest } = params;
+  const html = renderToStaticMarkup(
+    variant.render({
+      headline: subject,
+      content: React.createElement("div", {
+        dangerouslySetInnerHTML: { __html: body },
+      }),
+      ...rest,
+    })
+  );
+  return `<!--template:${id}-->${html}`;
+}


### PR DESCRIPTION
## Summary
- add `renderTemplate` helper for marketing email templates
- reuse template renderer in email scheduler
- refactor marketing email API route to use shared renderer
- add tests for template rendering

## Testing
- `pnpm exec jest src/__tests__/templates.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689cbe802dec832f8312121d5a027ba4