### PR TITLE
fix(ui): resolve useMediaUpload export conflicts

### DIFF
--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,7 +1,6 @@
 export * from "./useCart";
 export * from "./useImageUpload";
 export * from "./useFileUpload";
-export * from "./useMediaUpload"; // backwards compatibility
 export * from "./useImageOrientationValidation";
 export * from "./useProductEditorFormState";
 export * from "./useProductFilters";

--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -240,4 +240,7 @@ export { useFileUpload as useMediaUpload };
 export default useFileUpload;
 
 // legacy type aliases
-export type { UseFileUploadOptions as UseMediaUploadOptions };
+export type {
+  UseFileUploadOptions as UseMediaUploadOptions,
+  UseFileUploadResult as UseMediaUploadResult,
+};


### PR DESCRIPTION
## Summary
- remove duplicate `useMediaUpload` re-export from hooks barrel
- add legacy `UseMediaUploadResult` alias in `useFileUpload`

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file ... has not been built from source file ...)*
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689e2cc992d4832f8909d8ad043d7cf2