### PR TITLE
chore(platform-core): update TypeScript references

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -30,8 +30,11 @@
   "exclude": ["dist", "**/__tests__/**", ".turbo", "node_modules"],
 
   "references": [
-    { "path": "../lib" },
+    { "path": "../shared-utils" },
     { "path": "../types" },
+    { "path": "../date-utils" },
+    { "path": "../i18n" },
+    { "path": "../lib" },
     { "path": "../themes/base" }
   ]
 }


### PR DESCRIPTION
## Summary
- add workspace package references for shared utilities, types, date utilities, i18n, lib, and base theme to platform-core tsconfig

## Testing
- `pnpm tsc -b packages/platform-core` *(fails: cannot find modules such as '@acme/shared-utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a207d8bd68832fa4b1f1ffbe3a3ec1