### PR TITLE
feat: add editorial blog support

### DIFF
--- a/apps/cms/__tests__/saveSanityConfig.test.ts
+++ b/apps/cms/__tests__/saveSanityConfig.test.ts
@@ -32,7 +32,7 @@ describe("saveSanityConfig", () => {
 
   it("verifies credentials and saves config when using existing dataset", async () => {
     (verifyCredentials as jest.Mock).mockResolvedValue(true);
-    (getShopById as jest.Mock).mockResolvedValue({ id: "shop" });
+    (getShopById as jest.Mock).mockResolvedValue({ id: "shop", enableEditorial: false });
     (setSanityConfig as jest.Mock).mockReturnValue({
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
@@ -68,7 +68,7 @@ describe("saveSanityConfig", () => {
 
   it("creates dataset when requested", async () => {
     (setupSanityBlog as jest.Mock).mockResolvedValue({ success: true });
-    (getShopById as jest.Mock).mockResolvedValue({ id: "shop" });
+    (getShopById as jest.Mock).mockResolvedValue({ id: "shop", enableEditorial: true });
     (setSanityConfig as jest.Mock).mockReturnValue({
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
@@ -91,6 +91,7 @@ describe("saveSanityConfig", () => {
         dataset: "d",
         token: "t",
       },
+      true,
       "public",
     );
     expect(setSanityConfig).toHaveBeenCalledWith({ id: "shop" }, {
@@ -111,6 +112,7 @@ describe("saveSanityConfig", () => {
       error: "fail",
       code: "DATASET_CREATE_ERROR",
     });
+    (getShopById as jest.Mock).mockResolvedValue({ id: "shop", enableEditorial: true });
 
     const fd = new FormData();
     fd.set("projectId", "p");

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -17,6 +17,8 @@ export async function saveSanityConfig(
 }> {
   await ensureAuthorized();
 
+  const shop = await getShopById(shopId);
+
   const projectId = String(formData.get("projectId") ?? "");
   const dataset = String(formData.get("dataset") ?? "");
   const token = String(formData.get("token") ?? "");
@@ -28,6 +30,7 @@ export async function saveSanityConfig(
   if (createDataset) {
     const setup = await setupSanityBlog(
       config,
+      Boolean(shop.enableEditorial),
       aclMode as "public" | "private",
     );
     if (!setup.success) {
@@ -42,8 +45,6 @@ export async function saveSanityConfig(
       return { error: "Invalid Sanity credentials", errorCode: "INVALID_CREDENTIALS" };
     }
   }
-
-  const shop = await getShopById(shopId);
   const updated = setSanityConfig(shop, config);
   await updateShopInRepo(shopId, updated);
 

--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -12,6 +12,7 @@ export type SetupSanityBlogErrorCode =
   | "DATASET_LIST_ERROR"
   | "DATASET_CREATE_ERROR"
   | "SCHEMA_UPLOAD_ERROR"
+  | "CATEGORY_SEED_ERROR"
   | "UNKNOWN_ERROR";
 
 interface Result {
@@ -26,10 +27,12 @@ interface Result {
  */
 export async function setupSanityBlog(
   creds: SanityCredentials,
+  enableEditorial: boolean,
   aclMode: "public" | "private" = "public",
 ): Promise<Result> {
   "use server";
   await ensureAuthorized();
+  if (!enableEditorial) return { success: true };
 
   const { projectId, dataset, token } = creds;
 
@@ -173,6 +176,40 @@ export async function setupSanityBlog(
         success: false,
         error: "Failed to upload schema",
         code: "SCHEMA_UPLOAD_ERROR",
+      };
+    }
+
+    // Seed default Daily Editorial category
+    const categoryRes = await fetch(
+      `https://${projectId}.api.sanity.io/v${apiVersion}/data/mutate/${dataset}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          mutations: [
+            {
+              createIfNotExists: {
+                _id: "category-daily-editorial",
+                _type: "category",
+                title: "Daily Editorial",
+                slug: { _type: "slug", current: "daily-editorial" },
+              },
+            },
+          ],
+        }),
+      },
+    ).catch((err) => {
+      console.error("[setupSanityBlog]", err);
+      return null;
+    });
+    if (!categoryRes || !categoryRes.ok) {
+      return {
+        success: false,
+        error: "Failed to seed category",
+        code: "CATEGORY_SEED_ERROR",
       };
     }
 

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -40,7 +40,7 @@ export async function POST(
         projectId: data.SANITY_PROJECT_ID,
         dataset: data.SANITY_DATASET,
         token: data.SANITY_TOKEN,
-      }).catch((err) => {
+      }, data.ENABLE_EDITORIAL === "true").catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });
     }

--- a/apps/shop-abc/__tests__/homePage.test.tsx
+++ b/apps/shop-abc/__tests__/homePage.test.tsx
@@ -3,6 +3,16 @@ jest.mock("@platform-core/repositories/pages/index.server", () => ({
   __esModule: true,
   getPages: jest.fn(),
 }));
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  __esModule: true,
+  readShop: jest.fn(),
+}));
+jest.mock("@platform-core/analytics", () => ({
+  trackPageView: jest.fn(),
+}));
+jest.mock("@acme/sanity", () => ({
+  fetchPublishedPosts: jest.fn(),
+}));
 jest.mock("../src/app/[lang]/page.client", () => ({
   __esModule: true,
   default: jest.fn(() => null),
@@ -12,6 +22,8 @@ import type { PageComponent } from "@acme/types";
 import Page from "../src/app/[lang]/page";
 import Home from "../src/app/[lang]/page.client";
 import { getPages } from "@platform-core/repositories/pages/index.server";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { fetchPublishedPosts } from "@acme/sanity";
 
 test("Home receives components from pages repo", async () => {
   const components: PageComponent[] = [
@@ -20,10 +32,13 @@ test("Home receives components from pages repo", async () => {
   (getPages as jest.Mock).mockResolvedValue([
     { slug: "home", components } as any,
   ]);
+  (readShop as jest.Mock).mockResolvedValue({ id: "abc", enableEditorial: false });
 
-  const element = await Page();
+  const element = await Page({ params: { lang: "en" } });
 
   expect(getPages).toHaveBeenCalledWith("abc");
+  expect(fetchPublishedPosts).not.toHaveBeenCalled();
   expect(element.type).toBe(Home);
   expect(element.props.components).toEqual(components);
+  expect(element.props.locale).toBe("en");
 });

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -15,5 +15,11 @@
     }
   },
   "componentVersions": {},
-  "lastUpgrade": "1970-01-01T00:00:00.000Z"
+  "lastUpgrade": "1970-01-01T00:00:00.000Z",
+  "sanityBlog": {
+    "projectId": "demo",
+    "dataset": "production",
+    "token": "token"
+  },
+  "enableEditorial": false
 }

--- a/apps/shop-abc/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/page.tsx
@@ -1,8 +1,12 @@
 import BlogListing from "@ui/components/cms/blocks/BlogListing";
 import { fetchPublishedPosts } from "@acme/sanity";
+import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
+  if (!shop.enableEditorial) {
+    notFound();
+  }
   const posts = await fetchPublishedPosts(shop.id);
   const items = posts.map((p) => ({
     title: p.title,

--- a/apps/shop-abc/src/app/[lang]/page.client.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.client.tsx
@@ -4,13 +4,21 @@
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@acme/types";
 import type { Locale } from "@/i18n/locales";
+import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
 
 export default function Home({
   components,
   locale,
+  latestPost,
 }: {
   components: PageComponent[];
   locale: Locale;
+  latestPost?: BlogPost;
 }) {
-  return <DynamicRenderer components={components} locale={locale} />;
+  return (
+    <>
+      {latestPost && <BlogListing posts={[latestPost]} />}
+      <DynamicRenderer components={components} locale={locale} />
+    </>
+  );
 }

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -4,6 +4,8 @@ import { readShop } from "@platform-core/repositories/shops.server";
 import Home from "./page.client";
 import { trackPageView } from "@platform-core/analytics";
 import { env } from "@acme/config";
+import { fetchPublishedPosts } from "@acme/sanity";
+import type { BlogPost } from "@ui/components/cms/blocks/BlogListing";
 
 async function loadComponents(shopId: string): Promise<PageComponent[]> {
   const pages = await getPages(shopId);
@@ -17,6 +19,18 @@ export default async function Page({
 }) {
   const shop = await readShop(env.NEXT_PUBLIC_SHOP_ID || "shop-abc");
   const components = await loadComponents(shop.id);
+  let latestPost: BlogPost | undefined;
+  if (shop.enableEditorial) {
+    const posts = await fetchPublishedPosts(shop.id);
+    const first = posts[0];
+    if (first) {
+      latestPost = {
+        title: first.title,
+        excerpt: first.excerpt,
+        url: `/${params.lang}/blog/${first.slug}`,
+      };
+    }
+  }
   await trackPageView(shop.id, "home");
-  return <Home components={components} locale={params.lang} />;
+  return <Home components={components} locale={params.lang} latestPost={latestPost} />;
 }

--- a/apps/shop-bcd/__tests__/home-page.test.tsx
+++ b/apps/shop-bcd/__tests__/home-page.test.tsx
@@ -2,6 +2,9 @@
 jest.mock("node:fs", () => ({
   promises: { readFile: jest.fn() },
 }));
+jest.mock("@acme/sanity", () => ({
+  fetchPublishedPosts: jest.fn(),
+}));
 jest.mock("../src/app/[lang]/page.client", () => ({
   __esModule: true,
   default: jest.fn(() => null),
@@ -11,6 +14,7 @@ import type { PageComponent } from "@acme/types";
 import { promises as fs } from "node:fs";
 import Page from "../src/app/[lang]/page";
 import Home from "../src/app/[lang]/page.client";
+import { fetchPublishedPosts } from "@acme/sanity";
 
 test("Home receives components from fs", async () => {
   const components: PageComponent[] = [
@@ -27,4 +31,5 @@ test("Home receives components from fs", async () => {
   expect(element.type).toBe(Home);
   expect(element.props.components).toEqual(components);
   expect(element.props.locale).toBe("en");
+  expect(fetchPublishedPosts).not.toHaveBeenCalled();
 });

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -15,5 +15,11 @@
     }
   },
   "componentVersions": {},
-  "lastUpgrade": "1970-01-01T00:00:00.000Z"
+  "lastUpgrade": "1970-01-01T00:00:00.000Z",
+  "sanityBlog": {
+    "projectId": "demo",
+    "dataset": "production",
+    "token": "token"
+  },
+  "enableEditorial": false
 }

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -1,8 +1,12 @@
 import BlogListing from "@ui/components/cms/blocks/BlogListing";
 import { fetchPublishedPosts } from "@acme/sanity";
+import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
+  if (!shop.enableEditorial) {
+    notFound();
+  }
   const posts = await fetchPublishedPosts(shop.id);
   const items = posts.map((p) => ({
     title: p.title,

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -3,13 +3,21 @@
 
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@acme/types";
+import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
 
 export default function Home({
   components,
   locale,
+  latestPost,
 }: {
   components: PageComponent[];
   locale: string;
+  latestPost?: BlogPost;
 }) {
-  return <DynamicRenderer components={components} locale={locale} />;
+  return (
+    <>
+      {latestPost && <BlogListing posts={[latestPost]} />}
+      <DynamicRenderer components={components} locale={locale} />
+    </>
+  );
 }

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -3,6 +3,8 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import shop from "../../../shop.json";
 import Home from "./page.client";
+import { fetchPublishedPosts } from "@acme/sanity";
+import type { BlogPost } from "@ui/components/cms/blocks/BlogListing";
 
 async function loadComponents(): Promise<PageComponent[]> {
   try {
@@ -30,5 +32,17 @@ export default async function Page({
   params: { lang: string };
 }) {
   const components = await loadComponents();
-  return <Home components={components} locale={params.lang} />;
+  let latestPost: BlogPost | undefined;
+  if (shop.enableEditorial) {
+    const posts = await fetchPublishedPosts(shop.id);
+    const first = posts[0];
+    if (first) {
+      latestPost = {
+        title: first.title,
+        excerpt: first.excerpt,
+        url: `/${params.lang}/blog/${first.slug}`,
+      };
+    }
+  }
+  return <Home components={components} locale={params.lang} latestPost={latestPost} />;
 }

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -10,5 +10,11 @@
   "priceOverrides": {},
   "localeOverrides": {},
   "componentVersions": {},
-  "lastUpgrade": "1970-01-01T00:00:00.000Z"
+  "lastUpgrade": "1970-01-01T00:00:00.000Z",
+  "sanityBlog": {
+    "projectId": "demo",
+    "dataset": "production",
+    "token": "token"
+  },
+  "enableEditorial": false
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -10,5 +10,11 @@
   "priceOverrides": {},
   "localeOverrides": {},
   "componentVersions": {},
-  "lastUpgrade": "1970-01-01T00:00:00.000Z"
+  "lastUpgrade": "1970-01-01T00:00:00.000Z",
+  "sanityBlog": {
+    "projectId": "demo",
+    "dataset": "production",
+    "token": "token"
+  },
+  "enableEditorial": false
 }

--- a/packages/platform-core/src/components/blog/BlogPortableText.tsx
+++ b/packages/platform-core/src/components/blog/BlogPortableText.tsx
@@ -1,13 +1,17 @@
 // src/components/blog/BlogPortableText.tsx
 import { PortableText } from "@portabletext/react";
-import { getProductBySlug } from "@/lib/products";
+import { getProductBySlug, getProductById } from "@/lib/products";
 import { ProductCard } from "@/components/shop/ProductCard";
 
 const components = {
   types: {
     productReference: ({ value }: any) => {
-      if (typeof value?.slug !== "string") return null;
-      const sku = getProductBySlug(value.slug);
+      let sku;
+      if (typeof value?.slug === "string") {
+        sku = getProductBySlug(value.slug);
+      } else if (typeof value?.id === "string") {
+        sku = getProductById(value.id);
+      }
       return sku ? <ProductCard sku={sku} /> : null;
     },
     embed: ({ value }: any) => (

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -50,6 +50,7 @@ export async function createShop(
     taxProviders: [prepared.tax],
     paymentProviders: prepared.payment,
     sanityBlog: prepared.sanityBlog,
+    enableEditorial: prepared.enableEditorial,
   };
 
   await prisma.shop.create({ data: { id, data: shopData } });

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -47,6 +47,7 @@ export const createShopOptionsSchema = z
       })
       .optional(),
     sanityBlog: sanityBlogConfigSchema.optional(),
+    enableEditorial: z.boolean().optional(),
     navItems: z.array(navItemSchema).default([]),
     pages: z
       .array(
@@ -66,10 +67,14 @@ export const createShopOptionsSchema = z
 export type CreateShopOptions = z.infer<typeof createShopOptionsSchema>;
 
 export type PreparedCreateShopOptions = Required<
-  Omit<CreateShopOptions, "analytics" | "checkoutPage" | "sanityBlog">
+  Omit<
+    CreateShopOptions,
+    "analytics" | "checkoutPage" | "sanityBlog" | "enableEditorial"
+  >
 > & {
   analytics?: CreateShopOptions["analytics"];
   sanityBlog?: CreateShopOptions["sanityBlog"];
+  enableEditorial: boolean;
   checkoutPage: PageComponent[];
 };
 
@@ -120,5 +125,6 @@ export function prepareOptions(
     })),
     checkoutPage: parsed.checkoutPage,
     sanityBlog: parsed.sanityBlog,
+    enableEditorial: parsed.enableEditorial ?? false,
   };
 }

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -200,6 +200,7 @@ export declare const shopSchema: z.ZodObject<{
         dataset: string;
         token: string;
     } | undefined;
+    enableEditorial?: boolean | undefined;
     domain?: {
         name: string;
         status?: string | undefined;
@@ -237,6 +238,7 @@ export declare const shopSchema: z.ZodObject<{
         dataset: string;
         token: string;
     } | undefined;
+    enableEditorial?: boolean | undefined;
     domain?: {
         name: string;
         status?: string | undefined;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -85,6 +85,7 @@ export const shopSchema = z
       .array(z.object({ label: z.string(), url: z.string() }).strict())
       .optional(),
     sanityBlog: sanityBlogConfigSchema.optional(),
+    enableEditorial: z.boolean().optional(),
     domain: shopDomainSchema.optional(),
     analyticsEnabled: z.boolean().optional(),
     lastUpgrade: z.string().datetime().optional(),


### PR DESCRIPTION
## Summary
- add `enableEditorial` and Sanity blog config to shop types and data
- seed Sanity blog when editorial enabled and create default category
- surface latest editorial posts on home and blog pages and render product cards

## Testing
- `pnpm --filter @apps/cms test` (fails: Cannot find module '../src/app/cms/wizard/Wizard')
- `pnpm --filter @acme/platform-core test` (fails: Cannot find module '../src/app/cms/wizard/Wizard')

------
https://chatgpt.com/codex/tasks/task_e_689d8a9a7028832f81d3eab5b7823650