### PR TITLE
Fix TypeScript errors in shop-bcd login and preview pages

### DIFF
--- a/apps/shop-bcd/src/app/login/route.ts
+++ b/apps/shop-bcd/src/app/login/route.ts
@@ -36,7 +36,9 @@ async function validateCredentials(
 
 export async function POST(req: Request) {
   const parsed = await parseJsonBody<LoginInput>(req, LoginSchema, "1mb");
-  if (!parsed.success) return parsed.response;
+  if (parsed.success === false) {
+    return parsed.response;
+  }
 
   const csrfToken = req.headers.get("x-csrf-token");
   if (!csrfToken || !(await validateCsrfToken(csrfToken))) {

--- a/apps/shop-bcd/src/app/preview/[pageId]/page.tsx
+++ b/apps/shop-bcd/src/app/preview/[pageId]/page.tsx
@@ -9,7 +9,7 @@ export default async function PreviewPage({
   searchParams,
 }: {
   params: { pageId: string };
-  searchParams: { token?: string; upgrade?: string };
+  searchParams: { token?: string; upgrade?: string; device?: string; view?: string };
 }) {
   const { pageId } = params;
   const query = new URLSearchParams();

--- a/apps/shop-bcd/src/lib/seo.ts
+++ b/apps/shop-bcd/src/lib/seo.ts
@@ -26,7 +26,10 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<ExtendedSeoProps> = {}
 ): Promise<NextSeoProps> {
-  const shop = env.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop =
+    typeof env.NEXT_PUBLIC_SHOP_ID === "string"
+      ? env.NEXT_PUBLIC_SHOP_ID
+      : "default";
   const settings: ShopSettings = await getShopSettings(shop);
   const shopSeo = (settings.seo ?? {}) as Record<string, ExtendedSeoProps>;
   const base: ExtendedSeoProps = shopSeo[locale] ?? {};


### PR DESCRIPTION
## Summary
- handle parseJsonBody failure using explicit success check in shop-bcd login route
- allow preview page to read device and view search params
- ensure shop id resolved to string before fetching settings

## Testing
- `npx tsc -p apps/shop-bcd/tsconfig.json --noEmit` *(fails: Output file has not been built from source file)*
- `pnpm test --filter @apps/shop-bcd`

------
https://chatgpt.com/codex/tasks/task_e_68a0a4257260832fa2ceab0bf2f8a3a6