### PR TITLE
refactor: tighten dnd typings

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -119,7 +119,7 @@ const PageBuilder = memo(function PageBuilder({
   } = usePageBuilderDnD({
     components,
     dispatch,
-    defaults,
+    defaults: defaults as Record<string, Partial<PageComponent>>,
     containerTypes: CONTAINER_TYPES,
     selectId: setSelectedId,
     gridSize,


### PR DESCRIPTION
## Summary
- guard activator events to ensure pointer events before using coordinates
- type defaults map to avoid `as any` indexing

## Testing
- `npx jest --runTestsByPath packages/ui/__tests__/usePageBuilderDnD.test.tsx --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689e1ba2a3a0832f85a5be92033eba47