### PR TITLE
fix: correct media type definitions in storybook templates

### DIFF
--- a/packages/ui/src/components/templates/ProductDetailTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/ProductDetailTemplate.stories.tsx
@@ -11,7 +11,7 @@ const product: SKU = {
   stock: 0,
   forSale: true,
   forRental: false,
-  media: [{ url: "https://placehold.co/600", type: "image" }],
+  media: [{ url: "https://placehold.co/600", type: "image" as const }],
   sizes: [],
   description: "A wonderful item",
 };

--- a/packages/ui/src/components/templates/ProductMediaGalleryTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/ProductMediaGalleryTemplate.stories.tsx
@@ -15,8 +15,8 @@ const meta: Meta<typeof ProductMediaGalleryTemplate> = {
       forSale: true,
       forRental: false,
       media: [
-        { type: "image", url: "/placeholder.svg" },
-        { type: "image", url: "/placeholder.svg" },
+        { type: "image" as const, url: "/placeholder.svg" },
+        { type: "image" as const, url: "/placeholder.svg" },
       ],
       sizes: [],
       description: "",


### PR DESCRIPTION
## Summary
- ensure storybook product detail story asserts media type literals
- assert media gallery story media entries use strict literal types

## Testing
- `pnpm --filter @acme/ui build` (fails: Output file ... has not been built)
- `pnpm --filter @acme/ui test -- --testPathPattern packages/ui` (fails: unable to find label "Width (Desktop)")

------
https://chatgpt.com/codex/tasks/task_e_689e27b40824832fa961ff0a48f31138