### PR TITLE
feat: add drag overlay and snap lines

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -330,9 +330,10 @@ const CanvasItem = memo(function CanvasItem({
         ...(component.left ? { left: component.left } : {}),
       }}
       className={
-        "relative rounded border" +
+        "relative rounded border hover:border-dashed hover:border-primary" +
         (selected ? " ring-2 ring-blue-500" : "") +
-        (snapping ? " border-primary" : "")
+        (snapping ? " border-primary" : "") +
+        ((isOver || isDragging) ? " border-dashed border-primary" : "")
       }
     >
       <div
@@ -444,8 +445,8 @@ const CanvasItem = memo(function CanvasItem({
           >
             {isOver && (
               <div
-                data-testid="drop-placeholder"
-                className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10"
+                data-placeholder
+                className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10 ring-2 ring-primary"
               />
             )}
             {(component as any).children.map(

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -1,9 +1,3 @@
-import {
-  DndContext,
-  DragEndEvent,
-  DragMoveEvent,
-  closestCenter,
-} from "@dnd-kit/core";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import type { CSSProperties, DragEvent } from "react";
 import { Fragment } from "react";
@@ -17,9 +11,6 @@ interface Props {
   components: PageComponent[];
   selectedId: string | null;
   onSelectId: (id: string | null) => void;
-  sensors: any;
-  handleDragMove: (ev: DragMoveEvent) => void;
-  handleDragEnd: (ev: DragEndEvent) => void;
   canvasRef: React.RefObject<HTMLDivElement>;
   dragOver: boolean;
   setDragOver: (v: boolean) => void;
@@ -31,15 +22,13 @@ interface Props {
   showGrid?: boolean;
   gridCols: number;
   viewport: "desktop" | "tablet" | "mobile";
+  snapPosition: number | null;
 }
 
 const PageCanvas = ({
   components,
   selectedId,
   onSelectId,
-  sensors,
-  handleDragMove,
-  handleDragEnd,
   canvasRef,
   dragOver,
   setDragOver,
@@ -51,80 +40,86 @@ const PageCanvas = ({
   showGrid = false,
   gridCols,
   viewport,
+  snapPosition,
 }: Props) => (
-  <DndContext
-    sensors={sensors}
-    collisionDetection={closestCenter}
-    onDragEnd={handleDragEnd}
-    onDragMove={handleDragMove}
+  <SortableContext
+    items={components.map((c) => c.id)}
+    strategy={rectSortingStrategy}
   >
-    <SortableContext
-      items={components.map((c) => c.id)}
-      strategy={rectSortingStrategy}
+    <div
+      id="canvas"
+      ref={canvasRef}
+      style={containerStyle}
+      role="list"
+      aria-dropeffect="move"
+      onDrop={onFileDrop}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDragEnd={() => setDragOver(false)}
+      className={cn(
+        "relative mx-auto flex flex-col gap-4 rounded border",
+        dragOver && "ring-2 ring-primary"
+      )}
     >
-      <div
-        id="canvas"
-        ref={canvasRef}
-        style={containerStyle}
-        role="list"
-        aria-dropeffect="move"
-        onDrop={onFileDrop}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDragOver(true);
-        }}
-        onDragLeave={() => setDragOver(false)}
-        onDragEnd={() => setDragOver(false)}
-        className={cn(
-          "relative mx-auto flex flex-col gap-4 rounded border",
-          dragOver && "ring-2 ring-primary"
-        )}
-      >
-        {showGrid && (
-          <div
-            className="pointer-events-none absolute inset-0 z-10 grid"
-            style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
-          >
-            {Array.from({ length: gridCols }).map((_, i) => (
-              <div
-                key={i}
-                className="border-l border-dashed border-muted-foreground/40"
-              />
-            ))}
-          </div>
-        )}
-        {components.map((c, i) => (
-          <Fragment key={c.id}>
-            {insertIndex === i && (
-              <div
-                data-placeholder
-                className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10"
-              />
-            )}
-            <CanvasItem
-              component={c}
-              index={i}
-              parentId={undefined}
-              selectedId={selectedId}
-              onSelectId={onSelectId}
-              onRemove={() => dispatch({ type: "remove", id: c.id })}
-              dispatch={dispatch}
-              locale={locale}
-              gridEnabled={showGrid}
-              gridCols={gridCols}
-              viewport={viewport}
+      {showGrid && (
+        <div
+          className="pointer-events-none absolute inset-0 z-10 grid"
+          style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
+        >
+          {Array.from({ length: gridCols }).map((_, i) => (
+            <div
+              key={i}
+              className="border-l border-dashed border-muted-foreground/40"
             />
-          </Fragment>
-        ))}
-        {insertIndex === components.length && (
-          <div
-            data-placeholder
-            className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10"
+          ))}
+        </div>
+      )}
+      {snapPosition !== null && (
+        <div
+          className="pointer-events-none absolute top-0 bottom-0 w-px bg-primary"
+          style={{ left: snapPosition }}
+        />
+      )}
+      {components.map((c, i) => (
+        <Fragment key={c.id}>
+          {insertIndex === i && (
+            <div
+              data-placeholder
+              className={cn(
+                "h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10",
+                snapPosition !== null && "ring-2 ring-primary"
+              )}
+            />
+          )}
+          <CanvasItem
+            component={c}
+            index={i}
+            parentId={undefined}
+            selectedId={selectedId}
+            onSelectId={onSelectId}
+            onRemove={() => dispatch({ type: "remove", id: c.id })}
+            dispatch={dispatch}
+            locale={locale}
+            gridEnabled={showGrid}
+            gridCols={gridCols}
+            viewport={viewport}
           />
-        )}
-      </div>
-    </SortableContext>
-  </DndContext>
+        </Fragment>
+      ))}
+      {insertIndex === components.length && (
+        <div
+          data-placeholder
+          className={cn(
+            "h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10",
+            snapPosition !== null && "ring-2 ring-primary"
+          )}
+        />
+      )}
+    </div>
+  </SortableContext>
 );
 
 export default PageCanvas;


### PR DESCRIPTION
## Summary
- show snap lines and highlight drop targets on page canvas
- add dashed outlines for hovered/dragged canvas items
- snap drag positions to grid and display drag overlay preview

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689d922a45f8832f89183008c456d67b