### PR TITLE
feat: add shop and blog services

### DIFF
--- a/apps/cms/__tests__/shops.test.ts
+++ b/apps/cms/__tests__/shops.test.ts
@@ -74,7 +74,7 @@ describe("shop actions", () => {
         getServerSession: jest.fn().mockResolvedValue(adminSession),
       }));
 
-      const { updateShop } = await import("../src/actions/shops.server");
+      const { updateShop } = await import("../src/services/shops");
 
       const fd = new FormData();
       fd.append("id", "test");
@@ -142,7 +142,7 @@ describe("shop actions", () => {
         loadThemeTokens: jest.fn().mockResolvedValue(defaultTokens),
       }));
 
-      const { updateShop } = await import("../src/actions/shops.server");
+      const { updateShop } = await import("../src/services/shops");
 
       const overrides = { accent: "red", "accent-dark": "black" };
       const fd = new FormData();

--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -1,253 +1,50 @@
 // apps/cms/src/actions/blog.server.ts
 
-import { getSanityConfig } from "@platform-core/src/shops";
-import { getShopById } from "@platform-core/src/repositories/shop.server";
-import { ensureAuthorized } from "./common/auth";
 import {
-  query,
-  mutate,
-  slugExists,
-  type SanityConfig,
-} from "@acme/plugin-sanity";
+  getPosts as serviceGetPosts,
+  getPost as serviceGetPost,
+  createPost as serviceCreatePost,
+  updatePost as serviceUpdatePost,
+  publishPost as servicePublishPost,
+  unpublishPost as serviceUnpublishPost,
+  deletePost as serviceDeletePost,
+  type SanityPost,
+} from "../services/blog";
 
