### PR TITLE
test: cover theme token overrides

### DIFF
--- a/apps/cms/__tests__/resetThemeOverride.test.ts
+++ b/apps/cms/__tests__/resetThemeOverride.test.ts
@@ -1,0 +1,34 @@
+import { resetThemeOverride } from "../src/actions/shops.server";
+
+const ensureAuthorized = jest.fn();
+const getShopById = jest.fn();
+const updateShopInRepo = jest.fn();
+
+jest.mock("../src/actions/common/auth", () => ({ ensureAuthorized: () => ensureAuthorized() }));
+jest.mock("@platform-core/src/repositories/shop.server", () => ({
+  getShopById: (...args: any[]) => getShopById(...args),
+  updateShopInRepo: (...args: any[]) => updateShopInRepo(...args),
+}));
+jest.mock("@platform-core/src/createShop", () => ({
+  syncTheme: jest.fn(),
+  loadTokens: jest.fn(),
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+describe("resetThemeOverride", () => {
+  it("recomputes theme tokens from remaining overrides", async () => {
+    getShopById.mockResolvedValue({
+      id: "1",
+      themeDefaults: { "--color-bg": "white", "--color-primary": "blue" },
+      themeOverrides: { "--color-bg": "black", "--color-primary": "green" },
+    });
+
+    await resetThemeOverride("shop1", "--color-bg");
+
+    expect(updateShopInRepo).toHaveBeenCalledWith("shop1", {
+      id: "1",
+      themeOverrides: { "--color-primary": "green" },
+      themeTokens: { "--color-bg": "white", "--color-primary": "green" },
+    });
+  });
+});

--- a/apps/cms/__tests__/settingsPage.test.tsx
+++ b/apps/cms/__tests__/settingsPage.test.tsx
@@ -1,0 +1,49 @@
+import "@testing-library/jest-dom";
+import { render, screen, within } from "@testing-library/react";
+
+// Mock dependencies before importing the page
+jest.mock("@cms/auth/options", () => ({ authOptions: {} }));
+jest.mock("@cms/actions/shops.server", () => ({ resetThemeOverride: jest.fn() }));
+jest.mock("@acme/lib", () => ({ checkShopExists: jest.fn().mockResolvedValue(true) }));
+const mockReadSettings = jest.fn();
+const mockReadShop = jest.fn();
+jest.mock("@platform-core/repositories/json.server", () => ({
+  readSettings: (...args: any[]) => mockReadSettings(...args),
+  readShop: (...args: any[]) => mockReadShop(...args),
+}));
+jest.mock("next-auth", () => ({ getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }) }));
+jest.mock("next/dynamic", () => () => () => null);
+
+import SettingsPage from "../src/app/cms/shop/[shop]/settings/page";
+
+describe("Shop settings page", () => {
+  it("shows default and override tokens with reset button", async () => {
+    mockReadSettings.mockResolvedValue({
+      languages: ["en"],
+      currency: "USD",
+      taxRegion: "US",
+    });
+    mockReadShop.mockResolvedValue({
+      themeId: "base",
+      themeDefaults: {
+        "--color-bg": "#ffffff",
+        "--color-primary": "#00f",
+      },
+      themeOverrides: { "--color-bg": "#000000" },
+      catalogFilters: [],
+      filterMappings: {},
+    });
+
+    const Page = await SettingsPage({ params: Promise.resolve({ shop: "s1" }) });
+    render(Page);
+
+    const bgRow = screen.getByText("--color-bg").closest("tr")!;
+    expect(within(bgRow).getByText("#ffffff")).toBeInTheDocument();
+    expect(within(bgRow).getByText("#000000")).toBeInTheDocument();
+    expect(within(bgRow).getByRole("button", { name: /reset/i })).toBeInTheDocument();
+
+    const primaryRow = screen.getByText("--color-primary").closest("tr")!;
+    expect(within(primaryRow).getByText("#00f")).toBeInTheDocument();
+    expect(within(primaryRow).queryByRole("button", { name: /reset/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- test CMS shop settings page shows theme default and override tokens
- test resetThemeOverride recomputes theme tokens after removing an override

## Testing
- `pnpm --filter @apps/cms test -- __tests__/settingsPage.test.tsx __tests__/resetThemeOverride.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cde90f804832fac5014e837b7c0ed