### PR TITLE
feat: use timing-safe compare for API signatures

### DIFF
--- a/apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts
+++ b/apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts
@@ -14,8 +14,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!secret) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const expected = crypto.createHmac("sha256", secret).update(body).digest("hex");
-  if (signature !== expected) {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(body)
+    .digest("hex");
+  try {
+    if (
+      !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+    ) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+    }
+  } catch {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
   let event: any;
@@ -30,4 +39,3 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
   return NextResponse.json({ ok: true });
 }
-

--- a/apps/shop-abc/src/app/api/account/verify/route.ts
+++ b/apps/shop-abc/src/app/api/account/verify/route.ts
@@ -26,8 +26,13 @@ export async function POST(req: Request) {
 
   const secret = process.env.SESSION_SECRET ?? "test-secret";
   const expected = crypto.createHmac("sha256", secret).update(id).digest("hex");
-  if (sig !== expected)
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+    }
+  } catch {
     return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+  }
 
   const user = await getUserById(id);
   if (!user)


### PR DESCRIPTION
## Summary
- use `crypto.timingSafeEqual` to verify account token and webhook signatures
- wrap comparisons in `try/catch` to handle mismatched lengths

## Testing
- `pnpm exec eslint apps/shop-abc/src/app/api/account/verify/route.ts apps/cms/src/app/api/marketing/email/provider-webhooks/resend/route.ts` (files ignored: no matching configuration)
- `pnpm test --filter @apps/shop-abc --filter @apps/cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689cce880d54832f9986c809632daaef