### PR TITLE
Fix create shop scripts imports and args

### DIFF
--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import { parseArgs } from "./createShop/parse";
 import { gatherOptions } from "./createShop/prompts";
 import { writeShop } from "./createShop/write";
-import { ensureTemplateExists } from "../../packages/platform-core/src/createShop";
+import { ensureTemplateExists } from "../../packages/platform-core/src/createShop/fsUtils";
 
 function ensureRuntime() {
   const nodeMajor = Number(process.version.replace(/^v/, "").split(".")[0]);

--- a/scripts/src/createShop/write.ts
+++ b/scripts/src/createShop/write.ts
@@ -8,5 +8,5 @@ export async function writeShop(
   shopId: string,
   options: Options
 ): Promise<void> {
-  await createShop(shopId, options, { deploy: true });
+  await createShop(shopId, options);
 }

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -165,7 +165,7 @@ async function main() {
 
   const prefixedId = `shop-${shopId}`;
   try {
-    await createShop(prefixedId, options, { deploy: true });
+    await createShop(prefixedId, options);
   } catch (err) {
     console.error("Failed to create shop:", (err as Error).message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- use fsUtils ensureTemplateExists in create-shop script
- remove unnecessary deploy argument when calling createShop

## Testing
- `pnpm eslint scripts/src/create-shop.ts scripts/src/createShop/write.ts scripts/src/init-shop.ts` *(warning: File ignored because no matching configuration was supplied)*
- `pnpm jest test/unit/create-shop-cli.spec.ts test/unit/init-shop.spec.ts` *(fail: Cannot find module './createShop/parse'; SyntaxError: Cannot use 'import.meta' outside a module)*
- `npx tsc -p scripts/tsconfig.json` *(fail: Output file ... has not been built from source file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0689cbb04832fbc69ec069e3f4258