### PR TITLE
fix: resolve TypeScript errors in CMS actions and routes

### DIFF
--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -18,7 +18,13 @@ export async function createNewShop(
 
   let result: DeployStatusBase;
   try {
-    result = await createShop(id, options, { deploy: false });
+    result = await (
+      createShop as unknown as (
+        id: string,
+        opts: CreateShopOptions,
+        opts2: { deploy?: boolean }
+      ) => Promise<DeployStatusBase>
+    )(id, options, { deploy: false });
   } catch (err) {
     console.error("createShop failed", err);
     throw err;

--- a/apps/cms/src/app/[lang]/checkout/page.tsx
+++ b/apps/cms/src/app/[lang]/checkout/page.tsx
@@ -3,7 +3,7 @@ import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
-import { getCart } from "@platform-core/src/cartStore";
+import { createCartStore } from "@platform-core/src/cartStore";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 
@@ -27,7 +27,8 @@ export default async function CheckoutPage({
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
-  const cart = cartId ? await getCart(cartId) : {};
+  const store = createCartStore();
+  const cart = cartId ? await store.getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/apps/cms/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/cms/src/app/api/auth/[...nextauth]/route.ts
@@ -13,7 +13,6 @@ const handler = NextAuth(authOptions);
 const rateLimited = async (req: NextRequest, ctx: any) => {
   const ip =
     req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    req.ip ||
     "unknown";
 
   try {

--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -48,7 +48,11 @@ export async function POST(req: Request) {
       })
       .strict();
 
-    const parsed = await parseJsonBody(req, schema, "1mb");
+    const parsed = await parseJsonBody(
+      req as Request & { body: ReadableStream<Uint8Array> | null },
+      schema,
+      "1mb",
+    );
     if (!parsed.success) return parsed.response;
 
     const { id, csv, categories } = parsed.data;

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -21,12 +21,13 @@ export async function POST(
   try {
     const form = await req.formData();
     const file = form.get("file") as unknown;
-    if (!file || typeof (file as any).text !== "function") {
+    if (!file || typeof (file as Blob).text !== "function") {
       return NextResponse.json({ error: "No file provided" }, { status: 400 });
     }
-    const text = await (file as any).text();
+    const text = await (file as Blob).text();
     let raw: unknown;
-    if (file.type === "application/json" || file.name.endsWith(".json")) {
+    const f = file as File;
+    if (f.type === "application/json" || f.name.endsWith(".json")) {
       const data = JSON.parse(text);
       raw = Array.isArray(data)
         ? data.map((row: RawInventoryItem) => expandInventoryItem(row))

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -95,6 +95,8 @@
       "@acme/email/analytics": ["packages/email/src/analytics.ts"],
       "@acme/stripe": ["packages/stripe/src/index.ts"],
       "@acme/sanity": ["packages/sanity/src/index.ts"],
+      "@acme/plugin-sanity": ["packages/plugins/sanity/index.ts"],
+      "@acme/plugin-sanity/*": ["packages/plugins/sanity/*"],
       "@acme/date-utils": ["packages/date-utils/src/index.ts"],
       "@date-utils": ["packages/date-utils/src/index.ts"],
       "@acme/configurator": ["packages/configurator/src/index.ts"],


### PR DESCRIPTION
## Summary
- add path mapping for `@acme/plugin-sanity`
- update CMS checkout and API routes to match new types
- cast `createShop` invocation to maintain deploy options

## Testing
- `pnpm typecheck` (fails: File not listed etc.)
- `pnpm test:cms` (fails: unable to find element, inventory test mismatch)
- `pnpm test --filter @acme/plugin-sanity` (fails: test failed)


------
https://chatgpt.com/codex/tasks/task_e_68a05a41ae40832f92cbd1b5e94a64bd