### PR TITLE
feat(email): add marketing env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `LOG_LEVEL` – controls logging output (`error`, `warn`, `info`, `debug`; defaults to `info`)
 - `EMAIL_PROVIDER` – campaign email provider (`smtp`, `sendgrid`, or `resend`)
 - `SENDGRID_API_KEY` – API key for SendGrid when using the SendGrid provider
-- `RESEND_API_KEY` – API key for Resend when using the Resend provider
+- `SENDGRID_MARKETING_KEY` – API key for SendGrid marketing endpoints
+- `RESEND_API_KEY` – API key for Resend; requires `sending`, `audiences.read` and `audiences.write` scopes
 - `SENDGRID_WEBHOOK_PUBLIC_KEY` – public key to verify SendGrid event webhook signatures
 - `RESEND_WEBHOOK_SECRET` – secret used to verify Resend webhook signatures
 

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -22,6 +22,7 @@ export const coreEnvBaseSchema = z.object({
   CAMPAIGN_FROM: z.string().optional(),
   EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).optional(),
   SENDGRID_API_KEY: z.string().optional(),
+  SENDGRID_MARKETING_KEY: z.string().optional(),
   RESEND_API_KEY: z.string().optional(),
   EMAIL_BATCH_SIZE: z.coerce.number().optional(),
   EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -2,6 +2,16 @@
 
 Email helper utilities used across the monorepo.
 
+## Environment variables
+
+The utilities read configuration from the following variables:
+
+- `EMAIL_PROVIDER` – campaign email provider (`smtp`, `sendgrid`, or `resend`).
+- `SENDGRID_API_KEY` – API key used for sending email through SendGrid.
+- `SENDGRID_MARKETING_KEY` – API key for SendGrid marketing features such as contact and segment management.
+- `RESEND_API_KEY` – API key for Resend with `sending`, `audiences.read` and `audiences.write` scopes.
+- `CAMPAIGN_FROM` – default "from" address when sending mail.
+
 ## Provider sanity checks
 
 `SendgridProvider` and `ResendProvider` accept an optional `{ sanityCheck: true }`

--- a/packages/email/src/__tests__/providers.test.ts
+++ b/packages/email/src/__tests__/providers.test.ts
@@ -19,11 +19,12 @@ describe("Campaign providers segmentation", () => {
     jest.resetModules();
     jest.clearAllMocks();
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.RESEND_API_KEY;
   });
 
   it("sendgrid segmentation methods call API", async () => {
-    process.env.SENDGRID_API_KEY = "sg";
+    process.env.SENDGRID_MARKETING_KEY = "sg";
     const { SendgridProvider } = await import("../providers/sendgrid");
     const provider = new SendgridProvider();
 

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -62,13 +62,15 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async getCampaignStats(id: string): Promise<CampaignStats> {
-    if (!coreEnv.SENDGRID_API_KEY) return mapSendGridStats({});
+    const key =
+      coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return mapSendGridStats({});
     try {
       const res = await fetch(
         `https://api.sendgrid.com/v3/campaigns/${id}/stats`,
         {
           headers: {
-            Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+            Authorization: `Bearer ${key}`,
           },
         }
       );
@@ -80,12 +82,14 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async createContact(email: string): Promise<string> {
-    if (!coreEnv.SENDGRID_API_KEY) return "";
+    const key =
+      coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return "";
     try {
       const res = await fetch("https://api.sendgrid.com/v3/marketing/contacts", {
         method: "PUT",
         headers: {
-          Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+          Authorization: `Bearer ${key}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ contacts: [{ email }] }),
@@ -99,11 +103,13 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async addToList(contactId: string, listId: string): Promise<void> {
-    if (!coreEnv.SENDGRID_API_KEY) return;
+    const key =
+      coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return;
     await fetch(`https://api.sendgrid.com/v3/marketing/lists/${listId}/contacts`, {
       method: "PUT",
       headers: {
-        Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+        Authorization: `Bearer ${key}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ contact_ids: [contactId] }),
@@ -111,10 +117,12 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async listSegments(): Promise<{ id: string; name?: string }[]> {
-    if (!coreEnv.SENDGRID_API_KEY) return [];
+    const key =
+      coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return [];
     try {
       const res = await fetch("https://api.sendgrid.com/v3/marketing/segments", {
-        headers: { Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}` },
+        headers: { Authorization: `Bearer ${key}` },
       });
       const json = await res.json().catch(() => ({}));
       const segments = Array.isArray(json?.result) ? json.result : [];


### PR DESCRIPTION
## Summary
- include `SENDGRID_MARKETING_KEY` in core env schema
- use `SENDGRID_MARKETING_KEY` for SendGrid marketing APIs and document required env vars

## Testing
- `pnpm -F @acme/config test` *(no output)*
- `pnpm -F @acme/email test` *(fail: Cannot find module '@/components/cms/StyleEditor' from 'apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx')*
- `pnpm --filter @acme/email test packages/email/src/__tests__/providers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cc5d13b44832fba0d942e953214b1