### PR TITLE
feat: add DeviceSelector component

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -2,7 +2,6 @@
 
 "use client";
 
-import { Button, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/atoms";
 import { blockRegistry } from "@/components/cms/blocks";
 import { Footer, Header, SideNav } from "@/components/organisms";
 import { AppShell } from "@/components/templates/AppShell";
@@ -15,7 +14,8 @@ import {
   loadPreviewTokens,
   PREVIEW_TOKENS_EVENT,
 } from "./previewTokens";
-import { devicePresets, getLegacyPreset, type DevicePreset } from "@ui/utils/devicePresets";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
+import DeviceSelector from "@ui/components/common/DeviceSelector";
 
 interface Props {
   style: React.CSSProperties;
@@ -208,32 +208,7 @@ export default function WizardPreview({
   return (
     <div className="space-y-2">
       {/* viewport switcher */}
-      <div className="flex justify-end gap-2">
-        {(["desktop", "tablet", "mobile"] as const).map((t) => {
-          const preset = getLegacyPreset(t);
-          return (
-            <Button
-              key={t}
-              variant={deviceId === preset.id ? "default" : "outline"}
-              onClick={() => setDeviceId(preset.id)}
-            >
-              {t.charAt(0).toUpperCase() + t.slice(1)}
-            </Button>
-          );
-        })}
-        <Select value={deviceId} onValueChange={setDeviceId}>
-          <SelectTrigger aria-label="Device" className="w-40">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {devicePresets.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <DeviceSelector deviceId={deviceId} onChange={setDeviceId} />
 
       {/* live preview */}
       <div

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -196,7 +196,6 @@ const PageBuilder = memo(function PageBuilder({
       <div className="flex flex-1 flex-col gap-4">
         <div className="flex items-center justify-between">
           <PageToolbar
-            viewport={viewport}
             deviceId={deviceId}
             setDeviceId={setDeviceId}
             locale={locale}

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -1,18 +1,8 @@
 import type { Locale } from "@/i18n/locales";
-import { DesktopIcon, LaptopIcon, MobileIcon } from "@radix-ui/react-icons";
-import {
-  Button,
-  Input,
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from "../../atoms/shadcn";
-import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
+import { Button, Input } from "../../atoms/shadcn";
+import DeviceSelector from "../../common/DeviceSelector";
 
 interface Props {
-  viewport: "desktop" | "tablet" | "mobile";
   deviceId: string;
   setDeviceId: (id: string) => void;
   locale: Locale;
@@ -27,7 +17,6 @@ interface Props {
 }
 
 const PageToolbar = ({
-  viewport,
   deviceId,
   setDeviceId,
   locale,
@@ -41,38 +30,7 @@ const PageToolbar = ({
   setGridCols,
 }: Props) => (
   <div className="flex flex-col gap-4">
-    <div className="flex justify-end gap-2">
-      {(["desktop", "tablet", "mobile"] as const).map((t) => {
-        const preset = getLegacyPreset(t);
-        const Icon =
-          t === "desktop" ? DesktopIcon : t === "tablet" ? LaptopIcon : MobileIcon;
-        return (
-          <Button
-            key={t}
-            variant={deviceId === preset.id ? "default" : "outline"}
-            onClick={() => setDeviceId(preset.id)}
-            aria-label={t}
-          >
-            <Icon />
-            <span className="sr-only">
-              {t.charAt(0).toUpperCase() + t.slice(1)}
-            </span>
-          </Button>
-        );
-      })}
-      <Select value={deviceId} onValueChange={setDeviceId}>
-        <SelectTrigger aria-label="Device" className="w-40">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {devicePresets.map((p) => (
-            <SelectItem key={p.id} value={p.id}>
-              {p.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <DeviceSelector deviceId={deviceId} onChange={setDeviceId} />
     <div className="flex items-center justify-end gap-2">
       <Button
         variant={showGrid ? "default" : "outline"}

--- a/packages/ui/src/components/common/DeviceSelector.tsx
+++ b/packages/ui/src/components/common/DeviceSelector.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { DesktopIcon, LaptopIcon, MobileIcon } from "@radix-ui/react-icons";
+import {
+  Button,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "../atoms/shadcn";
+import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
+
+interface Props {
+  deviceId: string;
+  onChange: (id: string) => void;
+  showLegacyButtons?: boolean;
+}
+
+export default function DeviceSelector({
+  deviceId,
+  onChange,
+  showLegacyButtons = true,
+}: Props) {
+  return (
+    <div className="flex justify-end gap-2">
+      {showLegacyButtons && (
+        (["desktop", "tablet", "mobile"] as const).map((t) => {
+          const preset = getLegacyPreset(t);
+          const Icon =
+            t === "desktop" ? DesktopIcon : t === "tablet" ? LaptopIcon : MobileIcon;
+          return (
+            <Button
+              key={t}
+              variant={deviceId === preset.id ? "default" : "outline"}
+              onClick={() => onChange(preset.id)}
+              aria-label={t}
+            >
+              <Icon />
+              <span className="sr-only">
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </span>
+            </Button>
+          );
+        })
+      )}
+      <Select value={deviceId} onValueChange={onChange}>
+        <SelectTrigger aria-label="Device" className="w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {devicePresets.map((p) => (
+            <SelectItem key={p.id} value={p.id}>
+              {p.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -6,4 +6,5 @@ export * from "./organisms";
 export * from "./templates";
 export { default as DynamicRenderer } from "./DynamicRenderer";
 export { default as ThemeToggle } from "./ThemeToggle";
+export { default as DeviceSelector } from "./common/DeviceSelector";
 export * from "./overlays";


### PR DESCRIPTION
## Summary
- add reusable DeviceSelector with legacy buttons and preset dropdown
- use DeviceSelector in WizardPreview and PageToolbar, simplifying device switcher logic
- export DeviceSelector and update PageBuilder wiring

## Testing
- `pnpm lint --filter @acme/ui` *(no tasks)*
- `pnpm lint --filter @apps/cms` *(fails: ERR_MODULE_NOT_FOUND)*
- `pnpm test --filter @acme/ui` *(fails: Test failed. See above for more details.)*
- `pnpm test --filter @apps/cms` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_689df2ffe67c832f9364ed13cd6e26e1