### PR TITLE
fix: enable bundler module resolution for email package

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- use `moduleResolution: bundler` in email package tsconfig so subpath imports like `@acme/config/env/core` resolve

## Testing
- `pnpm --filter @acme/email exec tsc -p tsconfig.json --noEmit` *(fails: TypeScript errors in packages/types)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendInit.test.ts` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_689eed0ab514832fa76a25b9036fef7b