### PR TITLE
chore(ui): exclude test files from build

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -35,7 +35,8 @@
   "include": ["src/**/*"], // ONLY stuff inside src/
   "exclude": [
     "dist", // freshly emitted output
-    "__tests__", // unit/integration tests
+    "**/__tests__/**", // unit/integration tests
+    "**/*.test.*", // individual test files
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
   ]


### PR DESCRIPTION
## Summary
- exclude nested test files from UI package build

## Testing
- `pnpm --filter @acme/ui test src/components/molecules/__tests__/PaymentMethodSelector.test.tsx`
- `pnpm --filter @acme/ui build` *(fails: File '/workspace/base-shop/packages/shared-utils/src/fetchJson.ts' is not under 'rootDir')*

------
https://chatgpt.com/codex/tasks/task_e_689e35ec6a28832f989e688866d020f7