### PR TITLE
Add Stripe subscription proration and shop-aware storage

### DIFF
--- a/packages/platform-core/src/repositories/users.server.ts
+++ b/packages/platform-core/src/repositories/users.server.ts
@@ -4,11 +4,16 @@ import "server-only";
 export * from "../users";
 
 import { prisma } from "../db";
+import { readShop } from "./shops.server";
 
 export async function setStripeSubscriptionId(
   id: string,
   subscriptionId: string | null,
+  shopId: string,
 ): Promise<void> {
+  const shop = await readShop(shopId);
+  if (!shop.subscriptionsEnabled) return;
+
   await prisma.user.update({
     where: { id },
     data: { stripeSubscriptionId: subscriptionId },

--- a/packages/template-app/src/api/billing/webhook/route.ts
+++ b/packages/template-app/src/api/billing/webhook/route.ts
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
       const sub = event.data.object as Stripe.Subscription;
       const userId = sub.metadata?.userId;
       if (userId) {
-        await setStripeSubscriptionId(userId, null);
+        await setStripeSubscriptionId(userId, null, SHOP_ID);
       }
       break;
     }
@@ -43,7 +43,7 @@ export async function POST(req: NextRequest) {
       const sub = event.data.object as Stripe.Subscription;
       const userId = sub.metadata?.userId;
       if (userId) {
-        await setStripeSubscriptionId(userId, sub.id);
+        await setStripeSubscriptionId(userId, sub.id, SHOP_ID);
       }
       break;
     }

--- a/packages/template-app/src/api/subscribe/route.ts
+++ b/packages/template-app/src/api/subscribe/route.ts
@@ -46,7 +46,7 @@ export async function POST(req: NextRequest) {
           prorate: true,
         },
       );
-      await setStripeSubscriptionId(userId, sub.id);
+      await setStripeSubscriptionId(userId, sub.id, SHOP_ID);
       return NextResponse.json({ id: sub.id, status: sub.status });
     }
     const sub = await stripe.subscriptions.create({
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
       prorate: true,
       metadata: { userId, shop: SHOP_ID },
     });
-    await setStripeSubscriptionId(userId, sub.id);
+    await setStripeSubscriptionId(userId, sub.id, SHOP_ID);
     return NextResponse.json({ id: sub.id, status: sub.status });
   } catch (err: unknown) {
     if (err instanceof Error) {

--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -41,16 +41,17 @@ export async function POST(req: NextRequest) {
   }
 
   const plan = shop.rentalSubscriptions.find((p) => p.id === planId);
-  const proration_behavior = plan?.prorateOnChange
-    ? "create_prorations"
-    : "none";
+  if (!plan) {
+    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+  }
 
   try {
     const sub = await stripe.subscriptions.update(user.stripeSubscriptionId, {
       items: [{ price: priceId }],
-      proration_behavior,
+      // @ts-ignore - `prorate` is deprecated but required for this flow
+      prorate: true,
     });
-    await setStripeSubscriptionId(userId, sub.id);
+    await setStripeSubscriptionId(userId, sub.id, shopId);
     return NextResponse.json({ id: sub.id, status: sub.status });
   } catch (err: unknown) {
     if (err instanceof Error) {

--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -35,7 +35,7 @@ export default async function SubscribePage({
       prorate: true,
       metadata: { userId: session.customerId, shop: shopId },
     });
-    await setStripeSubscriptionId(session.customerId, sub.id);
+    await setStripeSubscriptionId(session.customerId, sub.id, shopId);
     await setUserPlan(shopId, session.customerId, planId);
   }
 


### PR DESCRIPTION
## Summary
- ensure Stripe subscription updates always prorate
- persist stripeSubscriptionId only when subscriptions are enabled for the shop

## Testing
- `pnpm lint` *(fails: command finished with error: command (/workspace/base-shop/apps/cms) /root/.nvm/versions/node/v20.19.4/bin/pnpm run lint exited (1))*
- `pnpm --filter @acme/platform-core test` *(fails: scheduler test exceeded timeout)*


------
https://chatgpt.com/codex/tasks/task_e_689e19fe0ad8832f90c33989da28f042