### PR TITLE
feat: add popup modal block

### DIFF
--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import DOMPurify from "dompurify";
+import { Dialog, DialogContent } from "../../atoms/shadcn";
+
+interface Props {
+  width?: string;
+  height?: string;
+  trigger?: "delay" | "exitIntent";
+  /** Delay in ms when trigger is set to `delay` */
+  delay?: number;
+  /** HTML content to display inside the modal */
+  content?: string;
+}
+
+export default function PopupModal({
+  width,
+  height,
+  trigger,
+  delay = 1000,
+  content,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (trigger === "delay") {
+      const t = setTimeout(() => setOpen(true), delay);
+      return () => clearTimeout(t);
+    }
+    if (trigger === "exitIntent") {
+      const handleMouseLeave = (e: MouseEvent) => {
+        if (e.clientY <= 0) {
+          setOpen(true);
+          document.removeEventListener("mouseout", handleMouseLeave);
+        }
+      };
+      document.addEventListener("mouseout", handleMouseLeave);
+      return () => document.removeEventListener("mouseout", handleMouseLeave);
+    }
+  }, [trigger, delay]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent style={{ width, height }}>
+        <div
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content ?? "") }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -32,6 +32,7 @@ import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import PopupModal from "./PopupModal";
 
 export {
   BlogListing,
@@ -68,6 +69,7 @@ export {
   ProductComparison,
   FeaturedProductBlock,
   GiftCardBlock,
+  PopupModal,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -35,6 +35,7 @@ import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import PopupModal from "./PopupModal";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -78,6 +79,7 @@ export const organismRegistry = {
   Tabs: { component: Tabs },
   ProductComparison: { component: ProductComparisonBlock },
   GiftCardBlock: { component: GiftCardBlock },
+  PopupModal: { component: PopupModal },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -36,6 +36,7 @@ import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
 import GiftCardEditor from "./GiftCardEditor";
+import PopupModalEditor from "./PopupModalEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -128,6 +129,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "ProductComparison":
       specific = (
         <ProductComparisonEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "PopupModal":
+      specific = (
+        <PopupModalEditor component={component} onChange={onChange} />
       );
       break;
     case "GiftCardBlock":

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -38,11 +38,15 @@ const palette = {
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })),
   organisms: (Object.keys(organismRegistry) as PageComponent["type"][])
+    .filter((t) => t !== "PopupModal")
     .sort()
     .map((t) => ({
       type: t,
       label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
+    }))
+    .concat([
+      { type: "PopupModal" as PageComponent["type"], label: "Popup Modal" },
+    ]),
 } as const;
 
 const PaletteItem = memo(function PaletteItem({

--- a/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
@@ -1,0 +1,58 @@
+import type { PageComponent } from "@acme/types";
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function PopupModalEditor({ component, onChange }: Props) {
+  const handleInput = (
+    field: string,
+    value: string | number | undefined
+  ) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).width ?? ""}
+        onChange={(e) => handleInput("width", e.target.value)}
+        placeholder="width"
+      />
+      <Input
+        value={(component as any).height ?? ""}
+        onChange={(e) => handleInput("height", e.target.value)}
+        placeholder="height"
+      />
+      <Select
+        value={(component as any).trigger ?? ""}
+        onValueChange={(val) => handleInput("trigger", val)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="trigger" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="">none</SelectItem>
+          <SelectItem value="delay">delay</SelectItem>
+          <SelectItem value="exitIntent">exitIntent</SelectItem>
+        </SelectContent>
+      </Select>
+      <Textarea
+        value={(component as any).content ?? ""}
+        onChange={(e) => handleInput("content", e.target.value)}
+        placeholder="content"
+      />
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -21,6 +21,7 @@ export { default as RecommendationCarouselEditor } from "./RecommendationCarouse
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as GiftCardEditor } from "./GiftCardEditor";
+export { default as PopupModalEditor } from "./PopupModalEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add PopupModal block with optional delay or exit intent trigger
- include PopupModal editor exposing size, trigger and content
- register block and surface in page builder palette

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/DynamicRenderer.test.tsx` *(fails: Missing elements for numerous blocks)*

------
https://chatgpt.com/codex/tasks/task_e_689cda1c702c832f8e566fcf7566663d