### PR TITLE
refactor: improve numeric field typing

### DIFF
--- a/packages/ui/src/components/cms/page-builder/state/layout.ts
+++ b/packages/ui/src/components/cms/page-builder/state/layout.ts
@@ -104,12 +104,15 @@ function updateComponent(
     "tabletItems",
     "mobileItems",
   ] as const;
-  const normalized: Partial<PageComponent> = { ...patch };
+  type NumericField = (typeof numericFields)[number];
+  const normalized: Partial<PageComponent> & Record<NumericField, number | undefined> = {
+    ...patch,
+  } as Partial<PageComponent> & Record<NumericField, number | undefined>;
   for (const key of numericFields) {
-    const val = normalized[key];
+    const val = (patch as Record<NumericField, unknown>)[key];
     if (typeof val === "string") {
       const num = Number(val);
-      normalized[key] = Number.isNaN(num) ? undefined : (num as any);
+      normalized[key] = Number.isNaN(num) ? undefined : (num as number);
     }
   }
   return list.map((c) => {


### PR DESCRIPTION
## Summary
- refine numeric field handling in layout updater
- replace broad numeric casts with explicit `number`

## Testing
- `pnpm --filter @acme/ui run test` *(fails: Exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ba9f86c832fb07a0507f43afb33