### PR TITLE
Expose return bag details and label link

### DIFF
--- a/data/return-logistics.json
+++ b/data/return-logistics.json
@@ -1,5 +1,5 @@
 {
-  "labelService": "MockLabelCo",
+  "labelService": "UPS",
   "inStore": true,
   "dropOffProvider": "UPS",
   "tracking": true,

--- a/packages/platform-core/src/returnLogistics.ts
+++ b/packages/platform-core/src/returnLogistics.ts
@@ -13,3 +13,14 @@ export async function getReturnLogistics(): Promise<ReturnLogistics> {
   cached = returnLogisticsSchema.parse(JSON.parse(buf));
   return cached;
 }
+
+export type ReturnBagAndLabel = Pick<
+  ReturnLogistics,
+  "bagType" | "labelService" | "dropOffProvider" | "tracking"
+>;
+
+export async function getReturnBagAndLabel(): Promise<ReturnBagAndLabel> {
+  const { bagType, labelService, dropOffProvider, tracking } =
+    await getReturnLogistics();
+  return { bagType, labelService, dropOffProvider, tracking };
+}

--- a/packages/template-app/src/app/account/returns/page.tsx
+++ b/packages/template-app/src/app/account/returns/page.tsx
@@ -1,0 +1,20 @@
+// packages/template-app/src/app/account/returns/page.tsx
+import { getReturnBagAndLabel } from "@platform-core/returnLogistics";
+
+export default async function AccountReturnsPage() {
+  const cfg = await getReturnBagAndLabel();
+  const labelHref = `https://${cfg.labelService.toLowerCase()}.com/`;
+  return (
+    <div className="p-6 space-y-4">
+      {cfg.bagType === "reusable" && (
+        <p>Please reuse the reusable bag to return your items.</p>
+      )}
+      {cfg.tracking && (
+        <a href={labelHref} className="text-primary underline">
+          Print {cfg.labelService} return label
+        </a>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- switch return label service to UPS and confirm bag, drop-off, tracking settings
- expose bag and label fields via `getReturnBagAndLabel`
- add account returns page with bag reuse instructions and label link

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689dc480b87c832f9222077da598722d