### PR TITLE
fix: correct RedisCartStore generics

### DIFF
--- a/packages/platform-core/src/cartStore/redisStore.ts
+++ b/packages/platform-core/src/cartStore/redisStore.ts
@@ -52,9 +52,11 @@ export class RedisCartStore implements CartStore {
   }
 
   async getCart(id: string): Promise<CartState> {
-    const qty = await this.exec(() => this.client.hgetall<number>(id));
+    const qty = await this.exec(() =>
+      this.client.hgetall<Record<string, number>>(id)
+    );
     const lines = await this.exec(() =>
-      this.client.hgetall<string>(this.skuKey(id))
+      this.client.hgetall<Record<string, string>>(this.skuKey(id))
     );
     if (!qty || !lines) {
       return this.fallback.getCart(id);


### PR DESCRIPTION
## Summary
- ensure Redis cart retrieval uses object-shaped generics for hgetall

## Testing
- `pnpm exec tsc -p packages/platform-core/tsconfig.json --noEmit` *(fails: missing dependencies)*
- `pnpm exec jest packages/platform-core/__tests__/cartStore/redis.test.ts` *(fails: missing module @acme/config/env/core)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f9038cf4832f8fa946200ae5d87c