### PR TITLE
fix: pass create-shop options to writeShop

### DIFF
--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -3,7 +3,7 @@
 import { execSync } from "node:child_process";
 import { parseArgs } from "./createShop/parse";
 import { gatherOptions } from "./createShop/prompts";
-import { writeShop } from "./createShop/write";
+import { writeShop, type Options as WriteOptions } from "./createShop/write";
 import { ensureTemplateExists } from "@acme/platform-core/createShop";
 
 function ensureRuntime() {
@@ -47,4 +47,4 @@ if (themeProvided || templateProvided) {
 }
 
 await gatherOptions(shopId, options, themeProvided, templateProvided);
-await writeShop(shopId, options);
+await writeShop(shopId, options as WriteOptions);


### PR DESCRIPTION
## Summary
- ensure create-shop script uses writeShop Options type when calling the helper

## Testing
- `pnpm exec eslint scripts/src/create-shop.ts`
- `pnpm exec tsc scripts/src/create-shop.ts --noEmit` *(fails: Cannot find module '@acme/platform-core/createShop')*


------
https://chatgpt.com/codex/tasks/task_e_68a5817b939c832fab24288f8f0c9586