### PR TITLE
Handle theme default updates from editor

### DIFF
--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -51,6 +51,7 @@ export const shopSchema = z
           .map((v) => v.trim())
           .filter(Boolean)
       ),
+    themeDefaults: jsonRecord.optional(),
     themeOverrides: jsonRecord,
     themeTokens: jsonRecord.optional(),
     filterMappings: jsonRecord,

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -50,10 +50,15 @@ export async function updateShop(
   const data: ShopForm = parsed.data;
 
   const overrides = data.themeOverrides as Record<string, string>;
-  const themeDefaults =
-    current.themeId !== data.themeId
-      ? await syncTheme(shop, data.themeId)
-      : await loadTokens(data.themeId);
+  let themeDefaults = (data.themeDefaults as Record<string, string>) || {};
+  if (Object.keys(themeDefaults).length === 0) {
+    themeDefaults =
+      current.themeId !== data.themeId
+        ? await syncTheme(shop, data.themeId)
+        : await loadTokens(data.themeId);
+  } else if (current.themeId !== data.themeId) {
+    await syncTheme(shop, data.themeId);
+  }
   const themeTokens = { ...themeDefaults, ...overrides };
 
   const patch: Partial<Shop> & { id: string } = {


### PR DESCRIPTION
## Summary
- update theme editor to track and submit theme defaults
- persist supplied theme defaults in shop update action
- test that switching themes updates defaults and tokens

## Testing
- `pnpm --filter @apps/cms test ThemeEditor.test.tsx shops.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cc71f9810832fb70abd3273925906