### PR TITLE
feat: support dynamic resize action

### DIFF
--- a/packages/ui/src/components/cms/page-builder/state/actions.ts
+++ b/packages/ui/src/components/cms/page-builder/state/actions.ts
@@ -40,6 +40,7 @@ export type ResizeAction = {
   paddingDesktop?: string;
   paddingTablet?: string;
   paddingMobile?: string;
+  [key: string]: string | undefined;
 };
 
 export type SetAction = { type: "set"; components: PageComponent[] };

--- a/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import type { Action } from "./state";
+import type { ResizeAction } from "./state/actions";
 import useGuides from "./useGuides";
 import { snapToGrid } from "./gridSnap";
 
@@ -9,7 +9,7 @@ interface Options {
   heightKey: string;
   widthVal?: string;
   heightVal?: string;
-  dispatch: React.Dispatch<Action>;
+  dispatch: React.Dispatch<ResizeAction>;
   gridEnabled?: boolean;
   gridCols: number;
   containerRef: React.RefObject<HTMLDivElement>;
@@ -88,7 +88,7 @@ export default function useCanvasResize({
         id: componentId,
         [widthKey]: snapW ? "100%" : `${newW}px`,
         [heightKey]: snapH ? "100%" : `${newH}px`,
-      } as any);
+      });
       setCurrent({ width: newW, height: newH, left, top });
       setSnapWidth(snapW || guideX !== null);
       setSnapHeight(snapH || guideY !== null);


### PR DESCRIPTION
## Summary
- allow ResizeAction to include dynamic keys
- type useCanvasResize dispatch to ResizeAction and drop `as any`

## Testing
- `pnpm --filter @acme/ui test -- --testPathPattern packages/ui` *(fails: numerous missing modules and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ba85ca8832fb970347d41a1af11