### PR TITLE
feat(auth): add requirePermission helper

### DIFF
--- a/packages/auth/__tests__/requirePermission.test.ts
+++ b/packages/auth/__tests__/requirePermission.test.ts
@@ -1,0 +1,30 @@
+import { requirePermission } from "../src/requirePermission";
+import { getCustomerSession } from "../src/session";
+import type { Role } from "../src/types";
+
+jest.mock("../src/session", () => ({
+  getCustomerSession: jest.fn(),
+}));
+
+const mockedGetSession = getCustomerSession as jest.Mock;
+
+describe("requirePermission", () => {
+  beforeEach(() => {
+    mockedGetSession.mockReset();
+  });
+
+  it("rejects when session is missing", async () => {
+    mockedGetSession.mockResolvedValue(null);
+    await expect(requirePermission("checkout")).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects when role lacks permission", async () => {
+    mockedGetSession.mockResolvedValue({ customerId: "1", role: "viewer" as Role });
+    await expect(requirePermission("checkout")).rejects.toThrow("Unauthorized");
+  });
+
+  it("allows when role has permission", async () => {
+    mockedGetSession.mockResolvedValue({ customerId: "1", role: "customer" as Role });
+    await expect(requirePermission("checkout")).resolves.toBeDefined();
+  });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,6 +3,7 @@
 export { canRead, canWrite, READ_ROLES, WRITE_ROLES } from "./rbac";
 export { extendRoles, isRole } from "./types/roles";
 export { hasPermission } from "./permissions";
+export { requirePermission } from "./requirePermission";
 export type { Role, Permission } from "./types";
 export {
   CUSTOMER_SESSION_COOKIE,

--- a/packages/auth/src/requirePermission.ts
+++ b/packages/auth/src/requirePermission.ts
@@ -1,0 +1,13 @@
+// packages/auth/src/requirePermission.ts
+import { getCustomerSession } from "./session";
+import { hasPermission } from "./permissions";
+import type { Permission } from "./types";
+
+export async function requirePermission(perm: Permission) {
+  const session = await getCustomerSession();
+  const role = session?.role;
+  if (!role || !hasPermission(role, perm)) {
+    throw new Error("Unauthorized");
+  }
+  return session;
+}


### PR DESCRIPTION
## Summary
- add requirePermission helper to enforce permissions by session role
- expose requirePermission via auth package index
- test that unauthorized roles are rejected

## Testing
- `pnpm --filter @acme/auth exec jest __tests__ --config ../../jest.config.cjs --runInBand --detectOpenHandles` *(fails: ReferenceError env is not defined in session tests)*
- `pnpm --filter @acme/auth exec jest __tests__/requirePermission.test.ts --config ../../jest.config.cjs --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_689bbc3e3bac832f93a84d2c9fa3c422