### PR TITLE
fix email tsconfig references

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -2,17 +2,24 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "declaration": true,
+    "declarationMap": true,
     "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
     "baseUrl": ".",
     "paths": {
       "@platform-core": [
-        "../platform-core/src/index"
+        "../platform-core/dist/index"
       ],
       "@platform-core/*": [
-        "../platform-core/src/*"
+        "../platform-core/dist/*"
       ],
       "@date-utils": [
         "types-compat/date-utils"
+      ],
+      "@acme/ui": [
+        "types-compat/ui"
       ]
     }
   },

--- a/packages/email/types-compat/ui.d.ts
+++ b/packages/email/types-compat/ui.d.ts
@@ -1,0 +1,3 @@
+declare module "@acme/ui" {
+  export const marketingEmailTemplates: any[];
+}


### PR DESCRIPTION
## Summary
- adjust email tsconfig to resolve platform-core from prebuilt dist and add baseUrl and paths
- stub out @acme/ui types for email build

## Testing
- `pnpm exec tsc -p packages/email/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9214000832fb1967045a2432bdf