### PR TITLE
chore(ui): exclude test directories from build

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/__snapshots__/MiniCart.test.tsx.snap
+++ b/packages/ui/src/components/organisms/__tests__/__snapshots__/MiniCart.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`MiniCart shows cart items and handles quantity changes and removal 1`] 
             <button
               aria-label="Decrease quantity"
               class="inline-flex items-center justify-center rounded-md text-sm font-medium text-fg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-fg hover:bg-primary/90 px-2 py-1 text-xs"
+              data-token="--color-primary"
             >
               -
             </button>
@@ -87,6 +88,7 @@ exports[`MiniCart shows cart items and handles quantity changes and removal 1`] 
             <button
               aria-label="Increase quantity"
               class="inline-flex items-center justify-center rounded-md text-sm font-medium text-fg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-fg hover:bg-primary/90 px-2 py-1 text-xs"
+              data-token="--color-primary"
             >
               +
             </button>

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -35,7 +35,7 @@
   "include": ["src/**/*"], // ONLY stuff inside src/
   "exclude": [
     "dist", // freshly emitted output
-    "__tests__", // unit/integration tests
+    "**/__tests__/**", // unit/integration tests
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
   ]


### PR DESCRIPTION
## Summary
- ensure UI package build ignores nested `__tests__` so Jest DOM matchers like `toBeInTheDocument` no longer cause type errors
- update MiniCart snapshot for new `data-token` attributes

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/MiniCart.test.tsx`
- `pnpm --filter @acme/ui exec tsc -p tsconfig.json --noEmit` *(fails: Output file '/workspace/base-shop/packages/types/dist/index.d.ts' has not been built from source file '/workspace/base-shop/packages/types/src/index.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689e3576263c832fbb576cc09a6376ab