### PR TITLE
feat: add premier delivery scheduling

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -65,6 +65,14 @@ export default async function SettingsPage({
           SEO settings
         </Link>
       </p>
+      <p className="mb-4 text-sm">
+        <Link
+          href={`/cms/shop/${shop}/settings/premier-delivery`}
+          className="text-primary underline"
+        >
+          Premier delivery settings
+        </Link>
+      </p>
       <h3 className="mt-4 font-medium">Languages</h3>
       <ul className="mt-2 list-disc pl-5 text-sm">
         {settings.languages.map((l: Locale) => (

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button, Input } from "@/components/atoms/shadcn";
+import { updatePremierDelivery } from "@cms/actions/shops.server";
+import { FormEvent, useState } from "react";
+
+interface Props {
+  shop: string;
+  initial: { regions: string[]; windows: string[] };
+}
+
+export default function PremierDeliveryEditor({ shop, initial }: Props) {
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData(e.currentTarget);
+    const result = await updatePremierDelivery(shop, fd);
+    if (result.errors) {
+      setErrors(result.errors);
+    } else {
+      setErrors({});
+    }
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="grid max-w-md gap-4">
+      <label className="flex flex-col gap-1">
+        <span>Regions (comma separated)</span>
+        <Input name="regions" defaultValue={initial.regions.join(", ")} />
+        {errors.regions && (
+          <span className="text-sm text-red-600">{errors.regions.join("; ")}</span>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span>Windows (comma separated)</span>
+        <Input name="windows" defaultValue={initial.windows.join(", ")} />
+        {errors.windows && (
+          <span className="text-sm text-red-600">{errors.windows.join("; ")}</span>
+        )}
+      </label>
+      <Button className="bg-primary text-white" disabled={saving} type="submit">
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/page.tsx
@@ -1,0 +1,29 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/page.tsx
+import { getSettings } from "@cms/actions/shops.server";
+import dynamic from "next/dynamic";
+
+const PremierDeliveryEditor = dynamic(() => import("./PremierDeliveryEditor"));
+void PremierDeliveryEditor;
+
+export const revalidate = 0;
+
+interface Params {
+  shop: string;
+}
+
+export default async function PremierDeliverySettingsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { shop } = await params;
+  const settings = await getSettings(shop);
+  const premierDelivery = settings.premierDelivery ?? { regions: [], windows: [] };
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Premier Delivery – {shop}</h2>
+      <PremierDeliveryEditor shop={shop} initial={premierDelivery} />
+    </div>
+  );
+}

--- a/apps/shop-abc/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/checkout/page.tsx
@@ -3,6 +3,7 @@
 import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
+import DeliveryScheduler from "@ui/components/organisms/DeliveryScheduler";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import {
   CART_COOKIE,
@@ -63,12 +64,41 @@ export default async function CheckoutPage({
 
   /* ---------- render ---------- */
   const settings = await getShopSettings(shop.id);
+  const premierDelivery = settings.premierDelivery;
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-10 p-6">
       <OrderSummary />
+      {premierDelivery && (
+        <PremierDeliveryPicker
+          windows={premierDelivery.windows}
+          region={premierDelivery.regions[0] ?? ""}
+        />
+      )}
       <CheckoutForm locale={lang} taxRegion={settings.taxRegion} />
     </div>
+  );
+}
+
+function PremierDeliveryPicker({
+  windows,
+  region,
+}: {
+  windows: string[];
+  region: string;
+}) {
+  "use client";
+  return (
+    <DeliveryScheduler
+      windows={windows}
+      onChange={({ time }) => {
+        fetch("/api/delivery/schedule", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ region, window: time }),
+        }).catch(() => {});
+      }}
+    />
   );
 }
 

--- a/apps/shop-abc/src/app/api/delivery/schedule/route.ts
+++ b/apps/shop-abc/src/app/api/delivery/schedule/route.ts
@@ -1,0 +1,34 @@
+// apps/shop-abc/src/app/api/delivery/schedule/route.ts
+import "@acme/lib/initZod";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
+import shop from "../../../../shop.json";
+
+export const runtime = "edge";
+
+const schema = z
+  .object({
+    region: z.string(),
+    window: z.string(),
+  })
+  .strict();
+
+export async function POST(req: NextRequest) {
+  const parsed = await parseJsonBody(req, schema, "1mb");
+  if (!parsed.success) return parsed.response;
+
+  const settings = await getShopSettings(shop.id);
+  const pd = settings.premierDelivery;
+  if (!pd) {
+    return NextResponse.json({ error: "Premier delivery not available" }, { status: 400 });
+  }
+  const { region, window } = parsed.data;
+  if (!pd.regions.includes(region) || !pd.windows.includes(window)) {
+    return NextResponse.json({ error: "Invalid selection" }, { status: 400 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set("delivery", JSON.stringify({ region, window }), { path: "/" });
+  return res;
+}

--- a/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
@@ -1,6 +1,7 @@
 // apps/shop-bcd/src/app/[lang]/checkout/page.tsx
 import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
+import DeliveryScheduler from "@ui/components/organisms/DeliveryScheduler";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
 import { cookies } from "next/headers";
@@ -34,12 +35,41 @@ export default async function CheckoutPage({
   }
 
   const settings = await getShopSettings(shop.id);
+  const premierDelivery = settings.premierDelivery;
 
   /* ---------- render ---------- */
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-10 p-6">
       <OrderSummary />
+      {premierDelivery && (
+        <PremierDeliveryPicker
+          windows={premierDelivery.windows}
+          region={premierDelivery.regions[0] ?? ""}
+        />
+      )}
       <CheckoutForm locale={lang} taxRegion={settings.taxRegion} />
     </div>
+  );
+}
+
+function PremierDeliveryPicker({
+  windows,
+  region,
+}: {
+  windows: string[];
+  region: string;
+}) {
+  "use client";
+  return (
+    <DeliveryScheduler
+      windows={windows}
+      onChange={({ time }) => {
+        fetch("/api/delivery/schedule", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ region, window: time }),
+        }).catch(() => {});
+      }}
+    />
   );
 }

--- a/apps/shop-bcd/src/app/api/delivery/schedule/route.ts
+++ b/apps/shop-bcd/src/app/api/delivery/schedule/route.ts
@@ -1,0 +1,34 @@
+// apps/shop-bcd/src/app/api/delivery/schedule/route.ts
+import "@acme/lib/initZod";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
+import shop from "../../../../shop.json";
+
+export const runtime = "edge";
+
+const schema = z
+  .object({
+    region: z.string(),
+    window: z.string(),
+  })
+  .strict();
+
+export async function POST(req: NextRequest) {
+  const parsed = await parseJsonBody(req, schema, "1mb");
+  if (!parsed.success) return parsed.response;
+
+  const settings = await getShopSettings(shop.id);
+  const pd = settings.premierDelivery;
+  if (!pd) {
+    return NextResponse.json({ error: "Premier delivery not available" }, { status: 400 });
+  }
+  const { region, window } = parsed.data;
+  if (!pd.regions.includes(region) || !pd.windows.includes(window)) {
+    return NextResponse.json({ error: "Invalid selection" }, { status: 400 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set("delivery", JSON.stringify({ region, window }), { path: "/" });
+  return res;
+}

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -66,6 +66,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
           upsEnabled: false,
           ...(parsed.data.returnService ?? {}),
         },
+        premierDelivery: parsed.data.premierDelivery,
         seo: {
           ...(parsed.data.seo ?? {}),
           aiCatalog: {
@@ -95,6 +96,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     taxRegion: "",
     depositService: { enabled: false, intervalMinutes: 60 },
     returnService: { upsEnabled: false },
+    premierDelivery: undefined,
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -7,6 +7,9 @@ export interface ShippingRateRequest {
   fromPostalCode: string;
   toPostalCode: string;
   weight: number;
+  region?: string;
+  window?: string;
+  premierDelivery?: { regions: string[]; windows: string[] };
 }
 
 /**
@@ -18,7 +21,21 @@ export async function getShippingRate({
   fromPostalCode,
   toPostalCode,
   weight,
+  region,
+  window,
+  premierDelivery,
 }: ShippingRateRequest): Promise<unknown> {
+  if (region || window) {
+    if (!premierDelivery) {
+      throw new Error("Premier delivery not configured");
+    }
+    if (!region || !premierDelivery.regions.includes(region)) {
+      throw new Error("Region not eligible for premier delivery");
+    }
+    if (!window || !premierDelivery.windows.includes(window)) {
+      throw new Error("Invalid delivery window");
+    }
+  }
   const apiKey = (shippingEnv as Record<string, string | undefined>)[
     `${provider.toUpperCase()}_KEY`
   ];

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -109,6 +109,16 @@ export declare const shopSettingsSchema: z.ZodObject<{
     }, {
         upsEnabled: boolean;
     }>>;
+    premierDelivery: z.ZodOptional<z.ZodObject<{
+        regions: z.ZodArray<z.ZodString, "many">;
+        windows: z.ZodArray<z.ZodString, "many">;
+    }, "strip", z.ZodTypeAny, {
+        regions: string[];
+        windows: string[];
+    }, {
+        regions: string[];
+        windows: string[];
+    }>>;
     updatedAt: z.ZodString;
     updatedBy: z.ZodString;
 }, "strip", z.ZodTypeAny, {
@@ -149,6 +159,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
     returnService?: {
         upsEnabled: boolean;
     } | undefined;
+    premierDelivery?: {
+        regions: string[];
+        windows: string[];
+    } | undefined;
 }, {
     seo: Partial<Record<"en" | "de" | "it", {
         title?: string | undefined;
@@ -186,6 +200,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
     } | undefined;
     returnService?: {
         upsEnabled: boolean;
+    } | undefined;
+    premierDelivery?: {
+        regions: string[];
+        windows: string[];
     } | undefined;
 }>; 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -55,6 +55,13 @@ export const shopSettingsSchema = z
       })
       .strict()
       .optional(),
+    premierDelivery: z
+      .object({
+        regions: z.array(z.string()),
+        windows: z.array(z.string()),
+      })
+      .strict()
+      .optional(),
     updatedAt: z.string(),
     updatedBy: z.string(),
   })

--- a/packages/ui/src/components/organisms/DeliveryScheduler.tsx
+++ b/packages/ui/src/components/organisms/DeliveryScheduler.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Input } from "../atoms/primitives/input";
@@ -17,6 +19,8 @@ export interface DeliverySchedulerProps
     date: string;
     time: string;
   }) => void;
+  /** Optional preset windows (e.g. `10-11`, `11-12`) */
+  windows?: string[];
 }
 
 export function DeliveryScheduler({
@@ -74,11 +78,26 @@ export function DeliveryScheduler({
       </label>
       <label className="flex flex-col gap-1 text-sm">
         Time
-        <Input
-          type="time"
-          value={time}
-          onChange={(e) => handleTime(e.target.value)}
-        />
+        {windows && windows.length ? (
+          <Select value={time} onValueChange={handleTime}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select window" />
+            </SelectTrigger>
+            <SelectContent>
+              {windows.map((w) => (
+                <SelectItem key={w} value={w}>
+                  {w}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Input
+            type="time"
+            value={time}
+            onChange={(e) => handleTime(e.target.value)}
+          />
+        )}
       </label>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow configurable premier delivery windows and regions
- validate premier delivery selections and persist via new API routes
- expose premier delivery settings in CMS and checkout

## Testing
- `pnpm test --filter @acme/ui --filter @acme/types --filter @acme/platform-core --filter @apps/cms --filter @apps/shop-abc --filter @apps/shop-bcd` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm lint --filter @acme/ui --filter @acme/types --filter @acme/platform-core --filter @apps/cms --filter @apps/shop-abc --filter @apps/shop-bcd` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689ced67990c832fb85a13a1f7f0bfb1