### PR TITLE
fix configurator persistence setState type

### DIFF
--- a/apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
@@ -1,7 +1,12 @@
 // apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
 "use client";
 
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import {
   wizardStateSchema,
   type WizardState,
@@ -33,7 +38,7 @@ export async function resetConfiguratorProgress(): Promise<void> {
  */
 export function useConfiguratorPersistence(
   state: WizardState,
-  setState: (s: WizardState) => void,
+  setState: Dispatch<SetStateAction<WizardState>>,
   onInvalid?: () => void,
   onSave?: () => void
 ): [


### PR DESCRIPTION
## Summary
- allow functional updates in configurator persistence hook

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Unknown file extension ".ts" for packages/config/src/env/core.ts)*
- `pnpm --filter @apps/cms exec tsc -p tsconfig.json --noEmit` *(fails: missing build artifacts and type errors in unrelated files)*
- `pnpm --filter @apps/cms test` *(fails: failing tests such as ThemeEditor and inventory import/export routes)*

------
https://chatgpt.com/codex/tasks/task_e_689f71928a4c832f89324266a49290f0