### PR TITLE
feat: add rollback to upgrade script

### DIFF
--- a/dist-scripts/upgrade-shop.d.ts
+++ b/dist-scripts/upgrade-shop.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=upgrade-shop.d.ts.map

--- a/dist-scripts/upgrade-shop.d.ts.map
+++ b/dist-scripts/upgrade-shop.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"upgrade-shop.d.ts","sourceRoot":"","sources":["../scripts/src/upgrade-shop.ts"],"names":[],"mappings":""}

--- a/dist-scripts/upgrade-shop.js
+++ b/dist-scripts/upgrade-shop.js
@@ -1,0 +1,72 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, unlinkSync, renameSync, readFileSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
+const args = process.argv.slice(2);
+const rollback = args.includes("--rollback");
+const slug = args.find((a) => !a.startsWith("--"));
+if (!slug) {
+    console.error("Usage: pnpm ts-node scripts/src/upgrade-shop.ts <shop-slug> [--rollback]");
+    process.exit(1);
+}
+const shopId = slug.startsWith("shop-") ? slug : `shop-${slug}`;
+const rootDir = path.resolve(__dirname, "..", "..");
+const appDir = path.join(rootDir, "apps", shopId);
+const templateDir = path.join(rootDir, "packages", "template-app");
+const shopJsonPath = path.join(rootDir, "data", "shops", shopId, "shop.json");
+if (!existsSync(appDir)) {
+    console.error(`Shop app does not exist: ${appDir}`);
+    process.exit(1);
+}
+if (rollback) {
+    restoreBackups(appDir);
+    restoreBackups(path.dirname(shopJsonPath));
+    if (existsSync(shopJsonPath)) {
+        const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
+        delete data.lastUpgrade;
+        writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
+    }
+    console.log(`Rollback completed for ${shopId}`);
+    process.exit(0);
+}
+copyTemplate(templateDir, appDir);
+if (existsSync(shopJsonPath)) {
+    cpSync(shopJsonPath, shopJsonPath + ".bak");
+    const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
+    data.lastUpgrade = new Date().toISOString();
+    writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
+}
+console.log(`Upgrade staged for ${shopId}. Backups saved with .bak extension. Use --rollback to undo.`);
+function copyTemplate(srcDir, destDir) {
+    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+        if (["node_modules", "dist", ".next"].includes(entry.name))
+            continue;
+        const srcPath = path.join(srcDir, entry.name);
+        const destPath = path.join(destDir, entry.name);
+        if (entry.isDirectory()) {
+            mkdirSync(destPath, { recursive: true });
+            copyTemplate(srcPath, destPath);
+        }
+        else {
+            if (existsSync(destPath)) {
+                cpSync(destPath, destPath + ".bak");
+            }
+            cpSync(srcPath, destPath);
+        }
+    }
+}
+function restoreBackups(dir) {
+    if (!existsSync(dir))
+        return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            restoreBackups(full);
+            continue;
+        }
+        if (!entry.name.endsWith(".bak"))
+            continue;
+        const original = full.slice(0, -4);
+        if (existsSync(original))
+            unlinkSync(original);
+        renameSync(full, original);
+    }
+}

--- a/doc/upgrade-preview-republish.md
+++ b/doc/upgrade-preview-republish.md
@@ -1,0 +1,26 @@
+# Upgrade, preview and republish
+
+The `upgrade-shop` script stages template changes into an existing shop app.
+
+## Upgrade
+
+Run the script with a shop identifier to copy files from the template:
+
+```bash
+pnpm ts-node scripts/src/upgrade-shop.ts <shop-id>
+```
+
+Existing files are backed up next to their originals using a `.bak` suffix before
+being replaced. The shop's `shop.json` gains a `lastUpgrade` timestamp so the
+operation can be tracked.
+
+## Rollback
+
+If an upgrade needs to be undone, invoke the script with `--rollback`:
+
+```bash
+pnpm ts-node scripts/src/upgrade-shop.ts <shop-id> --rollback
+```
+
+All `.bak` files are restored to their original locations and the `lastUpgrade`
+metadata is removed from `shop.json`.

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -1,0 +1,81 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, unlinkSync, renameSync, readFileSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
+
+const args = process.argv.slice(2);
+const rollback = args.includes("--rollback");
+const slug = args.find((a) => !a.startsWith("--"));
+
+if (!slug) {
+  console.error(
+    "Usage: pnpm ts-node scripts/src/upgrade-shop.ts <shop-slug> [--rollback]"
+  );
+  process.exit(1);
+}
+
+const shopId = slug.startsWith("shop-") ? slug : `shop-${slug}`;
+const rootDir = path.resolve(__dirname, "..", "..");
+const appDir = path.join(rootDir, "apps", shopId);
+const templateDir = path.join(rootDir, "packages", "template-app");
+const shopJsonPath = path.join(rootDir, "data", "shops", shopId, "shop.json");
+
+if (!existsSync(appDir)) {
+  console.error(`Shop app does not exist: ${appDir}`);
+  process.exit(1);
+}
+
+if (rollback) {
+  restoreBackups(appDir);
+  restoreBackups(path.dirname(shopJsonPath));
+  if (existsSync(shopJsonPath)) {
+    const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
+    delete (data as any).lastUpgrade;
+    writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
+  }
+  console.log(`Rollback completed for ${shopId}`);
+  process.exit(0);
+}
+
+copyTemplate(templateDir, appDir);
+
+if (existsSync(shopJsonPath)) {
+  cpSync(shopJsonPath, shopJsonPath + ".bak");
+  const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
+  (data as any).lastUpgrade = new Date().toISOString();
+  writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
+}
+
+console.log(
+  `Upgrade staged for ${shopId}. Backups saved with .bak extension. Use --rollback to undo.`
+);
+
+function copyTemplate(srcDir: string, destDir: string) {
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (["node_modules", "dist", ".next"].includes(entry.name)) continue;
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      mkdirSync(destPath, { recursive: true });
+      copyTemplate(srcPath, destPath);
+    } else {
+      if (existsSync(destPath)) {
+        cpSync(destPath, destPath + ".bak");
+      }
+      cpSync(srcPath, destPath);
+    }
+  }
+}
+
+function restoreBackups(dir: string) {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      restoreBackups(full);
+      continue;
+    }
+    if (!entry.name.endsWith(".bak")) continue;
+    const original = full.slice(0, -4);
+    if (existsSync(original)) unlinkSync(original);
+    renameSync(full, original);
+  }
+}


### PR DESCRIPTION
## Summary
- add upgrade-shop script with backup and rollback support
- document upgrade flow with rollback instructions

## Testing
- `pnpm exec eslint scripts/src/upgrade-shop.ts doc/upgrade-preview-republish.md`
- `pnpm test` *(fails: @acme/next-config:test command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_689cea1c9630832f84ce0a47358395d6