### PR TITLE
Fix TypeScript errors for UI account and checkout components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 packages/ui/src/**/*.js
 packages/ui/src/**/*.d.ts
 packages/ui/src/**/*.d.ts.map
+!packages/ui/src/types/qrcode.d.ts
 
 # ---------------------------
 # Misc

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -7,3 +7,4 @@ export * from "./defaultFilterMappings";
 export * from "./themeTokens";
 export * from "./dataRoot";
 export * from "./utils";
+export * from "./customerProfiles";

--- a/packages/ui/src/components/checkout/CheckoutForm.tsx
+++ b/packages/ui/src/components/checkout/CheckoutForm.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { useTranslations } from "@/i18n/Translations";
-import { paymentEnv } from "@acme/config/env/payments";
 import {
   Elements,
   PaymentElement,
@@ -18,7 +17,7 @@ import { isoDateInNDays } from "@acme/date-utils";
 import { useCurrency } from "@platform-core/src/contexts/CurrencyContext";
 
 const stripePromise = loadStripe(
-  paymentEnv.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY as string,
 );
 
 type Props = {

--- a/packages/ui/src/types/qrcode.d.ts
+++ b/packages/ui/src/types/qrcode.d.ts
@@ -1,0 +1,10 @@
+declare module "qrcode" {
+  export function toDataURL(
+    text: string,
+    opts?: unknown
+  ): Promise<string>;
+  const _default: {
+    toDataURL: typeof toDataURL;
+  };
+  export default _default;
+}


### PR DESCRIPTION
## Summary
- add qrcode module declaration and ignore override
- export customer profile helpers from platform-core
- use Stripe publishable key directly in CheckoutForm

## Testing
- `npx jest packages/ui/__tests__/MfaSetup.test.tsx packages/ui/__tests__/Profile.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a07e1b000c832fa8ac68bae125a877