### PR TITLE
fix: handle Stripe request options and client secret

### DIFF
--- a/packages/platform-core/src/checkout/session.ts
+++ b/packages/platform-core/src/checkout/session.ts
@@ -261,12 +261,15 @@ export async function createCheckoutSession(
     payment_intent_data: paymentIntentData,
     metadata,
     expand: ["payment_intent"],
-  }, clientIp ? { headers: { "Stripe-Client-IP": clientIp } } : undefined);
+  },
+  clientIp
+    ? ({ headers: { "Stripe-Client-IP": clientIp } } as Stripe.RequestOptions)
+    : undefined);
 
   const clientSecret =
     typeof session.payment_intent === "string"
       ? undefined
-      : session.payment_intent?.client_secret;
+      : session.payment_intent?.client_secret ?? undefined;
 
   return { clientSecret, sessionId: session.id };
 }


### PR DESCRIPTION
## Summary
- cast optional Stripe request options to allow Stripe-Client-IP header
- normalize client secret handling to avoid null values

## Testing
- `pnpm exec tsc -p packages/platform-core/tsconfig.json --noEmit` *(fails: Cannot find module './dataRoot'...)*
- `pnpm test` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8e5fb54832fb2db589371404c05