### PR TITLE
feat: add popup modal CMS block

### DIFF
--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  /** Width of the modal in pixels */
+  width?: number;
+  /** Height of the modal in pixels */
+  height?: number;
+  /** How the modal should be triggered */
+  trigger?: "delay" | "exitIntent";
+  /** Delay in ms before showing when using the delay trigger */
+  delay?: number;
+  /** HTML content shown inside the modal */
+  content?: string;
+}
+
+export default function PopupModal({
+  width = 400,
+  height = 300,
+  trigger = "delay",
+  delay = 1000,
+  content = "",
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (trigger === "delay") {
+      const t = setTimeout(() => setOpen(true), delay);
+      return () => clearTimeout(t);
+    }
+    if (trigger === "exitIntent") {
+      const handleMouseLeave = (e: MouseEvent) => {
+        if (e.clientY <= 0) {
+          setOpen(true);
+        }
+      };
+      document.addEventListener("mouseleave", handleMouseLeave);
+      return () => {
+        document.removeEventListener("mouseleave", handleMouseLeave);
+      };
+    }
+    // default: show immediately
+    setOpen(true);
+  }, [trigger, delay]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        className="relative bg-white p-4 shadow-lg"
+        style={{ width, height }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          aria-label="Close"
+          className="absolute right-2 top-2"
+          onClick={() => setOpen(false)}
+        >
+          ×
+        </button>
+        {content && <div dangerouslySetInnerHTML={{ __html: content }} />}
+      </div>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -32,6 +32,7 @@ import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import PopupModal from "./PopupModal";
 
 export {
   BlogListing,
@@ -68,6 +69,7 @@ export {
   ProductComparison,
   FeaturedProductBlock,
   GiftCardBlock,
+  PopupModal,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -35,6 +35,7 @@ import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import PopupModal from "./PopupModal";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -78,6 +79,7 @@ export const organismRegistry = {
   Tabs: { component: Tabs },
   ProductComparison: { component: ProductComparisonBlock },
   GiftCardBlock: { component: GiftCardBlock },
+  PopupModal: { component: PopupModal },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -36,6 +36,7 @@ import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
 import GiftCardEditor from "./GiftCardEditor";
+import PopupModalEditor from "./PopupModalEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -133,6 +134,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "GiftCardBlock":
       specific = (
         <GiftCardEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "PopupModal":
+      specific = (
+        <PopupModalEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -43,6 +43,9 @@ const palette = {
       type: t,
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })),
+  overlays: [
+    { type: "PopupModal", label: "Popup Modal" },
+  ] as { type: PageComponent["type"]; label: string }[],
 } as const;
 
 const PaletteItem = memo(function PaletteItem({

--- a/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
@@ -1,0 +1,54 @@
+import type { PageComponent } from "@acme/types";
+import {
+  Input,
+  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function PopupModalEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).width ?? ""}
+        onChange={(e) => handleInput("width", e.target.value)}
+        placeholder="width"
+      />
+      <Input
+        value={(component as any).height ?? ""}
+        onChange={(e) => handleInput("height", e.target.value)}
+        placeholder="height"
+      />
+      <Select
+        value={(component as any).trigger ?? ""}
+        onValueChange={(v) => handleInput("trigger", v)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="trigger" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="delay">delay</SelectItem>
+          <SelectItem value="exitIntent">exitIntent</SelectItem>
+        </SelectContent>
+      </Select>
+      <Textarea
+        value={(component as any).content ?? ""}
+        onChange={(e) => handleInput("content", e.target.value)}
+        placeholder="content"
+      />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -21,6 +21,7 @@ export { default as RecommendationCarouselEditor } from "./RecommendationCarouse
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as GiftCardEditor } from "./GiftCardEditor";
+export { default as PopupModalEditor } from "./PopupModalEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add configurable PopupModal block supporting delay and exit-intent triggers
- expose PopupModal settings in page builder editor
- register block in CMS registry and palette

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' and scheduler test error)*

------
https://chatgpt.com/codex/tasks/task_e_689cda04bc60832fa565d48c99745115