### PR TITLE
refactor: add connect form step flow

### DIFF
--- a/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useFormState, useFormStatus } from "react-dom";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/atoms/shadcn";
 import { Toast } from "@ui";
 import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
@@ -53,9 +53,11 @@ export default function ConnectForm({ shopId, initial }: Props) {
     "idle" | "loading" | "success" | "error"
   >("idle");
   const [verifyError, setVerifyError] = useState("");
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const creatingDatasetRef = useRef(false);
 
   async function verify() {
-    if (!projectId || !token) {
+    if (!projectId || !token || !dataset) {
       return;
     }
     setVerifyStatus("loading");
@@ -106,129 +108,190 @@ export default function ConnectForm({ shopId, initial }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (projectId && token && dataset) {
+      void verify();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataset]);
+
+  useEffect(() => {
+    if (state.message) {
+      if (creatingDatasetRef.current) {
+        void verify();
+        creatingDatasetRef.current = false;
+      }
+      setStep(3);
+    }
+  }, [state.message]);
+
   const message = state.message || disconnectState.message;
   const errorCode = state.errorCode || disconnectState.errorCode;
   const rawError = state.error || disconnectState.error;
   const error = errorCode ? errorMessages[errorCode] ?? rawError : rawError;
   return (
     <div className="space-y-4 max-w-md">
-      <form
-        action={formAction}
-        className="space-y-4"
-        onSubmit={() => void verify()}
-      >
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="projectId">
-            Project ID
-          </label>
-          <input
-            id="projectId"
-            name="projectId"
-            className="w-full rounded border p-2"
-            value={projectId}
-            onChange={(e) => setProjectId(e.target.value)}
-            onBlur={verify}
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            Find this in your Sanity project settings.
-          </p>
-        </div>
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="dataset">
-            Dataset
-          </label>
-          {isAddingDataset ? (
+      {step === 1 && (
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <label className="block text-sm font-medium" htmlFor="projectId">
+              Project ID
+            </label>
             <input
-              id="dataset"
-              name="dataset"
+              id="projectId"
+              name="projectId"
               className="w-full rounded border p-2"
-              value={dataset}
-              onChange={(e) => setDataset(e.target.value)}
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
               required
             />
-          ) : (
-            <select
-              id="dataset"
-              name="dataset"
+            <p className="text-xs text-muted-foreground">
+              Find this in your Sanity project settings.
+            </p>
+          </div>
+          <div className="space-y-1">
+            <label className="block text-sm font-medium" htmlFor="token">
+              Token
+            </label>
+            <input
+              id="token"
+              name="token"
+              type="password"
               className="w-full rounded border p-2"
-              value={dataset}
-              onChange={(e) => {
-                if (e.target.value === "__add__") {
-                  setIsAddingDataset(true);
-                } else {
-                  setIsAddingDataset(false);
-                  setDataset(e.target.value);
-                }
-              }}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
               required
+            />
+            <p className="text-xs text-muted-foreground">
+              Token with write scope for the default dataset.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Button
+              type="button"
+              className="bg-primary text-white"
+              onClick={() => void verify()}
             >
-              <option value="" disabled>
-                Select dataset
-              </option>
-              {datasets.map((d) => (
-                <option key={d} value={d}>
-                  {d}
+              Verify
+            </Button>
+            {verifyStatus === "loading" && (
+              <p className="text-xs text-muted-foreground">
+                Verifying credentials...
+              </p>
+            )}
+            {verifyStatus === "success" && (
+              <>
+                <p className="text-xs text-green-600">Credentials verified</p>
+                <Button type="button" onClick={() => setStep(2)}>
+                  Next
+                </Button>
+              </>
+            )}
+            {verifyStatus === "error" && (
+              <p className="text-xs text-red-600">{verifyError}</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <form
+          action={formAction}
+          className="space-y-4"
+          onSubmit={() => {
+            creatingDatasetRef.current =
+              isAddingDataset && dataset !== defaultDataset;
+          }}
+        >
+          <input type="hidden" name="projectId" value={projectId} />
+          <input type="hidden" name="token" value={token} />
+          <div className="space-y-1">
+            <label className="block text-sm font-medium" htmlFor="dataset">
+              Dataset
+            </label>
+            {isAddingDataset ? (
+              <input
+                id="dataset"
+                name="dataset"
+                className="w-full rounded border p-2"
+                value={dataset}
+                onChange={(e) => setDataset(e.target.value)}
+                required
+              />
+            ) : (
+              <select
+                id="dataset"
+                name="dataset"
+                className="w-full rounded border p-2"
+                value={dataset}
+                onChange={(e) => {
+                  if (e.target.value === "__add__") {
+                    setIsAddingDataset(true);
+                  } else {
+                    setIsAddingDataset(false);
+                    setDataset(e.target.value);
+                  }
+                }}
+                required
+              >
+                <option value="" disabled>
+                  Select dataset
                 </option>
-              ))}
-              <option value="__add__">Add dataset</option>
+                {datasets.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+                <option value="__add__">Add dataset</option>
+              </select>
+            )}
+            {isAddingDataset && dataset !== defaultDataset && (
+              <input type="hidden" name="createDataset" value="true" />
+            )}
+            <p className="text-xs text-muted-foreground">
+              Dataset with read and write permissions.
+            </p>
+            <DatasetCreationStatus isAddingDataset={isAddingDataset} />
+            {verifyStatus === "loading" && (
+              <p className="text-xs text-muted-foreground">Verifying dataset...</p>
+            )}
+            {verifyStatus === "success" && (
+              <p className="text-xs text-green-600">Dataset verified</p>
+            )}
+            {verifyStatus === "error" && (
+              <p className="text-xs text-red-600">{verifyError}</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <label className="block text-sm font-medium" htmlFor="aclMode">
+              Access level
+            </label>
+            <select
+              id="aclMode"
+              name="aclMode"
+              className="w-full rounded border p-2"
+              value={aclMode}
+              onChange={(e) =>
+                setAclMode(e.target.value as "public" | "private")
+              }
+            >
+              <option value="public">Public</option>
+              <option value="private">Private</option>
             </select>
-          )}
-          {isAddingDataset && dataset !== defaultDataset && (
-            <input type="hidden" name="createDataset" value="true" />
-          )}
-          <p className="text-xs text-muted-foreground">
-            Dataset with read and write permissions.
-          </p>
-          <DatasetCreationStatus isAddingDataset={isAddingDataset} />
+            <p className="text-xs text-muted-foreground">
+              Public datasets are readable by anyone; private require auth.
+            </p>
+          </div>
+          <SubmitButton isCreating={isAddingDataset} />
+        </form>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-2">
+          <p className="text-green-600">{state.message}</p>
         </div>
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="token">
-            Token
-          </label>
-          <input
-            id="token"
-            name="token"
-            type="password"
-            className="w-full rounded border p-2"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            onBlur={verify}
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            Token with write scope for the above dataset.
-          </p>
-          {verifyStatus === "loading" && (
-            <p className="text-xs text-muted-foreground">Verifying...</p>
-          )}
-          {verifyStatus === "success" && (
-            <p className="text-xs text-green-600">Credentials verified</p>
-          )}
-          {verifyStatus === "error" && (
-            <p className="text-xs text-red-600">{verifyError}</p>
-          )}
-        </div>
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="aclMode">
-            Access level
-          </label>
-          <select
-            id="aclMode"
-            name="aclMode"
-            className="w-full rounded border p-2"
-            value={aclMode}
-            onChange={(e) => setAclMode(e.target.value as "public" | "private")}
-          >
-            <option value="public">Public</option>
-            <option value="private">Private</option>
-          </select>
-          <p className="text-xs text-muted-foreground">
-            Public datasets are readable by anyone; private require auth.
-          </p>
-        </div>
-        <SubmitButton isCreating={isAddingDataset} />
-      </form>
+      )}
+
       {initial && (
         <form action={disconnectFormAction}>
           <Button type="submit" variant="destructive">


### PR DESCRIPTION
## Summary
- break Sanity connect form into credentials, dataset, and confirmation steps
- show progress messages for verification and dataset creation
- auto reverify when dataset changes or after creation

## Testing
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' and process.exit called with "1" during env validation)*

------
https://chatgpt.com/codex/tasks/task_e_689cde81d23c832f8d953d62b014eb2b