### PR TITLE
fix: specify Locale type in LanguageSwitcher

### DIFF
--- a/packages/ui/src/components/molecules/LanguageSwitcher.tsx
+++ b/packages/ui/src/components/molecules/LanguageSwitcher.tsx
@@ -7,17 +7,17 @@ import Link from "next/link";
 export default function LanguageSwitcher({ current }: { current: Locale }) {
   return (
     <div className="flex gap-2 text-sm">
-      {locales.map((l) => (
+      {locales.map((locale: Locale) => (
         <Link
-          href={`/${l}`}
-          key={l}
+          href={`/${locale}`}
+          key={locale}
           className={
-            l === current
+            locale === current
               ? "font-semibold underline"
               : "text-muted hover:underline"
           }
         >
-          {l.toUpperCase()}
+          {locale.toUpperCase()}
         </Link>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- specify Locale type when mapping over locales in LanguageSwitcher

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/molecules/__tests__/LanguageSwitcher.test.tsx` *(fails: Cannot find module '@/i18n/locales')*

------
https://chatgpt.com/codex/tasks/task_e_68a21c203f6c832f9096c6d8e801463b