### PR TITLE
feat: add product bundle block

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductBundle.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductBundle.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import type { SKU } from "@acme/types";
+import { getProductById } from "@platform-core/src/products";
+import { useCart } from "@platform-core/src/contexts/CartContext";
+import { Price } from "../../atoms/Price";
+
+interface BundleItem {
+  sku: string;
+  quantity?: number;
+}
+
+export interface ProductBundleProps {
+  items?: BundleItem[];
+  /** Discount percentage to apply to total price */
+  discountPercent?: number;
+}
+
+export default function ProductBundle({
+  items = [],
+  discountPercent = 0,
+}: ProductBundleProps) {
+  const [, dispatch] = useCart();
+  const [adding, setAdding] = useState(false);
+
+  const products = items
+    .map((item) => {
+      const sku = getProductById(item.sku);
+      if (!sku) return null;
+      const qty = item.quantity ? Number(item.quantity) : 1;
+      return { sku, quantity: isNaN(qty) ? 1 : qty };
+    })
+    .filter(Boolean) as { sku: SKU; quantity: number }[];
+
+  if (!products.length) return null;
+
+  const subtotal = products.reduce(
+    (sum, { sku, quantity }) => sum + sku.price * quantity,
+    0,
+  );
+  const total = subtotal * (1 - discountPercent / 100);
+
+  async function handleAdd() {
+    setAdding(true);
+    try {
+      for (const { sku, quantity } of products) {
+        await dispatch({ type: "add", sku, qty: quantity });
+      }
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <ul className="space-y-1">
+        {products.map(({ sku, quantity }) => (
+          <li key={sku.id} className="flex justify-between">
+            <span>
+              {sku.title} x{quantity}
+            </span>
+            <Price amount={sku.price * quantity} />
+          </li>
+        ))}
+      </ul>
+      <div className="flex items-baseline gap-2 font-semibold">
+        {discountPercent > 0 && (
+          <Price
+            amount={subtotal}
+            className="text-muted-foreground line-through"
+          />
+        )}
+        <Price amount={total} />
+      </div>
+      <button
+        onClick={handleAdd}
+        disabled={adding}
+        className="rounded bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-800 disabled:opacity-50"
+      >
+        {adding ? "Adding..." : "Add Bundle to Cart"}
+      </button>
+    </div>
+  );
+}
+
+export function getRuntimeProps() {
+  return {
+    items: [
+      { sku: "green-sneaker", quantity: 1 },
+      { sku: "sand-sneaker", quantity: 1 },
+    ],
+    discountPercent: 10,
+  } satisfies ProductBundleProps;
+}
+

--- a/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import ProductBundle from "../ProductBundle";
+
+jest.mock("@platform-core/src/contexts/CartContext", () => ({
+  useCart: () => [{}, jest.fn()],
+}));
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+describe("ProductBundle", () => {
+  it("calculates discounted bundle price", () => {
+    render(
+      <ProductBundle
+        items={[
+          { sku: "green-sneaker", quantity: 1 },
+          { sku: "sand-sneaker", quantity: 2 },
+        ]}
+        discountPercent={10}
+      />
+    );
+    expect(screen.getByText(/Eco Runner — Green/)).toBeInTheDocument();
+    expect(screen.getByText(/Eco Runner — Sand/)).toBeInTheDocument();
+    expect(screen.getByText("$357.00")).toBeInTheDocument();
+    expect(screen.getByText("$321.30")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -34,6 +34,7 @@ import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
+import ProductBundle from "./ProductBundle";
 
 export {
   BlogListing,
@@ -72,6 +73,7 @@ export {
   FeaturedProductBlock,
   GiftCardBlock,
   FormBuilderBlock,
+  ProductBundle,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -37,6 +37,9 @@ import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
+import ProductBundle, {
+  getRuntimeProps as getProductBundleRuntimeProps,
+} from "./ProductBundle";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -82,6 +85,10 @@ export const organismRegistry = {
   ProductComparison: { component: ProductComparisonBlock },
   GiftCardBlock: { component: GiftCardBlock },
   FormBuilderBlock: { component: FormBuilderBlock },
+  ProductBundle: {
+    component: ProductBundle,
+    getRuntimeProps: getProductBundleRuntimeProps,
+  },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -38,6 +38,7 @@ import RecommendationCarouselEditor from "./RecommendationCarouselEditor";
 import ProductComparisonEditor from "./ProductComparisonEditor";
 import GiftCardEditor from "./GiftCardEditor";
 import FormBuilderEditor from "./FormBuilderEditor";
+import ProductBundleEditor from "./ProductBundleEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -130,6 +131,11 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
     case "ProductComparison":
       specific = (
         <ProductComparisonEditor component={component} onChange={onChange} />
+      );
+      break;
+    case "ProductBundle":
+      specific = (
+        <ProductBundleEditor component={component} onChange={onChange} />
       );
       break;
     case "GiftCardBlock":

--- a/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
@@ -1,0 +1,29 @@
+import type { PageComponent } from "@acme/types";
+import { Input } from "../../atoms/shadcn";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function ProductBundleEditor({ component, onChange }: Props) {
+  const arrayEditor = useArrayEditor(onChange);
+
+  const handleNum = (value: string) => {
+    const num = value ? Number(value) : undefined;
+    onChange({ discountPercent: isNaN(num!) ? undefined : num } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      {arrayEditor("items", (component as any).items, ["sku", "quantity"])}
+      <Input
+        label="Discount %"
+        type="number"
+        value={(component as any).discountPercent ?? ""}
+        onChange={(e) => handleNum(e.target.value)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -23,6 +23,7 @@ export { default as ProductComparisonEditor } from "./ProductComparisonEditor";
 export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as GiftCardEditor } from "./GiftCardEditor";
 export { default as FormBuilderEditor } from "./FormBuilderEditor";
+export { default as ProductBundleEditor } from "./ProductBundleEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add ProductBundle block for bundling multiple products with discount pricing and unified add-to-cart
- support bundle editing in page builder for configuring items and discounts
- register ProductBundle in block registry and page-builder palette

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689cde7c2aac832f8d548c0dbbc7bfc5