### PR TITLE
fix: use bundler module resolution

### DIFF
--- a/packages/config/tsconfig.app.json
+++ b/packages/config/tsconfig.app.json
@@ -19,7 +19,7 @@
     "target": "ES2017",
     "strict": false,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "types": ["node", "react", "react-dom"],
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- use bundler module resolution for shared config package

## Testing
- `pnpm --filter @apps/cms exec tsc -p tsconfig.json --noEmit` (fails: Output file ... has not been built)
- `pnpm --filter @apps/cms test` (fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)


------
https://chatgpt.com/codex/tasks/task_e_689f59424c40832fad6cbdc38a482356