### PR TITLE
chore(stripe): exclude tests from typecheck

### DIFF
--- a/packages/stripe/tsconfig.json
+++ b/packages/stripe/tsconfig.json
@@ -10,5 +10,5 @@
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", ".turbo", "node_modules"]
+  "exclude": ["dist", "**/__tests__/**", ".turbo", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- exclude tests from stripe package's type checking

## Testing
- `pnpm exec tsc -p packages/stripe/tsconfig.json --noEmit`
- `pnpm typecheck` *(fails: Found 1648 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a064942ee4832f9d2fff05cbe7a079