### PR TITLE
feat: add live contrast warnings in theme editor

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ChangeEvent } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import { Button, Input } from "@/components/atoms/shadcn";
 import { hslToHex, hexToHsl, isHex, isHsl } from "@ui/utils/colorUtils";
+import ColorContrastChecker from "color-contrast-checker";
 
 interface Props {
   name: string;
@@ -11,6 +12,14 @@ interface Props {
   onChange: (value: string) => void;
   onReset: () => void;
   inputRef?: (el: HTMLInputElement | null) => void;
+  /** Current merged token values (defaults + overrides) */
+  tokens: Record<string, string>;
+  /** Keys for text/foreground tokens */
+  textTokens: string[];
+  /** Keys for background tokens */
+  bgTokens: string[];
+  /** Notify parent of contrast warning updates */
+  onWarningChange?: (token: string, warning: string | null) => void;
 }
 
 export default function ColorInput({
@@ -20,6 +29,10 @@ export default function ColorInput({
   onChange,
   onReset,
   inputRef,
+  tokens,
+  textTokens,
+  bgTokens,
+  onWarningChange,
 }: Props) {
   const hasOverride = value !== "";
   const isOverridden = hasOverride && value !== defaultValue;
@@ -33,10 +46,45 @@ export default function ColorInput({
       : hslToHex(current)
     : current;
 
+  const [warning, setWarning] = useState<string | null>(null);
+
+  const checkContrast = (raw: string) => {
+    const ccc = new ColorContrastChecker();
+    const colorHex = defaultIsHsl ? hslToHex(raw) : raw;
+    if (!isHex(colorHex)) return;
+    const isTextToken = /text|foreground/i.test(name);
+    const isBgToken = /bg|background/i.test(name);
+    const compareTokens = isTextToken
+      ? bgTokens
+      : isBgToken
+        ? textTokens
+        : [];
+    let warn: string | null = null;
+    for (const t of compareTokens) {
+      const other = tokens[t];
+      if (!other) continue;
+      const otherHex = isHsl(other) ? hslToHex(other) : other;
+      if (!isHex(otherHex)) continue;
+      const ratio = ccc.getContrastRatio(colorHex, otherHex);
+      if (ratio < 4.5) {
+        warn = `${name} on ${t} contrast ${ratio.toFixed(2)}:1`;
+        break;
+      }
+    }
+    setWarning(warn);
+    onWarningChange?.(name, warn);
+  };
+
+  useEffect(() => {
+    checkContrast(current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current, tokens]);
+
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
     const converted = defaultIsHsl ? hexToHsl(raw) : raw;
     onChange(converted === defaultValue ? "" : converted);
+    checkContrast(converted);
   };
 
   return (
@@ -44,7 +92,14 @@ export default function ColorInput({
       data-token-key={name}
       className={`flex flex-col gap-1 ${isOverridden ? "bg-amber-50" : ""}`}
     >
-      <span>{name}</span>
+      <span className="flex items-center gap-2">
+        {name}
+        {warning && (
+          <span className="rounded bg-amber-100 px-1 text-xs text-amber-800">
+            {warning}
+          </span>
+        )}
+      </span>
       <div className="flex items-center gap-2">
         <Input value={defaultValue} disabled />
         {isColor ? (

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
@@ -3,7 +3,6 @@
 "use client";
 import { Button, Input } from "@/components/atoms/shadcn";
 import { updateShop } from "@cms/actions/shops.server";
-import ColorContrastChecker from "color-contrast-checker";
 import {
   useState,
   ChangeEvent,
@@ -65,7 +64,8 @@ export default function ThemeEditor({
     setOverrides,
     setThemeDefaults,
   });
-  const [contrastWarnings, setContrastWarnings] = useState<string[]>([]);
+  const [contrastWarnings, setContrastWarnings] =
+    useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string[]>>({});
   const overrideRefs = useRef<Record<string, HTMLInputElement | null>>({});
@@ -74,6 +74,27 @@ export default function ThemeEditor({
     ...initialOverrides,
   });
   const debounceRef = useRef<number | null>(null);
+
+  const mergedTokens = useMemo(
+    () => ({ ...tokensByThemeState[theme], ...overrides }),
+    [theme, tokensByThemeState, overrides],
+  );
+
+  const textTokenKeys = useMemo(
+    () =>
+      Object.keys(tokensByThemeState[theme]).filter((k) =>
+        /text|foreground/i.test(k),
+      ),
+    [theme, tokensByThemeState],
+  );
+
+  const bgTokenKeys = useMemo(
+    () =>
+      Object.keys(tokensByThemeState[theme]).filter((k) =>
+        /bg|background/i.test(k),
+      ),
+    [theme, tokensByThemeState],
+  );
 
   const groupedTokens = useMemo(() => {
     const tokens = tokensByThemeState[theme];
@@ -99,6 +120,7 @@ export default function ThemeEditor({
     setOverrides({});
     setThemeDefaults(tokensByThemeState[next]);
     schedulePreviewUpdate(tokensByThemeState[next]);
+    setContrastWarnings({});
   };
 
   const schedulePreviewUpdate = (tokens: Record<string, string>) => {
@@ -108,6 +130,15 @@ export default function ThemeEditor({
     debounceRef.current = window.setTimeout(() => {
       setPreviewTokens(tokens);
     }, 100);
+  };
+
+  const handleWarningChange = (token: string, warning: string | null) => {
+    setContrastWarnings((prev) => {
+      const next = { ...prev };
+      if (warning) next[token] = warning;
+      else delete next[token];
+      return next;
+    });
   };
 
   const handleOverrideChange =
@@ -155,40 +186,6 @@ export default function ThemeEditor({
     };
   }, []);
 
-  useEffect(() => {
-    const ccc = new ColorContrastChecker();
-    const baseTokens = tokensByThemeState[theme];
-    const merged = previewTokens;
-    const textTokens = Object.keys(baseTokens).filter((k) =>
-      /text|foreground/i.test(k),
-    );
-    const bgTokens = Object.keys(baseTokens).filter((k) =>
-      /bg|background/i.test(k),
-    );
-    const warnings: string[] = [];
-    textTokens.forEach((t) => {
-      const fg = merged[t];
-      const fgDefault = baseTokens[t];
-      bgTokens.forEach((b) => {
-        const bg = merged[b];
-        const bgDefault = baseTokens[b];
-        if (!fg || !bg) return;
-        const fgHex = isHsl(fg) ? hslToHex(fg) : fg;
-        const bgHex = isHsl(bg) ? hslToHex(bg) : bg;
-        if (!isHex(fgHex) || !isHex(bgHex)) return;
-        const fgDefHex = isHsl(fgDefault) ? hslToHex(fgDefault) : fgDefault;
-        const bgDefHex = isHsl(bgDefault) ? hslToHex(bgDefault) : bgDefault;
-        const defaultRatio = ccc.getContrastRatio(fgDefHex, bgDefHex);
-        const ratio = ccc.getContrastRatio(fgHex, bgHex);
-        if (ratio < defaultRatio && ratio < 4.5) {
-          warnings.push(
-            `${t} on ${b} contrast ${ratio.toFixed(2)}:1`,
-          );
-        }
-      });
-    });
-    setContrastWarnings(warnings);
-  }, [theme, previewTokens, tokensByThemeState]);
 
   useEffect(() => {
     savePreviewTokens(previewTokens);
@@ -258,11 +255,11 @@ export default function ThemeEditor({
           </Button>
         )}
       </div>
-      {contrastWarnings.length > 0 && (
+      {Object.keys(contrastWarnings).length > 0 && (
         <div className="rounded border border-amber-300 bg-amber-50 p-2 text-sm text-amber-800">
           <p>Contrast warnings:</p>
           <ul className="list-disc pl-4">
-            {contrastWarnings.map((w, i) => (
+            {Object.values(contrastWarnings).map((w, i) => (
               <li key={i}>{w}</li>
             ))}
           </ul>
@@ -316,6 +313,10 @@ export default function ThemeEditor({
                     onChange={handleOverrideChange(k, defaultValue)}
                     onReset={handleReset(k)}
                     inputRef={(el) => (overrideRefs.current[k] = el)}
+                    tokens={mergedTokens}
+                    textTokens={textTokenKeys}
+                    bgTokens={bgTokenKeys}
+                    onWarningChange={handleWarningChange}
                   />
                 );
               })}


### PR DESCRIPTION
## Summary
- compute contrast as colors change and show inline warning badges
- aggregate contrast issues in ThemeEditor and expose to configuration view

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm test:cms` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*
- `pnpm typecheck` *(fails: Found 710 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689daaf67cb4832fb22b8053ece5bbea