### PR TITLE
fix: use import.meta.url in tailwind preset check

### DIFF
--- a/scripts/check-tailwind-preset.ts
+++ b/scripts/check-tailwind-preset.ts
@@ -1,13 +1,10 @@
 import { createRequire } from "node:module";
 import preset from "../packages/tailwind-config/src/index.ts";
 
-let moduleUrl = "";
-try {
-  moduleUrl = (0, eval)("import.meta.url");
-} catch {
-  moduleUrl = __filename;
-}
-const nodeRequire = createRequire(moduleUrl);
+// Node's `createRequire` expects a file URL when using ESM. Using
+// `import.meta.url` avoids relying on CommonJS globals like `__filename`
+// which are not available in this module scope.
+const nodeRequire = createRequire(import.meta.url);
 
 let resolvedPresetPath = "<unresolved>";
 try {


### PR DESCRIPTION
## Summary
- avoid using CommonJS globals in `scripts/check-tailwind-preset.ts`

## Testing
- `pnpm run check:tailwind-preset`
- `pnpm run build` *(fails: command /workspace/base-shop/packages/template-app run build exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68a18187c11c832fa35ba425533b382e