### PR TITLE
feat: add subscription proration and usage tracking

### DIFF
--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -34,14 +34,16 @@
       "price": 3000,
       "itemsIncluded": 3,
       "swapLimit": 1,
-      "shipmentCount": 1
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
     },
     {
       "id": "premium",
       "price": 5000,
       "itemsIncluded": 5,
       "swapLimit": 2,
-      "shipmentCount": 2
+      "shipmentsPerMonth": 2,
+      "prorateOnChange": true
     }
   ]
 }

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -31,14 +31,16 @@
       "price": 3000,
       "itemsIncluded": 3,
       "swapLimit": 1,
-      "shipmentCount": 1
+      "shipmentsPerMonth": 1,
+      "prorateOnChange": true
     },
     {
       "id": "premium",
       "price": 5000,
       "itemsIncluded": 5,
       "swapLimit": 2,
-      "shipmentCount": 2
+      "shipmentsPerMonth": 2,
+      "prorateOnChange": true
     }
   ]
 }

--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -43,6 +43,16 @@ model RentalOrder {
   @@index([customerId])
 }
 
+model SubscriptionUsage {
+  id         String @id @default(cuid())
+  shop       String
+  customerId String
+  month      String
+  shipments  Int    @default(0)
+
+  @@unique([shop, customerId, month])
+}
+
 model CustomerProfile {
   customerId String @id
   name       String

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -5,6 +5,7 @@ import { nowIso } from "@acme/date-utils";
 import type { RentalOrder } from "@acme/types";
 import { trackOrder } from "./analytics";
 import { prisma } from "./db";
+import { incrementSubscriptionUsage } from "./subscriptionUsage";
 
 type Order = RentalOrder;
 
@@ -38,6 +39,10 @@ export async function addOrder(
   };
   await prisma.rentalOrder.create({ data: order });
   await trackOrder(shop, order.id, deposit);
+  if (customerId) {
+    const month = new Date().toISOString().slice(0, 7);
+    await incrementSubscriptionUsage(shop, customerId, month);
+  }
   return order;
 }
 

--- a/packages/platform-core/src/repositories/subscriptionUsage.server.ts
+++ b/packages/platform-core/src/repositories/subscriptionUsage.server.ts
@@ -1,0 +1,3 @@
+// packages/platform-core/src/repositories/subscriptionUsage.server.ts
+import "server-only";
+export * from "../subscriptionUsage";

--- a/packages/platform-core/src/subscriptionUsage.ts
+++ b/packages/platform-core/src/subscriptionUsage.ts
@@ -1,0 +1,34 @@
+// packages/platform-core/src/subscriptionUsage.ts
+import "server-only";
+import { prisma } from "./db";
+
+export interface SubscriptionUsage {
+  id: string;
+  shop: string;
+  customerId: string;
+  month: string;
+  shipments: number;
+}
+
+export async function getSubscriptionUsage(
+  shop: string,
+  customerId: string,
+  month: string,
+): Promise<SubscriptionUsage | null> {
+  return prisma.subscriptionUsage.findUnique({
+    where: { shop_customerId_month: { shop, customerId, month } },
+  });
+}
+
+export async function incrementSubscriptionUsage(
+  shop: string,
+  customerId: string,
+  month: string,
+  count = 1,
+): Promise<void> {
+  await prisma.subscriptionUsage.upsert({
+    where: { shop_customerId_month: { shop, customerId, month } },
+    create: { shop, customerId, month, shipments: count },
+    update: { shipments: { increment: count } },
+  });
+}

--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -1,0 +1,47 @@
+// packages/template-app/src/api/subscription/change/route.ts
+import { stripe } from "@acme/stripe";
+import { NextRequest, NextResponse } from "next/server";
+import { readShop } from "@platform-core/repositories/shops.server";
+import {
+  getUserById,
+  setStripeSubscriptionId,
+} from "@platform-core/repositories/users";
+
+const SHOP_ID = "bcd";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const { userId, priceId, planId } = (await req.json()) as {
+    userId?: string;
+    priceId?: string;
+    planId?: string;
+  };
+  if (!userId || !priceId || !planId) {
+    return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
+  }
+
+  const shop = await readShop(SHOP_ID);
+  if (shop.billingProvider !== "stripe") {
+    return NextResponse.json({ error: "Billing not enabled" }, { status: 400 });
+  }
+
+  const user = await getUserById(userId);
+  if (!user || !user.stripeSubscriptionId) {
+    return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
+  }
+
+  const plan = shop.rentalSubscriptions.find((p) => p.id === planId);
+  const prorate = plan?.prorateOnChange !== false;
+
+  try {
+    const sub = await stripe.subscriptions.update(user.stripeSubscriptionId, {
+      items: [{ price: priceId }],
+      proration_behavior: prorate ? "create_prorations" : "none",
+    });
+    await setStripeSubscriptionId(userId, sub.id);
+    return NextResponse.json({ id: sub.id, status: sub.status });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -27,7 +27,7 @@ export default async function SubscribePage({
           <label key={p.id} className="flex items-center gap-2">
             <input type="radio" name="plan" value={p.id} />
             <span>
-              {p.id} – {p.itemsIncluded} items, {p.swapLimit} swaps, {p.shipmentCount}
+              {p.id} – {p.itemsIncluded} items, {p.swapLimit} swaps, {p.shipmentsPerMonth}
               {" "}shipments
             </span>
           </label>

--- a/packages/types/src/SubscriptionPlan.ts
+++ b/packages/types/src/SubscriptionPlan.ts
@@ -6,7 +6,8 @@ export const subscriptionPlanSchema = z
     price: z.number(),
     itemsIncluded: z.number(),
     swapLimit: z.number(),
-    shipmentCount: z.number(),
+    shipmentsPerMonth: z.number(),
+    prorateOnChange: z.boolean().default(true),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- extend subscription plans with shipmentsPerMonth and prorateOnChange toggles
- track subscriber shipment usage and expose change-plan API
- add shop config for plan proration options

## Testing
- `pnpm --filter @acme/platform-core exec prisma generate`
- `pnpm --filter @acme/types test`
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' from 'apps/cms/__tests__/wizard.test.tsx')*
- `pnpm --filter @acme/template-app test`


------
https://chatgpt.com/codex/tasks/task_e_689dacc479e0832f8b1119537ad3c1da