### PR TITLE
fix: resolve tsconfig and missing modules for shop-bcd

### DIFF
--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -16,7 +16,8 @@
     "@acme/date-utils": "workspace:*",
     "@acme/sanity": "workspace:*",
     "@acme/config": "workspace:*",
-    "@acme/email": "workspace:*"
+    "@acme/email": "workspace:*",
+    "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
@@ -6,7 +6,7 @@ import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import shop from "../../../shop.json";
+import shop from "../../../../shop.json";
 
 export const metadata = {
   title: "Checkout · Base-Shop",

--- a/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/product/[slug]/page.tsx
@@ -74,7 +74,7 @@ export default async function ProductDetailPage({
 }: {
   params: { slug: string; lang: string };
 }) {
-  const { isEnabled } = draftMode();
+  const { isEnabled } = await draftMode();
   const product = await getProduct(
     params.slug,
     params.lang as Locale,

--- a/apps/shop-bcd/src/app/[lang]/returns/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/returns/page.tsx
@@ -4,7 +4,7 @@ import {
   getReturnBagAndLabel,
 } from "@platform-core/returnLogistics";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import shop from "../../../shop.json";
+import shop from "../../../../shop.json";
 
 export const metadata = { title: "Return policy" };
 

--- a/apps/shop-bcd/src/app/api/delivery/schedule/route.ts
+++ b/apps/shop-bcd/src/app/api/delivery/schedule/route.ts
@@ -4,7 +4,7 @@ import { getShopSettings } from "@platform-core/repositories/settings.server";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
-import shop from "../../../../shop.json";
+import shop from "../../../../../shop.json";
 
 export const runtime = "edge";
 

--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@acme/config/tsconfig.app.json",
-  "include": ["src/**/*", ".next/types/**/*.ts"],
+  "include": ["src/**/*", ".next/types/**/*.ts", "shop.json"],
   "exclude": [
     "dist",
     "node_modules",
@@ -14,6 +14,7 @@
     { "path": "../../packages/i18n" },
     { "path": "../../packages/ui" },
     { "path": "../../packages/lib" },
-    { "path": "../../packages/email" }
+    { "path": "../../packages/email" },
+    { "path": "../../packages/sanity" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,9 @@ importers:
       '@themes/base':
         specifier: workspace:*
         version: link:../../packages/themes/base
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
     devDependencies:
       next:
         specifier: ^15.3.4


### PR DESCRIPTION
## Summary
- include `@acme/sanity` in shop-bcd's tsconfig and allow importing shop.json
- await `draftMode()` and correct shop.json import paths
- add `qrcode` dependency for order page QR code generation

## Testing
- `pnpm -F @apps/shop-bcd build` *(fails: Unknown file extension ".ts" for packages/config/src/env/core.ts)*
- `pnpm exec tsc -p apps/shop-bcd/tsconfig.json --noEmit` *(fails: Output file has not been built from source file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4551450832fb88f5a839b7e1078