### PR TITLE
refactor: extract component preview to shared UI

### DIFF
--- a/packages/template-app/src/app/upgrade-preview/page.tsx
+++ b/packages/template-app/src/app/upgrade-preview/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import ComponentPreview from "@ui/src/components/ComponentPreview";
 
 interface UpgradeComponent {
   file: string;
@@ -69,9 +70,11 @@ export default function UpgradePreviewPage() {
 
   return (
     <div className="space-y-8">
-      <ul className="list-disc pl-4">
+      <ul className="space-y-4">
         {changes.map((c) => (
-          <li key={c.file}>{c.componentName}</li>
+          <li key={c.file}>
+            <ComponentPreview component={c} />
+          </li>
         ))}
       </ul>
       {links.length > 0 && (

--- a/packages/ui/src/components/ComponentPreview.tsx
+++ b/packages/ui/src/components/ComponentPreview.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import type { UpgradeComponent } from "@acme/types/upgrade";
+
+class PreviewErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("Component preview failed", error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded border p-4 text-red-500">
+          Failed to render preview
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export interface ComponentPreviewProps {
+  component: UpgradeComponent;
+  componentProps?: Record<string, any>;
+}
+
+export default function ComponentPreview({ component, componentProps = {} }: ComponentPreviewProps) {
+  const [NewComp, setNewComp] = useState<React.ComponentType | null>(null);
+  const [OldComp, setOldComp] = useState<React.ComponentType | null>(null);
+  const [showCompare, setShowCompare] = useState(false);
+
+  useEffect(() => {
+    const basePath = `@ui/components/${component.file.replace(/\.[jt]sx?$/, "")}`;
+    const load = async (p: string) => {
+      if (
+        typeof globalThis !== "undefined" &&
+        (globalThis as any).__UPGRADE_MOCKS__?.[p]
+      ) {
+        return (globalThis as any).__UPGRADE_MOCKS__[p];
+      }
+      return import(p);
+    };
+
+    load(basePath)
+      .then((m) => setNewComp(() => (m[component.componentName] ?? m.default)))
+      .catch((err) =>
+        console.error("Failed to load component", component.componentName, err)
+      );
+    load(`${basePath}.bak`)
+      .then((m) => setOldComp(() => (m[component.componentName] ?? m.default)))
+      .catch(() => {});
+  }, [component]);
+
+  return (
+    <div className="space-y-2 rounded border p-4">
+      <div className="flex items-center justify-between">
+        <h3>{component.componentName}</h3>
+        {OldComp && (
+          <button
+            type="button"
+            className="rounded border px-2 py-1"
+            onClick={() => setShowCompare((s) => !s)}
+          >
+            {showCompare ? "Hide comparison" : "Compare"}
+          </button>
+        )}
+      </div>
+      <PreviewErrorBoundary>
+        {showCompare && OldComp ? (
+          <div className="grid grid-cols-2 gap-4">
+            <div>{NewComp ? <NewComp {...componentProps} /> : null}</div>
+            <div>{OldComp ? <OldComp {...componentProps} /> : null}</div>
+          </div>
+        ) : NewComp ? (
+          <NewComp {...componentProps} />
+        ) : null}
+      </PreviewErrorBoundary>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -6,4 +6,5 @@ export * from "./organisms";
 export * from "./templates";
 export { default as DynamicRenderer } from "./DynamicRenderer";
 export { default as ThemeToggle } from "./ThemeToggle";
+export { default as ComponentPreview } from "./ComponentPreview";
 export * from "./overlays";


### PR DESCRIPTION
## Summary
- move upgrade preview ComponentPreview into @acme/ui for reuse
- render shared ComponentPreview in shop and template upgrade pages
- export ComponentPreview from ui components index

## Testing
- `npx eslint packages/ui/src/components/ComponentPreview.tsx apps/shop-abc/src/app/upgrade-preview/page.tsx packages/template-app/src/app/upgrade-preview/page.tsx`
- `npx jest apps/shop-abc/__tests__/upgradePreview.test.tsx -c apps/shop-abc/jest.config.cjs`
- `pnpm --filter @acme/ui test -- ComponentPreview`


------
https://chatgpt.com/codex/tasks/task_e_689df2d89568832fad1eeda623aaf41e