### PR TITLE
feat: centralize checkout session logic

### DIFF
--- a/apps/shop-abc/src/app/api/checkout-session/route.ts
+++ b/apps/shop-abc/src/app/api/checkout-session/route.ts
@@ -4,158 +4,17 @@ import "@acme/lib/initZod";
 import {
   CART_COOKIE,
   decodeCartCookie,
-  type CartLine,
   type CartState,
 } from "@platform-core/src/cartCookie";
 import { getCart } from "@platform-core/src/cartStore";
-import { calculateRentalDays } from "@acme/date-utils";
-import { stripe } from "@acme/stripe";
 import { requirePermission } from "@auth";
-import { priceForDays, convertCurrency } from "@platform-core/pricing";
-import { findCoupon } from "@platform-core/coupons";
-import { trackEvent } from "@platform-core/analytics";
 import shop from "../../../../shop.json";
-import { getTaxRate } from "@platform-core/tax";
-
-import { NextRequest, NextResponse } from "next/server";
-import type Stripe from "stripe";
-import { z } from "zod";
 import { shippingSchema, billingSchema } from "@platform-core/schemas/address";
 import { parseJsonBody } from "@shared-utils";
+import { createCheckoutSession } from "@platform-core/checkout/session";
 
-/* ------------------------------------------------------------------ *
- *  Types
- * ------------------------------------------------------------------ */
-
-type CartItem = CartLine;
-type Cart = CartState;
-
-/* ------------------------------------------------------------------ *
- *  Helpers
- * ------------------------------------------------------------------ */
-
-/**
- * Produce the two Stripe line-items (rental + deposit) for a single cart item.
- */
-const buildLineItemsForItem = async (
-  item: CartItem,
-  rentalDays: number,
-  discountRate: number,
-  currency: string
-): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> => {
-  const unitPrice = await priceForDays(item.sku, rentalDays);
-  const discounted = Math.round(unitPrice * (1 - discountRate));
-  const unitConv = await convertCurrency(discounted, currency);
-  const depositConv = await convertCurrency(item.sku.deposit, currency);
-  const baseName = item.size
-    ? `${item.sku.title} (${item.size})`
-    : item.sku.title;
-
-  const lines: Stripe.Checkout.SessionCreateParams.LineItem[] = [
-    {
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: Math.round(unitConv * 100),
-        product_data: { name: baseName },
-      },
-      quantity: item.qty,
-    },
-  ];
-
-  if (item.sku.deposit > 0) {
-    lines.push({
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: Math.round(depositConv * 100),
-        product_data: { name: `${baseName} deposit` },
-      },
-      quantity: item.qty,
-    });
-  }
-
-  return lines;
-};
-
-/**
- * Aggregate rental and deposit totals for later bookkeeping.
- */
-const computeTotals = async (
-  cart: Cart,
-  rentalDays: number,
-  discountRate: number,
-  currency: string
-): Promise<{ subtotal: number; depositTotal: number; discount: number }> => {
-  const subtotals = await Promise.all(
-    Object.values(cart).map(async (item) => {
-      const unit = await priceForDays(item.sku, rentalDays);
-      const discounted = Math.round(unit * (1 - discountRate));
-      return { base: unit * item.qty, discounted: discounted * item.qty };
-    })
-  );
-
-  const subtotalBase = subtotals.reduce((sum, v) => sum + v.discounted, 0);
-  const originalBase = subtotals.reduce((sum, v) => sum + v.base, 0);
-  const discountBase = originalBase - subtotalBase;
-  const depositBase = Object.values(cart).reduce(
-    (sum, item) => sum + item.sku.deposit * item.qty,
-    0
-  );
-
-  return {
-    subtotal: await convertCurrency(subtotalBase, currency),
-    depositTotal: await convertCurrency(depositBase, currency),
-    discount: await convertCurrency(discountBase, currency),
-  };
-};
-
-/**
- * Build the shared metadata object for both the checkout session and
- * payment intent.
- */
-const buildCheckoutMetadata = ({
-  subtotal,
-  depositTotal,
-  returnDate,
-  rentalDays,
-  customerId,
-  discount,
-  coupon,
-  currency,
-  taxRate,
-  taxAmount,
-  clientIp,
-  sizes,
-}: {
-  subtotal: number;
-  depositTotal: number;
-  returnDate?: string;
-  rentalDays: number;
-  customerId?: string;
-  discount: number;
-  coupon?: string;
-  currency: string;
-  taxRate: number;
-  taxAmount: number;
-  clientIp?: string;
-  sizes?: string;
-}) => ({
-  subtotal: subtotal.toString(),
-  depositTotal: depositTotal.toString(),
-  returnDate: returnDate ?? "",
-  rentalDays: rentalDays.toString(),
-  ...(sizes ? { sizes } : {}),
-  customerId: customerId ?? "",
-  discount: discount.toString(),
-  coupon: coupon ?? "",
-  currency,
-  taxRate: taxRate.toString(),
-  taxAmount: taxAmount.toString(),
-  ...(clientIp ? { client_ip: clientIp } : {}),
-});
-
-/* ------------------------------------------------------------------ *
- *  Route handler
- * ------------------------------------------------------------------ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 
 export const runtime = "edge";
 
@@ -172,7 +31,6 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  /* 1️⃣ Decode cart cookie -------------------------------------------------- */
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
   const cartId = decodeCartCookie(rawCookie);
   const cart: CartState = cartId ? await getCart(cartId) : {};
