### PR TITLE
feat(ui): add CMS block previews

### DIFF
--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -14,6 +14,8 @@ import CustomHtml from "./CustomHtml";
 import ButtonBlock from "./Button";
 export { Divider, Spacer, CustomHtml, ButtonBlock as Button };
 
+const defaultPreview = "/window.svg";
+
 /* ──────────────────────────────────────────────────────────────────────────
  * Shared helpers
  * --------------------------------------------------------------------------*/
@@ -79,13 +81,20 @@ export const Image = memo(function Image({
 /* ──────────────────────────────────────────────────────────────────────────
  * Atom registry
  * --------------------------------------------------------------------------*/
-export const atomRegistry = {
-  Text: { component: Text },
-  Image: { component: Image },
+const atomEntries = {
+  Text: { component: Text, previewImage: "/file.svg" },
+  Image: { component: Image, previewImage: "/globe.svg" },
   Divider: { component: Divider },
   Spacer: { component: Spacer },
   CustomHtml: { component: CustomHtml },
   Button: { component: ButtonBlock },
-} as const satisfies Record<string, BlockRegistryEntry<any>>;
+} as const;
 
-export type AtomBlockType = keyof typeof atomRegistry;
+export const atomRegistry = Object.fromEntries(
+  Object.entries(atomEntries).map(([k, v]) => [
+    k,
+    { previewImage: defaultPreview, ...v },
+  ]),
+) as typeof atomEntries satisfies Record<string, BlockRegistryEntry<any>>;
+
+export type AtomBlockType = keyof typeof atomEntries;

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -2,9 +2,18 @@ import Section from "./Section";
 import MultiColumn from "./containers/MultiColumn";
 import type { BlockRegistryEntry } from "./types";
 
-export const containerRegistry = {
+const defaultPreview = "/window.svg";
+
+const containerEntries = {
   Section: { component: Section },
   MultiColumn: { component: MultiColumn },
-} as const satisfies Record<string, BlockRegistryEntry<any>>;
+} as const;
 
-export type ContainerBlockType = keyof typeof containerRegistry;
+export const containerRegistry = Object.fromEntries(
+  Object.entries(containerEntries).map(([k, v]) => [
+    k,
+    { previewImage: defaultPreview, ...v },
+  ]),
+) as typeof containerEntries satisfies Record<string, BlockRegistryEntry<any>>;
+
+export type ContainerBlockType = keyof typeof containerEntries;

--- a/packages/ui/src/components/cms/blocks/layout.tsx
+++ b/packages/ui/src/components/cms/blocks/layout.tsx
@@ -2,9 +2,18 @@ import Header from "./HeaderBlock";
 import Footer from "./FooterBlock";
 import type { BlockRegistryEntry } from "./types";
 
-export const layoutRegistry = {
+const defaultPreview = "/window.svg";
+
+const layoutEntries = {
   Header: { component: Header },
   Footer: { component: Footer },
-} as const satisfies Record<string, BlockRegistryEntry<any>>;
+} as const;
 
-export type LayoutBlockType = keyof typeof layoutRegistry;
+export const layoutRegistry = Object.fromEntries(
+  Object.entries(layoutEntries).map(([k, v]) => [
+    k,
+    { previewImage: defaultPreview, ...v },
+  ]),
+) as typeof layoutEntries satisfies Record<string, BlockRegistryEntry<any>>;
+
+export type LayoutBlockType = keyof typeof layoutEntries;

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -7,6 +7,8 @@ import type { BlockRegistryEntry } from "./types";
 import type { CategoryCollectionTemplateProps } from "../../templates/CategoryCollectionTemplate";
 import { CategoryCollectionTemplate } from "../../templates/CategoryCollectionTemplate";
 
+const defaultPreview = "/window.svg";
+
 /* ──────────────────────────────────────────────────────────────────────────
  * NewsletterForm
  * --------------------------------------------------------------------------*/
@@ -100,10 +102,17 @@ export const CategoryList = memo(function CategoryList({
 /* ──────────────────────────────────────────────────────────────────────────
  * Molecule registry
  * --------------------------------------------------------------------------*/
-export const moleculeRegistry = {
+const moleculeEntries = {
   NewsletterForm: { component: NewsletterForm },
   PromoBanner: { component: PromoBanner },
   CategoryList: { component: CategoryList },
-} as const satisfies Record<string, BlockRegistryEntry<any>>;
+} as const;
 
-export type MoleculeBlockType = keyof typeof moleculeRegistry;
+export const moleculeRegistry = Object.fromEntries(
+  Object.entries(moleculeEntries).map(([k, v]) => [
+    k,
+    { previewImage: defaultPreview, ...v },
+  ]),
+) as typeof moleculeEntries satisfies Record<string, BlockRegistryEntry<any>>;
+
+export type MoleculeBlockType = keyof typeof moleculeEntries;

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -45,7 +45,9 @@ import ProductBundle, {
 import ProductFilter from "./ProductFilter";
 import type { BlockRegistryEntry } from "./types";
 
-export const organismRegistry = {
+const defaultPreview = "/window.svg";
+
+const organismEntries = {
   AnnouncementBar: { component: AnnouncementBar },
   HeroBanner: { component: HeroBanner },
   ValueProps: { component: ValueProps },
@@ -96,6 +98,13 @@ export const organismRegistry = {
     getRuntimeProps: getProductBundleRuntimeProps,
   },
   ProductFilter: { component: ProductFilter },
-} as const satisfies Record<string, BlockRegistryEntry<any>>;
+} as const;
 
-export type OrganismBlockType = keyof typeof organismRegistry;
+export const organismRegistry = Object.fromEntries(
+  Object.entries(organismEntries).map(([k, v]) => [
+    k,
+    { previewImage: defaultPreview, ...v },
+  ]),
+) as typeof organismEntries satisfies Record<string, BlockRegistryEntry<any>>;
+
+export type OrganismBlockType = keyof typeof organismEntries;

--- a/packages/ui/src/components/cms/blocks/overlays.tsx
+++ b/packages/ui/src/components/cms/blocks/overlays.tsx
@@ -1,9 +1,18 @@
 import PopupModal from "./PopupModal";
 import type { BlockRegistryEntry } from "./types";
 
-export const overlayRegistry = {
-  PopupModal: { component: PopupModal },
-} as const satisfies Record<string, BlockRegistryEntry<any>>;
+const defaultPreview = "/window.svg";
 
-export type OverlayBlockType = keyof typeof overlayRegistry;
+const overlayEntries = {
+  PopupModal: { component: PopupModal },
+} as const;
+
+export const overlayRegistry = Object.fromEntries(
+  Object.entries(overlayEntries).map(([k, v]) => [
+    k,
+    { previewImage: defaultPreview, ...v },
+  ]),
+) as typeof overlayEntries satisfies Record<string, BlockRegistryEntry<any>>;
+
+export type OverlayBlockType = keyof typeof overlayEntries;
 

--- a/packages/ui/src/components/cms/blocks/types.ts
+++ b/packages/ui/src/components/cms/blocks/types.ts
@@ -4,6 +4,7 @@ import type { Locale } from "@/i18n/locales";
 
 export interface BlockRegistryEntry<P> {
   component: ComponentType<P>;
+  previewImage?: string;
   getRuntimeProps?: (
     block: PageComponent,
     locale: Locale

--- a/packages/ui/src/components/cms/page-builder/Palette.tsx
+++ b/packages/ui/src/components/cms/page-builder/Palette.tsx
@@ -25,7 +25,7 @@ interface PaletteMeta {
   label: string;
   icon: string;
   description?: string;
-  previewImage?: string;
+  previewImage: string;
 }
 
 const createPaletteItems = (
@@ -36,9 +36,9 @@ const createPaletteItems = (
     .map((t) => ({
       type: t,
       label: t.replace(/([A-Z])/g, " $1").trim(),
-      icon: defaultIcon,
+      icon: registry[t]?.previewImage ?? defaultIcon,
       description: registry[t]?.description,
-      previewImage: registry[t]?.previewImage,
+      previewImage: registry[t]?.previewImage ?? defaultIcon,
     }));
 
 const palette = {
@@ -92,33 +92,31 @@ const PaletteItem = memo(function PaletteItem({
       className="flex cursor-grab items-center gap-2 rounded border p-2 text-sm"
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
       onKeyDown={handleKeyDown}
     >
       <img
         src={icon}
         alt=""
         aria-hidden="true"
-        className="h-4 w-4"
+        className="h-6 w-6 rounded"
         loading="lazy"
       />
       <span>{label}</span>
     </div>
   );
 
-  if (!description && !previewImage) return content;
-
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{content}</PopoverTrigger>
       <PopoverContent className="w-64 space-y-2 text-sm">
-        {previewImage && (
-          <img
-            src={previewImage}
-            alt=""
-            className="w-full rounded"
-            loading="lazy"
-          />
-        )}
+        <img
+          src={previewImage}
+          alt=""
+          className="w-full rounded"
+          loading="lazy"
+        />
         {description && <p>{description}</p>}
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## Summary
- add `previewImage` to CMS block registries with fallback icons
- show thumbnails and hover/focus previews in page-builder palette

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm --filter @acme/ui test -- packages/ui`
- `pnpm --filter @acme/ui build`


------
https://chatgpt.com/codex/tasks/task_e_689e266ec3b8832fa23d41fc1419191e