### PR TITLE
refactor: type slot element

### DIFF
--- a/packages/ui/src/components/atoms/primitives/slot.tsx
+++ b/packages/ui/src/components/atoms/primitives/slot.tsx
@@ -8,11 +8,11 @@ export const Slot = React.forwardRef<HTMLElement, SlotProps>(
   ({ children, ...props }, ref) => {
     if (React.isValidElement(children)) {
       return React.cloneElement(
-        children as React.ReactElement<any>,
+        children as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
         {
           ...props,
           ref,
-        } as any
+        } as React.HTMLAttributes<HTMLElement> & { ref: React.Ref<HTMLElement> }
       );
     }
     return null;


### PR DESCRIPTION
## Summary
- refine Slot component typing for cloned child elements

## Testing
- `pnpm exec eslint packages/ui/src/components/atoms/primitives/slot.tsx`
- `pnpm test --filter @acme/ui` *(fails: process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_689e1ba7b6a4832f83d2816a0d929ceb