### PR TITLE
feat: add order tracking status and merged timelines

### DIFF
--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -36,6 +36,7 @@ model RentalOrder {
   riskLevel          String?
   riskScore          Int?
   flaggedForReview   Boolean? @default(false)
+  trackingEvents     Json?
 
   @@unique([shop, sessionId])
   @@index([customerId])

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -2,7 +2,8 @@
 import "server-only";
 import { ulid } from "ulid";
 import { nowIso } from "@acme/date-utils";
-import type { RentalOrder } from "@acme/types";
+import type { RentalOrder, TrackingEvent } from "@acme/types";
+import type { Prisma } from "@prisma/client";
 import { trackOrder } from "./analytics";
 import { prisma } from "./db";
 
@@ -97,6 +98,24 @@ export async function updateRisk(
         ...(riskLevel ? { riskLevel } : {}),
         ...(typeof riskScore === "number" ? { riskScore } : {}),
         ...(typeof flaggedForReview === "boolean" ? { flaggedForReview } : {}),
+      },
+    });
+    return order as Order;
+  } catch {
+    return null;
+  }
+}
+
+export async function updateTrackingEvents(
+  shop: string,
+  sessionId: string,
+  events: TrackingEvent[]
+): Promise<Order | null> {
+  try {
+    const order = await prisma.rentalOrder.update({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: {
+        trackingEvents: events as unknown as Prisma.JsonArray,
       },
     });
     return order as Order;

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -46,3 +46,36 @@ export async function getShippingRate({
 
   return res.json();
 }
+
+/**
+ * Retrieve the current tracking status for a shipment.
+ * Returns the raw provider response for now.
+ */
+export async function getTrackingStatus(
+  provider: "ups" | "dhl",
+  trackingNumber: string
+): Promise<unknown> {
+  const apiKey = (shippingEnv as Record<string, string | undefined>)[
+    `${provider.toUpperCase()}_KEY`
+  ];
+  if (!apiKey) {
+    throw new Error(`Missing ${provider.toUpperCase()}_KEY`);
+  }
+
+  const url =
+    provider === "ups"
+      ? `https://onlinetools.ups.com/track/v1/details/${trackingNumber}`
+      : `https://api.dhl.com/track/shipments?trackingNumber=${trackingNumber}`;
+
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch tracking from ${provider}`);
+  }
+
+  return res.json();
+}

--- a/packages/types/src/RentalOrder.ts
+++ b/packages/types/src/RentalOrder.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { trackingEventSchema } from "./TrackingEvent";
 
 export const rentalOrderSchema = z
   .object({
@@ -16,6 +17,7 @@ export const rentalOrderSchema = z
     riskLevel: z.string().optional(),
     riskScore: z.number().optional(),
     flaggedForReview: z.boolean().optional(),
+    trackingEvents: z.array(trackingEventSchema).optional(),
   })
   .strict();
 

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -87,6 +87,7 @@ export const shopSchema = z
     sanityBlog: sanityBlogConfigSchema.optional(),
     domain: shopDomainSchema.optional(),
     analyticsEnabled: z.boolean().optional(),
+    orderTrackingEnabled: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/types/src/TrackingEvent.ts
+++ b/packages/types/src/TrackingEvent.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const trackingEventSchema = z
+  .object({
+    type: z.enum(["shipping", "return"]),
+    status: z.string(),
+    date: z.string(),
+  })
+  .strict();
+
+export type TrackingEvent = z.infer<typeof trackingEventSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,3 +14,4 @@ export * from "./ReturnLogistics";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";
+export * from "./TrackingEvent";

--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -9,6 +9,8 @@ import { OrderTrackingTimeline } from "../organisms/OrderTrackingTimeline";
 export interface OrdersPageProps {
   /** ID of the current shop for fetching orders */
   shopId: string;
+  /** Whether order tracking features are enabled */
+  orderTrackingEnabled?: boolean;
   /** Optional heading override */
   title?: string;
   /** Destination to return to after login */
@@ -19,9 +21,13 @@ export const metadata = { title: "Orders" };
 
 export default async function OrdersPage({
   shopId,
+  orderTrackingEnabled = false,
   title = "Orders",
   callbackUrl = "/account/orders",
 }: OrdersPageProps) {
+  if (!orderTrackingEnabled) {
+    return <p className="p-6">Order tracking not enabled.</p>;
+  }
   const session = await getCustomerSession();
   if (!session) {
     redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
@@ -37,16 +43,23 @@ export default async function OrdersPage({
       <h1 className="p-6 text-xl">{title}</h1>
       <ul className="space-y-2 p-6">
         {orders.map((o) => {
-          const steps: OrderStep[] = [
+          const shippingSteps: OrderStep[] = [
             { label: "Placed", date: o.startedAt, complete: true },
           ];
+          const returnSteps: OrderStep[] = [];
+          (o.trackingEvents || []).forEach((e) => {
+            const step = { label: e.status, date: e.date, complete: true };
+            if (e.type === "shipping") shippingSteps.push(step);
+            else returnSteps.push(step);
+          });
+          if (!o.returnedAt) {
+            returnSteps.push({ label: "Return pending", complete: false });
+          }
           if (o.returnedAt) {
-            steps.push({ label: "Returned", date: o.returnedAt, complete: true });
-          } else {
-            steps.push({ label: "Return pending", complete: false });
+            returnSteps.push({ label: "Returned", date: o.returnedAt, complete: true });
           }
           if (o.refundedAt) {
-            steps.push({ label: "Refunded", date: o.refundedAt, complete: true });
+            returnSteps.push({ label: "Refunded", date: o.refundedAt, complete: true });
           }
           return (
             <li key={o.id} className="rounded border p-4">
@@ -54,7 +67,11 @@ export default async function OrdersPage({
               {o.expectedReturnDate && (
                 <div>Return: {o.expectedReturnDate}</div>
               )}
-              <OrderTrackingTimeline steps={steps} className="mt-2" />
+              <OrderTrackingTimeline
+                shippingSteps={shippingSteps}
+                returnSteps={returnSteps}
+                className="mt-2"
+              />
               {!o.returnedAt && <StartReturnButton sessionId={o.sessionId} />}
             </li>
           );

--- a/packages/ui/src/components/organisms/OrderTrackingTimeline.stories.tsx
+++ b/packages/ui/src/components/organisms/OrderTrackingTimeline.stories.tsx
@@ -5,9 +5,11 @@ const meta: Meta<typeof OrderTrackingTimeline> = {
   component: OrderTrackingTimeline,
   args: {
     itemSpacing: "space-y-6",
-    steps: [
+    shippingSteps: [
       { label: "Order placed", date: "2023-01-01", complete: true },
       { label: "Shipped", date: "2023-01-02", complete: true },
+    ],
+    returnSteps: [
       { label: "Out for delivery", date: "2023-01-03", complete: false },
     ],
   },

--- a/packages/ui/src/components/organisms/OrderTrackingTimeline.tsx
+++ b/packages/ui/src/components/organisms/OrderTrackingTimeline.tsx
@@ -10,7 +10,8 @@ export interface OrderStep {
 
 export interface OrderTrackingTimelineProps
   extends React.HTMLAttributes<HTMLOListElement> {
-  steps: OrderStep[];
+  shippingSteps: OrderStep[];
+  returnSteps?: OrderStep[];
   /** Tailwind vertical spacing utility like `space-y-6` */
   itemSpacing?: string;
 }
@@ -19,11 +20,16 @@ export interface OrderTrackingTimelineProps
  * Vertical timeline showing progress of an order.
  */
 export function OrderTrackingTimeline({
-  steps,
+  shippingSteps,
+  returnSteps = [],
   itemSpacing = "space-y-6",
   className,
   ...props
 }: OrderTrackingTimelineProps) {
+  const steps = [...shippingSteps, ...returnSteps].sort((a, b) => {
+    if (a.date && b.date) return a.date.localeCompare(b.date);
+    return 0;
+  });
   return (
     <ol
       className={cn("relative border-l pl-4", itemSpacing, className)}

--- a/packages/ui/src/components/templates/OrderTrackingTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/OrderTrackingTemplate.stories.tsx
@@ -6,16 +6,21 @@ const meta: Meta<typeof OrderTrackingTemplate> = {
   args: {
     orderId: "ABC123",
     address: "123 Main St",
-    steps: [
+    shippingSteps: [
       { label: "Ordered", date: "2023-01-01", complete: true },
       { label: "Shipped", date: "2023-01-02", complete: true },
       { label: "Delivered", date: "2023-01-03" },
+    ],
+    returnSteps: [
+      { label: "Return initiated", date: "2023-01-05", complete: true },
+      { label: "Refunded", date: "2023-01-06", complete: true },
     ],
   },
   argTypes: {
     orderId: { control: "text" },
     address: { control: "text" },
-    steps: { control: "object" },
+    shippingSteps: { control: "object" },
+    returnSteps: { control: "object" },
   },
 };
 export default meta;

--- a/packages/ui/src/components/templates/OrderTrackingTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderTrackingTemplate.tsx
@@ -6,14 +6,16 @@ import { OrderTrackingTimeline } from "../organisms/OrderTrackingTimeline";
 export interface OrderTrackingTemplateProps
   extends React.HTMLAttributes<HTMLDivElement> {
   orderId: string;
-  steps: OrderStep[];
+  shippingSteps: OrderStep[];
+  returnSteps?: OrderStep[];
   /** Optional shipping address to display */
   address?: string;
 }
 
 export function OrderTrackingTemplate({
   orderId,
-  steps,
+  shippingSteps,
+  returnSteps,
   address,
   className,
   ...props
@@ -27,7 +29,10 @@ export function OrderTrackingTemplate({
       {address && (
         <p className="text-muted-foreground text-sm">Shipping to {address}</p>
       )}
-      <OrderTrackingTimeline steps={steps} />
+      <OrderTrackingTimeline
+        shippingSteps={shippingSteps}
+        returnSteps={returnSteps}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add getTrackingStatus utility for shipping providers
- store tracking events on orders and expose updateTrackingEvents API
- merge shipping and return steps in OrderTrackingTimeline and template
- gate account order tracking behind orderTrackingEnabled flag

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689cf0b875ac832f8ecb12a08d193f68