### PR TITLE
chore(tsconfig): add missing package paths

### DIFF
--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -35,14 +35,31 @@
 
       /* shared lib utilities */
       "@acme/lib": ["packages/lib/src/index.ts"],
-      "@acme/lib/*": ["packages/lib/src/*"]
+      "@acme/lib/*": ["packages/lib/src/*"],
+
+      /* runtime config helper */
+      "@config": ["packages/config/src/env/index.ts"],
+      "@config/*": ["packages/config/src/env/*"],
+
+      /* date utilities */
+      "@date-utils": ["packages/date-utils/src/index.ts"],
+
+      /* shared runtime types */
+      "@acme/types": ["packages/types/src/index.ts"],
+      "@acme/types/*": ["packages/types/src/*"]
     }
   },
 
   /* ------------------------------------------------------------------
    *  Project references
    * ------------------------------------------------------------------ */
-  "references": [{ "path": "../platform-core" }, { "path": "../lib" }],
+  "references": [
+    { "path": "../platform-core" },
+    { "path": "../lib" },
+    { "path": "../config" },
+    { "path": "../date-utils" },
+    { "path": "../types" }
+  ],
 
   /* ------------------------------------------------------------------
    *  Source globs

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -89,6 +89,8 @@
       "@config": ["packages/config/src/env/index.ts"],
       "@config/*": ["packages/config/src/env/*"],
       "@config/src/*": ["packages/config/src/env/*"],
+      "@acme/config": ["packages/config/src/env/index.ts"],
+      "@acme/config/*": ["packages/config/src/env/*"],
 
       /* ─── shared utilities ──────────────────────────────────────── */
       "@shared-utils": ["packages/shared-utils/src/index.ts"],


### PR DESCRIPTION
## Summary
- map `@acme/config` in base tsconfig
- extend platform-machine tsconfig with config, date-utils and types references

## Testing
- `pnpm run typecheck` *(fails: File '/workspace/base-shop/packages/lib/src/zodErrorMap.ts' is not under 'rootDir' '/workspace/base-shop/packages/config/src')*
- `pnpm --filter @acme/platform-machine exec tsc -p tsconfig.json --noEmit` *(fails: Cannot find name 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68a068c3b0a8832faf6dbb503f0bb3b8