### PR TITLE
fix: address cms types

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
@@ -7,14 +7,14 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/atoms/shadcn";
+} from "@ui/components/atoms/shadcn";
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/atoms";
+} from "@ui/components/atoms";
 import ProductPageBuilder from "@/components/cms/ProductPageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@acme/types";
@@ -22,7 +22,7 @@ import { historyStateSchema } from "@acme/types";
 import { apiRequest } from "../lib/api";
 import { ulid } from "ulid";
 import { useEffect, useState } from "react";
-import { Toast } from "@/components/atoms";
+import { Toast } from "@ui/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 
@@ -80,15 +80,15 @@ export default function StepProductPage({
           : data.find((p) => p.slug === "product");
         if (existing) {
           setProductPageId(existing.id);
-          setProductComponents(existing.components);
+          setProductComponents(existing.components as PageComponent[]);
           if (typeof window !== "undefined") {
             localStorage.setItem(
               `page-builder-history-${existing.id}`,
               JSON.stringify(
                 historyStateSchema.parse(
-                  existing.history ?? {
+                  (existing as any).history ?? {
                     past: [],
-                    present: existing.components,
+                    present: existing.components as PageComponent[],
                     future: [],
                   }
                 )
@@ -119,7 +119,7 @@ export default function StepProductPage({
           <SelectItem
             value="blank"
             asChild
-            onSelect={(e) => {
+            onSelect={(e: Event) => {
               e.preventDefault();
               setSelectOpen(false);
               setPendingTemplate({ name: "blank", components: [], preview: "" });
@@ -134,7 +134,7 @@ export default function StepProductPage({
               key={t.name}
               value={t.name}
               asChild
-              onSelect={(e) => {
+              onSelect={(e: Event) => {
                 e.preventDefault();
                 setSelectOpen(false);
                 setPendingTemplate(t);
@@ -156,7 +156,7 @@ export default function StepProductPage({
       </Select>
       <Dialog
         open={!!pendingTemplate}
-        onOpenChange={(o) => {
+        onOpenChange={(o: boolean) => {
           if (!o) setPendingTemplate(null);
         }}
       >
@@ -225,7 +225,7 @@ export default function StepProductPage({
             createdBy: "",
           } as Page
         }
-        onSave={async (fd) => {
+        onSave={async (fd: FormData) => {
           setIsSaving(true);
           setSaveError(null);
           const { data, error } = await apiRequest<{ id: string }>(
@@ -240,7 +240,7 @@ export default function StepProductPage({
             setSaveError(error);
           }
         }}
-        onPublish={async (fd) => {
+        onPublish={async (fd: FormData) => {
           setIsPublishing(true);
           setPublishError(null);
           fd.set("status", "published");

--- a/apps/cms/src/app/cms/configurator/steps/StepSeedData.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepSeedData.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Button, Input } from "@ui/components/atoms/shadcn";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 
@@ -30,14 +30,18 @@ export default function StepSeedData({
         <span>Product CSV</span>
         <Input
           type="file"
-          onChange={(e) => setCsvFile(e.target.files?.[0] ?? null)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setCsvFile(e.target.files?.[0] ?? null)
+          }
         />
       </label>
       <label className="flex flex-col gap-1">
         <span>Categories (comma or newline separated)</span>
         <Input
           value={categoriesText}
-          onChange={(e) => setCategoriesText(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setCategoriesText(e.target.value)
+          }
           placeholder="Shoes, Shirts, Accessories"
         />
       </label>

--- a/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
@@ -8,7 +8,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/atoms/shadcn";
+} from "@ui/components/atoms/shadcn";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { z } from "zod";
@@ -107,7 +107,7 @@ export default function StepShopDetails({
         <span>Shop ID</span>
         <Input
           value={shopId}
-          onChange={(e) => setShopId(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setShopId(e.target.value)}
           placeholder="my-shop"
         />
         {getError("id") && (
@@ -118,7 +118,7 @@ export default function StepShopDetails({
         <span>Store Name</span>
         <Input
           value={storeName}
-          onChange={(e) => setStoreName(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setStoreName(e.target.value)}
           placeholder="My Store"
         />
         {getError("name") && (
@@ -129,7 +129,7 @@ export default function StepShopDetails({
         <span>Logo URL</span>
         <Input
           value={logo}
-          onChange={(e) => setLogo(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLogo(e.target.value)}
           placeholder="https://example.com/logo.png"
         />
         {getError("logo") && (
@@ -140,7 +140,7 @@ export default function StepShopDetails({
         <span>Contact Info</span>
         <Input
           value={contactInfo}
-          onChange={(e) => setContactInfo(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setContactInfo(e.target.value)}
           placeholder="Email or phone"
         />
         {getError("contactInfo") && (

--- a/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
@@ -7,21 +7,21 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/atoms/shadcn";
+} from "@ui/components/atoms/shadcn";
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/atoms";
+} from "@ui/components/atoms";
 import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@acme/types";
 import { apiRequest } from "../lib/api";
 import { ulid } from "ulid";
 import { useState } from "react";
-import { Toast } from "@/components/atoms";
+import { Toast } from "@ui/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 import { STORAGE_KEY } from "../hooks/useConfiguratorPersistence";
@@ -89,7 +89,7 @@ export default function StepShopPage({
           <SelectItem
             value="blank"
             asChild
-            onSelect={(e) => {
+            onSelect={(e: Event) => {
               e.preventDefault();
               setSelectOpen(false);
               setPendingTemplate({ name: "blank", components: [], preview: "" });
@@ -104,7 +104,7 @@ export default function StepShopPage({
               key={t.name}
               value={t.name}
               asChild
-              onSelect={(e) => {
+              onSelect={(e: Event) => {
                 e.preventDefault();
                 setSelectOpen(false);
                 setPendingTemplate(t);
@@ -126,7 +126,7 @@ export default function StepShopPage({
       </Select>
       <Dialog
         open={!!pendingTemplate}
-        onOpenChange={(o) => {
+        onOpenChange={(o: boolean) => {
           if (!o) setPendingTemplate(null);
         }}
       >
@@ -211,7 +211,7 @@ export default function StepShopPage({
             createdBy: "",
           } as Page
         }
-        onSave={async (fd) => {
+        onSave={async (fd: FormData) => {
           setIsSaving(true);
           setSaveError(null);
           const { data, error } = await apiRequest<{ id: string }>(
@@ -226,7 +226,7 @@ export default function StepShopPage({
             setSaveError(error);
           }
         }}
-        onPublish={async (fd) => {
+        onPublish={async (fd: FormData) => {
           setIsPublishing(true);
           setPublishError(null);
           fd.set("status", "published");

--- a/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Button, Input } from "@ui/components/atoms/shadcn";
 import { LOCALES } from "@acme/i18n";
 import type { Locale } from "@acme/types";
 import React from "react";
@@ -104,7 +104,7 @@ export default function StepSummary({
             <span>Home page title ({l})</span>
             <Input
               value={pageTitle[l]}
-              onChange={(e) =>
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setPageTitle({ ...pageTitle, [l]: e.target.value })
               }
               placeholder="Home"
@@ -120,7 +120,7 @@ export default function StepSummary({
             <span>Description ({l})</span>
             <Input
               value={pageDescription[l]}
-              onChange={(e) =>
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setPageDescription({
                   ...pageDescription,
                   [l]: e.target.value,
@@ -141,7 +141,9 @@ export default function StepSummary({
         <span>Social image URL</span>
         <Input
           value={socialImage}
-          onChange={(e) => setSocialImage(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setSocialImage(e.target.value)
+          }
           placeholder="https://example.com/og.png"
         />
         {errors.socialImage && (

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -7,7 +7,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/atoms/shadcn";
+} from "@ui/components/atoms/shadcn";
 import StyleEditor from "@ui/components/cms/StyleEditor";
 import { useCallback, useEffect, useState, useMemo } from "react";
 import type { TokenMap } from "@ui/hooks/useTokenEditor";
@@ -91,7 +91,8 @@ export default function StepTheme({
   );
   const device = useMemo<DevicePreset>(() => {
     const preset =
-      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+      devicePresets.find((d: DevicePreset) => d.id === deviceId) ??
+      devicePresets[0];
     return orientation === "portrait"
       ? { ...preset, orientation }
       : {
@@ -125,10 +126,8 @@ export default function StepTheme({
     (tokens: TokenMap) => {
       setThemeOverrides(
         Object.fromEntries(
-          Object.entries(tokens).filter(
-            ([k, v]) => themeDefaults[k] !== v
-          )
-        )
+          Object.entries(tokens).filter(([k, v]) => themeDefaults[k] !== v)
+        ) as Record<string, string>
       );
     },
     [setThemeOverrides, themeDefaults]
@@ -163,7 +162,7 @@ export default function StepTheme({
       {/* single accessible combobox (theme) */}
       <Select
         value={theme}
-        onValueChange={(v) => {
+        onValueChange={(v: string) => {
           update("theme", v);
           setThemeOverrides({});
           if (typeof window !== "undefined") {
@@ -257,7 +256,7 @@ export default function StepTheme({
         <DeviceSelector
           deviceId={deviceId}
           orientation={orientation}
-          setDeviceId={(id) => {
+          setDeviceId={(id: string) => {
             setDeviceId(id);
             setOrientation("portrait");
           }}

--- a/apps/cms/src/app/cms/dashboard/[shop]/components/Charts.client.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/components/Charts.client.tsx
@@ -167,11 +167,13 @@ export function Charts({
         <Line
           data={{
             labels: discountRedemptionsByCode.labels,
-            datasets: discountRedemptionsByCode.datasets.map((d, i) => ({
-              label: d.label,
-              data: d.data,
-              borderColor: colors[i % colors.length],
-            })),
+            datasets: discountRedemptionsByCode.datasets.map(
+              (d: { label: string; data: number[] }, i: number) => ({
+                label: d.label,
+                data: d.data,
+                borderColor: colors[i % colors.length],
+              })
+            ),
           }}
         />
       </div>

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.tsx
@@ -66,7 +66,7 @@ export default async function ShopDashboard({
                 <div className="mt-4">
                   <h3 className="mb-2 font-semibold">Top discount codes</h3>
                   <ul className="list-inside list-disc">
-                    {metrics.topDiscountCodes.map(([code, count]) => (
+                    {metrics.topDiscountCodes.map(([code, count]: [string, number]) => (
                       <li key={code}>
                         {code}: {count}
                       </li>

--- a/apps/cms/src/app/cms/rbac/page.tsx
+++ b/apps/cms/src/app/cms/rbac/page.tsx
@@ -1,5 +1,5 @@
 // apps/cms/src/app/cms/rbac/page.tsx
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Button, Input } from "@ui/components/atoms/shadcn";
 import {
   inviteUser,
   listUsers,
@@ -19,7 +19,7 @@ export default async function RbacPage() {
     redirect("/cms");
   }
 
-  const users = await listUsers();
+  const users: Awaited<ReturnType<typeof listUsers>> = await listUsers();
 
   async function save(formData: FormData) {
     "use server";

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Button, Textarea } from "@/components/atoms/shadcn";
+import { Button, Textarea } from "@ui/components/atoms/shadcn";
 import { pricingSchema, type PricingMatrix } from "@acme/types";
-import { FormEvent, useState } from "react";
+import { useState } from "react";
+import type { FormEvent, ChangeEvent } from "react";
 
 interface Props {
   shop: string;
@@ -48,7 +49,7 @@ export default function PricingForm({ shop, initial }: Props) {
     <form onSubmit={onSubmit} className="space-y-4">
       <Textarea
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
         rows={10}
       />
       {status === "saved" && (

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/ReturnLogisticsForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Button, Input, Checkbox } from "@/components/atoms/shadcn";
+import { Button, Input, Checkbox } from "@ui/components/atoms/shadcn";
 import { returnLogisticsSchema, type ReturnLogistics } from "@acme/types";
-import { FormEvent, useState } from "react";
+import { useState } from "react";
+import type { FormEvent, ChangeEvent } from "react";
 
 type FormState = Omit<ReturnLogistics, "returnCarrier"> & {
   returnCarrier: string[];
@@ -63,7 +64,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         <span>Label Service</span>
         <Input
           value={form.labelService}
-          onChange={(e) =>
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
             setForm((f) => ({
               ...f,
               labelService: e.target.value as FormState["labelService"],
@@ -74,7 +75,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
       <label className="flex items-center gap-2">
         <Checkbox
           checked={form.inStore}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setForm((f) => ({ ...f, inStore: Boolean(v) }))
           }
         />
@@ -84,7 +85,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         <span>Drop-off Provider</span>
         <Input
           value={form.dropOffProvider ?? ""}
-          onChange={(e) =>
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
             setForm((f) => ({
               ...f,
               dropOffProvider: e.target.value || undefined,
@@ -96,7 +97,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
         <span>Bag Type</span>
         <Input
           value={form.bagType}
-          onChange={(e) =>
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
             setForm((f) => ({
               ...f,
               bagType: e.target.value as FormState["bagType"],
@@ -110,7 +111,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
           <div key={i} className="flex items-center gap-2">
             <Input
               value={carrier}
-              onChange={(e) =>
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setForm((f) => {
                   const next = [...f.returnCarrier];
                   next[i] = e.target.value;
@@ -151,7 +152,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
           <div key={i} className="flex items-center gap-2">
             <Input
               value={zip}
-              onChange={(e) =>
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setForm((f) => {
                   const next = [...f.homePickupZipCodes];
                   next[i] = e.target.value;
@@ -191,7 +192,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
       <label className="flex items-center gap-2">
         <Checkbox
           checked={Boolean(form.tracking)}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setForm((f) => ({ ...f, tracking: Boolean(v) }))
           }
         />
@@ -200,7 +201,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
       <label className="flex items-center gap-2">
         <Checkbox
           checked={form.requireTags}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setForm((f) => ({ ...f, requireTags: Boolean(v) }))
           }
         />
@@ -209,7 +210,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
       <label className="flex items-center gap-2">
         <Checkbox
           checked={form.allowWear}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setForm((f) => ({ ...f, allowWear: Boolean(v) }))
           }
         />
@@ -218,7 +219,7 @@ export default function ReturnLogisticsForm({ shop, initial }: Props) {
       <label className="flex items-center gap-2">
         <Checkbox
           checked={Boolean(form.mobileApp)}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setForm((f) => ({ ...f, mobileApp: Boolean(v) }))
           }
         />

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
@@ -1,5 +1,5 @@
 import { checkShopExists } from "@acme/lib";
-import { readReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
+import { readReturnLogistics } from "@platform-core/src/repositories/returnLogistics.server";
 import { notFound } from "next/navigation";
 import ReturnLogisticsForm from "./ReturnLogisticsForm";
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { Button, Input } from "@/components/atoms/shadcn";
+import { Button, Input } from "@ui/components/atoms/shadcn";
 import { updateCurrencyAndTax } from "@cms/actions/shops.server";
-import { useState, FormEvent, ChangeEvent } from "react";
+import { useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
 
 interface Props {
   shop: string;

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Checkbox, Input } from "@/components/atoms/shadcn";
+import { Button, Checkbox, Input } from "@ui/components/atoms/shadcn";
 import { updateDeposit } from "@cms/actions/shops.server";
 import { useState, type ChangeEvent, type FormEvent } from "react";
 
@@ -39,7 +39,7 @@ export default function DepositsEditor({ shop, initial }: Props) {
         <Checkbox
           name="enabled"
           checked={state.enabled}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setState((s) => ({ ...s, enabled: Boolean(v) }))
           }
         />


### PR DESCRIPTION
## Summary
- fix type-only imports and implicit any in CMS forms
- update CMS pages to use shared UI component paths
- tighten configurator types and event handlers

## Testing
- `pnpm tsc -p apps/cms/tsconfig.json` *(fails: Could not find a declaration file for module 'jsdom')*
- `pnpm --filter @apps/cms lint` *(fails: Parsing error: Unexpected token <)*
- `pnpm --filter @apps/cms test` *(fails: Package subpath './jest.preset.cjs' is not defined by "exports")*

------
https://chatgpt.com/codex/tasks/task_e_68a594e9a7b8832f9c6d563ed63eb508