### PR TITLE
feat: type upgrade shop script

### DIFF
--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -1,0 +1,18 @@
+export interface ShopMetadata {
+  /** ISO timestamp of last upgrade */
+  lastUpgrade?: string;
+  /** Map of component package versions at upgrade time */
+  componentVersions?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface PageComponent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface PageRecord {
+  id: string;
+  components?: PageComponent[];
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary
- add ShopMetadata and PageRecord interfaces for script typing
- use typed properties when updating shop and page metadata

## Testing
- `pnpm test` *(fails: @apps/cms#test)*
- `pnpm lint` *(fails: @apps/cms#lint)*

------
https://chatgpt.com/codex/tasks/task_e_689de963b418832faac98e2403429477