### PR TITLE
chore: exclude platform-core tests from typecheck

### DIFF
--- a/packages/platform-core/tsconfig.test.json
+++ b/packages/platform-core/tsconfig.test.json
@@ -9,6 +9,6 @@
     "noEmit": true
   },
 
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": []
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
- exclude `packages/platform-core/__tests__` from typechecking by tightening the test tsconfig include patterns

## Testing
- `npx tsc -p packages/platform-core/tsconfig.test.json` *(fails: Module '@prisma/client' has no exported member 'Prisma')*


------
https://chatgpt.com/codex/tasks/task_e_68a4e6084e7c832f8cc59e56ade462a0