### PR TITLE
Add device preset validation tests and viewport e2e checks

### DIFF
--- a/cypress/e2e/edit-preview.cy.ts
+++ b/cypress/e2e/edit-preview.cy.ts
@@ -17,4 +17,23 @@ describe("edit preview page", () => {
       .click();
     cy.contains("li", "Breadcrumbs");
   });
+
+  it("updates preview size for selected device presets", () => {
+    cy.visit(`/cms/shop/${shopId}/edit-preview`);
+
+    const presets = [
+      { label: "Desktop 1280", width: 1280, height: 800 },
+      { label: "iPad", width: 768, height: 1024 },
+      { label: "iPhone 12", width: 390, height: 844 },
+    ];
+
+    presets.forEach(({ label, width, height }) => {
+      cy.get('[aria-label="Device"]').click();
+      cy.contains('[role="option"]', label).click();
+      cy.get('#canvas')
+        .parent()
+        .should('have.css', 'width', `${width}px`)
+        .and('have.css', 'height', `${height}px`);
+    });
+  });
 });

--- a/packages/ui/src/utils/__tests__/devicePresets.test.ts
+++ b/packages/ui/src/utils/__tests__/devicePresets.test.ts
@@ -1,0 +1,29 @@
+import { devicePresets, getLegacyPreset } from "../devicePresets";
+
+describe("devicePresets data", () => {
+  it("contains valid preset data", () => {
+    expect(devicePresets.length).toBeGreaterThan(0);
+
+    const ids = new Set<string>();
+    for (const preset of devicePresets) {
+      expect(typeof preset.id).toBe("string");
+      expect(preset.id).not.toHaveLength(0);
+      expect(typeof preset.label).toBe("string");
+      expect(preset.label).not.toHaveLength(0);
+      expect(typeof preset.width).toBe("number");
+      expect(preset.width).toBeGreaterThan(0);
+      expect(typeof preset.height).toBe("number");
+      expect(preset.height).toBeGreaterThan(0);
+      expect(["desktop", "tablet", "mobile"]).toContain(preset.type);
+      expect(ids.has(preset.id)).toBe(false);
+      ids.add(preset.id);
+    }
+  });
+
+  it("returns a preset for legacy viewport type", () => {
+    ( ["desktop", "tablet", "mobile"] as const ).forEach((type) => {
+      const preset = getLegacyPreset(type);
+      expect(preset.type).toBe(type);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- verify device preset data and legacy preset lookup
- assert preview resizes when switching device presets

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/utils/__tests__/devicePresets.test.ts`
- `pnpm e2e -- --spec cypress/e2e/edit-preview.cy.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df30559d0832f86637b25e5460dec