### PR TITLE
Fix BlogPortableText product lookup

### DIFF
--- a/packages/platform-core/src/components/blog/BlogPortableText.tsx
+++ b/packages/platform-core/src/components/blog/BlogPortableText.tsx
@@ -1,7 +1,7 @@
 // src/components/blog/BlogPortableText.tsx
 import { PortableText } from "@portabletext/react";
 import Link from "next/link";
-import { getProductBySlug, getProductById } from "@/lib/products";
+import { getProductBySlug, getProductById, type SKU } from "@/products";
 import { ProductCard } from "../shop/ProductCard";
 
 const components = {
@@ -16,9 +16,9 @@ const components = {
             : typeof value?.slug === "string"
               ? [value.slug]
               : [];
-      const products = ids
+      const products: SKU[] = ids
         .map((id) => getProductById(id) ?? getProductBySlug(id))
-        .filter(Boolean);
+        .filter((p): p is SKU => Boolean(p));
       if (products.length === 0) return null;
       if (products.length === 1) {
         const p = products[0]!;


### PR DESCRIPTION
## Summary
- Use synchronous product helpers for blog product references
- Ensure product list is typed to SKU for card rendering

## Testing
- `pnpm --filter @platform-core build` *(fails: Cannot find module '@acme/config/env/core' and related types)*
- `pnpm --filter @platform-core test`


------
https://chatgpt.com/codex/tasks/task_e_68a20b8778f0832fbed6225978a80a1f