### PR TITLE
fix: include delivery windows and regions props

### DIFF
--- a/packages/ui/src/components/organisms/DeliveryScheduler.tsx
+++ b/packages/ui/src/components/organisms/DeliveryScheduler.tsx
@@ -29,6 +29,8 @@ export interface DeliverySchedulerProps
 export function DeliveryScheduler({
   className,
   onChange,
+  regions,
+  windows,
   ...props
 }: DeliverySchedulerProps) {
   const [mode, setMode] = React.useState<"delivery" | "pickup">("delivery");


### PR DESCRIPTION
## Summary
- destructure `windows` and `regions` props in `DeliveryScheduler`

## Testing
- `pnpm --filter @acme/ui build` *(fails: File '/workspace/base-shop/packages/shared-utils/src/fetchJson.ts' is not under 'rootDir' '/workspace/base-shop/packages/ui/src')*
- `pnpm --filter @acme/ui test` *(fails: scheduler › sends due campaigns and marks them as sent)*

------
https://chatgpt.com/codex/tasks/task_e_689e34ff1cb0832f86525b79865c5997