### PR TITLE
feat(email): centralize template rendering

### DIFF
--- a/apps/cms/src/app/api/marketing/email/route.ts
+++ b/apps/cms/src/app/api/marketing/email/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-import { createCampaign, listCampaigns, type Campaign } from "@acme/email";
+import {
+  createCampaign,
+  listCampaigns,
+  type Campaign,
+  renderTemplate,
+} from "@acme/email";
 import { listEvents } from "@platform-core/repositories/analytics.server";
-import { marketingEmailTemplates } from "@acme/ui";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
@@ -52,20 +54,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
   let html = body;
   if (templateId) {
-    const variant = marketingEmailTemplates.find((t) => t.id === templateId);
-    if (variant) {
-      html = renderToStaticMarkup(
-        variant.render({
-          headline: subject,
-          content: React.createElement("div", {
-            dangerouslySetInnerHTML: { __html: body },
-          }),
-          footer: React.createElement("p", null, "%%UNSUBSCRIBE%%"),
-        })
-      );
-    }
-  }
-  if (!templateId) {
+    html = renderTemplate(templateId, { subject, body });
+  } else {
     html = `${body}<p>%%UNSUBSCRIBE%%</p>`;
   }
   try {

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -15,10 +15,13 @@
   },
   "dependencies": {
     "@acme/config": "workspace:*",
+    "@acme/ui": "workspace:*",
     "commander": "^11.1.0",
     "@sendgrid/mail": "^8.1.5",
     "nodemailer": "^6.10.1",
     "resend": "^3.5.0",
-    "sanitize-html": "^2.12.1"
+    "sanitize-html": "^2.12.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -24,6 +24,14 @@ jest.mock("@platform-core/repositories/analytics.server", () => ({
   __esModule: true,
   listEvents: jest.fn().mockResolvedValue([]),
 }));
+jest.mock(
+  "@acme/ui",
+  () => ({
+    __esModule: true,
+    marketingEmailTemplates: [],
+  }),
+  { virtual: true },
+);
 const { sendCampaignEmail } = require("../send");
 const sendCampaignEmailMock = sendCampaignEmail as jest.Mock;
 const { listEvents } = require("@platform-core/repositories/analytics.server");
@@ -98,7 +106,7 @@ describe("scheduler", () => {
   });
 
   it("includes token in tracking pixel URL", async () => {
-    const past = new Date(Date.now() - 1000).toISOString();
+    const past = new Date(baseNow.getTime() - 1000).toISOString();
     const campaigns = [
       {
         id: "c1",
@@ -114,7 +122,7 @@ describe("scheduler", () => {
       "utf8",
     );
 
-    const { sendDueCampaigns } = await import("../scheduler");
+    const { sendDueCampaigns } = await loadScheduler();
     await sendDueCampaigns();
 
     const call = sendCampaignEmailMock.mock.calls[0][0];

--- a/packages/email/src/__tests__/templates.test.ts
+++ b/packages/email/src/__tests__/templates.test.ts
@@ -1,0 +1,57 @@
+import { jest } from "@jest/globals";
+import * as React from "react";
+
+describe("renderTemplate", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("renders registered string templates with variables", async () => {
+    jest.doMock(
+      "@acme/ui",
+      () => ({ __esModule: true, marketingEmailTemplates: [] }),
+      { virtual: true },
+    );
+    const { registerTemplate, renderTemplate, clearTemplates } = await import(
+      "../templates"
+    );
+    registerTemplate("welcome", "<p>Hello {{name}}</p>");
+    const html = renderTemplate("welcome", { name: "Ada" });
+    expect(html).toBe("<p>Hello Ada</p>");
+    clearTemplates();
+  });
+
+  it("renders marketing email template variants", async () => {
+    jest.doMock(
+      "@acme/ui",
+      () => ({
+        __esModule: true,
+        marketingEmailTemplates: [
+          {
+            id: "basic",
+            render: ({ headline, content, footer }: any) => (
+              React.createElement(
+                "div",
+                null,
+                React.createElement("h1", null, headline),
+                content,
+                footer,
+              )
+            ),
+          },
+        ],
+      }),
+      { virtual: true },
+    );
+
+    const { renderTemplate } = await import("../templates");
+    const html = renderTemplate("basic", {
+      subject: "Hi",
+      body: "<p>Test</p>",
+    });
+    expect(html).toContain("<h1>Hi</h1>");
+    expect(html).toContain("<p>Test</p>");
+    expect(html).toContain("%%UNSUBSCRIBE%%");
+  });
+});
+

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -7,6 +7,7 @@ import { validateShopName } from "@acme/lib";
 import { getCampaignStore } from "./storage";
 import type { Campaign } from "./types";
 import { syncCampaignAnalytics as fetchCampaignAnalytics } from "./analytics";
+import { renderTemplate } from "./templates";
 
 export interface Clock {
   now(): Date;
@@ -59,7 +60,14 @@ async function filterUnsubscribed(
 
 async function deliverCampaign(shop: string, c: Campaign): Promise<void> {
   shop = validateShopName(shop);
-  const baseHtml = trackedBody(shop, c.id, c.body);
+  let rendered = c.body;
+  if (c.templateId) {
+    rendered = renderTemplate(c.templateId, {
+      subject: c.subject,
+      body: c.body,
+    });
+  }
+  const baseHtml = trackedBody(shop, c.id, rendered);
   let recipients = c.recipients;
   if (c.segment) {
     recipients = await resolveSegment(shop, c.segment);


### PR DESCRIPTION
## Summary
- add renderTemplate helper for email templates
- refactor marketing email API and scheduler to use new renderer
- test template rendering for string and marketing variants

## Testing
- `pnpm exec jest packages/email/src/__tests__/scheduler.test.ts packages/email/src/__tests__/templates.test.ts --config jest.config.cjs --runInBand`
- `pnpm exec jest apps/cms/__tests__/marketingEmailApi.test.ts --config jest.config.cjs --runInBand` *(fails: sendgrid_1.SendgridProvider is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_689cd4483db4832fb864d49feb344780