### PR TITLE
test: add jest-dom import to ProductCard test

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ProductCard } from "../ProductCard";
 import type { SKU } from "@acme/types";
+import "@testing-library/jest-dom";
 import "../../../../../../test/resetNextMocks";
 
 jest.mock("@platform-core/src/contexts/CurrencyContext", () => ({


### PR DESCRIPTION
## Summary
- include @testing-library/jest-dom in ProductCard test for matcher types

## Testing
- `pnpm --filter=@acme/ui test packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689e354137c4832f829445618763a609