### PR TITLE
chore(cms): simplify tsconfig to avoid rootDir issues

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "noEmit": false,
+    "noEmit": true,
 
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
@@ -16,9 +13,6 @@
 
     "jsx": "react-jsx",
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "declarationDir": "dist",
 
     "resolveJsonModule": true,
     "allowJs": false,


### PR DESCRIPTION
## Summary
- simplify CMS tsconfig for type checking by removing rootDir/outDir declarations and enabling noEmit

## Testing
- `pnpm --filter @apps/cms exec tsc -p tsconfig.json` *(fails: Cannot find module '@acme/email' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4df9e9f8c832f9eae9e20bef01024