### PR TITLE
feat(email): add pino logger for simulated emails

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -22,6 +22,7 @@
     "resend": "^3.5.0",
     "sanitize-html": "^2.12.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "pino": "^9.9.0"
   }
 }

--- a/packages/email/src/__tests__/sendEmail.test.ts
+++ b/packages/email/src/__tests__/sendEmail.test.ts
@@ -35,7 +35,7 @@ describe("sendEmail", () => {
     });
   });
 
-  it("logs email details when credentials are missing", async () => {
+  it("does not log email details when credentials are missing", async () => {
     process.env = {
       ...OLD_ENV,
       STRIPE_SECRET_KEY: "sk",
@@ -55,14 +55,7 @@ describe("sendEmail", () => {
     const { sendEmail } = await import("../sendEmail");
     await sendEmail("a@b.com", "Hi", "There");
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Email to",
-      "a@b.com",
-      "|",
-      "Hi",
-      "|",
-      "There"
-    );
+    expect(consoleSpy).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
   });

--- a/packages/email/src/sendEmail.ts
+++ b/packages/email/src/sendEmail.ts
@@ -2,6 +2,7 @@
 
 import { coreEnv } from "@acme/config/env/core";
 import nodemailer from "nodemailer";
+import pino from "pino";
 import { getDefaultSender } from "./config";
 
 const hasCreds = coreEnv.GMAIL_USER && coreEnv.GMAIL_PASS;
@@ -15,6 +16,10 @@ const transporter = hasCreds
       },
     })
   : null;
+
+const logger = pino({
+  level: process.env.EMAIL_LOG_LEVEL ?? "silent",
+});
 
 export async function sendEmail(
   to: string,
@@ -34,6 +39,6 @@ export async function sendEmail(
       throw error;
     }
   } else {
-    console.log("Email to", to, "|", subject, "|", body);
+    logger.info({ to }, "Email simulated");
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       nodemailer:
         specifier: ^6.10.1
         version: 6.10.1
+      pino:
+        specifier: ^9.9.0
+        version: 9.9.0
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
## Summary
- use pino with `EMAIL_LOG_LEVEL` to control sendEmail debug output
- mask simulated email log to only show recipient
- adjust sendEmail test to reflect masked logging

## Testing
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__/sendEmail.test.ts --config ../../jest.config.cjs --runInBand --detectOpenHandles`

------
https://chatgpt.com/codex/tasks/task_e_689e2658b3dc832f822e0bb49fc839b9