### PR TITLE
Guard rental and return APIs with manage_orders permission

### DIFF
--- a/apps/shop-abc/__tests__/rentalPermission.test.ts
+++ b/apps/shop-abc/__tests__/rentalPermission.test.ts
@@ -1,0 +1,85 @@
+// apps/shop-abc/__tests__/rentalPermission.test.ts
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+jest.mock("@acme/stripe", () => ({
+  stripe: {
+    checkout: { sessions: { retrieve: jest.fn() } },
+    refunds: { create: jest.fn() },
+  },
+}));
+
+jest.mock("@platform-core/repositories/rentalOrders.server", () => ({
+  addOrder: jest.fn(),
+  markReturned: jest.fn(),
+}));
+
+jest.mock("@auth", () => ({ requirePermission: jest.fn() }));
+
+jest.mock("@shared-utils", () => ({ parseJsonBody: jest.fn() }));
+
+import { POST, PATCH } from "../src/app/api/rental/route";
+import { requirePermission } from "@auth";
+import { stripe } from "@acme/stripe";
+import { addOrder, markReturned } from "@platform-core/repositories/rentalOrders.server";
+import { parseJsonBody } from "@shared-utils";
+
+function createRequest(body: any, method: string): Parameters<typeof POST>[0] {
+  return new Request("http://localhost/api/rental", {
+    method,
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("POST denies access without manage_orders permission", async () => {
+  (requirePermission as jest.Mock).mockRejectedValue(new Error("Unauthorized"));
+  const res = await POST({} as any);
+  expect(res.status).toBe(403);
+  expect(addOrder).not.toHaveBeenCalled();
+});
+
+test("POST allows access with manage_orders permission", async () => {
+  (requirePermission as jest.Mock).mockResolvedValue({});
+  (parseJsonBody as jest.Mock).mockResolvedValue({
+    success: true,
+    data: { sessionId: "s1" },
+  });
+  (stripe.checkout.sessions.retrieve as jest.Mock).mockResolvedValue({
+    metadata: { depositTotal: "5", returnDate: "2025-01-01" },
+  });
+  const res = await POST(createRequest({ sessionId: "s1" }, "POST"));
+  expect(res.status).toBe(200);
+  expect(addOrder).toHaveBeenCalled();
+});
+
+test("PATCH denies access without manage_orders permission", async () => {
+  (requirePermission as jest.Mock).mockRejectedValue(new Error("Unauthorized"));
+  const res = await PATCH({} as any);
+  expect(res.status).toBe(403);
+  expect(markReturned).not.toHaveBeenCalled();
+});
+
+test("PATCH allows access with manage_orders permission", async () => {
+  (requirePermission as jest.Mock).mockResolvedValue({});
+  (parseJsonBody as jest.Mock).mockResolvedValue({
+    success: true,
+    data: { sessionId: "s1" },
+  });
+  (markReturned as jest.Mock).mockResolvedValue({ deposit: 10 });
+  (stripe.checkout.sessions.retrieve as jest.Mock).mockResolvedValue({
+    payment_intent: { id: "pi_1" },
+  });
+  const res = await PATCH(createRequest({ sessionId: "s1" }, "PATCH"));
+  expect(res.status).toBe(200);
+  expect(markReturned).toHaveBeenCalled();
+});
+

--- a/apps/shop-abc/__tests__/returnPermission.test.ts
+++ b/apps/shop-abc/__tests__/returnPermission.test.ts
@@ -1,0 +1,64 @@
+// apps/shop-abc/__tests__/returnPermission.test.ts
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+jest.mock("@acme/stripe", () => ({
+  stripe: {
+    checkout: { sessions: { retrieve: jest.fn() } },
+    refunds: { create: jest.fn() },
+  },
+}));
+
+jest.mock("@platform-core/repositories/rentalOrders.server", () => ({
+  markReturned: jest.fn(),
+  markRefunded: jest.fn(),
+}));
+
+jest.mock("@auth", () => ({ requirePermission: jest.fn() }));
+
+jest.mock("@shared-utils", () => ({ parseJsonBody: jest.fn() }));
+
+import { POST } from "../src/app/api/return/route";
+import { requirePermission } from "@auth";
+import { stripe } from "@acme/stripe";
+import { markReturned } from "@platform-core/repositories/rentalOrders.server";
+import { parseJsonBody } from "@shared-utils";
+
+function createRequest(body = { sessionId: "s1" }): Parameters<typeof POST>[0] {
+  return new Request("http://localhost/api/return", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("denies access without manage_orders permission", async () => {
+  (requirePermission as jest.Mock).mockRejectedValue(new Error("Unauthorized"));
+  const res = await POST({} as any);
+  expect(res.status).toBe(403);
+  expect(markReturned).not.toHaveBeenCalled();
+});
+
+test("allows access with manage_orders permission", async () => {
+  (requirePermission as jest.Mock).mockResolvedValue({});
+  (parseJsonBody as jest.Mock).mockResolvedValue({
+    success: true,
+    data: { sessionId: "s1" },
+  });
+  (markReturned as jest.Mock).mockResolvedValue({ deposit: 10 });
+  (stripe.checkout.sessions.retrieve as jest.Mock).mockResolvedValue({
+    metadata: { depositTotal: "10" },
+    payment_intent: { id: "pi_1" },
+  });
+  const res = await POST(createRequest());
+  expect(res.status).toBe(200);
+});
+

--- a/apps/shop-abc/src/app/api/rental/route.ts
+++ b/apps/shop-abc/src/app/api/rental/route.ts
@@ -7,6 +7,7 @@ import {
   markReturned,
 } from "@platform-core/repositories/rentalOrders.server";
 import { NextRequest, NextResponse } from "next/server";
+import { requirePermission } from "@auth";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
 
@@ -18,6 +19,11 @@ const ReturnSchema = z
   .strict();
 
 export async function POST(req: NextRequest) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
   const parsed = await parseJsonBody(req, RentalSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId } = parsed.data;
@@ -29,6 +35,11 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId, damageFee } = parsed.data;

--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -7,6 +7,7 @@ import {
   markReturned,
 } from "@platform-core/repositories/rentalOrders.server";
 import { NextRequest, NextResponse } from "next/server";
+import { requirePermission } from "@auth";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
 
@@ -17,6 +18,11 @@ const ReturnSchema = z
   .strict();
 
 export async function POST(req: NextRequest) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId, damageFee } = parsed.data;


### PR DESCRIPTION
## Summary
- enforce `manage_orders` permission on rental and return API routes
- add tests for permitted and forbidden access to rental and return endpoints

## Testing
- `pnpm exec jest --config apps/shop-abc/jest.config.cjs apps/shop-abc/__tests__/returnPermission.test.ts apps/shop-abc/__tests__/rentalPermission.test.ts`
- `pnpm exec eslint apps/shop-abc/src/app/api/return/route.ts apps/shop-abc/src/app/api/rental/route.ts apps/shop-abc/__tests__/returnPermission.test.ts apps/shop-abc/__tests__/rentalPermission.test.ts` *(warn: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfea54d0832f9cd077c61d40c090