### PR TITLE
chore: clean up legacy tsconfig aliases

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,10 +31,6 @@
     /* ───────── monorepo path aliases ───────── */
     "paths": {
       /* ─── platform-core ─────────────────────────────────────────── */
-      "@platform-core": ["packages/platform-core/src/index.ts"],
-      "@platform-core/*": ["packages/platform-core/src/*"],
-      "@platform-core/src": ["packages/platform-core/src/index.ts"],
-      "@platform-core/src/*": ["packages/platform-core/src/*"],
       "@acme/platform-core": ["packages/platform-core/src/index.ts"],
       "@acme/platform-core/*": ["packages/platform-core/src/*"],
 
@@ -43,10 +39,6 @@
       "@acme/platform-machine/*": ["packages/platform-machine/src/*"],
 
       /* ─── design-system UI ──────────────────────────────────────── */
-      "@ui": ["packages/ui/src/index.ts"],
-      "@ui/*": ["packages/ui/src/*"],
-      "@ui/src": ["packages/ui/src/index.ts"],
-      "@ui/src/*": ["packages/ui/src/*"],
       "@acme/ui": ["packages/ui/src/index.ts"],
       "@acme/ui/*": ["packages/ui/src/*"],
 
@@ -56,30 +48,12 @@
       /* ─── themes (each theme has a /src folder) ─────────────────── */
       "@themes/*": ["packages/themes/*/src"],
 
-      /* ─── short '@/…' imports for components & hooks ────────────── */
-      "@/components/pdp/*": ["packages/platform-core/src/components/pdp/*"],
-      "@/components/shop/*": ["packages/platform-core/src/components/shop/*"],
-      "@/components/blog/*": ["packages/platform-core/src/components/blog/*"],
-      "@/components/*": ["packages/ui/src/components/*"],
-
-      /* ─── lib helpers (products, cookies, …) ────────────── */
-      "@lib/*": ["packages/platform-core/src/*"],
-
-      "@/lib/products": ["packages/platform-core/src/products.ts"],
-      "@/lib/cartCookie": ["packages/platform-core/src/cartCookie.ts"],
-      "@/lib/*": ["packages/platform-core/src/*"],
-
-      /* ─── shared contexts ───────────────────────────────────────── */
-      "@contexts/*": ["packages/platform-core/src/contexts/*"],
-      "@/contexts/*": ["packages/platform-core/src/contexts/*"],
-
       /* ─── shared lib package ─────────────────────────────────────── */
       "@acme/lib": ["packages/lib/src/index.ts"],
       "@acme/lib/*": ["packages/lib/src/*"],
 
       /* ─── i18n ──────────────────────────────────────────────────── */
       "@i18n/*": ["packages/i18n/src/*"],
-      "@/i18n/*": ["packages/i18n/src/*"],
 
       /* ─── auth ──────────────────────────────────────────────────── */
       "@auth": ["packages/auth/src/index.ts"],
@@ -88,13 +62,8 @@
       /* ─── runtime config helper ─────────────────────────────────── */
       "@config": ["packages/config/src/env/index.ts"],
       "@config/*": ["packages/config/src/env/*"],
-      "@config/src/*": ["packages/config/src/env/*"],
       "@acme/config": ["packages/config/src/env/index.ts"],
       "@acme/config/*": ["packages/config/src/env/*"],
-
-      /* ─── shared utilities ──────────────────────────────────────── */
-      "@shared-utils": ["packages/shared-utils/src/index.ts"],
-      "@shared-utils/*": ["packages/shared-utils/src/*"],
 
       /* ─── dedicated utility packages ───────────────────────────── */
       "@acme/email": ["packages/email"],
@@ -103,7 +72,6 @@
       "@acme/plugin-sanity": ["packages/plugins/sanity/index.ts"],
       "@acme/plugin-sanity/*": ["packages/plugins/sanity/*"],
       "@acme/date-utils": ["packages/date-utils/src/index.ts"],
-      "@date-utils": ["packages/date-utils/src/index.ts"],
       "@acme/configurator": ["packages/configurator/src/index.ts"],
       "@acme/configurator/*": ["packages/configurator/src/*"],
       "@acme/shared-utils": ["packages/shared-utils/src/index.ts"],
@@ -112,8 +80,6 @@
       /* ─── shared runtime types ──────────────────────────────────── */
       "@acme/types": ["packages/types/src/index.ts"],
       "@acme/types/*": ["packages/types/src/*"],
-      "@acme/types/root": ["src/types/index.ts"],
-      "@acme/types/root/*": ["src/types/*"],
 
       /* ─── Tailwind preset ───────────────────────────────────────── */
       "@acme/tailwind-config": ["packages/tailwind-config/src/index.ts"]


### PR DESCRIPTION
## Summary
- remove direct src aliases from tsconfig.base

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b65eaf78832f942e30841f3e5cfa