### PR TITLE
fix: correct StyleEditor imports

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/atoms/shadcn";
-import StyleEditor from "@/components/cms/StyleEditor";
+import StyleEditor from "@ui/components/cms/StyleEditor";
 import { useCallback, useEffect, useState, useMemo } from "react";
 import type { TokenMap } from "@ui/hooks/useTokenEditor";
 import { getContrast } from "@ui/components/cms";

--- a/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/atoms/shadcn";
-import StyleEditor from "@/components/cms/StyleEditor";
+import StyleEditor from "@ui/components/cms/StyleEditor";
 import WizardPreview from "../../wizard/WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";


### PR DESCRIPTION
## Summary
- fix StyleEditor imports in StepTokens and StepTheme

## Testing
- `cd apps/cms && pnpm tsc -p tsconfig.json --noEmit` *(fails: Output file ... has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_689f716e3c20832f888dddb75523c134