### PR TITLE
refactor: simplify wear count retrieval

### DIFF
--- a/packages/platform-machine/src/maintenanceScheduler.ts
+++ b/packages/platform-machine/src/maintenanceScheduler.ts
@@ -23,7 +23,7 @@ export async function runMaintenanceScan(
     for (const item of inventory) {
       const product = productMap.get(item.sku);
       if (!product) continue;
-      const wear = (item as any).wearCount ?? 0;
+      const wear = item.wearCount ?? 0;
       const limit = product.wearAndTearLimit ?? Infinity;
       const cycle = product.maintenanceCycle ?? Infinity;
       if (wear >= limit) {


### PR DESCRIPTION
## Summary
- use `item.wearCount ?? 0` directly instead of casting

## Testing
- `pnpm exec jest __tests__ --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs` *(fails: process.exit called with "1" in packages/config/src/env/payments.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689e522ce2f8832f9d7d03bbd1af7af1