### PR TITLE
Add late fee service with configuration

### DIFF
--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -11,6 +11,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "premierDelivery": {
     "regions": ["us-east"],

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -11,6 +11,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "premierDelivery": {
     "regions": ["us-west"],

--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -11,6 +11,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "seo": {
     "aiCatalog": {

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -10,6 +10,10 @@
     "enabled": false,
     "intervalMinutes": 60
   },
+  "lateFeeService": {
+    "enabled": true,
+    "intervalMinutes": 60
+  },
   "returnService": { "upsEnabled": false },
   "languages": [
     "en",

--- a/packages/platform-machine/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/__tests__/lateFeeService.test.ts
@@ -1,0 +1,107 @@
+// packages/platform-machine/__tests__/lateFeeService.test.ts
+import type { RentalOrder } from "@acme/types";
+
+describe("chargeLateFeesOnce", () => {
+  const OLD_ENV = process.env;
+  const OLD_NOW = Date.now;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+    } as NodeJS.ProcessEnv;
+    Date.now = jest.fn(() => new Date("2024-01-10T00:00:00Z").getTime());
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    Date.now = OLD_NOW;
+  });
+
+  it("charges overdue orders and marks them", async () => {
+    const stripeModule = await import("@acme/stripe");
+    const stripeRetrieve = jest.fn().mockResolvedValue({
+      customer: "cus_1",
+      payment_intent: { payment_method: "pm_1" },
+      currency: "usd",
+    });
+    const stripeCharge = jest.fn().mockResolvedValue({});
+    stripeModule.stripe.checkout.sessions.retrieve = stripeRetrieve as any;
+    stripeModule.stripe.paymentIntents.create = stripeCharge as any;
+
+    const orders: RentalOrder[] = [
+      {
+        id: "1",
+        sessionId: "sess1",
+        shop: "test",
+        returnDueDate: "2024-01-01",
+      },
+      {
+        id: "2",
+        sessionId: "sess2",
+        shop: "test",
+        returnDueDate: "2024-01-05",
+        returnReceivedAt: "2024-01-06",
+      },
+      {
+        id: "3",
+        sessionId: "sess3",
+        shop: "test",
+        returnDueDate: "2024-01-09",
+      },
+      {
+        id: "4",
+        sessionId: "sess4",
+        shop: "test",
+        returnDueDate: "2024-01-01",
+        lateFeeCharged: 25,
+      },
+    ];
+
+    const readOrders = jest.fn().mockResolvedValue(orders);
+    const markLateFeeCharged = jest.fn().mockResolvedValue(null);
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      readOrders,
+      markLateFeeCharged,
+    }));
+
+    const readFile = jest.fn().mockImplementation(async (path: string) => {
+      if (path.endsWith("shop.json")) {
+        return JSON.stringify({
+          lateFeePolicy: { gracePeriodDays: 3, feeAmount: 25 },
+        });
+      }
+      throw new Error("not found");
+    });
+    const readdir = jest.fn().mockResolvedValue(["test"]);
+    jest.doMock("node:fs/promises", () => ({
+      __esModule: true,
+      readFile,
+      readdir,
+    }));
+
+    const { chargeLateFeesOnce } = await import("../src/lateFeeService");
+    await chargeLateFeesOnce();
+
+    expect(stripeRetrieve).toHaveBeenCalledTimes(1);
+    expect(stripeRetrieve).toHaveBeenCalledWith("sess1", {
+      expand: ["payment_intent", "customer"],
+    });
+
+    expect(stripeCharge).toHaveBeenCalledTimes(1);
+    expect(stripeCharge).toHaveBeenCalledWith({
+      amount: 25 * 100,
+      currency: "usd",
+      customer: "cus_1",
+      payment_method: "pm_1",
+      off_session: true,
+      confirm: true,
+    });
+
+    expect(markLateFeeCharged).toHaveBeenCalledTimes(1);
+    expect(markLateFeeCharged).toHaveBeenCalledWith("test", "sess1", 25);
+  });
+});

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -156,3 +156,9 @@ export async function startLateFeeService(
 
   return () => timers.forEach((t) => clearInterval(t));
 }
+
+if (process.env.NODE_ENV !== "test") {
+  startLateFeeService().catch((err) =>
+    logger.error("failed to start late fee service", { err }),
+  );
+}


### PR DESCRIPTION
## Summary
- configure late fee service for each shop
- start late fee processor in platform machine
- test late fee charging and configuration

## Testing
- `pnpm --filter @acme/platform-machine test -- --runTestsByPath packages/platform-machine/__tests__/lateFeeService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689de773ffc8832fafb683d5cf118ed8