### PR TITLE
feat: add subscription plans and swap UI

### DIFF
--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -26,5 +26,21 @@
     "raTicketing": false,
     "fraudReview": false,
     "strictReturnConditions": false
-  }
+  },
+  "rentalSubscriptions": [
+    {
+      "id": "basic",
+      "price": 3000,
+      "itemsIncluded": 3,
+      "swapLimit": 1,
+      "shipmentCount": 1
+    },
+    {
+      "id": "premium",
+      "price": 5000,
+      "itemsIncluded": 5,
+      "swapLimit": 2,
+      "shipmentCount": 2
+    }
+  ]
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -22,5 +22,21 @@
     "raTicketing": false,
     "fraudReview": false,
     "strictReturnConditions": false
-  }
+  },
+  "rentalSubscriptions": [
+    {
+      "id": "basic",
+      "price": 3000,
+      "itemsIncluded": 3,
+      "swapLimit": 1,
+      "shipmentCount": 1
+    },
+    {
+      "id": "premium",
+      "price": 5000,
+      "itemsIncluded": 5,
+      "swapLimit": 2,
+      "shipmentCount": 2
+    }
+  ]
 }

--- a/packages/platform-core/src/createShop.ts
+++ b/packages/platform-core/src/createShop.ts
@@ -51,6 +51,8 @@ export async function createShop(
     paymentProviders: prepared.payment,
     sanityBlog: prepared.sanityBlog,
     enableEditorial: prepared.enableEditorial,
+    subscriptionsEnabled: prepared.enableSubscriptions,
+    rentalSubscriptions: [],
   };
 
   await prisma.shop.create({ data: { id, data: shopData } });

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -48,6 +48,7 @@ export const createShopOptionsSchema = z
       .optional(),
     sanityBlog: sanityBlogConfigSchema.optional(),
     enableEditorial: z.boolean().optional(),
+    enableSubscriptions: z.boolean().optional(),
     navItems: z.array(navItemSchema).default([]),
     pages: z
       .array(
@@ -69,12 +70,13 @@ export type CreateShopOptions = z.infer<typeof createShopOptionsSchema>;
 export type PreparedCreateShopOptions = Required<
   Omit<
     CreateShopOptions,
-    "analytics" | "checkoutPage" | "sanityBlog" | "enableEditorial"
+    "analytics" | "checkoutPage" | "sanityBlog" | "enableEditorial" | "enableSubscriptions"
   >
 > & {
   analytics?: CreateShopOptions["analytics"];
   sanityBlog?: CreateShopOptions["sanityBlog"];
   enableEditorial: boolean;
+  enableSubscriptions: boolean;
   checkoutPage: PageComponent[];
 };
 
@@ -126,5 +128,6 @@ export function prepareOptions(
     checkoutPage: parsed.checkoutPage,
     sanityBlog: parsed.sanityBlog,
     enableEditorial: parsed.enableEditorial ?? false,
+    enableSubscriptions: parsed.enableSubscriptions ?? false,
   };
 }

