### PR TITLE
fix: remove circular tsconfig reference

### DIFF
--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -17,9 +17,6 @@
     "allowImportingTsExtensions": false
   },
 
-  /* build dependency graph ------------------------------------------ */
-  "references": [{ "path": "../config" }],
-
   /* source globs ---------------------------------------------------- */
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
## Summary
- drop unnecessary `packages/lib` reference to `packages/config`

## Testing
- `npx tsc -b apps/cms --noEmit` *(fails: TypeScript errors in multiple packages)*
- `pnpm --filter @acme/lib test` *(terminated: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a072054e28832f94f39def1d269a79