### PR TITLE
feat: add content merchandising search

### DIFF
--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -4,8 +4,11 @@ import type { PageComponent } from "@acme/types";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
+import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
+import { fetchPublishedPosts } from "@acme/sanity";
 import { getPages } from "@platform-core/repositories/pages/index.server";
 import { LOCALES } from "@acme/i18n";
+import { env } from "@acme/config";
 import shop from "../../../../../shop.json";
 import PdpClient from "./PdpClient.client";
 import { trackPageView } from "@platform-core/analytics";
@@ -50,15 +53,40 @@ export default async function ProductDetailPage({
 
   const components = await loadComponents(params.slug);
   await trackPageView(shop.id, `product/${params.slug}`);
-  if (components && components.length) {
-    return (
+  let latestPost: BlogPost | undefined;
+  try {
+    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    if (luxury.contentMerchandising) {
+      const posts = await fetchPublishedPosts(shop.id);
+      const first = posts[0];
+      if (first) {
+        latestPost = {
+          title: first.title,
+          excerpt: first.excerpt,
+          url: `/${params.lang}/blog/${first.slug}`,
+        };
+      }
+    }
+  } catch {
+    /* ignore bad feature flags */
+  }
+
+  const content =
+    components && components.length ? (
       <DynamicRenderer
         components={components}
         locale={params.lang}
         runtimeData={{ ProductDetailTemplate: { product } }}
       />
+    ) : (
+      <PdpClient product={product} />
     );
-  }
-  return <PdpClient product={product} />;
+
+  return (
+    <>
+      {latestPost && <BlogListing posts={[latestPost]} />}
+      {content}
+    </>
+  );
 }
 

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -3,7 +3,10 @@ import { PRODUCTS } from "@/lib/products";
 import type { SKU, PageComponent } from "@acme/types";
 import type { Metadata } from "next";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
+import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
+import { fetchPublishedPosts } from "@acme/sanity";
 import { getPages } from "@platform-core/repositories/pages/index.server";
+import { env } from "@acme/config";
 import shop from "../../../../shop.json";
 import ShopClient from "./ShopClient.client";
 import { trackPageView } from "@platform-core/analytics";
@@ -27,9 +30,37 @@ export default async function ShopIndexPage({
 }) {
   const components = await loadComponents();
   await trackPageView(shop.id, "shop");
-  if (components && components.length) {
-    return <DynamicRenderer components={components} locale={params.lang} />;
+
+  let latestPost: BlogPost | undefined;
+  try {
+    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    if (luxury.contentMerchandising) {
+      const posts = await fetchPublishedPosts(shop.id);
+      const first = posts[0];
+      if (first) {
+        latestPost = {
+          title: first.title,
+          excerpt: first.excerpt,
+          url: `/${params.lang}/blog/${first.slug}`,
+        };
+      }
+    }
+  } catch {
+    /* ignore bad feature flags */
   }
-  return <ShopClient skus={PRODUCTS as SKU[]} />;
+
+  const content =
+    components && components.length ? (
+      <DynamicRenderer components={components} locale={params.lang} />
+    ) : (
+      <ShopClient skus={PRODUCTS as SKU[]} />
+    );
+
+  return (
+    <>
+      {latestPost && <BlogListing posts={[latestPost]} />}
+      {content}
+    </>
+  );
 }
 

--- a/apps/shop-abc/src/app/api/search/route.ts
+++ b/apps/shop-abc/src/app/api/search/route.ts
@@ -1,0 +1,37 @@
+// apps/shop-abc/src/app/api/search/route.ts
+import { NextResponse } from "next/server";
+import { PRODUCTS } from "@/lib/products";
+import { fetchPublishedPosts } from "@acme/sanity";
+import { env } from "@acme/config";
+import shop from "../../../../shop.json";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.toLowerCase() ?? "";
+
+  const products = PRODUCTS.filter((p) =>
+    p.title.toLowerCase().includes(q)
+  ).map((p) => ({
+    type: "product" as const,
+    title: p.title,
+    slug: p.slug,
+  }));
+
+  let posts: { type: "post"; title: string; slug: string }[] = [];
+  try {
+    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    if (luxury.contentMerchandising) {
+      const fetched = await fetchPublishedPosts(shop.id);
+      posts = fetched
+        .filter((p) => p.title.toLowerCase().includes(q))
+        .map((p) => ({ type: "post" as const, title: p.title, slug: p.slug }));
+    }
+  } catch {
+    /* ignore malformed feature flags */
+  }
+
+  return NextResponse.json({ results: [...products, ...posts] });
+}
+

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
@@ -4,6 +4,10 @@ import { getProductBySlug } from "@/lib/products";
 import { LOCALES } from "@acme/i18n";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
+import { fetchPublishedPosts } from "@acme/sanity";
+import { env } from "@acme/config";
+import shop from "../../../../../shop.json";
 import PdpClient from "./PdpClient.client";
 
 export async function generateStaticParams() {
@@ -28,14 +32,36 @@ export function generateMetadata({
   };
 }
 
-export default function ProductDetailPage({
+export default async function ProductDetailPage({
   params,
 }: {
-  params: { slug: string };
+  params: { slug: string; lang: string };
 }) {
   const product = getProductBySlug(params.slug);
   if (!product) return notFound();
 
-  /* ⬇️  Only data, no event handlers */
-  return <PdpClient product={product} />;
+  let latestPost: BlogPost | undefined;
+  try {
+    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    if (luxury.contentMerchandising) {
+      const posts = await fetchPublishedPosts(shop.id);
+      const first = posts[0];
+      if (first) {
+        latestPost = {
+          title: first.title,
+          excerpt: first.excerpt,
+          url: `/${params.lang}/blog/${first.slug}`,
+        };
+      }
+    }
+  } catch {
+    /* ignore bad feature flags */
+  }
+
+  return (
+    <>
+      {latestPost && <BlogListing posts={[latestPost]} />}
+      <PdpClient product={product} />
+    </>
+  );
 }

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -2,13 +2,42 @@
 import { PRODUCTS } from "@/lib/products";
 import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
+import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
+import { fetchPublishedPosts } from "@acme/sanity";
+import { env } from "@acme/config";
+import shop from "../../../../shop.json";
 import ShopClient from "./ShopClient.client";
 
 export const metadata: Metadata = {
   title: "Shop · Base-Shop",
 };
 
-export default function ShopIndexPage() {
-  // ⬇️ Purely server-side: just pass static data to the client component
-  return <ShopClient skus={PRODUCTS as SKU[]} />;
+export default async function ShopIndexPage({
+  params,
+}: {
+  params: { lang: string };
+}) {
+  let latestPost: BlogPost | undefined;
+  try {
+    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    if (luxury.contentMerchandising) {
+      const posts = await fetchPublishedPosts(shop.id);
+      const first = posts[0];
+      if (first) {
+        latestPost = {
+          title: first.title,
+          excerpt: first.excerpt,
+          url: `/${params.lang}/blog/${first.slug}`,
+        };
+      }
+    }
+  } catch {
+    /* ignore bad feature flags */
+  }
+  return (
+    <>
+      {latestPost && <BlogListing posts={[latestPost]} />}
+      <ShopClient skus={PRODUCTS as SKU[]} />
+    </>
+  );
 }

--- a/apps/shop-bcd/src/app/api/search/route.ts
+++ b/apps/shop-bcd/src/app/api/search/route.ts
@@ -1,0 +1,37 @@
+// apps/shop-bcd/src/app/api/search/route.ts
+import { NextResponse } from "next/server";
+import { PRODUCTS } from "@/lib/products";
+import { fetchPublishedPosts } from "@acme/sanity";
+import { env } from "@acme/config";
+import shop from "../../../../shop.json";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.toLowerCase() ?? "";
+
+  const products = PRODUCTS.filter((p) =>
+    p.title.toLowerCase().includes(q)
+  ).map((p) => ({
+    type: "product" as const,
+    title: p.title,
+    slug: p.slug,
+  }));
+
+  let posts: { type: "post"; title: string; slug: string }[] = [];
+  try {
+    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    if (luxury.contentMerchandising) {
+      const fetched = await fetchPublishedPosts(shop.id);
+      posts = fetched
+        .filter((p) => p.title.toLowerCase().includes(q))
+        .map((p) => ({ type: "post" as const, title: p.title, slug: p.slug }));
+    }
+  } catch {
+    /* ignore malformed feature flags */
+  }
+
+  return NextResponse.json({ results: [...products, ...posts] });
+}
+


### PR DESCRIPTION
## Summary
- add featured article slot to shop and product pages when luxury merchandising is enabled
- expose unified search API combining products and editorial posts

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689da31158c8832f83e96373c92d7301