### PR TITLE
Enable editorial blog and schedule publish worker

### DIFF
--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -23,7 +23,7 @@
     "dataset": "production",
     "token": "token"
   },
-  "editorialBlog": { "enabled": false },
+  "editorialBlog": { "enabled": true },
   "luxuryFeatures": {
     "contentMerchandising": false,
     "raTicketing": false,

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -20,7 +20,7 @@
     "dataset": "production",
     "token": "token"
   },
-  "editorialBlog": { "enabled": false },
+  "editorialBlog": { "enabled": true },
   "luxuryFeatures": {
     "contentMerchandising": false,
     "raTicketing": false,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,9 @@ name = "base-shop"
 pages_build_output_dir = ".vercel/output/static"
 compatibility_date    = "2025-06-20"
 
+[triggers]
+crons = ["0 0 * * *"]
+
 [[kv_namespaces]]
   binding = "CART_KV"
 id      = "TODO-replace-with-namespace-id"


### PR DESCRIPTION
## Summary
- enable editorial blog for shop configs
- add cron trigger to run publishEditorial worker daily

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689dc493e414832fb8dd0270e9055056