### PR TITLE
Fix parseJsonBody login handling and add redis dependency

### DIFF
--- a/apps/shop-abc/package.json
+++ b/apps/shop-abc/package.json
@@ -16,7 +16,8 @@
     "@acme/stripe": "workspace:*",
     "@acme/date-utils": "workspace:*",
     "@acme/sanity": "workspace:*",
-    "@acme/config": "workspace:*"
+    "@acme/config": "workspace:*",
+    "@upstash/redis": "^1.35.3"
   },
   "devDependencies": {
     "next": "^15.3.4"

--- a/apps/shop-abc/src/app/login/route.ts
+++ b/apps/shop-abc/src/app/login/route.ts
@@ -37,7 +37,7 @@ async function validateCredentials(
 
 export async function POST(req: Request) {
   const parsed = await parseJsonBody<LoginInput>(req, LoginSchema, "1mb");
-  if (!parsed.success) {
+  if (parsed.success === false) {
     return parsed.response;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,9 @@ importers:
       '@themes/base':
         specifier: workspace:*
         version: link:../../packages/themes/base
+      '@upstash/redis':
+        specifier: ^1.35.3
+        version: 1.35.3
     devDependencies:
       next:
         specifier: ^15.3.4


### PR DESCRIPTION
## Summary
- fix login handler to return parsed error response
- add @upstash/redis dependency for shop-abc

## Testing
- `pnpm test --filter @apps/shop-abc`
- `npx tsc -p apps/shop-abc/tsconfig.json --noEmit` *(fails: Output file ... has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b54cb314832fb1a9fb07af5bfff6