### PR TITLE
Handle Stripe checkout failures with 502 responses

### DIFF
--- a/apps/shop-abc/__tests__/checkoutSession.test.ts
+++ b/apps/shop-abc/__tests__/checkoutSession.test.ts
@@ -357,8 +357,13 @@ test("rounds unit amounts before sending to Stripe", async () => {
 });
 
 test("responds with 502 when Stripe session creation fails", async () => {
+  jest.useFakeTimers().setSystemTime(new Date("2025-01-01T00:00:00Z"));
   stripeCreate.mockReset();
+  findCouponMock.mockReset();
+  getTaxRateMock.mockReset();
   stripeCreate.mockRejectedValue(new Error("Stripe error"));
+  findCouponMock.mockResolvedValue(null);
+  getTaxRateMock.mockResolvedValue(0);
   const sku = PRODUCTS[0];
   const size = sku.sizes[0];
   const cart = { [`${sku.id}:${size}`]: { sku, qty: 1, size } };
@@ -368,5 +373,5 @@ test("responds with 502 when Stripe session creation fails", async () => {
   const res = await POST(req);
   expect(res.status).toBe(502);
   const body = await res.json();
-  expect(body.error).toBe("Checkout session failed");
+  expect(body.error).toBe("Checkout failed");
 });

--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -309,9 +309,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       expand: ["payment_intent"],
     });
   } catch (error) {
-    console.error(error);
+    console.error("Failed to create Stripe checkout session", error);
     return NextResponse.json(
-      { error: "Checkout session failed" },
+      { error: "Checkout failed" },
       { status: 502 }
     );
   }

--- a/apps/shop-bcd/src/api/checkout-session/route.js
+++ b/apps/shop-bcd/src/api/checkout-session/route.js
@@ -73,28 +73,35 @@ export async function POST(req) {
     const { subtotal, depositTotal } = await computeTotals(cart, rentalDays);
     const sizesMeta = JSON.stringify(Object.fromEntries(Object.values(cart).map((i) => [i.sku.id, i.size ?? ""])));
     /* 5️⃣  Create Stripe Checkout Session ---------------------------------- */
-    const session = await stripe.checkout.sessions.create({
-        mode: "payment",
-        line_items,
-        success_url: `${req.nextUrl.origin}/success`,
-        cancel_url: `${req.nextUrl.origin}/cancelled`,
-        payment_intent_data: {
+    let session;
+    try {
+        session = await stripe.checkout.sessions.create({
+            mode: "payment",
+            line_items,
+            success_url: `${req.nextUrl.origin}/success`,
+            cancel_url: `${req.nextUrl.origin}/cancelled`,
+            payment_intent_data: {
+                metadata: {
+                    subtotal: subtotal.toString(),
+                    depositTotal: depositTotal.toString(),
+                    returnDate: returnDate ?? "",
+                    rentalDays: rentalDays.toString(),
+                },
+            },
             metadata: {
                 subtotal: subtotal.toString(),
                 depositTotal: depositTotal.toString(),
                 returnDate: returnDate ?? "",
                 rentalDays: rentalDays.toString(),
+                sizes: sizesMeta,
             },
-        },
-        metadata: {
-            subtotal: subtotal.toString(),
-            depositTotal: depositTotal.toString(),
-            returnDate: returnDate ?? "",
-            rentalDays: rentalDays.toString(),
-            sizes: sizesMeta,
-        },
-        expand: ["payment_intent"],
-    });
+            expand: ["payment_intent"],
+        });
+    }
+    catch (error) {
+        console.error("Failed to create Stripe checkout session", error);
+        return NextResponse.json({ error: "Checkout failed" }, { status: 502 });
+    }
     /* 6️⃣  Return credentials to client ------------------------------------ */
     const clientSecret = typeof session.payment_intent === "string"
         ? undefined

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -19,6 +19,8 @@ const mutableEnv = process.env as unknown as Record<string, string>;
 mutableEnv.NODE_ENV ||= "development"; // relax “edge” runtime checks
 mutableEnv.CART_COOKIE_SECRET ||= "test-cart-secret"; // cart cookie signing
 mutableEnv.STRIPE_WEBHOOK_SECRET ||= "whsec_test"; // dummy Stripe webhook secret
+mutableEnv.NEXTAUTH_SECRET ||= "test-nextauth-secret";
+mutableEnv.SESSION_SECRET ||= "test-session-secret";
 
 /* -------------------------------------------------------------------------- */
 /* 2.  Polyfills missing from the JSDOM / Node test runtime                    */


### PR DESCRIPTION
## Summary
- handle Stripe checkout session errors across templates and shops with try/catch and 502 response
- set default secrets in Jest setup
- test Stripe failure returns 502 error

## Testing
- `npx jest apps/shop-abc/__tests__/checkoutSession.test.ts apps/shop-bcd/__tests__/checkout-session.test.ts packages/template-app/__tests__/checkout-session.test.ts`
- `npx eslint apps/shop-abc/src/app/api/checkout-session/route.ts apps/shop-bcd/src/api/checkout-session/route.ts packages/template-app/src/api/checkout-session/route.ts apps/shop-abc/__tests__/checkoutSession.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d9683b378832f96bee2875a47f894