### PR TITLE
refactor: add serialized inventory item type

### DIFF
--- a/packages/platform-core/src/repositories/inventory.json.server.ts
+++ b/packages/platform-core/src/repositories/inventory.json.server.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import { inventoryItemSchema, type InventoryItem } from "@acme/types";
+import {
+  inventoryItemSchema,
+  type InventoryItem,
+  type SerializedInventoryItem,
+} from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { validateShopName } from "../shops";
@@ -31,11 +35,11 @@ async function ensureDir(shop: string): Promise<void> {
 async function read(shop: string): Promise<InventoryItem[]> {
   try {
     const buf = await fs.readFile(inventoryPath(shop), "utf8");
-    const raw = JSON.parse(buf);
+    const raw: SerializedInventoryItem[] = JSON.parse(buf);
     return inventoryItemSchema
       .array()
       .parse(
-        raw.map((i: any) => ({
+        raw.map((i) => ({
           variantAttributes: {},
           ...i,
         })),
@@ -47,7 +51,7 @@ async function read(shop: string): Promise<InventoryItem[]> {
 }
 
 async function write(shop: string, items: InventoryItem[]): Promise<void> {
-  const normalized = inventoryItemSchema
+  const normalized: SerializedInventoryItem[] = inventoryItemSchema
     .array()
     .parse(
       items.map((i) => ({
@@ -83,18 +87,18 @@ async function update(
   mutate: InventoryMutateFn,
 ): Promise<InventoryItem | undefined> {
   const lockFile = `${inventoryPath(shop)}.lock`;
-  let normalized: InventoryItem[] = [];
+  let normalized: SerializedInventoryItem[] = [];
   const handle = await acquireLock(lockFile);
   let updated: InventoryItem | undefined;
   try {
     let items: InventoryItem[] = [];
     try {
       const buf = await fs.readFile(inventoryPath(shop), "utf8");
-      const raw = JSON.parse(buf);
+      const raw: SerializedInventoryItem[] = JSON.parse(buf);
       items = inventoryItemSchema
         .array()
         .parse(
-          raw.map((i: any) => ({
+          raw.map((i) => ({
             variantAttributes: {},
             ...i,
           })),

--- a/packages/types/src/InventoryItem.ts
+++ b/packages/types/src/InventoryItem.ts
@@ -3,6 +3,17 @@ import { z } from "zod";
 // Flexible map of variant attributes (e.g. size, color)
 export const variantAttributesSchema = z.record(z.string());
 
+export interface SerializedInventoryItem {
+  sku: string;
+  productId: string;
+  quantity: number;
+  variantAttributes?: Record<string, string>;
+  lowStockThreshold?: number;
+  wearCount?: number;
+  wearAndTearLimit?: number;
+  maintenanceCycle?: number;
+}
+
 export const inventoryItemSchema = z
   .object({
     sku: z.string(),


### PR DESCRIPTION
## Summary
- add `SerializedInventoryItem` type to `@acme/types`
- use `SerializedInventoryItem` in JSON and SQLite inventory repositories and remove `any` casts

## Testing
- `pnpm exec jest packages/platform-core/__tests__/inventory.test.ts --config jest.config.cjs` *(fails: Exceeded timeout and productId mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689e28170bd0832fa13e170a77633d67