### PR TITLE
feat: add upgrade preview page

### DIFF
--- a/apps/shop-abc/__tests__/__snapshots__/upgradePreview.test.tsx.snap
+++ b/apps/shop-abc/__tests__/__snapshots__/upgradePreview.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`upgrade preview page renders changes and publish CTA 1`] = `
+<body>
+  <div>
+    <div
+      class="space-y-8"
+    >
+      <div
+        class="space-y-2"
+      >
+        <h2
+          class="text-lg font-semibold"
+        >
+          TestComp
+        </h2>
+        <div
+          class="flex gap-4"
+        >
+          <div
+            class="flex-1 border p-2"
+          />
+          <div
+            class="flex-1 border p-2"
+          />
+        </div>
+      </div>
+      <button
+        class="rounded border px-4 py-2"
+        type="button"
+      >
+        Approve & publish
+      </button>
+    </div>
+  </div>
+</body>
+`;

--- a/apps/shop-abc/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-abc/__tests__/upgradePreview.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import UpgradePreviewPage from "../src/app/upgrade-preview/page";
+
+jest.mock("next/dynamic", () => () => () => null);
+
+describe("upgrade preview page", () => {
+  it("renders changes and publish CTA", async () => {
+    const fetchMock = jest.spyOn(global, "fetch" as any).mockResolvedValue({
+      json: async () => [
+        {
+          name: "TestComp",
+          before: { path: "@ui/components/Before" },
+          after: { path: "@ui/components/After" },
+        },
+      ],
+    } as any);
+
+    const { baseElement } = render(<UpgradePreviewPage />);
+    await screen.findByText("TestComp");
+    expect(screen.getByText("Approve & publish")).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot();
+    fetchMock.mockRestore();
+  });
+});

