### PR TITLE
refactor: centralize JSON parsing in API routes

### DIFF
--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "@platform-core/src/shops";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 /**
  * POST /cms/api/configurator/init-shop
@@ -46,11 +47,8 @@ export async function POST(req: Request) {
       })
       .strict();
 
-    const parsed = schema.safeParse(await req.json());
-    if (!parsed.success) {
-      const message = parsed.error.issues.map((i) => i.message).join(", ");
-      return NextResponse.json({ error: message }, { status: 400 });
-    }
+    const parsed = await parseJsonBody(req, schema);
+    if (!parsed.success) return parsed.response;
 
     const { id, csv, categories } = parsed.data;
     const dir = path.join(resolveDataRoot(), id);

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { z } from "zod";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { setupSanityBlog } from "@cms/actions/setupSanityBlog";
+import { parseJsonBody } from "@shared-utils";
 
 const schema = z.record(z.string(), z.string());
 
@@ -19,29 +20,25 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const body = schema.safeParse(await req.json());
-    if (!body.success) {
-      return NextResponse.json(
-        { error: body.error.message },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(req, schema);
+    if (!parsed.success) return parsed.response;
+    const data = parsed.data;
     const { shopId } = await context.params;
     const dir = path.join(resolveDataRoot(), shopId);
     await fs.mkdir(dir, { recursive: true });
-    const lines = Object.entries(body.data)
+    const lines = Object.entries(data)
       .map(([k, v]) => `${k}=${String(v)}`)
       .join("\n");
     await fs.writeFile(path.join(dir, ".env"), lines, "utf8");
     if (
-      body.data.SANITY_PROJECT_ID &&
-      body.data.SANITY_DATASET &&
-      body.data.SANITY_TOKEN
+      data.SANITY_PROJECT_ID &&
+      data.SANITY_DATASET &&
+      data.SANITY_TOKEN
     ) {
       await setupSanityBlog({
-        projectId: body.data.SANITY_PROJECT_ID,
-        dataset: body.data.SANITY_DATASET,
-        token: body.data.SANITY_TOKEN,
+        projectId: data.SANITY_PROJECT_ID,
+        dataset: data.SANITY_DATASET,
+        token: data.SANITY_TOKEN,
       }).catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });

--- a/apps/cms/src/app/api/providers/shop/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/shop/[shop]/route.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 const schema = z
   .object({
@@ -22,13 +23,8 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const parsed = schema.safeParse(await req.json());
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error.message },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(req, schema);
+    if (!parsed.success) return parsed.response;
     const { shop } = await context.params;
     const dir = path.join(resolveDataRoot(), shop);
     await fs.mkdir(dir, { recursive: true });

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -7,6 +7,7 @@ import {
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -53,11 +54,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
   try {
     await updateCustomerProfile(session.customerId, parsed.data);
   } catch (err) {

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -20,6 +20,7 @@ import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { z } from "zod";
 import { shippingSchema, billingSchema } from "@platform-core/schemas/address";
+import { parseJsonBody } from "@shared-utils";
 
 /* ------------------------------------------------------------------ *
  *  Types
@@ -139,13 +140,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   /* 2️⃣ Parse optional body ------------------------------------------------- */
-  const parsed = schema.safeParse(await req.json().catch(() => undefined));
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten().fieldErrors },
-      { status: 400 }
-    );
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   const {
     returnDate,

--- a/apps/shop-abc/src/app/api/mfa/verify/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/verify/route.ts
@@ -14,6 +14,7 @@ import {
   clearLoginAttempts,
   clearMfaAttempts,
 } from "../../../../middleware";
+import { parseJsonBody } from "@shared-utils";
 
 const schema = z
   .object({ token: z.string(), customerId: z.string().optional() })
@@ -25,9 +26,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!valid)
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
 
-  const parsed = schema.safeParse(await req.json());
-  if (!parsed.success)
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
   const { token, customerId } = parsed.data;
   if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });
 

--- a/apps/shop-abc/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-abc/src/app/api/shipping-rate/route.ts
@@ -3,6 +3,7 @@ import { getShippingRate } from "@acme/platform-core/shipping";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const rate = await getShippingRate(parsed.data);

--- a/apps/shop-abc/src/app/api/tax/route.ts
+++ b/apps/shop-abc/src/app/api/tax/route.ts
@@ -3,6 +3,7 @@ import { calculateTax } from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const tax = await calculateTax(parsed.data);

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -7,6 +7,7 @@ import {
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -37,11 +38,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json(parsed.error.flatten().fieldErrors, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   await updateCustomerProfile(session.customerId, parsed.data);
   const profile = await getCustomerProfile(session.customerId);

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -3,6 +3,7 @@ import { getShippingRate } from "@acme/platform-core/shipping";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const rate = await getShippingRate(parsed.data);

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -3,6 +3,7 @@ import { calculateTax } from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
 
 export const runtime = "edge";
 
@@ -16,11 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const json = await req.json();
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
+  const parsed = await parseJsonBody(req, schema);
+  if (!parsed.success) return parsed.response;
 
   try {
     const tax = await calculateTax(parsed.data);


### PR DESCRIPTION
## Summary
- replace manual req.json + schema.safeParse with shared parseJsonBody helper across API routes
- streamline request validation for checkout, profile, tax, shipping, MFA, and CMS endpoints

## Testing
- `pnpm jest apps/shop-bcd/__tests__/api/accountProfile.test.ts`
- `pnpm jest apps/shop-bcd/__tests__/checkout-session.test.ts`
- `pnpm jest apps/shop-abc/__tests__/api/accountProfile.test.ts`
- `pnpm jest apps/shop-abc/__tests__/mfaApi.test.ts` *(fails: Cannot find module '.prisma/client/index-browser')*
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689cc4b95e64832f96dd8d663af0a7de