### PR TITLE
refactor page builder viewport and upload hooks

### DIFF
--- a/packages/ui/__tests__/useFileDrop.test.tsx
+++ b/packages/ui/__tests__/useFileDrop.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook, act } from "@testing-library/react";
+import useFileDrop from "../src/components/cms/page-builder/hooks/useFileDrop";
+
+const onDropMock = jest.fn().mockResolvedValue(undefined);
+const useFileUploadMock = jest.fn(() => ({
+  onDrop: onDropMock,
+  progress: null,
+  isValid: true,
+}));
+
+jest.mock("@ui/hooks/useFileUpload", () => ({
+  __esModule: true,
+  default: (opts: any) => useFileUploadMock(opts),
+}));
+
+describe("useFileDrop", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("calls onDrop and resets drag state", async () => {
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useFileDrop({ shop: "shop", dispatch })
+    );
+
+    await act(async () => {
+      result.current.setDragOver(true);
+      await result.current.handleFileDrop({ dataTransfer: "data" } as any);
+    });
+
+    expect(result.current.dragOver).toBe(false);
+    expect(onDropMock).toHaveBeenCalledWith("data");
+  });
+
+  it("dispatches add action on upload", () => {
+    const dispatch = jest.fn();
+    renderHook(() => useFileDrop({ shop: "shop", dispatch }));
+    const opts = useFileUploadMock.mock.calls[0][0];
+    act(() => {
+      opts.onUploaded({ url: "u", altText: "a" });
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "add" })
+    );
+  });
+});

--- a/packages/ui/__tests__/useViewport.test.tsx
+++ b/packages/ui/__tests__/useViewport.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from "@testing-library/react";
+import useViewport from "../src/components/cms/page-builder/hooks/useViewport";
+import type { DevicePreset } from "@ui/utils/devicePresets";
+
+describe("useViewport", () => {
+  const desktop: DevicePreset = {
+    id: "d",
+    label: "Desktop",
+    type: "desktop",
+    width: 1000,
+    height: 800,
+  };
+  const tablet: DevicePreset = {
+    id: "t",
+    label: "Tablet",
+    type: "tablet",
+    width: 500,
+    height: 400,
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    (window.requestAnimationFrame as jest.Mock).mockRestore();
+  });
+
+  it("updates dimensions when device changes", () => {
+    const { result, rerender } = renderHook(
+      ({ device }) => useViewport(device),
+      { initialProps: { device: desktop } }
+    );
+
+    expect(result.current.canvasWidth).toBe(1000);
+    expect(result.current.canvasHeight).toBe(800);
+
+    rerender({ device: tablet });
+
+    expect(result.current.canvasWidth).toBe(500);
+    expect(result.current.canvasHeight).toBe(400);
+    expect(result.current.scale).toBe(1);
+  });
+});

--- a/packages/ui/src/components/cms/page-builder/GridOverlay.tsx
+++ b/packages/ui/src/components/cms/page-builder/GridOverlay.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  gridCols: number;
+}
+
+const GridOverlay = ({ gridCols }: Props) => (
+  <div
+    className="pointer-events-none absolute inset-0 z-10 grid"
+    style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
+  >
+    {Array.from({ length: gridCols }).map((_, i) => (
+      <div
+        key={i}
+        className="border-l border-dashed border-muted-foreground/40"
+      />
+    ))}
+  </div>
+);
+
+export default GridOverlay;

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -7,6 +7,8 @@ import type { Locale } from "@/i18n/locales";
 import type { Action } from "./state";
 import { cn } from "../../../utils/style";
 import type { DevicePreset } from "@ui/utils/devicePresets";
