### PR TITLE
Validate checkout rental days

### DIFF
--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -1,7 +1,8 @@
 // apps/shop-abc/__tests__/checkoutSession.test.ts
 import { encodeCartCookie } from "@platform-core/src/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
-import { calculateRentalDays } from "@acme/date-utils";
+import * as dateUtils from "@acme/date-utils";
+const { calculateRentalDays } = dateUtils;
 import { POST } from "../src/app/api/checkout-session/route";
 import { findCoupon } from "@platform-core/coupons";
 import { getTaxRate } from "@platform-core/tax";
@@ -136,6 +137,22 @@ test("responds with 400 on invalid returnDate", async () => {
   expect(res.status).toBe(400);
   const body = await res.json();
   expect(body.error).toMatch(/invalid/i);
+});
+
+test("responds with 400 on past or same-day returnDate", async () => {
+  jest.useFakeTimers().setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  const sku = PRODUCTS[0];
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
+  mockCart = cart;
+  const cookie = encodeCartCookie("test");
+  const spy = jest.spyOn(dateUtils, "calculateRentalDays").mockReturnValue(0);
+  const req = createRequest({ returnDate: "2025-01-01" }, cookie);
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toMatch(/invalid/i);
+  spy.mockRestore();
 });
 
 test("applies coupon discount and sets metadata", async () => {

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -166,6 +166,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   } catch {
     return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
   }
+  if (rentalDays <= 0) {
+    return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
+  }
 
   /* 3️⃣ Build Stripe line-items & totals ------------------------------------ */
   const lineItemsNested = await Promise.all(


### PR DESCRIPTION
## Summary
- ensure checkout session rejects non-future return dates
- add regression test for past or same-day returnDate

## Testing
- `NEXTAUTH_SECRET=1 CART_COOKIE_SECRET=1 SESSION_SECRET=1 pnpm exec jest apps/shop-abc/__tests__/checkoutSession.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cf1a795e8832f9f521cd9f77fa9ba