### PR TITLE
feat: add subscription plan proration

### DIFF
--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -27,4 +27,14 @@
     "token": "token"
   },
   "editorialBlog": { "enabled": false }
+  ,
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -23,4 +23,14 @@
     "token": "token"
   },
   "editorialBlog": { "enabled": false }
+  ,
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -21,4 +21,14 @@
     "token": "token"
   },
   "editorialBlog": { "enabled": false }
+  ,
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -17,4 +17,14 @@
     "token": "token"
   },
   "editorialBlog": { "enabled": false }
+  ,
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/packages/platform-core/src/repositories/subscriptionUsage.server.ts
+++ b/packages/platform-core/src/repositories/subscriptionUsage.server.ts
@@ -1,0 +1,56 @@
+// packages/platform-core/src/repositories/subscriptionUsage.server.ts
+import "server-only";
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { validateShopName } from "../shops";
+import { DATA_ROOT } from "../dataRoot";
+
+const FILE_NAME = "subscription-usage.json";
+
+function filePath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, FILE_NAME);
+}
+
+async function ensureDir(shop: string): Promise<void> {
+  shop = validateShopName(shop);
+  await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
+}
+
+async function readUsageRepo(shop: string): Promise<Record<string, number>> {
+  try {
+    const buf = await fs.readFile(filePath(shop), "utf8");
+    return JSON.parse(buf) as Record<string, number>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeUsageRepo(shop: string, data: Record<string, number>): Promise<void> {
+  await ensureDir(shop);
+  const tmp = `${filePath(shop)}.${Date.now()}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  await fs.rename(tmp, filePath(shop));
+}
+
+export async function getUsage(shop: string, customerId: string): Promise<number> {
+  const repo = await readUsageRepo(shop);
+  return repo[customerId] ?? 0;
+}
+
+export async function incrementUsage(
+  shop: string,
+  customerId: string,
+  amount = 1,
+): Promise<void> {
+  const repo = await readUsageRepo(shop);
+  repo[customerId] = (repo[customerId] ?? 0) + amount;
+  await writeUsageRepo(shop, repo);
+}
+
+export async function resetUsage(shop: string, customerId: string): Promise<void> {
+  const repo = await readUsageRepo(shop);
+  delete repo[customerId];
+  await writeUsageRepo(shop, repo);
+}

--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -1,0 +1,31 @@
+import { stripe } from "@acme/stripe";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const { subscriptionId, priceId, prorate } = (await req.json()) as {
+    subscriptionId?: string;
+    priceId?: string;
+    prorate?: boolean;
+  };
+  if (!subscriptionId || !priceId) {
+    return NextResponse.json(
+      { error: "Missing subscriptionId or priceId" },
+      { status: 400 },
+    );
+  }
+
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  const itemId = subscription.items.data[0]?.id;
+  if (!itemId) {
+    return NextResponse.json({ error: "No subscription item" }, { status: 400 });
+  }
+
+  const updated = await stripe.subscriptions.update(subscriptionId, {
+    items: [{ id: itemId, price: priceId }],
+    proration_behavior: prorate ? "create_prorations" : "none",
+  });
+
+  return NextResponse.json({ ok: true, subscription: updated });
+}

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { subscriptionPlanSchema } from "./SubscriptionPlan";
 export declare const shopSeoFieldsSchema: z.ZodObject<{
     canonicalBase: z.ZodOptional<z.ZodString>;
     title: z.ZodOptional<z.ZodString>;
@@ -173,6 +174,7 @@ export declare const shopSchema: z.ZodObject<{
     analyticsEnabled: z.ZodOptional<z.ZodBoolean>;
     lastUpgrade: z.ZodOptional<z.ZodString>;
     componentVersions: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodString>>;
+    subscriptionPlans: z.ZodOptional<z.ZodArray<typeof subscriptionPlanSchema, "many">>;
 }, "strict", z.ZodTypeAny, {
     id: string;
     name: string;
@@ -213,6 +215,7 @@ export declare const shopSchema: z.ZodObject<{
     analyticsEnabled?: boolean | undefined;
     lastUpgrade?: string | undefined;
     componentVersions: Record<string, string>;
+    subscriptionPlans?: import("./SubscriptionPlan").SubscriptionPlan[] | undefined;
 }, {
     id: string;
     name: string;
@@ -252,7 +255,8 @@ export declare const shopSchema: z.ZodObject<{
     returnsEnabled?: boolean | undefined;
     analyticsEnabled?: boolean | undefined;
     lastUpgrade?: string | undefined;
+    subscriptionPlans?: import("./SubscriptionPlan").SubscriptionPlan[] | undefined;
     componentVersions?: Record<string, string> | undefined;
-}>;
+}>; 
 export type Shop = z.infer<typeof shopSchema>;
 //# sourceMappingURL=Shop.d.ts.map

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { localeSchema } from "./Product";
+import { subscriptionPlanSchema } from "./SubscriptionPlan";
 
 export const shopSeoFieldsSchema = z
   .object({
@@ -99,6 +100,7 @@ export const shopSchema = z
     analyticsEnabled: z.boolean().optional(),
     lastUpgrade: z.string().datetime().optional(),
     componentVersions: z.record(z.string()).default({}),
+    subscriptionPlans: z.array(subscriptionPlanSchema).optional(),
   })
   .strict();
 

--- a/packages/types/src/SubscriptionPlan.ts
+++ b/packages/types/src/SubscriptionPlan.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+/** Definition for a subscription plan available in a shop. */
+export const subscriptionPlanSchema = z
+  .object({
+    /** Unique identifier for the plan */
+    id: z.string(),
+    /** Human readable name */
+    name: z.string(),
+    /** Stripe price identifier associated with this plan */
+    priceId: z.string(),
+    /** Number of shipments allowed per month */
+    shipmentsPerMonth: z.number().int().nonnegative().default(0),
+    /** Whether plan changes should be prorated by Stripe */
+    prorateOnChange: z.boolean().default(true),
+  })
+  .strict();
+
+export type SubscriptionPlan = z.infer<typeof subscriptionPlanSchema>;

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -11,4 +11,5 @@ export * from "./RentalOrder";
 export * from "./ReturnLogistics";
 export * from "./Shop";
 export * from "./ShopSettings";
+export * from "./SubscriptionPlan";
 //# sourceMappingURL=index.d.ts.map

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,3 +14,4 @@ export * from "./ReturnLogistics";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";
+export * from "./SubscriptionPlan";


### PR DESCRIPTION
## Summary
- define `SubscriptionPlan` model with shipment and proration options
- track per-subscriber shipment usage
- add API route to change subscriptions with optional proration

## Testing
- `pnpm test --filter @acme/platform-core` (fails: command exited with error)
- `pnpm test --filter @acme/template-app`
- `pnpm test --filter @acme/types`


------
https://chatgpt.com/codex/tasks/task_e_689da3f5797c832f907ed2c35951fc14