### PR TITLE
fix: type-safe cart line spread in MiniCart

### DIFF
--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCart } from "@platform-core/contexts/CartContext";
+import type { CartLine } from "@platform-core/cartCookie";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { drawerWidthProps } from "../../utils/style/drawerWidth";
@@ -32,7 +33,9 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
   const [toast, setToast] = React.useState<{ open: boolean; message: string }>(
     { open: false, message: "" }
   );
-  const lines = Object.entries(cart).map(([id, line]) => ({ id, ...line }));
+  const lines = (Object.entries(cart) as [string, CartLine][]).map(
+    ([id, line]) => ({ id, ...line })
+  );
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
   const { widthClass, style } = drawerWidthProps(width);
 


### PR DESCRIPTION
## Summary
- ensure cart lines are treated as objects by importing `CartLine`
- type `Object.entries` so MiniCart spreads lines safely

## Testing
- `pnpm test --filter @acme/ui` *(fails: Cannot find module '@date-utils' in unrelated tests)*
- `pnpm build --filter @acme/ui` *(fails: Cannot find module '@acme/tailwind-config')*

------
https://chatgpt.com/codex/tasks/task_e_68a21c0b3d98832f93abb013c4bd2b11