### PR TITLE
feat: type-safe component input handler

### DIFF
--- a/packages/ui/__tests__/ContentPanel.test.tsx
+++ b/packages/ui/__tests__/ContentPanel.test.tsx
@@ -17,7 +17,11 @@ test("updates min items", () => {
   const component: PageComponent = { id: "1", type: "ProductCarousel", minItems: 1, maxItems: 5 } as any;
   const onChange = jest.fn();
   render(
-    <ContentPanel component={component} onChange={onChange} handleInput={() => {}} />
+    <ContentPanel
+      component={component}
+      onChange={onChange}
+      handleInput={(() => {}) as any}
+    />
   );
   fireEvent.change(screen.getByLabelText("Min Items"), { target: { value: "2" } });
   expect(onChange).toHaveBeenCalledWith({ minItems: 2 });

--- a/packages/ui/__tests__/InteractionsPanel.test.tsx
+++ b/packages/ui/__tests__/InteractionsPanel.test.tsx
@@ -32,14 +32,13 @@ import type { PageComponent } from "@acme/types";
 
 function Wrapper({ component }: { component: PageComponent }) {
   const [comp, setComp] = useState(component);
-  return (
-    <InteractionsPanel
-      component={comp}
-      handleInput={(field, value) =>
-        setComp((prev) => ({ ...prev, [field]: value }))
-      }
-    />
-  );
+  const handleInput = <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K],
+  ) => {
+    setComp((prev) => ({ ...prev, [field]: value }));
+  };
+  return <InteractionsPanel component={comp} handleInput={handleInput} />;
 }
 
 test("updates interaction fields", () => {

--- a/packages/ui/__tests__/LayoutPanel.test.tsx
+++ b/packages/ui/__tests__/LayoutPanel.test.tsx
@@ -25,7 +25,7 @@ test("updates width via handleResize", () => {
   render(
     <LayoutPanel
       component={component}
-      handleInput={() => {}}
+      handleInput={(() => {}) as any}
       handleResize={handleResize}
       handleFullSize={() => {}}
     />

--- a/packages/ui/__tests__/componentHooks.test.tsx
+++ b/packages/ui/__tests__/componentHooks.test.tsx
@@ -4,8 +4,10 @@ import useComponentResize from "../src/components/cms/page-builder/useComponentR
 
 describe("component hooks", () => {
   it("useComponentInputs forwards field changes", () => {
-    const onChange = jest.fn();
-    const { result } = renderHook(() => useComponentInputs(onChange));
+    const onChange = jest.fn<(patch: Partial<Record<string, string>>) => void>();
+    const { result } = renderHook(() =>
+      useComponentInputs<Record<string, string>>(onChange),
+    );
     act(() => result.current.handleInput("foo", "bar"));
     expect(onChange).toHaveBeenCalledWith({ foo: "bar" });
   });

--- a/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
@@ -10,7 +10,10 @@ import editorRegistry from "../editorRegistry";
 interface Props {
   component: PageComponent;
   onChange: (patch: Partial<PageComponent>) => void;
-  handleInput: (field: string, value: any) => void;
+  handleInput: <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K],
+  ) => void;
 }
 
 export default function ContentPanel({

--- a/packages/ui/src/components/cms/page-builder/panels/InteractionsPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/InteractionsPanel.tsx
@@ -13,7 +13,10 @@ import {
 
 interface Props {
   component: PageComponent;
-  handleInput: (field: string, value: any) => void;
+  handleInput: <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K],
+  ) => void;
 }
 
 export default function InteractionsPanel({

--- a/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
@@ -15,7 +15,10 @@ import { Tooltip } from "../../../atoms";
 
 interface Props {
   component: PageComponent;
-  handleInput: (field: string, value: any) => void;
+  handleInput: <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K],
+  ) => void;
   handleResize: (field: string, value: string) => void;
   handleFullSize: (field: string) => void;
 }

--- a/packages/ui/src/components/cms/page-builder/useComponentInputs.ts
+++ b/packages/ui/src/components/cms/page-builder/useComponentInputs.ts
@@ -2,9 +2,11 @@ import { useCallback } from "react";
 
 export default function useComponentInputs<T>(
   onChange: (patch: Partial<T>) => void,
-) {
+): {
+  handleInput: <K extends keyof T>(field: K, value: T[K]) => void;
+} {
   const handleInput = useCallback(
-    (field: keyof T & string, value: any) => {
+    <K extends keyof T>(field: K, value: T[K]) => {
       onChange({ [field]: value } as Partial<T>);
     },
     [onChange],


### PR DESCRIPTION
## Summary
- add generic type parameters to handleInput for stronger type inference
- update CMS page builder panels and related tests to use typed handler

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/componentHooks.test.tsx packages/ui/__tests__/InteractionsPanel.test.tsx packages/ui/__tests__/ContentPanel.test.tsx packages/ui/__tests__/LayoutPanel.test.tsx` *(fails: LayoutPanel and ContentPanel DOM errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e52255c4c832f86909ba56f9fe3e2