### PR TITLE
feat: append token to email tracking pixel

### DIFF
--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -8,8 +8,10 @@ const pixel = Buffer.from(
 );
 
 export async function GET(req: NextRequest) {
-  const shop = req.nextUrl.searchParams.get("shop");
-  const campaign = req.nextUrl.searchParams.get("campaign");
+  const params = req.nextUrl.searchParams;
+  params.delete("t");
+  const shop = params.get("shop");
+  const campaign = params.get("campaign");
   if (shop && campaign) {
     await trackEvent(shop, { type: "email_open", campaign });
   }

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -83,6 +83,30 @@ describe("scheduler", () => {
     expect(futureCampaign.sentAt).toBeUndefined();
   });
 
+  it("includes token in tracking pixel URL", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const campaigns = [
+      {
+        id: "c1",
+        recipients: ["token@example.com"],
+        subject: "Token",
+        body: "<p>Token</p>",
+        sendAt: past,
+      },
+    ];
+    await fs.writeFile(
+      path.join(shopDir, "campaigns.json"),
+      JSON.stringify(campaigns, null, 2),
+      "utf8",
+    );
+
+    const { sendDueCampaigns } = await import("../scheduler");
+    await sendDueCampaigns();
+
+    const call = sendCampaignEmailMock.mock.calls[0][0];
+    expect(call.html).toMatch(/open\?shop=.*&campaign=.*&t=\d+/);
+  });
+
   it("creates campaigns and lists them", async () => {
     const { createCampaign, listCampaigns } = await import("../scheduler");
     const future = new Date(Date.now() + 1000).toISOString();

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -11,7 +11,7 @@ function trackedBody(shop: string, id: string, body: string): string {
   const base = coreEnv.NEXT_PUBLIC_BASE_URL || "";
   const pixelUrl = `${base}/api/marketing/email/open?shop=${encodeURIComponent(
     shop,
-  )}&campaign=${encodeURIComponent(id)}`;
+  )}&campaign=${encodeURIComponent(id)}&t=${Date.now()}`;
   const bodyWithPixel =
     body +
     `<img src="${pixelUrl}" alt="" style="display:none" width="1" height="1"/>`;


### PR DESCRIPTION
## Summary
- avoid cached email open tracking by appending timestamp token to pixel URL
- ignore token parameter in email open API endpoint
- test that tracking pixel URLs include the token

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/scheduler.test.ts --runTestsByPath`
- `pnpm --filter @apps/cms test src/app/api/marketing/email/open/route.ts --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_689cc653f7b0832f9062b2e4d316bef4