### PR TITLE
feat: add rental inventory maintenance

### DIFF
--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -13,6 +13,7 @@
   "priceOverrides": {},
   "localeOverrides": {},
   "analyticsEnabled": true,
+  "rentalInventoryAllocation": false,
   "plugins": {
     "paypal": {
       "clientId": "abc-client",

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -9,6 +9,7 @@
   "billingProvider": "stripe",
   "priceOverrides": {},
   "localeOverrides": {},
+  "rentalInventoryAllocation": false,
   "analyticsEnabled": false,
   "plugins": {
     "paypal": {

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -13,6 +13,7 @@
   },
   "priceOverrides": {},
   "localeOverrides": {},
+  "rentalInventoryAllocation": false,
   "componentVersions": {},
   "lastUpgrade": "1970-01-01T00:00:00.000Z",
   "sanityBlog": {

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -10,6 +10,7 @@
   "billingProvider": "stripe",
   "priceOverrides": {},
   "localeOverrides": {},
+  "rentalInventoryAllocation": false,
   "componentVersions": {},
   "lastUpgrade": "1970-01-01T00:00:00.000Z",
   "sanityBlog": {

--- a/packages/platform-core/src/orders/index.ts
+++ b/packages/platform-core/src/orders/index.ts
@@ -1,1 +1,2 @@
 export * from "../orders";
+export * from "./rentalAllocation";

--- a/packages/platform-core/src/orders/rentalAllocation.ts
+++ b/packages/platform-core/src/orders/rentalAllocation.ts
@@ -1,0 +1,41 @@
+import type { InventoryItem, SKU } from "@acme/types";
+
+/**
+ * Reserve a rental inventory item if available and within wear limits.
+ *
+ * @param items - inventory items for the SKU
+ * @param sku - product information containing availability and wear limits
+ * @param from - desired rental start ISO date
+ * @param to - desired rental end ISO date
+ * @returns the reserved item or null if none available
+ */
+export function reserveRentalInventory(
+  items: Array<InventoryItem & { wearCount?: number }>,
+  sku: SKU,
+  from: string,
+  to: string,
+): (InventoryItem & { wearCount: number }) | null {
+  // verify availability window
+  if (
+    sku.availability &&
+    !sku.availability.some((window) => from >= window.from && to <= window.to)
+  ) {
+    return null;
+  }
+
+  const limit = sku.wearAndTearLimit ?? Infinity;
+  const cycle = sku.maintenanceCycle ?? Infinity;
+
+  const selected = items.find((item) => {
+    const wear = item.wearCount ?? 0;
+    if (wear >= limit) return false; // item exceeded wear limit
+    if (cycle !== Infinity && wear > 0 && wear % cycle === 0) return false; // due for maintenance
+    return item.quantity > 0; // must have stock
+  });
+
+  if (!selected) return null;
+
+  selected.quantity -= 1;
+  selected.wearCount = (selected.wearCount ?? 0) + 1;
+  return selected as InventoryItem & { wearCount: number };
+}

--- a/packages/platform-machine/src/index.ts
+++ b/packages/platform-machine/src/index.ts
@@ -2,3 +2,4 @@ export * from "./fsm";
 export * from "./releaseDepositsService";
 export * from "./reverseLogisticsService";
 export * from "./useFSM";
+export * from "./maintenanceScheduler";

--- a/packages/platform-machine/src/maintenanceScheduler.ts
+++ b/packages/platform-machine/src/maintenanceScheduler.ts
@@ -1,0 +1,50 @@
+import { readdir } from "node:fs/promises";
+import { resolveDataRoot } from "@platform-core/dataRoot";
+import { readInventory } from "@platform-core/repositories/inventory.server";
+import { readRepo as readProducts } from "@platform-core/repositories/products.server";
+import { logger } from "@platform-core/utils";
+
+const DATA_ROOT = resolveDataRoot();
+
+/**
+ * Scan inventory nightly and log items that require maintenance or retirement.
+ */
+export async function runMaintenanceScan(
+  dataRoot: string = DATA_ROOT,
+): Promise<void> {
+  const shops = await readdir(dataRoot);
+  for (const shop of shops) {
+    const [inventory, products] = await Promise.all([
+      readInventory(shop),
+      readProducts(shop),
+    ]);
+    const productMap = new Map(products.map((p) => [p.sku, p]));
+
+    for (const item of inventory) {
+      const product = productMap.get(item.sku);
+      if (!product) continue;
+      const wear = (item as any).wearCount ?? 0;
+      const limit = product.wearAndTearLimit ?? Infinity;
+      const cycle = product.maintenanceCycle ?? Infinity;
+      if (wear >= limit) {
+        logger.info("item needs retirement", { shopId: shop, sku: item.sku });
+      } else if (cycle !== Infinity && wear > 0 && wear % cycle === 0) {
+        logger.info("item needs maintenance", { shopId: shop, sku: item.sku });
+      }
+    }
+  }
+}
+
+/**
+ * Start nightly maintenance scheduler.
+ */
+export function startMaintenanceScheduler(): NodeJS.Timeout {
+  const day = 24 * 60 * 60 * 1000;
+  const run = () =>
+    runMaintenanceScan().catch((err) =>
+      logger.error("maintenance scan failed", { err }),
+    );
+  // run immediately then every night
+  run();
+  return setInterval(run, day);
+}

--- a/packages/types/src/Product.d.ts
+++ b/packages/types/src/Product.d.ts
@@ -24,6 +24,10 @@ export declare const skuSchema: z.ZodObject<{
     weeklyRate: z.ZodOptional<z.ZodNumber>;
     /** monthly rental rate in minor currency units */
     monthlyRate: z.ZodOptional<z.ZodNumber>;
+    /** maximum number of rentals before retirement */
+    wearAndTearLimit: z.ZodOptional<z.ZodNumber>;
+    /** number of rentals between required maintenance */
+    maintenanceCycle: z.ZodOptional<z.ZodNumber>;
     /** availability windows as ISO timestamps */
     availability: z.ZodOptional<z.ZodArray<z.ZodObject<{
         from: z.ZodString;
@@ -73,6 +77,8 @@ export declare const skuSchema: z.ZodObject<{
     dailyRate?: number | undefined;
     weeklyRate?: number | undefined;
     monthlyRate?: number | undefined;
+    wearAndTearLimit?: number | undefined;
+    maintenanceCycle?: number | undefined;
     availability?: {
         from: string;
         to: string;
@@ -97,6 +103,8 @@ export declare const skuSchema: z.ZodObject<{
     dailyRate?: number | undefined;
     weeklyRate?: number | undefined;
     monthlyRate?: number | undefined;
+    wearAndTearLimit?: number | undefined;
+    maintenanceCycle?: number | undefined;
     availability?: {
         from: string;
         to: string;
@@ -124,6 +132,10 @@ export interface ProductCore {
     weeklyRate?: number;
     /** monthly rental rate in minor currency units */
     monthlyRate?: number;
+    /** maximum number of rentals before retirement */
+    wearAndTearLimit?: number;
+    /** number of rentals between required maintenance */
+    maintenanceCycle?: number;
     /** availability windows as ISO timestamps */
     availability?: {
         from: string;

--- a/packages/types/src/Product.ts
+++ b/packages/types/src/Product.ts
@@ -37,6 +37,10 @@ export const skuSchema = z
     weeklyRate: z.number().int().nonnegative().optional(),
     /** monthly rental rate in minor currency units */
     monthlyRate: z.number().int().nonnegative().optional(),
+    /** maximum number of rentals before retirement */
+    wearAndTearLimit: z.number().int().nonnegative().optional(),
+    /** number of rentals between required maintenance */
+    maintenanceCycle: z.number().int().nonnegative().optional(),
     /** availability windows as ISO timestamps */
     availability: z
       .array(z.object({ from: z.string(), to: z.string() }).strict())
@@ -72,6 +76,10 @@ export interface ProductCore {
   weeklyRate?: number;
   /** monthly rental rate in minor currency units */
   monthlyRate?: number;
+  /** maximum number of rentals before retirement */
+  wearAndTearLimit?: number;
+  /** number of rentals between required maintenance */
+  maintenanceCycle?: number;
   /** availability windows as ISO timestamps */
   availability?: { from: string; to: string }[];
 }

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -171,6 +171,7 @@ export declare const shopSchema: z.ZodObject<{
     returnPolicyUrl: z.ZodOptional<z.ZodString>;
     returnsEnabled: z.ZodOptional<z.ZodBoolean>;
     analyticsEnabled: z.ZodOptional<z.ZodBoolean>;
+    rentalInventoryAllocation: z.ZodOptional<z.ZodBoolean>;
     lastUpgrade: z.ZodOptional<z.ZodString>;
     componentVersions: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodString>>;
 }, "strict", z.ZodTypeAny, {
@@ -211,6 +212,7 @@ export declare const shopSchema: z.ZodObject<{
     returnPolicyUrl?: string | undefined;
     returnsEnabled?: boolean | undefined;
     analyticsEnabled?: boolean | undefined;
+    rentalInventoryAllocation?: boolean | undefined;
     lastUpgrade?: string | undefined;
     componentVersions: Record<string, string>;
 }, {
@@ -251,8 +253,9 @@ export declare const shopSchema: z.ZodObject<{
     returnPolicyUrl?: string | undefined;
     returnsEnabled?: boolean | undefined;
     analyticsEnabled?: boolean | undefined;
+    rentalInventoryAllocation?: boolean | undefined;
     lastUpgrade?: string | undefined;
     componentVersions?: Record<string, string> | undefined;
-}>;
+}>; 
 export type Shop = z.infer<typeof shopSchema>;
 //# sourceMappingURL=Shop.d.ts.map

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -98,6 +98,7 @@ export const shopSchema = z
     returnPolicyUrl: z.string().url().optional(),
     returnsEnabled: z.boolean().optional(),
     analyticsEnabled: z.boolean().optional(),
+    rentalInventoryAllocation: z.boolean().optional(),
     luxuryFeatures: z
       .object({
         contentMerchandising: z.boolean().default(false),


### PR DESCRIPTION
## Summary
- track wear limits on product SKUs
- reserve rental inventory with wear and availability checks
- flag inventory needing maintenance via nightly scheduler
- expose `rentalInventoryAllocation` flag in shop configs

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689da8fd2cc0832fbaa574feac72de2c