### PR TITLE
feat: add mobile return scanning

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
@@ -29,6 +29,7 @@ export async function POST(
       bagType,
       returnCarrier,
       homePickupZipCodes,
+      mobileApp,
     } = parsed.data;
     await writeReturnLogistics({
       labelService,
@@ -38,6 +39,7 @@ export async function POST(
       bagType,
       returnCarrier,
       homePickupZipCodes,
+      mobileApp,
     });
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -121,6 +121,15 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         />
         <span>Enable tracking numbers</span>
       </label>
+      <label className="flex items-center gap-2">
+        <Checkbox
+          checked={Boolean(form.mobileApp)}
+          onCheckedChange={(v) =>
+            setForm((f) => ({ ...f, mobileApp: Boolean(v) }))
+          }
+        />
+        <span>Enable mobile returns</span>
+      </label>
       {status === "saved" && (
         <p className="text-sm text-green-600">Saved!</p>
       )}

--- a/apps/shop-bcd/src/app/account/orders/[id]/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/[id]/page.tsx
@@ -1,8 +1,11 @@
 // apps/shop-bcd/src/app/account/orders/[id]/page.tsx
 import { getCustomerSession } from "@auth";
 import { getOrdersForCustomer } from "@platform-core/orders";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
 import { OrderTrackingTimeline, type OrderStep } from "@ui/components/organisms/OrderTrackingTimeline";
 import { redirect } from "next/navigation";
+import QRCode from "qrcode";
+import { useEffect, useState } from "react";
 import shop from "../../../../../shop.json";
 
 export const metadata = { title: "Order details" };
@@ -33,17 +36,36 @@ export default async function Page({
     const order = orders.find((o) => o.id === params.id);
     if (!order) return <p className="p-6">Order not found.</p>;
     const steps = await getTracking(order.id);
+    const cfg = await getReturnLogistics();
     return (
       <div className="space-y-4 p-6">
         <h1 className="text-xl">Order {order.id}</h1>
         {steps && steps.length > 0 && (
           <OrderTrackingTimeline steps={steps} className="mt-2" />
         )}
+        {cfg.mobileApp && <MobileReturnLink />}
       </div>
     );
   } catch (err) {
     console.error("Failed to load order", err);
     return <p className="p-6">Unable to load order.</p>;
   }
+}
+
+function MobileReturnLink() {
+  "use client";
+  const [qr, setQr] = useState<string | null>(null);
+  useEffect(() => {
+    const url = `${window.location.origin}/returns/mobile`;
+    QRCode.toDataURL(url).then(setQr).catch(console.error);
+  }, []);
+  return (
+    <div className="space-y-2">
+      <a href="/returns/mobile" className="text-blue-600 underline">
+        Return using mobile app
+      </a>
+      {qr && <img src={qr} alt="Mobile return QR" className="h-32 w-32" />}
+    </div>
+  );
 }
 

--- a/packages/template-app/src/api/returns/mobile/route.ts
+++ b/packages/template-app/src/api/returns/mobile/route.ts
@@ -1,0 +1,22 @@
+import { markReturned } from "@platform-core/repositories/rentalOrders.server";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const cfg = await getReturnLogistics();
+  if (!cfg.mobileApp) {
+    return NextResponse.json({ error: "Mobile returns disabled" }, { status: 403 });
+  }
+  const { sessionId } = (await req.json()) as { sessionId?: string };
+  if (!sessionId) {
+    return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
+  }
+  const order = await markReturned("bcd", sessionId);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}
+

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -1,0 +1,81 @@
+import { getReturnLogistics } from "@platform-core/returnLogistics";
+import { useEffect, useRef, useState } from "react";
+
+export const metadata = { title: "Mobile Returns" };
+
+export default async function MobileReturnPage() {
+  const cfg = await getReturnLogistics();
+  if (!cfg.mobileApp) {
+    return <p className="p-6">Mobile returns are not enabled.</p>;
+  }
+  return <Scanner />;
+}
+
+function Scanner() {
+  "use client";
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let active = true;
+    async function init() {
+      if (!("BarcodeDetector" in window)) {
+        setError("Scanning not supported on this device.");
+        return;
+      }
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+        });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+        const detector = new (window as any).BarcodeDetector({
+          formats: ["qr_code", "code_128", "ean_13", "upc_a"],
+        });
+        const scan = async () => {
+          if (!active || !videoRef.current) return;
+          try {
+            const codes = await detector.detect(videoRef.current);
+            if (codes.length > 0) {
+              const code = codes[0].rawValue;
+              setResult(code);
+              active = false;
+              stream?.getTracks().forEach((t) => t.stop());
+              await fetch("/api/returns/mobile", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ sessionId: code }),
+              });
+              return;
+            }
+          } catch (err) {
+            console.error(err);
+          }
+          requestAnimationFrame(scan);
+        };
+        requestAnimationFrame(scan);
+      } catch (err) {
+        setError("Unable to access camera.");
+      }
+    }
+    init();
+    return () => {
+      active = false;
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, []);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-semibold">Scan to mark return</h1>
+      <video ref={videoRef} className="w-full max-w-md" />
+      {result && <p>Scanned: {result}</p>}
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}
+

