### PR TITLE
fix(email): add sanitize-html types

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -16,13 +16,16 @@
   "dependencies": {
     "@acme/config": "workspace:*",
     "@acme/ui": "workspace:*",
-    "commander": "^11.1.0",
     "@sendgrid/mail": "^8.1.5",
+    "commander": "^11.1.0",
     "nodemailer": "^6.10.1",
-    "resend": "^3.5.0",
-    "sanitize-html": "^2.12.1",
+    "pino": "^9.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "pino": "^9.9.0"
+    "resend": "^3.5.0",
+    "sanitize-html": "^2.12.1"
+  },
+  "devDependencies": {
+    "@types/sanitize-html": "^2.16.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,10 @@ importers:
       sanitize-html:
         specifier: ^2.12.1
         version: 2.17.0
+    devDependencies:
+      '@types/sanitize-html':
+        specifier: ^2.16.0
+        version: 2.16.0
 
   packages/i18n:
     devDependencies:
@@ -4033,6 +4037,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/sanitize-html@2.16.0':
+    resolution: {integrity: sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==}
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
@@ -14436,6 +14443,10 @@ snapshots:
       csstype: 3.1.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/sanitize-html@2.16.0':
+    dependencies:
+      htmlparser2: 8.0.2
 
   '@types/semver@7.7.0': {}
 


### PR DESCRIPTION
## Summary
- add `@types/sanitize-html` to email package

## Testing
- `pnpm exec tsc -p packages/email/tsconfig.json --noEmit` *(fails: Cannot find name 'jest', missing built outputs)*
- `pnpm --filter @acme/email test -- packages/email/src` *(fails: Missing environment configuration causing process exit)*

------
https://chatgpt.com/codex/tasks/task_e_689f760c6a0c832f8206fede8e721641