### PR TITLE
refactor: use workspace package imports in shop scripts

### DIFF
--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import { parseArgs } from "./createShop/parse";
 import { gatherOptions } from "./createShop/prompts";
 import { writeShop } from "./createShop/write";
-import { ensureTemplateExists } from "../../packages/platform-core/src/createShop/fsUtils";
+import { ensureTemplateExists } from "@acme/platform-core/createShop";
 
 function ensureRuntime() {
   const nodeMajor = Number(process.version.replace(/^v/, "").split(".")[0]);

--- a/scripts/src/createShop/parse.ts
+++ b/scripts/src/createShop/parse.ts
@@ -1,17 +1,8 @@
-import { validateShopName } from "../../../packages/platform-core/src/shops";
+import { validateShopName } from "@acme/platform-core/shops";
+import type { CreateShopOptions } from "@acme/platform-core/createShop";
 
 /** Command line options for creating a shop. */
-export interface Options {
-  type: "sale" | "rental";
-  theme: string;
-  template: string;
-  payment: string[];
-  shipping: string[];
-  name?: string;
-  logo?: string;
-  contactInfo?: string;
-  enableSubscriptions?: boolean;
-}
+export type Options = CreateShopOptions;
 
 /**
  * Parse command line arguments for the create-shop script.

--- a/scripts/src/createShop/prompts.ts
+++ b/scripts/src/createShop/prompts.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from "fs";
 import readline from "node:readline";
 import { join } from "path";
-import { listProviders } from "../../../packages/platform-core/src/createShop/listProviders";
+import { listProviders } from "@acme/platform-core/createShop/listProviders";
 import type { Options } from "./parse";
 
 /**

--- a/scripts/src/createShop/write.ts
+++ b/scripts/src/createShop/write.ts
@@ -7,10 +7,7 @@
  * environment.  The `Options` type is aliased from `CreateShopOptions` to
  * match the original script’s signature.
  */
-import {
-  createShop,
-  type CreateShopOptions,
-} from "../../../packages/platform-core/src/createShop";
+import { createShop, type CreateShopOptions } from "@acme/platform-core/createShop";
 
 export type Options = CreateShopOptions;
 

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -1,31 +1,22 @@
 // scripts/src/init-shop.ts
-// Import createShop directly from the workspace source.  We use a relative
-// path because the `@acme/*` aliases are not available in this pared‑down
-// environment.  Importing from the compiled package entry point is not
-// necessary here since TypeScript will resolve the .ts file directly.
-import {
-  createShop,
-  type CreateShopOptions,
-} from "../../packages/platform-core/src/createShop";
+// Import platform helpers from the published package to avoid relying on
+// TypeScript path aliases when executing via ts-node.
+import { createShop, type CreateShopOptions } from "@acme/platform-core/createShop";
 
-// Pull in the shop name validator from the platform core package.  We avoid
-// using @acme/* aliases because they are not available in this environment.
-import { validateShopName } from "../../packages/platform-core/src/shops";
+// Pull in the shop name validator from the platform core package.
+import { validateShopName } from "@acme/platform-core/shops";
 
 import { execSync, spawnSync } from "node:child_process";
 import { readdirSync } from "node:fs";
-// Pull in the environment validator from the platform core source directly.  A
-// relative import is used here because the `@acme/*` path aliases are not
-// available in this environment.  The imported function validates the
-// generated `.env` file for the newly created shop and will throw if any
+// Validate the generated environment file for the new shop and throw if any
 // required variables are missing or invalid.
 import { stdin as input, stdout as output } from "node:process";
 import readline from "node:readline/promises";
-import { validateShopEnv } from "../../packages/platform-core/src/configurator";
+import { validateShopEnv } from "@acme/platform-core/configurator";
 // Import the provider listing utility via the defined subpath export.  This
 // module aggregates built‑in payment and shipping providers as well as any
 // plugins under packages/plugins.
-import { listProviders } from "../../packages/platform-core/src/createShop/listProviders";
+import { listProviders } from "@acme/platform-core/createShop/listProviders";
 
 /**
  * Ensure that the runtime meets the minimum supported versions for Node.js and pnpm.

--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -68,7 +68,7 @@ describe('init-shop wizard', () => {
         if (p.includes('@config/src/env')) {
           return { envSchema: { parse: envParse } };
         }
-        if (p.includes('../../packages/platform-core/src/createShop/listProviders')) {
+        if (p.includes('@acme/platform-core/createShop/listProviders')) {
           return {
             listProviders: jest.fn((kind: string) =>
               Promise.resolve(
@@ -79,10 +79,10 @@ describe('init-shop wizard', () => {
             ),
           };
         }
-        if (p.includes('../../packages/platform-core/src/createShop')) {
+        if (p.includes('@acme/platform-core/createShop')) {
           return { createShop };
         }
-        if (p.includes('../../packages/platform-core/src/configurator')) {
+        if (p.includes('@acme/platform-core/configurator')) {
           return { validateShopEnv };
         }
         return require(p);


### PR DESCRIPTION
## Summary
- refactor create-shop scripts to import from published `@acme/platform-core` package
- type `parseArgs` options via `CreateShopOptions`
- update CLI tests to use new imports and stubs

## Testing
- `pnpm exec tsc -b scripts/tsconfig.json` *(fails: Cannot find module '@acme/platform-core/createShop')*
- `pnpm exec jest test/unit/create-shop-cli.spec.ts`
- `pnpm exec jest test/unit/init-shop.spec.ts` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e5587f00832fa2e9a10d264c46b2