### PR TITLE
feat: enforce non-negative inventory values

### DIFF
--- a/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
+++ b/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
@@ -27,14 +27,9 @@ jest.mock("@acme/types", () => {
     .object({
       sku: z.string(),
       productId: z.string(),
-      variant: z
-        .object({
-          size: z.string(),
-          color: z.string().optional(),
-        })
-        .strict(),
-      quantity: z.number().min(1),
-      lowStockThreshold: z.number().optional(),
+      variantAttributes: z.record(z.string()),
+      quantity: z.number().int().min(0),
+      lowStockThreshold: z.number().int().min(0).optional(),
     })
     .strict();
   return { inventoryItemSchema };
@@ -54,14 +49,14 @@ describe("InventoryForm integration", () => {
       {
         sku: "sku1",
         productId: "sku1",
-        variant: { size: "M", color: "red" },
+        variantAttributes: { size: "M", color: "red" },
         quantity: 5,
         lowStockThreshold: 2,
       },
       {
         sku: "sku2",
         productId: "sku2",
-        variant: { size: "L", color: "blue" },
+        variantAttributes: { size: "L", color: "blue" },
         quantity: 3,
         lowStockThreshold: 1,
       },

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -92,7 +92,7 @@ export async function POST(
     const parsed = inventoryItemSchema.array().safeParse(raw);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.flatten().formErrors.join(", ") },
+        { error: parsed.error.issues.map((i) => i.message).join(", ") },
         { status: 400 }
       );
     }

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -243,6 +243,7 @@ export default function InventoryForm({ shop, initial }: Props) {
               <TableCell>
                 <Input
                   type="number"
+                  min={0}
                   value={item.quantity}
                   onChange={(e) => updateItem(idx, "quantity", e.target.value)}
                 />
@@ -250,6 +251,7 @@ export default function InventoryForm({ shop, initial }: Props) {
               <TableCell>
                 <Input
                   type="number"
+                  min={0}
                   value={item.lowStockThreshold ?? ""}
                   onChange={(e) =>
                     updateItem(idx, "lowStockThreshold", e.target.value)

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -28,8 +28,8 @@ jest.mock("@acme/types", () => {
       sku: z.string(),
       productId: z.string(),
       variantAttributes: z.record(z.string()),
-      quantity: z.number().min(1),
-      lowStockThreshold: z.number().optional(),
+      quantity: z.number().int().min(0),
+      lowStockThreshold: z.number().int().min(0).optional(),
     })
     .strict();
   return { inventoryItemSchema };
@@ -123,10 +123,10 @@ describe("InventoryForm", () => {
   it("shows validation errors", async () => {
     render(<InventoryForm shop="test" initial={initial} />);
     fireEvent.change(screen.getByDisplayValue("5"), {
-      target: { value: "0" },
+      target: { value: "-1" },
     });
-    fireEvent.click(screen.getByText("Save"));
-    await screen.findByText(/greater than or equal to 1/i);
+    fireEvent.submit(screen.getByText("Save").closest("form")!);
+    await screen.findByText(/greater than or equal to 0/i);
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/types/src/InventoryItem.ts
+++ b/packages/types/src/InventoryItem.ts
@@ -7,10 +7,10 @@ export const inventoryItemSchema = z
   .object({
     sku: z.string(),
     productId: z.string(),
-    quantity: z.number(),
+    quantity: z.number().int().min(0),
     // Each variant attribute is a free-form key/value string pair
     variantAttributes: variantAttributesSchema,
-    lowStockThreshold: z.number().optional(),
+    lowStockThreshold: z.number().int().min(0).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- require non-negative integer inventory quantities and low stock thresholds
- surface negative input errors in inventory import route and form
- test negative value rejection for inventory APIs and forms

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/inventory.test.ts`
- `pnpm --filter @apps/cms test apps/cms/__tests__/inventoryImportExport.test.ts`
- `cd apps/cms && pnpm test 'src/app/cms/shop/\[shop\]/data/inventory/__tests__/InventoryForm.test.tsx'`
- `pnpm --filter @apps/cms test apps/cms/__tests__/inventoryFormVariants.integration.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cec4a7af8832f8b0509a382e7246e