### PR TITLE
feat: expose return label details

### DIFF
--- a/data/return-logistics.json
+++ b/data/return-logistics.json
@@ -1,5 +1,5 @@
 {
-  "labelService": "MockLabelCo",
+  "labelService": "UPS",
   "inStore": true,
   "dropOffProvider": "UPS",
   "tracking": true,

--- a/packages/platform-core/src/returnLogistics.ts
+++ b/packages/platform-core/src/returnLogistics.ts
@@ -13,3 +13,13 @@ export async function getReturnLogistics(): Promise<ReturnLogistics> {
   cached = returnLogisticsSchema.parse(JSON.parse(buf));
   return cached;
 }
+
+export type ReturnBagAndLabel = Pick<
+  ReturnLogistics,
+  "bagType" | "labelService" | "tracking"
+>;
+
+export async function getReturnBagAndLabel(): Promise<ReturnBagAndLabel> {
+  const { bagType, labelService, tracking } = await getReturnLogistics();
+  return { bagType, labelService, tracking };
+}


### PR DESCRIPTION
## Summary
- update return logistics defaults to use UPS reusable bags with tracking
- expose bag and label info via platform-core helper
- show bag reuse instructions and print label link when tracking enabled

## Testing
- `pnpm exec jest packages/platform-core/__tests__/returnLogistics.test.ts --runInBand --detectOpenHandles`

------
https://chatgpt.com/codex/tasks/task_e_689de74b7a30832faf730bdf1512efe2