### PR TITLE
feat: add editorial blog config

### DIFF
--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -27,12 +27,23 @@ interface Result {
  */
 export async function setupSanityBlog(
   creds: SanityCredentials,
-  enableEditorial: boolean,
+  editorial?: { enabled: boolean; promoteSchedule?: string },
   aclMode: "public" | "private" = "public",
 ): Promise<Result> {
   "use server";
   await ensureAuthorized();
-  if (!enableEditorial) return { success: true };
+  if (!editorial?.enabled) return { success: true };
+  if (editorial.promoteSchedule) {
+    try {
+      await fetch(`/api/editorial/promote`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ schedule: editorial.promoteSchedule }),
+      });
+    } catch (err) {
+      console.error("[setupSanityBlog] failed to schedule promotion", err);
+    }
+  }
 
   const { projectId, dataset, token } = creds;
 

--- a/apps/cms/src/app/api/env/[shopId]/route.ts
+++ b/apps/cms/src/app/api/env/[shopId]/route.ts
@@ -36,11 +36,19 @@ export async function POST(
       data.SANITY_DATASET &&
       data.SANITY_TOKEN
     ) {
-      await setupSanityBlog({
-        projectId: data.SANITY_PROJECT_ID,
-        dataset: data.SANITY_DATASET,
-        token: data.SANITY_TOKEN,
-      }, data.ENABLE_EDITORIAL === "true").catch((err) => {
+      await setupSanityBlog(
+        {
+          projectId: data.SANITY_PROJECT_ID,
+          dataset: data.SANITY_DATASET,
+          token: data.SANITY_TOKEN,
+        },
+        {
+          enabled: data.ENABLE_EDITORIAL === "true",
+          ...(data.PROMOTE_SCHEDULE
+            ? { promoteSchedule: data.PROMOTE_SCHEDULE }
+            : {}),
+        },
+      ).catch((err) => {
         console.error("[env] failed to setup Sanity blog", err);
       });
     }

--- a/apps/shop-abc/__tests__/homePage.test.tsx
+++ b/apps/shop-abc/__tests__/homePage.test.tsx
@@ -32,7 +32,10 @@ test("Home receives components from pages repo", async () => {
   (getPages as jest.Mock).mockResolvedValue([
     { slug: "home", components } as any,
   ]);
-  (readShop as jest.Mock).mockResolvedValue({ id: "abc", enableEditorial: false });
+  (readShop as jest.Mock).mockResolvedValue({
+    id: "abc",
+    editorialBlog: { enabled: false },
+  });
 
   const element = await Page({ params: { lang: "en" } });
 

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -26,5 +26,5 @@
     "dataset": "production",
     "token": "token"
   },
-  "enableEditorial": false
+  "editorialBlog": { "enabled": false }
 }

--- a/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
@@ -8,10 +8,18 @@ export default async function BlogPostPage({
 }: {
   params: { lang: string; slug: string };
 }) {
+  if (!shop.editorialBlog?.enabled) {
+    notFound();
+  }
   const post = await fetchPostBySlug(shop.id, params.slug);
   if (!post) notFound();
   return (
     <article className="space-y-4">
+      {shop.editorialBlog?.promoteSchedule && (
+        <p className="rounded bg-muted p-2">
+          Daily Edit scheduled for {shop.editorialBlog.promoteSchedule}
+        </p>
+      )}
       <h1 className="text-2xl font-bold">{post.title}</h1>
       {post.excerpt && <p className="text-muted">{post.excerpt}</p>}
       {Array.isArray(post.body) ? (

--- a/apps/shop-abc/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
-  if (!shop.enableEditorial) {
+  if (!shop.editorialBlog?.enabled) {
     notFound();
   }
   const posts = await fetchPublishedPosts(shop.id);
@@ -13,5 +13,14 @@ export default async function BlogPage({ params }: { params: { lang: string } })
     excerpt: p.excerpt,
     url: `/${params.lang}/blog/${p.slug}`,
   }));
-  return <BlogListing posts={items} />;
+  return (
+    <>
+      {shop.editorialBlog?.promoteSchedule && (
+        <div className="rounded bg-muted p-2">
+          Daily Edit scheduled for {shop.editorialBlog.promoteSchedule}
+        </div>
+      )}
+      <BlogListing posts={items} />
+    </>
+  );
 }

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -20,7 +20,7 @@ export default async function Page({
   const shop = await readShop(env.NEXT_PUBLIC_SHOP_ID || "shop-abc");
   const components = await loadComponents(shop.id);
   let latestPost: BlogPost | undefined;
-  if (shop.enableEditorial) {
+  if (shop.editorialBlog?.enabled) {
     const posts = await fetchPublishedPosts(shop.id);
     const first = posts[0];
     if (first) {

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -22,5 +22,5 @@
     "dataset": "production",
     "token": "token"
   },
-  "enableEditorial": false
+  "editorialBlog": { "enabled": false }
 }

--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -8,10 +8,18 @@ export default async function BlogPostPage({
 }: {
   params: { lang: string; slug: string };
 }) {
+  if (!shop.editorialBlog?.enabled) {
+    notFound();
+  }
   const post = await fetchPostBySlug(shop.id, params.slug);
   if (!post) notFound();
   return (
     <article className="space-y-4">
+      {shop.editorialBlog?.promoteSchedule && (
+        <p className="rounded bg-muted p-2">
+          Daily Edit scheduled for {shop.editorialBlog.promoteSchedule}
+        </p>
+      )}
       <h1 className="text-2xl font-bold">{post.title}</h1>
       {post.excerpt && <p className="text-muted">{post.excerpt}</p>}
       {Array.isArray(post.body) ? (

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
-  if (!shop.enableEditorial) {
+  if (!shop.editorialBlog?.enabled) {
     notFound();
   }
   const posts = await fetchPublishedPosts(shop.id);
@@ -13,5 +13,14 @@ export default async function BlogPage({ params }: { params: { lang: string } })
     excerpt: p.excerpt,
     url: `/${params.lang}/blog/${p.slug}`,
   }));
-  return <BlogListing posts={items} />;
+  return (
+    <>
+      {shop.editorialBlog?.promoteSchedule && (
+        <div className="rounded bg-muted p-2">
+          Daily Edit scheduled for {shop.editorialBlog.promoteSchedule}
+        </div>
+      )}
+      <BlogListing posts={items} />
+    </>
+  );
 }

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -33,7 +33,7 @@ export default async function Page({
 }) {
   const components = await loadComponents();
   let latestPost: BlogPost | undefined;
-  if (shop.enableEditorial) {
+  if (shop.editorialBlog?.enabled) {
     const posts = await fetchPublishedPosts(shop.id);
     const first = posts[0];
     if (first) {

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -20,5 +20,5 @@
     "dataset": "production",
     "token": "token"
   },
-  "enableEditorial": false
+  "editorialBlog": { "enabled": false }
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -16,5 +16,5 @@
     "dataset": "production",
     "token": "token"
   },
-  "enableEditorial": false
+  "editorialBlog": { "enabled": false }
 }

--- a/doc/sanity-blog.md
+++ b/doc/sanity-blog.md
@@ -15,7 +15,9 @@ When setting up the connection the CMS seeds a minimal schema. Posts include a `
 
 ## Enable or disable editorial content
 
-The blog can be toggled in **Settings → Shop** using the **Enable blog** checkbox. This sets the `enableEditorial` flag in the shop settings. When disabled the storefront hides blog routes and the daily publication job skips the shop.
+The blog can be toggled in **Settings → Shop** using the **Enable blog** checkbox. This sets the `editorialBlog.enabled` flag in the shop settings. When disabled the storefront hides blog routes and the daily publication job skips the shop.
+
+To automatically surface the "Daily Edit" on the storefront home page, provide a `promoteSchedule` ISO timestamp. When set the CMS schedules a front‑page promotion at the chosen time.
 
 ## Daily publication job
 

--- a/packages/platform-core/src/shops.ts
+++ b/packages/platform-core/src/shops.ts
@@ -18,6 +18,28 @@ export function setSanityConfig(
   return next;
 }
 
+export function getEditorialBlog(
+  shop: Shop,
+): Shop["editorialBlog"] | undefined {
+  return (shop as Shop & { editorialBlog?: Shop["editorialBlog"] })
+    .editorialBlog;
+}
+
+export function setEditorialBlog(
+  shop: Shop,
+  editorial: Shop["editorialBlog"] | undefined,
+): Shop {
+  const next = { ...shop } as Shop & {
+    editorialBlog?: Shop["editorialBlog"];
+  };
+  if (editorial) {
+    next.editorialBlog = editorial;
+  } else {
+    delete next.editorialBlog;
+  }
+  return next;
+}
+
 export function getDomain(shop: Shop): ShopDomain | undefined {
   return (shop as Shop & { domain?: ShopDomain }).domain;
 }

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -85,6 +85,13 @@ export const shopSchema = z
       .array(z.object({ label: z.string(), url: z.string() }).strict())
       .optional(),
     sanityBlog: sanityBlogConfigSchema.optional(),
+    editorialBlog: z
+      .object({
+        enabled: z.boolean(),
+        promoteSchedule: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     enableEditorial: z.boolean().optional(),
     domain: shopDomainSchema.optional(),
     returnPolicyUrl: z.string().url().optional(),

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -62,6 +62,13 @@ export const shopSettingsSchema = z
       })
       .strict()
       .optional(),
+    editorialBlog: z
+      .object({
+        enabled: z.boolean(),
+        promoteSchedule: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     /** Tracking providers enabled for shipment/return tracking */
     trackingProviders: z.array(z.string()).optional(),
     updatedAt: z.string(),


### PR DESCRIPTION
## Summary
- add `editorialBlog` schema to shops and settings
- wire CMS actions to schedule editorial promotions
- surface scheduled "Daily Edit" on storefront blog pages

## Testing
- `pnpm lint --filter @acme/types --filter @acme/platform-core --filter @apps/cms --filter @apps/shop-abc --filter @apps/shop-bcd` *(fails: ERR_MODULE_NOT_FOUND)*
- `pnpm test --filter @apps/cms --filter @apps/shop-abc --filter @apps/shop-bcd --filter @acme/platform-core --filter @acme/types` *(fails: Test failed. See above for more details.)*
- `pnpm test --filter @apps/shop-abc`
- `pnpm test --filter @apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_689d954a2f74832fa3237f74499e8dc9