### PR TITLE
feat: implement late fee processing

### DIFF
--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -19,6 +19,7 @@
       "secret": "abc-secret"
     }
   },
+  "lateFeePolicy": { "gracePeriodDays": 3, "feeAmount": 15 },
   "componentVersions": {},
   "lastUpgrade": "1970-01-01T00:00:00.000Z",
   "sanityBlog": {

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -15,6 +15,7 @@
       "secret": "bcd-secret"
     }
   },
+  "lateFeePolicy": { "gracePeriodDays": 3, "feeAmount": 15 },
   "componentVersions": {},
   "lastUpgrade": "1970-01-01T00:00:00.000Z",
   "sanityBlog": {

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -13,6 +13,7 @@
   },
   "priceOverrides": {},
   "localeOverrides": {},
+  "lateFeePolicy": { "gracePeriodDays": 3, "feeAmount": 15 },
   "componentVersions": {},
   "lastUpgrade": "1970-01-01T00:00:00.000Z",
   "sanityBlog": {

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -9,6 +9,7 @@
   "taxProviders": ["taxjar"],
   "priceOverrides": {},
   "localeOverrides": {},
+  "lateFeePolicy": { "gracePeriodDays": 3, "feeAmount": 15 },
   "componentVersions": {},
   "lastUpgrade": "1970-01-01T00:00:00.000Z",
   "sanityBlog": {

--- a/packages/platform-core/prisma/migrations/20250302000000_add_return_fields_and_reverse_logistics_events/migration.sql
+++ b/packages/platform-core/prisma/migrations/20250302000000_add_return_fields_and_reverse_logistics_events/migration.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "RentalOrder"
+ADD COLUMN "returnDueDate" TEXT,
+ADD COLUMN "returnReceivedAt" TEXT,
+ADD COLUMN "lateFeeCharged" INTEGER;
+
+CREATE TABLE "ReverseLogisticsEvent" (
+  "id" TEXT PRIMARY KEY,
+  "shop" TEXT NOT NULL,
+  "sessionId" TEXT NOT NULL,
+  "event" TEXT NOT NULL,
+  "at" TEXT NOT NULL
+);
+
+CREATE INDEX "ReverseLogisticsEvent_shop_sessionId_idx" ON "ReverseLogisticsEvent"("shop", "sessionId");

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -31,6 +31,9 @@ model RentalOrder {
   startedAt          String
   returnedAt         String?
   refundedAt         String?
+  returnDueDate      String?
+  returnReceivedAt   String?
+  lateFeeCharged     Int?
   damageFee          Int?
   customerId         String?
   riskLevel          String?
@@ -41,6 +44,16 @@ model RentalOrder {
 
   @@unique([shop, sessionId])
   @@index([customerId])
+}
+
+model ReverseLogisticsEvent {
+  id        String @id
+  shop      String
+  sessionId String
+  event     String
+  at        String
+
+  @@index([shop, sessionId])
 }
 
 model CustomerProfile {

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -22,7 +22,8 @@ export async function addOrder(
   customerId?: string,
   riskLevel?: string,
   riskScore?: number,
-  flaggedForReview?: boolean
+  flaggedForReview?: boolean,
+  returnDueDate?: string,
 ): Promise<Order> {
   const order: Order = {
     id: ulid(),
@@ -30,6 +31,7 @@ export async function addOrder(
     shop,
     deposit,
     expectedReturnDate,
+    returnDueDate,
     startedAt: nowIso(),
     ...(customerId ? { customerId } : {}),
     ...(riskLevel ? { riskLevel } : {}),
@@ -76,6 +78,37 @@ export async function markRefunded(
         ...(typeof riskScore === "number" ? { riskScore } : {}),
         ...(typeof flaggedForReview === "boolean" ? { flaggedForReview } : {}),
       },
+    });
+    return order as Order;
+  } catch {
+    return null;
+  }
+}
+
+export async function markReturnReceived(
+  shop: string,
+  sessionId: string,
+): Promise<Order | null> {
+  try {
+    const order = await prisma.rentalOrder.update({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { returnReceivedAt: nowIso() },
+    });
+    return order as Order;
+  } catch {
+    return null;
+  }
+}
+
+export async function markLateFeeCharged(
+  shop: string,
+  sessionId: string,
+  amount: number,
+): Promise<Order | null> {
+  try {
+    const order = await prisma.rentalOrder.update({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { lateFeeCharged: amount },
     });
     return order as Order;
   } catch {

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -6,6 +6,8 @@ export {
   addOrder,
   markReturned,
   markRefunded,
+  markReturnReceived,
+  markLateFeeCharged,
   updateRisk,
   setReturnTracking,
 } from "../orders";

--- a/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
+++ b/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import { ulid } from "ulid";
+import { nowIso } from "@acme/date-utils";
+import type { ReverseLogisticsEvent } from "@acme/types";
+import { prisma } from "../db";
+
+export async function recordReverseLogisticsEvent(
+  shop: string,
+  sessionId: string,
+  event: ReverseLogisticsEvent["event"],
+): Promise<void> {
+  await prisma.reverseLogisticsEvent.create({
+    data: { id: ulid(), shop, sessionId, event, at: nowIso() },
+  });
+}
+
+export async function listReverseLogisticsEvents(
+  shop: string,
+  sessionId: string,
+): Promise<ReverseLogisticsEvent[]> {
+  return prisma.reverseLogisticsEvent.findMany({ where: { shop, sessionId } });
+}

--- a/packages/platform-core/src/repositories/shops/schema.json
+++ b/packages/platform-core/src/repositories/shops/schema.json
@@ -48,6 +48,15 @@
     "localeOverrides": {
       "type": "object",
       "additionalProperties": { "type": "string" }
+    },
+    "lateFeePolicy": {
+      "type": "object",
+      "properties": {
+        "gracePeriodDays": { "type": "number" },
+        "feeAmount": { "type": "number" }
+      },
+      "required": ["gracePeriodDays", "feeAmount"],
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/packages/platform-machine/src/index.ts
+++ b/packages/platform-machine/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./fsm";
 export * from "./releaseDepositsService";
 export * from "./useFSM";
+export * from "./lateFeeService";
+export * from "./reverseLogisticsWorker";

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -1,0 +1,101 @@
+import { stripe } from "@acme/stripe";
+import { readOrders, markLateFeeCharged } from "@platform-core/repositories/rentalOrders.server";
+import { getShopById } from "@platform-core/repositories/shop.server";
+import { resolveDataRoot } from "@platform-core/dataRoot";
+import { logger } from "@platform-core/utils";
+import { readdir } from "node:fs/promises";
+
+const DATA_ROOT = resolveDataRoot();
+
+export async function chargeLateFeesOnce(
+  shopId?: string,
+  dataRoot: string = DATA_ROOT,
+): Promise<void> {
+  const shops = shopId ? [shopId] : await readdir(dataRoot);
+  const now = Date.now();
+  for (const shop of shops) {
+    let policy: { gracePeriodDays: number; feeAmount: number } | undefined;
+    try {
+      const cfg = await getShopById(shop);
+      policy = cfg.lateFeePolicy as any;
+    } catch {
+      policy = undefined;
+    }
+    if (!policy) continue;
+
+    const orders = await readOrders(shop);
+    for (const order of orders) {
+      if (!order.returnDueDate || order.lateFeeCharged) continue;
+      const due = new Date(order.returnDueDate).getTime();
+      const graceMs = policy.gracePeriodDays * 24 * 60 * 60 * 1000;
+      if (now <= due + graceMs) continue;
+
+      try {
+        const session = await stripe.checkout.sessions.retrieve(order.sessionId, {
+          expand: ["payment_intent"],
+        });
+        const currency = session.currency ?? "usd";
+        const customer = session.customer as string | undefined;
+        const paymentMethod =
+          typeof session.payment_intent !== "string"
+            ? (session.payment_intent?.payment_method as string | undefined)
+            : undefined;
+        await stripe.paymentIntents.create({
+          amount: policy.feeAmount * 100,
+          currency,
+          customer,
+          payment_method: paymentMethod,
+          off_session: true,
+          confirm: true,
+        });
+        await markLateFeeCharged(shop, order.sessionId, policy.feeAmount);
+        logger.info("late fee charged", { shopId: shop, sessionId: order.sessionId });
+      } catch (err) {
+        logger.error("failed to charge late fee", {
+          shopId: shop,
+          sessionId: order.sessionId,
+          err,
+        });
+      }
+    }
+  }
+}
+
+type LateFeeConfig = {
+  enabled: boolean;
+  /** Interval in minutes between service runs */
+  intervalMinutes: number;
+};
+
+const DEFAULT_CONFIG: LateFeeConfig = {
+  enabled: false,
+  intervalMinutes: 60,
+};
+
+export async function startLateFeeService(
+  configs: Record<string, Partial<LateFeeConfig>> = {},
+  dataRoot: string = DATA_ROOT,
+): Promise<() => void> {
+  const shops = await readdir(dataRoot);
+  const timers: NodeJS.Timeout[] = [];
+
+  await Promise.all(
+    shops.map(async (shop) => {
+      const cfg = { ...DEFAULT_CONFIG, ...configs[shop] };
+      if (!cfg.enabled) return;
+
+      async function run() {
+        try {
+          await chargeLateFeesOnce(shop, dataRoot);
+        } catch (err) {
+          logger.error("late fee service failed", { shopId: shop, err });
+        }
+      }
+
+      await run();
+      timers.push(setInterval(run, cfg.intervalMinutes * 60 * 1000));
+    }),
+  );
+
+  return () => timers.forEach((t) => clearInterval(t));
+}

--- a/packages/platform-machine/src/reverseLogisticsWorker.ts
+++ b/packages/platform-machine/src/reverseLogisticsWorker.ts
@@ -1,0 +1,23 @@
+import { recordReverseLogisticsEvent } from "@platform-core/repositories/reverseLogisticsEvents.server";
+import { logger } from "@platform-core/utils";
+
+async function emit(
+  shop: string,
+  sessionId: string,
+  event: "received" | "cleaned" | "qaPassed",
+): Promise<void> {
+  await recordReverseLogisticsEvent(shop, sessionId, event);
+  logger.info(`reverse logistics ${event}`, { shopId: shop, sessionId });
+}
+
+export const reverseLogisticsWorker = {
+  async received(shop: string, sessionId: string) {
+    await emit(shop, sessionId, "received");
+  },
+  async cleaned(shop: string, sessionId: string) {
+    await emit(shop, sessionId, "cleaned");
+  },
+  async qaPassed(shop: string, sessionId: string) {
+    await emit(shop, sessionId, "qaPassed");
+  },
+};

--- a/packages/types/src/RentalOrder.d.ts
+++ b/packages/types/src/RentalOrder.d.ts
@@ -8,6 +8,9 @@ export declare const rentalOrderSchema: z.ZodObject<{
     startedAt: z.ZodString;
     returnedAt: z.ZodOptional<z.ZodString>;
     refundedAt: z.ZodOptional<z.ZodString>;
+    returnDueDate: z.ZodOptional<z.ZodString>;
+    returnReceivedAt: z.ZodOptional<z.ZodString>;
+    lateFeeCharged: z.ZodOptional<z.ZodNumber>;
     /** Optional damage fee deducted from the deposit */
     damageFee: z.ZodOptional<z.ZodNumber>;
     customerId: z.ZodOptional<z.ZodString>;
@@ -25,6 +28,9 @@ export declare const rentalOrderSchema: z.ZodObject<{
     expectedReturnDate?: string | undefined;
     returnedAt?: string | undefined;
     refundedAt?: string | undefined;
+    returnDueDate?: string | undefined;
+    returnReceivedAt?: string | undefined;
+    lateFeeCharged?: number | undefined;
     damageFee?: number | undefined;
     customerId?: string | undefined;
     riskLevel?: string | undefined;
@@ -41,6 +47,9 @@ export declare const rentalOrderSchema: z.ZodObject<{
     expectedReturnDate?: string | undefined;
     returnedAt?: string | undefined;
     refundedAt?: string | undefined;
+    returnDueDate?: string | undefined;
+    returnReceivedAt?: string | undefined;
+    lateFeeCharged?: number | undefined;
     damageFee?: number | undefined;
     customerId?: string | undefined;
     riskLevel?: string | undefined;

--- a/packages/types/src/RentalOrder.ts
+++ b/packages/types/src/RentalOrder.ts
@@ -10,6 +10,9 @@ export const rentalOrderSchema = z
     startedAt: z.string(),
     returnedAt: z.string().optional(),
     refundedAt: z.string().optional(),
+    returnDueDate: z.string().optional(),
+    returnReceivedAt: z.string().optional(),
+    lateFeeCharged: z.number().optional(),
     /** Optional damage fee deducted from the deposit */
     damageFee: z.number().optional(),
     customerId: z.string().optional(),

--- a/packages/types/src/ReverseLogisticsEvent.d.ts
+++ b/packages/types/src/ReverseLogisticsEvent.d.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+export declare const reverseLogisticsEventSchema: z.ZodObject<{
+    id: z.ZodString;
+    shop: z.ZodString;
+    sessionId: z.ZodString;
+    event: z.ZodEnum<["received", "cleaned", "qaPassed"]>;
+    at: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    shop: string;
+    sessionId: string;
+    event: "received" | "cleaned" | "qaPassed";
+    at: string;
+}, {
+    id: string;
+    shop: string;
+    sessionId: string;
+    event: "received" | "cleaned" | "qaPassed";
+    at: string;
+}>;
+export type ReverseLogisticsEvent = z.infer<typeof reverseLogisticsEventSchema>;
+//# sourceMappingURL=ReverseLogisticsEvent.d.ts.map

--- a/packages/types/src/ReverseLogisticsEvent.ts
+++ b/packages/types/src/ReverseLogisticsEvent.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const reverseLogisticsEventSchema = z
+  .object({
+    id: z.string(),
+    shop: z.string(),
+    sessionId: z.string(),
+    event: z.enum(["received", "cleaned", "qaPassed"]),
+    at: z.string(),
+  })
+  .strict();
+
+export type ReverseLogisticsEvent = z.infer<typeof reverseLogisticsEventSchema>;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -96,6 +96,13 @@ export const shopSchema = z
     domain: shopDomainSchema.optional(),
     returnPolicyUrl: z.string().url().optional(),
     returnsEnabled: z.boolean().optional(),
+    lateFeePolicy: z
+      .object({
+        gracePeriodDays: z.number().int().nonnegative(),
+        feeAmount: z.number().int().nonnegative(),
+      })
+      .strict()
+      .optional(),
     analyticsEnabled: z.boolean().optional(),
     lastUpgrade: z.string().datetime().optional(),
     componentVersions: z.record(z.string()).default({}),

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -9,6 +9,7 @@ export * from "./Product";
 export * from "./PublishLocation";
 export * from "./RentalOrder";
 export * from "./ReturnLogistics";
+export * from "./ReverseLogisticsEvent";
 export * from "./Shop";
 export * from "./ShopSettings";
 //# sourceMappingURL=index.d.ts.map

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,6 +11,7 @@ export * from "./Product";
 export * from "./PublishLocation";
 export * from "./RentalOrder";
 export * from "./ReturnLogistics";
+export * from "./ReverseLogisticsEvent";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";


### PR DESCRIPTION
## Summary
- extend rental orders with return due date, return received time, and late fee tracking
- add late fee service to charge overdue orders via Stripe
- log reverse logistics events for received, cleaned, and QA passed items
- configure shop late fee policy with grace period and fee amount

## Testing
- `pnpm --filter @acme/types test`
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm --filter @acme/platform-machine test` *(fails: process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689da3fc5f54832fb024a91417f241f2