### PR TITLE
feat: show cleaning info on return flows

### DIFF
--- a/packages/template-app/src/app/account/returns/page.tsx
+++ b/packages/template-app/src/app/account/returns/page.tsx
@@ -6,6 +6,8 @@ import { getShopSettings } from "@platform-core/repositories/settings.server";
 import React, { useEffect, useRef, useState } from "react";
 
 const SHOP_ID = "bcd";
+import CleaningInfo from "../../../components/CleaningInfo";
+import shop from "../../../../shop.json";
 
 export const metadata = { title: "Mobile Returns" };
 
@@ -20,7 +22,12 @@ export default async function ReturnsPage() {
   }
   const bagType = settings.returnService?.bagEnabled ? info.bagType : undefined;
   const tracking = info.tracking;
-  return <ReturnForm bagType={bagType} tracking={tracking} />;
+  return (
+    <>
+      <ReturnForm bagType={bagType} tracking={tracking} />
+      {shop.showCleaningTransparency && <CleaningInfo />}
+    </>
+  );
 }
 
 interface ReturnFormProps {

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -5,6 +5,8 @@ import {
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 
 const SHOP_ID = "bcd";
+import CleaningInfo from "../../../components/CleaningInfo";
+import shop from "../../../../shop.json";
 import { useEffect, useRef, useState } from "react";
 
 export const metadata = { title: "Mobile Returns" };
@@ -21,7 +23,12 @@ export default async function MobileReturnPage() {
   const allowed = settings.returnService?.homePickupEnabled
     ? info.homePickupZipCodes
     : [];
-  return <Scanner allowedZips={allowed} />;
+  return (
+    <>
+      <Scanner allowedZips={allowed} />
+      {shop.showCleaningTransparency && <CleaningInfo />}
+    </>
+  );
 }
 
 function Scanner({ allowedZips }: { allowedZips: string[] }) {


### PR DESCRIPTION
## Summary
- show reusable garment cleaning info on mobile return page
- show reusable garment cleaning info on account return page

## Testing
- `pnpm lint --filter @acme/template-app`
- `pnpm test --filter @acme/template-app`
- `pnpm exec tsc -p packages/template-app/tsconfig.json --noEmit` *(fails: Cannot find module '@/components/home/ValueProps' and related type declaration errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e1919fe0c832fa7be37d748015d2f