### PR TITLE
feat: support marketing email env

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
 - `LOG_LEVEL` – controls logging output (`error`, `warn`, `info`, `debug`; defaults to `info`)
 - `EMAIL_PROVIDER` – campaign email provider (`smtp`, `sendgrid`, or `resend`)
 - `SENDGRID_API_KEY` – API key for SendGrid when using the SendGrid provider
-- `RESEND_API_KEY` – API key for Resend when using the Resend provider
+- `SENDGRID_MARKETING_KEY` – API key for SendGrid marketing endpoints (contact management and segments)
+- `RESEND_API_KEY` – API key for Resend when using the Resend provider (requires `emails.send`, `contacts.write`, `contacts.read`, and `segments.read` scopes)
 - `SENDGRID_WEBHOOK_PUBLIC_KEY` – public key to verify SendGrid event webhook signatures
 - `RESEND_WEBHOOK_SECRET` – secret used to verify Resend webhook signatures
 

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -22,6 +22,7 @@ export const coreEnvBaseSchema = z.object({
   CAMPAIGN_FROM: z.string().optional(),
   EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).optional(),
   SENDGRID_API_KEY: z.string().optional(),
+  SENDGRID_MARKETING_KEY: z.string().optional(),
   RESEND_API_KEY: z.string().optional(),
   EMAIL_BATCH_SIZE: z.coerce.number().optional(),
   EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -23,6 +23,20 @@ These providers are tested against Node.js 18+. When upgrading SDK versions,
 ensure the APIs remain compatible with our wrapper implementations and supported
 Node versions.
 
+## Environment variables
+
+The email package relies on several environment variables when sending
+campaigns or managing contacts:
+
+- `SENDGRID_API_KEY` – used to send mail via the SendGrid provider
+- `SENDGRID_MARKETING_KEY` – grants access to SendGrid marketing APIs for
+  contact and segment management
+- `RESEND_API_KEY` – used by the Resend provider and must include `emails.send`,
+  `contacts.write`, `contacts.read`, and `segments.read` scopes
+
+Set the relevant variables in the host environment before invoking any of the
+package helpers.
+
 ## Provider sanity checks
 
 `SendgridProvider` and `ResendProvider` accept an optional `{ sanityCheck: true }`

--- a/packages/email/src/__tests__/campaign-integration.test.ts
+++ b/packages/email/src/__tests__/campaign-integration.test.ts
@@ -43,6 +43,7 @@ beforeEach(async () => {
 afterEach(() => {
   delete process.env.EMAIL_PROVIDER;
   delete process.env.SENDGRID_API_KEY;
+  delete process.env.SENDGRID_MARKETING_KEY;
   delete process.env.RESEND_API_KEY;
   delete process.env.CAMPAIGN_FROM;
   delete process.env.NEXT_PUBLIC_BASE_URL;

--- a/packages/email/src/__tests__/providers.test.ts
+++ b/packages/email/src/__tests__/providers.test.ts
@@ -19,11 +19,13 @@ describe("Campaign providers segmentation", () => {
     jest.resetModules();
     jest.clearAllMocks();
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.RESEND_API_KEY;
   });
 
   it("sendgrid segmentation methods call API", async () => {
     process.env.SENDGRID_API_KEY = "sg";
+    process.env.SENDGRID_MARKETING_KEY = "smk";
     const { SendgridProvider } = await import("../providers/sendgrid");
     const provider = new SendgridProvider();
 
@@ -36,7 +38,7 @@ describe("Campaign providers segmentation", () => {
       "https://api.sendgrid.com/v3/marketing/contacts",
       expect.objectContaining({
         method: "PUT",
-        headers: expect.objectContaining({ Authorization: "Bearer sg" }),
+        headers: expect.objectContaining({ Authorization: "Bearer smk" }),
       })
     );
     expect(id).toBe("c1");

--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -44,6 +44,7 @@ describe("sendCampaignEmail fallback and retry", () => {
     jest.clearAllTimers();
     delete process.env.EMAIL_PROVIDER;
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.RESEND_API_KEY;
     delete process.env.CAMPAIGN_FROM;
   });

--- a/packages/email/src/__tests__/sendCampaignEmail.test.ts
+++ b/packages/email/src/__tests__/sendCampaignEmail.test.ts
@@ -15,6 +15,7 @@ describe("sendCampaignEmail", () => {
     delete process.env.CAMPAIGN_FROM;
     delete process.env.EMAIL_PROVIDER;
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.RESEND_API_KEY;
   });
 

--- a/packages/email/src/__tests__/sendgrid.test.ts
+++ b/packages/email/src/__tests__/sendgrid.test.ts
@@ -5,6 +5,7 @@ describe("SendgridProvider", () => {
     jest.resetModules();
     jest.clearAllMocks();
     delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
     delete process.env.CAMPAIGN_FROM;
   });
 

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -87,12 +87,13 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async createContact(email: string): Promise<string> {
-    if (!coreEnv.SENDGRID_API_KEY) return "";
+    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return "";
     try {
       const res = await fetch("https://api.sendgrid.com/v3/marketing/contacts", {
         method: "PUT",
         headers: {
-          Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+          Authorization: `Bearer ${key}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ contacts: [{ email }] }),
@@ -106,11 +107,12 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async addToList(contactId: string, listId: string): Promise<void> {
-    if (!coreEnv.SENDGRID_API_KEY) return;
+    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return;
     await fetch(`https://api.sendgrid.com/v3/marketing/lists/${listId}/contacts`, {
       method: "PUT",
       headers: {
-        Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+        Authorization: `Bearer ${key}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ contact_ids: [contactId] }),
@@ -118,10 +120,11 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async listSegments(): Promise<{ id: string; name?: string }[]> {
-    if (!coreEnv.SENDGRID_API_KEY) return [];
+    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    if (!key) return [];
     try {
       const res = await fetch("https://api.sendgrid.com/v3/marketing/segments", {
-        headers: { Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}` },
+        headers: { Authorization: `Bearer ${key}` },
       });
       const json = await res.json().catch(() => ({}));
       const segments = Array.isArray(json?.result) ? json.result : [];


### PR DESCRIPTION
## Summary
- add `SENDGRID_MARKETING_KEY` to core env schema
- use marketing key for SendGrid contact and segment APIs
- document email provider environment variables and Resend API key scopes

## Testing
- `pnpm test --filter @acme/config` *(no tests run)*
- `npx jest packages/email/src/__tests__` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689ccb15f8c4832fa53d4e84c4020b01