### PR TITLE
fix: add date-utils reference for sanity

### DIFF
--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -10,9 +10,15 @@
     "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", ".turbo", "node_modules"],
+  "exclude": [
+    "dist",
+    ".turbo",
+    "node_modules",
+    "**/__tests__/**"
+  ],
   "references": [
     { "path": "../types" },
-    { "path": "../platform-core" }
+    { "path": "../platform-core" },
+    { "path": "../date-utils" }
   ]
 }


### PR DESCRIPTION
## Summary
- exclude test files from the sanity package build
- add date-utils as a project reference so sanity can import shared time helpers

## Testing
- `npx tsc --noEmit -p packages/sanity/tsconfig.json`
- `pnpm test --filter @acme/sanity` *(fails: Could not locate module @acme/email)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a82720e0832fa5394e59d7f2e07b