### PR TITLE
feat: add device orientation controls

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
@@ -1,21 +1,15 @@
 "use client";
 
-import {
-  Button,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/atoms/shadcn";
+import { Button } from "@/components/atoms/shadcn";
 import NavigationEditor from "@/components/cms/NavigationEditor";
 import NavigationPreview from "@/components/cms/NavigationPreview";
 import { useConfigurator } from "../ConfiguratorContext";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 import { useThemeLoader } from "../hooks/useThemeLoader";
-import { devicePresets } from "@ui/utils/devicePresets";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import { useState, useMemo } from "react";
+import DeviceSelector from "@ui/components/cms/DeviceSelector";
 
 interface NavItem {
   id: string;
@@ -32,9 +26,21 @@ export default function StepNavigation(): React.JSX.Element {
   const [, markComplete] = useStepCompletion("navigation");
   const router = useRouter();
   const [deviceId, setDeviceId] = useState(devicePresets[0].id);
-  const device = useMemo(() => {
-    return devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
-  }, [deviceId]);
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
+    "portrait"
+  );
+  const device = useMemo<DevicePreset>(() => {
+    const preset =
+      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+    return orientation === "portrait"
+      ? { ...preset, orientation }
+      : {
+          ...preset,
+          width: preset.height,
+          height: preset.width,
+          orientation,
+        };
+  }, [deviceId, orientation]);
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Navigation</h2>
@@ -44,18 +50,19 @@ export default function StepNavigation(): React.JSX.Element {
         </div>
         <div className="flex-1 space-y-2">
           <div className="flex justify-end">
-            <Select value={deviceId} onValueChange={setDeviceId}>
-              <SelectTrigger aria-label="Device" className="w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {devicePresets.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DeviceSelector
+              deviceId={deviceId}
+              orientation={orientation}
+              setDeviceId={(id) => {
+                setDeviceId(id);
+                setOrientation("portrait");
+              }}
+              toggleOrientation={() =>
+                setOrientation((o) =>
+                  o === "portrait" ? "landscape" : "portrait"
+                )
+              }
+            />
           </div>
           <div
             className="mx-auto"

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  Button,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/atoms/shadcn";
+import { Button } from "@/components/atoms/shadcn";
 import StyleEditor from "@/components/cms/StyleEditor";
 import { useCallback, useEffect, useState, useMemo } from "react";
 import type { TokenMap } from "@ui/hooks/useTokenEditor";
@@ -17,7 +10,8 @@ import { useRouter } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import { useThemeLoader } from "../hooks/useThemeLoader";
 import { STORAGE_KEY } from "../hooks/useConfiguratorPersistence";
-import { devicePresets } from "@ui/utils/devicePresets";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
+import DeviceSelector from "@ui/components/cms/DeviceSelector";
 
 const colorPalettes: Array<{
   name: string;
@@ -77,9 +71,21 @@ export default function StepTheme({
   const [, markComplete] = useStepCompletion("theme");
   const router = useRouter();
   const [deviceId, setDeviceId] = useState(devicePresets[0].id);
-  const device = useMemo(() => {
-    return devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
-  }, [deviceId]);
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
+    "portrait"
+  );
+  const device = useMemo<DevicePreset>(() => {
+    const preset =
+      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+    return orientation === "portrait"
+      ? { ...preset, orientation }
+      : {
+          ...preset,
+          width: preset.height,
+          height: preset.width,
+          orientation,
+        };
+  }, [deviceId, orientation]);
 
   const applyPalette = useCallback(
     (name: string) => {
@@ -196,18 +202,19 @@ export default function StepTheme({
       />
 
       <div className="flex justify-end">
-        <Select value={deviceId} onValueChange={setDeviceId}>
-          <SelectTrigger aria-label="Device" className="w-40">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {devicePresets.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <DeviceSelector
+          deviceId={deviceId}
+          orientation={orientation}
+          setDeviceId={(id) => {
+            setDeviceId(id);
+            setOrientation("portrait");
+          }}
+          toggleOrientation={() =>
+            setOrientation((o) =>
+              o === "portrait" ? "landscape" : "portrait"
+            )
+          }
+        />
       </div>
 
       <WizardPreview style={themeStyle} device={device} />

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { Button, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/atoms";
+import { Button } from "@/components/atoms";
 import { blockRegistry } from "@/components/cms/blocks";
 import { Footer, Header, SideNav } from "@/components/organisms";
 import { AppShell } from "@/components/templates/AppShell";
@@ -16,6 +16,7 @@ import {
   PREVIEW_TOKENS_EVENT,
 } from "./previewTokens";
 import { devicePresets, getLegacyPreset, type DevicePreset } from "@ui/utils/devicePresets";
+import DeviceSelector from "@ui/components/cms/DeviceSelector";
 
 interface Props {
   style: React.CSSProperties;
@@ -38,10 +39,22 @@ export default function WizardPreview({
   device: deviceProp,
 }: Props): React.JSX.Element {
   const [deviceId, setDeviceId] = useState(devicePresets[0].id);
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
+    "portrait"
+  );
   const device = useMemo<DevicePreset>(() => {
     if (deviceProp) return deviceProp;
-    return devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
-  }, [deviceId, deviceProp]);
+    const preset =
+      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+    return orientation === "portrait"
+      ? { ...preset, orientation }
+      : {
+          ...preset,
+          width: preset.height,
+          height: preset.width,
+          orientation,
+        };
+  }, [deviceId, orientation, deviceProp]);
   const viewport: "desktop" | "tablet" | "mobile" = device.type;
   const [components, setComponents] = useState<PageComponent[]>([]);
   const [themeStyle, setThemeStyle] = useState<React.CSSProperties>(() => ({
@@ -219,24 +232,28 @@ export default function WizardPreview({
               <Button
                 key={t}
                 variant={deviceId === preset.id ? "default" : "outline"}
-                onClick={() => setDeviceId(preset.id)}
+                onClick={() => {
+                  setDeviceId(preset.id);
+                  setOrientation("portrait");
+                }}
               >
                 {t.charAt(0).toUpperCase() + t.slice(1)}
               </Button>
             );
           })}
-          <Select value={deviceId} onValueChange={setDeviceId}>
-            <SelectTrigger aria-label="Device" className="w-40">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {devicePresets.map((p) => (
-                <SelectItem key={p.id} value={p.id}>
-                  {p.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <DeviceSelector
+            deviceId={deviceId}
+            orientation={orientation}
+            setDeviceId={(id) => {
+              setDeviceId(id);
+              setOrientation("portrait");
+            }}
+            toggleOrientation={() =>
+              setOrientation((o) =>
+                o === "portrait" ? "landscape" : "portrait"
+              )
+            }
+          />
         </div>
       )}
 

--- a/packages/ui/__tests__/useViewport.test.tsx
+++ b/packages/ui/__tests__/useViewport.test.tsx
@@ -9,6 +9,7 @@ describe("useViewport", () => {
     type: "desktop",
     width: 1000,
     height: 800,
+    orientation: "portrait",
   };
   const tablet: DevicePreset = {
     id: "t",
@@ -16,6 +17,7 @@ describe("useViewport", () => {
     type: "tablet",
     width: 500,
     height: 400,
+    orientation: "portrait",
   };
 
   beforeEach(() => {
@@ -45,5 +47,24 @@ describe("useViewport", () => {
     expect(result.current.canvasWidth).toBe(500);
     expect(result.current.canvasHeight).toBe(400);
     expect(result.current.scale).toBe(1);
+  });
+
+  it("updates dimensions when orientation changes", () => {
+    const { result, rerender } = renderHook(
+      ({ device }) => useViewport(device),
+      { initialProps: { device: desktop } }
+    );
+
+    const landscape = {
+      ...desktop,
+      width: desktop.height,
+      height: desktop.width,
+      orientation: "landscape" as const,
+    };
+
+    rerender({ device: landscape });
+
+    expect(result.current.canvasWidth).toBe(800);
+    expect(result.current.canvasHeight).toBe(1000);
   });
 });

--- a/packages/ui/src/components/cms/DeviceSelector.tsx
+++ b/packages/ui/src/components/cms/DeviceSelector.tsx
@@ -1,0 +1,50 @@
+import { ReloadIcon } from "@radix-ui/react-icons";
+import {
+  Button,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "../atoms/shadcn";
+import { devicePresets } from "@ui/utils/devicePresets";
+
+interface Props {
+  deviceId: string;
+  orientation: "portrait" | "landscape";
+  setDeviceId: (id: string) => void;
+  toggleOrientation: () => void;
+}
+
+export default function DeviceSelector({
+  deviceId,
+  orientation,
+  setDeviceId,
+  toggleOrientation,
+}: Props): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={deviceId} onValueChange={setDeviceId}>
+        <SelectTrigger aria-label="Device" className="w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {devicePresets.map((p) => (
+            <SelectItem key={p.id} value={p.id}>
+              {p.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        variant="outline"
+        onClick={toggleOrientation}
+        aria-label="Rotate"
+      >
+        <ReloadIcon
+          className={orientation === "landscape" ? "rotate-90" : ""}
+        />
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/index.ts
+++ b/packages/ui/src/components/cms/index.ts
@@ -9,3 +9,4 @@ export { RangeInput } from "./RangeInput";
 export { default as StyleEditor } from "./StyleEditor";
 export { default as PageBuilder } from "./page-builder/PageBuilder";
 export * from "./page-builder";
+export { default as DeviceSelector } from "./DeviceSelector";

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -63,9 +63,21 @@ const PageBuilder = memo(function PageBuilder({
   } = usePageBuilderState({ page, history: historyProp, onChange });
 
   const [deviceId, setDeviceId] = useState(devicePresets[0].id);
-  const device = useMemo< DevicePreset>(() => {
-    return devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
-  }, [deviceId]);
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
+    "portrait"
+  );
+  const device = useMemo<DevicePreset>(() => {
+    const preset =
+      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+    return orientation === "portrait"
+      ? { ...preset, orientation }
+      : {
+          ...preset,
+          width: preset.height,
+          height: preset.width,
+          orientation,
+        };
+  }, [deviceId, orientation]);
   const viewport: "desktop" | "tablet" | "mobile" = device.type;
   const [locale, setLocale] = useState<Locale>("en");
   const [publishCount, setPublishCount] = useState(0);
@@ -199,6 +211,8 @@ const PageBuilder = memo(function PageBuilder({
             viewport={viewport}
             deviceId={deviceId}
             setDeviceId={setDeviceId}
+            orientation={orientation}
+            setOrientation={setOrientation}
             locale={locale}
             setLocale={setLocale}
             locales={locales}

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -1,20 +1,15 @@
 import type { Locale } from "@/i18n/locales";
 import { DesktopIcon, LaptopIcon, MobileIcon } from "@radix-ui/react-icons";
-import {
-  Button,
-  Input,
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from "../../atoms/shadcn";
-import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
+import { Button, Input } from "../../atoms/shadcn";
+import { getLegacyPreset } from "@ui/utils/devicePresets";
+import DeviceSelector from "../DeviceSelector";
 
 interface Props {
   viewport: "desktop" | "tablet" | "mobile";
   deviceId: string;
   setDeviceId: (id: string) => void;
+  orientation: "portrait" | "landscape";
+  setOrientation: (o: "portrait" | "landscape") => void;
   locale: Locale;
   setLocale: (l: Locale) => void;
   locales: readonly Locale[];
@@ -60,18 +55,17 @@ const PageToolbar = ({
           </Button>
         );
       })}
-      <Select value={deviceId} onValueChange={setDeviceId}>
-        <SelectTrigger aria-label="Device" className="w-40">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {devicePresets.map((p) => (
-            <SelectItem key={p.id} value={p.id}>
-              {p.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <DeviceSelector
+        deviceId={deviceId}
+        orientation={orientation}
+        setDeviceId={(id) => {
+          setDeviceId(id);
+          setOrientation("portrait");
+        }}
+        toggleOrientation={() =>
+          setOrientation((o) => (o === "portrait" ? "landscape" : "portrait"))
+        }
+      />
     </div>
     <div className="flex items-center justify-end gap-2">
       <Button

--- a/packages/ui/src/utils/devicePresets.ts
+++ b/packages/ui/src/utils/devicePresets.ts
@@ -4,22 +4,72 @@ export type DevicePreset = {
   width: number;
   height: number;
   type: "desktop" | "tablet" | "mobile";
+  orientation: "portrait" | "landscape";
 };
 
 export const devicePresets: DevicePreset[] = [
-  { id: "desktop-1280", label: "Desktop 1280", width: 1280, height: 800, type: "desktop" },
-  { id: "desktop-1440", label: "Desktop 1440", width: 1440, height: 900, type: "desktop" },
-  { id: "ipad", label: "iPad", width: 768, height: 1024, type: "tablet" },
-  { id: "ipad-pro", label: "iPad Pro", width: 1024, height: 1366, type: "tablet" },
-  { id: "iphone-se", label: "iPhone SE", width: 375, height: 667, type: "mobile" },
-  { id: "iphone-12", label: "iPhone 12", width: 390, height: 844, type: "mobile" },
-  { id: "galaxy-s8", label: "Galaxy S8", width: 360, height: 740, type: "mobile" },
+  {
+    id: "desktop-1280",
+    label: "Desktop 1280",
+    width: 1280,
+    height: 800,
+    type: "desktop",
+    orientation: "portrait",
+  },
+  {
+    id: "desktop-1440",
+    label: "Desktop 1440",
+    width: 1440,
+    height: 900,
+    type: "desktop",
+    orientation: "portrait",
+  },
+  {
+    id: "ipad",
+    label: "iPad",
+    width: 768,
+    height: 1024,
+    type: "tablet",
+    orientation: "portrait",
+  },
+  {
+    id: "ipad-pro",
+    label: "iPad Pro",
+    width: 1024,
+    height: 1366,
+    type: "tablet",
+    orientation: "portrait",
+  },
+  {
+    id: "iphone-se",
+    label: "iPhone SE",
+    width: 375,
+    height: 667,
+    type: "mobile",
+    orientation: "portrait",
+  },
+  {
+    id: "iphone-12",
+    label: "iPhone 12",
+    width: 390,
+    height: 844,
+    type: "mobile",
+    orientation: "portrait",
+  },
+  {
+    id: "galaxy-s8",
+    label: "Galaxy S8",
+    width: 360,
+    height: 740,
+    type: "mobile",
+    orientation: "portrait",
+  },
 ];
 
 export function getLegacyPreset(type: "desktop" | "tablet" | "mobile"): DevicePreset {
-  return (
-    devicePresets.find((p) => p.type === type) || devicePresets[0]
-  );
+  const preset =
+    devicePresets.find((p) => p.type === type) || devicePresets[0];
+  return { ...preset };
 }
 
 export default devicePresets;


### PR DESCRIPTION
## Summary
- add orientation support to device presets
- introduce DeviceSelector with rotate capability
- recompute preview dimensions when rotating devices

## Testing
- `pnpm --filter @acme/ui test` (fails: scheduler test exceeded timeout)
- `pnpm --filter @apps/cms test` (fails: invalid core environment variables)


------
https://chatgpt.com/codex/tasks/task_e_689df74e4854832f8cf58adad61b555d