### PR TITLE
fix path alias and typing for shop-bcd API routes

### DIFF
--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -1,6 +1,9 @@
 // apps/shop-bcd/src/app/api/shipping-rate/route.ts
 import "@acme/lib/initZod";
-import { getShippingRate } from "@acme/platform-core/shipping";
+import {
+  getShippingRate,
+  type ShippingRateRequest,
+} from "@acme/platform-core/shipping";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import shop from "../../../../shop.json";
 import type { NextRequest } from "next/server";
@@ -41,7 +44,7 @@ export async function POST(req: NextRequest) {
   }
 
   const body = parsed.data;
-  let premierDelivery;
+  let premierDelivery: ShippingRateRequest["premierDelivery"];
   let provider = body.provider;
   if (body.provider === "premier-shipping") {
     const settings = await getShopSettings(shop.id);
@@ -58,7 +61,16 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const rate = await getShippingRate({ ...body, provider, premierDelivery });
+    const rate = await getShippingRate({
+      provider,
+      fromPostalCode: body.fromPostalCode,
+      toPostalCode: body.toPostalCode,
+      weight: body.weight,
+      region: body.region,
+      window: body.window,
+      carrier: body.carrier,
+      premierDelivery,
+    });
     return NextResponse.json({ rate });
   } catch (err) {
     return NextResponse.json(

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -1,6 +1,9 @@
 // apps/shop-bcd/src/app/api/tax/route.ts
 import "@acme/lib/initZod";
-import { calculateTax } from "@acme/platform-core/tax";
+import {
+  calculateTax,
+  type TaxCalculationRequest,
+} from "@acme/platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -24,7 +27,8 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const tax = await calculateTax(parsed.data);
+    const body: TaxCalculationRequest = parsed.data;
+    const tax = await calculateTax(body);
     return NextResponse.json({ tax });
   } catch (err) {
     return NextResponse.json(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,8 @@
     /* ───────── monorepo path aliases ───────── */
     "paths": {
       /* ─── platform-core ─────────────────────────────────────────── */
+      "@platform-core": ["packages/platform-core/src/index.ts"],
+      "@platform-core/*": ["packages/platform-core/src/*"],
       "@platform-core/src": ["packages/platform-core/src/index.ts"],
       "@platform-core/src/*": ["packages/platform-core/src/*"],
       "@acme/platform-core": ["packages/platform-core/src/index.ts"],


### PR DESCRIPTION
## Summary
- add `@platform-core` path alias for shared core package
- type shipping rate requests and build explicit payload
- enforce tax calculation request typing

## Testing
- `pnpm exec tsc -p apps/shop-bcd/tsconfig.json --noEmit --skipLibCheck` *(fails: Output file has not been built from source file)*
- `pnpm test --filter @apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_68a0afef2758832fae69d38ab18fe406