### PR TITLE
feat: autosave theme overrides

### DIFF
--- a/apps/cms/src/app/api/shops/[shop]/theme/route.ts
+++ b/apps/cms/src/app/api/shops/[shop]/theme/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { patchTheme } from "@cms/services/shops";
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ shop: string }> },
+) {
+  try {
+    const body = await req.json();
+    const { shop } = await context.params;
+    const { themeOverrides = {}, themeDefaults = {} } = body ?? {};
+    const result = await patchTheme(shop, {
+      themeOverrides,
+      themeDefaults,
+    });
+    return NextResponse.json({ shop: result.shop });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/cms/src/app/cms/shop/[shop]/themes/PalettePicker.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/PalettePicker.tsx
@@ -12,6 +12,7 @@ interface Props {
     defaultValue: string,
   ) => (value: string) => void;
   handleReset: (key: string) => () => void;
+  handleGroupReset: (keys: string[]) => () => void;
   overrideRefs: MutableRefObject<Record<string, HTMLInputElement | null>>;
   mergedTokens: Record<string, string>;
   textTokenKeys: string[];
@@ -25,6 +26,7 @@ export default function PalettePicker({
   overrides,
   handleOverrideChange,
   handleReset,
+  handleGroupReset,
   overrideRefs,
   mergedTokens,
   textTokenKeys,
@@ -36,7 +38,16 @@ export default function PalettePicker({
     <div className="space-y-6">
       {Object.entries(groupedTokens).map(([groupName, tokens]) => (
         <fieldset key={groupName} className="space-y-2">
-          <legend className="font-semibold">{groupName}</legend>
+          <legend className="flex items-center justify-between font-semibold">
+            {groupName}
+            <button
+              type="button"
+              className="text-sm underline"
+              onClick={handleGroupReset(tokens.map(([k]) => k))}
+            >
+              Reset
+            </button>
+          </legend>
           <div className="mb-2 flex flex-wrap gap-2">
             {tokens
               .filter(([, v]) => isHex(v) || isHsl(v))

--- a/apps/cms/src/app/cms/shop/[shop]/themes/tokenGroups.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/tokenGroups.ts
@@ -1,0 +1,6 @@
+export const tokenGroups: Record<string, string[]> = {
+  Background: ["--color-bg", "--color-bg-dark"],
+  Primary: ["--color-primary"],
+};
+
+export type TokenGroups = typeof tokenGroups;

--- a/apps/cms/src/app/cms/wizard/services/patchTheme.ts
+++ b/apps/cms/src/app/cms/wizard/services/patchTheme.ts
@@ -1,0 +1,13 @@
+// apps/cms/src/app/cms/wizard/services/patchTheme.ts
+"use client";
+
+export async function patchShopTheme(
+  shopId: string,
+  data: { themeOverrides: Record<string, string>; themeDefaults: Record<string, string> },
+) {
+  await fetch(`/cms/api/shops/${shopId}/theme`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}

--- a/apps/cms/src/services/shops.ts
+++ b/apps/cms/src/services/shops.ts
@@ -18,7 +18,7 @@ import {
   parsePremierDeliveryForm,
   parseAiCatalogForm,
 } from "./shops/validation";
-import { buildThemeData, removeThemeToken } from "./shops/theme";
+import { buildThemeData, removeThemeToken, mergeThemePatch } from "./shops/theme";
 import {
   fetchShop,
   persistShop,
@@ -284,6 +284,26 @@ export async function updateAiCatalog(
   const updated: ShopSettings = { ...current, seo };
   await persistSettings(shop, updated);
   return { settings: updated };
+}
+
+export async function patchTheme(
+  shop: string,
+  patch: { themeOverrides: Record<string, string>; themeDefaults: Record<string, string> },
+): Promise<{ shop: Shop }> {
+  await authorize();
+  const current = await fetchShop(shop);
+  const { themeDefaults, overrides, themeTokens } = mergeThemePatch(
+    current,
+    patch.themeOverrides,
+    patch.themeDefaults,
+  );
+  const saved = await persistShop(shop, {
+    id: current.id,
+    themeDefaults,
+    themeOverrides: overrides,
+    themeTokens,
+  });
+  return { shop: saved };
 }
 
 export async function resetThemeOverride(shop: string, token: string) {

--- a/apps/cms/src/services/shops/__tests__/theme.test.ts
+++ b/apps/cms/src/services/shops/__tests__/theme.test.ts
@@ -1,4 +1,4 @@
-import { buildThemeData, removeThemeToken } from "../theme";
+import { buildThemeData, removeThemeToken, mergeThemePatch } from "../theme";
 
 jest.mock("@platform-core/src/createShop", () => ({
   syncTheme: jest.fn().mockResolvedValue({ a: "1" }),
@@ -25,5 +25,15 @@ describe("theme service", () => {
     const result = removeThemeToken(current, "a");
     expect(result.overrides).toEqual({ b: "2" });
     expect(result.themeTokens).toEqual({ a: "0", b: "2" });
+  });
+
+  it("merges partial theme updates", () => {
+    const current: any = {
+      themeOverrides: { a: "1", b: "2" },
+      themeDefaults: { a: "0", b: "0", c: "3" },
+    };
+    const patch = mergeThemePatch(current, { b: "4", c: "3" }, {});
+    expect(patch.overrides).toEqual({ a: "1", b: "4" });
+    expect(patch.themeTokens).toEqual({ a: "1", b: "4", c: "3" });
   });
 });

--- a/apps/cms/src/services/shops/theme.ts
+++ b/apps/cms/src/services/shops/theme.ts
@@ -35,3 +35,27 @@ export function removeThemeToken(
   >;
   return { overrides, themeTokens };
 }
+
+export function mergeThemePatch(
+  current: Shop,
+  patchOverrides: Record<string, string>,
+  patchDefaults: Record<string, string>
+): {
+  themeDefaults: Record<string, string>;
+  overrides: Record<string, string>;
+  themeTokens: Record<string, string>;
+} {
+  const themeDefaults = {
+    ...(current.themeDefaults ?? {}),
+    ...patchDefaults,
+  } as Record<string, string>;
+  const overrides = {
+    ...(current.themeOverrides ?? {}),
+    ...patchOverrides,
+  } as Record<string, string>;
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v == null || v === themeDefaults[k]) delete overrides[k];
+  }
+  const themeTokens = { ...themeDefaults, ...overrides } as Record<string, string>;
+  return { themeDefaults, overrides, themeTokens };
+}


### PR DESCRIPTION
## Summary
- add API and service utilities for PATCHing theme overrides
- autosave theme overrides from editor and reset groups via config
- merge partial theme updates on server

## Testing
- `pnpm --filter @apps/cms test` *(fails: Unable to find button Save)*

------
https://chatgpt.com/codex/tasks/task_e_689dbe2b2054832fbdb40045e9112bdd