### PR TITLE
Fix module resolution for acme packages and align return logistics form types

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -64,7 +64,10 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         <Input
           value={form.labelService}
           onChange={(e) =>
-            setForm((f) => ({ ...f, labelService: e.target.value }))
+            setForm((f) => ({
+              ...f,
+              labelService: e.target.value as FormState["labelService"],
+            }))
           }
         />
       </label>
@@ -94,7 +97,10 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         <Input
           value={form.bagType}
           onChange={(e) =>
-            setForm((f) => ({ ...f, bagType: e.target.value }))
+            setForm((f) => ({
+              ...f,
+              bagType: e.target.value as FormState["bagType"],
+            }))
           }
         />
       </label>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,8 @@
       "@platform-core/*": ["packages/platform-core/src/*"],
       "@platform-core/src": ["packages/platform-core/src/index.ts"],
       "@platform-core/src/*": ["packages/platform-core/src/*"],
+      "@acme/platform-core": ["packages/platform-core/src/index.ts"],
+      "@acme/platform-core/*": ["packages/platform-core/src/*"],
 
       /* ─── platform-machine ──────────────────────────────────────── */
       "@acme/platform-machine": ["packages/platform-machine/src/index.ts"],
@@ -45,6 +47,8 @@
       "@ui/*": ["packages/ui/src/*"],
       "@ui/src": ["packages/ui/src/index.ts"],
       "@ui/src/*": ["packages/ui/src/*"],
+      "@acme/ui": ["packages/ui/src/index.ts"],
+      "@acme/ui/*": ["packages/ui/src/*"],
 
       /* ─── CMS front-end (Next app) ─────────────────────────────── */
       "@cms/*": ["apps/cms/src/*"],


### PR DESCRIPTION
## Summary
- map `@acme/ui` and `@acme/platform-core` to source paths for local TypeScript resolution
- cast return logistics form values to their literal types

## Testing
- `pnpm test --filter @apps/cms` *(fails: command /root/.nvm/versions/node/v20.19.4/bin/pnpm run test exited (1))*
- `pnpm exec tsc -p apps/cms/tsconfig.json` *(fails: missing built output files)*

------
https://chatgpt.com/codex/tasks/task_e_68a06449b708832f889e0cdf2b96b16c