### PR TITLE
Fix type errors in shop-bcd pages

### DIFF
--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import { notFound } from "next/navigation";
 import { fetchPostBySlug } from "@acme/sanity";
 import { BlogPortableText } from "@/components/blog/BlogPortableText";
-import shop from "../../../../../shop.json";
+import type { Shop } from "@acme/types";
+import shopJson from "../../../../../shop.json";
+
+const shop = shopJson as Shop;
 
 export default async function BlogPostPage({
   params,

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -1,7 +1,10 @@
 import BlogListing from "@ui/components/cms/blocks/BlogListing";
 import { fetchPublishedPosts } from "@acme/sanity";
 import { notFound } from "next/navigation";
-import shop from "../../../../shop.json";
+import type { Shop } from "@acme/types";
+import shopJson from "../../../../shop.json";
+
+const shop = shopJson as Shop;
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
   if (!shop.luxuryFeatures.blog) {

--- a/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
@@ -1,12 +1,12 @@
 // apps/shop-bcd/src/app/[lang]/checkout/page.tsx
 import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";
-import DeliveryScheduler from "@ui/components/organisms/DeliveryScheduler";
+import { DeliveryScheduler } from "@ui/components/organisms";
 import { Locale, resolveLocale } from "@/i18n/locales";
 import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import shop from "../../../shop.json";
+import shop from "../../../../shop.json";
 
 export const metadata = {
   title: "Checkout · Base-Shop",

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -4,6 +4,7 @@
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@acme/types";
 import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
+import type { Locale } from "@/i18n/locales";
 
 export default function Home({
   components,
@@ -11,7 +12,7 @@ export default function Home({
   latestPost,
 }: {
   components: PageComponent[];
-  locale: string;
+  locale: Locale;
   latestPost?: BlogPost;
 }) {
   return (

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -5,6 +5,7 @@ import shop from "../../../shop.json";
 import Home from "./page.client";
 import { fetchPublishedPosts } from "@acme/sanity";
 import type { BlogPost } from "@ui/components/cms/blocks/BlogListing";
+import { Locale, resolveLocale } from "@/i18n/locales";
 
 async function loadComponents(): Promise<PageComponent[]> {
   try {
@@ -50,5 +51,6 @@ export default async function Page({
       };
     }
   }
-  return <Home components={components} locale={params.lang} latestPost={latestPost} />;
+  const lang: Locale = resolveLocale(params.lang);
+  return <Home components={components} locale={lang} latestPost={latestPost} />;
 }


### PR DESCRIPTION
## Summary
- cast shop config to Shop in blog pages to access optional properties
- correct DeliveryScheduler usage and shop path in checkout page
- restrict locale types for home rendering and resolve locale on server

## Testing
- `pnpm lint --filter @apps/shop-bcd`
- `pnpm typecheck` *(fails: Cannot find module '@acme/config/env/core' and other type errors)*
- `pnpm test --filter @apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_68a0a46a3b10832f81c4de988ee00c39