### PR TITLE
feat: unify tracking with timeline and config toggles

### DIFF
--- a/apps/shop-abc/__tests__/accountOrders.test.tsx
+++ b/apps/shop-abc/__tests__/accountOrders.test.tsx
@@ -11,11 +11,14 @@ import shop from "../shop.json";
 
 describe("/account/orders page", () => {
   it("renders Orders component with shop config", () => {
-    OrdersPage();
-    expect((Orders as jest.Mock).mock.calls[0][0]).toEqual({
+    const element = OrdersPage();
+    expect(element.type).toBe(Orders);
+    expect(element.props).toEqual({
       shopId: shop.id,
       returnsEnabled: shop.returnsEnabled,
       returnPolicyUrl: shop.returnPolicyUrl,
+      trackingEnabled: shop.trackingEnabled,
+      trackingProviders: shop.trackingProviders,
     });
   });
 

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -16,6 +16,8 @@
   "localeOverrides": {},
   "analyticsEnabled": true,
   "rentalInventoryAllocation": false,
+  "trackingEnabled": true,
+  "trackingProviders": ["ups"],
   "plugins": {
     "paypal": {
       "clientId": "abc-client",

--- a/apps/shop-abc/src/app/account/orders/page.tsx
+++ b/apps/shop-abc/src/app/account/orders/page.tsx
@@ -10,6 +10,8 @@ export default function Page() {
       shopId={shop.id}
       returnsEnabled={shop.returnsEnabled}
       returnPolicyUrl={shop.returnPolicyUrl}
+      trackingEnabled={shop.trackingEnabled}
+      trackingProviders={shop.trackingProviders}
     />
   );
 }

--- a/apps/shop-bcd/__tests__/account-orders.test.tsx
+++ b/apps/shop-bcd/__tests__/account-orders.test.tsx
@@ -11,11 +11,14 @@ import shop from "../shop.json";
 
 describe("/account/orders page", () => {
   it("renders Orders component with shop config", () => {
-    OrdersPage();
-    expect((Orders as jest.Mock).mock.calls[0][0]).toEqual({
+    const element = OrdersPage();
+    expect(element.type).toBe(Orders);
+    expect(element.props).toEqual({
       shopId: shop.id,
       returnsEnabled: shop.returnsEnabled,
       returnPolicyUrl: shop.returnPolicyUrl,
+      trackingEnabled: shop.trackingEnabled,
+      trackingProviders: shop.trackingProviders,
     });
   });
 

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -13,6 +13,8 @@
   "localeOverrides": {},
   "rentalInventoryAllocation": false,
   "analyticsEnabled": false,
+  "trackingEnabled": true,
+  "trackingProviders": ["dhl"],
   "plugins": {
     "paypal": {
       "clientId": "bcd-client",

--- a/apps/shop-bcd/src/app/account/orders/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/page.tsx
@@ -10,6 +10,8 @@ export default function Page() {
       shopId={shop.id}
       returnsEnabled={shop.returnsEnabled}
       returnPolicyUrl={shop.returnPolicyUrl}
+      trackingEnabled={shop.trackingEnabled}
+      trackingProviders={shop.trackingProviders}
     />
   );
 }

--- a/packages/platform-core/src/returnAuthorization.ts
+++ b/packages/platform-core/src/returnAuthorization.ts
@@ -4,6 +4,12 @@ import {
   readReturnAuthorizations,
   getReturnAuthorization,
 } from "./repositories/returnAuthorization.server";
+export {
+  getTrackingStatus,
+  type TrackingStatusRequest,
+  type TrackingStatus,
+  type TrackingStep,
+} from "./shipping";
 
 export { getReturnAuthorization };
 

--- a/packages/types/src/ShopSettings.d.ts
+++ b/packages/types/src/ShopSettings.d.ts
@@ -145,6 +145,7 @@ export declare const shopSettingsSchema: z.ZodObject<{
         regions: string[];
         windows: string[];
     }>>;
+    trackingEnabled: z.ZodOptional<z.ZodBoolean>;
     trackingProviders: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     updatedAt: z.ZodString;
     updatedBy: z.ZodString;
@@ -200,6 +201,7 @@ export declare const shopSettingsSchema: z.ZodObject<{
         regions: string[];
         windows: string[];
     } | undefined;
+    trackingEnabled?: boolean | undefined;
     trackingProviders?: string[] | undefined;
 }, {
     seo: Partial<Record<"en" | "de" | "it", {
@@ -251,7 +253,8 @@ export declare const shopSettingsSchema: z.ZodObject<{
         regions: string[];
         windows: string[];
     } | undefined;
+    trackingEnabled?: boolean | undefined;
     trackingProviders?: string[] | undefined;
-}>;
+}>; 
 export type ShopSettings = z.infer<typeof shopSettingsSchema>;
 //# sourceMappingURL=ShopSettings.d.ts.map

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -104,6 +104,8 @@ export const shopSettingsSchema = z
         requireStrongCustomerAuth: false,
         strictReturnConditions: false,
       }),
+    /** Feature flag to enable or disable all tracking */
+    trackingEnabled: z.boolean().default(true).optional(),
     /** Tracking providers enabled for shipment/return tracking */
     trackingProviders: z.array(z.string()).optional(),
     updatedAt: z.string(),

--- a/packages/ui/__tests__/Orders.test.tsx
+++ b/packages/ui/__tests__/Orders.test.tsx
@@ -57,7 +57,8 @@ describe("OrdersPage permissions", () => {
     ]);
     const element = await OrdersPage({ shopId });
     expect(hasPermission).toHaveBeenCalledWith("customer", "view_orders");
-    const list = element.props.children[1];
+    const children = element.props.children;
+    const list = children[children.length - 1];
     expect(list.type).toBe("ul");
   });
 

--- a/packages/ui/src/components/organisms/OrderTrackingTimeline.tsx
+++ b/packages/ui/src/components/organisms/OrderTrackingTimeline.tsx
@@ -10,7 +10,10 @@ export interface OrderStep {
 
 export interface OrderTrackingTimelineProps
   extends React.HTMLAttributes<HTMLOListElement> {
-  steps: OrderStep[];
+  steps?: OrderStep[];
+  shippingSteps?: OrderStep[];
+  returnSteps?: OrderStep[];
+  trackingEnabled?: boolean;
   /** Tailwind vertical spacing utility like `space-y-6` */
   itemSpacing?: string;
 }
@@ -22,17 +25,22 @@ export interface OrderTrackingTimelineProps
  */
 export function OrderTrackingTimeline({
   steps,
+  shippingSteps = [],
+  returnSteps = [],
+  trackingEnabled = true,
   itemSpacing = "space-y-6",
   className,
   ...props
 }: OrderTrackingTimelineProps) {
+  if (!trackingEnabled) return null;
+  const merged = steps ?? [...shippingSteps, ...returnSteps];
+  if (merged.length === 0) return null;
   return (
     <ol
       className={cn("relative border-l pl-4", itemSpacing, className)}
       {...props}
     >
-      {" "}
-      {steps.map((step, idx) => (
+      {merged.map((step, idx) => (
         <li key={idx} className="ml-6">
           <span
             className={cn(


### PR DESCRIPTION
## Summary
- expose generic `getTrackingStatus` from platform core for shipping and returns
- allow shops to disable tracking or specify supported carriers
- unify order tracking timeline for shipping and return steps on account pages

## Testing
- `pnpm test --filter @acme/ui --filter @apps/shop-abc --filter @apps/shop-bcd` *(fails: command (@workspace/base-shop/packages/ui) ... exited (1))*
- `pnpm --filter @acme/ui test packages/ui/__tests__/Orders.test.tsx`
- `npx jest apps/shop-abc/__tests__/accountOrders.test.tsx`
- `npx jest apps/shop-bcd/__tests__/account-orders.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e2663c164832f9c173c067d603317