--- a/apps/shop-abc/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-abc/src/app/upgrade-preview/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+interface UpgradeComponent {
+  name: string;
+  before: {
+    path: string;
+    props?: Record<string, unknown>;
+  };
+  after: {
+    path: string;
+    props?: Record<string, unknown>;
+  };
+}
+
+export default function UpgradePreviewPage() {
+  const [changes, setChanges] = useState<UpgradeComponent[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/upgrade-changes");
+        const data = (await res.json()) as UpgradeComponent[];
+        setChanges(data);
+      } catch (err) {
+        console.error("Failed to load upgrade changes", err);
+      }
+    }
+    void load();
+  }, []);
+
+  async function handlePublish() {
+    try {
+      await fetch("/api/publish", { method: "POST" });
+    } catch (err) {
+      console.error("Publish failed", err);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {changes.map((c) => {
+        const Before = dynamic(() => import(c.before.path));
+        const After = dynamic(() => import(c.after.path));
+        return (
+          <div key={c.name} className="space-y-2">
+            <h2 className="text-lg font-semibold">{c.name}</h2>
+            <div className="flex gap-4">
+              <div className="flex-1 border p-2">
+                <Before {...c.before.props} />
+              </div>
+              <div className="flex-1 border p-2">
+                <After {...c.after.props} />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        onClick={handlePublish}
+        className="rounded border px-4 py-2"
+      >
+        Approve &amp; publish
+      </button>
+    </div>
+  );
+}
+

--- a/apps/shop-bcd/__tests__/__snapshots__/upgradePreview.test.tsx.snap
+++ b/apps/shop-bcd/__tests__/__snapshots__/upgradePreview.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`upgrade preview page renders changes and publish CTA 1`] = `
+<body>
+  <div>
+    <div
+      class="space-y-8"
+    >
+      <div
+        class="space-y-2"
+      >
+        <h2
+          class="text-lg font-semibold"
+        >
+          TestComp
+        </h2>
+        <div
+          class="flex gap-4"
+        >
+          <div
+            class="flex-1 border p-2"
+          />
+          <div
+            class="flex-1 border p-2"
+          />
+        </div>
+      </div>
+      <button
+        class="rounded border px-4 py-2"
+        type="button"
+      >
+        Approve & publish
+      </button>
+    </div>
+  </div>
+</body>
+`;

--- a/apps/shop-bcd/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-bcd/__tests__/upgradePreview.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import UpgradePreviewPage from "../src/app/upgrade-preview/page";
+
+jest.mock("next/dynamic", () => () => () => null);
+
+describe("upgrade preview page", () => {
+  it("renders changes and publish CTA", async () => {
+    const fetchMock = jest.spyOn(global, "fetch" as any).mockResolvedValue({
+      json: async () => [
+        {
+          name: "TestComp",
+          before: { path: "@ui/components/Before" },
+          after: { path: "@ui/components/After" },
+        },
+      ],
+    } as any);
+
+    const { baseElement } = render(<UpgradePreviewPage />);
+    await screen.findByText("TestComp");
+    expect(screen.getByText("Approve & publish")).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot();
+    fetchMock.mockRestore();
+  });
+});

--- a/apps/shop-bcd/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-bcd/src/app/upgrade-preview/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+interface UpgradeComponent {
+  name: string;
+  before: {
+    path: string;
+    props?: Record<string, unknown>;
+  };
+  after: {
+    path: string;
+    props?: Record<string, unknown>;
+  };
+}
+
+export default function UpgradePreviewPage() {
+  const [changes, setChanges] = useState<UpgradeComponent[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/upgrade-changes");
+        const data = (await res.json()) as UpgradeComponent[];
+        setChanges(data);
+      } catch (err) {
+        console.error("Failed to load upgrade changes", err);
+      }
+    }
+    void load();
+  }, []);
+
+  async function handlePublish() {
+    try {
+      await fetch("/api/publish", { method: "POST" });
+    } catch (err) {
+      console.error("Publish failed", err);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {changes.map((c) => {
+        const Before = dynamic(() => import(c.before.path));
+        const After = dynamic(() => import(c.after.path));
+        return (
+          <div key={c.name} className="space-y-2">
+            <h2 className="text-lg font-semibold">{c.name}</h2>
+            <div className="flex gap-4">
+              <div className="flex-1 border p-2">
+                <Before {...c.before.props} />
+              </div>
+              <div className="flex-1 border p-2">
+                <After {...c.after.props} />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        onClick={handlePublish}
+        className="rounded border px-4 py-2"
+      >
+        Approve &amp; publish
+      </button>
+    </div>
+  );
+}
+

--- a/packages/template-app/src/app/upgrade-preview/page.tsx
+++ b/packages/template-app/src/app/upgrade-preview/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+interface UpgradeComponent {
+  name: string;
+  before: {
+    path: string;
+    props?: Record<string, unknown>;
+  };
+  after: {
+    path: string;
+    props?: Record<string, unknown>;
+  };
+}
+
+export default function UpgradePreviewPage() {
+  const [changes, setChanges] = useState<UpgradeComponent[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/upgrade-changes");
+        const data = (await res.json()) as UpgradeComponent[];
+        setChanges(data);
+      } catch (err) {
+        console.error("Failed to load upgrade changes", err);
+      }
+    }
+    void load();
+  }, []);
+
+  async function handlePublish() {
+    try {
+      await fetch("/api/publish", { method: "POST" });
+    } catch (err) {
+      console.error("Publish failed", err);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {changes.map((c) => {
+        const Before = dynamic(() => import(c.before.path));
+        const After = dynamic(() => import(c.after.path));
+        return (
+          <div key={c.name} className="space-y-2">
+            <h2 className="text-lg font-semibold">{c.name}</h2>
+            <div className="flex gap-4">
+              <div className="flex-1 border p-2">
+                <Before {...c.before.props} />
+              </div>
+              <div className="flex-1 border p-2">
+                <After {...c.after.props} />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        onClick={handlePublish}
+        className="rounded border px-4 py-2"
+      >
+        Approve &amp; publish
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add upgrade preview page to shops and template
- dynamically show before/after component changes
- include publish call and snapshot tests

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/upgradePreview.test.tsx`
- `pnpm exec jest apps/shop-bcd/__tests__/upgradePreview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cea10ac80832faaa4f3048693f170