### PR TITLE
feat: add late fee service configuration

### DIFF
--- a/data/shops/c2/settings.json
+++ b/data/shops/c2/settings.json
@@ -12,7 +12,7 @@
     "intervalMinutes": 30
   },
   "lateFeeService": {
-    "enabled": true,
+    "enabled": false,
     "intervalMinutes": 60
   },
   "returnService": { "upsEnabled": false },

--- a/data/shops/r1/settings.json
+++ b/data/shops/r1/settings.json
@@ -1,3 +1,4 @@
 {
-  "reverseLogisticsService": { "enabled": true, "intervalMinutes": 30 }
+  "reverseLogisticsService": { "enabled": true, "intervalMinutes": 30 },
+  "lateFeeService": { "enabled": false, "intervalMinutes": 60 }
 }

--- a/data/shops/shop/settings.json
+++ b/data/shops/shop/settings.json
@@ -11,7 +11,7 @@
     "intervalMinutes": 30
   },
   "lateFeeService": {
-    "enabled": true,
+    "enabled": false,
     "intervalMinutes": 60
   },
   "returnService": { "upsEnabled": false },

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -141,6 +141,14 @@ export async function startLateFeeService(
       const cfg = await resolveConfig(shop, dataRoot, configs[shop]);
       if (!cfg.enabled) return;
 
+      try {
+        const raw = await readFile(join(dataRoot, shop, "shop.json"), "utf8");
+        const json = JSON.parse(raw);
+        if (json.type === "sale" || !json.lateFeePolicy) return;
+      } catch {
+        return;
+      }
+
       async function run() {
         try {
           await chargeLateFeesOnce(shop, dataRoot);

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -106,6 +106,18 @@ export declare const shopDomainSchema: z.ZodObject<{
     certificateStatus?: string | undefined;
 }>;
 export type ShopDomain = z.infer<typeof shopDomainSchema>;
+
+export declare const lateFeeServiceSchema: z.ZodObject<{
+    enabled: z.ZodBoolean;
+    intervalMinutes: z.ZodNumber;
+}, "strict", z.ZodTypeAny, {
+    enabled: boolean;
+    intervalMinutes: number;
+}, {
+    enabled: boolean;
+    intervalMinutes: number;
+}>;
+export type LateFeeService = z.infer<typeof lateFeeServiceSchema>;
 export declare const shopSchema: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -53,6 +53,16 @@ export const shopDomainSchema = z
 
 export type ShopDomain = z.infer<typeof shopDomainSchema>;
 
+export const lateFeeServiceSchema = z
+  .object({
+    enabled: z.boolean(),
+    /** Interval in minutes between service runs */
+    intervalMinutes: z.number().int().positive(),
+  })
+  .strict();
+
+export type LateFeeService = z.infer<typeof lateFeeServiceSchema>;
+
 export const shopSchema = z
   .object({
     id: z.string(),

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -112,6 +112,16 @@ export declare const shopSettingsSchema: z.ZodObject<{
         enabled: boolean;
         intervalMinutes: number;
     }>>;
+    lateFeeService: z.ZodOptional<z.ZodObject<{
+        enabled: z.ZodBoolean;
+        intervalMinutes: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        enabled: boolean;
+        intervalMinutes: number;
+    }, {
+        enabled: boolean;
+        intervalMinutes: number;
+    }>>;
     returnService: z.ZodOptional<z.ZodObject<{
         upsEnabled: z.ZodBoolean;
     }, "strip", z.ZodTypeAny, {
@@ -171,6 +181,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
         enabled: boolean;
         intervalMinutes: number;
     } | undefined;
+    lateFeeService?: {
+        enabled: boolean;
+        intervalMinutes: number;
+    } | undefined;
     returnService?: {
         upsEnabled: boolean;
     } | undefined;
@@ -215,6 +229,10 @@ export declare const shopSettingsSchema: z.ZodObject<{
         intervalMinutes: number;
     } | undefined;
     reverseLogisticsService?: {
+        enabled: boolean;
+        intervalMinutes: number;
+    } | undefined;
+    lateFeeService?: {
         enabled: boolean;
         intervalMinutes: number;
     } | undefined;

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { localeSchema } from "./Product";
-import { shopSeoFieldsSchema } from "./Shop";
+import { shopSeoFieldsSchema, lateFeeServiceSchema } from "./Shop";
 
 export const aiCatalogFieldSchema = z.enum([
   "id",
@@ -64,6 +64,7 @@ export const shopSettingsSchema = z
       })
       .strict()
       .optional(),
+    lateFeeService: lateFeeServiceSchema.optional(),
     returnService: z
       .object({
         upsEnabled: z.boolean(),


### PR DESCRIPTION
## Summary
- add late fee service schema and types
- disable late fee service for shops lacking policy
- skip processing for sale shops or shops without late fee policies

## Testing
- `pnpm lint --filter @acme/platform-machine --filter @acme/types`
- `pnpm --filter @acme/platform-machine test` *(fails: process.exit(1) at packages/config/src/env/payments.ts:16:11)*


------
https://chatgpt.com/codex/tasks/task_e_689df31a2968832f9a06debced54c5a8