### PR TITLE
fix minicart stories sku type

### DIFF
--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -12,9 +12,10 @@ const sku1: SKU = {
   title: "Item One",
   price: 20,
   deposit: 0,
+  stock: 0,
   forSale: true,
   forRental: false,
-  image: "https://placehold.co/64",
+  media: [{ url: "https://placehold.co/64", type: "image" }],
   sizes: [],
   description: "",
 };
@@ -24,9 +25,10 @@ const sku2: SKU = {
   title: "Item Two",
   price: 15,
   deposit: 0,
+  stock: 0,
   forSale: true,
   forRental: false,
-  image: "https://placehold.co/64",
+  media: [{ url: "https://placehold.co/64", type: "image" }],
   sizes: [],
   description: "",
 };


### PR DESCRIPTION
## Summary
- align MiniCart story SKU objects with SKU type requirements by removing invalid `image` property and adding `stock` and `media` fields

## Testing
- `pnpm --filter @acme/ui build`
- `pnpm --filter @acme/ui test -- packages/ui` *(fails: DynamicRenderer block registry coverage tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_689e34e7ebc0832fbcdfdcb66f86c58c