### PR TITLE
Add cleaning transparency info for rentals

### DIFF
--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -6,6 +6,7 @@
   "themeOverrides": {},
   "filterMappings": {},
   "shippingProviders": ["ups", "premier-shipping"],
+  "showCleaningTransparency": true,
   "premierDelivery": {
     "regions": ["us-east"],
     "windows": ["10-11", "11-12"]

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -6,6 +6,7 @@
   "themeOverrides": {},
   "filterMappings": {},
   "shippingProviders": ["dhl"],
+  "showCleaningTransparency": true,
   "billingProvider": "stripe",
   "priceOverrides": {},
   "localeOverrides": {},

--- a/data/rental/cleaning.json
+++ b/data/rental/cleaning.json
@@ -1,3 +1,4 @@
 {
-  "reusableBagPolicy": "Please return items in the reusable bag provided. A $10 fee applies if the bag is not returned."
+  "garment": "Garments are professionally cleaned with biodegradable detergents between rentals.",
+  "reusableBag": "Reusable bags are machine washed and sanitized after every return."
 }

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -5,6 +5,7 @@
   "themeId": "base",
   "themeOverrides": {},
   "filterMappings": {},
+  "showCleaningTransparency": true,
   "shippingProviders": ["ups", "premier-shipping"],
   "taxProviders": ["taxjar"],
   "premierDelivery": {

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -5,6 +5,7 @@
   "themeId": "base",
   "themeOverrides": {},
   "filterMappings": {},
+  "showCleaningTransparency": true,
   "shippingProviders": ["dhl"],
   "taxProviders": ["taxjar"],
   "billingProvider": "stripe",

--- a/packages/template-app/src/app/[lang]/product/[slug]/page.tsx
+++ b/packages/template-app/src/app/[lang]/product/[slug]/page.tsx
@@ -6,6 +6,8 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import PdpClient from "./PdpClient.client";
 import { getStructuredData, serializeJsonLd } from "../../../../lib/seo";
+import CleaningInfo from "../../../../components/CleaningInfo";
+import shop from "../../../../../shop.json";
 
 export async function generateStaticParams() {
   return LOCALES.flatMap((lang) =>
@@ -53,6 +55,7 @@ export default function ProductDetailPage({
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       <PdpClient product={product} />
+      {shop.showCleaningTransparency && <CleaningInfo />}
     </>
   );
 }

--- a/packages/template-app/src/app/returns/pickup/page.tsx
+++ b/packages/template-app/src/app/returns/pickup/page.tsx
@@ -1,5 +1,6 @@
 import { getReturnLogistics } from "@platform-core/returnLogistics";
 import CleaningInfo from "../../../components/CleaningInfo";
+import shop from "../../../../shop.json";
 
 export const metadata = { title: "Schedule pickup" };
 
@@ -33,7 +34,7 @@ export default async function PickupPage({
           </button>
         </form>
       )}
-      <CleaningInfo />
+      {shop.showCleaningTransparency && <CleaningInfo />}
     </div>
   );
 }

--- a/packages/template-app/src/components/CleaningInfo.tsx
+++ b/packages/template-app/src/components/CleaningInfo.tsx
@@ -2,9 +2,16 @@ import cleaning from "../../../../data/rental/cleaning.json";
 
 export default function CleaningInfo() {
   return (
-    <section className="space-y-2">
-      <h2 className="text-lg font-semibold">Bag Policy</h2>
-      <p>{cleaning.reusableBagPolicy}</p>
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold">Cleaning Information</h2>
+      <div className="space-y-1">
+        <h3 className="font-medium">Garments</h3>
+        <p>{cleaning.garment}</p>
+      </div>
+      <div className="space-y-1">
+        <h3 className="font-medium">Reusable Bags</h3>
+        <p>{cleaning.reusableBag}</p>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- document garment and bag cleaning methods
- show CleaningInfo component on product page and return pickup flow
- toggle visibility with `showCleaningTransparency` flag in `shop.json`

## Testing
- `pnpm test --filter @acme/template-app`


------
https://chatgpt.com/codex/tasks/task_e_689da93d5388832faa4bb0b750979b77