### PR TITLE
Add URL validation for SEO audits

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -15,17 +15,18 @@
     "@acme/email": "workspace:*",
     "@acme/i18n": "workspace:*",
     "@acme/next-config": "workspace:*",
-    "@acme/shared-utils": "workspace:*",
     "@acme/plugin-sanity": "workspace:*",
+    "@acme/shared-utils": "workspace:*",
     "@sendgrid/eventwebhook": "^7.2.7",
     "@themes/base": "workspace:*",
+    "busboy": "^1.6.0",
     "color-contrast-checker": "^2.1.0",
     "dompurify": "^3.2.6",
-    "busboy": "^1.6.0",
-    "file-type": "^21.0.0"
+    "file-type": "^21.0.0",
+    "validator": "^13.15.15"
   },
   "devDependencies": {
-    "next": "^15.3.4",
-    "@types/busboy": "^1.5.4"
+    "@types/busboy": "^1.5.4",
+    "next": "^15.3.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       file-type:
         specifier: ^21.0.0
         version: 21.0.0
+      validator:
+        specifier: ^13.15.15
+        version: 13.15.15
     devDependencies:
       '@types/busboy':
         specifier: ^1.5.4
@@ -10635,6 +10638,10 @@ packages:
   v8flags@4.0.1:
     resolution: {integrity: sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==}
     engines: {node: '>= 10.13.0'}
+
+  validator@13.15.15:
+    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+    engines: {node: '>= 0.10'}
 
   vercel@44.2.11:
     resolution: {integrity: sha512-0pvv4CizrDRZ7wxK7mOlCvIWUsUcbxRo8yfQQG0nnpX3p5XF9QvAN8iCW7YZYReWtShYJAtduwRXpyswkMAajA==}
@@ -22240,6 +22247,8 @@ snapshots:
       convert-source-map: 2.0.0
 
   v8flags@4.0.1: {}
+
+  validator@13.15.15: {}
 
   vercel@44.2.11(@swc/core@1.12.9)(rollup@4.44.1):
     dependencies:


### PR DESCRIPTION
## Summary
- validate SEO audit URL with validator's `isURL`
- restrict SEO audit requests to `LIGHTHOUSE_TRUSTED_HOSTS`
- add validator dependency for cms app

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Unknown file extension ".ts" for packages/config/src/env/core.ts)*
- `pnpm --filter @apps/cms test` *(fails: Exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a09064c764832f8f5498d736fae19e