### PR TITLE
Enable late fee service with policy and runtime startup

### DIFF
--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -7,6 +7,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "premierDelivery": {
     "regions": ["us-east"],

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -49,5 +49,8 @@
       "prorateOnChange": true
     }
   ],
-  "lateFeePolicy": { "gracePeriodDays": 3, "feeAmount": 25 }
+  "lateFeePolicy": {
+    "gracePeriodDays": 3,
+    "feeAmount": 25
+  }
 }

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -7,6 +7,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "premierDelivery": {
     "regions": ["us-west"],

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -46,5 +46,8 @@
       "prorateOnChange": true
     }
   ],
-  "lateFeePolicy": { "gracePeriodDays": 3, "feeAmount": 25 }
+  "lateFeePolicy": {
+    "gracePeriodDays": 3,
+    "feeAmount": 25
+  }
 }

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -7,6 +7,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "seo": {
     "aiCatalog": {

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -6,6 +6,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "languages": [
     "en",

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -156,3 +156,9 @@ export async function startLateFeeService(
 
   return () => timers.forEach((t) => clearInterval(t));
 }
+
+if (process.env.NODE_ENV === "production") {
+  startLateFeeService().catch((err) =>
+    logger.error("late fee service failed to start", { err }),
+  );
+}


### PR DESCRIPTION
## Summary
- configure late fee service for all shops
- document late fee policy in shop data
- automatically launch late fee processor in production

## Testing
- `pnpm --filter @acme/platform-machine test` *(fails: TestingLibraryElementError - Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689dc4878e28832f8dba949d9f2643cb