### PR TITLE
fix(cms): include scripts in tsconfig rootDir

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../packages/config/tsconfig.app.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
   "include": [
     "src/**/*",
     "../../src/lib/**/*",


### PR DESCRIPTION
## Summary
- allow apps/cms to resolve shared scripts by setting `rootDir` to repo root

## Testing
- `npx tsc -p apps/cms/tsconfig.json --noEmit` *(fails: File '/workspace/base-shop/packages/platform-machine/src/releaseDepositsService.ts' is not listed within the file list of project '/workspace/base-shop/apps/cms/tsconfig.json')*
- `pnpm test:cms` *(fails: jest-haste-map duplicate manual mock)*

------
https://chatgpt.com/codex/tasks/task_e_689f7fff67a8832fb1dc8b1cbbd9f025