@@ -180,6 +38,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });
   }
+
   let session;
   try {
     session = await requirePermission("checkout");
@@ -187,7 +46,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  /* 2️⃣ Parse optional body ------------------------------------------------- */
   const parsed = await parseJsonBody(req, schema, "1mb");
   if (!parsed.success) return parsed.response;
 
@@ -200,130 +58,30 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     shipping,
     billing_details,
   } = parsed.data;
-  const couponDef = await findCoupon(shop.id, coupon);
-  if (couponDef) {
-    await trackEvent(shop.id, {
-      type: "discount_redeemed",
-      code: couponDef.code,
-    });
-  }
-  const discountRate = couponDef ? couponDef.discountPercent / 100 : 0;
-  let rentalDays: number;
-  try {
-    rentalDays = calculateRentalDays(returnDate);
-  } catch {
-    return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
-  }
-  if (rentalDays <= 0) {
-    return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
-  }
 
-  /* 3️⃣ Build Stripe line-items & totals ------------------------------------ */
-  const lineItemsNested = await Promise.all(
-    Object.values(cart).map((item) =>
-      buildLineItemsForItem(item, rentalDays, discountRate, currency)
-    )
-  );
-  const line_items = lineItemsNested.flat();
-
-  const { subtotal, depositTotal, discount } = await computeTotals(
-    cart,
-    rentalDays,
-    discountRate,
-    currency
-  );
-
-  const taxRate = await getTaxRate(taxRegion);
-  const taxAmountCents = Math.round(subtotal * taxRate * 100);
-  const taxAmount = taxAmountCents / 100;
-  if (taxAmountCents > 0) {
-    line_items.push({
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: taxAmountCents,
-        product_data: { name: "Tax" },
-      },
-      quantity: 1,
-    });
-  }
-
-  /* 4️⃣ Serialize sizes for metadata --------------------------------------- */
-  const sizesMeta = JSON.stringify(
-    Object.fromEntries(
-      Object.values(cart).map((item) => [item.sku.id, item.size ?? ""])
-    )
-  );
-
-  /* 5️⃣ Create Checkout Session -------------------------------------------- */
-  const customer = customerId ?? session.customerId;
   const clientIp = req.headers?.get?.("x-forwarded-for")?.split(",")[0] ?? "";
 
-  const paymentIntentData: Stripe.Checkout.SessionCreateParams.PaymentIntentData =
-    {
-      ...(shipping ? { shipping } : {}),
-      payment_method_options: {
-        card: { request_three_d_secure: "automatic" },
-      },
-      metadata: buildCheckoutMetadata({
-        subtotal,
-        depositTotal,
-        returnDate,
-        rentalDays,
-        customerId: customer,
-        discount,
-        coupon: couponDef?.code,
-        currency,
-        taxRate,
-        taxAmount,
-        clientIp,
-      }),
-    } as any;
-
-  if (billing_details) {
-    (paymentIntentData as any).billing_details = billing_details;
-  }
-
-  let stripeSession: Stripe.Checkout.Session;
   try {
-    stripeSession = await stripe.checkout.sessions.create({
-      mode: "payment",
-      customer,
-      line_items,
-      success_url: `${req.nextUrl.origin}/success`,
-      cancel_url: `${req.nextUrl.origin}/cancelled`,
-      payment_intent_data: paymentIntentData,
-      metadata: buildCheckoutMetadata({
-        subtotal,
-        depositTotal,
-        returnDate,
-        rentalDays,
-        sizes: sizesMeta,
-        customerId: customer,
-        discount,
-        coupon: couponDef?.code,
-        currency,
-        taxRate,
-        taxAmount,
-        clientIp,
-      }),
-      expand: ["payment_intent"],
+    const result = await createCheckoutSession({
+      shopId: shop.id,
+      cart,
+      returnDate,
+      coupon,
+      currency,
+      taxRegion,
+      customerId: customerId ?? session.customerId,
+      shipping,
+      billingDetails: billing_details,
+      successUrl: `${req.nextUrl.origin}/success`,
+      cancelUrl: `${req.nextUrl.origin}/cancelled`,
+      clientIp,
     });
-  } catch (error) {
-    console.error("Failed to create Stripe checkout session", error);
-    return NextResponse.json(
-      { error: "Checkout failed" },
-      { status: 502 }
-    );
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Invalid returnDate") {
+      return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
+    }
+    console.error("Failed to create Stripe checkout session", err);
+    return NextResponse.json({ error: "Checkout failed" }, { status: 502 });
   }
-
-  /* 6️⃣ Return client credentials ------------------------------------------ */
-  const clientSecret =
-    typeof stripeSession.payment_intent === "string"
-      ? undefined
-      : stripeSession.payment_intent?.client_secret;
-
-  return NextResponse.json({
-    clientSecret,
-    sessionId: stripeSession.id,
-  });
 }

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -4,36 +4,14 @@ import "@acme/lib/initZod";
 import {
   CART_COOKIE,
   decodeCartCookie,
-  type CartLine,
   type CartState,
 } from "@/lib/cartCookie";
