### PR TITLE
fix: point cms tsconfig to local config

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@acme/config/tsconfig.app.json",
+  "extends": "../../packages/config/tsconfig.app.json",
   "include": [
     "src/**/*",
     "../../src/lib/**/*",


### PR DESCRIPTION
## Summary
- fix cms tsconfig extends path to use local package reference

## Testing
- `npx tsc -p apps/cms/tsconfig.json --noEmit` *(fails: apps/cms/src/app/cms/configurator/steps.ts...)*

------
https://chatgpt.com/codex/tasks/task_e_689e2620b210832f877c0cd9232ce21e