### PR TITLE
feat(cms): sanitize html with dompurify

### DIFF
--- a/apps/cms/__tests__/emailMarketingPage.sanitize.test.tsx
+++ b/apps/cms/__tests__/emailMarketingPage.sanitize.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import EmailMarketingPage from "../src/app/cms/marketing/email/page";
+
+jest.mock(
+  "@acme/ui",
+  () => ({
+    marketingEmailTemplates: [
+      {
+        id: "basic",
+        name: "Basic",
+        render: ({ headline, content }: any) => (
+          <div>
+            <h1>{headline}</h1>
+            {content}
+          </div>
+        ),
+      },
+    ],
+  }),
+  { virtual: true }
+);
+
+describe("EmailMarketingPage sanitization", () => {
+  it("cleans preview body HTML", async () => {
+    render(<EmailMarketingPage />);
+
+    const textarea = screen.getByPlaceholderText("HTML body");
+    fireEvent.change(textarea, {
+      target: {
+        value: '<img alt="malicious" src="x" onerror="alert(1)" />',
+      },
+    });
+
+    const img = await screen.findByAltText("malicious");
+    expect(img).toBeInTheDocument();
+    expect(img).not.toHaveAttribute("onerror");
+  });
+});
+

--- a/apps/cms/__tests__/wizardPreview.sanitize.test.tsx
+++ b/apps/cms/__tests__/wizardPreview.sanitize.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const STORAGE_KEY = "cms-configurator-progress";
+
+jest.mock("@/components/atoms", () => ({ Button: () => null }), {
+  virtual: true,
+});
+jest.mock("@/components/cms/blocks", () => ({ blockRegistry: {} }), {
+  virtual: true,
+});
+jest.mock(
+  "@/components/organisms",
+  () => ({ Footer: () => null, Header: () => null, SideNav: () => null }),
+  { virtual: true }
+);
+jest.mock(
+  "@/components/templates/AppShell",
+  () => ({ AppShell: ({ children }: any) => <div>{children}</div> }),
+  { virtual: true }
+);
+jest.mock(
+  "@/i18n/Translations",
+  () => ({ __esModule: true, default: ({ children }: any) => <>{children}</> }),
+  { virtual: true }
+);
+jest.mock("@i18n/en.json", () => ({}), { virtual: true });
+jest.mock(
+  "@ui/utils/devicePresets",
+  () => ({ devicePresets: [{ id: "d", type: "desktop", width: 100, height: 100 }] }),
+  { virtual: true }
+);
+jest.mock("@ui/components/common/DeviceSelector", () => ({ __esModule: true, default: () => null }), {
+  virtual: true,
+});
+jest.mock("@radix-ui/react-icons", () => ({ ReloadIcon: () => null }), {
+  virtual: true,
+});
+jest.mock("@ui/hooks", () => ({ usePreviewDevice: () => ["d", jest.fn()] }), {
+  virtual: true,
+});
+jest.mock("@platform-core/themeTokens", () => ({
+  baseTokens: {},
+  loadThemeTokensBrowser: () => ({}),
+}), { virtual: true });
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const WizardPreview = require("../src/app/cms/wizard/WizardPreview").default;
+
+describe("WizardPreview sanitization", () => {
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("sanitizes text block HTML", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        components: [
+          {
+            id: "1",
+            type: "Text",
+            text: '<img alt="malicious" src="x" onerror="alert(1)" />',
+          },
+        ],
+      })
+    );
+
+    render(<WizardPreview style={{}} />);
+
+    const img = await screen.findByAltText("malicious");
+    expect(img).toBeInTheDocument();
+    expect(img).not.toHaveAttribute("onerror");
+  });
+});
+

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -16,9 +16,10 @@
     "@acme/i18n": "workspace:*",
     "@acme/next-config": "workspace:*",
     "@acme/shared-utils": "workspace:*",