-import { calculateRentalDays } from "@acme/date-utils";
-import { stripe } from "@acme/stripe";
 import { getCustomerSession } from "@auth";
-import { priceForDays, convertCurrency } from "@platform-core/pricing";
-import { findCoupon } from "@platform-core/coupons";
-import { trackEvent } from "@platform-core/analytics";
 import shop from "../../../shop.json";
-import { getTaxRate } from "@platform-core/tax";
 import { NextRequest, NextResponse } from "next/server";
-import type Stripe from "stripe";
 import { z } from "zod";
 import { shippingSchema, billingSchema } from "@platform-core/schemas/address";
-
-/* ------------------------------------------------------------------ *
- *  Domain types
- * ------------------------------------------------------------------ */
-
-/**
- * Centralise type definitions under `src/types/` in your real code-base.
- * They are declared inline here for completeness.
- */
-type CartItem = CartLine;
-type Cart = CartState;
-
-/* ------------------------------------------------------------------ *
- *  Constants
- * ------------------------------------------------------------------ */
+import { createCheckoutSession } from "@platform-core/checkout/session";
 
 export const runtime = "edge";
 
@@ -49,99 +27,14 @@ const schema = z
   })
   .strict();
 
-/* ------------------------------------------------------------------ *
- *  Helper functions
- * ------------------------------------------------------------------ */
-
-/**
- * Build the rental-fee line-item and the refundable deposit line-item
- * for a single cart entry.
- */
-const buildLineItemsFor = async (
-  item: CartItem,
-  rentalDays: number,
-  discountRate: number,
-  currency: string
-): Promise<
-  [
-    Stripe.Checkout.SessionCreateParams.LineItem,
-    Stripe.Checkout.SessionCreateParams.LineItem,
-  ]
-> => {
-  const baseName = item.size
-    ? `${item.sku.title} (${item.size})`
-    : item.sku.title;
-  const unit = await priceForDays(item.sku, rentalDays);
-  const discounted = Math.round(unit * (1 - discountRate));
-  const unitConv = await convertCurrency(discounted, currency);
-  const depositConv = await convertCurrency(item.sku.deposit, currency);
-
-  return [
-    {
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: unitConv * 100,
-        product_data: { name: baseName },
-      },
-      quantity: item.qty,
-    },
-    {
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: depositConv * 100,
-        product_data: { name: `${baseName} deposit` },
-      },
-      quantity: item.qty,
-    },
-  ];
-};
-
-/**
- * Aggregate cart totals for metadata bookkeeping.
- */
-const computeTotals = async (
-  cart: Cart,
-  rentalDays: number,
-  discountRate: number,
-  currency: string
-): Promise<{ subtotal: number; depositTotal: number; discount: number }> => {
-  const rentalTotals = await Promise.all(
-    Object.values(cart).map(async (item) => {
-      const unit = await priceForDays(item.sku, rentalDays);
-      const discounted = Math.round(unit * (1 - discountRate));
-      return { base: unit * item.qty, discounted: discounted * item.qty };
-    })
-  );
-
-  const subtotalBase = rentalTotals.reduce((sum, v) => sum + v.discounted, 0);
-  const originalBase = rentalTotals.reduce((sum, v) => sum + v.base, 0);
-  const discountBase = originalBase - subtotalBase;
-  const depositBase = Object.values(cart).reduce(
-    (sum, item) => sum + item.sku.deposit * item.qty,
-    0
-  );
-
-  return {
-    subtotal: await convertCurrency(subtotalBase, currency),
-    depositTotal: await convertCurrency(depositBase, currency),
-    discount: await convertCurrency(discountBase, currency),
-  };
-};
-
-/* ------------------------------------------------------------------ *
- *  POST handler
- * ------------------------------------------------------------------ */
-
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  /* 1️⃣  Load and validate cart ------------------------------------------ */
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart = decodeCartCookie(rawCookie) as Cart;
+  const cart = decodeCartCookie(rawCookie) as CartState;
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });
   }
 
