### PR TITLE
fix(email): exclude tests from type checking

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -24,6 +24,7 @@
     "dist",
     ".turbo",
     "node_modules",
+    "**/__tests__/**",
     "**/__mocks__/**"
   ]
 }


### PR DESCRIPTION
## Summary
- ignore email package test files during TypeScript compilation

## Testing
- `pnpm exec jest packages/email/src/__tests__/templates.test.ts --config jest.config.cjs --runInBand`
- `pnpm exec tsc -b packages/email/tsconfig.json --noEmit` *(fails: file '/workspace/base-shop/packages/lib/src/initZod.ts' is not under 'rootDir')*

------
https://chatgpt.com/codex/tasks/task_e_68a064d2d298832fb026aa188bbbb952