### PR TITLE
fix(test): enable jest-dom matchers in PriceCluster tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { PriceCluster } from "../PriceCluster";
 


### PR DESCRIPTION
## Summary
- add `@testing-library/jest-dom` import to PriceCluster tests

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx`
- `pnpm eslint packages/ui/src/components/molecules/__tests__/PriceCluster.test.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm tsc -p packages/ui/tsconfig.test.json` *(fails: multiple TS errors from other files)*

------
https://chatgpt.com/codex/tasks/task_e_689e35df0eb0832facfb1b1230457134