### PR TITLE
refactor: use internal scheduler for email campaigns

### DIFF
--- a/packages/email/src/__tests__/campaign-integration.test.ts
+++ b/packages/email/src/__tests__/campaign-integration.test.ts
@@ -78,9 +78,9 @@ describe("campaign integration", () => {
       "utf8"
     );
 
-    const { sendScheduledCampaigns } = await import("../../../../functions/marketing-email-sender");
+    const { sendDueCampaigns } = await import("../scheduler");
     const sgMail = require("@sendgrid/mail").default;
-    await sendScheduledCampaigns();
+    await sendDueCampaigns();
 
     expect(sgMail.send).toHaveBeenCalledTimes(2);
     expect(sgMail.send).toHaveBeenCalledWith(
@@ -125,8 +125,8 @@ describe("campaign integration", () => {
       "utf8"
     );
 
-    const { sendScheduledCampaigns } = await import("../../../../functions/marketing-email-sender");
-    await sendScheduledCampaigns();
+    const { sendDueCampaigns } = await import("../scheduler");
+    await sendDueCampaigns();
 
     expect(resendSendMock).toHaveBeenCalledWith(
       expect.objectContaining({ to: "manual@example.com", subject: "Man" })

--- a/packages/email/src/cli.ts
+++ b/packages/email/src/cli.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "node:fs";
 import * as fsSync from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { sendScheduledCampaigns } from "../../../functions/marketing-email-sender.ts";
+import { sendDueCampaigns } from "./scheduler";
 import { nowIso } from "@date-utils";
 
 interface Campaign {
@@ -95,7 +95,7 @@ campaign
   .command("send")
   .description("Send due campaigns")
   .action(async () => {
-    await sendScheduledCampaigns();
+    await sendDueCampaigns();
     console.log("Sent due campaigns");
   });
 

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -16,7 +16,8 @@
     { "path": "../ui" },
     { "path": "../lib" },
     { "path": "../platform-core" },
-    { "path": "../types" }
+    { "path": "../types" },
+    { "path": "../date-utils" }
   ],
   "include": ["src/**/*"],
   "exclude": ["dist", ".turbo", "node_modules"]


### PR DESCRIPTION
## Summary
- use scheduler's `sendDueCampaigns` in email CLI
- adjust campaign integration tests to call scheduler directly
- add `date-utils` as a project reference for email package

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/campaign-integration.test.ts` *(fails: Invalid payment environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689f803e456c832f9a8a6f7d18f3acc4