### PR TITLE
Fix type errors in checkout and template components

### DIFF
--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -1,1 +1,0 @@
-export async function trackEvent(){}

--- a/packages/platform-core/src/repositories/products.server.ts
+++ b/packages/platform-core/src/repositories/products.server.ts
@@ -92,7 +92,3 @@ export async function duplicateProductInRepo<
   await writeRepo<T>(shop, [copy, ...catalogue]);
   return copy;
 }
-
-export async function readRepo(){
-  return { all: async ()=>[] as any[], byId: async (_id:string)=>null as any };
-}

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -61,7 +61,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     let coverageFee = 0;
     let coverageWaiver = 0;
     for (const code of coverageCodes) {
-      const rule = pricing.coverage?.[code];
+      const rule = pricing.coverage?.[
+        code as keyof NonNullable<typeof pricing.coverage>
+      ];
       if (rule) {
         coverageFee += rule.fee;
         coverageWaiver += rule.waiver;

--- a/packages/template-app/src/components/DynamicRenderer.tsx
+++ b/packages/template-app/src/components/DynamicRenderer.tsx
@@ -45,7 +45,7 @@ const CmsImage = React.memo(
  * Registry: block type → React component
  * ------------------------------------------------------------------ */
 const registry: Partial<
-  Record<PageComponent["type"], React.ComponentType<Record<string, unknown>>>
+  Record<PageComponent["type"], React.ComponentType<any>>
 > = {
   HeroBanner,
   ValueProps,


### PR DESCRIPTION
## Summary
- simplify DynamicRenderer registry typing to support ProductGrid
- remove redundant products repository helper and old analytics stub
- type coverage code lookup in checkout session route

## Testing
- `pnpm typecheck` *(fails: Cannot find module '@i18n/locales')*
- `pnpm exec tsc -p packages/template-app/tsconfig.json --noEmit` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm test` *(fails: Cannot find module '@cms/auth/options')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a3b948d4832fa6b096a2f474f84c