### PR TITLE
feat: add keyboard shortcuts and help modal to page builder

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -53,6 +53,12 @@ const PageBuilder = memo(function PageBuilder({
   onChange,
   style,
 }: Props) {
+  const formDataRef = useRef<FormData | null>(null);
+  const handleSaveShortcut = useCallback(() => {
+    if (formDataRef.current) {
+      void onSave(formDataRef.current);
+    }
+  }, [onSave]);
   const {
     state,
     components,
@@ -63,7 +69,15 @@ const PageBuilder = memo(function PageBuilder({
     setGridCols,
     liveMessage,
     clearHistory,
-  } = usePageBuilderState({ page, history: historyProp, onChange });
+  } = usePageBuilderState({
+    page,
+    history: historyProp,
+    onChange,
+    onSaveShortcut: handleSaveShortcut,
+    onTogglePreview: () => setShowPreview((p) => !p),
+    onRotateDevice: () =>
+      setOrientation((o) => (o === "portrait" ? "landscape" : "portrait")),
+  });
 
   const [deviceId, setDeviceId] = usePreviewDevice(devicePresets[0].id);
   const [orientation, setOrientation] = useState<"portrait" | "landscape">(
@@ -192,6 +206,9 @@ const PageBuilder = memo(function PageBuilder({
     fd.append("history", JSON.stringify(state));
     return fd;
   }, [page, components, state]);
+  useEffect(() => {
+    formDataRef.current = formData;
+  }, [formData]);
 
   const handleAutoSave = useCallback(() => {
     setAutoSaveState("saving");

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -1,7 +1,14 @@
 import type { Locale } from "@/i18n/locales";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { useEffect } from "react";
-import { Button, Input } from "../../atoms/shadcn";
+import {
+  Button,
+  Input,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "../../atoms/shadcn";
 import { getLegacyPreset } from "@ui/utils/devicePresets";
 import DeviceSelector from "@ui/components/common/DeviceSelector";
 
@@ -89,6 +96,47 @@ const PageToolbar = ({
             className={orientation === "landscape" ? "rotate-90" : ""}
           />
         </Button>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline" aria-label="Keyboard shortcuts">
+              ?
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="space-y-2">
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+            <ul className="space-y-1 text-sm">
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>S</kbd> Save
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>P</kbd> Toggle preview
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd> Rotate
+                device left
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd> Rotate
+                device right
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Z</kbd> Undo
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Y</kbd> Redo
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>1</kbd> Desktop view
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>2</kbd> Tablet view
+              </li>
+              <li>
+                <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>3</kbd> Mobile view
+              </li>
+            </ul>
+          </DialogContent>
+        </Dialog>
       </div>
       <div className="flex items-center justify-end gap-2">
         <Button

--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
@@ -6,9 +6,19 @@ interface Params {
   page: Page;
   history?: HistoryState;
   onChange?: (components: PageComponent[]) => void;
+  onSaveShortcut?: () => void;
+  onTogglePreview?: () => void;
+  onRotateDevice?: (direction: "left" | "right") => void;
 }
 
-export function usePageBuilderState({ page, history, onChange }: Params) {
+export function usePageBuilderState({
+  page,
+  history,
+  onChange,
+  onSaveShortcut,
+  onTogglePreview,
+  onRotateDevice,
+}: Params) {
   const storageKey = `page-builder-history-${page.id}`;
 
   const migrate = useCallback(
@@ -82,6 +92,15 @@ export function usePageBuilderState({ page, history, onChange }: Params) {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLElement &&
+        (e.target.tagName === "INPUT" ||
+          e.target.tagName === "TEXTAREA" ||
+          e.target.tagName === "SELECT" ||
+          e.target.isContentEditable)
+      ) {
+        return;
+      }
       if (!(e.ctrlKey || e.metaKey)) return;
       const k = e.key.toLowerCase();
       if (k === "z") {
@@ -90,11 +109,23 @@ export function usePageBuilderState({ page, history, onChange }: Params) {
       } else if (k === "y") {
         e.preventDefault();
         dispatch({ type: "redo" });
+      } else if (k === "s") {
+        e.preventDefault();
+        onSaveShortcut?.();
+      } else if (k === "p") {
+        e.preventDefault();
+        onTogglePreview?.();
+      } else if (k === "[" && e.shiftKey) {
+        e.preventDefault();
+        onRotateDevice?.("left");
+      } else if (k === "]" && e.shiftKey) {
+        e.preventDefault();
+        onRotateDevice?.("right");
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [dispatch]);
+  }, [dispatch, onSaveShortcut, onTogglePreview, onRotateDevice]);
 
   const setGridCols = useCallback(
     (n: number) => {


### PR DESCRIPTION
## Summary
- add save, preview and device rotation shortcuts with focus-safe handling
- wire page builder shortcuts to save, preview toggle and device rotation
- provide keyboard shortcut reference in toolbar help dialog

## Testing
- `pnpm lint --filter @acme/ui` *(no tasks run)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find accessible element with the role "button" and name `/^save$/i`)*
- `pnpm exec jest packages/ui/__tests__/usePageBuilderState.test.tsx --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_689e26796210832fb220d45633fb2c24