### PR TITLE
Use DAY_MS constant in late fee service

### DIFF
--- a/packages/platform-machine/src/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/src/__tests__/lateFeeService.test.ts
@@ -1,0 +1,77 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+jest.mock("@acme/stripe", () => ({
+  stripe: {
+    checkout: { sessions: { retrieve: jest.fn() } },
+    paymentIntents: { create: jest.fn() },
+  },
+}));
+
+jest.mock("@platform-core/repositories/rentalOrders.server", () => ({
+  readOrders: jest.fn(),
+  markLateFeeCharged: jest.fn(),
+}));
+
+jest.mock("@platform-core/utils", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+
+import { chargeLateFeesOnce } from "../lateFeeService";
+import { readOrders, markLateFeeCharged } from "@platform-core/repositories/rentalOrders.server";
+import { stripe } from "@acme/stripe";
+import { DAY_MS } from "@date-utils";
+
+describe("chargeLateFeesOnce", () => {
+  const shop = "s1";
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "late-fee-"));
+    await fs.mkdir(path.join(root, shop), { recursive: true });
+    await fs.writeFile(
+      path.join(root, shop, "shop.json"),
+      JSON.stringify({ lateFeePolicy: { gracePeriodDays: 1, feeAmount: 5 } }),
+    );
+
+    jest.spyOn(Date, "now").mockReturnValue(10 * DAY_MS);
+
+    (readOrders as jest.Mock).mockReset();
+    (markLateFeeCharged as jest.Mock).mockReset();
+    (stripe.checkout.sessions.retrieve as jest.Mock).mockReset();
+    (stripe.paymentIntents.create as jest.Mock).mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it("charges orders past the grace period", async () => {
+    (readOrders as jest.Mock).mockResolvedValue([
+      { sessionId: "sess1", returnDueDate: new Date(8 * DAY_MS).toISOString() },
+    ]);
+    (stripe.checkout.sessions.retrieve as jest.Mock).mockResolvedValue({
+      customer: "cus_1",
+      currency: "usd",
+      payment_intent: { payment_method: "pm_1" },
+    });
+
+    await chargeLateFeesOnce(shop, root);
+
+    expect(stripe.paymentIntents.create).toHaveBeenCalled();
+    expect(markLateFeeCharged).toHaveBeenCalledWith(shop, "sess1", 5);
+  });
+
+  it("skips orders within the grace period", async () => {
+    (readOrders as jest.Mock).mockResolvedValue([
+      { sessionId: "sess1", returnDueDate: new Date(9 * DAY_MS).toISOString() },
+    ]);
+
+    await chargeLateFeesOnce(shop, root);
+
+    expect(stripe.paymentIntents.create).not.toHaveBeenCalled();
+    expect(markLateFeeCharged).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -1,5 +1,6 @@
 import { coreEnv } from "@acme/config/env/core";
 import { stripe } from "@acme/stripe";
+import { DAY_MS } from "@date-utils";
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -32,7 +33,7 @@ export async function chargeLateFeesOnce(
       if (!order.returnDueDate || order.returnReceivedAt || order.lateFeeCharged)
         continue;
       const due = new Date(order.returnDueDate).getTime();
-      const grace = (policy.gracePeriodDays ?? 0) * 86400000;
+      const grace = (policy.gracePeriodDays ?? 0) * DAY_MS;
       if (now <= due + grace) continue;
       try {
         const session = await stripe.checkout.sessions.retrieve(order.sessionId, {

--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -35,7 +35,8 @@
 
       /* shared lib utilities */
       "@acme/lib": ["packages/lib/src/index.ts"],
-      "@acme/lib/*": ["packages/lib/src/*"]
+      "@acme/lib/*": ["packages/lib/src/*"],
+      "@date-utils": ["packages/date-utils/src/index.ts"]
     }
   },
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -95,6 +95,7 @@
       "@acme/stripe": ["packages/stripe/src/index.ts"],
       "@acme/sanity": ["packages/sanity/src/index.ts"],
       "@acme/date-utils": ["packages/date-utils/src/index.ts"],
+      "@date-utils": ["packages/date-utils/src/index.ts"],
 
       /* ─── shared runtime types ──────────────────────────────────── */
       "@acme/types": ["packages/types/src/index.ts"],


### PR DESCRIPTION
## Summary
- import `DAY_MS` from `@date-utils` and use it for late fee grace period
- add tsconfig alias for `@date-utils`
- test late fee service for grace period behavior

## Testing
- `pnpm exec jest packages/platform-machine/src/__tests__/lateFeeService.test.ts --config jest.config.cjs --runInBand --verbose`

------
https://chatgpt.com/codex/tasks/task_e_689e1a3adbbc832f80aacf6a15d32cfc