### PR TITLE
fix: use type-only import for ProductPublication

### DIFF
--- a/packages/platform-core/src/repositories/products.server.ts
+++ b/packages/platform-core/src/repositories/products.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { ulid } from "ulid";
-import { ProductPublication } from "../products";
+import type { ProductPublication } from "../products";
 import { validateShopName } from "../shops";
 import { DATA_ROOT } from "../dataRoot";
 import { nowIso } from "@acme/date-utils";


### PR DESCRIPTION
## Summary
- use type-only import for ProductPublication in products repository

## Testing
- `npx eslint packages/platform-core/src/repositories/products.server.ts --no-ignore` *(warn: File ignored because no matching configuration was supplied)*
- `pnpm --filter @platform-core build` *(fails: Cannot find module '@acme/config' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fdadfb48832fb7a42e0eaf9dbd6d