### PR TITLE
fix(tsconfig): include email package in CMS references

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../../packages/auth" },
     { "path": "../../packages/types" },
     { "path": "../../packages/config" },
+    { "path": "../../packages/email" },
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
     { "path": "../../packages/themes/base" },


### PR DESCRIPTION
## Summary
- reference `packages/email` in `apps/cms/tsconfig.json`

## Testing
- `npx tsc -p apps/cms/tsconfig.json --noEmit --pretty false` *(fails: apps/cms/src/app/cms/configurator/steps.ts: error TS1005: ',' expected)*

------
https://chatgpt.com/codex/tasks/task_e_689eed55c2b0832fafba198bbe336a0a