### PR TITLE
refactor: extract page builder hooks and defaults

### DIFF
--- a/packages/ui/__tests__/PageBuilder.drag.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.drag.test.tsx
@@ -1,58 +1,8 @@
 import { render, fireEvent } from "@testing-library/react";
-import { renderHook, act } from "@testing-library/react";
 import React from "react";
-import usePageBuilderDnD from "../src/components/cms/page-builder/hooks/usePageBuilderDnD";
 import { CanvasItem, renderCanvasItem, setRect } from "./helpers/pageBuilderSetup";
 
 describe("PageBuilder drag interactions", () => {
-  it("adds component on drag from palette to canvas", () => {
-    const dispatch = jest.fn();
-    const { result } = renderHook(() =>
-      usePageBuilderDnD({
-        components: [],
-        dispatch,
-        defaults: {},
-        containerTypes: [],
-        selectId: jest.fn(),
-      })
-    );
-
-    act(() =>
-      result.current.handleDragEnd({
-        active: { id: "a", data: { current: { from: "palette", type: "Text" } } },
-        over: { id: "canvas", data: { current: {} } },
-      } as any)
-    );
-
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "add",
-        component: expect.objectContaining({ type: "Text" }),
-      })
-    );
-  });
-
-  it("does not add component when dropped outside canvas", () => {
-    const dispatch = jest.fn();
-    const { result } = renderHook(() =>
-      usePageBuilderDnD({
-        components: [],
-        dispatch,
-        defaults: {},
-        containerTypes: [],
-        selectId: jest.fn(),
-      })
-    );
-
-    act(() =>
-      result.current.handleDragEnd({
-        active: { id: "a", data: { current: { from: "palette", type: "Text" } } },
-        over: null,
-      } as any)
-    );
-
-    expect(dispatch).not.toHaveBeenCalled();
-  });
 
   it("snaps to sibling edge when moving", () => {
     const c1: any = {

--- a/packages/ui/__tests__/componentHooks.test.tsx
+++ b/packages/ui/__tests__/componentHooks.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import useComponentInputs from "../src/components/cms/page-builder/useComponentInputs";
 import useComponentResize from "../src/components/cms/page-builder/useComponentResize";
-import usePageBuilderState from "../src/components/cms/page-builder/hooks/usePageBuilderState";
 
 describe("component hooks", () => {
   it("useComponentInputs forwards field changes", () => {
@@ -20,31 +19,5 @@ describe("component hooks", () => {
     expect(onResize).toHaveBeenCalledWith({ widthDesktop: undefined });
     act(() => result.current.handleFullSize("widthDesktop"));
     expect(onResize).toHaveBeenCalledWith({ widthDesktop: "100%" });
-  });
-
-  it("usePageBuilderState supports undo and redo", () => {
-    const page: any = {
-      id: "p1",
-      updatedAt: "now",
-      slug: "home",
-      status: "draft",
-      seo: { title: { en: "Home" } },
-      components: [],
-    };
-    const { result } = renderHook(() =>
-      usePageBuilderState({ page })
-    );
-    act(() =>
-      result.current.dispatch({
-        type: "add",
-        component: { id: "c1", type: "Text" } as any,
-      })
-    );
-    expect(result.current.components).toHaveLength(1);
-    act(() => result.current.dispatch({ type: "undo" }));
-    expect(result.current.components).toHaveLength(0);
-    act(() => result.current.dispatch({ type: "redo" }));
-    expect(result.current.components).toHaveLength(1);
-    act(() => result.current.clearHistory());
   });
 });

--- a/packages/ui/__tests__/usePageBuilderDnD.test.tsx
+++ b/packages/ui/__tests__/usePageBuilderDnD.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook, act } from "@testing-library/react";
+import usePageBuilderDnD from "../src/components/cms/page-builder/hooks/usePageBuilderDnD";
+
+describe("usePageBuilderDnD", () => {
+  it("adds component on drop from palette", () => {
+    const dispatch = jest.fn();
+    const selectId = jest.fn();
+    const { result } = renderHook(() =>
+      usePageBuilderDnD({
+        components: [],
+        dispatch,
+        defaults: {},
+        containerTypes: [],
+        selectId,
+      })
+    );
+
+    act(() =>
+      result.current.handleDragStart({
+        active: { data: { current: { type: "Text" } } },
+      } as any)
+    );
+    expect(result.current.activeType).toBe("Text");
+
+    act(() =>
+      result.current.handleDragEnd({
+        active: { data: { current: { from: "palette", type: "Text" } } },
+        over: { id: "canvas", data: { current: {} } },
+      } as any)
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "add",
+        component: expect.objectContaining({ type: "Text" }),
+      })
+    );
+    expect(selectId).toHaveBeenCalled();
+    expect(result.current.activeType).toBeNull();
+  });
+
+  it("sets insert index when moving over canvas", () => {
+    const { result } = renderHook(() =>
+      usePageBuilderDnD({
+        components: [],
+        dispatch: jest.fn(),
+        defaults: {},
+        containerTypes: [],
+        selectId: jest.fn(),
+      })
+    );
+
+    act(() =>
+      result.current.handleDragMove({
+        over: { id: "canvas", data: { current: {} } },
+        delta: { x: 0, y: 0 },
+        activatorEvent: { clientX: 0, clientY: 0 },
+      } as any)
+    );
+    expect(result.current.insertIndex).toBe(0);
+  });
+});

--- a/packages/ui/__tests__/usePageBuilderState.test.tsx
+++ b/packages/ui/__tests__/usePageBuilderState.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook, act } from "@testing-library/react";
+import usePageBuilderState from "../src/components/cms/page-builder/hooks/usePageBuilderState";
+
+describe("usePageBuilderState", () => {
+  it("supports undo and redo", () => {
+    const page: any = {
+      id: "p1",
+      updatedAt: "now",
+      slug: "home",
+      status: "draft",
+      seo: { title: { en: "Home" } },
+      components: [],
+    };
+    const { result } = renderHook(() => usePageBuilderState({ page }));
+    act(() =>
+      result.current.dispatch({
+        type: "add",
+        component: { id: "c1", type: "Text" } as any,
+      })
+    );
+    expect(result.current.components).toHaveLength(1);
+    act(() => result.current.dispatch({ type: "undo" }));
+    expect(result.current.components).toHaveLength(0);
+    act(() => result.current.dispatch({ type: "redo" }));
+    expect(result.current.components).toHaveLength(1);
+    act(() => result.current.clearHistory());
+  });
+});

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -15,13 +15,6 @@ import { Button } from "../../atoms/shadcn";
 import { Toast, Spinner } from "../../atoms";
 import { CheckIcon } from "@radix-ui/react-icons";
 import Palette from "./Palette";
-import {
-  atomRegistry,
-  moleculeRegistry,
-  organismRegistry,
-  containerRegistry,
-  layoutRegistry,
-} from "../blocks";
 import { getShopFromPath } from "@platform-core/utils";
 import useFileUpload from "@ui/hooks/useFileUpload";
 import usePageBuilderState from "./hooks/usePageBuilderState";
@@ -29,54 +22,7 @@ import usePageBuilderDnD from "./hooks/usePageBuilderDnD";
 import PageToolbar from "./PageToolbar";
 import PageCanvas from "./PageCanvas";
 import PageSidebar from "./PageSidebar";
-
-/* ════════════════ component catalogue ════════════════ */
-type ComponentType =
-  | keyof typeof atomRegistry
-  | keyof typeof moleculeRegistry
-  | keyof typeof organismRegistry
-  | keyof typeof containerRegistry
-  | keyof typeof layoutRegistry;
-
-const CONTAINER_TYPES = Object.keys(containerRegistry) as ComponentType[];
-
-const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
-  HeroBanner: { minItems: 1, maxItems: 5 },
-  ValueProps: { minItems: 1, maxItems: 6 },
-  ReviewsCarousel: { minItems: 1, maxItems: 10 },
-  SearchBar: { placeholder: "Search products…", limit: 5 },
-  ProductFilter: { showSize: true, showColor: true, showPrice: true },
-  ProductGrid: {
-    minItems: 1,
-    maxItems: 3,
-    desktopItems: 3,
-    tabletItems: 2,
-    mobileItems: 1,
-    mode: "collection",
-  },
-  ProductCarousel: {
-    minItems: 1,
-    maxItems: 10,
-    desktopItems: 4,
-    tabletItems: 2,
-    mobileItems: 1,
-    mode: "collection",
-  },
-  RecommendationCarousel: { minItems: 1, maxItems: 4 },
-  Testimonials: { minItems: 1, maxItems: 10 },
-  TestimonialSlider: { minItems: 1, maxItems: 10 },
-  ImageSlider: { minItems: 1, maxItems: 10 },
-  AnnouncementBar: {
-    position: "absolute",
-    top: "0",
-    left: "0",
-    width: "100%",
-  },
-  Lookbook: { minItems: 0, maxItems: 10 },
-  MultiColumn: { columns: 2, gap: "1rem" },
-  Divider: { width: "100%", height: "1px" },
-  Spacer: { width: "100%", height: "1rem" },
-};
+import { defaults, CONTAINER_TYPES } from "./defaults";
 
 interface Props {
   page: Page;

--- a/packages/ui/src/components/cms/page-builder/defaults.ts
+++ b/packages/ui/src/components/cms/page-builder/defaults.ts
@@ -1,0 +1,57 @@
+import type { PageComponent } from "@acme/types";
+import {
+  atomRegistry,
+  moleculeRegistry,
+  organismRegistry,
+  containerRegistry,
+  layoutRegistry,
+} from "../blocks";
+
+export type ComponentType =
+  | keyof typeof atomRegistry
+  | keyof typeof moleculeRegistry
+  | keyof typeof organismRegistry
+  | keyof typeof containerRegistry
+  | keyof typeof layoutRegistry;
+
+export const CONTAINER_TYPES = Object.keys(containerRegistry) as ComponentType[];
+
+export const defaults: Partial<Record<ComponentType, Partial<PageComponent>>> = {
+  HeroBanner: { minItems: 1, maxItems: 5 },
+  ValueProps: { minItems: 1, maxItems: 6 },
+  ReviewsCarousel: { minItems: 1, maxItems: 10 },
+  SearchBar: { placeholder: "Search products…", limit: 5 },
+  ProductFilter: { showSize: true, showColor: true, showPrice: true },
+  ProductGrid: {
+    minItems: 1,
+    maxItems: 3,
+    desktopItems: 3,
+    tabletItems: 2,
+    mobileItems: 1,
+    mode: "collection",
+  },
+  ProductCarousel: {
+    minItems: 1,
+    maxItems: 10,
+    desktopItems: 4,
+    tabletItems: 2,
+    mobileItems: 1,
+    mode: "collection",
+  },
+  RecommendationCarousel: { minItems: 1, maxItems: 4 },
+  Testimonials: { minItems: 1, maxItems: 10 },
+  TestimonialSlider: { minItems: 1, maxItems: 10 },
+  ImageSlider: { minItems: 1, maxItems: 10 },
+  AnnouncementBar: {
+    position: "absolute",
+    top: "0",
+    left: "0",
+    width: "100%",
+  },
+  Lookbook: { minItems: 0, maxItems: 10 },
+  MultiColumn: { columns: 2, gap: "1rem" },
+  Divider: { width: "100%", height: "1px" },
+  Spacer: { width: "100%", height: "1rem" },
+};
+
+export default defaults;

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -39,6 +39,7 @@ export { default as PageBuilder } from "./PageBuilder";
 export { default as PageToolbar } from "./PageToolbar";
 export { default as PageCanvas } from "./PageCanvas";
 export { default as PageSidebar } from "./PageSidebar";
+export { defaults, CONTAINER_TYPES } from "./defaults";
 export { historyStateSchema, reducer } from "./state";
 export { default as usePageBuilderState } from "./hooks/usePageBuilderState";
 export { default as usePageBuilderDnD } from "./hooks/usePageBuilderDnD";


### PR DESCRIPTION
## Summary
- move PageBuilder defaults into `defaults.ts`
- expose `usePageBuilderState` and `usePageBuilderDnD` hooks with dedicated tests
- re-export new utilities from page-builder index

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/usePageBuilderState.test.tsx packages/ui/__tests__/usePageBuilderDnD.test.tsx packages/ui/__tests__/componentHooks.test.tsx packages/ui/__tests__/PageBuilder.drag.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689db191c1d8832fb3425556591d945d