### PR TITLE
feat: add popup modal CMS block

### DIFF
--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+
+interface PopupModalProps {
+  width?: number;
+  height?: number;
+  /**
+   * Determines how the popup is triggered. If set to `delay` the modal
+   * will appear after the specified `delay` (in ms). If set to
+   * `exit-intent`, the modal will appear when the user's mouse leaves
+   * the viewport.
+   */
+  trigger?: "delay" | "exit-intent";
+  /** Delay in milliseconds used when trigger is `delay`. */
+  delay?: number;
+  /** HTML string rendered inside the modal. */
+  content?: string;
+}
+
+export default function PopupModal({
+  width = 400,
+  height = 300,
+  trigger,
+  delay = 0,
+  content,
+}: PopupModalProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (trigger === "delay") {
+      const timer = setTimeout(() => setOpen(true), delay);
+      return () => clearTimeout(timer);
+    }
+
+    if (trigger === "exit-intent") {
+      const handleMouseLeave = (e: MouseEvent) => {
+        if (e.clientY <= 0) {
+          setOpen(true);
+        }
+      };
+
+      document.addEventListener("mouseout", handleMouseLeave);
+      return () => document.removeEventListener("mouseout", handleMouseLeave);
+    }
+
+    // Default behaviour: show immediately
+    setOpen(true);
+  }, [trigger, delay]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        className="relative bg-white p-4"
+        style={{ width, height }}
+      >
+        <button
+          onClick={() => setOpen(false)}
+          className="absolute right-2 top-2"
+          aria-label="Close modal"
+        >
+          ×
+        </button>
+        {content ? (
+          <div dangerouslySetInnerHTML={{ __html: content }} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -34,6 +34,7 @@ import ProductComparison from "./ProductComparisonBlock";
 import FeaturedProductBlock from "./FeaturedProductBlock";
 import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
+import PopupModal from "./PopupModal";
 
 export {
   BlogListing,
@@ -72,6 +73,7 @@ export {
   FeaturedProductBlock,
   GiftCardBlock,
   FormBuilderBlock,
+  PopupModal,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -37,6 +37,7 @@ import SearchBar from "./SearchBar";
 import ProductComparisonBlock from "./ProductComparisonBlock";
 import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
+import PopupModal from "./PopupModal";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -82,6 +83,7 @@ export const organismRegistry = {
   ProductComparison: { component: ProductComparisonBlock },
   GiftCardBlock: { component: GiftCardBlock },
   FormBuilderBlock: { component: FormBuilderBlock },
+  PopupModal: { component: PopupModal },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -38,11 +38,13 @@ const palette = {
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })),
   organisms: (Object.keys(organismRegistry) as PageComponent["type"][])
+    .filter((t) => t !== "PopupModal")
     .sort()
     .map((t) => ({
       type: t,
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })),
+  overlays: [{ type: "PopupModal", label: "Popup Modal" }],
 } as const;
 
 const PaletteItem = memo(function PaletteItem({

--- a/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
@@ -1,0 +1,41 @@
+import type { PageComponent } from "@acme/types";
+import { Input, Textarea } from "../../atoms/shadcn";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function PopupModalEditor({ component, onChange }: Props) {
+  const handleChange = (field: string, value: any) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        type="number"
+        value={(component as any).width ?? ""}
+        onChange={(e) => handleChange("width", Number(e.target.value))}
+        placeholder="width"
+      />
+      <Input
+        type="number"
+        value={(component as any).height ?? ""}
+        onChange={(e) => handleChange("height", Number(e.target.value))}
+        placeholder="height"
+      />
+      <Input
+        value={(component as any).trigger ?? ""}
+        onChange={(e) => handleChange("trigger", e.target.value)}
+        placeholder="trigger (delay|exit-intent)"
+      />
+      <Textarea
+        value={(component as any).content ?? ""}
+        onChange={(e) => handleChange("content", e.target.value)}
+        placeholder="content"
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add PopupModal block with optional delay or exit-intent trigger
- expose PopupModal editor for width, height, trigger and content
- register PopupModal in block registry and page builder palette

## Testing
- `pnpm --filter @acme/ui test` (fails: Cannot find module '../src/app/cms/wizard/Wizard')
- `pnpm --filter @acme/ui lint` (fails: None of the selected packages has a "lint" script)


------
https://chatgpt.com/codex/tasks/task_e_689cde565e78832f94fd1af43e0c20c9