### PR TITLE
fix configurator type errors

### DIFF
--- a/apps/cms/src/app/cms/configurator/ConfiguratorContext.tsx
+++ b/apps/cms/src/app/cms/configurator/ConfiguratorContext.tsx
@@ -19,7 +19,9 @@ export interface ConfiguratorContextValue {
   markStepComplete: (stepId: string, status: StepStatus) => void;
   themeDefaults: Record<string, string>;
   themeOverrides: Record<string, string>;
-  setThemeOverrides: (v: Record<string, string>) => void;
+  setThemeOverrides: React.Dispatch<
+    React.SetStateAction<Record<string, string>>
+  >;
   dirty: boolean;
   resetDirty: () => void;
   saving: boolean;
@@ -41,7 +43,7 @@ export function ConfiguratorProvider({
   // Persist state to localStorage
   const [markStepComplete, saving] = useConfiguratorPersistence(
     state,
-    (s) => setState(() => s),
+    setState,
     undefined,
     resetDirty
   );
@@ -54,8 +56,14 @@ export function ConfiguratorProvider({
     setDirty(true);
   };
 
-  const setThemeOverrides = (v: Record<string, string>) => {
-    setState((prev) => ({ ...prev, themeOverrides: v }));
+  const setThemeOverrides = (
+    v: React.SetStateAction<Record<string, string>>
+  ) => {
+    setState((prev) => ({
+      ...prev,
+      themeOverrides:
+        typeof v === "function" ? v(prev.themeOverrides) : v,
+    }));
     setDirty(true);
   };
 

--- a/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
+++ b/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
@@ -33,7 +33,9 @@ interface Props {
   /** Called with normalized layout name and components when confirmed */
   onConfirm: (layout: string, components: PageComponent[]) => void;
   /** Optional props for the SelectTrigger */
-  triggerProps?: React.ComponentProps<typeof SelectTrigger>;
+  triggerProps?: React.ComponentProps<typeof SelectTrigger> & {
+    [key: `data-${string}`]: unknown;
+  };
 }
 
 /**

--- a/apps/cms/src/app/cms/configurator/lib/progress.ts
+++ b/apps/cms/src/app/cms/configurator/lib/progress.ts
@@ -1,5 +1,5 @@
 import { type ConfiguratorProgress } from "@platform-core/contexts/LayoutContext";
-import { type StepStatus } from "../wizard/schema";
+import { type StepStatus } from "../../wizard/schema";
 import { getSteps } from "../steps";
 
 export function calculateConfiguratorProgress(

--- a/apps/cms/src/app/cms/configurator/steps/StepHosting.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHosting.tsx
@@ -3,7 +3,7 @@
 import { Button, Input } from "@/components/atoms/shadcn";
 import type { DeployStatusBase } from "@platform-core/createShop";
 import { useEffect } from "react";
-import { getDeployStatus, type DeployInfo } from "../services/deployShop";
+import { getDeployStatus, type DeployInfo } from "../../wizard/services/deployShop";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -33,6 +33,7 @@
     { "path": "../../packages/lib" },
     { "path": "../../packages/date-utils" },
     { "path": "../../packages/platform-machine" },
-    { "path": "../../packages/stripe" }
+    { "path": "../../packages/stripe" },
+    { "path": "../../packages/configurator" }
   ]
 }


### PR DESCRIPTION
## Summary
- fix configurator state initialization and theme override updating
- correct wizard and deploy service import paths
- allow data attributes on template selector trigger and add configurator package to tsconfig references

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` (fails: Output file packages/... has not been built)
- `pnpm --filter @apps/cms test` (fails: Unable to find button with name /^save$/i)


------
https://chatgpt.com/codex/tasks/task_e_68a06473c840832f88048e912aecb2b3