### PR TITLE
chore: include date-utils in ui tsconfig references

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -29,7 +29,8 @@
     { "path": "../config" },
     { "path": "../auth" },
     { "path": "../lib" },
-    { "path": "../shared-utils" }
+    { "path": "../shared-utils" },
+    { "path": "../date-utils" }
   ],
 
   /* ---------- file globs ------------------------------------------ { "path": "../../apps/cms" } */


### PR DESCRIPTION
## Summary
- include @acme/date-utils in the UI package's TypeScript project references

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file '/workspace/base-shop/packages/types/dist/upgrade.d.ts' has not been built from source file '/workspace/base-shop/packages/types/src/upgrade.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68a076c74da4832f8c5fb7611654b526