### PR TITLE
fix module alias resolution

### DIFF
--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -11,7 +11,13 @@
       "@ui/src/*": ["../ui/src/*"],
       "@i18n/*": ["../i18n/src/*"],
       "@platform-core": ["../platform-core/src/index"],
-      "@platform-core/*": ["../platform-core/src/*"]
+      "@platform-core/*": ["../platform-core/src/*"],
+      "@acme/platform-core": ["../platform-core/src/index"],
+      "@acme/platform-core/*": ["../platform-core/src/*"],
+      "@auth": ["../auth/src/index", "../auth/src"],
+      "@auth/*": ["../auth/src/*"],
+      "@date-utils": ["../date-utils/src/index", "../date-utils/src"],
+      "@date-utils/*": ["../date-utils/src/*"]
     }
   },
   "include": ["next-env.d.ts", "src/**/*", "src/**/*.json", ".next/types/**/*.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -79,6 +79,12 @@
       "@platform-core/*": [
         "packages/platform-core/*"
       ],
+      "@acme/platform-core": [
+        "packages/platform-core"
+      ],
+      "@acme/platform-core/*": [
+        "packages/platform-core/*"
+      ],
       "@acme/shared-utils": [
         "packages/shared-utils"
       ],


### PR DESCRIPTION
## Summary
- add `@acme/platform-core` aliases
- expose `@auth` and `@date-utils` paths to template app

## Testing
- `pnpm exec tsc -p packages/template-app/tsconfig.json --noEmit` *(fails: Cannot find module '@acme/config/env/core' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a4afda40b4832f8ee64a348d49c0fc