### PR TITLE
fix analytics discount redemption typing

### DIFF
--- a/apps/cms/src/lib/analytics.ts
+++ b/apps/cms/src/lib/analytics.ts
@@ -102,11 +102,15 @@ export function buildMetrics(
 
   const discountRedemptions: Series = {
     labels: days,
-    data: days.map((d) => {
-      const byCode = aggregates
+    data: days.map((d): number => {
+      const byCode: Record<string, number> | undefined = aggregates
         ? aggregates.discount_redeemed[d]
         : discountByCodeByDay[d];
-      return byCode ? Object.values(byCode).reduce((a, b) => a + b, 0) : 0;
+      if (!byCode) return 0;
+      return Object.values(byCode).reduce(
+        (a: number, b: number) => a + b,
+        0,
+      );
     }),
   };
 


### PR DESCRIPTION
## Summary
- type discount redemption map values to numbers and handle empty entries

## Testing
- `pnpm -F @apps/cms test` *(fails: Could not locate module @acme/email)*
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Module '@acme/types' has no exported member 'ShopSeoFields')*

------
https://chatgpt.com/codex/tasks/task_e_68a0e97c3e24832f97b7917602bc87df