### PR TITLE
feat: add premier delivery scheduling with carriers and flag

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -44,6 +44,7 @@ describe("ShopEditor", () => {
         requireStrongCustomerAuth: false,
         strictReturnConditions: false,
         trackingDashboard: false,
+        premierDelivery: false,
       },
     };
 

--- a/apps/cms/__tests__/schemas.test.ts
+++ b/apps/cms/__tests__/schemas.test.ts
@@ -59,6 +59,7 @@ describe("zod schemas", () => {
       requireStrongCustomerAuth: false,
       strictReturnConditions: false,
       trackingDashboard: false,
+      premierDelivery: false,
     });
   });
 
@@ -109,6 +110,7 @@ describe("zod schemas", () => {
       requireStrongCustomerAuth: true,
       strictReturnConditions: false,
       trackingDashboard: false,
+      premierDelivery: false,
     });
   });
 });

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -79,6 +79,10 @@ export const shopSchema = z
       .preprocess((v) => v === "on", z.boolean())
       .optional()
       .default(false),
+    premierDelivery: z
+      .preprocess((v) => v === "on", z.boolean())
+      .optional()
+      .default(false),
     themeOverrides: jsonRecord,
     themeDefaults: jsonRecord,
     themeTokens: jsonRecord.optional(),
@@ -96,6 +100,7 @@ export const shopSchema = z
       requireStrongCustomerAuth,
       strictReturnConditions,
       trackingDashboard,
+      premierDelivery,
       ...rest
     }) => ({
       ...rest,
@@ -106,6 +111,7 @@ export const shopSchema = z
         requireStrongCustomerAuth,
         strictReturnConditions,
         trackingDashboard,
+        premierDelivery,
       },
     })
   );

--- a/apps/cms/src/services/shops/settingsService.ts
+++ b/apps/cms/src/services/shops/settingsService.ts
@@ -142,6 +142,13 @@ export async function updatePremierDelivery(
     premierDelivery: {
       regions: data.regions,
       windows: data.windows,
+      carriers: data.carriers,
+      surcharge: data.surcharge,
+      serviceLabel: data.serviceLabel,
+    },
+    luxuryFeatures: {
+      ...(current.luxuryFeatures ?? {}),
+      premierDelivery: true,
     },
   };
   await persistSettings(shop, updated);

--- a/apps/cms/src/services/shops/validation.ts
+++ b/apps/cms/src/services/shops/validation.ts
@@ -215,6 +215,9 @@ const premierDeliverySchema = z
   .object({
     regions: z.array(z.string().min(1)).default([]),
     windows: z.array(z.string().regex(/^\d{2}-\d{2}$/)).default([]),
+    carriers: z.array(z.string().min(1)).default([]),
+    surcharge: z.coerce.number().int().nonnegative().optional(),
+    serviceLabel: z.string().optional(),
   })
   .strict();
 
@@ -233,6 +236,13 @@ export function parsePremierDeliveryForm(formData: FormData): {
       .map(String)
       .map((v) => v.trim())
       .filter(Boolean),
+    carriers: formData
+      .getAll("carriers")
+      .map(String)
+      .map((v) => v.trim())
+      .filter(Boolean),
+    surcharge: formData.get("surcharge"),
+    serviceLabel: formData.get("serviceLabel")?.toString().trim() || undefined,
   };
   const parsed = premierDeliverySchema.safeParse(data);
   if (!parsed.success) {

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -13,7 +13,10 @@
   "coverageIncluded": true,
   "premierDelivery": {
     "regions": ["us-east"],
-    "windows": ["10-11", "11-12"]
+    "windows": ["10-11", "11-12"],
+    "carriers": ["fastship"],
+    "surcharge": 0,
+    "serviceLabel": "Premier"
   },
   "priceOverrides": {},
   "localeOverrides": {},
@@ -40,7 +43,8 @@
     "fraudReviewThreshold": 0,
     "requireStrongCustomerAuth": false,
     "strictReturnConditions": true,
-    "trackingDashboard": true
+    "trackingDashboard": true,
+    "premierDelivery": true
   },
   "editorialBlog": { "enabled": true }
 }

--- a/apps/shop-abc/src/app/api/delivery/schedule/route.ts
+++ b/apps/shop-abc/src/app/api/delivery/schedule/route.ts
@@ -5,13 +5,27 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
 import shop from "../../../../shop.json";
+import { initPlugins } from "@acme/platform-core/plugins";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const runtime = "edge";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pluginsDir = path.resolve(__dirname, "../../../../../../packages/plugins");
+const pluginsReady = initPlugins({
+  directories: [pluginsDir],
+  config: {
+    ...(shop as any).plugins,
+    "premier-shipping": (shop as any).premierDelivery,
+  },
+});
 
 const schema = z
   .object({
     region: z.string(),
     window: z.string(),
+    carrier: z.string().optional(),
   })
   .strict();
 
