### PR TITLE
Fix button variant types and schema in CMS

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -128,7 +128,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         ))}
         <Button
           type="button"
-          variant="secondary"
+          variant="ghost"
           onClick={() =>
             setForm((f) => ({
               ...f,
@@ -171,7 +171,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         ))}
         <Button
           type="button"
-          variant="secondary"
+          variant="ghost"
           onClick={() =>
             setForm((f) => ({
               ...f,

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
@@ -23,7 +23,11 @@ export default function ThemeTokens({ shop, tokenRows, info, errors }: Props) {
     <div className="col-span-2 flex flex-col gap-1">
       <div className="flex items-center justify-between">
         <span>Theme Tokens</span>
-        <Button asChild variant="link" className="h-auto p-0 text-primary">
+        <Button
+          asChild
+          variant="ghost"
+          className="h-auto p-0 text-primary hover:bg-transparent"
+        >
           <Link href={`/cms/shop/${shop}/themes`}>Edit Theme</Link>
         </Button>
       </div>
@@ -61,8 +65,8 @@ export default function ThemeTokens({ shop, tokenRows, info, errors }: Props) {
                     <form action={resetThemeOverride.bind(null, shop, token)}>
                       <Button
                         type="submit"
-                        variant="link"
-                        className="h-auto p-0 text-primary"
+                        variant="ghost"
+                        className="h-auto p-0 text-primary hover:bg-transparent"
                       >
                         Reset
                       </Button>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
@@ -76,7 +76,7 @@ export default function PremierDeliveryEditor({ shop, initial }: Props) {
             </Button>
           </div>
         ))}
-        <Button type="button" variant="secondary" onClick={addRegion}>
+        <Button type="button" variant="ghost" onClick={addRegion}>
           Add region
         </Button>
         {errors.regions && (
@@ -101,7 +101,7 @@ export default function PremierDeliveryEditor({ shop, initial }: Props) {
             </Button>
           </div>
         ))}
-        <Button type="button" variant="secondary" onClick={addWindow}>
+        <Button type="button" variant="ghost" onClick={addWindow}>
           Add window
         </Button>
         {errors.windows && (

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiFeedPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiFeedPanel.tsx
@@ -22,7 +22,7 @@ export default async function AiFeedPanel({ shop }: { shop: string }) {
     <ul className="space-y-1">
       {events.map((e, idx) => (
         <li key={idx}>
-          {formatTimestamp(e.timestamp as string)} – {e.status}
+          {formatTimestamp(e.timestamp as string)} – {String(e.status)}
         </li>
       ))}
     </ul>

--- a/apps/cms/src/app/cms/shop/[shop]/themes/TypographySettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/TypographySettings.tsx
@@ -44,7 +44,9 @@ export default function TypographySettings({
                 onChange={(e) =>
                   handleOverrideChange(k, defaultValue)(e.target.value)
                 }
-                ref={(el) => (overrideRefs.current[k] = el)}
+                ref={(el) => {
+                  overrideRefs.current[k] = el;
+                }}
               />
               {hasOverride && (
                 <button

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -28,14 +28,7 @@ const localeRecordSchema = z.record(localeSchema, z.string());
 /*  Nav‑item schema (recursive)                                               */
 /* -------------------------------------------------------------------------- */
 
-export interface NavItem {
-  id: string;
-  label: string;
-  url: string;
-  children?: NavItem[];
-}
-
-export const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
+export const navItemSchema = z.lazy(() =>
   z
     .object({
       id: z.string(),
@@ -45,6 +38,8 @@ export const navItemSchema: z.ZodType<NavItem> = z.lazy(() =>
     })
     .strict()
 );
+
+export type NavItem = z.infer<typeof navItemSchema>;
 
 /* -------------------------------------------------------------------------- */
 /*  Page‑info schema                                                          */

--- a/apps/cms/src/services/shops/theme.ts
+++ b/apps/cms/src/services/shops/theme.ts
@@ -1,4 +1,4 @@
-import { syncTheme } from "@platform-core/src/createShop";
+import { syncTheme } from "@platform-core/createShop";
 import { baseTokens, loadThemeTokens } from "@platform-core/themeTokens";
 import type { Shop } from "@acme/types";
 import type { ShopForm } from "./validation";


### PR DESCRIPTION
## Summary
- replace removed `secondary` and `link` button variants with `ghost`
- cast unknown values and clean up ref callbacks
- fix recursive nav item schema and correct theme sync import

## Testing
- `pnpm typecheck` *(fails: File '/workspace/base-shop/packages/platform-machine/src/index.ts' is not listed within the file list of project '/workspace/base-shop/scripts/tsconfig.json'. Projects must list all files or use an 'include' pattern.)*
- `pnpm test:cms` *(fails: process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_68a059bd9ac8832fb5926f170869614e