### PR TITLE
chore: type rental allocation

### DIFF
--- a/packages/platform-core/src/orders/rentalAllocation.ts
+++ b/packages/platform-core/src/orders/rentalAllocation.ts
@@ -12,11 +12,11 @@ import { updateInventoryItem } from "../repositories/inventory.server";
  */
 export async function reserveRentalInventory(
   shop: string,
-  items: Array<InventoryItem & { wearCount?: number }>,
+  items: InventoryItem[],
   sku: SKU,
   from: string,
   to: string,
-): Promise<(InventoryItem & { wearCount: number }) | null> {
+): Promise<InventoryItem | null> {
   // verify availability window
   if (
     sku.availability &&
@@ -51,7 +51,5 @@ export async function reserveRentalInventory(
     },
   );
 
-  return updated
-    ? (updated as InventoryItem & { wearCount: number })
-    : null;
+  return updated ?? null;
 }


### PR DESCRIPTION
## Summary
- type rental reservation helper to accept InventoryItem[] and SKU
- pass typed inventory and product data in rental API

## Testing
- `pnpm exec jest packages/template-app/__tests__/rental.test.ts packages/template-app/__tests__/rental-return-flow.test.ts` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689e1b9c8580832fa6c03f696369b533