### PR TITLE
fix: correct checkout session parameter types

### DIFF
--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -55,7 +55,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     customer: customerId,
     shipping,
     billing_details,
-  } = parsed.data;
+  } = parsed.data as {
+    returnDate?: string;
+    coupon?: string;
+    currency?: string;
+    taxRegion?: string;
+    customer?: string;
+    shipping?: z.infer<typeof shippingSchema>;
+    billing_details?: z.infer<typeof billingSchema>;
+  };
 
   const customerSession = await getCustomerSession();
   const customer = customerId ?? customerSession?.customerId;


### PR DESCRIPTION
## Summary
- ensure parsed checkout session fields are typed strings to avoid TS2322 errors

## Testing
- `pnpm typecheck` *(fails: File '/workspace/base-shop/packages/auth/src/roles.json' is not listed within the file list of project '/workspace/base-shop/packages/auth/tsconfig.json')*
- `pnpm test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b120e2f4832f928c4e11a1256304