### PR TITLE
Add drop-off provider and tracking support for returns

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
@@ -13,7 +13,13 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   try {
-    const body = await req.json();
+    const raw = await req.json();
+    const body = {
+      ...raw,
+      dropOffProvider: raw.dropOffProvider || undefined,
+      tracking:
+        typeof raw.tracking === "boolean" ? raw.tracking : undefined,
+    };
     const parsed = returnLogisticsSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -61,6 +61,27 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         />
         <span>Allow in-store returns</span>
       </label>
+      <label className="flex flex-col gap-1">
+        <span>Drop-off Provider</span>
+        <Input
+          value={form.dropOffProvider ?? ""}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              dropOffProvider: e.target.value || undefined,
+            }))
+          }
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        <Checkbox
+          checked={form.tracking ?? false}
+          onCheckedChange={(v) =>
+            setForm((f) => ({ ...f, tracking: Boolean(v) }))
+          }
+        />
+        <span>Include tracking numbers</span>
+      </label>
       {status === "saved" && (
         <p className="text-sm text-green-600">Saved!</p>
       )}

--- a/apps/shop-abc/src/app/[lang]/returns/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/returns/page.tsx
@@ -9,10 +9,20 @@ export default async function ReturnPolicyPage() {
     <div className="p-6 space-y-4">
       <h1 className="text-xl font-semibold">Return policy</h1>
       <p>Return labels provided by {cfg.labelService}.</p>
-      {cfg.dropOffProvider && <p>Drop-off: {cfg.dropOffProvider}</p>}
+      {cfg.dropOffProvider && (
+        <p>
+          Drop-off via {cfg.dropOffProvider}.
+          {cfg.dropOffProvider === "UPS" &&
+            " Bring your package and label to any UPS store or drop box."}
+        </p>
+      )}
       <p>In-store returns {cfg.inStore ? "available" : "unavailable"}.</p>
       {typeof cfg.tracking !== "undefined" && (
-        <p>Tracking {cfg.tracking ? "enabled" : "disabled"}.</p>
+        <p>
+          {cfg.tracking
+            ? "Shipments include tracking numbers."
+            : "Tracking numbers are not provided."}
+        </p>
       )}
     </div>
   );

--- a/apps/shop-abc/src/app/account/orders/[id]/page.tsx
+++ b/apps/shop-abc/src/app/account/orders/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getCustomerSession, hasPermission } from "@auth";
 import { getOrdersForCustomer } from "@platform-core/orders";
 import { OrderTrackingTimeline, type OrderStep } from "@ui/components/organisms/OrderTrackingTimeline";
 import { redirect } from "next/navigation";
+import { useState } from "react";
 import shop from "../../../../../shop.json";
 
 export const metadata = { title: "Order details" };
@@ -43,6 +44,60 @@ export default async function Page({
       {steps && steps.length > 0 && (
         <OrderTrackingTimeline steps={steps} className="mt-2" />
       )}
+      <StartReturn orderId={order.id} />
+    </div>
+  );
+}
+
+function StartReturn({ orderId }: { orderId: string }) {
+  "use client";
+  const [result, setResult] = useState<
+    | { labelUrl: string; trackingNumber?: string | undefined }
+    | null
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = async () => {
+    try {
+      setError(null);
+      const res = await fetch("/api/return", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: orderId }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        throw new Error(data.error || "Failed to start return");
+      }
+      setResult({
+        labelUrl: data.labelUrl,
+        trackingNumber: data.tracking?.number,
+      });
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={onClick}
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        Start return
+      </button>
+      {result && (
+        <div className="space-y-1">
+          <p>
+            Label: {" "}
+            <a href={result.labelUrl} className="text-blue-600 underline">
+              {result.labelUrl}
+            </a>
+          </p>
+          {result.trackingNumber && <p>Tracking #: {result.trackingNumber}</p>}
+        </div>
+      )}
+      {error && <p className="text-red-600">{error}</p>}
     </div>
   );
 }

--- a/apps/shop-abc/src/app/api/return/route.ts
+++ b/apps/shop-abc/src/app/api/return/route.ts
@@ -4,6 +4,7 @@ import "@acme/lib/initZod";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
 
 export const runtime = "edge";
 
@@ -19,6 +20,12 @@ export async function POST(req: NextRequest) {
   const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
   if (!parsed.success) return parsed.response;
   const { sessionId } = parsed.data;
+  const cfg = await getReturnLogistics();
   const { trackingNumber, labelUrl } = createUpsLabel(sessionId);
-  return NextResponse.json({ ok: true, trackingNumber, labelUrl });
+  return NextResponse.json({
+    ok: true,
+    dropOffProvider: cfg.dropOffProvider,
+    labelUrl,
+    tracking: { number: trackingNumber, url: labelUrl },
+  });
 }

--- a/packages/types/src/ReturnLogistics.d.ts
+++ b/packages/types/src/ReturnLogistics.d.ts
@@ -4,16 +4,23 @@ import { z } from "zod";
  *
  * - `labelService` specifies the provider used to create return shipping labels.
  * - `inStore` toggles whether items can be dropped off in store.
+ * - `dropOffProvider` names the third-party drop-off service, if any.
+ * - `tracking` indicates whether return shipments include tracking numbers.
  */
 export declare const returnLogisticsSchema: z.ZodObject<{
     labelService: z.ZodString;
     inStore: z.ZodBoolean;
+    dropOffProvider: z.ZodOptional<z.ZodString>;
+    tracking: z.ZodOptional<z.ZodBoolean>;
 }, "strip", z.ZodTypeAny, {
     labelService: string;
     inStore: boolean;
+    dropOffProvider?: string | undefined;
+    tracking?: boolean | undefined;
 }, {
     labelService: string;
     inStore: boolean;
+    dropOffProvider?: string | undefined;
+    tracking?: boolean | undefined;
 }>;
 export type ReturnLogistics = z.infer<typeof returnLogisticsSchema>;
-//# sourceMappingURL=ReturnLogistics.d.ts.map


### PR DESCRIPTION
## Summary
- extend return logistics form to configure drop-off provider and tracking
- surface drop-off provider and tracking details via API routes
- allow customers to start returns from order page and view label & tracking info

## Testing
- `pnpm test --filter @apps/shop-abc`
- `pnpm lint` *(fails: ERR_MODULE_NOT_FOUND in apps/cms)*

------
https://chatgpt.com/codex/tasks/task_e_689d908da798832fab397f3bc0be6f6d