-  /* 2️⃣  Parse request body ---------------------------------------------- */
   const parsed = schema.safeParse(await req.json().catch(() => undefined));
   if (!parsed.success) {
     return NextResponse.json(parsed.error.flatten().fieldErrors, {
@@ -157,119 +50,33 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     shipping,
     billing_details,
   } = parsed.data;
-  const couponDef = await findCoupon(shop.id, coupon);
-  if (couponDef) {
-    await trackEvent(shop.id, { type: "discount_redeemed", code: couponDef.code });
-  }
-  const discountRate = couponDef ? couponDef.discountPercent / 100 : 0;
-  let rentalDays: number;
-  try {
-    rentalDays = calculateRentalDays(returnDate);
-  } catch {
-    return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
-  }
 
-  /* 3️⃣  Build Stripe line-items ----------------------------------------- */
-  const nestedItems = await Promise.all(
-    Object.values(cart).map((item) =>
-      buildLineItemsFor(item, rentalDays, discountRate, currency)
-    )
-  );
-  const line_items = nestedItems.flat();
-
-  /* 4️⃣  Compute metadata ------------------------------------------------- */
-  const { subtotal, depositTotal, discount } = await computeTotals(
-    cart,
-    rentalDays,
-    discountRate,
-    currency
-  );
-
-  const taxRate = await getTaxRate(taxRegion);
-  const taxAmount = Math.round(subtotal * taxRate);
-  if (taxAmount > 0) {
-    line_items.push({
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: taxAmount * 100,
-        product_data: { name: "Tax" },
-      },
-      quantity: 1,
-    });
-  }
-
-  const sizesMeta = JSON.stringify(
-    Object.fromEntries(Object.values(cart).map((i) => [i.sku.id, i.size ?? ""]))
-  );
-
-  /* 5️⃣  Create Stripe Checkout Session ---------------------------------- */
   const customerSession = await getCustomerSession();
   const customer = customerId ?? customerSession?.customerId;
-  const clientIp =
-    req.headers?.get?.("x-forwarded-for")?.split(",")[0] ?? "";
 
-  const paymentIntentData: Stripe.Checkout.SessionCreateParams.PaymentIntentData = {
-    ...(shipping ? { shipping } : {}),
-    payment_method_options: {
-      card: { request_three_d_secure: "automatic" },
-    },
-    metadata: {
-      subtotal: subtotal.toString(),
-      depositTotal: depositTotal.toString(),
-      returnDate: returnDate ?? "",
-      rentalDays: rentalDays.toString(),
-      customerId: customer ?? "",
-      discount: discount.toString(),
-      coupon: couponDef?.code ?? "",
-      currency,
-      taxRate: taxRate.toString(),
-      taxAmount: taxAmount.toString(),
-      ...(clientIp ? { client_ip: clientIp } : {}),
-    },
-  } as any;
+  const clientIp = req.headers?.get?.("x-forwarded-for")?.split(",")[0] ?? "";
 
-  if (billing_details) {
-    (paymentIntentData as any).billing_details = billing_details;
-  }
-
-  let session: Stripe.Checkout.Session;
   try {
-    session = await stripe.checkout.sessions.create({
-      mode: "payment",
-      customer,
-      line_items,
-      success_url: `${req.nextUrl.origin}/success`,
-      cancel_url: `${req.nextUrl.origin}/cancelled`,
-      payment_intent_data: paymentIntentData,
-      metadata: {
-        subtotal: subtotal.toString(),
-        depositTotal: depositTotal.toString(),
-        returnDate: returnDate ?? "",
-        rentalDays: rentalDays.toString(),
-        sizes: sizesMeta,
-        customerId: customer ?? "",
-        discount: discount.toString(),
-        coupon: couponDef?.code ?? "",
-        currency,
-        taxRate: taxRate.toString(),
-        taxAmount: taxAmount.toString(),
-        ...(clientIp ? { client_ip: clientIp } : {}),
-      },
-      expand: ["payment_intent"],
+    const result = await createCheckoutSession({
+      shopId: shop.id,
+      cart,
+      returnDate,
+      coupon,
+      currency,
+      taxRegion,
+      customerId: customer,
+      shipping,
+      billingDetails: billing_details,
+      successUrl: `${req.nextUrl.origin}/success`,
+      cancelUrl: `${req.nextUrl.origin}/cancelled`,
+      clientIp,
     });
-  } catch (error) {
-    console.error("Failed to create Stripe checkout session", error);
-    return NextResponse.json(
-      { error: "Checkout failed" },
-      { status: 502 }
-    );
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Invalid returnDate") {
+      return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
+    }
+    console.error("Failed to create Stripe checkout session", err);
+    return NextResponse.json({ error: "Checkout failed" }, { status: 502 });
   }
-
-  /* 6️⃣  Return credentials to client ------------------------------------ */
-  const clientSecret =
-    typeof session.payment_intent === "string"
-      ? undefined
-      : session.payment_intent?.client_secret;
-
-  return NextResponse.json({ clientSecret, sessionId: session.id });
 }

--- a/packages/platform-core/__tests__/checkout-session.test.ts
+++ b/packages/platform-core/__tests__/checkout-session.test.ts
@@ -1,0 +1,80 @@
+import { jest } from "@jest/globals";
+
+const create = jest.fn(async () => ({
+  id: "cs_123",
+  payment_intent: { client_secret: "pi_secret" },
+}));
+
+jest.mock("@acme/stripe", () => ({
+  stripe: { checkout: { sessions: { create } } },
+}));
+
+const priceForDays = jest.fn(async () => 100);
+const convertCurrency = jest.fn(async (v: number) => v);
+jest.mock("../src/pricing", () => ({ priceForDays, convertCurrency }));
+
+const findCoupon = jest.fn(async () => ({ code: "SAVE", discountPercent: 20 }));
+jest.mock("../src/coupons", () => ({ findCoupon }));
+
+const trackEvent = jest.fn();
+jest.mock("../src/analytics", () => ({ trackEvent }));
+
+const getTaxRate = jest.fn(async () => 0.2);
+jest.mock("../src/tax", () => ({ getTaxRate }));
+
+const calculateRentalDays = jest.fn(() => 5);
+jest.mock("@acme/date-utils", () => ({ calculateRentalDays }));
+
+describe("createCheckoutSession", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a checkout session and returns credentials", async () => {
+    const { createCheckoutSession } = await import("../src/checkout/session");
+    const cart = {
+      line1: {
+        sku: { id: "sku_1", title: "Test", deposit: 50 },
+        qty: 2,
+        size: "M",
+      },
+    } as any;
+
+    const result = await createCheckoutSession({
+      shopId: "shop",
+      cart,
+      returnDate: "2024-01-01",
+      coupon: "SAVE",
+      currency: "EUR",
+      taxRegion: "EU",
+      customerId: "cust_1",
+      successUrl: "https://example.com/success",
+      cancelUrl: "https://example.com/cancelled",
+      clientIp: "1.2.3.4",
+    });
+
+    expect(findCoupon).toHaveBeenCalledWith("shop", "SAVE");
+    expect(trackEvent).toHaveBeenCalled();
+    expect(create).toHaveBeenCalled();
+    const args = create.mock.calls[0][0];
+    expect(args.line_items).toHaveLength(3);
+    expect(args.metadata.discount).toBe("40");
+    expect(result).toEqual({ clientSecret: "pi_secret", sessionId: "cs_123" });
+  });
+
+  it("throws on invalid return date", async () => {
+    calculateRentalDays.mockImplementationOnce(() => {
+      throw new Error("bad");
+    });
+    const { createCheckoutSession } = await import("../src/checkout/session");
+    await expect(
+      createCheckoutSession({
+        shopId: "shop",
+        cart: {},
+        currency: "EUR",
+        successUrl: "a",
+        cancelUrl: "b",
+      } as any)
+    ).rejects.toThrow("Invalid returnDate");
+  });
+});

