### PR TITLE
Persist preview device selection across sessions

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -17,6 +17,8 @@ import {
 } from "./previewTokens";
 import { devicePresets, getLegacyPreset, type DevicePreset } from "@ui/utils/devicePresets";
 
+const DEVICE_STORAGE_KEY = "preview-device";
+
 interface Props {
   style: React.CSSProperties;
   /** Enable inspection mode to highlight tokenised elements */
@@ -36,6 +38,26 @@ export default function WizardPreview({
   onTokenSelect,
 }: Props): React.JSX.Element {
   const [deviceId, setDeviceId] = useState(devicePresets[0].id);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(DEVICE_STORAGE_KEY);
+      if (stored && devicePresets.some((d) => d.id === stored)) {
+        setDeviceId(stored);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DEVICE_STORAGE_KEY, deviceId);
+    } catch {
+      /* ignore */
+    }
+  }, [deviceId]);
+
   const device = useMemo<DevicePreset>(() => {
     return devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
   }, [deviceId]);

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -25,6 +25,8 @@ import PageSidebar from "./PageSidebar";
 import { defaults, CONTAINER_TYPES } from "./defaults";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 
+const DEVICE_STORAGE_KEY = "preview-device";
+
 interface Props {
   page: Page;
   history?: HistoryState;
@@ -63,6 +65,26 @@ const PageBuilder = memo(function PageBuilder({
   } = usePageBuilderState({ page, history: historyProp, onChange });
 
   const [deviceId, setDeviceId] = useState(devicePresets[0].id);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(DEVICE_STORAGE_KEY);
+      if (stored && devicePresets.some((d) => d.id === stored)) {
+        setDeviceId(stored);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DEVICE_STORAGE_KEY, deviceId);
+    } catch {
+      /* ignore */
+    }
+  }, [deviceId]);
+
   const device = useMemo< DevicePreset>(() => {
     return devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
   }, [deviceId]);


### PR DESCRIPTION
## Summary
- save selected preview device to localStorage in Page Builder and Wizard Preview
- restore last used preview device on component mount

## Testing
- `pnpm test --filter @apps/cms --filter @acme/ui` (fails: Test failed. See above for more details)
- `pnpm lint --filter @apps/cms --filter @acme/ui` (fails: Command failed with exit code 1)


------
https://chatgpt.com/codex/tasks/task_e_689df302f460832f90dadbd5e2a845e0