### PR TITLE
feat(ui): add featured product block with editor

### DIFF
--- a/packages/ui/src/components/cms/blocks/FeaturedProductBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/FeaturedProductBlock.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FeaturedProductBlock from "./FeaturedProductBlock";
+import { PRODUCTS } from "@platform-core/src/products";
+
+const meta: Meta<typeof FeaturedProductBlock> = {
+  component: FeaturedProductBlock,
+  args: {
+    sku: PRODUCTS[0] as any,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof FeaturedProductBlock> = {};

--- a/packages/ui/src/components/cms/blocks/FeaturedProductBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FeaturedProductBlock.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import type { SKU } from "@acme/types";
+import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
+import { PRODUCTS } from "@platform-core/src/products";
+import { fetchCollection } from "./products/fetchCollection";
+import { Price } from "../../atoms/Price";
+import { ProductVariantSelector } from "../../organisms/ProductVariantSelector";
+
+export interface FeaturedProductBlockProps {
+  sku?: SKU;
+  collectionId?: string;
+}
+
+export function getRuntimeProps() {
+  return { sku: PRODUCTS[0] as SKU };
+}
+
+export default function FeaturedProductBlock({
+  sku,
+  collectionId,
+}: FeaturedProductBlockProps) {
+  const [product, setProduct] = useState<SKU | null>(sku ?? null);
+  const [size, setSize] = useState<string | undefined>();
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      if (collectionId) {
+        const fetched = await fetchCollection(collectionId);
+        if (!cancelled) setProduct(fetched[0] ?? null);
+      } else {
+        setProduct(sku ?? null);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionId, sku]);
+
+  if (!product) return null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {product.media[0] && (
+        <div className="relative aspect-square w-full">
+          {product.media[0].type === "image" ? (
+            <Image
+              src={product.media[0].url}
+              alt={product.title}
+              fill
+              sizes="(min-width: 768px) 50vw, 100vw"
+              className="rounded-md object-cover"
+            />
+          ) : (
+            <video
+              src={product.media[0].url}
+              className="h-full w-full rounded-md object-cover"
+              muted
+              playsInline
+            />
+          )}
+        </div>
+      )}
+      <h3 className="text-xl font-semibold">{product.title}</h3>
+      <Price amount={product.price} className="text-lg font-medium" />
+      <ProductVariantSelector
+        sizes={product.sizes}
+        selectedSize={size}
+        onSizeChange={setSize}
+        quantity={quantity}
+        onQuantityChange={setQuantity}
+      />
+      <AddToCartButton
+        sku={product}
+        size={size}
+        quantity={quantity}
+        disabled={product.sizes?.length > 0 && !size}
+      />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/FeaturedProductBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/FeaturedProductBlock.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SKU } from "@acme/types";
+import FeaturedProductBlock from "../FeaturedProductBlock";
+
+jest.mock("@platform-core/src/components/shop/AddToCartButton.client", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <button disabled={props.disabled}>Add to cart</button>
+  ),
+}));
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+describe("FeaturedProductBlock", () => {
+  const sku: SKU = {
+    id: "1",
+    slug: "prod-1",
+    title: "Test Product",
+    price: 100,
+    deposit: 0,
+    stock: 5,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: ["S", "M"],
+    description: "",
+  };
+
+  it("renders product info and variant selector", async () => {
+    render(<FeaturedProductBlock sku={sku} />);
+    expect(screen.getByText("Test Product")).toBeInTheDocument();
+    const select = screen.getByRole("combobox");
+    const button = screen.getByRole("button", { name: /add to cart/i });
+    expect(button).toBeDisabled();
+    await userEvent.selectOptions(select, "S");
+    expect(button).not.toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -30,6 +30,7 @@ import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
+import FeaturedProductBlock from "./FeaturedProductBlock";
 
 export {
   BlogListing,
@@ -64,6 +65,7 @@ export {
   Tabs,
   CollectionList,
   ProductComparison,
+  FeaturedProductBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -16,6 +16,9 @@ import ValueProps from "./ValueProps";
 import RecommendationCarousel, {
   getRuntimeProps as getRecommendationCarouselRuntimeProps,
 } from "./RecommendationCarousel";
+import FeaturedProductBlock, {
+  getRuntimeProps as getFeaturedProductRuntimeProps,
+} from "./FeaturedProductBlock";
 import AnnouncementBar from "./AnnouncementBarBlock";
 import MapBlock from "./MapBlock";
 import StoreLocatorBlock from "./StoreLocatorBlock";
@@ -48,6 +51,10 @@ export const organismRegistry = {
   RecommendationCarousel: {
     component: RecommendationCarousel,
     getRuntimeProps: getRecommendationCarouselRuntimeProps,
+  },
+  FeaturedProduct: {
+    component: FeaturedProductBlock,
+    getRuntimeProps: getFeaturedProductRuntimeProps,
   },
   ImageSlider: { component: ImageSlider },
   CollectionList: { component: CollectionList },

--- a/packages/ui/src/components/cms/page-builder/FeaturedProductEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FeaturedProductEditor.tsx
@@ -1,0 +1,28 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function FeaturedProductEditor({ component, onChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <Input
+        label="SKU"
+        placeholder="sku"
+        value={(component as any).sku ?? ""}
+        onChange={(e) => onChange({ sku: e.target.value } as Partial<PageComponent>)}
+      />
+      <Input
+        label="Collection ID"
+        placeholder="collectionId"
+        value={(component as any).collectionId ?? ""}
+        onChange={(e) =>
+          onChange({ collectionId: e.target.value } as Partial<PageComponent>)
+        }
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -10,6 +10,7 @@ import AnnouncementBarEditor from "../AnnouncementBarEditor";
 import SocialFeedEditor from "../SocialFeedEditor";
 import NewsletterSignupEditor from "../NewsletterSignupEditor";
 import StoreLocatorBlockEditor from "../StoreLocatorBlockEditor";
+import FeaturedProductEditor from "../FeaturedProductEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -86,6 +87,12 @@ describe("block editors", () => {
       StoreLocatorBlockEditor,
       { type: "StoreLocatorBlock", locations: [{ lat: "", lng: "", label: "" }] },
       "lat",
+    ],
+    [
+      "FeaturedProductEditor",
+      FeaturedProductEditor,
+      { type: "FeaturedProduct", sku: "" },
+      "sku",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -19,6 +19,7 @@ export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as SearchBarEditor } from "./SearchBarEditor";
 export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
+export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add featured product block with variant selector and quick-add
- allow selecting SKU or collection in FeaturedProductEditor
- register block and editor with story and tests

## Testing
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/FeaturedProductBlock.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689ccecd04f0832fade8d1bec2585018