### PR TITLE
feat: add return authorization support

### DIFF
--- a/apps/cms/src/app/cms/ra/page.tsx
+++ b/apps/cms/src/app/cms/ra/page.tsx
@@ -1,0 +1,40 @@
+// apps/cms/src/app/cms/ra/page.tsx
+import { listReturnAuthorizations } from "@platform-core/returnAuthorization";
+import { luxuryFeatures } from "@platform-core/luxuryFeatures";
+import { notFound } from "next/navigation";
+
+export const revalidate = 0;
+
+export default async function RaDashboardPage() {
+  if (!luxuryFeatures.raTicketing) notFound();
+  const ras = await listReturnAuthorizations();
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Return Authorizations</h2>
+      {ras.length === 0 ? (
+        <p>No return authorizations.</p>
+      ) : (
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b text-left">
+              <th className="p-2">RA ID</th>
+              <th className="p-2">Order ID</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ras.map((ra) => (
+              <tr key={ra.raId} className="border-b">
+                <td className="p-2">{ra.raId}</td>
+                <td className="p-2">{ra.orderId}</td>
+                <td className="p-2">{ra.status}</td>
+                <td className="p-2">{ra.inspectionNotes ?? ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/shop-abc/src/app/api/return-request/route.ts
+++ b/apps/shop-abc/src/app/api/return-request/route.ts
@@ -1,0 +1,36 @@
+// apps/shop-abc/src/app/api/return-request/route.ts
+import "@acme/lib/initZod";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
+import { createReturnAuthorization } from "@platform-core/returnAuthorization";
+import { sendEmail } from "@acme/email";
+
+export const runtime = "nodejs";
+
+const RequestSchema = z
+  .object({ orderId: z.string(), email: z.string().email() })
+  .strict();
+
+export async function POST(req: Request) {
+  const parsed = await parseJsonBody(req, RequestSchema, "1mb");
+  if (!parsed.success) return parsed.response;
+  const { orderId, email } = parsed.data;
+
+  const raId = `RA${Date.now().toString(36).toUpperCase()}`;
+  await createReturnAuthorization({
+    raId,
+    orderId,
+    status: "pending",
+    inspectionNotes: "",
+  });
+
+  await sendEmail(
+    email,
+    `Return Authorization ${raId}`,
+    `Your return request for order ${orderId} has been received. Your RA number is ${raId}.`,
+  );
+
+  return NextResponse.json({ ok: true, raId });
+}

--- a/apps/shop-bcd/src/app/api/return-request/route.ts
+++ b/apps/shop-bcd/src/app/api/return-request/route.ts
@@ -1,0 +1,36 @@
+// apps/shop-bcd/src/app/api/return-request/route.ts
+import "@acme/lib/initZod";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@shared-utils";
+import { createReturnAuthorization } from "@platform-core/returnAuthorization";
+import { sendEmail } from "@acme/email";
+
+export const runtime = "nodejs";
+
+const RequestSchema = z
+  .object({ orderId: z.string(), email: z.string().email() })
+  .strict();
+
+export async function POST(req: Request) {
+  const parsed = await parseJsonBody(req, RequestSchema, "1mb");
+  if (!parsed.success) return parsed.response;
+  const { orderId, email } = parsed.data;
+
+  const raId = `RA${Date.now().toString(36).toUpperCase()}`;
+  await createReturnAuthorization({
+    raId,
+    orderId,
+    status: "pending",
+    inspectionNotes: "",
+  });
+
+  await sendEmail(
+    email,
+    `Return Authorization ${raId}`,
+    `Your return request for order ${orderId} has been received. Your RA number is ${raId}.`,
+  );
+
+  return NextResponse.json({ ok: true, raId });
+}

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -31,6 +31,7 @@ export const coreEnvBaseSchema = z.object({
   SANITY_API_VERSION: z.string().optional(),
   CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
   CLOUDFLARE_API_TOKEN: z.string().optional(),
+  LUXURY_FEATURES_RA_TICKETING: z.coerce.boolean().optional(),
   DEPOSIT_RELEASE_ENABLED: z
     .string()
     .refine((v) => v === "true" || v === "false", {

--- a/packages/platform-core/src/luxuryFeatures.ts
+++ b/packages/platform-core/src/luxuryFeatures.ts
@@ -1,0 +1,5 @@
+import { coreEnv } from "@acme/config/env/core";
+
+export const luxuryFeatures = {
+  raTicketing: coreEnv.LUXURY_FEATURES_RA_TICKETING ?? false,
+};

--- a/packages/platform-core/src/repositories/returnAuthorization.server.ts
+++ b/packages/platform-core/src/repositories/returnAuthorization.server.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import { returnAuthorizationSchema, type ReturnAuthorization } from "@acme/types";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { resolveDataRoot } from "../dataRoot";
+import { z } from "zod";
+
+function raPath(): string {
+  return path.join(resolveDataRoot(), "..", "return-authorizations.json");
+}
+
+const raListSchema = z.array(returnAuthorizationSchema);
+
+export async function readReturnAuthorizations(): Promise<ReturnAuthorization[]> {
+  try {
+    const buf = await fs.readFile(raPath(), "utf8");
+    const parsed = raListSchema.safeParse(JSON.parse(buf));
+    if (parsed.success) return parsed.data;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  return [];
+}
+
+export async function writeReturnAuthorizations(
+  data: ReturnAuthorization[],
+): Promise<void> {
+  const file = raPath();
+  const tmp = `${file}.${Date.now()}.tmp`;
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  await fs.rename(tmp, file);
+}
+
+export async function addReturnAuthorization(
+  ra: ReturnAuthorization,
+): Promise<void> {
+  const list = await readReturnAuthorizations();
+  list.push(ra);
+  await writeReturnAuthorizations(list);
+}
+
+export async function getReturnAuthorization(
+  raId: string,
+): Promise<ReturnAuthorization | undefined> {
+  const list = await readReturnAuthorizations();
+  return list.find((r) => r.raId === raId);
+}

--- a/packages/platform-core/src/returnAuthorization.ts
+++ b/packages/platform-core/src/returnAuthorization.ts
@@ -1,0 +1,18 @@
+import type { ReturnAuthorization } from "@acme/types";
+import {
+  addReturnAuthorization,
+  readReturnAuthorizations,
+  getReturnAuthorization,
+} from "./repositories/returnAuthorization.server";
+
+export { getReturnAuthorization };
+
+export async function listReturnAuthorizations(): Promise<ReturnAuthorization[]> {
+  return readReturnAuthorizations();
+}
+
+export async function createReturnAuthorization(
+  ra: ReturnAuthorization,
+): Promise<void> {
+  await addReturnAuthorization(ra);
+}

--- a/packages/types/src/ReturnAuthorization.ts
+++ b/packages/types/src/ReturnAuthorization.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/**
+ * Represents a return authorization issued for an order.
+ */
+export const returnAuthorizationSchema = z
+  .object({
+    raId: z.string(),
+    orderId: z.string(),
+    status: z.string(),
+    inspectionNotes: z.string().optional(),
+  })
+  .strict();
+
+export type ReturnAuthorization = z.infer<typeof returnAuthorizationSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,6 +11,7 @@ export * from "./Product";
 export * from "./PublishLocation";
 export * from "./RentalOrder";
 export * from "./ReturnLogistics";
+export * from "./ReturnAuthorization";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -4,6 +4,7 @@ import { getShopFromPath } from "@platform-core/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { coreEnv } from "@acme/config/env/core";
+import { luxuryFeatures } from "@platform-core/luxuryFeatures";
 
 if (coreEnv.NODE_ENV === "development") {
   console.log("sidebar rendered on client");
@@ -77,6 +78,9 @@ export default function Sidebar({ role }: { role?: string }) {
             icon: "💰",
           },
         ]
+      : []),
+    ...(luxuryFeatures.raTicketing
+      ? [{ href: "/ra", label: "RA", icon: "↩️" }]
       : []),
     { href: "/live", label: "Live", icon: "🌐" },
     ...(role === "admin"


### PR DESCRIPTION
## Summary
- add ReturnAuthorization schema and repository utilities
- create return request API routes to issue RA numbers and email customers
- expose RA management dashboard in CMS when enabled

## Testing
- `pnpm test --filter @acme/types`
- `pnpm test --filter @acme/platform-core` *(fails: process.exit called)*
- `pnpm test --filter @acme/ui` *(fails: process.exit called)*
- `pnpm test --filter @apps/cms` *(fails: missing modules/env)*
- `pnpm test --filter @apps/shop-abc`


------
https://chatgpt.com/codex/tasks/task_e_689da30f0130832fb764367c0306cc68