### PR TITLE
fix: type search input event in ProductFilters

### DIFF
--- a/packages/ui/src/components/cms/ProductFilters.tsx
+++ b/packages/ui/src/components/cms/ProductFilters.tsx
@@ -25,7 +25,8 @@ export default function ProductFilters({
         placeholder="Search titles or SKU…"
         className="w-64"
         value={search}
-        onChange={(e) => onSearchChange(e.target.value)}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          onSearchChange(e.target.value)}
       />
       <select
         className="rounded-md border px-3 py-2 text-sm"


### PR DESCRIPTION
## Summary
- type ProductFilters search input event to avoid implicit any

## Testing
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server mapped as: /workspace/base-shop/apps/cms/$1)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c77f568832f8168a180eccd7c70