--- a/packages/platform-core/src/checkout/session.ts
+++ b/packages/platform-core/src/checkout/session.ts
@@ -1,0 +1,245 @@
+import { calculateRentalDays } from "@acme/date-utils";
+import { stripe } from "@acme/stripe";
+import { priceForDays, convertCurrency } from "../pricing.ts";
+import { findCoupon } from "../coupons.ts";
+import { trackEvent } from "../analytics.ts";
+import { getTaxRate } from "../tax/index.ts";
+import type { CartLine, CartState } from "../cartCookie.ts";
+import type Stripe from "stripe";
+
+/** Build the Stripe line-items (rental + deposit) for a cart item. */
+const buildLineItemsForItem = async (
+  item: CartLine,
+  rentalDays: number,
+  discountRate: number,
+  currency: string
+): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> => {
+  const unitPrice = await priceForDays(item.sku, rentalDays);
+  const discounted = Math.round(unitPrice * (1 - discountRate));
+  const unitConv = await convertCurrency(discounted, currency);
+  const depositConv = await convertCurrency(item.sku.deposit, currency);
+  const baseName = item.size ? `${item.sku.title} (${item.size})` : item.sku.title;
+  const lines: Stripe.Checkout.SessionCreateParams.LineItem[] = [
+    {
+      price_data: {
+        currency: currency.toLowerCase(),
+        unit_amount: Math.round(unitConv * 100),
+        product_data: { name: baseName },
+      },
+      quantity: item.qty,
+    },
+  ];
+  if (item.sku.deposit > 0) {
+    lines.push({
+      price_data: {
+        currency: currency.toLowerCase(),
+        unit_amount: Math.round(depositConv * 100),
+        product_data: { name: `${baseName} deposit` },
+      },
+      quantity: item.qty,
+    });
+  }
+  return lines;
+};
+
+/** Aggregate subtotal/discount/deposit totals for cart metadata. */
+const computeTotals = async (
+  cart: CartState,
+  rentalDays: number,
+  discountRate: number,
+  currency: string
+): Promise<{ subtotal: number; depositTotal: number; discount: number }> => {
+  const subtotals = await Promise.all(
+    Object.values(cart).map(async (item) => {
+      const unit = await priceForDays(item.sku, rentalDays);
+      const discounted = Math.round(unit * (1 - discountRate));
+      return { base: unit * item.qty, discounted: discounted * item.qty };
+    })
+  );
+  const subtotalBase = subtotals.reduce((sum, v) => sum + v.discounted, 0);
+  const originalBase = subtotals.reduce((sum, v) => sum + v.base, 0);
+  const discountBase = originalBase - subtotalBase;
+  const depositBase = Object.values(cart).reduce(
+    (sum, item) => sum + item.sku.deposit * item.qty,
+    0
+  );
+  return {
+    subtotal: await convertCurrency(subtotalBase, currency),
+    depositTotal: await convertCurrency(depositBase, currency),
+    discount: await convertCurrency(discountBase, currency),
+  };
+};
+
+/** Shared metadata for checkout session and payment intent. */
+const buildCheckoutMetadata = ({
+  subtotal,
+  depositTotal,
+  returnDate,
+  rentalDays,
+  customerId,
+  discount,
+  coupon,
+  currency,
+  taxRate,
+  taxAmount,
+  clientIp,
+  sizes,
+}: {
+  subtotal: number;
+  depositTotal: number;
+  returnDate?: string;
+  rentalDays: number;
+  customerId?: string;
+  discount: number;
+  coupon?: string;
+  currency: string;
+  taxRate: number;
+  taxAmount: number;
+  clientIp?: string;
+  sizes?: string;
+}) => ({
+  subtotal: subtotal.toString(),
+  depositTotal: depositTotal.toString(),
+  returnDate: returnDate ?? "",
+  rentalDays: rentalDays.toString(),
+  ...(sizes ? { sizes } : {}),
+  customerId: customerId ?? "",
+  discount: discount.toString(),
+  coupon: coupon ?? "",
+  currency,
+  taxRate: taxRate.toString(),
+  taxAmount: taxAmount.toString(),
+  ...(clientIp ? { client_ip: clientIp } : {}),
+});
+
+export interface CreateCheckoutSessionOptions {
+  shopId: string;
+  cart: CartState;
+  returnDate?: string;
+  coupon?: string;
+  currency: string;
+  taxRegion?: string;
+  customerId?: string;
+  shipping?: Stripe.Checkout.SessionCreateParams.ShippingAddress;
+  billingDetails?: Stripe.Checkout.SessionCreateParams.BillingDetails;
+  successUrl: string;
+  cancelUrl: string;
+  clientIp?: string;
+}
+
+export async function createCheckoutSession({
+  shopId,
+  cart,
+  returnDate,
+  coupon,
+  currency,
+  taxRegion,
+  customerId,
+  shipping,
+  billingDetails,
+  successUrl,
+  cancelUrl,
+  clientIp,
+}: CreateCheckoutSessionOptions): Promise<{ clientSecret?: string; sessionId: string }> {
+  const couponDef = await findCoupon(shopId, coupon);
+  if (couponDef) {
+    await trackEvent(shopId, { type: "discount_redeemed", code: couponDef.code });
+  }
+  const discountRate = couponDef ? couponDef.discountPercent / 100 : 0;
+
+  let rentalDays: number;
+  try {
+    rentalDays = calculateRentalDays(returnDate);
+  } catch {
+    throw new Error("Invalid returnDate");
+  }
+  if (rentalDays <= 0) throw new Error("Invalid returnDate");
+
+  const lineItemsNested = await Promise.all(
+    Object.values(cart).map((item) =>
+      buildLineItemsForItem(item, rentalDays, discountRate, currency)
+    )
+  );
+  const line_items = lineItemsNested.flat();
+
+  const { subtotal, depositTotal, discount } = await computeTotals(
+    cart,
+    rentalDays,
+    discountRate,
+    currency
+  );
+
+  const taxRate = await getTaxRate(taxRegion);
+  const taxAmountCents = Math.round(subtotal * taxRate * 100);
+  const taxAmount = taxAmountCents / 100;
+  if (taxAmountCents > 0) {
+    line_items.push({
+      price_data: {
+        currency: currency.toLowerCase(),
+        unit_amount: taxAmountCents,
+        product_data: { name: "Tax" },
+      },
+      quantity: 1,
+    });
+  }
+
+  const sizesMeta = JSON.stringify(
+    Object.fromEntries(
+      Object.values(cart).map((item) => [item.sku.id, item.size ?? ""])
+    )
+  );
+
+  const paymentIntentData: Stripe.Checkout.SessionCreateParams.PaymentIntentData = {
+    ...(shipping ? { shipping } : {}),
+    payment_method_options: { card: { request_three_d_secure: "automatic" } },
+    metadata: buildCheckoutMetadata({
+      subtotal,
+      depositTotal,
+      returnDate,
+      rentalDays,
+      customerId,
+      discount,
+      coupon: couponDef?.code,
+      currency,
+      taxRate,
+      taxAmount,
+      clientIp,
+    }),
+  } as any;
+
+  if (billingDetails) {
+    (paymentIntentData as any).billing_details = billingDetails;
+  }
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    customer: customerId,
+    line_items,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    payment_intent_data: paymentIntentData,
+    metadata: buildCheckoutMetadata({
+      subtotal,
+      depositTotal,
+      returnDate,
+      rentalDays,
+      sizes: sizesMeta,
+      customerId,
+      discount,
+      coupon: couponDef?.code,
+      currency,
+      taxRate,
+      taxAmount,
+      clientIp,
+    }),
+    expand: ["payment_intent"],
+  });
+
+  const clientSecret =
+    typeof session.payment_intent === "string"
+      ? undefined
+      : session.payment_intent?.client_secret;
+  return { clientSecret, sessionId: session.id };
+}
+
+export type { CartState };

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -1,125 +1,21 @@
 // packages/template-app/src/api/checkout-session/route.ts
