### PR TITLE
fix robots.ts import and sitemap

### DIFF
--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -9,7 +9,6 @@ export default function robots(): MetadataRoute.Robots {
       { userAgent: "GPTBot", allow: "/" },
       { userAgent: "ClaudeBot", allow: "/" },
     ],
-    sitemap: `${base}/sitemap.xml`,
-    additionalSitemaps: [`${base}/ai-sitemap.xml`],
+    sitemap: [`${base}/sitemap.xml`, `${base}/ai-sitemap.xml`],
   };
 }

--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../config/tsconfig.app.json",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "paths": {
       "@ui": ["../ui/src/index.ts"],
       "@ui/*": ["../ui/src/*"],


### PR DESCRIPTION
## Summary
- update robots file to use an array of sitemaps
- explicitly set moduleResolution bundler in template app tsconfig

## Testing
- `pnpm lint --filter @acme/template-app`
- `pnpm test --filter @acme/template-app`
- `pnpm exec tsc packages/template-app/src/app/robots.ts --noEmit` *(fails: Cannot find module '@acme/config/env/core' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a39bf2acec832f9f65853129ace29b