### PR TITLE
feat(cms): add auth rate limiting

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -16,9 +16,10 @@
     "@acme/i18n": "workspace:*",
     "@acme/next-config": "workspace:*",
     "@acme/shared-utils": "workspace:*",
+    "@sendgrid/eventwebhook": "^7.2.7",
     "@themes/base": "workspace:*",
     "color-contrast-checker": "^2.1.0",
-    "@sendgrid/eventwebhook": "^7.2.7"
+    "rate-limiter-flexible": "^7.2.0"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/cms/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/cms/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,24 @@
 // apps/cms/src/app/api/auth/[...nextauth]/route.ts
 import { authOptions } from "@cms/auth/options";
 import NextAuth from "next-auth";
+import { NextResponse } from "next/server";
+import { RateLimiterMemory } from "rate-limiter-flexible";
+
+const limiter = new RateLimiterMemory({ points: 10, duration: 60 });
 
 const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST };
+
+async function rateLimitedHandler(req: Request, context: unknown) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0] ?? "unknown";
+  try {
+    await limiter.consume(ip);
+  } catch {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429 },
+    );
+  }
+  return handler(req, context as any);
+}
+
+export { rateLimitedHandler as GET, rateLimitedHandler as POST };

--- a/doc/auth-rate-limiting.md
+++ b/doc/auth-rate-limiting.md
@@ -1,0 +1,12 @@
+# Authentication Rate Limiting
+
+The CMS authentication endpoint `/api/auth/[...nextauth]` uses [`rate-limiter-flexible`](https://github.com/animir/node-rate-limiter-flexible) to limit requests per IP address.
+
+## Thresholds
+
+- **Points**: 10 requests
+- **Duration**: 60 seconds
+
+Exceeding the limit returns **HTTP 429 Too Many Requests**.
+
+Update the limiter configuration in `apps/cms/src/app/api/auth/[...nextauth]/route.ts` to adjust thresholds.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       color-contrast-checker:
         specifier: ^2.1.0
         version: 2.1.0
+      rate-limiter-flexible:
+        specifier: ^7.2.0
+        version: 7.2.0
     devDependencies:
       next:
         specifier: ^15.3.4
@@ -8997,6 +9000,9 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rate-limiter-flexible@7.2.0:
+    resolution: {integrity: sha512-hrf0vIS/WOBegnHg+uPXxsXhuQYlNGfZiCmK5Wgudb12xlZUhpv9yD23yp/EW6BKQosshqnIQRQV+r3jyfIGQg==}
 
   raw-body@2.4.1:
     resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
@@ -20131,6 +20137,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  rate-limiter-flexible@7.2.0: {}
 
   raw-body@2.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
- throttle NextAuth requests per IP
- document auth rate limit configuration

## Testing
- `pnpm --filter @apps/cms lint` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `NEXTAUTH_SECRET=secret CART_COOKIE_SECRET=secret SESSION_SECRET=secret STRIPE_SECRET_KEY=1 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=1 STRIPE_WEBHOOK_SECRET=1 pnpm --filter @apps/cms test` *(fails: 33 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e265dca88832fa4d7f5656c296ea5