### PR TITLE
docs: document theme editing flow

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,21 @@
+# Theming and Live Preview
+
+Base themes provide the starting set of design tokens for a shop. The **Theme Editor** lets you pick a base theme and layer token overrides on top. Overrides merge with the base tokens and are persisted with the shop so they can be shared across sessions.
+
+## Selecting elements and overriding colors
+1. Open the Theme Editor in the CMS.
+2. The preview uses `WizardPreview` in inspect mode. Clicking any tokenised element highlights it and focuses its matching input.
+3. Click a color swatch or field to open the picker and enter a new value. Only differences from the base theme are stored as overrides.
+
+## Presets
+- Type a name in *Preset name* and press **Save Preset** to capture the current set of overrides.
+- Presets appear in the theme list and can be removed with **Delete Preset**.
+
+## Resetting to defaults
+- Use the reset icon beside a color input to remove its override.
+- To clear an override outside the editor, call `resetThemeOverride(shop, token)` from [`apps/cms/src/actions/shops.server.ts`](../apps/cms/src/actions/shops.server.ts).
+
+## Implementation references
+- **Theme Editor** – [`apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx`](../apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx)
+- **Live preview** – [`apps/cms/src/app/cms/wizard/WizardPreview.tsx`](../apps/cms/src/app/cms/wizard/WizardPreview.tsx)
+- **Server actions** – [`apps/cms/src/actions/shops.server.ts`](../apps/cms/src/actions/shops.server.ts)


### PR DESCRIPTION
## Summary
- add theming guide covering base themes, overrides, presets, and preview

## Testing
- `pnpm lint docs/theming.md` *(fails: Missing tasks in project)*
- `pnpm lint` *(fails: Could not resolve @acme/config/env/core.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d96ae52a8832faafa86eb830aa748