### PR TITLE
feat: support marketing email keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `LOG_LEVEL` – controls logging output (`error`, `warn`, `info`, `debug`; defaults to `info`)
 - `EMAIL_PROVIDER` – campaign email provider (`smtp`, `sendgrid`, or `resend`)
 - `SENDGRID_API_KEY` – API key for SendGrid when using the SendGrid provider
-- `RESEND_API_KEY` – API key for Resend when using the Resend provider
+- `SENDGRID_MARKETING_KEY` – optional API key for SendGrid's Marketing Campaigns API
+- `RESEND_API_KEY` – API key for Resend when using the Resend provider (requires send and schedule scopes)
 - `SENDGRID_WEBHOOK_PUBLIC_KEY` – public key to verify SendGrid event webhook signatures
 - `RESEND_WEBHOOK_SECRET` – secret used to verify Resend webhook signatures
 

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -22,6 +22,7 @@ export const coreEnvSchema = z.object({
   CAMPAIGN_FROM: z.string().optional(),
   EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).optional(),
   SENDGRID_API_KEY: z.string().optional(),
+  SENDGRID_MARKETING_KEY: z.string().optional(),
   RESEND_API_KEY: z.string().optional(),
   DATABASE_URL: z.string().optional(),
   SANITY_API_VERSION: z.string().optional(),

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -1,0 +1,10 @@
+# @acme/email
+
+Utilities for sending campaign and transactional emails.
+
+## Environment variables
+
+- `SENDGRID_MARKETING_KEY` – API key for SendGrid's Marketing Campaigns API.
+- `RESEND_API_KEY` – API key for Resend (requires send and schedule scopes).
+- `EMAIL_PROVIDER` – Set to `sendgrid` or `resend` to select a provider.
+- `CAMPAIGN_FROM` – Default sender address for campaign emails.

--- a/packages/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/email/src/__tests__/sendCampaignEmail.test.ts
@@ -23,6 +23,7 @@ describe("sendCampaignEmail", () => {
     delete process.env.CAMPAIGN_FROM;
     delete process.env.EMAIL_PROVIDER;
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.RESEND_API_KEY;
   });
 
@@ -57,7 +58,7 @@ describe("sendCampaignEmail", () => {
     (SendgridProvider as jest.Mock).mockImplementation(() => ({ send }));
 
     process.env.EMAIL_PROVIDER = "sendgrid";
-    process.env.SENDGRID_API_KEY = "sg";
+    process.env.SENDGRID_MARKETING_KEY = "sg";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
     const { sendCampaignEmail } = await import("../index");

--- a/packages/email/src/__tests__/sendgrid.test.ts
+++ b/packages/email/src/__tests__/sendgrid.test.ts
@@ -13,11 +13,12 @@ describe("SendgridProvider", () => {
     jest.resetModules();
     jest.clearAllMocks();
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.CAMPAIGN_FROM;
   });
 
   it("forwards payload to @sendgrid/mail", async () => {
-    process.env.SENDGRID_API_KEY = "sg";
+    process.env.SENDGRID_MARKETING_KEY = "sg";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
     const { SendgridProvider } = await import("../providers/sendgrid");

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -5,8 +5,9 @@ import type { CampaignProvider } from "./types";
 
 export class SendgridProvider implements CampaignProvider {
   constructor() {
-    if (coreEnv.SENDGRID_API_KEY) {
-      sgMail.setApiKey(coreEnv.SENDGRID_API_KEY);
+    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (key) {
+      sgMail.setApiKey(key);
     }
   }
 


### PR DESCRIPTION
## Summary
- add `SENDGRID_MARKETING_KEY` to core env schema
- read marketing key in Sendgrid provider
- document SendGrid and Resend email env vars

## Testing
- `pnpm exec jest packages/email/src/__tests__/abandonedCart.test.ts packages/email/src/__tests__/resend.test.ts packages/email/src/__tests__/sendCampaignEmail.test.ts packages/email/src/__tests__/sendEmail.test.ts packages/email/src/__tests__/sendgrid.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689bbc5ea138832f86142bc2387c59ec