### PR TITLE
feat: add barcode detector typings

### DIFF
--- a/packages/template-app/src/app/account/returns/page.tsx
+++ b/packages/template-app/src/app/account/returns/page.tsx
@@ -50,7 +50,7 @@ function ReturnForm({ bagType, tracking: trackingEnabled }: ReturnFormProps) {
           videoRef.current.srcObject = stream;
           await videoRef.current.play();
         }
-        const detector = new (window as any).BarcodeDetector({
+        const detector = new window.BarcodeDetector({
           formats: ["qr_code"],
         });
         const scan = async () => {

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -62,7 +62,7 @@ function Scanner({ allowedZips }: { allowedZips: string[] }) {
           videoRef.current.srcObject = stream;
           await videoRef.current.play();
         }
-        const detector = new (window as any).BarcodeDetector({
+        const detector = new window.BarcodeDetector({
           formats: ["qr_code", "code_128", "ean_13", "upc_a"],
         });
         const scan = async () => {
@@ -98,14 +98,14 @@ function Scanner({ allowedZips }: { allowedZips: string[] }) {
 
   if (done) {
     return (
-      <div className="p-6 space-y-4">
+      <div className="space-y-4 p-6">
         <p>Return recorded.</p>
       </div>
     );
   }
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="space-y-4 p-6">
       <h1 className="text-xl font-semibold">Scan to mark return</h1>
       {!result && <video ref={videoRef} className="w-full max-w-md" />}
       {result && allowedZips.length > 0 && (
@@ -127,7 +127,7 @@ function Scanner({ allowedZips }: { allowedZips: string[] }) {
             </select>
           </label>
           <button
-            className="px-4 py-2 bg-blue-600 text-white disabled:opacity-50"
+            className="bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
             disabled={!zip}
             onClick={() => result && finalize(result)}
           >
@@ -140,4 +140,3 @@ function Scanner({ allowedZips }: { allowedZips: string[] }) {
     </div>
   );
 }
-

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -5,8 +5,19 @@ export {};
 import type * as React from "react";
 
 declare global {
+  interface BarcodeDetector {
+    detect(image: ImageBitmapSource): Promise<DetectedBarcode[]>;
+  }
+
+  interface DetectedBarcode {
+    rawValue: string;
+    format: string;
+  }
+
   interface Window {
-    // put your globals back here
+    BarcodeDetector: {
+      new (options?: { formats?: string[] }): BarcodeDetector;
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add global `BarcodeDetector` interface and expose it on `window`
- use `window.BarcodeDetector` without casting

## Testing
- `pnpm lint --filter @acme/template-app`
- `pnpm test --filter @acme/template-app`
- `pnpm --filter @acme/template-app typecheck` *(fails: None of the selected packages has a "typecheck" script)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ba158d8832f945c2b9dff54adcd