### PR TITLE
refactor: use requirePermission in storefront APIs

### DIFF
--- a/apps/shop-abc/__tests__/api/accountProfile.test.ts
+++ b/apps/shop-abc/__tests__/api/accountProfile.test.ts
@@ -7,7 +7,7 @@ jest.mock("next/server", () => ({
   },
 }));
 
-const getCustomerSession = jest.fn();
+const requirePermission = jest.fn();
 const validateCsrfToken = jest.fn().mockResolvedValue(true);
 let profile: any;
 const updateCustomerProfile = jest.fn(async (id: string, data: any) => {
@@ -16,10 +16,11 @@ const updateCustomerProfile = jest.fn(async (id: string, data: any) => {
 });
 const getCustomerProfile = jest.fn(async (id: string) => profile);
 
-jest.mock("@auth", () => {
-  const { hasPermission } = require("../../../../packages/auth/src/permissions");
-  return { __esModule: true, getCustomerSession, validateCsrfToken, hasPermission };
-});
+jest.mock("@auth", () => ({
+  __esModule: true,
+  requirePermission,
+  validateCsrfToken,
+}));
 jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile,
@@ -37,20 +38,14 @@ beforeEach(() => {
   profile = { customerId: "cust1", name: "Old", email: "old@example.com" };
 });
 
-test("returns 401 for unauthorized", async () => {
-  getCustomerSession.mockResolvedValue(null);
+test("returns 401 when permission check fails", async () => {
+  requirePermission.mockRejectedValue(new Error("Unauthorized"));
   const res = await PUT(createRequest({ name: "New", email: "new@example.com" }));
   expect(res.status).toBe(401);
 });
 
-test("returns 403 without manage_profile permission", async () => {
-  getCustomerSession.mockResolvedValue({ customerId: "cust1", role: "viewer" });
-  const res = await PUT(createRequest({ name: "New", email: "new@example.com" }));
-  expect(res.status).toBe(403);
-});
-
 test("returns 400 with validation errors", async () => {
-  getCustomerSession.mockResolvedValue({ customerId: "cust1", role: "customer" });
+  requirePermission.mockResolvedValue({ customerId: "cust1" });
   const res = await PUT(createRequest({ name: "", email: "invalid" }));
   const body = await res.json();
   expect(res.status).toBe(400);
@@ -59,7 +54,7 @@ test("returns 400 with validation errors", async () => {
 });
 
 test("updates profile with valid payload", async () => {
-  getCustomerSession.mockResolvedValue({ customerId: "cust1", role: "customer" });
+  requirePermission.mockResolvedValue({ customerId: "cust1" });
   const res = await PUT(
     createRequest({ name: "New Name", email: "new@example.com" })
   );
@@ -75,7 +70,7 @@ test("updates profile with valid payload", async () => {
 });
 
 test("returns 409 when email already exists", async () => {
-  getCustomerSession.mockResolvedValue({ customerId: "cust1", role: "customer" });
+  requirePermission.mockResolvedValue({ customerId: "cust1" });
   updateCustomerProfile.mockRejectedValue(
     new Error("Conflict: email already in use")
   );

--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -22,7 +22,7 @@ jest.mock("@platform-core/pricing", () => ({
 
 jest.mock("@upstash/redis", () => ({ Redis: class {} }));
 jest.mock("@platform-core/analytics", () => ({ trackEvent: jest.fn() }));
-jest.mock("@auth", () => ({ getCustomerSession: jest.fn(async () => null) }));
+jest.mock("@auth", () => ({ requirePermission: jest.fn(async () => ({ customerId: "c1" })) }));
 let mockCart: any;
 jest.mock("@platform-core/src/cartStore", () => ({
   getCart: jest.fn(async () => mockCart),

--- a/apps/shop-abc/__tests__/registerApi.test.ts
+++ b/apps/shop-abc/__tests__/registerApi.test.ts
@@ -13,12 +13,11 @@ jest.mock("@acme/platform-core/users", () => ({
   ),
 }));
 
-const getCustomerSession = jest.fn();
+const requirePermission = jest.fn();
 
 jest.mock("@auth", () => ({
   validateCsrfToken: jest.fn().mockResolvedValue(true),
-  getCustomerSession,
-  hasPermission: jest.fn().mockReturnValue(true),
+  requirePermission,
 }));
 
 jest.mock("@upstash/redis", () => ({
@@ -142,7 +141,7 @@ describe("/register POST", () => {
       name: "",
       email: "user@example.com",
     });
-    getCustomerSession.mockResolvedValue({ customerId: "newuser" });
+    requirePermission.mockResolvedValue({ customerId: "newuser" });
     const profRes = await profileGET();
     expect(profRes.status).toBe(200);
     expect(await profRes.json()).toEqual({

--- a/apps/shop-abc/__tests__/rental-api.test.ts
+++ b/apps/shop-abc/__tests__/rental-api.test.ts
@@ -33,6 +33,7 @@ describe("/api/rental", () => {
       markReturned: jest.fn(),
       markRefunded: jest.fn(),
     }));
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
 
     const { POST } = await import("../src/app/api/rental/route");
     const res = await POST({
@@ -66,7 +67,7 @@ describe("/api/rental", () => {
       markReturned,
       markRefunded: jest.fn(),
     }));
-
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { PATCH } = await import("../src/app/api/rental/route");
     const res = await PATCH({
       json: async () => ({ sessionId: "sess", damageFee: 30 }),
@@ -102,7 +103,7 @@ describe("/api/rental", () => {
       }),
       { virtual: true }
     );
-
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { PATCH } = await import("../src/app/api/rental/route");
     const res = await PATCH({
       json: async () => ({ sessionId: "missing" }),
@@ -133,7 +134,7 @@ describe("/api/rental", () => {
       markReturned,
       markRefunded: jest.fn(),
     }));
-
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { PATCH } = await import("../src/app/api/rental/route");
     const res = await PATCH({
       json: async () => ({ sessionId: "sess", damageFee: 25 }),

--- a/apps/shop-abc/__tests__/returnApi.test.ts
+++ b/apps/shop-abc/__tests__/returnApi.test.ts
@@ -43,6 +43,7 @@ describe("/api/return", () => {
       markRefunded: jest.fn(),
       addOrder: jest.fn(),
     }));
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { POST } = await import("../src/app/api/return/route");
     const res = await POST({
       json: async () => ({ sessionId: "sess", damageFee: 20 }),
@@ -82,7 +83,7 @@ describe("/api/return", () => {
       }),
       { virtual: true }
     );
-
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { POST } = await import("../src/app/api/return/route");
     const res = await POST({
       json: async () => ({ sessionId: "sess" }),
@@ -97,12 +98,14 @@ describe("/api/return", () => {
   });
 
   test("returns 400 for missing sessionId", async () => {
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { POST } = await import("../src/app/api/return/route");
     const res = await POST({ json: async () => ({}) } as any);
     expect(res.status).toBe(400);
   });
 
   test("returns 400 for invalid request body", async () => {
+    jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { POST } = await import("../src/app/api/return/route");
     await expect(POST({ json: async () => null } as any)).rejects.toThrow();
   });

--- a/apps/shop-abc/src/app/api/account/profile/route.ts
+++ b/apps/shop-abc/src/app/api/account/profile/route.ts
@@ -1,6 +1,6 @@
 // apps/shop-abc/src/app/api/account/profile/route.ts
 import "@acme/lib/initZod";
-import { getCustomerSession, hasPermission, validateCsrfToken } from "@auth";
+import { requirePermission, validateCsrfToken } from "@auth";
 import {
   getCustomerProfile,
   updateCustomerProfile,
@@ -20,13 +20,11 @@ const schema = z
   .strict();
 
 export async function GET() {
-  const session = await getCustomerSession();
-  if (!session) {
+  let session;
+  try {
+    session = await requirePermission("view_profile");
+  } catch {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  if (!hasPermission(session.role, "view_profile")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const profile = await getCustomerProfile(session.customerId);
@@ -41,13 +39,11 @@ export async function GET() {
 }
 
 export async function PUT(req: NextRequest) {
-  const session = await getCustomerSession();
-  if (!session) {
+  let session;
+  try {
+    session = await requirePermission("manage_profile");
+  } catch {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  if (!hasPermission(session.role, "manage_profile")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const token = req.headers.get("x-csrf-token");

--- a/apps/shop-abc/src/app/api/cart/route.ts
+++ b/apps/shop-abc/src/app/api/cart/route.ts
@@ -1,5 +1,5 @@
 // apps/shop-abc/src/app/api/cart/route.ts
-import { getCustomerSession, hasPermission } from "@auth";
+import { requirePermission } from "@auth";
 import {
   runtime,
   DELETE as coreDELETE,
@@ -14,9 +14,10 @@ async function guard(
   req: NextRequest,
   handler: (req: NextRequest) => Promise<NextResponse>
 ): Promise<NextResponse> {
-  const session = await getCustomerSession();
-  if (!session || !hasPermission(session.role, "manage_cart")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  try {
+    await requirePermission("manage_cart");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   return handler(req);
 }

--- a/apps/shop-abc/src/app/api/rental/route.ts
+++ b/apps/shop-abc/src/app/api/rental/route.ts
@@ -2,6 +2,7 @@
 import "@acme/lib/initZod";
 
 import { stripe } from "@acme/stripe";
+import { requirePermission } from "@auth";
 import {
   addOrder,
   markReturned,
@@ -18,6 +19,11 @@ const ReturnSchema = z
   .strict();
 
 export async function POST(req: NextRequest) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const parsed = await parseJsonBody(req, RentalSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId } = parsed.data;
@@ -29,6 +35,11 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId, damageFee } = parsed.data;

--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -2,6 +2,7 @@
 import "@acme/lib/initZod";
 
 import { stripe } from "@acme/stripe";
+import { requirePermission } from "@auth";
 import {
   markRefunded,
   markReturned,
@@ -17,6 +18,11 @@ const ReturnSchema = z
   .strict();
 
 export async function POST(req: NextRequest) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId, damageFee } = parsed.data;


### PR DESCRIPTION
## Summary
- switch storefront API routes to `requirePermission`
- update tests to mock `requirePermission`
- standardize unauthorized responses

## Testing
- `pnpm exec jest apps/shop-abc` *(fails: process.exit called and missing env/config)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfec9f90832faaa16f8a12dbe1bc