### PR TITLE
fix: adjust env key typing

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepEnvVars.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepEnvVars.tsx
@@ -173,7 +173,7 @@ const ENV_VARS: EnvVar[] = [
   },
 ];
 
-const ENV_KEYS = ENV_VARS.map((v) => v.key) as const;
+const ENV_KEYS = [...ENV_VARS.map((v) => v.key)] as const;
 
 interface Props {
   env: Record<string, string>;


### PR DESCRIPTION
## Summary
- fix TypeScript const assertion for environment variable keys by wrapping map result in an array literal

## Testing
- `pnpm lint --filter=@apps/cms` (fails: Unknown file extension ".ts" for packages/config/src/env/core.ts)
- `pnpm test --filter=@apps/cms` (fails: ThemeEditor.colors.test.tsx and inventoryImportExport.test.ts)


------
https://chatgpt.com/codex/tasks/task_e_68a059f9f3f0832f88d0899dee27c96f