### PR TITLE
feat(ui): add design token attributes

### DIFF
--- a/doc/theme-editor-tokens.md
+++ b/doc/theme-editor-tokens.md
@@ -14,4 +14,11 @@ The following components expose design tokens via `data-token` attributes so the
 | Toast | `--color-fg`, `--color-bg` |
 | CheckoutTemplate | `--color-primary`, `--color-muted` |
 | CartTemplate | `--color-muted`, `--color-danger` |
+| GiftCardBlock | `--color-fg`, `--color-bg` |
+| ImageSlider | `--color-fg`, `--color-bg` |
+| RevokeSessionButton | `--color-primary`, `--color-primary-fg`, `--color-danger` |
+| MfaChallenge | `--color-primary`, `--color-primary-fg`, `--color-danger` |
+| Sessions | `--color-muted` |
+| ProfileForm | `--color-primary`, `--color-primary-fg`, `--color-success`, `--color-danger` |
+| CheckoutForm | `--color-danger`, `--color-fg`, `--color-bg` |
 

--- a/packages/ui/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/__tests__/GiftCardBlock.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import GiftCardBlock from "../src/components/cms/blocks/GiftCardBlock";
+
+describe("GiftCardBlock", () => {
+  it("exposes data-token attributes", () => {
+    render(<GiftCardBlock denominations={[25, 50]} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveAttribute("data-token", "--color-fg");
+    expect(buttons[0].querySelector("span")).toHaveAttribute(
+      "data-token",
+      "--color-bg"
+    );
+    expect(buttons[1]).toHaveAttribute("data-token", "--color-bg");
+  });
+});

--- a/packages/ui/__tests__/ProfileForm.test.tsx
+++ b/packages/ui/__tests__/ProfileForm.test.tsx
@@ -13,8 +13,12 @@ describe("ProfileForm", () => {
     render(<ProfileForm />);
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(await screen.findByText("Name is required.")).toBeInTheDocument();
-    expect(await screen.findByText("Email is required.")).toBeInTheDocument();
+    const nameError = await screen.findByText("Name is required.");
+    const emailError = await screen.findByText("Email is required.");
+    expect(nameError).toBeInTheDocument();
+    expect(emailError).toBeInTheDocument();
+    expect(nameError).toHaveAttribute("data-token", "--color-danger");
+    expect(emailError).toHaveAttribute("data-token", "--color-danger");
     fetchSpy.mockRestore();
   });
 });

--- a/packages/ui/src/components/account/MfaChallenge.tsx
+++ b/packages/ui/src/components/account/MfaChallenge.tsx
@@ -43,11 +43,18 @@ export default function MfaChallenge({ onSuccess, customerId }: MfaChallengeProp
       />
       <button
         type="submit"
-        className="rounded bg-primary px-4 py-2 text-primary-fg"
+        className="rounded bg-primary px-4 py-2"
+        data-token="--color-primary"
       >
-        Verify
+        <span className="text-primary-fg" data-token="--color-primary-fg">
+          Verify
+        </span>
       </button>
-      {error && <p className="text-red-600">{error}</p>}
+      {error && (
+        <p className="text-danger" data-token="--color-danger">
+          {error}
+        </p>
+      )}
     </form>
   );
 }

--- a/packages/ui/src/components/account/ProfileForm.tsx
+++ b/packages/ui/src/components/account/ProfileForm.tsx
@@ -89,7 +89,11 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
           className="rounded border p-2"
           required
         />
-        {errors.name && <p className="text-red-600 text-sm">{errors.name}</p>}
+        {errors.name && (
+          <p className="text-danger text-sm" data-token="--color-danger">
+            {errors.name}
+          </p>
+        )}
       </div>
       <div className="flex flex-col">
         <label htmlFor="email" className="mb-1">Email</label>
@@ -102,11 +106,31 @@ export default function ProfileForm({ name = "", email = "" }: ProfileFormProps)
           className="rounded border p-2"
           required
         />
