### PR TITLE
Prompt to retain theme overrides on theme change

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.colors.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.colors.test.tsx
@@ -263,4 +263,35 @@ describe("ThemeEditor - colors", () => {
     expect(result.shop.themeDefaults["--color-bg"]).toBe("#222222");
     expect(result.shop.themeTokens["--color-bg"]).toBe("#000000");
   });
+
+  it("keeps overrides when user confirms on theme change", async () => {
+    const tokensByTheme = {
+      base: { "--color-bg": "#ffffff" },
+      dark: { "--color-bg": "#000000" },
+    };
+    const confirmSpy = jest
+      .spyOn(window, "confirm")
+      .mockReturnValue(true);
+    renderThemeEditor({
+      tokensByTheme,
+      themes: ["base", "dark"],
+      initialOverrides: { "--color-bg": "#ff0000" },
+    });
+
+    fireEvent.change(screen.getByLabelText(/theme/i), {
+      target: { value: "dark" },
+    });
+
+    await waitFor(() => {
+      const bgLabel = screen.getByText("--color-bg").closest("label")!;
+      const defaultInput = within(bgLabel).getByRole("textbox");
+      expect(defaultInput).toHaveValue("#000000");
+      const overrideInput = within(bgLabel).getByLabelText("--color-bg", {
+        selector: 'input[type="color"]',
+      });
+      expect(overrideInput).toHaveValue("#ff0000");
+    });
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
 });

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
@@ -95,10 +95,19 @@ export default function ThemeEditor({
 
   const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const next = e.target.value;
+    const currentOverrides = overrides;
+    const keep =
+      Object.keys(currentOverrides).length > 0 &&
+      window.confirm("Keep current overrides?");
     setTheme(next);
-    setOverrides({});
-    setThemeDefaults(tokensByThemeState[next]);
-    schedulePreviewUpdate(tokensByThemeState[next]);
+    const defaults = tokensByThemeState[next];
+    setThemeDefaults(defaults);
+    if (keep) {
+      schedulePreviewUpdate({ ...defaults, ...currentOverrides });
+    } else {
+      setOverrides({});
+      schedulePreviewUpdate(defaults);
+    }
   };
 
   const schedulePreviewUpdate = (tokens: Record<string, string>) => {


### PR DESCRIPTION
## Summary
- ask whether to keep existing overrides when changing theme
- reapply overrides atop new defaults if user chooses to keep
- add test ensuring overrides persist when kept

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/ThemeEditor.colors.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689daafc1de0832fb99d74380d98fb0d