### PR TITLE
feat: gate subscription flows

### DIFF
--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -50,9 +50,13 @@ export default async function SubscribePage({
           >
             <input type="radio" name="plan" value={p.id} className="sr-only" />
             <span className="text-lg font-semibold">{p.id}</span>
-            <span>{p.itemsIncluded} items included</span>
-            <span>{p.swapLimit} swaps/month</span>
-            <span>{p.shipmentsPerMonth} shipments/month</span>
+            {shop.subscriptionsEnabled && (
+              <>
+                <span>{p.itemsIncluded} items included</span>
+                <span>{p.swapLimit} swaps/month</span>
+                <span>{p.shipmentsPerMonth} shipments/month</span>
+              </>
+            )}
           </label>
         ))}
         <button

--- a/packages/template-app/src/app/account/swaps/page.tsx
+++ b/packages/template-app/src/app/account/swaps/page.tsx
@@ -13,6 +13,7 @@ import { cookies } from "next/headers";
 import { getCustomerSession } from "@auth";
 import { readShop } from "@platform-core/src/repositories/shops.server";
 import { notFound } from "next/navigation";
+import { coreEnv } from "@acme/config/env/core";
 import {
   getUserPlan,
   getRemainingSwaps,
@@ -24,18 +25,24 @@ export default async function SwapPage() {
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
   const cart = cartId ? await getCart(cartId) : {};
   const session = await getCustomerSession();
-  const shop = await readShop("shop");
+  const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
+  const shop = await readShop(shopId);
   if (!shop.subscriptionsEnabled) return notFound();
   const planId = session?.customerId
-    ? await getUserPlan("shop", session.customerId)
+    ? await getUserPlan(shopId, session.customerId)
     : undefined;
-  const plan = planId
+  const selectedPlan = planId
     ? shop.rentalSubscriptions.find((p) => p.id === planId)
     : undefined;
   const month = new Date().toISOString().slice(0, 7);
   const remainingSwaps =
-    session?.customerId && plan
-      ? await getRemainingSwaps("shop", session.customerId, month, plan.swapLimit)
+    session?.customerId && selectedPlan
+      ? await getRemainingSwaps(
+          shopId,
+          session.customerId,
+          month,
+          selectedPlan.swapLimit,
+        )
       : 0;
   const canSwap = remainingSwaps > 0;
 
@@ -47,26 +54,27 @@ export default async function SwapPage() {
     const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
     const session = await getCustomerSession();
     if (!cartId || !session?.customerId) return;
-    const shop = await readShop("shop");
+    const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
+    const shop = await readShop(shopId);
     if (!shop.subscriptionsEnabled) return;
-    const planId = await getUserPlan("shop", session.customerId);
-    const plan = planId
+    const planId = await getUserPlan(shopId, session.customerId);
+    const selectedPlan = planId
       ? shop.rentalSubscriptions.find((p) => p.id === planId)
       : undefined;
     const month = new Date().toISOString().slice(0, 7);
-    if (!plan) return;
+    if (!selectedPlan) return;
     const remaining = await getRemainingSwaps(
-      "shop",
+      shopId,
       session.customerId,
       month,
-      plan.swapLimit,
+      selectedPlan.swapLimit,
     );
     if (remaining <= 0) return;
     const sku = getProductById(newSku);
     if (!sku) return;
     await removeItem(cartId, oldSku);
     await incrementQty(cartId, sku, 1);
-    await incrementSwapCount("shop", session.customerId, month);
+    await incrementSwapCount(shopId, session.customerId, month);
   }
 
   return (

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -128,7 +128,12 @@ export const shopSchema = z
     rentalSubscriptions: z
       .array(subscriptionPlanSchema)
       .default([]),
-    subscriptionsEnabled: z.boolean().optional(),
+    /**
+     * Feature flag to enable rental subscription flows.
+     * Sale-only shops should leave this disabled to retain
+     * traditional purchasing behavior.
+     */
+    subscriptionsEnabled: z.boolean().default(false),
     lateFeePolicy: z
       .object({
         gracePeriodDays: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- only show plan details on subscribe page when subscriptions are enabled
- ensure swap page honors selected plan and remaining swaps
- add subscriptionsEnabled feature flag to shop type

## Testing
- `pnpm test` (fails: @acme/next-config#test)
- `pnpm lint` (fails: @apps/cms#lint)


------
https://chatgpt.com/codex/tasks/task_e_689e187ace00832f89ee8623bf6eb132