### PR TITLE
feat: central price formatting helper

### DIFF
--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -7,7 +7,7 @@ import { Progress } from "@acme/ui";
 import { CampaignFilter } from "./components/CampaignFilter.client";
 import { Charts } from "./components/Charts.client";
 import { buildMetrics } from "@cms/lib/analytics";
-import { formatCurrency } from "@acme/shared-utils";
+import { formatPrice } from "@acme/shared-utils";
 
 export default async function ShopDashboard({
   params,
@@ -141,7 +141,7 @@ export default async function ShopDashboard({
               <h3 className="text-lg font-semibold">Campaign: {c}</h3>
               <p className="mb-2 text-sm">
                 Traffic: {totalTraffic} • Revenue:{" "}
-                {formatCurrency(totalRevenue)} • Conversion:{" "}
+                {formatPrice(totalRevenue)} • Conversion:{" "}
                 {conversionRate.toFixed(2)}%
               </p>
               <Charts

--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -1,0 +1,28 @@
+# Shared Utilities
+
+## formatPrice
+
+`formatPrice` provides consistent currency formatting in both browser and Node.js environments.
+
+### Client usage
+
+```tsx
+import { formatPrice } from "@acme/shared-utils";
+
+export function PriceTag({ amount }: { amount: number }) {
+  return <span>{formatPrice(amount, "EUR")}</span>;
+}
+```
+
+### Server usage
+
+```ts
+import { formatPrice } from "@acme/shared-utils";
+
+export function getTotal() {
+  const total = 42;
+  return formatPrice(total, "EUR", "en-US");
+}
+```
+
+The helper wraps `Intl.NumberFormat` so the output respects the provided locale and currency.

--- a/packages/shared-utils/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/__tests__/formatPrice.test.ts
@@ -1,0 +1,13 @@
+import { formatPrice } from "../src/formatPrice";
+
+describe("formatPrice", () => {
+  it("formats major-unit amounts using Intl.NumberFormat", () => {
+    const amount = 123.45;
+    expect(formatPrice(amount, "USD", "en-US")).toBe(
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }).format(amount)
+    );
+  });
+});

--- a/packages/shared-utils/src/formatPrice.ts
+++ b/packages/shared-utils/src/formatPrice.ts
@@ -1,0 +1,19 @@
+// packages/shared-utils/src/formatPrice.ts
+
+/**
+ * Format a major-unit amount (e.g. dollars) as a localized currency string.
+ *
+ * @param amount   Amount in major currency units
+ * @param currency ISO 4217 currency code (default: "USD")
+ * @param locale   Optional BCP 47 locale tag
+ */
+export function formatPrice(
+  amount: number,
+  currency = "USD",
+  locale?: string
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+  }).format(amount);
+}

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -6,3 +6,4 @@ export { getCsrfToken } from "./getCsrfToken";
 export { parseJsonBody } from "./parseJsonBody";
 export { jsonFieldHandler, type ErrorSetter } from "./jsonFieldHandler";
 export { formatCurrency } from "./formatCurrency";
+export { formatPrice } from "./formatPrice";

--- a/packages/ui/__tests__/OrderSummary.test.tsx
+++ b/packages/ui/__tests__/OrderSummary.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import type { CartState } from "@/lib/cartCookie";
 import OrderSummary from "../src/components/organisms/OrderSummary";
 import { useCart } from "@ui/hooks/useCart";
+import { formatPrice } from "@acme/shared-utils";
 
 jest.mock("@ui/hooks/useCart", () => ({
   useCart: jest.fn(),
@@ -9,12 +10,7 @@ jest.mock("@ui/hooks/useCart", () => ({
 
 jest.mock("../src/components/atoms/Price", () => ({
   Price: ({ amount }: { amount: number }) => (
-    <span>
-      {new Intl.NumberFormat(undefined, {
-        style: "currency",
-        currency: "EUR",
-      }).format(amount)}
-    </span>
+    <span>{formatPrice(amount, "EUR")}</span>
   ),
 }));
 
@@ -67,11 +63,7 @@ describe("OrderSummary", () => {
     expect(screen.getByText("2", { selector: "td" })).toBeInTheDocument();
     expect(screen.getByText("1", { selector: "td" })).toBeInTheDocument();
 
-    const fmt = (n: number) =>
-      new Intl.NumberFormat(undefined, {
-        style: "currency",
-        currency: "EUR",
-      }).format(n);
+    const fmt = (n: number) => formatPrice(n, "EUR");
 
     // per-item totals
     expect(screen.getAllByText(fmt(20)).length).toBe(2);

--- a/packages/ui/src/components/atoms/Price.tsx
+++ b/packages/ui/src/components/atoms/Price.tsx
@@ -1,4 +1,5 @@
 import { useCurrency } from "@platform-core/src/contexts/CurrencyContext";
+import { formatPrice } from "@acme/shared-utils";
 import * as React from "react";
 import { cn } from "../../utils/style";
 
@@ -14,10 +15,7 @@ export const Price = React.forwardRef<HTMLSpanElement, PriceProps>(
   ({ amount, currency, className, ...props }, ref) => {
     const [ctxCurrency] = useCurrency();
     const cur = currency ?? ctxCurrency ?? "EUR";
-    const formatted = new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: cur,
-    }).format(amount);
+    const formatted = formatPrice(amount, cur);
 
     return (
       <span ref={ref} className={cn(className)} {...props}>

--- a/packages/ui/src/components/organisms/__tests__/OrderSummary.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/OrderSummary.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import OrderSummary from "../OrderSummary";
+import { formatPrice } from "@acme/shared-utils";
 
 jest.mock("@ui/hooks/useCart", () => ({
   useCart: () => [{}, jest.fn()],
@@ -10,11 +11,7 @@ jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({
 }));
 
 describe("OrderSummary", () => {
-  const format = (amount: number) =>
-    new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: "EUR",
-    }).format(amount);
+  const format = (amount: number) => formatPrice(amount, "EUR");
 
   it("renders subtotal and deposit without tax or discount by default", () => {
     const cart = {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -95,6 +95,8 @@
       "@acme/stripe": ["packages/stripe/src/index.ts"],
       "@acme/sanity": ["packages/sanity/src/index.ts"],
       "@acme/date-utils": ["packages/date-utils/src/index.ts"],
+      "@acme/shared-utils": ["packages/shared-utils/src/index.ts"],
+      "@acme/shared-utils/*": ["packages/shared-utils/src/*"],
 
       /* ─── shared runtime types ──────────────────────────────────── */
       "@acme/types": ["packages/types/src/index.ts"],


### PR DESCRIPTION
## Summary
- add `formatPrice` helper for major-unit currency formatting
- refactor `Price` component and CMS dashboard to use `formatPrice`
- document client and server usage of `formatPrice`

## Testing
- `pnpm --filter @acme/shared-utils test -- packages/shared-utils/__tests__/formatPrice.test.ts`
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/OrderSummary.test.tsx`
- `pnpm --filter @acme/ui test -- packages/ui/src/components/organisms/__tests__/OrderSummary.test.tsx`
- `pnpm --filter @apps/cms test -- apps/cms/src/app/cms/dashboard/[shop]/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e1a3b6d48832f81a76d08fca0815f