### PR TITLE
feat(ui): add gift card block and editor

### DIFF
--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import GiftCardBlock from "./GiftCardBlock";
+
+const meta: Meta<typeof GiftCardBlock> = {
+  component: GiftCardBlock,
+  args: {
+    description: "Choose an amount",
+    amounts: [25, 50, 100],
+    ctaLabel: "Buy",
+    ctaHref: "/gift-card",
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof GiftCardBlock> = {};

--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Button } from "../../atoms/shadcn";
+
+interface Props {
+  amounts?: number[];
+  description?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+}
+
+/** Displays gift card denominations with a purchase button */
+export default function GiftCardBlock({
+  amounts = [],
+  description,
+  ctaLabel = "Purchase",
+  ctaHref = "#",
+}: Props) {
+  const [selected, setSelected] = useState<number | null>(
+    amounts.length ? amounts[0] : null
+  );
+
+  if (!amounts.length) return null;
+
+  const href = selected !== null ? `${ctaHref}?amount=${selected}` : ctaHref;
+
+  return (
+    <section className="space-y-4">
+      {description && <p>{description}</p>}
+      <div className="flex flex-wrap gap-2">
+        {amounts.map((amt) => (
+          <Button
+            key={amt}
+            type="button"
+            variant={selected === amt ? "default" : "outline"}
+            onClick={() => setSelected(amt)}
+          >
+            {`$${amt}`}
+          </Button>
+        ))}
+      </div>
+      <Button asChild>
+        <a href={href}>{ctaLabel}</a>
+      </Button>
+    </section>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import GiftCardBlock from "../GiftCardBlock";
+
+describe("GiftCardBlock", () => {
+  it("updates purchase link when selecting amount", () => {
+    render(<GiftCardBlock amounts={[25, 50]} ctaHref="/buy" ctaLabel="Buy" />);
+    const link = screen.getByRole("link", { name: "Buy" });
+    expect(link).toHaveAttribute("href", "/buy?amount=25");
+    fireEvent.click(screen.getByRole("button", { name: "$50" }));
+    expect(link).toHaveAttribute("href", "/buy?amount=50");
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -29,6 +29,7 @@ import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
+import GiftCard from "./GiftCardBlock";
 
 export {
   BlogListing,
@@ -62,6 +63,7 @@ export {
   Tabs,
   CollectionList,
   ProductComparison,
+  GiftCard,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -34,6 +34,7 @@ import CollectionListEditor from "./CollectionListEditor";
 import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
+import GiftCardEditor from "./GiftCardEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -120,6 +121,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "ProductComparison":
       specific = (
         <ProductComparisonEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "GiftCard":
+      specific = (
+        <GiftCardEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/GiftCardEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/GiftCardEditor.tsx
@@ -1,0 +1,61 @@
+import type { PageComponent } from "@acme/types";
+import { Button, Input, Textarea } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function GiftCardEditor({ component, onChange }: Props) {
+  const amounts = ((component as any).amounts ?? []) as number[];
+
+  const updateAmount = (idx: number, value: number) => {
+    const next = [...amounts];
+    next[idx] = value;
+    onChange({ amounts: next } as Partial<PageComponent>);
+  };
+
+  const removeAmount = (idx: number) => {
+    onChange({
+      amounts: amounts.filter((_, i) => i !== idx),
+    } as Partial<PageComponent>);
+  };
+
+  const addAmount = () => {
+    onChange({ amounts: [...amounts, 0] } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={(component as any).description ?? ""}
+        onChange={(e) =>
+          onChange({ description: e.target.value } as Partial<PageComponent>)
+        }
+        placeholder="description"
+      />
+      {amounts.map((amt, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <Input
+            type="number"
+            value={amt}
+            onChange={(e) => updateAmount(i, Number(e.target.value))}
+            placeholder="amount"
+            className="flex-1"
+          />
+          <Button
+            variant="destructive"
+            type="button"
+            onClick={() => removeAmount(i)}
+            disabled={amounts.length <= 1}
+          >
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button type="button" onClick={addAmount}>
+        Add Amount
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -18,6 +18,7 @@ export { default as SocialFeedEditor } from "./SocialFeedEditor";
 export { default as SearchBarEditor } from "./SearchBarEditor";
 export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
+export { default as GiftCardEditor } from "./GiftCardEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add GiftCardBlock to render selectable denominations with purchase link
- create GiftCardEditor for editing amounts and description
- register block and editor with page builder

## Testing
- `pnpm --filter @acme/ui test` *(fails: PageBuilder.drag-resize.test and others)*
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689cccba38bc832f958d2b380824c263