### PR TITLE
feat: cross-link products from blog posts

### DIFF
--- a/apps/cms/__tests__/blogActions.test.ts
+++ b/apps/cms/__tests__/blogActions.test.ts
@@ -110,6 +110,24 @@ describe("blog actions", () => {
     expect(body.mutations[0].create.products).toEqual([]);
   });
 
+  test("createPost forwards products from field", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ["foo", "bar"] })
+      .mockResolvedValueOnce({ json: async () => ({ result: null }) })
+      .mockResolvedValueOnce({ json: async () => ({ results: [{ id: "1" }] }) }) as any;
+    const { createPost } = await import("../src/actions/blog.server");
+    const fd = new FormData();
+    fd.set("title", "T");
+    fd.set("content", "[]");
+    fd.set("slug", "t");
+    fd.set("excerpt", "");
+    fd.set("products", "foo, bar");
+    await createPost("s", {} as any, fd);
+    const body = JSON.parse((fetch as jest.Mock).mock.calls.at(-1)[1].body);
+    expect(body.mutations[0].create.products).toEqual(["foo", "bar"]);
+  });
+
   test("updatePost filters invalid product slugs", async () => {
     global.fetch = jest
       .fn()

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -37,6 +37,7 @@ interface Props {
     mainImage?: string;
     author?: string;
     categories?: string[];
+    products?: string[];
   };
 }
 
@@ -137,6 +138,11 @@ function PostFormContent({ action, submitLabel, post }: Props) {
           name="categories"
           label="Categories (comma separated)"
           defaultValue={(post?.categories ?? []).join(", ")}
+        />
+        <Input
+          name="products"
+          label="Related products (comma separated IDs)"
+          defaultValue={(post?.products ?? []).join(", ")}
         />
         <Input
           type="datetime-local"

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -90,7 +90,15 @@ export async function createPost(
     body = [];
     products = [];
   }
-  const existingSlugs = await filterExistingProductSlugs(shopId, products);
+  const manualProductsInput = String(formData.get("products") ?? "");
+  const manualProducts = manualProductsInput
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const existingSlugs = await filterExistingProductSlugs(shopId, [
+    ...products,
+    ...manualProducts,
+  ]);
   products = existingSlugs;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
@@ -147,7 +155,15 @@ export async function updatePost(
     body = [];
     products = [];
   }
-  const existingSlugs = await filterExistingProductSlugs(shopId, products);
+  const manualProductsInput = String(formData.get("products") ?? "");
+  const manualProducts = manualProductsInput
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const existingSlugs = await filterExistingProductSlugs(shopId, [
+    ...products,
+    ...manualProducts,
+  ]);
   products = existingSlugs;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");

--- a/apps/shop-abc/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/page.tsx
@@ -12,6 +12,9 @@ export default async function BlogPage({ params }: { params: { lang: string } })
     title: p.title,
     excerpt: p.excerpt,
     url: `/${params.lang}/blog/${p.slug}`,
+    shopUrl: p.products?.[0]
+      ? `/${params.lang}/product/${p.products[0]}`
+      : undefined,
   }));
   return (
     <>

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -28,6 +28,9 @@ export default async function Page({
         title: first.title,
         excerpt: first.excerpt,
         url: `/${params.lang}/blog/${first.slug}`,
+        shopUrl: first.products?.[0]
+          ? `/${params.lang}/product/${first.products[0]}`
+          : undefined,
       };
     }
   }

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -104,6 +104,9 @@ export default async function ProductDetailPage({
           title: first.title,
           excerpt: first.excerpt,
           url: `/${params.lang}/blog/${first.slug}`,
+          shopUrl: first.products?.[0]
+            ? `/${params.lang}/product/${first.products[0]}`
+            : undefined,
         };
       }
     } catch {

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -42,6 +42,9 @@ export default async function ShopIndexPage({
           title: first.title,
           excerpt: first.excerpt,
           url: `/${params.lang}/blog/${first.slug}`,
+          shopUrl: first.products?.[0]
+            ? `/${params.lang}/product/${first.products[0]}`
+            : undefined,
         };
       }
     }

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -12,6 +12,9 @@ export default async function BlogPage({ params }: { params: { lang: string } })
     title: p.title,
     excerpt: p.excerpt,
     url: `/${params.lang}/blog/${p.slug}`,
+    shopUrl: p.products?.[0]
+      ? `/${params.lang}/product/${p.products[0]}`
+      : undefined,
   }));
   return (
     <>

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -41,6 +41,9 @@ export default async function Page({
         title: first.title,
         excerpt: first.excerpt,
         url: `/${params.lang}/blog/${first.slug}`,
+        shopUrl: first.products?.[0]
+          ? `/${params.lang}/product/${first.products[0]}`
+          : undefined,
       };
     }
   }

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
@@ -92,6 +92,9 @@ export default async function ProductDetailPage({
           title: first.title,
           excerpt: first.excerpt,
           url: `/${params.lang}/blog/${first.slug}`,
+          shopUrl: first.products?.[0]
+            ? `/${params.lang}/product/${first.products[0]}`
+            : undefined,
         };
       }
     } catch {

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -28,6 +28,9 @@ export default async function ShopIndexPage({
           title: first.title,
           excerpt: first.excerpt,
           url: `/${params.lang}/blog/${first.slug}`,
+          shopUrl: first.products?.[0]
+            ? `/${params.lang}/product/${first.products[0]}`
+            : undefined,
         };
       }
     }

