### PR TITLE
refactor: handle unknown errors

### DIFF
--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -49,16 +49,27 @@ export class ResendProvider implements CampaignProvider {
         html: options.html,
         text: options.text,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error("Campaign email send failed", {
+          provider: "resend",
+          recipient: options.to,
+          campaignId: options.campaignId,
+          error,
+        });
+        const status =
+          (error as any)?.code ??
+          (error as any)?.response?.statusCode ??
+          (error as any)?.statusCode;
+        const retryable = typeof status !== "number" || status >= 500;
+        throw new ProviderError(error.message, retryable);
+      }
       console.error("Campaign email send failed", {
         provider: "resend",
         recipient: options.to,
         campaignId: options.campaignId,
-        error,
       });
-      const status = error?.code ?? error?.response?.statusCode ?? error?.statusCode;
-      const retryable = typeof status !== "number" || status >= 500;
-      throw new ProviderError(error.message, retryable);
+      throw new ProviderError("Unknown error", true);
     }
   }
 

--- a/packages/shared-utils/src/parseJsonBody.ts
+++ b/packages/shared-utils/src/parseJsonBody.ts
@@ -20,8 +20,11 @@ export async function parseJsonBody<T>(
       limit,
       encoding: "utf8",
     });
-  } catch (err: any) {
-    if (err?.type === "entity.too.large") {
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err as { type?: string }).type === "entity.too.large"
+    ) {
       return {
         success: false,
         response: NextResponse.json(
@@ -30,6 +33,7 @@ export async function parseJsonBody<T>(
         ),
       };
     }
+    console.error(err instanceof Error ? err : "Unknown error");
     return {
       success: false,
       response: NextResponse.json(

--- a/packages/template-app/src/api/subscribe/route.ts
+++ b/packages/template-app/src/api/subscribe/route.ts
@@ -52,7 +52,11 @@ export async function POST(req: NextRequest) {
     });
     await setStripeSubscriptionId(userId, sub.id);
     return NextResponse.json({ id: sub.id, status: sub.status });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+    }
+    console.error("An unknown error occurred");
+    return NextResponse.json({ error: "Unknown error" }, { status: 500 });
   }
 }

--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -41,7 +41,11 @@ export async function POST(req: NextRequest) {
     });
     await setStripeSubscriptionId(userId, sub.id);
     return NextResponse.json({ id: sub.id, status: sub.status });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+    }
+    console.error("An unknown error occurred");
+    return NextResponse.json({ error: "Unknown error" }, { status: 500 });
   }
 }

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -55,9 +55,14 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
         );
         setClientSecret(clientSecret);
         setFetchError(false);
-      } catch (err: any) {
-        if (err?.name !== "AbortError") {
-          console.error(err);
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          if (err.name !== "AbortError") {
+            console.error(err);
+            setFetchError(true);
+          }
+        } else {
+          console.error("An unknown error occurred");
           setFetchError(true);
         }
       }


### PR DESCRIPTION
## Summary
- type catch blocks as unknown instead of any
- guard error handling with `instanceof Error`

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*
- `pnpm lint` *(fails: @apps/cms#lint)*

------
https://chatgpt.com/codex/tasks/task_e_689de9623b38832faabce2a4bc88ba23