### PR TITLE
feat: add draggable spacing handles

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -11,6 +11,7 @@ import TextBlock from "./TextBlock";
 import useSortableBlock from "./useSortableBlock";
 import useCanvasResize from "./useCanvasResize";
 import useCanvasDrag from "./useCanvasDrag";
+import useCanvasSpacing from "./useCanvasSpacing";
 import type { DevicePreset } from "@ui/utils/devicePresets";
 
 const CanvasItem = memo(function CanvasItem({
@@ -148,6 +149,16 @@ const CanvasItem = memo(function CanvasItem({
     containerRef,
   });
 
+  const { startSpacing, overlay: spacingOverlay } = useCanvasSpacing({
+    componentId: component.id,
+    marginKey,
+    paddingKey,
+    marginVal,
+    paddingVal,
+    dispatch,
+    containerRef,
+  });
+
   const guides =
     resizeGuides.x !== null || resizeGuides.y !== null
       ? resizeGuides
@@ -242,6 +253,17 @@ const CanvasItem = memo(function CanvasItem({
         )}
       </div>
       <Block component={component} locale={locale} />
+      {spacingOverlay && (
+        <div
+          className="pointer-events-none absolute z-30 bg-primary/20"
+          style={{
+            top: spacingOverlay.top,
+            left: spacingOverlay.left,
+            width: spacingOverlay.width,
+            height: spacingOverlay.height,
+          }}
+        />
+      )}
       {showOverlay && (
         <div className="pointer-events-none absolute -top-5 left-0 z-30 rounded bg-black/75 px-1 text-[10px] font-mono text-white shadow dark:bg-white/75 dark:text-black">
           {Math.round(overlayWidth)}×{Math.round(overlayHeight)} | {Math.round(overlayLeft)},{" "}
@@ -265,6 +287,38 @@ const CanvasItem = memo(function CanvasItem({
           <div
             onPointerDown={startResize}
             className="absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "margin", "top")}
+            className="absolute -top-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "margin", "bottom")}
+            className="absolute -bottom-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "margin", "left")}
+            className="absolute -left-2 top-1/2 w-1 h-4 -translate-y-1/2 cursor-w-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "margin", "right")}
+            className="absolute -right-2 top-1/2 w-1 h-4 -translate-y-1/2 cursor-e-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "padding", "top")}
+            className="absolute top-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "padding", "bottom")}
+            className="absolute bottom-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "padding", "left")}
+            className="absolute left-0 top-1/2 w-1 h-4 -translate-y-1/2 cursor-w-resize bg-primary"
+          />
+          <div
+            onPointerDown={(e) => startSpacing(e, "padding", "right")}
+            className="absolute right-0 top-1/2 w-1 h-4 -translate-y-1/2 cursor-e-resize bg-primary"
           />
         </>
       )}

--- a/packages/ui/src/components/cms/page-builder/useCanvasSpacing.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasSpacing.ts
@@ -1,0 +1,152 @@
+import { useState, useRef, useEffect } from "react";
+import type { ResizeAction } from "./state/actions";
+
+interface Options {
+  componentId: string;
+  marginKey: string;
+  paddingKey: string;
+  marginVal?: string;
+  paddingVal?: string;
+  dispatch: React.Dispatch<ResizeAction>;
+  containerRef: React.RefObject<HTMLDivElement>;
+}
+
+type SpacingType = "margin" | "padding";
+type SpacingSide = "top" | "right" | "bottom" | "left";
+
+interface Overlay {
+  type: SpacingType;
+  side: SpacingSide;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function parseSpacing(value?: string): [number, number, number, number] {
+  if (!value) return [0, 0, 0, 0];
+  const parts = value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((p) => parseFloat(p));
+  if (parts.length === 1) return [parts[0], parts[0], parts[0], parts[0]];
+  if (parts.length === 2) return [parts[0], parts[1], parts[0], parts[1]];
+  if (parts.length === 3) return [parts[0], parts[1], parts[2], parts[1]];
+  return [parts[0], parts[1], parts[2], parts[3]];
+}
+
+function formatSpacing(values: [number, number, number, number]) {
+  return values.map((v) => `${Math.round(v)}px`).join(" ");
+}
+
+function sideIndex(side: SpacingSide) {
+  return side === "top" ? 0 : side === "right" ? 1 : side === "bottom" ? 2 : 3;
+}
+
+export default function useCanvasSpacing({
+  componentId,
+  marginKey,
+  paddingKey,
+  marginVal,
+  paddingVal,
+  dispatch,
+  containerRef,
+}: Options) {
+  const startRef = useRef<{
+    x: number;
+    y: number;
+    margin: [number, number, number, number];
+    padding: [number, number, number, number];
+    width: number;
+    height: number;
+  } | null>(null);
+  const [active, setActive] = useState<null | { type: SpacingType; side: SpacingSide }>(null);
+  const [overlay, setOverlay] = useState<Overlay | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const handleMove = (e: PointerEvent) => {
+      if (!startRef.current) return;
+      const { x, y, margin, padding, width, height } = startRef.current;
+      const dx = e.clientX - x;
+      const dy = e.clientY - y;
+      const delta = active.side === "left" || active.side === "right" ? dx : dy;
+      const current = active.type === "margin" ? [...margin] : [...padding];
+      const idx = sideIndex(active.side);
+      current[idx] =
+        active.type === "padding" ? Math.max(0, current[idx] + delta) : current[idx] + delta;
+      const patchVal = formatSpacing(current as [number, number, number, number]);
+      dispatch({
+        type: "resize",
+        id: componentId,
+        [active.type === "margin" ? marginKey : paddingKey]: patchVal,
+      });
+      // compute overlay
+      if (active.type === "padding") {
+        let top = 0;
+        let left = 0;
+        let w = width;
+        let h = height;
+        if (active.side === "top") {
+          h = current[0];
+        } else if (active.side === "bottom") {
+          h = current[2];
+          top = height - h;
+        } else if (active.side === "left") {
+          w = current[3];
+        } else if (active.side === "right") {
+          w = current[1];
+          left = width - w;
+        }
+        setOverlay({ type: "padding", side: active.side, top, left, width: w, height: h });
+      } else {
+        let top = 0;
+        let left = 0;
+        let w = width;
+        let h = height;
+        if (active.side === "top") {
+          h = current[0];
+          top = -h;
+        } else if (active.side === "bottom") {
+          h = current[2];
+          top = height;
+        } else if (active.side === "left") {
+          w = current[3];
+          left = -w;
+        } else if (active.side === "right") {
+          w = current[1];
+          left = width;
+        }
+        setOverlay({ type: "margin", side: active.side, top, left, width: w, height: h });
+      }
+    };
+    const stop = () => {
+      setActive(null);
+      setOverlay(null);
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", stop);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", stop);
+    };
+  }, [active, componentId, dispatch, marginKey, paddingKey]);
+
+  const startSpacing = (e: React.PointerEvent, type: SpacingType, side: SpacingSide) => {
+    e.stopPropagation();
+    const el = containerRef.current;
+    if (!el) return;
+    startRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+      margin: parseSpacing(marginVal),
+      padding: parseSpacing(paddingVal),
+      width: el.offsetWidth,
+      height: el.offsetHeight,
+    };
+    setActive({ type, side });
+  };
+
+  return { startSpacing, overlay } as const;
+}
+


### PR DESCRIPTION
## Summary
- add margin and padding spacing controls with overlay feedback
- introduce useCanvasSpacing hook to update spacing props during drag

## Testing
- `pnpm --filter @acme/ui test` *(fails: Unable to find accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689e266f6034832fa0132d596afb4ba3