### PR TITLE
feat(auth): type redis session store

### DIFF
--- a/packages/auth/src/redisStore.ts
+++ b/packages/auth/src/redisStore.ts
@@ -13,9 +13,9 @@ export class RedisSessionStore implements SessionStore {
   }
 
   async get(id: string): Promise<SessionRecord | null> {
-    const data = await this.client.get<Record<string, any>>(this.key(id));
+    const data = await this.client.get<SessionRecord>(this.key(id));
     if (!data) return null;
-    return { ...data, createdAt: new Date(data.createdAt) } as SessionRecord;
+    return { ...data, createdAt: new Date(data.createdAt) };
   }
 
   async set(record: SessionRecord): Promise<void> {
@@ -35,11 +35,11 @@ export class RedisSessionStore implements SessionStore {
   async list(customerId: string): Promise<SessionRecord[]> {
     const ids = await this.client.smembers<string>(this.customerKey(customerId));
     if (!ids || ids.length === 0) return [];
-    const records = await this.client.mget<Record<string, any>>(
+    const records = await this.client.mget<SessionRecord>(
       ...ids.map((id) => this.key(id))
     );
     return records
-      .filter((r): r is Record<string, any> => r !== null)
-      .map((r) => ({ ...r, createdAt: new Date(r.createdAt) } as SessionRecord));
+      .filter((r): r is SessionRecord => r !== null)
+      .map((r) => ({ ...r, createdAt: new Date(r.createdAt) }));
   }
 }


### PR DESCRIPTION
## Summary
- use Redis client generics for session retrieval
- return typed SessionRecord objects without casts

## Testing
- `pnpm --filter @acme/auth test packages/auth/__tests__/session.test.ts` *(fails: Password string too short)*

------
https://chatgpt.com/codex/tasks/task_e_689df75ac8ec832fb2c1f3e25bc5be8b