### PR TITLE
feat(email): type analytics events

### DIFF
--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -2,6 +2,7 @@ import { sendCampaignEmail } from "./send";
 import { resolveSegment } from "./segments";
 import { emitSend } from "./hooks";
 import { listEvents } from "@platform-core/repositories/analytics.server";
+import type { AnalyticsEvent } from "@platform-core/analytics";
 import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
 import { getCampaignStore } from "./storage";
@@ -52,8 +53,11 @@ async function filterUnsubscribed(
   const events = await listEvents(shop).catch(() => []);
   const unsub = new Set(
     events
-      .filter((e: any) => e.type === "email_unsubscribe" && e.email)
-      .map((e: any) => e.email),
+      .filter(
+        (e): e is AnalyticsEvent & { email: string } =>
+          e.type === "email_unsubscribe" && typeof e.email === "string",
+      )
+      .map((e) => e.email),
   );
   return recipients.filter((r) => !unsub.has(r));
 }

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -1,4 +1,5 @@
 import { listEvents } from "@platform-core/repositories/analytics.server";
+import type { AnalyticsEvent } from "@platform-core/analytics";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { DATA_ROOT } from "@platform-core/dataRoot";
@@ -104,18 +105,18 @@ export async function resolveSegment(
     return [];
   }
 
-  const events = await listEvents(shop);
+  const events: AnalyticsEvent[] = await listEvents(shop);
   const emails = new Set<string>();
   for (const e of events) {
     let match = true;
     for (const f of def.filters) {
-      if ((e as any)[f.field] !== f.value) {
+      if (e[f.field] !== f.value) {
         match = false;
         break;
       }
     }
     if (match) {
-      const email = (e as any).email;
+      const email = e.email;
       if (typeof email === "string") emails.add(email);
     }
   }

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -11,11 +11,15 @@ export type AnalyticsEvent =
   | {
       type: "discount_redeemed";
       code: string;
+      email?: string;
+      segment?: string;
       timestamp?: string;
       [key: string]: unknown;
     }
   | {
     type: string;
+    email?: string;
+    segment?: string;
     timestamp?: string;
     [key: string]: unknown;
   };


### PR DESCRIPTION
## Summary
- extend AnalyticsEvent with email/segment fields
- type unsubscribe filtering with AnalyticsEvent
- use typed AnalyticsEvent when resolving segments

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: ThemeEditor - colors)*
- `pnpm --filter @acme/email test` *(fails: ThemeEditor - colors)*

------
https://chatgpt.com/codex/tasks/task_e_689e281b83fc832fb94b7f17dfd67608