### PR TITLE
fix: handle optional text

### DIFF
--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -55,7 +55,7 @@ export class ResendProvider implements CampaignProvider {
         to: options.to,
         subject: options.subject,
         html: options.html,
-        text: options.text,
+        text: options.text ?? "",
       });
     } catch (error: unknown) {
       if (error && typeof error === "object" && "message" in error) {

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -58,7 +58,7 @@ export class SendgridProvider implements CampaignProvider {
         from: getDefaultSender(),
         subject: options.subject,
         html: options.html,
-        text: options.text,
+        text: options.text ?? "",
       });
     } catch (error: unknown) {
       if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- ensure email providers always send a text value

## Testing
- `pnpm --filter @acme/email exec tsc -p tsconfig.json --noEmit` (fails: Output file not built)
- `pnpm --filter @acme/email test` (fails: process.exit called)


------
https://chatgpt.com/codex/tasks/task_e_689f729c0db0832f9ef401f6f8b40336