### PR TITLE
feat: add blog feature flag

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -38,6 +38,7 @@ describe("ShopEditor", () => {
       priceOverrides: {},
       localeOverrides: {},
       luxuryFeatures: {
+        blog: false,
         contentMerchandising: false,
         raTicketing: false,
         fraudReviewThreshold: 0,

--- a/apps/cms/__tests__/saveSanityConfig.test.ts
+++ b/apps/cms/__tests__/saveSanityConfig.test.ts
@@ -39,10 +39,12 @@ describe("saveSanityConfig", () => {
     (getShopById as jest.Mock).mockResolvedValue({
       id: "shop",
       editorialBlog: { enabled: false },
+      luxuryFeatures: { blog: false },
     });
     (setSanityConfig as jest.Mock).mockReturnValue({
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
+      luxuryFeatures: { blog: false },
     });
     (updateShopInRepo as jest.Mock).mockResolvedValue({ id: "shop" });
 
@@ -64,6 +66,7 @@ describe("saveSanityConfig", () => {
     expect(setSanityConfig).toHaveBeenCalledWith({
       id: "shop",
       editorialBlog: { enabled: false },
+      luxuryFeatures: { blog: false },
     }, {
       projectId: "p",
       dataset: "d",
@@ -73,6 +76,7 @@ describe("saveSanityConfig", () => {
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
       editorialBlog: { enabled: false },
+      luxuryFeatures: { blog: false },
       enableEditorial: false,
     });
     expect(res).toEqual({ message: "Sanity connected" });
@@ -83,10 +87,12 @@ describe("saveSanityConfig", () => {
     (getShopById as jest.Mock).mockResolvedValue({
       id: "shop",
       editorialBlog: { enabled: true },
+      luxuryFeatures: { blog: true },
     });
     (setSanityConfig as jest.Mock).mockReturnValue({
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
+      luxuryFeatures: { blog: true },
     });
     (updateShopInRepo as jest.Mock).mockResolvedValue({ id: "shop" });
 
@@ -112,6 +118,7 @@ describe("saveSanityConfig", () => {
     expect(setSanityConfig).toHaveBeenCalledWith({
       id: "shop",
       editorialBlog: { enabled: true },
+      luxuryFeatures: { blog: true },
     }, {
       projectId: "p",
       dataset: "d",
@@ -121,6 +128,7 @@ describe("saveSanityConfig", () => {
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
       editorialBlog: { enabled: true },
+      luxuryFeatures: { blog: true },
       enableEditorial: true,
     });
     expect(res).toEqual({ message: "Sanity connected" });
@@ -131,10 +139,12 @@ describe("saveSanityConfig", () => {
     (getShopById as jest.Mock).mockResolvedValue({
       id: "shop",
       editorialBlog: { enabled: false },
+      luxuryFeatures: { blog: false },
     });
     (setSanityConfig as jest.Mock).mockReturnValue({
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
+      luxuryFeatures: { blog: false },
     });
     (updateShopInRepo as jest.Mock).mockResolvedValue({ id: "shop" });
 
@@ -152,6 +162,7 @@ describe("saveSanityConfig", () => {
       id: "shop",
       sanityBlog: { projectId: "p", dataset: "d", token: "t" },
       editorialBlog: { enabled: true },
+      luxuryFeatures: { blog: true },
       enableEditorial: true,
     });
   });
@@ -165,6 +176,7 @@ describe("saveSanityConfig", () => {
     (getShopById as jest.Mock).mockResolvedValue({
       id: "shop",
       editorialBlog: { enabled: true },
+      luxuryFeatures: { blog: true },
     });
 
     const fd = new FormData();
@@ -183,6 +195,7 @@ describe("saveSanityConfig", () => {
     (getShopById as jest.Mock).mockResolvedValue({
       id: "shop",
       editorialBlog: { enabled: false },
+      luxuryFeatures: { blog: false },
     });
     (setSanityConfig as jest.Mock).mockReturnValue({
       id: "shop",

--- a/apps/cms/__tests__/schemas.test.ts
+++ b/apps/cms/__tests__/schemas.test.ts
@@ -51,8 +51,8 @@ describe("zod schemas", () => {
     });
 
     expect(parsed.catalogFilters).toEqual(["color", "size", "type"]);
-    expect(parsed.enableEditorial).toBe(false);
     expect(parsed.luxuryFeatures).toEqual({
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,
@@ -78,16 +78,16 @@ describe("zod schemas", () => {
     expect(errs.themeId?.[0]).toBe("Required");
   });
 
-  it("shopSchema parses enableEditorial checkbox", () => {
+  it("shopSchema parses blog checkbox", () => {
     const parsed = shopSchema.parse({
       id: "s1",
       name: "Shop",
       themeId: "base",
       catalogFilters: "",
-      enableEditorial: "on",
+      blog: "on",
     });
 
-    expect(parsed.enableEditorial).toBe(true);
+    expect(parsed.luxuryFeatures.blog).toBe(true);
   });
 
   it("shopSchema parses luxury feature checkboxes", () => {
@@ -103,6 +103,7 @@ describe("zod schemas", () => {
     });
 
     expect(parsed.luxuryFeatures).toEqual({
+      blog: false,
       contentMerchandising: true,
       raTicketing: true,
       fraudReviewThreshold: 150,

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -7,6 +7,7 @@ import {
   setSanityConfig,
   setEditorialBlog,
 } from "@platform-core/src/shops";
+import type { Shop } from "@acme/types";
 import { ensureAuthorized } from "./common/auth";
 import { setupSanityBlog } from "./setupSanityBlog";
 
@@ -31,7 +32,7 @@ export async function saveSanityConfig(
   const promoteScheduleRaw = formData.get("promoteSchedule");
   const editorialEnabled =
     enableEditorialRaw == null
-      ? Boolean(shop.editorialBlog?.enabled)
+      ? Boolean(shop.luxuryFeatures?.blog)
       : enableEditorialRaw === "on" || enableEditorialRaw === "true";
   const promoteSchedule =
     promoteScheduleRaw == null || String(promoteScheduleRaw) === ""
@@ -62,6 +63,10 @@ export async function saveSanityConfig(
     enabled: editorialEnabled,
     ...(promoteSchedule ? { promoteSchedule } : {}),
   });
+  updated.luxuryFeatures = {
+    ...(updated.luxuryFeatures ?? {}),
+    blog: editorialEnabled,
+  } as Shop["luxuryFeatures"];
   // maintain legacy flag
   (updated as any).enableEditorial = editorialEnabled;
   if (promoteSchedule) {

--- a/apps/cms/src/actions/schemas.ts
+++ b/apps/cms/src/actions/schemas.ts
@@ -51,7 +51,7 @@ export const shopSchema = z
           .map((v) => v.trim())
           .filter(Boolean)
       ),
-    enableEditorial: z
+    blog: z
       .preprocess((v) => v === "on", z.boolean())
       .optional()
       .default(false),
@@ -90,6 +90,7 @@ export const shopSchema = z
   .strict()
   .transform(
     ({
+      blog,
       contentMerchandising,
       raTicketing,
       fraudReviewThreshold,
@@ -100,6 +101,7 @@ export const shopSchema = z
     }) => ({
       ...rest,
       luxuryFeatures: {
+        blog,
         contentMerchandising,
         raTicketing,
         fraudReviewThreshold,

--- a/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
@@ -43,26 +43,25 @@ export default function GeneralSettings({
           <span className="text-sm text-red-600">{errors.themeId.join("; ")}</span>
         )}
       </label>
-      <div className="flex flex-col gap-1">
-        <label className="flex items-center gap-2">
-          <Checkbox
-            name="enableEditorial"
-            checked={info.enableEditorial ?? false}
-            onCheckedChange={(v) =>
-              setInfo((prev) => ({ ...prev, enableEditorial: Boolean(v) }))
-            }
-          />
-          <span>Enable blog</span>
-        </label>
-        {errors.enableEditorial && (
-          <span className="text-sm text-red-600">
-            {errors.enableEditorial.join("; ")}
-          </span>
-        )}
-      </div>
       <fieldset className="col-span-2 flex flex-col gap-1">
         <legend className="text-sm font-medium">Luxury features</legend>
         <div className="mt-2 grid gap-2">
+          <label className="flex items-center gap-2">
+            <Checkbox
+              name="blog"
+              checked={info.luxuryFeatures.blog ?? false}
+              onCheckedChange={(v) =>
+                setInfo((prev) => ({
+                  ...prev,
+                  luxuryFeatures: {
+                    ...prev.luxuryFeatures,
+                    blog: Boolean(v),
+                  },
+                }))
+              }
+            />
+            <span>Enable blog</span>
+          </label>
           <label className="flex items-center gap-2">
             <Checkbox
               name="contentMerchandising"

--- a/apps/cms/src/services/shops/seoService.ts
+++ b/apps/cms/src/services/shops/seoService.ts
@@ -87,6 +87,7 @@ export async function revertSeo(shop: string, timestamp: string) {
     languages: [] as Locale[],
     seo: {},
     luxuryFeatures: {
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,

--- a/apps/cms/src/services/shops/themeService.ts
+++ b/apps/cms/src/services/shops/themeService.ts
@@ -24,7 +24,6 @@ export async function updateShop(
     name: data.name,
     themeId: data.themeId,
     catalogFilters: data.catalogFilters,
-    enableEditorial: data.enableEditorial,
     themeDefaults: theme.themeDefaults,
     themeOverrides: theme.overrides,
     themeTokens: theme.themeTokens,

--- a/apps/shop-abc/__tests__/homePage.test.tsx
+++ b/apps/shop-abc/__tests__/homePage.test.tsx
@@ -38,7 +38,7 @@ test("Home receives components from pages repo when editorial disabled", async (
   (readShop as jest.Mock).mockResolvedValue({
     id: "abc",
     editorialBlog: { enabled: false },
-    luxuryFeatures: { contentMerchandising: true },
+    luxuryFeatures: { contentMerchandising: true, blog: false },
   });
 
   const element = await Page({ params: { lang: "en" } });
@@ -59,7 +59,7 @@ test("Home fetches latest post when merchandising enabled", async () => {
   (readShop as jest.Mock).mockResolvedValue({
     id: "abc",
     editorialBlog: { enabled: true },
-    luxuryFeatures: { contentMerchandising: true },
+    luxuryFeatures: { contentMerchandising: true, blog: true },
   });
   (fetchPublishedPosts as jest.Mock).mockResolvedValue([
     { title: "Hello", excerpt: "World", slug: "hello" },

--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -35,6 +35,7 @@
     "token": "token"
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ export default async function BlogPostPage({
 }: {
   params: { lang: string; slug: string };
 }) {
-  if (!shop.editorialBlog?.enabled) {
+  if (!shop.luxuryFeatures.blog) {
     notFound();
   }
   const post = await fetchPostBySlug(shop.id, params.slug);

--- a/apps/shop-abc/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
-  if (!shop.editorialBlog?.enabled) {
+  if (!shop.luxuryFeatures.blog) {
     notFound();
   }
   const posts = await fetchPublishedPosts(shop.id);

--- a/apps/shop-abc/src/app/[lang]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/page.tsx
@@ -20,7 +20,10 @@ export default async function Page({
   const shop = await readShop(env.NEXT_PUBLIC_SHOP_ID || "shop-abc");
   const components = await loadComponents(shop.id);
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures?.contentMerchandising && shop.editorialBlog?.enabled) {
+  if (
+    shop.luxuryFeatures?.contentMerchandising &&
+    shop.luxuryFeatures?.blog
+  ) {
     const posts = await fetchPublishedPosts(shop.id);
     const first = posts[0];
     if (first) {

--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -95,7 +95,7 @@ export default async function ProductDetailPage({
   const components = await loadComponents(params.slug);
   await trackPageView(shop.id, `product/${params.slug}`);
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures.contentMerchandising) {
+  if (shop.luxuryFeatures.contentMerchandising && shop.luxuryFeatures.blog) {
     try {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -34,7 +34,7 @@ export default async function ShopIndexPage({
   let latestPost: BlogPost | undefined;
   try {
     const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
-    if (luxury.contentMerchandising) {
+    if (luxury.contentMerchandising && luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];
       if (first) {

--- a/apps/shop-abc/src/app/api/search/route.ts
+++ b/apps/shop-abc/src/app/api/search/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
   }));
 
   let posts: { type: "post"; title: string; slug: string }[] = [];
-  if (shop.luxuryFeatures?.contentMerchandising) {
+  if (shop.luxuryFeatures?.contentMerchandising && shop.luxuryFeatures?.blog) {
     try {
       const fetched = await fetchPublishedPosts(shop.id);
       posts = fetched

--- a/apps/shop-bcd/shop.json
+++ b/apps/shop-bcd/shop.json
@@ -32,6 +32,7 @@
     "token": "token"
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ export default async function BlogPostPage({
 }: {
   params: { lang: string; slug: string };
 }) {
-  if (!shop.editorialBlog?.enabled) {
+  if (!shop.luxuryFeatures.blog) {
     notFound();
   }
   const post = await fetchPostBySlug(shop.id, params.slug);

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import shop from "../../../../shop.json";
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
-  if (!shop.editorialBlog?.enabled) {
+  if (!shop.luxuryFeatures.blog) {
     notFound();
   }
   const posts = await fetchPublishedPosts(shop.id);

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -33,7 +33,10 @@ export default async function Page({
 }) {
   const components = await loadComponents();
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures?.contentMerchandising && shop.editorialBlog?.enabled) {
+  if (
+    shop.luxuryFeatures?.contentMerchandising &&
+    shop.luxuryFeatures?.blog
+  ) {
     const posts = await fetchPublishedPosts(shop.id);
     const first = posts[0];
     if (first) {

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
@@ -83,7 +83,7 @@ export default async function ProductDetailPage({
   if (!product) return notFound();
 
   let latestPost: BlogPost | undefined;
-  if (shop.luxuryFeatures.contentMerchandising) {
+  if (shop.luxuryFeatures.contentMerchandising && shop.luxuryFeatures.blog) {
     try {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -20,7 +20,7 @@ export default async function ShopIndexPage({
   let latestPost: BlogPost | undefined;
   try {
     const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
-    if (luxury.contentMerchandising) {
+    if (luxury.contentMerchandising && luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];
       if (first) {

--- a/apps/shop-bcd/src/app/api/search/route.ts
+++ b/apps/shop-bcd/src/app/api/search/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
   }));
 
   let posts: { type: "post"; title: string; slug: string }[] = [];
-  if (shop.luxuryFeatures?.contentMerchandising) {
+  if (shop.luxuryFeatures?.contentMerchandising && shop.luxuryFeatures?.blog) {
     try {
       const fetched = await fetchPublishedPosts(shop.id);
       posts = fetched

--- a/data/shops/abc/settings.json
+++ b/data/shops/abc/settings.json
@@ -28,6 +28,7 @@
     }
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": false,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/data/shops/abc/shop.json
+++ b/data/shops/abc/shop.json
@@ -39,6 +39,7 @@
     "enabled": true
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": true,
     "fraudReviewThreshold": 0,

--- a/data/shops/bcd/settings.json
+++ b/data/shops/bcd/settings.json
@@ -28,6 +28,7 @@
     }
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": false,
     "raTicketing": false,
     "fraudReviewThreshold": 0,

--- a/data/shops/bcd/shop.json
+++ b/data/shops/bcd/shop.json
@@ -29,6 +29,7 @@
     "enabled": true
   },
   "luxuryFeatures": {
+    "blog": true,
     "contentMerchandising": true,
     "raTicketing": true,
     "fraudReviewThreshold": 0,

--- a/doc/luxury-features.md
+++ b/doc/luxury-features.md
@@ -9,7 +9,8 @@ and the shop operates normally without them. Enable features in a shop's
 
 | Feature | How to Enable | Notes |
 | ------- | ------------- | ----- |
-| `contentMerchandising` | Set `luxuryFeatures.contentMerchandising` to `true` in shop settings. | Requires the Editorial Blog to be enabled. Has no effect for shops that do not publish content. |
+| `blog` | Set `luxuryFeatures.blog` to `true` in shop settings. | Enables the editorial blog and related CMS endpoints. |
+| `contentMerchandising` | Set `luxuryFeatures.contentMerchandising` to `true` in shop settings. | Requires the blog to be enabled. Has no effect for shops that do not publish content. |
 | `raTicketing` | Set `luxuryFeatures.raTicketing` to `true` **and** enable the `raTicketing` flag in `@platform-core/features` (env `LUXURY_FEATURES_RA_TICKETING`). | Adds Return Authorization dashboard in the CMS. Shops that do not process returns should keep this disabled. |
 | `fraudReviewThreshold` | Provide a number greater than `0` for `luxuryFeatures.fraudReviewThreshold`. | Used in the Stripe webhook to trigger manual review; ignored for non‑Stripe flows. |
 | `requireStrongCustomerAuth` | Set `luxuryFeatures.requireStrongCustomerAuth` to `true`. | Forces 3‑D Secure on qualifying Stripe checkouts. Irrelevant when using other payment providers. |

--- a/doc/sanity-blog.md
+++ b/doc/sanity-blog.md
@@ -15,7 +15,7 @@ When setting up the connection the CMS seeds a minimal schema. Posts include a `
 
 ## Enable or disable editorial content
 
-The blog can be toggled in **Settings → Shop** using the **Enable blog** checkbox. This sets the `editorialBlog.enabled` flag in the shop settings. When disabled the storefront hides blog routes and the daily publication job skips the shop.
+The blog can be toggled in **Settings → Shop** using the **Enable blog** checkbox. This sets the `luxuryFeatures.blog` flag in the shop settings. When disabled the storefront hides blog routes and the daily publication job skips the shop.
 
 To automatically surface the "Daily Edit" on the storefront home page, provide a `promoteSchedule` ISO timestamp. When set the CMS schedules a front‑page promotion at the chosen time.
 

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -118,6 +118,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     premierDelivery: undefined,
     stockAlert: { recipients: [] },
     luxuryFeatures: {
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -79,6 +79,7 @@ export async function readShop(shop: string): Promise<Shop> {
     navigation: [],
     analyticsEnabled: false,
     luxuryFeatures: {
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -119,6 +119,7 @@ export const shopSchema = z
     rentalInventoryAllocation: z.boolean().optional(),
     luxuryFeatures: z
       .object({
+        blog: z.boolean().default(false),
         contentMerchandising: z.boolean().default(false),
         raTicketing: z.boolean().default(false),
         fraudReviewThreshold: z.number().nonnegative().default(0),
@@ -128,6 +129,7 @@ export const shopSchema = z
       })
       .strict()
       .default({
+        blog: false,
         contentMerchandising: false,
         raTicketing: false,
         fraudReviewThreshold: 0,

--- a/packages/types/src/ShopSettings.ts
+++ b/packages/types/src/ShopSettings.ts
@@ -90,6 +90,7 @@ export const shopSettingsSchema = z
       .optional(),
     luxuryFeatures: z
       .object({
+        blog: z.boolean().default(false),
         contentMerchandising: z.boolean().default(false),
         raTicketing: z.boolean().default(false),
         fraudReviewThreshold: z.number().nonnegative().default(0),
@@ -99,6 +100,7 @@ export const shopSettingsSchema = z
       })
       .strict()
       .default({
+        blog: false,
         contentMerchandising: false,
         raTicketing: false,
         fraudReviewThreshold: 0,

--- a/test/unit/shop-schema.spec.ts
+++ b/test/unit/shop-schema.spec.ts
@@ -32,6 +32,7 @@ describe("shop schema", () => {
     expect(parsed.componentVersions).toEqual({});
     expect(parsed.lastUpgrade).toBeUndefined();
     expect(parsed.luxuryFeatures).toEqual({
+      blog: false,
       contentMerchandising: false,
       raTicketing: false,
       fraudReviewThreshold: 0,


### PR DESCRIPTION
## Summary
- gate blog features behind `luxuryFeatures.blog`
- expose blog toggle in CMS shop settings
- update storefront pages and APIs to respect new flag

## Testing
- `pnpm test --filter @apps/cms --filter @apps/shop-abc --filter @apps/shop-bcd --filter @acme/types --filter @acme/platform-core` *(fails: command (/workspace/base-shop/apps/cms) ... exited (1))*
- `pnpm test --filter @acme/platform-core` *(fails: command (/workspace/base-shop/packages/platform-core) ... exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68a09435cd20832f83a35abc0d710fef