### PR TITLE
refactor: centralize nowIso usage

### DIFF
--- a/apps/cms/src/app/api/seo/audit/[shop]/route.ts
+++ b/apps/cms/src/app/api/seo/audit/[shop]/route.ts
@@ -7,6 +7,7 @@ import {
   readSeoAudits,
   type SeoAuditEntry,
 } from "@platform-core/repositories/seoAudit.server";
+import { nowIso } from "@date-utils";
 
 async function runLighthouse(url: string): Promise<SeoAuditEntry> {
   const chrome = await chromeLauncher.launch({ chromeFlags: ["--headless"] });
@@ -25,7 +26,7 @@ async function runLighthouse(url: string): Promise<SeoAuditEntry> {
         a.title,
       )
       .map((a) => a.title as string);
-    return { timestamp: new Date().toISOString(), score, recommendations };
+    return { timestamp: nowIso(), score, recommendations };
   } finally {
     await chrome.kill();
   }

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -13,6 +13,7 @@ import {
   type SanityConfig,
 } from "@platform-core/src/repositories/blog.server";
 import { ensureAuthorized } from "../actions/common/auth";
+import { nowIso } from "@date-utils";
 
 function collectProductSlugs(content: unknown): string[] {
   const slugs = new Set<string>();
@@ -193,7 +194,7 @@ export async function publishPost(
   const publishedAtInput = formData?.get("publishedAt");
   const publishedAt = publishedAtInput
     ? new Date(String(publishedAtInput)).toISOString()
-    : new Date().toISOString();
+    : nowIso();
   try {
     await repoPublishPost(config, id, publishedAt);
     return { message: "Post published" };

--- a/apps/shop-abc/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-abc/routes/__tests__/preview-upgrade.test.ts
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import type { Page } from "@acme/types";
 import { createHmac } from "node:crypto";
+import { nowIso } from "@date-utils";
 
 process.env.PREVIEW_TOKEN_SECRET = "testsecret";
 process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
@@ -24,8 +25,8 @@ test("valid upgrade token returns page JSON", async () => {
     status: "draft",
     components: [],
     seo: { title: "Home" },
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
     createdBy: "tester",
   };
   const getPages = jest.fn(async () => [page]);

--- a/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import type { Page } from "@acme/types";
 import { createHmac } from "node:crypto";
+import { nowIso } from "@date-utils";
 
 process.env.PREVIEW_TOKEN_SECRET = "testsecret";
 process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
@@ -24,8 +25,8 @@ test("valid upgrade token returns page JSON", async () => {
     status: "draft",
     components: [],
     seo: { title: "Home" },
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
     createdBy: "tester",
   };
   const getPages = jest.fn(async () => [page]);

--- a/functions/src/seoAudit.ts
+++ b/functions/src/seoAudit.ts
@@ -5,12 +5,13 @@ import { runSeoAudit } from "../../scripts/seo-audit";
 import { trackEvent } from "@platform-core/analytics";
 import { sendCampaignEmail } from "@acme/email";
 import { coreEnv } from "@acme/config/env/core";
+import { nowIso } from "@date-utils";
 
 async function auditShop(shop: string): Promise<void> {
   const url = `http://localhost:3000/${shop}`;
   const { score, recommendations } = await runSeoAudit(url);
   const record = {
-    timestamp: new Date().toISOString(),
+    timestamp: nowIso(),
     score,
     recommendations,
   };

--- a/functions/themes/[theme]/__tests__/cms-storefront-integration.test.ts
+++ b/functions/themes/[theme]/__tests__/cms-storefront-integration.test.ts
@@ -3,6 +3,7 @@ import { createHmac } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { nowIso } from "@date-utils";
 
 import type { Page } from "@acme/types";
 
@@ -54,7 +55,7 @@ describe("CMS → storefront flow", () => {
 
   test("published page is returned via preview route", async () => {
     await withRepo(async (repo) => {
-      const now = new Date().toISOString();
+      const now = nowIso();
       const page: Page = {
         id: "p1",
         slug: "home",

--- a/packages/email/src/__tests__/analytics.test.ts
+++ b/packages/email/src/__tests__/analytics.test.ts
@@ -1,3 +1,5 @@
+import { nowIso } from "@date-utils";
+
 process.env.CART_COOKIE_SECRET = "secret";
 
 describe("analytics mapping", () => {
@@ -129,8 +131,8 @@ describe("syncCampaignAnalytics", () => {
             recipients: [],
             subject: "s",
             body: "b",
-            sendAt: new Date().toISOString(),
-            sentAt: new Date().toISOString(),
+            sendAt: nowIso(),
+            sentAt: nowIso(),
           },
         ];
       },

--- a/packages/email/src/cli.ts
+++ b/packages/email/src/cli.ts
@@ -5,6 +5,7 @@ import * as fsSync from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { sendScheduledCampaigns } from "../../../functions/marketing-email-sender.ts";
+import { nowIso } from "@date-utils";
 
 interface Campaign {
   id: string;
@@ -60,7 +61,7 @@ campaign
   .requiredOption("--body <html>", "HTML body")
   .option("--recipients <emails>", "Comma separated recipient emails")
   .option("--segment <segment>", "Recipient segment name")
-  .option("--send-at <date>", "ISO send time", () => new Date().toISOString())
+  .option("--send-at <date>", "ISO send time", () => nowIso())
   .action(async (shop, options) => {
     const campaigns = await readCampaigns(shop);
     const recipients = options.recipients

--- a/packages/platform-core/__tests__/nowIsoMocking.test.ts
+++ b/packages/platform-core/__tests__/nowIsoMocking.test.ts
@@ -1,0 +1,21 @@
+import { jest } from "@jest/globals";
+
+const createMock = jest.fn(async ({ data }: any) => data);
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    rentalOrder: { create: createMock },
+  },
+}));
+
+jest.mock("../src/analytics", () => ({ trackOrder: jest.fn() }));
+
+jest.mock("@date-utils", () => ({ nowIso: jest.fn(() => "2000-01-01T00:00:00.000Z") }));
+
+describe("nowIso mocking", () => {
+  it("uses mocked nowIso in addOrder", async () => {
+    const { addOrder } = await import("../src/orders");
+    const order = await addOrder("shop", "sess", 10);
+    expect(order.startedAt).toBe("2000-01-01T00:00:00.000Z");
+  });
+});

--- a/packages/platform-core/__tests__/repositories.test.ts
+++ b/packages/platform-core/__tests__/repositories.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ProductPublication } from "../products";
+import { nowIso } from "@date-utils";
 
 /** The shape of the JSON-repository module we import dynamically */
 type JsonRepo = typeof import("../repositories/json.server");
@@ -59,8 +60,8 @@ describe("json repository", () => {
         price: 10,
         currency: "EUR",
         media: [],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
+        created_at: nowIso(),
+        updated_at: nowIso(),
         shop,
         status: "active",
         row_version: 1,

--- a/packages/platform-core/prisma/seed.ts
+++ b/packages/platform-core/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../src/db";
+import { nowIso } from "@date-utils";
 
 async function main() {
   await prisma.rentalOrder.createMany({
@@ -8,7 +9,7 @@ async function main() {
         shop: "seed-shop",
         sessionId: "seed-session",
         deposit: 0,
-        startedAt: new Date().toISOString(),
+        startedAt: nowIso(),
       },
     ],
     skipDuplicates: true,

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -1,7 +1,7 @@
 // packages/platform-core/src/orders.ts
 import "server-only";
 import { ulid } from "ulid";
-import { nowIso } from "@acme/date-utils";
+import { nowIso } from "@date-utils";
 import type { RentalOrder, Shop } from "@acme/types";
 import { trackOrder } from "./analytics";
 import { prisma } from "./db";
@@ -42,7 +42,7 @@ export async function addOrder(
   await prisma.rentalOrder.create({ data: order });
   await trackOrder(shop, order.id, deposit);
   if (customerId) {
-    const month = new Date().toISOString().slice(0, 7);
+    const month = nowIso().slice(0, 7);
     const record = await prisma.shop.findUnique({
       select: { data: true },
       where: { id: shop },

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -2,7 +2,7 @@
 import "server-only";
 
 import type { RentalOrder } from "@acme/types";
-import { nowIso } from "@acme/date-utils";
+import { nowIso } from "@date-utils";
 import { prisma } from "../db";
 
 export {

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "@sanity/client";
 import { getSanityConfig } from "@platform-core/shops";
 import { getShopById } from "@platform-core/repositories/shop.server";
 import type { SanityBlogConfig } from "@acme/types";
+import { nowIso } from "@date-utils";
 
 export interface ProductBlock {
   _type: "productReference";
@@ -73,7 +74,7 @@ export async function publishQueuedPost(shopId: string): Promise<void> {
     if (!next?._id) return;
     await client
       .patch(next._id)
-      .set({ published: true, publishedAt: new Date().toISOString() })
+      .set({ published: true, publishedAt: nowIso() })
       .commit();
   } catch {
     // swallow errors; scheduled job will handle logging

--- a/packages/template-app/__tests__/preview-route.test.ts
+++ b/packages/template-app/__tests__/preview-route.test.ts
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import type { Page } from "@acme/types";
 import { createHmac } from "node:crypto";
+import { nowIso } from "@date-utils";
 
 process.env.PREVIEW_TOKEN_SECRET = "testsecret";
 process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
@@ -24,8 +25,8 @@ test("valid token returns page JSON", async () => {
     status: "draft",
     components: [],
     seo: { title: "Home" },
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
     createdBy: "tester",
   };
   const getPages = jest.fn(async () => [page]);
@@ -83,8 +84,8 @@ test("valid upgrade token returns page JSON", async () => {
     status: "draft",
     components: [],
     seo: { title: "Home" },
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
     createdBy: "tester",
   };
   const getPages = jest.fn(async () => [page]);

--- a/packages/template-app/src/app/account/swaps/page.tsx
+++ b/packages/template-app/src/app/account/swaps/page.tsx
@@ -14,6 +14,7 @@ import { getCustomerSession } from "@auth";
 import { readShop } from "@platform-core/src/repositories/shops.server";
 import { notFound } from "next/navigation";
 import { coreEnv } from "@acme/config/env/core";
+import { nowIso } from "@date-utils";
 import {
   getUserPlan,
   getRemainingSwaps,
@@ -34,7 +35,7 @@ export default async function SwapPage() {
   const selectedPlan = planId
     ? shop.rentalSubscriptions.find((p) => p.id === planId)
     : undefined;
-  const month = new Date().toISOString().slice(0, 7);
+  const month = nowIso().slice(0, 7);
   const remainingSwaps =
     session?.customerId && selectedPlan
       ? await getRemainingSwaps(
@@ -61,7 +62,7 @@ export default async function SwapPage() {
     const selectedPlan = planId
       ? shop.rentalSubscriptions.find((p) => p.id === planId)
       : undefined;
-    const month = new Date().toISOString().slice(0, 7);
+    const month = nowIso().slice(0, 7);
     if (!selectedPlan) return;
     const remaining = await getRemainingSwaps(
       shopId,

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -3,11 +3,12 @@ import { getShopSettings } from "@platform-core/src/repositories/settings.server
 import { readRepo } from "@platform-core/src/repositories/products.server";
 import { coreEnv } from "@acme/config/env/core";
 import type { ProductPublication } from "@acme/types";
+import { nowIso } from "@date-utils";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
-  const now = new Date().toISOString();
+  const now = nowIso();
 
   const [settings, products] = await Promise.all([
     getShopSettings(shop),

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import * as path from "node:path";
 import { randomBytes, createHash } from "node:crypto";
+import { nowIso } from "@date-utils";
 import { getComponentNameMap } from "./component-names";
 import { generateExampleProps } from "./generate-example-props";
 import type { Page, ShopMetadata } from "@acme/types";
@@ -57,7 +58,7 @@ generateExampleProps(shopId, rootDir);
 if (existsSync(shopJsonPath)) {
   cpSync(shopJsonPath, shopJsonPath + ".bak");
   const data = JSON.parse(readFileSync(shopJsonPath, "utf8")) as ShopMetadata;
-  data.lastUpgrade = new Date().toISOString();
+  data.lastUpgrade = nowIso();
   data.componentVersions = existsSync(pkgPath)
     ? (JSON.parse(readFileSync(pkgPath, "utf8")).dependencies ?? {})
     : {};
@@ -129,7 +130,7 @@ writeFileSync(
   upgradeMetaPath,
   JSON.stringify(
     {
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
       componentVersions,
       components: changedComponents,
     },


### PR DESCRIPTION
## Summary
- replace direct `new Date().toISOString()` usages with `nowIso()` from `@date-utils`
- add test ensuring `nowIso` can be mocked for deterministic behavior

## Testing
- `npx jest packages/platform-core/__tests__/nowIsoMocking.test.ts packages/email/src/__tests__/analytics.test.ts packages/platform-core/__tests__/repositories.test.ts packages/template-app/__tests__/preview-route.test.ts apps/shop-abc/routes/__tests__/preview-upgrade.test.ts apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts functions/themes/[theme]/__tests__/cms-storefront-integration.test.ts` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_689e217290e0832fa86675d6ae6b6a17