### PR TITLE
fix wizard theme overrides usage

### DIFF
--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -6,7 +6,6 @@ import {
   type DeployStatusBase,
 } from "@platform-core/createShop";
 import { validateShopName } from "@platform-core/src/shops";
-import { loadThemeTokens } from "../tokenUtils";
 import type { WizardState } from "../schema";
 
 export interface SubmitResult {
@@ -48,7 +47,7 @@ export async function submitShop(
     type,
     template,
     theme,
-    themeVars,
+    themeOverrides,
     payment,
     shipping,
     pageTitle,
@@ -61,11 +60,6 @@ export async function submitShop(
     analyticsId,
     env,
   } = state;
-
-  const defaults = await loadThemeTokens(theme);
-  const themeOverrides = Object.fromEntries(
-    Object.entries(themeVars ?? {}).filter(([k, v]) => defaults[k] !== v)
-  );
 
   const options = {
     name: storeName || undefined,


### PR DESCRIPTION
## Summary
- fix submitShop to send themeOverrides instead of themeVars

## Testing
- `pnpm --filter @apps/cms lint` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `pnpm --filter @apps/cms test` *(fails: ThemeEditor colors tests, inventory export/import tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f597e5034832fb80b41d95ea6792a