### PR TITLE
chore(tsconfig): exclude mocks from typecheck

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -20,5 +20,10 @@
     { "path": "../date-utils" }
   ],
   "include": ["src/**/*"],
-  "exclude": ["dist", ".turbo", "node_modules"]
+  "exclude": [
+    "dist",
+    ".turbo",
+    "node_modules",
+    "**/__mocks__/**"
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -114,5 +114,6 @@
   },
 
   /* project-wide ambient declarations */
-  "files": ["./src/types/global.d.ts"]
+  "files": ["./src/types/global.d.ts"],
+  "exclude": ["**/__mocks__/**"]
 }


### PR DESCRIPTION
## Summary
- exclude __mocks__ directories from root TypeScript config
- ignore __mocks__ in email package

## Testing
- `pnpm typecheck` *(fails: Cannot find module '@config/src/env')*
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__/sendgrid.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a05a610728832f9d06ef7587b575a3