### PR TITLE
feat: add cache-busting token to email pixel

### DIFF
--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -8,6 +8,8 @@ const pixel = Buffer.from(
 );
 
 export async function GET(req: NextRequest) {
+  // ignore cache-busting token parameter
+  req.nextUrl.searchParams.delete("t");
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");
   if (shop && campaign) {

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -10,7 +10,7 @@ function trackedBody(shop: string, id: string, body: string): string {
   const base = coreEnv.NEXT_PUBLIC_BASE_URL || "";
   const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
     shop,
-  )}&campaign=${encodeURIComponent(id)}`;
+  )}&campaign=${encodeURIComponent(id)}&t=${Date.now()}`;
   const bodyWithPixel =
     body +
     `<img src="${pixelUrl}" alt="" style="display:none" width="1" height="1"/>`;


### PR DESCRIPTION
## Summary
- append cache-busting token to marketing email tracking pixel
- ignore token in open pixel endpoint
- test pixel URLs include token

## Testing
- `npx jest packages/email/src/__tests__/scheduler.test.ts -i`


------
https://chatgpt.com/codex/tasks/task_e_689cbddff5ac832fbc77ad5f299b6048