### PR TITLE
chore: type rental order update data

### DIFF
--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -2,6 +2,7 @@
 import "server-only";
 
 import type { RentalOrder } from "@acme/types";
+import type { Prisma } from "@prisma/client";
 import { nowIso } from "@date-utils";
 import { prisma } from "../db";
 
@@ -25,7 +26,7 @@ async function updateStatus(
   try {
     const order = await prisma.rentalOrder.update({
       where: { shop_sessionId: { shop, sessionId } },
-      data: { status, ...extra } as any,
+      data: { status, ...extra } as Prisma.RentalOrderUpdateInput,
     });
     return order as Order;
   } catch {
@@ -67,7 +68,7 @@ export async function markLateFeeCharged(
   try {
     const order = await prisma.rentalOrder.update({
       where: { shop_sessionId: { shop, sessionId } },
-      data: { lateFeeCharged: amount } as any,
+      data: { lateFeeCharged: amount } as Prisma.RentalOrderUpdateInput,
     });
     return order as Order;
   } catch {


### PR DESCRIPTION
## Summary
- type rental order update data using `Prisma.RentalOrderUpdateInput`

## Testing
- `pnpm --filter @acme/platform-core test -- --runTestsByPath packages/platform-core/src/repositories/__tests__/inventory.server.test.ts` *(fails: exceeded timeout for inventory test)*

------
https://chatgpt.com/codex/tasks/task_e_689e522ed7fc832f96057ee3f383e84b