### PR TITLE
feat(ui): expose design tokens

### DIFF
--- a/doc/theme-editor-tokens.md
+++ b/doc/theme-editor-tokens.md
@@ -1,0 +1,17 @@
+# Theme Editor Token Map
+
+The following components expose design tokens via `data-token` attributes so the CMS ThemeEditor can map DOM elements to token keys.
+
+| Component | Token(s) |
+| --- | --- |
+| AnnouncementBar | `--color-primary`, `--color-primary-fg` |
+| StickyAddToCartBar | `--color-bg` |
+| LiveChatWidget | `--color-bg`, `--color-primary`, `--color-muted` |
+| ProductBadge | `--color-muted`, `--color-fg`, `--color-danger`, `--color-danger-fg`, `--color-success`, `--color-success-fg` |
+| Tag | `--color-muted`, `--color-fg`, `--color-success`, `--color-success-fg`, `--color-warning`, `--color-warning-fg`, `--color-danger`, `--color-danger-fg` |
+| Progress | `--color-muted`, `--color-primary`, `--color-muted-fg` |
+| Switch | `--color-primary`, `--color-bg` |
+| Toast | `--color-fg`, `--color-bg` |
+| CheckoutTemplate | `--color-primary`, `--color-muted` |
+| CartTemplate | `--color-muted`, `--color-danger` |
+

--- a/packages/ui/src/components/atoms/ProductBadge.tsx
+++ b/packages/ui/src/components/atoms/ProductBadge.tsx
@@ -11,22 +11,40 @@ export const ProductBadge = React.forwardRef<
   HTMLSpanElement,
   ProductBadgeProps
 >(({ label, variant = "default", className, ...props }, ref) => {
-  const variants: Record<string, string> = {
-      default: "bg-muted text-fg",
-    sale: "bg-danger text-danger-foreground",
-    new: "bg-success text-success-fg",
+  const bgClasses: Record<string, string> = {
+    default: "bg-muted",
+    sale: "bg-danger",
+    new: "bg-success",
+  };
+  const textClasses: Record<string, string> = {
+    default: "text-fg",
+    sale: "text-danger-foreground",
+    new: "text-success-fg",
+  };
+  const bgTokens: Record<string, string> = {
+    default: "--color-muted",
+    sale: "--color-danger",
+    new: "--color-success",
+  };
+  const textTokens: Record<string, string> = {
+    default: "--color-fg",
+    sale: "--color-danger-fg",
+    new: "--color-success-fg",
   };
   return (
     <span
       ref={ref}
+      data-token={bgTokens[variant]}
       className={cn(
         "rounded px-2 py-1 text-xs font-semibold",
-        variants[variant],
+        bgClasses[variant],
         className
       )}
       {...props}
     >
-      {label}
+      <span className={textClasses[variant]} data-token={textTokens[variant]}>
+        {label}
+      </span>
     </span>
   );
 });

--- a/packages/ui/src/components/atoms/Progress.tsx
+++ b/packages/ui/src/components/atoms/Progress.tsx
@@ -10,14 +10,17 @@ export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
   ({ value, label, className, ...props }, ref) => {
     return (
       <div ref={ref} className={cn("space-y-1", className)} {...props}>
-        <div className="bg-muted h-2 w-full overflow-hidden rounded">
+        <div className="bg-muted h-2 w-full overflow-hidden rounded" data-token="--color-muted">
           <div
             className="bg-primary h-full transition-all"
             style={{ width: `${value}%` }}
+            data-token="--color-primary"
           />
         </div>
         {label ? (
-          <div className="text-muted-foreground text-right text-sm">{label}</div>
+          <div className="text-muted-foreground text-right text-sm" data-token="--color-muted-fg">
+            {label}
+          </div>
         ) : null}
       </div>
     );

--- a/packages/ui/src/components/atoms/Switch.tsx
+++ b/packages/ui/src/components/atoms/Switch.tsx
@@ -12,8 +12,14 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
       )}
     >
       <input ref={ref} type="checkbox" className="peer sr-only" {...props} />
-      <span className="bg-input peer-checked:bg-primary peer-focus:ring-ring peer-focus:ring-offset-background relative h-5 w-9 rounded-full transition-colors peer-focus:ring-2 peer-focus:ring-offset-2">
-        <span className="bg-background absolute top-0.5 left-0.5 h-4 w-4 rounded-full shadow transition-transform peer-checked:translate-x-4" />
+      <span
+        className="bg-input peer-checked:bg-primary peer-focus:ring-ring peer-focus:ring-offset-background relative h-5 w-9 rounded-full transition-colors peer-focus:ring-2 peer-focus:ring-offset-2"
+        data-token="--color-primary"
+      >
+        <span
+          className="bg-background absolute top-0.5 left-0.5 h-4 w-4 rounded-full shadow transition-transform peer-checked:translate-x-4"
+          data-token="--color-bg"
+        />
       </span>
     </label>
   )

