### PR TITLE
feat: add popup modal block

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -280,6 +280,12 @@ export interface GiftCardBlockComponent extends PageComponentBase {
   denominations?: number[];
   description?: string;
 }
+export interface PopupModalComponent extends PageComponentBase {
+  type: "PopupModal";
+  trigger?: "load" | "delay" | "exit";
+  delay?: number;
+  content?: string;
+}
 export interface SectionComponent extends PageComponentBase {
   type: "Section";
   children?: PageComponent[];
@@ -318,6 +324,7 @@ export type PageComponent =
   | BlogListingComponent
   | TestimonialsComponent
   | GiftCardBlockComponent
+  | PopupModalComponent
   | TestimonialSliderComponent
   | ImageComponent
   | TextComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -299,6 +299,13 @@ export interface GiftCardBlockComponent extends PageComponentBase {
   description?: string;
 }
 
+export interface PopupModalComponent extends PageComponentBase {
+  type: "PopupModal";
+  trigger?: "load" | "delay" | "exit";
+  delay?: number;
+  content?: string;
+}
+
 export interface TextComponent extends PageComponentBase {
   type: "Text";
   text?: string;
@@ -361,6 +368,7 @@ export type PageComponent =
   | PricingTableComponent
   | TestimonialSliderComponent
   | GiftCardBlockComponent
+  | PopupModalComponent
   | ImageComponent
   | TextComponent
   | CustomHtmlComponent
@@ -618,6 +626,13 @@ const giftCardBlockComponentSchema = baseComponentSchema.extend({
   description: z.string().optional(),
 });
 
+const popupModalComponentSchema = baseComponentSchema.extend({
+  type: z.literal("PopupModal"),
+  trigger: z.enum(["load", "delay", "exit"]).optional(),
+  delay: z.number().int().min(0).optional(),
+  content: z.string().optional(),
+});
+
 const imageComponentSchema = baseComponentSchema.extend({
   type: z.literal("Image"),
   src: z.string().optional(),
@@ -694,6 +709,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     testimonialsComponentSchema,
     pricingTableComponentSchema,
     giftCardBlockComponentSchema,
+    popupModalComponentSchema,
     testimonialSliderComponentSchema,
     imageComponentSchema,
     textComponentSchema,

--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  width?: string;
+  height?: string;
+  /** Trigger mode for the modal */
+  trigger?: "load" | "delay" | "exit";
+  /** Delay in ms before showing when trigger is "delay" */
+  delay?: number;
+  /** HTML content rendered inside the modal */
+  content?: string;
+}
+
+export default function PopupModal({
+  width = "400px",
+  height = "300px",
+  trigger = "load",
+  delay = 0,
+  content = "",
+}: Props) {
+  const [open, setOpen] = useState(trigger === "load" && delay === 0);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (trigger === "delay") {
+      timer = setTimeout(() => setOpen(true), delay);
+    } else if (trigger === "exit") {
+      const handleMouseLeave = (e: MouseEvent) => {
+        if (e.clientY <= 0) {
+          setOpen(true);
+          document.removeEventListener("mouseleave", handleMouseLeave);
+        }
+      };
+      document.addEventListener("mouseleave", handleMouseLeave);
+      return () => {
+        document.removeEventListener("mouseleave", handleMouseLeave);
+      };
+    } else {
+      setOpen(true);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [trigger, delay]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        className="relative bg-white p-4 shadow-lg"
+        style={{ width, height }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {content && (
+          <div dangerouslySetInnerHTML={{ __html: content }} />
+        )}
+        <button
+          type="button"
+          aria-label="Close"
+          className="absolute right-2 top-2 text-xl"
+          onClick={() => setOpen(false)}
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -34,6 +34,7 @@ import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
+import PopupModal from "./PopupModal";
 
 export {
   BlogListing,
@@ -72,6 +73,7 @@ export {
   FeaturedProductBlock,
   GiftCardBlock,
   FormBuilderBlock,
+  PopupModal,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -37,6 +37,7 @@ import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
+import PopupModal from "./PopupModal";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -82,6 +83,7 @@ export const organismRegistry = {
   ProductComparison: { component: ProductComparisonBlock },
   GiftCardBlock: { component: GiftCardBlock },
   FormBuilderBlock: { component: FormBuilderBlock },
+  PopupModal: { component: PopupModal },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -38,6 +38,7 @@ import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
 import GiftCardEditor from "./GiftCardEditor";
 import FormBuilderEditor from "./FormBuilderEditor";
+import PopupModalEditor from "./PopupModalEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -141,6 +142,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = (
         <FormBuilderEditor component={component} onChange={onChange} />
       );
+      break;
+    case "PopupModal":
+      specific = <PopupModalEditor component={component} onChange={onChange} />;
       break;
     case "ValueProps":
       specific = <ValuePropsEditor component={component} onChange={onChange} />;

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -39,10 +39,17 @@ const palette = {
     })),
   organisms: (Object.keys(organismRegistry) as PageComponent["type"][])
     .sort()
+    .filter((t) => t !== "PopupModal")
     .map((t) => ({
       type: t,
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })),
+  overlays: [
+    {
+      type: "PopupModal" as PageComponent["type"],
+      label: "Popup Modal",
+    },
+  ],
 } as const;
 
 const PaletteItem = memo(function PaletteItem({

--- a/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
@@ -1,0 +1,54 @@
+import type { PageComponent } from "@acme/types";
+import {
+  Input,
+  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function PopupModalEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: unknown) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={(component as any).width ?? ""}
+        onChange={(e) => handleInput("width", e.target.value)}
+        placeholder="width"
+      />
+      <Input
+        value={(component as any).height ?? ""}
+        onChange={(e) => handleInput("height", e.target.value)}
+        placeholder="height"
+      />
+      <Select
+        value={(component as any).trigger ?? ""}
+        onValueChange={(v) => handleInput("trigger", v)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="trigger" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="load">load</SelectItem>
+          <SelectItem value="delay">delay</SelectItem>
+          <SelectItem value="exit">exit intent</SelectItem>
+        </SelectContent>
+      </Select>
+      <Textarea
+        value={(component as any).content ?? ""}
+        onChange={(e) => handleInput("content", e.target.value)}
+        placeholder="content"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PopupModal component with configurable delay/exit intent
- add PopupModalEditor for width, height, trigger and content fields
- register PopupModal in block registry and palette

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689cdca8bc74832fafa83357cf8bafec