### PR TITLE
feat: surface cleaning transparency messaging on returns

### DIFF
--- a/packages/template-app/src/app/account/returns/page.tsx
+++ b/packages/template-app/src/app/account/returns/page.tsx
@@ -2,6 +2,8 @@ import {
   getReturnLogistics,
   getReturnBagAndLabel,
 } from "@platform-core/returnLogistics";
+import CleaningInfo from "../../../components/CleaningInfo";
+import shop from "../../../../shop.json";
 import React, { useEffect, useRef, useState } from "react";
 
 export const metadata = { title: "Mobile Returns" };
@@ -128,6 +130,7 @@ function ReturnForm({ bagType, tracking: trackingEnabled }: ReturnFormProps) {
         </p>
       )}
       {error && <p className="text-red-600">{error}</p>}
+      {shop.showCleaningTransparency && <CleaningInfo />}
     </div>
   );
 }

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -1,4 +1,6 @@
 import { getReturnLogistics } from "@platform-core/returnLogistics";
+import CleaningInfo from "../../../components/CleaningInfo";
+import shop from "../../../../shop.json";
 import { useEffect, useRef, useState } from "react";
 
 export const metadata = { title: "Mobile Returns" };
@@ -75,6 +77,7 @@ function Scanner() {
       <video ref={videoRef} className="w-full max-w-md" />
       {result && <p>Scanned: {result}</p>}
       {error && <p className="text-red-600">{error}</p>}
+      {shop.showCleaningTransparency && <CleaningInfo />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show CleaningInfo on mobile and account return pages when shop.showCleaningTransparency is true
- keep cleaning details externalized in data/rental/cleaning.json

## Testing
- `pnpm lint --filter @acme/template-app`
- `pnpm test --filter @acme/template-app`


------
https://chatgpt.com/codex/tasks/task_e_689df3116100832f982c6f78d8bcb1d4