### PR TITLE
feat: support theme defaults and overrides

### DIFF
--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -35,10 +35,16 @@ export async function updateShop(
   const current = await getShopById<Shop>(shop);
   if (current.id !== id) throw new Error(`Shop ${id} not found in ${shop}`);
 
+  // Read theme data separately so we can persist defaults and overrides
+  const themeDefaultsRaw = formData.get("themeDefaults") as string | null;
+  const themeOverridesRaw = formData.get("themeOverrides") as string | null;
+
   const parsed = shopSchema.safeParse({
     ...Object.fromEntries(
       formData as unknown as Iterable<[string, FormDataEntryValue]>
     ),
+    themeDefaults: themeDefaultsRaw ?? "{}",
+    themeOverrides: themeOverridesRaw ?? "{}",
     trackingProviders: formData.getAll("trackingProviders"),
   });
   if (!parsed.success) {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -33,20 +33,6 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
     }));
   };
 
-  const handleTokens = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    const { value } = e.target;
-    try {
-      const parsed = JSON.parse(value);
-      setInfo((prev) => ({ ...prev, themeTokens: parsed }));
-      setErrors((prev) => {
-        const { themeTokens, ...rest } = prev;
-        return rest;
-      });
-    } catch {
-      setErrors((prev) => ({ ...prev, themeTokens: ["Invalid JSON"] }));
-    }
-  };
-
   const handleMappings = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = e.target;
     try {
@@ -201,16 +187,30 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
         )}
       </label>
       <label className="flex flex-col gap-1">
-        <span>Theme Tokens (JSON)</span>
+        <span>Theme Defaults (JSON)</span>
         <Textarea
-          name="themeTokens"
-          defaultValue={JSON.stringify(info.themeTokens, null, 2)}
-          onChange={handleTokens}
+          name="themeDefaults"
+          defaultValue={JSON.stringify(info.themeDefaults ?? {}, null, 2)}
+          readOnly
           rows={4}
         />
-        {errors.themeTokens && (
+        {errors.themeDefaults && (
           <span className="text-sm text-red-600">
-            {errors.themeTokens.join("; ")}
+            {errors.themeDefaults.join("; ")}
+          </span>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span>Theme Overrides (JSON)</span>
+        <Textarea
+          name="themeOverrides"
+          defaultValue={JSON.stringify(info.themeOverrides ?? {}, null, 2)}
+          readOnly
+          rows={4}
+        />
+        {errors.themeOverrides && (
+          <span className="text-sm text-red-600">
+            {errors.themeOverrides.join("; ")}
           </span>
         )}
       </label>


### PR DESCRIPTION
## Summary
- show theme defaults and overrides in shop editor
- read and persist theme defaults and overrides on save
- normalize shop theme data when reading or writing to repo

## Testing
- `NEXTAUTH_SECRET=secret CART_COOKIE_SECRET=secret SESSION_SECRET=secret pnpm --filter @acme/platform-core test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `NEXTAUTH_SECRET=secret CART_COOKIE_SECRET=secret SESSION_SECRET=secret pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689d96aa51b0832fa547715bcfa2f734