### PR TITLE
feat: add store locator block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -191,6 +191,15 @@ export interface MapBlockComponent extends PageComponentBase {
   lng?: number;
   zoom?: number;
 }
+export interface StoreLocatorBlockComponent extends PageComponentBase {
+  type: "StoreLocatorBlock";
+  locations?: {
+    lat?: number;
+    lng?: number;
+    label?: string;
+  }[];
+  zoom?: number;
+}
 export interface VideoBlockComponent extends PageComponentBase {
   type: "VideoBlock";
   src?: string;
@@ -280,6 +289,7 @@ export type PageComponent =
   | SearchBarComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
+  | StoreLocatorBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
   | BlogListingComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -216,6 +216,12 @@ export interface MapBlockComponent extends PageComponentBase {
   zoom?: number;
 }
 
+export interface StoreLocatorBlockComponent extends PageComponentBase {
+  type: "StoreLocatorBlock";
+  locations?: { lat?: number; lng?: number; label?: string }[];
+  zoom?: number;
+}
+
 export interface VideoBlockComponent extends PageComponentBase {
   type: "VideoBlock";
   src?: string;
@@ -322,6 +328,7 @@ export type PageComponent =
   | SearchBarComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
+  | StoreLocatorBlockComponent
   | VideoBlockComponent
   | FAQBlockComponent
   | CountdownTimerComponent
@@ -449,6 +456,20 @@ const mapBlockComponentSchema = baseComponentSchema.extend({
   type: z.literal("MapBlock"),
   lat: z.number().optional(),
   lng: z.number().optional(),
+  zoom: z.number().optional(),
+});
+
+const storeLocatorBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("StoreLocatorBlock"),
+  locations: z
+    .array(
+      z.object({
+        lat: z.number().optional(),
+        lng: z.number().optional(),
+        label: z.string().optional(),
+      })
+    )
+    .optional(),
   zoom: z.number().optional(),
 });
 
@@ -616,6 +637,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     searchBarComponentSchema,
     contactFormWithMapComponentSchema,
     mapBlockComponentSchema,
+    storeLocatorBlockComponentSchema,
     videoBlockComponentSchema,
     faqBlockComponentSchema,
     countdownTimerComponentSchema,

