### PR TITLE
fix env feature flag parse and use platform-core package in email

### DIFF
--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -33,7 +33,11 @@ export default async function ShopIndexPage({
 
   let latestPost: BlogPost | undefined;
   try {
-    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    const luxury = JSON.parse(
+      typeof env.NEXT_PUBLIC_LUXURY_FEATURES === "string"
+        ? env.NEXT_PUBLIC_LUXURY_FEATURES
+        : "{}",
+    );
     if (luxury.contentMerchandising && luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -19,7 +19,11 @@ export default async function ShopIndexPage({
 }) {
   let latestPost: BlogPost | undefined;
   try {
-    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    const luxury = JSON.parse(
+      typeof env.NEXT_PUBLIC_LUXURY_FEATURES === "string"
+        ? env.NEXT_PUBLIC_LUXURY_FEATURES
+        : "{}",
+    );
     if (luxury.contentMerchandising && luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/packages/email/src/__tests__/abandonedCart.test.ts
+++ b/packages/email/src/__tests__/abandonedCart.test.ts
@@ -5,7 +5,7 @@ import {
   resolveAbandonedCartDelay,
 } from "../abandonedCart";
 import type { AbandonedCart } from "../abandonedCart";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 import { sendCampaignEmail } from "../send";
 
 jest.mock("../send", () => ({

--- a/packages/email/src/__tests__/analytics.test.ts
+++ b/packages/email/src/__tests__/analytics.test.ts
@@ -6,7 +6,7 @@ describe("analytics mapping", () => {
   it("normalizes SendGrid webhook events", async () => {
     jest.resetModules();
     process.env.CART_COOKIE_SECRET = "secret";
-    jest.doMock("@platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
+    jest.doMock("@acme/platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
     jest.doMock("../providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
     jest.doMock("../providers/resend", () => ({ ResendProvider: jest.fn() }));
     const { mapSendGridEvent } = await import("../analytics");
@@ -27,7 +27,7 @@ describe("analytics mapping", () => {
   it("normalizes Resend webhook events", async () => {
     jest.resetModules();
     process.env.CART_COOKIE_SECRET = "secret";
-    jest.doMock("@platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
+    jest.doMock("@acme/platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
     jest.doMock("../providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
     jest.doMock("../providers/resend", () => ({ ResendProvider: jest.fn() }));
     const { mapResendEvent } = await import("../analytics");
@@ -50,7 +50,7 @@ describe("analytics mapping", () => {
   it("maps SendGrid stats", async () => {
     jest.resetModules();
     process.env.CART_COOKIE_SECRET = "secret";
-    jest.doMock("@platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
+    jest.doMock("@acme/platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
     jest.doMock("../providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
     jest.doMock("../providers/resend", () => ({ ResendProvider: jest.fn() }));
     const { mapSendGridStats } = await import("../analytics");
@@ -73,7 +73,7 @@ describe("analytics mapping", () => {
   it("maps Resend stats", async () => {
     jest.resetModules();
     process.env.CART_COOKIE_SECRET = "secret";
-    jest.doMock("@platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
+    jest.doMock("@acme/platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
     jest.doMock("../providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
     jest.doMock("../providers/resend", () => ({ ResendProvider: jest.fn() }));
     const { mapResendStats } = await import("../analytics");
@@ -101,7 +101,7 @@ describe("syncCampaignAnalytics", () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
 
     const trackEvent = jest.fn().mockResolvedValue(undefined);
-    jest.doMock("@platform-core/analytics", () => ({
+    jest.doMock("@acme/platform-core/analytics", () => ({
       __esModule: true,
       trackEvent,
     }));

--- a/packages/email/src/__tests__/campaign-integration.test.ts
+++ b/packages/email/src/__tests__/campaign-integration.test.ts
@@ -1,9 +1,9 @@
 import { jest } from "@jest/globals";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 
-jest.mock("@platform-core/analytics", () => ({
+jest.mock("@acme/platform-core/analytics", () => ({
   __esModule: true,
   trackEvent: jest.fn(),
 }));
@@ -34,7 +34,7 @@ beforeEach(async () => {
   jest.clearAllMocks();
   await fs.rm(shopDir, { recursive: true, force: true });
   await fs.mkdir(shopDir, { recursive: true });
-  ({ trackEvent } = require("@platform-core/analytics"));
+  ({ trackEvent } = require("@acme/platform-core/analytics"));
   process.env.CART_COOKIE_SECRET = "secret";
   process.env.CAMPAIGN_FROM = "campaign@example.com";
   process.env.NEXT_PUBLIC_BASE_URL = "http://example.com";

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 import { setCampaignStore, fsCampaignStore } from "../storage";
 import type { CampaignStore, Campaign } from "../storage";
 
@@ -16,11 +16,11 @@ jest.mock("../segments", () => ({
   resolveSegment: jest.fn(),
 }));
 
-jest.mock("@platform-core/analytics", () => ({
+jest.mock("@acme/platform-core/analytics", () => ({
   __esModule: true,
   trackEvent: jest.fn().mockResolvedValue(undefined),
 }));
-jest.mock("@platform-core/repositories/analytics.server", () => ({
+jest.mock("@acme/platform-core/repositories/analytics.server", () => ({
   __esModule: true,
   listEvents: jest.fn().mockResolvedValue([]),
 }));
@@ -34,7 +34,7 @@ jest.mock(
 );
 const { sendCampaignEmail } = require("../send");
 const sendCampaignEmailMock = sendCampaignEmail as jest.Mock;
-const { listEvents } = require("@platform-core/repositories/analytics.server");
+const { listEvents } = require("@acme/platform-core/repositories/analytics.server");
 const listEventsMock = listEvents as jest.Mock;
 
 describe("scheduler", () => {

--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -2,7 +2,7 @@ const listEventsMock = jest.fn();
 const statMock = jest.fn();
 const readFileMock = jest.fn();
 
-jest.mock("@platform-core/repositories/analytics.server", () => ({
+jest.mock("@acme/platform-core/repositories/analytics.server", () => ({
   listEvents: (...args: unknown[]) => listEventsMock(...args),
 }));
 

--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -26,7 +26,7 @@ jest.mock("../providers/resend", () => ({
 }));
 
 jest.mock("../scheduler", () => ({}));
-jest.mock("@platform-core/analytics", () => ({
+jest.mock("@acme/platform-core/analytics", () => ({
   trackEvent: jest.fn(),
 }));
 

--- a/packages/email/src/abandonedCart.js
+++ b/packages/email/src/abandonedCart.js
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { sendCampaignEmail } from "./send";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 const DEFAULT_DELAY_MS = 1000 * 60 * 60 * 24;
 function envKey(shop) {
     return `ABANDONED_CART_DELAY_MS_${shop

--- a/packages/email/src/abandonedCart.ts
+++ b/packages/email/src/abandonedCart.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { sendCampaignEmail } from "./send";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 
 const DEFAULT_DELAY_MS = 1000 * 60 * 60 * 24;
 

--- a/packages/email/src/analytics.js
+++ b/packages/email/src/analytics.js
@@ -1,4 +1,4 @@
-import { trackEvent } from "@platform-core/analytics";
+import { trackEvent } from "@acme/platform-core/analytics";
 import { coreEnv } from "@acme/config/env/core";
 import { getCampaignStore } from "./storage";
 import { SendgridProvider } from "./providers/sendgrid";

--- a/packages/email/src/analytics.ts
+++ b/packages/email/src/analytics.ts
@@ -1,4 +1,4 @@
-import { trackEvent } from "@platform-core/analytics";
+import { trackEvent } from "@acme/platform-core/analytics";
 import { coreEnv } from "@acme/config/env/core";
 import { getCampaignStore } from "./storage";
 import { SendgridProvider } from "./providers/sendgrid";

--- a/packages/email/src/hooks.js
+++ b/packages/email/src/hooks.js
@@ -20,7 +20,7 @@ export async function emitClick(shop, payload) {
     await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
 }
 async function track(shop, data) {
-    const { trackEvent } = await import("@platform-core/analytics");
+    const { trackEvent } = await import("@acme/platform-core/analytics");
     await trackEvent(shop, data);
 }
 // default analytics listeners

--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -36,7 +36,7 @@ export async function emitClick(shop: string, payload: HookPayload): Promise<voi
 }
 
 async function track(shop: string, data: AnalyticsEvent): Promise<void> {
-  const { trackEvent } = await import("@platform-core/analytics");
+  const { trackEvent } = await import("@acme/platform-core/analytics");
   await trackEvent(shop, data);
 }
 

--- a/packages/email/src/scheduler.js
+++ b/packages/email/src/scheduler.js
@@ -1,7 +1,7 @@
 import { sendCampaignEmail } from "./send";
 import { resolveSegment } from "./segments";
 import { emitSend } from "./hooks";
-import { listEvents } from "@platform-core/repositories/analytics.server";
+import { listEvents } from "@acme/platform-core/repositories/analytics.server";
 import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
 import { getCampaignStore } from "./storage";

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -1,8 +1,8 @@
 import { sendCampaignEmail } from "./send";
 import { resolveSegment } from "./segments";
 import { emitSend } from "./hooks";
-import { listEvents } from "@platform-core/repositories/analytics.server";
-import type { AnalyticsEvent } from "@platform-core/analytics";
+import { listEvents } from "@acme/platform-core/repositories/analytics.server";
+import type { AnalyticsEvent } from "@acme/platform-core/analytics";
 import { coreEnv } from "@acme/config/env/core";
 import { validateShopName } from "@acme/lib";
 import { getCampaignStore } from "./storage";

--- a/packages/email/src/segments.js
+++ b/packages/email/src/segments.js
@@ -1,7 +1,7 @@
-import { listEvents } from "@platform-core/repositories/analytics.server";
+import { listEvents } from "@acme/platform-core/repositories/analytics.server";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 import { coreEnv } from "@acme/config/env/core";
 import { SendgridProvider } from "./providers/sendgrid";

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -1,8 +1,8 @@
-import { listEvents } from "@platform-core/repositories/analytics.server";
-import type { AnalyticsEvent } from "@platform-core/analytics";
+import { listEvents } from "@acme/platform-core/repositories/analytics.server";
+import type { AnalyticsEvent } from "@acme/platform-core/analytics";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 import { coreEnv } from "@acme/config/env/core";
 import { SendgridProvider } from "./providers/sendgrid";

--- a/packages/email/src/storage/fsStore.js
+++ b/packages/email/src/storage/fsStore.js
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 function campaignsPath(shop) {
     shop = validateShopName(shop);

--- a/packages/email/src/storage/fsStore.ts
+++ b/packages/email/src/storage/fsStore.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { Campaign } from "../types";
 import type { CampaignStore } from "./types";
-import { DATA_ROOT } from "@platform-core/dataRoot";
+import { DATA_ROOT } from "@acme/platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 
 function campaignsPath(shop: string): string {

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -15,6 +15,12 @@
       "@platform-core/*": [
         "../platform-core/dist/*"
       ],
+      "@acme/platform-core": [
+        "../platform-core/dist/index"
+      ],
+      "@acme/platform-core/*": [
+        "../platform-core/dist/*"
+      ],
       "@date-utils": [
         "types-compat/date-utils"
       ],


### PR DESCRIPTION
## Summary
- safeguard NEXT_PUBLIC_LUXURY_FEATURES parsing in shop pages
- reference platform-core via workspace package in email service and tests
- map @acme/platform-core paths to built output for email package

## Testing
- `pnpm exec jest packages/email/src/__tests__/segments.test.ts -c jest.config.cjs --runTestsByPath` *(fails: Could not locate module @acme/platform-core/repositories/analytics.server mapped as /workspace/base-shop/packages/platform-core/$1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5816f3a70832fbdc714782dde00ec