### PR TITLE
fix: include shared types in platform-core tests

### DIFF
--- a/packages/platform-core/__tests__/tsconfig.json
+++ b/packages/platform-core/__tests__/tsconfig.json
@@ -10,6 +10,8 @@
     "../../../test/mswServer.ts",
     "../../../apps/cms/src/**/*.ts",
     "../../../apps/cms/src/**/*.tsx",
-    "../../../src/**/*"
+    "../../../src/**/*",
+    "../../types/src/**/*.ts",
+    "../../../scripts/src/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add types source files to platform-core test tsconfig
- include scripts for CMS rollback in test tsconfig

## Testing
- `pnpm exec tsc -p packages/platform-core/__tests__/tsconfig.json` *(fails: Cannot find module '@acme/i18n' etc., but no TS6307 errors remain)*
- `pnpm test --filter @acme/platform-core` *(fails: No tasks were executed)*

------
https://chatgpt.com/codex/tasks/task_e_68a581d7a928832fb951cbb9e3dd1e60