### PR TITLE
feat: add configurable form builder block

### DIFF
--- a/packages/ui/src/components/cms/blocks/FormBuilderBlock.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/FormBuilderBlock.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FormBuilderBlock from "./FormBuilderBlock";
+
+const meta: Meta<typeof FormBuilderBlock> = {
+  component: FormBuilderBlock,
+  args: {
+    fields: [
+      { type: "text", name: "name", label: "Name" },
+      { type: "email", name: "email", label: "Email" },
+      {
+        type: "select",
+        name: "color",
+        label: "Color",
+        options: [
+          { label: "Red", value: "red" },
+          { label: "Blue", value: "blue" },
+        ],
+      },
+    ],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof FormBuilderBlock> = {};

--- a/packages/ui/src/components/cms/blocks/FormBuilderBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FormBuilderBlock.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+interface FieldOption {
+  label: string;
+  value: string;
+}
+
+interface FieldConfig {
+  type: "text" | "email" | "select";
+  name: string;
+  label?: string;
+  options?: FieldOption[];
+}
+
+interface Props {
+  action?: string;
+  method?: string;
+  fields?: FieldConfig[];
+  submitLabel?: string;
+}
+
+export default function FormBuilderBlock({
+  action = "#",
+  method = "post",
+  fields = [],
+  submitLabel = "Submit",
+}: Props) {
+  return (
+    <form className="space-y-2" action={action} method={method}>
+      {fields.map((field, idx) => {
+        if (field.type === "select") {
+          return (
+            <select
+              key={idx}
+              name={field.name}
+              className="w-full rounded border p-2"
+            >
+              {field.options?.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          );
+        }
+        return (
+          <input
+            key={idx}
+            type={field.type}
+            name={field.name}
+            placeholder={field.label}
+            className="w-full rounded border p-2"
+          />
+        );
+      })}
+      <button
+        type="submit"
+        className="rounded bg-primary px-4 py-2 text-primary-fg"
+      >
+        {submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/__tests__/FormBuilderBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/FormBuilderBlock.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import FormBuilderBlock from "../FormBuilderBlock";
+
+describe("FormBuilderBlock", () => {
+  it("renders configured fields", () => {
+    render(
+      <FormBuilderBlock
+        fields={[
+          { type: "text", name: "name", label: "Name" },
+          { type: "email", name: "email", label: "Email" },
+          {
+            type: "select",
+            name: "color",
+            label: "Color",
+            options: [
+              { label: "Red", value: "red" },
+              { label: "Blue", value: "blue" },
+            ],
+          },
+        ]}
+      />
+    );
+    expect(screen.getByPlaceholderText("Name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Email")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Red" })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -32,6 +32,7 @@ import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import FormBuilderBlock from "./FormBuilderBlock";
 
 export {
   BlogListing,
@@ -68,6 +69,7 @@ export {
   ProductComparison,
   FeaturedProductBlock,
   GiftCardBlock,
+  FormBuilderBlock,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -35,6 +35,7 @@ import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import FormBuilderBlock from "./FormBuilderBlock";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -78,6 +79,7 @@ export const organismRegistry = {
   Tabs: { component: Tabs },
   ProductComparison: { component: ProductComparisonBlock },
   GiftCardBlock: { component: GiftCardBlock },
+  FormBuilderBlock: { component: FormBuilderBlock },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -36,6 +36,7 @@ import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
 import GiftCardEditor from "./GiftCardEditor";
+import FormBuilderEditor from "./FormBuilderEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -133,6 +134,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "GiftCardBlock":
       specific = (
         <GiftCardEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "FormBuilderBlock":
+      specific = (
+        <FormBuilderEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
@@ -1,0 +1,92 @@
+import type { PageComponent } from "@acme/types";
+import {
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function FormBuilderEditor({ component, onChange }: Props) {
+  const fields = ((component as any).fields ?? []) as any[];
+
+  const updateField = (idx: number, key: string, value: any) => {
+    const next = [...fields];
+    next[idx] = { ...next[idx], [key]: value };
+    onChange({ fields: next } as Partial<PageComponent>);
+  };
+
+  const addField = () => {
+    onChange({
+      fields: [...fields, { type: "text", name: "", label: "" }],
+    } as Partial<PageComponent>);
+  };
+
+  const removeField = (idx: number) => {
+    const next = fields.filter((_, i) => i !== idx);
+    onChange({ fields: next } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      {fields.map((field, idx) => (
+        <div key={idx} className="space-y-1 rounded border p-2">
+          <Select
+            value={field.type}
+            onValueChange={(v) => updateField(idx, "type", v)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="text">text</SelectItem>
+              <SelectItem value="email">email</SelectItem>
+              <SelectItem value="select">select</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            value={field.name ?? ""}
+            onChange={(e) => updateField(idx, "name", e.target.value)}
+            placeholder="name"
+          />
+          <Input
+            value={field.label ?? ""}
+            onChange={(e) => updateField(idx, "label", e.target.value)}
+            placeholder="label"
+          />
+          {field.type === "select" && (
+            <Input
+              value={(field.options ?? []).map((o: any) => o.label).join(",")}
+              onChange={(e) =>
+                updateField(
+                  idx,
+                  "options",
+                  e.target.value
+                    .split(",")
+                    .map((v: string) => v.trim())
+                    .filter(Boolean)
+                    .map((v: string) => ({ label: v, value: v }))
+                )
+              }
+              placeholder="options (comma separated)"
+            />
+          )}
+          <Button
+            variant="destructive"
+            onClick={() => removeField(idx)}
+          >
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button onClick={addField}>Add field</Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -11,6 +11,7 @@ import SocialFeedEditor from "../SocialFeedEditor";
 import NewsletterSignupEditor from "../NewsletterSignupEditor";
 import StoreLocatorBlockEditor from "../StoreLocatorBlockEditor";
 import FeaturedProductEditor from "../FeaturedProductEditor";
+import FormBuilderEditor from "../FormBuilderEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -93,6 +94,12 @@ describe("block editors", () => {
       FeaturedProductEditor,
       { type: "FeaturedProduct", sku: "" },
       "sku",
+    ],
+    [
+      "FormBuilderEditor",
+      FormBuilderEditor,
+      { type: "FormBuilderBlock", fields: [{ type: "text", name: "" }] },
+      "name",
     ],
   ];
 

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -21,6 +21,7 @@ export { default as RecommendationCarouselEditor } from "./RecommendationCarouse
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as GiftCardEditor } from "./GiftCardEditor";
+export { default as FormBuilderEditor } from "./FormBuilderEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add FormBuilderBlock for rendering configurable form fields
- add FormBuilderEditor to manage custom fields in page builder
- register block/editor and add accompanying stories and tests

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/FormBuilderBlock.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689cd9dfc56c832facb163fa510e687d