### PR TITLE
feat: validate inventory item parsing

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -3,7 +3,10 @@ import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { inventoryItemSchema } from "@acme/types";
 import { inventoryRepository } from "@platform-core/repositories/inventory.server";
-import { expandInventoryItem } from "@platform-core/utils/inventory";
+import {
+  expandInventoryItem,
+  type RawInventoryItem,
+} from "@platform-core/utils/inventory";
 import { parse } from "fast-csv";
 import { Readable } from "node:stream";
 
@@ -26,8 +29,8 @@ export async function POST(
     if (file.type === "application/json" || file.name.endsWith(".json")) {
       const data = JSON.parse(text);
       raw = Array.isArray(data)
-        ? data.map((row: Record<string, unknown>) => expandInventoryItem(row))
-        : expandInventoryItem(data as Record<string, unknown>);
+        ? data.map((row: RawInventoryItem) => expandInventoryItem(row))
+        : expandInventoryItem(data as RawInventoryItem);
     } else {
       raw = await new Promise((resolve, reject) => {
         const rows: unknown[] = [];
@@ -35,7 +38,7 @@ export async function POST(
           .pipe(parse({ headers: true, ignoreEmpty: true }))
           .on("error", reject)
           .on("data", (row) => {
-            rows.push(expandInventoryItem(row as Record<string, unknown>));
+            rows.push(expandInventoryItem(row as RawInventoryItem));
           })
           .on("end", () => resolve(rows));
       });

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/useInventoryValidation.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/useInventoryValidation.ts
@@ -6,15 +6,19 @@ import { expandInventoryItem } from "@platform-core/utils/inventory";
  * @returns parsed items on success or an error message on failure.
  */
 export function validateInventoryItems(items: InventoryItem[]) {
-  const normalized = items.map((i) => expandInventoryItem(i));
-  const parsed = inventoryItemSchema.array().safeParse(normalized);
-  if (!parsed.success) {
-    return {
-      success: false as const,
-      error: parsed.error.issues.map((i) => i.message).join(", "),
-    };
+  try {
+    const normalized = items.map((i) => expandInventoryItem(i));
+    const parsed = inventoryItemSchema.array().safeParse(normalized);
+    if (!parsed.success) {
+      return {
+        success: false as const,
+        error: parsed.error.issues.map((i) => i.message).join(", "),
+      };
+    }
+    return { success: true as const, data: parsed.data };
+  } catch (err) {
+    return { success: false as const, error: (err as Error).message };
   }
-  return { success: true as const, data: parsed.data };
 }
 
 /**

--- a/packages/platform-core/src/utils/__tests__/inventory.test.ts
+++ b/packages/platform-core/src/utils/__tests__/inventory.test.ts
@@ -1,4 +1,8 @@
-import { flattenInventoryItem, expandInventoryItem } from "../inventory";
+import {
+  flattenInventoryItem,
+  expandInventoryItem,
+  type RawInventoryItem,
+} from "../inventory";
 import { InventoryItem } from "@acme/types";
 
 describe("inventory utils", () => {
@@ -17,13 +21,13 @@ describe("inventory utils", () => {
   });
 
   it("expands and flattens round trip", () => {
-    const flat = {
+    const flat: RawInventoryItem = {
       sku: "sku1",
       productId: "prod1",
       "variant.color": "red",
       quantity: "5",
       lowStockThreshold: "2",
-    } as Record<string, unknown>;
+    };
     const expanded = expandInventoryItem(flat);
     const flattened = flattenInventoryItem(expanded);
     expect(flattened).toEqual({

--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -3,4 +3,8 @@ export { replaceShopInPath } from "./replaceShopInPath";
 export { initTheme } from "./initTheme";
 export { logger } from "./logger";
 export type { LogMeta } from "./logger";
-export { flattenInventoryItem, expandInventoryItem } from "./inventory";
+export {
+  flattenInventoryItem,
+  expandInventoryItem,
+} from "./inventory";
+export type { RawInventoryItem, FlattenedInventoryItem } from "./inventory";


### PR DESCRIPTION
## Summary
- add RawInventoryItem interface with type guard
- parse inventory entries using @acme/types schema
- handle expandInventoryItem errors in inventory validation and import route

## Testing
- `pnpm --filter @acme/platform-core run test packages/platform-core/src/utils/__tests__/inventory.test.ts`
- `pnpm --filter @apps/cms run test 'src/app/cms/shop/\\[shop\\]/data/inventory/__tests__/inventoryValidation.test.ts'`


------
https://chatgpt.com/codex/tasks/task_e_689de961439c832fbee7c2b074f9a297