### PR TITLE
chore(platform-machine): exclude tests from typecheck

### DIFF
--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -51,6 +51,7 @@
   "exclude": [
     "dist", // freshly emitted output
     ".turbo", // turbo cache
-    "node_modules" // package deps (if any local)
+    "node_modules", // package deps (if any local)
+    "src/__tests__" // tests aren't part of the build
   ]
 }


### PR DESCRIPTION
## Summary
- exclude platform-machine test sources from TypeScript typecheck

## Testing
- `pnpm --filter @acme/platform-machine build` *(fails: Cannot find module '@config/core' and other missing build artifacts)*
- `pnpm --filter @acme/platform-machine test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i` in apps/cms/__tests__/ThemeEditor.colors.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a068e5d15c832f9df93bbef14364ff