### PR TITLE
fix: specify RentalOrder type for orders

### DIFF
--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -3,6 +3,7 @@ import { getCustomerSession, hasPermission } from "@auth";
 import { getOrdersForCustomer } from "@platform-core/orders";
 import { getTrackingStatus as getShippingTrackingStatus } from "@platform-core/shipping";
 import { getTrackingStatus as getReturnTrackingStatus } from "@platform-core/returnAuthorization";
+import type { RentalOrder } from "@acme/types";
 import { redirect } from "next/navigation";
 import StartReturnButton from "./StartReturnButton";
 import type { OrderStep } from "../organisms/OrderTrackingTimeline";
@@ -44,7 +45,10 @@ export default async function OrdersPage({
   if (!hasPermission(session.role, "view_orders")) {
     return <p className="p-6">Not authorized.</p>;
   }
-  const orders = await getOrdersForCustomer(shopId, session.customerId);
+  const orders: RentalOrder[] = await getOrdersForCustomer(
+    shopId,
+    session.customerId,
+  );
   if (!orders.length) return <p className="p-6">No orders yet.</p>;
 
   const items = await Promise.all(


### PR DESCRIPTION
## Summary
- type getOrdersForCustomer response as RentalOrder to avoid implicit any when mapping orders

## Testing
- `pnpm --filter @acme/ui build` (fails: Property 'id' does not exist on type 'WishlistItem', Cannot find module '@platform-core/contexts/CartContext')
- `pnpm --filter @acme/ui test` (fails: Could not locate module @cms/actions/shops.server mapped as /workspace/base-shop/apps/cms/$1)


------
https://chatgpt.com/codex/tasks/task_e_68a246d27abc832f9e8346c89c7df4f7