### PR TITLE
feat: display dimension overlay during drag and resize

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -101,6 +101,11 @@ const CanvasItem = memo(function CanvasItem({
     startResize,
     guides: resizeGuides,
     snapping: resizeSnapping,
+    width: resizeWidth,
+    height: resizeHeight,
+    left: resizeLeft,
+    top: resizeTop,
+    resizing,
   } = useCanvasResize({
     componentId: component.id,
     widthKey,
@@ -117,6 +122,11 @@ const CanvasItem = memo(function CanvasItem({
     startDrag,
     guides: dragGuides,
     snapping: dragSnapping,
+    width: dragWidth,
+    height: dragHeight,
+    left: dragLeft,
+    top: dragTop,
+    moving,
   } = useCanvasDrag({
     componentId: component.id,
     dispatch,
@@ -130,6 +140,12 @@ const CanvasItem = memo(function CanvasItem({
       ? resizeGuides
       : dragGuides;
   const snapping = resizeSnapping || dragSnapping;
+
+  const showOverlay = resizing || moving;
+  const overlayWidth = resizing ? resizeWidth : dragWidth;
+  const overlayHeight = resizing ? resizeHeight : dragHeight;
+  const overlayLeft = resizing ? resizeLeft : dragLeft;
+  const overlayTop = resizing ? resizeTop : dragTop;
 
   const hasChildren = Array.isArray((component as any).children);
   const childIds = hasChildren
@@ -195,6 +211,12 @@ const CanvasItem = memo(function CanvasItem({
         </div>
       )}
       <Block component={component} locale={locale} />
+      {showOverlay && (
+        <div className="pointer-events-none absolute -top-5 left-0 z-30 rounded bg-black/75 px-1 text-[10px] font-mono text-white shadow dark:bg-white/75 dark:text-black">
+          {Math.round(overlayWidth)}×{Math.round(overlayHeight)} | {Math.round(overlayLeft)},{" "}
+          {Math.round(overlayTop)}
+        </div>
+      )}
       {selected && (
         <>
           <div

--- a/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
@@ -24,6 +24,12 @@ export default function useCanvasDrag({
     null
   );
   const [moving, setMoving] = useState(false);
+  const [current, setCurrent] = useState({
+    left: 0,
+    top: 0,
+    width: 0,
+    height: 0,
+  });
   const { guides, setGuides, siblingEdgesRef, computeSiblingEdges } = useGuides(
     containerRef
   );
@@ -75,6 +81,7 @@ export default function useCanvasDrag({
         left: `${newL}px`,
         top: `${newT}px`,
       });
+      setCurrent({ left: newL, top: newT, width, height });
       setGuides({
         x: guideX !== null ? guideX - newL : null,
         y: guideY !== null ? guideY - newT : null,
@@ -102,11 +109,26 @@ export default function useCanvasDrag({
       l: el.offsetLeft,
       t: el.offsetTop,
     };
+    setCurrent({
+      left: el.offsetLeft,
+      top: el.offsetTop,
+      width: el.offsetWidth,
+      height: el.offsetHeight,
+    });
     computeSiblingEdges();
     setMoving(true);
   };
 
   const snapping = guides.x !== null || guides.y !== null;
 
-  return { startDrag, guides, snapping, moving } as const;
+  return {
+    startDrag,
+    guides,
+    snapping,
+    moving,
+    left: current.left,
+    top: current.top,
+    width: current.width,
+    height: current.height,
+  } as const;
 }

--- a/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
@@ -34,6 +34,12 @@ export default function useCanvasResize({
   const [resizing, setResizing] = useState(false);
   const [snapWidth, setSnapWidth] = useState(false);
   const [snapHeight, setSnapHeight] = useState(false);
+  const [current, setCurrent] = useState({
+    width: 0,
+    height: 0,
+    left: 0,
+    top: 0,
+  });
   const { guides, setGuides, siblingEdgesRef, computeSiblingEdges } = useGuides(
     containerRef
   );
@@ -83,6 +89,7 @@ export default function useCanvasResize({
         [widthKey]: snapW ? "100%" : `${newW}px`,
         [heightKey]: snapH ? "100%" : `${newH}px`,
       } as any);
+      setCurrent({ width: newW, height: newH, left, top });
       setSnapWidth(snapW || guideX !== null);
       setSnapHeight(snapH || guideY !== null);
       setGuides({
@@ -132,6 +139,12 @@ export default function useCanvasResize({
       w: startWidth,
       h: startHeight,
     };
+    setCurrent({
+      width: startWidth,
+      height: startHeight,
+      left: el.offsetLeft,
+      top: el.offsetTop,
+    });
     computeSiblingEdges();
     setResizing(true);
   };
@@ -139,5 +152,14 @@ export default function useCanvasResize({
   const snapping =
     snapWidth || snapHeight || guides.x !== null || guides.y !== null;
 
-  return { startResize, guides, snapping, resizing } as const;
+  return {
+    startResize,
+    guides,
+    snapping,
+    resizing,
+    width: current.width,
+    height: current.height,
+    left: current.left,
+    top: current.top,
+  } as const;
 }


### PR DESCRIPTION
## Summary
- show width/height and position overlay while dragging or resizing page-builder items
- expose current dimensions and coordinates from `useCanvasResize` and `useCanvasDrag`

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*


------
https://chatgpt.com/codex/tasks/task_e_689da95a0b18832f822fbca0f2c50f17