### PR TITLE
Include page usage in upgrade summary

### DIFF
--- a/apps/shop-abc/__tests__/upgrade-changes.test.ts
+++ b/apps/shop-abc/__tests__/upgrade-changes.test.ts
@@ -61,6 +61,7 @@ describe("/api/upgrade-changes", () => {
           newChecksum: "new1",
         },
       ],
+      pages: [],
     });
   });
 

--- a/apps/shop-abc/src/app/api/upgrade-changes/route.ts
+++ b/apps/shop-abc/src/app/api/upgrade-changes/route.ts
@@ -23,8 +23,9 @@ export async function GET() {
     const components = rawComponents.filter(
       (c: any) => c.oldChecksum !== c.newChecksum
     );
-    return NextResponse.json({ components });
+    const pages = Array.isArray(data.pages) ? data.pages : [];
+    return NextResponse.json({ components, pages });
   } catch {
-    return NextResponse.json({ components: [] });
+    return NextResponse.json({ components: [], pages: [] });
   }
 }

--- a/apps/shop-bcd/__tests__/upgrade-changes.test.ts
+++ b/apps/shop-bcd/__tests__/upgrade-changes.test.ts
@@ -61,6 +61,7 @@ describe("/api/upgrade-changes", () => {
           newChecksum: "new1",
         },
       ],
+      pages: [],
     });
   });
 

--- a/apps/shop-bcd/src/app/api/upgrade-changes/route.ts
+++ b/apps/shop-bcd/src/app/api/upgrade-changes/route.ts
@@ -23,8 +23,9 @@ export async function GET() {
     const components = rawComponents.filter(
       (c: any) => c.oldChecksum !== c.newChecksum
     );
-    return NextResponse.json({ components });
+    const pages = Array.isArray(data.pages) ? data.pages : [];
+    return NextResponse.json({ components, pages });
   } catch {
-    return NextResponse.json({ components: [] });
+    return NextResponse.json({ components: [], pages: [] });
   }
 }


### PR DESCRIPTION
## Summary
- detect which shop pages use updated components when generating `upgrade-changes.json`
- expose affected page IDs via each shop's `/api/upgrade-changes` endpoint
- adjust tests to cover new `pages` field

## Testing
- `pnpm jest apps/shop-abc/__tests__/upgrade-changes.test.ts apps/shop-bcd/__tests__/upgrade-changes.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689da98914b4832f95b3568de54ea078