### PR TITLE
Fix CMS service imports and defaults

### DIFF
--- a/apps/cms/src/services/shops/seoService.ts
+++ b/apps/cms/src/services/shops/seoService.ts
@@ -57,7 +57,7 @@ export async function generateSeo(
   }
 
   const { id, locale, title, description } = data;
-  const { generateMeta } = await import("@acme/lib/generateMeta");
+  const { generateMeta } = await import("@acme/lib");
 
   const result = await generateMeta({ id, title, description });
   const current = await fetchSettings(shop);
@@ -87,6 +87,7 @@ export async function revertSeo(shop: string, timestamp: string) {
     languages: [] as Locale[],
     seo: {},
     luxuryFeatures: {
+      premierDelivery: false,
       blog: false,
       contentMerchandising: false,
       raTicketing: false,

--- a/apps/cms/src/services/shops/theme.ts
+++ b/apps/cms/src/services/shops/theme.ts
@@ -13,12 +13,14 @@ export async function buildThemeData(
   themeTokens: Record<string, string>;
 }> {
   const overrides = form.themeOverrides as Record<string, string>;
-  let themeDefaults = form.themeDefaults as Record<string, string> | undefined;
-  if (!themeDefaults || Object.keys(themeDefaults).length === 0) {
+  let themeDefaults: Record<string, string>;
+  if (!form.themeDefaults || Object.keys(form.themeDefaults).length === 0) {
     themeDefaults =
       current.themeId !== form.themeId
         ? await syncTheme(shop, form.themeId)
         : { ...baseTokens, ...(await loadThemeTokens(form.themeId)) };
+  } else {
+    themeDefaults = form.themeDefaults as Record<string, string>;
   }
   const themeTokens = { ...themeDefaults, ...overrides };
   return { themeDefaults, overrides, themeTokens };

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -30,13 +30,16 @@
       "@auth": ["../../packages/auth/src/index.ts"],
       "@auth/*": ["../../packages/auth/src/*"],
       "@acme/lib": ["../../packages/lib/src/index.ts"],
+      "@acme/lib/*": ["../../packages/lib/src/*"],
       "@acme/shared-utils": ["../../packages/shared-utils/src/index.ts"],
       "@acme/shared-utils/*": ["../../packages/shared-utils/src/*"],
       "@acme/types/*": ["../../packages/types/src/*"],
       "@shared-utils": ["../../packages/shared-utils/src/index.ts"],
       "@shared-utils/*": ["../../packages/shared-utils/src/*"],
       "@date-utils": ["../../packages/date-utils/src/index.ts"],
-      "@date-utils/*": ["../../packages/date-utils/src/*"]
+      "@date-utils/*": ["../../packages/date-utils/src/*"],
+      "@platform-core": ["../../packages/platform-core/src/index.ts"],
+      "@platform-core/*": ["../../packages/platform-core/src/*"]
     }
   },
   "include": ["next-env.d.ts", "src/**/*"],


### PR DESCRIPTION
## Summary
- ensure CMS tsconfig resolves platform-core and lib subpaths
- load generateMeta from @acme/lib and include premierDelivery in SEO revert defaults
- guarantee themeDefaults is defined when building theme tokens

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Cannot find module '@acme/email' and other packages)*
- `pnpm --filter @apps/cms test apps/cms/src/services/shops/seoService.test.ts apps/cms/src/services/shops/theme.test.ts apps/cms/src/services/shops/persistence.test.ts` *(fails: Package subpath './jest.preset.cjs' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a581f89ce0832f9a5544ef27fd07cf