### PR TITLE
fix: ensure cart lines are typed objects in order confirmation

### DIFF
--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -15,7 +15,9 @@ export function OrderConfirmationTemplate({
   className,
   ...props
 }: OrderConfirmationTemplateProps) {
-  const lines = Object.entries(cart).map(([id, line]) => ({ id, ...line }));
+  const lines = (Object.entries(cart) as [string, CartState[string]][]).map(
+    ([id, line]) => ({ id, ...line })
+  );
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 


### PR DESCRIPTION
## Summary
- type Object.entries in OrderConfirmationTemplate so line items spread correctly

## Testing
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@auth' etc)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a21bddde7c832fbcc5448138069510