### PR TITLE
fix: use type-only ReactNode imports

### DIFF
--- a/packages/i18n/src/Translations.d.ts
+++ b/packages/i18n/src/Translations.d.ts
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import type { ReactNode } from "react";
 /**
  * Key–value map of translation messages.
  */

--- a/packages/i18n/src/Translations.tsx
+++ b/packages/i18n/src/Translations.tsx
@@ -1,7 +1,7 @@
 // packages/i18n/src/Translations.tsx
 "use client";
 
-import React, { createContext, ReactNode, useContext, useMemo } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 
 /**
  * Key–value map of translation messages.

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -6,10 +6,10 @@ import { type CartState } from "../cartCookie";
 import type { SKU } from "@acme/types";
 import {
   createContext,
-  ReactNode,
   useContext,
   useEffect,
   useState,
+  type ReactNode,
 } from "react";
 
 /* ------------------------------------------------------------------

--- a/packages/platform-core/src/contexts/CurrencyContext.tsx
+++ b/packages/platform-core/src/contexts/CurrencyContext.tsx
@@ -2,10 +2,10 @@
 
 import {
   createContext,
-  ReactNode,
   useContext,
   useEffect,
   useState,
+  type ReactNode,
 } from "react";
 
 export type Currency = "EUR" | "USD" | "GBP";

--- a/packages/platform-core/src/contexts/LayoutContext.tsx
+++ b/packages/platform-core/src/contexts/LayoutContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { createContext, ReactNode, useContext, useState } from "react";
+import { createContext, useContext, useState, type ReactNode } from "react";
 
 export interface ConfiguratorProgress {
   completedRequired: number;

--- a/packages/platform-core/src/contexts/ThemeContext.tsx
+++ b/packages/platform-core/src/contexts/ThemeContext.tsx
@@ -2,11 +2,11 @@
 
 import {
   createContext,
-  ReactNode,
   useContext,
   useEffect,
   useLayoutEffect,
   useState,
+  type ReactNode,
 } from "react";
 
 export type Theme = "base" | "dark" | "brandx" | "system";


### PR DESCRIPTION
## Summary
- use type-only ReactNode imports in platform-core contexts and i18n Translations module

## Testing
- `pnpm exec tsc -p packages/platform-core/tsconfig.json --noEmit` *(fails: Cannot find module '@acme/config/env/core', etc.)*
- `pnpm exec tsc -p packages/i18n/tsconfig.json --noEmit`
- `pnpm --filter @acme/i18n test` *(fails: Could not locate module @cms/actions/shops.server)*
- `pnpm exec jest packages/platform-core/src/contexts/__tests__/CartContext.test.tsx --config jest.config.cjs` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8d661a4832fba98c8bc0011ddd8