### PR TITLE
feat: add reset token expiry

### DIFF
--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -7,6 +7,7 @@ import crypto from "crypto";
 import {
   getUserByResetToken,
   updatePassword,
+  setResetToken,
 } from "@acme/platform-core/users";
 import { validateCsrfToken } from "@auth";
 import { parseJsonBody } from "@shared-utils";
@@ -50,5 +51,6 @@ export async function POST(req: Request) {
 
   const passwordHash = await bcrypt.hash(password, 10);
   await updatePassword(user.id, passwordHash);
+  await setResetToken(user.id, null, null);
   return NextResponse.json({ ok: true });
 }

--- a/apps/shop-abc/src/app/api/account/reset/request/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/request/route.ts
@@ -40,7 +40,8 @@ export async function POST(req: Request) {
       .createHash("sha256")
       .update(token)
       .digest("hex");
-    await setResetToken(user.id, hashedToken);
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    await setResetToken(user.id, hashedToken, expiresAt);
     const resetUrl = `/account/reset?token=${token}`;
     await sendEmail(
       parsed.data.email,

--- a/packages/platform-core/__tests__/users.resetToken.test.ts
+++ b/packages/platform-core/__tests__/users.resetToken.test.ts
@@ -1,0 +1,55 @@
+import { setResetToken, getUserByResetToken } from "../src/users";
+import { prisma } from "../src/db";
+
+type StoreUser = {
+  id: string;
+  resetToken: string | null;
+  resetTokenExpiresAt: Date | null;
+};
+
+const store: Record<string, StoreUser> = {};
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    user: {
+      update: jest.fn(async ({ where, data }) => {
+        const existing = store[where.id] ?? { id: where.id, resetToken: null, resetTokenExpiresAt: null };
+        store[where.id] = { ...existing, ...data };
+        return store[where.id];
+      }),
+      findFirst: jest.fn(async ({ where }) => {
+        const match = Object.values(store).find(
+          (u) =>
+            u.resetToken === where.resetToken &&
+            u.resetTokenExpiresAt &&
+            u.resetTokenExpiresAt > where.resetTokenExpiresAt.gt,
+        );
+        return match ?? null;
+      }),
+    },
+  },
+}));
+
+const updateMock = (prisma as any).user.update as jest.Mock;
+const findFirstMock = (prisma as any).user.findFirst as jest.Mock;
+
+describe("reset token expiry", () => {
+  afterEach(() => {
+    updateMock.mockClear();
+    findFirstMock.mockClear();
+    for (const key in store) delete store[key];
+  });
+
+  it("returns null for expired tokens", async () => {
+    await setResetToken("u1", "tok", new Date(Date.now() - 1000));
+    const user = await getUserByResetToken("tok");
+    expect(user).toBeNull();
+  });
+
+  it("returns user when token valid", async () => {
+    const expires = new Date(Date.now() + 1000);
+    await setResetToken("u2", "tok2", expires);
+    const user = await getUserByResetToken("tok2");
+    expect(user?.id).toBe("u2");
+  });
+});

--- a/packages/platform-core/prisma/migrations/20250301010000_add_reset_token_expiry/migration.sql
+++ b/packages/platform-core/prisma/migrations/20250301010000_add_reset_token_expiry/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "resetTokenExpiresAt" DATETIME;

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -59,5 +59,6 @@ model User {
   passwordHash String
   role         String
   resetToken   String?
+  resetTokenExpiresAt DateTime?
   emailVerified Boolean @default(false)
 }

--- a/packages/platform-core/src/users.ts
+++ b/packages/platform-core/src/users.ts
@@ -8,6 +8,7 @@ export interface User {
   passwordHash: string;
   role: string;
   resetToken: string | null;
+  resetTokenExpiresAt: Date | null;
   emailVerified: boolean;
 }
 
@@ -37,14 +38,26 @@ export async function createUser({
   });
 }
 
-export async function setResetToken(id: string, token: string | null): Promise<void> {
-  await prisma.user.update({ where: { id }, data: { resetToken: token } });
+export async function setResetToken(
+  id: string,
+  token: string | null,
+  expiresAt: Date | null,
+): Promise<void> {
+  await prisma.user.update({
+    where: { id },
+    data: { resetToken: token, resetTokenExpiresAt: expiresAt },
+  });
 }
 
 export async function getUserByResetToken(
   token: string,
 ): Promise<User | null> {
-  return prisma.user.findFirst({ where: { resetToken: token } });
+  return prisma.user.findFirst({
+    where: {
+      resetToken: token,
+      resetTokenExpiresAt: { gt: new Date() },
+    },
+  });
 }
 
 export async function updatePassword(
@@ -53,7 +66,7 @@ export async function updatePassword(
 ): Promise<void> {
   await prisma.user.update({
     where: { id },
-    data: { passwordHash, resetToken: null },
+    data: { passwordHash },
   });
 }
 


### PR DESCRIPTION
## Summary
- store password reset token expiry and validate when fetching
- expire reset tokens after password reset
- test expired reset token behavior

## Testing
- `pnpm exec jest packages/platform-core/__tests__/users.resetToken.test.ts apps/shop-abc/__tests__/changePasswordPermission.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cdc10cff0832f91f6f7b41d75cb6e