### PR TITLE
feat: add product bundle block and editor

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -299,6 +299,13 @@ export interface GiftCardBlockComponent extends PageComponentBase {
   description?: string;
 }
 
+export interface ProductBundleComponent extends PageComponentBase {
+  type: "ProductBundle";
+  products?: { sku: string; quantity?: number }[];
+  discount?: number;
+  collectionId?: string;
+}
+
 export interface TextComponent extends PageComponentBase {
   type: "Text";
   text?: string;
@@ -361,6 +368,7 @@ export type PageComponent =
   | PricingTableComponent
   | TestimonialSliderComponent
   | GiftCardBlockComponent
+  | ProductBundleComponent
   | ImageComponent
   | TextComponent
   | CustomHtmlComponent
@@ -618,6 +626,20 @@ const giftCardBlockComponentSchema = baseComponentSchema.extend({
   description: z.string().optional(),
 });
 
+const productBundleComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ProductBundle"),
+  products: z
+    .array(
+      z.object({
+        sku: z.string(),
+        quantity: z.number().optional(),
+      }),
+    )
+    .optional(),
+  discount: z.number().optional(),
+  collectionId: z.string().optional(),
+});
+
 const imageComponentSchema = baseComponentSchema.extend({
   type: z.literal("Image"),
   src: z.string().optional(),
@@ -694,6 +716,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     testimonialsComponentSchema,
     pricingTableComponentSchema,
     giftCardBlockComponentSchema,
+    productBundleComponentSchema,
     testimonialSliderComponentSchema,
     imageComponentSchema,
     textComponentSchema,

--- a/packages/ui/src/components/cms/blocks/ProductBundle.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductBundle.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import type { SKU } from "@acme/types";
+import { PRODUCTS } from "@platform-core/src/products";
+import { fetchCollection } from "./products/fetchCollection";
+import { Price } from "../../atoms/Price";
+
+interface ProductBundleProps {
+  skus?: SKU[];
+  quantities?: number[];
+  discount?: number;
+  collectionId?: string;
+}
+
+export function getRuntimeProps() {
+  return {
+    skus: PRODUCTS.slice(0, 2) as SKU[],
+    quantities: [1, 1],
+    discount: 10,
+  };
+}
+
+export default function ProductBundle({
+  skus,
+  quantities = [],
+  discount = 0,
+  collectionId,
+}: ProductBundleProps) {
+  const [items, setItems] = useState<SKU[]>(skus ?? []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      if (collectionId) {
+        const fetched = await fetchCollection(collectionId);
+        if (!cancelled) setItems(fetched);
+      } else {
+        setItems(skus ?? []);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionId, skus]);
+
+  if (!items.length) return null;
+
+  const total = items.reduce(
+    (sum, sku, idx) => sum + sku.price * (quantities[idx] ?? 1),
+    0,
+  );
+  const bundlePrice = Math.round(total * (1 - discount / 100));
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        {items.map((sku, idx) => (
+          <div key={sku.id} className="flex gap-4">
+            {sku.image && (
+              <img
+                src={sku.image}
+                alt={sku.title}
+                className="h-24 w-24 rounded object-cover"
+              />
+            )}
+            <div className="flex flex-col justify-center">
+              <span className="font-semibold">{sku.title}</span>
+              <Price amount={sku.price} className="text-sm" />
+              <span className="text-xs text-muted">x {quantities[idx] ?? 1}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between border-t pt-2">
+        <span className="font-medium">Bundle price</span>
+        <Price amount={bundlePrice} className="text-lg font-semibold" />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -33,6 +33,7 @@ import SearchBar from "./SearchBar";
 import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import ProductBundle from "./ProductBundle";
 
 export {
   BlogListing,
@@ -70,6 +71,7 @@ export {
   ProductComparison,
   FeaturedProductBlock,
   GiftCardBlock,
+  ProductBundle,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -36,6 +36,9 @@ import CollectionList from "./CollectionList";
 import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
+import ProductBundle, {
+  getRuntimeProps as getProductBundleRuntimeProps,
+} from "./ProductBundle";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -57,6 +60,10 @@ export const organismRegistry = {
   FeaturedProduct: {
     component: FeaturedProductBlock,
     getRuntimeProps: getFeaturedProductRuntimeProps,
+  },
+  ProductBundle: {
+    component: ProductBundle,
+    getRuntimeProps: getProductBundleRuntimeProps,
   },
   ImageSlider: { component: ImageSlider },
   CollectionList: { component: CollectionList },

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -37,6 +37,7 @@ import SearchBarEditor from "./SearchBarEditor";
 import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
 import GiftCardEditor from "./GiftCardEditor";
+import ProductBundleEditor from "./ProductBundleEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -134,6 +135,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "GiftCardBlock":
       specific = (
         <GiftCardEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "ProductBundle":
+      specific = (
+        <ProductBundleEditor component={component} onChange={onChange} />
       );
       break;
     case "ValueProps":

--- a/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
@@ -1,0 +1,25 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ProductBundleEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+  return (
+    <div className="space-y-2">
+      {arrayEditor("products", (component as any).products, ["sku", "quantity"])}
+      <Input
+        label="Discount (%)"
+        type="number"
+        value={(component as any).discount ?? 0}
+        onChange={(e) =>
+          onChange({ discount: Number(e.target.value) } as Partial<PageComponent>)
+        }
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -12,6 +12,7 @@ import SocialProofEditor from "../SocialProofEditor";
 import NewsletterSignupEditor from "../NewsletterSignupEditor";
 import StoreLocatorBlockEditor from "../StoreLocatorBlockEditor";
 import FeaturedProductEditor from "../FeaturedProductEditor";
+import ProductBundleEditor from "../ProductBundleEditor";
 
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
@@ -99,6 +100,12 @@ describe("block editors", () => {
       "FeaturedProductEditor",
       FeaturedProductEditor,
       { type: "FeaturedProduct", sku: "" },
+      "sku",
+    ],
+    [
+      "ProductBundleEditor",
+      ProductBundleEditor,
+      { type: "ProductBundle", products: [{ sku: "", quantity: "" }], discount: 0 },
       "sku",
     ],
   ];

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -22,6 +22,7 @@ export { default as RecommendationCarouselEditor } from "./RecommendationCarouse
 export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as GiftCardEditor } from "./GiftCardEditor";
+export { default as ProductBundleEditor } from "./ProductBundleEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add ProductBundle CMS block with bundle pricing
- allow editors to manage bundle items, quantity and discount
- register ProductBundle in block registry and editor switch

## Testing
- `pnpm lint --filter @acme/ui` *(no tasks were executed)*
- `pnpm --filter @acme/ui test` *(failed: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx'; exceeded timeout in packages/email/src/__tests__/scheduler.test.ts; process.exit called in apps/cms/__tests__/media.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_689cda3dc378832f9065a98324bdb456