### PR TITLE
refactor: use formatTimestamp for consistent date formatting

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { formatTimestamp } from "@acme/date-utils";
+import { getPost, updatePost } from "@cms/actions/blog.server";
+import { getSanityConfig } from "@platform-core/src/shops";
+import { getShopById } from "@platform-core/src/repositories/shop.server";
 import PostForm from "../PostForm.client";
 import PublishButton from "../PublishButton.client";
 import UnpublishButton from "../UnpublishButton.client";
 import DeleteButton from "../DeleteButton.client";
-import { getPost, updatePost } from "@cms/actions/blog.server";
-import { getSanityConfig } from "@platform-core/src/shops";
-import { getShopById } from "@platform-core/src/repositories/shop.server";
 
 interface Params {
   params: { id: string };
@@ -40,11 +41,9 @@ export default async function EditPostPage({
   if (!post) return notFound();
   const status = post.published
     ? post.publishedAt && new Date(post.publishedAt) > new Date()
-      ? `Scheduled for ${new Date(post.publishedAt).toLocaleString()}`
+      ? `Scheduled for ${formatTimestamp(post.publishedAt)}`
       : `Published${
-          post.publishedAt
-            ? ` on ${new Date(post.publishedAt).toLocaleString()}`
-            : ""
+          post.publishedAt ? ` on ${formatTimestamp(post.publishedAt)}` : ""
         }`
     : "Draft";
   return (

--- a/apps/cms/src/app/cms/blog/posts/page.tsx
+++ b/apps/cms/src/app/cms/blog/posts/page.tsx
@@ -1,6 +1,7 @@
 // apps/cms/src/app/cms/blog/posts/page.tsx
 
 import Link from "next/link";
+import { formatTimestamp } from "@acme/date-utils";
 import { Button } from "@ui";
 import { getPosts } from "@cms/actions/blog.server";
 import { getSanityConfig } from "@platform-core/src/shops";
@@ -41,7 +42,7 @@ export default async function BlogPostsPage({
         {posts.map((post) => {
           const status =
             post.publishedAt && new Date(post.publishedAt) > new Date()
-              ? `scheduled for ${new Date(post.publishedAt).toLocaleString()}`
+              ? `scheduled for ${formatTimestamp(post.publishedAt)}`
               : post.published
                 ? "published"
                 : "draft";

--- a/apps/cms/src/app/cms/marketing/email/page.tsx
+++ b/apps/cms/src/app/cms/marketing/email/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { formatTimestamp } from "@acme/date-utils";
 import { marketingEmailTemplates } from "@acme/ui";
 
 interface Campaign {
@@ -166,7 +167,7 @@ export default function EmailMarketingPage() {
                 <td className="border px-2 py-1">{c.subject}</td>
                 <td className="border px-2 py-1">{c.recipients.join(", ")}</td>
                 <td className="border px-2 py-1 text-center">
-                  {new Date(c.sendAt).toLocaleString()}
+                  {formatTimestamp(c.sendAt)}
                 </td>
                 <td className="border px-2 py-1 text-center">
                   {c.sentAt

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogSettings.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useState, type FormEvent } from "react";
 import { Button, Checkbox, Input } from "@/components/atoms/shadcn";
 import { updateAiCatalog } from "@cms/actions/shops.server";
+import { formatTimestamp } from "@acme/date-utils";
 import type { AiCatalogField } from "@acme/types";
-import { useState, type FormEvent } from "react";
 
 const ALL_FIELDS: AiCatalogField[] = [
   "id",
@@ -96,7 +97,7 @@ export default function AiCatalogSettings({ shop, initial }: Props) {
       </label>
       {state.lastCrawl && (
         <p className="text-sm text-gray-600">
-          Last crawl: {new Date(state.lastCrawl).toLocaleString()}
+          Last crawl: {formatTimestamp(state.lastCrawl)}
         </p>
       )}
       <Button className="bg-primary text-white" type="submit" disabled={saving}>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoAuditPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoAuditPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/atoms/shadcn";
+import { formatTimestamp } from "@acme/date-utils";
 
 interface AuditRecord {
   timestamp: string;
@@ -49,7 +50,7 @@ export default function SeoAuditPanel({ shop }: { shop: string }) {
       {running && <p className="mt-2 text-sm">Audit in progress…</p>}
       {last && (
         <div className="mt-4 text-sm">
-          <p>Last run: {new Date(last.timestamp).toLocaleString()}</p>
+          <p>Last run: {formatTimestamp(last.timestamp)}</p>
           <p>Score: {Math.round(last.score * 100)}</p>
           <p>Issues found: {last.issues}</p>
         </div>

--- a/packages/template-app/src/app/account/orders/[id]/timeline.tsx
+++ b/packages/template-app/src/app/account/orders/[id]/timeline.tsx
@@ -1,3 +1,4 @@
+import { formatTimestamp } from "@acme/date-utils";
 import { listEvents } from "@platform-core/repositories/reverseLogisticsEvents.server";
 import shop from "../../../../../shop.json";
 
@@ -29,7 +30,7 @@ export default async function OrderTimeline({
                 {STATUS_LABELS[evt.event] ?? evt.event}
               </span>
               <time dateTime={evt.createdAt} className="text-sm text-gray-500">
-                {new Date(evt.createdAt).toLocaleString()}
+                {formatTimestamp(evt.createdAt)}
               </time>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- replace `toLocaleString` with shared `formatTimestamp`
- add date utility imports across CMS and template app

## Testing
- `pnpm lint` *(fails: Cannot find module '@acme/config/env/core.ts')*
- `pnpm test` *(fails: Cannot find module '@acme/config/env/core.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689de9134504832fb615e760cb0f2594