### PR TITLE
fix page-builder component types

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductBundleEditor.tsx
@@ -1,7 +1,7 @@
-import type { PageComponent } from "@acme/types";
+import type { PageComponentBase } from "@acme/types";
 import { Input, Textarea } from "../../atoms/shadcn";
 
-type ProductBundleComponent = PageComponent & {
+type ProductBundleComponent = PageComponentBase & {
   type: "ProductBundle";
   skus?: string[];
   discount?: number;

--- a/packages/ui/src/components/cms/page-builder/ProductComparisonEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductComparisonEditor.tsx
@@ -1,7 +1,7 @@
-import type { PageComponent } from "@acme/types";
+import type { PageComponentBase } from "@acme/types";
 import { Textarea } from "../../atoms/shadcn";
 
-type ProductComparisonComponent = PageComponent & {
+type ProductComparisonComponent = PageComponentBase & {
   type: "ProductComparison";
   skus?: string[];
   attributes?: string[];

--- a/packages/ui/src/components/cms/page-builder/ProductFilterEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductFilterEditor.tsx
@@ -1,7 +1,7 @@
-import type { PageComponent } from "@acme/types";
+import type { PageComponentBase } from "@acme/types";
 import useComponentInputs from "./useComponentInputs";
 
-type ProductFilterComponent = PageComponent & {
+type ProductFilterComponent = PageComponentBase & {
   type: "ProductFilter";
   showSize?: boolean;
   showColor?: boolean;

--- a/packages/ui/src/components/cms/page-builder/ProductGridEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ProductGridEditor.tsx
@@ -23,7 +23,9 @@ export default function ProductGridEditor({ component, onChange }: Props) {
       </div>
       <Select
         value={component.mode ?? "collection"}
-        onValueChange={(v) => handleInput("mode", v)}
+        onValueChange={(v: "manual" | "collection") =>
+          handleInput("mode", v)
+        }
       >
         <SelectTrigger>
           <SelectValue placeholder="Source" />

--- a/packages/ui/src/components/cms/page-builder/state/layout.ts
+++ b/packages/ui/src/components/cms/page-builder/state/layout.ts
@@ -27,17 +27,26 @@ function addComponent(
   }
   return list.map((c) => {
     if (c.id === parentId && "children" in c) {
+      const childList = (c as { children?: PageComponent[] }).children ?? [];
       const children = addAt(
-        (c.children ?? []) as PageComponent[],
-        index ?? (c.children?.length ?? 0),
+        childList,
+        index ?? childList.length,
         component,
       );
       return { ...c, children } as PageComponent;
     }
-    if ("children" in c && Array.isArray(c.children)) {
+    if (
+      "children" in c &&
+      Array.isArray((c as { children?: PageComponent[] }).children)
+    ) {
       return {
         ...c,
-        children: addComponent(c.children, parentId, index, component),
+        children: addComponent(
+          (c as { children: PageComponent[] }).children,
+          parentId,
+          index,
+          component,
+        ),
       } as PageComponent;
     }
     return c;

--- a/packages/ui/src/components/cms/page-builder/state/schema.ts
+++ b/packages/ui/src/components/cms/page-builder/state/schema.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 import { pageComponentSchema } from "@acme/types";
-import type { HistoryState } from "@acme/types";
-
-export const historyStateSchema: z.ZodType<HistoryState> = z
+export const historyStateSchema = z
   .object({
     past: z.array(z.array(pageComponentSchema)),
     present: z.array(pageComponentSchema),

--- a/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
@@ -8,7 +8,7 @@ interface Options {
   dispatch: React.Dispatch<Action>;
   gridEnabled?: boolean;
   gridCols: number;
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   disabled?: boolean;
 }
 

--- a/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasResize.ts
@@ -12,7 +12,7 @@ interface Options {
   dispatch: React.Dispatch<ResizeAction>;
   gridEnabled?: boolean;
   gridCols: number;
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   disabled?: boolean;
 }
 

--- a/packages/ui/src/components/cms/page-builder/useComponentInputs.ts
+++ b/packages/ui/src/components/cms/page-builder/useComponentInputs.ts
@@ -7,7 +7,7 @@ export default function useComponentInputs<T>(
 } {
   const handleInput = useCallback(
     <K extends keyof T>(field: K, value: T[K]) => {
-      onChange({ [field]: value } as Partial<T>);
+      onChange({ [field]: value } as Pick<T, K>);
     },
     [onChange],
   );


### PR DESCRIPTION
## Summary
- type custom page-builder components using PageComponentBase
- allow canvas hooks to accept nullable refs
- tighten generic input handler typings and clean up layout utility

## Testing
- `pnpm --filter @acme/ui run build` *(fails: Output file has not been built from source files)*
- `pnpm --filter @acme/ui test` *(fails: tests in other packages failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f80e46648832f81b9cf83e5f8b979