### PR TITLE
feat: add returns and rentals permissions

### DIFF
--- a/apps/cms/src/lib/rbacStore.ts
+++ b/apps/cms/src/lib/rbacStore.ts
@@ -77,12 +77,17 @@ export async function readRbac(): Promise<RbacDB> {
   try {
     const buf = await fs.readFile(FILE, "utf8");
     const parsed = JSON.parse(buf) as RbacDB;
-    if (parsed && parsed.users && parsed.roles && parsed.permissions)
-      return {
-        ...DEFAULT_DB,
-        ...parsed,
-        permissions: { ...DEFAULT_DB.permissions, ...parsed.permissions },
+    if (parsed && parsed.users && parsed.roles && parsed.permissions) {
+      const permissions: Record<Role, Permission[]> = {
+        ...DEFAULT_DB.permissions,
       };
+      for (const role of Object.keys(parsed.permissions) as Role[]) {
+        permissions[role] = Array.from(
+          new Set([...(permissions[role] ?? []), ...parsed.permissions[role]])
+        );
+      }
+      return { ...DEFAULT_DB, ...parsed, permissions };
+    }
   } catch {
     /* ignore */
   }

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -16,6 +16,8 @@ This guide lists built-in permissions and their default role mappings.
 | `view_orders` | customer, admin, ShopAdmin |
 | `manage_orders` | admin, ShopAdmin |
 | `manage_sessions` | admin, ShopAdmin |
+| `process_returns` | admin, ShopAdmin |
+| `manage_rentals` | admin, ShopAdmin |
 
 ## read
 Allows viewing CMS content and APIs.

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -20,7 +20,9 @@
     "manage_cart",
     "view_orders",
     "manage_orders",
-    "manage_sessions"
+    "manage_sessions",
+    "process_returns",
+    "manage_rentals"
   ],
   "ShopAdmin": [
     "view_products",
@@ -32,7 +34,9 @@
     "manage_cart",
     "view_orders",
     "manage_orders",
-    "manage_sessions"
+    "manage_sessions",
+    "process_returns",
+    "manage_rentals"
   ],
   "CatalogManager": [
     "view_products",


### PR DESCRIPTION
## Summary
- add `process_returns` and `manage_rentals` permissions
- document new permissions
- merge default permissions with stored RBAC data

## Testing
- `pnpm lint --filter=@acme/auth --filter=@apps/cms` *(fails: Cannot find module '@acme/config/env/core.ts')*
- `pnpm test --filter=@acme/auth --filter=@apps/cms` *(fails: invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfeb38d0832f8a8143a91e702307