### PR TITLE
feat: add luxury feature flags

### DIFF
--- a/apps/cms/__tests__/schemas.test.ts
+++ b/apps/cms/__tests__/schemas.test.ts
@@ -52,6 +52,12 @@ describe("zod schemas", () => {
 
     expect(parsed.catalogFilters).toEqual(["color", "size", "type"]);
     expect(parsed.enableEditorial).toBe(false);
+    expect(parsed.luxuryFeatures).toEqual({
+      contentMerchandising: false,
+      raTicketing: false,
+      fraudReview: false,
+      strictReturnConditions: false,
+    });
   });
 
   it("shopSchema requires name and themeId", () => {
@@ -80,5 +86,23 @@ describe("zod schemas", () => {
     });
 
     expect(parsed.enableEditorial).toBe(true);
+  });
+
+  it("shopSchema parses luxury feature checkboxes", () => {
+    const parsed = shopSchema.parse({
+      id: "s1",
+      name: "Shop",
+      themeId: "base",
+      catalogFilters: "",
+      contentMerchandising: "on",
+      raTicketing: "on",
+    });
+
+    expect(parsed.luxuryFeatures).toEqual({
+      contentMerchandising: true,
+      raTicketing: true,
+      fraudReview: false,
+      strictReturnConditions: false,
+    });
   });
 });

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -55,6 +55,22 @@ export const shopSchema = z
       .preprocess((v) => v === "on", z.boolean())
       .optional()
       .default(false),
+    contentMerchandising: z
+      .preprocess((v) => v === "on", z.boolean())
+      .optional()
+      .default(false),
+    raTicketing: z
+      .preprocess((v) => v === "on", z.boolean())
+      .optional()
+      .default(false),
+    fraudReview: z
+      .preprocess((v) => v === "on", z.boolean())
+      .optional()
+      .default(false),
+    strictReturnConditions: z
+      .preprocess((v) => v === "on", z.boolean())
+      .optional()
+      .default(false),
     themeOverrides: jsonRecord,
     themeDefaults: jsonRecord,
     themeTokens: jsonRecord.optional(),
@@ -63,7 +79,24 @@ export const shopSchema = z
     localeOverrides: jsonRecord,
     trackingProviders: z.array(z.string()).optional().default([]),
   })
-  .strict();
+  .strict()
+  .transform(
+    ({
+      contentMerchandising,
+      raTicketing,
+      fraudReview,
+      strictReturnConditions,
+      ...rest
+    }) => ({
+      ...rest,
+      luxuryFeatures: {
+        contentMerchandising,
+        raTicketing,
+        fraudReview,
+        strictReturnConditions,
+      },
+    })
+  );
 
 export type ProductForm = z.infer<typeof productSchema>;
 export type ShopForm = z.infer<typeof shopSchema>;

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -80,6 +80,7 @@ export async function updateShop(
     filterMappings: data.filterMappings as Record<string, string>,
     priceOverrides: data.priceOverrides as Partial<Record<Locale, number>>,
     localeOverrides: data.localeOverrides as Record<string, Locale>,
+    luxuryFeatures: data.luxuryFeatures,
   };
 
   const saved = await updateShopInRepo(shop, patch);
@@ -88,6 +89,7 @@ export async function updateShop(
   const updatedSettings: ShopSettings = {
     ...settings,
     trackingProviders: data.trackingProviders,
+    luxuryFeatures: data.luxuryFeatures,
   };
   await saveShopSettings(shop, updatedSettings);
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -154,6 +154,75 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
           </span>
         )}
       </div>
+      <fieldset className="col-span-2 flex flex-col gap-1">
+        <legend className="text-sm font-medium">Luxury features</legend>
+        <div className="mt-2 grid gap-2">
+          <label className="flex items-center gap-2">
+            <Checkbox
+              name="contentMerchandising"
+              checked={info.luxuryFeatures.contentMerchandising}
+              onCheckedChange={(v) =>
+                setInfo((prev) => ({
+                  ...prev,
+                  luxuryFeatures: {
+                    ...prev.luxuryFeatures,
+                    contentMerchandising: Boolean(v),
+                  },
+                }))
+              }
+            />
+            <span>Content merchandising</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <Checkbox
+              name="raTicketing"
+              checked={info.luxuryFeatures.raTicketing}
+              onCheckedChange={(v) =>
+                setInfo((prev) => ({
+                  ...prev,
+                  luxuryFeatures: {
+                    ...prev.luxuryFeatures,
+                    raTicketing: Boolean(v),
+                  },
+                }))
+              }
+            />
+            <span>RA ticketing</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <Checkbox
+              name="fraudReview"
+              checked={info.luxuryFeatures.fraudReview}
+              onCheckedChange={(v) =>
+                setInfo((prev) => ({
+                  ...prev,
+                  luxuryFeatures: {
+                    ...prev.luxuryFeatures,
+                    fraudReview: Boolean(v),
+                  },
+                }))
+              }
+            />
+            <span>Fraud review</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <Checkbox
+              name="strictReturnConditions"
+              checked={info.luxuryFeatures.strictReturnConditions}
+              onCheckedChange={(v) =>
+                setInfo((prev) => ({
+                  ...prev,
+                  luxuryFeatures: {
+                    ...prev.luxuryFeatures,
+                    strictReturnConditions: Boolean(v),
+                  },
+                }))
+              }
+            />
+            <span>Strict return conditions</span>
+          </label>
+        </div>
+      </fieldset>
       <label className="flex flex-col gap-1">
         <span>Catalog Filters (comma separated)</span>
         <Input

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -20,5 +20,11 @@
     "dataset": "production",
     "token": "token"
   },
