### PR TITLE
chore: include jest-dom types for ui tests

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -19,7 +19,7 @@
 
     /* ---------- misc ---------------------------------------------- */
     "allowImportingTsExtensions": false,
-    "types": ["react", "react-dom", "jest"]
+    "types": ["react", "react-dom", "jest", "@testing-library/jest-dom"]
   },
 
   /* ---------- project references (build order) -------------------- */


### PR DESCRIPTION
## Summary
- include `@testing-library/jest-dom` types in UI package tsconfig so jest matchers like `toHaveAttribute` compile

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/src/components/molecules/__tests__/SearchBar.test.tsx`
- `pnpm --filter @acme/ui build` *(fails: Output file '.../packages/types/dist/index.d.ts' has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_689e5292ce58832fabd12e22acd91ef1