### PR TITLE
fix config env exports

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./env/index.ts",
-    "./env": "./env/index.ts",
-    "./env/core": "./env/core.ts",
-    "./env/payments": "./env/payments.ts",
-    "./env/shipping": "./env/shipping.ts",
+    ".": "./src/env/index.ts",
+    "./env": "./src/env/index.ts",
+    "./env/core": "./src/env/core.ts",
+    "./env/payments": "./src/env/payments.ts",
+    "./env/shipping": "./src/env/shipping.ts",
     "./tsconfig.app.json": "./tsconfig.app.json",
     "./jest.preset.cjs": "./jest.preset.cjs"
   }

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- point `@acme/config` package exports to actual env source files
- use bundler module resolution in email package tsconfig

## Testing
- `pnpm exec tsc -p packages/email/tsconfig.json --noEmit` *(fails: TS errors in unrelated packages)*
- `pnpm test --filter @acme/email` *(fails: tests in dependent packages fail)*

------
https://chatgpt.com/codex/tasks/task_e_689eed2d53dc832fb3fb9c88f00e29ed