+import GridOverlay from "./GridOverlay";
+import SnapLine from "./SnapLine";
 
 interface Props {
   components: PageComponent[];
@@ -67,25 +69,8 @@ const PageCanvas = ({
         dragOver && "ring-2 ring-primary"
       )}
     >
-      {showGrid && (
-        <div
-          className="pointer-events-none absolute inset-0 z-10 grid"
-          style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
-        >
-          {Array.from({ length: gridCols }).map((_, i) => (
-            <div
-              key={i}
-              className="border-l border-dashed border-muted-foreground/40"
-            />
-          ))}
-        </div>
-      )}
-      {snapPosition !== null && (
-        <div
-          className="pointer-events-none absolute top-0 bottom-0 w-px bg-primary"
-          style={{ left: snapPosition }}
-        />
-      )}
+      {showGrid && <GridOverlay gridCols={gridCols} />}
+      <SnapLine position={snapPosition} />
       {components.map((c, i) => (
         <Fragment key={c.id}>
           {insertIndex === i && (

--- a/packages/ui/src/components/cms/page-builder/SnapLine.tsx
+++ b/packages/ui/src/components/cms/page-builder/SnapLine.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  position: number | null;
+}
+
+const SnapLine = ({ position }: Props) => {
+  if (position === null) return null;
+  return (
+    <div
+      className="pointer-events-none absolute top-0 bottom-0 w-px bg-primary"
+      style={{ left: position }}
+    />
+  );
+};
+
+export default SnapLine;

--- a/packages/ui/src/components/cms/page-builder/hooks/useFileDrop.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/useFileDrop.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import type { DragEvent } from "react";
+import { ulid } from "ulid";
+import type { PageComponent, MediaItem } from "@acme/types";
+import useFileUpload from "@ui/hooks/useFileUpload";
+import { defaults } from "../defaults";
+
+interface Options {
+  shop: string;
+  dispatch: (action: { type: string; component: PageComponent }) => void;
+}
+
+const useFileDrop = ({ shop, dispatch }: Options) => {
+  const [dragOver, setDragOver] = useState(false);
+
+  const { onDrop, progress, isValid } = useFileUpload({
+    shop,
+    requiredOrientation: "landscape",
+    onUploaded: (item: MediaItem) => {
+      dispatch({
+        type: "add",
+        component: {
+          id: ulid(),
+          type: "Image",
+          src: item.url,
+          alt: item.altText,
+          ...(defaults.Image ?? {}),
+        } as PageComponent,
+      });
+    },
+  });
+
+  const handleFileDrop = useCallback(
+    (ev: DragEvent<HTMLDivElement>) => {
+      setDragOver(false);
+      onDrop(ev.dataTransfer).catch((err: unknown) => {
+        console.error(err);
+      });
+    },
+    [onDrop]
+  );
+
+  return {
+    dragOver,
+    setDragOver,
+    handleFileDrop,
+    progress,
+    isValid,
+  };
+};
+
+export default useFileDrop;

--- a/packages/ui/src/components/cms/page-builder/hooks/useViewport.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/useViewport.ts
@@ -1,0 +1,43 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { DevicePreset } from "@ui/utils/devicePresets";
+
+const useViewport = (device: DevicePreset) => {
+  const [canvasWidth, setCanvasWidth] = useState(device.width);
+  const [canvasHeight, setCanvasHeight] = useState(device.height);
+  const [scale, setScale] = useState(1);
+  const prevWidth = useRef(device.width);
+
+  useEffect(() => {
+    const prev = prevWidth.current;
+    setCanvasWidth(device.width);
+    setCanvasHeight(device.height);
+    setScale(prev / device.width);
+    const raf = requestAnimationFrame(() => setScale(1));
+    prevWidth.current = device.width;
+    return () => cancelAnimationFrame(raf);
+  }, [device]);
+
+  const viewportStyle = useMemo(
+    () => ({
+      width: `${canvasWidth}px`,
+      height: `${canvasHeight}px`,
+      transform: `scale(${scale})`,
+      transformOrigin: "top center",
+      transition: "transform 0.3s ease",
+    }),
+    [canvasWidth, canvasHeight, scale]
+  );
+
+  const frameClass = useMemo(
+    () => ({
+      desktop: "",
+      tablet: "rounded-xl border border-muted-foreground/40 p-2",
+      mobile: "rounded-[2rem] border border-muted-foreground/40 p-4",
+    }),
+    []
+  );
+
+  return { canvasWidth, canvasHeight, scale, viewportStyle, frameClass };
+};
+
+export default useViewport;


### PR DESCRIPTION
## Summary
- refactor PageBuilder to use dedicated `useFileDrop` and `useViewport` hooks
- extract grid overlay elements into standalone components
- add tests for new hooks

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/useFileDrop.test.tsx packages/ui/__tests__/useViewport.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689dc72325ac832fa84a0598330f4345