### PR TITLE
Traverse app directory for bak cleanup

### DIFF
--- a/scripts/src/republish-shop.ts
+++ b/scripts/src/republish-shop.ts
@@ -80,7 +80,7 @@ export function republishShop(id: string, root = process.cwd()): void {
   if (existsSync(upgradeChanges)) {
     unlinkSync(upgradeChanges);
   }
-  removeBakFiles(join(appDir, "src", "components"));
+  removeBakFiles(appDir);
 }
 
 function main(): void {


### PR DESCRIPTION
## Summary
- scan whole app for `.bak` files instead of only `src/components`
- verify republish script cleans arbitrary subdirectories

## Testing
- `pnpm exec jest scripts/__tests__/republish-shop.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a08a4d5710832f990976c689c7ade1