### PR TITLE
fix: reference page schema

### DIFF
--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -1,6 +1,6 @@
-import type { PageComponent } from "@acme/types";
+import type { PageComponent } from "@acme/types/page";
 import { localeSchema, sanityBlogConfigSchema } from "@acme/types";
-import { pageComponentSchema } from "@acme/types";
+import { pageComponentSchema } from "@acme/types/page";
 import { z } from "zod";
 import { slugify } from "@acme/shared-utils";
 import { fillLocales } from "@acme/i18n/fillLocales";

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -22,7 +22,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@platform-core/*": ["./src/*"]
+      "@platform-core/*": ["./src/*"],
+      "@acme/types": ["../types/src/index.ts"],
+      "@acme/types/*": ["../types/src/*"]
     },
     "types": ["react", "react-dom", "next"]
   },


### PR DESCRIPTION
## Summary
- import page component schema from the types subpath
- add path aliases for types package in platform-core tsconfig

## Testing
- `pnpm --filter @platform-core exec tsc -p tsconfig.json` *(fails: Output file '/workspace/base-shop/packages/i18n/dist/fillLocales.d.ts' has not been built from source file '/workspace/base-shop/packages/i18n/src/fillLocales.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68a20b76fef8832fa2b6953750090b7a