### PR TITLE
feat: centralize zod error map initialization

### DIFF
--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";

--- a/apps/cms/src/app/api/configurator/route.ts
+++ b/apps/cms/src/app/api/configurator/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { createNewShop } from "@cms/actions/createShop.server";
 import { createShopOptionsSchema } from "@platform-core/createShop";
 import { validateShopEnv } from "@platform-core/configurator";

--- a/apps/cms/src/app/api/create-shop/route.ts
+++ b/apps/cms/src/app/api/create-shop/route.ts
@@ -1,4 +1,5 @@
 // apps/cms/src/app/api/create-shop/route.ts
+import "@acme/lib/initZod";
 import { createNewShop } from "@cms/actions/createShop.server";
 import { createShopOptionsSchema } from "@platform-core/createShop";
 import { NextResponse } from "next/server";

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -1,4 +1,5 @@
 // apps/cms/src/app/api/env/[shopId]/route.ts
+import "@acme/lib/initZod";
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";

--- a/apps/cms/src/app/api/products/[shop]/[id]/route.ts
+++ b/apps/cms/src/app/api/products/[shop]/[id]/route.ts
@@ -1,4 +1,5 @@
 // apps/cms/src/app/api/products/[shop]/[id]/route.ts
+import "@acme/lib/initZod";
 
 import { getProductById } from "@platform-core/repositories/json.server";
 import { NextResponse, type NextRequest } from "next/server";

