### PR TITLE
Handle Stripe checkout errors

### DIFF
--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -1,4 +1,8 @@
 // apps/shop-abc/__tests__/checkoutSession.test.ts
+
+process.env.NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET || "test-secret";
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || "test-secret";
+
 import { encodeCartCookie } from "@platform-core/src/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import * as dateUtils from "@acme/date-utils";
@@ -289,4 +293,22 @@ test("rounds unit amounts before sending to Stripe", async () => {
   expect(Number.isInteger(args.line_items[1].price_data.unit_amount)).toBe(
     true,
   );
+});
+
+test("responds with 502 when Stripe session creation fails", async () => {
+  jest.useFakeTimers().setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  stripeCreate.mockReset();
+  stripeCreate.mockRejectedValue(new Error("fail"));
+
+  const sku = PRODUCTS[0];
+  const size = sku.sizes[0];
+  const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
+  mockCart = cart;
+  const cookie = encodeCartCookie("test");
+  const req = createRequest({ returnDate: "2025-01-02" }, cookie);
+
+  const res = await POST(req);
+  expect(res.status).toBe(502);
+  const body = await res.json();
+  expect(body).toEqual({ error: "Checkout failed" });
 });

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -279,29 +279,38 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     (paymentIntentData as any).billing_details = billing_details;
   }
 
-  const stripeSession = await stripe.checkout.sessions.create({
-    mode: "payment",
-    customer,
-    line_items,
-    success_url: `${req.nextUrl.origin}/success`,
-    cancel_url: `${req.nextUrl.origin}/cancelled`,
-    payment_intent_data: paymentIntentData,
-    metadata: buildCheckoutMetadata({
-      subtotal,
-      depositTotal,
-      returnDate,
-      rentalDays,
-      sizes: sizesMeta,
-      customerId: customer,
-      discount,
-      coupon: couponDef?.code,
-      currency,
-      taxRate,
-      taxAmount,
-      clientIp,
-    }),
-    expand: ["payment_intent"],
-  });
+  let stripeSession: Stripe.Checkout.Session;
+  try {
+    stripeSession = await stripe.checkout.sessions.create({
+      mode: "payment",
+      customer,
+      line_items,
+      success_url: `${req.nextUrl.origin}/success`,
+      cancel_url: `${req.nextUrl.origin}/cancelled`,
+      payment_intent_data: paymentIntentData,
+      metadata: buildCheckoutMetadata({
+        subtotal,
+        depositTotal,
+        returnDate,
+        rentalDays,
+        sizes: sizesMeta,
+        customerId: customer,
+        discount,
+        coupon: couponDef?.code,
+        currency,
+        taxRate,
+        taxAmount,
+        clientIp,
+      }),
+      expand: ["payment_intent"],
+    });
+  } catch (error) {
+    console.error("Failed to create checkout session", error);
+    return NextResponse.json(
+      { error: "Checkout failed" },
+      { status: 502 },
+    );
+  }
 
   /* 6️⃣ Return client credentials ------------------------------------------ */
   const clientSecret =


### PR DESCRIPTION
## Summary
- wrap Stripe checkout session creation in a try/catch and return 502 on failure
- add regression test verifying 502 response when Stripe throws

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/checkoutSession.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d930a77ac832fa8706e92af36cd0b