### PR TITLE
feat: debounce checkout session creation

### DIFF
--- a/test/__mocks__/currencyContextMock.tsx
+++ b/test/__mocks__/currencyContextMock.tsx
@@ -1,17 +1,12 @@
 import React, { createContext, useContext, useState } from "react";
 
-type CurrencyCtx = { currency: string; setCurrency: (c: string) => void };
-const Ctx = createContext<CurrencyCtx>({
-  currency: "USD",
-  setCurrency: () => {},
-});
+const Ctx = createContext<[string, (c: string) => void]>(["USD", () => {}]);
 
 export function CurrencyProvider({ children }: { children: React.ReactNode }) {
-  const [currency, setCurrency] = useState("USD");
-  return (
-    <Ctx.Provider value={{ currency, setCurrency }}>{children}</Ctx.Provider>
-  );
+  const state = useState("USD");
+  return <Ctx.Provider value={state}>{children}</Ctx.Provider>;
 }
+
 export function useCurrency() {
   return useContext(Ctx);
 }


### PR DESCRIPTION
## Summary
- debounce checkout session creation with abortable fetch
- mock currency context for testing and add debounce test

## Testing
- `pnpm exec jest test/checkout.test.tsx -t "only final return date triggers request"`


------
https://chatgpt.com/codex/tasks/task_e_689cdfd9df78832fae755fae4bfd8bb5