### PR TITLE
chore(ui): add shared-utils reference

### DIFF
--- a/packages/ui/src/components/atoms/ARViewer.tsx
+++ b/packages/ui/src/components/atoms/ARViewer.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../types/model-viewer.d.ts" />
-
 import * as React from "react";
 import { cn } from "../../utils/style";
 

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -28,7 +28,8 @@
     { "path": "../i18n" },
     { "path": "../config" },
     { "path": "../auth" },
-    { "path": "../lib" }
+    { "path": "../lib" },
+    { "path": "../shared-utils" }
   ],
 
   /* ---------- file globs ------------------------------------------ { "path": "../../apps/cms" } */


### PR DESCRIPTION
## Summary
- add shared-utils project reference for the ui package
- drop obsolete model-viewer triple-slash reference

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file '/workspace-base-shop/packages/shared-utils/dist/index.d.ts' has not been built from source file '/workspace-base-shop/packages/shared-utils/src/index.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68a06e9307dc832f80be9c64640df2d1