### PR TITLE
feat: add viewport icons and animated scaling

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from "@/i18n/locales";
+import { DesktopIcon, LaptopIcon, MobileIcon } from "@radix-ui/react-icons";
 import { Button, Input } from "../../atoms/shadcn";
 
 interface Props {
@@ -30,15 +31,23 @@ const PageToolbar = ({
 }: Props) => (
   <div className="flex flex-col gap-4">
     <div className="flex justify-end gap-2">
-      {(["desktop", "tablet", "mobile"] as const).map((v) => (
-        <Button
-          key={v}
-          variant={viewport === v ? "default" : "outline"}
-          onClick={() => setViewport(v)}
-        >
-          {v.charAt(0).toUpperCase() + v.slice(1)}
-        </Button>
-      ))}
+      {(["desktop", "tablet", "mobile"] as const).map((v) => {
+        const Icon =
+          v === "desktop" ? DesktopIcon : v === "tablet" ? LaptopIcon : MobileIcon;
+        return (
+          <Button
+            key={v}
+            variant={viewport === v ? "default" : "outline"}
+            onClick={() => setViewport(v)}
+            aria-label={v}
+          >
+            <Icon />
+            <span className="sr-only">
+              {v.charAt(0).toUpperCase() + v.slice(1)}
+            </span>
+          </Button>
+        );
+      })}
     </div>
     <div className="flex items-center justify-end gap-2">
       <Button


### PR DESCRIPTION
## Summary
- replace PageToolbar viewport text buttons with device icons
- animate PageBuilder canvas scaling between desktop, tablet, and mobile viewports
- add subtle frame styling around canvas for device preview

## Testing
- `pnpm test --filter @acme/ui` *(fails: Cannot find module '../src/app/cms/wizard/Wizard')*

------
https://chatgpt.com/codex/tasks/task_e_689daeaf8a44832f9fc9f5cdfcdcb1cb