### PR TITLE
fix: align ai catalog field type

### DIFF
--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -7,7 +7,7 @@ export const aiCatalogFieldSchema = z.enum([
   "title",
   "description",
   "price",
-  "images",
+  "media",
 ]);
 
 export const aiCatalogConfigSchema = z


### PR DESCRIPTION
## Summary
- rename `aiCatalogFieldSchema` entry from `images` to `media`

## Testing
- `pnpm lint --filter @acme/types`
- `pnpm test --filter @acme/types`
- `pnpm --filter @acme/types exec tsc --noEmit` *(fails: Module "./constants" has already exported a member named 'Locale'. Consider explicitly re-exporting to resolve the ambiguity.)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e6d9f54832f9335ee254a0a7945