### PR TITLE
fix: add alias for acme ui package

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -45,6 +45,8 @@
       "@ui/*": ["packages/ui/src/*"],
       "@ui/src": ["packages/ui/src/index.ts"],
       "@ui/src/*": ["packages/ui/src/*"],
+      "@acme/ui": ["packages/ui/src/index.ts"],
+      "@acme/ui/*": ["packages/ui/src/*"],
 
       /* ─── CMS front-end (Next app) ─────────────────────────────── */
       "@cms/*": ["apps/cms/src/*"],


### PR DESCRIPTION
## Summary
- map `@acme/ui` to the UI package source to resolve module imports

## Testing
- `pnpm exec eslint tsconfig.base.json`
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Output file ... has not been built from source file ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a0646381ec832fa9a8b2a844d4503c