### PR TITLE
fix zod-utils export path

### DIFF
--- a/packages/zod-utils/package.json
+++ b/packages/zod-utils/package.json
@@ -11,7 +11,7 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "/*": {
+    "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",
       "default": "./dist/*.js"


### PR DESCRIPTION
## Summary
- correct @acme/zod-utils wildcard export path to use `./*`

## Testing
- `pnpm --filter @acme/config run build`
- `pnpm --filter @acme/template-app run build` *(fails: Module not found: Can't resolve '@acme/i18n/locales')*

------
https://chatgpt.com/codex/tasks/task_e_68a4da0405b4832f98131557ced60324