### PR TITLE
refactor: modularize shop services

### DIFF
--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -3,19 +3,20 @@
 import {
   updateShop as serviceUpdateShop,
   getSettings as serviceGetSettings,
-  updateSeo as serviceUpdateSeo,
-  generateSeo as serviceGenerateSeo,
-  revertSeo as serviceRevertSeo,
   setFreezeTranslations as serviceSetFreezeTranslations,
   updateCurrencyAndTax as serviceUpdateCurrencyAndTax,
-  updateDeposit as serviceUpdateDeposit,
+  updateDepositService as serviceUpdateDeposit,
   updateUpsReturns as serviceUpdateUpsReturns,
   updatePremierDelivery as serviceUpdatePremierDelivery,
   updateAiCatalog as serviceUpdateAiCatalog,
-  resetThemeOverride as serviceResetThemeOverride,
-  type Shop,
-  type ShopSettings,
-} from "../services/shops";
+} from "../services/shops/settingsService";
+import {
+  updateSeo as serviceUpdateSeo,
+  generateSeo as serviceGenerateSeo,
+  revertSeo as serviceRevertSeo,
+} from "../services/shops/seoService";
+import { resetThemeOverride as serviceResetThemeOverride } from "../services/shops/themeService";
+import type { Shop, ShopSettings } from "@acme/types";
 
 export async function updateShop(
   shop: string,
@@ -63,7 +64,7 @@ export async function updateCurrencyAndTax(
   return serviceUpdateCurrencyAndTax(shop, formData);
 }
 
-export async function updateDeposit(shop: string, formData: FormData) {
+export async function updateDepositService(shop: string, formData: FormData) {
   "use server";
   return serviceUpdateDeposit(shop, formData);
 }

--- a/apps/cms/src/app/api/shops/[shop]/theme/route.ts
+++ b/apps/cms/src/app/api/shops/[shop]/theme/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { patchTheme } from "@cms/services/shops";
+import { patchTheme } from "@cms/services/shops/themeService";
 
 export async function PATCH(
   req: NextRequest,

--- a/apps/cms/src/services/shops/__tests__/seoService.test.ts
+++ b/apps/cms/src/services/shops/__tests__/seoService.test.ts
@@ -1,0 +1,38 @@
+import { updateSeo } from "../seoService";
+import { authorize } from "../authorization";
+import { fetchSettings, persistSettings } from "../persistence";
+import { parseSeoForm } from "../validation";
+
+jest.mock("../authorization", () => ({ authorize: jest.fn() }));
+jest.mock("../persistence", () => ({
+  fetchSettings: jest.fn().mockResolvedValue({}),
+  persistSettings: jest.fn(),
+}));
+jest.mock("../validation", () => ({
+  parseSeoForm: jest.fn(),
+}));
+
+describe("seoService", () => {
+  it("updates seo and reports warnings", async () => {
+    (parseSeoForm as jest.Mock).mockReturnValue({
+      data: {
+        locale: "en",
+        title: "t".repeat(71),
+        description: "d".repeat(161),
+        image: "img",
+        alt: "alt",
+        canonicalBase: "base",
+        ogUrl: "",
+        twitterCard: "",
+      },
+      errors: undefined,
+    });
+    const result = await updateSeo("shop", new FormData());
+    expect(authorize).toHaveBeenCalled();
+    expect(persistSettings).toHaveBeenCalled();
+    expect(result.warnings).toEqual([
+      "Title exceeds 70 characters",
+      "Description exceeds 160 characters",
+    ]);
+  });
+});

--- a/apps/cms/src/services/shops/__tests__/settingsService.test.ts
+++ b/apps/cms/src/services/shops/__tests__/settingsService.test.ts
@@ -1,0 +1,29 @@
+import { updateCurrencyAndTax } from "../settingsService";
+import { authorize } from "../authorization";
+import { fetchSettings, persistSettings } from "../persistence";
+import { parseCurrencyTaxForm } from "../validation";
+
+jest.mock("../authorization", () => ({ authorize: jest.fn() }));
+jest.mock("../persistence", () => ({
+  fetchSettings: jest.fn().mockResolvedValue({ currency: "USD", taxRegion: "US" }),
+  persistSettings: jest.fn(),
+}));
+jest.mock("../validation", () => ({
+  parseCurrencyTaxForm: jest.fn(),
+}));
+
+describe("settingsService", () => {
+  it("updates currency and tax region", async () => {
+    (parseCurrencyTaxForm as jest.Mock).mockReturnValue({
+      data: { currency: "EUR", taxRegion: "EU" },
+      errors: undefined,
+    });
+    const result = await updateCurrencyAndTax("shop", new FormData());
+    expect(authorize).toHaveBeenCalled();
+    expect(persistSettings).toHaveBeenCalledWith("shop", {
+      currency: "EUR",
+      taxRegion: "EU",
+    });
+    expect(result.settings?.currency).toBe("EUR");
+  });
+});

--- a/apps/cms/src/services/shops/__tests__/themeService.test.ts
+++ b/apps/cms/src/services/shops/__tests__/themeService.test.ts
@@ -1,0 +1,43 @@
+import { patchTheme, resetThemeOverride } from "../themeService";
+import { authorize } from "../authorization";
+import { fetchShop, persistShop } from "../persistence";
+import { mergeThemePatch, removeThemeToken } from "../theme";
+import { revalidatePath } from "next/cache";
+
+jest.mock("../authorization", () => ({ authorize: jest.fn() }));
+jest.mock("../persistence", () => ({
+  fetchShop: jest.fn().mockResolvedValue({ id: "1" }),
+  persistShop: jest.fn().mockResolvedValue({ id: "1" }),
+}));
+jest.mock("../theme", () => ({
+  mergeThemePatch: jest.fn().mockReturnValue({
+    themeDefaults: {},
+    overrides: { a: "1" },
+    themeTokens: { a: "1" },
+  }),
+  removeThemeToken: jest.fn().mockReturnValue({
+    overrides: {},
+    themeTokens: {},
+  }),
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+describe("themeService", () => {
+  it("patches theme and persists", async () => {
+    const result = await patchTheme("shop", {
+      themeOverrides: { a: "1" },
+      themeDefaults: {},
+    });
+    expect(authorize).toHaveBeenCalled();
+    expect(mergeThemePatch).toHaveBeenCalled();
+    expect(persistShop).toHaveBeenCalled();
+    expect(result.shop).toBeDefined();
+  });
+
+  it("resets theme override", async () => {
+    await resetThemeOverride("shop", "a");
+    expect(removeThemeToken).toHaveBeenCalled();
+    expect(persistShop).toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalled();
+  });
+});

--- a/apps/cms/src/services/shops/seoService.ts
+++ b/apps/cms/src/services/shops/seoService.ts
@@ -1,0 +1,115 @@
+import type { Locale, ShopSeoFields, ShopSettings } from "@acme/types";
+import { authorize } from "./authorization";
+import { parseSeoForm, parseGenerateSeoForm } from "./validation";
+import {
+  fetchSettings,
+  persistSettings,
+  fetchDiffHistory,
+} from "./persistence";
+
+export async function updateSeo(
+  shop: string,
+  formData: FormData,
+): Promise<{
+  settings?: unknown;
+  errors?: Record<string, string[]>;
+  warnings?: string[];
+}> {
+  await authorize();
+  const { data, errors } = parseSeoForm(formData);
+  if (!data) {
+    console.error(`[updateSeo] validation failed for shop ${shop}`, errors);
+    return { errors };
+  }
+
+  const {
+    locale,
+    title,
+    description,
+    image,
+    alt,
+    canonicalBase,
+    ogUrl,
+    twitterCard,
+  } = data;
+
+  const warnings: string[] = [];
+  if (title.length > 70) warnings.push("Title exceeds 70 characters");
+  if (description.length > 160)
+    warnings.push("Description exceeds 160 characters");
+
+  const current = await fetchSettings(shop);
+  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
+  seo[locale] = {
+    title,
+    description,
+    image,
+    alt,
+    canonicalBase,
+    openGraph: ogUrl ? { url: ogUrl } : undefined,
+    twitter: twitterCard ? { card: twitterCard } : undefined,
+  };
+  const updated: ShopSettings = {
+    ...current,
+    seo,
+  };
+  await persistSettings(shop, updated);
+
+  return { settings: updated, warnings };
+}
+
+export async function generateSeo(
+  shop: string,
+  formData: FormData,
+): Promise<{
+  generated?: { title: string; description: string; image: string };
+  errors?: Record<string, string[]>;
+}> {
+  await authorize();
+  const { data, errors } = parseGenerateSeoForm(formData);
+  if (!data) {
+    return { errors };
+  }
+
+  const { id, locale, title, description } = data;
+  const { generateMeta } = await import(
+    /* @vite-ignore */ "../../../../../scripts/generate-meta.ts"
+  );
+
+  const result = await generateMeta({ id, title, description });
+  const current = await fetchSettings(shop);
+  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
+  seo[locale] = {
+    ...(seo[locale] ?? {}),
+    title: result.title,
+    description: result.description,
+    image: result.image,
+    openGraph: { ...(seo[locale]?.openGraph ?? {}), image: result.image },
+  };
+  const updated: ShopSettings = { ...current, seo };
+  await persistSettings(shop, updated);
+
+  return { generated: result };
+}
+
+export async function revertSeo(shop: string, timestamp: string) {
+  await authorize();
+  const history = await fetchDiffHistory(shop);
+  const sorted = history.sort((a: any, b: any) =>
+    a.timestamp.localeCompare(b.timestamp),
+  );
+  const idx = sorted.findIndex((e: any) => e.timestamp === timestamp);
+  if (idx === -1) throw new Error("Version not found");
+  let state: ShopSettings = {
+    languages: [],
+    seo: {},
+    freezeTranslations: false,
+    updatedAt: "",
+    updatedBy: "",
+  };
+  for (let i = 0; i < idx; i++) {
+    state = { ...state, ...sorted[i].diff } as ShopSettings;
+  }
+  await persistSettings(shop, state);
+  return state;
+}

--- a/apps/cms/src/services/shops/settingsService.ts
+++ b/apps/cms/src/services/shops/settingsService.ts
@@ -1,31 +1,22 @@
-// apps/cms/src/services/shops.ts
-
-import { revalidatePath } from "next/cache";
-import type {
-  Locale,
-  Shop,
-  ShopSeoFields,
-  ShopSettings,
-} from "@acme/types";
-import { authorize } from "./shops/authorization";
+import type { Locale, Shop, ShopSettings } from "@acme/types";
+import { authorize } from "./authorization";
 import {
   parseShopForm,
-  parseSeoForm,
-  parseGenerateSeoForm,
   parseCurrencyTaxForm,
   parseDepositForm,
   parseUpsReturnsForm,
   parsePremierDeliveryForm,
   parseAiCatalogForm,
-} from "./shops/validation";
-import { buildThemeData, removeThemeToken, mergeThemePatch } from "./shops/theme";
+} from "./validation";
+import {
+  buildThemeData,
+} from "./theme";
 import {
   fetchShop,
   persistShop,
   fetchSettings,
   persistSettings,
-  fetchDiffHistory,
-} from "./shops/persistence";
+} from "./persistence";
 
 export async function updateShop(
   shop: string,
@@ -72,113 +63,6 @@ export async function updateShop(
 
 export function getSettings(shop: string) {
   return fetchSettings(shop);
-}
-
-export async function updateSeo(
-  shop: string,
-  formData: FormData,
-): Promise<{
-  settings?: unknown;
-  errors?: Record<string, string[]>;
-  warnings?: string[];
-}> {
-  await authorize();
-  const { data, errors } = parseSeoForm(formData);
-  if (!data) {
-    console.error(`[updateSeo] validation failed for shop ${shop}`, errors);
-    return { errors };
-  }
-
-  const {
-    locale,
-    title,
-    description,
-    image,
-    alt,
-    canonicalBase,
-    ogUrl,
-    twitterCard,
-  } = data;
-
-  const warnings: string[] = [];
-  if (title.length > 70) warnings.push("Title exceeds 70 characters");
-  if (description.length > 160)
-    warnings.push("Description exceeds 160 characters");
-
-  const current = await fetchSettings(shop);
-  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
-  seo[locale] = {
-    title,
-    description,
-    image,
-    alt,
-    canonicalBase,
-    openGraph: ogUrl ? { url: ogUrl } : undefined,
-    twitter: twitterCard ? { card: twitterCard } : undefined,
-  };
-  const updated: ShopSettings = {
-    ...current,
-    seo,
-  };
-  await persistSettings(shop, updated);
-
-  return { settings: updated, warnings };
-}
-
-export async function generateSeo(
-  shop: string,
-  formData: FormData,
-): Promise<{
-  generated?: { title: string; description: string; image: string };
-  errors?: Record<string, string[]>;
-}> {
-  await authorize();
-  const { data, errors } = parseGenerateSeoForm(formData);
-  if (!data) {
-    return { errors };
-  }
-
-  const { id, locale, title, description } = data;
-  const { generateMeta } = await import(
-    /* @vite-ignore */ "../../../../scripts/generate-meta.ts"
-  );
-
-  const result = await generateMeta({ id, title, description });
-  const current = await fetchSettings(shop);
-  const seo = { ...(current.seo ?? {}) } as Record<Locale, ShopSeoFields>;
-  seo[locale] = {
-    ...(seo[locale] ?? {}),
-    title: result.title,
-    description: result.description,
-    image: result.image,
-    openGraph: { ...(seo[locale]?.openGraph ?? {}), image: result.image },
-  };
-  const updated: ShopSettings = { ...current, seo };
-  await persistSettings(shop, updated);
-
-  return { generated: result };
-}
-
-export async function revertSeo(shop: string, timestamp: string) {
-  await authorize();
-  const history = await fetchDiffHistory(shop);
-  const sorted = history.sort((a: any, b: any) =>
-    a.timestamp.localeCompare(b.timestamp),
-  );
-  const idx = sorted.findIndex((e: any) => e.timestamp === timestamp);
-  if (idx === -1) throw new Error("Version not found");
-  let state: ShopSettings = {
-    languages: [],
-    seo: {},
-    freezeTranslations: false,
-    updatedAt: "",
-    updatedBy: "",
-  };
-  for (let i = 0; i < idx; i++) {
-    state = { ...state, ...sorted[i].diff } as ShopSettings;
-  }
-  await persistSettings(shop, state);
-  return state;
 }
 
 export async function setFreezeTranslations(shop: string, freeze: boolean) {
@@ -284,38 +168,6 @@ export async function updateAiCatalog(
   const updated: ShopSettings = { ...current, seo };
   await persistSettings(shop, updated);
   return { settings: updated };
-}
-
-export async function patchTheme(
-  shop: string,
-  patch: { themeOverrides: Record<string, string>; themeDefaults: Record<string, string> },
-): Promise<{ shop: Shop }> {
-  await authorize();
-  const current = await fetchShop(shop);
-  const { themeDefaults, overrides, themeTokens } = mergeThemePatch(
-    current,
-    patch.themeOverrides,
-    patch.themeDefaults,
-  );
-  const saved = await persistShop(shop, {
-    id: current.id,
-    themeDefaults,
-    themeOverrides: overrides,
-    themeTokens,
-  });
-  return { shop: saved };
-}
-
-export async function resetThemeOverride(shop: string, token: string) {
-  await authorize();
-  const current = await fetchShop(shop);
-  const { overrides, themeTokens } = removeThemeToken(current, token);
-  await persistShop(shop, {
-    id: current.id,
-    themeOverrides: overrides,
-    themeTokens,
-  });
-  revalidatePath(`/cms/shop/${shop}/settings`);
 }
 
 export type { Shop, ShopSettings };

--- a/apps/cms/src/services/shops/themeService.ts
+++ b/apps/cms/src/services/shops/themeService.ts
@@ -1,0 +1,37 @@
+import { revalidatePath } from "next/cache";
+import type { Shop } from "@acme/types";
+import { authorize } from "./authorization";
+import { fetchShop, persistShop } from "./persistence";
+import { mergeThemePatch, removeThemeToken } from "./theme";
+
+export async function patchTheme(
+  shop: string,
+  patch: { themeOverrides: Record<string, string>; themeDefaults: Record<string, string> },
+): Promise<{ shop: Shop }> {
+  await authorize();
+  const current = await fetchShop(shop);
+  const { themeDefaults, overrides, themeTokens } = mergeThemePatch(
+    current,
+    patch.themeOverrides,
+    patch.themeDefaults,
+  );
+  const saved = await persistShop(shop, {
+    id: current.id,
+    themeDefaults,
+    themeOverrides: overrides,
+    themeTokens,
+  });
+  return { shop: saved };
+}
+
+export async function resetThemeOverride(shop: string, token: string) {
+  await authorize();
+  const current = await fetchShop(shop);
+  const { overrides, themeTokens } = removeThemeToken(current, token);
+  await persistShop(shop, {
+    id: current.id,
+    themeOverrides: overrides,
+    themeTokens,
+  });
+  revalidatePath(`/cms/shop/${shop}/settings`);
+}


### PR DESCRIPTION
## Summary
- split shop services into seo, theme, and settings modules
- add unit tests for each new service
- update actions and API route to new modules

## Testing
- `pnpm test:cms` *(fails: process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689dc46e33cc832fb849f36f399ac01f