### PR TITLE
Add upgrade preview token support

### DIFF
--- a/apps/shop-abc/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-abc/routes/__tests__/preview-upgrade.test.ts
@@ -1,0 +1,82 @@
+import { jest } from "@jest/globals";
+import type { Page } from "@acme/types";
+import { createHmac } from "node:crypto";
+
+process.env.PREVIEW_TOKEN_SECRET = "testsecret";
+process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
+process.env.NEXT_PUBLIC_SHOP_ID = "shop";
+
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+afterEach(() => jest.resetModules());
+
+function tokenFor(id: string, secret: string): string {
+  return createHmac("sha256", secret).update(id).digest("hex");
+}
+
+test("valid upgrade token returns page JSON", async () => {
+  const page: Page = {
+    id: "1",
+    slug: "home",
+    status: "draft",
+    components: [],
+    seo: { title: "Home" },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    createdBy: "tester",
+  };
+  const getPages = jest.fn(async () => [page]);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(
+      `http://test?upgrade=${tokenFor("1", "upgradesecret")}`,
+    ),
+  } as any);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(page);
+});
+
+test("invalid upgrade token yields 401", async () => {
+  const getPages = jest.fn(async () => []);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(`http://test?upgrade=bad`),
+  } as any);
+
+  expect(res.status).toBe(401);
+});
+
+test("standard token not accepted as upgrade token", async () => {
+  const getPages = jest.fn(async () => []);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(
+      `http://test?upgrade=${tokenFor("1", "testsecret")}`,
+    ),
+  } as any);
+
+  expect(res.status).toBe(401);
+});
+

--- a/apps/shop-abc/src/routes/preview/[pageId].ts
+++ b/apps/shop-abc/src/routes/preview/[pageId].ts
@@ -7,10 +7,15 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { env } from "@acme/config";
 
 const secret = env.PREVIEW_TOKEN_SECRET;
+const upgradeSecret = env.UPGRADE_PREVIEW_TOKEN_SECRET;
 
-function verify(id: string, token: string | null): boolean {
-  if (!secret || !token) return false;
-  const digest = createHmac("sha256", secret).update(id).digest("hex");
+function verify(
+  id: string,
+  token: string | null,
+  key: string | undefined,
+): boolean {
+  if (!key || !token) return false;
+  const digest = createHmac("sha256", key).update(id).digest("hex");
   try {
     return timingSafeEqual(Buffer.from(digest), Buffer.from(token));
   } catch {
@@ -23,8 +28,14 @@ export const onRequest = async ({
   request,
 }: EventContext<unknown, string, Record<string, unknown>>) => {
   const pageId = String(params.pageId);
-  const token = new URL(request.url).searchParams.get("token");
-  if (!verify(pageId, token)) {
+  const search = new URL(request.url).searchParams;
+  const upgradeToken = search.get("upgrade");
+  const token = search.get("token");
+  if (upgradeToken) {
+    if (!verify(pageId, upgradeToken, upgradeSecret)) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  } else if (!verify(pageId, token, secret)) {
     return new Response("Unauthorized", { status: 401 });
   }
   const shop = env.NEXT_PUBLIC_SHOP_ID || "default";

--- a/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
@@ -1,0 +1,82 @@
+import { jest } from "@jest/globals";
+import type { Page } from "@acme/types";
+import { createHmac } from "node:crypto";
+
+process.env.PREVIEW_TOKEN_SECRET = "testsecret";
+process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
+process.env.NEXT_PUBLIC_SHOP_ID = "shop";
+
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+afterEach(() => jest.resetModules());
+
+function tokenFor(id: string, secret: string): string {
+  return createHmac("sha256", secret).update(id).digest("hex");
+}
+
+test("valid upgrade token returns page JSON", async () => {
+  const page: Page = {
+    id: "1",
+    slug: "home",
+    status: "draft",
+    components: [],
+    seo: { title: "Home" },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    createdBy: "tester",
+  };
+  const getPages = jest.fn(async () => [page]);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(
+      `http://test?upgrade=${tokenFor("1", "upgradesecret")}`,
+    ),
+  } as any);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(page);
+});
+
+test("invalid upgrade token yields 401", async () => {
+  const getPages = jest.fn(async () => []);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(`http://test?upgrade=bad`),
+  } as any);
+
+  expect(res.status).toBe(401);
+});
+
+test("standard token not accepted as upgrade token", async () => {
+  const getPages = jest.fn(async () => []);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(
+      `http://test?upgrade=${tokenFor("1", "testsecret")}`,
+    ),
+  } as any);
+
+  expect(res.status).toBe(401);
+});
+

--- a/apps/shop-bcd/src/routes/preview/[pageId].ts
+++ b/apps/shop-bcd/src/routes/preview/[pageId].ts
@@ -8,10 +8,15 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { env } from "@acme/config";
 
 const secret = env.PREVIEW_TOKEN_SECRET;
+const upgradeSecret = env.UPGRADE_PREVIEW_TOKEN_SECRET;
 
