### PR TITLE
Sanitize PopupModal content

### DIFF
--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import DOMPurify from "dompurify";
 import { useEffect, useState } from "react";
 
 interface Props {
@@ -21,6 +22,7 @@ export default function PopupModal({
   content = "",
 }: Props) {
   const [open, setOpen] = useState(trigger === "load" && delay === 0);
+  const sanitized = DOMPurify.sanitize(content);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -67,7 +69,7 @@ export default function PopupModal({
         onClick={(e) => e.stopPropagation()}
       >
         {content && (
-          <div dangerouslySetInnerHTML={{ __html: content }} />
+          <div dangerouslySetInnerHTML={{ __html: sanitized }} />
         )}
         <button
           type="button"

--- a/packages/ui/src/components/cms/blocks/__tests__/PopupModal.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/PopupModal.test.tsx
@@ -1,0 +1,13 @@
+import { render } from "@testing-library/react";
+import PopupModal from "../PopupModal";
+
+describe("PopupModal", () => {
+  it("strips malicious HTML", () => {
+    const malicious = '<img src="x" onerror="alert(1)"><script>alert("xss")</script>';
+    const { container } = render(<PopupModal content={malicious} />);
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img?.getAttribute("onerror")).toBeNull();
+    expect(container.querySelector("script")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize HTML content in PopupModal using DOMPurify before rendering
- add unit test confirming malicious HTML is stripped

## Testing
- `pnpm --filter @acme/ui test` *(fails: unable to find button in ThemeEditor tests)*
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/PopupModal.test.tsx --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68a089ba100c832f871c27deaa532025