### PR TITLE
Add tests for coupon discounts and tax metadata in checkout session

### DIFF
--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -231,7 +231,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     (paymentIntentData as any).billing_details = billing_details;
   }
 
-  const session = await stripe.checkout.sessions.create({
+    const stripeSession = await stripe.checkout.sessions.create({
     mode: "payment",
     customer,
     line_items,
@@ -256,10 +256,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   });
 
   /* 6️⃣ Return client credentials ------------------------------------------ */
-  const clientSecret =
-    typeof session.payment_intent === "string"
-      ? undefined
-      : session.payment_intent?.client_secret;
+    const clientSecret =
+      typeof stripeSession.payment_intent === "string"
+        ? undefined
+        : stripeSession.payment_intent?.client_secret;
 
-  return NextResponse.json({ clientSecret, sessionId: session.id });
+    return NextResponse.json({
+      clientSecret,
+      sessionId: stripeSession.id,
+    });
 }


### PR DESCRIPTION
## Summary
- add mocks for coupons and tax to test Stripe session metadata
- test coupon discount reduces subtotal and discount metadata
- test tax region adds tax line item and metadata
- rename Stripe session variable to avoid shadowing in checkout route

## Testing
- `NEXTAUTH_SECRET=secret SESSION_SECRET=secret npx jest apps/shop-abc/__tests__/checkoutSession.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_689ce6b20090832fa20ecf5f4a2e4fc6