### PR TITLE
feat: add subscription plan proration

### DIFF
--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -27,4 +27,14 @@
     "token": "token"
   },
   "editorialBlog": { "enabled": false }
+,
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -23,4 +23,14 @@
     "token": "token"
   },
   "editorialBlog": { "enabled": false }
+,
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -26,5 +26,14 @@
     "raTicketing": false,
     "fraudReview": false,
     "strictReturnConditions": false
-  }
+  },
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -22,5 +22,14 @@
     "raTicketing": false,
     "fraudReview": false,
     "strictReturnConditions": false
-  }
+  },
+  "subscriptionPlans": [
+    {
+      "id": "basic",
+      "name": "Basic",
+      "priceId": "price_basic",
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
+    }
+  ]
 }

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -55,6 +55,16 @@ model CustomerMfa {
   enabled    Boolean @default(false)
 }
 
+model SubscriptionUsage {
+  id         String @id @default(cuid())
+  shop       String
+  customerId String
+  period     String
+  shipments  Int    @default(0)
+
+  @@unique([shop, customerId, period], name: "shop_customerId_period")
+}
+
 model User {
   id           String  @id
   email        String  @unique

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -5,6 +5,7 @@ import { nowIso } from "@acme/date-utils";
 import type { RentalOrder } from "@acme/types";
 import { trackOrder } from "./analytics";
 import { prisma } from "./db";
+import { currentPeriod, incrementUsage } from "./repositories/subscriptionUsage.server";
 
 type Order = RentalOrder;
 
@@ -38,6 +39,10 @@ export async function addOrder(
   };
   await prisma.rentalOrder.create({ data: order });
   await trackOrder(shop, order.id, deposit);
+  if (customerId) {
+    const period = currentPeriod();
+    await incrementUsage(shop, customerId, period);
+  }
   return order;
 }
 

--- a/packages/platform-core/src/repositories/subscriptionUsage.server.ts
+++ b/packages/platform-core/src/repositories/subscriptionUsage.server.ts
@@ -1,0 +1,41 @@
+// packages/platform-core/src/repositories/subscriptionUsage.server.ts
+import "server-only";
+
+import { prisma } from "../db";
+
+/**
+ * Retrieves the number of shipments used by a customer for the
+ * current billing period (calendar month).
+ */
+export async function getUsage(
+  shop: string,
+  customerId: string,
+  period: string,
+): Promise<number> {
+  const record = await prisma.subscriptionUsage.findUnique({
+    where: { shop_customerId_period: { shop, customerId, period } },
+  });
+  return record?.shipments ?? 0;
+}
+
+/**
+ * Increments the shipment usage counter for the given customer
+ * in the current billing period.
+ */
+export async function incrementUsage(
+  shop: string,
+  customerId: string,
+  period: string,
+): Promise<void> {
+  await prisma.subscriptionUsage.upsert({
+    where: { shop_customerId_period: { shop, customerId, period } },
+    update: { shipments: { increment: 1 } },
+    create: { shop, customerId, period, shipments: 1 },
+  });
+}
+
+/** Utility to generate a YYYY-MM period string for the current month */
+export function currentPeriod(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}

--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -1,0 +1,27 @@
+import { stripe } from "@acme/stripe";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+interface Body {
+  subscriptionId?: string;
+  priceId?: string;
+  prorate?: boolean;
+}
+
+export async function POST(req: NextRequest) {
+  const { subscriptionId, priceId, prorate = true } = (await req.json()) as Body;
+  if (!subscriptionId || !priceId) {
+    return NextResponse.json(
+      { error: "Missing subscriptionId or priceId" },
+      { status: 400 },
+    );
+  }
+
+  await stripe.subscriptions.update(subscriptionId, {
+    items: [{ price: priceId }],
+    proration_behavior: prorate ? "create_prorations" : "none",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { localeSchema } from "./Product";
+import { subscriptionPlanSchema } from "./SubscriptionPlan";
 
 export const shopSeoFieldsSchema = z
   .object({
@@ -113,6 +114,7 @@ export const shopSchema = z
       }),
     lastUpgrade: z.string().datetime().optional(),
     componentVersions: z.record(z.string()).default({}),
+    subscriptionPlans: z.array(subscriptionPlanSchema).default([]),
   })
   .strict();
 

--- a/packages/types/src/SubscriptionPlan.ts
+++ b/packages/types/src/SubscriptionPlan.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+/**
+ * Subscription plan definition used by shops to configure
+ * available subscription options. Plans map to Stripe prices
+ * and control shipment allowances.
+ */
+export const subscriptionPlanSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    /** Stripe price identifier for billing */
+    priceId: z.string(),
+    /** Number of shipments included per month */
+    shipmentsPerMonth: z.number().int().nonnegative().default(0),
+    /** Whether changing to this plan should create prorations */
+    prorateOnChange: z.boolean().default(true),
+  })
+  .strict();
+
+export type SubscriptionPlan = z.infer<typeof subscriptionPlanSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,3 +15,4 @@ export * from "./ReturnAuthorization";
 export * from "./Shop";
 export * from "./ShopSettings";
 export * from "./Coupon";
+export * from "./SubscriptionPlan";


### PR DESCRIPTION
## Summary
- add subscription plan schema with shipment limits and proration toggle
- track monthly shipment usage per customer
- support changing plans with optional Stripe proration

## Testing
- `pnpm test` *(fails: Cannot find module, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_689da8e19354832f9c96679de1c51a26