### PR TITLE
fix zod-utils export path

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,6 +26,7 @@
   "files": ["dist"],
   "sideEffects": false,
   "scripts": {
+    "prebuild": "pnpm --filter @acme/zod-utils run build",
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w",
     "clean": "rimraf dist *.tsbuildinfo"

--- a/packages/zod-utils/package.json
+++ b/packages/zod-utils/package.json
@@ -11,7 +11,7 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "/*": {
+    "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",
       "default": "./dist/*.js"


### PR DESCRIPTION
## Summary
- correct `@acme/zod-utils` wildcard export path to use `./*`
- build `@acme/zod-utils` automatically when building `@acme/config`

## Testing
- `pnpm --filter @acme/config run build`
- `pnpm --filter @acme/template-app run build` *(fails: Cannot resolve './shops.server.js' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4da0405b4832f98131557ced60324