### PR TITLE
fix: allow cross-package imports in CMS

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -163,7 +163,7 @@ export default function StepTheme({
       {/* single accessible combobox (theme) */}
       <Select
         value={theme}
-        onValueChange={(v) => {
+        onValueChange={(v: string) => {
           update("theme", v);
           setThemeOverrides({});
           if (typeof window !== "undefined") {

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -6,8 +6,8 @@
     "emitDeclarationOnly": true,
     "noEmit": false,
 
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],
 
@@ -16,7 +16,7 @@
 
     "jsx": "react-jsx",
     "baseUrl": ".",
-    "rootDir": "src",
+    "rootDir": "../..",
     "outDir": "dist",
     "declarationDir": "dist",
 


### PR DESCRIPTION
## Summary
- adjust CMS tsconfig to use ESNext modules, Bundler resolution, and project root for rootDir
- explicitly type theme select callback parameter to avoid implicit any

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Cannot find module '@acme/platform-core')*
- `pnpm test:cms` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dff18610832f9a5d026eab418343