### PR TITLE
feat: add lookbook block with draggable hotspots

### DIFF
--- a/packages/types/src/Page.ts
+++ b/packages/types/src/Page.ts
@@ -199,6 +199,13 @@ export interface GalleryComponent extends PageComponentBase {
   images?: { src: string; alt?: string }[];
 }
 
+export interface LookbookComponent extends PageComponentBase {
+  type: "Lookbook";
+  src?: string;
+  alt?: string;
+  hotspots?: { sku?: string; x: number; y: number }[];
+}
+
 export interface ImageSliderComponent extends PageComponentBase {
   type: "ImageSlider";
   slides?: { src: string; alt?: string; caption?: string }[];
@@ -357,6 +364,7 @@ export type PageComponent =
   | CollectionListComponent
   | RecommendationCarouselComponent
   | GalleryComponent
+  | LookbookComponent
   | ImageSliderComponent
   | ContactFormComponent
   | NewsletterSignupComponent
@@ -468,6 +476,21 @@ const galleryComponentSchema = baseComponentSchema.extend({
   type: z.literal("Gallery"),
   images: z
     .array(z.object({ src: z.string(), alt: z.string().optional() }))
+    .optional(),
+});
+
+const lookbookComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Lookbook"),
+  src: z.string().optional(),
+  alt: z.string().optional(),
+  hotspots: z
+    .array(
+      z.object({
+        sku: z.string().optional(),
+        x: z.number(),
+        y: z.number(),
+      })
+    )
     .optional(),
 });
 
