### PR TITLE
chore: add upstash redis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.3.1",
     "@tanstack/react-query": "^5.81.4",
+    "@upstash/redis": "^1.35.3",
     "argon2": "^0.44.0",
     "chart.js": "^4.5.0",
     "fast-csv": "^5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.81.4
         version: 5.81.5(react@19.1.0)
+      '@upstash/redis':
+        specifier: ^1.35.3
+        version: 1.35.3
       argon2:
         specifier: ^0.44.0
         version: 0.44.0


### PR DESCRIPTION
## Summary
- add @upstash/redis dependency for cache middleware

## Testing
- `pnpm typecheck` *(fails: Cannot find module '@platform-core/repositories/settings.server' etc.)*
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b157abd4832f9c2636a212d5a39e