### PR TITLE
fix: align shop settings and features types

### DIFF
--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -129,7 +129,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     },
     updatedAt: "",
     updatedBy: "",
-  };
+  } as ShopSettings;
 }
 
 export async function saveShopSettings(

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -86,6 +86,7 @@ export async function readShop(shop: string): Promise<Shop> {
       requireStrongCustomerAuth: false,
       strictReturnConditions: false,
       trackingDashboard: false,
+      premierDelivery: false,
     },
   };
   return await applyThemeData(empty);


### PR DESCRIPTION
## Summary
- cast default shop settings to `ShopSettings`
- include `premierDelivery` flag in default `luxuryFeatures`

## Testing
- `pnpm --filter @platform-core build` *(fails: Cannot find module '@acme/email')*
- `pnpm test --filter @platform-core`


------
https://chatgpt.com/codex/tasks/task_e_68a1f80d2648832f82f9dbcfc8dfeaa9