### PR TITLE
fix Header test matcher typings

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/Header.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/Header.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Header } from "../Header";


### PR DESCRIPTION
## Summary
- add `@testing-library/jest-dom` import to `Header` test so custom matchers like `toBeInTheDocument` are recognized

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/Header.test.tsx --silent`
- `pnpm --filter @acme/ui exec tsc -p tsconfig.test.json --noEmit` *(fails: File '/workspace/base-shop/packages/platform-core/src/utils/replaceShopInPath.ts' is not listed within the file list of project '/workspace/base-shop/packages/ui/tsconfig.test.json'. Projects must list all files or use an 'include' pattern.)*

------
https://chatgpt.com/codex/tasks/task_e_689e3584a3a4832fb45269f730f33f7a