### PR TITLE
chore: align zod version across repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "sharp": "^0.34.2",
     "stripe": "^18.2.1",
     "ulid": "^3.0.1",
-    "zod": "^3.25.67"
+    "zod": "^3.25.73"
   },
   "devDependencies": {
     "@acme/tailwind-config": "workspace:*",
@@ -160,7 +160,8 @@
   "pnpm": {
     "overrides": {
       "@shadcn/ui": "0.0.4",
-      "scheduler": "0.26.0"
+      "scheduler": "0.26.0",
+      "zod": "3.25.73"
     }
   }
 }

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -23,7 +23,7 @@
     "better-sqlite3": "^12.2.0",
     "dinero.js": "^1.9.1",
     "pino": "^9.9.0",
-    "zod": "^3.25.67"
+    "zod": "^3.25.73"
   },
   "peerDependencies": {
     "next": "^15.0.0",

--- a/packages/plugins/paypal/package.json
+++ b/packages/plugins/paypal/package.json
@@ -7,6 +7,6 @@
     ".": "./index.ts"
   },
   "dependencies": {
-    "zod": "^3.25.67"
+    "zod": "^3.25.73"
   }
 }

--- a/packages/plugins/sanity/package.json
+++ b/packages/plugins/sanity/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@sanity/client": "^6.15.0",
-    "zod": "^3.25.67"
+    "zod": "^3.25.73"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@shadcn/ui': 0.0.4
   scheduler: 0.26.0
+  zod: 3.25.73
 
 importers:
 
@@ -127,7 +128,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       zod:
-        specifier: ^3.25.67
+        specifier: 3.25.73
         version: 3.25.73
     devDependencies:
       '@acme/tailwind-config':
@@ -541,7 +542,7 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
       zod:
-        specifier: ^3.25.67
+        specifier: 3.25.73
         version: 3.25.73
     devDependencies:
       next:
@@ -570,7 +571,7 @@ importers:
   packages/plugins/paypal:
     dependencies:
       zod:
-        specifier: ^3.25.67
+        specifier: 3.25.73
         version: 3.25.73
 
   packages/plugins/sanity:
@@ -579,7 +580,7 @@ importers:
         specifier: ^6.15.0
         version: 6.29.1
       zod:
-        specifier: ^3.25.67
+        specifier: 3.25.73
         version: 3.25.73
 
   packages/sanity:
@@ -2280,6 +2281,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
@@ -7585,6 +7589,9 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
@@ -8339,7 +8346,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: 3.25.73
     peerDependenciesMeta:
       ws:
         optional: true
@@ -8595,6 +8602,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -10730,12 +10741,6 @@ packages:
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
 
-  zod@3.22.3:
-    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
-
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.25.73:
     resolution: {integrity: sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA==}
 
@@ -12368,6 +12373,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -13189,7 +13196,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.44.1
 
@@ -14605,7 +14612,7 @@ snapshots:
       glob: 10.4.5
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -15561,7 +15568,7 @@ snapshots:
       devtools-protocol: 0.0.1312386
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
-      zod: 3.23.8
+      zod: 3.25.73
 
   ci-info@3.9.0: {}
 
@@ -16891,7 +16898,7 @@ snapshots:
 
   esrap@2.1.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   esrecurse@4.3.0:
     dependencies:
@@ -17233,7 +17240,7 @@ snapshots:
   fs-extra@11.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.1.0
+      jsonfile: 6.2.0
       universalify: 2.0.1
 
   fs-extra@9.1.0:
@@ -18609,6 +18616,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsprim@2.0.2:
     dependencies:
       assert-plus: 1.0.0
@@ -18979,7 +18992,7 @@ snapshots:
       workerd: 1.20250408.0
       ws: 8.18.0
       youch: 3.3.4
-      zod: 3.22.3
+      zod: 3.25.73
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -18997,7 +19010,7 @@ snapshots:
       workerd: 1.20250617.0
       ws: 8.18.0
       youch: 3.3.4
-      zod: 3.22.3
+      zod: 3.25.73
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -19723,6 +19736,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -21125,7 +21140,7 @@ snapshots:
   svelte@5.35.2:
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
       '@types/estree': 1.0.8
       acorn: 8.15.0
@@ -22116,9 +22131,5 @@ snapshots:
       stacktracey: 2.1.8
 
   zimmerframe@1.1.2: {}
-
-  zod@3.22.3: {}
-
-  zod@3.23.8: {}
 
   zod@3.25.73: {}


### PR DESCRIPTION
## Summary
- align all package.json files to zod ^3.25.73
- pin zod via pnpm override and refresh lockfile

## Testing
- `pnpm update zod@3.25.73`
- `pnpm install`
- `pnpm build` *(fails: __filename is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_689e264af76c832f91cb4bc9c2ca73a5