### PR TITLE
refactor: move generate meta util to shared lib

### DIFF
--- a/apps/cms/src/app/api/seo/generate/route.ts
+++ b/apps/cms/src/app/api/seo/generate/route.ts
@@ -19,9 +19,7 @@ export async function POST(req: NextRequest) {
 
   const shop = validateShopName(body.shop);
 
-  const { generateMeta } = await import(
-    /* @vite-ignore */ "../../../../../../../scripts/generate-meta.ts"
-  );
+  const { generateMeta } = await import("@acme/lib/generateMeta");
 
   const result = await generateMeta({
     id: body.id,

--- a/apps/cms/src/services/shops/seoService.ts
+++ b/apps/cms/src/services/shops/seoService.ts
@@ -57,9 +57,7 @@ export async function generateSeo(
   }
 
   const { id, locale, title, description } = data;
-  const { generateMeta } = await import(
-    /* @vite-ignore */ "../../../../../scripts/generate-meta.ts"
-  );
+  const { generateMeta } = await import("@acme/lib/generateMeta");
 
   const result = await generateMeta({ id, title, description });
   const current = await fetchSettings(shop);

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../../packages/ui" },
     { "path": "../../packages/themes/base" },
     { "path": "../../packages/email" },
-    { "path": "../../packages/shared-utils" }
+    { "path": "../../packages/shared-utils" },
+    { "path": "../../packages/lib" }
   ]
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -8,7 +8,8 @@
     "./validateShopName": "./src/validateShopName.ts",
     "./checkShopExists.server": "./src/checkShopExists.server.ts",
     "./zodErrorMap": "./src/zodErrorMap.ts",
-    "./initZod": "./src/initZod.ts"
+    "./initZod": "./src/initZod.ts",
+    "./generateMeta": "./src/generateMeta.ts"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/lib/src/generateMeta.ts
+++ b/packages/lib/src/generateMeta.ts
@@ -1,0 +1,69 @@
+import OpenAI from "openai";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { env } from "@config";
+
+export interface ProductData {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface GeneratedMeta {
+  title: string;
+  description: string;
+  alt: string;
+  image: string;
+}
+
+/**
+ * Generate metadata for a product using an LLM and image model.
+ * Requires OPENAI_API_KEY to be set. Generated images are written to
+ * `public/og/<id>.png` and the returned `image` field is the public path.
+ */
+export async function generateMeta(product: ProductData): Promise<GeneratedMeta> {
+  const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+
+  const prompt = `Generate SEO metadata for a product as JSON with keys title, description, alt.\n\nTitle: ${product.title}\nDescription: ${product.description}`;
+
+  const text = await client.responses.create({
+    model: "gpt-4o-mini",
+    input: prompt,
+  });
+
+  let data: { title: string; description: string; alt: string } = {
+    title: product.title,
+    description: product.description,
+    alt: product.title,
+  };
+  try {
+    const first = text.output?.[0];
+    if (first && "content" in first) {
+      const output = first.content?.[0];
+      const content = typeof output === "string" ? output : (output as any)?.text;
+      if (content) {
+        data = JSON.parse(content);
+      }
+    }
+  } catch {
+    // fall back to defaults
+  }
+
+  const img = await client.images.generate({
+    model: "gpt-image-1",
+    prompt: `Generate a 1200x630 social media share image for ${product.title}`,
+    size: "1024x1024",
+  });
+  const b64 = img.data?.[0]?.b64_json ?? "";
+  const buffer = Buffer.from(b64, "base64");
+  const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, buffer);
+
+  return {
+    title: data.title,
+    description: data.description,
+    alt: data.alt,
+    image: `/og/${product.id}.png`,
+  };
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,5 @@
 export { SHOP_NAME_RE, validateShopName } from "./validateShopName";
 export { checkShopExists } from "./checkShopExists.server";
 export { applyFriendlyZodMessages, friendlyErrorMap } from "./zodErrorMap";
+export { generateMeta } from "./generateMeta";
+export type { ProductData, GeneratedMeta } from "./generateMeta";

--- a/scripts/generate-meta.ts
+++ b/scripts/generate-meta.ts
@@ -1,73 +1,5 @@
-import OpenAI from "openai";
 import { promises as fs } from "node:fs";
-import path from "node:path";
-import { env } from "@config";
-
-export interface ProductData {
-  id: string;
-  title: string;
-  description: string;
-}
-
-export interface GeneratedMeta {
-  title: string;
-  description: string;
-  alt: string;
-  image: string;
-}
-
-/**
- * Generate metadata for a product using an LLM and image model.
- * Requires OPENAI_API_KEY to be set. Generated images are written to
- * `public/og/<id>.png` and the returned `image` field is the public path.
- */
-export async function generateMeta(product: ProductData): Promise<GeneratedMeta> {
-  const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
-
-  const prompt = `Generate SEO metadata for a product as JSON with keys title, description, alt.\n\nTitle: ${product.title}\nDescription: ${product.description}`;
-
-  const text = await client.responses.create({
-    model: "gpt-4o-mini",
-    input: prompt,
-  });
-
-  let data: { title: string; description: string; alt: string } = {
-    title: product.title,
-    description: product.description,
-    alt: product.title,
-  };
-  try {
-    const first = text.output?.[0];
-    if (first && "content" in first) {
-      const output = first.content?.[0];
-      const content =
-        typeof output === "string" ? output : (output as any)?.text;
-      if (content) {
-        data = JSON.parse(content);
-      }
-    }
-  } catch {
-    // fall back to defaults
-  }
-
-  const img = await client.images.generate({
-    model: "gpt-image-1",
-    prompt: `Generate a 1200x630 social media share image for ${product.title}`,
-    size: "1024x1024",
-  });
-  const b64 = img.data?.[0]?.b64_json ?? "";
-  const buffer = Buffer.from(b64, "base64");
-  const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await fs.writeFile(file, buffer);
-
-  return {
-    title: data.title,
-    description: data.description,
-    alt: data.alt,
-    image: `/og/${product.id}.png`,
-  };
-}
+import { generateMeta, type ProductData } from "@acme/lib/generateMeta";
 
 // CLI usage: tsx scripts/generate-meta.ts path/to/product.json
 if (process.argv[1] && process.argv[1].endsWith("generate-meta.ts")) {
@@ -84,4 +16,3 @@ if (process.argv[1] && process.argv[1].endsWith("generate-meta.ts")) {
     console.log(JSON.stringify(result, null, 2));
   })();
 }
-


### PR DESCRIPTION
## Summary
- move generateMeta implementation to `@acme/lib`
- update SEO service and route to import shared util
- streamline CLI script to call shared generateMeta

## Testing
- `pnpm eslint apps/cms/src/services/shops/seoService.ts apps/cms/src/app/api/seo/generate/route.ts packages/lib/src/generateMeta.ts scripts/generate-meta.ts`
- `pnpm test:cms` *(fails: duplicate manual mocks and failing tests)*
- `pnpm typecheck` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f59103a24832f992bd0a0f94cfffa