### PR TITLE
fix: add typings for unsubscribe filtering

### DIFF
--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -50,11 +50,13 @@ async function filterUnsubscribed(
   shop: string,
   recipients: string[],
 ): Promise<string[]> {
-  const events = await listEvents(shop).catch(() => []);
+  const events: AnalyticsEvent[] = await listEvents(shop).catch(
+    (): AnalyticsEvent[] => [],
+  );
   const unsub = new Set(
     events
       .filter(
-        (e): e is AnalyticsEvent & { email: string } =>
+        (e: AnalyticsEvent): e is AnalyticsEvent & { email: string } =>
           e.type === "email_unsubscribe" && typeof e.email === "string",
       )
       .map((e) => e.email),


### PR DESCRIPTION
## Summary
- type guard for unsubscribe events

## Testing
- `pnpm --filter @acme/email test` *(fails: Could not locate module @acme/email)*

------
https://chatgpt.com/codex/tasks/task_e_68a21ba22054832f8a0f893bb4d0fd1b