### PR TITLE
refactor: extract canvas hooks and text block

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx
@@ -1,0 +1,63 @@
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import useCanvasDrag from "../useCanvasDrag";
+
+// jsdom may not define PointerEvent
+if (typeof window !== "undefined" && !(window as any).PointerEvent) {
+  (window as any).PointerEvent = MouseEvent as any;
+}
+
+test("moves element", () => {
+  const dispatch = jest.fn();
+  function Wrapper() {
+    const ref = React.useRef<HTMLDivElement>(null);
+    const { startDrag } = useCanvasDrag({
+      componentId: "c1",
+      dispatch,
+      gridCols: 12,
+      containerRef: ref,
+    });
+    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+  }
+  const { getByTestId } = render(<Wrapper />);
+  const box = getByTestId("box") as HTMLElement;
+  Object.defineProperty(box, "offsetLeft", { value: 0, writable: true });
+  Object.defineProperty(box, "offsetTop", { value: 0, writable: true });
+  Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
+  Object.defineProperty(box, "offsetHeight", { value: 100, writable: true });
+  fireEvent.pointerDown(box, { clientX: 0, clientY: 0 });
+  fireEvent.pointerMove(window, { clientX: 50, clientY: 60 });
+  fireEvent.pointerUp(window);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({ left: "50px", top: "60px" })
+  );
+});
+
+test("snaps to grid units", () => {
+  const dispatch = jest.fn();
+  function Wrapper() {
+    const ref = React.useRef<HTMLDivElement>(null);
+    const { startDrag } = useCanvasDrag({
+      componentId: "c1",
+      dispatch,
+      gridEnabled: true,
+      gridCols: 4,
+      containerRef: ref,
+    });
+    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+  }
+  const { getByTestId } = render(<Wrapper />);
+  const box = getByTestId("box") as HTMLElement;
+  const parent = box.parentElement as HTMLElement;
+  Object.defineProperty(parent, "offsetWidth", { value: 400, writable: true });
+  Object.defineProperty(box, "offsetLeft", { value: 0, writable: true });
+  Object.defineProperty(box, "offsetTop", { value: 0, writable: true });
+  Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
+  Object.defineProperty(box, "offsetHeight", { value: 100, writable: true });
+  fireEvent.pointerDown(box, { clientX: 0, clientY: 0 });
+  fireEvent.pointerMove(window, { clientX: 130, clientY: 130 });
+  fireEvent.pointerUp(window);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({ left: "100px", top: "100px" })
+  );
+});

--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasResize.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasResize.test.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import useCanvasResize from "../useCanvasResize";
+
+// jsdom may not define PointerEvent
+if (typeof window !== "undefined" && !(window as any).PointerEvent) {
+  (window as any).PointerEvent = MouseEvent as any;
+}
+
+test("resizes element", () => {
+  const dispatch = jest.fn();
+  function Wrapper() {
+    const ref = React.useRef<HTMLDivElement>(null);
+    const { startResize } = useCanvasResize({
+      componentId: "c1",
+      widthKey: "widthDesktop",
+      heightKey: "heightDesktop",
+      widthVal: "100px",
+      heightVal: "100px",
+      dispatch,
+      gridCols: 12,
+      containerRef: ref,
+    });
+    return <div ref={ref} onPointerDown={startResize} data-testid="box" />;
+  }
+  const { getByTestId } = render(<Wrapper />);
+  const box = getByTestId("box") as HTMLElement;
+  Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
+  Object.defineProperty(box, "offsetHeight", { value: 100, writable: true });
+  Object.defineProperty(box, "offsetLeft", { value: 0, writable: true });
+  Object.defineProperty(box, "offsetTop", { value: 0, writable: true });
+  fireEvent.pointerDown(box, { clientX: 100, clientY: 100 });
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 150 });
+  fireEvent.pointerUp(window);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({ widthDesktop: "150px", heightDesktop: "150px" })
+  );
+});
+
+test("snaps to grid units", () => {
+  const dispatch = jest.fn();
+  function Wrapper() {
+    const ref = React.useRef<HTMLDivElement>(null);
+    const { startResize } = useCanvasResize({
+      componentId: "c1",
+      widthKey: "widthDesktop",
+      heightKey: "heightDesktop",
+      widthVal: "100px",
+      heightVal: "100px",
+      dispatch,
+      gridEnabled: true,
+      gridCols: 4,
+      containerRef: ref,
+    });
+    return <div ref={ref} onPointerDown={startResize} data-testid="box" />;
+  }
+  const { getByTestId } = render(<Wrapper />);
+  const box = getByTestId("box") as HTMLElement;
+  const parent = box.parentElement as HTMLElement;
+  Object.defineProperty(parent, "offsetWidth", { value: 400, writable: true });
+  Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
+  Object.defineProperty(box, "offsetHeight", { value: 100, writable: true });
+  Object.defineProperty(box, "offsetLeft", { value: 0, writable: true });
+  Object.defineProperty(box, "offsetTop", { value: 0, writable: true });
+  fireEvent.pointerDown(box, { clientX: 100, clientY: 100 });
+  fireEvent.pointerMove(window, { clientX: 175, clientY: 175 });
+  fireEvent.pointerUp(window);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({ widthDesktop: "200px", heightDesktop: "200px" })
+  );
+});

