### PR TITLE
fix: handle web stream types

### DIFF
--- a/packages/shared-utils/src/parseJsonBody.ts
+++ b/packages/shared-utils/src/parseJsonBody.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import getRawBody from "raw-body";
 import { Readable } from "node:stream";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 
 export type ParseJsonResult<T> =
   | { success: true; data: T }
@@ -16,7 +17,7 @@ function hasErrorType(err: unknown): err is { type: string } {
 }
 
 export async function parseJsonBody<T>(
-  req: Request & { body: ReadableStream<Uint8Array> | null },
+  req: Request & { body: NodeReadableStream<Uint8Array> | null },
   schema: z.ZodSchema<T>,
   limit: string | number,
 ): Promise<ParseJsonResult<T>> {


### PR DESCRIPTION
## Summary
- ensure parseJsonBody accepts Node ReadableStream from web streams

## Testing
- `pnpm tsc -p packages/shared-utils/tsconfig.json`
- `pnpm --filter @acme/shared-utils test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689ee3f611dc832f9d9f6dccd29334f0