### PR TITLE
refactor: remove unsupported button size

### DIFF
--- a/packages/ui/src/components/organisms/ProductGrid.tsx
+++ b/packages/ui/src/components/organisms/ProductGrid.tsx
@@ -112,8 +112,7 @@ export function ProductGrid({
             {enableQuickView && (
               <Button
                 variant="outline"
-                size="sm"
-                className="absolute right-2 top-2"
+                className="absolute right-2 top-2 h-8 px-2"
                 aria-label={`Quick view ${p.title}`}
                 onClick={() => setQuickViewProduct(p)}
               >


### PR DESCRIPTION
## Summary
- remove unsupported size prop from quick view button in `ProductGrid`

## Testing
- `pnpm test` *(fails: ELIFECYCLE, Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e34783e54832fbe7fc751c4eefa35