--- a/packages/ui/src/components/atoms/Tag.tsx
+++ b/packages/ui/src/components/atoms/Tag.tsx
@@ -6,23 +6,46 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 export const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
-  ({ className, variant = "default", ...props }, ref) => {
-    const variants: Record<string, string> = {
-      default: "bg-muted text-fg",
-      success: "bg-success text-success-fg",
-      warning: "bg-warning text-warning-fg",
-      destructive: "bg-danger text-danger-foreground",
+  ({ className, variant = "default", children, ...props }, ref) => {
+    const bgClasses: Record<string, string> = {
+      default: "bg-muted",
+      success: "bg-success",
+      warning: "bg-warning",
+      destructive: "bg-danger",
+    };
+    const textClasses: Record<string, string> = {
+      default: "text-fg",
+      success: "text-success-fg",
+      warning: "text-warning-fg",
+      destructive: "text-danger-foreground",
+    };
+    const bgTokens: Record<string, string> = {
+      default: "--color-muted",
+      success: "--color-success",
+      warning: "--color-warning",
+      destructive: "--color-danger",
+    };
+    const textTokens: Record<string, string> = {
+      default: "--color-fg",
+      success: "--color-success-fg",
+      warning: "--color-warning-fg",
+      destructive: "--color-danger-fg",
     };
     return (
       <span
         ref={ref}
+        data-token={bgTokens[variant]}
         className={cn(
           "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
-          variants[variant],
+          bgClasses[variant],
           className
         )}
         {...props}
-      />
+      >
+        <span className={textClasses[variant]} data-token={textTokens[variant]}>
+          {children}
+        </span>
+      </span>
     );
   }
 );

--- a/packages/ui/src/components/atoms/Toast.tsx
+++ b/packages/ui/src/components/atoms/Toast.tsx
@@ -17,11 +17,17 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
           "bg-fg text-bg fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-md px-4 py-2 shadow-lg",
           className
         )}
+        data-token="--color-fg"
         {...props}
       >
-        {message}
+        <span data-token="--color-bg">{message}</span>
         {onClose && (
-          <button type="button" onClick={onClose} className="ml-2 font-bold">
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-2 font-bold"
+            data-token="--color-bg"
+          >
             ×
           </button>
         )}

--- a/packages/ui/src/components/organisms/AnnouncementBar.tsx
+++ b/packages/ui/src/components/organisms/AnnouncementBar.tsx
@@ -28,18 +28,22 @@ export default function AnnouncementBar({
   const content = (
     <div
       className={cn(
-        "flex w-full items-center justify-center gap-2 bg-primary px-4 py-2 text-sm text-primary-foreground",
+        "flex w-full items-center justify-center gap-2 bg-primary px-4 py-2 text-sm",
         className,
       )}
+      data-token="--color-primary"
       {...props}
     >
-      <span>{text}</span>
+      <span className="text-primary-foreground" data-token="--color-primary-fg">
+        {text}
+      </span>
       {closable && (
         <button
           type="button"
           aria-label="Close announcement"
           onClick={() => setOpen(false)}
           className="ml-2 text-primary-foreground/70 hover:text-primary-foreground"
+          data-token="--color-primary-fg"
         >
           &times;
         </button>

--- a/packages/ui/src/components/organisms/LiveChatWidget.tsx
+++ b/packages/ui/src/components/organisms/LiveChatWidget.tsx
@@ -89,6 +89,7 @@ export function LiveChatWidget({
           widthClass,
           bottomClass
         )}
+        data-token="--color-bg"
       >
         {" "}
         <DialogHeader>
@@ -107,6 +108,9 @@ export function LiveChatWidget({
                     ? "bg-primary text-primary-foreground"
                     : "bg-muted"
                 )}
+                data-token={
+                  m.sender === "user" ? "--color-primary" : "--color-muted"
+                }
               >
                 {m.text}
               </div>

--- a/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
+++ b/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
@@ -31,6 +31,7 @@ export function StickyAddToCartBar({
         padding,
         className
       )}
+      data-token="--color-bg"
       {...props}
     >
       <div className="flex flex-col">

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -68,7 +68,9 @@ export function CartTemplate({
                   )}
                   {line.sku.title}
                   {line.size && (
-                    <span className="ml-1 text-xs text-muted">({line.size})</span>
+                    <span className="ml-1 text-xs text-muted" data-token="--color-muted">
+                      ({line.size})
+                    </span>
                   )}
                 </div>
               </td>
@@ -88,6 +90,7 @@ export function CartTemplate({
                     type="button"
                     onClick={() => onRemove(line.id)}
                     className="text-danger hover:underline"
+                    data-token="--color-danger"
                   >
                     Remove
                   </button>

--- a/packages/ui/src/components/templates/CheckoutTemplate.tsx
+++ b/packages/ui/src/components/templates/CheckoutTemplate.tsx
@@ -45,6 +45,11 @@ export function CheckoutTemplate({
                     ? "bg-primary/80 border-primary/80 text-primary-fg"
                     : "bg-muted text-muted-foreground"
               )}
+              data-token={
+                idx === step || idx < step
+                  ? "--color-primary"
+                  : "--color-muted"
+              }
             >
               {idx + 1}
             </div>


### PR DESCRIPTION
## Summary
- expose `data-token` attributes across UI components so ThemeEditor can target design tokens
- document token mappings for CMS

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689cc55509bc832f867d8307ab8d1c68