### PR TITLE
feat: add reverse logistics worker

### DIFF
--- a/doc/machine.md
+++ b/doc/machine.md
@@ -38,6 +38,36 @@ Stripe credentials (`STRIPE_SECRET_KEY`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, a
 pnpm release-deposits
 ```
 
+## Reverse logistics service
+
+Rental operations often track returned items through several post‑rental stages. The reverse logistics worker in `@acme/platform-machine` reads event files for each shop and updates rental order statuses.
+
+```ts
+import {
+  processReverseLogisticsEventsOnce,
+  startReverseLogisticsService,
+} from "@acme/platform-machine";
+
+// handle all pending events once
+await processReverseLogisticsEventsOnce();
+
+// or run on an interval (default: hourly)
+const stop = await startReverseLogisticsService();
+// stop(); // call to clear the interval
+```
+
+Events are JSON files placed in `data/shops/<id>/reverse-logistics/` with a `sessionId` and `status` field (e.g. `received`, `cleaning`, `repair`, `qa`, or `available`).
+
+Each shop controls the worker in `data/shops/<id>/settings.json` under `reverseLogisticsService`:
+
+```json
+{
+  "reverseLogisticsService": { "enabled": true, "intervalMinutes": 60 }
+}
+```
+
+Running `pnpm ts-node scripts/setup-ci.ts <shop>` exposes a `REVERSE_LOGISTICS_ENABLED` environment variable in the generated workflow so the service can be toggled per shop.
+
 ## Finite State Machine (FSM)
 
 The package also exports a tiny, type-safe FSM helper for modeling UI or service workflows.

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -45,6 +45,20 @@ export const coreEnvBaseSchema = z.object({
     })
     .transform((v) => Number(v))
     .optional(),
+  REVERSE_LOGISTICS_ENABLED: z
+    .string()
+    .refine((v) => v === "true" || v === "false", {
+      message: "must be true or false",
+    })
+    .transform((v) => v === "true")
+    .optional(),
+  REVERSE_LOGISTICS_INTERVAL_MS: z
+    .string()
+    .refine((v) => !Number.isNaN(Number(v)), {
+      message: "must be a number",
+    })
+    .transform((v) => Number(v))
+    .optional(),
   OPENAI_API_KEY: z.string().optional(),
   SESSION_SECRET: z.string().min(1),
   COOKIE_DOMAIN: z.string().optional(),
@@ -65,8 +79,15 @@ export function depositReleaseEnvRefinement(
   ctx: z.RefinementCtx,
 ): void {
   for (const [key, value] of Object.entries(env)) {
-    if (!key.startsWith("DEPOSIT_RELEASE_")) continue;
-    if (key === "DEPOSIT_RELEASE_ENABLED" || key === "DEPOSIT_RELEASE_INTERVAL_MS")
+    const isDeposit = key.startsWith("DEPOSIT_RELEASE_");
+    const isReverse = key.startsWith("REVERSE_LOGISTICS_");
+    if (!isDeposit && !isReverse) continue;
+    if (
+      key === "DEPOSIT_RELEASE_ENABLED" ||
+      key === "DEPOSIT_RELEASE_INTERVAL_MS" ||
+      key === "REVERSE_LOGISTICS_ENABLED" ||
+      key === "REVERSE_LOGISTICS_INTERVAL_MS"
+    )
       continue;
     if (key.includes("ENABLED")) {
       if (value !== "true" && value !== "false") {

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -1,6 +1,9 @@
 // packages/platform-core/src/repositories/rentalOrders.server.ts
 import "server-only";
 
+import type { RentalOrder } from "@acme/types";
+import { prisma } from "../db";
+
 export {
   listOrders as readOrders,
   addOrder,
@@ -9,3 +12,46 @@ export {
   updateRisk,
   setReturnTracking,
 } from "../orders";
+
+type Order = RentalOrder;
+
+async function updateStatus(
+  shop: string,
+  sessionId: string,
+  status: NonNullable<Order["status"]>,
+): Promise<Order | null> {
+  try {
+    const order = await prisma.rentalOrder.update({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { status } as any,
+    });
+    return order as Order;
+  } catch {
+    return null;
+  }
+}
+
+export const markReceived = (
+  shop: string,
+  sessionId: string,
+): Promise<Order | null> => updateStatus(shop, sessionId, "received");
+
+export const markCleaning = (
+  shop: string,
+  sessionId: string,
+): Promise<Order | null> => updateStatus(shop, sessionId, "cleaning");
+
+export const markRepair = (
+  shop: string,
+  sessionId: string,
+): Promise<Order | null> => updateStatus(shop, sessionId, "repair");
+
+export const markQa = (
+  shop: string,
+  sessionId: string,
+): Promise<Order | null> => updateStatus(shop, sessionId, "qa");
+
+export const markAvailable = (
+  shop: string,
+  sessionId: string,
+): Promise<Order | null> => updateStatus(shop, sessionId, "available");

--- a/packages/platform-machine/src/index.ts
+++ b/packages/platform-machine/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./fsm";
 export * from "./releaseDepositsService";
+export * from "./reverseLogisticsService";
 export * from "./useFSM";

--- a/packages/platform-machine/src/reverseLogisticsService.ts
+++ b/packages/platform-machine/src/reverseLogisticsService.ts
@@ -1,0 +1,158 @@
+import { coreEnv } from "@acme/config/env/core";
+import type { RentalOrder } from "@acme/types";
+import {
+  markAvailable,
+  markCleaning,
+  markQa,
+  markReceived,
+  markRepair,
+} from "@platform-core/repositories/rentalOrders.server";
+import { resolveDataRoot } from "@platform-core/dataRoot";
+import { logger } from "@platform-core/utils";
+import { readdir, readFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+const DATA_ROOT = resolveDataRoot();
+
+interface ReverseLogisticsEvent {
+  sessionId: string;
+  status: NonNullable<RentalOrder["status"]>;
+}
+
+export async function processReverseLogisticsEventsOnce(
+  shopId?: string,
+  dataRoot: string = DATA_ROOT,
+): Promise<void> {
+  const shops = shopId ? [shopId] : await readdir(dataRoot);
+  for (const shop of shops) {
+    const dir = join(dataRoot, shop, "reverse-logistics");
+    let files: string[] = [];
+    try {
+      files = await readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const full = join(dir, file);
+      try {
+        const raw = await readFile(full, "utf8");
+        const evt = JSON.parse(raw) as ReverseLogisticsEvent;
+        switch (evt.status) {
+          case "received":
+            await markReceived(shop, evt.sessionId);
+            break;
+          case "cleaning":
+            await markCleaning(shop, evt.sessionId);
+            break;
+          case "repair":
+            await markRepair(shop, evt.sessionId);
+            break;
+          case "qa":
+            await markQa(shop, evt.sessionId);
+            break;
+          case "available":
+            await markAvailable(shop, evt.sessionId);
+            break;
+        }
+      } catch (err) {
+        logger.error("reverse logistics event failed", {
+          shopId: shop,
+          file,
+          err,
+        });
+      } finally {
+        try {
+          await unlink(full);
+        } catch {}
+      }
+    }
+  }
+}
+
+type ReverseLogisticsConfig = {
+  enabled: boolean;
+  /** Interval in minutes between service runs */
+  intervalMinutes: number;
+};
+
+const DEFAULT_CONFIG: ReverseLogisticsConfig = {
+  enabled: false,
+  intervalMinutes: 60,
+};
+
+function envKey(shop: string, key: string): string {
+  return `REVERSE_LOGISTICS_${key}_${shop.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+}
+
+async function resolveConfig(
+  shop: string,
+  dataRoot: string,
+  override: Partial<ReverseLogisticsConfig> = {},
+): Promise<ReverseLogisticsConfig> {
+  let config: ReverseLogisticsConfig = { ...DEFAULT_CONFIG };
+
+  try {
+    const file = join(dataRoot, shop, "settings.json");
+    const json = JSON.parse(await readFile(file, "utf8"));
+    const cfg = json.reverseLogisticsService;
+    if (cfg) {
+      if (typeof cfg.enabled === "boolean") config.enabled = cfg.enabled;
+      if (typeof cfg.intervalMinutes === "number")
+        config.intervalMinutes = cfg.intervalMinutes;
+    }
+  } catch {}
+
+  const envEnabled = process.env[envKey(shop, "ENABLED")];
+  if (envEnabled !== undefined) {
+    config.enabled = envEnabled !== "false";
+  } else if (coreEnv.REVERSE_LOGISTICS_ENABLED !== undefined) {
+    config.enabled = coreEnv.REVERSE_LOGISTICS_ENABLED;
+  }
+
+  const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
+  if (envInterval !== undefined) {
+    const num = Number(envInterval);
+    if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
+  } else if (coreEnv.REVERSE_LOGISTICS_INTERVAL_MS !== undefined) {
+    config.intervalMinutes = Math.round(
+      coreEnv.REVERSE_LOGISTICS_INTERVAL_MS / 60000,
+    );
+  }
+
+  if (override.enabled !== undefined) config.enabled = override.enabled;
+  if (override.intervalMinutes !== undefined)
+    config.intervalMinutes = override.intervalMinutes;
+
+  return config;
+}
+
+export async function startReverseLogisticsService(
+  configs: Record<string, Partial<ReverseLogisticsConfig>> = {},
+  dataRoot: string = DATA_ROOT,
+): Promise<() => void> {
+  const shops = await readdir(dataRoot);
+  const timers: NodeJS.Timeout[] = [];
+
+  await Promise.all(
+    shops.map(async (shop) => {
+      const cfg = await resolveConfig(shop, dataRoot, configs[shop]);
+      if (!cfg.enabled) return;
+
+      async function run() {
+        try {
+          await processReverseLogisticsEventsOnce(shop, dataRoot);
+        } catch (err) {
+          logger.error("reverse logistics processing failed", {
+            shopId: shop,
+            err,
+          });
+        }
+      }
+
+      await run();
+      timers.push(setInterval(run, cfg.intervalMinutes * 60 * 1000));
+    }),
+  );
+
+  return () => timers.forEach((t) => clearInterval(t));
+}

--- a/packages/types/src/RentalOrder.d.ts
+++ b/packages/types/src/RentalOrder.d.ts
@@ -16,6 +16,7 @@ export declare const rentalOrderSchema: z.ZodObject<{
     flaggedForReview: z.ZodOptional<z.ZodBoolean>;
     trackingNumber: z.ZodOptional<z.ZodString>;
     labelUrl: z.ZodOptional<z.ZodString>;
+    status: z.ZodOptional<z.ZodEnum<["received", "cleaning", "repair", "qa", "available"]>>;
 }, "strip", z.ZodTypeAny, {
     id: string;
     deposit: number;
@@ -32,6 +33,7 @@ export declare const rentalOrderSchema: z.ZodObject<{
     flaggedForReview?: boolean | undefined;
     trackingNumber?: string | undefined;
     labelUrl?: string | undefined;
+    status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined;
 }, {
     id: string;
     deposit: number;
@@ -48,6 +50,7 @@ export declare const rentalOrderSchema: z.ZodObject<{
     flaggedForReview?: boolean | undefined;
     trackingNumber?: string | undefined;
     labelUrl?: string | undefined;
+    status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined;
 }>;
 export type RentalOrder = z.infer<typeof rentalOrderSchema>;
 //# sourceMappingURL=RentalOrder.d.ts.map

--- a/packages/types/src/RentalOrder.ts
+++ b/packages/types/src/RentalOrder.ts
@@ -18,6 +18,9 @@ export const rentalOrderSchema = z
     flaggedForReview: z.boolean().optional(),
     trackingNumber: z.string().optional(),
     labelUrl: z.string().url().optional(),
+    status: z
+      .enum(["received", "cleaning", "repair", "qa", "available"])
+      .optional(),
   })
   .strict();
 

--- a/scripts/src/setup-ci.ts
+++ b/scripts/src/setup-ci.ts
@@ -48,7 +48,23 @@ if (existsSync(shopConfigPath)) {
   }
 }
 
