### PR TITLE
test: fix RecommendationCarousel tests for SKU type

### DIFF
--- a/packages/ui/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/__tests__/RecommendationCarousel.test.tsx
@@ -1,28 +1,36 @@
 import React from "react";
 import { render, waitFor, act } from "@testing-library/react";
 import { RecommendationCarousel } from "../src/components/organisms/RecommendationCarousel";
-import type { Product } from "../src/components/organisms/ProductCard";
+import type { SKU } from "@acme/types";
 
 jest.mock("../src/components/organisms/ProductCard", () => ({
-  ProductCard: ({ product }: { product: Product }) => (
+  ProductCard: ({ product }: { product: SKU }) => (
     <div data-testid={`product-${product.id}`} />
   ),
 }));
 
-const products: Product[] = Array.from({ length: 3 }).map((_, i) => ({
+const products: SKU[] = Array.from({ length: 3 }).map((_, i) => ({
   id: String(i + 1),
+  slug: `product-${i + 1}`,
   title: `Product ${i + 1}`,
-  media: [{ url: "", type: "image" }],
   price: (i + 1) * 10,
+  deposit: 0,
+  stock: 0,
+  forSale: true,
+  forRental: false,
+  media: [{ url: "", type: "image" }],
+  sizes: [],
+  description: "",
 }));
 
 describe("RecommendationCarousel", () => {
   beforeEach(() => {
-    // @ts-expect-error mock fetch
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => products,
-    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => products,
+      }) as unknown as typeof fetch;
   });
 
   it("clamps item count between min and max based on screen width", async () => {

--- a/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
@@ -39,11 +39,12 @@ const products: SKU[] = [
 
 describe("RecommendationCarousel responsive counts", () => {
   beforeEach(() => {
-    // @ts-expect-error mock fetch
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => products,
-    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => products,
+      }) as unknown as typeof fetch;
   });
 
   function setWidth(width: number) {


### PR DESCRIPTION
## Summary
- adjust RecommendationCarousel tests to align with SKU shape
- properly type fetch mock and drop unnecessary ts-expect-error

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx`
- `pnpm --filter @acme/ui test packages/ui/__tests__/RecommendationCarousel.test.tsx`
- `pnpm eslint packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx packages/ui/__tests__/RecommendationCarousel.test.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `tsc -p packages/ui/tsconfig.json` *(fails: rootDir is expected to contain all source files and other dependency build issues)*

------
https://chatgpt.com/codex/tasks/task_e_689e35160638832f8c1a6fa5e6d8e8cc