### PR TITLE
feat: record published component versions

### DIFF
--- a/scripts/__tests__/republish-shop.test.ts
+++ b/scripts/__tests__/republish-shop.test.ts
@@ -68,4 +68,26 @@ describe("republish-shop", () => {
       join(componentsDir, "nested", "c.bak")
     );
   });
+
+  it("updates componentVersions in shop.json", async () => {
+    const pkg = join(appDir, "package.json");
+    fsMock.existsSync.mockImplementation((p: any) => p === pkg || p === shopJson);
+    fsMock.readFileSync.mockImplementation((p: any) => {
+      if (p === pkg) return JSON.stringify({ dependencies: { comp: "1.0.0" } });
+      if (p === shopJson) return "{}";
+      return "";
+    });
+
+    const { republishShop } = await import("../src/republish-shop");
+    republishShop(shopId, root);
+
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      shopJson,
+      JSON.stringify(
+        { status: "published", componentVersions: { comp: "1.0.0" } },
+        null,
+        2
+      )
+    );
+  });
 });

--- a/scripts/src/republish-shop.ts
+++ b/scripts/src/republish-shop.ts
@@ -26,6 +26,10 @@ function updateStatus(root: string, id: string): void {
   const file = join(root, "data", "shops", id, "shop.json");
   const json = JSON.parse(readFileSync(file, "utf8"));
   json.status = "published";
+  const pkgPath = join(root, "apps", id, "package.json");
+  json.componentVersions = existsSync(pkgPath)
+    ? JSON.parse(readFileSync(pkgPath, "utf8")).dependencies ?? {}
+    : {};
   writeFileSync(file, JSON.stringify(json, null, 2));
 }
 

--- a/test/integration/republish-shop.spec.ts
+++ b/test/integration/republish-shop.spec.ts
@@ -44,7 +44,10 @@ describe("republish-shop script", () => {
 
       const appDir = join(tmp, "apps", "shop-test");
       mkdirSync(appDir, { recursive: true });
-      writeFileSync(join(appDir, "shop.json"), JSON.stringify({ id: "shop-test" }, null, 2));
+      writeFileSync(
+        join(appDir, "package.json"),
+        JSON.stringify({ dependencies: { comp: "1.0.0" } }, null, 2)
+      );
       const dataDir = join(tmp, "data", "shops", "shop-test");
       mkdirSync(dataDir, { recursive: true });
       writeFileSync(join(dataDir, "upgrade.json"), JSON.stringify({ ok: true }));
@@ -60,6 +63,7 @@ describe("republish-shop script", () => {
       expect(log).toContain("--filter apps/shop-test deploy");
       const final = JSON.parse(readFileSync(join(dataDir, "shop.json"), "utf8"));
       expect(final.status).toBe("published");
+      expect(final.componentVersions).toEqual({ comp: "1.0.0" });
       expect(existsSync(join(dataDir, "upgrade.json"))).toBe(false);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
@@ -97,7 +101,10 @@ describe("republish-shop script", () => {
 
       const appDir = join(tmp, "apps", "shop-edit");
       mkdirSync(appDir, { recursive: true });
-      writeFileSync(join(appDir, "shop.json"), JSON.stringify({ id: "shop-edit" }, null, 2));
+      writeFileSync(
+        join(appDir, "package.json"),
+        JSON.stringify({ dependencies: { comp: "1.0.0" } }, null, 2)
+      );
       const dataDir = join(tmp, "data", "shops", "shop-edit");
       mkdirSync(dataDir, { recursive: true });
       writeFileSync(join(dataDir, "shop.json"), JSON.stringify({ id: "shop-edit" }, null, 2));
@@ -112,6 +119,7 @@ describe("republish-shop script", () => {
       expect(log).toContain("--filter apps/shop-edit deploy");
       const final = JSON.parse(readFileSync(join(dataDir, "shop.json"), "utf8"));
       expect(final.status).toBe("published");
+      expect(final.componentVersions).toEqual({ comp: "1.0.0" });
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- capture package dependency versions when a shop is published
- test capturing component versions in publish script

## Testing
- `pnpm exec eslint scripts/src/republish-shop.ts scripts/__tests__/republish-shop.test.ts test/integration/republish-shop.spec.ts`
- `pnpm exec jest scripts/__tests__/republish-shop.test.ts test/integration/republish-shop.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_689e2227ddd8832f89842e9f63fb29ff