### PR TITLE
fix create-shop options type mismatch

### DIFF
--- a/scripts/src/createShop/parse.ts
+++ b/scripts/src/createShop/parse.ts
@@ -1,17 +1,8 @@
 import { validateShopName } from "../../../packages/platform-core/src/shops";
+import type { CreateShopOptions } from "../../../packages/platform-core/src/createShop";
 
 /** Command line options for creating a shop. */
-export interface Options {
-  type: "sale" | "rental";
-  theme: string;
-  template: string;
-  payment: string[];
-  shipping: string[];
-  name?: string;
-  logo?: string;
-  contactInfo?: string;
-  enableSubscriptions?: boolean;
-}
+export type Options = CreateShopOptions;
 
 /**
  * Parse command line arguments for the create-shop script.
@@ -46,6 +37,11 @@ export function parseArgs(argv: string[]): {
     payment: [],
     shipping: [],
     enableSubscriptions: false,
+    pages: [],
+    themeOverrides: {},
+    tax: "taxjar",
+    navItems: [],
+    checkoutPage: [],
   };
 
   let themeProvided = false;
@@ -71,10 +67,10 @@ export function parseArgs(argv: string[]): {
         templateProvided = true;
         break;
       case "payment":
-        opts.payment = val.split(",").filter(Boolean);
+        opts.payment = val.split(",").filter(Boolean) as Options["payment"];
         break;
       case "shipping":
-        opts.shipping = val.split(",").filter(Boolean);
+        opts.shipping = val.split(",").filter(Boolean) as Options["shipping"];
         break;
       case "subscriptions":
         opts.enableSubscriptions = val === "" ? true : val !== "false";

--- a/scripts/src/createShop/prompts.ts
+++ b/scripts/src/createShop/prompts.ts
@@ -127,7 +127,7 @@ export async function gatherOptions(
             options.payment = ans
               .split(",")
               .map((s) => s.trim())
-              .filter((p) => providers.includes(p));
+              .filter((p) => providers.includes(p)) as Options["payment"];
             rl.close();
             resolve();
           }
@@ -151,7 +151,7 @@ export async function gatherOptions(
             options.shipping = ans
               .split(",")
               .map((s) => s.trim())
-              .filter((p) => providers.includes(p));
+              .filter((p) => providers.includes(p)) as Options["shipping"];
             rl.close();
             resolve();
           }


### PR DESCRIPTION
## Summary
- align `parseArgs` option type with core `CreateShopOptions`
- ensure CLI parsing and prompts cast provider arrays to typed unions

## Testing
- `pnpm tsc -p scripts/tsconfig.json` *(fails: Output file has not been built from source)*
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@acme/types')*
- `pnpm test` *(fails: Cannot find module '@acme/config/dist/env/core.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a4e8f4d8e0832f9c3800736a0e2ad9