### PR TITLE
Handle new components in upgrade metadata

### DIFF
--- a/apps/shop-abc/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-abc/__tests__/upgradePreview.test.tsx
@@ -25,6 +25,8 @@ describe("upgrade preview page", () => {
           {
             file: "molecules/Breadcrumbs.tsx",
             componentName: "Breadcrumbs",
+            oldChecksum: "old1",
+            newChecksum: "new1",
           },
         ],
       }),

--- a/apps/shop-abc/src/app/api/upgrade-changes/route.ts
+++ b/apps/shop-abc/src/app/api/upgrade-changes/route.ts
@@ -25,7 +25,7 @@ export async function GET() {
       .array(upgradeComponentSchema)
       .catch([])
       .parse(data.components)
-      .filter((c) => c.oldChecksum !== c.newChecksum);
+      .filter((c) => c.oldChecksum == null || c.oldChecksum !== c.newChecksum);
     const pages = z.array(z.string()).catch([]).parse(data.pages);
     return NextResponse.json({ components, pages });
   } catch {

--- a/apps/shop-abc/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-abc/src/app/upgrade-preview/page.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from "react";
 import { exampleProps } from "./example-props";
 import { z } from "zod";
-import { type UpgradeComponent } from "@acme/types/upgrade";
+import {
+  type UpgradeComponent,
+  upgradeComponentSchema,
+} from "@acme/types/upgrade";
 import ComponentPreview from "@ui/src/components/ComponentPreview";
 
 export default function UpgradePreviewPage() {
@@ -17,14 +20,7 @@ export default function UpgradePreviewPage() {
       try {
         const res = await fetch("/api/upgrade-changes");
         const schema = z.object({
-          components: z.array(
-            z.object({
-              file: z.string(),
-              componentName: z.string(),
-              oldChecksum: z.string().optional(),
-              newChecksum: z.string().optional(),
-            }),
-          ),
+          components: z.array(upgradeComponentSchema),
           pages: z.array(z.string()).optional(),
         });
         const data = schema.parse(await res.json());
@@ -98,6 +94,9 @@ export default function UpgradePreviewPage() {
               component={c}
               componentProps={exampleProps[c.componentName] ?? {}}
             />
+            {!c.oldChecksum && (
+              <p className="text-sm text-gray-600">New component</p>
+            )}
           </li>
         ))}
       </ul>

--- a/packages/types/src/upgrade.ts
+++ b/packages/types/src/upgrade.ts
@@ -4,7 +4,7 @@ export const upgradeComponentSchema = z
   .object({
     file: z.string(),
     componentName: z.string(),
-    oldChecksum: z.string(),
+    oldChecksum: z.string().nullish(),
     newChecksum: z.string(),
   })
   .strict();

--- a/scripts/src/upgrade-shop.ts
+++ b/scripts/src/upgrade-shop.ts
@@ -72,16 +72,21 @@ const changedComponents = Object.entries(componentMap).flatMap(
   ([file, componentName]) => {
     const destPath = path.join(appDir, "src", "components", file);
     const bakPath = destPath + ".bak";
-    if (!existsSync(destPath) || !existsSync(bakPath)) return [];
+    if (!existsSync(destPath)) return [];
     const newHash = createHash("sha256")
       .update(readFileSync(destPath))
       .digest("hex");
-    const oldHash = createHash("sha256")
-      .update(readFileSync(bakPath))
-      .digest("hex");
-    if (newHash === oldHash) return [];
+    if (existsSync(bakPath)) {
+      const oldHash = createHash("sha256")
+        .update(readFileSync(bakPath))
+        .digest("hex");
+      if (newHash === oldHash) return [];
+      return [
+        { file, componentName, oldChecksum: oldHash, newChecksum: newHash },
+      ];
+    }
     return [
-      { file, componentName, oldChecksum: oldHash, newChecksum: newHash },
+      { file, componentName, oldChecksum: null, newChecksum: newHash },
     ];
   }
 );


### PR DESCRIPTION
## Summary
- include components without backups in upgrade metadata with null `oldChecksum`
- allow missing `oldChecksum` in upgrade schema and API route
- flag new components in upgrade preview UI

## Testing
- `pnpm jest packages/types apps/shop-abc/__tests__/upgrade-changes.test.ts apps/shop-abc/__tests__/upgradePreview.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a08a4bf0dc832fa295b3c4ac79f978