### PR TITLE
feat(blog): add scheduled posts with SKU links and flag

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -38,6 +38,7 @@ describe("ShopEditor", () => {
       priceOverrides: {},
       localeOverrides: {},
       luxuryFeatures: {
+        blog: false,
         contentMerchandising: false,
         raTicketing: false,
         fraudReviewThreshold: 0,

--- a/apps/cms/__tests__/blogActions.test.ts
+++ b/apps/cms/__tests__/blogActions.test.ts
@@ -45,7 +45,7 @@ describe("blog actions", () => {
     );
   });
 
-  test("createPost collects product slugs", async () => {
+  test("createPost collects product skus", async () => {
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({ ok: true })
@@ -56,7 +56,7 @@ describe("blog actions", () => {
     fd.set("title", "T");
     fd.set(
       "content",
-      JSON.stringify([{ _type: "productReference", slug: "foo" }]),
+      JSON.stringify([{ _type: "productReference", sku: "foo" }]),
     );
     fd.set("slug", "t");
     fd.set("excerpt", "");
@@ -65,7 +65,7 @@ describe("blog actions", () => {
     expect(body.mutations[0].create.products).toEqual(["foo"]);
   });
 
-  test("updatePost collects product slugs", async () => {
+  test("updatePost collects product skus", async () => {
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({ ok: true })
@@ -79,8 +79,8 @@ describe("blog actions", () => {
     fd.set(
       "content",
       JSON.stringify([
-        { _type: "productReference", slug: "foo" },
-        { _type: "productReference", slug: "bar" },
+        { _type: "productReference", sku: "foo" },
+        { _type: "productReference", sku: "bar" },
       ]),
     );
     fd.set("slug", "t");
@@ -90,7 +90,7 @@ describe("blog actions", () => {
     expect(body.mutations[0].patch.set.products).toEqual(["foo", "bar"]);
   });
 
-  test("createPost filters invalid product slugs", async () => {
+  test("createPost filters invalid product skus", async () => {
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({ ok: false })
@@ -101,7 +101,7 @@ describe("blog actions", () => {
     fd.set("title", "T");
     fd.set(
       "content",
-      JSON.stringify([{ _type: "productReference", slug: "foo" }]),
+      JSON.stringify([{ _type: "productReference", sku: "foo" }]),
     );
     fd.set("slug", "t");
     fd.set("excerpt", "");
@@ -128,7 +128,7 @@ describe("blog actions", () => {
     expect(body.mutations[0].create.products).toEqual(["foo", "bar"]);
   });
 
-  test("updatePost filters invalid product slugs", async () => {
+  test("updatePost filters invalid product skus", async () => {
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({ ok: false })
@@ -140,7 +140,7 @@ describe("blog actions", () => {
     fd.set("title", "T");
     fd.set(
       "content",
-      JSON.stringify([{ _type: "productReference", slug: "foo" }]),
+      JSON.stringify([{ _type: "productReference", sku: "foo" }]),
     );
     fd.set("slug", "t");
     fd.set("excerpt", "");

--- a/apps/cms/__tests__/schemas.test.ts
+++ b/apps/cms/__tests__/schemas.test.ts
@@ -53,6 +53,7 @@ describe("zod schemas", () => {
     expect(parsed.catalogFilters).toEqual(["color", "size", "type"]);
     expect(parsed.enableEditorial).toBe(false);
     expect(parsed.luxuryFeatures).toEqual({
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,
@@ -102,6 +103,7 @@ describe("zod schemas", () => {
     });
 
     expect(parsed.luxuryFeatures).toEqual({
+      blog: false,
       contentMerchandising: true,
       raTicketing: true,
       fraudReviewThreshold: 150,

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -55,6 +55,10 @@ export const shopSchema = z
       .preprocess((v) => v === "on", z.boolean())
       .optional()
       .default(false),
+    blog: z
+      .preprocess((v) => v === "on", z.boolean())
+      .optional()
+      .default(false),
     contentMerchandising: z
       .preprocess((v) => v === "on", z.boolean())
       .optional()
@@ -86,6 +90,7 @@ export const shopSchema = z
   .strict()
   .transform(
     ({
+      blog,
       contentMerchandising,
       raTicketing,
       fraudReviewThreshold,
@@ -95,6 +100,7 @@ export const shopSchema = z
     }) => ({
       ...rest,
       luxuryFeatures: {
+        blog,
         contentMerchandising,
         raTicketing,
         fraudReviewThreshold,

--- a/apps/cms/src/actions/setupSanityBlog.ts
+++ b/apps/cms/src/actions/setupSanityBlog.ts
@@ -135,7 +135,7 @@ export async function setupSanityBlog(
                         name: "productReference",
                         title: "Product",
                         fields: [
-                          { name: "slug", type: "string", title: "Product Slug" },
+                          { name: "sku", type: "string", title: "Product SKU" },
                         ],
                       },
                     ],

--- a/apps/cms/src/app/api/blog/publish/route.ts
+++ b/apps/cms/src/app/api/blog/publish/route.ts
@@ -1,0 +1,26 @@
+import "@acme/lib/initZod";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { publishPost } from "@cms/actions/blog.server";
+
+const schema = z.object({
+  shopId: z.string(),
+  id: z.string(),
+  publishedAt: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  const data = await req.json().catch(() => null);
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  const { shopId, id, publishedAt } = parsed.data;
+  const form = new FormData();
+  if (publishedAt) form.set("publishedAt", publishedAt);
+  const result = await publishPost(shopId, id, undefined, form);
+  if (result.error) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/apps/cms/src/app/api/products/[shop]/skus/route.ts
+++ b/apps/cms/src/app/api/products/[shop]/skus/route.ts
@@ -1,4 +1,4 @@
-// apps/cms/src/app/api/products/[shop]/slugs/route.ts
+// apps/cms/src/app/api/products/[shop]/skus/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
 import { readRepo } from "@platform-core/repositories/json.server";
@@ -10,17 +10,17 @@ export async function POST(
 ) {
   const { shop } = await context.params;
   const body = await req.json().catch(() => null);
-  const slugs = Array.isArray(body?.slugs) ? (body.slugs as string[]) : [];
-  if (slugs.length === 0) {
+  const skus = Array.isArray(body?.skus) ? (body.skus as string[]) : [];
+  if (skus.length === 0) {
     return NextResponse.json([]);
   }
 
   const catalogue = await readRepo<ProductPublication>(shop);
-  const wanted = new Set(slugs);
+  const wanted = new Set(skus);
   const existing: string[] = [];
   for (const p of catalogue) {
-    const slug = p.sku ?? p.id;
-    if (wanted.has(slug)) existing.push(slug);
+    const sku = p.sku ?? p.id;
+    if (wanted.has(sku)) existing.push(sku);
   }
 
   return NextResponse.json(existing);

--- a/apps/cms/src/app/api/products/route.ts
+++ b/apps/cms/src/app/api/products/route.ts
@@ -12,7 +12,7 @@ import type {
 const searchSchema = z
   .object({
     q: z.string().optional(),
-    slug: z.string().optional(),
+    sku: z.string().optional(),
     shop: z.string().default("abc"),
   })
   .strict();
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Invalid search parameters" }, { status: 400 });
   }
 
-  const { q, slug, shop } = parsed.data;
+  const { q, sku, shop } = parsed.data;
   const query = q?.toLowerCase() ?? "";
 
   const [catalogue, inventory] = await Promise.all([
@@ -52,9 +52,9 @@ export async function GET(req: NextRequest) {
     availability: p.availability ?? [],
   });
 
-  if (slug) {
+  if (sku) {
     const product = catalogue.find(
-      (p) => p.sku === slug || p.id === slug,
+      (p) => p.sku === sku || p.id === sku,
     );
     if (!product)
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -141,7 +141,7 @@ function PostFormContent({ action, submitLabel, post }: Props) {
         />
         <Input
           name="products"
-          label="Related products (comma separated IDs)"
+          label="Related products (comma separated SKUs)"
           defaultValue={(post?.products ?? []).join(", ")}
         />
         <Input

--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -3,11 +3,11 @@ import type { SKU } from "@acme/types";
 import { formatCurrency } from "@acme/shared-utils";
 
 export interface Props {
-  slug: string;
+  sku: string;
   onValidChange?: (valid: boolean) => void;
 }
 
-export default function ProductPreview({ slug, onValidChange }: Props) {
+export default function ProductPreview({ sku, onValidChange }: Props) {
   const [product, setProduct] = useState<SKU | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -18,7 +18,7 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
       setLoading(true);
       try {
         const res = await fetch(
-          `/api/products?slug=${encodeURIComponent(slug)}`
+          `/api/products?sku=${encodeURIComponent(sku)}`
         );
         if (!res.ok) throw new Error("Failed to load product");
         const data: SKU = await res.json();
@@ -41,7 +41,7 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
       active = false;
       onValidChange?.(true);
     };
-  }, [slug, onValidChange]);
+  }, [sku, onValidChange]);
 
   if (loading) return <div className="border p-2">Loading…</div>;
   if (error || !product)

--- a/apps/cms/src/app/cms/blog/posts/RichTextEditor.tsx
+++ b/apps/cms/src/app/cms/blog/posts/RichTextEditor.tsx
@@ -136,7 +136,7 @@ function ProductSearch({
                       editor,
                       { name: "productReference" },
                       {
-                        slug: p.slug,
+                        sku: p.slug,
                       }
                     )
                   }

--- a/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
@@ -12,7 +12,7 @@ describe("ProductPreview", () => {
       json: async () => ({ title: "Test", price: 100 }),
     });
     const onValid = jest.fn();
-    render(<ProductPreview slug="t" onValidChange={onValid} />);
+    render(<ProductPreview sku="t" onValidChange={onValid} />);
     await screen.findByText("Test");
     expect(onValid).toHaveBeenCalledWith(true);
   });
@@ -20,7 +20,7 @@ describe("ProductPreview", () => {
   it("handles error", async () => {
     (global as any).fetch.mockRejectedValueOnce(new Error("fail"));
     const onValid = jest.fn();
-    render(<ProductPreview slug="t" onValidChange={onValid} />);
+    render(<ProductPreview sku="t" onValidChange={onValid} />);
     await waitFor(() => expect(onValid).toHaveBeenCalledWith(false));
   });
 });

--- a/apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.ts
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.ts
@@ -9,6 +9,6 @@ describe("schema", () => {
       (b) => b.name === "productReference",
     );
     expect(block).toBeTruthy();
-    expect(block.fields).toEqual([{ name: "slug", type: "string" }]);
+    expect(block.fields).toEqual([{ name: "sku", type: "string" }]);
   });
 });

--- a/apps/cms/src/app/cms/blog/posts/invalidProductContext.tsx
+++ b/apps/cms/src/app/cms/blog/posts/invalidProductContext.tsx
@@ -2,20 +2,20 @@ import { createContext, useCallback, useContext, useState, type ReactNode } from
 
 interface InvalidProductContextValue {
   invalidProducts: Record<string, string>;
-  markValidity: (key: string, valid: boolean, slug: string) => void;
+  markValidity: (key: string, valid: boolean, sku: string) => void;
 }
 
 export const InvalidProductContext = createContext<InvalidProductContextValue | null>(null);
 
 export function InvalidProductProvider({ children }: { children: ReactNode }) {
   const [invalidProducts, setInvalidProducts] = useState<Record<string, string>>({});
-  const markValidity = useCallback((key: string, valid: boolean, slug: string) => {
+  const markValidity = useCallback((key: string, valid: boolean, sku: string) => {
     setInvalidProducts((prev) => {
       const next = { ...prev };
       if (valid) {
         delete next[key];
       } else {
-        next[key] = slug;
+        next[key] = sku;
       }
       return next;
     });

--- a/apps/cms/src/app/cms/blog/posts/schema.ts
+++ b/apps/cms/src/app/cms/blog/posts/schema.ts
@@ -32,7 +32,7 @@ export const schema = defineSchema({
     {
       name: "productReference",
       type: "object",
-      fields: [{ name: "slug", type: "string" }],
+      fields: [{ name: "sku", type: "string" }],
     },
     {
       name: "embed",
@@ -53,7 +53,7 @@ export const schema = defineSchema({
 function ProductReferenceBlock(props: BlockRenderProps) {
   const editor = useEditor();
   const ctx = useContext(InvalidProductContext);
-  const slug = (props.value as any).slug as string;
+  const sku = (props.value as any).sku as string;
   const isInvalid = Boolean(ctx?.invalidProducts[props.value._key as string]);
   const remove = () => {
     const sel = {
@@ -67,7 +67,7 @@ function ProductReferenceBlock(props: BlockRenderProps) {
     );
   };
   const edit = () => {
-    const next = prompt("Product slug", slug);
+    const next = prompt("Product SKU", sku);
     if (!next) return;
     const sel = {
       anchor: { path: props.path, offset: 0 },
@@ -81,7 +81,7 @@ function ProductReferenceBlock(props: BlockRenderProps) {
     PortableTextEditor.insertBlock(
       editor as unknown as PortableTextEditor,
       { name: "productReference" },
-      { slug: next },
+      { sku: next },
     );
   };
   const className = `space-y-2 ${isInvalid ? "rounded border border-red-500 p-2" : ""}`;
@@ -89,9 +89,9 @@ function ProductReferenceBlock(props: BlockRenderProps) {
     "div",
     { className },
     React.createElement(ProductPreview, {
-      slug,
+      sku,
       onValidChange: (valid: boolean) =>
-        ctx?.markValidity(props.value._key as string, valid, slug),
+        ctx?.markValidity(props.value._key as string, valid, sku),
     }),
     React.createElement(
       "div",
@@ -137,7 +137,7 @@ export const renderBlock: RenderBlockFunction = (props) => {
 export const previewComponents = {
   types: {
     productReference: ({ value }: any) =>
-      React.createElement(ProductPreview, { slug: value.slug }),
+      React.createElement(ProductPreview, { sku: value.sku }),
     embed: ({ value }: any) =>
       React.createElement(
         "div",

--- a/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
@@ -65,6 +65,22 @@ export default function GeneralSettings({
         <div className="mt-2 grid gap-2">
           <label className="flex items-center gap-2">
             <Checkbox
+              name="blog"
+              checked={info.luxuryFeatures.blog ?? false}
+              onCheckedChange={(v) =>
+                setInfo((prev) => ({
+                  ...prev,
+                  luxuryFeatures: {
+                    ...prev.luxuryFeatures,
+                    blog: Boolean(v),
+                  },
+                }))
+              }
+            />
+            <span>Blog module</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <Checkbox
               name="contentMerchandising"
               checked={info.luxuryFeatures.contentMerchandising ?? false}
               onCheckedChange={(v) =>

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -15,8 +15,8 @@ import {
 import { ensureAuthorized } from "../actions/common/auth";
 import { nowIso } from "@date-utils";
 
-function collectProductSlugs(content: unknown): string[] {
-  const slugs = new Set<string>();
+function collectProductSkus(content: unknown): string[] {
+  const skus = new Set<string>();
   const walk = (node: any) => {
     if (!node) return;
     if (Array.isArray(node)) {
@@ -24,8 +24,8 @@ function collectProductSlugs(content: unknown): string[] {
       return;
     }
     if (typeof node === "object") {
-      if (node._type === "productReference" && typeof node.slug === "string") {
-        slugs.add(node.slug);
+      if (node._type === "productReference" && typeof node.sku === "string") {
+        skus.add(node.sku);
       }
       for (const value of Object.values(node)) {
         walk(value);
@@ -33,16 +33,16 @@ function collectProductSlugs(content: unknown): string[] {
     }
   };
   walk(content);
-  return Array.from(slugs);
+  return Array.from(skus);
 }
 
-async function filterExistingProductSlugs(shopId: string, slugs: string[]): Promise<string[]> {
-  if (slugs.length === 0) return [];
+async function filterExistingProductSkus(shopId: string, skus: string[]): Promise<string[]> {
+  if (skus.length === 0) return [];
   try {
-    const res = await fetch(`/api/products/${shopId}/slugs`, {
+    const res = await fetch(`/api/products/${shopId}/skus`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ slugs }),
+      body: JSON.stringify({ skus }),
     });
     if (!res.ok) return [];
     const existing = await res.json();
@@ -85,7 +85,7 @@ export async function createPost(
   let products: string[] = [];
   try {
     body = JSON.parse(content);
-    products = collectProductSlugs(body);
+    products = collectProductSkus(body);
   } catch {
     body = [];
     products = [];
@@ -95,11 +95,11 @@ export async function createPost(
     .split(",")
     .map((p) => p.trim())
     .filter(Boolean);
-  const existingSlugs = await filterExistingProductSlugs(shopId, [
+  const existingSkus = await filterExistingProductSkus(shopId, [
     ...products,
     ...manualProducts,
   ]);
-  products = existingSlugs;
+  products = existingSkus;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const mainImage = String(formData.get("mainImage") ?? "");
@@ -150,7 +150,7 @@ export async function updatePost(
   let products: string[] = [];
   try {
     body = JSON.parse(content);
-    products = collectProductSlugs(body);
+    products = collectProductSkus(body);
   } catch {
     body = [];
     products = [];
@@ -160,11 +160,11 @@ export async function updatePost(
     .split(",")
     .map((p) => p.trim())
     .filter(Boolean);
-  const existingSlugs = await filterExistingProductSlugs(shopId, [
+  const existingSkus = await filterExistingProductSkus(shopId, [
     ...products,
     ...manualProducts,
   ]);
-  products = existingSlugs;
+  products = existingSkus;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const mainImage = String(formData.get("mainImage") ?? "");

--- a/apps/cms/src/services/shops/seoService.ts
+++ b/apps/cms/src/services/shops/seoService.ts
@@ -87,6 +87,7 @@ export async function revertSeo(shop: string, timestamp: string) {
     languages: [] as Locale[],
     seo: {},
     luxuryFeatures: {
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,

--- a/apps/shop-abc/__tests__/homePage.test.tsx
+++ b/apps/shop-abc/__tests__/homePage.test.tsx
@@ -38,7 +38,7 @@ test("Home receives components from pages repo when editorial disabled", async (
   (readShop as jest.Mock).mockResolvedValue({
     id: "abc",
     editorialBlog: { enabled: false },
-    luxuryFeatures: { contentMerchandising: true },
+    luxuryFeatures: { blog: true },
   });
 
   const element = await Page({ params: { lang: "en" } });
@@ -59,7 +59,7 @@ test("Home fetches latest post when merchandising enabled", async () => {
   (readShop as jest.Mock).mockResolvedValue({
     id: "abc",
     editorialBlog: { enabled: true },
-    luxuryFeatures: { contentMerchandising: true },
+    luxuryFeatures: { blog: true },
   });
   (fetchPublishedPosts as jest.Mock).mockResolvedValue([
     { title: "Hello", excerpt: "World", slug: "hello" },

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -35,6 +35,7 @@
     "token": "token"
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/apps/shop-abc/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
-  if (!shop.editorialBlog?.enabled) {
+  if (!shop.editorialBlog?.enabled || !shop.luxuryFeatures?.blog) {
     notFound();
   }
   const posts = await fetchPublishedPosts(shop.id);

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -20,7 +20,7 @@ export default async function Page({
   const shop = await readShop(env.NEXT_PUBLIC_SHOP_ID || "shop-abc");
   const components = await loadComponents(shop.id);
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures?.contentMerchandising && shop.editorialBlog?.enabled) {
+  if (shop.luxuryFeatures?.blog && shop.editorialBlog?.enabled) {
     const posts = await fetchPublishedPosts(shop.id);
     const first = posts[0];
     if (first) {

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -95,7 +95,7 @@ export default async function ProductDetailPage({
   const components = await loadComponents(params.slug);
   await trackPageView(shop.id, `product/${params.slug}`);
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures.contentMerchandising) {
+  if (shop.luxuryFeatures.blog) {
     try {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -34,7 +34,7 @@ export default async function ShopIndexPage({
   let latestPost: BlogPost | undefined;
   try {
     const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
-    if (luxury.contentMerchandising) {
+    if (luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];
       if (first) {

--- a/apps/shop-abc/src/app/api/search/route.ts
+++ b/apps/shop-abc/src/app/api/search/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
   }));
 
   let posts: { type: "post"; title: string; slug: string }[] = [];
-  if (shop.luxuryFeatures?.contentMerchandising) {
+  if (shop.luxuryFeatures?.blog) {
     try {
       const fetched = await fetchPublishedPosts(shop.id);
       posts = fetched

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -32,6 +32,7 @@
     "token": "token"
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
-  if (!shop.editorialBlog?.enabled) {
+  if (!shop.editorialBlog?.enabled || !shop.luxuryFeatures?.blog) {
     notFound();
   }
   const posts = await fetchPublishedPosts(shop.id);

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -33,7 +33,7 @@ export default async function Page({
 }) {
   const components = await loadComponents();
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures?.contentMerchandising && shop.editorialBlog?.enabled) {
+  if (shop.luxuryFeatures?.blog && shop.editorialBlog?.enabled) {
     const posts = await fetchPublishedPosts(shop.id);
     const first = posts[0];
     if (first) {

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
@@ -83,7 +83,7 @@ export default async function ProductDetailPage({
   if (!product) return notFound();
 
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures.contentMerchandising) {
+  if (shop.luxuryFeatures.blog) {
     try {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -20,7 +20,7 @@ export default async function ShopIndexPage({
   let latestPost: BlogPost | undefined;
   try {
     const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
-    if (luxury.contentMerchandising) {
+    if (luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];
       if (first) {

--- a/apps/shop-bcd/src/app/api/search/route.ts
+++ b/apps/shop-bcd/src/app/api/search/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
   }));
 
   let posts: { type: "post"; title: string; slug: string }[] = [];
-  if (shop.luxuryFeatures?.contentMerchandising) {
+  if (shop.luxuryFeatures?.blog) {
     try {
       const fetched = await fetchPublishedPosts(shop.id);
       posts = fetched

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -28,6 +28,7 @@
     }
   },
   "luxuryFeatures": {
+    "blog": false,
     "contentMerchandising": false,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -39,6 +39,7 @@
     "enabled": true
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": true,
     "fraudReviewThreshold": 0,

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -28,6 +28,7 @@
     }
   },
   "luxuryFeatures": {
+    "blog": false,
     "contentMerchandising": false,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -29,6 +29,7 @@
     "enabled": true
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": true,
     "fraudReviewThreshold": 0,

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -36,6 +36,7 @@ export const coreEnvBaseSchema = z.object({
   LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: z.coerce
     .boolean()
     .optional(),
+  LUXURY_FEATURES_BLOG: z.coerce.boolean().optional(),
   DEPOSIT_RELEASE_ENABLED: z
     .string()
     .refine((v) => v === "true" || v === "false", {

--- a/packages/platform-core/src/components/blog/BlogPortableText.tsx
+++ b/packages/platform-core/src/components/blog/BlogPortableText.tsx
@@ -9,12 +9,12 @@ const components = {
     productReference: ({ value }: any) => {
       const ids: string[] = Array.isArray(value?.ids)
         ? value.ids
-        : Array.isArray(value?.slugs)
-          ? value.slugs
+        : Array.isArray(value?.skus)
+          ? value.skus
           : typeof value?.id === "string"
             ? [value.id]
-            : typeof value?.slug === "string"
-              ? [value.slug]
+            : typeof value?.sku === "string"
+              ? [value.sku]
               : [];
       const products = ids
         .map((id) => getProductById(id) ?? getProductBySlug(id))

--- a/packages/platform-core/src/luxuryFeatures.ts
+++ b/packages/platform-core/src/luxuryFeatures.ts
@@ -1,6 +1,7 @@
 import { coreEnv } from "@acme/config/env/core";
 
 export const luxuryFeatures = {
+  blog: coreEnv.LUXURY_FEATURES_BLOG ?? false,
   raTicketing: coreEnv.LUXURY_FEATURES_RA_TICKETING ?? false,
   fraudReviewThreshold: Number(
     coreEnv.LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD ?? 0,

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -118,6 +118,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     premierDelivery: undefined,
     stockAlert: { recipients: [] },
     luxuryFeatures: {
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -79,6 +79,7 @@ export async function readShop(shop: string): Promise<Shop> {
     navigation: [],
     analyticsEnabled: false,
     luxuryFeatures: {
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -7,7 +7,7 @@ import { nowIso } from "@date-utils";
 
 export interface ProductBlock {
   _type: "productReference";
-  slug: string;
+  sku: string;
 }
 
 export interface BlogPost {
@@ -58,8 +58,8 @@ export async function fetchPostBySlug(
 ): Promise<BlogPost | null> {
   try {
     const client = await getClient(shopId);
-    const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, mainImage, author, categories, products, body[]{..., _type == "productReference" => { _type, slug }}}`;
-    const post = await client.fetch<BlogPost | null>(query, { slug });
+  const query = `*[_type == "post" && slug.current == $slug && published == true][0]{title, "slug": slug.current, excerpt, mainImage, author, categories, products, body[]{..., _type == "productReference" => { _type, sku }}}`;
+  const post = await client.fetch<BlogPost | null>(query, { slug });
     return post;
   } catch {
     return null;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -119,6 +119,7 @@ export const shopSchema = z
     rentalInventoryAllocation: z.boolean().optional(),
     luxuryFeatures: z
       .object({
+        blog: z.boolean().default(false),
         contentMerchandising: z.boolean().default(false),
         raTicketing: z.boolean().default(false),
         fraudReviewThreshold: z.number().nonnegative().default(0),
@@ -127,6 +128,7 @@ export const shopSchema = z
       })
       .strict()
       .default({
+        blog: false,
         contentMerchandising: false,
         raTicketing: false,
         fraudReviewThreshold: 0,

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -90,6 +90,7 @@ export const shopSettingsSchema = z
       .optional(),
     luxuryFeatures: z
       .object({
+        blog: z.boolean().default(false),
         contentMerchandising: z.boolean().default(false),
         raTicketing: z.boolean().default(false),
         fraudReviewThreshold: z.number().nonnegative().default(0),
@@ -98,6 +99,7 @@ export const shopSettingsSchema = z
       })
       .strict()
       .default({
+        blog: false,
         contentMerchandising: false,
         raTicketing: false,
         fraudReviewThreshold: 0,

--- a/packages/ui/src/components/cms/blocks/BlogListing.tsx
+++ b/packages/ui/src/components/cms/blocks/BlogListing.tsx
@@ -29,7 +29,7 @@ export default function BlogListing({ posts = [] }: { posts?: BlogPost[] }) {
           {p.shopUrl && (
             <p>
               <Link href={p.shopUrl} className="text-primary underline">
-                Shop the story
+                Shop the Look
               </Link>
             </p>
           )}

--- a/test/unit/shop-schema.spec.ts
+++ b/test/unit/shop-schema.spec.ts
@@ -32,6 +32,7 @@ describe("shop schema", () => {
     expect(parsed.componentVersions).toEqual({});
     expect(parsed.lastUpgrade).toBeUndefined();
     expect(parsed.luxuryFeatures).toEqual({
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,


### PR DESCRIPTION
## Summary
- add blog feature flag and expose new `/api/blog/publish` endpoint
- track product SKUs in CMS blog posts and show “Shop the Look” links
- allow enabling blog module via luxury features config

## Testing
- `pnpm test` *(fails: ERR_UNKNOWN_FILE_EXTENSION for core.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a089a16070832fa0c9abe109a0eb7e