### PR TITLE
feat(ui): add inline validation and tooltips

### DIFF
--- a/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
@@ -3,6 +3,7 @@
 
 import type { PageComponent } from "@acme/types";
 import { Input } from "../../../atoms/shadcn";
+import { Tooltip } from "../../../atoms";
 import { Suspense } from "react";
 import editorRegistry from "../editorRegistry";
 
@@ -26,14 +27,43 @@ export default function ContentPanel({
     mobileItems?: number;
     columns?: number;
   };
+  const nonNegative = (v?: number) => (v !== undefined && v < 0 ? "Must be ≥ 0" : undefined);
+  const minItemsError =
+    nonNegative(comp.minItems) ||
+    (comp.minItems !== undefined &&
+    comp.maxItems !== undefined &&
+    comp.minItems > comp.maxItems
+      ? "Min Items cannot exceed Max Items"
+      : undefined);
+  const maxItemsError =
+    nonNegative(comp.maxItems) ||
+    (comp.minItems !== undefined &&
+    comp.maxItems !== undefined &&
+    comp.maxItems < comp.minItems
+      ? "Max Items cannot be less than Min Items"
+      : undefined);
+  const desktopItemsError = nonNegative(comp.desktopItems);
+  const tabletItemsError = nonNegative(comp.tabletItems);
+  const mobileItemsError = nonNegative(comp.mobileItems);
+  const columnsError =
+    nonNegative(comp.columns) ||
+    (comp.columns !== undefined &&
+    ((comp.minItems !== undefined && comp.columns < comp.minItems) ||
+      (comp.maxItems !== undefined && comp.columns > comp.maxItems))
+      ? "Columns must be between min and max items"
+      : undefined);
   return (
     <div className="space-y-2">
       {("minItems" in component || "maxItems" in component) && (
         <>
           <Input
-            label="Min Items"
+            label={
+              <span className="flex items-center gap-1">
+                Min Items
+                <Tooltip text="Minimum number of items">?</Tooltip>
+              </span>
+            }
             type="number"
-            title="Minimum number of items"
             value={comp.minItems ?? ""}
             onChange={(e) => {
               const val =
@@ -51,11 +81,16 @@ export default function ContentPanel({
             }}
             min={0}
             max={comp.maxItems ?? undefined}
+            error={minItemsError}
           />
           <Input
-            label="Max Items"
+            label={
+              <span className="flex items-center gap-1">
+                Max Items
+                <Tooltip text="Maximum number of items">?</Tooltip>
+              </span>
+            }
             type="number"
-            title="Maximum number of items"
             value={comp.maxItems ?? ""}
             onChange={(e) => {
               const val =
@@ -72,6 +107,7 @@ export default function ContentPanel({
               onChange(patch);
             }}
             min={comp.minItems ?? 0}
+            error={maxItemsError}
           />
         </>
       )}
@@ -80,9 +116,13 @@ export default function ContentPanel({
         "mobileItems" in component) && (
         <>
           <Input
-            label="Desktop Items"
+            label={
+              <span className="flex items-center gap-1">
+                Desktop Items
+                <Tooltip text="Items shown on desktop">?</Tooltip>
+              </span>
+            }
             type="number"
-            title="Items shown on desktop"
             value={comp.desktopItems ?? ""}
             onChange={(e) =>
               handleInput(
@@ -91,11 +131,16 @@ export default function ContentPanel({
               )
             }
             min={0}
+            error={desktopItemsError}
           />
           <Input
-            label="Tablet Items"
+            label={
+              <span className="flex items-center gap-1">
+                Tablet Items
+                <Tooltip text="Items shown on tablet">?</Tooltip>
+              </span>
+            }
             type="number"
-            title="Items shown on tablet"
             value={comp.tabletItems ?? ""}
             onChange={(e) =>
               handleInput(
@@ -104,11 +149,16 @@ export default function ContentPanel({
               )
             }
             min={0}
+            error={tabletItemsError}
           />
           <Input
-            label="Mobile Items"
+            label={
+              <span className="flex items-center gap-1">
+                Mobile Items
+                <Tooltip text="Items shown on mobile">?</Tooltip>
+              </span>
+            }
             type="number"
-            title="Items shown on mobile"
             value={comp.mobileItems ?? ""}
             onChange={(e) =>
               handleInput(
@@ -117,14 +167,19 @@ export default function ContentPanel({
               )
             }
             min={0}
+            error={mobileItemsError}
           />
         </>
       )}
       {"columns" in component && (
         <Input
-          label="Columns"
+          label={
+            <span className="flex items-center gap-1">
+              Columns
+              <Tooltip text="Number of columns">?</Tooltip>
+            </span>
+          }
           type="number"
-          title="Number of columns"
           value={comp.columns ?? ""}
           onChange={(e) =>
             handleInput(
@@ -134,6 +189,7 @@ export default function ContentPanel({
           }
           min={comp.minItems}
           max={comp.maxItems}
+          error={columnsError}
         />
       )}
       <Suspense fallback={<p className="text-muted text-sm">Loading...</p>}>

--- a/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../../atoms/shadcn";
+import { Tooltip } from "../../../atoms";
 
 interface Props {
   component: PageComponent;
@@ -25,18 +26,30 @@ export default function LayoutPanel({
   handleResize,
   handleFullSize,
 }: Props) {
+  const cssError = (prop: string, value?: string) =>
+    value && !globalThis.CSS?.supports(prop, value)
+      ? `Invalid ${prop} value`
+      : undefined;
   return (
     <div className="space-y-2">
       {(["Desktop", "Tablet", "Mobile"] as const).map((vp) => (
         <div key={vp} className="space-y-2">
           <div className="flex items-end gap-2">
             <Input
-              label={`Width (${vp})`}
+              label={
+                <span className="flex items-center gap-1">
+                  {`Width (${vp})`}
+                  <Tooltip text="CSS width value with units">?</Tooltip>
+                </span>
+              }
               placeholder="e.g. 100px or 50%"
-              title="CSS width value with units"
               value={
                 (component[`width${vp}` as keyof PageComponent] as string) ?? ""
               }
+              error={cssError(
+                "width",
+                component[`width${vp}` as keyof PageComponent] as string
+              )}
               onChange={(e) => handleResize(`width${vp}`, e.target.value)}
             />
             <Button
@@ -49,13 +62,21 @@ export default function LayoutPanel({
           </div>
           <div className="flex items-end gap-2">
             <Input
-              label={`Height (${vp})`}
+              label={
+                <span className="flex items-center gap-1">
+                  {`Height (${vp})`}
+                  <Tooltip text="CSS height value with units">?</Tooltip>
+                </span>
+              }
               placeholder="e.g. 1px or 1rem"
-              title="CSS height value with units"
               value={
                 (component[`height${vp}` as keyof PageComponent] as string) ??
                 ""
               }
+              error={cssError(
+                "height",
+                component[`height${vp}` as keyof PageComponent] as string
+              )}
               onChange={(e) => handleResize(`height${vp}`, e.target.value)}
             />
             <Button
@@ -72,9 +93,11 @@ export default function LayoutPanel({
         value={component.position ?? ""}
         onValueChange={(v) => handleInput("position", v || undefined)}
       >
-        <SelectTrigger title="CSS position property">
-          <SelectValue placeholder="Position" />
-        </SelectTrigger>
+        <Tooltip text="CSS position property" className="block">
+          <SelectTrigger>
+            <SelectValue placeholder="Position" />
+          </SelectTrigger>
+        </Tooltip>
         <SelectContent>
           <SelectItem value="relative">relative</SelectItem>
           <SelectItem value="absolute">absolute</SelectItem>
@@ -83,17 +106,27 @@ export default function LayoutPanel({
       {component.position === "absolute" && (
         <>
           <Input
-            label="Top"
+            label={
+              <span className="flex items-center gap-1">
+                Top
+                <Tooltip text="CSS top offset with units">?</Tooltip>
+              </span>
+            }
             placeholder="e.g. 10px"
-            title="CSS top offset with units"
             value={component.top ?? ""}
+            error={cssError("top", component.top)}
             onChange={(e) => handleResize("top", e.target.value)}
           />
           <Input
-            label="Left"
+            label={
+              <span className="flex items-center gap-1">
+                Left
+                <Tooltip text="CSS left offset with units">?</Tooltip>
+              </span>
+            }
             placeholder="e.g. 10px"
-            title="CSS left offset with units"
             value={component.left ?? ""}
+            error={cssError("left", component.left)}
             onChange={(e) => handleResize("left", e.target.value)}
           />
         </>
@@ -101,49 +134,78 @@ export default function LayoutPanel({
       {(["Desktop", "Tablet", "Mobile"] as const).map((vp) => (
         <div key={`spacing-${vp}`} className="space-y-2">
           <Input
-            label={`Margin (${vp})`}
+            label={
+              <span className="flex items-center gap-1">
+                {`Margin (${vp})`}
+                <Tooltip text="CSS margin value with units">?</Tooltip>
+              </span>
+            }
             placeholder="e.g. 1rem"
-            title="CSS margin value with units"
             value={
               (component[`margin${vp}` as keyof PageComponent] as string) ??
               ""
             }
+            error={cssError(
+              "margin",
+              component[`margin${vp}` as keyof PageComponent] as string
+            )}
             onChange={(e) => handleResize(`margin${vp}`, e.target.value)}
           />
           <Input
-            label={`Padding (${vp})`}
+            label={
+              <span className="flex items-center gap-1">
+                {`Padding (${vp})`}
+                <Tooltip text="CSS padding value with units">?</Tooltip>
+              </span>
+            }
             placeholder="e.g. 1rem"
-            title="CSS padding value with units"
             value={
               (component[`padding${vp}` as keyof PageComponent] as string) ??
               ""
             }
+            error={cssError(
+              "padding",
+              component[`padding${vp}` as keyof PageComponent] as string
+            )}
             onChange={(e) => handleResize(`padding${vp}`, e.target.value)}
           />
         </div>
       ))}
       <Input
-        label="Margin"
+        label={
+          <span className="flex items-center gap-1">
+            Margin
+            <Tooltip text="Global CSS margin value with units">?</Tooltip>
+          </span>
+        }
         placeholder="e.g. 1rem"
-        title="Global CSS margin value with units"
         value={component.margin ?? ""}
+        error={cssError("margin", component.margin)}
         onChange={(e) => handleInput("margin", e.target.value)}
       />
       <Input
-        label="Padding"
+        label={
+          <span className="flex items-center gap-1">
+            Padding
+            <Tooltip text="Global CSS padding value with units">?</Tooltip>
+          </span>
+        }
         placeholder="e.g. 1rem"
-        title="Global CSS padding value with units"
         value={component.padding ?? ""}
+        error={cssError("padding", component.padding)}
         onChange={(e) => handleInput("padding", e.target.value)}
       />
       {"gap" in component && (
         <Input
-          label="Gap"
-          placeholder="e.g. 1rem"
-          title="Gap between items"
-          value={
-            (component as { gap?: string }).gap ?? ""
+          label={
+            <span className="flex items-center gap-1">
+              Gap
+              <Tooltip text="Gap between items">?</Tooltip>
+            </span>
           }
+          placeholder="e.g. 1rem"
+          value={(component as { gap?: string }).gap ?? ""}
+          error={cssError("gap", (component as { gap?: string }).gap)}
           onChange={(e) => handleInput("gap", e.target.value)}
         />
       )}


### PR DESCRIPTION
## Summary
- add tooltip-wrapped labels and validation to layout controls
- inline validate item counts with user guidance

## Testing
- `pnpm test --filter @acme/ui` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b8affa0832f90c12b5df044b10a