### PR TITLE
feat: add upgrade preview token api

### DIFF
--- a/packages/template-app/__tests__/preview-route.test.ts
+++ b/packages/template-app/__tests__/preview-route.test.ts
@@ -3,6 +3,7 @@ import type { Page } from "@acme/types";
 import { createHmac } from "node:crypto";
 
 process.env.PREVIEW_TOKEN_SECRET = "testsecret";
+process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
 process.env.NEXT_PUBLIC_SHOP_ID = "shop";
 
 if (typeof (Response as any).json !== "function") {
@@ -61,7 +62,7 @@ test("invalid token yields 401", async () => {
 
 test("valid token with missing page yields 404", async () => {
   const getPages = jest.fn(async () => [] as Page[]);
-  jest.doMock("@platform-core/repositories/pages", () => ({
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
     __esModule: true,
     getPages,
   }));
@@ -73,4 +74,70 @@ test("valid token with missing page yields 404", async () => {
   } as any);
 
   expect(res.status).toBe(404);
+});
+
+test("valid upgrade token returns page JSON", async () => {
+  const page: Page = {
+    id: "1",
+    slug: "home",
+    status: "draft",
+    components: [],
+    seo: { title: "Home" },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    createdBy: "tester",
+  };
+  const getPages = jest.fn(async () => [page]);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+  jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
+
+  const { GET: tokenGET } = await import(
+    "../src/app/api/preview-token/route"
+  );
+  const tokenRes = await tokenGET(new Request("http://test?pageId=1") as any);
+  const { token } = (await tokenRes.json()) as { token: string };
+
+  const { onRequest } = await import("../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(`http://test?upgrade=${token}`),
+  } as any);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(page);
+});
+
+test("invalid upgrade token yields 401", async () => {
+  const getPages = jest.fn(async () => []);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request("http://test?upgrade=bad"),
+  } as any);
+
+  expect(res.status).toBe(401);
+});
+
+test("standard token not accepted as upgrade token", async () => {
+  const getPages = jest.fn(async () => []);
+  jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+    __esModule: true,
+    getPages,
+  }));
+
+  const { onRequest } = await import("../src/routes/preview/[pageId].ts");
+  const res = await onRequest({
+    params: { pageId: "1" },
+    request: new Request(`http://test?upgrade=${tokenFor("1")}`),
+  } as any);
+
+  expect(res.status).toBe(401);
 });

--- a/packages/template-app/src/app/api/preview-token/route.ts
+++ b/packages/template-app/src/app/api/preview-token/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { createHmac } from "node:crypto";
+import { requirePermission } from "@auth";
+import { coreEnv } from "@acme/config/env/core";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  try {
+    await requirePermission("manage_orders");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const pageId = new URL(req.url).searchParams.get("pageId");
+  if (!pageId) {
+    return NextResponse.json({ error: "Missing pageId" }, { status: 400 });
+  }
+  const secret = coreEnv.UPGRADE_PREVIEW_TOKEN_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Token secret not configured" },
+      { status: 500 },
+    );
+  }
+  const token = createHmac("sha256", secret).update(pageId).digest("hex");
+  return NextResponse.json({ token });
+}


### PR DESCRIPTION
## Summary
- add API route to generate upgrade preview tokens
- verify upgrade tokens in preview route
- cover upgrade token flow with new tests

## Testing
- `npx jest packages/template-app/__tests__/preview-route.test.ts`
- `npx jest apps/shop-abc/routes/__tests__/preview-upgrade.test.ts`
- `npx jest apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689da05bca84832f86b4f5e568e937bf