### PR TITLE
feat(cms): add configurator progress

### DIFF
--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { steps } from "../steps";
+import { ConfiguratorProgress, getSteps, stepIndex, steps } from "../steps";
+import { useConfigurator } from "../ConfiguratorContext";
 
 interface Props {
   stepId: string;
@@ -8,11 +9,22 @@ interface Props {
 
 export default function StepPage({ stepId }: Props) {
   const step = steps[stepId];
+  const { state } = useConfigurator();
   if (!step) {
     return null;
   }
 
+  const list = getSteps();
+  const idx = stepIndex[stepId] ?? 0;
+  const prev = list[idx - 1];
+  const next = list[idx + 1];
+
   const StepComponent = step.component as React.ComponentType<any>;
 
-  return <StepComponent />;
+  return (
+    <div className="space-y-4">
+      <ConfiguratorProgress currentStepId={stepId} completed={state.completed} />
+      <StepComponent prevStepId={prev?.id} nextStepId={next?.id} />
+    </div>
+  );
 }

--- a/apps/cms/src/app/cms/configurator/steps.ts
+++ b/apps/cms/src/app/cms/configurator/steps.ts
@@ -14,6 +14,9 @@ import StepSummary from "./steps/StepSummary";
 import StepImportData from "./steps/StepImportData";
 import StepSeedData from "./steps/StepSeedData";
 import StepHosting from "./steps/StepHosting";
+import { CheckIcon } from "@radix-ui/react-icons";
+import type { StepStatus } from "../wizard/schema";
+import { cn } from "@ui/utils/style";
 
 export interface ConfiguratorStep {
   id: string;
@@ -96,3 +99,52 @@ export const getRequiredSteps = (): ConfiguratorStep[] =>
 export const steps: Record<string, ConfiguratorStep> = Object.fromEntries(
   getSteps().map((s) => [s.id, s])
 );
+
+/** Mapping of step id to its index in the overall flow */
+export const stepIndex: Record<string, number> = Object.fromEntries(
+  stepList.map((s, i) => [s.id, i])
+);
+
+interface ProgressProps {
+  currentStepId: string;
+  completed: Record<string, StepStatus | undefined>;
+}
+
+/** Horizontal progress indicator for the configurator wizard. */
+export function ConfiguratorProgress({
+  currentStepId,
+  completed,
+}: ProgressProps) {
+  const list = getSteps();
+  const currentIdx = stepIndex[currentStepId] ?? 0;
+  return (
+    <ol className="flex items-center gap-4 text-sm">
+      {list.map((s, idx) => (
+        <li key={s.id} className="flex flex-1 items-center gap-2">
+          <span
+            className={cn(
+              "grid size-6 place-content-center rounded-full border",
+              completed[s.id] === "complete" &&
+                "bg-primary border-primary text-primary-fg",
+              idx === currentIdx && "border-primary",
+              idx > currentIdx && "text-muted-foreground border-muted"
+            )}
+          >
+            {completed[s.id] === "complete" ? (
+              <CheckIcon className="h-4 w-4" />
+            ) : (
+              idx + 1
+            )}
+          </span>
+          <span className={cn(idx === currentIdx && "font-medium")}>{
+            s.label
+          }</span>
+          {idx < list.length - 1 && (
+            <span className="border-muted ml-2 flex-1 border-t" />
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+

--- a/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
@@ -29,6 +29,8 @@ interface Props {
   setHomePageId: (v: string | null) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  prevStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepHomePage({
@@ -41,6 +43,8 @@ export default function StepHomePage({
   setHomePageId,
   shopId,
   themeStyle,
+  prevStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -172,15 +176,25 @@ export default function StepHomePage({
         onChange={setComponents}
         style={themeStyle}
       />
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
+      <div className="flex justify-between">
+        {prevStepId && (
+          <Button
+            variant="outline"
+            onClick={() => router.push(`/cms/configurator/${prevStepId}`)}
+          >
+            Back
+          </Button>
+        )}
+        {nextStepId && (
+          <Button
+            onClick={() => {
+              markComplete(true);
+              router.push(`/cms/configurator/${nextStepId}`);
+            }}
+          >
+            Next
+          </Button>
+        )}
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
@@ -28,6 +28,8 @@ interface Props {
   setShopPageId: (v: string | null) => void;
   shopId: string;
   themeStyle: React.CSSProperties;
+  prevStepId?: string;
+  nextStepId?: string;
 }
 
 export default function StepShopPage({
@@ -40,6 +42,8 @@ export default function StepShopPage({
   setShopPageId,
   shopId,
   themeStyle,
+  prevStepId,
+  nextStepId,
 }: Props): React.JSX.Element {
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
@@ -140,15 +144,25 @@ export default function StepShopPage({
         onChange={setShopComponents}
         style={themeStyle}
       />
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
+      <div className="flex justify-between">
+        {prevStepId && (
+          <Button
+            variant="outline"
+            onClick={() => router.push(`/cms/configurator/${prevStepId}`)}
+          >
+            Back
+          </Button>
+        )}
+        {nextStepId && (
+          <Button
+            onClick={() => {
+              markComplete(true);
+              router.push(`/cms/configurator/${nextStepId}`);
+            }}
+          >
+            Next
+          </Button>
+        )}
       </div>
       <Toast
         open={toast.open}

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -57,9 +57,15 @@ const colorPalettes: Array<{
 
 interface Props {
   themes: string[];
+  prevStepId?: string;
+  nextStepId?: string;
 }
 
-export default function StepTheme({ themes }: Props): React.JSX.Element {
+export default function StepTheme({
+  themes,
+  prevStepId,
+  nextStepId,
+}: Props): React.JSX.Element {
   const themeStyle = useThemeLoader();
   const { state, update, themeDefaults, setThemeOverrides } =
     useConfigurator();
@@ -142,15 +148,25 @@ export default function StepTheme({ themes }: Props): React.JSX.Element {
 
       <WizardPreview style={themeStyle} />
 
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            markComplete(true);
-            router.push("/cms/configurator");
-          }}
-        >
-          Save & return
-        </Button>
+      <div className="flex justify-between">
+        {prevStepId && (
+          <Button
+            variant="outline"
+            onClick={() => router.push(`/cms/configurator/${prevStepId}`)}
+          >
+            Back
+          </Button>
+        )}
+        {nextStepId && (
+          <Button
+            onClick={() => {
+              markComplete(true);
+              router.push(`/cms/configurator/${nextStepId}`);
+            }}
+          >
+            Next
+          </Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add configurable progress component mapping steps to indices and completion state
- render progress with back/next navigation in step pages
- update theme, home and shop step components with back/next buttons

## Testing
- `pnpm lint --filter=@apps/cms` *(fails: ERR_MODULE_NOT_FOUND)*
- `pnpm test:cms` *(fails: process.exit called with "1")*


------
https://chatgpt.com/codex/tasks/task_e_689d95a41120832fa386729b03cae76a