-import { stripe } from "@acme/stripe";
-import { calculateRentalDays } from "@acme/date-utils";
-import {
-  CART_COOKIE,
-  decodeCartCookie,
-  type CartLine,
-  type CartState,
-} from "@platform-core/src/cartCookie";
+import { CART_COOKIE, decodeCartCookie, type CartState } from "@platform-core/src/cartCookie";
 import { getCart } from "@platform-core/src/cartStore";
-import { priceForDays, convertCurrency } from "@platform-core/src/pricing";
-import { getProductById } from "@platform-core/src/products";
-import { findCoupon } from "@platform-core/src/coupons";
-import { trackEvent } from "@platform-core/src/analytics";
 import { coreEnv } from "@acme/config/env/core";
-import { getTaxRate } from "@platform-core/src/tax";
 import { NextRequest, NextResponse } from "next/server";
-import type Stripe from "stripe";
+import { createCheckoutSession } from "@platform-core/checkout/session";
 
-/* ------------------------------------------------------------------
- * Types held in the cart cookie
- * ------------------------------------------------------------------ */
-type Cart = CartState;
-
-/* ------------------------------------------------------------------
- * Helpers
- * ------------------------------------------------------------------ */
-
-/** Build Stripe line-items for one cart entry */
-async function buildLineItemsForItem(
-  item: CartLine,
-  rentalDays: number,
-  discountRate: number,
-  currency: string
-): Promise<
-  [
-    Stripe.Checkout.SessionCreateParams.LineItem,
-    Stripe.Checkout.SessionCreateParams.LineItem,
-  ]
-> {
-  const sku = getProductById(item.sku.id); // ← full SKU
-
-  const baseName = item.size ? `${sku.title} (${item.size})` : sku.title;
-  const unit = await priceForDays(sku, rentalDays);
-  const discounted = Math.round(unit * (1 - discountRate));
-  const unitConv = await convertCurrency(discounted, currency);
-  const depositConv = await convertCurrency(sku.deposit, currency);
-
-  return [
-    {
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: unitConv * 100,
-        product_data: { name: baseName },
-      },
-      quantity: item.qty,
-    },
-    {
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: depositConv * 100,
-        product_data: { name: `${baseName} deposit` },
-      },
-      quantity: item.qty,
-    },
-  ];
-}
-
-/** Cart-wide subtotals */
-async function computeTotals(
-  cart: CartState,
-  rentalDays: number,
-  discountRate: number,
-  currency: string
-) {
-  const lineTotals = await Promise.all(
-    Object.values(cart).map(async (item) => {
-      const sku = getProductById(item.sku.id);
-      const unit = await priceForDays(sku, rentalDays);
-      const discounted = Math.round(unit * (1 - discountRate));
-      return {
-        base: unit * item.qty,
-        discounted: discounted * item.qty,
-      };
-    })
-  );
-
-  const subtotalBase = lineTotals.reduce((s, n) => s + n.discounted, 0);
-  const originalBase = lineTotals.reduce((s, n) => s + n.base, 0);
-  const discountBase = originalBase - subtotalBase;
-  const depositBase = Object.values(cart).reduce((s, item) => {
-    const deposit = getProductById(item.sku.id)?.deposit;
-    if (deposit === undefined) {
-      console.warn(`Deposit lookup failed for SKU ${item.sku.id}`);
-      return s;
-    }
-    return s + deposit * item.qty;
-  }, 0);
-
-  return {
-    subtotal: await convertCurrency(subtotalBase, currency),
-    depositTotal: await convertCurrency(depositBase, currency),
-    discount: await convertCurrency(discountBase, currency),
-  };
-}
-
-/* ------------------------------------------------------------------
- *  Route handler
- * ------------------------------------------------------------------ */
 export const runtime = "edge";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  /* 1  Decode cart -------------------------------------------------- */
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
   const cartId = decodeCartCookie(rawCookie);
