### PR TITLE
feat(cms): improve Sanity blog schema

### DIFF
--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -102,13 +102,13 @@ export async function setupSanityBlog(
                   { name: "title", type: "string", title: "Title" },
                   { name: "slug", type: "slug", title: "Slug", options: { source: "title" } },
                   { name: "excerpt", type: "text", title: "Excerpt" },
-                  { name: "mainImage", type: "string", title: "Main Image URL" },
+                  { name: "mainImage", type: "image", title: "Main Image" },
                   { name: "author", type: "string", title: "Author" },
                   {
                     name: "categories",
                     type: "array",
                     title: "Categories",
-                    of: [{ type: "string" }],
+                    of: [{ type: "reference", to: [{ type: "category" }] }],
                   },
                   {
                     name: "body",
@@ -139,6 +139,24 @@ export async function setupSanityBlog(
                     title: "Products",
                     of: [{ type: "string" }],
                     description: "Shop product IDs or slugs",
+                  },
+                ],
+              },
+            },
+            {
+              createOrReplace: {
+                _id: "schema-category",
+                _type: "schema",
+                name: "category",
+                title: "Category",
+                type: "document",
+                fields: [
+                  { name: "title", type: "string", title: "Title" },
+                  {
+                    name: "slug",
+                    type: "slug",
+                    title: "Slug",
+                    options: { source: "title" },
                   },
                 ],
               },

--- a/doc/sanity-blog.md
+++ b/doc/sanity-blog.md
@@ -2,6 +2,10 @@
 
 Shop owners can connect a Sanity project to manage blog posts alongside the shop catalog. Follow these steps to enable and use the integration.
 
+## Schema
+
+When setting up the connection the CMS seeds a minimal schema. Posts include a `mainImage` field using Sanity's `image` type and a `categories` field that stores references to `category` documents. A `category` document contains a `title` and generated `slug` so categories can be reused across posts.
+
 ## Connect your Sanity project
 
 1. Obtain your **project ID**, **dataset**, and an API **token** from the Sanity dashboard.


### PR DESCRIPTION
## Summary
- use Sanity `image` type for post `mainImage`
- model post `categories` as references to `category` documents
- document new image and category fields in blog setup guide

## Testing
- `pnpm exec eslint apps/cms/src/actions/setupSanityBlog.ts doc/sanity-blog.md` *(warning: File ignored because no matching configuration was supplied)*
- `pnpm test:cms` *(fail: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx'; process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689cde83ce08832fa177b5e0775a603d