--- a/packages/ui/src/components/cms/page-builder/gridSnap.ts
+++ b/packages/ui/src/components/cms/page-builder/gridSnap.ts
@@ -1,0 +1,4 @@
+export const snapToGrid = (value: number, gridSize: number) =>
+  Math.round(value / gridSize) * gridSize;
+
+export default snapToGrid;

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -34,3 +34,5 @@ export { default as PageCanvas } from "./PageCanvas";
 export { default as PageSidebar } from "./PageSidebar";
 export { historyStateSchema, reducer } from "./state";
 export { default as usePageBuilderDrag } from "./usePageBuilderDrag";
+export { default as useCanvasDrag } from "./useCanvasDrag";
+export { default as useCanvasResize } from "./useCanvasResize";

--- a/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
@@ -1,0 +1,112 @@
+import { useState, useRef, useEffect } from "react";
+import type { Action } from "./state";
+import useGuides from "./useGuides";
+import { snapToGrid } from "./gridSnap";
+
+interface Options {
+  componentId: string;
+  dispatch: React.Dispatch<Action>;
+  gridEnabled?: boolean;
+  gridCols: number;
+  containerRef: React.RefObject<HTMLDivElement>;
+  disabled?: boolean;
+}
+
+export default function useCanvasDrag({
+  componentId,
+  dispatch,
+  gridEnabled = false,
+  gridCols,
+  containerRef,
+  disabled = false,
+}: Options) {
+  const moveRef = useRef<{ x: number; y: number; l: number; t: number } | null>(
+    null
+  );
+  const [moving, setMoving] = useState(false);
+  const { guides, setGuides, siblingEdgesRef, computeSiblingEdges } = useGuides(
+    containerRef
+  );
+
+  useEffect(() => {
+    if (!moving) return;
+    const handleMove = (e: PointerEvent) => {
+      if (!moveRef.current || !containerRef.current) return;
+      const dx = e.clientX - moveRef.current.x;
+      const dy = e.clientY - moveRef.current.y;
+      let newL = moveRef.current.l + dx;
+      let newT = moveRef.current.t + dy;
+      const threshold = 10;
+      let guideX: number | null = null;
+      let guideY: number | null = null;
+      const width = containerRef.current.offsetWidth;
+      const height = containerRef.current.offsetHeight;
+      siblingEdgesRef.current.vertical.forEach((edge) => {
+        if (Math.abs(newL - edge) <= threshold) {
+          newL = edge;
+          guideX = edge;
+        }
+        if (Math.abs(newL + width - edge) <= threshold) {
+          newL = edge - width;
+          guideX = edge;
+        }
+      });
+      siblingEdgesRef.current.horizontal.forEach((edge) => {
+        if (Math.abs(newT - edge) <= threshold) {
+          newT = edge;
+          guideY = edge;
+        }
+        if (Math.abs(newT + height - edge) <= threshold) {
+          newT = edge - height;
+          guideY = edge;
+        }
+      });
+      if (gridEnabled) {
+        const parent = containerRef.current.parentElement;
+        const unit = parent ? parent.offsetWidth / gridCols : null;
+        if (unit) {
+          newL = snapToGrid(newL, unit);
+          newT = snapToGrid(newT, unit);
+        }
+      }
+      dispatch({
+        type: "resize",
+        id: componentId,
+        left: `${newL}px`,
+        top: `${newT}px`,
+      });
+      setGuides({
+        x: guideX !== null ? guideX - newL : null,
+        y: guideY !== null ? guideY - newT : null,
+      });
+    };
+    const stop = () => {
+      setMoving(false);
+      setGuides({ x: null, y: null });
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", stop);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", stop);
+    };
+  }, [moving, componentId, dispatch, gridEnabled, gridCols, setGuides, siblingEdgesRef, containerRef]);
+
+  const startDrag = (e: React.PointerEvent) => {
+    if (disabled) return;
+    const el = containerRef.current;
+    if (!el) return;
+    moveRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+      l: el.offsetLeft,
+      t: el.offsetTop,
+    };
+    computeSiblingEdges();
+    setMoving(true);
+  };
+
+  const snapping = guides.x !== null || guides.y !== null;
+
+  return { startDrag, guides, snapping, moving } as const;
+}

