### PR TITLE
fix luxury flags parsing and email tsconfig

### DIFF
--- a/apps/shop-abc/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/shop/page.tsx
@@ -33,7 +33,11 @@ export default async function ShopIndexPage({
 
   let latestPost: BlogPost | undefined;
   try {
-    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    const luxury = JSON.parse(
+      typeof env.NEXT_PUBLIC_LUXURY_FEATURES === "string"
+        ? env.NEXT_PUBLIC_LUXURY_FEATURES
+        : "{}",
+    );
     if (luxury.contentMerchandising && luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -19,7 +19,11 @@ export default async function ShopIndexPage({
 }) {
   let latestPost: BlogPost | undefined;
   try {
-    const luxury = JSON.parse(env.NEXT_PUBLIC_LUXURY_FEATURES ?? "{}");
+    const luxury = JSON.parse(
+      typeof env.NEXT_PUBLIC_LUXURY_FEATURES === "string"
+        ? env.NEXT_PUBLIC_LUXURY_FEATURES
+        : "{}",
+    );
     if (luxury.contentMerchandising && luxury.blog) {
       const posts = await fetchPublishedPosts(shop.id);
       const first = posts[0];

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -9,20 +9,15 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@platform-core": ["../platform-core/dist/index"],
-      "@platform-core/*": ["../platform-core/dist/*"],
-      "@acme/config": ["../config/dist/index"],
-      "@acme/config/*": ["../config/dist/*"],
-      "@acme/lib": ["../lib/dist/index"],
-      "@acme/lib/*": ["../lib/dist/*"],
-      "@acme/types": ["../types/dist/index"],
-      "@acme/types/*": ["../types/dist/*"],
       "@date-utils": ["types-compat/date-utils"],
       "@acme/ui": ["types-compat/ui"]
     }
   },
-  "include": [
-    "src",
-    "types-compat/**/*.d.ts"
+  "include": ["src", "types-compat/**/*.d.ts"],
+  "references": [
+    { "path": "../platform-core" },
+    { "path": "../config" },
+    { "path": "../lib" },
+    { "path": "../types" }
   ]
 }


### PR DESCRIPTION
## Summary
- safely parse NEXT_PUBLIC_LUXURY_FEATURES for shop pages
- set up project references for email package tsconfig

## Testing
- `pnpm tsc -p packages/email/tsconfig.json` *(fails: Cannot find module '@platform-core/dataRoot' or its corresponding type declarations)*
- `pnpm --filter @acme/email test` *(fails: Configuration error: Could not locate module @cms/actions/shops.server mapped as /workspace/base-shop/apps/cms/$1)*
- `pnpm tsc -p apps/shop-bcd/tsconfig.json` *(fails: Cannot find module '@/lib/cartCookie' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a5870d9034832f92634ab271b8c41b