### PR TITLE
chore(config): compile env core to dist

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -6,10 +6,13 @@
   "exports": {
     ".": "./src/env/index.ts",
     "./env": "./src/env/index.ts",
-    "./env/core": "./src/env/core.ts",
+    "./env/core": "./dist/env/core.js",
     "./env/payments": "./src/env/payments.ts",
     "./env/shipping": "./src/env/shipping.ts",
     "./tsconfig.app.json": "./tsconfig.app.json",
     "./jest.preset.cjs": "./jest.preset.cjs"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
   }
 }

--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+// Load runtime environment from compiled config output
 import { coreEnv } from "@acme/config/env/core";
 import { baseConfig, withShopCode } from "./index.mjs";
 


### PR DESCRIPTION
## Summary
- compile `@acme/config` env core to `dist/env/core.js`
- export compiled core env and add build script
- load compiled core env in shared Next.js config

## Testing
- `pnpm --filter @acme/config run build`
- `NEXTAUTH_SECRET=foo CART_COOKIE_SECRET=bar SESSION_SECRET=baz pnpm exec tsx apps/shop-abc/next.config.mjs`
- `NEXTAUTH_SECRET=foo CART_COOKIE_SECRET=bar SESSION_SECRET=baz pnpm exec tsx apps/shop-bcd/next.config.mjs`
- `NEXTAUTH_SECRET=foo CART_COOKIE_SECRET=bar SESSION_SECRET=baz pnpm exec tsx apps/cms/next.config.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a1a2a66ca4832f99677f083f16a3e7