### PR TITLE
fix: improve inventory form typing

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -50,9 +50,14 @@ export default function InventoryForm({ shop, initial }: Props) {
       } else if (field === "sku") {
         item.sku = value;
         item.productId = value;
-      } else {
-        // other top-level fields
-        item[field] = value;
+      } else if (field === "productId") {
+        item.productId = value;
+      } else if (field === "wearCount") {
+        item.wearCount = value === "" ? undefined : Number(value);
+      } else if (field === "wearAndTearLimit") {
+        item.wearAndTearLimit = value === "" ? undefined : Number(value);
+      } else if (field === "maintenanceCycle") {
+        item.maintenanceCycle = value === "" ? undefined : Number(value);
       }
       next[index] = item;
       return next;

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryRow.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryRow.tsx
@@ -7,6 +7,7 @@ import {
   TableRow,
 } from "@/components/atoms/shadcn";
 import type { InventoryItem } from "@acme/types";
+import type { ChangeEvent } from "react";
 
 interface Props {
   item: InventoryItem;
@@ -33,14 +34,16 @@ export default function InventoryRow({
       <TableCell>
         <Input
           value={item.sku}
-          onChange={(e) => updateItem(index, "sku", e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            updateItem(index, "sku", e.target.value)
+          }
         />
       </TableCell>
       {attributes.map((attr) => (
         <TableCell key={attr}>
           <Input
             value={item.variantAttributes[attr] ?? ""}
-            onChange={(e) =>
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
               updateItem(index, `variantAttributes.${attr}`, e.target.value)
             }
           />
@@ -51,7 +54,9 @@ export default function InventoryRow({
           type="number"
           min={0}
           value={item.quantity}
-          onChange={(e) => updateItem(index, "quantity", e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            updateItem(index, "quantity", e.target.value)
+          }
         />
       </TableCell>
       <TableCell>
@@ -59,7 +64,9 @@ export default function InventoryRow({
           type="number"
           min={0}
           value={item.lowStockThreshold ?? ""}
-          onChange={(e) => updateItem(index, "lowStockThreshold", e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            updateItem(index, "lowStockThreshold", e.target.value)
+          }
         />
       </TableCell>
       <TableCell>


### PR DESCRIPTION
## Summary
- handle numeric inventory fields explicitly instead of assigning via dynamic index
- type inventory row change handlers

## Testing
- `pnpm test` (fails: @acme/next-config#test)
- `pnpm --filter @apps/cms test` (fails: package subpath './jest.preset.cjs' not defined)
- `pnpm --filter @apps/cms lint` (fails: numerous parsing errors)


------
https://chatgpt.com/codex/tasks/task_e_68a4df3476a0832f9fa54c1c58fb3d22