### PR TITLE
refactor tsconfig path aliases to package roots

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,92 +31,75 @@
     /* ───────── monorepo path aliases ───────── */
     "paths": {
       /* ─── platform-core ─────────────────────────────────────────── */
-      "@platform-core": ["packages/platform-core/src/index.ts"],
-      "@platform-core/*": ["packages/platform-core/src/*"],
-      "@platform-core/src": ["packages/platform-core/src/index.ts"],
-      "@platform-core/src/*": ["packages/platform-core/src/*"],
-      "@acme/platform-core": ["packages/platform-core/src/index.ts"],
-      "@acme/platform-core/*": ["packages/platform-core/src/*"],
+      "@platform-core": ["packages/platform-core"],
+      "@platform-core/*": ["packages/platform-core/*"],
+      "@acme/platform-core": ["packages/platform-core"],
+      "@acme/platform-core/*": ["packages/platform-core/*"],
 
       /* ─── platform-machine ──────────────────────────────────────── */
-      "@acme/platform-machine": ["packages/platform-machine/src/index.ts"],
-      "@acme/platform-machine/*": ["packages/platform-machine/src/*"],
+      "@acme/platform-machine": ["packages/platform-machine"],
+      "@acme/platform-machine/*": ["packages/platform-machine/*"],
 
       /* ─── design-system UI ──────────────────────────────────────── */
-      "@ui": ["packages/ui/src/index.ts"],
-      "@ui/*": ["packages/ui/src/*"],
-      "@ui/src": ["packages/ui/src/index.ts"],
-      "@ui/src/*": ["packages/ui/src/*"],
-      "@acme/ui": ["packages/ui/src/index.ts"],
-      "@acme/ui/*": ["packages/ui/src/*"],
+      "@ui": ["packages/ui"],
+      "@ui/*": ["packages/ui/*"],
+      "@acme/ui": ["packages/ui"],
+      "@acme/ui/*": ["packages/ui/*"],
 
       /* ─── CMS front-end (Next app) ─────────────────────────────── */
-      "@cms/*": ["apps/cms/src/*"],
+      "@cms": ["apps/cms"],
+      "@cms/*": ["apps/cms/*"],
 
       /* ─── themes (each theme has a /src folder) ─────────────────── */
-      "@themes/*": ["packages/themes/*/src"],
-
-      /* ─── short '@/…' imports for components & hooks ────────────── */
-      "@/components/pdp/*": ["packages/platform-core/src/components/pdp/*"],
-      "@/components/shop/*": ["packages/platform-core/src/components/shop/*"],
-      "@/components/blog/*": ["packages/platform-core/src/components/blog/*"],
-      "@/components/*": ["packages/ui/src/components/*"],
-
-      /* ─── lib helpers (products, cookies, …) ────────────── */
-      "@lib/*": ["packages/platform-core/src/*"],
-
-      "@/lib/products": ["packages/platform-core/src/products.ts"],
-      "@/lib/cartCookie": ["packages/platform-core/src/cartCookie.ts"],
-      "@/lib/*": ["packages/platform-core/src/*"],
-
-      /* ─── shared contexts ───────────────────────────────────────── */
-      "@contexts/*": ["packages/platform-core/src/contexts/*"],
-      "@/contexts/*": ["packages/platform-core/src/contexts/*"],
+      "@themes/*": ["packages/themes/*"],
 
       /* ─── shared lib package ─────────────────────────────────────── */
-      "@acme/lib": ["packages/lib/src/index.ts"],
-      "@acme/lib/*": ["packages/lib/src/*"],
+      "@acme/lib": ["packages/lib"],
+      "@acme/lib/*": ["packages/lib/*"],
 
       /* ─── i18n ──────────────────────────────────────────────────── */
-      "@i18n/*": ["packages/i18n/src/*"],
-      "@/i18n/*": ["packages/i18n/src/*"],
+      "@i18n": ["packages/i18n"],
+      "@i18n/*": ["packages/i18n/*"],
 
       /* ─── auth ──────────────────────────────────────────────────── */
-      "@auth": ["packages/auth/src/index.ts"],
-      "@auth/*": ["packages/auth/src/*"],
+      "@auth": ["packages/auth"],
+      "@auth/*": ["packages/auth/*"],
 
       /* ─── runtime config helper ─────────────────────────────────── */
-      "@config": ["packages/config/src/env/index.ts"],
-      "@config/*": ["packages/config/src/env/*"],
-      "@config/src/*": ["packages/config/src/env/*"],
-      "@acme/config": ["packages/config/src/env/index.ts"],
-      "@acme/config/*": ["packages/config/src/env/*"],
+      "@config": ["packages/config"],
+      "@config/*": ["packages/config/*"],
+      "@acme/config": ["packages/config"],
+      "@acme/config/*": ["packages/config/*"],
 
       /* ─── shared utilities ──────────────────────────────────────── */
-      "@shared-utils": ["packages/shared-utils/src/index.ts"],
-      "@shared-utils/*": ["packages/shared-utils/src/*"],
+      "@shared-utils": ["packages/shared-utils"],
+      "@shared-utils/*": ["packages/shared-utils/*"],
+      "@acme/shared-utils": ["packages/shared-utils"],
+      "@acme/shared-utils/*": ["packages/shared-utils/*"],
 
       /* ─── dedicated utility packages ───────────────────────────── */
       "@acme/email": ["packages/email"],
-      "@acme/stripe": ["packages/stripe/src/index.ts"],
-      "@acme/sanity": ["packages/sanity/src/index.ts"],
-      "@acme/plugin-sanity": ["packages/plugins/sanity/index.ts"],
+      "@acme/email/*": ["packages/email/*"],
+      "@acme/stripe": ["packages/stripe"],
+      "@acme/stripe/*": ["packages/stripe/*"],
+      "@acme/sanity": ["packages/sanity"],
+      "@acme/sanity/*": ["packages/sanity/*"],
+      "@acme/plugin-sanity": ["packages/plugins/sanity"],
       "@acme/plugin-sanity/*": ["packages/plugins/sanity/*"],
-      "@acme/date-utils": ["packages/date-utils/src/index.ts"],
-      "@date-utils": ["packages/date-utils/src/index.ts"],
-      "@acme/configurator": ["packages/configurator/src/index.ts"],
-      "@acme/configurator/*": ["packages/configurator/src/*"],
-      "@acme/shared-utils": ["packages/shared-utils/src/index.ts"],
-      "@acme/shared-utils/*": ["packages/shared-utils/src/*"],
+      "@acme/date-utils": ["packages/date-utils"],
+      "@acme/date-utils/*": ["packages/date-utils/*"],
+      "@date-utils": ["packages/date-utils"],
+      "@date-utils/*": ["packages/date-utils/*"],
+      "@acme/configurator": ["packages/configurator"],
+      "@acme/configurator/*": ["packages/configurator/*"],
 
       /* ─── shared runtime types ──────────────────────────────────── */
-      "@acme/types": ["packages/types/src/index.ts"],
-      "@acme/types/*": ["packages/types/src/*"],
-      "@acme/types/root": ["src/types/index.ts"],
-      "@acme/types/root/*": ["src/types/*"],
+      "@acme/types": ["packages/types"],
+      "@acme/types/*": ["packages/types/*"],
 
       /* ─── Tailwind preset ───────────────────────────────────────── */
-      "@acme/tailwind-config": ["packages/tailwind-config/src/index.ts"]
+      "@acme/tailwind-config": ["packages/tailwind-config"],
+      "@acme/tailwind-config/*": ["packages/tailwind-config/*"]
     }
   },
 


### PR DESCRIPTION
## Summary
- target monorepo path aliases at package roots instead of src files
- drop stale aliases that referenced src directories

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b65b10cc832f98898de05be19af1