### PR TITLE
Add default fields to Shop repository placeholder

### DIFF
--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -78,6 +78,10 @@ export async function readShop(shop: string): Promise<Shop> {
     localeOverrides: {},
     navigation: [],
     analyticsEnabled: false,
+    coverageIncluded: true,
+    componentVersions: {},
+    rentalSubscriptions: [],
+    subscriptionsEnabled: false,
     luxuryFeatures: {
       blog: false,
       contentMerchandising: false,


### PR DESCRIPTION
## Summary
- include default values for `coverageIncluded`, `componentVersions`, `rentalSubscriptions`, and `subscriptionsEnabled` when constructing empty Shop records

## Testing
- `pnpm lint --filter @platform-core`
- `pnpm test --filter @platform-core`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd9f1ae4832f91f800755803e8d7