### PR TITLE
Persist theme defaults on theme change

### DIFF
--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -52,6 +52,7 @@ export const shopSchema = z
           .filter(Boolean)
       ),
     themeOverrides: jsonRecord,
+    themeDefaults: jsonRecord,
     themeTokens: jsonRecord.optional(),
     filterMappings: jsonRecord,
     priceOverrides: jsonRecord,

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -50,10 +50,16 @@ export async function updateShop(
   const data: ShopForm = parsed.data;
 
   const overrides = data.themeOverrides as Record<string, string>;
-  const themeDefaults =
-    current.themeId !== data.themeId
-      ? syncTheme(shop, data.themeId)
-      : loadTokens(data.themeId);
+  let themeDefaults = data.themeDefaults as Record<string, string>;
+  if (!themeDefaults || Object.keys(themeDefaults).length === 0) {
+    themeDefaults =
+      current.themeId !== data.themeId
+        ? syncTheme(shop, data.themeId)
+        : loadTokens(data.themeId);
+  } else if (current.themeId !== data.themeId) {
+    // Ensure theme assets are synchronized when theme changes
+    syncTheme(shop, data.themeId);
+  }
   const themeTokens = { ...themeDefaults, ...overrides };
 
   const patch: Partial<Shop> & { id: string } = {

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
@@ -119,6 +119,9 @@ export default function ThemeEditor({
   const [availableThemes, setAvailableThemes] = useState(themes);
   const [tokensByThemeState, setTokensByThemeState] =
     useState<Record<string, Record<string, string>>>(tokensByTheme);
+  const [themeDefaults, setThemeDefaults] = useState<Record<string, string>>(
+    tokensByTheme[initialTheme]
+  );
   const [presetThemes, setPresetThemes] = useState(presets);
   const [presetName, setPresetName] = useState("");
   const [contrastWarnings, setContrastWarnings] = useState<string[]>([]);
@@ -128,7 +131,7 @@ export default function ThemeEditor({
   const previewRef = useRef<HTMLIFrameElement | null>(null);
 
   const groupedTokens = useMemo(() => {
-    const tokens = tokensByThemeState[theme];
+    const tokens = themeDefaults;
     const groups: Record<string, [string, string][]> = {
       Background: [],
       Text: [],
@@ -143,14 +146,13 @@ export default function ThemeEditor({
       else groups.Other.push([k, v]);
     });
     return groups;
-  }, [theme, tokensByThemeState]);
+  }, [themeDefaults]);
 
   const changedOverrides = useMemo(() => {
-    const tokens = tokensByThemeState[theme];
     return Object.fromEntries(
-      Object.entries(overrides).filter(([k, v]) => tokens[k] !== v)
+      Object.entries(overrides).filter(([k, v]) => themeDefaults[k] !== v)
     );
-  }, [overrides, tokensByThemeState, theme]);
+  }, [overrides, themeDefaults]);
 
   useEffect(() => {
     const handleMessage = (e: MessageEvent) => {
@@ -190,7 +192,7 @@ export default function ThemeEditor({
       const doc = iframe.contentDocument;
       if (!doc) return;
       const root = doc.documentElement;
-      const tokens = tokensByThemeState[theme];
+      const tokens = themeDefaults;
       Object.entries(tokens).forEach(([k, v]) => {
         root.style.setProperty(k, overrides[k] ?? v);
       });
@@ -207,11 +209,12 @@ export default function ThemeEditor({
       const doc = iframe.contentDocument;
       doc?.removeEventListener("click", handleClick);
     };
-  }, [theme, overrides, tokensByThemeState]);
+  }, [themeDefaults, overrides]);
 
   const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const next = e.target.value;
     setTheme(next);
+    setThemeDefaults(tokensByThemeState[next]);
     setOverrides({});
   };
 
@@ -241,7 +244,7 @@ export default function ThemeEditor({
 
   useEffect(() => {
     const ccc = new ColorContrastChecker();
-    const baseTokens = tokensByThemeState[theme];
+    const baseTokens = themeDefaults;
     const merged = { ...baseTokens, ...overrides };
     const textTokens = Object.keys(baseTokens).filter((k) =>
       /text|foreground/i.test(k),
@@ -272,13 +275,14 @@ export default function ThemeEditor({
       });
     });
     setContrastWarnings(warnings);
-  }, [theme, overrides, tokensByThemeState]);
+  }, [themeDefaults, overrides]);
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSaving(true);
     const fd = new FormData(e.currentTarget);
     fd.set("themeOverrides", JSON.stringify(changedOverrides));
+    fd.set("themeDefaults", JSON.stringify(themeDefaults));
     const result = await updateShop(shop, fd);
     if (result.errors) {
       setErrors(result.errors);
@@ -291,12 +295,13 @@ export default function ThemeEditor({
   const handleSavePreset = async () => {
     const name = presetName.trim();
     if (!name) return;
-    const tokens = { ...tokensByThemeState[theme], ...overrides };
+    const tokens = { ...themeDefaults, ...overrides };
     await savePreset(shop, name, tokens);
     setTokensByThemeState((prev) => ({ ...prev, [name]: tokens }));
     setAvailableThemes((prev) => [...prev, name]);
     setPresetThemes((prev) => [...prev, name]);
     setTheme(name);
+    setThemeDefaults(tokens);
     setOverrides({});
     setPresetName("");
   };
@@ -312,6 +317,7 @@ export default function ThemeEditor({
     setPresetThemes((prev) => prev.filter((t) => t !== theme));
     const fallback = themes[0];
     setTheme(fallback);
+    setThemeDefaults(tokensByThemeState[fallback]);
     setOverrides({});
   };
 
@@ -322,6 +328,11 @@ export default function ThemeEditor({
         type="hidden"
         name="themeOverrides"
         value={JSON.stringify(changedOverrides)}
+      />
+      <input
+        type="hidden"
+        name="themeDefaults"
+        value={JSON.stringify(themeDefaults)}
       />
       <label className="flex flex-col gap-1">
         <span>Theme</span>


### PR DESCRIPTION
## Summary
- track theme defaults in ThemeEditor, resetting overrides and sending defaults on save
- update shop action to accept theme defaults from client and recompute theme tokens
- test switching themes updates saved defaults and tokens

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/ThemeEditor.test.tsx apps/cms/__tests__/shops.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689cc025bca0832fab164d97b7fac8e4