### PR TITLE
refactor: share form builder field types

### DIFF
--- a/packages/types/src/page/forms.ts
+++ b/packages/types/src/page/forms.ts
@@ -1,0 +1,12 @@
+export interface FormFieldOption {
+  label: string;
+  value: string;
+}
+
+export interface FormField {
+  type: "text" | "email" | "select";
+  name?: string;
+  label?: string;
+  options?: FormFieldOption[];
+}
+

--- a/packages/types/src/page/index.ts
+++ b/packages/types/src/page/index.ts
@@ -4,3 +4,4 @@ export * from "./molecules";
 export * from "./organisms";
 export * from "./layouts";
 export * from "./page";
+export * from "./forms";

--- a/packages/ui/src/components/cms/blocks/FormBuilderBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FormBuilderBlock.tsx
@@ -1,21 +1,11 @@
 "use client";
 
-interface FieldOption {
-  label: string;
-  value: string;
-}
-
-interface FieldConfig {
-  type: "text" | "email" | "select";
-  name: string;
-  label?: string;
-  options?: FieldOption[];
-}
+import type { FormField } from "@acme/types";
 
 interface Props {
   action?: string;
   method?: string;
-  fields?: FieldConfig[];
+  fields?: FormField[];
   submitLabel?: string;
 }
 

--- a/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
@@ -1,4 +1,4 @@
-import type { PageComponent } from "@acme/types";
+import type { FormField, FormFieldOption, PageComponent } from "@acme/types";
 import {
   Button,
   Input,
@@ -8,13 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../atoms/shadcn";
-
-type FormField = {
-  type: string;
-  name?: string;
-  label?: string;
-  options?: { label: string; value: string }[];
-};
 
 type FormBuilderComponent = PageComponent & {
   type: "FormBuilderBlock";
@@ -29,7 +22,11 @@ interface Props {
 export default function FormBuilderEditor({ component, onChange }: Props) {
   const fields = component.fields ?? [];
 
-  const updateField = (idx: number, key: keyof FormField, value: any) => {
+  const updateField = <K extends keyof FormField>(
+    idx: number,
+    key: K,
+    value: FormField[K]
+  ) => {
     const next = [...fields];
     next[idx] = { ...next[idx], [key]: value };
     onChange({ fields: next });
@@ -75,7 +72,9 @@ export default function FormBuilderEditor({ component, onChange }: Props) {
           />
           {field.type === "select" && (
             <Input
-              value={(field.options ?? []).map((o: any) => o.label).join(",")}
+              value={(field.options ?? [])
+                .map((o: FormFieldOption) => o.label)
+                .join(",")}
               onChange={(e) =>
                 updateField(
                   idx,


### PR DESCRIPTION
## Summary
- move reusable `FormField` and `FormFieldOption` types to shared `@acme/types`
- update form builder editor to use shared types and stronger generics
- refactor form builder block to consume shared field type

## Testing
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*
- `pnpm --filter @acme/types test`

------
https://chatgpt.com/codex/tasks/task_e_689e52267090832f8736da9d8ce2f695