### PR TITLE
fix: include email package in cms tsconfig and use bundler resolution

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
     { "path": "../../packages/themes/base" },
-    { "path": "../../packages/shared-utils" }
+    { "path": "../../packages/shared-utils" },
+    { "path": "../../packages/email" }
   ]
 }

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- include email package in CMS TypeScript references to avoid rootDir errors
- use bundler module resolution in email package

## Testing
- `npx tsc -p packages/email/tsconfig.json --noEmit` *(fails: Cannot find name 'expect' and rootDir errors)*
- `pnpm --filter @acme/email run test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_689eed4311e0832fae3a4a639dbb2f5e