### PR TITLE
feat: show configurator save status

### DIFF
--- a/apps/cms/src/app/cms/configurator/ConfiguratorContext.tsx
+++ b/apps/cms/src/app/cms/configurator/ConfiguratorContext.tsx
@@ -10,7 +10,7 @@ import {
 import { useConfiguratorPersistence } from "./hooks/useConfiguratorPersistence";
 import ConfiguratorStatusBar from "./ConfiguratorStatusBar";
 
-interface ConfiguratorContextValue {
+export interface ConfiguratorContextValue {
   state: WizardState;
   setState: React.Dispatch<React.SetStateAction<WizardState>>;
   update: <K extends keyof WizardState>(key: K, value: WizardState[K]) => void;
@@ -88,7 +88,7 @@ export function ConfiguratorProvider({
 }
 
 export function useConfigurator(): ConfiguratorContextValue {
-const ctx = useContext(ConfiguratorContext);
+  const ctx = useContext(ConfiguratorContext);
   if (!ctx)
     throw new Error("useConfigurator must be used within ConfiguratorProvider");
   return ctx;

--- a/apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
+++ b/apps/cms/src/app/cms/configurator/ConfiguratorStatusBar.tsx
@@ -3,14 +3,25 @@
 
 import { useConfigurator } from "./ConfiguratorContext";
 import { useGuidedTour } from "./GuidedTour";
+import { Loader, Tag } from "@ui";
+import { CheckIcon } from "@radix-ui/react-icons";
 
 export default function ConfiguratorStatusBar(): React.JSX.Element {
-  const { saving } = useConfigurator();
+  const { saving, dirty } = useConfigurator();
   const { replay } = useGuidedTour();
+
+  let status: React.ReactNode = null;
+  if (saving) {
+    status = <Loader size={16} />;
+  } else if (dirty) {
+    status = <Tag variant="warning">Unsaved changes</Tag>;
+  } else {
+    status = <CheckIcon className="h-4 w-4 text-success" />;
+  }
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between bg-muted py-2 px-4 text-sm">
-      <span>{saving ? "Saving…" : null}</span>
+      <span className="flex items-center gap-2">{status}</span>
       <button type="button" onClick={replay} className="underline">
         Replay tour
       </button>


### PR DESCRIPTION
## Summary
- expose configurator dirty tracking and reset utilities
- show save spinner, success checkmark and unsaved badge in status bar

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '@acme/config/env/core.ts')*
- `pnpm --filter @apps/cms test` *(fails: TestingLibraryElementError: Unable to find element and process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689dc49f2258832f9b350ee12904a62f