### PR TITLE
feat: enforce return conditions

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/return-logistics/route.ts
@@ -30,6 +30,8 @@ export async function POST(
       returnCarrier,
       homePickupZipCodes,
       mobileApp,
+      requireTags,
+      allowWear,
     } = parsed.data;
     await writeReturnLogistics({
       labelService,
@@ -40,6 +42,8 @@ export async function POST(
       returnCarrier,
       homePickupZipCodes,
       mobileApp,
+      requireTags,
+      allowWear,
     });
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -123,6 +123,24 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
       </label>
       <label className="flex items-center gap-2">
         <Checkbox
+          checked={form.requireTags}
+          onCheckedChange={(v) =>
+            setForm((f) => ({ ...f, requireTags: Boolean(v) }))
+          }
+        />
+        <span>Require tags for returns</span>
+      </label>
+      <label className="flex items-center gap-2">
+        <Checkbox
+          checked={form.allowWear}
+          onCheckedChange={(v) =>
+            setForm((f) => ({ ...f, allowWear: Boolean(v) }))
+          }
+        />
+        <span>Allow signs of wear</span>
+      </label>
+      <label className="flex items-center gap-2">
+        <Checkbox
           checked={Boolean(form.mobileApp)}
           onCheckedChange={(v) =>
             setForm((f) => ({ ...f, mobileApp: Boolean(v) }))

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { env } from "@acme/config";
 import shop from "../../../../../shop.json";
 import PdpClient from "./PdpClient.client";
 import { trackPageView } from "@platform-core/analytics";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
 
 async function loadComponents(slug: string): Promise<PageComponent[] | null> {
   const pages = await getPages(shop.id);
@@ -123,10 +124,19 @@ export default async function ProductDetailPage({
       <PdpClient product={product} />
     );
 
+  const cfg = await getReturnLogistics();
   return (
     <>
       {latestPost && <BlogListing posts={[latestPost]} />}
       {content}
+      <div className="p-6 space-y-1 text-sm text-gray-600">
+        {cfg.requireTags && (
+          <p>Items must have all tags attached for return.</p>
+        )}
+        {!cfg.allowWear && (
+          <p>Items showing signs of wear may be rejected.</p>
+        )}
+      </div>
     </>
   );
 }

--- a/apps/shop-abc/src/app/[lang]/returns/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/returns/page.tsx
@@ -23,6 +23,8 @@ export default async function ReturnPolicyPage() {
           {cfg.tracking && " and numbers provided with each label."}
         </p>
       )}
+      {cfg.requireTags && <p>Items must have all tags attached for return.</p>}
+      {!cfg.allowWear && <p>Items showing signs of wear may be rejected.</p>}
     </div>
   );
 }

--- a/apps/shop-abc/src/app/api/return-request/route.ts
+++ b/apps/shop-abc/src/app/api/return-request/route.ts
@@ -6,17 +6,37 @@ import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
 import { createReturnAuthorization } from "@platform-core/returnAuthorization";
 import { sendEmail } from "@acme/email";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import shop from "../../../../shop.json";
 
 export const runtime = "nodejs";
 
 const RequestSchema = z
