### PR TITLE
feat(ui): add lookbook block with draggable hotspots

### DIFF
--- a/packages/types/src/Page.d.ts
+++ b/packages/types/src/Page.d.ts
@@ -171,6 +171,13 @@ export interface GalleryComponent extends PageComponentBase {
     alt?: string;
   }[];
 }
+
+export interface LookbookComponent extends PageComponentBase {
+  type: "Lookbook";
+  src?: string;
+  alt?: string;
+  hotspots?: { x: number; y: number; sku?: string }[];
+}
 export interface ImageSliderComponent extends PageComponentBase {
   type: "ImageSlider";
   slides?: {
@@ -312,6 +319,7 @@ export type PageComponent =
   | CollectionListComponent
   | RecommendationCarouselComponent
   | GalleryComponent
+  | LookbookComponent
   | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent

--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -195,6 +195,13 @@ export interface GalleryComponent extends PageComponentBase {
   images?: { src: string; alt?: string }[];
 }
 
+export interface LookbookComponent extends PageComponentBase {
+  type: "Lookbook";
+  src?: string;
+  alt?: string;
+  hotspots?: { x: number; y: number; sku?: string }[];
+}
+
 export interface ImageSliderComponent extends PageComponentBase {
   type: "ImageSlider";
   slides?: { src: string; alt?: string; caption?: string }[];
@@ -353,6 +360,7 @@ export type PageComponent =
   | CollectionListComponent
   | RecommendationCarouselComponent
   | GalleryComponent
+  | LookbookComponent
   | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
@@ -464,6 +472,21 @@ const galleryComponentSchema = baseComponentSchema.extend({
   type: z.literal("Gallery"),
   images: z
     .array(z.object({ src: z.string(), alt: z.string().optional() }))
+    .optional(),
+});
+
+const lookbookComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Lookbook"),
+  src: z.string().optional(),
+  alt: z.string().optional(),
+  hotspots: z
+    .array(
+      z.object({
+        x: z.number(),
+        y: z.number(),
+        sku: z.string().optional(),
+      })
+    )
     .optional(),
 });
 
@@ -691,6 +714,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     productCarouselComponentSchema,
     recommendationCarouselComponentSchema,
     galleryComponentSchema,
+    lookbookComponentSchema,
     contactFormComponentSchema,
     newsletterSignupComponentSchema,
     searchBarComponentSchema,

--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -71,4 +71,23 @@ describe("ComponentEditor", () => {
     fireEvent.change(getByLabelText("Max Items"), { target: { value: "0" } });
     expect(onChange).toHaveBeenNthCalledWith(2, { maxItems: 0, minItems: 0 });
   });
+
+  it("allows adding hotspots for Lookbook", () => {
+    const component: PageComponent = {
+      id: "1",
+      type: "Lookbook",
+      src: "image.jpg",
+      hotspots: [],
+      minItems: 0,
+      maxItems: 5,
+    } as any;
+    const onChange = jest.fn();
+    const { getByText } = render(
+      <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
+    );
+    fireEvent.click(getByText("Add hotspot"));
+    expect(onChange).toHaveBeenCalledWith({
+      hotspots: [{ x: 50, y: 50, sku: "" }],
+    });
+  });
 });