-  const cart = cartId ? ((await getCart(cartId)) as CartState) : {};
+  const cart: CartState = cartId ? await getCart(cartId) : {};
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });
   }
 
-  /* 2  Rental days -------------------------------------------------- */
   const {
     returnDate,
     coupon,
@@ -128,128 +24,32 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     customer,
     shipping,
     billing_details,
-  } = (await req.json().catch(() => ({}))) as {
-    returnDate?: string;
-    coupon?: string;
-    currency?: string;
-    taxRegion?: string;
-    customer?: string;
-    shipping?: Stripe.Checkout.SessionCreateParams.ShippingAddress;
-    billing_details?: Record<string, any>;
-  };
+  } = (await req.json().catch(() => ({}))) as any;
+
+  const clientIp = req.headers?.get?.("x-forwarded-for")?.split(",")[0] ?? "";
   const shop = coreEnv.NEXT_PUBLIC_DEFAULT_SHOP || "shop";
-  const couponDef = await findCoupon(shop, coupon);
-  if (couponDef) {
-    await trackEvent(shop, { type: "discount_redeemed", code: couponDef.code });
-  }
-  const discountRate = couponDef ? couponDef.discountPercent / 100 : 0;
-  let rentalDays: number;
+
   try {
-    rentalDays = calculateRentalDays(returnDate);
-  } catch {
-    return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
-  }
-
-  /* 3  Stripe line-items ------------------------------------------- */
-  const nested = await Promise.all(
-    Object.values(cart).map((item) =>
-      buildLineItemsForItem(item, rentalDays, discountRate, currency)
-    )
-  );
-  const line_items = nested.flat();
-
-  /* 4  Totals / metadata ------------------------------------------- */
-  const { subtotal, depositTotal, discount } = await computeTotals(
-    cart,
-    rentalDays,
-    discountRate,
-    currency
-  );
-
-  const taxRate = await getTaxRate(taxRegion);
-  const taxAmount = Math.round(subtotal * taxRate);
-  if (taxAmount > 0) {
-    line_items.push({
-      price_data: {
-        currency: currency.toLowerCase(),
-        unit_amount: taxAmount * 100,
-        product_data: { name: "Tax" },
-      },
-      quantity: 1,
-    });
-  }
-
-  const sizesMeta = JSON.stringify(
-    Object.fromEntries(
-      Object.values(cart).map((item) => [item.sku.id, item.size ?? ""])
-    )
-  );
-
-  /* 5  Create checkout session ------------------------------------- */
-  const clientIp =
-    req.headers?.get?.("x-forwarded-for")?.split(",")[0] ?? "";
-
-  const paymentIntentData: Stripe.Checkout.SessionCreateParams.PaymentIntentData = {
-    ...(shipping ? { shipping } : {}),
-    payment_method_options: {
-      card: { request_three_d_secure: "automatic" },
-    },
-    metadata: {
-      subtotal: String(subtotal),
-      depositTotal: String(depositTotal),
-      returnDate: returnDate ?? "",
-      rentalDays: String(rentalDays),
-      discount: String(discount),
-      coupon: couponDef?.code ?? "",
+    const result = await createCheckoutSession({
+      shopId: shop,
+      cart,
+      returnDate,
+      coupon,
       currency,
-      taxRate: String(taxRate),
-      taxAmount: String(taxAmount),
-    },
-  } as any;
-
-  if (billing_details) {
-    (paymentIntentData as any).billing_details = billing_details;
+      taxRegion,
+      customerId: customer,
+      shipping,
+      billingDetails: billing_details,
+      successUrl: `${req.nextUrl.origin}/success`,
+      cancelUrl: `${req.nextUrl.origin}/cancelled`,
+      clientIp,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Invalid returnDate") {
+      return NextResponse.json({ error: "Invalid returnDate" }, { status: 400 });
+    }
+    console.error("Failed to create Stripe checkout session", err);
+    return NextResponse.json({ error: "Checkout failed" }, { status: 502 });
   }
-
-  let session: Stripe.Checkout.Session;
-  try {
-    session = await stripe.checkout.sessions.create(
-      {
-        mode: "payment",
-        customer,
-        line_items,
-        success_url: `${req.nextUrl.origin}/success`,
-        cancel_url: `${req.nextUrl.origin}/cancelled`,
-        payment_intent_data: paymentIntentData,
-        metadata: {
-          subtotal: String(subtotal),
-          depositTotal: String(depositTotal),
-          returnDate: returnDate ?? "",
-          rentalDays: String(rentalDays),
-          sizes: sizesMeta,
-          discount: String(discount),
-          coupon: couponDef?.code ?? "",
-          currency,
-          taxRate: String(taxRate),
-          taxAmount: String(taxAmount),
-        },
-        expand: ["payment_intent"],
-      },
-      { headers: { "Stripe-Client-IP": clientIp } }
-    );
-  } catch (error) {
-    console.error("Failed to create Stripe checkout session", error);
-    return NextResponse.json(
-      { error: "Checkout failed" },
-      { status: 502 }
-    );
-  }
-
-  /* 6  Return client credentials ----------------------------------- */
-  const clientSecret =
-    typeof session.payment_intent === "string"
-      ? undefined
-      : session.payment_intent?.client_secret;
-
-  return NextResponse.json({ clientSecret, sessionId: session.id });
 }


### PR DESCRIPTION
## Summary
- centralize Stripe checkout session workflow in reusable service
- update shop routes to use shared checkout session helper
- add tests for checkout session helper

## Testing
- `npx jest packages/platform-core/__tests__/checkout-session.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689db1a0b450832f936c9260d81e3951