### PR TITLE
chore(cms): reference date-utils package

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -17,6 +17,7 @@
     { "path": "../../packages/themes/base" },
     { "path": "../../packages/email" },
     { "path": "../../packages/shared-utils" },
-    { "path": "../../packages/lib" }
+    { "path": "../../packages/lib" },
+    { "path": "../../packages/date-utils" }
   ]
 }


### PR DESCRIPTION
## Summary
- add @acme/date-utils to CMS tsconfig references so imports from the package no longer fall outside the project

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Cannot find module '@/components/atoms/shadcn' and other missing declarations)*
- `pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --testPathPattern packages/date-utils` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e318fa8832fa88b5aa35bca0344