### PR TITLE
Validate checkout currency and tax region

### DIFF
--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -184,7 +184,7 @@ test("adds tax line item and metadata", async () => {
   mockCart = cart;
   const cookie = encodeCartCookie("test");
   const req = createRequest(
-    { returnDate: "2025-01-02", taxRegion: "DE" },
+    { returnDate: "2025-01-02", taxRegion: "EU" },
     cookie,
   );
 
@@ -197,4 +197,36 @@ test("adds tax line item and metadata", async () => {
   expect(args.metadata.taxAmount).toBe("2");
   expect(args.metadata.taxRate).toBe("0.2");
   expect(args.payment_intent_data.metadata.taxAmount).toBe("2");
+});
+
+test("returns 400 for unsupported currency", async () => {
+  const sku = PRODUCTS[0];
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
+  mockCart = cart;
+  const cookie = encodeCartCookie("test");
+  const req = createRequest(
+    { returnDate: "2025-01-02", currency: "JPY" },
+    cookie,
+  );
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.currency[0]).toMatch(/invalid/i);
+});
+
+test("returns 400 for unsupported tax region", async () => {
+  const sku = PRODUCTS[0];
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
+  mockCart = cart;
+  const cookie = encodeCartCookie("test");
+  const req = createRequest(
+    { returnDate: "2025-01-02", taxRegion: "DE" },
+    cookie,
+  );
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.taxRegion[0]).toMatch(/invalid/i);
 });

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -118,8 +118,8 @@ const schema = z
   .object({
     returnDate: z.string().optional(),
     coupon: z.string().optional(),
-    currency: z.string().default("EUR"),
-    taxRegion: z.string().default(""),
+    currency: z.enum(["EUR", "USD", "GBP"]).default("EUR"),
+    taxRegion: z.enum(["", "EU", "US"]).default(""),
     customer: z.string().optional(),
     shipping: shippingSchema.optional(),
     billing_details: billingSchema.optional(),


### PR DESCRIPTION
## Summary
- restrict checkout-session currency and taxRegion to defined enums
- add tests for invalid currency and tax region

## Testing
- `NEXTAUTH_SECRET=test SESSION_SECRET=test pnpm jest apps/shop-abc/__tests__/checkoutSession.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cec214694832fa44dcd3b8a59d5f1