-function verify(id: string, token: string | null): boolean {
-  if (!secret || !token) return false;
-  const digest = createHmac("sha256", secret).update(id).digest("hex");
+function verify(
+  id: string,
+  token: string | null,
+  key: string | undefined,
+): boolean {
+  if (!key || !token) return false;
+  const digest = createHmac("sha256", key).update(id).digest("hex");
   try {
     return timingSafeEqual(Buffer.from(digest), Buffer.from(token));
   } catch {
@@ -24,8 +29,14 @@ export const onRequest = async ({
   request,
 }: EventContext<unknown, string, Record<string, unknown>>) => {
   const pageId = String(params.pageId);
-  const token = new URL(request.url).searchParams.get("token");
-  if (!verify(pageId, token)) {
+  const search = new URL(request.url).searchParams;
+  const upgradeToken = search.get("upgrade");
+  const token = search.get("token");
+  if (upgradeToken) {
+    if (!verify(pageId, upgradeToken, upgradeSecret)) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  } else if (!verify(pageId, token, secret)) {
     return new Response("Unauthorized", { status: 401 });
   }
   const shop = env.NEXT_PUBLIC_SHOP_ID || "default";

--- a/dist-scripts/upgrade-shop.js
+++ b/dist-scripts/upgrade-shop.js
@@ -1,5 +1,6 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, unlinkSync, renameSync, readFileSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
+import { randomBytes } from "node:crypto";
 const args = process.argv.slice(2);
 const rollback = args.includes("--rollback");
 const slug = args.find((a) => !a.startsWith("--"));
@@ -33,6 +34,14 @@ if (existsSync(shopJsonPath)) {
     const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
     data.lastUpgrade = new Date().toISOString();
     writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
+}
+const envPath = path.join(appDir, ".env");
+if (existsSync(envPath)) {
+    const envContent = readFileSync(envPath, "utf8");
+    if (!envContent.includes("UPGRADE_PREVIEW_TOKEN_SECRET=")) {
+        const upgradeToken = randomBytes(32).toString("hex");
+        writeFileSync(envPath, envContent + `\nUPGRADE_PREVIEW_TOKEN_SECRET=${upgradeToken}\n`);
+    }
 }
 console.log(`Upgrade staged for ${shopId}. Backups saved with .bak extension. Use --rollback to undo.`);
 function copyTemplate(srcDir, destDir) {

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -15,6 +15,8 @@ describe("envSchema", () => {
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
         CART_COOKIE_SECRET: "secret",
         STRIPE_WEBHOOK_SECRET: "whsec",
+        NEXTAUTH_SECRET: "nextauth",
+        SESSION_SECRET: "session",
       } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");
@@ -24,12 +26,16 @@ describe("envSchema", () => {
           process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
         CART_COOKIE_SECRET: process.env.CART_COOKIE_SECRET!,
         STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET!,
+        NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET!,
+        SESSION_SECRET: process.env.SESSION_SECRET!,
       });
       expect(parsed).toEqual({
         STRIPE_SECRET_KEY: "sk",
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
         CART_COOKIE_SECRET: "secret",
         STRIPE_WEBHOOK_SECRET: "whsec",
+        NEXTAUTH_SECRET: "nextauth",
+        SESSION_SECRET: "session",
       });
   });
 
@@ -39,6 +45,9 @@ describe("envSchema", () => {
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
       CART_COOKIE_SECRET: "secret",
+      STRIPE_WEBHOOK_SECRET: "whsec",
+      NEXTAUTH_SECRET: "nextauth",
+      SESSION_SECRET: "session",
     } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export const coreEnvBaseSchema = z.object({
   NEXTAUTH_SECRET: z.string().min(1),
   PREVIEW_TOKEN_SECRET: z.string().optional(),
+  UPGRADE_PREVIEW_TOKEN_SECRET: z.string().optional(),
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
   OUTPUT_EXPORT: z.coerce.boolean().optional(),
   NEXT_PUBLIC_PHASE: z.string().optional(),

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -1,5 +1,6 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, unlinkSync, renameSync, readFileSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
+import { randomBytes } from "node:crypto";
 
 const args = process.argv.slice(2);
 const rollback = args.includes("--rollback");
@@ -42,6 +43,18 @@ if (existsSync(shopJsonPath)) {
   const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
   (data as any).lastUpgrade = new Date().toISOString();
   writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
+}
+
+const envPath = path.join(appDir, ".env");
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, "utf8");
+  if (!envContent.includes("UPGRADE_PREVIEW_TOKEN_SECRET=")) {
+    const upgradeToken = randomBytes(32).toString("hex");
+    writeFileSync(
+      envPath,
+      envContent + `\nUPGRADE_PREVIEW_TOKEN_SECRET=${upgradeToken}\n`,
+    );
+  }
 }
 
 console.log(


### PR DESCRIPTION
## Summary
- allow preview route to accept upgrade-specific tokens
- generate upgrade preview secrets when staging upgrades
- test preview upgrade token handling

## Testing
- `NEXTAUTH_SECRET=a SESSION_SECRET=b CART_COOKIE_SECRET=c STRIPE_SECRET_KEY=sk NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk STRIPE_WEBHOOK_SECRET=wh pnpm exec jest apps/shop-abc/routes/__tests__/preview-upgrade.test.ts apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts packages/config/__tests__/env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689cedc3ba48832f87ca51e91dc046af