### PR TITLE
chore: build platform-core before scripts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "./apps/cms" },
     { "path": "./apps/shop-abc" },
     { "path": "./apps/shop-bcd" },
+    { "path": "packages/platform-core" },
     { "path": "./scripts" }
   ]
 }


### PR DESCRIPTION
## Summary
- build platform-core before scripts

## Testing
- `npx tsc -b -v --pretty false` *(fails: Module "./constants" has already exported a member named 'Locale' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac67a408832fa8b8e4e68c70aae1