### PR TITLE
feat: add analytics event type

### DIFF
--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -1,3 +1,5 @@
+import type { AnalyticsEvent } from "@acme/types";
+
 export type HookPayload = { campaign: string };
 
 export type HookHandler = (
@@ -33,7 +35,7 @@ export async function emitClick(shop: string, payload: HookPayload): Promise<voi
   await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
 }
 
-async function track(shop: string, data: any): Promise<void> {
+async function track(shop: string, data: AnalyticsEvent): Promise<void> {
   const { trackEvent } = await import("@platform-core/analytics");
   await trackEvent(shop, data);
 }

--- a/packages/types/src/AnalyticsEvent.ts
+++ b/packages/types/src/AnalyticsEvent.ts
@@ -1,0 +1,6 @@
+export interface AnalyticsEvent {
+  type: "email_sent" | "email_open" | "email_click";
+  campaign: string;
+  [key: string]: unknown;
+}
+

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -21,3 +21,4 @@ export * from "./Coverage";
 export * from "./upgrade";
 export * from "./ExampleProps";
 export * from "./Segment";
+export * from "./AnalyticsEvent";


### PR DESCRIPTION
## Summary
- add AnalyticsEvent type for email campaign events
- use AnalyticsEvent in email hooks for default analytics tracking
- export AnalyticsEvent from shared types package

## Testing
- `pnpm --filter "@acme/types" test` (no tests found)
- `pnpm --filter "@acme/email" test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*

------
https://chatgpt.com/codex/tasks/task_e_689e346725f8832fb053a2e44558473f