### PR TITLE
fix: handle token overrides indexing

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
@@ -20,9 +20,9 @@ export default function StepTokens(): React.JSX.Element {
 
   const handleChange = (next: TokenMap) => {
     const overrides: TokenMap = { ...next };
-    for (const key of Object.keys(overrides)) {
-      if (overrides[key as keyof TokenMap] === themeDefaults[key as keyof TokenMap]) {
-        delete overrides[key as keyof TokenMap];
+    for (const key of Object.keys(overrides) as Array<keyof TokenMap & string>) {
+      if (overrides[key] === themeDefaults[key]) {
+        delete overrides[key];
       }
     }
     setThemeOverrides(overrides);


### PR DESCRIPTION
## Summary
- fix token override comparisons by iterating over string keys

## Testing
- `pnpm --filter @apps/cms lint` *(fails: Parsing error: Unexpected token <)*
- `pnpm --filter @apps/cms test` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './jest.preset.cjs' is not defined)*
- `pnpm typecheck` *(fails: Found 870 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dfc0a298832f9bc38b99c5d52669