### PR TITLE
feat(platform-core): use Dinero for currency conversion

### DIFF
--- a/packages/platform-core/__tests__/pricing.test.ts
+++ b/packages/platform-core/__tests__/pricing.test.ts
@@ -39,6 +39,8 @@ describe('pricing utilities', () => {
 
     await expect(convertCurrency(100, 'USD')).resolves.toBe(100);
     await expect(convertCurrency(100, 'EUR')).resolves.toBe(50);
+    // HALF_EVEN rounding: 101 * 0.5 = 50.5 -> 50
+    await expect(convertCurrency(101, 'EUR')).resolves.toBe(50);
     await expect(convertCurrency(100, 'GBP')).rejects.toThrow(
       'Missing exchange rate for GBP'
     );

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -15,12 +15,13 @@
     "./stripe-webhook": "./src/stripe-webhook.ts"
   },
   "dependencies": {
+    "@acme/date-utils": "workspace:*",
+    "@acme/email": "workspace:*",
     "@acme/shared-utils": "workspace:*",
     "@prisma/client": "^5.15.1",
     "@upstash/redis": "^1.35.3",
-    "@acme/email": "workspace:*",
-    "@acme/date-utils": "workspace:*",
     "better-sqlite3": "^12.2.0",
+    "dinero.js": "^1.9.1",
     "pino": "^9.9.0",
     "zod": "^3.25.67"
   },

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -4,6 +4,7 @@ import type { PricingMatrix, SKU } from "@acme/types";
 import { pricingSchema } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import Dinero from "dinero.js";
 import { resolveDataRoot } from "./dataRoot";
 
 let cached: PricingMatrix | null = null;
@@ -34,7 +35,8 @@ export async function convertCurrency(
   if (to === base) return amount;
   const rate = rates[to];
   if (!rate) throw new Error(`Missing exchange rate for ${to}`);
-  return Math.round(amount * rate);
+  const dineroAmount = Dinero({ amount });
+  return dineroAmount.multiply(rate, "HALF_EVEN").getAmount();
 }
 
 export function applyDurationDiscount(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       better-sqlite3:
         specifier: ^12.2.0
         version: 12.2.0
+      dinero.js:
+        specifier: ^1.9.1
+        version: 1.9.1
       pino:
         specifier: ^9.9.0
         version: 9.9.0
@@ -5540,6 +5543,9 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dinero.js@1.9.1:
+    resolution: {integrity: sha512-1HXiF2vv3ZeRQ23yr+9lFxj/PbZqutuYWJnE0qfCB9xYBPnuaJ8lXtli1cJM0TvUXW1JTOaePldmqN5JVNxKSA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -16071,6 +16077,8 @@ snapshots:
       randombytes: 2.1.0
 
   dijkstrajs@1.0.3: {}
+
+  dinero.js@1.9.1: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add dinero.js dependency for monetary calculations
- refactor convertCurrency to use Dinero for rate conversion with HALF_EVEN rounding
- test conversion rounding behavior

## Testing
- `pnpm exec jest packages/platform-core/__tests__/pricing.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`
- `pnpm exec jest packages/platform-core/__tests__/checkout-session.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689df4a19604832f8826e2ea5df054d3