### PR TITLE
feat(core): add typed plugin payload contexts

### DIFF
--- a/packages/plugins/paypal/index.ts
+++ b/packages/plugins/paypal/index.ts
@@ -1,5 +1,9 @@
 // packages/plugins/paypal/index.ts
-import type { Plugin, PaymentRegistry } from "@acme/platform-core/plugins";
+import type {
+  PaymentPayload,
+  Plugin,
+  PaymentRegistry,
+} from "@acme/platform-core/plugins";
 import { z } from "zod";
 
 const configSchema = z
@@ -11,7 +15,7 @@ const configSchema = z
 
 type PayPalConfig = z.infer<typeof configSchema>;
 
-const paypalPlugin: Plugin<any, any, any, PayPalConfig> = {
+const paypalPlugin: Plugin<any, any, any, any, any, any, PayPalConfig> = {
   id: "paypal",
   name: "PayPal",
   description: "Example PayPal payment provider",
@@ -19,7 +23,7 @@ const paypalPlugin: Plugin<any, any, any, PayPalConfig> = {
   configSchema,
   registerPayments(registry: PaymentRegistry, _cfg: PayPalConfig) {
     registry.add("paypal", {
-      async processPayment() {
+      async processPayment(_payload: PaymentPayload) {
         // placeholder implementation
         return { success: true };
       },

--- a/packages/plugins/premier-shipping/index.ts
+++ b/packages/plugins/premier-shipping/index.ts
@@ -2,7 +2,11 @@
 //
 // Shops that do not offer luxury models can omit this plugin by removing
 // "premier-shipping" from their `shippingProviders` configuration.
-import type { Plugin, ShippingRegistry } from "@acme/platform-core/plugins";
+import type {
+  Plugin,
+  ShippingRegistry,
+  ShippingRequest,
+} from "@acme/platform-core/plugins";
 
 interface PremierPickupState {
   region?: string;
@@ -10,14 +14,14 @@ interface PremierPickupState {
   window?: string;
 }
 interface PremierShippingProvider {
-  calculateShipping(): unknown;
+  calculateShipping(request: ShippingRequest): unknown;
   schedulePickup(region: string, date: string, hourWindow: string): void;
 }
 
 class PremierShipping implements PremierShippingProvider {
   private state: PremierPickupState = {};
 
-  calculateShipping() {
+  calculateShipping(_request: ShippingRequest) {
     // placeholder implementation
     return { rate: 0 };
   }
@@ -29,7 +33,7 @@ class PremierShipping implements PremierShippingProvider {
 
 const provider = new PremierShipping();
 
-const premierShippingPlugin: Plugin<any, PremierShippingProvider> = {
+const premierShippingPlugin: Plugin<any, ShippingRequest, any, any, PremierShippingProvider> = {
   id: "premier-shipping",
   name: "Premier Shipping",
   registerShipping(registry: ShippingRegistry<PremierShippingProvider>) {

--- a/packages/plugins/sanity/index.ts
+++ b/packages/plugins/sanity/index.ts
@@ -73,7 +73,7 @@ export async function slugExists(
   return Boolean(res?._id);
 }
 
-const sanityPlugin: Plugin<any, any, any, SanityConfig> = {
+const sanityPlugin: Plugin<any, any, any, any, any, any, SanityConfig> = {
   id: "sanity",
   name: "Sanity",
   description: "Sanity CMS integration",


### PR DESCRIPTION
## Summary
- add PaymentPayload, ShippingRequest and WidgetProps base types
- type PaymentProvider and ShippingProvider payloads and update registries
- wire plugin implementations to new generics

## Testing
- `pnpm test --filter @acme/platform-core` *(fails: ELIFECYCLE Test failed)*
- `pnpm test --filter @acme/plugin-paypal`


------
https://chatgpt.com/codex/tasks/task_e_689de95f5a10832f9a34392f61ff8a0b