### PR TITLE
fix: include createShop sources in tsconfig

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -19,7 +19,7 @@
   "include": [
     "src*",
     "src*.json",
-    "src*",
-    "src*.json"
+    "src/**/*",
+    "src/**/*.json"
   ]
 }


### PR DESCRIPTION
## Summary
- include createShop subdirectory in platform-core tsconfig

## Testing
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@acme/config/env/core' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e5aef830832fb96eb182bf9b0225