### PR TITLE
feat(ui): add product comparison block

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductComparisonBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductComparisonBlock.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { SKU } from "@acme/types";
+import ProductComparisonBlock from "./ProductComparisonBlock";
+
+const sku1: SKU = {
+  id: "01",
+  slug: "prod-1",
+  title: "Product One",
+  price: 100,
+  deposit: 10,
+  stock: 5,
+  forSale: true,
+  forRental: false,
+  media: [],
+  sizes: [],
+  description: "",
+};
+
+const sku2: SKU = {
+  id: "02",
+  slug: "prod-2",
+  title: "Product Two",
+  price: 200,
+  deposit: 20,
+  stock: 10,
+  forSale: true,
+  forRental: false,
+  media: [],
+  sizes: [],
+  description: "",
+};
+
+const meta: Meta<typeof ProductComparisonBlock> = {
+  component: ProductComparisonBlock,
+  args: {
+    skus: [sku1, sku2],
+    attributes: ["price", "stock", "deposit"],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ProductComparisonBlock> = {};
+

--- a/packages/ui/src/components/cms/blocks/ProductComparisonBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductComparisonBlock.tsx
@@ -1,0 +1,42 @@
+import type { SKU } from "@acme/types";
+
+interface Props {
+  skus?: SKU[];
+  /** Attributes to display from each SKU (e.g. price, stock) */
+  attributes?: (keyof SKU)[];
+}
+
+/**
+ * Display a simple comparison table for selected products.
+ */
+export default function ProductComparisonBlock({ skus = [], attributes = [] }: Props) {
+  if (!skus.length || !attributes.length) return null;
+
+  return (
+    <table className="w-full border-collapse text-sm">
+      <thead>
+        <tr>
+          <th className="border px-2 py-1 text-left">Product</th>
+          {attributes.map((attr) => (
+            <th key={attr} className="border px-2 py-1 text-left capitalize">
+              {attr}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {skus.map((sku) => (
+          <tr key={sku.id}>
+            <td className="border px-2 py-1">{sku.title}</td>
+            {attributes.map((attr) => (
+              <td key={attr} className="border px-2 py-1">
+                {String((sku as any)[attr] ?? "")}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/ProductComparisonBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductComparisonBlock.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import type { SKU } from "@acme/types";
+import ProductComparisonBlock from "../ProductComparisonBlock";
+
+describe("ProductComparisonBlock", () => {
+  const sku1: SKU = {
+    id: "01",
+    slug: "prod-1",
+    title: "Product One",
+    price: 100,
+    deposit: 10,
+    stock: 5,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: [],
+    description: "",
+  };
+  const sku2: SKU = {
+    id: "02",
+    slug: "prod-2",
+    title: "Product Two",
+    price: 200,
+    deposit: 20,
+    stock: 10,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: [],
+    description: "",
+  };
+
+  it("renders a comparison table", () => {
+    render(
+      <ProductComparisonBlock
+        skus={[sku1, sku2]}
+        attributes={["price", "stock"]}
+      />
+    );
+    expect(screen.getByText("Product One")).toBeInTheDocument();
+    expect(screen.getByText("Product Two")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /price/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /stock/i })).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+});
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -28,6 +28,7 @@ import Tabs from "./Tabs";
 import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
+import ProductComparison from "./ProductComparisonBlock";
 
 export {
   BlogListing,
@@ -60,6 +61,7 @@ export {
   PricingTable,
   Tabs,
   CollectionList,
+  ProductComparison,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -29,6 +29,7 @@ import Tabs from "./Tabs";
 import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
+import ProductComparisonBlock from "./ProductComparisonBlock";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -65,6 +66,7 @@ export const organismRegistry = {
   SearchBar: { component: SearchBar },
   PricingTable: { component: PricingTable },
   Tabs: { component: Tabs },
+  ProductComparison: { component: ProductComparisonBlock },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -33,6 +33,7 @@ import ImageSliderEditor from "./ImageSliderEditor";
 import CollectionListEditor from "./CollectionListEditor";
 import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
+import ProductComparisonEditor from "./ProductComparisonEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -114,6 +115,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "RecommendationCarousel":
       specific = (
         <RecommendationCarouselEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "ProductComparison":
+      specific = (
+        <ProductComparisonEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/ProductComparisonEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductComparisonEditor.tsx
@@ -1,0 +1,33 @@
+import type { PageComponent } from "@acme/types";
+import { Textarea } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ProductComparisonEditor({ component, onChange }: Props) {
+  const handleList = (field: string, value: string) => {
+    const items = value
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    onChange({ [field]: items } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        label="SKUs (comma or newline separated)"
+        value={((component as any).skus ?? []).join(",")}
+        onChange={(e) => handleList("skus", e.target.value)}
+      />
+      <Textarea
+        label="Attributes (comma separated)"
+        value={((component as any).attributes ?? []).join(",")}
+        onChange={(e) => handleList("attributes", e.target.value)}
+      />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -17,6 +17,7 @@ export { default as ImageSliderEditor } from "./ImageSliderEditor";
 export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as SearchBarEditor } from "./SearchBarEditor";
 export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
+export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add ProductComparison block with table of selected product attributes
- allow editing SKUs and attributes via ProductComparisonEditor
- register block and editor with CMS registries

## Testing
- `pnpm --filter @acme/ui test src/components/cms/blocks/__tests__/ProductComparisonBlock.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689cc9954340832fa22dd8e7db698a20