### PR TITLE
feat: add publish API endpoint

### DIFF
--- a/apps/shop-abc/src/app/api/publish/route.ts
+++ b/apps/shop-abc/src/app/api/publish/route.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { NextResponse } from "next/server";
+import { requirePermission } from "@auth";
+import { republishShop } from "../../../../../../scripts/src/republish-shop";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const raw = await fs.readFile(join(process.cwd(), "shop.json"), "utf8");
+    const { id } = JSON.parse(raw) as { id: string };
+    const root = join(process.cwd(), "..", "..");
+    const cwd = process.cwd();
+    try {
+      process.chdir(root);
+      republishShop(id, root);
+    } finally {
+      process.chdir(cwd);
+    }
+    return NextResponse.json({ status: "ok" });
+  } catch (err) {
+    console.error("Publish failed", err);
+    return NextResponse.json({ error: "Publish failed" }, { status: 500 });
+  }
+}

--- a/apps/shop-abc/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-abc/src/app/upgrade-preview/page.tsx
@@ -9,6 +9,8 @@ interface UpgradeComponent {
 
 export default function UpgradePreviewPage() {
   const [changes, setChanges] = useState<UpgradeComponent[]>([]);
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -26,10 +28,19 @@ export default function UpgradePreviewPage() {
   }, []);
 
   async function handlePublish() {
+    setPublishing(true);
+    setError(null);
     try {
-      await fetch("/api/publish", { method: "POST" });
+      const res = await fetch("/api/publish", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error((data as any).error || "Publish failed");
+      }
     } catch (err) {
       console.error("Publish failed", err);
+      setError(err instanceof Error ? err.message : "Publish failed");
+    } finally {
+      setPublishing(false);
     }
   }
 
@@ -44,9 +55,11 @@ export default function UpgradePreviewPage() {
         type="button"
         onClick={handlePublish}
         className="rounded border px-4 py-2"
+        disabled={publishing}
       >
-        Approve &amp; publish
+        {publishing ? "Publishing..." : "Approve & publish"}
       </button>
+      {error && <p role="alert" className="text-red-600">{error}</p>}
     </div>
   );
 }

--- a/apps/shop-bcd/src/app/api/publish/route.ts
+++ b/apps/shop-bcd/src/app/api/publish/route.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { NextResponse } from "next/server";
+import { requirePermission } from "@auth";
+import { republishShop } from "../../../../../../scripts/src/republish-shop";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const raw = await fs.readFile(join(process.cwd(), "shop.json"), "utf8");
+    const { id } = JSON.parse(raw) as { id: string };
+    const root = join(process.cwd(), "..", "..");
+    const cwd = process.cwd();
+    try {
+      process.chdir(root);
+      republishShop(id, root);
+    } finally {
+      process.chdir(cwd);
+    }
+    return NextResponse.json({ status: "ok" });
+  } catch (err) {
+    console.error("Publish failed", err);
+    return NextResponse.json({ error: "Publish failed" }, { status: 500 });
+  }
+}

--- a/apps/shop-bcd/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-bcd/src/app/upgrade-preview/page.tsx
@@ -9,6 +9,8 @@ interface UpgradeComponent {
 
 export default function UpgradePreviewPage() {
   const [changes, setChanges] = useState<UpgradeComponent[]>([]);
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -26,10 +28,19 @@ export default function UpgradePreviewPage() {
   }, []);
 
   async function handlePublish() {
+    setPublishing(true);
+    setError(null);
     try {
-      await fetch("/api/publish", { method: "POST" });
+      const res = await fetch("/api/publish", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error((data as any).error || "Publish failed");
+      }
     } catch (err) {
       console.error("Publish failed", err);
+      setError(err instanceof Error ? err.message : "Publish failed");
+    } finally {
+      setPublishing(false);
     }
   }
 
@@ -44,9 +55,11 @@ export default function UpgradePreviewPage() {
         type="button"
         onClick={handlePublish}
         className="rounded border px-4 py-2"
+        disabled={publishing}
       >
-        Approve &amp; publish
+        {publishing ? "Publishing..." : "Approve & publish"}
       </button>
+      {error && <p role="alert" className="text-red-600">{error}</p>}
     </div>
   );
 }

--- a/packages/template-app/src/app/api/publish/route.ts
+++ b/packages/template-app/src/app/api/publish/route.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { NextResponse } from "next/server";
+import { requirePermission } from "@auth";
+import { republishShop } from "../../../../../../scripts/src/republish-shop";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const raw = await fs.readFile(join(process.cwd(), "shop.json"), "utf8");
+    const { id } = JSON.parse(raw) as { id: string };
+    const root = join(process.cwd(), "..", "..");
+    const cwd = process.cwd();
+    try {
+      process.chdir(root);
+      republishShop(id, root);
+    } finally {
+      process.chdir(cwd);
+    }
+    return NextResponse.json({ status: "ok" });
+  } catch (err) {
+    console.error("Publish failed", err);
+    return NextResponse.json({ error: "Publish failed" }, { status: 500 });
+  }
+}

--- a/packages/template-app/src/app/upgrade-preview/page.tsx
+++ b/packages/template-app/src/app/upgrade-preview/page.tsx
@@ -9,6 +9,8 @@ interface UpgradeComponent {
 
 export default function UpgradePreviewPage() {
   const [changes, setChanges] = useState<UpgradeComponent[]>([]);
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -26,10 +28,19 @@ export default function UpgradePreviewPage() {
   }, []);
 
   async function handlePublish() {
+    setPublishing(true);
+    setError(null);
     try {
-      await fetch("/api/publish", { method: "POST" });
+      const res = await fetch("/api/publish", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error((data as any).error || "Publish failed");
+      }
     } catch (err) {
       console.error("Publish failed", err);
+      setError(err instanceof Error ? err.message : "Publish failed");
+    } finally {
+      setPublishing(false);
     }
   }
 
@@ -44,9 +55,11 @@ export default function UpgradePreviewPage() {
         type="button"
         onClick={handlePublish}
         className="rounded border px-4 py-2"
+        disabled={publishing}
       >
-        Approve &amp; publish
+        {publishing ? "Publishing..." : "Approve & publish"}
       </button>
+      {error && <p role="alert" className="text-red-600">{error}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- export republishShop function and reuse in publish API routes
- add publish API routes validating permissions
- improve upgrade preview publishing UX and integration tests

## Testing
- `pnpm exec jest test/integration/publish-api.spec.ts test/integration/republish-shop.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d96bf1aac832f9121d1b8a1fbdfb0