### PR TITLE
feat: share AnalyticsEvent type across packages

### DIFF
--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -1,3 +1,5 @@
+import type { AnalyticsEvent } from "@acme/types";
+
 export type HookPayload = { campaign: string };
 
 export type HookHandler = (
@@ -33,7 +35,7 @@ export async function emitClick(shop: string, payload: HookPayload): Promise<voi
   await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
 }
 
-async function track(shop: string, data: any): Promise<void> {
+async function track(shop: string, data: AnalyticsEvent): Promise<void> {
   const { trackEvent } = await import("@platform-core/analytics");
   await trackEvent(shop, data);
 }

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -6,19 +6,9 @@ import { DATA_ROOT } from "./dataRoot";
 import { validateShopName } from "./shops";
 import { getShopSettings, readShop } from "./repositories/shops.server";
 import { coreEnv } from "@acme/config/env/core";
+import type { AnalyticsEvent } from "@acme/types";
 
-export type AnalyticsEvent =
-  | {
-      type: "discount_redeemed";
-      code: string;
-      timestamp?: string;
-      [key: string]: unknown;
-    }
-  | {
-    type: string;
-    timestamp?: string;
-    [key: string]: unknown;
-  };
+export type { AnalyticsEvent } from "@acme/types";
 
 export interface AnalyticsProvider {
   track(event: AnalyticsEvent): Promise<void> | void;

--- a/packages/types/src/AnalyticsEvent.ts
+++ b/packages/types/src/AnalyticsEvent.ts
@@ -1,0 +1,18 @@
+export type AnalyticsEvent =
+  | {
+      type: "email_sent" | "email_open" | "email_click";
+      campaign: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: "discount_redeemed";
+      code: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,3 +19,4 @@ export * from "./SubscriptionPlan";
 export * from "./Coverage";
 export * from "./upgrade";
 export * from "./ExampleProps";
+export * from "./AnalyticsEvent";


### PR DESCRIPTION
## Summary
- add shared AnalyticsEvent union in `@acme/types`
- track email analytics using typed events
- re-export AnalyticsEvent from platform-core analytics

## Testing
- `pnpm --filter @acme/types test` *(no tests found)*
- `pnpm --filter @acme/email test` *(fails: TestingLibraryElementError in ThemeEditor colors test)*
- `pnpm --filter @acme/platform-core test` *(aborted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_689e2819e040832fab3d19da548d6742