### PR TITLE
Enable declaration emit for platform-core

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmit": false, // ← must allow emit
 
     /* ───── output location ───── */
+    "declaration": true,
     "declarationDir": "dist",
     "declarationMap": true,
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- enable declaration generation for `@acme/platform-core`

## Testing
- `pnpm exec tsc -p packages/platform-core/tsconfig.json --noEmitOnError false` *(fails: multiple TypeScript errors across packages)*
- `pnpm --filter @acme/platform-core test` *(fails: Could not locate module `@acme/email`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac6b839c832fbdba10908b0ac752