### PR TITLE
feat: add in-editor responsive preview

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -80,6 +80,26 @@ const PageBuilder = memo(function PageBuilder({
   }, [deviceId, orientation]);
   const viewport: "desktop" | "tablet" | "mobile" = device.type;
   const [locale, setLocale] = useState<Locale>("en");
+  const [showPreview, setShowPreview] = useState(false);
+  const [previewViewport, setPreviewViewport] =
+    useState<"desktop" | "tablet" | "mobile">("desktop");
+  const presetByType = useMemo(
+    () => ({
+      desktop: devicePresets.find((d) => d.type === "desktop")!,
+      tablet: devicePresets.find((d) => d.type === "tablet")!,
+      mobile: devicePresets.find((d) => d.type === "mobile")!,
+    }),
+    []
+  );
+  const previewDevice = useMemo<DevicePreset>(
+    () => presetByType[previewViewport],
+    [presetByType, previewViewport]
+  );
+  const previewRef = useRef<HTMLDivElement>(null);
+  const {
+    viewportStyle: previewViewportStyle,
+    frameClass: previewFrameClass,
+  } = useViewport(previewDevice);
   const [publishCount, setPublishCount] = useState(0);
   const prevId = useRef(page.id);
   const pathname = usePathname() ?? "";
@@ -223,16 +243,25 @@ const PageBuilder = memo(function PageBuilder({
             gridCols={gridCols}
             setGridCols={setGridCols}
           />
-          {autoSaveState === "saving" && (
-            <div className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Spinner className="h-4 w-4" /> Saving…
-            </div>
-          )}
-          {autoSaveState === "saved" && (
-            <div className="flex items-center gap-1 text-sm text-muted-foreground">
-              <CheckIcon className="h-4 w-4 text-green-500" /> Saved
-            </div>
-          )}
+          <div className="flex items-center gap-2">
+            {autoSaveState === "saving" && (
+              <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                <Spinner className="h-4 w-4" /> Saving…
+              </div>
+            )}
+            {autoSaveState === "saved" && (
+              <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                <CheckIcon className="h-4 w-4 text-green-500" /> Saved
+              </div>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowPreview((p) => !p)}
+            >
+              {showPreview ? "Hide preview" : "Show preview"}
+            </Button>
+          </div>
         </div>
         <div aria-live="polite" role="status" className="sr-only">
           {liveMessage}
@@ -272,6 +301,53 @@ const PageBuilder = memo(function PageBuilder({
             )}
           </DragOverlay>
         </DndContext>
+        {showPreview && (
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2">
+              <Button
+                variant={
+                  previewViewport === "desktop" ? "default" : "outline"
+                }
+                size="sm"
+                onClick={() => setPreviewViewport("desktop")}
+              >
+                Desktop
+              </Button>
+              <Button
+                variant={
+                  previewViewport === "tablet" ? "default" : "outline"
+                }
+                size="sm"
+                onClick={() => setPreviewViewport("tablet")}
+              >
+                Tablet
+              </Button>
+              <Button
+                variant={
+                  previewViewport === "mobile" ? "default" : "outline"
+                }
+                size="sm"
+                onClick={() => setPreviewViewport("mobile")}
+              >
+                Mobile
+              </Button>
+            </div>
+            <div
+              className={previewFrameClass[previewViewport]}
+              style={previewViewportStyle}
+            >
+              <PageCanvas
+                preview
+                components={components}
+                locale={locale}
+                containerStyle={{ width: "100%" }}
+                viewport={previewViewport}
+                device={previewDevice}
+                canvasRef={previewRef}
+              />
+            </div>
+          </div>
+        )}
         <div className="flex gap-2">
           <Button onClick={() => dispatch({ type: "undo" })} disabled={!state.past.length}>
             Undo

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -9,55 +9,59 @@ import { cn } from "../../../utils/style";
 import type { DevicePreset } from "@ui/utils/devicePresets";
 import GridOverlay from "./GridOverlay";
 import SnapLine from "./SnapLine";
+import Block from "./Block";
 
 interface Props {
   components: PageComponent[];
-  selectedId: string | null;
-  onSelectId: (id: string | null) => void;
-  canvasRef: React.RefObject<HTMLDivElement>;
-  dragOver: boolean;
-  setDragOver: (v: boolean) => void;
-  onFileDrop: (e: DragEvent<HTMLDivElement>) => void;
-  insertIndex: number | null;
-  dispatch: (action: Action) => void;
+  selectedId?: string | null;
+  onSelectId?: (id: string | null) => void;
+  canvasRef?: React.RefObject<HTMLDivElement>;
+  dragOver?: boolean;
+  setDragOver?: (v: boolean) => void;
+  onFileDrop?: (e: DragEvent<HTMLDivElement>) => void;
+  insertIndex?: number | null;
+  dispatch?: (action: Action) => void;
   locale: Locale;
   containerStyle: CSSProperties;
   showGrid?: boolean;
-  gridCols: number;
+  gridCols?: number;
   viewport: "desktop" | "tablet" | "mobile";
-  snapPosition: number | null;
+  snapPosition?: number | null;
   device?: DevicePreset;
+  preview?: boolean;
 }
 
 const PageCanvas = ({
   components,
-  selectedId,
-  onSelectId,
+  selectedId = null,
+  onSelectId = () => {},
   canvasRef,
-  dragOver,
-  setDragOver,
-  onFileDrop,
-  insertIndex,
-  dispatch,
+  dragOver = false,
+  setDragOver = () => {},
+  onFileDrop = () => {},
+  insertIndex = null,
+  dispatch = () => {},
   locale,
   containerStyle,
   showGrid = false,
-  gridCols,
+  gridCols = 1,
   viewport,
-  snapPosition,
+  snapPosition = null,
   device,
+  preview = false,
 }: Props) => {
   const [dropRect, setDropRect] = useState<
     { left: number; top: number; width: number; height: number } | null
   >(null);
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    if (preview) return;
     e.preventDefault();
     setDragOver(true);
     const target = (e.target as HTMLElement).closest(
       '[role="listitem"], #canvas'
     );
-    if (target instanceof HTMLElement && canvasRef.current) {
+    if (target instanceof HTMLElement && canvasRef?.current) {
       const canvasBounds = canvasRef.current.getBoundingClientRect();
       const rect = target.getBoundingClientRect();
       setDropRect({
@@ -75,6 +79,21 @@ const PageCanvas = ({
     setDragOver(false);
     setDropRect(null);
   };
+
+  if (preview) {
+    return (
+      <div
+        id="canvas"
+        ref={canvasRef}
+        style={containerStyle}
+        className="relative mx-auto flex flex-col gap-4"
+      >
+        {components.map((c) => (
+          <Block key={c.id} component={c} locale={locale} />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <SortableContext


### PR DESCRIPTION
## Summary
- add preview state and device controls to PageBuilder
- introduce preview mode for PageCanvas
- enable in-editor responsive preview pane

## Testing
- `pnpm --filter @acme/ui test packages/ui` *(fails: DynamicRenderer block registry coverage › renders Divider block, PageBuilder resize interactions › resizes via sidebar inputs, useProductEditorFormState tests)*
- `pnpm exec eslint packages/ui/src/components/cms/page-builder/PageBuilder.tsx packages/ui/src/components/cms/page-builder/PageCanvas.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689e1b87f734832fa6fa2229ee56f556