### PR TITLE
refactor inventory repository interface

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts
@@ -2,7 +2,7 @@ import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { inventoryItemSchema } from "@acme/types";
-import { updateInventoryItem } from "@platform-core/repositories/inventory.server";
+import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 
 export async function PATCH(
   req: NextRequest,
@@ -24,7 +24,7 @@ export async function PATCH(
     const { shop, sku } = await context.params;
     const patch = parsed.data;
     const variantAttributes = patch.variantAttributes ?? {};
-    const updated = await updateInventoryItem(
+    const updated = await inventoryRepository.update(
       shop,
       sku,
       variantAttributes,

--- a/apps/cms/src/app/api/data/[shop]/inventory/export/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/export/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { readInventory } from "@platform-core/repositories/inventory.server";
+import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 import { format as formatCsv } from "fast-csv";
 import { flattenInventoryItem } from "@platform-core/utils/inventory";
 
@@ -15,7 +15,7 @@ export async function GET(
   }
   try {
     const { shop } = await context.params;
-    const items = await readInventory(shop);
+    const items = await inventoryRepository.read(shop);
     const format = new URL(req.url).searchParams.get("format");
     if (format === "csv") {
       const csv = await new Promise<string>((resolve, reject) => {

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -2,7 +2,7 @@ import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { inventoryItemSchema } from "@acme/types";
-import { writeInventory } from "@platform-core/repositories/inventory.server";
+import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 import { expandInventoryItem } from "@platform-core/utils/inventory";
 import { parse } from "fast-csv";
 import { Readable } from "node:stream";
@@ -48,7 +48,7 @@ export async function POST(
       );
     }
     const { shop } = await context.params;
-    await writeInventory(shop, parsed.data);
+    await inventoryRepository.write(shop, parsed.data);
     return NextResponse.json({ success: true, items: parsed.data });
   } catch (err) {
     return NextResponse.json(

--- a/apps/cms/src/app/api/data/[shop]/inventory/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/route.ts
@@ -2,7 +2,7 @@ import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { inventoryItemSchema } from "@acme/types";
-import { writeInventory } from "@platform-core/repositories/inventory.server";
+import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 
 export async function POST(
   req: NextRequest,
@@ -22,7 +22,7 @@ export async function POST(
       );
     }
     const { shop } = await context.params;
-    await writeInventory(shop, parsed.data);
+    await inventoryRepository.write(shop, parsed.data);
     return NextResponse.json({ success: true });
   } catch (err) {
     return NextResponse.json(

--- a/packages/platform-core/src/repositories/inventory.types.ts
+++ b/packages/platform-core/src/repositories/inventory.types.ts
@@ -1,0 +1,16 @@
+import type { InventoryItem } from "@acme/types";
+
+export type InventoryMutateFn = (
+  current: InventoryItem | undefined,
+) => InventoryItem | undefined;
+
+export interface InventoryRepository {
+  read(shop: string): Promise<InventoryItem[]>;
+  write(shop: string, items: InventoryItem[]): Promise<void>;
+  update(
+    shop: string,
+    sku: string,
+    variantAttributes: Record<string, string>,
+    mutate: InventoryMutateFn,
+  ): Promise<InventoryItem | undefined>;
+}


### PR DESCRIPTION
## Summary
- define `InventoryRepository` interface for read/write/update
- add JSON and SQLite implementations behind a thin adapter
- update CMS inventory routes to use the repository

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard'...)*
- `pnpm exec jest packages/platform-core/__tests__/inventory.test.ts --runInBand`
- `pnpm exec eslint packages/platform-core/src/repositories/inventory.types.ts packages/platform-core/src/repositories/inventory.json.server.ts packages/platform-core/src/repositories/inventory.sqlite.server.ts packages/platform-core/src/repositories/inventory.server.ts apps/cms/src/app/api/data/[shop]/inventory/route.ts apps/cms/src/app/api/data/[shop]/inventory/export/route.ts apps/cms/src/app/api/data/[shop]/inventory/import/route.ts apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts` *(warnings: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689d909d7a70832f8e64cf52b2210d7a