### PR TITLE
feat: centralize provider metadata

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -21,7 +21,9 @@ describe("ShopEditor", () => {
       localeOverrides: {},
     };
 
-    render(<ShopEditor shop="shop" initial={initial} />);
+    render(
+      <ShopEditor shop="shop" initial={initial} initialTrackingProviders={[]} />,
+    );
 
     fireEvent.change(screen.getByLabelText(/theme tokens/i), {
       target: { value: "{invalid" },

--- a/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
@@ -13,6 +13,7 @@ import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import useStepCompletion from "../hooks/useStepCompletion";
+import { providersByType } from "@acme/configurator/providers";
 
 export default function StepOptions(): React.JSX.Element {
   const { state, update } = useConfigurator();
@@ -32,14 +33,20 @@ export default function StepOptions(): React.JSX.Element {
   const searchParams = useSearchParams();
   const [, markComplete] = useStepCompletion("options");
 
+  const paymentProviders = providersByType("payment");
+  const paymentIds = paymentProviders.map((p) => p.id);
+  const shippingProviders = providersByType("shipping");
+  const shippingIds = shippingProviders.map((p) => p.id);
+  const analyticsProviders = providersByType("analytics");
+
   useEffect(() => {
     const provider = searchParams.get("connected");
     if (!provider) return;
 
-    if (["stripe", "paypal"].includes(provider) && !payment.includes(provider)) {
+    if (paymentIds.includes(provider) && !payment.includes(provider)) {
       setPayment([...payment, provider]);
     }
-    if (["dhl", "ups"].includes(provider) && !shipping.includes(provider)) {
+    if (shippingIds.includes(provider) && !shipping.includes(provider)) {
       setShipping([...shipping, provider]);
     }
 
@@ -61,41 +68,29 @@ export default function StepOptions(): React.JSX.Element {
       </p>
       <div>
         <p className="font-medium">Payment Providers</p>
-        <div className="flex items-center gap-2 text-sm">
-          Stripe
-          {payment.includes("stripe") ? (
-            <Button disabled>Connected</Button>
-          ) : (
-            <Button onClick={() => connect("stripe")}>Connect</Button>
-          )}
-        </div>
-        <div className="flex items-center gap-2 text-sm">
-          PayPal
-          {payment.includes("paypal") ? (
-            <Button disabled>Connected</Button>
-          ) : (
-            <Button onClick={() => connect("paypal")}>Connect</Button>
-          )}
-        </div>
+        {paymentProviders.map((p) => (
+          <div key={p.id} className="flex items-center gap-2 text-sm">
+            {p.name}
+            {payment.includes(p.id) ? (
+              <Button disabled>Connected</Button>
+            ) : (
+              <Button onClick={() => connect(p.id)}>Connect</Button>
+            )}
+          </div>
+        ))}
       </div>
       <div>
         <p className="font-medium">Shipping Providers</p>
-        <div className="flex items-center gap-2 text-sm">
-          DHL
-          {shipping.includes("dhl") ? (
-            <Button disabled>Connected</Button>
-          ) : (
-            <Button onClick={() => connect("dhl")}>Connect</Button>
-          )}
-        </div>
-        <div className="flex items-center gap-2 text-sm">
-          UPS
-          {shipping.includes("ups") ? (
-            <Button disabled>Connected</Button>
-          ) : (
-            <Button onClick={() => connect("ups")}>Connect</Button>
-          )}
-        </div>
+        {shippingProviders.map((p) => (
+          <div key={p.id} className="flex items-center gap-2 text-sm">
+            {p.name}
+            {shipping.includes(p.id) ? (
+              <Button disabled>Connected</Button>
+            ) : (
+              <Button onClick={() => connect(p.id)}>Connect</Button>
+            )}
+          </div>
+        ))}
       </div>
       <div>
         <p className="font-medium">Analytics</p>
@@ -108,7 +103,11 @@ export default function StepOptions(): React.JSX.Element {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="none">None</SelectItem>
-            <SelectItem value="ga">Google Analytics</SelectItem>
+            {analyticsProviders.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
         {analyticsProvider === "ga" && (

--- a/apps/cms/src/app/cms/shop/[shop]/settings/SEOSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/SEOSettings.tsx
@@ -8,6 +8,7 @@ import type {
   SetStateAction,
 } from "react";
 import { jsonFieldHandler, ErrorSetter } from "../utils/formValidators";
+import type { Provider } from "@acme/configurator/providers";
 
 interface Props {
   info: Shop;
@@ -16,6 +17,7 @@ interface Props {
   setTrackingProviders: Dispatch<SetStateAction<string[]>>;
   errors: Record<string, string[]>;
   setErrors: ErrorSetter;
+  shippingProviders: Provider[];
 }
 
 export default function SEOSettings({
@@ -25,6 +27,7 @@ export default function SEOSettings({
   setTrackingProviders,
   errors,
   setErrors,
+  shippingProviders,
 }: Props) {
   const handleFilters = (e: ChangeEvent<HTMLInputElement>) => {
     setInfo((prev) => ({
@@ -69,8 +72,11 @@ export default function SEOSettings({
           onChange={handleTracking}
           className="border p-2"
         >
-          <option value="ups">UPS</option>
-          <option value="dhl">DHL</option>
+          {shippingProviders.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
         </select>
         {errors.trackingProviders && (
           <span className="text-sm text-red-600">

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -10,6 +10,7 @@ import GeneralSettings from "./GeneralSettings";
 import SEOSettings from "./SEOSettings";
 import ThemeTokens from "./ThemeTokens";
 import OverridesSettings from "./OverridesSettings";
+import { providersByType } from "@acme/configurator/providers";
 
 export { default as GeneralSettings } from "./GeneralSettings";
 export { default as SEOSettings } from "./SEOSettings";
@@ -29,6 +30,8 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
   );
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  const shippingProviders = providersByType("shipping");
 
   const tokenRows = useMemo(() => {
     const defaults = info.themeDefaults ?? {};
@@ -93,6 +96,7 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
         setTrackingProviders={setTrackingProviders}
         errors={errors}
         setErrors={setErrors}
+        shippingProviders={shippingProviders}
       />
       <ThemeTokens
         shop={shop}

--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -7,7 +7,8 @@
     "configurator": "./dist/index.js"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./providers": "./src/providers.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250702.0",

--- a/packages/configurator/src/providers.ts
+++ b/packages/configurator/src/providers.ts
@@ -1,0 +1,17 @@
+export interface Provider {
+  id: string;
+  name: string;
+  type: 'payment' | 'shipping' | 'analytics';
+}
+
+export const providers: Provider[] = [
+  { id: 'stripe', name: 'Stripe', type: 'payment' },
+  { id: 'paypal', name: 'PayPal', type: 'payment' },
+  { id: 'dhl', name: 'DHL', type: 'shipping' },
+  { id: 'ups', name: 'UPS', type: 'shipping' },
+  { id: 'ga', name: 'Google Analytics', type: 'analytics' },
+];
+
+export function providersByType(type: Provider['type']): Provider[] {
+  return providers.filter((p) => p.type === type);
+}


### PR DESCRIPTION
## Summary
- centralize provider metadata for payment, shipping, and analytics plugins
- render provider options dynamically in configurator and shop settings
- allow new providers by adding metadata entries

## Testing
- `pnpm test --filter @apps/cms` *(fails: ThemeEditor.colors.test.tsx missing Save button)*
- `pnpm --filter @apps/cms test -- ShopEditor.test.tsx` *(fails: Cannot find module '@/components/atoms/shadcn')*


------
https://chatgpt.com/codex/tasks/task_e_689dc2d6c2cc832f86807d879a3161f9