### PR TITLE
refactor: decouple email templates from ui

### DIFF
--- a/apps/cms/__tests__/marketingEmailApi.test.ts
+++ b/apps/cms/__tests__/marketingEmailApi.test.ts
@@ -3,25 +3,20 @@ import type { NextRequest } from "next/server";
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import { DATA_ROOT } from "@platform-core/dataRoot";
+import { setMarketingEmailTemplates } from "@acme/email";
 
 jest.doMock("@platform-core/analytics", () => ({
   __esModule: true,
   trackEvent: jest.fn(),
 }));
-jest.doMock(
-  "@acme/ui",
-  () => ({
-    __esModule: true,
-    marketingEmailTemplates: [],
-  }),
-  { virtual: true }
-);
 
 process.env.CART_COOKIE_SECRET = "secret";
 process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.RESEND_API_KEY = "re_test";
+
+setMarketingEmailTemplates([]);
 
 const ResponseWithJson = Response as unknown as typeof Response & {
   json?: (data: unknown, init?: ResponseInit) => Response;

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -24,18 +24,13 @@ jest.mock("@platform-core/repositories/analytics.server", () => ({
   __esModule: true,
   listEvents: jest.fn().mockResolvedValue([]),
 }));
-jest.mock(
-  "@acme/ui",
-  () => ({
-    __esModule: true,
-    marketingEmailTemplates: [],
-  }),
-  { virtual: true },
-);
 const { sendCampaignEmail } = require("../send");
 const sendCampaignEmailMock = sendCampaignEmail as jest.Mock;
 const { listEvents } = require("@platform-core/repositories/analytics.server");
 const listEventsMock = listEvents as jest.Mock;
+
+const { setMarketingEmailTemplates } = require("../templates");
+setMarketingEmailTemplates([]);
 
 describe("scheduler", () => {
   const shop = "schedulertest";

--- a/packages/email/src/__tests__/templates.test.ts
+++ b/packages/email/src/__tests__/templates.test.ts
@@ -1,20 +1,14 @@
-import { jest } from "@jest/globals";
 import * as React from "react";
 
 describe("renderTemplate", () => {
-  afterEach(() => {
-    jest.resetModules();
-  });
-
   it("renders registered string templates with variables", async () => {
-    jest.doMock(
-      "@acme/ui",
-      () => ({ __esModule: true, marketingEmailTemplates: [] }),
-      { virtual: true },
-    );
-    const { registerTemplate, renderTemplate, clearTemplates } = await import(
-      "../templates"
-    );
+    const {
+      registerTemplate,
+      renderTemplate,
+      clearTemplates,
+      setMarketingEmailTemplates,
+    } = await import("../templates");
+    setMarketingEmailTemplates([]);
     registerTemplate("welcome", "<p>Hello {{name}}</p>");
     const html = renderTemplate("welcome", { name: "Ada" });
     expect(html).toBe("<p>Hello Ada</p>");
@@ -22,29 +16,22 @@ describe("renderTemplate", () => {
   });
 
   it("renders marketing email template variants", async () => {
-    jest.doMock(
-      "@acme/ui",
-      () => ({
-        __esModule: true,
-        marketingEmailTemplates: [
-          {
-            id: "basic",
-            render: ({ headline, content, footer }: any) => (
-              React.createElement(
-                "div",
-                null,
-                React.createElement("h1", null, headline),
-                content,
-                footer,
-              )
-            ),
-          },
-        ],
-      }),
-      { virtual: true },
+    const { renderTemplate, setMarketingEmailTemplates } = await import(
+      "../templates",
     );
-
-    const { renderTemplate } = await import("../templates");
+    setMarketingEmailTemplates([
+      {
+        id: "basic",
+        render: ({ headline, content, footer }: any) =>
+          React.createElement(
+            "div",
+            null,
+            React.createElement("h1", null, headline),
+            content,
+            footer,
+          ),
+      },
+    ]);
     const html = renderTemplate("basic", {
       subject: "Hi",
       body: "<p>Test</p>",

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,6 +1,22 @@
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { marketingEmailTemplates } from "@acme/ui";
+
+export interface MarketingEmailTemplateVariant {
+  id: string;
+  render: (props: {
+    headline: string;
+    content: React.ReactNode;
+    footer: React.ReactNode;
+  }) => React.ReactElement;
+}
+
+let marketingEmailTemplates: MarketingEmailTemplateVariant[] = [];
+
+export function setMarketingEmailTemplates(
+  templates: MarketingEmailTemplateVariant[],
+): void {
+  marketingEmailTemplates = templates;
+}
 
 const templates: Record<string, string> = {};
 

--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -8,7 +8,7 @@ import { defaultPaymentProviders } from "./defaultPaymentProviders";
 import { defaultShippingProviders } from "./defaultShippingProviders";
 import { defaultTaxProviders } from "./defaultTaxProviders";
 
-interface NavItem {
+export interface NavItem {
   label: string;
   url: string;
   children?: NavItem[];

--- a/packages/platform-core/src/tax/index.ts
+++ b/packages/platform-core/src/tax/index.ts
@@ -3,7 +3,7 @@
 import "server-only";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { shippingEnv } from "@acme/config/env/shipping";
+import { shippingEnv } from "@acme/config/shipping";
 import { resolveDataRoot } from "../dataRoot";
 
 export interface TaxCalculationRequest {

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -35,7 +35,7 @@
   "include": ["src/**/*"],
   "exclude": [
     "dist", // freshly emitted output
-    "__tests__", // unit/integration tests
+    "**/__tests__/**", // unit/integration tests
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
   ],
@@ -43,5 +43,15 @@
   /* ------------------------------------------------------------------
    *  Build order
    * ------------------------------------------------------------------ */
-  "references": [{ "path": "../lib" }, { "path": "../types" }]
+  "references": [
+    { "path": "../lib" },
+    { "path": "../types" },
+    { "path": "../config" },
+    { "path": "../date-utils" },
+    { "path": "../stripe" },
+    { "path": "../shared-utils" },
+    { "path": "../email" },
+    { "path": "../plugins/sanity" },
+    { "path": "../themes/base" }
+  ]
 }

--- a/packages/plugins/sanity/tsconfig.json
+++ b/packages/plugins/sanity/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "rootDir": ".",
+    "outDir": "dist",
+    "allowImportingTsExtensions": false
+  },
+  "include": ["index.ts"],
+  "exclude": ["dist", "node_modules", "**/__tests__/**"]
+}


### PR DESCRIPTION
## Summary
- avoid hard-coded dependency on @acme/ui for email templates by allowing runtime registration
- clean up marketing email tests and set templates explicitly
- expand platform-core references and fix mis-typed config import

## Testing
- `pnpm tsc -p packages/platform-core/tsconfig.json` *(fails: Namespace '"stripe".Stripe.Checkout.SessionCreateParams.PaymentIntentData' has no exported member 'BillingDetails')*
- `pnpm --filter @acme/email test` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e5bd998832f9c54d85d82ee8f50