### PR TITLE
fix(cms): cast NEXTAUTH_SECRET to string

### DIFF
--- a/apps/cms/src/auth/secret.js
+++ b/apps/cms/src/auth/secret.js
@@ -3,4 +3,5 @@ import { env } from "@acme/config";
 if (!env.NEXTAUTH_SECRET) {
     throw new Error("NEXTAUTH_SECRET is not set");
 }
-export const authSecret = env.NEXTAUTH_SECRET;
+// Ensure the secret is treated as a string at runtime
+export const authSecret = String(env.NEXTAUTH_SECRET);

--- a/apps/cms/src/auth/secret.ts
+++ b/apps/cms/src/auth/secret.ts
@@ -6,4 +6,5 @@ if (!env.NEXTAUTH_SECRET) {
   throw new Error("NEXTAUTH_SECRET is not set");
 }
 
-export const authSecret = env.NEXTAUTH_SECRET;
+// Explicitly cast to string so consumers receive a correctly typed secret
+export const authSecret = env.NEXTAUTH_SECRET as string;


### PR DESCRIPTION
## Summary
- cast NEXTAUTH_SECRET to string in CMS auth secret helper

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Output file ... has not been built)*
- `pnpm --filter @apps/cms test` *(fails: Unable to find accessible element and configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a07690f2c8832f84f2a619e29c756a