### PR TITLE
feat: add NextAuth rate limiting

### DIFF
--- a/apps/cms/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/cms/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,27 @@
 // apps/cms/src/app/api/auth/[...nextauth]/route.ts
 import { authOptions } from "@cms/auth/options";
 import NextAuth from "next-auth";
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import type { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+
+const limiter = new RateLimiterMemory({ points: 5, duration: 60 });
 
 const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST };
+
+const rateLimited = async (req: NextRequest, ctx: any) => {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    req.ip ||
+    "unknown";
+
+  try {
+    await limiter.consume(ip);
+    return handler(req, ctx);
+  } catch {
+    return new Response("Too Many Requests", { status: 429 });
+  }
+};
+
+export { rateLimited as GET, rateLimited as POST };

--- a/docs/auth-rate-limiting.md
+++ b/docs/auth-rate-limiting.md
@@ -1,0 +1,9 @@
+# Authentication Rate Limiting
+
+The NextAuth handler in `apps/cms` is protected with a simple in-memory rate limiter using [`rate-limiter-flexible`](https://www.npmjs.com/package/rate-limiter-flexible).
+
+- **Points:** 5 requests
+- **Duration:** per 60 seconds
+- Exceeding the limit returns **HTTP 429 Too Many Requests**.
+
+Adjust `points` or `duration` in `apps/cms/src/app/api/auth/[...nextauth]/route.ts` to change these thresholds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,4 @@
 - [Upgrade flow](./upgrade-flow.md)
 - [Theming](./theming.md)
 - [Advanced theming](./theming-advanced.md)
+- [Authentication rate limiting](./auth-rate-limiting.md)

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "next-seo": "^6.8.0",
     "nodemailer": "^6.10.1",
     "openai": "^4.104.0",
+    "rate-limiter-flexible": "^7.2.0",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       dompurify:
         specifier: ^3.2.6
         version: 3.2.6
+      rate-limiter-flexible:
+        specifier: ^7.2.0
+        version: 7.2.0
     devDependencies:
       next:
         specifier: ^15.3.4
@@ -603,15 +606,15 @@ importers:
 
   packages/shared-utils:
     dependencies:
+      pino:
+        specifier: ^9.9.0
+        version: 9.9.0
       raw-body:
         specifier: 2.4.1
         version: 2.4.1
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
-      pino:
-        specifier: ^9.9.0
-        version: 9.9.0
     devDependencies:
       next:
         specifier: ^15.3.4
@@ -9062,6 +9065,9 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rate-limiter-flexible@7.2.0:
+    resolution: {integrity: sha512-hrf0vIS/WOBegnHg+uPXxsXhuQYlNGfZiCmK5Wgudb12xlZUhpv9yD23yp/EW6BKQosshqnIQRQV+r3jyfIGQg==}
 
   raw-body@2.4.1:
     resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
@@ -20260,6 +20266,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  rate-limiter-flexible@7.2.0: {}
 
   raw-body@2.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add `rate-limiter-flexible` dependency
- throttle NextAuth route to 5 requests/min per IP and return 429 on limit
- document auth rate limiting configuration

## Testing
- `pnpm test:cms` *(fails: scheduler test timeout and process.exit call)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c4644b8832f820bbde1e9197f69