### PR TITLE
feat: support optional damage coverage for rentals

### DIFF
--- a/data/rental/pricing.json
+++ b/data/rental/pricing.json
@@ -7,10 +7,12 @@
   "damageFees": {
     "scuff": 20,
     "tear": 50,
-    "lost": "deposit"
+    "lost": "deposit",
+    "scratch": 15
   },
   "coverage": {
     "scuff": { "fee": 5, "waiver": 20 },
-    "tear": { "fee": 10, "waiver": 50 }
+    "tear": { "fee": 10, "waiver": 50 },
+    "scratch": { "fee": 4, "waiver": 15 }
   }
 }

--- a/packages/platform-core/__tests__/pricing.test.ts
+++ b/packages/platform-core/__tests__/pricing.test.ts
@@ -88,5 +88,17 @@ describe('pricing utilities', () => {
     expect(readFile).toHaveBeenCalledTimes(1);
     expect(readFile.mock.calls[0][0]).toContain('pricing.json');
   });
+
+  it('waives fee when coverage purchased or included', async () => {
+    const { computeDamageFee } = await setup({
+      baseDailyRate: 0,
+      durationDiscounts: [],
+      damageFees: { scuff: 20 },
+      coverage: { scuff: { fee: 5, waiver: 20 } },
+    });
+
+    await expect(computeDamageFee('scuff', 50, ['scuff'])).resolves.toBe(0);
+    await expect(computeDamageFee('scuff', 50, [], true)).resolves.toBe(0);
+  });
 });
 

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -60,6 +60,7 @@ export async function computeDamageFee(
   kind: string | number | undefined,
   deposit: number,
   coverageCodes: string[] = [],
+  coverageIncluded = false,
 ): Promise<number> {
   if (kind == null) return 0;
   const pricing = await getPricing();
@@ -73,10 +74,9 @@ export async function computeDamageFee(
     fee = rule;
   }
 
-  if (coverageCodes.length && pricing.coverage) {
-    const coverage = coverageCodes.includes(kind)
-      ? pricing.coverage[kind]
-      : undefined;
+  if (pricing.coverage) {
+    const covered = coverageIncluded || coverageCodes.includes(kind);
+    const coverage = covered ? pricing.coverage[kind] : undefined;
     if (coverage && typeof rule === "number") {
       fee = Math.max(0, fee - coverage.waiver);
     }

--- a/packages/template-app/__tests__/return.test.ts
+++ b/packages/template-app/__tests__/return.test.ts
@@ -28,6 +28,11 @@ describe("/api/return", () => {
     const refundCreate = jest.fn();
     const computeDamageFee = jest.fn(async () => 20);
 
+    jest.doMock("@platform-core/src/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn(async () => ({ coverageIncluded: true })),
+    }));
+
     jest.doMock(
       "@acme/stripe",
       () => ({
@@ -55,7 +60,7 @@ describe("/api/return", () => {
     const res = await POST({
       json: async () => ({ sessionId: "sess", damage: "scratch" }),
     } as unknown as NextRequest);
-    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50);
+    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50, [], true);
     expect(refundCreate).toHaveBeenCalledWith({
       payment_intent: "pi_1",
       amount: 30 * 100,
@@ -90,6 +95,10 @@ describe("/api/return", () => {
     }));
     jest.doMock("@platform-core/pricing", () => ({
       computeDamageFee: jest.fn(),
+    }));
+    jest.doMock("@platform-core/src/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn(async () => ({ coverageIncluded: true })),
     }));
 
     const { POST } = await import("../src/api/return/route");

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -1,5 +1,4 @@
 // packages/template-app/src/app/[lang]/checkout/page.tsx
-import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import {
@@ -12,6 +11,8 @@ import { getCart } from "@platform-core/src/cartStore";
 import { getProductById } from "@platform-core/src/products";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
+import { useState } from "react";
+import CheckoutForm from "@/components/checkout/CheckoutForm";
 
 export const metadata = {
   title: "Checkout · Base-Shop",
@@ -65,7 +66,35 @@ export default async function CheckoutPage({
         cart={validatedCart}
         totals={{ subtotal, deposit, total }}
       />
-      <CheckoutForm locale={lang} taxRegion={settings.taxRegion} />
+      <CheckoutWithCoverage locale={lang} taxRegion={settings.taxRegion} />
+    </div>
+  );
+}
+
+function CheckoutWithCoverage({
+  locale,
+  taxRegion,
+}: {
+  locale: Locale;
+  taxRegion: string;
+}) {
+  "use client";
+  const [selected, setSelected] = useState(false);
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={(e) => setSelected(e.target.checked)}
+        />
+        Add damage coverage
+      </label>
+      <CheckoutForm
+        locale={locale}
+        taxRegion={taxRegion}
+        coverage={selected ? ["scuff", "tear", "scratch"] : []}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -21,11 +21,15 @@ const stripePromise = loadStripe(
   paymentEnv.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 );
 
-type Props = { locale: "en" | "de" | "it"; taxRegion: string };
+type Props = {
+  locale: "en" | "de" | "it";
+  taxRegion: string;
+  coverage?: string[];
+};
 
 type FormValues = { returnDate: string };
 
-export default function CheckoutForm({ locale, taxRegion }: Props) {
+export default function CheckoutForm({ locale, taxRegion, coverage = [] }: Props) {
   const [clientSecret, setClientSecret] = useState<string>();
   const [fetchError, setFetchError] = useState(false);
   const [retry, setRetry] = useState(0);
@@ -38,6 +42,7 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
     defaultValues: { returnDate: defaultDate },
   });
   const returnDate = form.watch("returnDate");
+  const coverageCodes = coverage;
 
   /* --- create session on mount or when returnDate changes --- */
   useEffect(() => {
@@ -49,7 +54,12 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ returnDate, currency, taxRegion }),
+            body: JSON.stringify({
+              returnDate,
+              currency,
+              taxRegion,
+              coverage: coverageCodes,
+            }),
             signal: controller.signal,
           }
         );
@@ -67,7 +77,7 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
       controller.abort();
       clearTimeout(timeout);
     };
-  }, [returnDate, currency, taxRegion, retry]);
+  }, [returnDate, currency, taxRegion, coverageCodes, retry]);
 
   if (!clientSecret) {
     if (fetchError)


### PR DESCRIPTION
## Summary
- add coverage fee/waiver entries to rental pricing
- allow checkout to purchase coverage and send codes to session metadata
- waive damage fees when coverage is selected or included by shop

## Testing
- `pnpm exec jest --runTestsByPath packages/platform-core/__tests__/pricing.test.ts packages/template-app/__tests__/rental.test.ts packages/template-app/__tests__/return.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689de5680b7c832fb6b6ca54e946882b