### PR TITLE
feat(ui): add destructive button variant

### DIFF
--- a/packages/ui/src/components/atoms/primitives/button.tsx
+++ b/packages/ui/src/components/atoms/primitives/button.tsx
@@ -6,7 +6,7 @@ import { Slot } from "./slot";
 /* -------------------------------------------------------------------------- */
 /*  Types                                                                     */
 /* -------------------------------------------------------------------------- */
-type ButtonVariant = "default" | "outline" | "ghost";
+type ButtonVariant = "default" | "outline" | "ghost" | "destructive";
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -28,6 +28,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       outline:
         "border border-input hover:bg-accent hover:text-accent-foreground",
       ghost: "hover:bg-accent hover:text-accent-foreground",
+      destructive:
+        "bg-destructive text-destructive-foreground hover:bg-destructive/90",
     };
 
     const Comp = asChild ? Slot : "button";
@@ -35,6 +37,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       default: "--color-primary",
       outline: "--color-accent",
       ghost: "--color-accent",
+      destructive: "--color-danger",
     };
 
     return (


### PR DESCRIPTION
## Summary
- allow Button primitive to accept `destructive` variant with proper styles

## Testing
- `pnpm --filter @acme/ui test -- --testPathPattern packages/ui` *(fails: Cannot find module '../components/atoms/VideoPlayer')*

------
https://chatgpt.com/codex/tasks/task_e_689f71c83be0832f9d83c1f6782acb72