### PR TITLE
fix: resolve page builder type errors

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -144,7 +144,7 @@ const PageBuilder = memo(function PageBuilder({
     [],
   );
   const handleTourCallback = useCallback((data: CallBackProps) => {
-    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(data.status)) {
+    if (data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED) {
       setRunTour(false);
       if (typeof window !== "undefined") {
         localStorage.setItem("page-builder-tour", "done");
@@ -320,14 +320,12 @@ const PageBuilder = memo(function PageBuilder({
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
-              size="sm"
               onClick={() => setRunTour(true)}
             >
               Tour
             </Button>
             <Button
               variant="outline"
-              size="sm"
               onClick={() => setShowPreview((p) => !p)}
             >
               {showPreview ? "Hide preview" : "Show preview"}

--- a/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageCanvas.tsx
@@ -15,7 +15,7 @@ interface Props {
   components: PageComponent[];
   selectedId?: string | null;
   onSelectId?: (id: string | null) => void;
-  canvasRef?: React.RefObject<HTMLDivElement>;
+  canvasRef?: React.RefObject<HTMLDivElement | null>;
   dragOver?: boolean;
   setDragOver?: (v: boolean) => void;
   onFileDrop?: (e: DragEvent<HTMLDivElement>) => void;

--- a/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageToolbar.tsx
@@ -88,7 +88,7 @@ const PageToolbar = ({
         <Button
           variant="outline"
           onClick={() =>
-            setOrientation((o) => (o === "portrait" ? "landscape" : "portrait"))
+            setOrientation(orientation === "portrait" ? "landscape" : "portrait")
           }
           aria-label="Rotate"
         >

--- a/packages/ui/src/components/cms/page-builder/hooks/useFileDrop.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/useFileDrop.ts
@@ -4,10 +4,11 @@ import { ulid } from "ulid";
 import type { PageComponent, MediaItem } from "@acme/types";
 import useFileUpload from "@ui/hooks/useFileUpload";
 import { defaults } from "../defaults";
+import type { Action } from "../state/actions";
 
 interface Options {
   shop: string;
-  dispatch: (action: { type: string; component: PageComponent }) => void;
+  dispatch: (action: Action) => void;
 }
 
 const useFileDrop = ({ shop, dispatch }: Options) => {

--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
@@ -33,7 +33,7 @@ interface Params {
   containerTypes: string[];
   selectId: (id: string) => void;
   gridSize?: number;
-  canvasRef?: React.RefObject<HTMLDivElement>;
+  canvasRef?: React.RefObject<HTMLDivElement | null>;
   setSnapPosition?: (x: number | null) => void;
 }
 

--- a/packages/ui/src/components/cms/page-builder/useComponentInputs.ts
+++ b/packages/ui/src/components/cms/page-builder/useComponentInputs.ts
@@ -7,7 +7,7 @@ export default function useComponentInputs<T>(
 } {
   const handleInput = useCallback(
     <K extends keyof T>(field: K, value: T[K]) => {
-      onChange({ [field]: value } as Pick<T, K>);
+      onChange({ [field]: value } as Partial<T>);
     },
     [onChange],
   );

--- a/packages/ui/src/components/cms/page-builder/useGuides.ts
+++ b/packages/ui/src/components/cms/page-builder/useGuides.ts
@@ -6,7 +6,7 @@ export interface Guides {
 }
 
 export default function useGuides(
-  containerRef: React.RefObject<HTMLElement>
+  containerRef: React.RefObject<HTMLElement | null>
 ) {
   const siblingEdgesRef = useRef<{ vertical: number[]; horizontal: number[] }>(
     { vertical: [], horizontal: [] }


### PR DESCRIPTION
## Summary
- widen dispatch type for file drop handler
- adjust ref types and button usage in page builder
- allow orientation toggling with value update

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file '/workspace/base-shop/packages/types/dist/index.d.ts' has not been built)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find an accessible element with role "button" named `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68a06526bdac832f9c405600360b5fe4