### PR TITLE
feat: add atomic inventory item updates

### DIFF
--- a/apps/cms/__tests__/inventoryUpdateRoute.test.ts
+++ b/apps/cms/__tests__/inventoryUpdateRoute.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// Polyfill Response.json when missing
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+async function withTempRepo(cb: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "inv-route-"));
+  const shopDir = path.join(dir, "data", "shops", "test");
+  await fs.mkdir(shopDir, { recursive: true });
+  const cwd = process.cwd();
+  process.chdir(dir);
+  jest.resetModules();
+  try {
+    await cb(dir);
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+describe("inventory update route", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
+  it("applies partial updates", async () => {
+    await withTempRepo(async () => {
+      process.env.SKIP_STOCK_ALERT = "1";
+      jest.doMock("next-auth", () => ({
+        getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),
+      }));
+      jest.doMock("@acme/config", () => ({
+        env: {
+          NEXTAUTH_SECRET: "s",
+          CART_COOKIE_SECRET: "c",
+          SESSION_SECRET: "s",
+        },
+      }));
+      const { writeInventory, readInventory } = await import(
+        "@platform-core/repositories/inventory.server",
+      );
+      await writeInventory("test", [
+        {
+          sku: "a",
+          productId: "p1",
+          quantity: 1,
+          lowStockThreshold: 2,
+          variantAttributes: {},
+        },
+      ]);
+      const route = await import(
+        "../src/app/api/data/[shop]/inventory/[sku]/route",
+      );
+      const req = { json: async () => ({ quantity: 5, variantAttributes: {} }) } as any;
+      const res = await route.PATCH(req, {
+        params: Promise.resolve({ shop: "test", sku: "a" }),
+      });
+      expect(res.status).toBe(200);
+      const items = await readInventory("test");
+      expect(items).toEqual([
+        {
+          sku: "a",
+          productId: "p1",
+          quantity: 5,
+          lowStockThreshold: 2,
+          variantAttributes: {},
+        },
+      ]);
+    });
+  });
+
+  it("merges concurrent updates", async () => {
+    await withTempRepo(async () => {
+      process.env.SKIP_STOCK_ALERT = "1";
+      jest.doMock("next-auth", () => ({
+        getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),
+      }));
+      jest.doMock("@acme/config", () => ({
+        env: {
+          NEXTAUTH_SECRET: "s",
+          CART_COOKIE_SECRET: "c",
+          SESSION_SECRET: "s",
+        },
+      }));
+      const { writeInventory, readInventory } = await import(
+        "@platform-core/repositories/inventory.server",
+      );
+      await writeInventory("test", [
+        { sku: "a", productId: "p1", quantity: 0, variantAttributes: {} },
+      ]);
+      const route = await import(
+        "../src/app/api/data/[shop]/inventory/[sku]/route",
+      );
+      const req1 = { json: async () => ({ quantity: 5, variantAttributes: {} }) } as any;
+      const req2 = {
+        json: async () => ({ lowStockThreshold: 2, variantAttributes: {} }),
+      } as any;
+      await Promise.all([
+        route.PATCH(req1, {
+          params: Promise.resolve({ shop: "test", sku: "a" }),
+        }),
+        route.PATCH(req2, {
+          params: Promise.resolve({ shop: "test", sku: "a" }),
+        }),
+      ]);
+      const items = await readInventory("test");
+      expect(items).toEqual([
+        {
+          sku: "a",
+          productId: "p1",
+          quantity: 5,
+          lowStockThreshold: 2,
+          variantAttributes: {},
+        },
+      ]);
+    });
+  });
+});

--- a/apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts
@@ -1,0 +1,41 @@
+import { authOptions } from "@cms/auth/options";
+import { getServerSession } from "next-auth";
+import { NextResponse, type NextRequest } from "next/server";
+import { inventoryItemSchema } from "@acme/types";
+import { updateInventoryItem } from "@platform-core/repositories/inventory.server";
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ shop: string; sku: string }> },
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const body = await req.json();
+    const parsed = inventoryItemSchema.partial().safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().formErrors.join(", ") },
+        { status: 400 },
+      );
+    }
+    const { shop, sku } = await context.params;
+    const patch = parsed.data;
+    const variantAttributes = patch.variantAttributes ?? {};
+    const updated = await updateInventoryItem(
+      shop,
+      sku,
+      variantAttributes,
+      (current) => {
+        if (!current) throw new Error("Not found");
+        return { ...current, ...patch, sku, variantAttributes };
+      },
+    );
+    return NextResponse.json(updated);
+  } catch (err) {
+    const status = (err as Error).message === "Not found" ? 404 : 400;
+    return NextResponse.json({ error: (err as Error).message }, { status });
+  }
+}

--- a/packages/platform-core/src/repositories/__tests__/inventory.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/inventory.server.test.ts
@@ -46,4 +46,64 @@ describe("inventory repository concurrency", () => {
     const json = JSON.stringify(result);
     expect(sets.map((s) => JSON.stringify(s))).toContain(json);
   });
+
+  it("updates items concurrently without losing changes", async () => {
+    process.env.SKIP_STOCK_ALERT = "1";
+    const { writeInventory, readInventory, updateInventoryItem } = await import(
+      "../inventory.server",
+    );
+    const shop = "demo";
+    await writeInventory(shop, [
+      { sku: "a", productId: "p1", quantity: 0, variantAttributes: {} },
+    ]);
+
+    await Promise.all(
+      Array.from({ length: 5 }).map(() =>
+        updateInventoryItem(shop, "a", {}, (current) => ({
+          sku: "a",
+          productId: "p1",
+          variantAttributes: {},
+          quantity: (current?.quantity ?? 0) + 1,
+        })),
+      ),
+    );
+
+    const result = await readInventory(shop);
+    expect(result).toEqual([
+      { sku: "a", productId: "p1", quantity: 5, variantAttributes: {} },
+    ]);
+  });
+
+  it("supports partial updates", async () => {
+    process.env.SKIP_STOCK_ALERT = "1";
+    const { writeInventory, readInventory, updateInventoryItem } = await import(
+      "../inventory.server",
+    );
+    const shop = "demo";
+    await writeInventory(shop, [
+      {
+        sku: "a",
+        productId: "p1",
+        quantity: 1,
+        lowStockThreshold: 2,
+        variantAttributes: {},
+      },
+    ]);
+
+    await updateInventoryItem(shop, "a", {}, (current) => ({
+      ...current!,
+      quantity: 10,
+    }));
+
+    const result = await readInventory(shop);
+    expect(result).toEqual([
+      {
+        sku: "a",
+        productId: "p1",
+        quantity: 10,
+        lowStockThreshold: 2,
+        variantAttributes: {},
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- implement `updateInventoryItem` with file locking
- add `PATCH /api/data/[shop]/inventory/[sku]` route for partial inventory updates
- test concurrent updates and partial writes

## Testing
- `pnpm exec jest src/repositories/__tests__/inventory.server.test.ts --config ../../jest.config.cjs`
- `pnpm exec jest apps/cms/__tests__/inventoryUpdateRoute.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689cef99d88c832f9b4a895017a53043