### PR TITLE
feat: add preview token API and links

### DIFF
--- a/apps/shop-abc/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-abc/routes/__tests__/preview-upgrade.test.ts
@@ -33,13 +33,24 @@ test("valid upgrade token returns page JSON", async () => {
     __esModule: true,
     getPages,
   }));
+  jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
+  jest.doMock("@acme/config", () => ({
+    __esModule: true,
+    env: { UPGRADE_PREVIEW_TOKEN_SECRET: "upgradesecret" },
+  }));
+
+  const { GET: tokenGET } = await import(
+    "../../src/app/api/preview-token/route"
+  );
+  const tokenRes = await tokenGET(
+    new Request("http://test?pageId=1") as any,
+  );
+  const { token } = await tokenRes.json();
 
   const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
   const res = await onRequest({
     params: { pageId: "1" },
-    request: new Request(
-      `http://test?upgrade=${tokenFor("1", "upgradesecret")}`,
-    ),
+    request: new Request(`http://test?upgrade=${token}`),
   } as any);
 
   expect(res.status).toBe(200);

--- a/apps/shop-abc/src/app/api/preview-token/route.ts
+++ b/apps/shop-abc/src/app/api/preview-token/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createHmac } from "node:crypto";
+import { requirePermission } from "@auth";
+import { env } from "@acme/config";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const pageId = new URL(req.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "Missing pageId" }, { status: 400 });
+  }
+  const secret = env.UPGRADE_PREVIEW_TOKEN_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Token secret not configured" },
+      { status: 500 },
+    );
+  }
+  const token = createHmac("sha256", secret).update(pageId).digest("hex");
+  return NextResponse.json({ token });
+}
+

--- a/apps/shop-abc/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-abc/src/app/upgrade-preview/page.tsx
@@ -106,13 +106,36 @@ export default function UpgradePreviewPage() {
   const [changes, setChanges] = useState<UpgradeComponent[]>([]);
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [links, setLinks] = useState<{ id: string; url: string }[]>([]);
 
   useEffect(() => {
     async function load() {
       try {
         const res = await fetch("/api/upgrade-changes");
-        const data = (await res.json()) as { components: UpgradeComponent[] };
+        const data = (await res.json()) as {
+          components: UpgradeComponent[];
+          pages?: string[];
+        };
         setChanges(data.components);
+        if (Array.isArray(data.pages)) {
+          const pageLinks = (
+            await Promise.all(
+              data.pages.map(async (id) => {
+                try {
+                  const r = await fetch(
+                    `/api/preview-token?pageId=${encodeURIComponent(id)}`,
+                  );
+                  if (!r.ok) return null;
+                  const { token } = (await r.json()) as { token: string };
+                  return { id, url: `/preview/${id}?upgrade=${token}` };
+                } catch {
+                  return null;
+                }
+              }),
+            )
+          ).filter(Boolean) as { id: string; url: string }[];
+          setLinks(pageLinks);
+        }
       } catch (err) {
         console.error("Failed to load upgrade changes", err);
       }
@@ -146,6 +169,21 @@ export default function UpgradePreviewPage() {
           </li>
         ))}
       </ul>
+      {links.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="font-semibold">Preview pages</h2>
+          <ul className="list-disc pl-4">
+            {links.map((l) => (
+              <li key={l.id}>
+                <a
+                  href={l.url}
+                  className="text-blue-600 underline"
+                >{`/preview/${l.id}`}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <button
         type="button"
         onClick={handlePublish}

--- a/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
@@ -33,13 +33,24 @@ test("valid upgrade token returns page JSON", async () => {
     __esModule: true,
     getPages,
   }));
+  jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
+  jest.doMock("@acme/config", () => ({
+    __esModule: true,
+    env: { UPGRADE_PREVIEW_TOKEN_SECRET: "upgradesecret" },
+  }));
+
+  const { GET: tokenGET } = await import(
+    "../../src/app/api/preview-token/route"
+  );
+  const tokenRes = await tokenGET(
+    new Request("http://test?pageId=1") as any,
+  );
+  const { token } = await tokenRes.json();
 
   const { onRequest } = await import("../../src/routes/preview/[pageId].ts");
   const res = await onRequest({
     params: { pageId: "1" },
-    request: new Request(
-      `http://test?upgrade=${tokenFor("1", "upgradesecret")}`,
-    ),
+    request: new Request(`http://test?upgrade=${token}`),
   } as any);
 
   expect(res.status).toBe(200);

--- a/apps/shop-bcd/src/app/api/preview-token/route.ts
+++ b/apps/shop-bcd/src/app/api/preview-token/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createHmac } from "node:crypto";
+import { requirePermission } from "@auth";
+import { env } from "@acme/config";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const pageId = new URL(req.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "Missing pageId" }, { status: 400 });
+  }
+  const secret = env.UPGRADE_PREVIEW_TOKEN_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Token secret not configured" },
+      { status: 500 },
+    );
+  }
+  const token = createHmac("sha256", secret).update(pageId).digest("hex");
+  return NextResponse.json({ token });
+}
+

--- a/packages/template-app/src/app/upgrade-preview/page.tsx
+++ b/packages/template-app/src/app/upgrade-preview/page.tsx
@@ -11,6 +11,7 @@ export default function UpgradePreviewPage() {
   const [changes, setChanges] = useState<UpgradeComponent[]>([]);
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [links, setLinks] = useState<{ id: string; url: string }[]>([]);
 
   useEffect(() => {
     async function load() {
@@ -18,8 +19,28 @@ export default function UpgradePreviewPage() {
         const res = await fetch("/api/upgrade-changes");
         const data = (await res.json()) as {
           components: UpgradeComponent[];
+          pages?: string[];
         };
         setChanges(data.components);
+        if (Array.isArray(data.pages)) {
+          const pageLinks = (
+            await Promise.all(
+              data.pages.map(async (id) => {
+                try {
+                  const r = await fetch(
+                    `/api/preview-token?pageId=${encodeURIComponent(id)}`,
+                  );
+                  if (!r.ok) return null;
+                  const { token } = (await r.json()) as { token: string };
+                  return { id, url: `/preview/${id}?upgrade=${token}` };
+                } catch {
+                  return null;
+                }
+              }),
+            )
+          ).filter(Boolean) as { id: string; url: string }[];
+          setLinks(pageLinks);
+        }
       } catch (err) {
         console.error("Failed to load upgrade changes", err);
       }
@@ -51,6 +72,18 @@ export default function UpgradePreviewPage() {
           <li key={c.file}>{c.componentName}</li>
         ))}
       </ul>
+      {links.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="font-semibold">Preview pages</h2>
+          <ul className="list-disc pl-4">
+            {links.map((l) => (
+              <li key={l.id}>
+                <a href={l.url} className="text-blue-600 underline">{`/preview/${l.id}`}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <button
         type="button"
         onClick={handlePublish}


### PR DESCRIPTION
## Summary
- add `preview-token` API to hash page IDs with `UPGRADE_PREVIEW_TOKEN_SECRET`
- surface preview links for affected pages in upgrade preview
- ensure preview route accepts tokens from API and rejects invalid ones

## Testing
- `pnpm exec jest apps/shop-abc/routes/__tests__/preview-upgrade.test.ts`
- `pnpm exec jest apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts`
- `pnpm test --filter @apps/shop-abc` *(fails: missing env & prisma client)*

------
https://chatgpt.com/codex/tasks/task_e_689d9b647a9c832f8c03270bdd97ae3b