### PR TITLE
feat: add ProductFilter CMS block

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductFilter.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductFilter.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useProductFilters } from "@ui/hooks/useProductFilters";
+import { PRODUCTS } from "@platform-core/src/products";
+
+export interface ProductFilterProps {
+  showSize?: boolean;
+  showColor?: boolean;
+  showPrice?: boolean;
+}
+
+export default function ProductFilter({
+  showSize = true,
+  showColor = true,
+  showPrice = true,
+}: ProductFilterProps) {
+  const { filteredRows } = useProductFilters(PRODUCTS as any);
+
+  const sizes = useMemo(() => {
+    const s = new Set<string>();
+    filteredRows.forEach((p: any) => p.sizes?.forEach((sz: string) => s.add(sz)));
+    return Array.from(s).sort();
+  }, [filteredRows]);
+
+  const colors = useMemo(() => {
+    const s = new Set<string>();
+    filteredRows.forEach((p: any) => {
+      const c = (p.id ?? "").split("-")[0];
+      if (c) s.add(c);
+    });
+    return Array.from(s).sort();
+  }, [filteredRows]);
+
+  const priceBounds = useMemo(() => {
+    const prices = filteredRows.map((p: any) => p.price ?? 0);
+    const min = prices.length ? Math.min(...prices) : 0;
+    const max = prices.length ? Math.max(...prices) : 0;
+    return [min, max];
+  }, [filteredRows]);
+
+  const [size, setSize] = useState("");
+  const [color, setColor] = useState("");
+  const [minPrice, setMinPrice] = useState(priceBounds[0]);
+  const [maxPrice, setMaxPrice] = useState(priceBounds[1]);
+
+  const results = useMemo(() => {
+    return filteredRows.filter((p: any) => {
+      const sizeMatch = !size || p.sizes?.includes(size);
+      const colorMatch = !color || (p.id ?? "").includes(color);
+      const price = p.price ?? 0;
+      const priceMatch = price >= minPrice && price <= maxPrice;
+      return sizeMatch && colorMatch && priceMatch;
+    });
+  }, [filteredRows, size, color, minPrice, maxPrice]);
+
+  return (
+    <div className="space-y-4">
+      {showSize && (
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Size</label>
+          <select
+            value={size}
+            onChange={(e) => setSize(e.target.value)}
+            className="w-full rounded border p-2 text-sm"
+          >
+            <option value="">All</option>
+            {sizes.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      {showColor && (
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Color</label>
+          <select
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="w-full rounded border p-2 text-sm"
+          >
+            <option value="">All</option>
+            {colors.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      {showPrice && (
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Price</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              value={minPrice}
+              onChange={(e) => setMinPrice(Number(e.target.value))}
+              className="w-20 rounded border p-1 text-sm"
+            />
+            <span className="text-sm">-</span>
+            <input
+              type="number"
+              value={maxPrice}
+              onChange={(e) => setMaxPrice(Number(e.target.value))}
+              className="w-20 rounded border p-1 text-sm"
+            />
+          </div>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">{results.length} products</p>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -36,6 +36,7 @@ import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
 import PopupModal from "./PopupModal";
 import ProductBundle from "./ProductBundle";
+import ProductFilter from "./ProductFilter";
 
 export {
   BlogListing,
@@ -76,6 +77,7 @@ export {
   FormBuilderBlock,
   ProductBundle,
   PopupModal,
+  ProductFilter,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -41,6 +41,7 @@ import PopupModal from "./PopupModal";
 import ProductBundle, {
   getRuntimeProps as getProductBundleRuntimeProps,
 } from "./ProductBundle";
+import ProductFilter from "./ProductFilter";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -91,6 +92,7 @@ export const organismRegistry = {
     component: ProductBundle,
     getRuntimeProps: getProductBundleRuntimeProps,
   },
+  ProductFilter: { component: ProductFilter },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -116,6 +116,36 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
         <SearchBarEditor component={component} onChange={onChange} />
       );
       break;
+    case "ProductFilter":
+      specific = (
+        <>
+          <div className="flex items-center gap-2">
+            <label className="text-sm">Show size</label>
+            <input
+              type="checkbox"
+              checked={(component as any).showSize ?? true}
+              onChange={(e) => handleInput("showSize", e.target.checked)}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm">Show color</label>
+            <input
+              type="checkbox"
+              checked={(component as any).showColor ?? true}
+              onChange={(e) => handleInput("showColor", e.target.checked)}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm">Show price</label>
+            <input
+              type="checkbox"
+              checked={(component as any).showPrice ?? true}
+              onChange={(e) => handleInput("showPrice", e.target.checked)}
+            />
+          </div>
+        </>
+      );
+      break;
     case "ImageSlider":
       specific = <ImageSliderEditor component={component} onChange={onChange} />;
       break;

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -39,6 +39,7 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   ValueProps: { minItems: 1, maxItems: 6 },
   ReviewsCarousel: { minItems: 1, maxItems: 10 },
   SearchBar: { placeholder: "Search products…", limit: 5 },
+  ProductFilter: { showSize: true, showColor: true, showPrice: true },
   ProductGrid: {
     minItems: 1,
     maxItems: 3,


### PR DESCRIPTION
## Summary
- add ProductFilter block rendering size, color and price facets
- register ProductFilter in block registry and page builder catalog
- expose facet toggles in component editor

## Testing
- `pnpm lint --filter @acme/ui` (no tasks)
- `pnpm test --filter @acme/ui` (fails: missing core environment variables)


------
https://chatgpt.com/codex/tasks/task_e_689cf1891de4832f85a7929076838f00