### PR TITLE
Refactor blog post form into modular components

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/MainImageField.tsx
+++ b/apps/cms/src/app/cms/blog/posts/MainImageField.tsx
@@ -1,0 +1,22 @@
+import { Button, ImagePicker } from "@ui";
+
+interface Props {
+  value: string;
+  onChange: (url: string) => void;
+}
+
+export default function MainImageField({ value, onChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <label className="block font-medium">Main image</label>
+      <ImagePicker onSelect={onChange}>
+        <Button type="button" variant="outline">
+          {value ? "Change image" : "Select image"}
+        </Button>
+      </ImagePicker>
+      {value && (
+        <img src={value} alt="Main image" className="h-32 w-auto rounded object-cover" />
+      )}
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -2,29 +2,21 @@
 "use client";
 
 import { useFormState } from "react-dom";
-import {
-  useState,
-  useEffect,
-  createContext,
-  useContext,
-  useCallback,
-} from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { Button, Input, Switch, Textarea, Toast, ImagePicker } from "@ui";
+import { Button, Input, Switch, Textarea, Toast } from "@ui";
 import { slugify } from "@acme/shared-utils";
-import type { SKU } from "@acme/types";
-import {
-  EditorProvider,
-  PortableTextEditable,
-  PortableTextEditor,
-  useEditor,
-  defineSchema,
-  type PortableTextBlock,
-  type RenderBlockFunction,
-  type BlockRenderProps,
-} from "@portabletext/editor";
-import { EventListenerPlugin } from "@portabletext/editor/plugins";
 import { PortableText } from "@portabletext/react";
+import {
+  previewComponents,
+  type PortableTextBlock,
+} from "./schema";
+import {
+  InvalidProductProvider,
+  useInvalidProductContext,
+} from "./invalidProductContext";
+import MainImageField from "./MainImageField";
+import RichTextEditor from "./RichTextEditor";
 
 export interface FormState {
   message?: string;
@@ -48,361 +40,7 @@ interface Props {
   };
 }
 
-const schema = defineSchema({
-  decorators: [{ name: "strong" }, { name: "em" }],
-  styles: [
-    { name: "normal" },
-    { name: "h1" },
-    { name: "h2" },
-    { name: "h3" },
-  ],
-  lists: [{ name: "bullet" }, { name: "number" }],
-  annotations: [
-    {
-      name: "link",
-      type: "object",
-      fields: [{ name: "href", type: "string" }],
-    },
-  ],
-  inlineObjects: [],
-  blockObjects: [
-    {
-      name: "productReference",
-      type: "object",
-      fields: [{ name: "slug", type: "string" }],
-    },
-    {
-      name: "embed",
-      type: "object",
-      fields: [{ name: "url", type: "string" }],
-    },
-    {
-      name: "image",
-      type: "object",
-      fields: [
-        { name: "url", type: "string" },
-        { name: "alt", type: "string" },
-      ],
-    },
-  ],
-});
-
-interface InvalidProductContextValue {
-  invalidProducts: Record<string, string>;
-  markValidity: (key: string, valid: boolean, slug: string) => void;
-}
-
-const InvalidProductContext =
-  createContext<InvalidProductContextValue | null>(null);
-
-function ProductPreview({
-  slug,
-  onValidChange,
-}: {
-  slug: string;
-  onValidChange?: (valid: boolean) => void;
-}) {
-  const [product, setProduct] = useState<SKU | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    async function load() {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/products?slug=${encodeURIComponent(slug)}`);
-        if (!res.ok) throw new Error("Failed to load product");
-        const data: SKU = await res.json();
-        if (active) {
-          setProduct(data);
-          setError(null);
-          onValidChange?.(true);
-        }
-      } catch {
-        if (active) {
-          setError("Failed to load product");
-          onValidChange?.(false);
-        }
-      } finally {
-        if (active) setLoading(false);
-      }
-    }
-    load();
-    return () => {
-      active = false;
-      onValidChange?.(true);
-    };
-  }, [slug, onValidChange]);
-
-  if (loading) return <div className="border p-2">Loading…</div>;
-  if (error || !product)
-    return <div className="border p-2 text-red-500">{error ?? "Not found"}</div>;
-  const available = (product.stock ?? 0) > 0;
-  return (
-    <div className="flex gap-2 border p-2">
-      {product.media?.[0] && (
-        <img
-          src={product.media[0].url}
-          alt={product.title}
-          className="h-16 w-16 object-cover"
-        />
-      )}
-      <div className="space-y-1">
-        <div className="font-semibold">{product.title}</div>
-        <div>{(product.price / 100).toFixed(2)}</div>
-        <div className="text-sm">
-          {available ? "In stock" : "Out of stock"}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const previewComponents = {
-  types: {
-    productReference: ({ value }: any) => <ProductPreview slug={value.slug} />,
-    embed: ({ value }: any) => (
-      <div className="aspect-video">
-        <iframe src={value.url} className="h-full w-full" />
-      </div>
-    ),
-    image: ({ value }: any) => (
-      <img src={value.url} alt={value.alt || ""} className="max-w-full" />
-    ),
-  },
-  marks: {
-    link: ({ children, value }: any) => (
-      <a
-        href={value.href}
-        className="text-blue-600 underline"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {children}
-      </a>
-    ),
-  },
-  block: {
-    h1: ({ children }: any) => <h1>{children}</h1>,
-    h2: ({ children }: any) => <h2>{children}</h2>,
-    h3: ({ children }: any) => <h3>{children}</h3>,
-  },
-};
-
-function ProductReferenceBlock(props: BlockRenderProps) {
-  const editor = useEditor();
-  const ctx = useContext(InvalidProductContext);
-  const slug = props.value.slug as string;
-  const isInvalid = Boolean(ctx?.invalidProducts[props.value._key as string]);
-  const remove = () => {
-    const sel = {
-      anchor: { path: props.path, offset: 0 },
-      focus: { path: props.path, offset: 0 },
-    };
-    PortableTextEditor.delete(editor, sel, { mode: "blocks" });
-  };
-  const edit = () => {
-    const next = prompt("Product slug", slug);
-    if (!next) return;
-    const sel = {
-      anchor: { path: props.path, offset: 0 },
-      focus: { path: props.path, offset: 0 },
-    };
-    PortableTextEditor.delete(editor, sel, { mode: "blocks" });
-    PortableTextEditor.insertBlock(editor, "productReference", { slug: next });
-  };
-  return (
-    <div
-      className={`space-y-2 ${
-        isInvalid ? "rounded border border-red-500 p-2" : ""
-      }`}
-    >
-      <ProductPreview
-        slug={slug}
-        onValidChange={(valid) =>
-          ctx?.markValidity(props.value._key as string, valid, slug)
-        }
-      />
-      <div className="flex gap-2">
-        <Button type="button" variant="outline" onClick={edit}>
-          Edit
-        </Button>
-        <Button type="button" variant="outline" onClick={remove}>
-          Remove
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-const renderBlock: RenderBlockFunction = (props) => {
-  if (props.value._type === "productReference") {
-    return <ProductReferenceBlock {...props} />;
-  }
-  if (props.value._type === "embed") {
-    return (
-      <div className="aspect-video">
-        <iframe src={props.value.url} className="h-full w-full" />
-      </div>
-    );
-  }
-  if (props.value._type === "image") {
-    return (
-      <img
-        src={props.value.url}
-        alt={props.value.alt || ""}
-        className="max-w-full"
-      />
-    );
-  }
-  return <div>{props.children}</div>;
-};
-
-function Toolbar() {
-  const editor = useEditor();
-  const addLink = () => {
-    const href = prompt("URL");
-    if (!href) return;
-    if (PortableTextEditor.isAnnotationActive(editor, "link")) {
-      PortableTextEditor.removeAnnotation(editor, "link");
-    }
-    PortableTextEditor.addAnnotation(editor, "link", { href });
-  };
-  const addEmbed = () => {
-    const url = prompt("Embed URL");
-    if (url) PortableTextEditor.insertBlock(editor, "embed", { url });
-  };
-  const addImage = useCallback(
-    (url: string) => {
-      PortableTextEditor.insertBlock(editor, "image", { url });
-    },
-    [editor],
-  );
-  return (
-    <div className="flex flex-wrap gap-2">
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => PortableTextEditor.toggleMark(editor, "strong")}
-      >
-        Bold
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => PortableTextEditor.toggleMark(editor, "em")}
-      >
-        Italic
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => PortableTextEditor.toggleBlockStyle(editor, "h1")}
-      >
-        H1
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => PortableTextEditor.toggleBlockStyle(editor, "h2")}
-      >
-        H2
-      </Button>
-      <Button type="button" variant="outline" onClick={addLink}>
-        Link
-      </Button>
-      <Button type="button" variant="outline" onClick={addEmbed}>
-        Embed
-      </Button>
-      <ImagePicker onSelect={addImage}>
-        <Button type="button" variant="outline">
-          Image
-        </Button>
-      </ImagePicker>
-    </div>
-  );
-}
-
-function ProductSearch({
-  query,
-  setQuery,
-}: {
-  query: string;
-  setQuery: (v: string) => void;
-}) {
-  const editor = useEditor();
-  const [matches, setMatches] = useState<SKU[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!query) {
-      setMatches([]);
-      setError(null);
-      return;
-    }
-    const handle = setTimeout(async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/products?q=${encodeURIComponent(query)}`);
-        if (!res.ok) throw new Error("Failed to load products");
-        const data: SKU[] = await res.json();
-        setMatches(data);
-        setError(null);
-      } catch {
-        setError("Failed to load products");
-      } finally {
-        setLoading(false);
-      }
-    }, 300);
-    return () => clearTimeout(handle);
-  }, [query]);
-
-  return (
-    <div className="space-y-1">
-      <Input
-        label="Search products"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
-      {loading && <div>Loading…</div>}
-      {error && <div className="text-red-500">{error}</div>}
-      {query && !loading && !error && (
-        <ul className="space-y-1">
-          {matches.map((p) => (
-            <li key={p.slug}>
-              <Button
-                type="button"
-                variant="outline"
-                className="flex items-center gap-2"
-                onClick={() =>
-                  PortableTextEditor.insertBlock(editor, "productReference", {
-                    slug: p.slug,
-                  })
-                }
-              >
-                {p.image && (
-                  <img
-                    src={p.image}
-                    alt={p.title}
-                    className="h-8 w-8 object-cover"
-                  />
-                )}
-                <span className="flex-1 text-left">{p.title}</span>
-                <span className="text-sm">
-                  {(p.price / 100).toFixed(2)}
-                </span>
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-export default function PostForm({ action, submitLabel, post }: Props) {
+function PostFormContent({ action, submitLabel, post }: Props) {
   const [state, formAction] = useFormState(action, { message: "", error: "" });
   const [title, setTitle] = useState(post?.title ?? "");
   const [slug, setSlug] = useState(post?.slug ?? "");
@@ -455,30 +93,12 @@ export default function PostForm({ action, submitLabel, post }: Props) {
         ? JSON.parse(post.body)
         : [],
   );
-  const [query, setQuery] = useState("");
-  const [invalidProducts, setInvalidProducts] = useState<Record<string, string>>({});
-  const markValidity = useCallback(
-    (key: string, valid: boolean, slug: string) => {
-      setInvalidProducts((prev) => {
-        const next = { ...prev };
-        if (valid) {
-          delete next[key];
-        } else {
-          next[key] = slug;
-        }
-        return next;
-      });
-    },
-    [],
-  );
+  const { invalidProducts } = useInvalidProductContext();
   const hasInvalidProducts = Object.keys(invalidProducts).length > 0;
 
   return (
-    <InvalidProductContext.Provider
-      value={{ markValidity, invalidProducts }}
-    >
-      <div className="space-y-4">
-        <form action={formAction} className="space-y-4 max-w-xl">
+    <div className="space-y-4">
+      <form action={formAction} className="space-y-4 max-w-xl">
         <Input
           name="title"
           label="Title"
@@ -506,22 +126,8 @@ export default function PostForm({ action, submitLabel, post }: Props) {
           </div>
         </div>
         <Textarea name="excerpt" label="Excerpt" defaultValue={post?.excerpt ?? ""} />
-        <div className="space-y-2">
-          <label className="block font-medium">Main image</label>
-          <ImagePicker onSelect={(url) => setMainImage(url)}>
-            <Button type="button" variant="outline">
-              {mainImage ? "Change image" : "Select image"}
-            </Button>
-          </ImagePicker>
-          {mainImage && (
-            <img
-              src={mainImage}
-              alt="Main image"
-              className="h-32 w-auto rounded object-cover"
-            />
-          )}
-          <input type="hidden" name="mainImage" value={mainImage} />
-        </div>
+        <MainImageField value={mainImage} onChange={setMainImage} />
+        <input type="hidden" name="mainImage" value={mainImage} />
         <Input
           name="author"
           label="Author"
@@ -540,23 +146,7 @@ export default function PostForm({ action, submitLabel, post }: Props) {
           onChange={(e) => setPublishedAt(e.target.value)}
         />
         <div className="space-y-2">
-          <EditorProvider
-            initialConfig={{ schemaDefinition: schema, initialValue: content }}
-          >
-            <EventListenerPlugin
-              on={(event) => {
-                if (event.type === "mutation") {
-                  setContent(event.value as PortableTextBlock[]);
-                }
-              }}
-            />
-            <Toolbar />
-            <PortableTextEditable
-              className="min-h-[200px] rounded border p-2"
-              renderBlock={renderBlock}
-            />
-            <ProductSearch query={query} setQuery={setQuery} />
-          </EditorProvider>
+          <RichTextEditor value={content} onChange={setContent} />
         </div>
         <input
           type="hidden"
@@ -592,7 +182,14 @@ export default function PostForm({ action, submitLabel, post }: Props) {
           <PortableText value={content} components={previewComponents} />
         </div>
       </div>
-      </div>
-    </InvalidProductContext.Provider>
+    </div>
+  );
+}
+
+export default function PostForm(props: Props) {
+  return (
+    <InvalidProductProvider>
+      <PostFormContent {...props} />
+    </InvalidProductProvider>
   );
 }

--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import type { SKU } from "@acme/types";
+
+interface Props {
+  slug: string;
+  onValidChange?: (valid: boolean) => void;
+}
+
+export default function ProductPreview({ slug, onValidChange }: Props) {
+  const [product, setProduct] = useState<SKU | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/products?slug=${encodeURIComponent(slug)}`);
+        if (!res.ok) throw new Error("Failed to load product");
+        const data: SKU = await res.json();
+        if (active) {
+          setProduct(data);
+          setError(null);
+          onValidChange?.(true);
+        }
+      } catch {
+        if (active) {
+          setError("Failed to load product");
+          onValidChange?.(false);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      active = false;
+      onValidChange?.(true);
+    };
+  }, [slug, onValidChange]);
+
+  if (loading) return <div className="border p-2">Loading…</div>;
+  if (error || !product)
+    return <div className="border p-2 text-red-500">{error ?? "Not found"}</div>;
+  const available = (product.stock ?? 0) > 0;
+  return (
+    <div className="flex gap-2 border p-2">
+      {product.media?.[0] && (
+        <img
+          src={product.media[0].url}
+          alt={product.title}
+          className="h-16 w-16 object-cover"
+        />
+      )}
+      <div className="space-y-1">
+        <div className="font-semibold">{product.title}</div>
+        <div>{(product.price / 100).toFixed(2)}</div>
+        <div className="text-sm">
+          {available ? "In stock" : "Out of stock"}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/RichTextEditor.tsx
+++ b/apps/cms/src/app/cms/blog/posts/RichTextEditor.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect, useCallback } from "react";
+import { Button, Input, ImagePicker } from "@ui";
+import {
+  EditorProvider,
+  PortableTextEditable,
+  PortableTextEditor,
+  useEditor,
+} from "@portabletext/editor";
+import { EventListenerPlugin } from "@portabletext/editor/plugins";
+import type { PortableTextBlock } from "./schema";
+import { schema, renderBlock } from "./schema";
+import type { SKU } from "@acme/types";
+
+function Toolbar() {
+  const editor = useEditor();
+  const addLink = () => {
+    const href = prompt("URL");
+    if (!href) return;
+    if (PortableTextEditor.isAnnotationActive(editor, "link")) {
+      PortableTextEditor.removeAnnotation(editor, "link");
+    }
+    PortableTextEditor.addAnnotation(editor, "link", { href });
+  };
+  const addEmbed = () => {
+    const url = prompt("Embed URL");
+    if (url) PortableTextEditor.insertBlock(editor, "embed", { url });
+  };
+  const addImage = useCallback(
+    (url: string) => {
+      PortableTextEditor.insertBlock(editor, "image", { url });
+    },
+    [editor],
+  );
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => PortableTextEditor.toggleMark(editor, "strong")}
+      >
+        Bold
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => PortableTextEditor.toggleMark(editor, "em")}
+      >
+        Italic
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => PortableTextEditor.toggleBlockStyle(editor, "h1")}
+      >
+        H1
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => PortableTextEditor.toggleBlockStyle(editor, "h2")}
+      >
+        H2
+      </Button>
+      <Button type="button" variant="outline" onClick={addLink}>
+        Link
+      </Button>
+      <Button type="button" variant="outline" onClick={addEmbed}>
+        Embed
+      </Button>
+      <ImagePicker onSelect={addImage}>
+        <Button type="button" variant="outline">
+          Image
+        </Button>
+      </ImagePicker>
+    </div>
+  );
+}
+
+function ProductSearch({
+  query,
+  setQuery,
+}: {
+  query: string;
+  setQuery: (v: string) => void;
+}) {
+  const editor = useEditor();
+  const [matches, setMatches] = useState<SKU[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!query) {
+      setMatches([]);
+      setError(null);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/products?q=${encodeURIComponent(query)}`);
+        if (!res.ok) throw new Error("Failed to load products");
+        const data: SKU[] = await res.json();
+        setMatches(data);
+        setError(null);
+      } catch {
+        setError("Failed to load products");
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  return (
+    <div className="space-y-1">
+      <Input
+        label="Search products"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {loading && <div>Loading…</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {query && !loading && !error && (
+        <ul className="space-y-1">
+          {matches.map((p) => (
+            <li key={p.slug}>
+              <Button
+                type="button"
+                variant="outline"
+                className="flex items-center gap-2"
+                onClick={() =>
+                  PortableTextEditor.insertBlock(editor, "productReference", {
+                    slug: p.slug,
+                  })
+                }
+              >
+                {p.image && (
+                  <img
+                    src={p.image}
+                    alt={p.title}
+                    className="h-8 w-8 object-cover"
+                  />
+                )}
+                <span className="flex-1 text-left">{p.title}</span>
+                <span className="text-sm">{(p.price / 100).toFixed(2)}</span>
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function RichTextEditor({
+  value,
+  onChange,
+}: {
+  value: PortableTextBlock[];
+  onChange: (v: PortableTextBlock[]) => void;
+}) {
+  const [query, setQuery] = useState("");
+  return (
+    <EditorProvider initialConfig={{ schemaDefinition: schema, initialValue: value }}>
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === "mutation") {
+            onChange(event.value as PortableTextBlock[]);
+          }
+        }}
+      />
+      <Toolbar />
+      <PortableTextEditable
+        className="min-h-[200px] rounded border p-2"
+        renderBlock={renderBlock}
+      />
+      <ProductSearch query={query} setQuery={setQuery} />
+    </EditorProvider>
+  );
+}

--- a/apps/cms/src/app/cms/blog/posts/__tests__/MainImageField.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/MainImageField.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import MainImageField from "@cms/app/cms/blog/posts/MainImageField";
+
+jest.mock("@ui", () => ({
+  Button: ({ children }: any) => <button>{children}</button>,
+  ImagePicker: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe("MainImageField", () => {
+  it("shows select label when empty", () => {
+    render(<MainImageField value="" onChange={() => {}} />);
+    expect(screen.getByText("Select image")).toBeInTheDocument();
+  });
+  it("shows preview when value present", () => {
+    render(<MainImageField value="/test.png" onChange={() => {}} />);
+    expect(screen.getByAltText("Main image")).toHaveAttribute("src", "/test.png");
+    expect(screen.getByText("Change image")).toBeInTheDocument();
+  });
+});

--- a/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import ProductPreview from "@cms/app/cms/blog/posts/ProductPreview";
+
+describe("ProductPreview", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  it("renders product info", async () => {
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ title: "Test", price: 100 }),
+    });
+    const onValid = jest.fn();
+    render(<ProductPreview slug="t" onValidChange={onValid} />);
+    await screen.findByText("Test");
+    expect(onValid).toHaveBeenCalledWith(true);
+  });
+
+  it("handles error", async () => {
+    (global as any).fetch.mockRejectedValueOnce(new Error("fail"));
+    const onValid = jest.fn();
+    render(<ProductPreview slug="t" onValidChange={onValid} />);
+    await waitFor(() => expect(onValid).toHaveBeenCalledWith(false));
+  });
+});

--- a/apps/cms/src/app/cms/blog/posts/__tests__/RichTextEditor.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/RichTextEditor.spec.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import RichTextEditor from "@cms/app/cms/blog/posts/RichTextEditor";
+import type { PortableTextBlock } from "@cms/app/cms/blog/posts/schema";
+
+jest.mock("@ui", () => ({
+  Button: ({ children }: any) => <button>{children}</button>,
+  Input: (props: any) => <input {...props} />,
+  ImagePicker: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock("@portabletext/editor", () => ({
+  defineSchema: (x: any) => x,
+  EditorProvider: ({ children }: any) => <div>{children}</div>,
+  PortableTextEditable: () => <div />,
+  PortableTextEditor: {
+    insertBlock: jest.fn(),
+    toggleMark: jest.fn(),
+    toggleBlockStyle: jest.fn(),
+    addAnnotation: jest.fn(),
+    removeAnnotation: jest.fn(),
+    isAnnotationActive: jest.fn(),
+  },
+  useEditor: () => ({}),
+}));
+
+let captured: any;
+jest.mock("@portabletext/editor/plugins", () => ({
+  EventListenerPlugin: ({ on }: any) => {
+    captured = on;
+    return null;
+  },
+}));
+
+describe("RichTextEditor", () => {
+  it("invokes onChange on mutation", () => {
+    const onChange = jest.fn();
+    const initial: PortableTextBlock[] = [];
+    render(<RichTextEditor value={initial} onChange={onChange} />);
+    captured({ type: "mutation", value: [{ _type: "block", _key: "a" }] });
+    expect(onChange).toHaveBeenCalledWith([{ _type: "block", _key: "a" }]);
+  });
+});

--- a/apps/cms/src/app/cms/blog/posts/__tests__/invalidProductContext.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/invalidProductContext.spec.tsx
@@ -1,0 +1,18 @@
+import { renderHook, act } from "@testing-library/react";
+import {
+  InvalidProductProvider,
+  useInvalidProductContext,
+} from "@cms/app/cms/blog/posts/invalidProductContext";
+
+describe("InvalidProductContext", () => {
+  it("tracks invalid products", () => {
+    const wrapper = ({ children }: any) => (
+      <InvalidProductProvider>{children}</InvalidProductProvider>
+    );
+    const { result } = renderHook(() => useInvalidProductContext(), { wrapper });
+    act(() => result.current.markValidity("k1", false, "p1"));
+    expect(result.current.invalidProducts).toEqual({ k1: "p1" });
+    act(() => result.current.markValidity("k1", true, "p1"));
+    expect(result.current.invalidProducts).toEqual({});
+  });
+});

--- a/apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.ts
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.ts
@@ -1,0 +1,14 @@
+import { schema } from "@cms/app/cms/blog/posts/schema";
+
+jest.mock("@ui", () => ({ Button: () => null }));
+jest.mock("@portabletext/editor", () => ({ defineSchema: (x: any) => x }));
+
+describe("schema", () => {
+  it("includes productReference block", () => {
+    const block = (schema.blockObjects as any[]).find(
+      (b) => b.name === "productReference",
+    );
+    expect(block).toBeTruthy();
+    expect(block.fields).toEqual([{ name: "slug", type: "string" }]);
+  });
+});

--- a/apps/cms/src/app/cms/blog/posts/invalidProductContext.tsx
+++ b/apps/cms/src/app/cms/blog/posts/invalidProductContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+
+interface InvalidProductContextValue {
+  invalidProducts: Record<string, string>;
+  markValidity: (key: string, valid: boolean, slug: string) => void;
+}
+
+export const InvalidProductContext = createContext<InvalidProductContextValue | null>(null);
+
+export function InvalidProductProvider({ children }: { children: ReactNode }) {
+  const [invalidProducts, setInvalidProducts] = useState<Record<string, string>>({});
+  const markValidity = useCallback((key: string, valid: boolean, slug: string) => {
+    setInvalidProducts((prev) => {
+      const next = { ...prev };
+      if (valid) {
+        delete next[key];
+      } else {
+        next[key] = slug;
+      }
+      return next;
+    });
+  }, []);
+  return (
+    <InvalidProductContext.Provider value={{ invalidProducts, markValidity }}>
+      {children}
+    </InvalidProductContext.Provider>
+  );
+}
+
+export function useInvalidProductContext() {
+  const ctx = useContext(InvalidProductContext);
+  if (!ctx) throw new Error("useInvalidProductContext must be used within InvalidProductProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- extract rich text schema and block rendering into `schema.ts`
- encapsulate invalid product tracking in `invalidProductContext`
- split image, preview and editor logic into dedicated components with tests

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/blog/posts/*.ts apps/cms/src/app/cms/blog/posts/*.tsx`
- `pnpm test:cms apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx apps/cms/src/app/cms/blog/posts/__tests__/MainImageField.spec.tsx apps/cms/src/app/cms/blog/posts/__tests__/invalidProductContext.spec.tsx apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.ts apps/cms/src/app/cms/blog/posts/__tests__/RichTextEditor.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d8ebcd2ec832fa0b36d200dee52eb