### PR TITLE
chore: add next-config path alias

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -92,6 +92,8 @@
       "@date-utils/*": ["packages/date-utils/*"],
       "@acme/configurator": ["packages/configurator"],
       "@acme/configurator/*": ["packages/configurator/*"],
+      "@acme/next-config": ["packages/next-config"],
+      "@acme/next-config/*": ["packages/next-config/*"],
 
       /* ─── shared runtime types ──────────────────────────────────── */
       "@acme/types": ["packages/types"],


### PR DESCRIPTION
## Summary
- add `@acme/next-config` root and wildcard aliases to tsconfig

## Testing
- `pnpm test` *(fails: Unknown file extension ".ts" in @acme/next-config tests)*
- `pnpm lint` *(fails: Unknown file extension ".ts" in CMS lint step)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b90af9a4832faefeb69a35fc4f97