### PR TITLE
chore(date-utils): exclude tests from TypeScript build

### DIFF
--- a/packages/date-utils/tsconfig.json
+++ b/packages/date-utils/tsconfig.json
@@ -10,5 +10,5 @@
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", ".turbo", "node_modules"]
+  "exclude": ["dist", "**/__tests__/**", ".turbo", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- avoid compiling test files in date-utils package

## Testing
- `npx tsc -p packages/date-utils/tsconfig.json`
- `pnpm -F @acme/date-utils test packages/date-utils/src/__tests__/date.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f80183228832fb66c6bd9964886ea