### PR TITLE
chore: switch platform-core imports to acme namespace

### DIFF
--- a/packages/lib/__tests__/checkShopExists.server.test.ts
+++ b/packages/lib/__tests__/checkShopExists.server.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 
-jest.mock('@platform-core/dataRoot', () => ({
+jest.mock('@acme/platform-core/dataRoot', () => ({
   resolveDataRoot: jest.fn(() => '/data/root'),
 }));
 

--- a/packages/lib/src/checkShopExists.server.ts
+++ b/packages/lib/src/checkShopExists.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { resolveDataRoot } from "@platform-core/dataRoot";
+import { resolveDataRoot } from "@acme/platform-core/dataRoot";
 import { validateShopName } from "./validateShopName";
 
 const DATA_ROOT = resolveDataRoot();

--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -2,7 +2,7 @@
 
 import { CartProvider, useCart } from "@/contexts/CartContext";
 import AddToCartButton from "@platform-core/src/components/shop/AddToCartButton.client";
-import { PRODUCTS } from "@platform-core/products";
+import { PRODUCTS } from "@acme/platform-core/products";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 jest.mock("react", () => jest.requireActual("react"));
 jest.mock("react-dom", () => jest.requireActual("react-dom"));

--- a/packages/platform-core/src/cartApi.ts
+++ b/packages/platform-core/src/cartApi.ts
@@ -10,7 +10,7 @@ import { createCartStore } from "@platform-core/src/cartStore";
 import { getProductById, PRODUCTS } from "@platform-core/src/products";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { postSchema, patchSchema, putSchema } from "@platform-core/schemas/cart";
+import { postSchema, patchSchema, putSchema } from "@acme/platform-core/schemas/cart";
 import { z } from "zod";
 
 export const runtime = "edge";

--- a/packages/platform-core/src/hooks/__tests__/usePublishLocations.test.tsx
+++ b/packages/platform-core/src/hooks/__tests__/usePublishLocations.test.tsx
@@ -1,6 +1,6 @@
 // packages/platform-core/hooks/__tests__/usePublishLocations.test.tsx
 import { render, screen, waitFor } from "@testing-library/react";
-import { usePublishLocations } from "@platform-core/hooks/usePublishLocations";
+import { usePublishLocations } from "@acme/platform-core/hooks/usePublishLocations";
 
 describe("usePublishLocations", () => {
   it("fetches locations from API", async () => {

--- a/scripts/src/createShop/write.ts
+++ b/scripts/src/createShop/write.ts
@@ -1,4 +1,4 @@
-import { createShop } from "@platform-core/createShop";
+import { createShop } from "@acme/platform-core/createShop";
 import type { Options } from "./parse";
 
 /**

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -1,11 +1,11 @@
-import { createShop, type CreateShopOptions } from "@platform-core/createShop";
-import { validateShopName } from "@platform-core/shops";
+import { createShop, type CreateShopOptions } from "@acme/platform-core/createShop";
+import { validateShopName } from "@acme/platform-core/shops";
 import { spawnSync, execSync } from "node:child_process";
 import { readdirSync } from "node:fs";
-import { validateShopEnv } from "@platform-core/configurator";
+import { validateShopEnv } from "@acme/platform-core/configurator";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import { listProviders } from "@platform-core/createShop/listProviders";
+import { listProviders } from "@acme/platform-core/createShop/listProviders";
 
 function ensureRuntime() {
   const nodeMajor = Number(process.version.replace(/^v/, "").split(".")[0]);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,8 +31,6 @@
     /* ───────── monorepo path aliases ───────── */
     "paths": {
       /* ─── platform-core ─────────────────────────────────────────── */
-      "@platform-core": ["packages/platform-core/src/index.ts"],
-      "@platform-core/*": ["packages/platform-core/src/*"],
       "@platform-core/src": ["packages/platform-core/src/index.ts"],
       "@platform-core/src/*": ["packages/platform-core/src/*"],
       "@acme/platform-core": ["packages/platform-core/src/index.ts"],


### PR DESCRIPTION
## Summary
- update init-shop scripts to import from `@acme/platform-core`
- drop legacy `@platform-core` path alias in `tsconfig.base.json`
- adjust dependent utilities to the new namespace

## Testing
- `pnpm tsc -b packages/platform-core packages/lib packages/config packages/types scripts/tsconfig.json` *(fails: File '/workspace/base-shop/packages/config/src/env/payments.ts' is not under 'rootDir' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac6a8544832fa669c2198aedb3cc