### PR TITLE
fix(ui): add jest-dom matcher import for QuantityInput tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/QuantityInput.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/QuantityInput.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { fireEvent, render } from "@testing-library/react";
 import { QuantityInput } from "../QuantityInput";
 
@@ -5,7 +6,7 @@ describe("QuantityInput", () => {
   it("disables decrement at minimum and increments", () => {
     const handleChange = jest.fn();
     const { getByText } = render(
-      <QuantityInput value={1} min={1} max={5} onChange={handleChange} />,
+      <QuantityInput value={1} min={1} max={5} onChange={handleChange} />
     );
     const dec = getByText("-");
     const inc = getByText("+");
@@ -24,7 +25,7 @@ describe("QuantityInput", () => {
   it("disables increment at maximum and decrements", () => {
     const handleChange = jest.fn();
     const { getByText } = render(
-      <QuantityInput value={5} min={1} max={5} onChange={handleChange} />,
+      <QuantityInput value={5} min={1} max={5} onChange={handleChange} />
     );
     const dec = getByText("-");
     const inc = getByText("+");
@@ -40,4 +41,3 @@ describe("QuantityInput", () => {
     expect(handleChange).toHaveBeenCalledWith(4);
   });
 });
-


### PR DESCRIPTION
## Summary
- include `@testing-library/jest-dom` import so `toBeDisabled` matcher is available in QuantityInput tests

## Testing
- `pnpm --filter @acme/ui test src/components/molecules/__tests__/QuantityInput.test.tsx`
- `pnpm --filter @acme/ui build` *(fails: File 'packages/shared-utils/src/fetchJson.ts' is not under 'rootDir')*


------
https://chatgpt.com/codex/tasks/task_e_689e35cff860832fa69d80472ad750dd