### PR TITLE
fix: resolve platform core paths in scripts

### DIFF
--- a/scripts/src/create-shop.ts
+++ b/scripts/src/create-shop.ts
@@ -39,7 +39,7 @@ const { shopId, options, themeProvided, templateProvided } = parseArgs(
 );
 if (themeProvided || templateProvided) {
   try {
-    ensureTemplateExists(options.theme, options.template);
+    ensureTemplateExists(options.theme as string, options.template as string);
   } catch (err) {
     console.error((err as Error).message);
     process.exit(1);

--- a/scripts/src/createShop/prompts.ts
+++ b/scripts/src/createShop/prompts.ts
@@ -114,7 +114,7 @@ export async function gatherOptions(
 
   /** Prompt for payment providers when none are provided on the command line. */
   async function ensurePayment() {
-    if (options.payment.length === 0 && process.stdin.isTTY) {
+    if ((options.payment as string[]).length === 0 && process.stdin.isTTY) {
       const providers = await listProviders("payment");
       const rl = readline.createInterface({
         input: process.stdin,
@@ -138,7 +138,7 @@ export async function gatherOptions(
 
   /** Prompt for shipping providers when none are provided on the command line. */
   async function ensureShipping() {
-    if (options.shipping.length === 0 && process.stdin.isTTY) {
+    if ((options.shipping as string[]).length === 0 && process.stdin.isTTY) {
       const providers = await listProviders("shipping");
       const rl = readline.createInterface({
         input: process.stdin,

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -21,6 +21,12 @@
     /* ───── Node typings only ───── */
     "types": ["node"],
 
+    /* ───── workspace package resolution ───── */
+    "paths": {
+      "@acme/platform-core": ["./packages/platform-core/src/index"],
+      "@acme/platform-core/*": ["./packages/platform-core/src/*"]
+    },
+
     /* ───── keep imports extension-less ───── */
   },
 
@@ -28,7 +34,8 @@
   "references": [
     { "path": "../packages/platform-core" },
     { "path": "../packages/lib" },
-    { "path": "../packages/config" }
+    { "path": "../packages/config" },
+    { "path": "../packages/types" }
   ],
 
   /* ───── source globs ───── */


### PR DESCRIPTION
## Summary
- map @acme/platform-core to local sources for scripts
- tighten type usage in create-shop utilities

## Testing
- `pnpm -w tsc -p scripts/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68a594032c30832f9e875780600a737f