### PR TITLE
fix: remove extra generic args in settings diff

### DIFF
--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -47,7 +47,7 @@ function diffSettings(
     const a = JSON.stringify(oldS[key]);
     const b = JSON.stringify(newS[key]);
     if (a !== b) {
-      setPatchValue<ShopSettings>(patch, key, newS[key]);
+      setPatchValue(patch, key, newS[key]);
     }
   }
   return patch;


### PR DESCRIPTION
## Summary
- remove explicit generic type when patching settings

## Testing
- `pnpm lint --filter @platform-core`
- `pnpm --filter @platform-core build` *(fails: Cannot find module '@acme/config' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f817891c832fbd66ada31375147d