### PR TITLE
fix: align plugin manager generics

### DIFF
--- a/packages/platform-core/src/plugins.ts
+++ b/packages/platform-core/src/plugins.ts
@@ -127,7 +127,15 @@ export async function initPlugins<
   options: InitPluginsOptions = {},
 ): Promise<PluginManager<PPay, SReq, WProp, P, S, W>> {
   const manager = new PluginManager<PPay, SReq, WProp, P, S, W>();
-  const loaded = await loadPlugins(options);
+  const loaded = (await loadPlugins(options)) as Plugin<
+    Record<string, unknown>,
+    PPay,
+    SReq,
+    WProp,
+    P,
+    S,
+    W
+  >[];
   for (const plugin of loaded) {
     const raw = {
       ...(plugin.defaultConfig ?? {}),

--- a/packages/platform-core/src/plugins/PluginManager.ts
+++ b/packages/platform-core/src/plugins/PluginManager.ts
@@ -48,7 +48,10 @@ export class PluginManager<
   readonly payments = new MapRegistry<P>();
   readonly shipping = new MapRegistry<S>();
   readonly widgets = new MapRegistry<W>();
-  private plugins = new Map<string, PluginMetadata<Plugin<unknown, PPay, SReq, WProp, P, S, W>>>();
+  private plugins = new Map<
+    string,
+    PluginMetadata<Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>>
+  >();
 
   addPlugin<C>(plugin: Plugin<C, PPay, SReq, WProp, P, S, W>): void {
     this.plugins.set(plugin.id, {
@@ -61,11 +64,17 @@ export class PluginManager<
 
   getPlugin(
     id: string,
-  ): PluginMetadata<Plugin<unknown, PPay, SReq, WProp, P, S, W>> | undefined {
+  ):
+    | PluginMetadata<
+        Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>
+      >
+    | undefined {
     return this.plugins.get(id);
   }
 
-  listPlugins(): PluginMetadata<Plugin<unknown, PPay, SReq, WProp, P, S, W>>[] {
+  listPlugins(): PluginMetadata<
+    Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>
+  >[] {
     return Array.from(this.plugins.values());
   }
 }


### PR DESCRIPTION
## Summary
- ensure PluginManager tracks plugins using config objects and proper generics
- align initPlugins with PluginManager generics for type-safe registration

## Testing
- `pnpm typecheck` *(fails: Output file '...dist/createShop/index.d.ts' has not been built...)*
- `pnpm --filter @platform-core build` *(fails: Expected 2 type arguments, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8a2ad4c832fa9876028eb9c4227