### PR TITLE
feat: add keyboard add for palette

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -24,6 +24,7 @@ import PageCanvas from "./PageCanvas";
 import PageSidebar from "./PageSidebar";
 import { defaults, CONTAINER_TYPES } from "./defaults";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
+import { ulid } from "ulid";
 
 interface Props {
   page: Page;
@@ -127,6 +128,26 @@ const PageBuilder = memo(function PageBuilder({
     setSnapPosition,
   });
 
+  const handleAddFromPalette = useCallback(
+    (type: PageComponent["type"]) => {
+      const isContainer = CONTAINER_TYPES.includes(type);
+      const component = {
+        id: ulid(),
+        type,
+        ...(defaults[type] ?? {}),
+        ...(isContainer ? { children: [] } : {}),
+      } as PageComponent;
+      dispatch({
+        type: "add",
+        component,
+        parentId: undefined,
+        index: components.length,
+      });
+      setSelectedId(component.id);
+    },
+    [dispatch, components.length, setSelectedId]
+  );
+
   const { viewportStyle, frameClass } = useViewport(device);
 
   useEffect(() => {
@@ -203,7 +224,7 @@ const PageBuilder = memo(function PageBuilder({
   return (
     <div className="flex gap-4" style={style}>
       <aside className="w-48 shrink-0">
-        <Palette />
+        <Palette onAdd={handleAddFromPalette} />
       </aside>
       <div className="flex flex-1 flex-col gap-4">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- add keyboard interaction to page builder palette
- allow pressing Enter/Space to insert component and announce via aria-live
- expose onAdd handler from PageBuilder

## Testing
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/usePageBuilderDnD.test.tsx` *(fails: SyntaxError: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a5b8b90832f98b22861ae4d2566