### PR TITLE
refactor(fetchJson): treat parsed data as unknown

### DIFF
--- a/packages/shared-utils/src/fetchJson.ts
+++ b/packages/shared-utils/src/fetchJson.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 export async function fetchJson<T>(
   input: RequestInfo | URL,
   init?: RequestInit,
-  schema?: z.ZodType<T>,
+  schema?: z.ZodType<T>
 ): Promise<T> {
   const res = await fetch(input, init);
-  let data: any;
+  let data: unknown;
   try {
     const text = await res.text();
     data = text ? JSON.parse(text) : undefined;
@@ -14,8 +14,10 @@ export async function fetchJson<T>(
     data = undefined;
   }
   if (!res.ok) {
-    const message =
-      (data && data.error) || res.statusText || `HTTP ${res.status}`;
+    const error = z.object({ error: z.string() }).safeParse(data);
+    const message = error.success
+      ? error.data.error
+      : res.statusText || `HTTP ${res.status}`;
     throw new Error(message);
   }
   return schema ? schema.parse(data) : (data as T);


### PR DESCRIPTION
## Summary
- keep parsed JSON typed as `unknown`
- validate error payloads with zod before use

## Testing
- `pnpm exec eslint packages/shared-utils/src/fetchJson.ts` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm exec jest --runTestsByPath packages/shared-utils/src/fetchJson.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e52237db0832f9a51c0adf70348d2