@@ -21,14 +35,52 @@ export async function POST(req: NextRequest) {
 
   const settings = await getShopSettings(shop.id);
   const pd = settings.premierDelivery;
-  if (!pd) {
-    return NextResponse.json({ error: "Premier delivery not available" }, { status: 400 });
-  }
-  const { region, window } = parsed.data;
-  if (!pd.regions.includes(region) || !pd.windows.includes(window)) {
-    return NextResponse.json({ error: "Invalid selection" }, { status: 400 });
+  if (
+    !settings.luxuryFeatures?.premierDelivery ||
+    !pd ||
+    !pd.regions.includes(parsed.data.region) ||
+    !pd.windows.includes(parsed.data.window)
+  ) {
+    return NextResponse.json(
+      { error: "Premier delivery not available" },
+      { status: 400 },
+    );
   }
   const res = NextResponse.json({ ok: true });
-  res.cookies.set("delivery", JSON.stringify({ region, window }), { path: "/" });
+  res.cookies.set(
+    "delivery",
+    JSON.stringify({
+      region: parsed.data.region,
+      window: parsed.data.window,
+      carrier: parsed.data.carrier,
+    }),
+    { path: "/" },
+  );
   return res;
+}
+
+export async function GET(req: NextRequest) {
+  const region = req.nextUrl.searchParams.get("region") ?? "";
+  const settings = await getShopSettings(shop.id);
+  if (
+    !settings.luxuryFeatures?.premierDelivery ||
+    !settings.premierDelivery ||
+    !region ||
+    !settings.premierDelivery.regions.includes(region)
+  ) {
+    return NextResponse.json({ windows: [], carriers: [] });
+  }
+  const manager = await pluginsReady;
+  const provider = manager.shipping.get("premier-shipping") as
+    | { getAvailableSlots: (region: string) => { windows: string[]; carriers: string[] } }
+    | undefined;
+  if (!provider) {
+    return NextResponse.json({ windows: [], carriers: [] });
+  }
+  try {
+    const slots = provider.getAvailableSlots(region);
+    return NextResponse.json(slots);
+  } catch {
+    return NextResponse.json({ windows: [], carriers: [] });
+  }
 }

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -37,7 +37,8 @@
     "fraudReviewThreshold": 0,
     "requireStrongCustomerAuth": false,
     "strictReturnConditions": true,
-    "trackingDashboard": true
+    "trackingDashboard": true,
+    "premierDelivery": false
   },
   "editorialBlog": { "enabled": true }
 }

--- a/apps/shop-bcd/src/app/api/delivery/route.ts
+++ b/apps/shop-bcd/src/app/api/delivery/route.ts
@@ -26,6 +26,7 @@ const schema = z
     region: z.string(),
     date: z.string(),
     window: z.string(),
+    carrier: z.string().optional(),
   })
   .strict();
 
@@ -42,7 +43,14 @@ export async function POST(req: NextRequest) {
 
   const manager = await pluginsReady;
   const provider = manager.shipping.get("premier-shipping") as
-    | { schedulePickup: (region: string, date: string, hourWindow: string) => void }
+    | {
+        schedulePickup: (
+          region: string,
+          date: string,
+          hourWindow: string,
+          carrier?: string,
+        ) => void;
+      }
     | undefined;
 
   if (!provider) {
@@ -53,8 +61,8 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { region, date, window } = parsed.data;
-    provider.schedulePickup(region, date, window);
+    const { region, date, window, carrier } = parsed.data;
+    provider.schedulePickup(region, date, window, carrier);
     return NextResponse.json({ ok: true });
   } catch (err) {
     return NextResponse.json(

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -18,6 +18,7 @@ const schema = z
     weight: z.number(),
     region: z.string().optional(),
     window: z.string().optional(),
+    carrier: z.string().optional(),
   })
   .superRefine((val, ctx) => {
     if (val.provider === "premier-shipping") {
@@ -26,6 +27,9 @@ const schema = z
       }
       if (!val.window) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["window"], message: "Required" });
+      }
+      if (!val.carrier) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["carrier"], message: "Required" });
       }
     }
   });
