### PR TITLE
feat: add open graph image prop

### DIFF
--- a/apps/shop-abc/src/app/lib/seo.ts
+++ b/apps/shop-abc/src/app/lib/seo.ts
@@ -4,8 +4,14 @@ import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 import { env } from "@acme/config";
 
-interface ExtendedSeoProps extends Partial<NextSeoProps> {
+interface OpenGraphImageProps {
+  image?: string;
+}
+
+interface ExtendedSeoProps
+  extends Omit<Partial<NextSeoProps>, "openGraph"> {
   canonicalBase?: string;
+  openGraph?: OpenGraphImageProps & NextSeoProps["openGraph"];
 }
 
 const fallback: NextSeoProps = {
@@ -18,7 +24,7 @@ const fallback: NextSeoProps = {
 
 export async function getSeo(
   locale: Locale,
-  pageSeo: Partial<NextSeoProps> = {}
+  pageSeo: Partial<ExtendedSeoProps> = {}
 ): Promise<NextSeoProps> {
   const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
   const settings: ShopSettings = await getShopSettings(shop);

--- a/apps/shop-bcd/src/lib/seo.ts
+++ b/apps/shop-bcd/src/lib/seo.ts
@@ -4,8 +4,14 @@ import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 import { env } from "@acme/config";
 
-interface ExtendedSeoProps extends Partial<NextSeoProps> {
+interface OpenGraphImageProps {
+  image?: string;
+}
+
+interface ExtendedSeoProps
+  extends Omit<Partial<NextSeoProps>, "openGraph"> {
   canonicalBase?: string;
+  openGraph?: OpenGraphImageProps & NextSeoProps["openGraph"];
 }
 
 const fallback: NextSeoProps = {
@@ -18,7 +24,7 @@ const fallback: NextSeoProps = {
 
 export async function getSeo(
   locale: Locale,
-  pageSeo: Partial<NextSeoProps> = {}
+  pageSeo: Partial<ExtendedSeoProps> = {}
 ): Promise<NextSeoProps> {
   const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
   const settings: ShopSettings = await getShopSettings(shop);

--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -3,8 +3,14 @@ import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 import { coreEnv } from "@acme/config/env/core";
 
-interface ExtendedSeoProps extends Partial<NextSeoProps> {
+interface OpenGraphImageProps {
+  image?: string;
+}
+
+interface ExtendedSeoProps
+  extends Omit<Partial<NextSeoProps>, "openGraph"> {
   canonicalBase?: string;
+  openGraph?: OpenGraphImageProps & NextSeoProps["openGraph"];
 }
 
 const fallback: NextSeoProps = {
@@ -17,7 +23,7 @@ const fallback: NextSeoProps = {
 
 export async function getSeo(
   locale: Locale,
-  pageSeo: Partial<NextSeoProps> = {}
+  pageSeo: Partial<ExtendedSeoProps> = {}
 ): Promise<NextSeoProps> {
   const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
   const { getShopSettings } = await import(
@@ -56,10 +62,10 @@ export async function getSeo(
 
   const imagePath =
     pageSeo.openGraph?.images?.[0]?.url ||
-    (pageSeo.openGraph as any)?.image ||
+    pageSeo.openGraph?.image ||
     pageSeo.image ||
     base.openGraph?.images?.[0]?.url ||
-    (base.openGraph as any)?.image ||
+    base.openGraph?.image ||
     base.image;
   const resolvedImage =
     imagePath && !/^https?:/i.test(imagePath)


### PR DESCRIPTION
## Summary
- allow OpenGraph images to be defined as a simple string
- use updated types to access openGraph.image without casts

## Testing
- `pnpm test --filter=@acme/template-app --filter=@apps/shop-bcd --filter=@apps/shop-abc`
- `pnpm typecheck` *(fails: Found 840 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b9d71f8832fac39cee483ff597b