### PR TITLE
feat(ui): extend order summary with tax and discount rows

### DIFF
--- a/packages/ui/src/components/organisms/OrderSummary.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.tsx
@@ -9,6 +9,10 @@ import React, { useMemo } from "react";
 type Totals = {
   subtotal: number;
   deposit: number;
+  /** Tax amount applied to the order */
+  tax?: number;
+  /** Discount amount applied to the order */
+  discount?: number;
   total: number;
 };
 
@@ -56,7 +60,9 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
 
   const subtotal = totals?.subtotal ?? computedTotals.subtotal;
   const deposit = totals?.deposit ?? computedTotals.deposit;
-  const total = totals?.total ?? subtotal + deposit;
+  const tax = totals?.tax ?? 0;
+  const discount = totals?.discount ?? 0;
+  const total = totals?.total ?? subtotal + deposit + tax - discount;
 
   /* ------------------------------------------------------------------
    * Render
@@ -91,11 +97,36 @@ function OrderSummary({ cart: cartProp, totals }: Props) {
       <tfoot>
         <tr>
           <td />
+          <td className="py-2">Subtotal</td>
+          <td className="text-right">
+            <Price amount={subtotal} />
+          </td>
+        </tr>
+        <tr>
+          <td />
           <td className="py-2">Deposit</td>
           <td className="text-right">
             <Price amount={deposit} />
           </td>
         </tr>
+        {totals?.tax !== undefined && (
+          <tr>
+            <td />
+            <td className="py-2">Tax</td>
+            <td className="text-right">
+              <Price amount={tax} />
+            </td>
+          </tr>
+        )}
+        {totals?.discount !== undefined && (
+          <tr>
+            <td />
+            <td className="py-2">Discount</td>
+            <td className="text-right">
+              <Price amount={-discount} />
+            </td>
+          </tr>
+        )}
         <tr>
           <td />
           <td className="py-2 font-semibold">Total</td>

--- a/packages/ui/src/components/organisms/__tests__/OrderSummary.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/OrderSummary.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import OrderSummary from "../OrderSummary";
+
+jest.mock("@ui/hooks/useCart", () => ({
+  useCart: () => [{}, jest.fn()],
+}));
+
+jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["EUR", jest.fn()],
+}));
+
+describe("OrderSummary", () => {
+  const format = (amount: number) =>
+    new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "EUR",
+    }).format(amount);
+
+  it("renders subtotal and deposit without tax or discount by default", () => {
+    const cart = {
+      "sku1": {
+        sku: { id: "sku1", title: "Item1", price: 10, deposit: 2 },
+        qty: 1,
+      },
+      "sku2": {
+        sku: { id: "sku2", title: "Item2", price: 5, deposit: 1 },
+        qty: 2,
+      },
+    };
+
+    render(<OrderSummary cart={cart} />);
+
+    expect(screen.getByText("Subtotal")).toBeInTheDocument();
+    expect(screen.getByText(format(20))).toBeInTheDocument();
+    expect(screen.getByText("Deposit")).toBeInTheDocument();
+    expect(screen.getByText(format(4))).toBeInTheDocument();
+    expect(screen.queryByText("Tax")).not.toBeInTheDocument();
+    expect(screen.queryByText("Discount")).not.toBeInTheDocument();
+  });
+
+  it("renders tax and discount rows when provided", () => {
+    const totals = { subtotal: 20, deposit: 4, tax: 3, discount: 1, total: 26 };
+    render(<OrderSummary cart={{}} totals={totals} />);
+
+    expect(screen.getByText("Tax")).toBeInTheDocument();
+    expect(screen.getByText(format(3))).toBeInTheDocument();
+    expect(screen.getByText("Discount")).toBeInTheDocument();
+    expect(screen.getByText(format(-1))).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show subtotal, tax, and discount rows in OrderSummary
- add unit tests covering subtotal, tax, and discount rendering

## Testing
- `pnpm --filter @acme/ui test -- packages/ui` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter @acme/ui test -- packages/ui/src/components/organisms/__tests__/OrderSummary.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d930f928c832f82a9263d0995efa5