### PR TITLE
chore: enforce hashed passwords

### DIFF
--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -52,12 +52,20 @@ export function createAuthOptions(overrides: Overrides = {}): NextAuthOptions {
 
           /* -------------------------------------------------------------- */
           /*  Password check                                                */
-          /*  - user.id === "1": plain‑text (dev fixture)                   */
-          /*  - everyone else : argon2                                     */
+          /*  - dev fixture allowed only in development                     */
+          /*  - otherwise require argon2 hashed passwords                   */
           /* -------------------------------------------------------------- */
+          const isDevFixture =
+            process.env.NODE_ENV === "development" && user?.id === "1";
+
+          if (user && !isDevFixture && !user.password.startsWith("$argon2")) {
+            console.log("[auth] user password is not hashed", { id: user.id });
+            throw new Error("Invalid email or password");
+          }
+
           const ok =
             user &&
-            (user.id === "1"
+            (isDevFixture
               ? credentials.password === user.password
               : await argonVerify(user.password, credentials.password));
 


### PR DESCRIPTION
## Summary
- guard legacy plain-text dev fixture to development mode
- enforce hashed password requirement before verification

## Testing
- `pnpm --filter @apps/cms test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i` in ThemeEditor.colors.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689e2bdb66a8832fa9fe47dfabb8b1e3