### PR TITLE
fix: resolve lib tsconfig path

### DIFF
--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -22,8 +22,4 @@
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
   ]
-,
-
-  /* build dependency graph ------------------------------------------ */
-  "references": [{ "path": "../lib" }]
 }

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -22,5 +22,11 @@
     "dist", // freshly emitted output
     ".turbo", // turbo cache
     "node_modules" // package deps (if any local)
+  ],
+
+  "references": [
+    { "path": "../platform-core" },
+    { "path": "../config" },
+    { "path": "../zod-utils" }
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -74,10 +74,10 @@
         "packages/config/*"
       ],
       "@platform-core": [
-        "packages/platform-core/src/index.ts"
+        "packages/platform-core"
       ],
       "@platform-core/*": [
-        "packages/platform-core/src/*"
+        "packages/platform-core/*"
       ],
       "@acme/shared-utils": [
         "packages/shared-utils"


### PR DESCRIPTION
## Summary
- resolve platform-core path mapping in base tsconfig
- add project references for lib package dependencies
- remove outdated config reference that caused TS cycles

## Testing
- `npx tsc -p packages/lib/tsconfig.json`
- `pnpm --filter @acme/lib test` *(fails: Could not locate module @cms/actions/shops.server, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f60d79c832f87e9c152cb7668dd