-function collectProductSlugs(content: unknown): string[] {
-  const slugs = new Set<string>();
-  const walk = (node: any) => {
-    if (!node) return;
-    if (Array.isArray(node)) {
-      node.forEach(walk);
-      return;
-    }
-    if (typeof node === "object") {
-      if (node._type === "productReference" && typeof node.slug === "string") {
-        slugs.add(node.slug);
-      }
-      for (const value of Object.values(node)) {
-        walk(value);
-      }
-    }
-  };
-  walk(content);
-  return Array.from(slugs);
+export function getPosts(shopId: string): Promise<SanityPost[]> {
+  return serviceGetPosts(shopId);
 }
 
-async function filterExistingProductSlugs(
-  shopId: string,
-  slugs: string[],
-): Promise<string[]> {
-  if (slugs.length === 0) return [];
-  try {
-    const res = await fetch(`/api/products/${shopId}/slugs`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ slugs }),
-    });
-    if (!res.ok) return [];
-    const existing = await res.json();
-    return Array.isArray(existing) ? existing : [];
-  } catch {
-    return [];
-  }
-}
-
-interface SanityPost {
-  _id: string;
-  title?: string;
-  body?: string;
-  published?: boolean;
-  publishedAt?: string;
-  slug?: string;
-  excerpt?: string;
-  mainImage?: string;
-  author?: string;
-  categories?: string[];
-}
-async function getConfig(shopId: string): Promise<SanityConfig> {
-  const shop = await getShopById(shopId);
-  const sanity = getSanityConfig(shop);
-  if (!sanity) {
-    throw new Error(`Missing Sanity config for shop ${shopId}`);
-  }
-  return sanity;
-}
-
-export async function getPosts(shopId: string): Promise<SanityPost[]> {
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  const posts = await query<SanityPost[]>(
-    config,
-    '*[_type=="post"]{_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories}',
-  );
-  return posts ?? [];
-}
-
-export async function getPost(
-  shopId: string,
-  id: string
-): Promise<SanityPost | null> {
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  const post = await query<SanityPost | null>(
-    config,
-    `*[_type=="post" && _id=="${id}"][0]{_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories}`,
-  );
-  return post ?? null;
+export function getPost(shopId: string, id: string): Promise<SanityPost | null> {
+  return serviceGetPost(shopId, id);
 }
 
 export async function createPost(
   shopId: string,
   _prev: unknown,
-  formData: FormData
+  formData: FormData,
 ): Promise<{ message?: string; error?: string; id?: string }> {
   "use server";
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  const title = String(formData.get("title") ?? "");
-  const content = String(formData.get("content") ?? "[]");
-  let body: unknown = [];
-  let products: string[] = [];
-  try {
-    body = JSON.parse(content);
-    products = collectProductSlugs(body);
-  } catch {
-    body = [];
-    products = [];
-  }
-  const existingSlugs = await filterExistingProductSlugs(shopId, products);
-  products = existingSlugs;
-  const slug = String(formData.get("slug") ?? "");
-  const excerpt = String(formData.get("excerpt") ?? "");
-  const mainImage = String(formData.get("mainImage") ?? "");
-  const author = String(formData.get("author") ?? "");
-  const categoriesInput = String(formData.get("categories") ?? "");
-  const categories = categoriesInput
-    .split(",")
-    .map((c) => c.trim())
-    .filter(Boolean);
-  const publishedAtInput = formData.get("publishedAt");
-  const publishedAt = publishedAtInput
-    ? new Date(String(publishedAtInput)).toISOString()
-    : undefined;
-  try {
-    if (slug && (await slugExists(config, slug))) {
-      return { error: "Slug already exists" };
-    }
-    const result = await mutate(config, {
-      mutations: [
-        {
-          create: {
-            _type: "post",
-            title,
-            body,
-            products,
-            published: false,
-            slug: slug ? { current: slug } : undefined,
-            excerpt: excerpt || undefined,
-            mainImage: mainImage || undefined,
-            author: author || undefined,
-            ...(categories.length ? { categories } : {}),
-            ...(publishedAt ? { publishedAt } : {}),
-          },
-        },
-      ],
-      returnIds: true,
-    });
-    const id = (result as any)?.results?.[0]?.id as string | undefined;
-    return { message: "Post created", id };
-  } catch (err) {
-    console.error("Failed to create post", err);
-    return { error: "Failed to create post" };
-  }
+  return serviceCreatePost(shopId, formData);
 }
 
 export async function updatePost(
   shopId: string,
   _prev: unknown,
-  formData: FormData
+  formData: FormData,
 ): Promise<{ message?: string; error?: string }> {
   "use server";
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  const id = String(formData.get("id") ?? "");
-  const title = String(formData.get("title") ?? "");
-  const content = String(formData.get("content") ?? "[]");
-  let body: unknown = [];
-  let products: string[] = [];
-  try {
-    body = JSON.parse(content);
-    products = collectProductSlugs(body);
-  } catch {
-    body = [];
-    products = [];
-  }
-  const existingSlugs = await filterExistingProductSlugs(shopId, products);
-  products = existingSlugs;
-  const slug = String(formData.get("slug") ?? "");
-  const excerpt = String(formData.get("excerpt") ?? "");
-  const mainImage = String(formData.get("mainImage") ?? "");
-  const author = String(formData.get("author") ?? "");
-  const categoriesInput = String(formData.get("categories") ?? "");
-  const categories = categoriesInput
-    .split(",")
-    .map((c) => c.trim())
-    .filter(Boolean);
-  const publishedAtInput = formData.get("publishedAt");
-  const publishedAt = publishedAtInput
-    ? new Date(String(publishedAtInput)).toISOString()
-    : undefined;
-  try {
-    if (slug && (await slugExists(config, slug, id))) {
-      return { error: "Slug already exists" };
-    }
-    await mutate(config, {
-      mutations: [
-        {
-          patch: {
-            id,
-            set: {
-              title,
-              body,
-              products,
-              slug: slug ? { current: slug } : undefined,
-              excerpt: excerpt || undefined,
-              mainImage: mainImage || undefined,
-              author: author || undefined,
-              ...(categories.length ? { categories } : {}),
-              ...(publishedAt ? { publishedAt } : {}),
-            },
-          },
-        },
-      ],
-    });
-    return { message: "Post updated" };
-  } catch (err) {
-    console.error("Failed to update post", err);
-    return { error: "Failed to update post" };
-  }
+  return serviceUpdatePost(shopId, formData);
 }
 
 export async function publishPost(
   shopId: string,
   id: string,
   _prev?: unknown,
-  formData?: FormData
+  formData?: FormData,
 ): Promise<{ message?: string; error?: string }> {
   "use server";
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  const publishedAtInput = formData?.get("publishedAt");
-  const publishedAt = publishedAtInput
-    ? new Date(String(publishedAtInput)).toISOString()
-    : new Date().toISOString();
-  try {
-    await mutate(config, {
-      mutations: [{ patch: { id, set: { published: true, publishedAt } } }],
-    });
-    return { message: "Post published" };
-  } catch (err) {
-    console.error("Failed to publish post", err);
-    return { error: "Failed to publish post" };
-  }
+  return servicePublishPost(shopId, id, formData);
 }
 
 export async function unpublishPost(
@@ -257,17 +54,7 @@ export async function unpublishPost(
   _formData?: FormData,
 ): Promise<{ message?: string; error?: string }> {
   "use server";
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  try {
-    await mutate(config, {
-      mutations: [{ patch: { id, set: { published: false }, unset: ["publishedAt"] } }],
-    });
-    return { message: "Post unpublished" };
-  } catch (err) {
-    console.error("Failed to unpublish post", err);
-    return { error: "Failed to unpublish post" };
-  }
+  return serviceUnpublishPost(shopId, id);
 }
 
 export async function deletePost(
@@ -275,15 +62,7 @@ export async function deletePost(
   id: string,
 ): Promise<{ message?: string; error?: string }> {
   "use server";
-  await ensureAuthorized();
-  const config = await getConfig(shopId);
-  try {
-    await mutate(config, { mutations: [{ delete: { id } }] });
-    return { message: "Post deleted" };
-  } catch (err) {
-    console.error("Failed to delete post", err);
-    return { error: "Failed to delete post" };
-  }
+  return serviceDeletePost(shopId, id);
 }
 
 export type { SanityPost };

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -1,301 +1,94 @@
 // apps/cms/src/actions/shops.server.ts
 
-"use server";
-
-import { revalidatePath } from "next/cache";
-import type {
-  Locale,
-  Shop,
-  ShopSeoFields,
-  ShopSettings,
-} from "@acme/types";
-import { authorize } from "../services/shops/authorization";
 import {
-  parseShopForm,
-  parseSeoForm,
-  parseGenerateSeoForm,
-  parseCurrencyTaxForm,
-  parseDepositForm,
-  parseUpsReturnsForm,
-  parsePremierDeliveryForm,
-  parseAiCatalogForm,
-} from "../services/shops/validation";
-import { buildThemeData, removeThemeToken } from "../services/shops/theme";
-import {
-  fetchShop,
-  persistShop,
-  fetchSettings,
-  persistSettings,
-  fetchDiffHistory,
-} from "../services/shops/persistence";
+  updateShop as serviceUpdateShop,
+  getSettings as serviceGetSettings,
+  updateSeo as serviceUpdateSeo,
+  generateSeo as serviceGenerateSeo,
+  revertSeo as serviceRevertSeo,
+  setFreezeTranslations as serviceSetFreezeTranslations,
+  updateCurrencyAndTax as serviceUpdateCurrencyAndTax,
+  updateDeposit as serviceUpdateDeposit,
+  updateUpsReturns as serviceUpdateUpsReturns,
+  updatePremierDelivery as serviceUpdatePremierDelivery,
+  updateAiCatalog as serviceUpdateAiCatalog,
+  resetThemeOverride as serviceResetThemeOverride,
+  type Shop,
+  type ShopSettings,
+} from "../services/shops";
 
 export async function updateShop(
   shop: string,
   formData: FormData,
 ): Promise<{ shop?: Shop; errors?: Record<string, string[]> }> {
-  await authorize();
-  const current = await fetchShop(shop);
-  const { data, errors } = parseShopForm(formData);
-  if (!data) {
-    console.error(`[updateShop] validation failed for shop ${shop}`, errors);
-    return { errors };
-  }
-  if (current.id !== data.id) throw new Error(`Shop ${data.id} not found in ${shop}`);
-
-  const theme = await buildThemeData(shop, data, current);
-
-  const patch: Partial<Shop> & { id: string } = {
-    id: current.id,
-    name: data.name,
-    themeId: data.themeId,
-    catalogFilters: data.catalogFilters,
-    enableEditorial: data.enableEditorial,
-    themeDefaults: theme.themeDefaults,
-    themeOverrides: theme.overrides,
-    themeTokens: theme.themeTokens,
-    filterMappings: data.filterMappings as Record<string, string>,
-    priceOverrides: data.priceOverrides as Partial<Record<Locale, number>>,
-    localeOverrides: data.localeOverrides as Record<string, Locale>,
-    luxuryFeatures: data.luxuryFeatures,
-  };
-
-  const saved = await persistShop(shop, patch);
-
-  const settings = await fetchSettings(shop);
-  const updatedSettings: ShopSettings = {
-    ...settings,
-    trackingProviders: data.trackingProviders,
-    luxuryFeatures: data.luxuryFeatures,
-  };
-  await persistSettings(shop, updatedSettings);
-
-  return { shop: saved };
+  "use server";
+  return serviceUpdateShop(shop, formData);
 }
 
 export function getSettings(shop: string) {
-  return fetchSettings(shop);
+  return serviceGetSettings(shop);
 }
 
 export async function updateSeo(
   shop: string,
   formData: FormData,
-): Promise<{
-  settings?: unknown;
-  errors?: Record<string, string[]>;
-  warnings?: string[];
-}> {
-  await authorize();
-  const { data, errors } = parseSeoForm(formData);
-  if (!data) {
-    console.error(`[updateSeo] validation failed for shop ${shop}`, errors);
-    return { errors };
-  }
-
-  const {
-    locale,
-    title,
-    description,
-    image,
-    alt,
-    canonicalBase,
-    ogUrl,
-    twitterCard,
-  } = data;
-
-  const warnings: string[] = [];
-  if (title.length > 70) warnings.push("Title exceeds 70 characters");
-  if (description.length > 160)
-    warnings.push("Description exceeds 160 characters");
-
-  const current = await fetchSettings(shop);
-  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
-  seo[locale] = {
-    title,
-    description,
-    image,
-    alt,
-    canonicalBase,
-    openGraph: ogUrl ? { url: ogUrl } : undefined,
-    twitter: twitterCard ? { card: twitterCard } : undefined,
-  };
-  const updated: ShopSettings = {
-    ...current,
-    seo,
-  };
-  await persistSettings(shop, updated);
-
-  return { settings: updated, warnings };
+) {
+  "use server";
+  return serviceUpdateSeo(shop, formData);
 }
 
 export async function generateSeo(
   shop: string,
   formData: FormData,
-): Promise<{
-  generated?: { title: string; description: string; image: string };
-  errors?: Record<string, string[]>;
-}> {
-  await authorize();
-  const { data, errors } = parseGenerateSeoForm(formData);
-  if (!data) {
-    return { errors };
-  }
-
-  const { id, locale, title, description } = data;
-  const { generateMeta } = await import(
-    /* @vite-ignore */ "../../../../scripts/generate-meta.ts"
-  );
-
-  const result = await generateMeta({ id, title, description });
-  const current = await fetchSettings(shop);
-  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
-  seo[locale] = {
-    ...(seo[locale] ?? {}),
-    title: result.title,
-    description: result.description,
-    image: result.image,
-    openGraph: { ...(seo[locale]?.openGraph ?? {}), image: result.image },
-  };
-  const updated: ShopSettings = { ...current, seo };
-  await persistSettings(shop, updated);
-
-  return { generated: result };
+) {
+  "use server";
+  return serviceGenerateSeo(shop, formData);
 }
 
 export async function revertSeo(shop: string, timestamp: string) {
-  await authorize();
-  const history = await fetchDiffHistory(shop);
-  const sorted = history.sort((a: any, b: any) =>
-    a.timestamp.localeCompare(b.timestamp),
-  );
-  const idx = sorted.findIndex((e: any) => e.timestamp === timestamp);
-  if (idx === -1) throw new Error("Version not found");
-  let state: ShopSettings = {
-    languages: [],
-    seo: {},
-    freezeTranslations: false,
-    updatedAt: "",
-    updatedBy: "",
-  };
-  for (let i = 0; i < idx; i++) {
-    state = { ...state, ...sorted[i].diff } as ShopSettings;
-  }
-  await persistSettings(shop, state);
-  return state;
+  "use server";
+  return serviceRevertSeo(shop, timestamp);
 }
 
 export async function setFreezeTranslations(shop: string, freeze: boolean) {
-  await authorize();
-  const current = await fetchSettings(shop);
-  const updated: ShopSettings = { ...current, freezeTranslations: freeze };
-  await persistSettings(shop, updated);
-  return updated;
+  "use server";
+  return serviceSetFreezeTranslations(shop, freeze);
 }
 
 export async function updateCurrencyAndTax(
   shop: string,
   formData: FormData,
-): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
-  await authorize();
-  const { data, errors } = parseCurrencyTaxForm(formData);
-  if (!data) {
-    return { errors };
-  }
-  const current = await fetchSettings(shop);
-  const updated: ShopSettings = {
-    ...current,
-    currency: data.currency,
-    taxRegion: data.taxRegion,
-  };
-  await persistSettings(shop, updated);
-  return { settings: updated };
+) {
+  "use server";
+  return serviceUpdateCurrencyAndTax(shop, formData);
 }
 
-export async function updateDepositService(
-  shop: string,
-  formData: FormData,
-): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
-  await authorize();
-  const { data, errors } = parseDepositForm(formData);
-  if (!data) {
-    return { errors };
-  }
-  const current = await fetchSettings(shop);
-  const updated: ShopSettings = {
-    ...current,
-    depositService: {
-      enabled: data.enabled,
-      intervalMinutes: data.intervalMinutes,
-    },
-  };
-  await persistSettings(shop, updated);
-  return { settings: updated };
+export async function updateDeposit(shop: string, formData: FormData) {
+  "use server";
+  return serviceUpdateDeposit(shop, formData);
 }
 
-export async function updateUpsReturns(
-  shop: string,
-  formData: FormData,
-): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
-  await authorize();
-  const { data, errors } = parseUpsReturnsForm(formData);
-  if (!data) {
-    return { errors };
-  }
-  const current = await fetchSettings(shop);
-  const updated: ShopSettings = {
-    ...current,
-    returnService: { upsEnabled: data.enabled },
-  };
-  await persistSettings(shop, updated);
-  return { settings: updated };
+export async function updateUpsReturns(shop: string, formData: FormData) {
+  "use server";
+  return serviceUpdateUpsReturns(shop, formData);
 }
 
 export async function updatePremierDelivery(
   shop: string,
   formData: FormData,
-): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
-  await authorize();
-  const { data, errors } = parsePremierDeliveryForm(formData);
-  if (!data) {
-    return { errors };
-  }
-  const current = await fetchSettings(shop);
-  const updated: ShopSettings = {
-    ...current,
-    premierDelivery: data,
-  };
-  await persistSettings(shop, updated);
-  return { settings: updated };
+) {
+  "use server";
+  return serviceUpdatePremierDelivery(shop, formData);
 }
 
