### PR TITLE
fix: export Product type from ProductCarousel

### DIFF
--- a/packages/ui/src/components/organisms/ProductCarousel.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.tsx
@@ -5,6 +5,8 @@ import { ProductQuickView } from "../overlays/ProductQuickView";
 import type { SKU } from "@acme/types";
 import { ProductCard } from "./ProductCard";
 
+export type Product = SKU;
+
 export interface ProductCarouselProps
   extends React.HTMLAttributes<HTMLDivElement> {
   products: SKU[];


### PR DESCRIPTION
## Summary
- export `Product` type from `ProductCarousel` so tests can import it

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e35313970832fb40dda3a16b865a0