### PR TITLE
fix: specify index type in DataTable

### DIFF
--- a/packages/ui/src/components/organisms/DataTable.tsx
+++ b/packages/ui/src/components/organisms/DataTable.tsx
@@ -35,7 +35,7 @@ export function DataTable<T>({
   const toggle = (idx: number) => {
     const next = toggleItem(selected, idx);
     setSelected(next);
-    onSelectionChange?.(next.map((i) => rows[i]));
+    onSelectionChange?.(next.map((i: number) => rows[i]));
   };
 
   return (


### PR DESCRIPTION
## Summary
- type annotate selection index in DataTable to prevent implicit any

## Testing
- `pnpm exec eslint packages/ui/src/components/organisms/DataTable.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm --filter @acme/ui test` *(fails: configuration errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c156cc4832f86617fa2ab33b126