### PR TITLE
fix: correct nav item schema typing

### DIFF
--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -35,14 +35,16 @@ export interface NavItem {
   children?: NavItem[];
 }
 
-export const navItemSchema: z.ZodType<NavItem> = z
-  .object({
-    id: z.string(),
-    label: z.string(),
-    url: z.string().url(),
-    children: z.array(z.lazy(() => navItemSchema)).optional(),
-  })
-  .strict();
+export const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
+  z
+    .object({
+      id: z.string(),
+      label: z.string(),
+      url: z.string().url(),
+      children: z.array(navItemSchema).optional(),
+    })
+    .strict()
+);
 
 /* -------------------------------------------------------------------------- */
 /*  Page‑info schema                                                          */


### PR DESCRIPTION
## Summary
- fix nav item schema to use top-level `z.lazy` and enforce required fields

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Unknown file extension `.ts`)*
- `pnpm --filter @apps/cms test` *(fails: Unable to find button 'save'; environment errors)*
- `pnpm typecheck` *(fails: 1954 TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e4a4578832f9dc43acb81e64663