### PR TITLE
fix(cms): type auth secret as string

### DIFF
--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -14,7 +14,8 @@ import { authSecret } from "./secret";
 /*  Secret handling                                                           */
 /* -------------------------------------------------------------------------- */
 
-const secret = authSecret;
+// Explicitly type the secret so NextAuth receives a string
+const secret: string = authSecret as string;
 
 /* -------------------------------------------------------------------------- */
 /*  AuthOptions factory (dependency‑injectable for tests)                     */

--- a/apps/cms/src/middleware.ts
+++ b/apps/cms/src/middleware.ts
@@ -34,7 +34,8 @@ export async function middleware(req: NextRequest) {
   /* Decode JWT */
   const token = (await getToken({
     req,
-    secret: authSecret,
+    // Ensure the secret is treated as a string for JWT decoding
+    secret: authSecret as string,
   })) as CmsToken | null;
   const role: Role | null = token?.role ?? null;
   logger.debug("role", { role });


### PR DESCRIPTION
## Summary
- ensure NextAuth secret is a string in CMS auth options and middleware

## Testing
- `pnpm eslint apps/cms/src/auth/options.ts apps/cms/src/middleware.ts`
- `pnpm tsc -p apps/cms/tsconfig.json` *(fails: Output file ... has not been built from source file ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a07dd1e5f8832f97004c198d515f2d