### PR TITLE
fix: adjust environment import and listEvents calls

### DIFF
--- a/packages/configurator/src/index.ts
+++ b/packages/configurator/src/index.ts
@@ -1,8 +1,8 @@
-import { env, envSchema } from "@acme/config";
+import { envSchema } from "@acme/config/env";
 import { spawnSync } from "node:child_process";
 
 try {
-  envSchema.parse(env);
+  envSchema.parse(process.env);
 } catch (err) {
   console.error("Invalid environment variables:\n", err);
   process.exit(1);

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -50,7 +50,7 @@ async function filterUnsubscribed(
   shop: string,
   recipients: string[],
 ): Promise<string[]> {
-  const events: AnalyticsEvent[] = await listEvents(shop).catch(
+  const events: AnalyticsEvent[] = await listEvents().catch(
     (): AnalyticsEvent[] => [],
   );
   const unsub = new Set(

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -105,7 +105,7 @@ export async function resolveSegment(
     return [];
   }
 
-  const events: AnalyticsEvent[] = await listEvents(shop);
+  const events: AnalyticsEvent[] = await listEvents();
   const emails = new Set<string>();
   for (const e of events) {
     let match = true;


### PR DESCRIPTION
## Summary
- adjust listEvents usage in email scheduler and segments
- load env schema directly in configurator

## Testing
- `pnpm lint --filter=@acme/email --filter=@acme/configurator`
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/packages/email' must have setting "composite" true, plus other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4afc5072c832f904f6594bf59308c