### PR TITLE
feat(analytics): type discount redeemed event

### DIFF
--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -55,8 +55,8 @@ export async function GET(req: NextRequest) {
   ]);
   const counts: Record<string, number> = {};
   for (const e of events) {
-    if (e.type === "discount_redeemed" && typeof (e as any).code === "string") {
-      const code = (e as any).code as string;
+    if (e.type === "discount_redeemed") {
+      const code = e.code;
       counts[code] = (counts[code] || 0) + 1;
     }
   }

--- a/apps/cms/src/lib/__tests__/analytics.test.ts
+++ b/apps/cms/src/lib/__tests__/analytics.test.ts
@@ -23,17 +23,17 @@ describe("buildMetrics", () => {
         type: "discount_redeemed",
         timestamp: "2024-05-01T12:04:00Z",
         code: "ABC",
-      } as AnalyticsEvent,
+      },
       {
         type: "discount_redeemed",
         timestamp: "2024-05-02T12:04:00Z",
         code: "ABC",
-      } as AnalyticsEvent,
+      },
       {
         type: "discount_redeemed",
         timestamp: "2024-05-02T12:05:00Z",
         code: "XYZ",
-      } as AnalyticsEvent,
+      },
     ];
 
     const metrics = buildMetrics(events);

--- a/apps/cms/src/lib/analytics.ts
+++ b/apps/cms/src/lib/analytics.ts
@@ -35,8 +35,8 @@ export function buildMetrics(
       campaignSalesByDay[day] = (campaignSalesByDay[day] || 0) + amount;
       campaignSalesCountByDay[day] =
         (campaignSalesCountByDay[day] || 0) + 1;
-    } else if (e.type === "discount_redeemed" && typeof (e as any).code === "string") {
-      const code = (e as any).code as string;
+    } else if (e.type === "discount_redeemed") {
+      const code = e.code;
       const entry = discountByCodeByDay[day] || {};
       entry[code] = (entry[code] || 0) + 1;
       discountByCodeByDay[day] = entry;

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -7,11 +7,18 @@ import { validateShopName } from "./shops";
 import { getShopSettings, readShop } from "./repositories/shops.server";
 import { coreEnv } from "@acme/config/env/core";
 
-export interface AnalyticsEvent {
-  type: string;
-  timestamp?: string;
-  [key: string]: unknown;
-}
+export type AnalyticsEvent =
+  | {
+      type: "discount_redeemed";
+      code: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    }
+  | {
+    type: string;
+    timestamp?: string;
+    [key: string]: unknown;
+  };
 
 export interface AnalyticsProvider {
   track(event: AnalyticsEvent): Promise<void> | void;
@@ -172,7 +179,7 @@ async function updateAggregates(
     entry.amount += amount;
     agg.order[day] = entry;
   } else if (event.type === "discount_redeemed") {
-    const code = typeof (event as any).code === "string" ? (event as any).code : "";
+    const code = event.code;
     if (code) {
       const entry = agg.discount_redeemed[day] || {};
       entry[code] = (entry[code] || 0) + 1;


### PR DESCRIPTION
## Summary
- type `discount_redeemed` analytics event with a `code` field
- consume `code` without `any` casts
- align analytics consumers and tests with typed event

## Testing
- `pnpm test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689df75d9f1c832fb1dc016011f4d3da