--- a/packages/ui/src/components/cms/blocks/StoreLocatorBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/StoreLocatorBlock.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import StoreLocatorBlock from "./StoreLocatorBlock";
+
+const meta: Meta<typeof StoreLocatorBlock> = {
+  component: StoreLocatorBlock,
+  args: {
+    locations: [
+      { lat: 40.7128, lng: -74.006, label: "New York" },
+      { lat: 34.0522, lng: -118.2437, label: "Los Angeles" },
+    ],
+    zoom: 4,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof StoreLocatorBlock> = {};

--- a/packages/ui/src/components/cms/blocks/StoreLocatorBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/StoreLocatorBlock.tsx
@@ -1,0 +1,34 @@
+// packages/ui/src/components/cms/blocks/StoreLocatorBlock.tsx
+"use client";
+
+import { StoreLocatorMap, type Location } from "../../organisms/StoreLocatorMap";
+
+interface LocationInput {
+  lat?: number | string;
+  lng?: number | string;
+  label?: string;
+}
+
+interface Props {
+  /** Locations to display on the map */
+  locations?: LocationInput[];
+  /** Initial zoom level */
+  zoom?: number;
+}
+
+/** CMS wrapper for the StoreLocatorMap organism supporting multiple locations */
+export default function StoreLocatorBlock({ locations = [], zoom }: Props) {
+  const valid: Location[] = locations
+    .map((loc) => ({
+      lat: typeof loc.lat === "string" ? Number(loc.lat) : loc.lat,
+      lng: typeof loc.lng === "string" ? Number(loc.lng) : loc.lng,
+      label: loc.label,
+    }))
+    .filter(
+      (l): l is Location => typeof l.lat === "number" && !isNaN(l.lat) && typeof l.lng === "number" && !isNaN(l.lng)
+    );
+
+  if (valid.length === 0) return null;
+
+  return <StoreLocatorMap locations={valid} zoom={zoom} heightClass="h-full" />;
+}

--- a/packages/ui/src/components/cms/blocks/__tests__/StoreLocatorBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/StoreLocatorBlock.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+import StoreLocatorBlock from "../StoreLocatorBlock";
+
+describe("StoreLocatorBlock", () => {
+  it("renders map when locations provided", () => {
+    const { container } = render(
+      <StoreLocatorBlock locations={[{ lat: 1, lng: 2, label: "A" }]} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("returns null when no valid locations", () => {
+    const { container } = render(<StoreLocatorBlock locations={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -13,6 +13,7 @@ import RecommendationCarousel from "./RecommendationCarousel";
 import Section from "./Section";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
+import StoreLocatorBlock from "./StoreLocatorBlock";
 import MultiColumn from "./containers/MultiColumn";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
@@ -45,6 +46,7 @@ export {
   Section,
   AnnouncementBar,
   MapBlock,
+  StoreLocatorBlock,
   MultiColumn,
   VideoBlock,
   FAQBlock,

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -18,6 +18,7 @@ import RecommendationCarousel, {
 } from "./RecommendationCarousel";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
+import StoreLocatorBlock from "./StoreLocatorBlock";
 import VideoBlock from "./VideoBlock";
 import FAQBlock from "./FAQBlock";
 import CountdownTimer from "./CountdownTimer";
@@ -56,6 +57,7 @@ export const organismRegistry = {
   Testimonials: { component: Testimonials },
   TestimonialSlider: { component: TestimonialSlider },
   MapBlock: { component: MapBlock },
+  StoreLocatorBlock: { component: StoreLocatorBlock },
   VideoBlock: { component: VideoBlock },
   FAQBlock: { component: FAQBlock },
   CountdownTimer: { component: CountdownTimer },

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -23,6 +23,7 @@ import ReviewsCarouselEditor from "./ReviewsCarouselEditor";
 import AnnouncementBarEditor from "./AnnouncementBarEditor";
 import SocialFeedEditor from "./SocialFeedEditor";
 import MapBlockEditor from "./MapBlockEditor";
+import StoreLocatorBlockEditor from "./StoreLocatorBlockEditor";
 import VideoBlockEditor from "./VideoBlockEditor";
 import FAQBlockEditor from "./FAQBlockEditor";
 import HeaderEditor from "./HeaderEditor";
@@ -129,6 +130,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "MapBlock":
       specific = <MapBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "StoreLocatorBlock":
+      specific = (
+        <StoreLocatorBlockEditor component={component} onChange={onChange} />
+      );
       break;
     case "VideoBlock":
       specific = <VideoBlockEditor component={component} onChange={onChange} />;

--- a/packages/ui/src/components/cms/page-builder/StoreLocatorBlockEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/StoreLocatorBlockEditor.tsx
@@ -1,0 +1,28 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function StoreLocatorBlockEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  const handleNumber = (field: string, value: string) => {
+    const num = value === "" ? undefined : Number(value);
+    onChange({ [field]: isNaN(num as number) ? undefined : num } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      {arrayEditor("locations", (component as any).locations, ["lat", "lng", "label"])}
+      <Input
+        label="Zoom"
+        type="number"
+        value={(component as any).zoom ?? ""}
+        onChange={(e) => handleNumber("zoom", e.target.value)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -9,6 +9,7 @@ import ReviewsCarouselEditor from "../ReviewsCarouselEditor";
 import AnnouncementBarEditor from "../AnnouncementBarEditor";
 import SocialFeedEditor from "../SocialFeedEditor";
 import NewsletterSignupEditor from "../NewsletterSignupEditor";
+import StoreLocatorBlockEditor from "../StoreLocatorBlockEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -79,6 +80,12 @@ describe("block editors", () => {
       SocialFeedEditor,
       { type: "SocialFeed", platform: "twitter", account: "" },
       "account",
+    ],
+    [
+      "StoreLocatorBlockEditor",
+      StoreLocatorBlockEditor,
+      { type: "StoreLocatorBlock", locations: [{ lat: "", lng: "", label: "" }] },
+      "lat",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -9,6 +9,7 @@ export { default as ValuePropsEditor } from "./ValuePropsEditor";
 export { default as ReviewsCarouselEditor } from "./ReviewsCarouselEditor";
 export { default as AnnouncementBarEditor } from "./AnnouncementBarEditor";
 export { default as MapBlockEditor } from "./MapBlockEditor";
+export { default as StoreLocatorBlockEditor } from "./StoreLocatorBlockEditor";
 export { default as VideoBlockEditor } from "./VideoBlockEditor";
 export { default as FAQBlockEditor } from "./FAQBlockEditor";
 export { default as PricingTableEditor } from "./PricingTableEditor";


### PR DESCRIPTION
## Summary
- add StoreLocatorBlock and editor for multiple map locations
- export new block and editor
- extend page types for StoreLocatorBlock

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/StoreLocatorBlock.test.tsx`
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx`
- `pnpm --filter @acme/ui test` *(fails: PageBuilder.drag-resize.test.tsx expected width style; wizard test missing module; media test process.exit)*

------
https://chatgpt.com/codex/tasks/task_e_689cc98c334c832faa648f2e6d3fce2b