@@ -36,13 +40,23 @@ export async function POST(req: NextRequest) {
 
   const body = parsed.data;
   let premierDelivery;
+  let provider = body.provider;
   if (body.provider === "premier-shipping") {
     const settings = await getShopSettings(shop.id);
-    premierDelivery = settings.premierDelivery;
+    if (
+      settings.luxuryFeatures?.premierDelivery &&
+      settings.premierDelivery &&
+      body.region &&
+      settings.premierDelivery.regions.includes(body.region)
+    ) {
+      premierDelivery = settings.premierDelivery;
+    } else {
+      provider = "dhl";
+    }
   }
 
   try {
-    const rate = await getShippingRate({ ...body, premierDelivery });
+    const rate = await getShippingRate({ ...body, provider, premierDelivery });
     return NextResponse.json({ rate });
   } catch (err) {
     return NextResponse.json(

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -18,7 +18,10 @@
   "returnService": { "upsEnabled": false, "bagEnabled": false, "homePickupEnabled": false },
   "premierDelivery": {
     "regions": ["us-east"],
-    "windows": ["10-11", "11-12"]
+    "windows": ["10-11", "11-12"],
+    "carriers": ["fastship"],
+    "surcharge": 0,
+    "serviceLabel": "Premier"
   },
   "seo": {
     "aiCatalog": {
@@ -33,7 +36,8 @@
     "fraudReviewThreshold": 0,
     "requireStrongCustomerAuth": false,
     "strictReturnConditions": true,
-    "trackingDashboard": true
+    "trackingDashboard": true,
+    "premierDelivery": true
   },
   "updatedAt": "",
   "updatedBy": ""

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -23,7 +23,10 @@
     "windows": [
       "10-11",
       "11-12"
-    ]
+    ],
+    "carriers": ["fastship"],
+    "surcharge": 0,
+    "serviceLabel": "Premier"
   },
   "priceOverrides": {},
   "localeOverrides": {},
@@ -44,7 +47,8 @@
     "fraudReviewThreshold": 0,
     "requireStrongCustomerAuth": false,
     "strictReturnConditions": true,
-    "trackingDashboard": true
+    "trackingDashboard": true,
+    "premierDelivery": true
   },
   "rentalSubscriptions": [
     {

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -33,7 +33,8 @@
     "fraudReviewThreshold": 0,
     "requireStrongCustomerAuth": false,
     "strictReturnConditions": true,
-    "trackingDashboard": true
+    "trackingDashboard": true,
+    "premierDelivery": false
   },
   "updatedAt": "",
   "updatedBy": ""

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -34,7 +34,8 @@
     "fraudReviewThreshold": 0,
     "requireStrongCustomerAuth": false,
     "strictReturnConditions": true,
-    "trackingDashboard": true
+    "trackingDashboard": true,
+    "premierDelivery": false
   },
   "rentalSubscriptions": [
     {

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -124,6 +124,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
       requireStrongCustomerAuth: false,
       strictReturnConditions: false,
       trackingDashboard: false,
+      premierDelivery: false,
     },
     updatedAt: "",
     updatedBy: "",

--- a/packages/plugins/premier-shipping/__tests__/premier-shipping.test.ts
+++ b/packages/plugins/premier-shipping/__tests__/premier-shipping.test.ts
@@ -1,0 +1,25 @@
+import plugin from "../index";
+
+test("calculateShipping includes surcharge and label", () => {
+  const registry = { add: jest.fn() } as any;
+  plugin.registerShipping(registry, {
+    regions: ["zone1"],
+    windows: ["10-11"],
+    carriers: ["fast"],
+    rate: 5,
+    surcharge: 2,
+    serviceLabel: "Premier",
+  });
+  const provider = registry.add.mock.calls[0][1] as any;
+  const result = provider.calculateShipping({
+    provider: "premier-shipping",
+    region: "zone1",
+    window: "10-11",
+    carrier: "fast",
+  });
+  expect(result.rate).toBe(7);
+  expect(result.surcharge).toBe(2);
+  expect(result.serviceLabel).toBe("Premier");
+  const slots = provider.getAvailableSlots("zone1");
+  expect(slots.carriers).toContain("fast");
+});

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -125,6 +125,7 @@ export const shopSchema = z
         requireStrongCustomerAuth: z.boolean().default(false),
         strictReturnConditions: z.boolean().default(false),
         trackingDashboard: z.boolean().default(false),
+        premierDelivery: z.boolean().default(false),
       })
       .strict()
       .default({
@@ -134,6 +135,7 @@ export const shopSchema = z
         requireStrongCustomerAuth: false,
         strictReturnConditions: false,
         trackingDashboard: false,
+        premierDelivery: false,
       }),
     lastUpgrade: z.string().datetime().optional(),
     componentVersions: z.record(z.string()).default({}),

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -77,6 +77,9 @@ export const shopSettingsSchema = z
       .object({
         regions: z.array(z.string()),
         windows: z.array(z.string()),
+        carriers: z.array(z.string()).default([]),
+        surcharge: z.number().int().nonnegative().optional(),
+        serviceLabel: z.string().optional(),
       })
       .strict()
       .optional(),
@@ -96,6 +99,7 @@ export const shopSettingsSchema = z
         requireStrongCustomerAuth: z.boolean().default(false),
         strictReturnConditions: z.boolean().default(false),
         trackingDashboard: z.boolean().default(false),
+        premierDelivery: z.boolean().default(false),
       })
       .strict()
       .default({
@@ -105,6 +109,7 @@ export const shopSettingsSchema = z
         requireStrongCustomerAuth: false,
         strictReturnConditions: false,
         trackingDashboard: false,
+        premierDelivery: false,
       }),
     /** Feature flag to enable or disable all tracking */
     trackingEnabled: z.boolean().default(true).optional(),


### PR DESCRIPTION
## Summary
- extend premier shipping plugin with carrier support, surcharge and service label plus real-time slot lookup
- expose premier delivery flag and region/carrier validation in shipping service and APIs
- add scheduling endpoint for one-hour windows and config updates across shops

## Testing
- `pnpm exec jest packages/plugins/premier-shipping/__tests__/premier-shipping.test.ts`
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68a091fec600832f931b87b144a5a3fb