### PR TITLE
feat(config): add late fee env vars

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -64,6 +64,20 @@ export const coreEnvBaseSchema = z.object({
     })
     .transform((v) => Number(v))
     .optional(),
+  LATE_FEE_ENABLED: z
+    .string()
+    .refine((v) => v === "true" || v === "false", {
+      message: "must be true or false",
+    })
+    .transform((v) => v === "true")
+    .optional(),
+  LATE_FEE_INTERVAL_MS: z
+    .string()
+    .refine((v) => !Number.isNaN(Number(v)), {
+      message: "must be a number",
+    })
+    .transform((v) => Number(v))
+    .optional(),
   OPENAI_API_KEY: z.string().optional(),
   SESSION_SECRET: z.string().min(1),
   COOKIE_DOMAIN: z.string().optional(),
@@ -86,12 +100,15 @@ export function depositReleaseEnvRefinement(
   for (const [key, value] of Object.entries(env)) {
     const isDeposit = key.startsWith("DEPOSIT_RELEASE_");
     const isReverse = key.startsWith("REVERSE_LOGISTICS_");
-    if (!isDeposit && !isReverse) continue;
+    const isLateFee = key.startsWith("LATE_FEE_");
+    if (!isDeposit && !isReverse && !isLateFee) continue;
     if (
       key === "DEPOSIT_RELEASE_ENABLED" ||
       key === "DEPOSIT_RELEASE_INTERVAL_MS" ||
       key === "REVERSE_LOGISTICS_ENABLED" ||
-      key === "REVERSE_LOGISTICS_INTERVAL_MS"
+      key === "REVERSE_LOGISTICS_INTERVAL_MS" ||
+      key === "LATE_FEE_ENABLED" ||
+      key === "LATE_FEE_INTERVAL_MS"
     )
       continue;
     if (key.includes("ENABLED")) {


### PR DESCRIPTION
## Summary
- add late fee env variables to core config
- validate dynamic late fee env keys

## Testing
- `pnpm exec tsc -p packages/config/tsconfig.json --noEmit` (fails: File '/workspace/base-shop/packages/lib/src/initZod.ts' is not under 'rootDir')
- `pnpm --filter @acme/platform-machine build` (fails: Output file has not been built from source file)
- `pnpm test --filter @acme/config`
- `pnpm test --filter @acme/platform-machine` (fails: command exited with 1)


------
https://chatgpt.com/codex/tasks/task_e_68a06e2ef028832fbb1d8027917c0e29