### PR TITLE
fix: widen return carrier state type

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -4,13 +4,17 @@ import { Button, Input, Checkbox } from "@/components/atoms/shadcn";
 import { returnLogisticsSchema, type ReturnLogistics } from "@acme/types";
 import { FormEvent, useState } from "react";
 
+type FormState = Omit<ReturnLogistics, "returnCarrier"> & {
+  returnCarrier: string[];
+};
+
 interface Props {
   shop: string;
   initial: ReturnLogistics;
 }
 
 export default function ReturnLogisticsForm({ shop, initial }: Props) {
-  const [form, setForm] = useState<ReturnLogistics>(() => ({
+  const [form, setForm] = useState<FormState>(() => ({
     ...initial,
     returnCarrier: initial.returnCarrier.length
       ? initial.returnCarrier


### PR DESCRIPTION
## Summary
- allow editing return carriers by widening form state type to string[]

## Testing
- `pnpm lint:apps` *(fails: all files matching apps/**/*.{ts,tsx} are ignored)*
- `pnpm test:cms` *(fails: ThemeEditor and inventory import/export tests)*
- `pnpm typecheck` *(fails: 1922 errors)*


------
https://chatgpt.com/codex/tasks/task_e_689f712cf750832f926a0e7840dfdc88