### PR TITLE
refactor page builder types

### DIFF
--- a/packages/ui/src/components/cms/page-builder/Block.tsx
+++ b/packages/ui/src/components/cms/page-builder/Block.tsx
@@ -6,16 +6,20 @@ import { blockRegistry } from "../blocks";
 
 function Block({ component, locale }: { component: PageComponent; locale: Locale }) {
   if (component.type === "Text") {
-    const text = (component as any).text;
-    const value = typeof text === "string" ? text : (text?.[locale] ?? "");
+    const { text } =
+      component as Extract<
+        PageComponent,
+        { type: "Text"; text?: string | Record<string, string> }
+      >;
+    const value = typeof text === "string" ? text : text?.[locale] ?? "";
     const sanitized = DOMPurify.sanitize(value);
     return <div dangerouslySetInnerHTML={{ __html: sanitized }} />;
   }
   const entry = blockRegistry[component.type];
   if (!entry) return null;
   const Comp = entry.component;
-  const { id, type, ...props } = component as any;
-  return <Comp {...props} locale={locale} />;
+  const { id, type, ...props } = component;
+  return <Comp {...(props as Record<string, unknown>)} locale={locale} />;
 }
 
 export default memo(Block);

--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -83,8 +83,12 @@ const CanvasItem = memo(function CanvasItem({
       : viewport === "tablet"
       ? "heightTablet"
       : "heightMobile";
-  const widthVal = (component as any)[widthKey] ?? component.width;
-  const heightVal = (component as any)[heightKey] ?? component.height;
+  const widthVal =
+    (component[widthKey as keyof PageComponent] as string | undefined) ??
+    component.width;
+  const heightVal =
+    (component[heightKey as keyof PageComponent] as string | undefined) ??
+    component.height;
   const marginKey =
     viewport === "desktop"
       ? "marginDesktop"
@@ -97,8 +101,12 @@ const CanvasItem = memo(function CanvasItem({
       : viewport === "tablet"
       ? "paddingTablet"
       : "paddingMobile";
-  const marginVal = (component as any)[marginKey] ?? component.margin;
-  const paddingVal = (component as any)[paddingKey] ?? component.padding;
+  const marginVal =
+    (component[marginKey as keyof PageComponent] as string | undefined) ??
+    component.margin;
+  const paddingVal =
+    (component[paddingKey as keyof PageComponent] as string | undefined) ??
+    component.padding;
 
   const {
     startResize,
@@ -150,10 +158,9 @@ const CanvasItem = memo(function CanvasItem({
   const overlayLeft = resizing ? resizeLeft : dragLeft;
   const overlayTop = resizing ? resizeTop : dragTop;
 
-  const hasChildren = Array.isArray((component as any).children);
-  const childIds = hasChildren
-    ? ((component as any).children as PageComponent[]).map((c) => c.id)
-    : [];
+  const children = (component as { children?: PageComponent[] }).children;
+  const hasChildren = Array.isArray(children);
+  const childIds = hasChildren ? children!.map((c) => c.id) : [];
 
   return (
     <div
@@ -269,7 +276,7 @@ const CanvasItem = memo(function CanvasItem({
                 className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10 ring-2 ring-primary"
               />
             )}
-            {(component as any).children.map(
+            {children!.map(
               (child: PageComponent, i: number) => (
                 <CanvasItem
                   key={child.id}

--- a/packages/ui/src/components/cms/page-builder/FeaturedProductEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FeaturedProductEditor.tsx
@@ -1,9 +1,15 @@
 import type { PageComponent } from "@acme/types";
 import { Input } from "../../atoms/shadcn";
 
+type FeaturedProductComponent = PageComponent & {
+  type: "FeaturedProduct";
+  sku?: string;
+  collectionId?: string;
+};
+
 interface Props {
-  component: PageComponent;
-  onChange: (patch: Partial<PageComponent>) => void;
+  component: FeaturedProductComponent;
+  onChange: (patch: Partial<FeaturedProductComponent>) => void;
 }
 
 export default function FeaturedProductEditor({ component, onChange }: Props) {
@@ -12,16 +18,14 @@ export default function FeaturedProductEditor({ component, onChange }: Props) {
       <Input
         label="SKU"
         placeholder="sku"
-        value={(component as any).sku ?? ""}
-        onChange={(e) => onChange({ sku: e.target.value } as Partial<PageComponent>)}
+        value={component.sku ?? ""}
+        onChange={(e) => onChange({ sku: e.target.value })}
       />
       <Input
         label="Collection ID"
         placeholder="collectionId"
-        value={(component as any).collectionId ?? ""}
-        onChange={(e) =>
-          onChange({ collectionId: e.target.value } as Partial<PageComponent>)
-        }
+        value={component.collectionId ?? ""}
+        onChange={(e) => onChange({ collectionId: e.target.value })}
       />
     </div>
   );

--- a/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
@@ -9,29 +9,41 @@ import {
   SelectValue,
 } from "../../atoms/shadcn";
 
+type FormField = {
+  type: string;
+  name?: string;
+  label?: string;
+  options?: { label: string; value: string }[];
+};
+
+type FormBuilderComponent = PageComponent & {
+  type: "FormBuilderBlock";
+  fields?: FormField[];
+};
+
 interface Props {
-  component: PageComponent;
-  onChange: (patch: Partial<PageComponent>) => void;
+  component: FormBuilderComponent;
+  onChange: (patch: Partial<FormBuilderComponent>) => void;
 }
 
 export default function FormBuilderEditor({ component, onChange }: Props) {
-  const fields = ((component as any).fields ?? []) as any[];
+  const fields = component.fields ?? [];
 
-  const updateField = (idx: number, key: string, value: any) => {
+  const updateField = (idx: number, key: keyof FormField, value: any) => {
     const next = [...fields];
     next[idx] = { ...next[idx], [key]: value };
-    onChange({ fields: next } as Partial<PageComponent>);
+    onChange({ fields: next });
   };
 
   const addField = () => {
     onChange({
       fields: [...fields, { type: "text", name: "", label: "" }],
-    } as Partial<PageComponent>);
+    });
   };
 
   const removeField = (idx: number) => {
     const next = fields.filter((_, i) => i !== idx);
-    onChange({ fields: next } as Partial<PageComponent>);
+    onChange({ fields: next });
   };
 
   return (

--- a/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
@@ -1,9 +1,16 @@
 import type { PageComponent } from "@acme/types";
 import { Input, Textarea } from "../../atoms/shadcn";
 
+type ProductBundleComponent = PageComponent & {
+  type: "ProductBundle";
+  skus?: string[];
+  discount?: number;
+  quantity?: number;
+};
+
 interface Props {
-  component: PageComponent;
-  onChange: (patch: Partial<PageComponent>) => void;
+  component: ProductBundleComponent;
+  onChange: (patch: Partial<ProductBundleComponent>) => void;
 }
 
 export default function ProductBundleEditor({ component, onChange }: Props) {
@@ -12,7 +19,7 @@ export default function ProductBundleEditor({ component, onChange }: Props) {
       .split(/[\s,]+/)
       .map((s) => s.trim())
       .filter(Boolean);
-    onChange({ skus: items } as Partial<PageComponent>);
+    onChange({ skus: items });
   };
 
   return (
@@ -20,26 +27,22 @@ export default function ProductBundleEditor({ component, onChange }: Props) {
       <Textarea
         label="SKUs"
         placeholder="skus"
-        value={((component as any).skus ?? []).join(",")}
+        value={(component.skus ?? []).join(",")}
         onChange={(e) => handleSkus(e.target.value)}
       />
       <Input
         label="Discount (%)"
         placeholder="discount"
         type="number"
-        value={(component as any).discount ?? ""}
-        onChange={(e) =>
-          onChange({ discount: Number(e.target.value) } as Partial<PageComponent>)
-        }
+        value={component.discount ?? ""}
+        onChange={(e) => onChange({ discount: Number(e.target.value) })}
       />
       <Input
         label="Quantity"
         placeholder="quantity"
         type="number"
-        value={(component as any).quantity ?? ""}
-        onChange={(e) =>
-          onChange({ quantity: Number(e.target.value) } as Partial<PageComponent>)
-        }
+        value={component.quantity ?? ""}
+        onChange={(e) => onChange({ quantity: Number(e.target.value) })}
       />
     </div>
   );

--- a/packages/ui/src/components/cms/page-builder/ProductComparisonEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductComparisonEditor.tsx
@@ -1,30 +1,39 @@
 import type { PageComponent } from "@acme/types";
 import { Textarea } from "../../atoms/shadcn";
 
+type ProductComparisonComponent = PageComponent & {
+  type: "ProductComparison";
+  skus?: string[];
+  attributes?: string[];
+};
+
 interface Props {
-  component: PageComponent;
-  onChange: (patch: Partial<PageComponent>) => void;
+  component: ProductComparisonComponent;
+  onChange: (patch: Partial<ProductComparisonComponent>) => void;
 }
 
 export default function ProductComparisonEditor({ component, onChange }: Props) {
-  const handleList = (field: string, value: string) => {
+  const handleList = (
+    field: keyof ProductComparisonComponent & string,
+    value: string,
+  ) => {
     const items = value
       .split(/[\s,]+/)
       .map((s) => s.trim())
       .filter(Boolean);
-    onChange({ [field]: items } as Partial<PageComponent>);
+    onChange({ [field]: items } as Partial<ProductComparisonComponent>);
   };
 
   return (
     <div className="space-y-2">
       <Textarea
         label="SKUs (comma or newline separated)"
-        value={((component as any).skus ?? []).join(",")}
+        value={(component.skus ?? []).join(",")}
         onChange={(e) => handleList("skus", e.target.value)}
       />
       <Textarea
         label="Attributes (comma separated)"
-        value={((component as any).attributes ?? []).join(",")}
+        value={(component.attributes ?? []).join(",")}
         onChange={(e) => handleList("attributes", e.target.value)}
       />
     </div>

--- a/packages/ui/src/components/cms/page-builder/ProductFilterEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductFilterEditor.tsx
@@ -1,20 +1,27 @@
 import type { PageComponent } from "@acme/types";
 import useComponentInputs from "./useComponentInputs";
 
+type ProductFilterComponent = PageComponent & {
+  type: "ProductFilter";
+  showSize?: boolean;
+  showColor?: boolean;
+  showPrice?: boolean;
+};
+
 interface Props {
-  component: PageComponent;
-  onChange: (patch: Partial<PageComponent>) => void;
+  component: ProductFilterComponent;
+  onChange: (patch: Partial<ProductFilterComponent>) => void;
 }
 
 export default function ProductFilterEditor({ component, onChange }: Props) {
-  const { handleInput } = useComponentInputs(onChange);
+  const { handleInput } = useComponentInputs<ProductFilterComponent>(onChange);
   return (
     <>
       <div className="flex items-center gap-2">
         <label className="text-sm">Show size</label>
         <input
           type="checkbox"
-          checked={(component as any).showSize ?? true}
+          checked={component.showSize ?? true}
           onChange={(e) => handleInput("showSize", e.target.checked)}
         />
       </div>
@@ -22,7 +29,7 @@ export default function ProductFilterEditor({ component, onChange }: Props) {
         <label className="text-sm">Show color</label>
         <input
           type="checkbox"
-          checked={(component as any).showColor ?? true}
+          checked={component.showColor ?? true}
           onChange={(e) => handleInput("showColor", e.target.checked)}
         />
       </div>
@@ -30,7 +37,7 @@ export default function ProductFilterEditor({ component, onChange }: Props) {
         <label className="text-sm">Show price</label>
         <input
           type="checkbox"
-          checked={(component as any).showPrice ?? true}
+          checked={component.showPrice ?? true}
           onChange={(e) => handleInput("showPrice", e.target.checked)}
         />
       </div>

--- a/packages/ui/src/components/cms/page-builder/TabsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/TabsEditor.tsx
@@ -1,14 +1,14 @@
-import type { PageComponent } from "@acme/types";
+import type { TabsComponent } from "@acme/types";
 import { Button, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../atoms/shadcn";
 
 interface Props {
-  component: PageComponent;
-  onChange: (patch: Partial<PageComponent>) => void;
+  component: TabsComponent;
+  onChange: (patch: Partial<TabsComponent>) => void;
 }
 
 export default function TabsEditor({ component, onChange }: Props) {
-  const labels = (component as any).labels ?? [];
-  const active = (component as any).active ?? 0;
+  const labels = component.labels ?? [];
+  const active = component.active ?? 0;
   return (
     <>
       {labels.map((label: string, i: number) => (
@@ -27,7 +27,7 @@ export default function TabsEditor({ component, onChange }: Props) {
             variant="outline"
             onClick={() => {
               const copy = labels.filter((_: string, idx: number) => idx !== i);
-              const patch: Partial<PageComponent> = { labels: copy };
+              const patch: Partial<TabsComponent> = { labels: copy };
               if (active >= copy.length) patch.active = 0;
               onChange(patch);
             }}

--- a/packages/ui/src/components/cms/page-builder/TextBlock.tsx
+++ b/packages/ui/src/components/cms/page-builder/TextBlock.tsx
@@ -13,6 +13,11 @@ import useCanvasResize from "./useCanvasResize";
 import useCanvasDrag from "./useCanvasDrag";
 import type { Action } from "./state";
 
+type TextComponent = Extract<
+  PageComponent,
+  { type: "Text" }
+> & { text?: string | Record<string, string>; [key: string]: unknown };
+
 const TextBlock = memo(function TextBlock({
   component,
   index,
@@ -26,7 +31,7 @@ const TextBlock = memo(function TextBlock({
   gridCols,
   viewport,
 }: {
-  component: PageComponent;
+  component: TextComponent;
   index: number;
   parentId: string | undefined;
   selectedId: string | null;
@@ -62,8 +67,12 @@ const TextBlock = memo(function TextBlock({
       : viewport === "tablet"
       ? "heightTablet"
       : "heightMobile";
-  const widthVal = (component as any)[widthKey] ?? component.width;
-  const heightVal = (component as any)[heightKey] ?? component.height;
+  const widthVal =
+    (component[widthKey as keyof TextComponent] as string | undefined) ??
+    component.width;
+  const heightVal =
+    (component[heightKey as keyof TextComponent] as string | undefined) ??
+    component.height;
   const marginKey =
     viewport === "desktop"
       ? "marginDesktop"
@@ -76,8 +85,12 @@ const TextBlock = memo(function TextBlock({
       : viewport === "tablet"
       ? "paddingTablet"
       : "paddingMobile";
-  const marginVal = (component as any)[marginKey] ?? component.margin;
-  const paddingVal = (component as any)[paddingKey] ?? component.padding;
+  const marginVal =
+    (component[marginKey as keyof TextComponent] as string | undefined) ??
+    component.margin;
+  const paddingVal =
+    (component[paddingKey as keyof TextComponent] as string | undefined) ??
+    component.padding;
 
   const {
     startResize,
@@ -124,12 +137,10 @@ const TextBlock = memo(function TextBlock({
       id: component.id,
       patch: {
         text: {
-          ...(typeof (component as any).text === "object"
-            ? (component as any).text
-            : {}),
+          ...(typeof component.text === "object" ? component.text : {}),
           [locale]: editor.getHTML(),
         },
-      } as Partial<PageComponent>,
+      } as Partial<TextComponent>,
     });
     setEditing(false);
   }, [editor, dispatch, component.id, locale, component]);
@@ -213,9 +224,9 @@ const TextBlock = memo(function TextBlock({
           }}
           dangerouslySetInnerHTML={{
             __html: DOMPurify.sanitize(
-              typeof (component as any).text === "string"
-                ? (component as any).text
-                : (component as any).text?.[locale] ?? ""
+              typeof component.text === "string"
+                ? component.text
+                : component.text?.[locale] ?? ""
             ),
           }}
         />

--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
@@ -22,8 +22,8 @@ export function usePageBuilderState({ page, history, onChange }: Params) {
   );
 
   const [state, rawDispatch] = useReducer(reducer, undefined, (): HistoryState => {
-    const initial = migrate(page.components as PageComponent[]);
-    const fromServer = history ?? (page as any).history;
+    const initial = migrate(page.components);
+    const fromServer = history ?? page.history;
     const parsedServer = fromServer
       ? (() => {
           try {

--- a/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
@@ -18,6 +18,14 @@ export default function ContentPanel({
   handleInput,
 }: Props) {
   const Specific = editorRegistry[component.type];
+  const comp = component as PageComponent & {
+    minItems?: number;
+    maxItems?: number;
+    desktopItems?: number;
+    tabletItems?: number;
+    mobileItems?: number;
+    columns?: number;
+  };
   return (
     <div className="space-y-2">
       {("minItems" in component || "maxItems" in component) && (
@@ -26,7 +34,7 @@ export default function ContentPanel({
             label="Min Items"
             type="number"
             title="Minimum number of items"
-            value={(component as any).minItems ?? ""}
+            value={comp.minItems ?? ""}
             onChange={(e) => {
               const val =
                 e.target.value === "" ? undefined : Number(e.target.value);
@@ -34,7 +42,7 @@ export default function ContentPanel({
                 handleInput("minItems", undefined);
                 return;
               }
-              const max = (component as any).maxItems;
+              const max = comp.maxItems;
               const patch: Partial<PageComponent> = { minItems: val };
               if (max !== undefined && val > max) {
                 patch.maxItems = val;
@@ -42,13 +50,13 @@ export default function ContentPanel({
               onChange(patch);
             }}
             min={0}
-            max={(component as any).maxItems ?? undefined}
+            max={comp.maxItems ?? undefined}
           />
           <Input
             label="Max Items"
             type="number"
             title="Maximum number of items"
-            value={(component as any).maxItems ?? ""}
+            value={comp.maxItems ?? ""}
             onChange={(e) => {
               const val =
                 e.target.value === "" ? undefined : Number(e.target.value);
@@ -56,14 +64,14 @@ export default function ContentPanel({
                 handleInput("maxItems", undefined);
                 return;
               }
-              const min = (component as any).minItems;
+              const min = comp.minItems;
               const patch: Partial<PageComponent> = { maxItems: val };
               if (min !== undefined && val < min) {
                 patch.minItems = val;
               }
               onChange(patch);
             }}
-            min={(component as any).minItems ?? 0}
+            min={comp.minItems ?? 0}
           />
         </>
       )}
@@ -75,7 +83,7 @@ export default function ContentPanel({
             label="Desktop Items"
             type="number"
             title="Items shown on desktop"
-            value={(component as any).desktopItems ?? ""}
+            value={comp.desktopItems ?? ""}
             onChange={(e) =>
               handleInput(
                 "desktopItems",
@@ -88,7 +96,7 @@ export default function ContentPanel({
             label="Tablet Items"
             type="number"
             title="Items shown on tablet"
-            value={(component as any).tabletItems ?? ""}
+            value={comp.tabletItems ?? ""}
             onChange={(e) =>
               handleInput(
                 "tabletItems",
@@ -101,7 +109,7 @@ export default function ContentPanel({
             label="Mobile Items"
             type="number"
             title="Items shown on mobile"
-            value={(component as any).mobileItems ?? ""}
+            value={comp.mobileItems ?? ""}
             onChange={(e) =>
               handleInput(
                 "mobileItems",
@@ -117,15 +125,15 @@ export default function ContentPanel({
           label="Columns"
           type="number"
           title="Number of columns"
-          value={(component as any).columns ?? ""}
+          value={comp.columns ?? ""}
           onChange={(e) =>
             handleInput(
               "columns",
               e.target.value === "" ? undefined : Number(e.target.value)
             )
           }
-          min={(component as any).minItems}
-          max={(component as any).maxItems}
+          min={comp.minItems}
+          max={comp.maxItems}
         />
       )}
       <Suspense fallback={<p className="text-muted text-sm">Loading...</p>}>

--- a/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
@@ -34,7 +34,9 @@ export default function LayoutPanel({
               label={`Width (${vp})`}
               placeholder="e.g. 100px or 50%"
               title="CSS width value with units"
-              value={(component as any)[`width${vp}`] ?? ""}
+              value={
+                (component[`width${vp}` as keyof PageComponent] as string) ?? ""
+              }
               onChange={(e) => handleResize(`width${vp}`, e.target.value)}
             />
             <Button
@@ -50,7 +52,10 @@ export default function LayoutPanel({
               label={`Height (${vp})`}
               placeholder="e.g. 1px or 1rem"
               title="CSS height value with units"
-              value={(component as any)[`height${vp}`] ?? ""}
+              value={
+                (component[`height${vp}` as keyof PageComponent] as string) ??
+                ""
+              }
               onChange={(e) => handleResize(`height${vp}`, e.target.value)}
             />
             <Button
@@ -99,14 +104,20 @@ export default function LayoutPanel({
             label={`Margin (${vp})`}
             placeholder="e.g. 1rem"
             title="CSS margin value with units"
-            value={(component as any)[`margin${vp}`] ?? ""}
+            value={
+              (component[`margin${vp}` as keyof PageComponent] as string) ??
+              ""
+            }
             onChange={(e) => handleResize(`margin${vp}`, e.target.value)}
           />
           <Input
             label={`Padding (${vp})`}
             placeholder="e.g. 1rem"
             title="CSS padding value with units"
-            value={(component as any)[`padding${vp}`] ?? ""}
+            value={
+              (component[`padding${vp}` as keyof PageComponent] as string) ??
+              ""
+            }
             onChange={(e) => handleResize(`padding${vp}`, e.target.value)}
           />
         </div>
@@ -130,7 +141,9 @@ export default function LayoutPanel({
           label="Gap"
           placeholder="e.g. 1rem"
           title="Gap between items"
-          value={(component as any).gap ?? ""}
+          value={
+            (component as { gap?: string }).gap ?? ""
+          }
           onChange={(e) => handleInput("gap", e.target.value)}
         />
       )}

--- a/packages/ui/src/components/cms/page-builder/useTextEditor.ts
+++ b/packages/ui/src/components/cms/page-builder/useTextEditor.ts
@@ -5,14 +5,19 @@ import type { Locale } from "@/i18n/locales";
 import type { PageComponent } from "@acme/types";
 import { useEffect } from "react";
 
-function getContent(component: PageComponent, locale: Locale) {
-  return typeof (component as any).text === "string"
-    ? (component as any).text
-    : ( (component as any).text?.[locale] ?? "");
+type TextComponent = PageComponent & {
+  type: "Text";
+  text?: string | Record<string, string>;
+};
+
+function getContent(component: TextComponent, locale: Locale) {
+  return typeof component.text === "string"
+    ? component.text
+    : component.text?.[locale] ?? "";
 }
 
 export default function useTextEditor(
-  component: PageComponent,
+  component: TextComponent,
   locale: Locale,
   editing: boolean,
 ) {


### PR DESCRIPTION
## Summary
- replace untyped component casts with PageComponent-based discriminated unions
- type page builder hooks and panels to operate on PageComponent

## Testing
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError in ThemeEditor colors test)*

------
https://chatgpt.com/codex/tasks/task_e_689df760c244832fa21fa9c5e2dcbccc