### PR TITLE
feat(theme): preview override swatches

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.presets.test.tsx
+++ b/apps/cms/__tests__/ThemeEditor.presets.test.tsx
@@ -8,6 +8,11 @@ import {
   act,
 } from "./ThemeEditor.test-utils";
 
+jest.mock("../src/app/cms/wizard/previewTokens", () => ({
+  savePreviewTokens: jest.fn(),
+}));
+import { savePreviewTokens as mockSavePreviewTokens } from "../src/app/cms/wizard/previewTokens";
+
 describe("ThemeEditor - presets", () => {
   beforeEach(() => {
     mockSavePreset.mockClear();
@@ -61,5 +66,26 @@ describe("ThemeEditor - presets", () => {
       expect(screen.getByLabelText(/theme/i)).toHaveValue("base")
     );
     expect(screen.queryByRole("button", { name: /delete preset/i })).toBeNull();
+  });
+
+  it("updates preview tokens when switching themes", async () => {
+    const tokensByTheme = {
+      light: { "--color-bg": "#ffffff" },
+      dark: { "--color-bg": "#000000" },
+    };
+    renderThemeEditor({
+      tokensByTheme,
+      themes: ["light", "dark"],
+      initialTheme: "light",
+    });
+
+    const select = screen.getByLabelText(/theme/i);
+    (mockSavePreviewTokens as jest.Mock).mockClear();
+    fireEvent.change(select, { target: { value: "dark" } });
+    await waitFor(() =>
+      expect(mockSavePreviewTokens).toHaveBeenCalledWith({
+        "--color-bg": "#000000",
+      })
+    );
   });
 });

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
@@ -40,11 +40,19 @@ export default function ColorInput({
   const defaultIsHex = isHex(defaultValue);
   const isColor = defaultIsHsl || defaultIsHex;
   const current = hasOverride ? value : defaultValue;
+  const defaultHex = defaultIsHsl ? hslToHex(defaultValue) : defaultValue;
   const colorValue = defaultIsHsl
     ? isHex(current)
       ? current
       : hslToHex(current)
     : current;
+  const overrideHex = hasOverride
+    ? defaultIsHsl
+      ? isHex(value)
+        ? value
+        : hslToHex(value)
+      : value
+    : defaultHex;
 
   const [warning, setWarning] = useState<string | null>(null);
 
@@ -111,7 +119,18 @@ export default function ColorInput({
               ref={inputRef}
               className={isOverridden ? "bg-amber-100" : ""}
             />
-            <span className="h-6 w-6 rounded border" style={{ background: colorValue }} />
+            <div className="flex items-center gap-1">
+              <span
+                className="h-6 w-6 rounded border"
+                title="Default"
+                style={{ background: defaultHex }}
+              />
+              <span
+                className="h-6 w-6 rounded border"
+                title={hasOverride ? "Custom" : "Default"}
+                style={{ background: overrideHex }}
+              />
+            </div>
           </>
         ) : (
           <Input

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -83,9 +83,11 @@ export default function WizardPreview({
     handle();
     window.addEventListener("storage", handle);
     window.addEventListener(PREVIEW_TOKENS_EVENT, handle);
+    window.addEventListener("theme:change", handle);
     return () => {
       window.removeEventListener("storage", handle);
       window.removeEventListener(PREVIEW_TOKENS_EVENT, handle);
+      window.removeEventListener("theme:change", handle);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- show default and custom color swatches for each token
- persist tokens and fire `theme:change` on theme selection
- update preview when switching themes

## Testing
- `pnpm test --filter @apps/cms -- --runTestsByPath __tests__/ThemeEditor.colors.test.tsx __tests__/ThemeEditor.reload.test.tsx __tests__/ThemeEditor.presets.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689daf1258fc832f8d26df66a5f837c9