### PR TITLE
feat: apply rental coverage waivers from session

### DIFF
--- a/apps/shop-bcd/__tests__/return-api.test.ts
+++ b/apps/shop-bcd/__tests__/return-api.test.ts
@@ -44,6 +44,10 @@ describe("/api/return", () => {
       markRefunded,
       addOrder: jest.fn(),
     }));
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ coverageIncluded: true }),
+    }));
     jest.doMock("@platform-core/pricing", () => ({
       __esModule: true,
       computeDamageFee,
@@ -56,7 +60,7 @@ describe("/api/return", () => {
     } as any);
 
     expect(retrieve).toHaveBeenCalledWith("sess", { expand: ["payment_intent"] });
-    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50);
+    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50, []);
     expect(refundCreate).toHaveBeenCalledWith({
       payment_intent: "pi_123",
       amount: 30 * 100,
@@ -98,6 +102,10 @@ describe("/api/return", () => {
       markReturned,
       markRefunded,
       addOrder: jest.fn(),
+    }));
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ coverageIncluded: true }),
     }));
     jest.doMock("@platform-core/pricing", () => ({
       __esModule: true,

--- a/data/rental/pricing.json
+++ b/data/rental/pricing.json
@@ -11,6 +11,7 @@
   },
   "coverage": {
     "scuff": { "fee": 5, "waiver": 20 },
-    "tear": { "fee": 10, "waiver": 50 }
+    "tear": { "fee": 10, "waiver": 50 },
+    "lost": { "fee": 20, "waiver": 1000 }
   }
 }

--- a/packages/template-app/__tests__/return.test.ts
+++ b/packages/template-app/__tests__/return.test.ts
@@ -47,6 +47,10 @@ describe("/api/return", () => {
       markRefunded: jest.fn(),
       addOrder: jest.fn(),
     }));
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true, coverageIncluded: true }),
+    }));
     jest.doMock("@platform-core/pricing", () => ({
       computeDamageFee,
     }));
@@ -55,7 +59,7 @@ describe("/api/return", () => {
     const res = await POST({
       json: async () => ({ sessionId: "sess", damage: "scratch" }),
     } as unknown as NextRequest);
-    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50);
+    expect(computeDamageFee).toHaveBeenCalledWith("scratch", 50, []);
     expect(refundCreate).toHaveBeenCalledWith({
       payment_intent: "pi_1",
       amount: 30 * 100,
@@ -87,6 +91,10 @@ describe("/api/return", () => {
         .mockResolvedValue({} as RentalOrder),
       markRefunded: jest.fn(),
       addOrder: jest.fn(),
+    }));
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true, coverageIncluded: true }),
     }));
     jest.doMock("@platform-core/pricing", () => ({
       computeDamageFee: jest.fn(),

--- a/packages/template-app/src/api/rental/route.ts
+++ b/packages/template-app/src/api/rental/route.ts
@@ -69,7 +69,9 @@ export async function PATCH(req: NextRequest) {
   }
 
   const session = await stripe.checkout.sessions.retrieve(sessionId);
-  const coverageCodes = session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
+  const coverageCodes = shop.coverageIncluded
+    ? session.metadata?.coverage?.split(",").filter(Boolean) ?? []
+    : [];
   const damageFee = await computeDamageFee(
     damage,
     order.deposit,

--- a/packages/template-app/src/api/return/route.ts
+++ b/packages/template-app/src/api/return/route.ts
@@ -66,7 +66,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, message: "No deposit found" });
     }
 
-    const damageFee = await computeDamageFee(damage, deposit);
+    const coverageCodes = shop.coverageIncluded
+      ? session.metadata?.coverage?.split(",").filter(Boolean) ?? []
+      : [];
+    const damageFee = await computeDamageFee(damage, deposit, coverageCodes);
     if (damageFee) {
       await markReturned(SHOP_ID, sessionId, damageFee);
     }


### PR DESCRIPTION
## Summary
- add `lost` damage coverage rules to rental pricing
- honor checkout coverage metadata when computing damage fees
- skip damage fees if shop includes coverage

## Testing
- `pnpm exec jest packages/platform-core/__tests__/pricing.test.ts`
- `pnpm exec jest packages/template-app/__tests__/rental.test.ts packages/template-app/__tests__/return.test.ts apps/shop-bcd/__tests__/return-api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689df313de94832fb98efb8183d47ae4