-  .object({ orderId: z.string(), email: z.string().email() })
+  .object({
+    orderId: z.string(),
+    email: z.string().email(),
+    hasTags: z.boolean().optional(),
+    isWorn: z.boolean().optional(),
+  })
   .strict();
 
 export async function POST(req: Request) {
   const parsed = await parseJsonBody(req, RequestSchema, "1mb");
   if (!parsed.success) return parsed.response;
-  const { orderId, email } = parsed.data;
+  const { orderId, email, hasTags = true, isWorn = false } = parsed.data;
+
+  const cfg = await getReturnLogistics();
+  const settings = await getShopSettings(shop.id);
+  if (
+    settings.luxuryFeatures.strictReturnConditions &&
+    ((cfg.requireTags && !hasTags) || (!cfg.allowWear && isWorn))
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Return rejected" },
+      { status: 400 },
+    );
+  }
 
   const raId = `RA${Date.now().toString(36).toUpperCase()}`;
   await createReturnAuthorization({

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
@@ -11,6 +11,7 @@ import shop from "../../../../../shop.json";
 import PdpClient from "./PdpClient.client";
 import { readRepo } from "@platform-core/repositories/json.server";
 import type { SKU, ProductPublication, Locale } from "@acme/types";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
 
 async function getProduct(
   slug: string,
@@ -100,10 +101,19 @@ export default async function ProductDetailPage({
     /* ignore bad feature flags */
   }
 
+  const cfg = await getReturnLogistics();
   return (
     <>
       {latestPost && <BlogListing posts={[latestPost]} />}
       <PdpClient product={product} />
+      <div className="p-6 space-y-1 text-sm text-gray-600">
+        {cfg.requireTags && (
+          <p>Items must have all tags attached for return.</p>
+        )}
+        {!cfg.allowWear && (
+          <p>Items showing signs of wear may be rejected.</p>
+        )}
+      </div>
     </>
   );
 }

--- a/apps/shop-bcd/src/app/[lang]/returns/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/returns/page.tsx
@@ -14,6 +14,8 @@ export default async function ReturnPolicyPage() {
       {typeof cfg.tracking !== "undefined" && (
         <p>Tracking {cfg.tracking ? "enabled" : "disabled"}.</p>
       )}
+      {cfg.requireTags && <p>Items must have all tags attached for return.</p>}
+      {!cfg.allowWear && <p>Items showing signs of wear may be rejected.</p>}
     </div>
   );
 }

--- a/apps/shop-bcd/src/app/api/return-request/route.ts
+++ b/apps/shop-bcd/src/app/api/return-request/route.ts
@@ -6,17 +6,37 @@ import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
 import { createReturnAuthorization } from "@platform-core/returnAuthorization";
 import { sendEmail } from "@acme/email";
+import { getReturnLogistics } from "@platform-core/returnLogistics";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import shop from "../../../../shop.json";
 
 export const runtime = "nodejs";
 
 const RequestSchema = z
-  .object({ orderId: z.string(), email: z.string().email() })
+  .object({
+    orderId: z.string(),
+    email: z.string().email(),
+    hasTags: z.boolean().optional(),
+    isWorn: z.boolean().optional(),
+  })
   .strict();
 
 export async function POST(req: Request) {
   const parsed = await parseJsonBody(req, RequestSchema, "1mb");
   if (!parsed.success) return parsed.response;
-  const { orderId, email } = parsed.data;
+  const { orderId, email, hasTags = true, isWorn = false } = parsed.data;
+
+  const cfg = await getReturnLogistics();
+  const settings = await getShopSettings(shop.id);
+  if (
+    settings.luxuryFeatures.strictReturnConditions &&
+    ((cfg.requireTags && !hasTags) || (!cfg.allowWear && isWorn))
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Return rejected" },
+      { status: 400 },
+    );
+  }
 
   const raId = `RA${Date.now().toString(36).toUpperCase()}`;
   await createReturnAuthorization({

--- a/data/return-logistics.json
+++ b/data/return-logistics.json
@@ -5,5 +5,7 @@
   "tracking": true,
   "bagType": "reusable",
   "returnCarrier": ["UPS"],
-  "homePickupZipCodes": ["94105", "94107"]
+  "homePickupZipCodes": ["94105", "94107"],
+  "requireTags": true,
+  "allowWear": false
 }

--- a/packages/platform-core/__tests__/returnLogistics.test.ts
+++ b/packages/platform-core/__tests__/returnLogistics.test.ts
@@ -46,6 +46,8 @@ describe("return logistics config", () => {
       bagType: "reusable",
       returnCarrier: ["UPS"],
       homePickupZipCodes: [],
+      requireTags: true,
+      allowWear: false,
     };
     await withConfig(cfg, async ({ getReturnLogistics }) => {
       const first = await getReturnLogistics();
@@ -62,6 +64,8 @@ describe("return logistics config", () => {
       bagType: "reusable",
       returnCarrier: ["UPS"],
       homePickupZipCodes: [],
+      requireTags: true,
+      allowWear: false,
     };
     await withTempDir(async ({ getReturnLogistics }, dir) => {
       const readFile = jest
@@ -86,6 +90,8 @@ describe("return logistics config", () => {
       bagType: "reusable",
       returnCarrier: ["UPS"],
       homePickupZipCodes: [],
+      requireTags: true,
+      allowWear: false,
     };
     const invalid = {
       labelService: 123,
@@ -93,6 +99,8 @@ describe("return logistics config", () => {
       bagType: "reusable",
       returnCarrier: ["UPS"],
       homePickupZipCodes: [],
+      requireTags: true,
+      allowWear: false,
     } as any;
     await withTempDir(async ({ getReturnLogistics }, dir) => {
       const readFile = jest

--- a/packages/types/src/ReturnLogistics.d.ts
+++ b/packages/types/src/ReturnLogistics.d.ts
@@ -10,6 +10,8 @@ import { z } from "zod";
  * - `returnCarrier` lists supported carriers for return shipments.
  * - `homePickupZipCodes` enumerates ZIP codes eligible for carrier pickup.
  * - `mobileApp` toggles access to the mobile return application.
+ * - `requireTags` specifies if items must have all tags attached.
+ * - `allowWear` indicates whether signs of wear are acceptable.
  */
 export declare const returnLogisticsSchema: z.ZodObject<{
     labelService: z.ZodString;
@@ -20,6 +22,8 @@ export declare const returnLogisticsSchema: z.ZodObject<{
     returnCarrier: z.ZodArray<z.ZodString, "many">;
     homePickupZipCodes: z.ZodArray<z.ZodString, "many">;
     mobileApp: z.ZodOptional<z.ZodBoolean>;
+    requireTags: z.ZodBoolean;
+    allowWear: z.ZodBoolean;
 }, "strip", z.ZodTypeAny, {
     labelService: string;
     inStore: boolean;
@@ -29,6 +33,8 @@ export declare const returnLogisticsSchema: z.ZodObject<{
     returnCarrier: string[];
     homePickupZipCodes: string[];
     mobileApp?: boolean | undefined;
+    requireTags: boolean;
+    allowWear: boolean;
 }, {
     labelService: string;
     inStore: boolean;
@@ -38,5 +44,7 @@ export declare const returnLogisticsSchema: z.ZodObject<{
     returnCarrier: string[];
     homePickupZipCodes: string[];
     mobileApp?: boolean | undefined;
+    requireTags: boolean;
+    allowWear: boolean;
 }>;
 export type ReturnLogistics = z.infer<typeof returnLogisticsSchema>;

--- a/packages/types/src/ReturnLogistics.ts
+++ b/packages/types/src/ReturnLogistics.ts
@@ -11,6 +11,8 @@ import { z } from "zod";
  * - `returnCarrier` lists supported carriers for return shipments.
  * - `homePickupZipCodes` enumerates ZIP codes eligible for carrier pickup.
  * - `mobileApp` toggles access to the mobile return application.
+ * - `requireTags` specifies if items must have all tags attached.
+ * - `allowWear` indicates whether signs of wear are acceptable.
  */
 export const returnLogisticsSchema = z
   .object({
@@ -22,6 +24,8 @@ export const returnLogisticsSchema = z
     returnCarrier: z.array(z.string()),
     homePickupZipCodes: z.array(z.string()),
     mobileApp: z.boolean().optional(),
+    requireTags: z.boolean(),
+    allowWear: z.boolean(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- extend return logistics with requireTags and allowWear flags
- show return condition rules on product and return policy pages
- reject RA requests missing tags or showing wear when strict return conditions enabled

## Testing
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/returnLogistics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689dad78df34832f9857f0921972228b