### PR TITLE
feat: republish shop script

### DIFF
--- a/scripts/src/republish-shop.ts
+++ b/scripts/src/republish-shop.ts
@@ -1,0 +1,36 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function readUpgradeMeta(id: string): unknown {
+  const file = join("data", "shops", id, "upgrade.json");
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function run(cmd: string, args: string[]): void {
+  const res = spawnSync(cmd, args, { stdio: "inherit" });
+  if (res.status !== 0) {
+    process.exit(res.status ?? 1);
+  }
+}
+
+function updateStatus(id: string): void {
+  const file = join("data", "shops", id, "shop.json");
+  const json = JSON.parse(readFileSync(file, "utf8"));
+  json.status = "published";
+  writeFileSync(file, JSON.stringify(json, null, 2));
+}
+
+function main(): void {
+  const shopId = process.argv[2];
+  if (!shopId) {
+    console.error("Usage: republish-shop <shopId>");
+    process.exit(1);
+  }
+  readUpgradeMeta(shopId);
+  run("pnpm", ["--filter", `apps/${shopId}`, "build"]);
+  run("pnpm", ["--filter", `apps/${shopId}`, "deploy"]);
+  updateStatus(shopId);
+}
+
+main();

--- a/test/integration/republish-shop.spec.ts
+++ b/test/integration/republish-shop.spec.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from "child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import ts from "typescript";
+
+describe("republish-shop script", () => {
+  it("builds, deploys and updates status", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "republish-"));
+    try {
+      const scriptsDir = join(tmp, "scripts");
+      mkdirSync(scriptsDir, { recursive: true });
+      const source = readFileSync(
+        join(__dirname, "../../scripts/src/republish-shop.ts"),
+        "utf8"
+      );
+      const js = ts
+        .transpileModule(source, {
+          compilerOptions: {
+            module: ts.ModuleKind.CommonJS,
+            target: ts.ScriptTarget.ES2019,
+          },
+        })
+        .outputText;
+      const scriptPath = join(scriptsDir, "republish-shop.js");
+      writeFileSync(scriptPath, js);
+
+      const binDir = join(tmp, "bin");
+      mkdirSync(binDir);
+      const logPath = join(tmp, "pnpm.log");
+      writeFileSync(
+        join(binDir, "pnpm"),
+        `#!/usr/bin/env node\nconst fs=require("fs");fs.appendFileSync(process.env.LOG_PATH, process.argv.slice(2).join(" ")+"\\n");`
+      );
+      chmodSync(join(binDir, "pnpm"), 0o755);
+
+      const appDir = join(tmp, "apps", "shop-test");
+      mkdirSync(appDir, { recursive: true });
+      writeFileSync(join(appDir, "shop.json"), JSON.stringify({ id: "shop-test" }, null, 2));
+      const dataDir = join(tmp, "data", "shops", "shop-test");
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, "upgrade.json"), JSON.stringify({ ok: true }));
+      writeFileSync(join(dataDir, "shop.json"), JSON.stringify({ id: "shop-test" }, null, 2));
+
+      execFileSync(process.execPath, [scriptPath, "shop-test"], {
+        cwd: tmp,
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, LOG_PATH: logPath },
+      });
+
+      const log = readFileSync(logPath, "utf8").trim().split("\n");
+      expect(log).toContain("--filter apps/shop-test build");
+      expect(log).toContain("--filter apps/shop-test deploy");
+      const final = JSON.parse(readFileSync(join(dataDir, "shop.json"), "utf8"));
+      expect(final.status).toBe("published");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add script to republish a shop by reading upgrade metadata, building and deploying the app, and marking the shop as published
- add integration test verifying republish workflow

## Testing
- `pnpm exec jest test/integration/republish-shop.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cea146908832f9501ac9c3fb78cad