### PR TITLE
fix: type inference for device presets

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -87,7 +87,8 @@ const PageBuilder = memo(function PageBuilder({
   );
   const device = useMemo<DevicePreset>(() => {
     const preset =
-      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+      devicePresets.find((d: DevicePreset) => d.id === deviceId) ??
+      devicePresets[0];
     return orientation === "portrait"
       ? { ...preset, orientation }
       : {
@@ -106,7 +107,8 @@ const PageBuilder = memo(function PageBuilder({
   const [runTour, setRunTour] = useState(false);
   const previewDevice = useMemo<DevicePreset>(
     () =>
-      devicePresets.find((d) => d.id === previewDeviceId) ?? devicePresets[0],
+      devicePresets.find((d: DevicePreset) => d.id === previewDeviceId) ??
+      devicePresets[0],
     [previewDeviceId],
   );
   const previewViewport: "desktop" | "tablet" | "mobile" = previewDevice.type;


### PR DESCRIPTION
## Summary
- fix implicit `any` for device preset lookup in PageBuilder

## Testing
- `pnpm exec eslint -c eslint.config.mjs packages/ui/src/components/cms/page-builder/PageBuilder.tsx` *(fails: Cannot find package '@typescript-eslint/parser')*
- `pnpm test --filter @acme/ui` *(fails: cannot find module '@acme/stripe')*

------
https://chatgpt.com/codex/tasks/task_e_68a2308040b0832f9325a99d11fb75a9