### PR TITLE
feat: anchor inline color picker to preview token

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemePreview.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemePreview.tsx
@@ -33,11 +33,23 @@ export default function ThemePreview({
 
   const handleTokenClick = (
     token: string,
-    coords: { x: number; y: number },
+    coords: { x: number; y: number } | DOMRect,
   ) => {
     const defaultValue = themeDefaults[token];
     if (!defaultValue) return;
-    setPicker({ token, x: coords.x, y: coords.y, defaultValue });
+
+    let x: number;
+    let y: number;
+
+    if ("width" in coords) {
+      x = coords.left + coords.width / 2;
+      y = coords.top + coords.height;
+    } else {
+      x = coords.x;
+      y = coords.y;
+    }
+
+    setPicker({ token, x, y, defaultValue });
     onTokenSelect?.(token);
   };
 


### PR DESCRIPTION
## Summary
- position inline color picker using clicked element's bounding box
- allow picker to fall back to provided coordinates

## Testing
- `pnpm test:cms` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68a089cdc730832f895130b2ce95bf9d