### PR TITLE
fix: type upload panel inputs

### DIFF
--- a/packages/ui/src/components/cms/media/UploadPanel.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.tsx
@@ -4,7 +4,7 @@
 import { Input } from "@ui/components/atoms/shadcn";
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";
-import { ReactElement, useState } from "react";
+import { ChangeEvent, ReactElement, useState } from "react";
 
 interface UploadPanelProps {
   shop: string;
@@ -110,14 +110,18 @@ export default function UploadPanel({ shop, onUploaded }: UploadPanelProps): Rea
                 <Input
                   type="text"
                   value={altText}
-                  onChange={(e) => setAltText(e.target.value)}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setAltText(e.target.value)
+                  }
                   placeholder={isVideo ? "Title" : "Alt text"}
                   className="flex-1"
                 />
                 <Input
                   type="text"
                   value={uploadTags}
-                  onChange={(e) => setUploadTags(e.target.value)}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setUploadTags(e.target.value)
+                  }
                   placeholder="Tags (comma separated)"
                   className="flex-1"
                 />


### PR DESCRIPTION
## Summary
- type ChangeEvent handlers for alt text and tag inputs in UploadPanel

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/media/UploadPanel.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/i18n/locales' and other modules)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a246a8c95c832fbd25c0af03557932