### PR TITLE
fix: tighten plugin generic constraints

### DIFF
--- a/packages/platform-core/src/plugins.ts
+++ b/packages/platform-core/src/plugins.ts
@@ -117,9 +117,9 @@ export interface InitPluginsOptions extends LoadPluginsOptions {
 
 /** Load plugins and call their registration hooks */
 export async function initPlugins<
-  PPay = PaymentPayload,
-  SReq = ShippingRequest,
-  WProp = WidgetProps,
+  PPay extends PaymentPayload = PaymentPayload,
+  SReq extends ShippingRequest = ShippingRequest,
+  WProp extends WidgetProps = WidgetProps,
   P extends PaymentProvider<PPay> = PaymentProvider<PPay>,
   S extends ShippingProvider<SReq> = ShippingProvider<SReq>,
   W extends WidgetComponent<WProp> = WidgetComponent<WProp>,
@@ -127,7 +127,7 @@ export async function initPlugins<
   options: InitPluginsOptions = {},
 ): Promise<PluginManager<PPay, SReq, WProp, P, S, W>> {
   const manager = new PluginManager<PPay, SReq, WProp, P, S, W>();
-  const loaded = (await loadPlugins(options)) as Plugin<
+  const loaded = (await loadPlugins(options)) as unknown as Plugin<
     Record<string, unknown>,
     PPay,
     SReq,

--- a/packages/platform-core/src/plugins/PluginManager.ts
+++ b/packages/platform-core/src/plugins/PluginManager.ts
@@ -30,7 +30,9 @@ class MapRegistry<T> {
   }
 }
 
-export interface PluginMetadata<T extends Plugin = Plugin> {
+export interface PluginMetadata<
+  T extends Plugin<any, any, any, any, any, any, any> = Plugin,
+> {
   id: string;
   name?: string;
   description?: string;
@@ -38,9 +40,9 @@ export interface PluginMetadata<T extends Plugin = Plugin> {
 }
 
 export class PluginManager<
-  PPay = PaymentPayload,
-  SReq = ShippingRequest,
-  WProp = WidgetProps,
+  PPay extends PaymentPayload = PaymentPayload,
+  SReq extends ShippingRequest = ShippingRequest,
+  WProp extends WidgetProps = WidgetProps,
   P extends PaymentProvider<PPay> = PaymentProvider<PPay>,
   S extends ShippingProvider<SReq> = ShippingProvider<SReq>,
   W extends WidgetComponent<WProp> = WidgetComponent<WProp>,
@@ -53,12 +55,22 @@ export class PluginManager<
     PluginMetadata<Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>>
   >();
 
-  addPlugin<C>(plugin: Plugin<C, PPay, SReq, WProp, P, S, W>): void {
+  addPlugin<C extends Record<string, unknown>>(
+    plugin: Plugin<C, PPay, SReq, WProp, P, S, W>,
+  ): void {
     this.plugins.set(plugin.id, {
       id: plugin.id,
       name: plugin.name,
       description: plugin.description,
-      plugin,
+      plugin: plugin as unknown as Plugin<
+        Record<string, unknown>,
+        PPay,
+        SReq,
+        WProp,
+        P,
+        S,
+        W
+      >,
     });
   }
 


### PR DESCRIPTION
## Summary
- constrain plugin generics to extend base payment, shipping and widget types
- relax PluginManager metadata to accept broader plugin configs and cast stored plugins

## Testing
- `pnpm exec tsc -p packages/platform-core/tsconfig.json` *(fails: Cannot find module '@acme/types/page'...)*
- `pnpm exec jest packages/platform-core/__tests__/plugins.test.ts` *(fails: Could not locate module @acme/shared-utils/logger)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fdc1d7b8832f8c582ab9ca985e0a