--- a/apps/cms/src/app/api/products/route.ts
+++ b/apps/cms/src/app/api/products/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 import {

--- a/apps/cms/src/app/api/providers/[provider]/route.ts
+++ b/apps/cms/src/app/api/providers/[provider]/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "node:fs";
 import path from "node:path";

--- a/apps/cms/src/app/api/providers/shop/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/shop/[shop]/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";

--- a/apps/cms/src/app/api/wizard-progress/route.ts
+++ b/apps/cms/src/app/api/wizard-progress/route.ts
@@ -1,4 +1,5 @@
 // apps/cms/src/app/api/wizard-progress/route.ts
+import "@acme/lib/initZod";
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";

--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -1,14 +1,11 @@
 // apps/cms/src/app/layout.tsx
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
-import { applyFriendlyZodMessages } from "@acme/lib";
+import "@acme/lib/initZod";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import "./globals.css";
-
-// Ensure friendly Zod messages for all validations
-applyFriendlyZodMessages();
 
 const geistSans = Geist({
   subsets: ["latin"],

--- a/apps/shop-abc/src/app/api/account/change-password/route.ts
+++ b/apps/shop-abc/src/app/api/account/change-password/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/account/profile/route.ts
+import "@acme/lib/initZod";
 import { getCustomerSession, hasPermission, validateCsrfToken } from "@auth";
 import {
   getCustomerProfile,

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/account/reset/complete/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/account/reset/request/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import crypto from "crypto";

--- a/apps/shop-abc/src/app/api/account/verify/route.ts
+++ b/apps/shop-abc/src/app/api/account/verify/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/account/verify/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import crypto from "crypto";

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/checkout-session/route.ts
+import "@acme/lib/initZod";
 
 import {
   CART_COOKIE,

--- a/apps/shop-abc/src/app/api/mfa/verify/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/verify/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/mfa/verify/route.ts
+import "@acme/lib/initZod";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import {

--- a/apps/shop-abc/src/app/api/register/route.ts
+++ b/apps/shop-abc/src/app/api/register/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/register/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";

--- a/apps/shop-abc/src/app/api/rental/route.ts
+++ b/apps/shop-abc/src/app/api/rental/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/rental/route.ts
+import "@acme/lib/initZod";
 
 import { stripe } from "@acme/stripe";
 import {

--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/return/route.ts
+import "@acme/lib/initZod";
 
 import { stripe } from "@acme/stripe";
 import {

--- a/apps/shop-abc/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-abc/src/app/api/shipping-rate/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/shipping-rate/route.ts
+import "@acme/lib/initZod";
 import { getShippingRate } from "@acme/platform-core/shipping";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/apps/shop-abc/src/app/api/tax/route.ts
+++ b/apps/shop-abc/src/app/api/tax/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/tax/route.ts
+import "@acme/lib/initZod";
 import { calculateTax } from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/apps/shop-abc/src/app/layout.js
+++ b/apps/shop-abc/src/app/layout.js
@@ -2,9 +2,8 @@ import { jsx as _jsx } from "react/jsx-runtime";
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { applyFriendlyZodMessages } from "@acme/lib";
+import "@acme/lib/initZod";
 import { Geist, Geist_Mono } from "next/font/google";
-applyFriendlyZodMessages();
 const geistSans = Geist({
     subsets: ["latin"],
     variable: "--font-geist-sans",

--- a/apps/shop-abc/src/app/layout.tsx
+++ b/apps/shop-abc/src/app/layout.tsx
@@ -2,16 +2,13 @@
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
-import { applyFriendlyZodMessages } from "@acme/lib";
+import "@acme/lib/initZod";
 import { initPlugins } from "@acme/platform-core/plugins";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import shop from "../../shop.json";
-
-// Ensure friendly Zod messages for all validations
-applyFriendlyZodMessages();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginsDir = path.resolve(__dirname, "../../../../packages/plugins");

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/login/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { createCustomerSession, validateCsrfToken } from "@auth";
 import { isMfaEnabled } from "@auth/mfa";

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/register/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";

--- a/apps/shop-bcd/src/api/cart/route.js
+++ b/apps/shop-bcd/src/api/cart/route.js
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/cart/route.ts
+import "@acme/lib/initZod";
 import { asSetCookieHeader, CART_COOKIE, decodeCartCookie, encodeCartCookie, } from "@/lib/cartCookie";
 import { getProductById } from "@/lib/products";
 import { NextResponse } from "next/server";

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-abc/src/app/api/cart/route.ts
+import "@acme/lib/initZod";
 
 import {
   asSetCookieHeader,

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-bcd/src/app/api/checkout-session/route.ts
+import "@acme/lib/initZod";
 
 import {
   CART_COOKIE,

--- a/apps/shop-bcd/src/api/return/route.js
+++ b/apps/shop-bcd/src/api/return/route.js
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { stripe } from "@acme/stripe";
 import { computeDamageFee } from "@platform-core/pricing";
 import { markRefunded, markReturned, } from "@platform-core/repositories/rentalOrders.server";

--- a/apps/shop-bcd/src/api/return/route.ts
+++ b/apps/shop-bcd/src/api/return/route.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { stripe } from "@acme/stripe";
 import { computeDamageFee } from "@platform-core/pricing";
 import {

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-bcd/src/app/api/account/profile/route.ts
+import "@acme/lib/initZod";
 import { getCustomerSession } from "@auth";
 import {
   getCustomerProfile,

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-bcd/src/app/api/shipping-rate/route.ts
+import "@acme/lib/initZod";
 import { getShippingRate } from "@acme/platform-core/shipping";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-bcd/src/app/api/tax/route.ts
+import "@acme/lib/initZod";
 import { calculateTax } from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/apps/shop-bcd/src/app/layout.js
+++ b/apps/shop-bcd/src/app/layout.js
@@ -2,9 +2,8 @@ import { jsx as _jsx } from "react/jsx-runtime";
 // src/app/layout.tsx
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
-import { applyFriendlyZodMessages } from "@acme/lib";
+import "@acme/lib/initZod";
 import { Geist, Geist_Mono } from "next/font/google";
-applyFriendlyZodMessages();
 const geistSans = Geist({
     subsets: ["latin"],
     variable: "--font-geist-sans",

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -2,16 +2,13 @@
 import "./globals.css";
 import { CartProvider } from "@/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
-import { applyFriendlyZodMessages } from "@acme/lib";
+import "@acme/lib/initZod";
 import { initPlugins } from "@acme/platform-core/plugins";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import shop from "../../shop.json";
-
-// Ensure friendly Zod messages for all validations
-applyFriendlyZodMessages();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginsDir = path.resolve(__dirname, "../../../../packages/plugins");

--- a/apps/shop-bcd/src/app/login/route.ts
+++ b/apps/shop-bcd/src/app/login/route.ts
@@ -1,4 +1,5 @@
 // apps/shop-bcd/src/app/login/route.ts
+import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { createCustomerSession, validateCsrfToken } from "@auth";
 import type { Role } from "@auth/types/roles";

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,5 +1,5 @@
+import "@acme/lib/initZod";
 import { z } from "zod";
-import { applyFriendlyZodMessages } from "@acme/lib";
 
 export const coreEnvBaseSchema = z.object({
   NEXTAUTH_SECRET: z.string().optional(),
@@ -89,8 +89,6 @@ export function depositReleaseEnvRefinement(
 export const coreEnvSchema = coreEnvBaseSchema.superRefine(
   depositReleaseEnvRefinement,
 );
-
-applyFriendlyZodMessages();
 
 const parsed = coreEnvSchema.safeParse(process.env);
 if (!parsed.success) {

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -1,5 +1,5 @@
+import "@acme/lib/initZod";
 import { z } from "zod";
-import { applyFriendlyZodMessages } from "@acme/lib";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
@@ -16,8 +16,6 @@ export const envSchema = mergeEnvSchemas(
   paymentEnvSchema,
   shippingEnvSchema,
 ).superRefine(depositReleaseEnvRefinement);
-
-applyFriendlyZodMessages();
 
 const parsed = envSchema.safeParse(process.env);
 if (!parsed.success) {

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -1,13 +1,11 @@
+import "@acme/lib/initZod";
 import { z } from "zod";
-import { applyFriendlyZodMessages } from "@acme/lib";
 
 export const paymentEnvSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
   STRIPE_WEBHOOK_SECRET: z.string().min(1),
 });
-
-applyFriendlyZodMessages();
 
 const parsed = paymentEnvSchema.safeParse(process.env);
 if (!parsed.success) {

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -1,13 +1,11 @@
+import "@acme/lib/initZod";
 import { z } from "zod";
-import { applyFriendlyZodMessages } from "@acme/lib";
 
 export const shippingEnvSchema = z.object({
   TAXJAR_KEY: z.string().optional(),
   UPS_KEY: z.string().optional(),
   DHL_KEY: z.string().optional(),
 });
-
-applyFriendlyZodMessages();
 
 const parsed = shippingEnvSchema.safeParse(process.env);
 if (!parsed.success) {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -7,7 +7,8 @@
     ".": "./src/index.ts",
     "./validateShopName": "./src/validateShopName.ts",
     "./checkShopExists.server": "./src/checkShopExists.server.ts",
-    "./zodErrorMap": "./src/zodErrorMap.ts"
+    "./zodErrorMap": "./src/zodErrorMap.ts",
+    "./initZod": "./src/initZod.ts"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/lib/src/initZod.ts
+++ b/packages/lib/src/initZod.ts
@@ -1,0 +1,3 @@
+import { applyFriendlyZodMessages } from "./zodErrorMap";
+
+applyFriendlyZodMessages();

--- a/scripts/src/migrate-cms.ts
+++ b/scripts/src/migrate-cms.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { env, envSchema } from "@acme/config";
 import fetch from "cross-fetch";
 import { readFile } from "node:fs/promises";

--- a/scripts/src/validate-env.ts
+++ b/scripts/src/validate-env.ts
@@ -1,3 +1,4 @@
+import "@acme/lib/initZod";
 import { envSchema } from "@config/src/env";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";


### PR DESCRIPTION
## Summary
- add `initZod` helper that applies friendly Zod messages
- import `@acme/lib/initZod` across API routes, layouts, and scripts
- remove direct `applyFriendlyZodMessages` calls

## Testing
- `pnpm exec jest packages/lib --config jest.config.cjs --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_689cc49997d0832f83771e5bfbdbb00a