### PR TITLE
Derive tax region from settings

### DIFF
--- a/apps/shop-abc/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/checkout/page.tsx
@@ -80,7 +80,7 @@ export default async function CheckoutPage({
             region={premierDelivery.regions[0] ?? ""}
           />
         )}
-      <CheckoutForm locale={lang} taxRegion={settings.taxRegion} />
+      <CheckoutForm locale={lang} />
     </div>
   );
 }

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -21,11 +21,11 @@ const stripePromise = loadStripe(
   paymentEnv.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 );
 
-type Props = { locale: "en" | "de" | "it"; taxRegion: string };
+type Props = { locale: "en" | "de" | "it" };
 
 type FormValues = { returnDate: string };
 
-export default function CheckoutForm({ locale, taxRegion }: Props) {
+export default function CheckoutForm({ locale }: Props) {
   const [clientSecret, setClientSecret] = useState<string>();
   const [fetchError, setFetchError] = useState(false);
   const [retry, setRetry] = useState(0);
@@ -49,7 +49,7 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ returnDate, currency, taxRegion }),
+            body: JSON.stringify({ returnDate, currency }),
             signal: controller.signal,
           }
         );
@@ -67,7 +67,7 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
       controller.abort();
       clearTimeout(timeout);
     };
-  }, [returnDate, currency, taxRegion, retry]);
+  }, [returnDate, currency, retry]);
 
   if (!clientSecret) {
     if (fetchError)


### PR DESCRIPTION
## Summary
- Read taxRegion from shop settings in checkout API
- Remove taxRegion from checkout form and page
- Add integration test to ignore forged taxRegion values

## Testing
- `pnpm exec jest apps/shop-abc/__tests__/checkoutSession.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d930959a4832f9c541320cf13cc5c