### PR TITLE
feat: enhance mobile return scanning

### DIFF
--- a/packages/template-app/src/api/returns/mobile/route.ts
+++ b/packages/template-app/src/api/returns/mobile/route.ts
@@ -37,9 +37,15 @@ export async function POST(req: NextRequest) {
       { status: 403 }
     );
   }
-  const { sessionId } = (await req.json()) as { sessionId?: string };
+  const { sessionId, zip } = (await req.json()) as {
+    sessionId?: string;
+    zip?: string;
+  };
   if (!sessionId) {
     return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
+  }
+  if (zip && !cfg.homePickupZipCodes.includes(zip)) {
+    return NextResponse.json({ error: "ZIP not eligible" }, { status: 400 });
   }
   const order = await markReturned(SHOP_ID, sessionId);
   if (!order) {


### PR DESCRIPTION
## Summary
- show scanner UI when mobile returns enabled and support optional home pickup ZIP selection
- validate mobile return scans, generate UPS labels, and ensure ZIP eligibility

## Testing
- `pnpm test packages/template-app` *(fails: Could not find task `packages/template-app`)*

------
https://chatgpt.com/codex/tasks/task_e_689df310d644832fb8ce41d26a1d59b2