### PR TITLE
chore: add explicit types for marketing pages

### DIFF
--- a/apps/cms/src/app/cms/marketing/email/page.tsx
+++ b/apps/cms/src/app/cms/marketing/email/page.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { formatTimestamp } from "@acme/date-utils";
-import { marketingEmailTemplates } from "@acme/ui";
+import {
+  marketingEmailTemplates,
+  type MarketingEmailTemplateVariant,
+} from "@acme/ui";
 import DOMPurify from "dompurify";
 
 interface Campaign {
@@ -136,7 +139,7 @@ export default function EmailMarketingPage() {
           value={templateId}
           onChange={(e) => setTemplateId(e.target.value)}
         >
-          {marketingEmailTemplates.map((t) => (
+          {marketingEmailTemplates.map((t: MarketingEmailTemplateVariant) => (
             <option key={t.id} value={t.id}>
               {t.name}
             </option>
@@ -197,7 +200,7 @@ export default function EmailMarketingPage() {
       )}
         <div className="mt-4">
           {marketingEmailTemplates
-            .find((t) => t.id === templateId)
+            .find((t: MarketingEmailTemplateVariant) => t.id === templateId)
             ?.render({
               headline: subject || "",
               content: (

--- a/apps/cms/src/app/cms/marketing/page.tsx
+++ b/apps/cms/src/app/cms/marketing/page.tsx
@@ -1,16 +1,19 @@
 import Link from "next/link";
 import { listShops } from "../listShops";
 import { listEvents } from "@platform-core/repositories/analytics.server";
+import type { AnalyticsEvent } from "@platform-core/analytics";
 
 export default async function MarketingPage() {
   const shops = await listShops();
   const campaignsByShop: Record<string, string[]> = {};
   for (const shop of shops) {
-    const events = await listEvents(shop);
+    const events: AnalyticsEvent[] = await listEvents(shop);
     const campaigns = Array.from(
       new Set(
         events
-          .map((e) => (typeof e.campaign === "string" ? e.campaign : null))
+          .map((e: AnalyticsEvent) =>
+            typeof e.campaign === "string" ? e.campaign : null,
+          )
           .filter(Boolean) as string[],
       ),
     );


### PR DESCRIPTION
## Summary
- type analytics events to extract campaign names safely
- annotate email template parameters with explicit types

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Parsing error: Unexpected token <)*
- `pnpm --filter @apps/cms test` *(fails: Package subpath './jest.preset.cjs' is not defined by "exports")*
- `pnpm exec tsc -p apps/cms/tsconfig.json` *(fails: parameter 'v' implicitly has an 'any' type and other type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a4df83a29c832f88c5a72867885f6b