### PR TITLE
fix: export ProductPreview props

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { SKU } from "@acme/types";
 import { formatCurrency } from "@acme/shared-utils";
 
-interface Props {
+export interface Props {
   slug: string;
   onValidChange?: (valid: boolean) => void;
 }


### PR DESCRIPTION
## Summary
- export ProductPreview props interface so previewComponents can reference named type

## Testing
- `pnpm tsc -p apps/cms/tsconfig.json --noEmit` (fails: scripts/src/setup-ci.ts ',' expected)
- `pnpm --filter @apps/cms lint` (fails: Unknown file extension ".ts" for packages/config/src/env/core.ts)
- `pnpm --filter @apps/cms test` (fails: multiple failing tests)


------
https://chatgpt.com/codex/tasks/task_e_689f75c1af5c832fbf60cc09e24e6b4f