### PR TITLE
feat: incremental inventory persistence

### DIFF
--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -67,7 +67,11 @@ export function readInventory(shop: string) {
 }
 
 export function writeInventory(shop: string, items: InventoryItem[]) {
-  return inventoryRepository.write(shop, items);
+  return Promise.all(
+    items.map((i) =>
+      inventoryRepository.update(shop, i.sku, i.variantAttributes, () => i),
+    ),
+  ).then(() => {});
 }
 
 export function updateInventoryItem(


### PR DESCRIPTION
## Summary
- persist inventory items as individual JSON files with per-file locking
- merge writes by updating only affected inventory records
- test inventory repository for new per-item storage format

## Testing
- `npm test -- src/repositories/__tests__/inventory.server.test.ts __tests__/inventory.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d93c5f9e4832f9ef4d99383c91d3b