### PR TITLE
Fix imports in WizardPreview to use UI package alias

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -7,10 +7,10 @@ import {
   Popover,
   PopoverAnchor,
   PopoverContent,
-} from "@/components/atoms";
-import { blockRegistry } from "@/components/cms/blocks";
-import { Footer, Header, SideNav } from "@/components/organisms";
-import { AppShell } from "@/components/templates/AppShell";
+} from "@ui/components/atoms";
+import { blockRegistry } from "@ui/components/cms/blocks";
+import { Footer, Header, SideNav } from "@ui/components/organisms";
+import { AppShell } from "@ui/components/templates";
 import TranslationsProvider from "@/i18n/Translations";
 import enMessages from "@i18n/en.json";
 import type { PageComponent } from "@acme/types";


### PR DESCRIPTION
## Summary
- fix import paths in CMS WizardPreview to reference `@ui` components

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Unknown file extension ".ts" for packages/config/src/env/core.ts)*
- `pnpm --filter @apps/cms test` *(fails: @apps/cms@ test: jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_689f596bc1d0832fbf281e2ef6452d1a