### PR TITLE
fix cms block typing and imports

### DIFF
--- a/packages/ui/src/components/cms/blocks/CustomHtml.tsx
+++ b/packages/ui/src/components/cms/blocks/CustomHtml.tsx
@@ -1,7 +1,7 @@
 import DOMPurify from "dompurify";
 import { memo } from "react";
 
-interface CustomHtmlProps {
+export interface CustomHtmlProps {
   html?: string;
 }
 

--- a/packages/ui/src/components/cms/blocks/FooterBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FooterBlock.tsx
@@ -1,5 +1,5 @@
 import type { Locale } from "@/i18n/locales";
-import Footer, { type FooterLink } from "../../organisms/Footer";
+import { Footer, type FooterLink } from "../../organisms/Footer";
 
 interface Props {
   links?: FooterLink[];

--- a/packages/ui/src/components/cms/blocks/HeaderBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/HeaderBlock.tsx
@@ -1,5 +1,5 @@
 import type { Locale } from "@/i18n/locales";
-import Header, { type NavSection } from "../../organisms/Header";
+import { Header, type NavSection } from "../../organisms/Header";
 
 interface Props {
   nav?: NavSection[];

--- a/packages/ui/src/components/cms/blocks/layout.tsx
+++ b/packages/ui/src/components/cms/blocks/layout.tsx
@@ -9,11 +9,15 @@ const layoutEntries = {
   Footer: { component: Footer },
 } as const;
 
+type LayoutRegistry = {
+  [K in keyof typeof layoutEntries]: BlockRegistryEntry<any>;
+};
+
 export const layoutRegistry = Object.fromEntries(
   Object.entries(layoutEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as typeof layoutEntries satisfies Record<string, BlockRegistryEntry<any>>;
+) as LayoutRegistry;
 
 export type LayoutBlockType = keyof typeof layoutEntries;

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -108,11 +108,15 @@ const moleculeEntries = {
   CategoryList: { component: CategoryList },
 } as const;
 
+type MoleculeRegistry = {
+  [K in keyof typeof moleculeEntries]: BlockRegistryEntry<any>;
+};
+
 export const moleculeRegistry = Object.fromEntries(
   Object.entries(moleculeEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as typeof moleculeEntries satisfies Record<string, BlockRegistryEntry<any>>;
+) as MoleculeRegistry;
 
 export type MoleculeBlockType = keyof typeof moleculeEntries;

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -100,11 +100,15 @@ const organismEntries = {
   ProductFilter: { component: ProductFilter },
 } as const;
 
+type OrganismRegistry = {
+  [K in keyof typeof organismEntries]: BlockRegistryEntry<any>;
+};
+
 export const organismRegistry = Object.fromEntries(
   Object.entries(organismEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as typeof organismEntries satisfies Record<string, BlockRegistryEntry<any>>;
+) as OrganismRegistry;
 
 export type OrganismBlockType = keyof typeof organismEntries;

--- a/packages/ui/src/components/cms/blocks/overlays.tsx
+++ b/packages/ui/src/components/cms/blocks/overlays.tsx
@@ -7,12 +7,16 @@ const overlayEntries = {
   PopupModal: { component: PopupModal },
 } as const;
 
+type OverlayRegistry = {
+  [K in keyof typeof overlayEntries]: BlockRegistryEntry<any>;
+};
+
 export const overlayRegistry = Object.fromEntries(
   Object.entries(overlayEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as typeof overlayEntries satisfies Record<string, BlockRegistryEntry<any>>;
+) as OverlayRegistry;
 
 export type OverlayBlockType = keyof typeof overlayEntries;
 


### PR DESCRIPTION
## Summary
- fix Footer and Header blocks to use named imports
- export CustomHtml props interface
- add explicit types for block registries

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file ... has not been built from source file)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/Footer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a06e737ca8832fa69c38e3e05be493