### PR TITLE
feat: map component names for upgrade preview

### DIFF
--- a/apps/shop-abc/__tests__/__snapshots__/upgradePreview.test.tsx.snap
+++ b/apps/shop-abc/__tests__/__snapshots__/upgradePreview.test.tsx.snap
@@ -6,25 +6,13 @@ exports[`upgrade preview page renders changes and publish CTA 1`] = `
     <div
       class="space-y-8"
     >
-      <div
-        class="space-y-2"
+      <ul
+        class="list-disc pl-4"
       >
-        <h2
-          class="text-lg font-semibold"
-        >
-          TestComp
-        </h2>
-        <div
-          class="flex gap-4"
-        >
-          <div
-            class="flex-1 border p-2"
-          />
-          <div
-            class="flex-1 border p-2"
-          />
-        </div>
-      </div>
+        <li>
+          Breadcrumbs
+        </li>
+      </ul>
       <button
         class="rounded border px-4 py-2"
         type="button"

--- a/apps/shop-abc/__tests__/upgrade-changes.test.ts
+++ b/apps/shop-abc/__tests__/upgrade-changes.test.ts
@@ -26,12 +26,23 @@ describe("/api/upgrade-changes", () => {
   });
 
   test("returns components for authorized requests", async () => {
-    await fs.writeFile(filePath, JSON.stringify({ components: ["Header"] }));
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        components: [
+          { file: "molecules/Breadcrumbs.tsx", componentName: "Breadcrumbs" },
+        ],
+      }),
+    );
     jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { GET } = await import("../src/app/api/upgrade-changes/route");
     const res = await GET();
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ components: ["Header"] });
+    expect(await res.json()).toEqual({
+      components: [
+        { file: "molecules/Breadcrumbs.tsx", componentName: "Breadcrumbs" },
+      ],
+    });
   });
 
   test("returns 401 for unauthorized", async () => {

--- a/apps/shop-abc/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-abc/__tests__/upgradePreview.test.tsx
@@ -2,22 +2,21 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import UpgradePreviewPage from "../src/app/upgrade-preview/page";
 
-jest.mock("next/dynamic", () => () => () => null);
-
 describe("upgrade preview page", () => {
   it("renders changes and publish CTA", async () => {
     const fetchMock = jest.spyOn(global, "fetch" as any).mockResolvedValue({
-      json: async () => [
-        {
-          name: "TestComp",
-          before: { path: "@ui/components/Before" },
-          after: { path: "@ui/components/After" },
-        },
-      ],
+      json: async () => ({
+        components: [
+          {
+            file: "molecules/Breadcrumbs.tsx",
+            componentName: "Breadcrumbs",
+          },
+        ],
+      }),
     } as any);
 
     const { baseElement } = render(<UpgradePreviewPage />);
-    await screen.findByText("TestComp");
+    await screen.findByText("Breadcrumbs");
     expect(screen.getByText("Approve & publish")).toBeInTheDocument();
     expect(baseElement).toMatchSnapshot();
     fetchMock.mockRestore();

--- a/apps/shop-abc/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-abc/src/app/upgrade-preview/page.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import dynamic from "next/dynamic";
 
 interface UpgradeComponent {
-  name: string;
-  before: {
-    path: string;
-    props?: Record<string, unknown>;
-  };
-  after: {
-    path: string;
-    props?: Record<string, unknown>;
-  };
+  file: string;
+  componentName: string;
 }
 
 export default function UpgradePreviewPage() {
@@ -22,8 +14,10 @@ export default function UpgradePreviewPage() {
     async function load() {
       try {
         const res = await fetch("/api/upgrade-changes");
-        const data = (await res.json()) as UpgradeComponent[];
-        setChanges(data);
+        const data = (await res.json()) as {
+          components: UpgradeComponent[];
+        };
+        setChanges(data.components);
       } catch (err) {
         console.error("Failed to load upgrade changes", err);
       }
@@ -41,23 +35,11 @@ export default function UpgradePreviewPage() {
 
   return (
     <div className="space-y-8">
-      {changes.map((c) => {
-        const Before = dynamic(() => import(c.before.path));
-        const After = dynamic(() => import(c.after.path));
-        return (
-          <div key={c.name} className="space-y-2">
-            <h2 className="text-lg font-semibold">{c.name}</h2>
-            <div className="flex gap-4">
-              <div className="flex-1 border p-2">
-                <Before {...c.before.props} />
-              </div>
-              <div className="flex-1 border p-2">
-                <After {...c.after.props} />
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      <ul className="list-disc pl-4">
+        {changes.map((c) => (
+          <li key={c.file}>{c.componentName}</li>
+        ))}
+      </ul>
       <button
         type="button"
         onClick={handlePublish}

--- a/apps/shop-bcd/__tests__/__snapshots__/upgradePreview.test.tsx.snap
+++ b/apps/shop-bcd/__tests__/__snapshots__/upgradePreview.test.tsx.snap
@@ -6,25 +6,13 @@ exports[`upgrade preview page renders changes and publish CTA 1`] = `
     <div
       class="space-y-8"
     >
