### PR TITLE
docs: add advanced theming guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ rearrange and publish blocks.
 The CMS theme editor lets admins customize design tokens per shop. Tokens are
 grouped by purpose (Background, Text, Accent) and each color token displays a
 preview swatch. Clicking a swatch focuses its corresponding field, where a color
-picker enables quick overrides. Save the form to persist any changes.
+picker enables quick overrides. Save the form to persist any changes. For a deeper look at base themes, overrides, persistence and live preview, see [docs/theming-advanced.md](docs/theming-advanced.md).
 
 ## Shop maintenance
 

--- a/doc/cms.md
+++ b/doc/cms.md
@@ -12,7 +12,7 @@ The sidebar inside the CMS provides quick access to different sections:
 - **Products** – Lists all products. If a shop is selected, also shows **New Product**.
 - **Pages** – Lists pages for the current shop with a **New Page** link when a shop is selected.
 - **Media** – Upload and manage media files.
-- **Theme** – Customize the shop's appearance. Visible to admins and shop owners.
+- **Theme** – Customize the shop's appearance. Visible to admins and shop owners. See [advanced theming](../docs/theming-advanced.md) for base themes, overrides, persistence and live preview.
 - **Settings** – Shop settings. When a shop is active an additional **SEO** option appears.
 - **Live** – Opens a list of running shop instances.
 - **RBAC** – (Admin only) Manage user roles.
@@ -41,7 +41,7 @@ Admins can scaffold and launch a shop directly from the CMS at `/cms/wizard`. Th
 
 1. **Shop details** – provide the shop ID, display name, logo URL, contact email and choose whether it's for sales or rentals.
 2. **Options** – select the starter template and theme.
-3. **Theme tokens** – tweak design tokens to match your brand.
+3. **Theme tokens** – tweak design tokens to match your brand. See [advanced theming](../docs/theming-advanced.md) for details.
 4. **Navigation** – build the header navigation tree.
 5. **Page layouts** – configure home, shop, product and checkout pages and any optional additional pages.
 6. **Environment** – supply required environment variables.

--- a/docs/theming-advanced.md
+++ b/docs/theming-advanced.md
@@ -1,0 +1,87 @@
+# Advanced Theming
+
+## Base themes
+Selecting a base theme resets overrides and reloads its default tokens:
+
+```tsx
+// apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+  const next = e.target.value;
+  setTheme(next);
+  setOverrides({});
+  setThemeDefaults(tokensByThemeState[next]);
+  schedulePreviewUpdate(tokensByThemeState[next]);
+};
+```
+
+## Element overrides
+Each override merges with the current theme and updates the preview:
+
+```tsx
+// apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+const handleOverrideChange = (key: string, defaultValue: string) => (value: string) => {
+  setOverrides((prev) => {
+    const next = { ...prev };
+    if (!value || value === defaultValue) {
+      delete next[key];
+    } else {
+      next[key] = value;
+    }
+    const merged = { ...tokensByThemeState[theme], ...next };
+    schedulePreviewUpdate(merged);
+    return next;
+  });
+};
+```
+
+## Persistence
+Preview tokens are saved to `localStorage` and shop configs persist theme data:
+
+```tsx
+// apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+useEffect(() => {
+  savePreviewTokens(previewTokens);
+}, [previewTokens]);
+```
+
+```json
+// packages/platform-core/src/repositories/shops/schema.json
+{
+  "themeId": { "type": "string" },
+  "themeDefaults": {
+    "type": "object",
+    "additionalProperties": { "type": "string" },
+    "description": "Mapping of design tokens to original theme values",
+    "default": {}
+  },
+  "themeOverrides": {
+    "type": "object",
+    "additionalProperties": { "type": "string" },
+    "default": {}
+  },
+  "themeTokens": {
+    "type": "object",
+    "additionalProperties": { "type": "string" },
+    "description": "Mapping of design tokens to theme values (defaults merged with overrides)"
+  }
+}
+```
+
+## Live preview
+`WizardPreview` listens for token updates and merges them into its styles:
+
+```tsx
+// apps/cms/src/app/cms/wizard/WizardPreview.tsx
+useEffect(() => {
+  const handle = () => {
+    setThemeStyle((prev) => ({ ...prev, ...loadPreviewTokens() }));
+  };
+  handle();
+  window.addEventListener("storage", handle);
+  window.addEventListener(PREVIEW_TOKENS_EVENT, handle);
+  return () => {
+    window.removeEventListener("storage", handle);
+    window.removeEventListener(PREVIEW_TOKENS_EVENT, handle);
+  };
+}, []);
+```


### PR DESCRIPTION
## Summary
- document advanced theming features with code snippets
- link advanced theming guide from README and CMS help

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689daaf91dbc832fad74f69c9adce1bb