### PR TITLE
docs: document upgrade flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Switch between widths using the desktop/tablet/mobile buttons or the dropdown. T
 
 See [doc/upgrade-preview-republish.md](doc/upgrade-preview-republish.md) for guidance on upgrading a shop, previewing changes and republishing.
 See [doc/edit-preview-republish.md](doc/edit-preview-republish.md) for details on editing components, previewing those edits and republishing.
+See [docs/upgrade-flow.md](docs/upgrade-flow.md) for version tracking, the diff API, using previews and republishing or rolling back upgrades.
 
 ## Inventory Management
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Documentation
+
+- [Upgrade flow](./upgrade-flow.md)
+- [Theming](./theming.md)
+- [Advanced theming](./theming-advanced.md)

--- a/docs/upgrade-flow.md
+++ b/docs/upgrade-flow.md
@@ -1,0 +1,23 @@
+# Upgrade flow
+
+The upgrade system stages template changes, tracks versions, lets them be previewed and republishes or rolls back depending on the review.
+
+## Version tracking
+- `data/shops/<id>/shop.json` stores `lastUpgrade` and a `componentVersions` map recording the package version used for each UI component.
+- `data/shops/<id>/upgrade.json` is written when `upgrade-shop` runs and records the timestamp, the components that changed and the component versions used.
+
+## Diff API
+- `GET /components/:shopId` lists packages whose versions differ from those recorded in `shop.json`.
+- Adding `?diff` also returns lists of template and translation files that changed relative to `packages/template-app`.
+
+## Preview upgrades
+- `pnpm ts-node scripts/src/upgrade-shop.ts <shop-id>` stages files from the template and generates `upgrade-changes.json` alongside example props so changed components can render.
+- Navigate to `/upgrade-preview` in the shop to render each changed component and follow any page links to validate affected pages.
+
+## Republish or rollback
+- After verifying the preview, publish the upgrade with `pnpm ts-node scripts/src/republish-shop.ts <shop-id>`.
+- If the upgrade should be aborted, run `pnpm ts-node scripts/src/upgrade-shop.ts <shop-id> --rollback` to restore the previous files and component versions.
+
+## Extending the diff/preview pipeline
+- **New component layers** – create the layer under `packages/ui/src/components`, export it from the barrel files and, if components require props, extend `scripts/src/generate-example-props.ts` with defaults so upgrade previews render.
+- **Plugin components** – add plugins under `packages/plugins/*` and export a default plugin object. Ensure their package names appear in `shop.json`'s `componentVersions` so the diff API can detect upgrades. If plugin components live outside `packages/ui/src/components`, update `scripts/src/component-names.ts` to include those directories.


### PR DESCRIPTION
## Summary
- add upgrade flow documentation covering version tracking, diff API, preview and rollback steps
- link upgrade flow guide from docs index and README

## Testing
- `pnpm lint` *(fails: ERR_MODULE_NOT_FOUND for @acme/config)*
- `pnpm test` *(fails: 6 failing tests in @acme/next-config)*

------
https://chatgpt.com/codex/tasks/task_e_689e26833054832f801b0139aa2f80c4