--- a/packages/types/src/ReturnLogistics.d.ts
+++ b/packages/types/src/ReturnLogistics.d.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
  * - `bagType` describes the packaging customers should reuse when returning items.
  * - `returnCarrier` lists supported carriers for return shipments.
  * - `homePickupZipCodes` enumerates ZIP codes eligible for carrier pickup.
+ * - `mobileApp` toggles access to the mobile return application.
  */
 export declare const returnLogisticsSchema: z.ZodObject<{
     labelService: z.ZodString;
@@ -18,6 +19,7 @@ export declare const returnLogisticsSchema: z.ZodObject<{
     bagType: z.ZodString;
     returnCarrier: z.ZodArray<z.ZodString, "many">;
     homePickupZipCodes: z.ZodArray<z.ZodString, "many">;
+    mobileApp: z.ZodOptional<z.ZodBoolean>;
 }, "strip", z.ZodTypeAny, {
     labelService: string;
     inStore: boolean;
@@ -26,6 +28,7 @@ export declare const returnLogisticsSchema: z.ZodObject<{
     bagType: string;
     returnCarrier: string[];
     homePickupZipCodes: string[];
+    mobileApp?: boolean | undefined;
 }, {
     labelService: string;
     inStore: boolean;
@@ -34,5 +37,6 @@ export declare const returnLogisticsSchema: z.ZodObject<{
     bagType: string;
     returnCarrier: string[];
     homePickupZipCodes: string[];
+    mobileApp?: boolean | undefined;
 }>;
 export type ReturnLogistics = z.infer<typeof returnLogisticsSchema>;

--- a/packages/types/src/ReturnLogistics.ts
+++ b/packages/types/src/ReturnLogistics.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
  * - `bagType` describes the packaging customers should reuse when returning items.
  * - `returnCarrier` lists supported carriers for return shipments.
  * - `homePickupZipCodes` enumerates ZIP codes eligible for carrier pickup.
+ * - `mobileApp` toggles access to the mobile return application.
  */
 export const returnLogisticsSchema = z
   .object({
@@ -20,6 +21,7 @@ export const returnLogisticsSchema = z
     bagType: z.string(),
     returnCarrier: z.array(z.string()),
     homePickupZipCodes: z.array(z.string()),
+    mobileApp: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- add optional `mobileApp` toggle in return logistics schema
- enable mobile returns via scanning page and API
- expose mobile return QR/link on account order pages and CMS config

## Testing
- `pnpm test --filter @acme/types --filter @acme/template-app --filter @apps/shop-abc --filter @apps/shop-bcd --no-cache` (no tests in scope)
- `pnpm test --filter @apps/cms` *(fails: Missing environment configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689da9d622bc832f95cea6a9c16e53f1