### PR TITLE
feat(cms): add deposit and return settings links

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -73,6 +73,22 @@ export default async function SettingsPage({
           Premier delivery settings
         </Link>
       </p>
+      <p className="mb-4 text-sm">
+        <Link
+          href={`/cms/shop/${shop}/settings/deposits`}
+          className="text-primary underline"
+        >
+          Deposit release settings
+        </Link>
+      </p>
+      <p className="mb-4 text-sm">
+        <Link
+          href={`/cms/shop/${shop}/settings/returns`}
+          className="text-primary underline"
+        >
+          Return service settings
+        </Link>
+      </p>
       <h3 className="mt-4 font-medium">Languages</h3>
       <ul className="mt-2 list-disc pl-5 text-sm">
         {settings.languages.map((l: Locale) => (


### PR DESCRIPTION
## Summary
- add navigation to deposit release settings
- add navigation to return service settings

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/shop/[shop]/settings/page.tsx`
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689db1e8a4b8832fbad653d9763e2521