### PR TITLE
refactor: require session secrets

### DIFF
--- a/apps/cms/__tests__/products.test.ts
+++ b/apps/cms/__tests__/products.test.ts
@@ -3,7 +3,7 @@
 import type { ProductPublication } from "../../../packages/platform-core/src/products";
 
 // Ensure auth options do not throw on import
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "secret";
 jest.mock("next-auth", () => ({
   getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),
 }));

--- a/apps/cms/__tests__/rbacPermissions.integration.test.tsx
+++ b/apps/cms/__tests__/rbacPermissions.integration.test.tsx
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 process.env.STRIPE_SECRET_KEY = "sk_test_123";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_123";
-process.env.CART_COOKIE_SECRET = "test-secret";
+process.env.CART_COOKIE_SECRET = "secret";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 
 async function withRepo(cb: () => Promise<void>): Promise<void> {

--- a/apps/cms/__tests__/wizardPage.test.tsx
+++ b/apps/cms/__tests__/wizardPage.test.tsx
@@ -7,7 +7,7 @@ import path from "node:path";
 /* -------------------------------------------------------------------------- */
 /*  Minimal env & auth/navigation stubs                                       */
 /* -------------------------------------------------------------------------- */
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "secret";
 
 jest.mock("next-auth", () => ({
   getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),

--- a/apps/cms/__tests__/wizardRoute.test.ts
+++ b/apps/cms/__tests__/wizardRoute.test.ts
@@ -6,7 +6,7 @@ import { ReactNode } from "react";
 /*  Environment setup                                                 */
 /* ------------------------------------------------------------------ */
 
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "secret";
 
 /* ------------------------------------------------------------------ */
 /*  External-module stubs                                             */

--- a/apps/cms/jest.setup.tsx
+++ b/apps/cms/jest.setup.tsx
@@ -13,7 +13,8 @@ import { TextDecoder, TextEncoder } from "node:util";
 
 Object.assign(process.env, {
   NODE_ENV: "test", // make it explicit
-  NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET ?? "test-secret",
+  NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET ?? "secret",
+  SESSION_SECRET: process.env.SESSION_SECRET ?? "secret",
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY ?? "sk_test",
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "pk_test",

--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -16,12 +16,7 @@ import { authSecret } from "./secret";
 
 const NODE_ENV = env.NODE_ENV ?? "development";
 
-/**
- * In tests we default to a dummy secret so Jest doesn't explode.
- * Production *still* requires NEXTAUTH_SECRET — we just relax the rule
- * for "development" and "test".
- */
-const secret = authSecret || (NODE_ENV === "test" ? "test-secret" : undefined);
+const secret = authSecret;
 
 if (NODE_ENV === "production" && !secret) {
   throw new Error("NEXTAUTH_SECRET must be set when NODE_ENV is 'production'");

--- a/apps/cms/src/auth/secret.js
+++ b/apps/cms/src/auth/secret.js
@@ -1,3 +1,6 @@
 // apps/cms/src/auth/secret.ts
 import { env } from "@acme/config";
-export const authSecret = env.NEXTAUTH_SECRET || "dev-secret";
+if (!env.NEXTAUTH_SECRET) {
+  throw new Error("NEXTAUTH_SECRET is not set");
+}
+export const authSecret = env.NEXTAUTH_SECRET;

--- a/apps/cms/src/auth/secret.ts
+++ b/apps/cms/src/auth/secret.ts
@@ -2,4 +2,8 @@
 
 import { env } from "@acme/config";
 
-export const authSecret = env.NEXTAUTH_SECRET || "dev-secret";
+if (!env.NEXTAUTH_SECRET) {
+  throw new Error("NEXTAUTH_SECRET is not set");
+}
+
+export const authSecret = env.NEXTAUTH_SECRET;

--- a/apps/shop-abc/src/app/api/account/verify/route.ts
+++ b/apps/shop-abc/src/app/api/account/verify/route.ts
@@ -6,6 +6,7 @@ import crypto from "crypto";
 import { getUserById } from "@acme/platform-core/users";
 import { validateCsrfToken } from "@auth";
 import { parseJsonBody } from "@shared-utils";
+import { env } from "@acme/config";
 
 export const VerifySchema = z.object({ token: z.string() }).strict();
 export type VerifyInput = z.infer<typeof VerifySchema>;
@@ -24,7 +25,10 @@ export async function POST(req: Request) {
   if (!id || !sig)
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });
 
-  const secret = process.env.SESSION_SECRET ?? "test-secret";
+  const secret = env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET is not set");
+  }
   const expected = crypto.createHmac("sha256", secret).update(id).digest("hex");
   if (sig !== expected)
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -13,6 +13,7 @@ import { checkRegistrationRateLimit } from "../../middleware";
 import { validateCsrfToken } from "@auth";
 import { updateCustomerProfile } from "@acme/platform-core/customerProfiles";
 import { sendEmail } from "@acme/email";
+import { env } from "@acme/config";
 
 const RegisterSchema = z
   .object({
@@ -58,7 +59,10 @@ export async function POST(req: Request) {
   await createUser({ id: customerId, email, passwordHash });
   await updateCustomerProfile(customerId, { name: "", email });
 
-  const secret = process.env.SESSION_SECRET ?? "test-secret";
+  const secret = env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET is not set");
+  }
   const signature = crypto
     .createHmac("sha256", secret)
     .update(customerId)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -17,7 +17,8 @@
 const mutableEnv = process.env as unknown as Record<string, string>;
 
 mutableEnv.NODE_ENV ||= "development"; // relax “edge” runtime checks
-mutableEnv.NEXTAUTH_SECRET ||= "test-secret"; // dummy secret for Next-Auth
+mutableEnv.NEXTAUTH_SECRET ||= "secret"; // dummy secret for Next-Auth
+mutableEnv.SESSION_SECRET ||= "secret"; // dummy secret for sessions
 mutableEnv.CART_COOKIE_SECRET ||= "test-cart-secret"; // cart cookie signing
 mutableEnv.STRIPE_WEBHOOK_SECRET ||= "whsec_test"; // dummy Stripe webhook secret
 

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -2,7 +2,7 @@ import "@acme/lib/initZod";
 import { z } from "zod";
 
 export const coreEnvBaseSchema = z.object({
-  NEXTAUTH_SECRET: z.string().optional(),
+  NEXTAUTH_SECRET: z.string().min(1),
   PREVIEW_TOKEN_SECRET: z.string().optional(),
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
   OUTPUT_EXPORT: z.coerce.boolean().optional(),
@@ -44,7 +44,7 @@ export const coreEnvBaseSchema = z.object({
     .transform((v) => Number(v))
     .optional(),
   OPENAI_API_KEY: z.string().optional(),
-  SESSION_SECRET: z.string().optional(),
+  SESSION_SECRET: z.string().min(1),
   COOKIE_DOMAIN: z.string().optional(),
   LOGIN_RATE_LIMIT_REDIS_URL: z.string().url().optional(),
   LOGIN_RATE_LIMIT_REDIS_TOKEN: z.string().optional(),

--- a/packages/next-config/__tests__/index.test.mjs
+++ b/packages/next-config/__tests__/index.test.mjs
@@ -2,6 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
+process.env.NEXTAUTH_SECRET ||= 'secret';
+process.env.SESSION_SECRET ||= 'secret';
+
 const moduleUrl = new URL('../index.mjs', import.meta.url);
 const freshImport = () => import(`${moduleUrl.href}?t=${Date.now()}&r=${Math.random()}`);
 


### PR DESCRIPTION
## Summary
- ensure CMS auth uses NEXTAUTH_SECRET from config
- read SESSION_SECRET from config in shop-abc routes
- validate SESSION_SECRET and NEXTAUTH_SECRET env vars
- drop `test-secret` fallbacks across tests

## Testing
- `pnpm test` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689cce85b5b0832f8db0978cb706076f