### PR TITLE
feat(email): sync campaign analytics

### DIFF
--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -8,6 +8,7 @@ export {
   createCampaign,
   listCampaigns,
   sendDueCampaigns,
+  syncCampaignAnalytics,
 } from "./scheduler";
 export { setCampaignStore, fsCampaignStore } from "./storage";
 export type { CampaignStore, Campaign } from "./storage";

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -5,6 +5,7 @@ import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
 import { getCampaignStore } from "./storage";
 import type { Campaign } from "./storage";
+import { syncCampaignAnalytics as fetchCampaignAnalytics } from "./analytics";
 
 function trackedBody(shop: string, id: string, body: string): string {
   const base = coreEnv.NEXT_PUBLIC_BASE_URL || "";
@@ -106,4 +107,11 @@ export async function sendDueCampaigns(): Promise<void> {
     }
     if (changed) await store.writeCampaigns(shop, campaigns);
   }
+}
+
+/**
+ * Periodically sync campaign analytics for all shops.
+ */
+export async function syncCampaignAnalytics(): Promise<void> {
+  await fetchCampaignAnalytics();
 }


### PR DESCRIPTION
## Summary
- add campaign stats sync to email analytics and expose via scheduler
- wire scheduler to sync analytics across shops
- test analytics mapping and sync behavior

## Testing
- `pnpm exec jest packages/email/src/__tests__/analytics.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689cbe50ab9c832f92ac05f8f67f5a26