### PR TITLE
Add rental damage coverage selection and waiver logic

### DIFF
--- a/data/rental/pricing.json
+++ b/data/rental/pricing.json
@@ -11,6 +11,7 @@
   },
   "coverage": {
     "scuff": { "fee": 5, "waiver": 20 },
-    "tear": { "fee": 10, "waiver": 50 }
+    "tear": { "fee": 10, "waiver": 50 },
+    "lost": { "fee": 15, "waiver": 50 }
   }
 }

--- a/packages/template-app/src/api/rental/route.ts
+++ b/packages/template-app/src/api/rental/route.ts
@@ -69,7 +69,11 @@ export async function PATCH(req: NextRequest) {
   }
 
   const session = await stripe.checkout.sessions.retrieve(sessionId);
-  const coverageCodes = session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
+  let coverageCodes =
+    session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
+  if (shop.coverageIncluded && typeof damage === "string") {
+    coverageCodes = Array.from(new Set([...coverageCodes, damage]));
+  }
   const damageFee = await computeDamageFee(
     damage,
     order.deposit,

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -13,6 +13,7 @@ import { getProductById } from "@platform-core/src/products";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/src/repositories/settings.server";
 import { readShop } from "@platform-core/src/repositories/shops.server";
+import { useState } from "react";
 
 export const metadata = {
   title: "Checkout · Base-Shop",
@@ -69,10 +70,38 @@ export default async function CheckoutPage({
           cart={validatedCart}
           totals={{ subtotal, deposit, total }}
         />
-        <CheckoutForm locale={lang} taxRegion={settings.taxRegion} />
+        <CheckoutSection locale={lang} taxRegion={settings.taxRegion} />
       </div>
     );
   }
 
   return <p className="p-8 text-center">Rental checkout not implemented.</p>;
+}
+
+function CheckoutSection({
+  locale,
+  taxRegion,
+}: {
+  locale: Locale;
+  taxRegion: string;
+}) {
+  "use client";
+  const [coverage, setCoverage] = useState(false);
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={coverage}
+          onChange={(e) => setCoverage(e.target.checked)}
+        />
+        Add coverage
+      </label>
+      <CheckoutForm
+        locale={locale}
+        taxRegion={taxRegion}
+        coverage={coverage ? ["scuff", "tear"] : []}
+      />
+    </div>
+  );
 }

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -21,11 +21,19 @@ const stripePromise = loadStripe(
   paymentEnv.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 );
 
-type Props = { locale: "en" | "de" | "it"; taxRegion: string };
+type Props = {
+  locale: "en" | "de" | "it";
+  taxRegion: string;
+  coverage?: string[];
+};
 
 type FormValues = { returnDate: string };
 
-export default function CheckoutForm({ locale, taxRegion }: Props) {
+export default function CheckoutForm({
+  locale,
+  taxRegion,
+  coverage = [],
+}: Props) {
   const [clientSecret, setClientSecret] = useState<string>();
   const [fetchError, setFetchError] = useState(false);
   const [retry, setRetry] = useState(0);
@@ -49,7 +57,7 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ returnDate, currency, taxRegion }),
+            body: JSON.stringify({ returnDate, currency, taxRegion, coverage }),
             signal: controller.signal,
           }
         );
@@ -72,7 +80,7 @@ export default function CheckoutForm({ locale, taxRegion }: Props) {
       controller.abort();
       clearTimeout(timeout);
     };
-  }, [returnDate, currency, taxRegion, retry]);
+  }, [returnDate, currency, taxRegion, coverage, retry]);
 
   if (!clientSecret) {
     if (fetchError)


### PR DESCRIPTION
## Summary
- extend pricing matrix with coverage rules
- add checkout UI for optional coverage and send selection to session
- waive damage fees when coverage purchased or shop covers damage

## Testing
- `pnpm test --filter @acme/template-app` *(no tests found)*
- `STRIPE_SECRET_KEY=dummy NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy STRIPE_WEBHOOK_SECRET=dummy pnpm test --filter @acme/ui` *(fails: packages/config/src/env/payments.ts:16:11)*

------
https://chatgpt.com/codex/tasks/task_e_689df44e3420832fac8dfaf0f5d95ec5