### PR TITLE
refactor: use shared shop types

### DIFF
--- a/packages/types/src/upgrade.ts
+++ b/packages/types/src/upgrade.ts
@@ -10,3 +10,12 @@ export const upgradeComponentSchema = z
   .strict();
 
 export type UpgradeComponent = z.infer<typeof upgradeComponentSchema>;
+
+export const shopMetadataSchema = z
+  .object({
+    lastUpgrade: z.string().datetime().optional(),
+    componentVersions: z.record(z.string()).optional(),
+  })
+  .catchall(z.unknown());
+
+export type ShopMetadata = z.infer<typeof shopMetadataSchema>;

--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -1,18 +1,2 @@
-export interface ShopMetadata {
-  /** ISO timestamp of last upgrade */
-  lastUpgrade?: string;
-  /** Map of component package versions at upgrade time */
-  componentVersions?: Record<string, string>;
-  [key: string]: unknown;
-}
+export type { Page, PageComponent, ShopMetadata } from "@acme/types";
 
-export interface PageComponent {
-  type: string;
-  [key: string]: unknown;
-}
-
-export interface PageRecord {
-  id: string;
-  components?: PageComponent[];
-  [key: string]: unknown;
-}

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 import { randomBytes, createHash } from "node:crypto";
 import { getComponentNameMap } from "./component-names";
 import { generateExampleProps } from "./generate-example-props";
-import type { PageRecord, ShopMetadata } from "./types";
+import type { Page, ShopMetadata } from "@acme/types";
 
 const args = process.argv.slice(2);
 const rollback = args.includes("--rollback");
@@ -90,7 +90,7 @@ const pageIds = new Set<string>();
 if (existsSync(pagesJsonPath)) {
   try {
     const parsed = JSON.parse(readFileSync(pagesJsonPath, "utf8"));
-    const pages: PageRecord[] = Array.isArray(parsed) ? parsed : [];
+    const pages: Page[] = Array.isArray(parsed) ? parsed : [];
     const changedTypes = new Set(changedComponents.map((c) => c.componentName));
     for (const page of pages) {
       if (!Array.isArray(page.components)) continue;


### PR DESCRIPTION
## Summary
- remove local shop interfaces and re-export shared types
- add ShopMetadata schema to shared types package
- update upgrade script to consume shared Page and ShopMetadata types

## Testing
- `pnpm tsc -p packages/types/tsconfig.json` *(fails: Module "./constants" has already exported a member named 'Locale'.)*
- `pnpm tsc -p scripts/tsconfig.json` *(fails: scripts/src/setup-ci.ts(88,37): error TS1005: ',' expected.)*
- `pnpm jest packages/types/__tests__`


------
https://chatgpt.com/codex/tasks/task_e_689e1b9b6aac832fbb2d1af6b928ae5a