### PR TITLE
feat: add popup modal overlay block

### DIFF
--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -45,6 +45,15 @@ export default function PopupModal({
     };
   }, [trigger, delay]);
 
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
   if (!open) return null;
 
   return (

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -80,12 +80,14 @@ export * from "./atoms";
 export * from "./molecules";
 export * from "./organisms";
 export * from "./layout";
+export * from "./overlays";
 
 import { atomRegistry } from "./atoms";
 import { moleculeRegistry } from "./molecules";
 import { organismRegistry } from "./organisms";
 import { containerRegistry } from "./containers";
 import { layoutRegistry } from "./layout";
+import { overlayRegistry } from "./overlays";
 
 // Re-export individual registries so consumers can access them directly.
 export {
@@ -94,6 +96,7 @@ export {
   organismRegistry,
   containerRegistry,
   layoutRegistry,
+  overlayRegistry,
 };
 
 export const blockRegistry = {
@@ -102,6 +105,7 @@ export const blockRegistry = {
   ...atomRegistry,
   ...moleculeRegistry,
   ...organismRegistry,
+  ...overlayRegistry,
 } as const;
 
 export type BlockType = keyof typeof blockRegistry;

--- a/packages/ui/src/components/cms/blocks/overlays.tsx
+++ b/packages/ui/src/components/cms/blocks/overlays.tsx
@@ -1,0 +1,8 @@
+import PopupModal from "./PopupModal";
+
+export const overlayRegistry = {
+  PopupModal: { component: PopupModal },
+} as const;
+
+export type OverlayBlockType = keyof typeof overlayRegistry;
+

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -10,6 +10,7 @@ import {
   organismRegistry,
   containerRegistry,
   layoutRegistry,
+  overlayRegistry,
 } from "../blocks";
 
 const palette = {
@@ -39,17 +40,16 @@ const palette = {
     })),
   organisms: (Object.keys(organismRegistry) as PageComponent["type"][])
     .sort()
-    .filter((t) => t !== "PopupModal")
     .map((t) => ({
       type: t,
       label: t.replace(/([A-Z])/g, " $1").trim(),
     })),
-  overlays: [
-    {
-      type: "PopupModal" as PageComponent["type"],
-      label: "Popup Modal",
-    },
-  ],
+  overlays: (Object.keys(overlayRegistry) as PageComponent["type"][])
+    .sort()
+    .map((t) => ({
+      type: t,
+      label: t.replace(/([A-Z])/g, " $1").trim(),
+    })),
 } as const;
 
 const PaletteItem = memo(function PaletteItem({

--- a/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PopupModalEditor.tsx
@@ -44,6 +44,17 @@ export default function PopupModalEditor({ component, onChange }: Props) {
           <SelectItem value="exit">exit intent</SelectItem>
         </SelectContent>
       </Select>
+      <Input
+        type="number"
+        value={(component as any).delay ?? ""}
+        onChange={(e) =>
+          handleInput(
+            "delay",
+            e.target.value ? Number(e.target.value) : undefined
+          )
+        }
+        placeholder="delay (ms)"
+      />
       <Textarea
         value={(component as any).content ?? ""}
         onChange={(e) => handleInput("content", e.target.value)}


### PR DESCRIPTION
## Summary
- add PopupModal overlay with delay and exit intent triggers
- allow configuring modal via PopupModalEditor
- expose overlay registry and show in palette

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter @acme/ui lint` *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_689ce331a2f0832fa91b18846bc5ed83