### PR TITLE
Enable reverse logistics service and helper

### DIFF
--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -8,8 +8,8 @@
     "intervalMinutes": 60
   },
   "reverseLogisticsService": {
-    "enabled": false,
-    "intervalMinutes": 60
+    "enabled": true,
+    "intervalMinutes": 30
   },
   "returnService": { "upsEnabled": false },
   "premierDelivery": {

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -8,8 +8,8 @@
     "intervalMinutes": 60
   },
   "reverseLogisticsService": {
-    "enabled": false,
-    "intervalMinutes": 60
+    "enabled": true,
+    "intervalMinutes": 30
   },
   "returnService": { "upsEnabled": false },
   "premierDelivery": {

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -8,8 +8,8 @@
     "intervalMinutes": 60
   },
   "reverseLogisticsService": {
-    "enabled": false,
-    "intervalMinutes": 60
+    "enabled": true,
+    "intervalMinutes": 30
   },
   "returnService": { "upsEnabled": false },
   "seo": {

--- a/data/shops/r1/settings.json
+++ b/data/shops/r1/settings.json
@@ -1,0 +1,3 @@
+{
+  "reverseLogisticsService": { "enabled": true, "intervalMinutes": 30 }
+}

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -7,8 +7,8 @@
     "intervalMinutes": 60
   },
   "reverseLogisticsService": {
-    "enabled": false,
-    "intervalMinutes": 60
+    "enabled": true,
+    "intervalMinutes": 30
   },
   "returnService": { "upsEnabled": false },
   "languages": [

--- a/packages/platform-machine/src/reverseLogisticsService.ts
+++ b/packages/platform-machine/src/reverseLogisticsService.ts
@@ -10,14 +10,27 @@ import {
 import { recordEvent } from "@platform-core/repositories/reverseLogisticsEvents.server";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { logger } from "@platform-core/utils";
-import { readdir, readFile, unlink } from "node:fs/promises";
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 
 const DATA_ROOT = resolveDataRoot();
 
 interface ReverseLogisticsEvent {
   sessionId: string;
   status: NonNullable<RentalOrder["status"]>;
+}
+
+export async function writeReverseLogisticsEvent(
+  shop: string,
+  sessionId: string,
+  status: ReverseLogisticsEvent["status"],
+  dataRoot: string = DATA_ROOT,
+): Promise<void> {
+  const dir = join(dataRoot, shop, "reverse-logistics");
+  await mkdir(dir, { recursive: true });
+  const file = join(dir, `${randomUUID()}.json`);
+  await writeFile(file, JSON.stringify({ sessionId, status }));
 }
 
 export async function processReverseLogisticsEventsOnce(
@@ -159,4 +172,10 @@ export async function startReverseLogisticsService(
   );
 
   return () => timers.forEach((t) => clearInterval(t));
+}
+
+if (process.env.NODE_ENV !== "test") {
+  startReverseLogisticsService().catch((err) =>
+    logger.error("failed to start reverse logistics service", { err }),
+  );
 }


### PR DESCRIPTION
## Summary
- enable reverse logistics service for sample shops
- add helper to queue reverse logistics events and auto-start service

## Testing
- `pnpm exec jest --config jest.config.cjs --runTestsByPath packages/platform-machine/__tests__/fsm.test.ts`
- `pnpm exec jest --config jest.config.cjs --runTestsByPath packages/platform-core/src/repositories/__tests__/pricing.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689de6b80d64832f98493e73acacb0e1