### PR TITLE
chore(cms): exclude test specs from typecheck

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -6,7 +6,16 @@
     "../../packages/i18n/src/**/*.json",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["dist", "node_modules", "../../apps-script", "**/__tests__/**"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "../../apps-script",
+    "**/__tests__/**",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
   "references": [
     { "path": "../../packages/auth" },
     { "path": "../../packages/types" },


### PR DESCRIPTION
## Summary
- avoid typechecking Jest specs in CMS build by excluding `*.spec.ts(x)` and `*.test.ts(x)` files

## Testing
- `pnpm exec tsc -b apps/cms/tsconfig.json` *(fails: Module "./constants" has already exported a member named 'Locale')*
- `pnpm test:cms` *(fails: packages/email/src/__tests__/abandonedCart.test.ts(18,1): error TS2593: Cannot find name 'describe')*

------
https://chatgpt.com/codex/tasks/task_e_689f72800ac4832f96cf3b77652293ea