### PR TITLE
fix cms tsconfig include scripts

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -4,6 +4,7 @@
     "src/**/*",
     "../../src/lib/**/*",
     "../../packages/i18n/src/**/*.json",
+    "../../scripts/src/**/*",
     ".next/types/**/*.ts"
   ],
   "exclude": ["dist", "node_modules", "../../apps-script", "**/__tests__/**"],


### PR DESCRIPTION
## Summary
- include scripts folder in CMS tsconfig so rollback-shop.ts resolves

## Testing
- `pnpm --filter @apps/cms lint` (fails: Unknown file extension ".ts")
- `pnpm --filter @apps/cms test` (fails: unable to find save button; process.exit)
- `pnpm typecheck` (fails: Found 1799 errors)


------
https://chatgpt.com/codex/tasks/task_e_689f71d76024832fa7714344d7740c34