-        {errors.email && <p className="text-red-600 text-sm">{errors.email}</p>}
+        {errors.email && (
+          <p className="text-danger text-sm" data-token="--color-danger">
+            {errors.email}
+          </p>
+        )}
       </div>
-      <button type="submit" className="rounded bg-primary px-4 py-2 text-primary-fg">Save</button>
-      {status === "success" && <p className="text-green-600">{message}</p>}
-      {status === "error" && <p className="text-red-600">{message}</p>}
+      <button
+        type="submit"
+        className="rounded bg-primary px-4 py-2"
+        data-token="--color-primary"
+      >
+        <span className="text-primary-fg" data-token="--color-primary-fg">
+          Save
+        </span>
+      </button>
+      {status === "success" && (
+        <p className="text-success" data-token="--color-success">
+          {message}
+        </p>
+      )}
+      {status === "error" && (
+        <p className="text-danger" data-token="--color-danger">
+          {message}
+        </p>
+      )}
     </form>
   );
 }

--- a/packages/ui/src/components/account/RevokeSessionButton.tsx
+++ b/packages/ui/src/components/account/RevokeSessionButton.tsx
@@ -32,11 +32,18 @@ export default function RevokeSessionButton({ sessionId }: RevokeSessionButtonPr
         type="button"
         onClick={handleClick}
         disabled={isPending}
-        className="rounded bg-primary px-4 py-2 text-primary-fg"
+        className="rounded bg-primary px-4 py-2"
+        data-token="--color-primary"
       >
-        {isPending ? "Revoking..." : "Revoke"}
+        <span className="text-primary-fg" data-token="--color-primary-fg">
+          {isPending ? "Revoking..." : "Revoke"}
+        </span>
       </button>
-      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      {error && (
+        <p className="mt-2 text-sm text-danger" data-token="--color-danger">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/account/Sessions.tsx
+++ b/packages/ui/src/components/account/Sessions.tsx
@@ -56,7 +56,9 @@ export default async function SessionsPage({
           <li key={s.sessionId} className="flex items-center justify-between rounded border p-4">
             <div>
               <div>{s.userAgent}</div>
-              <div className="text-sm text-gray-500">{s.createdAt.toISOString()}</div>
+              <div className="text-sm text-muted" data-token="--color-muted">
+                {s.createdAt.toISOString()}
+              </div>
             </div>
             <RevokeSessionButton sessionId={s.sessionId} />
           </li>

--- a/packages/ui/src/components/atoms/StockStatus.tsx
+++ b/packages/ui/src/components/atoms/StockStatus.tsx
@@ -20,10 +20,12 @@ export const StockStatus = React.forwardRef<HTMLSpanElement, StockStatusProps>(
     ref
   ) => {
     const color = inStock ? "text-success" : "text-danger";
+    const token = inStock ? "--color-success" : "--color-danger";
     return (
       <span
         ref={ref}
         className={cn("text-sm font-medium", color, className)}
+        data-token={token}
         {...props}
       >
         {inStock ? labelInStock : labelOutOfStock}

--- a/packages/ui/src/components/atoms/primitives/input.tsx
+++ b/packages/ui/src/components/atoms/primitives/input.tsx
@@ -130,7 +130,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             />
           </>
         )}
-        {error && <p className="mt-1 text-sm text-danger">{error}</p>}
+        {error && (
+          <p className="mt-1 text-sm text-danger" data-token="--color-danger">
+            {error}
+          </p>
+        )}
       </div>
     );
   }

--- a/packages/ui/src/components/atoms/primitives/textarea.tsx
+++ b/packages/ui/src/components/atoms/primitives/textarea.tsx
@@ -113,7 +113,11 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             />
           </>
         )}
-        {error && <p className="mt-1 text-sm text-danger">{error}</p>}
+        {error && (
+          <p className="mt-1 text-sm text-danger" data-token="--color-danger">
+            {error}
+          </p>
+        )}
       </div>
     );
   }

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -115,13 +115,20 @@ function PaymentForm({
         />
       </label>
       <PaymentElement />
-      {error && <p className="text-sm text-danger">{error}</p>}
+      {error && (
+        <p className="text-sm text-danger" data-token="--color-danger">
+          {error}
+        </p>
+      )}
       <button
         type="submit"
         disabled={!stripe || processing}
-        className="w-full rounded bg-fg py-2 text-bg disabled:opacity-50"
+        className="w-full rounded bg-fg py-2 disabled:opacity-50"
+        data-token="--color-fg"
       >
-        {processing ? t("checkout.processing") : t("checkout.pay")}
+        <span className="text-bg" data-token="--color-bg">
+          {processing ? t("checkout.processing") : t("checkout.pay")}
+        </span>
       </button>
     </form>
   );

--- a/packages/ui/src/components/cms/ImageUploaderWithOrientationCheck.tsx
+++ b/packages/ui/src/components/cms/ImageUploaderWithOrientationCheck.tsx
@@ -52,6 +52,7 @@ function ImageUploaderWithOrientationCheckInner({
           className={
             isValid ? "text-sm text-success" : "text-sm text-danger"
           }
+          data-token={isValid ? "--color-success" : "--color-danger"}
         >
           {isValid
             ? `Image orientation is ${actual}; requirement satisfied.`

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -167,9 +167,13 @@ function MediaManagerBase({
 
       {/* Validation / progress feedback */}
       <div id={feedbackId} role="status" aria-live="polite" className="space-y-2">
-        {error && <p className="text-sm text-danger">{error}</p>}
+        {error && (
+          <p className="text-sm text-danger" data-token="--color-danger">
+            {error}
+          </p>
+        )}
         {progress && (
-          <p className="text-sm text-muted">
+          <p className="text-sm text-muted" data-token="--color-muted">
             Uploaded {progress.done}/{progress.total}
           </p>
         )}
@@ -187,6 +191,7 @@ function MediaManagerBase({
                 className={
                   isValid ? "text-sm text-success" : "text-sm text-danger"
                 }
+                data-token={isValid ? "--color-success" : "--color-danger"}
               >
                 {isValid
                   ? `Image orientation is ${actual}; requirement satisfied.`

--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -54,7 +54,7 @@ export default function ProductEditorForm({
       <CardContent>
         <form onSubmit={handleSubmit} className="@container grid gap-6">
           {Object.keys(errors).length > 0 && (
-            <div className="text-sm text-danger">
+            <div className="text-sm text-danger" data-token="--color-danger">
               {Object.entries(errors).map(([k, v]) => (
                 <p key={k}>{v.join("; ")}</p>
               ))}

--- a/packages/ui/src/components/cms/ShopSelector.tsx
+++ b/packages/ui/src/components/cms/ShopSelector.tsx
@@ -62,7 +62,7 @@ export default function ShopSelector() {
     return <span className="text-sm">Loading shops…</span>;
   if (status === "error")
     return (
-      <span className="text-sm text-danger">
+      <span className="text-sm text-danger" data-token="--color-danger">
         {errorMsg ?? "Failed to load shops"}
       </span>
     );

--- a/packages/ui/src/components/cms/StyleEditor.tsx
+++ b/packages/ui/src/components/cms/StyleEditor.tsx
@@ -54,13 +54,15 @@ export default function StyleEditor({
     ) as HTMLElement | null;
     if (el) {
       el.scrollIntoView({ behavior: "smooth", block: "center" });
-      el.classList.add("ring-2", "ring-blue-500");
+      el.classList.add("ring-2", "ring-info");
+      el.dataset.token = "--color-info";
       const input = el.querySelector<HTMLElement>(
         "input, select, textarea, button"
       );
       input?.focus();
       const t = setTimeout(() => {
-        el.classList.remove("ring-2", "ring-blue-500");
+        el.classList.remove("ring-2", "ring-info");
+        delete el.dataset.token;
       }, 2000);
       return () => clearTimeout(t);
     }
@@ -88,7 +90,7 @@ export default function StyleEditor({
         if (contrast < 4.5) {
           const suggestion = suggestContrastColor(v, pairVal);
           warning = (
-            <span className="text-xs text-red-600">
+            <span className="text-xs text-danger" data-token="--color-danger">
               Low contrast ({contrast.toFixed(2)}:1)
               {suggestion ? ` – try ${suggestion}` : ""}
             </span>
@@ -100,8 +102,9 @@ export default function StyleEditor({
           key={k}
           data-token-key={k}
           className={`flex flex-col gap-1 text-sm ${
-            isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
+            isOverridden ? "border-l-2 border-l-info pl-2" : ""
           }`}
+          data-token={isOverridden ? "--color-info" : undefined}
         >
           <span className="flex items-center gap-2">
             <span className="w-40 flex-shrink-0">{k}</span>
@@ -134,8 +137,9 @@ export default function StyleEditor({
           key={k}
           data-token-key={k}
           className={`flex flex-col gap-1 text-sm ${
-            isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
+            isOverridden ? "border-l-2 border-l-info pl-2" : ""
           }`}
+          data-token={isOverridden ? "--color-info" : undefined}
         >
           <span className="flex items-center gap-2">
             <span className="w-40 flex-shrink-0">{k}</span>
@@ -186,8 +190,9 @@ export default function StyleEditor({
           key={k}
           data-token-key={k}
           className={`flex items-center gap-2 text-sm ${
-            isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
+            isOverridden ? "border-l-2 border-l-info pl-2" : ""
           }`}
+          data-token={isOverridden ? "--color-info" : undefined}
         >
           <span className="w-40 flex-shrink-0">{k}</span>
           <RangeInput value={v} onChange={(val) => setToken(k, val)} />
@@ -214,8 +219,9 @@ export default function StyleEditor({
         key={k}
         data-token-key={k}
         className={`flex items-center gap-2 text-sm ${
-          isOverridden ? "border-l-2 border-l-blue-500 pl-2" : ""
+          isOverridden ? "border-l-2 border-l-info pl-2" : ""
         }`}
+        data-token={isOverridden ? "--color-info" : undefined}
       >
         <span className="w-40 flex-shrink-0">{k}</span>
         <Input value={v} onChange={(e) => setToken(k, e.target.value)} />

--- a/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/GiftCardBlock.tsx
@@ -40,12 +40,15 @@ export default function GiftCardBlock({
             type="button"
             onClick={() => setAmount(value)}
             className={`rounded border px-3 py-2 ${
-              amount === value
-                ? "bg-gray-900 text-white"
-                : "bg-white text-gray-900"
+              amount === value ? "bg-fg" : "bg-bg"
             }`}
+            data-token={amount === value ? "--color-fg" : "--color-bg"}
           >
-            <Price amount={value} />
+            <Price
+              amount={value}
+              className={amount === value ? "text-bg" : "text-fg"}
+              data-token={amount === value ? "--color-bg" : "--color-fg"}
+            />
           </button>
         ))}
       </div>

--- a/packages/ui/src/components/cms/blocks/ImageSlider.tsx
+++ b/packages/ui/src/components/cms/blocks/ImageSlider.tsx
@@ -59,17 +59,19 @@ export default function ImageSlider({
             type="button"
             onClick={prev}
             aria-label="Previous slide"
-            className="absolute left-2 top-1/2 -translate-y-1/2 rounded bg-black/50 p-2 text-white"
+            className="absolute left-2 top-1/2 -translate-y-1/2 rounded bg-fg/50 p-2"
+            data-token="--color-fg"
           >
-            ‹
+            <span className="text-bg" data-token="--color-bg">‹</span>
           </button>
           <button
             type="button"
             onClick={next}
             aria-label="Next slide"
-            className="absolute right-2 top-1/2 -translate-y-1/2 rounded bg-black/50 p-2 text-white"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded bg-fg/50 p-2"
+            data-token="--color-fg"
           >
-            ›
+            <span className="text-bg" data-token="--color-bg">›</span>
           </button>
         </>
       )}

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -422,9 +422,12 @@ const CanvasItem = memo(function CanvasItem({
       <button
         type="button"
         onClick={onRemove}
-        className="absolute top-1 right-1 rounded bg-danger px-2 text-xs text-danger-foreground"
+        className="absolute top-1 right-1 rounded bg-danger px-2 text-xs"
+        data-token="--color-danger"
       >
-        ×
+        <span className="text-danger-foreground" data-token="--color-danger-fg">
+          ×
+        </span>
       </button>
       {hasChildren && (
         <SortableContext

--- a/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
@@ -79,7 +79,11 @@ function ImagePicker({ onSelect, children }: Props) {
               : `Selected image is ${actual}; please upload a landscape image.`}
           </p>
         )}
-        {error && <p className="text-sm text-danger">{error}</p>}
+        {error && (
+          <p className="text-sm text-danger" data-token="--color-danger">
+            {error}
+          </p>
+        )}
         <div className="grid max-h-64 grid-cols-3 gap-2 overflow-auto">
           {media.filter((m) => m.type === "image").map((m) => (
             <button

--- a/packages/ui/src/components/cms/products/ProductRowActions.tsx
+++ b/packages/ui/src/components/cms/products/ProductRowActions.tsx
@@ -42,6 +42,7 @@ export default function ProductRowActions({
         onClick={() => onDelete(product.id)}
         variant="outline"
         className="px-2 py-1 text-xs hover:bg-danger hover:text-danger-foreground"
+        data-token="--color-danger"
       >
         Delete
       </Button>

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -50,8 +50,16 @@ export default function HeaderClient({
         <Link href={`/${lang}/checkout`} className="relative hover:underline">
           Cart
           {qty > 0 && (
-            <span className="absolute -top-2 -right-3 rounded-full bg-danger px-1.5 text-xs text-danger-foreground">
-              {qty}
+            <span
+              className="absolute -top-2 -right-3 rounded-full bg-danger px-1.5 text-xs"
+              data-token="--color-danger"
+            >
+              <span
+                className="text-danger-foreground"
+                data-token="--color-danger-fg"
+              >
+                {qty}
+              </span>
             </span>
           )}
         </Link>

--- a/packages/ui/src/components/molecules/FormField.tsx
+++ b/packages/ui/src/components/molecules/FormField.tsx
@@ -49,13 +49,21 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
         <label htmlFor={htmlFor} className="text-sm font-medium">
           {label}
           {required && (
-            <span aria-hidden="true" className="text-danger">
+            <span
+              aria-hidden="true"
+              className="text-danger"
+              data-token="--color-danger"
+            >
               *
             </span>
           )}
         </label>
         {children}
-        {error && <p className="text-sm text-danger">{error}</p>}
+        {error && (
+          <p className="text-sm text-danger" data-token="--color-danger">
+            {error}
+          </p>
+        )}
       </div>
     );
   }

--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -193,7 +193,7 @@ export function useFileUpload(
           </p>
         )}
 
-        {error && <p className="mt-2 text-sm text-danger">{error}</p>}
+        {error && (<p className="mt-2 text-sm text-danger" data-token="--color-danger">{error}</p>)}
         {isValid === false && !isVideo && (
           <p className="mt-2 text-sm text-warning">
             Wrong orientation (needs {requiredOrientation})


### PR DESCRIPTION
## Summary
- replace hard-coded color classes in UI with token-based classes and data-token attributes
- document newly tokenised components in Theme Editor token map
- verify exposed tokens with tests

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689cde9305b8832fa10024eece6299ea