### PR TITLE
fix: inherit module resolution for email

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -8,7 +8,6 @@
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node"],
-    "moduleResolution": "node",
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- rely on base tsconfig module resolution for the email package

## Testing
- `pnpm exec tsc -p packages/email/tsconfig.json --noEmit` *(fails: TypeScript found 491 errors across unrelated packages)*
- `pnpm exec jest packages/email/src/__tests__/sendInit.test.ts --config jest.config.cjs --runInBand --detectOpenHandles --ci` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_689eee3963c8832f9bdf6522e3580fd9