### PR TITLE
fix: narrow registry types

### DIFF
--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -94,11 +94,15 @@ const atomEntries = {
   Button: { component: ButtonBlock },
 } as const;
 
+type AtomRegistry = {
+  [K in keyof typeof atomEntries]: BlockRegistryEntry<any>;
+};
+
 export const atomRegistry = Object.fromEntries(
   Object.entries(atomEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as typeof atomEntries satisfies Record<string, BlockRegistryEntry<any>>;
+) as AtomRegistry;
 
 export type AtomBlockType = keyof typeof atomEntries;

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -9,11 +9,15 @@ const containerEntries = {
   MultiColumn: { component: MultiColumn },
 } as const;
 
+type ContainerRegistry = {
+  [K in keyof typeof containerEntries]: BlockRegistryEntry<any>;
+};
+
 export const containerRegistry = Object.fromEntries(
   Object.entries(containerEntries).map(([k, v]) => [
     k,
     { previewImage: defaultPreview, ...v },
   ]),
-) as typeof containerEntries satisfies Record<string, BlockRegistryEntry<any>>;
+) as ContainerRegistry;
 
 export type ContainerBlockType = keyof typeof containerEntries;


### PR DESCRIPTION
## Summary
- ensure atom and container block registries have key-specific types

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file dist not built / missing properties in ProductWithVariants)*
- `pnpm --filter @acme/ui test` *(fails: jest exits 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a076d25664832fb5709a1a981e3b62