### PR TITLE
feat(theme): live update preview tokens

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
@@ -40,7 +40,10 @@ export default function ColorInput({
   };
 
   return (
-    <label className={`flex flex-col gap-1 ${isOverridden ? "bg-amber-50" : ""}`}>
+    <label
+      data-token-key={name}
+      className={`flex flex-col gap-1 ${isOverridden ? "bg-amber-50" : ""}`}
+    >
       <span>{name}</span>
       <div className="flex items-center gap-2">
         <Input value={defaultValue} disabled />

--- a/apps/cms/src/app/cms/wizard/previewTokens.ts
+++ b/apps/cms/src/app/cms/wizard/previewTokens.ts
@@ -1,0 +1,22 @@
+"use client";
+
+export const PREVIEW_TOKENS_KEY = "cms-preview-tokens";
+export const PREVIEW_TOKENS_EVENT = "previewTokens:update";
+
+export function savePreviewTokens(tokens: Record<string, string>): void {
+  try {
+    localStorage.setItem(PREVIEW_TOKENS_KEY, JSON.stringify(tokens));
+    window.dispatchEvent(new Event(PREVIEW_TOKENS_EVENT));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function loadPreviewTokens(): Record<string, string> {
+  try {
+    const json = localStorage.getItem(PREVIEW_TOKENS_KEY);
+    return json ? (JSON.parse(json) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary
- sync theme override changes to a previewTokens state and localStorage
- subscribe WizardPreview to preview token updates for immediate style refresh
- expose token keys in ColorInput for easier targeting

## Testing
- `pnpm --filter @apps/cms test -- ThemeEditor`

------
https://chatgpt.com/codex/tasks/task_e_689d9b4a2184832f906cda1f00b7906a