### PR TITLE
feat: add ExampleProps interface for example prop generation

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./src/index";
+export { ExampleProps } from "./src/ExampleProps";

--- a/packages/types/src/ExampleProps.ts
+++ b/packages/types/src/ExampleProps.ts
@@ -1,0 +1,3 @@
+export interface ExampleProps {
+  [componentName: string]: unknown;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,3 +18,4 @@ export * from "./Coupon";
 export * from "./SubscriptionPlan";
 export * from "./Coverage";
 export * from "./upgrade";
+export * from "./ExampleProps";

--- a/scripts/src/generate-example-props.ts
+++ b/scripts/src/generate-example-props.ts
@@ -1,8 +1,9 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { ExampleProps } from "@acme/types";
 import { getComponentNameMap } from "./component-names";
 
-const examples: Record<string, any> = {
+const examples: ExampleProps = {
   Breadcrumbs: {
     items: [
       { label: "Home", href: "/" },
@@ -26,7 +27,7 @@ export function generateExampleProps(
   const names = Array.from(
     new Set(componentNames.filter((n) => /^[A-Z][A-Za-z0-9]*$/.test(n)))
   );
-  const map: Record<string, any> = {};
+  const map: ExampleProps = {};
   for (const name of names) {
     map[name] = examples[name] ?? {};
   }
@@ -43,7 +44,9 @@ export function generateExampleProps(
   const content = `// apps/${shopId}/src/app/upgrade-preview/example-props.ts
 // Map of example props for all UI components so upgrade previews can render reliably
 
-export const exampleProps: Record<string, any> = ${JSON.stringify(
+import type { ExampleProps } from "@acme/types";
+
+export const exampleProps: ExampleProps = ${JSON.stringify(
     map,
     null,
     2


### PR DESCRIPTION
## Summary
- add `ExampleProps` interface to @acme/types and re-export it
- type example props generation script with `ExampleProps`

## Testing
- `pnpm lint --filter @acme/types`
- `pnpm eslint scripts/src/generate-example-props.ts`
- `pnpm test --filter @acme/types`
- `pnpm tsc -p packages/types/tsconfig.json --noEmit` *(fails: Module "./constants" has already exported a member named 'Locale'.)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b9ae604832f9404846a1d7a0013