--- a/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
@@ -1,0 +1,143 @@
+import { useState, useRef, useEffect } from "react";
+import type { Action } from "./state";
+import useGuides from "./useGuides";
+import { snapToGrid } from "./gridSnap";
+
+interface Options {
+  componentId: string;
+  widthKey: string;
+  heightKey: string;
+  widthVal?: string;
+  heightVal?: string;
+  dispatch: React.Dispatch<Action>;
+  gridEnabled?: boolean;
+  gridCols: number;
+  containerRef: React.RefObject<HTMLDivElement>;
+  disabled?: boolean;
+}
+
+export default function useCanvasResize({
+  componentId,
+  widthKey,
+  heightKey,
+  widthVal,
+  heightVal,
+  dispatch,
+  gridEnabled = false,
+  gridCols,
+  containerRef,
+  disabled = false,
+}: Options) {
+  const startRef = useRef<{ x: number; y: number; w: number; h: number } | null>(
+    null
+  );
+  const [resizing, setResizing] = useState(false);
+  const [snapWidth, setSnapWidth] = useState(false);
+  const [snapHeight, setSnapHeight] = useState(false);
+  const { guides, setGuides, siblingEdgesRef, computeSiblingEdges } = useGuides(
+    containerRef
+  );
+
+  useEffect(() => {
+    if (!resizing) return;
+    const handleMove = (e: PointerEvent) => {
+      if (!startRef.current || !containerRef.current) return;
+      const dx = e.clientX - startRef.current.x;
+      const dy = e.clientY - startRef.current.y;
+      const parent = containerRef.current.parentElement;
+      const parentW = parent?.offsetWidth ?? startRef.current.w + dx;
+      const parentH = parent?.offsetHeight ?? startRef.current.h + dy;
+      let newW = startRef.current.w + dx;
+      let newH = startRef.current.h + dy;
+      const threshold = 10;
+      const left = containerRef.current.offsetLeft;
+      const top = containerRef.current.offsetTop;
+      let guideX: number | null = null;
+      let guideY: number | null = null;
+      siblingEdgesRef.current.vertical.forEach((edge) => {
+        const right = left + newW;
+        if (Math.abs(right - edge) <= threshold) {
+          newW = edge - left;
+          guideX = edge;
+        }
+      });
+      siblingEdgesRef.current.horizontal.forEach((edge) => {
+        const bottom = top + newH;
+        if (Math.abs(bottom - edge) <= threshold) {
+          newH = edge - top;
+          guideY = edge;
+        }
+      });
+      const snapW = e.shiftKey || Math.abs(parentW - newW) <= threshold;
+      const snapH = e.shiftKey || Math.abs(parentH - newH) <= threshold;
+      if (gridEnabled) {
+        const unit = parent ? parent.offsetWidth / gridCols : null;
+        if (unit) {
+          newW = snapToGrid(newW, unit);
+          newH = snapToGrid(newH, unit);
+        }
+      }
+      dispatch({
+        type: "resize",
+        id: componentId,
+        [widthKey]: snapW ? "100%" : `${newW}px`,
+        [heightKey]: snapH ? "100%" : `${newH}px`,
+      } as any);
+      setSnapWidth(snapW || guideX !== null);
+      setSnapHeight(snapH || guideY !== null);
+      setGuides({
+        x: guideX !== null ? guideX - left : null,
+        y: guideY !== null ? guideY - top : null,
+      });
+    };
+    const stop = () => {
+      setResizing(false);
+      setSnapWidth(false);
+      setSnapHeight(false);
+      setGuides({ x: null, y: null });
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", stop);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", stop);
+    };
+  }, [
+    resizing,
+    componentId,
+    dispatch,
+    gridEnabled,
+    gridCols,
+    widthKey,
+    heightKey,
+    setGuides,
+    siblingEdgesRef,
+    containerRef,
+  ]);
+
+  const startResize = (e: React.PointerEvent) => {
+    if (disabled) return;
+    e.stopPropagation();
+    const el = containerRef.current;
+    if (!el) return;
+    const startWidth =
+      widthVal && widthVal.endsWith("px") ? parseFloat(widthVal) : el.offsetWidth;
+    const startHeight =
+      heightVal && heightVal.endsWith("px")
+        ? parseFloat(heightVal)
+        : el.offsetHeight;
+    startRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+      w: startWidth,
+      h: startHeight,
+    };
+    computeSiblingEdges();
+    setResizing(true);
+  };
+
+  const snapping =
+    snapWidth || snapHeight || guides.x !== null || guides.y !== null;
+
+  return { startResize, guides, snapping, resizing } as const;
+}

