### PR TITLE
Use raw-body to enforce JSON body size limits

### DIFF
--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
       })
       .strict();
 
-    const parsed = await parseJsonBody(req, schema);
+    const parsed = await parseJsonBody(req, schema, "1mb");
     if (!parsed.success) return parsed.response;
 
     const { id, csv, categories } = parsed.data;

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -21,7 +21,7 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const parsed = await parseJsonBody(req, schema);
+    const parsed = await parseJsonBody(req, schema, "1mb");
     if (!parsed.success) return parsed.response;
     const data = parsed.data;
     const { shopId } = await context.params;

--- a/apps/cms/src/app/api/providers/shop/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/shop/[shop]/route.ts
@@ -24,7 +24,7 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const parsed = await parseJsonBody(req, schema);
+    const parsed = await parseJsonBody(req, schema, "1mb");
     if (!parsed.success) return parsed.response;
     const { shop } = await context.params;
     const dir = path.join(resolveDataRoot(), shop);

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -55,7 +55,7 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
   }
 
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
   try {
     await updateCustomerProfile(session.customerId, parsed.data);

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -29,6 +29,7 @@ export async function POST(req: Request) {
   const parsed = await parseJsonBody<ResetCompleteInput>(
     req,
     ResetCompleteSchema,
+    "1mb",
   );
   if (!parsed.success) return parsed.response;
 

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -20,6 +20,7 @@ export async function POST(req: Request) {
   const parsed = await parseJsonBody<ResetRequestInput>(
     req,
     ResetRequestSchema,
+    "1mb",
   );
   if (!parsed.success) return parsed.response;
 

--- a/apps/shop-abc/src/app/api/account/verify/route.ts
+++ b/apps/shop-abc/src/app/api/account/verify/route.ts
@@ -11,7 +11,7 @@ export const VerifySchema = z.object({ token: z.string() }).strict();
 export type VerifyInput = z.infer<typeof VerifySchema>;
 
 export async function POST(req: Request) {
-  const parsed = await parseJsonBody<VerifyInput>(req, VerifySchema);
+  const parsed = await parseJsonBody<VerifyInput>(req, VerifySchema, "1mb");
   if (!parsed.success) return parsed.response;
 
   const csrfToken = req.headers.get("x-csrf-token");

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -141,7 +141,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   /* 2️⃣ Parse optional body ------------------------------------------------- */
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
   const {

--- a/apps/shop-abc/src/app/api/mfa/verify/route.ts
+++ b/apps/shop-abc/src/app/api/mfa/verify/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!valid)
     return NextResponse.json({ error: "Invalid CSRF token" }, { status: 403 });
 
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
   const { token, customerId } = parsed.data;
   if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });

--- a/apps/shop-abc/src/app/api/rental/route.ts
+++ b/apps/shop-abc/src/app/api/rental/route.ts
@@ -18,7 +18,7 @@ const ReturnSchema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, RentalSchema);
+  const parsed = await parseJsonBody(req, RentalSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId } = parsed.data;
   const session = await stripe.checkout.sessions.retrieve(sessionId);
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  const parsed = await parseJsonBody(req, ReturnSchema);
+  const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId, damageFee } = parsed.data;
   const order = await markReturned("abc", sessionId, damageFee);

--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -17,7 +17,7 @@ const ReturnSchema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, ReturnSchema);
+  const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId, damageFee } = parsed.data;
 

--- a/apps/shop-abc/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-abc/src/app/api/shipping-rate/route.ts
@@ -18,7 +18,7 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
   try {

--- a/apps/shop-abc/src/app/api/tax/route.ts
+++ b/apps/shop-abc/src/app/api/tax/route.ts
@@ -18,7 +18,7 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
   try {

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -32,7 +32,7 @@ async function validateCredentials(
 }
 
 export async function POST(req: Request) {
-  const parsed = await parseJsonBody<LoginInput>(req, LoginSchema);
+  const parsed = await parseJsonBody<LoginInput>(req, LoginSchema, "1mb");
   if (!parsed.success) return parsed.response;
 
   const csrfToken = req.headers.get("x-csrf-token");

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -39,7 +39,7 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
   await updateCustomerProfile(session.customerId, parsed.data);

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -18,7 +18,7 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
   try {

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -18,7 +18,7 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema);
+  const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
   try {

--- a/apps/shop-bcd/src/app/login/route.ts
+++ b/apps/shop-bcd/src/app/login/route.ts
@@ -35,7 +35,7 @@ async function validateCredentials(
 }
 
 export async function POST(req: Request) {
-  const parsed = await parseJsonBody<LoginInput>(req, LoginSchema);
+  const parsed = await parseJsonBody<LoginInput>(req, LoginSchema, "1mb");
   if (!parsed.success) return parsed.response;
 
   const csrfToken = req.headers.get("x-csrf-token");

--- a/packages/shared-utils/__tests__/parseJsonBody.test.ts
+++ b/packages/shared-utils/__tests__/parseJsonBody.test.ts
@@ -12,13 +12,13 @@ function makeRequest(body: unknown) {
 describe("parseJsonBody", () => {
   it("returns data when valid", async () => {
     const schema = z.object({ x: z.string() }).strict();
-    const result = await parseJsonBody(makeRequest({ x: "hi" }), schema);
+    const result = await parseJsonBody(makeRequest({ x: "hi" }), schema, "1mb");
     expect(result).toEqual({ success: true, data: { x: "hi" } });
   });
 
   it("returns response when invalid", async () => {
     const schema = z.object({ x: z.string() }).strict();
-    const result = await parseJsonBody(makeRequest({}), schema);
+    const result = await parseJsonBody(makeRequest({}), schema, "1mb");
     expect(result.success).toBe(false);
     expect(result.response.status).toBe(400);
   });
@@ -30,9 +30,16 @@ describe("parseJsonBody", () => {
       headers: { "Content-Type": "application/json" },
       body: "{invalid}",
     });
-    const result = await parseJsonBody(req, schema);
+    const result = await parseJsonBody(req, schema, "1mb");
     expect(result.success).toBe(false);
     expect(result.response.status).toBe(400);
     expect(await result.response.json()).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("returns 413 when body exceeds limit", async () => {
+    const schema = z.object({ x: z.string() }).strict();
+    const result = await parseJsonBody(makeRequest({ x: "hi" }), schema, "5b");
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(413);
   });
 });

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
+  "dependencies": {
+    "raw-body": "2.4.1"
+  },
   "devDependencies": {
     "next": "^15.3.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,10 @@ importers:
         version: 6.29.1
 
   packages/shared-utils:
+    dependencies:
+      raw-body:
+        specifier: 2.4.1
+        version: 2.4.1
     devDependencies:
       next:
         specifier: ^15.3.4


### PR DESCRIPTION
## Summary
- parse JSON request bodies with `raw-body` and size limit
- propagate body-size limit to API route callers
- add regression tests for invalid and oversize payloads

## Testing
- `pnpm --filter @acme/shared-utils test packages/shared-utils/__tests__/parseJsonBody.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689cce8d0984832f9cf2a4b42c08b183