### PR TITLE
Fix env typing and use source createShop imports

### DIFF
--- a/apps/cms/src/app/api/blog/slug/route.ts
+++ b/apps/cms/src/app/api/blog/slug/route.ts
@@ -4,7 +4,10 @@ import { getShopById } from "@platform-core/src/repositories/shop.server";
 import { getSanityConfig } from "@platform-core/src/shops";
 import { ensureAuthorized } from "@cms/actions/common/auth";
 
-const apiVersion = env.SANITY_API_VERSION || "2021-10-21";
+const apiVersion: string =
+  typeof env.SANITY_API_VERSION === "string"
+    ? env.SANITY_API_VERSION
+    : "2021-10-21";
 
 interface Config {
   projectId: string;

--- a/apps/cms/src/app/api/configurator/route.ts
+++ b/apps/cms/src/app/api/configurator/route.ts
@@ -1,6 +1,6 @@
 import "@acme/lib/initZod";
 import { createNewShop } from "@cms/actions/createShop.server";
-import { createShopOptionsSchema } from "@platform-core/createShop";
+import { createShopOptionsSchema } from "@platform-core/src/createShop";
 import { validateShopEnv } from "@platform-core/configurator";
 import { NextResponse } from "next/server";
 import { z } from "zod";

--- a/apps/cms/src/app/api/create-shop/route.ts
+++ b/apps/cms/src/app/api/create-shop/route.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/app/api/create-shop/route.ts
 import "@acme/lib/initZod";
 import { createNewShop } from "@cms/actions/createShop.server";
-import { createShopOptionsSchema } from "@platform-core/createShop";
+import { createShopOptionsSchema } from "@platform-core/src/createShop";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 

--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -14,9 +14,11 @@ interface Discount extends Coupon {
 
 function getShop(req: NextRequest): string {
   const { searchParams } = new URL(req.url);
-  return (
-    searchParams.get("shop") || env.NEXT_PUBLIC_DEFAULT_SHOP || "abc"
-  );
+  const fromQuery = searchParams.get("shop");
+  if (fromQuery) return fromQuery;
+  return typeof env.NEXT_PUBLIC_DEFAULT_SHOP === "string"
+    ? env.NEXT_PUBLIC_DEFAULT_SHOP
+    : "abc";
 }
 
 function filePath(shop: string): string {


### PR DESCRIPTION
## Summary
- ensure `SANITY_API_VERSION` fallback is treated as string in blog slug route
- guard shop resolution with env fallback in marketing discounts API
- import createShop utilities from source to avoid missing build artifacts

## Testing
- `npx tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Output file ... has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68a076aef794832f8a8c4d5e40b577dc