### PR TITLE
feat(template-app): support prorate in stripe subscription params

### DIFF
--- a/packages/template-app/src/api/subscribe/route.ts
+++ b/packages/template-app/src/api/subscribe/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: NextRequest) {
         user.stripeSubscriptionId,
         {
           items: [{ price: priceId }],
-          // @ts-ignore - `prorate` is deprecated but required for this flow
+          // `prorate` is deprecated but required for this flow
           prorate: true,
         },
       );
@@ -52,7 +52,7 @@ export async function POST(req: NextRequest) {
     const sub = await stripe.subscriptions.create({
       customer: userId,
       items: [{ price: priceId }],
-      // @ts-ignore - `prorate` is deprecated but required for this flow
+      // `prorate` is deprecated but required for this flow
       prorate: true,
       metadata: { userId, shop: SHOP_ID },
     });

--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -31,7 +31,7 @@ export default async function SubscribePage({
     const sub = await stripe.subscriptions.create({
       customer: session.customerId,
       items: [{ price: priceId }],
-      // @ts-ignore - `prorate` is deprecated but required for this flow
+      // `prorate` is deprecated but required for this flow
       prorate: true,
       metadata: { userId: session.customerId, shop: shopId },
     });

--- a/packages/template-app/src/types/stripe.d.ts
+++ b/packages/template-app/src/types/stripe.d.ts
@@ -1,0 +1,10 @@
+declare module "stripe" {
+  namespace Stripe {
+    interface SubscriptionCreateParams {
+      prorate?: boolean;
+    }
+    interface SubscriptionUpdateParams {
+      prorate?: boolean;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow Stripe subscription params to include deprecated `prorate`
- remove `ts-ignore` comments where prorate is used

## Testing
- `pnpm exec tsc -p packages/template-app/tsconfig.json --noEmit` (fails: missing build artifacts and modules)
- `pnpm test --filter @acme/template-app`


------
https://chatgpt.com/codex/tasks/task_e_689df75f8b18832f96e76591b3642ecf