### PR TITLE
fix email package tsconfig paths

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -9,18 +9,16 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@platform-core": [
-        "../platform-core/dist/index"
-      ],
-      "@platform-core/*": [
-        "../platform-core/dist/*"
-      ],
-      "@date-utils": [
-        "types-compat/date-utils"
-      ],
-      "@acme/ui": [
-        "types-compat/ui"
-      ]
+      "@platform-core": ["../platform-core/dist/index"],
+      "@platform-core/*": ["../platform-core/dist/*"],
+      "@acme/config": ["../config/dist/index"],
+      "@acme/config/*": ["../config/dist/*"],
+      "@acme/lib": ["../lib/dist/index"],
+      "@acme/lib/*": ["../lib/dist/*"],
+      "@acme/types": ["../types/dist/index"],
+      "@acme/types/*": ["../types/dist/*"],
+      "@date-utils": ["types-compat/date-utils"],
+      "@acme/ui": ["types-compat/ui"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- map email package TypeScript paths to built output of shared packages

## Testing
- `npx tsc -p packages/email/tsconfig.json`
- `pnpm --filter @acme/email test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a581aebe54832fb15dfc172af8c1ec