### PR TITLE
Fix PageBuilder import resolution

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/new/builder/page.tsx
@@ -25,7 +25,7 @@ export default async function NewPageBuilderRoute({
 }) {
   const { shop } = await params;
 
-  const blank: Page = {
+  const blank = {
     id: "",
     slug: "",
     status: "draft",
@@ -41,7 +41,7 @@ export default async function NewPageBuilderRoute({
     createdAt: "",
     updatedAt: "",
     createdBy: "",
-  };
+  } as Page;
 
   async function save(formData: FormData) {
     "use server";

--- a/packages/ui/src/components/cms/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/PageBuilder.tsx
@@ -1,0 +1,6 @@
+import PageBuilder from "./page-builder/PageBuilder";
+
+export type PageBuilderProps = React.ComponentProps<typeof PageBuilder>;
+
+export default PageBuilder;
+


### PR DESCRIPTION
## Summary
- add re-exported PageBuilder component for `@ui/components/cms` path
- cast blank page data to `Page` in builder route to satisfy type checker

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Output file ... has not been built)*
- `pnpm --filter @apps/cms test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*


------
https://chatgpt.com/codex/tasks/task_e_68a059ce0548832f80cf39b3dd6b3593