### PR TITLE
feat(configurator): autosave with dirty tracking

### DIFF
--- a/apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
+++ b/apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
@@ -1,0 +1,14 @@
+// apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
+"use client";
+
+import { useConfigurator } from "./ConfiguratorContext";
+
+export default function ConfiguratorStatusBar(): React.JSX.Element | null {
+  const { saving } = useConfigurator();
+  if (!saving) return null;
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 flex justify-center bg-muted py-2 text-sm">
+      Saving…
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -60,7 +60,7 @@ export default function ConfiguratorDashboard() {
     window.addEventListener("configurator:update", handler);
     return () => window.removeEventListener("configurator:update", handler);
   }, [fetchState]);
-  const markStepComplete = useConfiguratorPersistence(state, setState);
+  const [markStepComplete] = useConfiguratorPersistence(state, setState);
   const stepList = useMemo(() => getSteps(), []);
   const missingRequired = getRequiredSteps().filter(
     (s) => state?.completed?.[s.id] !== "complete"

--- a/apps/cms/src/app/cms/configurator/hooks/useStepCompletion.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/useStepCompletion.ts
@@ -26,12 +26,13 @@ export const validators: Record<string, Validator> = {
 };
 
 export function useStepCompletion(stepId: string): [boolean, (v: boolean) => void] {
-  const { state, markStepComplete } = useConfigurator();
+  const { state, markStepComplete, resetDirty } = useConfigurator();
   const validate = validators[stepId] ?? (() => true);
   const completed = state.completed[stepId] === "complete" && validate(state);
   const setCompleted = (v: boolean) => {
     if (v && !validate(state)) return;
     markStepComplete(stepId, v ? "complete" : "pending");
+    if (v) resetDirty();
   };
   return [completed, setCompleted];
 }


### PR DESCRIPTION
## Summary
- track dirty state in configurator and prompt before unloading
- add debounced auto-save with status bar indicator
- clear dirty flag when saving or completing steps

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689d922bacf0832fa69730c405c90889