### PR TITLE
chore: use workspace imports for createShop

### DIFF
--- a/scripts/src/createShop/write.ts
+++ b/scripts/src/createShop/write.ts
@@ -1,4 +1,4 @@
-import { createShop } from "../../../packages/platform-core/src/createShop";
+import { createShop } from "@platform-core/createShop";
 import type { Options } from "./parse";
 
 /**

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -1,14 +1,11 @@
-import {
-  createShop,
-  type CreateShopOptions,
-} from "../../packages/platform-core/src/createShop";
-import { validateShopName } from "../../packages/platform-core/src/shops";
+import { createShop, type CreateShopOptions } from "@platform-core/createShop";
+import { validateShopName } from "@platform-core/shops";
 import { spawnSync, execSync } from "node:child_process";
 import { readdirSync } from "node:fs";
-import { validateShopEnv } from "../../packages/platform-core/src/configurator";
+import { validateShopEnv } from "@platform-core/configurator";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import { listProviders } from "../../packages/platform-core/src/createShop/listProviders";
+import { listProviders } from "@platform-core/createShop/listProviders";
 
 function ensureRuntime() {
   const nodeMajor = Number(process.version.replace(/^v/, "").split(".")[0]);


### PR DESCRIPTION
## Summary
- replace relative imports with workspace paths for createShop utilities

## Testing
- `pnpm tsc -b scripts --noEmit` *(fails: packages/types page type errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a07dc5f794832f83cd44b4e061ee24