### PR TITLE
feat(email): centralize sender config

### DIFF
--- a/packages/email/src/__tests__/config.test.ts
+++ b/packages/email/src/__tests__/config.test.ts
@@ -1,0 +1,43 @@
+describe("getDefaultSender", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  it("throws when sender is missing", async () => {
+    process.env = { ...OLD_ENV } as NodeJS.ProcessEnv;
+    delete process.env.CAMPAIGN_FROM;
+    delete process.env.GMAIL_USER;
+
+    const { getDefaultSender } = await import("../config");
+    expect(() => getDefaultSender()).toThrow(
+      "Default sender email is required"
+    );
+  });
+
+  it("throws when sender format is invalid", async () => {
+    process.env = {
+      ...OLD_ENV,
+      CAMPAIGN_FROM: "invalid",
+    } as NodeJS.ProcessEnv;
+    delete process.env.GMAIL_USER;
+
+    const { getDefaultSender } = await import("../config");
+    expect(() => getDefaultSender()).toThrow(
+      "Invalid sender email address: invalid"
+    );
+  });
+
+  it("returns sender when valid", async () => {
+    process.env = {
+      ...OLD_ENV,
+      CAMPAIGN_FROM: "sender@example.com",
+    } as NodeJS.ProcessEnv;
+    delete process.env.GMAIL_USER;
+
+    const { getDefaultSender } = await import("../config");
+    expect(getDefaultSender()).toBe("sender@example.com");
+  });
+});

--- a/packages/email/src/config.ts
+++ b/packages/email/src/config.ts
@@ -1,0 +1,17 @@
+import { coreEnv } from "@acme/config/env/core";
+import { z } from "zod";
+
+const emailSchema = z.string().email();
+
+export function getDefaultSender(): string {
+  const sender = coreEnv.CAMPAIGN_FROM || coreEnv.GMAIL_USER;
+  if (!sender) {
+    throw new Error(
+      "Default sender email is required. Set CAMPAIGN_FROM or GMAIL_USER."
+    );
+  }
+  if (!emailSchema.safeParse(sender).success) {
+    throw new Error(`Invalid sender email address: ${sender}`);
+  }
+  return sender;
+}

--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -4,6 +4,7 @@ import type { CampaignOptions } from "../send";
 import { ProviderError } from "./types";
 import type { CampaignProvider } from "./types";
 import { mapResendStats, type CampaignStats } from "../analytics";
+import { getDefaultSender } from "../config";
 
 interface ProviderOptions {
   /**
@@ -42,7 +43,7 @@ export class ResendProvider implements CampaignProvider {
   async send(options: CampaignOptions): Promise<void> {
     try {
       await this.client.emails.send({
-        from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
+        from: getDefaultSender(),
         to: options.to,
         subject: options.subject,
         html: options.html,

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -4,6 +4,7 @@ import type { CampaignOptions } from "../send";
 import { ProviderError } from "./types";
 import type { CampaignProvider } from "./types";
 import { mapSendGridStats, type CampaignStats } from "../analytics";
+import { getDefaultSender } from "../config";
 
 interface ProviderOptions {
   /**
@@ -49,7 +50,7 @@ export class SendgridProvider implements CampaignProvider {
     try {
       await sgMail.send({
         to: options.to,
-        from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
+        from: getDefaultSender(),
         subject: options.subject,
         html: options.html,
         text: options.text,

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,5 +1,6 @@
 import nodemailer from "nodemailer";
 import { coreEnv } from "@acme/config/env/core";
+import { getDefaultSender } from "./config";
 import { SendgridProvider } from "./providers/sendgrid";
 import { ResendProvider } from "./providers/resend";
 import type { CampaignProvider } from "./providers/types";
@@ -112,7 +113,7 @@ async function sendWithNodemailer(options: CampaignOptions): Promise<void> {
   });
 
   await transport.sendMail({
-    from: coreEnv.CAMPAIGN_FROM || "no-reply@example.com",
+    from: getDefaultSender(),
     to: options.to,
     subject: options.subject,
     html: options.html,

--- a/packages/email/src/sendEmail.ts
+++ b/packages/email/src/sendEmail.ts
@@ -2,6 +2,7 @@
 
 import { coreEnv } from "@acme/config/env/core";
 import nodemailer from "nodemailer";
+import { getDefaultSender } from "./config";
 
 const hasCreds = coreEnv.GMAIL_USER && coreEnv.GMAIL_PASS;
 
@@ -23,7 +24,7 @@ export async function sendEmail(
   if (transporter) {
     try {
       await transporter.sendMail({
-        from: coreEnv.GMAIL_USER,
+        from: getDefaultSender(),
         to,
         subject,
         text: body,


### PR DESCRIPTION
## Summary
- centralize default sender retrieval with validation
- use shared sender config across email senders
- add tests for sender config validation

## Testing
- `pnpm --filter @acme/email run test packages/email` *(fails: send.test.ts cannot find module '.prisma/client/index-browser')*
- `pnpm --filter @acme/email run test packages/email/src/__tests__/config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cbf13d474832fa88e6d4046087c3e