### PR TITLE
feat: add segment schema validation

### DIFF
--- a/packages/types/src/Segment.ts
+++ b/packages/types/src/Segment.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const segmentSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    filters: z.array(
+      z.object({ field: z.string(), value: z.string() }).strict()
+    ),
+  })
+  .strict();
+
+export type Segment = z.infer<typeof segmentSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,3 +19,4 @@ export * from "./SubscriptionPlan";
 export * from "./Coverage";
 export * from "./upgrade";
 export * from "./ExampleProps";
+export * from "./Segment";


### PR DESCRIPTION
## Summary
- expose reusable segment schema in @acme/types
- validate segments API with zod and parseJsonBody

## Testing
- `pnpm run test --filter @acme/types`
- `pnpm run test --filter @apps/cms` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*
- `pnpm run lint --filter @acme/types`
- `pnpm run lint --filter @apps/cms` *(fails: Cannot find module '@acme/config/env/core.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689e264614b8832f8831144787030a0a