### PR TITLE
Fix TypeScript references and createShop exports

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -32,6 +32,7 @@
     { "path": "../../packages/shared-utils" },
     { "path": "../../packages/lib" },
     { "path": "../../packages/date-utils" },
+    { "path": "../../packages/platform-core" },
     { "path": "../../packages/platform-machine" },
     { "path": "../../packages/stripe" },
     { "path": "../../packages/configurator" }

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -13,23 +13,31 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   ? I
   : never;
 
-type MergedShape<T extends readonly z.ZodObject<any, any, any, any, any>[]> =
+type AnyZodObject = z.ZodObject<z.ZodRawShape, any, any, any, any>;
+
+type MergedShape<T extends readonly AnyZodObject[]> =
   UnionToIntersection<
     {
-      [K in keyof T]: T[K] extends z.ZodObject<infer S, any, any, any, any>
+      [K in keyof T]: T[K] extends z.ZodObject<
+        infer S extends z.ZodRawShape,
+        any,
+        any,
+        any,
+        any
+      >
         ? S
         : never;
     }[number]
-  >;
+  > &
+  z.ZodRawShape;
 
-export const mergeEnvSchemas = <
-  T extends readonly z.ZodObject<any, any, any, any, any>[]
->(
+export const mergeEnvSchemas = <T extends readonly AnyZodObject[]>(
   ...schemas: T
 ): z.ZodObject<MergedShape<T>> =>
-  schemas.reduce((acc, s) => acc.merge(s), z.object({})) as z.ZodObject<
-    MergedShape<T>
-  >;
+  schemas.reduce(
+    (acc, s) => acc.merge(s),
+    z.object({})
+  ) as z.ZodObject<MergedShape<T>>;
 
 const mergedEnvSchema = mergeEnvSchemas(
   coreEnvBaseSchema,

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -23,6 +23,8 @@
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
   ]
+,
 
-  /* no project-references needed; the file is self-contained */
+  /* build dependency graph ------------------------------------------ */
+  "references": [{ "path": "../lib" }]
 }

--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -1,20 +1,20 @@
-// packages/platform-core/createShop.ts
+// packages/platform-core/src/createShop/index.ts
 import { readdirSync, existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { prisma } from "./db";
-import { validateShopName } from "./shops";
+import { prisma } from "../db";
+import { validateShopName } from "../shops";
 import {
   prepareOptions,
   createShopOptionsSchema as baseCreateShopOptionsSchema,
   type CreateShopOptions,
   type PreparedCreateShopOptions,
-} from "./createShop/schema";
-import { loadTokens } from "./createShop/themeUtils";
-import type { DeployStatusBase, DeployShopResult } from "./createShop/deployTypes";
+} from "./schema";
+import { loadTokens } from "./themeUtils";
+import type { DeployStatusBase, DeployShopResult } from "./deployTypes";
 import {
   defaultDeploymentAdapter,
   type ShopDeploymentAdapter,
-} from "./createShop/deploymentAdapter";
+} from "./deploymentAdapter";
 /**
  * Create a new shop app and seed data.
  * Paths are resolved relative to the repository root.
@@ -154,17 +154,17 @@ export function syncTheme(shop: string, theme: string): Record<string, string> {
 export const createShopOptionsSchema = baseCreateShopOptionsSchema.strict();
 export { prepareOptions };
 export type { CreateShopOptions, PreparedCreateShopOptions };
-export type { DeployStatusBase, DeployShopResult } from "./createShop/deployTypes";
+export type { DeployStatusBase, DeployShopResult } from "./deployTypes";
 export {
   ensureTemplateExists,
   copyTemplate,
   readFile,
   writeFile,
-} from "./createShop/fsUtils";
-export { loadTokens, loadBaseTokens } from "./createShop/themeUtils";
+} from "./fsUtils";
+export { loadTokens, loadBaseTokens } from "./themeUtils";
 export { syncTheme };
 export {
   type ShopDeploymentAdapter,
   CloudflareDeploymentAdapter,
   defaultDeploymentAdapter,
-} from "./createShop/deploymentAdapter";
+} from "./deploymentAdapter";

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -1,4 +1,7 @@
-import { createShop } from "../../packages/platform-core/src/createShop";
+import {
+  createShop,
+  type CreateShopOptions,
+} from "../../packages/platform-core/src/createShop";
 import { validateShopName } from "../../packages/platform-core/src/shops";
 import { spawnSync, execSync } from "node:child_process";
 import { readdirSync } from "node:fs";
@@ -131,7 +134,8 @@ async function main() {
   const logo = await promptUrl("Logo URL (optional): ");
   const contact = await promptEmail("Contact email (optional): ");
   const typeAns = await prompt("Shop type (sale or rental) [sale]: ", "sale");
-  const type = typeAns.toLowerCase() === "rental" ? "rental" : "sale";
+  const type: "sale" | "rental" =
+    typeAns.toLowerCase() === "rental" ? "rental" : "sale";
   const themes = listDirNames(new URL("../../packages/themes", import.meta.url));
   const theme = await selectOption(
     "theme",
@@ -152,7 +156,7 @@ async function main() {
   const shipping = await selectProviders("shipping providers", shippingProviders);
   const ciAns = await prompt("Setup CI workflow? (y/N): ");
 
-  const options = {
+  const options: CreateShopOptions = {
     ...(name && { name }),
     ...(logo && { logo }),
     ...(contact && { contactInfo: contact }),


### PR DESCRIPTION
## Summary
- link config package to shared lib to avoid rootDir errors
- reference platform-core in CMS tsconfig
- move createShop implementation under its own directory and export syncTheme
- tighten env schema merging types
- type options for init-shop script

## Testing
- `pnpm -s tsc -p packages/config/tsconfig.json`
- `pnpm -s tsc -p packages/platform-core/tsconfig.json`
- `pnpm -s tsc --noEmit scripts/src/init-shop.ts`
- `pnpm -s tsc -p apps/cms/tsconfig.json` *(fails: Output file ... has not been built)*
- `pnpm -s --filter @acme/platform-core test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a06e1fe240832f8d9ef616199d34a0