### PR TITLE
feat: sync theme preview tokens across editor and preview

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
@@ -1,12 +1,6 @@
 // apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
 "use client";
-import {
-  useState,
-  useMemo,
-  useRef,
-  useEffect,
-  ChangeEvent,
-} from "react";
+import { useState, useMemo, useRef, useEffect, ChangeEvent } from "react";
 import { patchShopTheme } from "../../../wizard/services/patchTheme";
 import { tokenGroups } from "./tokenGroups";
 import { useThemePresets } from "./useThemePresets";
@@ -30,9 +24,10 @@ export function useThemeEditor({
   presets,
 }: Options) {
   const [theme, setTheme] = useState(initialTheme);
-  const [overrides, setOverrides] = useState<Record<string, string>>(initialOverrides);
+  const [overrides, setOverrides] =
+    useState<Record<string, string>>(initialOverrides);
   const [, setThemeDefaults] = useState<Record<string, string>>(
-    tokensByTheme[initialTheme],
+    tokensByTheme[initialTheme]
   );
   const {
     availableThemes,
@@ -53,7 +48,9 @@ export function useThemeEditor({
     setOverrides,
     setThemeDefaults,
   });
-  const [contrastWarnings, setContrastWarnings] = useState<Record<string, string>>({});
+  const [contrastWarnings, setContrastWarnings] = useState<
+    Record<string, string>
+  >({});
   const overrideRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const [previewTokens, setPreviewTokens] = useState<Record<string, string>>({
     ...tokensByThemeState[initialTheme],
@@ -68,23 +65,23 @@ export function useThemeEditor({
 
   const mergedTokens = useMemo(
     () => ({ ...tokensByThemeState[theme], ...overrides }),
-    [theme, tokensByThemeState, overrides],
+    [theme, tokensByThemeState, overrides]
   );
 
   const textTokenKeys = useMemo(
     () =>
       Object.keys(tokensByThemeState[theme]).filter((k) =>
-        /text|foreground/i.test(k),
+        /text|foreground/i.test(k)
       ),
-    [theme, tokensByThemeState],
+    [theme, tokensByThemeState]
   );
 
   const bgTokenKeys = useMemo(
     () =>
       Object.keys(tokensByThemeState[theme]).filter((k) =>
-        /bg|background/i.test(k),
+        /bg|background/i.test(k)
       ),
-    [theme, tokensByThemeState],
+    [theme, tokensByThemeState]
   );
 
   const groupedTokens = useMemo(() => {
@@ -121,7 +118,7 @@ export function useThemeEditor({
 
   const scheduleSave = (
     overridesPatch: Record<string, string>,
-    defaultsPatch: Record<string, string> = {},
+    defaultsPatch: Record<string, string> = {}
   ) => {
     pendingPatchRef.current = {
       overrides: {
@@ -150,6 +147,11 @@ export function useThemeEditor({
     }, 500);
   };
 
+  // Persist merged tokens and broadcast to preview whenever they change
+  useEffect(() => {
+    schedulePreviewUpdate(mergedTokens);
+  }, [mergedTokens]);
+
   const handleWarningChange = (token: string, warning: string | null) => {
     setContrastWarnings((prev) => {
       const next = { ...prev };
@@ -160,8 +162,7 @@ export function useThemeEditor({
   };
 
   const handleOverrideChange =
-    (key: string, defaultValue: string) =>
-    (value: string) => {
+    (key: string, defaultValue: string) => (value: string) => {
       setOverrides((prev) => {
         const next = { ...prev };
         const patch: Record<string, string> = {};
@@ -172,8 +173,6 @@ export function useThemeEditor({
           next[key] = value;
           patch[key] = value;
         }
-        const merged = { ...tokensByThemeState[theme], ...next };
-        schedulePreviewUpdate(merged);
         scheduleSave(patch);
         return next;
       });
@@ -183,8 +182,6 @@ export function useThemeEditor({
     setOverrides((prev) => {
       const next = { ...prev };
       delete next[key];
-      const merged = { ...tokensByThemeState[theme], ...next };
-      schedulePreviewUpdate(merged);
       scheduleSave({ [key]: tokensByThemeState[theme][key] });
       return next;
     });
@@ -198,8 +195,6 @@ export function useThemeEditor({
         delete next[k];
         patch[k] = tokensByThemeState[theme][k];
       });
-      const merged = { ...tokensByThemeState[theme], ...next };
-      schedulePreviewUpdate(merged);
       scheduleSave(patch);
       return next;
     });
@@ -234,15 +229,11 @@ export function useThemeEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleThemeChange = async (
-    e: ChangeEvent<HTMLSelectElement>,
-  ) => {
+  const handleThemeChange = async (e: ChangeEvent<HTMLSelectElement>) => {
     const newTheme = e.target.value;
     setTheme(newTheme);
     setOverrides({});
     setThemeDefaults(tokensByThemeState[newTheme]);
-    const merged = { ...tokensByThemeState[newTheme] };
-    schedulePreviewUpdate(merged);
   };
 
   const handleResetAll = async () => {
@@ -254,8 +245,6 @@ export function useThemeEditor({
       patch[k] = tokensByThemeState[theme][k];
     });
     setOverrides({});
-    const merged = { ...tokensByThemeState[theme] };
-    schedulePreviewUpdate(merged);
     scheduleSave(patch);
   };
 

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -17,10 +17,7 @@ import type { PageComponent } from "@acme/types";
 import DOMPurify from "dompurify";
 import React, { useEffect, useRef, useState, useMemo } from "react";
 import { STORAGE_KEY } from "../configurator/hooks/useConfiguratorPersistence";
-import {
-  loadPreviewTokens,
-  PREVIEW_TOKENS_EVENT,
-} from "./previewTokens";
+import { loadPreviewTokens, PREVIEW_TOKENS_EVENT } from "./previewTokens";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import DeviceSelector from "@ui/components/common/DeviceSelector";
 import { ReloadIcon } from "@radix-ui/react-icons";
@@ -119,11 +116,9 @@ export default function WizardPreview({
     handle();
     window.addEventListener("storage", handle);
     window.addEventListener(PREVIEW_TOKENS_EVENT, handle);
-    window.addEventListener("theme:change", handle);
     return () => {
       window.removeEventListener("storage", handle);
       window.removeEventListener(PREVIEW_TOKENS_EVENT, handle);
-      window.removeEventListener("theme:change", handle);
     };
   }, []);
 
@@ -186,17 +181,17 @@ export default function WizardPreview({
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!inspectMode || popoverOpen) return;
-    const el = (e.target as HTMLElement).closest("[data-token]") as
-      | HTMLElement
-      | null;
+    const el = (e.target as HTMLElement).closest(
+      "[data-token]"
+    ) as HTMLElement | null;
     setHoverEl(el);
   };
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!inspectMode) return;
-    const el = (e.target as HTMLElement).closest("[data-token]") as
-      | HTMLElement
-      | null;
+    const el = (e.target as HTMLElement).closest(
+      "[data-token]"
+    ) as HTMLElement | null;
     if (!el) return;
     e.preventDefault();
     e.stopPropagation();
@@ -369,9 +364,7 @@ export default function WizardPreview({
               <span className="font-mono text-xs">{selected.token}</span>
               <Button
                 className="px-2 py-1 text-xs"
-                onClick={() =>
-                  onTokenSelect?.(selected.token, popoverPos)
-                }
+                onClick={() => onTokenSelect?.(selected.token, popoverPos)}
               >
                 Jump to editor
               </Button>


### PR DESCRIPTION
## Summary
- ensure merged theme tokens are saved and broadcast to preview
- listen for preview token updates via storage and custom events

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Cannot find package '@acme/lib')*
- `pnpm --filter @apps/cms test` *(fails: process.exit called with "1")*


------
https://chatgpt.com/codex/tasks/task_e_68a089e01ecc832f84368d1f90cfb420