### PR TITLE
feat: add configurator guided tour

### DIFF
--- a/apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
+++ b/apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
@@ -2,13 +2,18 @@
 "use client";
 
 import { useConfigurator } from "./ConfiguratorContext";
+import { useGuidedTour } from "./GuidedTour";
 
-export default function ConfiguratorStatusBar(): React.JSX.Element | null {
+export default function ConfiguratorStatusBar(): React.JSX.Element {
   const { saving } = useConfigurator();
-  if (!saving) return null;
+  const { replay } = useGuidedTour();
+
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 flex justify-center bg-muted py-2 text-sm">
-      Saving…
+    <div className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between bg-muted py-2 px-4 text-sm">
+      <span>{saving ? "Saving…" : null}</span>
+      <button type="button" onClick={replay} className="underline">
+        Replay tour
+      </button>
     </div>
   );
 }

--- a/apps/cms/src/app/cms/configurator/GuidedTour.tsx
+++ b/apps/cms/src/app/cms/configurator/GuidedTour.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface Step {
+  selector: string;
+  content: React.ReactNode;
+}
+
+const TOUR_KEY = "configurator-guided-tour";
+
+const steps: Step[] = [
+  {
+    selector: '[data-tour="select-template"]',
+    content: "Start by selecting a template for your page.",
+  },
+  {
+    selector: '[data-tour="drag-component"]',
+    content: "Drag components from the palette into the page.",
+  },
+  {
+    selector: '[data-tour="edit-properties"]',
+    content: "Edit the selected component's properties here.",
+  },
+  {
+    selector: '[data-tour="publish"]',
+    content: "Publish your work when you're ready.",
+  },
+];
+
+interface GuidedTourContextValue {
+  replay: () => void;
+}
+
+const GuidedTourContext = createContext<GuidedTourContextValue>({
+  replay: () => {},
+});
+
+export function useGuidedTour(): GuidedTourContextValue {
+  return useContext(GuidedTourContext);
+}
+
+export default function GuidedTour({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const [stepIndex, setStepIndex] = useState<number | null>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+
+  const start = useCallback(() => {
+    setStepIndex(0);
+  }, []);
+
+  const replay = useCallback(() => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(TOUR_KEY);
+    }
+    start();
+  }, [start]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!localStorage.getItem(TOUR_KEY)) {
+      start();
+    }
+  }, [start]);
+
+  const current = stepIndex !== null ? steps[stepIndex] : null;
+
+  useEffect(() => {
+    if (!current) return;
+    const el = document.querySelector(current.selector) as HTMLElement | null;
+    if (!el) {
+      setStepIndex((i) => (i === null ? i : i + 1));
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    setCoords({ top: rect.bottom + 8, left: rect.left });
+  }, [current]);
+
+  const next = useCallback(() => {
+    setStepIndex((i) => {
+      if (i === null) return i;
+      if (i + 1 >= steps.length) {
+        if (typeof window !== "undefined") {
+          localStorage.setItem(TOUR_KEY, "done");
+        }
+        return null;
+      }
+      return i + 1;
+    });
+  }, []);
+
+  return (
+    <GuidedTourContext.Provider value={{ replay }}>
+      {children}
+      {current && coords && (
+        <div
+          className="fixed z-50 rounded bg-primary p-4 text-primary-foreground shadow"
+          style={{ top: coords.top, left: coords.left }}
+        >
+          <div>{current.content}</div>
+          <button className="mt-2 text-sm underline" onClick={next}>
+            {stepIndex === steps.length - 1 ? "Finish" : "Next"}
+          </button>
+        </div>
+      )}
+    </GuidedTourContext.Provider>
+  );
+}

--- a/apps/cms/src/app/cms/configurator/page.tsx
+++ b/apps/cms/src/app/cms/configurator/page.tsx
@@ -1,6 +1,11 @@
 import ConfiguratorDashboard from "./Dashboard";
+import GuidedTour from "./GuidedTour";
 
 export default function ConfiguratorPage() {
-  return <ConfiguratorDashboard />;
+  return (
+    <GuidedTour>
+      <ConfiguratorDashboard />
+    </GuidedTour>
+  );
 }
 

--- a/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
@@ -124,7 +124,7 @@ export default function StepHomePage({
           }
         }}
       >
-        <SelectTrigger className="w-full">
+        <SelectTrigger className="w-full" data-tour="select-template">
           <SelectValue placeholder="Select template" />
         </SelectTrigger>
         <SelectContent>

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -385,7 +385,12 @@ const PageBuilder = memo(function PageBuilder({
             )}
           </div>
           <div className="flex flex-col gap-1">
-            <Button variant="outline" onClick={handlePublish} disabled={publishing}>
+            <Button
+              variant="outline"
+              onClick={handlePublish}
+              disabled={publishing}
+              data-tour="publish"
+            >
               {publishing ? <Spinner className="h-4 w-4" /> : "Publish"}
             </Button>
             {publishError && (

--- a/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageSidebar.tsx
@@ -48,13 +48,13 @@ const PageSidebar = ({ components, selectedId, dispatch }: Props) => {
     dispatch({ type: "duplicate", id: selectedId });
   }, [dispatch, selectedId]);
 
-  return (
-    <aside className="w-72 shrink-0 space-y-2">
-      <Button type="button" variant="outline" onClick={handleDuplicate}>
-        Duplicate
-      </Button>
-      <ComponentEditor
-        component={components.find((c) => c.id === selectedId)!}
+    return (
+      <aside className="w-72 shrink-0 space-y-2" data-tour="edit-properties">
+        <Button type="button" variant="outline" onClick={handleDuplicate}>
+          Duplicate
+        </Button>
+        <ComponentEditor
+          component={components.find((c) => c.id === selectedId)!}
         onChange={handleChange}
         onResize={handleResize}
       />

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -80,21 +80,21 @@ const PaletteItem = memo(function PaletteItem({
   );
 });
 
-const Palette = memo(function Palette() {
-  return (
-    <div className="flex flex-col gap-4">
-      {Object.entries(palette).map(([category, items]) => (
-        <div key={category} className="space-y-2">
-          <h4 className="font-semibold capitalize">{category}</h4>
-          <div className="flex flex-col gap-2">
-            {items.map((p) => (
-              <PaletteItem key={p.type} type={p.type} />
-            ))}
+  const Palette = memo(function Palette() {
+    return (
+      <div className="flex flex-col gap-4" data-tour="drag-component">
+        {Object.entries(palette).map(([category, items]) => (
+          <div key={category} className="space-y-2">
+            <h4 className="font-semibold capitalize">{category}</h4>
+            <div className="flex flex-col gap-2">
+              {items.map((p) => (
+                <PaletteItem key={p.type} type={p.type} />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
-    </div>
-  );
-});
+        ))}
+      </div>
+    );
+  });
 
 export default Palette;


### PR DESCRIPTION
## Summary
- add reusable guided tour with steps for template selection, component dragging, editing, and publishing
- allow replaying the tour from status bar
- tag key configurator elements for tour highlights

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689da95d2d78832fb2fb542352151458