### PR TITLE
fix: resolve cms ui type issues

### DIFF
--- a/packages/ui/src/components/DynamicRenderer.tsx
+++ b/packages/ui/src/components/DynamicRenderer.tsx
@@ -24,8 +24,7 @@ export default function DynamicRenderer({
       return null;
     }
 
-    type Block = Extract<PageComponent, { type: typeof block.type }>;
-    const { component: Comp, getRuntimeProps } = entry as BlockRegistryEntry<Block>;
+    const { component: Comp, getRuntimeProps } = entry as BlockRegistryEntry<any>;
 
     const {
       id,
@@ -37,8 +36,9 @@ export default function DynamicRenderer({
       position,
       top,
       left,
+      children: childBlocks,
       ...rest
-    } = block as Block;
+    } = block as PageComponent & { children?: PageComponent[] };
 
     const style: CSSProperties = {
       width,
@@ -50,42 +50,23 @@ export default function DynamicRenderer({
       left,
     };
 
-    type BlockProps = Omit<
-      Block,
-      | "id"
-      | "type"
-      | "children"
-      | "width"
-      | "height"
-      | "margin"
-      | "padding"
-      | "position"
-      | "top"
-      | "left"
-    >;
-    const props = rest as BlockProps;
-
-    let extraProps: Partial<BlockProps> = {};
+    let extraProps: Record<string, unknown> = {};
     if (getRuntimeProps) {
       const runtime = getRuntimeProps(block, locale);
-      extraProps = { ...extraProps, ...(runtime as Partial<BlockProps>) };
+      extraProps = { ...extraProps, ...(runtime as Record<string, unknown>) };
     }
 
     if (runtimeData && runtimeData[block.type]) {
       extraProps = {
         ...extraProps,
-        ...(runtimeData[block.type] as Partial<BlockProps>),
+        ...runtimeData[block.type],
       };
     }
-
-    const childBlocks = (block as Block & {
-      children?: PageComponent[];
-    }).children;
 
     return (
       <div key={id} style={style}>
         <Comp
-          {...(props as BlockProps)}
+          {...rest}
           {...extraProps}
           id={id}
           type={_type}

--- a/packages/ui/src/components/cms/ProductsTable.client.tsx
+++ b/packages/ui/src/components/cms/ProductsTable.client.tsx
@@ -2,7 +2,10 @@
 
 "use client";
 
-import { ProductPublication } from "@platform-core/src/products";
+import {
+  ProductPublication,
+  PublicationStatus,
+} from "@platform-core/src/products";
 import { useProductFilters } from "@ui/hooks/useProductFilters";
 import { formatCurrency } from "@acme/shared-utils";
 import Link from "next/link";
@@ -51,7 +54,7 @@ function ProductsTableBase({
   /*  Filters                                                               */
   /* ---------------------------------------------------------------------- */
   const { search, status, setSearch, setStatus, filteredRows } =
-    useProductFilters(rows);
+    useProductFilters<ProductPublication, PublicationStatus>(rows);
 
   /* ---------------------------------------------------------------------- */
   /*  Stable action handlers                                                */

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -3,7 +3,7 @@
 import { getShopFromPath } from "@platform-core/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { coreEnv } from "@acme/config/env/core";
+import { coreEnv } from "@config/core";
 import { luxuryFeatures } from "@platform-core/luxuryFeatures";
 
 if (coreEnv.NODE_ENV === "development") {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -32,7 +32,7 @@
   ],
 
   /* ---------- file globs ------------------------------------------ { "path": "../../apps/cms" } */
-  "include": ["src/**/*"], // ONLY stuff inside src/
+  "include": ["src/**/*", "src/**/*.json"], // ONLY stuff inside src/
   "exclude": [
     "dist", // freshly emitted output
     "**/__tests__/**", // unit/integration tests


### PR DESCRIPTION
## Summary
- align product filter typing with publication statuses
- fix import path for config core env
- relax dynamic renderer typing and include json assets in tsconfig

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file 'packages/types/dist/index.d.ts' has not been built)*
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68a06508bfb8832fb8aa55863a24183b