### PR TITLE
fix: address type errors in login and register flows

### DIFF
--- a/apps/shop-abc/src/app/login/page.tsx
+++ b/apps/shop-abc/src/app/login/page.tsx
@@ -29,7 +29,10 @@ export default function LoginPage() {
       },
       body: JSON.stringify(body),
     });
-    const data = await res.json().catch(() => ({}));
+    const data = (await res.json().catch(() => ({}))) as {
+      mfaRequired?: boolean;
+      error?: string;
+    };
     if (res.ok) {
       if (data.mfaRequired) {
         setMfaUser(body.customerId);

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -37,7 +37,9 @@ async function validateCredentials(
 
 export async function POST(req: Request) {
   const parsed = await parseJsonBody<LoginInput>(req, LoginSchema, "1mb");
-  if (!parsed.success) return parsed.response;
+  if (!parsed.success) {
+    return parsed.response;
+  }
 
   const csrfToken = req.headers.get("x-csrf-token");
   if (!csrfToken || !(await validateCsrfToken(csrfToken))) {

--- a/apps/shop-abc/src/app/preview/[pageId]/page.tsx
+++ b/apps/shop-abc/src/app/preview/[pageId]/page.tsx
@@ -9,7 +9,12 @@ export default async function PreviewPage({
   searchParams,
 }: {
   params: { pageId: string };
-  searchParams: { token?: string; upgrade?: string };
+  searchParams: {
+    token?: string;
+    upgrade?: string;
+    device?: string;
+    view?: string;
+  };
 }) {
   const { pageId } = params;
   const query = new URLSearchParams();

--- a/apps/shop-abc/src/app/register/page.tsx
+++ b/apps/shop-abc/src/app/register/page.tsx
@@ -29,7 +29,9 @@ export default function RegisterPage() {
       },
       body: JSON.stringify(body),
     });
-    const data = await res.json().catch(() => ({}));
+    const data = (await res.json().catch(() => ({}))) as {
+      error?: string;
+    };
     setMsg(res.ok ? "Account created" : data.error || "Error");
   }
   return (

--- a/apps/shop-abc/src/app/register/route.ts
+++ b/apps/shop-abc/src/app/register/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
   await updateCustomerProfile(customerId, { name: "", email });
 
   const secret = env.SESSION_SECRET;
-  if (!secret) {
+  if (typeof secret !== "string") {
     throw new Error("SESSION_SECRET is not set");
   }
   const signature = crypto


### PR DESCRIPTION
## Summary
- type fetch responses in login and register pages
- narrow parseJsonBody result in login route
- extend preview page search params typing
- guard SESSION_SECRET before HMAC in register route

## Testing
- `pnpm exec tsc -p apps/shop-abc/tsconfig.json --noEmit` *(fails: Output file ... has not been built)*
- `pnpm --filter @apps/shop-abc exec jest` *(fails: Cannot find module '@platform-core/repositories/rentalOrders.server' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b16e6d4c832fa9353ddf952a6d92