### PR TITLE
Fix TypeScript errors in env and marketing routes

### DIFF
--- a/apps/cms/src/app/api/page/[shop]/route.ts
+++ b/apps/cms/src/app/api/page/[shop]/route.ts
@@ -33,12 +33,16 @@ export async function POST(
       }
     }
 
-    await updatePageInRepo(shop, {
-      id: existing.id,
-      updatedAt: existing.updatedAt,
-      status: "published",
-      components,
-    });
+    await updatePageInRepo(
+      shop,
+      {
+        id: existing.id,
+        updatedAt: existing.updatedAt,
+        status: "published",
+        components,
+      },
+      existing,
+    );
 
     return NextResponse.json({ id: existing.id });
   } catch (err) {

--- a/packages/email/src/analytics.ts
+++ b/packages/email/src/analytics.ts
@@ -17,6 +17,7 @@ export interface EmailAnalyticsEvent {
   campaign?: string;
   messageId?: string;
   recipient?: string;
+  [key: string]: unknown;
 }
 
 export interface CampaignStats {

--- a/packages/shared-utils/src/parseJsonBody.ts
+++ b/packages/shared-utils/src/parseJsonBody.ts
@@ -17,7 +17,7 @@ function hasErrorType(err: unknown): err is { type: string } {
 }
 
 export async function parseJsonBody<T>(
-  req: Request & { body: NodeReadableStream<Uint8Array> | null },
+  req: Request,
   schema: z.ZodSchema<T>,
   limit: string | number,
 ): Promise<ParseJsonResult<T>> {


### PR DESCRIPTION
## Summary
- relax parseJsonBody to accept Request objects
- allow email analytics events to carry arbitrary fields
- include previous page when updating CMS pages

## Testing
- `pnpm typecheck` *(fails: File '/workspace/base-shop/packages/platform-machine/src/index.ts' is not listed within the file list of project '/workspace/base-shop/scripts/tsconfig.json')*
- `pnpm --filter @acme/shared-utils test` *(fails: ThemeEditor - colors tests cannot find Save button)*


------
https://chatgpt.com/codex/tasks/task_e_68a05a2f50c8832fbd71c0056f269f84