-export async function updateAiCatalog(
-  shop: string,
-  formData: FormData,
-): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
-  await authorize();
-  const { data, errors } = parseAiCatalogForm(formData);
-  if (!data) {
-    return { errors };
-  }
-  const current = await fetchSettings(shop);
-  const seo = { ...(current.seo ?? {}) };
-  (seo as any).aiCatalog = {
-    enabled: data.enabled,
-    fields: data.fields,
-    pageSize: data.pageSize,
-  };
-  const updated: ShopSettings = { ...current, seo };
-  await persistSettings(shop, updated);
-  return { settings: updated };
+export async function updateAiCatalog(shop: string, formData: FormData) {
+  "use server";
+  return serviceUpdateAiCatalog(shop, formData);
 }
 
 export async function resetThemeOverride(shop: string, token: string) {
-  await authorize();
-  const current = await fetchShop(shop);
-  const { overrides, themeTokens } = removeThemeToken(current, token);
-  await persistShop(shop, {
-    id: current.id,
-    themeOverrides: overrides,
-    themeTokens,
-  });
-  revalidatePath(`/cms/shop/${shop}/settings`);
+  "use server";
+  return serviceResetThemeOverride(shop, token);
 }
+
+export type { Shop, ShopSettings };

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -1,0 +1,236 @@
+import { getSanityConfig } from "@platform-core/src/shops";
+import { getShopById } from "@platform-core/src/repositories/shop.server";
+import {
+  listPosts,
+  getPost as repoGetPost,
+  createPost as repoCreatePost,
+  updatePost as repoUpdatePost,
+  publishPost as repoPublishPost,
+  unpublishPost as repoUnpublishPost,
+  deletePost as repoDeletePost,
+  slugExists,
+  type SanityPost,
+  type SanityConfig,
+} from "@platform-core/src/repositories/blog.server";
+import { ensureAuthorized } from "../actions/common/auth";
+
+function collectProductSlugs(content: unknown): string[] {
+  const slugs = new Set<string>();
+  const walk = (node: any) => {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (typeof node === "object") {
+      if (node._type === "productReference" && typeof node.slug === "string") {
+        slugs.add(node.slug);
+      }
+      for (const value of Object.values(node)) {
+        walk(value);
+      }
+    }
+  };
+  walk(content);
+  return Array.from(slugs);
+}
+
+async function filterExistingProductSlugs(shopId: string, slugs: string[]): Promise<string[]> {
+  if (slugs.length === 0) return [];
+  try {
+    const res = await fetch(`/api/products/${shopId}/slugs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slugs }),
+    });
+    if (!res.ok) return [];
+    const existing = await res.json();
+    return Array.isArray(existing) ? existing : [];
+  } catch {
+    return [];
+  }
+}
+
+async function getConfig(shopId: string): Promise<SanityConfig> {
+  const shop = await getShopById(shopId);
+  const sanity = getSanityConfig(shop);
+  if (!sanity) {
+    throw new Error(`Missing Sanity config for shop ${shopId}`);
+  }
+  return sanity;
+}
+
+export async function getPosts(shopId: string): Promise<SanityPost[]> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  return listPosts(config);
+}
+
+export async function getPost(shopId: string, id: string): Promise<SanityPost | null> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  return repoGetPost(config, id);
+}
+
+export async function createPost(
+  shopId: string,
+  formData: FormData,
+): Promise<{ message?: string; error?: string; id?: string }> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  const title = String(formData.get("title") ?? "");
+  const content = String(formData.get("content") ?? "[]");
+  let body: unknown = [];
+  let products: string[] = [];
+  try {
+    body = JSON.parse(content);
+    products = collectProductSlugs(body);
+  } catch {
+    body = [];
+    products = [];
+  }
+  const existingSlugs = await filterExistingProductSlugs(shopId, products);
+  products = existingSlugs;
+  const slug = String(formData.get("slug") ?? "");
+  const excerpt = String(formData.get("excerpt") ?? "");
+  const mainImage = String(formData.get("mainImage") ?? "");
+  const author = String(formData.get("author") ?? "");
+  const categoriesInput = String(formData.get("categories") ?? "");
+  const categories = categoriesInput
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  const publishedAtInput = formData.get("publishedAt");
+  const publishedAt = publishedAtInput
+    ? new Date(String(publishedAtInput)).toISOString()
+    : undefined;
+  try {
+    if (slug && (await slugExists(config, slug))) {
+      return { error: "Slug already exists" };
+    }
+    const id = await repoCreatePost(config, {
+      _type: "post",
+      title,
+      body,
+      products,
+      published: false,
+      slug: slug ? { current: slug } : undefined,
+      excerpt: excerpt || undefined,
+      mainImage: mainImage || undefined,
+      author: author || undefined,
+      ...(categories.length ? { categories } : {}),
+      ...(publishedAt ? { publishedAt } : {}),
+    });
+    return { message: "Post created", id };
+  } catch (err) {
+    console.error("Failed to create post", err);
+    return { error: "Failed to create post" };
+  }
+}
+
+export async function updatePost(
+  shopId: string,
+  formData: FormData,
+): Promise<{ message?: string; error?: string }> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  const id = String(formData.get("id") ?? "");
+  const title = String(formData.get("title") ?? "");
+  const content = String(formData.get("content") ?? "[]");
+  let body: unknown = [];
+  let products: string[] = [];
+  try {
+    body = JSON.parse(content);
+    products = collectProductSlugs(body);
+  } catch {
+    body = [];
+    products = [];
+  }
+  const existingSlugs = await filterExistingProductSlugs(shopId, products);
+  products = existingSlugs;
+  const slug = String(formData.get("slug") ?? "");
+  const excerpt = String(formData.get("excerpt") ?? "");
+  const mainImage = String(formData.get("mainImage") ?? "");
+  const author = String(formData.get("author") ?? "");
+  const categoriesInput = String(formData.get("categories") ?? "");
+  const categories = categoriesInput
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  const publishedAtInput = formData.get("publishedAt");
+  const publishedAt = publishedAtInput
+    ? new Date(String(publishedAtInput)).toISOString()
+    : undefined;
+  try {
+    if (slug && (await slugExists(config, slug, id))) {
+      return { error: "Slug already exists" };
+    }
+    await repoUpdatePost(config, id, {
+      title,
+      body,
+      products,
+      slug: slug ? { current: slug } : undefined,
+      excerpt: excerpt || undefined,
+      mainImage: mainImage || undefined,
+      author: author || undefined,
+      ...(categories.length ? { categories } : {}),
+      ...(publishedAt ? { publishedAt } : {}),
+    });
+    return { message: "Post updated" };
+  } catch (err) {
+    console.error("Failed to update post", err);
+    return { error: "Failed to update post" };
+  }
+}
+
+export async function publishPost(
+  shopId: string,
+  id: string,
+  formData?: FormData,
+): Promise<{ message?: string; error?: string }> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  const publishedAtInput = formData?.get("publishedAt");
+  const publishedAt = publishedAtInput
+    ? new Date(String(publishedAtInput)).toISOString()
+    : new Date().toISOString();
+  try {
+    await repoPublishPost(config, id, publishedAt);
+    return { message: "Post published" };
+  } catch (err) {
+    console.error("Failed to publish post", err);
+    return { error: "Failed to publish post" };
+  }
+}
+
+export async function unpublishPost(
+  shopId: string,
+  id: string,
+): Promise<{ message?: string; error?: string }> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  try {
+    await repoUnpublishPost(config, id);
+    return { message: "Post unpublished" };
+  } catch (err) {
+    console.error("Failed to unpublish post", err);
+    return { error: "Failed to unpublish post" };
+  }
+}
+
+export async function deletePost(
+  shopId: string,
+  id: string,
+): Promise<{ message?: string; error?: string }> {
+  await ensureAuthorized();
+  const config = await getConfig(shopId);
+  try {
+    await repoDeletePost(config, id);
+    return { message: "Post deleted" };
+  } catch (err) {
+    console.error("Failed to delete post", err);
+    return { error: "Failed to delete post" };
+  }
+}
+
+export type { SanityPost };

--- a/apps/cms/src/services/shops.ts
+++ b/apps/cms/src/services/shops.ts
@@ -1,0 +1,301 @@
+// apps/cms/src/services/shops.ts
+
+import { revalidatePath } from "next/cache";
+import type {
+  Locale,
+  Shop,
+  ShopSeoFields,
+  ShopSettings,
+} from "@acme/types";
+import { authorize } from "./shops/authorization";
+import {
+  parseShopForm,
+  parseSeoForm,
+  parseGenerateSeoForm,
+  parseCurrencyTaxForm,
+  parseDepositForm,
+  parseUpsReturnsForm,
+  parsePremierDeliveryForm,
+  parseAiCatalogForm,
+} from "./shops/validation";
+import { buildThemeData, removeThemeToken } from "./shops/theme";
+import {
+  fetchShop,
+  persistShop,
+  fetchSettings,
+  persistSettings,
+  fetchDiffHistory,
+} from "./shops/persistence";
+
+export async function updateShop(
+  shop: string,
+  formData: FormData,
+): Promise<{ shop?: Shop; errors?: Record<string, string[]> }> {
+  await authorize();
+  const current = await fetchShop(shop);
+  const { data, errors } = parseShopForm(formData);
+  if (!data) {
+    console.error(`[updateShop] validation failed for shop ${shop}`, errors);
+    return { errors };
+  }
+  if (current.id !== data.id) throw new Error(`Shop ${data.id} not found in ${shop}`);
+
+  const theme = await buildThemeData(shop, data, current);
+
+  const patch: Partial<Shop> & { id: string } = {
+    id: current.id,
+    name: data.name,
+    themeId: data.themeId,
+    catalogFilters: data.catalogFilters,
+    enableEditorial: data.enableEditorial,
+    themeDefaults: theme.themeDefaults,
+    themeOverrides: theme.overrides,
+    themeTokens: theme.themeTokens,
+    filterMappings: data.filterMappings as Record<string, string>,
+    priceOverrides: data.priceOverrides as Partial<Record<Locale, number>>,
+    localeOverrides: data.localeOverrides as Record<string, Locale>,
+    luxuryFeatures: data.luxuryFeatures,
+  };
+
+  const saved = await persistShop(shop, patch);
+
+  const settings = await fetchSettings(shop);
+  const updatedSettings: ShopSettings = {
+    ...settings,
+    trackingProviders: data.trackingProviders,
+    luxuryFeatures: data.luxuryFeatures,
+  };
+  await persistSettings(shop, updatedSettings);
+
+  return { shop: saved };
+}
+
+export function getSettings(shop: string) {
+  return fetchSettings(shop);
+}
+
+export async function updateSeo(
+  shop: string,
+  formData: FormData,
+): Promise<{
+  settings?: unknown;
+  errors?: Record<string, string[]>;
+  warnings?: string[];
+}> {
+  await authorize();
+  const { data, errors } = parseSeoForm(formData);
+  if (!data) {
+    console.error(`[updateSeo] validation failed for shop ${shop}`, errors);
+    return { errors };
+  }
+
+  const {
+    locale,
+    title,
+    description,
+    image,
+    alt,
+    canonicalBase,
+    ogUrl,
+    twitterCard,
+  } = data;
+
+  const warnings: string[] = [];
+  if (title.length > 70) warnings.push("Title exceeds 70 characters");
+  if (description.length > 160)
+    warnings.push("Description exceeds 160 characters");
+
+  const current = await fetchSettings(shop);
+  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
+  seo[locale] = {
+    title,
+    description,
+    image,
+    alt,
+    canonicalBase,
+    openGraph: ogUrl ? { url: ogUrl } : undefined,
+    twitter: twitterCard ? { card: twitterCard } : undefined,
+  };
+  const updated: ShopSettings = {
+    ...current,
+    seo,
+  };
+  await persistSettings(shop, updated);
+
+  return { settings: updated, warnings };
+}
+
+export async function generateSeo(
+  shop: string,
+  formData: FormData,
+): Promise<{
+  generated?: { title: string; description: string; image: string };
+  errors?: Record<string, string[]>;
+}> {
+  await authorize();
+  const { data, errors } = parseGenerateSeoForm(formData);
+  if (!data) {
+    return { errors };
+  }
+
+  const { id, locale, title, description } = data;
+  const { generateMeta } = await import(
+    /* @vite-ignore */ "../../../../scripts/generate-meta.ts"
+  );
+
+  const result = await generateMeta({ id, title, description });
+  const current = await fetchSettings(shop);
+  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
+  seo[locale] = {
+    ...(seo[locale] ?? {}),
+    title: result.title,
+    description: result.description,
+    image: result.image,
+    openGraph: { ...(seo[locale]?.openGraph ?? {}), image: result.image },
+  };
+  const updated: ShopSettings = { ...current, seo };
+  await persistSettings(shop, updated);
+
+  return { generated: result };
+}
+
+export async function revertSeo(shop: string, timestamp: string) {
+  await authorize();
+  const history = await fetchDiffHistory(shop);
+  const sorted = history.sort((a: any, b: any) =>
+    a.timestamp.localeCompare(b.timestamp),
+  );
+  const idx = sorted.findIndex((e: any) => e.timestamp === timestamp);
+  if (idx === -1) throw new Error("Version not found");
+  let state: ShopSettings = {
+    languages: [],
+    seo: {},
+    freezeTranslations: false,
+    updatedAt: "",
+    updatedBy: "",
+  };
+  for (let i = 0; i < idx; i++) {
+    state = { ...state, ...sorted[i].diff } as ShopSettings;
+  }
+  await persistSettings(shop, state);
+  return state;
+}
+
+export async function setFreezeTranslations(shop: string, freeze: boolean) {
+  await authorize();
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = { ...current, freezeTranslations: freeze };
+  await persistSettings(shop, updated);
+  return updated;
+}
+
+export async function updateCurrencyAndTax(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parseCurrencyTaxForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = {
+    ...current,
+    currency: data.currency,
+    taxRegion: data.taxRegion,
+  };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function updateDepositService(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parseDepositForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = {
+    ...current,
+    depositService: {
+      enabled: data.enabled,
+      intervalMinutes: data.intervalMinutes,
+    },
+  };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function updateUpsReturns(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parseUpsReturnsForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = {
+    ...current,
+    returnService: { upsEnabled: data.enabled },
+  };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function updatePremierDelivery(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parsePremierDeliveryForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = {
+    ...current,
+    premierDelivery: data,
+  };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function updateAiCatalog(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parseAiCatalogForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const seo = { ...(current.seo ?? {}) };
+  (seo as any).aiCatalog = {
+    enabled: data.enabled,
+    fields: data.fields,
+    pageSize: data.pageSize,
+  };
+  const updated: ShopSettings = { ...current, seo };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function resetThemeOverride(shop: string, token: string) {
+  await authorize();
+  const current = await fetchShop(shop);
+  const { overrides, themeTokens } = removeThemeToken(current, token);
+  await persistShop(shop, {
+    id: current.id,
+    themeOverrides: overrides,
+    themeTokens,
+  });
+  revalidatePath(`/cms/shop/${shop}/settings`);
+}
+
+export type { Shop, ShopSettings };

--- a/packages/platform-core/src/repositories/blog.server.ts
+++ b/packages/platform-core/src/repositories/blog.server.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import { query, mutate, slugExists, type SanityConfig } from "@acme/plugin-sanity";
+
+export interface SanityPost {
+  _id: string;
+  title?: string;
+  body?: string;
+  published?: boolean;
+  publishedAt?: string;
+  slug?: string;
+  excerpt?: string;
+  mainImage?: string;
+  author?: string;
+  categories?: string[];
+}
+
+const POST_FIELDS = '_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories';
+
+export async function listPosts(config: SanityConfig): Promise<SanityPost[]> {
+  const posts = await query<SanityPost[]>(config, `*[_type=="post"]{${POST_FIELDS}}`);
+  return posts ?? [];
+}
+
+export async function getPost(config: SanityConfig, id: string): Promise<SanityPost | null> {
+  const post = await query<SanityPost | null>(
+    config,
+    `*[_type=="post" && _id=="${id}"][0]{${POST_FIELDS}}`
+  );
+  return post ?? null;
+}
+
+export async function createPost(config: SanityConfig, doc: any): Promise<string | undefined> {
+  const result = await mutate(config, { mutations: [{ create: doc }], returnIds: true });
+  return (result as any)?.results?.[0]?.id as string | undefined;
+}
+
+export async function updatePost(config: SanityConfig, id: string, set: any): Promise<void> {
+  await mutate(config, { mutations: [{ patch: { id, set } }] });
+}
+
+export async function publishPost(config: SanityConfig, id: string, publishedAt: string): Promise<void> {
+  await mutate(config, { mutations: [{ patch: { id, set: { published: true, publishedAt } } }] });
+}
+
+export async function unpublishPost(config: SanityConfig, id: string): Promise<void> {
+  await mutate(config, { mutations: [{ patch: { id, set: { published: false }, unset: ["publishedAt"] } }] });
+}
+
+export async function deletePost(config: SanityConfig, id: string): Promise<void> {
+  await mutate(config, { mutations: [{ delete: { id } }] });
+}
+
+export { slugExists };
+export type { SanityConfig };


### PR DESCRIPTION
## Summary
- add blog repository for Sanity-backed CRUD
- introduce blog and shop services and delegate actions to them
- test blog and shop services

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/blog.server.test.ts apps/cms/__tests__/shops.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689db1a81534832f92c5642ca682cda0