### PR TITLE
fix: update platform-core tsconfig references

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -35,7 +35,7 @@
   "include": ["src/**/*"],
   "exclude": [
     "dist", // freshly emitted output
-    "__tests__", // unit/integration tests
+    "**/__tests__/**", // unit/integration tests
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
   ],
@@ -46,6 +46,6 @@
   "references": [
     { "path": "../lib" },
     { "path": "../types" },
-    { "path": "../ui" }
+    { "path": "../themes/base" }
   ]
 }


### PR DESCRIPTION
## Summary
- remove circular reference to `ui` in platform-core tsconfig
- add theme base package reference
- exclude nested test directories from compilation

## Testing
- `npx tsc -b tsconfig.packages.json --noEmit` *(fails: File '/workspace/base-shop/packages/platform-core/src/dataRoot.ts' is not under 'rootDir' '/workspace/base-shop/packages/lib/src'. Projects must list all files or use an 'include' pattern, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a084f8ea34832f872990271e3b09ec