### PR TITLE
fix: use coreEnv session secret

### DIFF
--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -88,9 +88,9 @@ export async function getCustomerSession(): Promise<CustomerSession | null> {
 }
 
 export async function createCustomerSession(sessionData: CustomerSession): Promise<void> {
-  const secret = env.SESSION_SECRET;
+  const secret = coreEnv.SESSION_SECRET;
   if (!secret) {
-    throw new Error("SESSION_SECRET is not set");
+    throw new Error("SESSION_SECRET is not set in core environment configuration");
   }
   const store = await cookies();
   const session: InternalSession = {


### PR DESCRIPTION
## Summary
- use `coreEnv.SESSION_SECRET` when creating customer sessions
- error if `SESSION_SECRET` is missing from core env

## Testing
- `pnpm lint --filter @acme/auth` *(no tasks)*
- `pnpm test --filter @acme/auth` *(fails: PageBuilder interactions resizes via sidebar inputs, Wizard test suite cannot find module, scheduler test, config paymentEnv process.exit called)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb3862fc832fb3a1dc67e2a78d31