### PR TITLE
refactor: use shared logger exports

### DIFF
--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -5,7 +5,7 @@ import type { JWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
 import { readRbac as defaultReadRbac } from "../lib/rbacStore";
 
-import { logger } from "@acme/shared-utils/logger";
+import { logger } from "@acme/shared-utils";
 
 import type { Role } from "@acme/types";
 import { authSecret } from "./secret";

--- a/apps/cms/src/middleware.ts
+++ b/apps/cms/src/middleware.ts
@@ -6,7 +6,7 @@ import { getToken } from "next-auth/jwt";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { authSecret } from "./auth/secret";
-import { logger } from "@acme/shared-utils/logger";
+import { logger } from "@acme/shared-utils";
 
 /**
  * JWT payload shape for this CMS.

--- a/packages/platform-core/src/utils/logger.ts
+++ b/packages/platform-core/src/utils/logger.ts
@@ -1,3 +1,2 @@
-// packages/platform-core/src/utils/logger.ts
 export { logger } from "@acme/shared-utils";
 export type { LogMeta } from "@acme/shared-utils";


### PR DESCRIPTION
## Summary
- re-export logger and LogMeta from platform-core through shared utils
- use top-level shared-utils logger import in CMS auth and middleware

## Testing
- `pnpm --filter @acme/shared-utils test` *(fails: Could not locate module @cms/actions/shops.server mapped as...)*

------
https://chatgpt.com/codex/tasks/task_e_68a207d25388832fb56cc2549c59518f