### PR TITLE
feat(page-toolbar): add hotkeys for device preview

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from "@/i18n/locales";
 import { DesktopIcon, LaptopIcon, MobileIcon } from "@radix-ui/react-icons";
+import { useEffect } from "react";
 import { Button, Input } from "../../atoms/shadcn";
 import { getLegacyPreset } from "@ui/utils/devicePresets";
 import DeviceSelector from "../DeviceSelector";
@@ -25,6 +26,8 @@ const PageToolbar = ({
   viewport,
   deviceId,
   setDeviceId,
+  orientation,
+  setOrientation,
   locale,
   setLocale,
   locales,
@@ -34,77 +37,113 @@ const PageToolbar = ({
   toggleGrid,
   gridCols,
   setGridCols,
-}: Props) => (
-  <div className="flex flex-col gap-4">
-    <div className="flex justify-end gap-2">
-      {(["desktop", "tablet", "mobile"] as const).map((t) => {
-        const preset = getLegacyPreset(t);
-        const Icon =
-          t === "desktop" ? DesktopIcon : t === "tablet" ? LaptopIcon : MobileIcon;
-        return (
-          <Button
-            key={t}
-            variant={deviceId === preset.id ? "default" : "outline"}
-            onClick={() => setDeviceId(preset.id)}
-            aria-label={t}
-          >
-            <Icon />
-            <span className="sr-only">
-              {t.charAt(0).toUpperCase() + t.slice(1)}
-            </span>
-          </Button>
-        );
-      })}
-      <DeviceSelector
-        deviceId={deviceId}
-        orientation={orientation}
-        setDeviceId={(id) => {
-          setDeviceId(id);
-          setOrientation("portrait");
-        }}
-        toggleOrientation={() =>
-          setOrientation((o) => (o === "portrait" ? "landscape" : "portrait"))
-        }
-      />
-    </div>
-    <div className="flex items-center justify-end gap-2">
-      <Button
-        variant={showGrid ? "default" : "outline"}
-        onClick={toggleGrid}
-      >
-        {showGrid ? "Hide grid" : "Show grid"}
-      </Button>
-      <Input
-        type="number"
-        min={1}
-        max={24}
-        value={gridCols}
-        onChange={(e) => setGridCols(Number(e.target.value))}
-        className="w-16"
-      />
-    </div>
-    <div className="flex justify-end gap-2">
-      {locales.map((l) => (
+}: Props) => {
+  useEffect(() => {
+    const presets: Record<string, string> = {
+      1: getLegacyPreset("desktop").id,
+      2: getLegacyPreset("tablet").id,
+      3: getLegacyPreset("mobile").id,
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLElement &&
+        (e.target.tagName === "INPUT" ||
+          e.target.tagName === "TEXTAREA" ||
+          e.target.tagName === "SELECT" ||
+          e.target.isContentEditable)
+      ) {
+        return;
+      }
+      const id = presets[e.key];
+      if (id && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        setDeviceId(id);
+        setOrientation("portrait");
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [setDeviceId, setOrientation]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-end gap-2">
+        {(["desktop", "tablet", "mobile"] as const).map((t, i) => {
+          const preset = getLegacyPreset(t);
+          const Icon =
+            t === "desktop" ? DesktopIcon : t === "tablet" ? LaptopIcon : MobileIcon;
+          const shortcut = `Ctrl+${i + 1}`;
+          return (
+            <Button
+              key={t}
+              variant={deviceId === preset.id ? "default" : "outline"}
+              onClick={() => {
+                setDeviceId(preset.id);
+                setOrientation("portrait");
+              }}
+              title={`${t.charAt(0).toUpperCase() + t.slice(1)} (${shortcut})`}
+              aria-label={`${t} (${shortcut})`}
+            >
+              <Icon />
+              <span className="sr-only">
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </span>
+            </Button>
+          );
+        })}
+        <DeviceSelector
+          deviceId={deviceId}
+          orientation={orientation}
+          setDeviceId={(id) => {
+            setDeviceId(id);
+            setOrientation("portrait");
+          }}
+          toggleOrientation={() =>
+            setOrientation((o) => (o === "portrait" ? "landscape" : "portrait"))
+          }
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2">
         <Button
-          key={l}
-          variant={locale === l ? "default" : "outline"}
-          onClick={() => setLocale(l)}
+          variant={showGrid ? "default" : "outline"}
+          onClick={toggleGrid}
         >
-          {l.toUpperCase()}
+          {showGrid ? "Hide grid" : "Show grid"}
         </Button>
-      ))}
+        <Input
+          type="number"
+          min={1}
+          max={24}
+          value={gridCols}
+          onChange={(e) => setGridCols(Number(e.target.value))}
+          className="w-16"
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        {locales.map((l) => (
+          <Button
+            key={l}
+            variant={locale === l ? "default" : "outline"}
+            onClick={() => setLocale(l)}
+          >
+            {l.toUpperCase()}
+          </Button>
+        ))}
+      </div>
+      {progress && (
+        <p className="text-sm">
+          Uploading image… {progress.done}/{progress.total}
+        </p>
+      )}
+      {isValid === false && (
+        <p className="text-sm text-warning">
+          Wrong orientation (needs landscape)
+        </p>
+      )}
     </div>
-    {progress && (
-      <p className="text-sm">
-        Uploading image… {progress.done}/{progress.total}
-      </p>
-    )}
-    {isValid === false && (
-      <p className="text-sm text-warning">
-        Wrong orientation (needs landscape)
-      </p>
-    )}
-  </div>
-);
+  );
+};
 
 export default PageToolbar;


### PR DESCRIPTION
## Summary
- allow switching device preview with Ctrl+1/2/3
- show desktop/tablet/mobile preview icons directly with shortcut hints

## Testing
- `pnpm --filter @acme/ui lint`
- `pnpm --filter @acme/ui test` *(fails: inventory import/export routes › imports inventory from json; scheduler › sends due campaigns and marks them as sent; process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689e1b8d37f8832f88233efb64c9933b