### PR TITLE
Export SKU type and fix product filter typings

### DIFF
--- a/packages/platform-core/src/products.ts
+++ b/packages/platform-core/src/products.ts
@@ -74,6 +74,7 @@ export type {
   ProductCore,
   ProductPublication,
   PublicationStatus,
+  SKU,
 } from "@acme/types";
 
 /* -------------------------------------------------------------------------- */

--- a/packages/ui/src/components/cms/blocks/ProductFilter.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductFilter.tsx
@@ -19,7 +19,7 @@ export default function ProductFilter({
 
   const sizes = useMemo(() => {
     const s = new Set<string>();
-    filteredRows.forEach((p) => p.sizes?.forEach((sz) => s.add(sz)));
+    filteredRows.forEach((p) => p.sizes?.forEach((sz: string) => s.add(sz)));
     return Array.from(s).sort();
   }, [filteredRows]);
 

--- a/packages/ui/src/components/cms/blocks/ProductGrid.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductGrid.stories.tsx
@@ -4,7 +4,7 @@ import { PRODUCTS } from "@platform-core/src/products";
 
 const meta: Meta<typeof ProductGrid> = {
   component: ProductGrid,
-  args: { skus: PRODUCTS },
+  args: { skus: [...PRODUCTS] },
 };
 export default meta;
 


### PR DESCRIPTION
## Summary
- re-export `SKU` from platform-core product helpers
- annotate product filter size iteration
- copy product list before passing to ProductGrid story

## Testing
- `pnpm -F ui test -- --runTestsByPath packages/ui/src/components/cms/blocks/ProductFilter.tsx`
- `pnpm -F platform-core test -- --runTestsByPath packages/platform-core/src/products.ts`
- `pnpm typecheck` *(fails: Output file '/workspace/base-shop/packages/platform-core/dist/createShop.d.ts' has not been built from source file '/workspace/base-shop/packages/platform-core/src/createShop.ts'. Found 1189 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a06e627ae8832fb1acb11d1a84984c