### PR TITLE
fix GitHub branch interpolation in setup-ci workflow script

### DIFF
--- a/scripts/src/setup-ci.ts
+++ b/scripts/src/setup-ci.ts
@@ -85,7 +85,7 @@ ${envLines}
       - run: pnpm --filter @apps/shop-${shopId} build
       - run: npx @cloudflare/next-on-pages deploy \\
                --project-name=shop-${shopId} \\
-               --branch=\\${{ github.ref_name }}
+               --branch=\${{ github.ref_name }}
 `;
 
 writeFileSync(wfPath, workflow);


### PR DESCRIPTION
## Summary
- escape GitHub branch expression correctly in setup-ci workflow script

## Testing
- `pnpm exec tsc --noEmit scripts/src/setup-ci.ts` *(fails: Cannot find module '@config/src/env')*
- `pnpm exec eslint scripts/src/setup-ci.ts` *(warn: File ignored because no matching configuration was supplied)*
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_689f7556b100832fa740695f254118df