### PR TITLE
Clarify rental shop schema

### DIFF
--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -5,6 +5,7 @@
   "themeId": "base",
   "themeOverrides": {},
   "filterMappings": {},
+  "type": "rental",
   "showCleaningTransparency": true,
   "shippingProviders": [
     "ups",
@@ -61,6 +62,7 @@
       "prorateOnChange": true
     }
   ],
+  "subscriptionsEnabled": true,
   "lateFeePolicy": {
     "gracePeriodDays": 3,
     "feeAmount": 25

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -5,6 +5,7 @@
   "themeId": "base",
   "themeOverrides": {},
   "filterMappings": {},
+  "type": "rental",
   "showCleaningTransparency": true,
   "shippingProviders": [
     "dhl"
@@ -52,6 +53,7 @@
       "prorateOnChange": true
     }
   ],
+  "subscriptionsEnabled": true,
   "lateFeePolicy": {
     "gracePeriodDays": 3,
     "feeAmount": 25

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -75,6 +75,11 @@ export const shopSchema = z
       .default({}),
     /** Optional redirect overrides for locale detection */
     localeOverrides: z.record(z.string(), localeSchema).default({}),
+    /**
+     * Shop business model.
+     * "sale" indicates a traditional commerce shop while "rental" enables
+     * rental-specific features.
+     */
     type: z.string().optional(),
     paymentProviders: z.array(z.string()).optional(),
     shippingProviders: z.array(z.string()).optional(),
@@ -100,6 +105,7 @@ export const shopSchema = z
     returnsEnabled: z.boolean().optional(),
     analyticsEnabled: z.boolean().optional(),
     coverageIncluded: z.boolean().default(true),
+    showCleaningTransparency: z.boolean().optional(),
     rentalInventoryAllocation: z.boolean().optional(),
     luxuryFeatures: z
       .object({
@@ -122,7 +128,7 @@ export const shopSchema = z
     rentalSubscriptions: z
       .array(subscriptionPlanSchema)
       .default([]),
-    subscriptionsEnabled: z.boolean().default(false),
+    subscriptionsEnabled: z.boolean().optional(),
     lateFeePolicy: z
       .object({
         gracePeriodDays: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- document shop type as "sale" vs "rental"
- add optional showCleaningTransparency and subscriptionsEnabled fields
- mark sample rental shops with type and subscriptionsEnabled

## Testing
- `pnpm lint --filter @acme/types`
- `pnpm test --filter @acme/types`


------
https://chatgpt.com/codex/tasks/task_e_689de8e878c8832fa36f1fb0f8c5c1a6