### PR TITLE
Use typed helpers for page and settings diffs

### DIFF
--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -51,14 +51,21 @@ function mergeDefined<T extends object>(base: T, patch: Partial<T>): T {
   return { ...base, ...(Object.fromEntries(definedEntries) as Partial<T>) };
 }
 
+function setPatchValue<T extends object, K extends keyof T>(
+  patch: Partial<T>,
+  key: K,
+  value: T[K]
+): void {
+  patch[key] = value;
+}
+
 function diffPages(oldP: Page | undefined, newP: Page): Partial<Page> {
   const patch: Partial<Page> = {};
   for (const key of Object.keys(newP) as (keyof Page)[]) {
     const a = oldP ? JSON.stringify(oldP[key]) : undefined;
     const b = JSON.stringify(newP[key]);
     if (a !== b) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (patch as any)[key] = newP[key];
+      setPatchValue<Page>(patch, key, newP[key]);
     }
   }
   return patch;

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -30,6 +30,14 @@ async function ensureDir(shop: string): Promise<void> {
   await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
 }
 
+function setPatchValue<T extends object, K extends keyof T>(
+  patch: Partial<T>,
+  key: K,
+  value: T[K]
+): void {
+  patch[key] = value;
+}
+
 function diffSettings(
   oldS: ShopSettings,
   newS: ShopSettings
@@ -39,8 +47,7 @@ function diffSettings(
     const a = JSON.stringify(oldS[key]);
     const b = JSON.stringify(newS[key]);
     if (a !== b) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (patch as any)[key] = newS[key];
+      setPatchValue<ShopSettings>(patch, key, newS[key]);
     }
   }
   return patch;


### PR DESCRIPTION
## Summary
- introduce generic `setPatchValue` helper to build typed diffs for pages and shop settings
- remove `any` casts from `diffPages` and `diffSettings`

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: scheduler test timeout and media test exits)*
- `pnpm lint --filter @acme/platform-core`


------
https://chatgpt.com/codex/tasks/task_e_689e2817d3b4832f8e63587cad72a641