### PR TITLE
feat(email): centralize campaign type

### DIFF
--- a/apps/cms/src/app/api/marketing/email/route.ts
+++ b/apps/cms/src/app/api/marketing/email/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { createCampaign, listCampaigns } from "@acme/email";
+import { createCampaign, listCampaigns, type Campaign } from "@acme/email";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 import { marketingEmailTemplates } from "@acme/ui";
 
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
   if (!shop)
     return NextResponse.json({ error: "Missing shop" }, { status: 400 });
-  const campaigns = await listCampaigns(shop);
+  const campaigns: Campaign[] = await listCampaigns(shop);
   const events = await listEvents(shop);
   const withMetrics = campaigns.map((c) => {
     const metrics = { sent: 0, opened: 0, clicked: 0 };

--- a/functions/marketing-email-sender.ts
+++ b/functions/marketing-email-sender.ts
@@ -1,6 +1,7 @@
-import { sendDueCampaigns } from "@acme/email";
+import { sendDueCampaigns, type Campaign } from "@acme/email";
 
 export { sendDueCampaigns };
+export type { Campaign };
 
 export const onScheduled = async () => {
   await sendDueCampaigns();

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -11,7 +11,8 @@ export {
   syncCampaignAnalytics,
 } from "./scheduler";
 export { setCampaignStore, fsCampaignStore } from "./storage";
-export type { CampaignStore, Campaign } from "./storage";
+export type { CampaignStore } from "./storage";
+export type { Campaign } from "./types";
 export {
   onSend,
   onOpen,

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -5,7 +5,7 @@ import { listEvents } from "@platform-core/repositories/analytics.server";
 import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
 import { getCampaignStore } from "./storage";
-import type { Campaign } from "./storage";
+import type { Campaign } from "./types";
 import { syncCampaignAnalytics as fetchCampaignAnalytics } from "./analytics";
 
 function trackedBody(shop: string, id: string, body: string): string {

--- a/packages/email/src/storage/index.ts
+++ b/packages/email/src/storage/index.ts
@@ -1,5 +1,6 @@
 import { fsCampaignStore } from "./fsStore";
-import type { CampaignStore, Campaign } from "./types";
+import type { CampaignStore } from "./types";
+import type { Campaign } from "../types";
 
 let store: CampaignStore = fsCampaignStore;
 

--- a/packages/email/src/storage/types.ts
+++ b/packages/email/src/storage/types.ts
@@ -1,13 +1,4 @@
-export interface Campaign {
-  id: string;
-  recipients: string[];
-  subject: string;
-  body: string;
-  segment?: string | null;
-  sendAt: string;
-  sentAt?: string;
-  templateId?: string | null;
-}
+import type { Campaign } from "../types";
 
 export interface CampaignStore {
   /**

--- a/packages/email/src/types.ts
+++ b/packages/email/src/types.ts
@@ -1,0 +1,10 @@
+export interface Campaign {
+  id: string;
+  recipients: string[];
+  subject: string;
+  body: string;
+  segment?: string | null;
+  sendAt: string;
+  sentAt?: string;
+  templateId?: string | null;
+}


### PR DESCRIPTION
## Summary
- add shared Campaign interface for email package
- use Campaign type across scheduler, function and CMS API

## Testing
- `pnpm typecheck` *(fails: File '/workspace/base-shop/packages/shared-utils/src/parseJsonBody.ts' is not listed within the file list of project '/workspace/base-shop/apps/shop-bcd/tsconfig.json')*


------
https://chatgpt.com/codex/tasks/task_e_689cc941e9c0832f9c17590580db2976