### PR TITLE
feat: expose compiled config entry

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,16 +3,27 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/env/index.ts",
-    "./env": "./src/env/index.ts",
-    "./env/core": "./dist/env/core.js",
-    "./env/payments": "./src/env/payments.ts",
-    "./env/shipping": "./src/env/shipping.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./env/*": {
+      "types": "./dist/env/*.d.ts",
+      "import": "./dist/env/*.js",
+      "default": "./dist/env/*.js"
+    },
     "./tsconfig.app.json": "./tsconfig.app.json",
     "./jest.preset.cjs": "./jest.preset.cjs"
   },
+  "files": ["dist"],
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json -w",
+    "clean": "rimraf dist *.tsbuildinfo"
   }
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,6 @@
+// packages/config/src/index.ts
+// Re-export compiled env in a stable, root entry for all consumers.
+import { coreEnv } from "./env/core";
+
+export const env = coreEnv;
+export type { CoreEnv as Env } from "./env/core";

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "@platform-core": "workspace:*",
-    "@acme/config": "workspace:*"
+    "@acme/config": "workspace:^"
   }
 }

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -10,6 +10,6 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@acme/config": "workspace:*"
+    "@acme/config": "workspace:^"
   }
 }

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -3,11 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -55,17 +53,19 @@
       "default": "./dist/repositories/*.js"
     }
   },
-
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
-
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo"
   },
-
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "dependencies": {
+    "@acme/config": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,7 +555,7 @@ importers:
   packages/lib:
     dependencies:
       '@acme/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../config
       '@platform-core':
         specifier: workspace:*
@@ -568,11 +568,14 @@ importers:
   packages/next-config:
     dependencies:
       '@acme/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../config
 
   packages/platform-core:
     dependencies:
+      '@acme/config':
+        specifier: workspace:^
+        version: link:../config
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.1.0

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,8 @@
       "dependsOn": ["^dev"]
     },
     "build": {
-      "outputs": [".vercel/**", "dist/**"]
+      "dependsOn": ["^build"],
+      "outputs": [".vercel/**", "dist/**", ".next/**"]
     },
     "lint": {},
     "test": {


### PR DESCRIPTION
## Summary
- expose compiled env through @acme/config root entry
- point config package exports to dist output
- declare @acme/config workspace dependency for related packages
- sync turbo build pipeline dependencies

## Testing
- `pnpm -F @acme/config build`
- `pnpm -F @acme/lib build`
- `pnpm -F @platform-core build` *(fails: Cannot find module '@prisma/client', missing types, etc.)*
- `pnpm -F @acme/next-config test` *(fails: Cannot find package '@acme/lib' imported from config)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b1b93560832f842d18b01415093e