### PR TITLE
feat: add search and icons to page builder palette

### DIFF
--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -3,7 +3,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { PageComponent } from "@acme/types";
-import { memo } from "react";
+import { memo, useState } from "react";
 import {
   atomRegistry,
   moleculeRegistry,
@@ -13,49 +13,34 @@ import {
   overlayRegistry,
 } from "../blocks";
 
+const defaultIcon = "/window.svg";
+
+const createPaletteItems = (registry: Record<string, unknown>) =>
+  (Object.keys(registry) as PageComponent["type"][])
+    .sort()
+    .map((t) => ({
+      type: t,
+      label: t.replace(/([A-Z])/g, " $1").trim(),
+      icon: defaultIcon,
+    }));
+
 const palette = {
-  layout: (Object.keys(layoutRegistry) as PageComponent["type"][])
-    .sort()
-    .map((t) => ({
-      type: t,
-      label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
-  containers: (Object.keys(containerRegistry) as PageComponent["type"][])
-    .sort()
-    .map((t) => ({
-      type: t,
-      label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
-  atoms: (Object.keys(atomRegistry) as PageComponent["type"][])
-    .sort()
-    .map((t) => ({
-      type: t,
-      label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
-  molecules: (Object.keys(moleculeRegistry) as PageComponent["type"][])
-    .sort()
-    .map((t) => ({
-      type: t,
-      label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
-  organisms: (Object.keys(organismRegistry) as PageComponent["type"][])
-    .sort()
-    .map((t) => ({
-      type: t,
-      label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
-  overlays: (Object.keys(overlayRegistry) as PageComponent["type"][])
-    .sort()
-    .map((t) => ({
-      type: t,
-      label: t.replace(/([A-Z])/g, " $1").trim(),
-    })),
+  layout: createPaletteItems(layoutRegistry),
+  containers: createPaletteItems(containerRegistry),
+  atoms: createPaletteItems(atomRegistry),
+  molecules: createPaletteItems(moleculeRegistry),
+  organisms: createPaletteItems(organismRegistry),
+  overlays: createPaletteItems(overlayRegistry),
 } as const;
 
 const PaletteItem = memo(function PaletteItem({
   type,
+  label,
+  icon,
 }: {
   type: PageComponent["type"];
+  label: string;
+  icon: string;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useSortable({
@@ -73,28 +58,49 @@ const PaletteItem = memo(function PaletteItem({
       aria-grabbed={isDragging}
       title="Drag or press space/enter to add"
       style={{ transform: CSS.Transform.toString(transform) }}
-      className="cursor-grab rounded border p-2 text-center text-sm"
+      className="flex cursor-grab items-center gap-2 rounded border p-2 text-sm"
     >
-      {type}
+      <img src={icon} alt="" aria-hidden="true" className="h-4 w-4" />
+      <span>{label}</span>
     </div>
   );
 });
+const Palette = memo(function Palette() {
+  const [search, setSearch] = useState("");
 
-  const Palette = memo(function Palette() {
-    return (
-      <div className="flex flex-col gap-4" data-tour="drag-component">
-        {Object.entries(palette).map(([category, items]) => (
+  return (
+    <div className="flex flex-col gap-4" data-tour="drag-component">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search components..."
+        aria-label="Search components"
+        className="rounded border p-2 text-sm"
+      />
+      {Object.entries(palette).map(([category, items]) => {
+        const filtered = items.filter((p) =>
+          p.label.toLowerCase().includes(search.toLowerCase()),
+        );
+        if (!filtered.length) return null;
+        return (
           <div key={category} className="space-y-2">
             <h4 className="font-semibold capitalize">{category}</h4>
             <div className="flex flex-col gap-2">
-              {items.map((p) => (
-                <PaletteItem key={p.type} type={p.type} />
+              {filtered.map((p) => (
+                <PaletteItem
+                  key={p.type}
+                  type={p.type}
+                  label={p.label}
+                  icon={p.icon}
+                />
               ))}
             </div>
           </div>
-        ))}
-      </div>
-    );
-  });
+        );
+      })}
+    </div>
+  );
+});
 
 export default Palette;


### PR DESCRIPTION
## Summary
- add placeholder icons for palette items and show them with labels
- add search input to filter palette items

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../src/app/cms/wizard/Wizard' and process.exit called)*
- `pnpm --filter @acme/ui lint` *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_689daddd703c832f81f081b21701e226