### PR TITLE
Broadcast theme token updates to live preview

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
@@ -119,6 +119,7 @@ export function useThemeEditor({
     }
     debounceRef.current = window.setTimeout(() => {
       setPreviewTokens(tokens);
+      savePreviewTokens(tokens);
     }, 100);
   };
 
@@ -245,9 +246,11 @@ export function useThemeEditor({
     };
   }, []);
 
+  // Broadcast initial tokens so previews reflect the current theme on mount
   useEffect(() => {
     savePreviewTokens(previewTokens);
-  }, [previewTokens]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleThemeChange = async (
     e: ChangeEvent<HTMLSelectElement>,
@@ -257,8 +260,7 @@ export function useThemeEditor({
     setOverrides({});
     setThemeDefaults(tokensByThemeState[newTheme]);
     const merged = { ...tokensByThemeState[newTheme] };
-    setPreviewTokens(merged);
-    savePreviewTokens(merged);
+    schedulePreviewUpdate(merged);
   };
 
   const handleResetAll = async () => {
@@ -272,7 +274,6 @@ export function useThemeEditor({
     setOverrides({});
     const merged = { ...tokensByThemeState[theme] };
     schedulePreviewUpdate(merged);
-    savePreviewTokens(merged);
     scheduleSave(patch);
   };
 


### PR DESCRIPTION
## Summary
- Debounce preview token updates and persist them for cross-tab previews
- Ensure theme changes and reset-all actions schedule a broadcast

## Testing
- `pnpm test` *(fails: @acme/next-config#test exited 1)*
- `pnpm --filter @apps/cms test` *(fails: jest exit 1)*
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module @acme/config/env/core.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689df772fbf4832fbb5c558dda9912db