### PR TITLE
chore(cms): reference shared utils package

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../../packages/config" },
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
-    { "path": "../../packages/themes/base" }
+    { "path": "../../packages/themes/base" },
+    { "path": "../../packages/shared-utils" }
   ]
 }


### PR DESCRIPTION
## Summary
- fix CMS tsconfig to include shared-utils package in project references

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: steps.ts syntax errors)*
- `pnpm --filter @apps/cms test` *(fails: jest unable to find Save button and inventory import/export failing)*

------
https://chatgpt.com/codex/tasks/task_e_689ee4bf0c34832f88a44e93247c91db