--- a/packages/ui/src/components/cms/blocks/Lookbook.tsx
+++ b/packages/ui/src/components/cms/blocks/Lookbook.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Image from "next/image";
+import { useState, useCallback } from "react";
+
+export interface Hotspot {
+  x: number; // percentage
+  y: number; // percentage
+  sku?: string;
+}
+
+interface Props {
+  src: string;
+  alt?: string;
+  hotspots?: Hotspot[];
+  /** called when a hotspot is moved */
+  onHotspotChange?: (index: number, x: number, y: number) => void;
+  /** grid size expressed as percentage step. defaults to 5 (5%) */
+  grid?: number;
+}
+
+function clamp(v: number, min = 0, max = 100) {
+  return Math.min(max, Math.max(min, v));
+}
+
+export default function Lookbook({
+  src,
+  alt = "",
+  hotspots = [],
+  onHotspotChange,
+  grid = 5,
+}: Props) {
+  const [active, setActive] = useState<number | null>(null);
+
+  const handleDown = useCallback(
+    (index: number) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      setActive(index);
+    },
+    []
+  );
+
+  const handleMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (active === null || !onHotspotChange) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const snap = (val: number) => Math.round(val / grid) * grid;
+      const x = snap(clamp(((e.clientX - rect.left) / rect.width) * 100));
+      const y = snap(clamp(((e.clientY - rect.top) / rect.height) * 100));
+      onHotspotChange(active, x, y);
+    },
+    [active, grid, onHotspotChange]
+  );
+
+  const handleUp = useCallback(() => setActive(null), []);
+
+  return (
+    <div
+      className="relative h-full w-full"
+      onMouseMove={handleMove}
+      onMouseUp={handleUp}
+      onMouseLeave={handleUp}
+    >
+      {src && (
+        <Image src={src} alt={alt} fill className="object-cover" />
+      )}
+      {hotspots.map((spot, i) => (
+        <div
+          key={i}
+          onMouseDown={handleDown(i)}
+          className="absolute z-10 h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-move rounded-full border-2 border-white bg-primary"
+          style={{ left: `${spot.x}%`, top: `${spot.y}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -36,6 +36,7 @@ import GiftCardBlock from "./GiftCardBlock";
 import FormBuilderBlock from "./FormBuilderBlock";
 import PopupModal from "./PopupModal";
 import ProductBundle from "./ProductBundle";
+import Lookbook from "./Lookbook";
 
 export {
   BlogListing,
@@ -76,6 +77,7 @@ export {
   FormBuilderBlock,
   ProductBundle,
   PopupModal,
+  Lookbook,
 };
 
 export * from "./atoms";

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -41,6 +41,7 @@ import PopupModal from "./PopupModal";
 import ProductBundle, {
   getRuntimeProps as getProductBundleRuntimeProps,
 } from "./ProductBundle";
+import Lookbook from "./Lookbook";
 
 export const organismRegistry = {
   AnnouncementBar: { component: AnnouncementBar },
@@ -91,6 +92,7 @@ export const organismRegistry = {
     component: ProductBundle,
     getRuntimeProps: getProductBundleRuntimeProps,
   },
+  Lookbook: { component: Lookbook },
 } as const;
 
 export type OrganismBlockType = keyof typeof organismRegistry;

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -40,6 +40,7 @@ import GiftCardEditor from "./GiftCardEditor";
 import FormBuilderEditor from "./FormBuilderEditor";
 import PopupModalEditor from "./PopupModalEditor";
 import ProductBundleEditor from "./ProductBundleEditor";
+import LookbookEditor from "./LookbookEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -138,6 +139,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       specific = (
         <ProductBundleEditor component={component} onChange={onChange} />
       );
+      break;
+    case "Lookbook":
+      specific = <LookbookEditor component={component} onChange={onChange} />;
       break;
     case "GiftCardBlock":
       specific = (

--- a/packages/ui/src/components/cms/page-builder/LookbookEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/LookbookEditor.tsx
@@ -1,0 +1,97 @@
+import type { PageComponent } from "@acme/types";
+import { Button, Input } from "../../atoms/shadcn";
+import ImagePicker from "./ImagePicker";
+import Lookbook, { Hotspot } from "../blocks/Lookbook";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function LookbookEditor({ component, onChange }: Props) {
+  const hotspots: Hotspot[] = (component as any).hotspots ?? [];
+
+  const handleHotspotChange = (index: number, x: number, y: number) => {
+    const next = [...hotspots];
+    next[index] = { ...next[index], x, y };
+    onChange({ hotspots: next } as Partial<PageComponent>);
+  };
+
+  const handleSkuChange = (index: number, sku: string) => {
+    const next = [...hotspots];
+    next[index] = { ...next[index], sku };
+    onChange({ hotspots: next } as Partial<PageComponent>);
+  };
+
+  const handleAdd = () => {
+    onChange({
+      hotspots: [...hotspots, { x: 50, y: 50, sku: "" }],
+    } as Partial<PageComponent>);
+  };
+
+  const handleRemove = (idx: number) => {
+    const next = hotspots.filter((_, i) => i !== idx);
+    onChange({ hotspots: next } as Partial<PageComponent>);
+  };
+
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start gap-2">
+        <Input
+          value={(component as any).src ?? ""}
+          onChange={(e) => handleInput("src", e.target.value)}
+          placeholder="src"
+          className="flex-1"
+        />
+        <ImagePicker onSelect={(url) => handleInput("src", url)}>
+          <Button type="button" variant="outline">
+            Pick
+          </Button>
+        </ImagePicker>
+      </div>
+      <Input
+        value={(component as any).alt ?? ""}
+        onChange={(e) => handleInput("alt", e.target.value)}
+        placeholder="alt"
+      />
+      { (component as any).src && (
+        <div className="relative aspect-video w-full">
+          <Lookbook
+            src={(component as any).src}
+            alt={(component as any).alt}
+            hotspots={hotspots}
+            onHotspotChange={handleHotspotChange}
+          />
+        </div>
+      )}
+      {hotspots.map((hs, idx) => (
+        <div key={idx} className="flex items-start gap-2">
+          <Input
+            placeholder="SKU"
+            value={hs.sku ?? ""}
+            onChange={(e) => handleSkuChange(idx, e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            variant="destructive"
+            onClick={() => handleRemove(idx)}
+            disabled={hotspots.length <= ((component as any).minItems ?? 0)}
+          >
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button
+        onClick={handleAdd}
+        disabled={hotspots.length >= ((component as any).maxItems ?? Infinity)}
+      >
+        Add hotspot
+      </Button>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -59,6 +59,7 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
   Testimonials: { minItems: 1, maxItems: 10 },
   TestimonialSlider: { minItems: 1, maxItems: 10 },
   ImageSlider: { minItems: 1, maxItems: 10 },
+  Lookbook: { minItems: 0, maxItems: 10 },
   AnnouncementBar: {
     position: "absolute",
     top: "0",

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -24,6 +24,7 @@ export { default as FeaturedProductEditor } from "./FeaturedProductEditor";
 export { default as ProductBundleEditor } from "./ProductBundleEditor";
 export { default as GiftCardEditor } from "./GiftCardEditor";
 export { default as FormBuilderEditor } from "./FormBuilderEditor";
+export { default as LookbookEditor } from "./LookbookEditor";
 export { default as useMediaLibrary } from "./useMediaLibrary";
 export { useArrayEditor } from "./useArrayEditor";
 export { default as CanvasItem } from "./CanvasItem";


### PR DESCRIPTION
## Summary
- add Lookbook block displaying images with draggable product hotspots
- allow editing Lookbook hotspots and SKU management in ComponentEditor
- register Lookbook block and types with defaults

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689cf1923dfc832f89264c769bf4da30