### PR TITLE
feat(cms): add upgrade preview page

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/page.tsx
@@ -3,6 +3,7 @@
 import { checkShopExists } from "@acme/lib";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { useState } from "react";
 
 export const metadata: Metadata = {
   title: "Dashboard · Base-Shop",
@@ -21,6 +22,7 @@ export default async function ShopDashboardPage({
       <p>
         Welcome to the {shop} shop dashboard. Use the sidebar to manage content.
       </p>
+      <UpgradeButton shop={shop} />
       <form
         action={`/api/shop/${shop}/rollback`}
         method="post"
@@ -33,6 +35,59 @@ export default async function ShopDashboardPage({
           Revert to previous version
         </button>
       </form>
+    </div>
+  );
+}
+
+function UpgradeButton({ shop }: { shop: string }) {
+  "use client";
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/upgrade-shop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shop }),
+      });
+      if (!res.ok) {
+        const data: unknown = await res.json().catch(() => ({}));
+        const message =
+          typeof data === "object" &&
+          data !== null &&
+          "error" in data &&
+          typeof (data as { error?: unknown }).error === "string"
+            ? (data as { error: string }).error
+            : "Upgrade failed";
+        throw new Error(message);
+      }
+      window.location.href = `/cms/shop/${shop}/upgrade-preview`;
+    } catch (err) {
+      console.error("Upgrade failed", err);
+      setError(err instanceof Error ? err.message : "Upgrade failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 space-y-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        className="rounded border px-4 py-2"
+        disabled={loading}
+      >
+        {loading ? "Upgrading..." : "Upgrade & preview"}
+      </button>
+      {error && (
+        <p role="alert" className="text-red-600">
+          {error}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add CMS upgrade preview page to render updated components
- link dashboard upgrade action to new preview page

## Testing
- `pnpm lint --filter @apps/cms` *(fails: Unknown file extension ".ts" for env/core.ts)*
- `pnpm test --filter @apps/cms` *(fails: TestingLibraryElementError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a09000c988832f9f54504663fd27f2