### PR TITLE
refactor: add DevicePreset type to DeviceSelector

### DIFF
--- a/packages/ui/src/components/DeviceSelector.tsx
+++ b/packages/ui/src/components/DeviceSelector.tsx
@@ -9,7 +9,11 @@ import {
   SelectContent,
   SelectItem,
 } from "./atoms/shadcn";
-import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
+import {
+  devicePresets,
+  getLegacyPreset,
+  type DevicePreset,
+} from "@ui/utils/devicePresets";
 
 interface DeviceSelectorProps {
   deviceId: string;
@@ -45,7 +49,7 @@ export default function DeviceSelector({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {devicePresets.map((p) => (
+          {devicePresets.map((p: DevicePreset) => (
             <SelectItem key={p.id} value={p.id}>
               {p.label}
             </SelectItem>

--- a/packages/ui/src/components/cms/DeviceSelector.tsx
+++ b/packages/ui/src/components/cms/DeviceSelector.tsx
@@ -7,7 +7,7 @@ import {
   SelectContent,
   SelectItem,
 } from "../atoms/shadcn";
-import { devicePresets } from "@ui/utils/devicePresets";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 
 interface Props {
   deviceId: string;
@@ -29,7 +29,7 @@ export default function DeviceSelector({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {devicePresets.map((p) => (
+          {devicePresets.map((p: DevicePreset) => (
             <SelectItem key={p.id} value={p.id}>
               {p.label}
             </SelectItem>

--- a/packages/ui/src/components/common/DeviceSelector.tsx
+++ b/packages/ui/src/components/common/DeviceSelector.tsx
@@ -7,7 +7,11 @@ import {
   SelectContent,
   SelectItem,
 } from "../atoms/shadcn";
-import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
+import {
+  devicePresets,
+  getLegacyPreset,
+  type DevicePreset,
+} from "@ui/utils/devicePresets";
 
 interface Props {
   deviceId: string;
@@ -46,7 +50,7 @@ export default function DeviceSelector({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {devicePresets.map((p) => (
+          {devicePresets.map((p: DevicePreset) => (
             <SelectItem key={p.id} value={p.id}>
               {p.label}
             </SelectItem>


### PR DESCRIPTION
## Summary
- annotate device selector presets with explicit DevicePreset type

## Testing
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@ui/hooks/useFileUpload' and others)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c54f0f4832f930bf1857bdb58c5