### PR TITLE
fix: remove unsupported button size

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -269,7 +269,7 @@ const PageBuilder = memo(function PageBuilder({
             )}
             <Button
               variant="outline"
-              size="sm"
+              className="h-8 px-2"
               onClick={() => setShowPreview((p) => !p)}
             >
               {showPreview ? "Hide preview" : "Show preview"}

--- a/packages/ui/src/components/organisms/ProductCarousel.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.tsx
@@ -112,8 +112,7 @@ export function ProductCarousel({
               {enableQuickView && (
                 <Button
                   variant="outline"
-                  size="sm"
-                  className="absolute right-2 top-2"
+                  className="absolute right-2 top-2 h-8 px-2"
                   aria-label={`Quick view ${p.title}`}
                   onClick={() => setQuickViewProduct(p)}
                 >

--- a/packages/ui/src/components/organisms/ProductGrid.tsx
+++ b/packages/ui/src/components/organisms/ProductGrid.tsx
@@ -112,8 +112,7 @@ export function ProductGrid({
             {enableQuickView && (
               <Button
                 variant="outline"
-                size="sm"
-                className="absolute right-2 top-2"
+                className="absolute right-2 top-2 h-8 px-2"
                 aria-label={`Quick view ${p.title}`}
                 onClick={() => setQuickViewProduct(p)}
               >


### PR DESCRIPTION
## Summary
- remove unsupported `size="sm"` prop from quick view buttons
- adjust PageBuilder preview toggle button styling

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file ... has not been built)*
- `pnpm exec eslint packages/ui/src/components/organisms/ProductGrid.tsx packages/ui/src/components/organisms/ProductCarousel.tsx packages/ui/src/components/cms/page-builder/PageBuilder.tsx` *(warn: File ignored because no matching configuration was supplied)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find element with role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689e27f3bbfc832fbee0e77bb537b025