-  "editorialBlog": { "enabled": false }
+  "editorialBlog": { "enabled": false },
+  "luxuryFeatures": {
+    "contentMerchandising": false,
+    "raTicketing": false,
+    "fraudReview": false,
+    "strictReturnConditions": false
+  }
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -16,5 +16,11 @@
     "dataset": "production",
     "token": "token"
   },
-  "editorialBlog": { "enabled": false }
+  "editorialBlog": { "enabled": false },
+  "luxuryFeatures": {
+    "contentMerchandising": false,
+    "raTicketing": false,
+    "fraudReview": false,
+    "strictReturnConditions": false
+  }
 }

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -97,6 +97,12 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     depositService: { enabled: false, intervalMinutes: 60 },
     returnService: { upsEnabled: false },
     premierDelivery: undefined,
+    luxuryFeatures: {
+      contentMerchandising: false,
+      raTicketing: false,
+      fraudReview: false,
+      strictReturnConditions: false,
+    },
     updatedAt: "",
     updatedBy: "",
   };

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -78,6 +78,12 @@ export async function readShop(shop: string): Promise<Shop> {
     localeOverrides: {},
     navigation: [],
     analyticsEnabled: false,
+    luxuryFeatures: {
+      contentMerchandising: false,
+      raTicketing: false,
+      fraudReview: false,
+      strictReturnConditions: false,
+    },
   };
   return await applyThemeData(empty);
 }

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -97,6 +97,20 @@ export const shopSchema = z
     returnPolicyUrl: z.string().url().optional(),
     returnsEnabled: z.boolean().optional(),
     analyticsEnabled: z.boolean().optional(),
+    luxuryFeatures: z
+      .object({
+        contentMerchandising: z.boolean().default(false),
+        raTicketing: z.boolean().default(false),
+        fraudReview: z.boolean().default(false),
+        strictReturnConditions: z.boolean().default(false),
+      })
+      .strict()
+      .default({
+        contentMerchandising: false,
+        raTicketing: false,
+        fraudReview: false,
+        strictReturnConditions: false,
+      }),
     lastUpgrade: z.string().datetime().optional(),
     componentVersions: z.record(z.string()).default({}),
   })

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -69,6 +69,20 @@ export const shopSettingsSchema = z
       })
       .strict()
       .optional(),
+    luxuryFeatures: z
+      .object({
+        contentMerchandising: z.boolean().default(false),
+        raTicketing: z.boolean().default(false),
+        fraudReview: z.boolean().default(false),
+        strictReturnConditions: z.boolean().default(false),
+      })
+      .strict()
+      .default({
+        contentMerchandising: false,
+        raTicketing: false,
+        fraudReview: false,
+        strictReturnConditions: false,
+      }),
     /** Tracking providers enabled for shipment/return tracking */
     trackingProviders: z.array(z.string()).optional(),
     updatedAt: z.string(),

--- a/test/unit/shop-schema.spec.ts
+++ b/test/unit/shop-schema.spec.ts
@@ -31,5 +31,11 @@ describe("shop schema", () => {
     const parsed = shopSchema.parse(base);
     expect(parsed.componentVersions).toEqual({});
     expect(parsed.lastUpgrade).toBeUndefined();
+    expect(parsed.luxuryFeatures).toEqual({
+      contentMerchandising: false,
+      raTicketing: false,
+      fraudReview: false,
+      strictReturnConditions: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- support luxuryFeatures flags in Shop and ShopSettings types
- expose luxuryFeatures checkboxes in CMS shop settings form
- persist luxuryFeatures options in shop data

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*
- `pnpm exec jest test/unit/shop-schema.spec.ts apps/cms/__tests__/schemas.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689da3096074832f86926ee45870436c