### PR TITLE
fix(blog): update shop type casting

### DIFF
--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -4,7 +4,8 @@ import { BlogPortableText } from "@/components/blog/BlogPortableText";
 import type { Shop } from "@acme/types";
 import shopJson from "../../../../../shop.json";
 
-const shop = shopJson as Shop;
+type BlogShop = Pick<Shop, "id" | "luxuryFeatures" | "editorialBlog">;
+const shop: BlogShop = shopJson;
 
 export default async function BlogPostPage({
   params,

--- a/apps/shop-bcd/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/page.tsx
@@ -4,7 +4,8 @@ import { notFound } from "next/navigation";
 import type { Shop } from "@acme/types";
 import shopJson from "../../../../shop.json";
 
-const shop = shopJson as Shop;
+type BlogShop = Pick<Shop, "id" | "luxuryFeatures" | "editorialBlog">;
+const shop: BlogShop = shopJson;
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
   if (!shop.luxuryFeatures.blog) {

--- a/apps/shop-bcd/src/types/qrcode.d.ts
+++ b/apps/shop-bcd/src/types/qrcode.d.ts
@@ -1,0 +1,7 @@
+declare module "qrcode" {
+  export function toDataURL(text: string, opts?: unknown): Promise<string>;
+  const _default: {
+    toDataURL: typeof toDataURL;
+  };
+  export default _default;
+}


### PR DESCRIPTION
## Summary
- narrow shop type to required fields for blog pages
- add qrcode type stub for order QR code generation

## Testing
- `pnpm test --filter @apps/shop-bcd^...` *(fails: 5 subtests failed in @acme/next-config)*
- `pnpm exec tsc -p apps/shop-bcd/tsconfig.json --noEmit` *(fails: output file has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a80c1480832f8d50e08949408c3f