### PR TITLE
chore: reference email package in shop apps

### DIFF
--- a/apps/shop-abc/tsconfig.json
+++ b/apps/shop-abc/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../../packages/platform-core" },
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
-    { "path": "../../packages/lib" }
+    { "path": "../../packages/lib" },
+    { "path": "../../packages/email" }
   ]
 }

--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -15,7 +15,8 @@
     "@acme/stripe": "workspace:*",
     "@acme/date-utils": "workspace:*",
     "@acme/sanity": "workspace:*",
-    "@acme/config": "workspace:*"
+    "@acme/config": "workspace:*",
+    "@acme/email": "workspace:*"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../../packages/platform-core" },
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
-    { "path": "../../packages/lib" }
+    { "path": "../../packages/lib" },
+    { "path": "../../packages/email" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
       '@acme/date-utils':
         specifier: workspace:*
         version: link:../../packages/date-utils
+      '@acme/email':
+        specifier: workspace:*
+        version: link:../../packages/email
       '@acme/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n


### PR DESCRIPTION
## Summary
- reference email package in both shop app tsconfigs
- add email workspace dependency to shop-bcd

## Testing
- `pnpm tsc -p apps/shop-bcd/tsconfig.json --noEmit` *(fails: Output file has not been built from source file)*
- `pnpm tsc -p apps/shop-abc/tsconfig.json --noEmit` *(fails: Output file has not been built from source file)*
- `pnpm install --ignore-scripts`


------
https://chatgpt.com/codex/tasks/task_e_68a096f110e0832f96fb38d01d163808