### PR TITLE
feat: add gift card CMS block and editor

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -269,6 +269,12 @@ export interface TestimonialsComponent extends PageComponentBase {
     name?: string;
   }[];
 }
+
+export interface GiftCardBlockComponent extends PageComponentBase {
+  type: "GiftCardBlock";
+  denominations?: number[];
+  description?: string;
+}
 export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
@@ -306,6 +312,7 @@ export type PageComponent =
   | FAQBlockComponent
   | BlogListingComponent
   | TestimonialsComponent
+  | GiftCardBlockComponent
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -287,6 +287,12 @@ export interface PricingTableComponent extends PageComponentBase {
   }[];
 }
 
+export interface GiftCardBlockComponent extends PageComponentBase {
+  type: "GiftCardBlock";
+  denominations?: number[];
+  description?: string;
+}
+
 export interface TextComponent extends PageComponentBase {
   type: "Text";
   text?: string;
@@ -348,6 +354,7 @@ export type PageComponent =
   | TestimonialsComponent
   | PricingTableComponent
   | TestimonialSliderComponent
+  | GiftCardBlockComponent
   | ImageComponent
   | TextComponent
   | CustomHtmlComponent
@@ -592,6 +599,12 @@ const pricingTableComponentSchema = baseComponentSchema.extend({
     .optional(),
 });
 
+const giftCardBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("GiftCardBlock"),
+  denominations: z.array(z.number()).optional(),
+  description: z.string().optional(),
+});
+
 const imageComponentSchema = baseComponentSchema.extend({
   type: z.literal("Image"),
   src: z.string().optional(),
@@ -666,6 +679,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     blogListingComponentSchema,
     testimonialsComponentSchema,
     pricingTableComponentSchema,
+    giftCardBlockComponentSchema,
     testimonialSliderComponentSchema,
     imageComponentSchema,
     textComponentSchema,

--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import GiftCardBlock from "./GiftCardBlock";
+
+const meta: Meta<typeof GiftCardBlock> = {
+  title: "CMS/Blocks/GiftCardBlock",
+  component: GiftCardBlock,
+  tags: ["autodocs"],
+};
+export default meta;
+
+export const Default: StoryObj<typeof GiftCardBlock> = {
+  args: {
+    denominations: [25, 50, 100],
+    description: "Give the gift of choice.",
+  },
+};

--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import type { SKU } from "@acme/types";
+import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
+import { Price } from "../../atoms/Price";
+
+interface Props {
+  denominations?: number[];
+  description?: string;
+}
+
+export default function GiftCardBlock({
+  denominations = [25, 50, 100],
+  description,
+}: Props) {
+  const [amount, setAmount] = useState(denominations[0]);
+
+  const sku: SKU = {
+    id: `gift-${amount}`,
+    slug: `gift-card-${amount}`,
+    title: `Gift Card` ,
+    price: amount,
+    deposit: 0,
+    stock: 9999,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: [],
+    description: description ?? "",
+  } as SKU;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {description && <p>{description}</p>}
+      <div className="flex gap-2">
+        {denominations.map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setAmount(value)}
+            className={`rounded border px-3 py-2 ${
+              amount === value
+                ? "bg-gray-900 text-white"
+                : "bg-white text-gray-900"
+            }`}
+          >
+            <Price amount={value} />
+          </button>
+        ))}
+      </div>
+      <AddToCartButton sku={sku} />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import GiftCardBlock from "../GiftCardBlock";
+
+jest.mock("@platform-core/src/components/shop/AddToCartButton.client", () => ({
+  __esModule: true,
+  default: () => <button>Purchase</button>,
+}));
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+describe("GiftCardBlock", () => {
+  it("renders denominations and purchase button", () => {
+    render(<GiftCardBlock denominations={[25, 50]} description="Gift" />);
+    expect(screen.getByText("Gift")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "$25.00" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "$50.00" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /purchase/i })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -31,6 +31,7 @@ import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
+import GiftCardBlock from "./GiftCardBlock";
 
 export {
   BlogListing,
@@ -66,6 +67,7 @@ export {
   CollectionList,
   ProductComparison,
   FeaturedProductBlock,
+  GiftCardBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -34,6 +34,7 @@ import ImageSlider from "./ImageSlider";
 import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
+import GiftCardBlock from "./GiftCardBlock";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -76,6 +77,7 @@ export const organismRegistry = {
   PricingTable: { component: PricingTable },
   Tabs: { component: Tabs },
   ProductComparison: { component: ProductComparisonBlock },
+  GiftCardBlock: { component: GiftCardBlock },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -35,6 +35,7 @@ import CollectionListEditor from "./CollectionListEditor";
 import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
+import GiftCardEditor from "./GiftCardEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -127,6 +128,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "ProductComparison":
       specific = (
         <ProductComparisonEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "GiftCardBlock":
+      specific = (
+        <GiftCardEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/GiftCardEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/GiftCardEditor.tsx
@@ -1,0 +1,31 @@
+import type { PageComponent } from "@acme/types";
+import { Input, Textarea } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function GiftCardEditor({ component, onChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).denominations?.join(",") ?? ""}
+        onChange={(e) =>
+          onChange({
+            denominations: e.target.value
+              .split(/[\s,]+/)
+              .map((s) => parseInt(s.trim(), 10))
+              .filter((n) => !isNaN(n)),
+          })
+        }
+        placeholder="Amounts (comma separated)"
+      />
+      <Textarea
+        value={(component as any).description ?? ""}
+        onChange={(e) => onChange({ description: e.target.value })}
+        placeholder="Description"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -20,6 +20,7 @@ export { default as SearchBarEditor } from "./SearchBarEditor";
 export { default as RecommendationCarouselEditor } from "./RecommendationCarouselEditor";
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
+export { default as GiftCardEditor } from "./GiftCardEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add GiftCardBlock component with selectable denominations and purchase button
- create GiftCardEditor for editing amounts and description
- register GiftCard block and include story and tests

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689cd4c647bc832f8297a1f676c986ef