### PR TITLE
feat: add shared AnalyticsEvent type

### DIFF
--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -1,3 +1,5 @@
+import type { AnalyticsEvent } from "@acme/types";
+
 export type HookPayload = { campaign: string };
 
 export type HookHandler = (
@@ -33,7 +35,7 @@ export async function emitClick(shop: string, payload: HookPayload): Promise<voi
   await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
 }
 
-async function track(shop: string, data: any): Promise<void> {
+async function track(shop: string, data: AnalyticsEvent): Promise<void> {
   const { trackEvent } = await import("@platform-core/analytics");
   await trackEvent(shop, data);
 }

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -6,23 +6,9 @@ import { DATA_ROOT } from "./dataRoot";
 import { validateShopName } from "./shops";
 import { getShopSettings, readShop } from "./repositories/shops.server";
 import { coreEnv } from "@acme/config/env/core";
+import type { AnalyticsEvent } from "@acme/types";
 
-export type AnalyticsEvent =
-  | {
-      type: "discount_redeemed";
-      code: string;
-      email?: string;
-      segment?: string;
-      timestamp?: string;
-      [key: string]: unknown;
-    }
-  | {
-    type: string;
-    email?: string;
-    segment?: string;
-    timestamp?: string;
-    [key: string]: unknown;
-  };
+export type { AnalyticsEvent };
 
 export interface AnalyticsProvider {
   track(event: AnalyticsEvent): Promise<void> | void;

--- a/packages/types/src/AnalyticsEvent.ts
+++ b/packages/types/src/AnalyticsEvent.ts
@@ -1,0 +1,25 @@
+export type AnalyticsEvent =
+  | {
+      type: "email_sent" | "email_open" | "email_click";
+      campaign: string;
+      email?: string;
+      segment?: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: "discount_redeemed";
+      code: string;
+      email?: string;
+      segment?: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: string;
+      campaign?: string;
+      email?: string;
+      segment?: string;
+      timestamp?: string;
+      [key: string]: unknown;
+    };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,3 +22,4 @@ export * from "./upgrade";
 export * from "./ExampleProps";
 export * from "./Segment";
 export * from "./plugins";
+export * from "./AnalyticsEvent";


### PR DESCRIPTION
## Summary
- add shared `AnalyticsEvent` union in `@acme/types`
- type email tracking hooks with `AnalyticsEvent`
- import and re-export `AnalyticsEvent` from platform-core analytics

## Testing
- `pnpm --filter @acme/types test` *(no tests found)*
- `pnpm --filter @acme/email test` *(fails: Exceeded timeout of 5000 ms for a test)*
- `pnpm --filter @acme/platform-core test` *(fails: process.exit called with "1")*


------
https://chatgpt.com/codex/tasks/task_e_689e50f1fb2c832f8c502c9b4d1caaca