@@ -695,6 +718,7 @@ export const pageComponentSchema: z.ZodType<PageComponent> = z.lazy(() =>
     productCarouselComponentSchema,
     recommendationCarouselComponentSchema,
     galleryComponentSchema,
+    lookbookComponentSchema,
     contactFormComponentSchema,
     newsletterSignupComponentSchema,
     searchBarComponentSchema,

--- a/packages/ui/src/components/cms/blocks/Lookbook.tsx
+++ b/packages/ui/src/components/cms/blocks/Lookbook.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRef, useState, useEffect, PointerEvent as ReactPointerEvent } from "react";
+
+export type LookbookHotspot = {
+  sku?: string;
+  x: number; // percentage
+  y: number; // percentage
+};
+
+interface Props {
+  src?: string;
+  alt?: string;
+  hotspots?: LookbookHotspot[];
+  /** Callback when hotspots are moved. Useful in editors */
+  onHotspotsChange?: (hotspots: LookbookHotspot[]) => void;
+}
+
+const SNAP = 5; // percent step for snapping
+
+export default function Lookbook({ src, alt = "", hotspots = [], onHotspotsChange }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [points, setPoints] = useState<LookbookHotspot[]>(hotspots);
+  const pointsRef = useRef(points);
+
+  useEffect(() => {
+    setPoints(hotspots);
+  }, [hotspots]);
+
+  useEffect(() => {
+    pointsRef.current = points;
+  }, [points]);
+
+  const handlePointerDown = (index: number) => (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+
+    const move = (ev: PointerEvent) => {
+      const rawX = ((ev.clientX - rect.left) / rect.width) * 100;
+      const rawY = ((ev.clientY - rect.top) / rect.height) * 100;
+      const snap = (v: number) => Math.max(0, Math.min(100, Math.round(v / SNAP) * SNAP));
+      const next = pointsRef.current.map((p, i) =>
+        i === index ? { ...p, x: snap(rawX), y: snap(rawY) } : p,
+      );
+      setPoints(next);
+    };
+
+    const up = () => {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+      onHotspotsChange?.(pointsRef.current);
+    };
+
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+  };
+
+  return (
+    <div ref={containerRef} className="relative h-full w-full">
+      {src && <img src={src} alt={alt} className="h-full w-full object-cover" />}
+      {points.map((p, idx) => (
+        <div
+          key={idx}
+          onPointerDown={handlePointerDown(idx)}
+          className="absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-move rounded-full bg-primary"
+          style={{ left: `${p.x}%`, top: `${p.y}%` }}
+          title={p.sku}
+        />
+      ))}
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/blocks/index.tsx
+++ b/packages/ui/src/components/cms/blocks/index.tsx
@@ -2,6 +2,7 @@ import BlogListing from "./BlogListing";
 import ContactForm from "./ContactForm";
 import ContactFormWithMap from "./ContactFormWithMap";
 import Gallery from "./Gallery";
+import Lookbook from "./Lookbook";
 import HeroBanner from "./HeroBanner";
 import ProductCarousel from "./ProductCarousel";
 import ProductGrid from "./ProductGrid.client";
@@ -43,6 +44,7 @@ export {
   ContactForm,
   ContactFormWithMap,
   Gallery,
+  Lookbook,
   HeroBanner,
   ProductCarousel,
   ProductGrid,

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -2,6 +2,7 @@ import BlogListing from "./BlogListing";
 import ContactForm from "./ContactForm";
 import ContactFormWithMap from "./ContactFormWithMap";
 import Gallery from "./Gallery";
+import Lookbook from "./Lookbook";
 import HeroBanner from "./HeroBanner";
 import ProductCarousel, {
   getRuntimeProps as getProductCarouselRuntimeProps,
@@ -67,6 +68,7 @@ export const organismRegistry = {
   ImageSlider: { component: ImageSlider },
   CollectionList: { component: CollectionList },
   Gallery: { component: Gallery },
+  Lookbook: { component: Lookbook },
   ContactForm: { component: ContactForm },
   ContactFormWithMap: { component: ContactFormWithMap },
   BlogListing: { component: BlogListing },

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -41,6 +41,7 @@ import GiftCardEditor from "./GiftCardEditor";
 import FormBuilderEditor from "./FormBuilderEditor";
 import PopupModalEditor from "./PopupModalEditor";
 import ProductBundleEditor from "./ProductBundleEditor";
+import LookbookEditor from "./LookbookEditor";
 
 interface Props {
   component: PageComponent | null;
@@ -88,6 +89,9 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
       break;
     case "Image":
       specific = <ImageBlockEditor component={component} onChange={onChange} />;
+      break;
+    case "Lookbook":
+      specific = <LookbookEditor component={component} onChange={onChange} />;
       break;
     case "Testimonials":
       specific = (

--- a/packages/ui/src/components/cms/page-builder/LookbookEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/LookbookEditor.tsx
@@ -1,0 +1,50 @@
+import type { PageComponent } from "@acme/types";
+import { Button, Input } from "../../atoms/shadcn";
+import ImagePicker from "./ImagePicker";
+import { useArrayEditor } from "./useArrayEditor";
+
+interface Props {
+  component: PageComponent;
+  onChange: (patch: Partial<PageComponent>) => void;
+}
+
+export default function LookbookEditor({ component, onChange }: Props) {
+  const handleInput = (field: string, value: string) => {
+    onChange({ [field]: value } as Partial<PageComponent>);
+  };
+
+  const arrayEditor = useArrayEditor(onChange);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start gap-2">
+        <Input
+          value={(component as any).src ?? ""}
+          onChange={(e) => handleInput("src", e.target.value)}
+          placeholder="Image URL"
+          className="flex-1"
+        />
+        <ImagePicker onSelect={(url) => handleInput("src", url)}>
+          <Button type="button" variant="outline">
+            Pick
+          </Button>
+        </ImagePicker>
+      </div>
+      <Input
+        value={(component as any).alt ?? ""}
+        onChange={(e) => handleInput("alt", e.target.value)}
+        placeholder="Alt text"
+      />
+      {arrayEditor(
+        "hotspots",
+        (component as any).hotspots,
+        ["sku", "x", "y"],
+        {
+          minItems: (component as any).minItems,
+          maxItems: (component as any).maxItems,
+        }
+      )}
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -66,6 +66,7 @@ const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
     left: "0",
     width: "100%",
   },
+  Lookbook: { minItems: 0, maxItems: 10 },
   MultiColumn: { columns: 2, gap: "1rem" },
   Divider: { width: "100%", height: "1px" },
   Spacer: { width: "100%", height: "1rem" },


### PR DESCRIPTION
## Summary
- add Lookbook block rendering image with draggable hotspots
- expose Lookbook in block registry and page builder defaults
- extend component editor for configuring hotspots

## Testing
- `pnpm test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' in apps/cms/__tests__/wizard.test.tsx; process.exit called in packages/email/src/__tests__/scheduler.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d25fcd4832f9e81432b300fbbd5