### PR TITLE
feat(ui): add theme editor link for shop owners

### DIFF
--- a/doc/cms.md
+++ b/doc/cms.md
@@ -12,6 +12,7 @@ The sidebar inside the CMS provides quick access to different sections:
 - **Products** – Lists all products. If a shop is selected, also shows **New Product**.
 - **Pages** – Lists pages for the current shop with a **New Page** link when a shop is selected.
 - **Media** – Upload and manage media files.
+- **Theme** – Customize the shop's appearance. Visible to admins and shop owners.
 - **Settings** – Shop settings. When a shop is active an additional **SEO** option appears.
 - **Live** – Opens a list of running shop instances.
 - **RBAC** – (Admin only) Manage user roles.

--- a/packages/ui/__tests__/Sidebar.test.tsx
+++ b/packages/ui/__tests__/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import Sidebar from "../components/cms/Sidebar.client";
+import Sidebar from "../src/components/cms/Sidebar.client";
 
 jest.mock("next/navigation", () => ({
   usePathname: jest.fn(),
@@ -26,5 +26,23 @@ describe("Sidebar", () => {
 
     render(<Sidebar />);
     expect(screen.queryByText("Shops")).toBeNull();
+  });
+
+  it("shows Theme link for shop owners", () => {
+    mockPathname.mockReturnValue("/cms/shop/abc");
+
+    render(<Sidebar role="ShopAdmin" />);
+    const theme = screen.getByText("Theme");
+    expect(theme.closest("a")).toHaveAttribute(
+      "href",
+      "/cms/shop/abc/themes",
+    );
+  });
+
+  it("hides Theme link for viewers", () => {
+    mockPathname.mockReturnValue("/cms/shop/abc");
+
+    render(<Sidebar role="viewer" />);
+    expect(screen.queryByText("Theme")).toBeNull();
   });
 });

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -50,6 +50,15 @@ export default function Sidebar({ role }: { role?: string }) {
       label: "Media",
       icon: "🖼️",
     },
+    ...(shop && role && ["admin", "ShopAdmin", "ThemeEditor"].includes(role)
+      ? [
+          {
+            href: `/shop/${shop}/themes`,
+            label: "Theme",
+            icon: "🎨",
+          },
+        ]
+      : []),
     {
       href: shop ? `/shop/${shop}/settings` : "/settings",
       label: "Settings",


### PR DESCRIPTION
## Summary
- add Theme link to CMS sidebar for admin and shop owners
- test sidebar Theme visibility
- document new Theme link in CMS navigation guide

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: command exited with error)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/Sidebar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cc99cef64832fac8000cc4cc83340