### PR TITLE
fix: cast object entries in product form

### DIFF
--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -56,7 +56,12 @@ export default function ProductEditorForm({
         <form onSubmit={handleSubmit} className="@container grid gap-6">
           {Object.keys(errors).length > 0 && (
             <div className="text-sm text-danger" data-token="--color-danger">
-              {Object.entries(errors).map(([k, v]: [string, string[]]) => (
+              {(
+                Object.entries(errors as Record<string, string[]>) as [
+                  string,
+                  string[]
+                ][]
+              ).map(([k, v]) => (
                 <p key={k}>{v.join("; ")}</p>
               ))}
             </div>
@@ -76,7 +81,12 @@ export default function ProductEditorForm({
           </label>
 
           {/* Variant attributes -------------------------------------- */}
-          {Object.entries(product.variants).map(([attr, values]: [string, string[]]) => (
+          {(
+            Object.entries(product.variants as Record<string, string[]>) as [
+              string,
+              string[]
+            ][]
+          ).map(([attr, values]) => (
             <div key={attr} className="flex flex-col gap-2">
               <span>{`Variant ${attr}`}</span>
               {values.map((v: string, i: number) => (


### PR DESCRIPTION
## Summary
- cast errors and variants to typed entries in ProductEditorForm

## Testing
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server mapped as)*
- `pnpm --filter @acme/ui build` *(fails: Property 'id' does not exist on type 'WishlistItem', Cannot find module '@platform-core/contexts/CartContext')*


------
https://chatgpt.com/codex/tasks/task_e_68a246991b40832f815e0210fc659064