-      <div
-        class="space-y-2"
+      <ul
+        class="list-disc pl-4"
       >
-        <h2
-          class="text-lg font-semibold"
-        >
-          TestComp
-        </h2>
-        <div
-          class="flex gap-4"
-        >
-          <div
-            class="flex-1 border p-2"
-          />
-          <div
-            class="flex-1 border p-2"
-          />
-        </div>
-      </div>
+        <li>
+          Breadcrumbs
+        </li>
+      </ul>
       <button
         class="rounded border px-4 py-2"
         type="button"

--- a/apps/shop-bcd/__tests__/upgrade-changes.test.ts
+++ b/apps/shop-bcd/__tests__/upgrade-changes.test.ts
@@ -26,12 +26,23 @@ describe("/api/upgrade-changes", () => {
   });
 
   test("returns components for authorized requests", async () => {
-    await fs.writeFile(filePath, JSON.stringify({ components: ["Header"] }));
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        components: [
+          { file: "molecules/Breadcrumbs.tsx", componentName: "Breadcrumbs" },
+        ],
+      }),
+    );
     jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
     const { GET } = await import("../src/app/api/upgrade-changes/route");
     const res = await GET();
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ components: ["Header"] });
+    expect(await res.json()).toEqual({
+      components: [
+        { file: "molecules/Breadcrumbs.tsx", componentName: "Breadcrumbs" },
+      ],
+    });
   });
 
   test("returns 401 for unauthorized", async () => {

--- a/apps/shop-bcd/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-bcd/__tests__/upgradePreview.test.tsx
@@ -2,22 +2,21 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import UpgradePreviewPage from "../src/app/upgrade-preview/page";
 
-jest.mock("next/dynamic", () => () => () => null);
-
 describe("upgrade preview page", () => {
   it("renders changes and publish CTA", async () => {
     const fetchMock = jest.spyOn(global, "fetch" as any).mockResolvedValue({
-      json: async () => [
-        {
-          name: "TestComp",
-          before: { path: "@ui/components/Before" },
-          after: { path: "@ui/components/After" },
-        },
-      ],
+      json: async () => ({
+        components: [
+          {
+            file: "molecules/Breadcrumbs.tsx",
+            componentName: "Breadcrumbs",
+          },
+        ],
+      }),
     } as any);
 
     const { baseElement } = render(<UpgradePreviewPage />);
-    await screen.findByText("TestComp");
+    await screen.findByText("Breadcrumbs");
     expect(screen.getByText("Approve & publish")).toBeInTheDocument();
     expect(baseElement).toMatchSnapshot();
     fetchMock.mockRestore();

--- a/apps/shop-bcd/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-bcd/src/app/upgrade-preview/page.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import dynamic from "next/dynamic";
 
 interface UpgradeComponent {
-  name: string;
-  before: {
-    path: string;
-    props?: Record<string, unknown>;
-  };
-  after: {
-    path: string;
-    props?: Record<string, unknown>;
-  };
+  file: string;
+  componentName: string;
 }
 
 export default function UpgradePreviewPage() {
@@ -22,8 +14,10 @@ export default function UpgradePreviewPage() {
     async function load() {
       try {
         const res = await fetch("/api/upgrade-changes");
-        const data = (await res.json()) as UpgradeComponent[];
-        setChanges(data);
+        const data = (await res.json()) as {
+          components: UpgradeComponent[];
+        };
+        setChanges(data.components);
       } catch (err) {
         console.error("Failed to load upgrade changes", err);
       }
@@ -41,23 +35,11 @@ export default function UpgradePreviewPage() {
 
   return (
     <div className="space-y-8">
-      {changes.map((c) => {
-        const Before = dynamic(() => import(c.before.path));
-        const After = dynamic(() => import(c.after.path));
-        return (
-          <div key={c.name} className="space-y-2">
-            <h2 className="text-lg font-semibold">{c.name}</h2>
-            <div className="flex gap-4">
-              <div className="flex-1 border p-2">
-                <Before {...c.before.props} />
-              </div>
-              <div className="flex-1 border p-2">
-                <After {...c.after.props} />
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      <ul className="list-disc pl-4">
+        {changes.map((c) => (
+          <li key={c.file}>{c.componentName}</li>
+        ))}
+      </ul>
       <button
         type="button"
         onClick={handlePublish}

--- a/packages/template-app/src/app/upgrade-preview/page.tsx
+++ b/packages/template-app/src/app/upgrade-preview/page.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import dynamic from "next/dynamic";
 
 interface UpgradeComponent {
-  name: string;
-  before: {
-    path: string;
-    props?: Record<string, unknown>;
-  };
-  after: {
-    path: string;
-    props?: Record<string, unknown>;
-  };
+  file: string;
+  componentName: string;
 }
 
 export default function UpgradePreviewPage() {
@@ -22,8 +14,10 @@ export default function UpgradePreviewPage() {
     async function load() {
       try {
         const res = await fetch("/api/upgrade-changes");
-        const data = (await res.json()) as UpgradeComponent[];
-        setChanges(data);
+        const data = (await res.json()) as {
+          components: UpgradeComponent[];
+        };
+        setChanges(data.components);
       } catch (err) {
         console.error("Failed to load upgrade changes", err);
       }
@@ -41,23 +35,11 @@ export default function UpgradePreviewPage() {
 
   return (
     <div className="space-y-8">
-      {changes.map((c) => {
-        const Before = dynamic(() => import(c.before.path));
-        const After = dynamic(() => import(c.after.path));
-        return (
-          <div key={c.name} className="space-y-2">
-            <h2 className="text-lg font-semibold">{c.name}</h2>
-            <div className="flex gap-4">
-              <div className="flex-1 border p-2">
-                <Before {...c.before.props} />
-              </div>
-              <div className="flex-1 border p-2">
-                <After {...c.after.props} />
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      <ul className="list-disc pl-4">
+        {changes.map((c) => (
+          <li key={c.file}>{c.componentName}</li>
+        ))}
+      </ul>
       <button
         type="button"
         onClick={handlePublish}

--- a/scripts/__tests__/component-names.test.ts
+++ b/scripts/__tests__/component-names.test.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+import { getComponentNameMap } from "../src/component-names";
+
+describe("component name resolution", () => {
+  it("maps file paths to exported component names", () => {
+    const componentsDir = path.join(
+      __dirname,
+      "..",
+      "..",
+      "packages",
+      "ui",
+      "src",
+      "components",
+    );
+    const map = getComponentNameMap(componentsDir);
+    expect(map[path.join("molecules", "Breadcrumbs.tsx").replace(/\\/g, "/")]).toBe(
+      "Breadcrumbs",
+    );
+    expect(map[path.join("molecules", "FormField.tsx").replace(/\\/g, "/")]).toBe(
+      "FormField",
+    );
+    expect(map["ThemeToggle.tsx"]).toBe("ThemeToggle");
+  });
+});

--- a/scripts/src/component-names.ts
+++ b/scripts/src/component-names.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Builds a mapping of component source files to their exported name
+ * by walking through barrel files in the components directory.
+ */
+export function getComponentNameMap(componentsDir: string): Record<string, string> {
+  const map = new Map<string, string>();
+
+  function resolveFile(dir: string, rel: string): string | undefined {
+    const exts = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+    for (const ext of exts) {
+      const full = path.join(dir, rel + ext);
+      if (existsSync(full)) return full;
+    }
+    const indexExts = ["/index.ts", "/index.tsx"];
+    for (const ext of indexExts) {
+      const full = path.join(dir, rel + ext);
+      if (existsSync(full)) return full;
+    }
+    return undefined;
+  }
+
+  function walk(dir: string) {
+    const indexFile = path.join(dir, "index.ts");
+    if (!existsSync(indexFile)) return;
+    const src = readFileSync(indexFile, "utf8");
+
+    // Handle re-exporting entire directories
+    const starRe = /export\s+\*\s+from\s+["']\.\/(.+?)["'];?/g;
+    let starMatch: RegExpExecArray | null;
+    while ((starMatch = starRe.exec(src))) {
+      walk(path.join(dir, starMatch[1]));
+    }
+
+    // Handle named/default exports
+    const namedRe = /export\s+\{([^}]+)\}\s+from\s+["']\.\/(.+?)["'];?/g;
+    let namedMatch: RegExpExecArray | null;
+    while ((namedMatch = namedRe.exec(src))) {
+      const rel = namedMatch[2];
+      const specifiers = namedMatch[1].split(",").map((s) => s.trim()).filter(Boolean);
+      const file = resolveFile(dir, rel);
+      if (!file) continue;
+      for (const spec of specifiers) {
+        let name = spec;
+        if (spec.startsWith("default as ")) {
+          name = spec.slice("default as ".length).trim();
+        } else if (spec.includes(" as ")) {
+          name = spec.split(/\s+as\s+/)[1];
+        }
+        const key = path.relative(componentsDir, file).replace(/\\/g, "/");
+        map.set(key, name);
+      }
+    }
+  }
+
+  walk(componentsDir);
+  return Object.fromEntries(map.entries());
+}
+

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -1,6 +1,16 @@
-import { cpSync, existsSync, mkdirSync, readdirSync, unlinkSync, renameSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  unlinkSync,
+  renameSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import * as path from "node:path";
 import { randomBytes } from "node:crypto";
+import { getComponentNameMap } from "./component-names";
 
 const args = process.argv.slice(2);
 const rollback = args.includes("--rollback");
@@ -49,6 +59,18 @@ if (existsSync(shopJsonPath)) {
     : {};
   writeFileSync(shopJsonPath, JSON.stringify(data, null, 2));
 }
+
+// generate upgrade-changes.json with component name mappings
+const componentsDir = path.join(rootDir, "packages", "ui", "src", "components");
+const componentMap = getComponentNameMap(componentsDir);
+const components = Object.entries(componentMap).map(([file, componentName]) => ({
+  file,
+  componentName,
+}));
+writeFileSync(
+  path.join(appDir, "upgrade-changes.json"),
+  JSON.stringify({ components }, null, 2),
+);
 
 const envPath = path.join(appDir, ".env");
 if (existsSync(envPath)) {


### PR DESCRIPTION
## Summary
- derive component export names from UI barrel files
- write component name mapping to upgrade-changes.json
- show human-friendly names on upgrade-preview page

## Testing
- `pnpm jest apps/shop-abc/__tests__/upgradePreview.test.tsx apps/shop-abc/__tests__/upgrade-changes.test.ts apps/shop-bcd/__tests__/upgradePreview.test.tsx apps/shop-bcd/__tests__/upgrade-changes.test.ts scripts/__tests__/component-names.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d8c6d9b54832f94ced9fbadaafc79