### PR TITLE
Remove @ui dependency from platform-core components

### DIFF
--- a/packages/platform-core/src/components/blog/BlogPortableText.tsx
+++ b/packages/platform-core/src/components/blog/BlogPortableText.tsx
@@ -2,7 +2,7 @@
 import { PortableText } from "@portabletext/react";
 import Link from "next/link";
 import { getProductBySlug, getProductById } from "@/lib/products";
-import { ProductCarousel } from "@ui";
+import { ProductCard } from "../shop/ProductCard";
 
 const components = {
   types: {
@@ -28,7 +28,13 @@ const components = {
           </Link>
         );
       }
-      return <ProductCarousel products={products} />;
+      return (
+        <div className="flex gap-4 overflow-x-auto py-4">
+          {products.map((p) => (
+            <ProductCard key={p.id} sku={p} />
+          ))}
+        </div>
+      );
     },
     embed: ({ value }: any) => (
       <div className="aspect-video">

--- a/packages/platform-core/src/components/shop/ProductCard.tsx
+++ b/packages/platform-core/src/components/shop/ProductCard.tsx
@@ -2,9 +2,21 @@
 import type { SKU } from "@acme/types";
 import Image from "next/image";
 import Link from "next/link";
-import { Price } from "@ui/components/atoms/Price";
+import { useCurrency } from "@/contexts/CurrencyContext";
+import { formatPrice } from "@acme/shared-utils";
 import { memo } from "react";
 import AddToCartButton from "./AddToCartButton.client";
+
+interface PriceProps {
+  amount: number;
+  currency?: string;
+}
+
+function Price({ amount, currency }: PriceProps) {
+  const [ctxCurrency] = useCurrency();
+  const cur = currency ?? ctxCurrency ?? "EUR";
+  return <span>{formatPrice(amount, cur)}</span>;
+}
 
 function ProductCardInner({ sku }: { sku: SKU }) {
   return (


### PR DESCRIPTION
## Summary
- avoid cross-package imports from @ui in platform-core components by implementing a local `Price` helper
- replace `ProductCarousel` usage with inline list of `ProductCard`

## Testing
- `pnpm tsc -p packages/platform-core/tsconfig.json --noEmit` *(fails: File '/workspace/base-shop/packages/ui/src/hooks/usePublishLocations.ts' is not listed within the file list of project '/workspace-base-shop/packages/platform-core/tsconfig.json')*
- `pnpm --filter @acme/platform-core test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i` in ThemeEditor tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a076fd0550832faf60fc660301deae