### PR TITLE
fix: correct nav item schema types

### DIFF
--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -35,16 +35,14 @@ export interface NavItem {
   children?: NavItem[];
 }
 
-export const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
-  z
-    .object({
-      id: z.string(),
-      label: z.string(),
-      url: z.string().url(),
-      children: z.array(navItemSchema).optional(),
-    })
-    .strict()
-);
+export const navItemSchema: z.ZodType<NavItem> = z
+  .object({
+    id: z.string(),
+    label: z.string(),
+    url: z.string().url(),
+    children: z.array(z.lazy(() => navItemSchema)).optional(),
+  })
+  .strict();
 
 /* -------------------------------------------------------------------------- */
 /*  Page‑info schema                                                          */


### PR DESCRIPTION
## Summary
- fix nav item schema typing error by avoiding top-level lazy and lazily define children

## Testing
- `pnpm --filter @apps/cms test` (fails: Unable to find an accessible element with role "button" and name `/^save$/i`; failing inventory import/export tests; process.exit in env)
- `pnpm --filter @apps/cms exec tsc --noEmit` (fails: numerous missing build artifacts and type errors)


------
https://chatgpt.com/codex/tasks/task_e_689f598bdc8c832f829b2e45630d7ae0