### PR TITLE
feat: add configurator progress and navigation

### DIFF
--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { steps } from "../steps";
+import { orderedSteps, steps, StepProgress } from "../steps";
 
 interface Props {
   stepId: string;
@@ -13,6 +13,13 @@ export default function StepPage({ stepId }: Props) {
   }
 
   const StepComponent = step.component as React.ComponentType<any>;
+  const prev = orderedSteps[step.index - 1];
+  const next = orderedSteps[step.index + 1];
 
-  return <StepComponent />;
+  return (
+    <>
+      <StepProgress currentStepId={stepId} />
+      <StepComponent previousStepId={prev?.id} nextStepId={next?.id} />
+    </>
+  );
 }

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import StepShopDetails from "./steps/StepShopDetails";
 import StepTheme from "./steps/StepTheme";
 import StepTokens from "./steps/StepTokens";
@@ -14,6 +16,10 @@ import StepSummary from "./steps/StepSummary";
 import StepImportData from "./steps/StepImportData";
 import StepSeedData from "./steps/StepSeedData";
 import StepHosting from "./steps/StepHosting";
+import { Button } from "@/components/atoms/shadcn";
+import { useConfigurator } from "./ConfiguratorContext";
+import { useRouter } from "next/navigation";
+import React from "react";
 
 export interface ConfiguratorStep {
   id: string;
@@ -88,11 +94,84 @@ const stepList: ConfiguratorStep[] = [
   },
 ];
 
+/** Ordered list of configurator steps including their index. */
+export const orderedSteps: Array<ConfiguratorStep & { index: number }> =
+  stepList.map((s, i) => ({ ...s, index: i }));
+
 export const getSteps = (): ConfiguratorStep[] => [...stepList];
 
 export const getRequiredSteps = (): ConfiguratorStep[] =>
   getSteps().filter((s) => !s.optional);
 
