### PR TITLE
fix: type safe useCart

### DIFF
--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -153,7 +153,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useCart() {
+export function useCart(): [CartState, Dispatch] {
   const ctx = useContext(CartContext);
   if (!ctx) throw new Error("useCart must be inside CartProvider");
   return ctx;


### PR DESCRIPTION
## Summary
- annotate `useCart` return value so consumers see a typed cart/dispatch tuple

## Testing
- `pnpm -F @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c2b79f0832fb07c81f8615da2b2