### PR TITLE
fix(ui): resolve duplicated media upload exports

### DIFF
--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -227,14 +227,4 @@ export function useFileUpload(
  *  Compatibility exports
  * ------------------------------------------------------------------ */
 
-// 1. allow `import { useMediaUpload } from "@ui/hooks/useMediaUpload"`
-export { useFileUpload as useMediaUpload };
-
-// 2. allow `import useMediaUpload from "@ui/hooks/useMediaUpload"`
 export default useFileUpload;
-
-// legacy type aliases
-export type {
-  UseFileUploadOptions as UseMediaUploadOptions,
-  UseFileUploadResult as UseMediaUploadResult,
-};

--- a/packages/ui/src/hooks/useMediaUpload.tsx
+++ b/packages/ui/src/hooks/useMediaUpload.tsx
@@ -71,8 +71,5 @@ export function useMediaUpload(
   return { ...base, thumbnail };
 }
 
-export type {
-  UseFileUploadOptions as UseMediaUploadOptions,
-  UseMediaUploadResult,
-};
+export type { UseFileUploadOptions as UseMediaUploadOptions };
 export default useMediaUpload;


### PR DESCRIPTION
## Summary
- remove legacy media upload re-exports from `useFileUpload`
- simplify `useMediaUpload` type exports to avoid conflicts

## Testing
- `pnpm --filter @acme/ui build` *(fails: cannot find built dependencies, missing types)*
- `pnpm --filter @acme/ui test packages/ui/src/hooks/__tests__/useFileUpload.test.ts`
- `pnpm --filter @acme/ui test packages/ui` *(fails: numerous test failures, e.g. PageBuilder resize interactions)*

------
https://chatgpt.com/codex/tasks/task_e_689e2715b73c832f9e217038517237ac