### PR TITLE
fix: add explicit types for theme editor

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ColorInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEvent, useEffect, useState } from "react";
+import { useEffect, useState, type ChangeEvent } from "react";
 import { Button, Input } from "@/components/atoms/shadcn";
 import { hslToHex, hexToHsl, isHex, isHsl } from "@ui/utils/colorUtils";
 import ColorContrastChecker from "color-contrast-checker";
@@ -136,7 +136,9 @@ export default function ColorInput({
           <Input
             placeholder={defaultValue}
             value={value}
-            onChange={(e) => onChange(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              onChange(e.target.value)
+            }
             ref={inputRef}
             className={isOverridden ? "bg-amber-100" : ""}
           />

--- a/apps/cms/src/app/cms/shop/[shop]/themes/InlineColorPicker.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/InlineColorPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, ChangeEvent } from "react";
+import { useEffect, useRef, type ChangeEvent } from "react";
 import { hslToHex, hexToHsl, isHsl, isHex } from "@ui/utils/colorUtils";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemeSelector.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemeSelector.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/shop/[shop]/themes/ThemeSelector.tsx
 "use client";
-import { ChangeEvent } from "react";
+import type { ChangeEvent } from "react";
 
 interface Props {
   themes: string[];

--- a/apps/cms/src/app/cms/shop/[shop]/themes/TypographySettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/TypographySettings.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/themes/TypographySettings.tsx
 "use client";
 import { Input } from "@/components/atoms/shadcn";
-import type { MutableRefObject } from "react";
+import type { MutableRefObject, ChangeEvent } from "react";
 
 interface Props {
   tokens: Record<string, string>;
@@ -41,10 +41,10 @@ export default function TypographySettings({
                 name={k}
                 defaultValue={defaultValue}
                 value={overrideValue}
-                onChange={(e) =>
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
                   handleOverrideChange(k, defaultValue)(e.target.value)
                 }
-                ref={(el) => {
+                ref={(el: HTMLInputElement | null) => {
                   overrideRefs.current[k] = el;
                 }}
               />

--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
 "use client";
-import { useState, useMemo, useRef, useEffect, ChangeEvent } from "react";
+import { useState, useMemo, useRef, useEffect, type ChangeEvent } from "react";
 import { patchShopTheme } from "../../../wizard/services/patchTheme";
 import { tokenGroups } from "./tokenGroups";
 import { useThemePresets } from "./useThemePresets";


### PR DESCRIPTION
## Summary
- add explicit ChangeEvent and ref types for theme typography settings
- use type-only ChangeEvent imports across theme editor components
- type onChange handler in ColorInput

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Relative import paths need explicit file extensions when moduleResolution is node16 or nodenext)*
- `pnpm --filter @apps/cms lint` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6421290832fbe607c00c81ff043