-const allEnv = { ...env, ...domainVars };
+const settingsPath = join("data", "shops", shopId, "settings.json");
+let workerVars: Record<string, string> = {};
+if (existsSync(settingsPath)) {
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as {
+      reverseLogisticsService?: { enabled?: boolean };
+    };
+    if (typeof settings.reverseLogisticsService?.enabled === "boolean") {
+      workerVars.REVERSE_LOGISTICS_ENABLED = String(
+        settings.reverseLogisticsService.enabled,
+      );
+    }
+  } catch {
+    // ignore errors reading settings
+  }
+}
+const allEnv = { ...env, ...domainVars, ...workerVars };
 const envLines = Object.entries(allEnv)
   .map(([k, v]) => `      ${k}: ${v}`)
   .join("\n");


### PR DESCRIPTION
## Summary
- support new rental order lifecycle statuses
- add state transition helpers for rental orders
- introduce reverse logistics worker service
- expose worker toggle in CI setup and docs

## Testing
- `pnpm test` *(fails: command '@apps/cms#test' exited with code 1)*
- `pnpm --filter @acme/platform-machine test -- packages/platform-machine` *(fails: Test Suites: 1 failed, 2 passed, 3 total)*

------
https://chatgpt.com/codex/tasks/task_e_689da3f90ff4832fb4f07f269cca7f0d