### PR TITLE
feat: add rental inventory allocation

### DIFF
--- a/packages/template-app/__tests__/rental-return-flow.test.ts
+++ b/packages/template-app/__tests__/rental-return-flow.test.ts
@@ -23,6 +23,19 @@ async function withShop(
     path.join(__dirname, "../../..", "data", "rental", "pricing.json"),
     path.join(dir, "data", "rental", "pricing.json")
   );
+  await fs.writeFile(
+    path.join(dir, "data", "shops", "bcd", "shop.json"),
+    JSON.stringify({
+      id: "bcd",
+      name: "bcd",
+      catalogFilters: [],
+      themeId: "base",
+      filterMappings: {},
+      rentalInventoryAllocation: true,
+      returnsEnabled: true,
+      coverageIncluded: true,
+    }),
+  );
   const cwd = process.cwd();
   process.chdir(dir);
   jest.resetModules();


### PR DESCRIPTION
## Summary
- reserve rental inventory when the shop enables allocation
- allow rental API to fall back to standard flow when allocation disabled
- ensure rental return flow test has shop config enabling allocation

## Testing
- `pnpm jest packages/template-app/__tests__/rental.test.ts packages/template-app/__tests__/rental-return-flow.test.ts` *(fails: Cannot find module '.prisma/client/index-browser')*


------
https://chatgpt.com/codex/tasks/task_e_689df8bec4c8832face6748ffab10dc7