### PR TITLE
feat: add responsive margin and padding controls

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -47,11 +47,23 @@ export interface PageComponentBase {
    * Accepts any valid CSS margin value or Tailwind class.
    */
   margin?: string;
+  /** Margin on large (desktop) viewports. Overrides `margin` when provided. */
+  marginDesktop?: string;
+  /** Margin on medium (tablet) viewports. Overrides `margin` when provided. */
+  marginTablet?: string;
+  /** Margin on small (mobile) viewports. Overrides `margin` when provided. */
+  marginMobile?: string;
   /**
    * Padding applied to the outer container when rendered.
    * Accepts any valid CSS padding value or Tailwind class.
    */
   padding?: string;
+  /** Padding on large (desktop) viewports. Overrides `padding` when provided. */
+  paddingDesktop?: string;
+  /** Padding on medium (tablet) viewports. Overrides `padding` when provided. */
+  paddingTablet?: string;
+  /** Padding on small (mobile) viewports. Overrides `padding` when provided. */
+  paddingMobile?: string;
   /** Minimum number of items allowed for list components */
   minItems?: number;
   /** Maximum number of items allowed for list components */

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -72,11 +72,23 @@ export interface PageComponentBase {
    * Accepts any valid CSS margin value or Tailwind class.
    */
   margin?: string;
+  /** Margin on desktop viewports. Overrides `margin` on large screens. */
+  marginDesktop?: string;
+  /** Margin on tablet viewports. Overrides `margin` on medium screens. */
+  marginTablet?: string;
+  /** Margin on mobile viewports. Overrides `margin` on small screens. */
+  marginMobile?: string;
   /**
    * Padding applied to the outer container when rendered.
    * Accepts any valid CSS padding value or Tailwind class.
    */
   padding?: string;
+  /** Padding on desktop viewports. Overrides `padding` on large screens. */
+  paddingDesktop?: string;
+  /** Padding on tablet viewports. Overrides `padding` on medium screens. */
+  paddingTablet?: string;
+  /** Padding on mobile viewports. Overrides `padding` on small screens. */
+  paddingMobile?: string;
   /** Minimum number of items allowed for components with lists */
   minItems?: number;
   /** Maximum number of items allowed for components with lists */
@@ -356,7 +368,13 @@ const baseComponentSchema = z
     top: z.string().optional(),
     left: z.string().optional(),
     margin: z.string().optional(),
+    marginDesktop: z.string().optional(),
+    marginTablet: z.string().optional(),
+    marginMobile: z.string().optional(),
     padding: z.string().optional(),
+    paddingDesktop: z.string().optional(),
+    paddingTablet: z.string().optional(),
+    paddingMobile: z.string().optional(),
     minItems: z.number().int().min(0).optional(),
     maxItems: z.number().int().min(0).optional(),
     desktopItems: z.number().int().min(0).optional(),

--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -3,7 +3,7 @@ import ComponentEditor from "../src/components/cms/page-builder/ComponentEditor"
 import type { PageComponent } from "@acme/types";
 
 describe("ComponentEditor", () => {
-  it("updates width and height", () => {
+  it("updates width, height, margin and padding", () => {
     const component: PageComponent = {
       id: "1",
       type: "Image",
@@ -16,14 +16,26 @@ describe("ComponentEditor", () => {
         onResize={onResize}
       />
     );
-    fireEvent.change(getByLabelText("Width (Desktop)"), { target: { value: "200" } });
+    fireEvent.change(getByLabelText("Width (Desktop)"), {
+      target: { value: "200" },
+    });
     expect(onResize).toHaveBeenCalledWith({ widthDesktop: "200" });
     fireEvent.click(getAllByText("Full width")[0]);
     expect(onResize).toHaveBeenCalledWith({ widthDesktop: "100%" });
-    fireEvent.change(getByLabelText("Height (Desktop)"), { target: { value: "300" } });
+    fireEvent.change(getByLabelText("Height (Desktop)"), {
+      target: { value: "300" },
+    });
     expect(onResize).toHaveBeenCalledWith({ heightDesktop: "300" });
     fireEvent.click(getAllByText("Full height")[0]);
     expect(onResize).toHaveBeenCalledWith({ heightDesktop: "100%" });
+    fireEvent.change(getByLabelText("Margin (Desktop)"), {
+      target: { value: "10px" },
+    });
+    expect(onResize).toHaveBeenCalledWith({ marginDesktop: "10px" });
+    fireEvent.change(getByLabelText("Padding (Desktop)"), {
+      target: { value: "5px" },
+    });
+    expect(onResize).toHaveBeenCalledWith({ paddingDesktop: "5px" });
   });
 
   it("updates minItems and maxItems", () => {

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -87,6 +87,20 @@ const CanvasItem = memo(function CanvasItem({
       : "heightMobile";
   const widthVal = (component as any)[widthKey] ?? component.width;
   const heightVal = (component as any)[heightKey] ?? component.height;
+  const marginKey =
+    viewport === "desktop"
+      ? "marginDesktop"
+      : viewport === "tablet"
+      ? "marginTablet"
+      : "marginMobile";
+  const paddingKey =
+    viewport === "desktop"
+      ? "paddingDesktop"
+      : viewport === "tablet"
+      ? "paddingTablet"
+      : "paddingMobile";
+  const marginVal = (component as any)[marginKey] ?? component.margin;
+  const paddingVal = (component as any)[paddingKey] ?? component.padding;
 
   const editor = useTextEditor(component, locale, editing);
 
@@ -309,8 +323,8 @@ const CanvasItem = memo(function CanvasItem({
         transform: CSS.Transform.toString(transform),
         ...(widthVal ? { width: widthVal } : {}),
         ...(heightVal ? { height: heightVal } : {}),
-        ...(component.margin ? { margin: component.margin } : {}),
-        ...(component.padding ? { padding: component.padding } : {}),
+        ...(marginVal ? { margin: marginVal } : {}),
+        ...(paddingVal ? { padding: paddingVal } : {}),
         ...(component.position ? { position: component.position } : {}),
         ...(component.top ? { top: component.top } : {}),
         ...(component.left ? { left: component.left } : {}),

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -48,6 +48,12 @@ interface Props {
     heightDesktop?: string;
     heightTablet?: string;
     heightMobile?: string;
+    marginDesktop?: string;
+    marginTablet?: string;
+    marginMobile?: string;
+    paddingDesktop?: string;
+    paddingTablet?: string;
+    paddingMobile?: string;
   }) => void;
 }
 
@@ -385,6 +391,22 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
               Full height
             </Button>
           </div>
+          <Input
+            label={`Margin (${vp})`}
+            value={(component as any)[`margin${vp}`] ?? ""}
+            onChange={(e) => {
+              const v = e.target.value.trim();
+              onResize({ [`margin${vp}`]: v || undefined } as any);
+            }}
+          />
+          <Input
+            label={`Padding (${vp})`}
+            value={(component as any)[`padding${vp}`] ?? ""}
+            onChange={(e) => {
+              const v = e.target.value.trim();
+              onResize({ [`padding${vp}`]: v || undefined } as any);
+            }}
+          />
         </div>
       ))}
       <Input

--- a/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
@@ -32,6 +32,12 @@ const PageSidebar = ({ components, selectedId, dispatch }: Props) => {
         heightDesktop?: string;
         heightTablet?: string;
         heightMobile?: string;
+        marginDesktop?: string;
+        marginTablet?: string;
+        marginMobile?: string;
+        paddingDesktop?: string;
+        paddingTablet?: string;
+        paddingMobile?: string;
       },
     ) =>
       dispatch({ type: "resize", id: selectedId, ...size }),

--- a/packages/ui/src/components/cms/page-builder/state.ts
+++ b/packages/ui/src/components/cms/page-builder/state.ts
@@ -43,6 +43,12 @@ export type ChangeAction =
       heightDesktop?: string;
       heightTablet?: string;
       heightMobile?: string;
+      marginDesktop?: string;
+      marginTablet?: string;
+      marginMobile?: string;
+      paddingDesktop?: string;
+      paddingTablet?: string;
+      paddingMobile?: string;
     }
   | { type: "set"; components: PageComponent[] };
 
@@ -168,6 +174,12 @@ function resizeComponent(
     heightDesktop?: string;
     heightTablet?: string;
     heightMobile?: string;
+    marginDesktop?: string;
+    marginTablet?: string;
+    marginMobile?: string;
+    paddingDesktop?: string;
+    paddingTablet?: string;
+    paddingMobile?: string;
   },
 ): PageComponent[] {
   return list.map((c) => {
@@ -248,15 +260,51 @@ function componentsReducer(
         height?: string;
         left?: string;
         top?: string;
+        widthDesktop?: string;
+        widthTablet?: string;
+        widthMobile?: string;
+        heightDesktop?: string;
+        heightTablet?: string;
+        heightMobile?: string;
+        marginDesktop?: string;
+        marginTablet?: string;
+        marginMobile?: string;
+        paddingDesktop?: string;
+        paddingTablet?: string;
+        paddingMobile?: string;
       } = {};
       const width = normalize(action.width);
       const height = normalize(action.height);
       const left = normalize(action.left);
       const top = normalize(action.top);
+      const widthDesktop = normalize(action.widthDesktop);
+      const widthTablet = normalize(action.widthTablet);
+      const widthMobile = normalize(action.widthMobile);
+      const heightDesktop = normalize(action.heightDesktop);
+      const heightTablet = normalize(action.heightTablet);
+      const heightMobile = normalize(action.heightMobile);
+      const marginDesktop = normalize(action.marginDesktop);
+      const marginTablet = normalize(action.marginTablet);
+      const marginMobile = normalize(action.marginMobile);
+      const paddingDesktop = normalize(action.paddingDesktop);
+      const paddingTablet = normalize(action.paddingTablet);
+      const paddingMobile = normalize(action.paddingMobile);
       if (width !== undefined) patch.width = width;
       if (height !== undefined) patch.height = height;
       if (left !== undefined) patch.left = left;
       if (top !== undefined) patch.top = top;
+      if (widthDesktop !== undefined) patch.widthDesktop = widthDesktop;
+      if (widthTablet !== undefined) patch.widthTablet = widthTablet;
+      if (widthMobile !== undefined) patch.widthMobile = widthMobile;
+      if (heightDesktop !== undefined) patch.heightDesktop = heightDesktop;
+      if (heightTablet !== undefined) patch.heightTablet = heightTablet;
+      if (heightMobile !== undefined) patch.heightMobile = heightMobile;
+      if (marginDesktop !== undefined) patch.marginDesktop = marginDesktop;
+      if (marginTablet !== undefined) patch.marginTablet = marginTablet;
+      if (marginMobile !== undefined) patch.marginMobile = marginMobile;
+      if (paddingDesktop !== undefined) patch.paddingDesktop = paddingDesktop;
+      if (paddingTablet !== undefined) patch.paddingTablet = paddingTablet;
+      if (paddingMobile !== undefined) patch.paddingMobile = paddingMobile;
       return resizeComponent(state, action.id, patch);
     case "set":
       return action.components;


### PR DESCRIPTION
## Summary
- add per-viewport margin and padding fields to ComponentEditor
- persist responsive spacing values through resize actions and state
- extend type definitions for margin/padding across viewports

## Testing
- `pnpm --filter @acme/types test` *(no tests found)*
- `pnpm --filter @acme/ui run test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689cc99fe6f8832fba7f492a8abce71d