### PR TITLE
fix: cast env vars to strings

### DIFF
--- a/apps/cms/src/app/api/blog/slug/route.ts
+++ b/apps/cms/src/app/api/blog/slug/route.ts
@@ -4,10 +4,8 @@ import { getShopById } from "@platform-core/src/repositories/shop.server";
 import { getSanityConfig } from "@platform-core/src/shops";
 import { ensureAuthorized } from "@cms/actions/common/auth";
 
-const apiVersion: string =
-  typeof env.SANITY_API_VERSION === "string"
-    ? env.SANITY_API_VERSION
-    : "2021-10-21";
+const apiVersion =
+  (env.SANITY_API_VERSION as string | undefined) ?? "2021-10-21";
 
 interface Config {
   projectId: string;

--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -16,9 +16,9 @@ function getShop(req: NextRequest): string {
   const { searchParams } = new URL(req.url);
   const fromQuery = searchParams.get("shop");
   if (fromQuery) return fromQuery;
-  return typeof env.NEXT_PUBLIC_DEFAULT_SHOP === "string"
-    ? env.NEXT_PUBLIC_DEFAULT_SHOP
-    : "abc";
+  return (
+    (env.NEXT_PUBLIC_DEFAULT_SHOP as string | undefined) ?? "abc"
+  );
 }
 
 function filePath(shop: string): string {


### PR DESCRIPTION
## Summary
- ensure SANITY_API_VERSION env var defaults to string
- cast default shop env var to string in discount route

## Testing
- `pnpm --filter @apps/cms test` *(fails: Unable to find accessible element, module mapping error, inventory import expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68a07de6999c832f9d4903163a1da110