### PR TITLE
fix jest-dom matchers typing in PaginationControl test

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/PaginationControl.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/PaginationControl.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="@testing-library/jest-dom" />
 import { render, fireEvent, screen } from "@testing-library/react";
 import { PaginationControl } from "../PaginationControl";
 


### PR DESCRIPTION
## Summary
- reference `@testing-library/jest-dom` types in `PaginationControl` test so `toBeDisabled` matcher compiles

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/molecules/__tests__/PaginationControl.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e3608368c832f93a66c67629e3ead