--- a/packages/ui/src/components/cms/page-builder/useGuides.ts
+++ b/packages/ui/src/components/cms/page-builder/useGuides.ts
@@ -1,0 +1,33 @@
+import { useState, useRef } from "react";
+
+export interface Guides {
+  x: number | null;
+  y: number | null;
+}
+
+export default function useGuides(
+  containerRef: React.RefObject<HTMLElement>
+) {
+  const siblingEdgesRef = useRef<{ vertical: number[]; horizontal: number[] }>(
+    { vertical: [], horizontal: [] }
+  );
+  const [guides, setGuides] = useState<Guides>({ x: null, y: null });
+
+  const computeSiblingEdges = () => {
+    const el = containerRef.current;
+    const parent = el?.parentElement;
+    if (!el || !parent) return { vertical: [], horizontal: [] };
+    const vertical: number[] = [];
+    const horizontal: number[] = [];
+    Array.from(parent.children).forEach((child) => {
+      if (child === el) return;
+      const c = child as HTMLElement;
+      vertical.push(c.offsetLeft, c.offsetLeft + c.offsetWidth);
+      horizontal.push(c.offsetTop, c.offsetTop + c.offsetHeight);
+    });
+    siblingEdgesRef.current = { vertical, horizontal };
+    return siblingEdgesRef.current;
+  };
+
+  return { guides, setGuides, siblingEdgesRef, computeSiblingEdges };
+}

--- a/packages/ui/src/components/cms/page-builder/usePageBuilderDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/usePageBuilderDrag.ts
@@ -11,6 +11,7 @@ import { ulid } from "ulid";
 import { useCallback } from "react";
 import type { PageComponent } from "@acme/types";
 import type { Action } from "./state";
+import { snapToGrid } from "./gridSnap";
 
 interface Params {
   components: PageComponent[];
@@ -21,9 +22,6 @@ interface Params {
   selectId: (id: string) => void;
   gridSize?: number;
 }
-
-export const snapToGrid = (value: number, gridSize: number) =>
-  Math.round(value / gridSize) * gridSize;
 
 export function usePageBuilderDrag({
   components,


### PR DESCRIPTION
## Summary
- extract grid snap utility and guide calculations into reusable modules
- add `useCanvasDrag` and `useCanvasResize` hooks with tests
- move text editing to new `TextBlock` component and simplify `CanvasItem`

## Testing
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useCanvasResize.test.tsx packages/ui/__tests__/CanvasItem.test.tsx packages/ui/__tests__/PageBuilder.drag-resize.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d8ec05590832fb21012c52701daa6