### PR TITLE
fix: allow ui package to import date-utils

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDeclarationOnly": false,
 
     /* ---------- output locations ---------------------------------- */
-    "rootDir": "./src", // <- compiled sources live here
+    "rootDir": "./", // allow imports from workspace packages
     "outDir": "./dist", // <- JS + d.ts land here
     "declarationDir": "./dist",
     "declarationMap": true,


### PR DESCRIPTION
## Summary
- expand `rootDir` in `packages/ui/tsconfig.json` so workspace packages like `@acme/date-utils` are within the TypeScript project

## Testing
- `pnpm --filter @acme/ui build` *(fails: Output file has not been built from source file)*
- `pnpm --filter @acme/ui test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68a07dfe84a4832f9de9634e221d3b29