### PR TITLE
feat: add form builder block

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -198,6 +198,18 @@ export interface NewsletterSignupComponent extends PageComponentBase {
   submitLabel?: string;
 }
 
+export interface FormBuilderComponent extends PageComponentBase {
+  type: "FormBuilder";
+  action?: string;
+  method?: string;
+  fields?: {
+    type: string;
+    name: string;
+    label?: string;
+    options?: { label: string; value: string }[];
+  }[];
+}
+
 export interface SearchBarComponent extends PageComponentBase {
   type: "SearchBar";
   placeholder?: string;
@@ -325,6 +337,7 @@ export type PageComponent =
   | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
+  | FormBuilderComponent
   | SearchBarComponent
   | ContactFormWithMapComponent
   | MapBlockComponent
@@ -439,6 +452,24 @@ const newsletterSignupComponentSchema = baseComponentSchema.extend({
   action: z.string().optional(),
   placeholder: z.string().optional(),
   submitLabel: z.string().optional(),
+});
+
+const formBuilderComponentSchema = baseComponentSchema.extend({
+  type: z.literal("FormBuilder"),
+  action: z.string().optional(),
+  method: z.string().optional(),
+  fields: z
+    .array(
+      z.object({
+        type: z.string(),
+        name: z.string(),
+        label: z.string().optional(),
+        options: z
+          .array(z.object({ label: z.string(), value: z.string() }))
+          .optional(),
+      })
+    )
+    .optional(),
 });
 
 const searchBarComponentSchema = baseComponentSchema.extend({
@@ -634,6 +665,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     galleryComponentSchema,
     contactFormComponentSchema,
     newsletterSignupComponentSchema,
+    formBuilderComponentSchema,
     searchBarComponentSchema,
     contactFormWithMapComponentSchema,
     mapBlockComponentSchema,

--- a/packages/ui/src/components/cms/blocks/FormBuilderBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/FormBuilderBlock.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FormBuilderBlock from "./FormBuilderBlock";
+
+const meta: Meta<typeof FormBuilderBlock> = {
+  title: "CMS/Blocks/FormBuilder",
+  component: FormBuilderBlock,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof FormBuilderBlock> = {
+  args: {
+    fields: [
+      { type: "text", name: "name", label: "Name" },
+      { type: "email", name: "email", label: "Email" },
+      {
+        type: "select",
+        name: "color",
+        label: "Favorite Color",
+        options: [
+          { label: "Red", value: "red" },
+          { label: "Blue", value: "blue" },
+        ],
+      },
+    ],
+  },
+};
+

--- a/packages/ui/src/components/cms/blocks/FormBuilderBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FormBuilderBlock.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+interface Field {
+  type: string;
+  name: string;
+  label?: string;
+  options?: { label: string; value: string }[];
+}
+
+interface Props {
+  action?: string;
+  method?: string;
+  fields?: Field[];
+}
+
+export default function FormBuilderBlock({
+  action = "#",
+  method = "post",
+  fields = [],
+}: Props) {
+  return (
+    <form className="space-y-2" action={action} method={method}>
+      {fields.map((field) => {
+        const key = field.name;
+        const label = field.label;
+        switch (field.type) {
+          case "textarea":
+            return (
+              <div key={key} className="space-y-1">
+                {label && (
+                  <label htmlFor={key} className="block text-sm font-medium">
+                    {label}
+                  </label>
+                )}
+                <textarea
+                  id={key}
+                  name={field.name}
+                  className="w-full rounded border p-2"
+                />
+              </div>
+            );
+          case "select":
+            return (
+              <div key={key} className="space-y-1">
+                {label && (
+                  <label htmlFor={key} className="block text-sm font-medium">
+                    {label}
+                  </label>
+                )}
+                <select
+                  id={key}
+                  name={field.name}
+                  className="w-full rounded border p-2"
+                >
+                  {(field.options ?? []).map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          default:
+            return (
+              <div key={key} className="space-y-1">
+                {label && (
+                  <label htmlFor={key} className="block text-sm font-medium">
+                    {label}
+                  </label>
+                )}
+                <input
+                  id={key}
+                  type={field.type}
+                  name={field.name}
+                  className="w-full rounded border p-2"
+                />
+              </div>
+            );
+        }
+      })}
+      <button
+        type="submit"
+        className="rounded bg-primary px-4 py-2 text-primary-fg"
+      >
+        Submit
+      </button>
+    </form>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/FormBuilderBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/FormBuilderBlock.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import FormBuilderBlock from "../FormBuilderBlock";
+
+describe("FormBuilderBlock", () => {
+  it("renders configured fields", () => {
+    render(
+      <FormBuilderBlock
+        fields={[
+          { type: "text", name: "name", label: "Name" },
+          { type: "email", name: "email", label: "Email" },
+          {
+            type: "select",
+            name: "color",
+            label: "Favorite Color",
+            options: [
+              { label: "Red", value: "red" },
+              { label: "Blue", value: "blue" },
+            ],
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Favorite Color")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Red" })).toBeInTheDocument();
+  });
+});
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -30,6 +30,7 @@ import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
+import FormBuilder from "./FormBuilderBlock";
 
 export {
   BlogListing,
@@ -64,6 +65,7 @@ export {
   Tabs,
   CollectionList,
   ProductComparison,
+  FormBuilder,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -31,6 +31,7 @@ import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
+import FormBuilder from "./FormBuilderBlock";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -69,6 +70,7 @@ export const organismRegistry = {
   PricingTable: { component: PricingTable },
   Tabs: { component: Tabs },
   ProductComparison: { component: ProductComparisonBlock },
+  FormBuilder: { component: FormBuilder },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
@@ -1,0 +1,106 @@
+import type { PageComponent } from "@acme/types";
+import {
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+const FIELD_TYPES = ["text", "email", "textarea", "select"] as const;
+
+type Field = {
+  type: string;
+  name: string;
+  label?: string;
+  options?: { label: string; value: string }[];
+};
+
+export default function FormBuilderEditor({ component, onChange }: Props) {
+  const fields = ((component as any).fields ?? []) as Field[];
+
+  const updateField = (
+    idx: number,
+    patch: Partial<Field>
+  ) => {
+    const next = [...fields];
+    next[idx] = { ...next[idx], ...patch };
+    onChange({ fields: next } as Partial<PageComponent>);
+  };
+
+  const removeField = (idx: number) => {
+    const next = fields.filter((_, i) => i !== idx);
+    onChange({ fields: next } as Partial<PageComponent>);
+  };
+
+  const addField = () => {
+    onChange({
+      fields: [...fields, { type: "text", name: "", label: "" }],
+    } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      {fields.map((field, idx) => (
+        <div key={idx} className="space-y-2 rounded border p-2">
+          <Select
+            value={field.type}
+            onValueChange={(value) => updateField(idx, { type: value })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="type" />
+            </SelectTrigger>
+            <SelectContent>
+              {FIELD_TYPES.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            value={field.name ?? ""}
+            onChange={(e) => updateField(idx, { name: e.target.value })}
+            placeholder="name"
+          />
+          <Input
+            value={field.label ?? ""}
+            onChange={(e) => updateField(idx, { label: e.target.value })}
+            placeholder="label"
+          />
+          {field.type === "select" && (
+            <Input
+              value={(field.options ?? [])
+                .map((o) => o.label)
+                .join(",")}
+              onChange={(e) =>
+                updateField(idx, {
+                  options: e.target.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                    .map((s) => ({ label: s, value: s })),
+                })
+              }
+              placeholder="options (comma separated)"
+            />
+          )}
+          <Button variant="destructive" onClick={() => removeField(idx)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button type="button" onClick={addField}>
+        Add field
+      </Button>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -19,6 +19,7 @@ export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as SearchBarEditor } from "./SearchBarEditor";
 export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
+export { default as FormBuilderEditor } from "./FormBuilderEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add flexible FormBuilder block with support for text, email, textarea and select fields
- implement FormBuilderEditor for adding/removing fields in page builder
- register FormBuilder across block and editor registries and extend Page types

## Testing
- `node ../../node_modules/jest/bin/jest.js --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs __tests__/pageSchema.test.ts`
- `pnpm test src/components/cms/blocks/__tests__/FormBuilderBlock.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ccda7ce68832f8ad7e198f63d0f7f