### PR TITLE
Persist preview device selection

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -17,6 +17,7 @@ import {
 } from "./previewTokens";
 import { devicePresets, getLegacyPreset, type DevicePreset } from "@ui/utils/devicePresets";
 import DeviceSelector from "@ui/components/cms/DeviceSelector";
+import { usePreviewDevice } from "@ui/hooks";
 
 interface Props {
   style: React.CSSProperties;
@@ -38,7 +39,7 @@ export default function WizardPreview({
   onTokenSelect,
   device: deviceProp,
 }: Props): React.JSX.Element {
-  const [deviceId, setDeviceId] = useState(devicePresets[0].id);
+  const [deviceId, setDeviceId] = usePreviewDevice(devicePresets[0].id);
   const [orientation, setOrientation] = useState<"portrait" | "landscape">(
     "portrait"
   );

--- a/apps/shop-abc/src/app/preview/[pageId]/PreviewClient.tsx
+++ b/apps/shop-abc/src/app/preview/[pageId]/PreviewClient.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { PageComponent } from "@acme/types";
 import type { Locale } from "@i18n/locales";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import DeviceSelector from "@ui/components/DeviceSelector";
 import { devicePresets } from "@ui/utils/devicePresets";
+import { usePreviewDevice } from "@ui/hooks";
 
 interface PreviewClientProps {
   components: PageComponent[];
@@ -18,7 +19,7 @@ export default function PreviewClient({
   locale,
   initialDeviceId,
 }: PreviewClientProps) {
-  const [deviceId, setDeviceId] = useState(initialDeviceId);
+  const [deviceId, setDeviceId] = usePreviewDevice(initialDeviceId);
   const device = useMemo(
     () => devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0],
     [deviceId],

--- a/apps/shop-bcd/src/app/preview/[pageId]/PreviewClient.tsx
+++ b/apps/shop-bcd/src/app/preview/[pageId]/PreviewClient.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { PageComponent } from "@acme/types";
 import type { Locale } from "@i18n/locales";
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import DeviceSelector from "@ui/components/DeviceSelector";
 import { devicePresets } from "@ui/utils/devicePresets";
+import { usePreviewDevice } from "@ui/hooks";
 
 interface PreviewClientProps {
   components: PageComponent[];
@@ -18,7 +19,7 @@ export default function PreviewClient({
   locale,
   initialDeviceId,
 }: PreviewClientProps) {
-  const [deviceId, setDeviceId] = useState(initialDeviceId);
+  const [deviceId, setDeviceId] = usePreviewDevice(initialDeviceId);
   const device = useMemo(
     () => devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0],
     [deviceId],

--- a/packages/template-app/src/app/preview/[pageId]/PreviewClient.tsx
+++ b/packages/template-app/src/app/preview/[pageId]/PreviewClient.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { PageComponent } from "@acme/types";
 import type { Locale } from "@i18n/locales";
 import DynamicRenderer from "@/components/DynamicRenderer";
 import DeviceSelector from "@ui/src/components/DeviceSelector";
 import { devicePresets } from "@ui/utils/devicePresets";
+import { usePreviewDevice } from "@ui/src/hooks/usePreviewDevice";
 
 interface PreviewClientProps {
   components: PageComponent[];
@@ -18,7 +19,7 @@ export default function PreviewClient({
   locale,
   initialDeviceId,
 }: PreviewClientProps) {
-  const [deviceId, setDeviceId] = useState(initialDeviceId);
+  const [deviceId, setDeviceId] = usePreviewDevice(initialDeviceId);
   const device = useMemo(
     () => devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0],
     [deviceId],

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -24,6 +24,7 @@ import PageCanvas from "./PageCanvas";
 import PageSidebar from "./PageSidebar";
 import { defaults, CONTAINER_TYPES } from "./defaults";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
+import { usePreviewDevice } from "@ui/hooks";
 
 interface Props {
   page: Page;
@@ -62,7 +63,7 @@ const PageBuilder = memo(function PageBuilder({
     clearHistory,
   } = usePageBuilderState({ page, history: historyProp, onChange });
 
-  const [deviceId, setDeviceId] = useState(devicePresets[0].id);
+  const [deviceId, setDeviceId] = usePreviewDevice(devicePresets[0].id);
   const [orientation, setOrientation] = useState<"portrait" | "landscape">(
     "portrait"
   );

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -7,3 +7,4 @@ export * from "./useProductEditorFormState";
 export * from "./useProductFilters";
 export * from "./useTokenEditor";
 export * from "./usePublishLocations";
+export * from "./usePreviewDevice";

--- a/packages/ui/src/hooks/usePreviewDevice.ts
+++ b/packages/ui/src/hooks/usePreviewDevice.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "preview-device";
+
+export function usePreviewDevice(initialId: string) {
+  const [deviceId, setDeviceId] = useState(initialId);
+
+  // load stored device on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setDeviceId(stored);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // persist device on change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, deviceId);
+    } catch {
+      // ignore
+    }
+  }, [deviceId]);
+
+  return [deviceId, setDeviceId] as const;
+}
+
+export const PREVIEW_DEVICE_STORAGE_KEY = STORAGE_KEY;


### PR DESCRIPTION
## Summary
- persist device choice between sessions with usePreviewDevice hook
- read and store device selection in PreviewClient, PageBuilder, and WizardPreview

## Testing
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*
- `pnpm --filter @apps/cms test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*
- `pnpm --filter @acme/ui lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689e1816a424832f9efd838eea19c996