### PR TITLE
fix: correct date utils import in platform-core seed

### DIFF
--- a/packages/platform-core/prisma/seed.ts
+++ b/packages/platform-core/prisma/seed.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../src/db";
-import { nowIso } from "@date-utils";
+import { nowIso } from "@acme/date-utils";
 
 async function main() {
   await prisma.rentalOrder.createMany({


### PR DESCRIPTION
## Summary
- fix incorrect `@date-utils` import in platform-core seed script

## Testing
- `pnpm test --filter @acme/platform-core` *(no tests found)*
- `pnpm --filter @acme/platform-core exec tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@acme/types' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a581e246b8832f9872aab565eb6387