### PR TITLE
fix: adapt CMS theme sync to new core API

### DIFF
--- a/apps/cms/__tests__/resetThemeOverride.test.ts
+++ b/apps/cms/__tests__/resetThemeOverride.test.ts
@@ -9,9 +9,12 @@ jest.mock("@platform-core/src/repositories/shop.server", () => ({
   getShopById: (...args: any[]) => getShopById(...args),
   updateShopInRepo: (...args: any[]) => updateShopInRepo(...args),
 }));
-jest.mock("@platform-core/src/createShop", () => ({
+jest.mock("@platform-core/createShop", () => ({
   syncTheme: jest.fn(),
-  loadTokens: jest.fn(),
+}));
+jest.mock("@platform-core/themeTokens", () => ({
+  baseTokens: {},
+  loadThemeTokens: jest.fn(),
 }));
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 

--- a/apps/cms/__tests__/shops.test.ts
+++ b/apps/cms/__tests__/shops.test.ts
@@ -60,9 +60,10 @@ describe("shop actions", () => {
       }));
 
       jest.doMock("@acme/config", () => ({ env: { NEXTAUTH_SECRET: "secret" } }));
-      jest.doMock("@platform-core/src/createShop", () => ({
-        syncTheme: jest.fn(),
-        loadTokens: jest.fn().mockReturnValue({}),
+      jest.doMock("@platform-core/createShop", () => ({ syncTheme: jest.fn() }));
+      jest.doMock("@platform-core/themeTokens", () => ({
+        baseTokens: {},
+        loadThemeTokens: jest.fn().mockResolvedValue({}),
       }));
 
       /* ----------------------------------------------------------------
@@ -133,11 +134,10 @@ describe("shop actions", () => {
         accent: "blue",
         "accent-dark": "navy",
       };
-      jest.doMock("@platform-core/src/createShop", () => ({
-        syncTheme: jest.fn(),
-        loadTokens: jest.fn().mockReturnValue(defaultTokens),
+      jest.doMock("@platform-core/createShop", () => ({
+        syncTheme: jest.fn().mockResolvedValue(defaultTokens),
       }));
-      jest.doMock("@platform-core/src/themeTokens", () => ({
+      jest.doMock("@platform-core/themeTokens", () => ({
         baseTokens: {},
         loadThemeTokens: jest.fn().mockResolvedValue(defaultTokens),
       }));

--- a/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
@@ -1,5 +1,6 @@
 // apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
-import { listThemes, loadTokens } from "@platform-core/src/createShop";
+import { listThemes } from "@platform-core/createShop";
+import { baseTokens, loadThemeTokens } from "@platform-core/themeTokens";
 import { readShop } from "@platform-core/src/repositories/shops.server";
 import {
   getThemePresets,
@@ -33,7 +34,11 @@ export default async function ShopThemePage({
   const presets = await getThemePresets(shop);
   const themes = [...builtInThemes, ...Object.keys(presets)];
   const tokensByTheme = {
-    ...Object.fromEntries(builtInThemes.map((t) => [t, loadTokens(t)])),
+    ...Object.fromEntries(
+      await Promise.all(
+        builtInThemes.map(async (t) => [t, { ...baseTokens, ...(await loadThemeTokens(t)) }])
+      )
+    ),
     ...presets,
   } as Record<string, Record<string, string>>;
 

--- a/apps/cms/src/services/shops/__tests__/theme.test.ts
+++ b/apps/cms/src/services/shops/__tests__/theme.test.ts
@@ -1,8 +1,11 @@
 import { buildThemeData, removeThemeToken, mergeThemePatch } from "../theme";
 
-jest.mock("@platform-core/src/createShop", () => ({
+jest.mock("@platform-core/createShop", () => ({
   syncTheme: jest.fn().mockResolvedValue({ a: "1" }),
-  loadTokens: jest.fn().mockResolvedValue({ a: "0" }),
+}));
+jest.mock("@platform-core/themeTokens", () => ({
+  baseTokens: {},
+  loadThemeTokens: jest.fn().mockResolvedValue({ a: "0" }),
 }));
 
 describe("theme service", () => {

--- a/apps/cms/src/services/shops/theme.ts
+++ b/apps/cms/src/services/shops/theme.ts
@@ -1,4 +1,5 @@
-import { syncTheme, loadTokens } from "@platform-core/src/createShop";
+import { syncTheme } from "@platform-core/createShop";
+import { baseTokens, loadThemeTokens } from "@platform-core/themeTokens";
 import type { Shop } from "@acme/types";
 import type { ShopForm } from "./validation";
 
@@ -17,7 +18,7 @@ export async function buildThemeData(
     themeDefaults =
       current.themeId !== form.themeId
         ? await syncTheme(shop, form.themeId)
-        : await loadTokens(form.themeId);
+        : { ...baseTokens, ...(await loadThemeTokens(form.themeId)) };
   }
   const themeTokens = { ...themeDefaults, ...overrides };
   return { themeDefaults, overrides, themeTokens };


### PR DESCRIPTION
## Summary
- refactor CMS theme service to use `syncTheme` and `loadThemeTokens`
- load theme tokens asynchronously on theme settings page
- update tests for new theme token API

## Testing
- `pnpm test:cms apps/cms/src/services/shops/__tests__/theme.test.ts apps/cms/__tests__/resetThemeOverride.test.ts apps/cms/__tests__/shops.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689eee735d00832f80eec5eb76e84479