### PR TITLE
fix: avoid cross-package type import

### DIFF
--- a/apps/cms/src/app/cms/page.tsx
+++ b/apps/cms/src/app/cms/page.tsx
@@ -4,7 +4,7 @@ import { approveAccount, listPendingUsers } from "@cms/actions/accounts.server";
 import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
 import { readRbac } from "@cms/lib/rbacStore";
-import type { StatItem } from "@ui/components/organisms/StatsGrid";
+import type { ReactNode } from "react";
 import { DashboardTemplate } from "@ui/components/templates";
 import type { Metadata } from "next";
 import { getServerSession } from "next-auth";
@@ -23,6 +23,11 @@ type Stats = {
   users: number;
   shops: number;
   products: number;
+};
+
+type StatItem = {
+  label: string;
+  value: ReactNode;
 };
 
 async function collectStats(): Promise<Stats> {


### PR DESCRIPTION
## Summary
- add local `StatItem` type and use React's `ReactNode` to avoid importing from UI package

## Testing
- `npx tsc -p apps/cms/tsconfig.json` *(fails: Cannot find module '@/components/atoms/shadcn' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4df6bc4d0832f85c1c55e2e66cd8e