### PR TITLE
feat: enable keyboard insertion in page builder palette

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -191,7 +191,11 @@ const PageBuilder = memo(function PageBuilder({
   return (
     <div className="flex gap-4" style={style}>
       <aside className="w-48 shrink-0">
-        <Palette />
+        <Palette
+          components={components}
+          dispatch={dispatch}
+          selectId={setSelectedId}
+        />
       </aside>
       <div className="flex flex-1 flex-col gap-4">
         <div className="flex items-center justify-between">

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -3,7 +3,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { PageComponent } from "@acme/types";
-import { memo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import {
   atomRegistry,
   moleculeRegistry,
@@ -12,6 +12,9 @@ import {
   layoutRegistry,
   overlayRegistry,
 } from "../blocks";
+import { ulid } from "ulid";
+import { defaults, CONTAINER_TYPES } from "./defaults";
+import type { Action } from "./state";
 
 const defaultIcon = "/window.svg";
 
@@ -37,10 +40,12 @@ const PaletteItem = memo(function PaletteItem({
   type,
   label,
   icon,
+  onAdd,
 }: {
   type: PageComponent["type"];
   label: string;
   icon: string;
+  onAdd: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useSortable({
@@ -48,16 +53,27 @@ const PaletteItem = memo(function PaletteItem({
       data: { from: "palette", type },
     });
 
+  const { onKeyDown, ...otherListeners } = listeners;
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onAdd();
+      return;
+    }
+    onKeyDown?.(e);
+  };
+
   return (
     <div
       ref={setNodeRef}
       {...attributes}
-      {...listeners}
+      {...otherListeners}
       role="button"
       tabIndex={0}
       aria-grabbed={isDragging}
       title="Drag or press space/enter to add"
       style={{ transform: CSS.Transform.toString(transform) }}
+      onKeyDown={handleKeyDown}
       className="flex cursor-grab items-center gap-2 rounded border p-2 text-sm"
     >
       <img src={icon} alt="" aria-hidden="true" className="h-4 w-4" />
@@ -65,11 +81,38 @@ const PaletteItem = memo(function PaletteItem({
     </div>
   );
 });
-const Palette = memo(function Palette() {
+interface Props {
+  components: PageComponent[];
+  dispatch: (action: Action) => void;
+  selectId: (id: string) => void;
+}
+
+const Palette = memo(function Palette({ components, dispatch, selectId }: Props) {
   const [search, setSearch] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleAdd = useCallback(
+    (type: PageComponent["type"], label: string) => {
+      const isContainer = CONTAINER_TYPES.includes(type as any);
+      const component = {
+        id: ulid(),
+        type: type as any,
+        ...(defaults[type as any] ?? {}),
+        ...(isContainer ? { children: [] } : {}),
+      } as PageComponent;
+      dispatch({ type: "add", component, index: components.length });
+      selectId(component.id);
+      setMessage(`${label} added`);
+      setTimeout(() => setMessage(""), 500);
+    },
+    [components.length, dispatch, selectId]
+  );
 
   return (
     <div className="flex flex-col gap-4" data-tour="drag-component">
+      <div aria-live="polite" className="sr-only">
+        {message}
+      </div>
       <input
         type="text"
         value={search}
@@ -93,6 +136,7 @@ const Palette = memo(function Palette() {
                   type={p.type}
                   label={p.label}
                   icon={p.icon}
+                  onAdd={() => handleAdd(p.type, p.label)}
                 />
               ))}
             </div>

--- a/packages/ui/src/components/cms/page-builder/__tests__/Palette.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/Palette.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import Palette from "../Palette";
+
+describe("Palette keyboard addition", () => {
+  it("dispatches add action when Enter is pressed", () => {
+    const dispatch = jest.fn();
+    const selectId = jest.fn();
+    render(<Palette components={[]} dispatch={dispatch} selectId={selectId} />);
+    const item = screen.getAllByRole("button")[0];
+    fireEvent.keyDown(item, { key: "Enter" });
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: "add" }));
+  });
+});


### PR DESCRIPTION
## Summary
- allow palette items to add components via Enter/Space
- announce inserted component with aria-live message
- cover keyboard addition with unit test

## Testing
- `pnpm lint --filter @acme/ui` (no tasks)
- `pnpm test --filter @acme/ui` (fails: Test failed)
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/page-builder/__tests__/Palette.test.tsx --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689df3238944832fbff0b36be81eb96a