### PR TITLE
chore(ts): exclude tests from compilation

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -46,7 +46,7 @@
     }
   },
   "include": ["next-env.d.ts", "src/**/*"],
-  "exclude": [".next", "node_modules", "dist"],
+  "exclude": [".next", "node_modules", "dist", "**/__tests__/**"],
   "references": [
     { "path": "../../packages/platform-core" },
     { "path": "../../packages/ui" },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -92,5 +92,5 @@
 
   /* project-wide ambient declarations */
   "files": ["./src/types/global.d.ts"],
-  "exclude": ["**/__mocks__/**"]
+  "exclude": ["**/__mocks__/**", "**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
- ignore `__tests__` directories in base TypeScript config
- exclude test directories from the CMS app build

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: multiple existing TypeScript errors)*
- `pnpm test:cms` *(fails: module resolution errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a217be0fdc832f9e3e715c0e01b0ff