### PR TITLE
refactor: enforce session secret config

### DIFF
--- a/apps/shop-abc/__tests__/authFlow.test.ts
+++ b/apps/shop-abc/__tests__/authFlow.test.ts
@@ -64,6 +64,7 @@ let requestPOST: typeof import("../src/app/api/account/reset/request/route").POS
 let completePOST: typeof import("../src/app/api/account/reset/complete/route").POST;
 
 beforeAll(async () => {
+  process.env.SESSION_SECRET = "test-secret";
   ({ POST: registerPOST } = await import("../src/app/register/route"));
   ({ POST: loginPOST } = await import("../src/app/login/route"));
   ({ POST: requestPOST } = await import(

--- a/apps/shop-abc/__tests__/registerApi.test.ts
+++ b/apps/shop-abc/__tests__/registerApi.test.ts
@@ -48,9 +48,16 @@ jest.mock("next/server", () => ({
   },
 }));
 
-import { POST } from "../src/app/register/route";
-import { GET as profileGET } from "../src/app/api/account/profile/route";
 import { updateCustomerProfile } from "@acme/platform-core/customerProfiles";
+
+let POST: typeof import("../src/app/register/route").POST;
+let profileGET: typeof import("../src/app/api/account/profile/route").GET;
+
+beforeAll(async () => {
+  process.env.SESSION_SECRET = "test-secret";
+  ({ POST } = await import("../src/app/register/route"));
+  ({ GET: profileGET } = await import("../src/app/api/account/profile/route"));
+});
 
 describe("/register POST", () => {
   afterEach(() => {

--- a/apps/shop-abc/__tests__/registerRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/registerRateLimit.test.ts
@@ -26,6 +26,7 @@ let __resetRegistrationRateLimiter: typeof import("../src/middleware").__resetRe
 let MAX_REGISTRATION_ATTEMPTS: number;
 
 beforeAll(async () => {
+  process.env.SESSION_SECRET = "test-secret";
   ({ __resetRegistrationRateLimiter, MAX_REGISTRATION_ATTEMPTS } = await import(
     "../src/middleware"
   ));

--- a/apps/shop-abc/src/app/api/account/verify/route.ts
+++ b/apps/shop-abc/src/app/api/account/verify/route.ts
@@ -6,6 +6,7 @@ import crypto from "crypto";
 import { getUserById } from "@acme/platform-core/users";
 import { validateCsrfToken } from "@auth";
 import { parseJsonBody } from "@shared-utils";
+import { coreEnv } from "@acme/config/env/core";
 
 export const VerifySchema = z.object({ token: z.string() }).strict();
 export type VerifyInput = z.infer<typeof VerifySchema>;
@@ -24,7 +25,10 @@ export async function POST(req: Request) {
   if (!id || !sig)
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });
 
-  const secret = process.env.SESSION_SECRET ?? "test-secret";
+  const secret = coreEnv.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET is not set");
+  }
   const expected = crypto.createHmac("sha256", secret).update(id).digest("hex");
   if (sig !== expected)
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -13,6 +13,7 @@ import { checkRegistrationRateLimit } from "../../middleware";
 import { validateCsrfToken } from "@auth";
 import { updateCustomerProfile } from "@acme/platform-core/customerProfiles";
 import { sendEmail } from "@acme/email";
+import { coreEnv } from "@acme/config/env/core";
 
 const RegisterSchema = z
   .object({
@@ -58,7 +59,10 @@ export async function POST(req: Request) {
   await createUser({ id: customerId, email, passwordHash });
   await updateCustomerProfile(customerId, { name: "", email });
 
-  const secret = process.env.SESSION_SECRET ?? "test-secret";
+  const secret = coreEnv.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET is not set");
+  }
   const signature = crypto
     .createHmac("sha256", secret)
     .update(customerId)


### PR DESCRIPTION
## Summary
- use coreEnv.SESSION_SECRET instead of process.env fallback in account verification and registration flows
- raise error when SESSION_SECRET is missing
- provide SESSION_SECRET in tests to satisfy new requirement

## Testing
- `npx jest apps/shop-abc/__tests__/registerApi.test.ts apps/shop-abc/__tests__/registerRateLimit.test.ts apps/shop-abc/__tests__/authFlow.test.ts` *(fails: Cannot find module '.prisma/client/index-browser'...)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb3a6830832f91e55459173ae3ce