### PR TITLE
fix: filter media items by url

### DIFF
--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -15,7 +15,7 @@ import {
 import { fillLocales } from "@i18n/fillLocales";
 import type { ProductPublication, PublicationStatus } from "@platform-core/src/products";
 import * as Sentry from "@sentry/node";
-import type { Locale } from "@acme/types";
+import type { Locale, MediaItem } from "@acme/types";
 import { ensureAuthorized } from "./common/auth";
 import { redirect } from "next/navigation";
 import { ulid } from "ulid";
@@ -117,6 +117,9 @@ export async function updateProduct(
 
   const data: ProductForm = parsed.data;
   const { id, price, media: nextMedia } = data;
+  const mediaItems: MediaItem[] = nextMedia.filter(
+    (m): m is MediaItem => Boolean(m.url) && Boolean(m.type)
+  );
   const current = await getProductById(shop, id);
   if (!current) throw new Error(`Product ${id} not found in ${shop}`);
 
@@ -125,7 +128,7 @@ export async function updateProduct(
     title: { ...current.title, ...data.title },
     description: { ...current.description, ...data.description },
     price,
-    media: nextMedia,
+    media: mediaItems,
     row_version: current.row_version + 1,
     updated_at: nowIso(),
   };


### PR DESCRIPTION
## Summary
- ensure product updates only include media entries with required url and type

## Testing
- `pnpm test:cms` *(fails: process.exit called with "1")*
- `pnpm typecheck` *(fails: Command failed with exit code 2)*

------
https://chatgpt.com/codex/tasks/task_e_689f72352220832f8f357887c37300cf