### PR TITLE
feat: warn on low contrast and reset theme

### DIFF
--- a/packages/ui/src/components/cms/style/Tokens.tsx
+++ b/packages/ui/src/components/cms/style/Tokens.tsx
@@ -80,6 +80,16 @@ export default function Tokens({
         pairKey = `--color-fg${k.slice("--color-bg".length)}`;
       } else if (k.startsWith("--color-fg")) {
         pairKey = `--color-bg${k.slice("--color-fg".length)}`;
+      } else if (k.endsWith("-fg")) {
+        pairKey = k.slice(0, -3);
+      } else {
+        const candidate = `${k}-fg`;
+        if (
+          tokens[candidate as keyof TokenMap] !== undefined ||
+          baseTokens[candidate as keyof TokenMap] !== undefined
+        ) {
+          pairKey = candidate;
+        }
       }
       const pairVal = pairKey
         ? tokens[pairKey as keyof TokenMap] ?? baseTokens[pairKey as keyof TokenMap]


### PR DESCRIPTION
## Summary
- check contrast for palette swatches and flag low-contrast options
- warn on token pairs with insufficient contrast
- allow resetting theme overrides to default palette

## Testing
- `pnpm --filter @acme/ui test` (fails: process.exit in payments env)
- `pnpm --filter @apps/cms test` (fails: process.exit in core env)


------
https://chatgpt.com/codex/tasks/task_e_689e193a7644832f958087af71f3c1c4