### PR TITLE
feat: strengthen middleware security headers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { createHeadersObject } from "next-secure-headers";
+import helmet from "helmet";
 
 export function middleware(request: NextRequest) {
   const headers = createHeadersObject({
@@ -24,8 +25,20 @@ export function middleware(request: NextRequest) {
     noopen: "noopen",
   });
 
+  const helmetHeaders: Record<string, string> = {};
+  const helmetRes = {
+    setHeader(key: string, value: unknown) {
+      helmetHeaders[key] = Array.isArray(value) ? value.join("; ") : String(value);
+    },
+  };
+
+  helmet.crossOriginOpenerPolicy()(undefined as any, helmetRes as any, () => {});
+  helmet.crossOriginEmbedderPolicy()(undefined as any, helmetRes as any, () => {});
+  helmetHeaders["Permissions-Policy"] =
+    "camera=(), microphone=(), geolocation=()";
+
   const response = NextResponse.next();
-  for (const [key, value] of Object.entries(headers)) {
+  for (const [key, value] of Object.entries({ ...headers, ...helmetHeaders })) {
     response.headers.set(key, value);
   }
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "bcryptjs": "^3.0.2",
     "chart.js": "^4.5.0",
     "fast-csv": "^5.0.5",
+    "helmet": "^8.1.0",
     "identity-obj-proxy": "^3.0.0",
     "next": "15.3.5",
     "next-auth": "4.24.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       fast-csv:
         specifier: ^5.0.5
         version: 5.0.5
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       identity-obj-proxy:
         specifier: ^3.0.0
         version: 3.0.0
@@ -6785,6 +6788,10 @@ packages:
 
   headers-polyfill@3.2.5:
     resolution: {integrity: sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
@@ -17512,6 +17519,8 @@ snapshots:
       tslib: 2.8.1
 
   headers-polyfill@3.2.5: {}
+
+  helmet@8.1.0: {}
 
   hmac-drbg@1.0.1:
     dependencies:

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+
+describe("middleware security headers", () => {
+  it("sets cross-origin and permissions policy headers", () => {
+    const request = new NextRequest("http://example.com");
+    const response = middleware(request);
+
+    expect(response.headers.get("Permissions-Policy")).toBe(
+      "camera=(), microphone=(), geolocation=()",
+    );
+    expect(response.headers.get("Cross-Origin-Opener-Policy")).toBe(
+      "same-origin",
+    );
+    expect(response.headers.get("Cross-Origin-Embedder-Policy")).toBe(
+      "require-corp",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use `helmet` to set `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy`
- add `Permissions-Policy` to disable camera, microphone, and geolocation
- add regression test for middleware headers

## Testing
- `pnpm exec jest test/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e265a92f8832fbe4f8f4b0c6d8995