### PR TITLE
fix: annotate SKU parameter in ProductFilter callbacks

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductFilter.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductFilter.tsx
@@ -19,13 +19,13 @@ export default function ProductFilter({
 
   const sizes = useMemo(() => {
     const s = new Set<string>();
-    filteredRows.forEach((p) => p.sizes?.forEach((sz: string) => s.add(sz)));
+    filteredRows.forEach((p: SKU) => p.sizes?.forEach((sz: string) => s.add(sz)));
     return Array.from(s).sort();
   }, [filteredRows]);
 
   const colors = useMemo(() => {
     const s = new Set<string>();
-    filteredRows.forEach((p) => {
+    filteredRows.forEach((p: SKU) => {
       const c = p.id.split("-")[0];
       if (c) s.add(c);
     });
@@ -33,7 +33,7 @@ export default function ProductFilter({
   }, [filteredRows]);
 
   const priceBounds = useMemo(() => {
-    const prices = filteredRows.map((p) => p.price ?? 0);
+    const prices = filteredRows.map((p: SKU) => p.price ?? 0);
     const min = prices.length ? Math.min(...prices) : 0;
     const max = prices.length ? Math.max(...prices) : 0;
     return [min, max];
@@ -45,7 +45,7 @@ export default function ProductFilter({
   const [maxPrice, setMaxPrice] = useState(priceBounds[1]);
 
   const results = useMemo(() => {
-    return filteredRows.filter((p) => {
+    return filteredRows.filter((p: SKU) => {
       const sizeMatch = !size || p.sizes?.includes(size);
       const colorMatch = !color || p.id.includes(color);
       const price = p.price ?? 0;


### PR DESCRIPTION
## Summary
- annotate SKU callbacks in ProductFilter to satisfy TypeScript noImplicitAny

## Testing
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@i18n/parseMultilingualInput' and other missing modules)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a230ccdabc832f91c1add75495f411