### PR TITLE
feat: add stock alert settings

### DIFF
--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -13,6 +13,7 @@ import {
   updateUpsReturns as serviceUpdateUpsReturns,
   updatePremierDelivery as serviceUpdatePremierDelivery,
   updateAiCatalog as serviceUpdateAiCatalog,
+  updateStockAlert as serviceUpdateStockAlert,
   resetThemeOverride as serviceResetThemeOverride,
   type Shop,
   type ShopSettings,
@@ -77,6 +78,11 @@ export async function updateReverseLogistics(shop: string, formData: FormData) {
 export async function updateUpsReturns(shop: string, formData: FormData) {
   "use server";
   return serviceUpdateUpsReturns(shop, formData);
+}
+
+export async function updateStockAlert(shop: string, formData: FormData) {
+  "use server";
+  return serviceUpdateStockAlert(shop, formData);
 }
 
 export async function updatePremierDelivery(

--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -97,6 +97,14 @@ export default async function SettingsPage({
           Reverse logistics settings
         </Link>
       </p>
+      <p className="mb-4 text-sm">
+        <Link
+          href={`/cms/shop/${shop}/settings/stock-alerts`}
+          className="text-primary underline"
+        >
+          Stock alert settings
+        </Link>
+      </p>
       <h3 className="mt-4 font-medium">Languages</h3>
       <ul className="mt-2 list-disc pl-5 text-sm">
         {settings.languages.map((l: Locale) => (

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/StockAlertsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/StockAlertsEditor.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Button, Input } from "@/components/atoms/shadcn";
+import { updateStockAlert } from "@cms/actions/shops.server";
+import { useState, type ChangeEvent, type FormEvent } from "react";
+
+interface Props {
+  shop: string;
+  initial: { recipients: string[]; webhook?: string; threshold?: number };
+}
+
+export default function StockAlertsEditor({ shop, initial }: Props) {
+  const [state, setState] = useState({
+    recipients: initial.recipients.join(", "),
+    webhook: initial.webhook ?? "",
+    threshold: initial.threshold ? String(initial.threshold) : "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setState((s) => ({ ...s, [name]: value }));
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData(e.currentTarget);
+    const result = await updateStockAlert(shop, fd);
+    if (result.errors) {
+      setErrors(result.errors);
+    } else if (result.settings?.stockAlert) {
+      setState({
+        recipients: result.settings.stockAlert.recipients.join(", "),
+        webhook: result.settings.stockAlert.webhook ?? "",
+        threshold: result.settings.stockAlert.threshold
+          ? String(result.settings.stockAlert.threshold)
+          : "",
+      });
+      setErrors({});
+    }
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="grid max-w-md gap-4">
+      <label className="flex flex-col gap-1">
+        <span>Recipients (comma-separated)</span>
+        <Input
+          name="recipients"
+          value={state.recipients}
+          onChange={handleChange}
+        />
+        {errors.recipients && (
+          <span className="text-sm text-red-600">
+            {errors.recipients.join("; ")}
+          </span>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span>Webhook URL</span>
+        <Input name="webhook" value={state.webhook} onChange={handleChange} />
+        {errors.webhook && (
+          <span className="text-sm text-red-600">
+            {errors.webhook.join("; ")}
+          </span>
+        )}
+      </label>
+      <label className="flex flex-col gap-1">
+        <span>Default Threshold</span>
+        <Input
+          type="number"
+          name="threshold"
+          value={state.threshold}
+          onChange={handleChange}
+        />
+        {errors.threshold && (
+          <span className="text-sm text-red-600">
+            {errors.threshold.join("; ")}
+          </span>
+        )}
+      </label>
+      <Button className="bg-primary text-white" disabled={saving} type="submit">
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/page.tsx
@@ -1,0 +1,30 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/page.tsx
+import { getSettings } from "@cms/actions/shops.server";
+import dynamic from "next/dynamic";
+
+const StockAlertsEditor = dynamic(() => import("./StockAlertsEditor"));
+void StockAlertsEditor;
+
+export const revalidate = 0;
+
+interface Params {
+  shop: string;
+}
+
+export default async function StockAlertsSettingsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { shop } = await params;
+  const settings = await getSettings(shop);
+  const stockAlert = settings.stockAlert ?? { recipients: [] };
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Stock Alerts – {shop}</h2>
+      <StockAlertsEditor shop={shop} initial={stockAlert} />
+    </div>
+  );
+}
+

--- a/apps/cms/src/services/shops/settingsService.ts
+++ b/apps/cms/src/services/shops/settingsService.ts
@@ -7,6 +7,7 @@ import {
   parseUpsReturnsForm,
   parsePremierDeliveryForm,
   parseAiCatalogForm,
+  parseStockAlertForm,
 } from "./validation";
 
 export function getSettings(shop: string) {
@@ -95,6 +96,24 @@ export async function updateUpsReturns(
   const updated: ShopSettings = {
     ...current,
     returnService: { upsEnabled: data.enabled },
+  };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function updateStockAlert(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parseStockAlertForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = {
+    ...current,
+    stockAlert: data,
   };
   await persistSettings(shop, updated);
   return { settings: updated };

--- a/apps/cms/src/services/shops/validation.ts
+++ b/apps/cms/src/services/shops/validation.ts
@@ -257,6 +257,33 @@ export function parseAiCatalogForm(formData: FormData): {
   return { data: parsed.data };
 }
 
+const stockAlertFormSchema = z
+  .object({
+    recipients: z.array(z.string().email()),
+    webhook: z.string().url().optional(),
+    threshold: z.coerce.number().int().min(1, "Must be at least 1").optional(),
+  })
+  .strict();
+
+export function parseStockAlertForm(formData: FormData): {
+  data?: z.infer<typeof stockAlertFormSchema>;
+  errors?: Record<string, string[]>;
+} {
+  const data = {
+    recipients: String(formData.get("recipients") ?? "")
+      .split(",")
+      .map((r) => r.trim())
+      .filter(Boolean),
+    webhook: formData.get("webhook")?.toString().trim() || undefined,
+    threshold: formData.get("threshold"),
+  };
+  const parsed = stockAlertFormSchema.safeParse(data);
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors };
+  }
+  return { data: parsed.data };
+}
+
 export type SeoForm = z.infer<typeof seoSchema> & { locale: Locale; };
 export type GenerateSeoForm = z.infer<typeof generateSchema>;
 export type CurrencyTaxForm = z.infer<typeof currencyTaxSchema>;
@@ -265,3 +292,4 @@ export type ReverseLogisticsForm = z.infer<typeof reverseLogisticsSchema>;
 export type UpsReturnsForm = z.infer<typeof returnsSchema>;
 export type PremierDeliveryForm = z.infer<typeof premierDeliverySchema>;
 export type AiCatalogForm = z.infer<typeof aiCatalogFormSchema>;
+export type StockAlertForm = z.infer<typeof stockAlertFormSchema>;

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -72,6 +72,10 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
           ...(parsed.data.returnService ?? {}),
         },
         premierDelivery: parsed.data.premierDelivery,
+        stockAlert: {
+          recipients: [],
+          ...(parsed.data.stockAlert ?? {}),
+        },
         seo: {
           ...(parsed.data.seo ?? {}),
           aiCatalog: {
@@ -103,6 +107,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     reverseLogisticsService: { enabled: false, intervalMinutes: 60 },
     returnService: { upsEnabled: false },
     premierDelivery: undefined,
+    stockAlert: { recipients: [] },
     luxuryFeatures: {
       contentMerchandising: false,
       raTicketing: false,

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -24,6 +24,14 @@ export const seoSettingsSchema = z
   })
   .catchall(shopSeoFieldsSchema);
 
+export const stockAlertConfigSchema = z
+  .object({
+    recipients: z.array(z.string().email()),
+    webhook: z.string().url().optional(),
+    threshold: z.number().int().positive().optional(),
+  })
+  .strict();
+
 export const shopSettingsSchema = z
   .object({
     languages: z.array(localeSchema).readonly(),
@@ -69,6 +77,7 @@ export const shopSettingsSchema = z
       })
       .strict()
       .optional(),
+    stockAlert: stockAlertConfigSchema.optional(),
     editorialBlog: z
       .object({
         enabled: z.boolean(),
@@ -102,3 +111,4 @@ export const shopSettingsSchema = z
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
 export type AiCatalogConfig = z.infer<typeof aiCatalogConfigSchema>;
 export type AiCatalogField = z.infer<typeof aiCatalogFieldSchema>;
+export type StockAlertConfig = z.infer<typeof stockAlertConfigSchema>;


### PR DESCRIPTION
## Summary
- add stock alert config schema and defaults
- expose stock alert settings with server actions and UI
- read per-shop stock alert configuration in platform-core

## Testing
- `pnpm test` *(fails: @acme/next-config test failures)*
- `pnpm lint` *(fails: module resolution error in @apps/cms)*

------
https://chatgpt.com/codex/tasks/task_e_689de4a64c64832fbf3e7c0b8287b4f1