### PR TITLE
docs(email): document sendgrid and resend sdk versions

### DIFF
--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -2,6 +2,27 @@
 
 Email helper utilities used across the monorepo.
 
+## SDK versions
+
+This package wraps the official SendGrid and Resend Node SDKs.
+
+- [`@sendgrid/mail` v8.1.5](https://www.npmjs.com/package/@sendgrid/mail)
+- [`resend` v3.5.0](https://www.npmjs.com/package/resend)
+
+## Updating SDKs
+
+When bumping either SDK:
+
+1. Update `package.json` with the new versions.
+2. Review upstream release notes for breaking changes and verify the providers remain compatible, especially around the `sanityCheck` option.
+3. Run the test suite and update this README with the new versions and any compatibility notes.
+
+## Compatibility notes
+
+These providers are tested against Node.js 18+. When upgrading SDK versions,
+ensure the APIs remain compatible with our wrapper implementations and supported
+Node versions.
+
 ## Provider sanity checks
 
 `SendgridProvider` and `ResendProvider` accept an optional `{ sanityCheck: true }`


### PR DESCRIPTION
## Summary
- document @sendgrid/mail and resend versions with links
- add SDK update instructions and compatibility notes for email package

## Testing
- `pnpm --filter @acme/email test packages/email` *(fails: TypeError: sendScheduledCampaigns is not a function; Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689cc631c1e8832fbc2e8ee3342a67ce