### PR TITLE
feat: honor coverage selections when computing damage

### DIFF
--- a/apps/shop-bcd/src/api/rental/route.js
+++ b/apps/shop-bcd/src/api/rental/route.js
@@ -25,13 +25,17 @@ export async function PATCH(req) {
         return NextResponse.json({ error: "Order not found" }, { status: 404 });
     }
     const shop = await readShop("bcd");
-    const damageFee = await computeDamageFee(damage, order.deposit, [], shop.coverageIncluded);
-    if (damageFee) {
-        await markReturned("bcd", sessionId, damageFee);
-    }
     const session = await stripe.checkout.sessions.retrieve(sessionId, {
         expand: ["payment_intent"],
     });
+    let coverageCodes = session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
+    if (shop.coverageIncluded && typeof damage === "string") {
+        coverageCodes = Array.from(new Set([...coverageCodes, damage]));
+    }
+    const damageFee = await computeDamageFee(damage, order.deposit, coverageCodes, shop.coverageIncluded);
+    if (damageFee) {
+        await markReturned("bcd", sessionId, damageFee);
+    }
     const pi = typeof session.payment_intent === "string"
         ? session.payment_intent
         : session.payment_intent?.id;

--- a/apps/shop-bcd/src/api/return/route.ts
+++ b/apps/shop-bcd/src/api/return/route.ts
@@ -45,10 +45,15 @@ export async function POST(req: NextRequest) {
   }
 
   const shop = await readShop("bcd");
+  let coverageCodes =
+    session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
+  if (shop.coverageIncluded && typeof damage === "string") {
+    coverageCodes = Array.from(new Set([...coverageCodes, damage]));
+  }
   const damageFee = await computeDamageFee(
     damage,
     deposit,
-    [],
+    coverageCodes,
     shop.coverageIncluded,
   );
   if (damageFee) {

--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -80,7 +80,7 @@ export async function computeDamageFee(
     const hasCoverage = coverageIncluded || coverageCodes.includes(kind);
     if (hasCoverage) {
       const coverage = pricing.coverage[kind];
-      if (coverage && typeof rule === "number") {
+      if (coverage) {
         fee = Math.max(0, fee - coverage.waiver);
       }
     }

--- a/packages/template-app/src/api/return/route.ts
+++ b/packages/template-app/src/api/return/route.ts
@@ -67,10 +67,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, message: "No deposit found" });
     }
 
+    let coverageCodes =
+      session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
+    if (shop.coverageIncluded && typeof damage === "string") {
+      coverageCodes = Array.from(new Set([...coverageCodes, damage]));
+    }
+
     const damageFee = await computeDamageFee(
       damage,
       deposit,
-      [],
+      coverageCodes,
       shop.coverageIncluded,
     );
     if (damageFee) {


### PR DESCRIPTION
## Summary
- waive damage fees when coverage codes or shop policy cover the damage
- pass selected coverage codes from checkout session metadata to damage fee calculation

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: process.exit(1) due to missing env)*
- `pnpm --filter @apps/shop-bcd test`
- `pnpm --filter @acme/template-app test`


------
https://chatgpt.com/codex/tasks/task_e_689e1f5ad690832f8bfc59b415e87c0c