### PR TITLE
Pass payment error to cancelled page via query param

### DIFF
--- a/apps/cms/src/app/cancelled/page.tsx
+++ b/apps/cms/src/app/cancelled/page.tsx
@@ -1,9 +1,15 @@
 // apps/cms/src/app/cancelled/page.tsx
 
-export default function Cancelled() {
+export default function Cancelled({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const { error } = searchParams;
   return (
     <div className="mx-auto max-w-lg py-20 text-center">
       <h1 className="mb-4 text-3xl font-semibold">Payment cancelled</h1>
+      {error && <p className="mb-4">{error}</p>}
       <p>You have not been charged. Feel free to keep shopping.</p>
     </div>
   );

--- a/apps/shop-abc/src/app/[lang]/cancelled/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/cancelled/page.tsx
@@ -1,7 +1,13 @@
-export default function Cancelled() {
+export default function Cancelled({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const { error } = searchParams;
   return (
     <div className="mx-auto max-w-lg py-20 text-center">
       <h1 className="mb-4 text-3xl font-semibold">Payment cancelled</h1>
+      {error && <p className="mb-4">{error}</p>}
       <p>You have not been charged. Feel free to keep shopping.</p>
     </div>
   );

--- a/apps/shop-abc/src/app/cancelled/page.tsx
+++ b/apps/shop-abc/src/app/cancelled/page.tsx
@@ -1,7 +1,13 @@
-export default function Cancelled() {
+export default function Cancelled({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const { error } = searchParams;
   return (
     <div className="mx-auto max-w-lg py-20 text-center">
       <h1 className="mb-4 text-3xl font-semibold">Payment cancelled</h1>
+      {error && <p className="mb-4">{error}</p>}
       <p>You have not been charged. Feel free to keep shopping.</p>
     </div>
   );

--- a/apps/shop-bcd/src/app/[lang]/cancelled/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/cancelled/page.tsx
@@ -1,7 +1,13 @@
-export default function Cancelled() {
+export default function Cancelled({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const { error } = searchParams;
   return (
     <div className="mx-auto max-w-lg py-20 text-center">
       <h1 className="mb-4 text-3xl font-semibold">Payment cancelled</h1>
+      {error && <p className="mb-4">{error}</p>}
       <p>You have not been charged. Feel free to keep shopping.</p>
     </div>
   );

--- a/apps/shop-bcd/src/app/cancelled/page.tsx
+++ b/apps/shop-bcd/src/app/cancelled/page.tsx
@@ -1,7 +1,13 @@
-export default function Cancelled() {
+export default function Cancelled({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const { error } = searchParams;
   return (
     <div className="mx-auto max-w-lg py-20 text-center">
       <h1 className="mb-4 text-3xl font-semibold">Payment cancelled</h1>
+      {error && <p className="mb-4">{error}</p>}
       <p>You have not been charged. Feel free to keep shopping.</p>
     </div>
   );

--- a/packages/template-app/src/app/cancelled/page.tsx
+++ b/packages/template-app/src/app/cancelled/page.tsx
@@ -1,7 +1,13 @@
-export default function Cancelled() {
+export default function Cancelled({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const { error } = searchParams;
   return (
     <div className="mx-auto max-w-lg py-20 text-center">
       <h1 className="mb-4 text-3xl font-semibold">Payment cancelled</h1>
+      {error && <p className="mb-4">{error}</p>}
       <p>You have not been charged. Feel free to keep shopping.</p>
     </div>
   );

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -92,7 +92,6 @@ function PaymentForm({
   const router = useRouter();
 
   const [processing, setProcessing] = useState(false);
-  const [error, setError] = useState<string>();
 
   const onSubmit = handleSubmit(async () => {
     if (!stripe || !elements) return;
@@ -107,9 +106,9 @@ function PaymentForm({
     });
 
     if (error) {
-      setError(error.message ?? "Payment failed");
       setProcessing(false);
-      router.push(`/${locale}/cancelled`);
+      const message = encodeURIComponent(error.message ?? "Payment failed");
+      router.push(`/${locale}/cancelled?error=${message}`);
     } else {
       router.push(`/${locale}/success`);
     }
@@ -126,11 +125,6 @@ function PaymentForm({
         />
       </label>
       <PaymentElement />
-      {error && (
-        <p className="text-sm text-danger" data-token="--color-danger">
-          {error}
-        </p>
-      )}
       <button
         type="submit"
         disabled={!stripe || processing}


### PR DESCRIPTION
## Summary
- propagate Stripe errors via query string when redirecting to cancelled page
- display optional error message on cancelled pages
- test redirection with error query

## Testing
- `pnpm exec jest test/checkout.test.tsx -t "failed payment redirects to cancelled with error"`
- `pnpm exec jest test/checkout.test.tsx` *(fails: Unable to find an element by [data-testid="payment-element"])`

------
https://chatgpt.com/codex/tasks/task_e_689cec026160832f88f2961548e5d98a