### PR TITLE
feat(email): add analytics hooks

### DIFF
--- a/apps/cms/src/app/api/marketing/email/click/route.ts
+++ b/apps/cms/src/app/api/marketing/email/click/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { trackEvent } from "@platform-core/analytics";
+import { emitClick } from "@acme/email";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");
   const url = req.nextUrl.searchParams.get("url") || "/";
   if (shop && campaign) {
-    await trackEvent(shop, { type: "email_click", campaign });
+    await emitClick(shop, { campaign });
   }
   return NextResponse.redirect(url);
 }

--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { trackEvent } from "@platform-core/analytics";
+import { emitOpen } from "@acme/email";
 
 // 1x1 transparent gif
 const pixel = Buffer.from(
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");
   if (shop && campaign) {
-    await trackEvent(shop, { type: "email_open", campaign });
+    await emitOpen(shop, { campaign });
   }
   return new Response(pixel, {
     headers: {

--- a/functions/marketing-email-sender.ts
+++ b/functions/marketing-email-sender.ts
@@ -6,3 +6,8 @@ export const onScheduled = async () => {
   await sendDueCampaigns();
 };
 
+// backwards compatible helper
+export const sendScheduledCampaigns = async () => {
+  await sendDueCampaigns();
+};
+

--- a/packages/email/marketing-automation.md
+++ b/packages/email/marketing-automation.md
@@ -62,3 +62,23 @@ const clickRate = sent ? clicked / sent : 0;
 ```
 
 These metrics correspond to the values returned by the CMS `/api/marketing/email` endpoint and can guide future campaign iterations.
+
+Custom analytics handlers can be registered through hooks exported from `@acme/email`. Use `onSend`, `onOpen`, and `onClick` to listen for campaign activity and run additional logic:
+
+```ts
+import { onSend, onOpen, onClick } from "@acme/email";
+
+onSend((shop, { campaign }) => {
+  console.log("sent", shop, campaign);
+});
+
+onOpen((shop, { campaign }) => {
+  // send to an external analytics service
+});
+
+onClick((shop, { campaign }) => {
+  // custom click tracking
+});
+```
+
+The default listeners continue to record analytics events, so existing metrics remain available while allowing additional tracking behavior.

--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -1,0 +1,44 @@
+export type HookPayload = { campaign: string };
+
+export type HookHandler = (
+  shop: string,
+  payload: HookPayload
+) => void | Promise<void>;
+
+const sendListeners: HookHandler[] = [];
+const openListeners: HookHandler[] = [];
+const clickListeners: HookHandler[] = [];
+
+export function onSend(listener: HookHandler): void {
+  sendListeners.push(listener);
+}
+
+export function onOpen(listener: HookHandler): void {
+  openListeners.push(listener);
+}
+
+export function onClick(listener: HookHandler): void {
+  clickListeners.push(listener);
+}
+
+export async function emitSend(shop: string, payload: HookPayload): Promise<void> {
+  await Promise.all(sendListeners.map((fn) => fn(shop, payload)));
+}
+
+export async function emitOpen(shop: string, payload: HookPayload): Promise<void> {
+  await Promise.all(openListeners.map((fn) => fn(shop, payload)));
+}
+
+export async function emitClick(shop: string, payload: HookPayload): Promise<void> {
+  await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
+}
+
+async function track(shop: string, data: any): Promise<void> {
+  const { trackEvent } = await import("@platform-core/analytics");
+  await trackEvent(shop, data);
+}
+
+// default analytics listeners
+onSend((shop, { campaign }) => track(shop, { type: "email_sent", campaign }));
+onOpen((shop, { campaign }) => track(shop, { type: "email_open", campaign }));
+onClick((shop, { campaign }) => track(shop, { type: "email_click", campaign }));

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -11,3 +11,11 @@ export {
 } from "./scheduler";
 export { setCampaignStore, fsCampaignStore } from "./storage";
 export type { CampaignStore, Campaign } from "./storage";
+export {
+  onSend,
+  onOpen,
+  onClick,
+  emitSend,
+  emitOpen,
+  emitClick,
+} from "./hooks";

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -1,6 +1,6 @@
 import { sendCampaignEmail } from "./send";
 import { resolveSegment } from "./segments";
-import { trackEvent } from "@platform-core/analytics";
+import { emitSend } from "./hooks";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
@@ -76,7 +76,7 @@ async function deliverCampaign(shop: string, c: Campaign): Promise<void> {
         subject: c.subject,
         html,
       });
-      await trackEvent(shop, { type: "email_sent", campaign: c.id });
+      await emitSend(shop, { campaign: c.id });
     }
     if (i + batchSize < recipients.length && batchDelay > 0) {
       await new Promise((resolve) => setTimeout(resolve, batchDelay));


### PR DESCRIPTION
## Summary
- add hook system for email events with default analytics listeners
- emit hooks from scheduler and CMS tracking routes
- document hook usage and expose registration APIs

## Testing
- `npx jest --runTestsByPath packages/email/src/__tests__/scheduler.test.ts`
- `npx jest --runTestsByPath packages/email/src/__tests__/send.test.ts`
- `npx jest --runTestsByPath apps/cms/__tests__/emailProviderWebhooks.test.ts`
- `npx jest --runTestsByPath packages/email/src/__tests__/campaign-integration.test.ts` *(fails: "sendScheduledCampaigns" expectation and sendgrid not called)*

------
https://chatgpt.com/codex/tasks/task_e_689cc47a963c832faee7a140210a4105