### PR TITLE
feat: manage upgrade metadata

### DIFF
--- a/doc/upgrade-preview-republish.md
+++ b/doc/upgrade-preview-republish.md
@@ -12,7 +12,7 @@ Run the script with a shop identifier to copy files from the template:
 pnpm ts-node scripts/src/upgrade-shop.ts <shop-id>
 ```
 
-Existing files are backed up with a `.bak` suffix and the shop's `shop.json` gains a `lastUpgrade` timestamp. Use `--rollback` to restore the backups:
+Existing files are backed up with a `.bak` suffix, the shop's `shop.json` gains a `lastUpgrade` timestamp, and `data/shops/<id>/upgrade.json` is generated with metadata about the staged components. Use `--rollback` to restore the backups:
 
 ```bash
 pnpm ts-node scripts/src/upgrade-shop.ts <shop-id> --rollback
@@ -26,7 +26,7 @@ After testing an upgrade, rebuild and deploy the shop:
 pnpm ts-node scripts/src/republish-shop.ts <shop-id>
 ```
 
-The script requires a corresponding `data/shops/<id>/upgrade.json`, runs `pnpm --filter apps/<id> build` followed by `deploy`, and marks the shop as `published` in `shop.json`.
+The script requires a corresponding `data/shops/<id>/upgrade.json`, runs `pnpm --filter apps/<id> build` followed by `deploy`, marks the shop as `published` in `shop.json`, and removes the upgrade metadata file.
 
 ## API endpoints
 
@@ -39,5 +39,5 @@ CMS components fetch the preview endpoint and render changes live. The wizard's 
 ## Metadata
 
 - `data/shops/<id>/shop.json` stores `lastUpgrade` and the publish `status`.
-- `data/shops/<id>/upgrade.json` captures information about the staged upgrade.
+- `data/shops/<id>/upgrade.json` captures information about the staged upgrade and is deleted after publishing.
 - `data/shops/<id>/deploy.json` stores the `previewUrl` and deployment instructions.

--- a/scripts/src/republish-shop.ts
+++ b/scripts/src/republish-shop.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -29,6 +29,9 @@ export function republishShop(id: string, root = process.cwd()): void {
   run("pnpm", ["--filter", `apps/${id}`, "build"]);
   run("pnpm", ["--filter", `apps/${id}`, "deploy"]);
   updateStatus(root, id);
+  if (existsSync(upgradeFile)) {
+    unlinkSync(upgradeFile);
+  }
 }
 
 function main(): void {

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -28,6 +28,7 @@ const rootDir = path.resolve(__dirname, "..", "..");
 const appDir = path.join(rootDir, "apps", shopId);
 const templateDir = path.join(rootDir, "packages", "template-app");
 const shopJsonPath = path.join(rootDir, "data", "shops", shopId, "shop.json");
+const pkgPath = path.join(appDir, "package.json");
 
 if (!existsSync(appDir)) {
   console.error(`Shop app does not exist: ${appDir}`);
@@ -53,7 +54,6 @@ if (existsSync(shopJsonPath)) {
   cpSync(shopJsonPath, shopJsonPath + ".bak");
   const data = JSON.parse(readFileSync(shopJsonPath, "utf8"));
   (data as any).lastUpgrade = new Date().toISOString();
-  const pkgPath = path.join(appDir, "package.json");
   (data as any).componentVersions = existsSync(pkgPath)
     ? (JSON.parse(readFileSync(pkgPath, "utf8")).dependencies ?? {})
     : {};
@@ -119,6 +119,29 @@ writeFileSync(
     null,
     2
   )
+);
+
+const upgradeMetaPath = path.join(
+  rootDir,
+  "data",
+  "shops",
+  shopId,
+  "upgrade.json",
+);
+const componentVersions = existsSync(pkgPath)
+  ? (JSON.parse(readFileSync(pkgPath, "utf8")).dependencies ?? {})
+  : {};
+writeFileSync(
+  upgradeMetaPath,
+  JSON.stringify(
+    {
+      timestamp: new Date().toISOString(),
+      componentVersions,
+      components: changedComponents,
+    },
+    null,
+    2,
+  ),
 );
 
 const envPath = path.join(appDir, ".env");

--- a/test/integration/republish-shop.spec.ts
+++ b/test/integration/republish-shop.spec.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "child_process";
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -59,6 +60,7 @@ describe("republish-shop script", () => {
       expect(log).toContain("--filter apps/shop-test deploy");
       const final = JSON.parse(readFileSync(join(dataDir, "shop.json"), "utf8"));
       expect(final.status).toBe("published");
+      expect(existsSync(join(dataDir, "upgrade.json"))).toBe(false);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- record upgrade metadata in `upgrade.json`
- clean up upgrade metadata after publishing
- document upgrade metadata lifecycle and test republish flow

## Testing
- `pnpm exec jest test/integration/republish-shop.spec.ts test/integration/publish-api.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689daf9b2dec832f99d50e3116a0eb99