-export const steps: Record<string, ConfiguratorStep> = Object.fromEntries(
-  getSteps().map((s) => [s.id, s])
-);
+/** Map of step ID to step config including index. */
+export const steps: Record<string, ConfiguratorStep & { index: number }> =
+  Object.fromEntries(orderedSteps.map((s) => [s.id, s]));
+
+interface ProgressProps {
+  currentStepId: string;
+}
+
+/** Progress indicator showing completion state for each step. */
+export function StepProgress({ currentStepId }: ProgressProps): React.JSX.Element {
+  const { state } = useConfigurator();
+  return (
+    <ol className="mb-4 flex flex-wrap gap-2">
+      {orderedSteps.map((s) => {
+        const completed = state.completed[s.id] === "complete";
+        const isCurrent = s.id === currentStepId;
+        return (
+          <li key={s.id} className="flex items-center">
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full text-xs ${
+                completed ? "bg-green-500 text-white" : "bg-gray-200 text-gray-800"
+              } ${isCurrent ? "ring-2 ring-primary" : ""}`}
+            >
+              {s.index + 1}
+            </span>
+            <span className={`ml-1 text-sm ${isCurrent ? "font-medium" : ""}`}>
+              {s.label}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+interface ControlsProps {
+  prev?: string;
+  next?: string;
+  onNext?: () => Promise<void> | void;
+  nextDisabled?: boolean;
+}
+
+/** Renders "Back" and "Next" buttons for navigating between steps. */
+export function StepControls({
+  prev,
+  next,
+  onNext,
+  nextDisabled,
+}: ControlsProps): React.JSX.Element {
+  const router = useRouter();
+  return (
+    <div className="mt-4 flex justify-between">
+      {prev ? (
+        <Button variant="outline" onClick={() => router.push(`/cms/configurator/${prev}`)}>
+          Back
+        </Button>
+      ) : (
+        <span />
+      )}
+      <Button
+        onClick={async () => {
+          await onNext?.();
+          router.push(next ? `/cms/configurator/${next}` : "/cms/configurator");
+        }}
+        disabled={nextDisabled}
+      >
+        {next ? "Next" : "Finish"}
+      </Button>
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/configurator/steps/StepAdditionalPages/StepAdditionalPages.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepAdditionalPages/StepAdditionalPages.tsx
@@ -15,7 +15,7 @@ import PageMetaForm from "./PageMetaForm";
 import useNewPageState from "./useNewPageState";
 import usePagesLoader from "./usePagesLoader";
 import useStepCompletion from "../../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../../steps";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -23,6 +23,8 @@ interface Props {
   setPages: (v: PageInfo[]) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepAdditionalPages({
@@ -31,6 +33,8 @@ export default function StepAdditionalPages({
   setPages,
   shopId,
   themeStyle,
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const languages = LOCALES as readonly Locale[];
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
@@ -58,7 +62,6 @@ export default function StepAdditionalPages({
     resetFields,
   } = useNewPageState(languages);
   const [, markComplete] = useStepCompletion("additional-pages");
-  const router = useRouter();
 
   usePagesLoader({
     shopId,
@@ -170,16 +173,11 @@ export default function StepAdditionalPages({
         </div>
       )}
       {!adding && <Button onClick={() => setAdding(true)}>Add Page</Button>}
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
       <Toast
         open={toast.open}
         onClose={() => setToast((t) => ({ ...t, open: false }))}

--- a/apps/cms/src/app/cms/configurator/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepCheckoutPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Button,
   Select,
   SelectContent,
   SelectItem,
@@ -16,7 +15,7 @@ import { ulid } from "ulid";
 import { useState } from "react";
 import { Toast } from "@/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -28,6 +27,8 @@ interface Props {
   setCheckoutPageId: (v: string | null) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepCheckoutPage({
@@ -46,7 +47,6 @@ export default function StepCheckoutPage({
     message: "",
   });
   const [, markComplete] = useStepCompletion("checkout-page");
-  const router = useRouter();
 
   return (
     <div className="space-y-4">
@@ -117,16 +117,11 @@ export default function StepCheckoutPage({
         onChange={setCheckoutComponents}
         style={themeStyle}
       />
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
       <Toast
         open={toast.open}
         onClose={() => setToast((t) => ({ ...t, open: false }))}

--- a/apps/cms/src/app/cms/configurator/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepEnvVars.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import {
-  Button,
-  Input,
-} from "@/components/atoms/shadcn";
+import { Input } from "@/components/atoms/shadcn";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
   const ENV_KEYS = [
     "STRIPE_SECRET_KEY",
@@ -32,14 +29,17 @@ import { useRouter } from "next/navigation";
 interface Props {
   env: Record<string, string>;
   setEnv: (key: string, value: string) => void;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepEnvVars({
   env,
   setEnv,
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [, markComplete] = useStepCompletion("env-vars");
-  const router = useRouter();
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Environment Variables</h2>
@@ -60,16 +60,11 @@ export default function StepEnvVars({
           />
         </label>
       ))}
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Button,
   Select,
   SelectContent,
   SelectItem,
@@ -17,7 +16,7 @@ import { ulid } from "ulid";
 import { useEffect, useState } from "react";
 import { Toast } from "@/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -29,6 +28,8 @@ interface Props {
   setHomePageId: (v: string | null) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepHomePage({
@@ -47,7 +48,6 @@ export default function StepHomePage({
     message: "",
   });
   const [, markComplete] = useStepCompletion("home-page");
-  const router = useRouter();
 
   useEffect(() => {
     (async () => {
@@ -162,16 +162,11 @@ export default function StepHomePage({
         onChange={setComponents}
         style={themeStyle}
       />
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
       <Toast
         open={toast.open}
         onClose={() => setToast((t) => ({ ...t, open: false }))}

--- a/apps/cms/src/app/cms/configurator/steps/StepHosting.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHosting.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Input } from "@/components/atoms/shadcn";
 import type { DeployStatusBase } from "@platform-core/createShop";
 import { useEffect } from "react";
 import { getDeployStatus, type DeployInfo } from "../services/deployShop";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   shopId: string;
@@ -18,6 +18,8 @@ interface Props {
   ) => void;
   deploying: boolean;
   deploy: () => Promise<void> | void;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepHosting({
@@ -29,9 +31,10 @@ export default function StepHosting({
   setDeployInfo,
   deploying,
   deploy,
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [, markComplete] = useStepCompletion("hosting");
-  const router = useRouter();
   useEffect(() => {
     if (!shopId || !deployInfo) return;
     if (
@@ -96,18 +99,15 @@ export default function StepHosting({
       {deployInfo?.status === "error" && deployInfo.error && (
         <p className="text-sm text-red-600">{deployInfo.error}</p>
       )}
-      <div className="flex justify-end">
-        <Button
-          disabled={deploying}
-          onClick={async () => {
-            await deploy();
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          {deploying ? "Deploying…" : "Save & return"}
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={async () => {
+          await deploy();
+          markComplete(true);
+        }}
+        nextDisabled={deploying}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepImportData.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepImportData.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button, Input, Textarea } from "@/components/atoms/shadcn";
+import { Input, Textarea } from "@/components/atoms/shadcn";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   setCsvFile: (f: File | null) => void;
@@ -11,6 +11,8 @@ interface Props {
   importResult: string | null;
   importing: boolean;
   saveData: () => Promise<void> | void;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepImportData({
@@ -20,9 +22,10 @@ export default function StepImportData({
   importResult,
   importing,
   saveData,
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [, markComplete] = useStepCompletion("import-data");
-  const router = useRouter();
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Import Data</h2>
@@ -41,18 +44,15 @@ export default function StepImportData({
         placeholder='["Shoes","Accessories"]'
       />
       {importResult && <p className="text-sm">{importResult}</p>}
-      <div className="flex justify-end gap-2">
-        <Button
-          disabled={importing}
-          onClick={async () => {
-            await saveData();
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          {importing ? "Saving…" : "Save & return"}
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={async () => {
+          await saveData();
+          markComplete(true);
+        }}
+        nextDisabled={importing}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepLayout.tsx
@@ -1,7 +1,6 @@
 // src/components/cms/StepLayout.tsx
 "use client";
 
-import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@acme/types";
@@ -9,18 +8,24 @@ import { fetchJson } from "@shared-utils";
 import { ReactNode, useState } from "react";
 import { Toast } from "@/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import { useThemeLoader } from "../hooks/useThemeLoader";
+import { StepControls } from "../steps";
 
 interface Props {
   /** Optional inner content for the step */
   children?: ReactNode;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 const emptyTranslated = () => fillLocales(undefined, "");
 
-export default function StepLayout({ children }: Props): React.JSX.Element {
+export default function StepLayout({
+  children,
+  previousStepId,
+  nextStepId,
+}: Props): React.JSX.Element {
   const { state, update } = useConfigurator();
   const {
     headerComponents,
@@ -40,7 +45,6 @@ export default function StepLayout({ children }: Props): React.JSX.Element {
     message: "",
   });
   const [, markComplete] = useStepCompletion("layout");
-  const router = useRouter();
 
   return (
     <fieldset className="space-y-4">
@@ -138,16 +142,11 @@ export default function StepLayout({ children }: Props): React.JSX.Element {
       {children}
 
       {/* Navigation ------------------------------------------------------ */}
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
       <Toast
         open={toast.open}
         onClose={() => setToast((t) => ({ ...t, open: false }))}

--- a/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Button } from "@/components/atoms/shadcn";
 import NavigationEditor from "@/components/cms/NavigationEditor";
 import { useConfigurator } from "../ConfiguratorContext";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface NavItem {
   id: string;
@@ -13,26 +12,28 @@ interface NavItem {
   children?: NavItem[];
 }
 
-export default function StepNavigation(): React.JSX.Element {
+interface Props {
+  previousStepId?: string;
+  nextStepId?: string;
+}
+
+export default function StepNavigation({
+  previousStepId,
+  nextStepId,
+}: Props): React.JSX.Element {
   const { state, update } = useConfigurator();
   const navItems = state.navItems;
   const setNavItems = (items: NavItem[]) => update("navItems", items);
   const [, markComplete] = useStepCompletion("navigation");
-  const router = useRouter();
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Navigation</h2>
       <NavigationEditor items={navItems} onChange={setNavItems} />
-      <div className="flex justify-end gap-2">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
@@ -13,8 +13,17 @@ import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import useStepCompletion from "../hooks/useStepCompletion";
+import { StepControls } from "../steps";
 
-export default function StepOptions(): React.JSX.Element {
+interface Props {
+  previousStepId?: string;
+  nextStepId?: string;
+}
+
+export default function StepOptions({
+  previousStepId,
+  nextStepId,
+}: Props): React.JSX.Element {
   const { state, update } = useConfigurator();
   const {
     shopId,
@@ -120,16 +129,11 @@ export default function StepOptions(): React.JSX.Element {
           />
         )}
       </div>
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Button,
   Select,
   SelectContent,
   SelectItem,
@@ -17,7 +16,7 @@ import { ulid } from "ulid";
 import { useEffect, useState } from "react";
 import { Toast } from "@/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -29,6 +28,8 @@ interface Props {
   setProductPageId: (v: string | null) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepProductPage({
@@ -41,6 +42,8 @@ export default function StepProductPage({
   setProductPageId,
   shopId,
   themeStyle,
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -79,7 +82,6 @@ export default function StepProductPage({
     })();
   }, [shopId, productPageId, setProductComponents, setProductPageId]);
   const [, markComplete] = useStepCompletion("product-page");
-  const router = useRouter();
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Product Detail Page</h2>
@@ -164,16 +166,11 @@ export default function StepProductPage({
         onChange={setProductComponents}
         style={themeStyle}
       />
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
       <Toast
         open={toast.open}
         onClose={() => setToast((t) => ({ ...t, open: false }))}

--- a/apps/cms/src/app/cms/configurator/steps/StepSeedData.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepSeedData.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Input } from "@/components/atoms/shadcn";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   setCsvFile: (f: File | null) => void;
@@ -11,6 +11,8 @@ interface Props {
   seedResult: string | null;
   seeding: boolean;
   seed: () => Promise<void> | void;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepSeedData({
@@ -20,9 +22,10 @@ export default function StepSeedData({
   seedResult,
   seeding,
   seed,
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [, markComplete] = useStepCompletion("seed-data");
-  const router = useRouter();
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Seed Data</h2>
@@ -42,18 +45,15 @@ export default function StepSeedData({
         />
       </label>
       {seedResult && <p className="text-sm">{seedResult}</p>}
-      <div className="flex justify-end gap-2">
-        <Button
-          disabled={seeding}
-          onClick={async () => {
-            await seed();
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          {seeding ? "Saving…" : "Save & return"}
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={async () => {
+          await seed();
+          markComplete(true);
+        }}
+        nextDisabled={seeding}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Button,
   Input,
   Select,
   SelectContent,
@@ -9,8 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/atoms/shadcn";
-import { useRouter } from "next/navigation";
 import useStepCompletion from "../hooks/useStepCompletion";
+import { StepControls } from "../steps";
 
 interface Props {
   shopId: string;
@@ -27,6 +26,8 @@ interface Props {
   setTemplate: (v: string) => void;
   templates: string[];
   errors?: Record<string, string[]>;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepShopDetails({
@@ -44,8 +45,9 @@ export default function StepShopDetails({
   setTemplate,
   templates,
   errors = {},
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
-  const router = useRouter();
   const [, markComplete] = useStepCompletion("shop-details");
   return (
     <div className="space-y-4">
@@ -124,17 +126,12 @@ export default function StepShopDetails({
           </SelectContent>
         </Select>
       </label>
-      <div className="flex justify-end">
-        <Button
-          disabled={!shopId}
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+        nextDisabled={!shopId}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Button,
   Select,
   SelectContent,
   SelectItem,
@@ -16,7 +15,7 @@ import { ulid } from "ulid";
 import { useState } from "react";
 import { Toast } from "@/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   pageTemplates: Array<{ name: string; components: PageComponent[] }>;
@@ -28,6 +27,8 @@ interface Props {
   setShopPageId: (v: string | null) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepShopPage({
@@ -46,7 +47,6 @@ export default function StepShopPage({
     message: "",
   });
   const [, markComplete] = useStepCompletion("shop-page");
-  const router = useRouter();
 
   return (
     <div className="space-y-4">
@@ -132,16 +132,11 @@ export default function StepShopPage({
         onChange={setShopComponents}
         style={themeStyle}
       />
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
       <Toast
         open={toast.open}
         onClose={() => setToast((t) => ({ ...t, open: false }))}

--- a/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
@@ -2,13 +2,13 @@
 
 "use client";
 
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Input } from "@/components/atoms/shadcn";
 import { LOCALES } from "@acme/i18n";
 import type { Locale } from "@acme/types";
 import React from "react";
 import WizardPreview from "../../wizard/WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
+import { StepControls } from "../steps";
 
 interface Props {
   shopId: string;
@@ -32,6 +32,8 @@ interface Props {
   creating: boolean;
   submit: () => Promise<void> | void;
   errors?: Record<string, string[]>;
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepSummary({
@@ -56,10 +58,11 @@ export default function StepSummary({
   creating,
   submit,
   errors = {},
+  previousStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const languages = LOCALES as readonly Locale[];
   const [, markComplete] = useStepCompletion("summary");
-  const router = useRouter();
 
   return (
     <div className="space-y-4">
@@ -153,19 +156,15 @@ export default function StepSummary({
 
       <WizardPreview style={themeStyle} />
 
-      <div className="flex justify-end">
-        <Button
-          disabled={creating}
-          onClick={async () => {
-            await submit();
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-          className="ml-auto"
-        >
-          {creating ? "Saving…" : "Save & return"}
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={async () => {
+          await submit();
+          markComplete(true);
+        }}
+        nextDisabled={creating}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -12,9 +12,9 @@ import StyleEditor from "@/components/cms/StyleEditor";
 import { useCallback, useEffect, useState } from "react";
 import WizardPreview from "../../wizard/WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import { useThemeLoader } from "../hooks/useThemeLoader";
+import { StepControls } from "../steps";
 
 const colorPalettes: Array<{
   name: string;
@@ -57,16 +57,21 @@ const colorPalettes: Array<{
 
 interface Props {
   themes: string[];
+  previousStepId?: string;
+  nextStepId?: string;
 }
 
-export default function StepTheme({ themes }: Props): React.JSX.Element {
+export default function StepTheme({
+  themes,
+  previousStepId,
+  nextStepId,
+}: Props): React.JSX.Element {
   const themeStyle = useThemeLoader();
   const { state, update, themeDefaults, setThemeOverrides } =
     useConfigurator();
   const { theme, themeOverrides } = state;
   const [palette, setPalette] = useState(colorPalettes[0].name);
   const [, markComplete] = useStepCompletion("theme");
-  const router = useRouter();
 
   const applyPalette = useCallback(
     (name: string) => {
@@ -142,16 +147,11 @@ export default function StepTheme({ themes }: Props): React.JSX.Element {
 
       <WizardPreview style={themeStyle} />
 
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
@@ -1,19 +1,25 @@
 "use client";
 
-import { Button } from "@/components/atoms/shadcn";
 import StyleEditor from "@/components/cms/StyleEditor";
 import WizardPreview from "../../wizard/WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { type TokenMap } from "../../wizard/tokenUtils";
 import { useConfigurator } from "../ConfiguratorContext";
 import { useThemeLoader } from "../hooks/useThemeLoader";
+import { StepControls } from "../steps";
 
-export default function StepTokens(): React.JSX.Element {
+interface Props {
+  previousStepId?: string;
+  nextStepId?: string;
+}
+
+export default function StepTokens({
+  previousStepId,
+  nextStepId,
+}: Props): React.JSX.Element {
   const themeStyle = useThemeLoader();
   const [, markComplete] = useStepCompletion("tokens");
-  const router = useRouter();
   const { themeDefaults, themeOverrides, setThemeOverrides } = useConfigurator();
   const tokens = { ...themeDefaults, ...themeOverrides } as TokenMap;
   const [selected, setSelected] = useState<string | null>(null);
@@ -46,16 +52,11 @@ export default function StepTokens(): React.JSX.Element {
           focusToken={selected}
         />
       )}
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
-      </div>
+      <StepControls
+        prev={previousStepId}
+        next={nextStepId}
+        onNext={() => markComplete(true)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add progress UI mapping configurator steps to indexes
- derive previous/next steps and show back/next navigation
- hook step completion state into progress indicator

## Testing
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_689d921eeadc832fa250d7477302c027