### PR TITLE
feat(ui): add style token presets

### DIFF
--- a/packages/ui/__tests__/StylePresets.test.tsx
+++ b/packages/ui/__tests__/StylePresets.test.tsx
@@ -1,7 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import Presets from "../src/components/cms/style/Presets";
+import presetData from "../src/components/cms/style/presets.json";
 
-test("renders presets placeholder", () => {
-  render(<Presets tokens={{}} baseTokens={{}} onChange={() => {}} />);
-  expect(screen.getByTestId("presets-placeholder")).toBeInTheDocument();
+test("applies selected preset and can revert to defaults", async () => {
+  const handleChange = jest.fn();
+  const initial = { "--font-sans": "system" } as Record<string, string>;
+
+  render(<Presets tokens={initial} baseTokens={{}} onChange={handleChange} />);
+
+  const select = await screen.findByTestId("preset-select");
+  fireEvent.change(select, { target: { value: "dark" } });
+
+  const dark = (presetData as any).find((p: any) => p.id === "dark")!.tokens;
+  expect(handleChange).toHaveBeenLastCalledWith({ ...initial, ...dark });
+
+  const reset = screen.getByTestId("preset-reset");
+  fireEvent.click(reset);
+  expect(handleChange).toHaveBeenLastCalledWith({});
 });

--- a/packages/ui/src/components/cms/style/Presets.tsx
+++ b/packages/ui/src/components/cms/style/Presets.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { TokenMap } from "@ui/hooks/useTokenEditor";
-import { ReactElement } from "react";
+import { ReactElement, useEffect, useState } from "react";
 
 interface PresetsProps {
   tokens: TokenMap;
@@ -10,11 +10,94 @@ interface PresetsProps {
   onChange: (tokens: TokenMap) => void;
 }
 
-export default function Presets(_: PresetsProps): ReactElement {
+interface PresetOption {
+  id: string;
+  name: string;
+  tokens: TokenMap;
+}
+
+export default function Presets({
+  tokens,
+  onChange,
+}: PresetsProps): ReactElement {
+  const [presetList, setPresetList] = useState<PresetOption[] | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    import("./presets.json")
+      .then((mod) => {
+        if (active) {
+          setPresetList(mod.default as PresetOption[]);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setPresetList([]);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const applyPreset = (id: string) => {
+    const preset = presetList?.find((p) => p.id === id);
+    if (preset) {
+      onChange({ ...tokens, ...preset.tokens });
+    }
+  };
+
+  const resetTokens = () => {
+    // Revert to defaults by clearing overrides
+    onChange({});
+  };
+
+  if (presetList === null) {
+    return (
+      <p className="text-sm text-muted" data-testid="presets-placeholder">
+        Loading presets...
+      </p>
+    );
+  }
+
+  if (presetList.length === 0) {
+    return (
+      <p className="text-sm text-muted" data-testid="presets-placeholder">
+        No presets available
+      </p>
+    );
+  }
+
   return (
-    <p className="text-sm text-muted" data-testid="presets-placeholder">
-      No presets available
-    </p>
+    <div className="flex items-center gap-2 text-sm">
+      <label className="flex items-center gap-2">
+        <span>Preset</span>
+        <select
+          data-testid="preset-select"
+          className="rounded border p-1"
+          defaultValue=""
+          onChange={(e) => applyPreset(e.target.value)}
+        >
+          <option value="" disabled>
+            Choose…
+          </option>
+          {presetList.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        data-testid="preset-reset"
+        className="rounded border px-2 py-1"
+        onClick={resetTokens}
+      >
+        Default
+      </button>
+    </div>
   );
 }
+
 

--- a/packages/ui/src/components/cms/style/presets.json
+++ b/packages/ui/src/components/cms/style/presets.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "light",
+    "name": "Light",
+    "tokens": {
+      "--color-bg": "0 0% 100%",
+      "--color-fg": "0 0% 10%",
+      "--color-primary": "220 90% 56%",
+      "--color-primary-fg": "0 0% 100%"
+    }
+  },
+  {
+    "id": "dark",
+    "name": "Dark",
+    "tokens": {
+      "--color-bg": "0 0% 4%",
+      "--color-fg": "0 0% 93%",
+      "--color-primary": "220 90% 66%",
+      "--color-primary-fg": "0 0% 10%"
+    }
+  },
+  {
+    "id": "brand",
+    "name": "Brand",
+    "tokens": {
+      "--color-primary": "340 82% 52%",
+      "--color-accent": "260 83% 70%",
+      "--color-accent-fg": "0 0% 10%"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- load style preset options from a JSON file and expose in the editor
- merge selected preset tokens with current overrides
- allow reverting to default tokens

## Testing
- `npx jest packages/ui/__tests__/StylePresets.test.tsx -c jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689e26726a3c832fa992d142efeb01fd