--- a/packages/platform-core/src/components/blog/BlogPortableText.tsx
+++ b/packages/platform-core/src/components/blog/BlogPortableText.tsx
@@ -1,18 +1,34 @@
 // src/components/blog/BlogPortableText.tsx
 import { PortableText } from "@portabletext/react";
+import Link from "next/link";
 import { getProductBySlug, getProductById } from "@/lib/products";
-import { ProductCard } from "@/components/shop/ProductCard";
+import { ProductCarousel } from "@ui";
 
 const components = {
   types: {
     productReference: ({ value }: any) => {
-      let sku;
-      if (typeof value?.slug === "string") {
-        sku = getProductBySlug(value.slug);
-      } else if (typeof value?.id === "string") {
-        sku = getProductById(value.id);
+      const ids: string[] = Array.isArray(value?.ids)
+        ? value.ids
+        : Array.isArray(value?.slugs)
+          ? value.slugs
+          : typeof value?.id === "string"
+            ? [value.id]
+            : typeof value?.slug === "string"
+              ? [value.slug]
+              : [];
+      const products = ids
+        .map((id) => getProductById(id) ?? getProductBySlug(id))
+        .filter(Boolean);
+      if (products.length === 0) return null;
+      if (products.length === 1) {
+        const p = products[0]!;
+        return (
+          <Link href={`../product/${p.slug}`} className="underline">
+            {p.title}
+          </Link>
+        );
       }
-      return sku ? <ProductCard sku={sku} /> : null;
+      return <ProductCarousel products={products} />;
     },
     embed: ({ value }: any) => (
       <div className="aspect-video">

--- a/packages/platform-core/src/repositories/blog.server.ts
+++ b/packages/platform-core/src/repositories/blog.server.ts
@@ -13,9 +13,10 @@ export interface SanityPost {
   mainImage?: string;
   author?: string;
   categories?: string[];
+  products?: string[];
 }
 
-const POST_FIELDS = '_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories';
+const POST_FIELDS = '_id,title,body,published,publishedAt,"slug":slug.current,excerpt,mainImage,author,categories,products';
 
 export async function listPosts(config: SanityConfig): Promise<SanityPost[]> {
   const posts = await query<SanityPost[]>(config, `*[_type=="post"]{${POST_FIELDS}}`);

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -18,6 +18,7 @@ export interface BlogPost {
   mainImage?: string;
   author?: string;
   categories?: string[];
+  products?: string[];
 }
 
 export async function getConfig(shopId: string): Promise<SanityBlogConfig> {
@@ -43,7 +44,7 @@ async function getClient(shopId: string) {
 export async function fetchPublishedPosts(shopId: string): Promise<BlogPost[]> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && defined(slug.current) && published == true && !(_id in path('drafts.**'))]{title, "slug": slug.current, excerpt, mainImage, author, categories}`;
+    const query = `*[_type == "post" && defined(slug.current) && published == true && !(_id in path('drafts.**'))]{title, "slug": slug.current, excerpt, mainImage, author, categories, products}`;
     const posts = await client.fetch<BlogPost[]>(query);
     return posts;
   } catch {
@@ -57,7 +58,7 @@ export async function fetchPostBySlug(
 ): Promise<BlogPost | null> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, mainImage, author, categories, body[]{..., _type == "productReference" => { _type, slug }}}`;
+    const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, mainImage, author, categories, products, body[]{..., _type == "productReference" => { _type, slug }}}`;
     const post = await client.fetch<BlogPost | null>(query, { slug });
     return post;
   } catch {

--- a/packages/types/src/page/organisms.ts
+++ b/packages/types/src/page/organisms.ts
@@ -138,14 +138,19 @@ export const storeLocatorBlockComponentSchema = baseComponentSchema.extend({
 
 export interface BlogListingComponent extends PageComponentBase {
   type: "BlogListing";
-  posts?: { title: string; excerpt?: string; url?: string }[];
+  posts?: { title: string; excerpt?: string; url?: string; shopUrl?: string }[];
 }
 
 export const blogListingComponentSchema = baseComponentSchema.extend({
   type: z.literal("BlogListing"),
   posts: z
     .array(
-      z.object({ title: z.string(), excerpt: z.string().optional(), url: z.string().optional() })
+      z.object({
+        title: z.string(),
+        excerpt: z.string().optional(),
+        url: z.string().optional(),
+        shopUrl: z.string().optional(),
+      })
     )
     .optional(),
 });

--- a/packages/ui/src/components/cms/blocks/BlogListing.tsx
+++ b/packages/ui/src/components/cms/blocks/BlogListing.tsx
@@ -1,7 +1,12 @@
 "use client";
 import Link from "next/link";
 
-export type BlogPost = { title: string; excerpt?: string; url?: string };
+export type BlogPost = {
+  title: string;
+  excerpt?: string;
+  url?: string;
+  shopUrl?: string;
+};
 
 export default function BlogListing({ posts = [] }: { posts?: BlogPost[] }) {
   if (!posts.length) return null;
@@ -19,6 +24,13 @@ export default function BlogListing({ posts = [] }: { posts?: BlogPost[] }) {
           {p.excerpt && (
             <p className="text-muted" data-token="--color-muted">
               {p.excerpt}
+            </p>
+          )}
+          {p.shopUrl && (
+            <p>
+              <Link href={p.shopUrl} className="text-primary underline">
+                Shop the story
+              </Link>
             </p>
           )}
         </article>


### PR DESCRIPTION
## Summary
- resolve blog product references to links or carousels
- allow CMS authors to add related product IDs
- surface "Shop the story" links on blog listings

## Testing
- `pnpm test --filter @apps/cms` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_689e266639ec832fa0d9ea5887e94408