### PR TITLE
feat: add security headers middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Key points:
   A multilingual, hybrid-rendered e-commerce demo built with **Next.js 15** and **React 19**.
   The full technical roadmap is documented in [./IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md).
 
+## Security Headers
+
+The root middleware applies [next-secure-headers](https://www.npmjs.com/package/next-secure-headers) to every request with:
+
+- **Content-Security-Policy** – limits all resources to this origin (`default-src 'self'`, `base-uri 'self'`, `object-src 'none'`, `form-action 'self'`, `frame-ancestors 'none'`).
+- **Strict-Transport-Security** – `max-age=31536000; includeSubDomains; preload` to enforce HTTPS.
+- **X-Frame-Options** – `DENY` to block iframe embedding.
+- **Referrer-Policy** – `no-referrer`.
+- **X-Content-Type-Options** and **X-Download-Options** – `nosniff` and `noopen`.
+
 ---
 
 ## Getting Started

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+// middleware.ts
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createHeadersObject } from "next-secure-headers";
+
+export function middleware(request: NextRequest) {
+  const headers = createHeadersObject({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: "'self'",
+        baseUri: "'self'",
+        objectSrc: "'none'",
+        formAction: "'self'",
+        frameAncestors: "'none'",
+      },
+    },
+    forceHTTPSRedirect: [
+      true,
+      { maxAge: 60 * 60 * 24 * 365, includeSubDomains: true, preload: true },
+    ],
+    frameGuard: "deny",
+    referrerPolicy: "no-referrer",
+    nosniff: "nosniff",
+    noopen: "noopen",
+  });
+
+  const response = NextResponse.next();
+  for (const [key, value] of Object.entries(headers)) {
+    response.headers.set(key, value);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: "/:path*",
+};

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "next": "15.3.5",
     "next-auth": "4.24.11",
     "next-intl": "^3.5.0",
+    "next-secure-headers": "^2.2.0",
     "next-seo": "^6.8.0",
     "nodemailer": "^6.10.1",
     "openai": "^4.104.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       next-intl:
         specifier: ^3.5.0
         version: 3.26.5(next@15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      next-secure-headers:
+        specifier: ^2.2.0
+        version: 2.2.0
       next-seo:
         specifier: ^6.8.0
         version: 6.8.0(next@15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -8020,6 +8023,10 @@ packages:
     peerDependencies:
       next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
+  next-secure-headers@2.2.0:
+    resolution: {integrity: sha512-C7OfZ9JdSJyYMz2ZBMI/WwNbt0qNjlFWX9afUp8nEUzbz6ez3JbeopdyxSZJZJAzVLIAfyk6n73rFpd4e22jRg==}
+    engines: {node: '>=10.0.0'}
 
   next-seo@6.8.0:
     resolution: {integrity: sha512-zcxaV67PFXCSf8e6SXxbxPaOTgc8St/esxfsYXfQXMM24UESUVSXFm7f2A9HMkAwa0Gqn4s64HxYZAGfdF4Vhg==}
@@ -18924,6 +18931,8 @@ snapshots:
       next: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       use-intl: 3.26.5(react@19.1.0)
+
+  next-secure-headers@2.2.0: {}
 
   next-seo@6.8.0(next@15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- add `next-secure-headers` dependency
- apply strict CSP, HSTS and X-Frame-Options via root middleware
- document security headers in README

## Testing
- `pnpm exec eslint middleware.ts README.md` (warnings: file ignored)
- `pnpm test` (fails: @acme/next-config#test)


------
https://chatgpt.com/codex/tasks/task_e_689cce8dfa54832f81a6cac8f08761f9