--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -1,0 +1,44 @@
+// packages/template-app/src/app/[lang]/subscribe/page.tsx
+import { Locale, resolveLocale } from "@/i18n/locales";
+import { readShop } from "@platform-core/src/repositories/shops.server";
+import { addOrder } from "@platform-core/src/repositories/rentalOrders.server";
+
+export default async function SubscribePage({
+  params,
+}: {
+  params: Promise<{ lang?: string }>;
+}) {
+  const { lang: rawLang } = await params;
+  const lang: Locale = resolveLocale(rawLang);
+  const shop = await readShop("shop");
+
+  async function selectPlan(formData: FormData) {
+    "use server";
+    const planId = formData.get("plan") as string;
+    if (!planId) return;
+    await addOrder("shop", `sub-${planId}-${Date.now()}`, 0);
+  }
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+      <h1 className="text-2xl font-bold">Choose a Plan</h1>
+      <form action={selectPlan} className="flex flex-col gap-4">
+        {shop.rentalSubscriptions.map((p) => (
+          <label key={p.id} className="flex items-center gap-2">
+            <input type="radio" name="plan" value={p.id} />
+            <span>
+              {p.id} – {p.itemsIncluded} items, {p.swapLimit} swaps, {p.shipmentCount}
+              {" "}shipments
+            </span>
+          </label>
+        ))}
+        <button
+          type="submit"
+          className="mt-4 rounded bg-black px-4 py-2 text-white"
+        >
+          Subscribe
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/packages/template-app/src/app/account/swaps/page.tsx
+++ b/packages/template-app/src/app/account/swaps/page.tsx
@@ -1,0 +1,55 @@
+// packages/template-app/src/app/account/swaps/page.tsx
+import {
+  CART_COOKIE,
+  decodeCartCookie,
+} from "@platform-core/src/cartCookie";
+import {
+  getCart,
+  removeItem,
+  incrementQty,
+} from "@platform-core/src/cartStore";
+import { getProductById } from "@platform-core/src/products";
+import { cookies } from "next/headers";
+
+export default async function SwapPage() {
+  const cookieStore = await cookies();
+  const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cart = cartId ? await getCart(cartId) : {};
+
+  async function swap(formData: FormData) {
+    "use server";
+    const oldSku = formData.get("old") as string;
+    const newSku = formData.get("new") as string;
+    const cookieStore = await cookies();
+    const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+    if (!cartId) return;
+    const sku = getProductById(newSku);
+    if (!sku) return;
+    await removeItem(cartId, oldSku);
+    await incrementQty(cartId, sku, 1);
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-4 text-2xl font-bold">Swap Items</h1>
+      {Object.entries(cart).map(([id, line]) => (
+        <form key={id} action={swap} className="mb-3 flex gap-2">
+          <span className="flex-1">{line.sku.name}</span>
+          <input type="hidden" name="old" value={id} />
+          <input
+            type="text"
+            name="new"
+            placeholder="New SKU ID"
+            className="w-40 border p-1"
+          />
+          <button
+            type="submit"
+            className="rounded bg-black px-2 py-1 text-white"
+          >
+            Swap
+          </button>
+        </form>
+      ))}
+    </div>
+  );
+}

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { localeSchema } from "./Product";
+import { subscriptionPlanSchema } from "./SubscriptionPlan";
 
 export const shopSeoFieldsSchema = z
   .object({
@@ -113,6 +114,10 @@ export const shopSchema = z
       }),
     lastUpgrade: z.string().datetime().optional(),
     componentVersions: z.record(z.string()).default({}),
+    rentalSubscriptions: z
+      .array(subscriptionPlanSchema)
+      .default([]),
+    subscriptionsEnabled: z.boolean().default(false),
   })
   .strict();
 

--- a/packages/types/src/SubscriptionPlan.ts
+++ b/packages/types/src/SubscriptionPlan.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const subscriptionPlanSchema = z
+  .object({
+    id: z.string(),
+    price: z.number(),
+    itemsIncluded: z.number(),
+    swapLimit: z.number(),
+    shipmentCount: z.number(),
+  })
+  .strict();
+
+export type SubscriptionPlan = z.infer<typeof subscriptionPlanSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,3 +15,4 @@ export * from "./ReturnAuthorization";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";
+export * from "./SubscriptionPlan";


### PR DESCRIPTION
## Summary
- define `SubscriptionPlan` schema and expose on `Shop`
- add rental subscription plans in sample shop data
- add subscription signup and swap pages to template app
- support enabling subscriptions when creating a shop

## Testing
- `npx eslint packages/types/src/SubscriptionPlan.ts packages/types/src/Shop.ts packages/template-app/src/app/[lang]/subscribe/page.tsx packages/template-app/src/app/account/swaps/page.tsx packages/platform-core/src/createShop.ts packages/platform-core/src/createShop/schema.ts scripts/src/create-shop.ts` *(warn: File ignored because no matching configuration was supplied)*
- `pnpm typecheck` *(failed: packages/shared-utils/src/parseJsonBody.ts is not listed within the file list of project '/workspace/base-shop/apps/shop-bcd/tsconfig.json'. Projects must list all files or use an 'include' pattern.)*
- `pnpm test` *(failed: @acme/next-config:test: # fail 6)*

------
https://chatgpt.com/codex/tasks/task_e_689da8268a8c832fb60f30f04b72cab7