### PR TITLE
refactor: type early fraud warnings

### DIFF
--- a/packages/platform-core/src/stripe-webhook.ts
+++ b/packages/platform-core/src/stripe-webhook.ts
@@ -110,13 +110,19 @@ export async function handleStripeWebhook(
     }
     default: {
       if (type.startsWith("radar.early_fraud_warning.")) {
-        const warning = data.object as any; // Stripe.Radar.EarlyFraudWarning
-        const chargeId =
-          typeof warning.charge === "string" ? warning.charge : warning.charge?.id;
+        const warning = data.object as Stripe.Radar.EarlyFraudWarning;
+        const charge = warning.charge;
+        const chargeId = typeof charge === "string" ? charge : charge?.id;
         if (chargeId) {
-          const riskLevel = warning.risk_level as string | undefined;
-          const riskScore = warning.risk_score as number | undefined;
-          await updateRisk(shop, chargeId, riskLevel, riskScore, true);
+          const riskLevel = warning.risk_level;
+          const riskScore = warning.risk_score;
+          await updateRisk(
+            shop,
+            chargeId,
+            riskLevel,
+            typeof riskScore === "number" ? riskScore : undefined,
+            true
+          );
           if (
             riskLevel === "highest" ||
             (typeof riskScore === "number" && riskScore > 75)


### PR DESCRIPTION
## Summary
- type early fraud warning objects in webhook handler
- access risk attributes without `any` casts

## Testing
- `pnpm lint --filter @acme/platform-core` *(no tasks executed)*
- `pnpm test --filter @acme/platform-core` *(fails: process.exit called and missing button)*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/__tests__/stripe-webhook.test.ts` *(fails: SyntaxError: Unexpected token, expected "from" (2:12))*
- `pnpm typecheck --filter @acme/platform-core` *(fails: Unknown build option '--filter')*

------
https://chatgpt.com/codex/tasks/task_e_689e281dc410832f8893a9519d57a284