### PR TITLE
fix: correct product lib export

### DIFF
--- a/packages/platform-core/src/lib/products.ts
+++ b/packages/platform-core/src/lib/products.ts
@@ -1,1 +1,5 @@
-export { getProductBySlug, getProductById } from "../repositories/products.server";
+export {
+  PRODUCTS,
+  getProductBySlug,
+  getProductById,
+} from "../products";


### PR DESCRIPTION
## Summary
- export product helpers from products module

## Testing
- `pnpm --filter @platform-core build` (fails: Cannot find module '@acme/config/env/core')
- `pnpm turbo run test --filter @platform-core`

------
https://chatgpt.com/codex/tasks/task_e_68a20b6bb5e8832f9b832bec0fc12cbf