### PR TITLE
secure rental and return APIs with manage_orders permission

### DIFF
--- a/apps/shop-abc/__tests__/rentalPermission.test.ts
+++ b/apps/shop-abc/__tests__/rentalPermission.test.ts
@@ -1,0 +1,150 @@
+// apps/shop-abc/__tests__/rentalPermission.test.ts
+import type { NextRequest } from "next/server";
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe("/api/rental permission", () => {
+  test("POST denies access without manage_orders permission", async () => {
+    jest.doMock("next/server", () => ({
+      NextResponse: {
+        json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+      },
+    }));
+    jest.doMock(
+      "@acme/stripe",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: { sessions: { retrieve: jest.fn() } },
+          refunds: { create: jest.fn() },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      addOrder: jest.fn(),
+      markReturned: jest.fn(),
+    }));
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockRejectedValue(new Error("nope")),
+    }));
+    const { POST } = await import("../src/app/api/rental/route");
+    const res = await POST({} as NextRequest);
+    expect(res.status).toBe(403);
+  });
+
+  test("POST allows access with manage_orders permission", async () => {
+    jest.doMock("next/server", () => ({
+      NextResponse: {
+        json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+      },
+    }));
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockResolvedValue({}),
+    }));
+    jest.doMock(
+      "@acme/stripe",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: {
+            sessions: {
+              retrieve: jest.fn().mockResolvedValue({
+                metadata: { depositTotal: "50", returnDate: "2030-01-02" },
+              }),
+            },
+          },
+          refunds: { create: jest.fn() },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      addOrder: jest.fn(),
+      markReturned: jest.fn(),
+    }));
+    jest.doMock("@shared-utils", () => ({
+      __esModule: true,
+      parseJsonBody: jest.fn().mockResolvedValue({ success: true, data: { sessionId: "sess" } }),
+    }));
+    const { POST } = await import("../src/app/api/rental/route");
+    const res = await POST({} as any);
+    expect(res.status).toBe(200);
+  });
+
+  test("PATCH denies access without manage_orders permission", async () => {
+    jest.doMock("next/server", () => ({
+      NextResponse: {
+        json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+      },
+    }));
+    jest.doMock(
+      "@acme/stripe",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: { sessions: { retrieve: jest.fn() } },
+          refunds: { create: jest.fn() },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      addOrder: jest.fn(),
+      markReturned: jest.fn(),
+    }));
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockRejectedValue(new Error("nope")),
+    }));
+    const { PATCH } = await import("../src/app/api/rental/route");
+    const res = await PATCH({} as NextRequest);
+    expect(res.status).toBe(403);
+  });
+
+  test("PATCH allows access with manage_orders permission", async () => {
+    jest.doMock("next/server", () => ({
+      NextResponse: {
+        json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+      },
+    }));
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockResolvedValue({}),
+    }));
+    jest.doMock(
+      "@acme/stripe",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: { sessions: { retrieve: jest.fn().mockResolvedValue({ payment_intent: { id: "pi_1" } }) } },
+          refunds: { create: jest.fn() },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      addOrder: jest.fn(),
+      markReturned: jest.fn().mockResolvedValue({ deposit: 40 }),
+    }));
+    jest.doMock("@shared-utils", () => ({
+      __esModule: true,
+      parseJsonBody: jest
+        .fn()
+        .mockResolvedValue({ success: true, data: { sessionId: "sess", damageFee: 10 } }),
+    }));
+    const { PATCH } = await import("../src/app/api/rental/route");
+    const res = await PATCH({} as any);
+    expect(res.status).toBe(200);
+  });
+});
+

--- a/apps/shop-abc/__tests__/returnPermission.test.ts
+++ b/apps/shop-abc/__tests__/returnPermission.test.ts
@@ -1,0 +1,91 @@
+// apps/shop-abc/__tests__/returnPermission.test.ts
+import type { NextRequest } from "next/server";
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe("/api/return permission", () => {
+  test("denies access without manage_orders permission", async () => {
+    jest.doMock("next/server", () => ({
+      NextResponse: {
+        json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+      },
+    }));
+    jest.doMock(
+      "@acme/stripe",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: { sessions: { retrieve: jest.fn() } },
+          refunds: { create: jest.fn() },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn(),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@shared-utils", () => ({
+      __esModule: true,
+      parseJsonBody: jest.fn().mockResolvedValue({ success: true, data: { sessionId: "sess", damageFee: 0 } }),
+    }));
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockRejectedValue(new Error("nope")),
+    }));
+    const { POST } = await import("../src/app/api/return/route");
+    const res = await POST({} as NextRequest);
+    expect(res.status).toBe(403);
+  });
+
+  test("allows access with manage_orders permission", async () => {
+    jest.doMock("next/server", () => ({
+      NextResponse: {
+        json: (data: any, init?: ResponseInit) => new Response(JSON.stringify(data), init),
+      },
+    }));
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockResolvedValue({}),
+    }));
+    jest.doMock(
+      "@acme/stripe",
+      () => ({
+        __esModule: true,
+        stripe: {
+          checkout: {
+            sessions: {
+              retrieve: jest.fn().mockResolvedValue({
+                metadata: { depositTotal: "50" },
+                payment_intent: { id: "pi_1" },
+              }),
+            },
+          },
+          refunds: { create: jest.fn() },
+        },
+      }),
+      { virtual: true }
+    );
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn().mockResolvedValue({ deposit: 50 }),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@shared-utils", () => ({
+      __esModule: true,
+      parseJsonBody: jest
+        .fn()
+        .mockResolvedValue({ success: true, data: { sessionId: "sess", damageFee: 20 } }),
+    }));
+    const { POST } = await import("../src/app/api/return/route");
+    const res = await POST({} as any);
+    expect(res.status).toBe(200);
+  });
+});
+

--- a/apps/shop-abc/src/app/api/rental/route.ts
+++ b/apps/shop-abc/src/app/api/rental/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
   try {
     await requirePermission("manage_orders");
   } catch {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   const parsed = await parseJsonBody(req, RentalSchema, "1mb");
   if (!parsed.success) return parsed.response;
@@ -38,7 +38,7 @@ export async function PATCH(req: NextRequest) {
   try {
     await requirePermission("manage_orders");
   } catch {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;

--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest) {
   try {
     await requirePermission("manage_orders");
   } catch {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;


### PR DESCRIPTION
## Summary
- enforce `manage_orders` permission on rental and return API routes, returning 403 when missing
- add tests covering permitted and forbidden access for rental and return endpoints

## Testing
- `npx jest --runTestsByPath apps/shop-abc/__tests__/rentalPermission.test.ts apps/shop-abc/__tests__/returnPermission.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689ce3dd3528832fa5adff8cbc9e8adf