### PR TITLE
fix: remove conflicting type re-export

### DIFF
--- a/packages/platform-core/src/shops/index.ts
+++ b/packages/platform-core/src/shops/index.ts
@@ -145,5 +145,3 @@ export function setDomain(shop: Shop, domain: ShopDomain | undefined): Shop {
   return next;
 }
 
-// Re-export relevant types so callers do not need to import @acme/types directly.
-export type { SanityBlogConfig, Shop, ShopDomain };


### PR DESCRIPTION
## Summary
- remove redundant type re-export in platform-core shops module

## Testing
- `pnpm --filter @platform-core build` *(fails: Cannot find module '@acme/config/env/core' etc)*
- `pnpm --filter @platform-core exec jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f7fbeeec832f9ec89a1ad449fae2