### PR TITLE
feat(email): validate provider

### DIFF
--- a/packages/email/src/__tests__/sendInit.test.ts
+++ b/packages/email/src/__tests__/sendInit.test.ts
@@ -1,0 +1,33 @@
+jest.mock("../providers/sendgrid", () => ({
+  SendgridProvider: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
+}));
+
+jest.mock("../providers/resend", () => ({
+  ResendProvider: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
+}));
+
+describe("EMAIL_PROVIDER validation", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    delete process.env.EMAIL_PROVIDER;
+  });
+
+  it("logs error when EMAIL_PROVIDER is unset", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await import("../send");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("EMAIL_PROVIDER is not set")
+    );
+  });
+
+  it("throws when EMAIL_PROVIDER is unsupported", async () => {
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: { EMAIL_PROVIDER: "mailchimp" },
+    }));
+
+    await expect(import("../send")).rejects.toThrow(
+      /Unsupported EMAIL_PROVIDER/
+    );
+  });
+});

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -20,6 +20,18 @@ const providers: Record<string, CampaignProvider> = {
   resend: new ResendProvider(),
 };
 
+const availableProviders = [...Object.keys(providers), "smtp"];
+
+if (!coreEnv.EMAIL_PROVIDER) {
+  console.error(
+    `EMAIL_PROVIDER is not set. Available providers: ${availableProviders.join(", ")}`
+  );
+} else if (!availableProviders.includes(coreEnv.EMAIL_PROVIDER)) {
+  throw new Error(
+    `Unsupported EMAIL_PROVIDER "${coreEnv.EMAIL_PROVIDER}". Available providers: ${availableProviders.join(", ")}`
+  );
+}
+
 /**
  * Send a campaign email using the configured provider.
  * Falls back to Nodemailer when EMAIL_PROVIDER is unset or unrecognized.


### PR DESCRIPTION
## Summary
- validate `coreEnv.EMAIL_PROVIDER` on module load, logging when unset and throwing for unsupported providers
- add tests covering provider validation

## Testing
- `npx jest packages/email/src/__tests__/sendInit.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689bbd6364c0832fb206fa96daa66382