### PR TITLE
Fix RA dashboard typing for return authorizations

### DIFF
--- a/apps/cms/src/app/cms/ra/page.tsx
+++ b/apps/cms/src/app/cms/ra/page.tsx
@@ -2,12 +2,13 @@
 import { listReturnAuthorizations } from "@platform-core/returnAuthorization";
 import { features } from "@platform-core/features";
 import { notFound } from "next/navigation";
+import type { ReturnAuthorization } from "@acme/types";
 
 export const revalidate = 0;
 
 export default async function RaDashboardPage() {
   if (!features.raTicketing) notFound();
-  const ras = await listReturnAuthorizations();
+  const ras: ReturnAuthorization[] = await listReturnAuthorizations();
   return (
     <div>
       <h2 className="mb-4 text-xl font-semibold">Return Authorizations</h2>


### PR DESCRIPTION
## Summary
- add ReturnAuthorization type for RA dashboard mapping

## Testing
- `pnpm --filter @apps/cms lint` (fails: Parsing error Unexpected token `<`)
- `pnpm --filter @apps/cms test` (fails: ERR_PACKAGE_PATH_NOT_EXPORTED)
- `pnpm --filter @apps/cms exec tsc --noEmit` (fails: TS2835 relative import paths need file extensions)


------
https://chatgpt.com/codex/tasks/task_e_68a4df539658832f94bcaf9a9bbfd1ea