### PR TITLE
test: split ThemeEditor tests

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.presets.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.presets.test.tsx
@@ -1,0 +1,65 @@
+import {
+  fireEvent,
+  renderThemeEditor,
+  screen,
+  waitFor,
+  mockSavePreset,
+  mockDeletePreset,
+  act,
+} from "./ThemeEditor.test-utils";
+
+describe("ThemeEditor - presets", () => {
+  beforeEach(() => {
+    mockSavePreset.mockClear();
+    mockDeletePreset.mockClear();
+  });
+
+  it("saves a new preset and switches theme", async () => {
+    const tokensByTheme = { base: { "--color-bg": "#ffffff" } };
+    mockSavePreset.mockResolvedValue({});
+    renderThemeEditor({
+      tokensByTheme,
+      initialOverrides: { "--color-bg": "#000000" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/preset name/i), {
+      target: { value: "custom" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save preset/i }));
+    });
+
+    await waitFor(() => expect(mockSavePreset).toHaveBeenCalled());
+    expect(mockSavePreset).toHaveBeenCalledWith("test", "custom", {
+      "--color-bg": "#000000",
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText(/theme/i)).toHaveValue("custom")
+    );
+  });
+
+  it("deletes a preset and reverts to base theme", async () => {
+    const tokensByTheme = {
+      base: { "--color-bg": "#ffffff" },
+      custom: { "--color-bg": "#000000" },
+    };
+    mockDeletePreset.mockResolvedValue({});
+    renderThemeEditor({
+      tokensByTheme,
+      themes: ["base", "custom"],
+      initialTheme: "custom",
+      presets: ["custom"],
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /delete preset/i }));
+    });
+
+    await waitFor(() => expect(mockDeletePreset).toHaveBeenCalled());
+    expect(mockDeletePreset).toHaveBeenCalledWith("test", "custom");
+    await waitFor(() =>
+      expect(screen.getByLabelText(/theme/i)).toHaveValue("base")
+    );
+    expect(screen.queryByRole("button", { name: /delete preset/i })).toBeNull();
+  });
+});

--- a/apps/cms/__tests__/ThemeEditor.test-utils.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test-utils.tsx
@@ -1,0 +1,101 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, within, waitFor, act } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import ThemeEditor from "../src/app/cms/shop/[shop]/themes/ThemeEditor";
+import { updateShop } from "@cms/actions/shops.server";
+import { savePreset, deletePreset } from "../src/app/cms/shop/[shop]/themes/page";
+
+jest.mock("@cms/actions/shops.server", () => ({
+  updateShop: jest.fn(),
+}));
+jest.mock("../src/app/cms/shop/[shop]/themes/page", () => ({
+  savePreset: jest.fn(),
+  deletePreset: jest.fn(),
+}));
+jest.mock(
+  "@/components/cms/StyleEditor",
+  () => {
+    const React = require("react");
+    function MockStyleEditor({ tokens, baseTokens, onChange, focusToken }: any) {
+      const ref = React.useRef<HTMLDivElement | null>(null);
+      React.useEffect(() => {
+        if (!focusToken) return;
+        const el = ref.current?.querySelector(
+          `[data-token-key="${focusToken}"]`
+        ) as HTMLElement | null;
+        el?.scrollIntoView?.();
+        const input = el?.querySelector("input");
+        (input as HTMLElement | null)?.focus();
+      }, [focusToken]);
+      return (
+        <div ref={ref}>
+          {Object.entries(baseTokens).map(([k, defaultValue]: any) => {
+            const val = tokens[k] || defaultValue;
+            return (
+              <label key={k} data-token-key={k}>
+                <input
+                  aria-label={k}
+                  type="color"
+                  value={val}
+                  onChange={(e) =>
+                    onChange({ ...tokens, [k]: e.target.value })
+                  }
+                />
+              </label>
+            );
+          })}
+        </div>
+      );
+    }
+    return { __esModule: true, default: MockStyleEditor };
+  },
+  { virtual: true }
+);
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => ({
+    Button: (props: any) => <button {...props} />,
+    Input: (props: any) => <input {...props} />,
+  }),
+  { virtual: true }
+);
+jest.mock("../src/app/cms/wizard/WizardPreview", () => ({
+  __esModule: true,
+  default: ({ onTokenSelect }: any) => (
+    <div>
+      <div
+        data-token="--color-primary"
+        onClick={(e: any) =>
+          onTokenSelect(e.currentTarget.getAttribute("data-token"))
+        }
+      />
+      <div
+        data-token="--color-bg"
+        onClick={(e: any) =>
+          onTokenSelect(e.currentTarget.getAttribute("data-token"))
+        }
+      />
+    </div>
+  ),
+}));
+
+export { fireEvent, render, screen, within, waitFor, act };
+
+export const mockUpdateShop = updateShop as jest.Mock;
+export const mockSavePreset = savePreset as jest.Mock;
+export const mockDeletePreset = deletePreset as jest.Mock;
+
+export interface RenderOptions
+  extends Partial<ComponentProps<typeof ThemeEditor>> {}
+
+export function renderThemeEditor(options: RenderOptions = {}) {
+  const defaultProps: ComponentProps<typeof ThemeEditor> = {
+    shop: "test",
+    themes: ["base"],
+    tokensByTheme: { base: { "--color-bg": "#ffffff" } },
+    initialTheme: "base",
+    initialOverrides: {},
+    presets: [],
+  };
+  return render(<ThemeEditor {...defaultProps} {...options} />);
+}


### PR DESCRIPTION
## Summary
- break ThemeEditor tests into color and preset suites
- centralize shared mocks in ThemeEditor test-utils
- add coverage for saving and deleting theme presets

## Testing
- `pnpm test:cms ThemeEditor`

------
https://chatgpt.com/codex/tasks/task_e_689d8ec0c5c4832f86ea3e507d9ae2e4