### PR TITLE
fix: align parseJsonBody usage with updated types

### DIFF
--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -39,8 +39,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const parsed = await parseJsonBody(req, schema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
 

--- a/apps/shop-bcd/src/app/api/delivery/route.ts
+++ b/apps/shop-bcd/src/app/api/delivery/route.ts
@@ -38,8 +38,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const parsed = await parseJsonBody(req, schema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
 

--- a/apps/shop-bcd/src/app/api/delivery/schedule/route.ts
+++ b/apps/shop-bcd/src/app/api/delivery/schedule/route.ts
@@ -17,8 +17,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
 

--- a/apps/shop-bcd/src/app/api/return-request/route.ts
+++ b/apps/shop-bcd/src/app/api/return-request/route.ts
@@ -22,8 +22,8 @@ const RequestSchema = z
   .strict();
 
 export async function POST(req: Request) {
-  const parsed = await parseJsonBody(req, RequestSchema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof RequestSchema>>(req, RequestSchema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
   const { orderId, email, hasTags = true, isWorn = false } = parsed.data;

--- a/apps/shop-bcd/src/app/api/return/route.ts
+++ b/apps/shop-bcd/src/app/api/return/route.ts
@@ -39,8 +39,8 @@ async function getUpsStatus(tracking: string) {
 }
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, ReturnSchema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof ReturnSchema>>(req, ReturnSchema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
   const { sessionId } = parsed.data;

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -35,8 +35,8 @@ const schema = z
   });
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
 

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -18,8 +18,8 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody(req, schema, "1mb");
-  if (!parsed.success) {
+  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
+  if (parsed.success === false) {
     return parsed.response;
   }
 


### PR DESCRIPTION
## Summary
- use explicit type parameters with parseJsonBody in shop-bcd API routes
- handle parseJsonBody results with discriminated union check

## Testing
- `pnpm test --filter @apps/shop-bcd`
- `pnpm exec tsc -p apps/shop-bcd/tsconfig.json --noEmit` *(fails: output files have not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a8011710832f8f747e0f5722177c