### PR TITLE
feat: restore cart store helpers

### DIFF
--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -65,3 +65,44 @@ export function createCartStore(options: CartStoreOptions = {}): CartStore {
   return createMemoryCartStore(ttl);
 }
 
+/**
+ * Legacy convenience wrappers using a singleton cart store. These helpers
+ * preserve the previous API so existing imports like `getCart` continue to
+ * function. New code should prefer `createCartStore()` and call methods on the
+ * returned store instance directly.
+ */
+const defaultStore = createCartStore();
+
+export function createCart() {
+  return defaultStore.createCart();
+}
+
+export function getCart(id: string) {
+  return defaultStore.getCart(id);
+}
+
+export function setCart(id: string, cart: CartState) {
+  return defaultStore.setCart(id, cart);
+}
+
+export function deleteCart(id: string) {
+  return defaultStore.deleteCart(id);
+}
+
+export function incrementQty(
+  id: string,
+  sku: SKU,
+  qty: number,
+  size?: string,
+) {
+  return defaultStore.incrementQty(id, sku, qty, size);
+}
+
+export function setQty(id: string, skuId: string, qty: number) {
+  return defaultStore.setQty(id, skuId, qty);
+}
+
+export function removeItem(id: string, skuId: string) {
+  return defaultStore.removeItem(id, skuId);
+}
+

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -35,7 +35,7 @@ export default async function CheckoutPage({
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
-  const cart = cartId ? await getCart(cartId) : {};
+  const cart: CartState = cartId ? await getCart(cartId) : {};
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {


### PR DESCRIPTION
## Summary
- restore legacy cart store helper functions (`getCart`, `createCart`, etc.) via default store instance
- type checkout cart as `CartState` to avoid unknown properties

## Testing
- `pnpm exec eslint packages/platform-core/src/cartStore.ts packages/template-app/src/app/[lang]/checkout/page.tsx` *(warn: File ignored because no matching configuration was supplied)*
- `pnpm exec tsc -p packages/template-app/tsconfig.json --noEmit` *(fail: Output file has not been built / missing type declarations)*
- `pnpm exec jest packages/template-app/__tests__/cart.test.ts --runInBand` *(fail: Could not locate module @acme/config/env/core)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f299348832fa916c21ed4018e76