### PR TITLE
feat: add gift card block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -176,6 +176,11 @@ export interface NewsletterSignupComponent extends PageComponentBase {
   placeholder?: string;
   submitLabel?: string;
 }
+export interface GiftCardBlockComponent extends PageComponentBase {
+  type: "GiftCardBlock";
+  amounts?: number[];
+  description?: string;
+}
 export interface SearchBarComponent extends PageComponentBase {
   type: "SearchBar";
   placeholder?: string;
@@ -277,6 +282,7 @@ export type PageComponent =
   | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
+  | GiftCardBlockComponent
   | SearchBarComponent
   | ContactFormWithMapComponent
   | MapBlockComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -198,6 +198,12 @@ export interface NewsletterSignupComponent extends PageComponentBase {
   submitLabel?: string;
 }
 
+export interface GiftCardBlockComponent extends PageComponentBase {
+  type: "GiftCardBlock";
+  amounts?: number[];
+  description?: string;
+}
+
 export interface SearchBarComponent extends PageComponentBase {
   type: "SearchBar";
   placeholder?: string;
@@ -319,6 +325,7 @@ export type PageComponent =
   | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
+  | GiftCardBlockComponent
   | SearchBarComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
@@ -432,6 +439,12 @@ const newsletterSignupComponentSchema = baseComponentSchema.extend({
   action: z.string().optional(),
   placeholder: z.string().optional(),
   submitLabel: z.string().optional(),
+});
+
+const giftCardBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("GiftCardBlock"),
+  amounts: z.array(z.number()).optional(),
+  description: z.string().optional(),
 });
 
 const searchBarComponentSchema = baseComponentSchema.extend({
@@ -613,6 +626,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     galleryComponentSchema,
     contactFormComponentSchema,
     newsletterSignupComponentSchema,
+    giftCardBlockComponentSchema,
     searchBarComponentSchema,
     contactFormWithMapComponentSchema,
     mapBlockComponentSchema,

--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import GiftCardBlock from "./GiftCardBlock";
+
+const meta: Meta<typeof GiftCardBlock> = {
+  component: GiftCardBlock,
+  args: {
+    amounts: [25, 50, 100],
+    description: "Choose a gift card amount",
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof GiftCardBlock> = {};
+

--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "../../atoms/shadcn";
+
+interface Props {
+  /** Available gift card denominations */
+  amounts?: number[];
+  /** Optional description shown above the options */
+  description?: string;
+  /** Callback when purchase button is clicked */
+  onPurchase?: (amount: number) => void;
+}
+
+export default function GiftCardBlock({
+  amounts = [],
+  description,
+  onPurchase,
+}: Props) {
+  const [selected, setSelected] = useState<number | null>(
+    amounts.length ? amounts[0] : null,
+  );
+
+  const handlePurchase = () => {
+    if (selected != null) {
+      onPurchase?.(selected);
+    }
+  };
+
+  if (!amounts.length) return null;
+
+  return (
+    <div className="space-y-4">
+      {description && <p>{description}</p>}
+      <div className="flex flex-wrap gap-2">
+        {amounts.map((amt) => (
+          <Button
+            key={amt}
+            type="button"
+            variant={selected === amt ? "default" : "outline"}
+            onClick={() => setSelected(amt)}
+          >
+            ${amt}
+          </Button>
+        ))}
+      </div>
+      <Button type="button" onClick={handlePurchase} disabled={selected == null}>
+        Purchase
+      </Button>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import GiftCardBlock from "../GiftCardBlock";
+
+describe("GiftCardBlock", () => {
+  it("renders amounts and handles purchase", () => {
+    const onPurchase = jest.fn();
+    render(
+      <GiftCardBlock
+        amounts={[25, 50]}
+        description="Give a gift"
+        onPurchase={onPurchase}
+      />
+    );
+    expect(screen.getByText("Give a gift")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "$25" }));
+    fireEvent.click(screen.getByRole("button", { name: "Purchase" }));
+    expect(onPurchase).toHaveBeenCalledWith(25);
+  });
+});
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -28,6 +28,7 @@ import Tabs from "./Tabs";
 import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
+import GiftCardBlock from "./GiftCardBlock";
 
 export {
   BlogListing,
@@ -60,6 +61,7 @@ export {
   PricingTable,
   Tabs,
   CollectionList,
+  GiftCardBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -29,6 +29,7 @@ import Tabs from "./Tabs";
 import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
+import GiftCardBlock from "./GiftCardBlock";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -65,6 +66,7 @@ export const organismRegistry = {
   SearchBar: { component: SearchBar },
   PricingTable: { component: PricingTable },
   Tabs: { component: Tabs },
+  GiftCardBlock: { component: GiftCardBlock },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -33,6 +33,7 @@ import ImageSliderEditor from "./ImageSliderEditor";
 import CollectionListEditor from "./CollectionListEditor";
 import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
+import GiftCardEditor from "./GiftCardEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -97,6 +98,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = (
         <NewsletterSignupEditor component={component} onChange={onChange} />
       );
+      break;
+    case "GiftCardBlock":
+      specific = <GiftCardEditor component={component} onChange={onChange} />;
       break;
     case "SearchBar":
       specific = (

--- a/packages/ui/src/components/cms/page-builder/GiftCardEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/GiftCardEditor.tsx
@@ -1,0 +1,51 @@
+import type { PageComponent } from "@acme/types";
+import { Button, Input, Textarea } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function GiftCardEditor({ component, onChange }: Props) {
+  const amounts = ((component as any).amounts ?? []) as number[];
+  const description = (component as any).description ?? "";
+
+  const updateAmounts = (next: number[]) => {
+    onChange({ amounts: next } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={description}
+        onChange={(e) =>
+          onChange({ description: e.target.value } as Partial<PageComponent>)
+        }
+        placeholder="description"
+      />
+      {amounts.map((amt, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <Input
+            type="number"
+            value={amt}
+            onChange={(e) => {
+              const next = [...amounts];
+              next[i] = Number(e.target.value);
+              updateAmounts(next);
+            }}
+            placeholder="amount"
+            className="flex-1"
+          />
+          <Button
+            variant="destructive"
+            onClick={() => updateAmounts(amounts.filter((_, idx) => idx !== i))}
+          >
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button onClick={() => updateAmounts([...amounts, 0])}>Add Amount</Button>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -17,6 +17,7 @@ export { default as ImageSliderEditor } from "./ImageSliderEditor";
 export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as SearchBarEditor } from "./SearchBarEditor";
 export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
+export { default as GiftCardEditor } from "./GiftCardEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add GiftCardBlock with selectable denominations
- create GiftCardEditor for managing presets and descriptions
- wire block into registries and page builder, add story and tests

## Testing
- `pnpm --filter @acme/ui run test` *(fails: PageBuilder.drag-resize.test.tsx)*
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx --runTestsByPath packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cc98d0c98832fabd05527f32cad62