### PR TITLE
refactor: type-safe page builder panels

### DIFF
--- a/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/ContentPanel.tsx
@@ -10,7 +10,10 @@ import editorRegistry from "../editorRegistry";
 interface Props {
   component: PageComponent;
   onChange: (patch: Partial<PageComponent>) => void;
-  handleInput: (field: string, value: any) => void;
+  handleInput: <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K]
+  ) => void;
 }
 
 export default function ContentPanel({
@@ -19,37 +22,32 @@ export default function ContentPanel({
   handleInput,
 }: Props) {
   const Specific = editorRegistry[component.type];
-  const comp = component as PageComponent & {
-    minItems?: number;
-    maxItems?: number;
-    desktopItems?: number;
-    tabletItems?: number;
-    mobileItems?: number;
-    columns?: number;
-  };
-  const nonNegative = (v?: number) => (v !== undefined && v < 0 ? "Must be ≥ 0" : undefined);
+  const nonNegative = (v?: number) =>
+    v !== undefined && v < 0 ? "Must be ≥ 0" : undefined;
   const minItemsError =
-    nonNegative(comp.minItems) ||
-    (comp.minItems !== undefined &&
-    comp.maxItems !== undefined &&
-    comp.minItems > comp.maxItems
+    nonNegative(component.minItems) ||
+    (component.minItems !== undefined &&
+    component.maxItems !== undefined &&
+    component.minItems > component.maxItems
       ? "Min Items cannot exceed Max Items"
       : undefined);
   const maxItemsError =
-    nonNegative(comp.maxItems) ||
-    (comp.minItems !== undefined &&
-    comp.maxItems !== undefined &&
-    comp.maxItems < comp.minItems
+    nonNegative(component.maxItems) ||
+    (component.minItems !== undefined &&
+    component.maxItems !== undefined &&
+    component.maxItems < component.minItems
       ? "Max Items cannot be less than Min Items"
       : undefined);
-  const desktopItemsError = nonNegative(comp.desktopItems);
-  const tabletItemsError = nonNegative(comp.tabletItems);
-  const mobileItemsError = nonNegative(comp.mobileItems);
+  const desktopItemsError = nonNegative(component.desktopItems);
+  const tabletItemsError = nonNegative(component.tabletItems);
+  const mobileItemsError = nonNegative(component.mobileItems);
   const columnsError =
-    nonNegative(comp.columns) ||
-    (comp.columns !== undefined &&
-    ((comp.minItems !== undefined && comp.columns < comp.minItems) ||
-      (comp.maxItems !== undefined && comp.columns > comp.maxItems))
+    nonNegative(component.columns) ||
+    (component.columns !== undefined &&
+    ((component.minItems !== undefined &&
+      component.columns < component.minItems) ||
+      (component.maxItems !== undefined &&
+        component.columns > component.maxItems))
       ? "Columns must be between min and max items"
       : undefined);
   return (
@@ -64,7 +62,7 @@ export default function ContentPanel({
               </span>
             }
             type="number"
-            value={comp.minItems ?? ""}
+            value={component.minItems ?? ""}
             onChange={(e) => {
               const val =
                 e.target.value === "" ? undefined : Number(e.target.value);
@@ -72,7 +70,7 @@ export default function ContentPanel({
                 handleInput("minItems", undefined);
                 return;
               }
-              const max = comp.maxItems;
+              const max = component.maxItems;
               const patch: Partial<PageComponent> = { minItems: val };
               if (max !== undefined && val > max) {
                 patch.maxItems = val;
@@ -80,7 +78,7 @@ export default function ContentPanel({
               onChange(patch);
             }}
             min={0}
-            max={comp.maxItems ?? undefined}
+            max={component.maxItems ?? undefined}
             error={minItemsError}
           />
           <Input
@@ -91,7 +89,7 @@ export default function ContentPanel({
               </span>
             }
             type="number"
-            value={comp.maxItems ?? ""}
+            value={component.maxItems ?? ""}
             onChange={(e) => {
               const val =
                 e.target.value === "" ? undefined : Number(e.target.value);
@@ -99,14 +97,14 @@ export default function ContentPanel({
                 handleInput("maxItems", undefined);
                 return;
               }
-              const min = comp.minItems;
+              const min = component.minItems;
               const patch: Partial<PageComponent> = { maxItems: val };
               if (min !== undefined && val < min) {
                 patch.minItems = val;
               }
               onChange(patch);
             }}
-            min={comp.minItems ?? 0}
+            min={component.minItems ?? 0}
             error={maxItemsError}
           />
         </>
@@ -123,7 +121,7 @@ export default function ContentPanel({
               </span>
             }
             type="number"
-            value={comp.desktopItems ?? ""}
+            value={component.desktopItems ?? ""}
             onChange={(e) =>
               handleInput(
                 "desktopItems",
@@ -141,7 +139,7 @@ export default function ContentPanel({
               </span>
             }
             type="number"
-            value={comp.tabletItems ?? ""}
+            value={component.tabletItems ?? ""}
             onChange={(e) =>
               handleInput(
                 "tabletItems",
@@ -159,7 +157,7 @@ export default function ContentPanel({
               </span>
             }
             type="number"
-            value={comp.mobileItems ?? ""}
+            value={component.mobileItems ?? ""}
             onChange={(e) =>
               handleInput(
                 "mobileItems",
@@ -180,15 +178,15 @@ export default function ContentPanel({
             </span>
           }
           type="number"
-          value={comp.columns ?? ""}
+          value={component.columns ?? ""}
           onChange={(e) =>
             handleInput(
               "columns",
               e.target.value === "" ? undefined : Number(e.target.value)
             )
           }
-          min={comp.minItems}
-          max={comp.maxItems}
+          min={component.minItems}
+          max={component.maxItems}
           error={columnsError}
         />
       )}
@@ -202,4 +200,3 @@ export default function ContentPanel({
     </div>
   );
 }
-

--- a/packages/ui/src/components/cms/page-builder/panels/InteractionsPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/InteractionsPanel.tsx
@@ -13,15 +13,15 @@ import {
 
 interface Props {
   component: PageComponent;
-  handleInput: (field: string, value: any) => void;
+  handleInput: <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K]
+  ) => void;
 }
 
-export default function InteractionsPanel({
-  component,
-  handleInput,
-}: Props) {
-  const clickAction = (component as any).clickAction ?? "none";
-  const animation = (component as any).animation ?? "none";
+export default function InteractionsPanel({ component, handleInput }: Props) {
+  const clickAction = component.clickAction ?? "none";
+  const animation = component.animation ?? "none";
   return (
     <div className="space-y-2">
       <Select
@@ -43,7 +43,7 @@ export default function InteractionsPanel({
         <Input
           label="Target"
           placeholder="https://example.com"
-          value={(component as any).href ?? ""}
+          value={component.href ?? ""}
           onChange={(e) => handleInput("href", e.target.value)}
         />
       )}
@@ -65,4 +65,3 @@ export default function InteractionsPanel({
     </div>
   );
 }
-

--- a/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/LayoutPanel.tsx
@@ -15,7 +15,10 @@ import { Tooltip } from "../../../atoms";
 
 interface Props {
   component: PageComponent;
-  handleInput: (field: string, value: any) => void;
+  handleInput: <K extends keyof PageComponent>(
+    field: K,
+    value: PageComponent[K]
+  ) => void;
   handleResize: (field: string, value: string) => void;
   handleFullSize: (field: string) => void;
 }
@@ -30,9 +33,30 @@ export default function LayoutPanel({
     value && !globalThis.CSS?.supports(prop, value)
       ? `Invalid ${prop} value`
       : undefined;
+  const viewports = ["Desktop", "Tablet", "Mobile"] as const;
+  const widthKeys = {
+    Desktop: "widthDesktop",
+    Tablet: "widthTablet",
+    Mobile: "widthMobile",
+  } as const;
+  const heightKeys = {
+    Desktop: "heightDesktop",
+    Tablet: "heightTablet",
+    Mobile: "heightMobile",
+  } as const;
+  const marginKeys = {
+    Desktop: "marginDesktop",
+    Tablet: "marginTablet",
+    Mobile: "marginMobile",
+  } as const;
+  const paddingKeys = {
+    Desktop: "paddingDesktop",
+    Tablet: "paddingTablet",
+    Mobile: "paddingMobile",
+  } as const;
   return (
     <div className="space-y-2">
-      {(["Desktop", "Tablet", "Mobile"] as const).map((vp) => (
+      {viewports.map((vp) => (
         <div key={vp} className="space-y-2">
           <div className="flex items-end gap-2">
             <Input
@@ -43,19 +67,14 @@ export default function LayoutPanel({
                 </span>
               }
               placeholder="e.g. 100px or 50%"
-              value={
-                (component[`width${vp}` as keyof PageComponent] as string) ?? ""
-              }
-              error={cssError(
-                "width",
-                component[`width${vp}` as keyof PageComponent] as string
-              )}
-              onChange={(e) => handleResize(`width${vp}`, e.target.value)}
+              value={component[widthKeys[vp]] ?? ""}
+              error={cssError("width", component[widthKeys[vp]])}
+              onChange={(e) => handleResize(widthKeys[vp], e.target.value)}
             />
             <Button
               type="button"
               variant="outline"
-              onClick={() => handleFullSize(`width${vp}`)}
+              onClick={() => handleFullSize(widthKeys[vp])}
             >
               Full width
             </Button>
@@ -69,20 +88,14 @@ export default function LayoutPanel({
                 </span>
               }
               placeholder="e.g. 1px or 1rem"
-              value={
-                (component[`height${vp}` as keyof PageComponent] as string) ??
-                ""
-              }
-              error={cssError(
-                "height",
-                component[`height${vp}` as keyof PageComponent] as string
-              )}
-              onChange={(e) => handleResize(`height${vp}`, e.target.value)}
+              value={component[heightKeys[vp]] ?? ""}
+              error={cssError("height", component[heightKeys[vp]])}
+              onChange={(e) => handleResize(heightKeys[vp], e.target.value)}
             />
             <Button
               type="button"
               variant="outline"
-              onClick={() => handleFullSize(`height${vp}`)}
+              onClick={() => handleFullSize(heightKeys[vp])}
             >
               Full height
             </Button>
@@ -131,7 +144,7 @@ export default function LayoutPanel({
           />
         </>
       )}
-      {(["Desktop", "Tablet", "Mobile"] as const).map((vp) => (
+      {viewports.map((vp) => (
         <div key={`spacing-${vp}`} className="space-y-2">
           <Input
             label={
@@ -141,15 +154,9 @@ export default function LayoutPanel({
               </span>
             }
             placeholder="e.g. 1rem"
-            value={
-              (component[`margin${vp}` as keyof PageComponent] as string) ??
-              ""
-            }
-            error={cssError(
-              "margin",
-              component[`margin${vp}` as keyof PageComponent] as string
-            )}
-            onChange={(e) => handleResize(`margin${vp}`, e.target.value)}
+            value={component[marginKeys[vp]] ?? ""}
+            error={cssError("margin", component[marginKeys[vp]])}
+            onChange={(e) => handleResize(marginKeys[vp], e.target.value)}
           />
           <Input
             label={
@@ -159,15 +166,9 @@ export default function LayoutPanel({
               </span>
             }
             placeholder="e.g. 1rem"
-            value={
-              (component[`padding${vp}` as keyof PageComponent] as string) ??
-              ""
-            }
-            error={cssError(
-              "padding",
-              component[`padding${vp}` as keyof PageComponent] as string
-            )}
-            onChange={(e) => handleResize(`padding${vp}`, e.target.value)}
+            value={component[paddingKeys[vp]] ?? ""}
+            error={cssError("padding", component[paddingKeys[vp]])}
+            onChange={(e) => handleResize(paddingKeys[vp], e.target.value)}
           />
         </div>
       ))}
@@ -204,12 +205,11 @@ export default function LayoutPanel({
             </span>
           }
           placeholder="e.g. 1rem"
-          value={(component as { gap?: string }).gap ?? ""}
-          error={cssError("gap", (component as { gap?: string }).gap)}
+          value={component.gap ?? ""}
+          error={cssError("gap", component.gap)}
           onChange={(e) => handleInput("gap", e.target.value)}
         />
       )}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- use generic handleInput for PageComponent fields
- read component properties directly without casts

## Testing
- `pnpm --filter @acme/ui test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e522792ac832f8e8a106b64262da8