### PR TITLE
feat(auth): expand permission map with order controls

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -2,6 +2,21 @@
 
 This guide lists built-in permissions and their default role mappings.
 
+## Default permission map
+
+| Permission | Default roles |
+| --- | --- |
+| `view_products` | viewer, customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `add_to_cart` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `checkout` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `view_profile` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `manage_profile` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `change_password` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `manage_cart` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
+| `view_orders` | customer, admin, ShopAdmin |
+| `manage_orders` | admin, ShopAdmin |
+| `manage_sessions` | admin, ShopAdmin |
+
 ## read
 Allows viewing CMS content and APIs.
 

--- a/packages/auth/__tests__/permissions.test.ts
+++ b/packages/auth/__tests__/permissions.test.ts
@@ -26,4 +26,20 @@ describe("hasPermission", () => {
   it("customer can checkout", () => {
     expect(hasPermission("customer", "checkout")).toBe(true);
   });
+
+  it("customer can view orders but cannot manage them", () => {
+    expect(hasPermission("customer", "view_orders")).toBe(true);
+    expect(hasPermission("customer", "manage_orders")).toBe(false);
+  });
+
+  it("admin and ShopAdmin can manage orders and sessions", () => {
+    expect(hasPermission("admin", "manage_orders")).toBe(true);
+    expect(hasPermission("admin", "manage_sessions")).toBe(true);
+    expect(hasPermission("ShopAdmin", "manage_orders")).toBe(true);
+    expect(hasPermission("ShopAdmin", "manage_sessions")).toBe(true);
+  });
+
+  it("viewer cannot view orders", () => {
+    expect(hasPermission("viewer", "view_orders")).toBe(false);
+  });
 });

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -7,7 +7,8 @@
     "view_profile",
     "manage_profile",
     "change_password",
-    "manage_cart"
+    "manage_cart",
+    "view_orders"
   ],
   "admin": [
     "view_products",
@@ -16,7 +17,10 @@
     "view_profile",
     "manage_profile",
     "change_password",
-    "manage_cart"
+    "manage_cart",
+    "view_orders",
+    "manage_orders",
+    "manage_sessions"
   ],
   "ShopAdmin": [
     "view_products",
@@ -25,7 +29,10 @@
     "view_profile",
     "manage_profile",
     "change_password",
-    "manage_cart"
+    "manage_cart",
+    "view_orders",
+    "manage_orders",
+    "manage_sessions"
   ],
   "CatalogManager": [
     "view_products",

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -4,7 +4,8 @@ import permissionsConfig from "./permissions.json";
 import type { Role } from "./types/roles";
 import type { Permission } from "./types/permissions";
 
-// Role to permission mapping loaded from configuration
+// Role to permission mapping loaded from configuration.
+// Includes granular permissions such as view_orders and manage_sessions.
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = permissionsConfig as Record<Role, Permission[]>;
 
 export function hasPermission(role: Role, perm: Permission): boolean {


### PR DESCRIPTION
## Summary
- add granular permissions for orders, sessions, and passwords
- document default permission mappings
- test new permissions

## Testing
- `pnpm --filter @acme/auth test -- --runTestsByPath packages/auth/__tests__/permissions.test.ts packages/auth/__tests__/rbac.test.ts packages/auth/__tests__/roles.test.ts`
- `pnpm --filter @acme/auth test -- --runTestsByPath packages/auth/__tests__/permissions.test.ts packages/auth/__tests__/rbac.test.ts packages/auth/__tests__/roles.test.ts packages/auth/__tests__/session.test.ts` *(fails: Expected: {"customerId": "abc", "role": "customer"} Received: null)*

------
https://chatgpt.com/codex/tasks/task_e_689cbe715f54832f9af497cc8db84e58