### PR TITLE
fix: refine molecule registry typing

### DIFF
--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -107,16 +107,11 @@ const moleculeEntries = {
   PromoBanner: { component: PromoBanner },
   CategoryList: { component: CategoryList },
 } as const;
-
-type MoleculeRegistry = {
-  [K in keyof typeof moleculeEntries]: BlockRegistryEntry<any>;
-};
-
 export const moleculeRegistry = Object.fromEntries(
   Object.entries(moleculeEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as MoleculeRegistry;
+) as typeof moleculeEntries satisfies Record<string, BlockRegistryEntry<any>>;
 
 export type MoleculeBlockType = keyof typeof moleculeEntries;


### PR DESCRIPTION
## Summary
- refine moleculeRegistry typing using `satisfies` to avoid TS2352 error

## Testing
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError: Unable to find an accessible element)*
- `pnpm --filter @acme/ui build` *(fails: TS6305: Output file has not been built from source)*

------
https://chatgpt.com/codex/tasks/task_e_68a076bbb6b8832fa4de1f51702887b8