### PR TITLE
feat: migrate password hashing to argon2

### DIFF
--- a/apps/cms/__tests__/accounts.test.ts
+++ b/apps/cms/__tests__/accounts.test.ts
@@ -1,7 +1,7 @@
 // apps/cms/__tests__/accounts.test.ts
 /* eslint-env jest */
 
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -55,7 +55,7 @@ describe("account actions", () => {
 
       const stored = pending[0];
       expect(stored.password).not.toBe("secret");
-      await expect(bcrypt.compare("secret", stored.password)).resolves.toBe(
+      await expect(argon2.verify(stored.password, "secret")).resolves.toBe(
         true
       );
     });

--- a/apps/cms/src/actions/accounts.server.ts
+++ b/apps/cms/src/actions/accounts.server.ts
@@ -4,7 +4,7 @@
 
 import type { Role } from "@cms/auth/roles";
 import type { CmsUser } from "@cms/auth/users";
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import { ulid } from "ulid";
 import { sendEmail } from "@acme/email";
 import { readRbac, writeRbac } from "../lib/rbacStore";
@@ -22,7 +22,7 @@ export async function requestAccount(formData: FormData): Promise<void> {
   const name = String(formData.get("name") ?? "");
   const email = String(formData.get("email") ?? "");
   const password = String(formData.get("password") ?? "");
-  const hashed = await bcrypt.hash(password, 10);
+  const hashed = await argon2.hash(password);
   const id = ulid();
   PENDING_USERS[id] = { id, name, email, password: hashed };
 }

--- a/apps/cms/src/actions/rbac.server.ts
+++ b/apps/cms/src/actions/rbac.server.ts
@@ -4,7 +4,7 @@
 import type { Role } from "@cms/auth/roles";
 import type { CmsUser } from "@cms/auth/users";
 import type { Permission } from "@auth";
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import { ulid } from "ulid";
 import { readRbac, writeRbac } from "../lib/rbacStore";
 
@@ -32,7 +32,7 @@ export async function inviteUser(formData: FormData): Promise<void> {
   const password = String(formData.get("password") ?? "");
   const roles = formData.getAll("roles") as Role[];
 
-  const hashed = await bcrypt.hash(password, 10);
+  const hashed = await argon2.hash(password);
   const id = ulid();
   const db = await readRbac();
   db.users[id] = { id, name, email, password: hashed };
@@ -40,9 +40,7 @@ export async function inviteUser(formData: FormData): Promise<void> {
   await writeRbac(db);
 }
 
-export async function updateRolePermissions(
-  formData: FormData
-): Promise<void> {
+export async function updateRolePermissions(formData: FormData): Promise<void> {
   const role = String(formData.get("role") ?? "") as Role;
   const permissions = formData.getAll("permissions") as Permission[];
   const db = await readRbac();

--- a/apps/cms/src/auth/options.js
+++ b/apps/cms/src/auth/options.js
@@ -1,62 +1,65 @@
 // apps/cms/src/auth/options.ts
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import Credentials from "next-auth/providers/credentials";
 import { readRbac } from "../lib/rbacStore";
 import { authSecret } from "./secret";
 const secret = authSecret;
 export const authOptions = {
-    secret,
-    providers: [
-        Credentials({
-            name: "Credentials",
-            credentials: {
-                email: { label: "Email", type: "text" },
-                password: { label: "Password", type: "password" },
-            },
-            async authorize(credentials) {
-                console.log("[auth] authorize called", credentials);
-                if (!credentials)
-                    return null;
-                const { users, roles } = await readRbac();
-                const user = Object.values(users).find((u) => u.email === credentials.email);
-                console.log("[auth] found user", Boolean(user));
-                if (user &&
-                    (user.id === "1"
-                        ? credentials.password === user.password
-                        : await bcrypt.compare(credentials.password, user.password))) {
-                    /* Strip password before handing the user object to NextAuth */
-                    const { password: _password, ...safeUser } = user;
-                    void _password;
-                    const r = roles[user.id];
-                    const role = Array.isArray(r) ? r[0] : r;
-                    console.log("[auth] login success", { id: user.id, role });
-                    return { ...safeUser, role };
-                }
-                console.log("[auth] login failed for", credentials.email);
-                throw new Error("Invalid email or password");
-            },
-        }),
-    ],
-    session: { strategy: "jwt" },
-    callbacks: {
-        async jwt({ token, user }) {
-            /* `user` exists only on sign-in; cast to access `role` */
-            if (user) {
-                const u = user;
-                console.log("[auth] jwt assign role", u.role);
-                token.role = u.role;
-            }
-            return token;
-        },
-        async session({ session, token }) {
-            /* Forward the role from JWT to the client session */
-            const role = token.role;
-            console.log("[auth] session role", role);
-            if (role) {
-                session.user.role = role;
-            }
-            return session;
-        },
+  secret,
+  providers: [
+    Credentials({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "text" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        console.log("[auth] authorize called", credentials);
+        if (!credentials) return null;
+        const { users, roles } = await readRbac();
+        const user = Object.values(users).find(
+          (u) => u.email === credentials.email
+        );
+        console.log("[auth] found user", Boolean(user));
+        if (
+          user &&
+          (user.id === "1"
+            ? credentials.password === user.password
+            : await argon2.verify(user.password, credentials.password))
+        ) {
+          /* Strip password before handing the user object to NextAuth */
+          const { password: _password, ...safeUser } = user;
+          void _password;
+          const r = roles[user.id];
+          const role = Array.isArray(r) ? r[0] : r;
+          console.log("[auth] login success", { id: user.id, role });
+          return { ...safeUser, role };
+        }
+        console.log("[auth] login failed for", credentials.email);
+        throw new Error("Invalid email or password");
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async jwt({ token, user }) {
+      /* `user` exists only on sign-in; cast to access `role` */
+      if (user) {
+        const u = user;
+        console.log("[auth] jwt assign role", u.role);
+        token.role = u.role;
+      }
+      return token;
     },
-    pages: { signIn: "/login" },
+    async session({ session, token }) {
+      /* Forward the role from JWT to the client session */
+      const role = token.role;
+      console.log("[auth] session role", role);
+      if (role) {
+        session.user.role = role;
+      }
+      return session;
+    },
+  },
+  pages: { signIn: "/login" },
 };

--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -1,6 +1,6 @@
 // apps/cms/src/auth/options.ts
 /* eslint-disable no-console */
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import type { NextAuthOptions } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
@@ -21,12 +21,12 @@ const secret = authSecret;
 
 interface Overrides {
   readRbac?: typeof defaultReadRbac;
-  bcryptCompare?: typeof bcrypt.compare;
+  argonVerify?: typeof argon2.verify;
 }
 
 export function createAuthOptions(overrides: Overrides = {}): NextAuthOptions {
   const readRbac = overrides.readRbac ?? defaultReadRbac;
-  const bcryptCompare = overrides.bcryptCompare ?? bcrypt.compare;
+  const argonVerify = overrides.argonVerify ?? argon2.verify;
 
   return {
     secret,
@@ -53,13 +53,13 @@ export function createAuthOptions(overrides: Overrides = {}): NextAuthOptions {
           /* -------------------------------------------------------------- */
           /*  Password check                                                */
           /*  - user.id === "1": plain‑text (dev fixture)                   */
-          /*  - everyone else : bcrypt                                      */
+          /*  - everyone else : argon2                                     */
           /* -------------------------------------------------------------- */
           const ok =
             user &&
             (user.id === "1"
               ? credentials.password === user.password
-              : await bcryptCompare(credentials.password, user.password));
+              : await argonVerify(user.password, credentials.password));
 
           if (ok && user) {
             /* Strip the password before returning */

--- a/apps/cms/src/auth/users.d.ts
+++ b/apps/cms/src/auth/users.d.ts
@@ -1,9 +1,9 @@
 export interface CmsUser {
-    id: string;
-    name: string;
-    email: string;
-    /** bcrypt hashed password */
-    password: string;
+  id: string;
+  name: string;
+  email: string;
+  /** argon2 hashed password */
+  password: string;
 }
 /** Phase-0 in-memory users (replace with DB in Phase-1). */
 export declare const USERS: Record<string, CmsUser>;

--- a/apps/cms/src/auth/users.js
+++ b/apps/cms/src/auth/users.js
@@ -1,39 +1,43 @@
 // apps/cms/src/auth/users.ts
 /** Phase-0 in-memory users (replace with DB in Phase-1). */
 export const USERS = {
-    admin: {
-        id: "1",
-        name: "Admin",
-        email: "admin@example.com",
-        //password: "admin",
-        password: "admin", // NOTE: stored in plain text
-    },
-    viewer: {
-        id: "2",
-        name: "Viewer",
-        email: "viewer@example.com",
-        //password: "viewer",
-        password: "$2b$10$zrw7b.7IguK2cWtM83jgKOKe0YiM6BTzGI.S60J1nlanjPw7G5dt6",
-    },
-    shopAdmin: {
-        id: "3",
-        name: "Shop Admin",
-        email: "shopadmin@example.com",
-        //password: "shopadmin",
-        password: "$2b$10$iiBPVdzX6hr0R.9eOSN36uhBqt0iOIj6ecZlPA.NBpzswomxcTvfi",
-    },
-    catalogManager: {
-        id: "4",
-        name: "Catalog Manager",
-        email: "catalogmanager@example.com",
-        //password: "catalogmanager",
-        password: "$2b$10$bXz7QTWvPrn7okbbk58uDOJKBPJfPU6RI8F5HV4M5DnBFwSIbXi/y",
-    },
-    themeEditor: {
-        id: "5",
-        name: "Theme Editor",
-        email: "themeeditor@example.com",
-        //password: "themeeditor",
-        password: "$2b$10$XCLdGULFzVh56kw/oRP2husM07I1fPe0NqjIUxk9d2/PZBTwVIruK",
-    },
+  admin: {
+    id: "1",
+    name: "Admin",
+    email: "admin@example.com",
+    //password: "admin",
+    password: "admin", // NOTE: stored in plain text
+  },
+  viewer: {
+    id: "2",
+    name: "Viewer",
+    email: "viewer@example.com",
+    //password: "viewer",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$EJTukba6cgu3oddf7NWibw$925GwzuYHM9wGz+R+j8TDed1jF1sllCqEOyQ63g5Iw4",
+  },
+  shopAdmin: {
+    id: "3",
+    name: "Shop Admin",
+    email: "shopadmin@example.com",
+    //password: "shopadmin",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$Qzzwz9iLHAK1XFp0gY8CaA$mRWqHTICaS4hB/E7TheLtyQjbmvzN2QKVuz0NnCKr+w",
+  },
+  catalogManager: {
+    id: "4",
+    name: "Catalog Manager",
+    email: "catalogmanager@example.com",
+    //password: "catalogmanager",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$1ie22pUv+lwFEJcQy15tHg$zJRHh2i3T5UpBpO0ffpDSnQbRpDwWh5bTqbCgLq22JE",
+  },
+  themeEditor: {
+    id: "5",
+    name: "Theme Editor",
+    email: "themeeditor@example.com",
+    //password: "themeeditor",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$XCickdgFmjP4faHZ2TCafA$x/vBXe/eGRdl3IgI1fNbb9RBXhOGpUGkJPsHbmV98Bw",
+  },
 };

--- a/apps/cms/src/auth/users.ts
+++ b/apps/cms/src/auth/users.ts
@@ -17,27 +17,31 @@ export const USERS: Record<string, CmsUser> = {
     name: "Viewer",
     email: "viewer@example.com",
     //password: "viewer",
-    password: "$2b$10$zrw7b.7IguK2cWtM83jgKOKe0YiM6BTzGI.S60J1nlanjPw7G5dt6",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$EJTukba6cgu3oddf7NWibw$925GwzuYHM9wGz+R+j8TDed1jF1sllCqEOyQ63g5Iw4",
   },
   shopAdmin: {
     id: "3",
     name: "Shop Admin",
     email: "shopadmin@example.com",
     //password: "shopadmin",
-    password: "$2b$10$iiBPVdzX6hr0R.9eOSN36uhBqt0iOIj6ecZlPA.NBpzswomxcTvfi",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$Qzzwz9iLHAK1XFp0gY8CaA$mRWqHTICaS4hB/E7TheLtyQjbmvzN2QKVuz0NnCKr+w",
   },
   catalogManager: {
     id: "4",
     name: "Catalog Manager",
     email: "catalogmanager@example.com",
     //password: "catalogmanager",
-    password: "$2b$10$bXz7QTWvPrn7okbbk58uDOJKBPJfPU6RI8F5HV4M5DnBFwSIbXi/y",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$1ie22pUv+lwFEJcQy15tHg$zJRHh2i3T5UpBpO0ffpDSnQbRpDwWh5bTqbCgLq22JE",
   },
   themeEditor: {
     id: "5",
     name: "Theme Editor",
     email: "themeeditor@example.com",
     //password: "themeeditor",
-    password: "$2b$10$XCLdGULFzVh56kw/oRP2husM07I1fPe0NqjIUxk9d2/PZBTwVIruK",
+    password:
+      "$argon2id$v=19$m=65536,t=3,p=4$XCickdgFmjP4faHZ2TCafA$x/vBXe/eGRdl3IgI1fNbb9RBXhOGpUGkJPsHbmV98Bw",
   },
 };

--- a/apps/shop-abc/__tests__/loginRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/loginRateLimit.test.ts
@@ -15,7 +15,7 @@ jest.mock("@acme/platform-core/users", () => ({
   getUserById: jest.fn(async (id: string) =>
     id === "cust1"
       ? { passwordHash: "correctpass", role: "customer", emailVerified: true }
-      : null,
+      : null
   ),
 }));
 
@@ -23,8 +23,8 @@ jest.mock("@acme/config", () => ({
   env: {},
 }));
 
-jest.mock("bcryptjs", () => ({
-  compare: jest.fn(async (a: string, b: string) => a === b),
+jest.mock("argon2", () => ({
+  verify: jest.fn(async (hash: string, plain: string) => hash === plain),
 }));
 
 let POST: typeof import("../src/app/login/route").POST;
@@ -32,18 +32,20 @@ let __resetLoginRateLimiter: typeof import("../src/middleware").__resetLoginRate
 let MAX_ATTEMPTS: number;
 
 beforeAll(async () => {
-  ({ __resetLoginRateLimiter, MAX_ATTEMPTS } = await import("../src/middleware"));
+  ({ __resetLoginRateLimiter, MAX_ATTEMPTS } = await import(
+    "../src/middleware"
+  ));
   ({ POST } = await import("../src/app/login/route"));
 });
 
 function makeRequest(body: any, ip = "1.1.1.1") {
-    return {
-      json: async () => body,
-      headers: new Headers({
-        "x-forwarded-for": ip,
-        "x-csrf-token": "tok",
-      }),
-    } as any;
+  return {
+    json: async () => body,
+    headers: new Headers({
+      "x-forwarded-for": ip,
+      "x-csrf-token": "tok",
+    }),
+  } as any;
 }
 
 afterEach(async () => {
@@ -54,18 +56,18 @@ describe("login rate limiting", () => {
   it("returns 429 after too many attempts", async () => {
     for (let i = 0; i < MAX_ATTEMPTS; i++) {
       const res = await POST(
-        makeRequest({ customerId: "cust1", password: "wrongpass" }),
+        makeRequest({ customerId: "cust1", password: "wrongpass" })
       );
       expect(res.status).toBe(401);
     }
 
     const locked = await POST(
-      makeRequest({ customerId: "cust1", password: "wrongpass" }),
+      makeRequest({ customerId: "cust1", password: "wrongpass" })
     );
     expect(locked.status).toBe(429);
 
     const stillLocked = await POST(
-      makeRequest({ customerId: "cust1", password: "correctpass" }),
+      makeRequest({ customerId: "cust1", password: "correctpass" })
     );
     expect(stillLocked.status).toBe(429);
   });

--- a/apps/shop-abc/__tests__/registerRateLimit.test.ts
+++ b/apps/shop-abc/__tests__/registerRateLimit.test.ts
@@ -21,7 +21,7 @@ jest.mock("@acme/platform-core/customerProfiles", () => ({
   updateCustomerProfile: jest.fn(),
 }));
 
-jest.mock("bcryptjs", () => ({
+jest.mock("argon2", () => ({
   hash: jest.fn().mockResolvedValue("hashed"),
 }));
 
@@ -42,13 +42,13 @@ beforeAll(async () => {
 });
 
 function makeRequest(body: any, ip = "1.1.1.1") {
-    return {
-      json: async () => body,
-      headers: new Headers({
-        "x-forwarded-for": ip,
-        "x-csrf-token": "tok",
-      }),
-    } as any;
+  return {
+    json: async () => body,
+    headers: new Headers({
+      "x-forwarded-for": ip,
+      "x-csrf-token": "tok",
+    }),
+  } as any;
 }
 
 afterEach(async () => {
@@ -63,7 +63,7 @@ describe("registration rate limiting", () => {
           customerId: `cust${i}`,
           email: `test${i}@example.com`,
           password: "Str0ngPass",
-        }),
+        })
       );
       expect(res.status).toBe(200);
     }
@@ -73,7 +73,7 @@ describe("registration rate limiting", () => {
         customerId: "cust-final",
         email: "final@example.com",
         password: "Str0ngPass",
-      }),
+      })
     );
     expect(locked.status).toBe(429);
 
@@ -82,7 +82,7 @@ describe("registration rate limiting", () => {
         customerId: "cust-other",
         email: "other@example.com",
         password: "Str0ngPass",
-      }),
+      })
     );
     expect(stillLocked.status).toBe(429);
   });

--- a/apps/shop-abc/src/app/api/account/reset/complete/route.ts
+++ b/apps/shop-abc/src/app/api/account/reset/complete/route.ts
@@ -2,7 +2,7 @@
 import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import crypto from "crypto";
 import {
   getUserByResetToken,
@@ -20,7 +20,7 @@ export const ResetCompleteSchema = z
       .min(8, "Password must be at least 8 characters long")
       .regex(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
-        "Password must include uppercase, lowercase, and number",
+        "Password must include uppercase, lowercase, and number"
       ),
   })
   .strict();
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   const parsed = await parseJsonBody<ResetCompleteInput>(
     req,
     ResetCompleteSchema,
-    "1mb",
+    "1mb"
   );
   if (!parsed.success) return parsed.response;
 
@@ -45,11 +45,11 @@ export async function POST(req: Request) {
   if (!user) {
     return NextResponse.json(
       { error: "Invalid or expired token" },
-      { status: 400 },
+      { status: 400 }
     );
   }
 
-  const passwordHash = await bcrypt.hash(password, 10);
+  const passwordHash = await argon2.hash(password);
   await updatePassword(user.id, passwordHash);
   await setResetToken(user.id, null, null);
   return NextResponse.json({ ok: true });

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -2,7 +2,7 @@
 import "@acme/lib/initZod";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import bcrypt from "bcryptjs";
+import argon2 from "argon2";
 import crypto from "crypto";
 import {
   createUser,
@@ -24,7 +24,7 @@ const RegisterSchema = z
       .min(8, "Password must be at least 8 characters long")
       .regex(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
-        "Password must include uppercase, lowercase, and number",
+        "Password must include uppercase, lowercase, and number"
       ),
   })
   .strict();
@@ -52,10 +52,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "User already exists" }, { status: 400 });
   }
   if (await getUserByEmail(email)) {
-    return NextResponse.json({ error: "Email already registered" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Email already registered" },
+      { status: 400 }
+    );
   }
 
-  const passwordHash = await bcrypt.hash(password, 10);
+  const passwordHash = await argon2.hash(password);
   await createUser({ id: customerId, email, passwordHash });
   await updateCustomerProfile(customerId, { name: "", email });
 
@@ -71,7 +74,7 @@ export async function POST(req: Request) {
   await sendEmail(
     email,
     "Verify your account",
-    `Your verification token is ${token}`,
+    `Your verification token is ${token}`
   );
 
   return NextResponse.json({ ok: true });

--- a/doc/argon2-migration.md
+++ b/doc/argon2-migration.md
@@ -1,0 +1,10 @@
+# Migrating bcrypt hashes to argon2
+
+Existing users have passwords stored with bcrypt. After upgrading to argon2 all bcrypt hashes must be rehashed.
+
+1. Detect bcrypt hashes: bcrypt hashes start with `$2`.
+2. On next successful login:
+   - Verify the bcrypt hash using a one-off bcrypt check.
+   - Re-hash the plain password with `argon2.hash` and store the result.
+3. Users who never log in can be migrated in bulk by verifying their bcrypt hash and writing back an argon2 hash.
+4. Once all hashes begin with `$argon2`, remove any bcrypt fallback logic.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.3.1",
     "@tanstack/react-query": "^5.81.4",
-    "bcryptjs": "^3.0.2",
+    "argon2": "^0.44.0",
     "chart.js": "^4.5.0",
     "fast-csv": "^5.0.5",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/types/src/CmsUser.ts
+++ b/packages/types/src/CmsUser.ts
@@ -2,6 +2,6 @@ export interface CmsUser {
   id: string;
   name: string;
   email: string;
-  /** bcrypt hashed password */
+  /** argon2 hashed password */
   password: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.81.4
         version: 5.81.5(react@19.1.0)
-      bcryptjs:
-        specifier: ^3.0.2
-        version: 3.0.2
+      argon2:
+        specifier: ^0.44.0
+        version: 0.44.0
       chart.js:
         specifier: ^4.5.0
         version: 4.5.0
@@ -1525,6 +1525,9 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
+
   '@esbuild/aix-ppc64@0.25.4':
     resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
     engines: {node: '>=18'}
@@ -2604,6 +2607,10 @@ packages:
   '@peculiar/webcrypto@1.5.0':
     resolution: {integrity: sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==}
     engines: {node: '>=10.12.0'}
+
+  '@phc/format@1.0.0':
+    resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
+    engines: {node: '>=10'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4518,6 +4525,10 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  argon2@0.44.0:
+    resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
+    engines: {node: '>=16.17.0'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -4770,10 +4781,6 @@ packages:
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-
-  bcryptjs@3.0.2:
-    resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
-    hasBin: true
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -5283,6 +5290,11 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-env@10.0.0:
+    resolution: {integrity: sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -8157,6 +8169,10 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -11715,6 +11731,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
@@ -12754,6 +12772,8 @@ snapshots:
       pvtsutils: 1.3.6
       tslib: 2.8.1
       webcrypto-core: 1.8.1
+
+  '@phc/format@1.0.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -14977,6 +14997,13 @@ snapshots:
 
   arg@4.1.3: {}
 
+  argon2@0.44.0:
+    dependencies:
+      '@phc/format': 1.0.0
+      cross-env: 10.0.0
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -15278,8 +15305,6 @@ snapshots:
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
-
-  bcryptjs@3.0.2: {}
 
   better-opn@3.0.2:
     dependencies:
@@ -15806,6 +15831,11 @@ snapshots:
   create-require@1.1.1: {}
 
   crelt@1.0.6: {}
+
+  cross-env@10.0.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-env@7.0.3:
     dependencies:
@@ -19213,6 +19243,8 @@ snapshots:
       semver: 7.7.2
 
   node-abort-controller@3.1.1: {}
+
+  node-addon-api@8.5.0: {}
 
   node-domexception@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- replace bcryptjs with argon2 for CMS authentication and password utilities
- hash new passwords with argon2 across services
- document how to migrate existing bcrypt hashes

## Testing
- `pnpm test` *(fails: @acme/next-config:test: command ... exited (1))*
- `pnpm --filter @apps/cms test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689e2656c138832fbcc4b8b840606266