### PR TITLE
fix(cms): include email package in project refs

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
     { "path": "../../packages/themes/base" },
+    { "path": "../../packages/email" },
     { "path": "../../packages/shared-utils" }
   ]
 }


### PR DESCRIPTION
## Summary
- include `packages/email` in CMS tsconfig references so its sources are built

## Testing
- `pnpm tsc -p apps/cms/tsconfig.json` *(fails: ',' expected at apps/cms/src/app/cms/configurator/steps.ts)*
- `pnpm --filter @acme/email test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689eed229554832f9c7d99c1eca4cc3c