### PR TITLE
feat: add product save result type

### DIFF
--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -4,7 +4,10 @@
 import { Button, Card, CardContent, Input } from "@ui/components/atoms/shadcn";
 import type { Locale, ProductPublication } from "@platform-core/src/products";
 import { useProductEditorFormState } from "@ui/hooks/useProductEditorFormState";
-import type { ProductWithVariants } from "@ui/hooks/useProductEditorFormState";
+import type {
+  ProductWithVariants,
+  ProductSaveResult,
+} from "@ui/hooks/useProductEditorFormState";
 import MultilingualFields from "./MultilingualFields";
 import PublishLocationSelector from "./PublishLocationSelector";
 
@@ -16,10 +19,7 @@ interface BaseProps {
   /** Current product snapshot (all locales) */
   product: ProductWithVariants;
   /** Called with FormData → resolves to updated product or errors */
-  onSave(fd: FormData): Promise<{
-    product?: ProductPublication;
-    errors?: Record<string, string[]>;
-  }>;
+  onSave(fd: FormData): Promise<ProductSaveResult>;
   /** Locales enabled for the current shop */
   locales: readonly Locale[];
 }

--- a/packages/ui/src/hooks/__tests__/useProductEditorFormState.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useProductEditorFormState.test.tsx
@@ -2,7 +2,10 @@
 
 import type { Locale, ProductPublication } from "@platform-core/src/products";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { useProductEditorFormState } from "../useProductEditorFormState";
+import {
+  useProductEditorFormState,
+  type ProductSaveResult,
+} from "../useProductEditorFormState";
 
 /* ------------------------------------------------------------------ *
  *  Mock the file-upload and publish-location hooks (no network, no DOM)
@@ -47,10 +50,7 @@ const locales: readonly Locale[] = ["en", "de"];
 function Wrapper({
   onSave,
 }: {
-  onSave: (fd: FormData) => Promise<{
-    product?: ProductPublication;
-    errors?: Record<string, string[]>;
-  }>;
+  onSave: (fd: FormData) => Promise<ProductSaveResult>;
 }) {
   const state = useProductEditorFormState(product, locales, onSave);
 
@@ -108,7 +108,7 @@ describe("useProductEditorFormState", () => {
 
   it("handleSubmit calls save callback with generated FormData", async () => {
     const onSave = jest
-      .fn<Promise<{ product: ProductPublication }>, [FormData]>()
+      .fn<Promise<ProductSaveResult>, [FormData]>()
       .mockResolvedValue({ product });
 
     render(<Wrapper onSave={onSave} />);

--- a/packages/ui/src/hooks/useProductEditorFormState.tsx
+++ b/packages/ui/src/hooks/useProductEditorFormState.tsx
@@ -19,6 +19,11 @@ export interface ProductWithVariants extends ProductPublication {
   variants: Record<string, string[]>;
 }
 
+export interface ProductSaveResult {
+  product?: ProductPublication & { variants?: Record<string, string[]> };
+  errors?: Record<string, string[]>;
+}
+
 export interface UseProductEditorFormReturn {
   product: ProductWithVariants;
   errors: Record<string, string[]>;
@@ -42,10 +47,7 @@ export interface UseProductEditorFormReturn {
 export function useProductEditorFormState(
   init: ProductPublication & { variants?: Record<string, string[]> },
   locales: readonly Locale[],
-  onSave: (fd: FormData) => Promise<{
-    product?: ProductPublication;
-    errors?: Record<string, string[]>;
-  }>
+  onSave: (fd: FormData) => Promise<ProductSaveResult>
 ): UseProductEditorFormReturn {
   /* ---------- state ------------------------------------------------ */
   const [product, setProduct] = useState<ProductWithVariants>({
@@ -154,10 +156,11 @@ export function useProductEditorFormState(
       if (result.errors) {
         setErrors(result.errors);
       } else if (result.product) {
-        setProduct({
-          ...(result.product as ProductWithVariants),
-          variants: (result.product as any).variants ?? product.variants,
-        });
+        const updated: ProductWithVariants = {
+          ...result.product,
+          variants: result.product.variants ?? product.variants,
+        };
+        setProduct(updated);
         setErrors({});
       }
       setSaving(false);


### PR DESCRIPTION
## Summary
- define `ProductSaveResult` interface with optional variants
- use `ProductSaveResult` for product editor save callbacks
- clean up product editor handleSubmit and remove `any` casts

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/hooks/__tests__/useProductEditorFormState.test.tsx` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_689e1baabef0832fa891171ff48d0083