+    "@sendgrid/eventwebhook": "^7.2.7",
     "@themes/base": "workspace:*",
     "color-contrast-checker": "^2.1.0",
-    "@sendgrid/eventwebhook": "^7.2.7"
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/cms/src/app/cms/marketing/email/page.tsx
+++ b/apps/cms/src/app/cms/marketing/email/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { formatTimestamp } from "@acme/date-utils";
 import { marketingEmailTemplates } from "@acme/ui";
+import DOMPurify from "dompurify";
 
 interface Campaign {
   id: string;
@@ -25,8 +26,8 @@ export default function EmailMarketingPage() {
   const [templateId, setTemplateId] = useState(
     marketingEmailTemplates[0]?.id || ""
   );
-  const [status, setStatus] = useState<string | null>(null);
-  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+    const [status, setStatus] = useState<string | null>(null);
+    const [campaigns, setCampaigns] = useState<Campaign[]>([]);
 
   async function loadCampaigns(s: string) {
     if (!s) return;
@@ -53,7 +54,7 @@ export default function EmailMarketingPage() {
     }
   }
 
-  async function send(e: React.FormEvent) {
+    async function send(e: React.FormEvent) {
     e.preventDefault();
     setStatus(null);
     try {
@@ -85,10 +86,14 @@ export default function EmailMarketingPage() {
     } catch {
       setStatus("Failed");
     }
-  }
+    }
 
-  return (
-    <div className="space-y-4 p-4">
+    const sanitizedBody = DOMPurify.sanitize(
+      body || "<p>Preview content</p>"
+    );
+
+    return (
+      <div className="space-y-4 p-4">
       <form onSubmit={send} className="space-y-2">
         <input
           className="w-full border p-2"
@@ -190,20 +195,16 @@ export default function EmailMarketingPage() {
           </tbody>
         </table>
       )}
-      <div className="mt-4">
-        {marketingEmailTemplates
-          .find((t) => t.id === templateId)
-          ?.render({
-            headline: subject || "",
-            content: (
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: body || "<p>Preview content</p>",
-                }}
-              />
-            ),
-          })}
+        <div className="mt-4">
+          {marketingEmailTemplates
+            .find((t) => t.id === templateId)
+            ?.render({
+              headline: subject || "",
+              content: (
+                <div dangerouslySetInnerHTML={{ __html: sanitizedBody }} />
+              ),
+            })}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -9,6 +9,7 @@ import { AppShell } from "@/components/templates/AppShell";
 import TranslationsProvider from "@/i18n/Translations";
 import enMessages from "@i18n/en.json";
 import type { PageComponent } from "@acme/types";
+import DOMPurify from "dompurify";
 import React, { useEffect, useRef, useState, useMemo } from "react";
 import { STORAGE_KEY } from "../configurator/hooks/useConfiguratorPersistence";
 import {
@@ -191,7 +192,8 @@ export default function WizardPreview({
         typeof text === "string"
           ? text
           : ((text as Record<string, string>).en ?? "");
-      return <div dangerouslySetInnerHTML={{ __html: value }} />;
+      const sanitized = DOMPurify.sanitize(value);
+      return <div dangerouslySetInnerHTML={{ __html: sanitized }} />;
     }
 
     /* Look up the React component in the block registry.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       color-contrast-checker:
         specifier: ^2.1.0
         version: 2.1.0
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
     devDependencies:
       next:
         specifier: ^15.3.4


### PR DESCRIPTION
## Summary
- sanitize wizard preview and marketing email bodies using DOMPurify
- add DOMPurify dependency for CMS app
- test sanitization of wizard and email previews

## Testing
- `pnpm --filter @apps/cms test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*
- `pnpm --filter @apps/cms test __tests__/wizardPreview.sanitize.test.tsx __tests__/emailMarketingPage.sanitize.test.tsx`
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/env/core.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689e26580e9c832fb4c0b165e227b00e