### PR TITLE
docs: document edit preview republish flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ picker enables quick overrides. Save the form to persist any changes.
 ## Shop maintenance
 
 See [doc/upgrade-preview-republish.md](doc/upgrade-preview-republish.md) for guidance on upgrading a shop, previewing changes and republishing.
+See [doc/edit-preview-republish.md](doc/edit-preview-republish.md) for details on editing components, previewing those edits and republishing.
 
 ## Inventory Management
 

--- a/doc/edit-preview-republish.md
+++ b/doc/edit-preview-republish.md
@@ -1,0 +1,25 @@
+# Edit components, preview and republish
+
+Shop owners can tweak individual components in their shops without touching the underlying template. Edits are staged locally so they can be reviewed before publishing.
+
+## Edit components
+
+Use the CMS or theme editor to modify component properties such as text, images or layout options. Save the changes to persist them to the shop's data files.
+
+## Preview with `/edit-preview`
+
+Navigate to `/edit-preview` in the running shop to see the edits rendered. The route loads the staged component data and lets owners validate changes in context before they go live.
+
+## Republish the shop
+
+After verifying the preview, rebuild and deploy the shop so the edits appear on the live site:
+
+```bash
+pnpm ts-node scripts/src/republish-shop.ts <shop-id>
+```
+
+The script rebuilds the shop, deploys it and marks it as `published` in `data/shops/<id>/shop.json`.
+
+## How this differs from upgrading
+
+The edit flow focuses on content tweaks made through the CMS. By contrast, the [upgrade flow](./upgrade-preview-republish.md) applies template updates using `upgrade-shop` before republishing. Upgrades may overwrite files and require a backup/rollback plan, while simple component edits only affect the shop's data.


### PR DESCRIPTION
## Summary
- document editing, previewing, and republishing for shops
- link the new guide from README near upgrade docs

## Testing
- `pnpm exec prettier --check doc/edit-preview-republish.md README.md doc/upgrade-preview-republish.md`

------
https://chatgpt.com/codex/tasks/task_e_689da97fd158832fb7d81efda65d20f7