### PR TITLE
fix configurator step types

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
@@ -4,8 +4,11 @@ import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
 import TemplateSelector from "../components/TemplateSelector";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@acme/types";
-import { historyStateSchema } from "@acme/types";
+import {
+  type Page,
+  type PageComponent,
+  historyStateSchema,
+} from "@acme/types";
 import { apiRequest } from "../lib/api";
 import { useEffect, useState } from "react";
 import { Toast } from "@/components/atoms";
@@ -62,12 +65,12 @@ export default function StepHomePage({
         `/cms/api/pages/${shopId}`,
       );
       if (data) {
-        const existing = homePageId
+        const existing: Page | undefined = homePageId
           ? data.find((p) => p.id === homePageId)
           : data.find((p) => p.slug === "");
         if (existing) {
           setHomePageId(existing.id);
-          setComponents(existing.components);
+          setComponents(existing.components as PageComponent[]);
           if (typeof window !== "undefined") {
             localStorage.setItem(
               `page-builder-history-${existing.id}`,
@@ -75,7 +78,7 @@ export default function StepHomePage({
                 historyStateSchema.parse(
                   existing.history ?? {
                     past: [],
-                    present: existing.components,
+                    present: existing.components as PageComponent[],
                     future: [],
                   }
                 )
@@ -134,7 +137,7 @@ export default function StepHomePage({
             createdBy: "",
           } as Page
         }
-        onSave={async (fd) => {
+        onSave={async (fd: FormData) => {
           setIsSaving(true);
           setSaveError(null);
           const { data, error } = await apiRequest<{ id: string }>(
@@ -149,7 +152,7 @@ export default function StepHomePage({
             setSaveError(error);
           }
         }}
-        onPublish={async (fd) => {
+        onPublish={async (fd: FormData) => {
           setIsPublishing(true);
           setPublishError(null);
           fd.set("status", "published");

--- a/apps/cms/src/app/cms/configurator/steps/StepHosting.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHosting.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Input } from "@/components/atoms/shadcn";
-import { useEffect } from "react";
+import { useEffect, type ChangeEvent } from "react";
 import { getDeployStatus, type DeployInfo } from "../../wizard/services/deployShop";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
@@ -63,7 +63,9 @@ export default function StepHosting({
         <span>Custom Domain</span>
         <Input
           value={domain}
-          onChange={(e) => setDomain(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setDomain(e.target.value)
+          }
           placeholder="myshop.example.com"
         />
       </label>

--- a/apps/cms/src/app/cms/configurator/steps/StepLayout.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepLayout.tsx
@@ -6,7 +6,7 @@ import PageBuilder from "@/components/cms/PageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
 import type { Page, PageComponent } from "@acme/types";
 import { apiRequest } from "../lib/api";
-import { ReactNode, useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, type ReactNode } from "react";
 import { Toast, Spinner } from "@/components/atoms";
 import { CheckIcon } from "@radix-ui/react-icons";
 import useStepCompletion from "../hooks/useStepCompletion";
@@ -116,7 +116,7 @@ export default function StepLayout({ children }: Props): React.JSX.Element {
               createdBy: "",
             } as Page
           }
-          onSave={async (fd) => {
+          onSave={async (fd: FormData) => {
             setHeaderSaving(true);
             setHeaderError(null);
             setHeaderSaved(false);
@@ -174,7 +174,7 @@ export default function StepLayout({ children }: Props): React.JSX.Element {
               createdBy: "",
             } as Page
           }
-          onSave={async (fd) => {
+          onSave={async (fd: FormData) => {
             setFooterSaving(true);
             setFooterError(null);
             setFooterSaved(false);

--- a/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
@@ -31,7 +31,8 @@ export default function StepNavigation(): React.JSX.Element {
   );
   const device = useMemo<DevicePreset>(() => {
     const preset =
-      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+      devicePresets.find((d: DevicePreset) => d.id === deviceId) ??
+      devicePresets[0];
     return orientation === "portrait"
       ? { ...preset, orientation }
       : {

--- a/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
@@ -9,11 +9,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/atoms/shadcn";
-import { useEffect } from "react";
+import { useEffect, type ChangeEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import useStepCompletion from "../hooks/useStepCompletion";
-import { providersByType } from "@acme/configurator/providers";
+import { providersByType, type Provider } from "@acme/configurator/providers";
 
 export default function StepOptions(): React.JSX.Element {
   const { state, update } = useConfigurator();
@@ -33,11 +33,11 @@ export default function StepOptions(): React.JSX.Element {
   const searchParams = useSearchParams();
   const [, markComplete] = useStepCompletion("options");
 
-  const paymentProviders = providersByType("payment");
-  const paymentIds = paymentProviders.map((p) => p.id);
-  const shippingProviders = providersByType("shipping");
-  const shippingIds = shippingProviders.map((p) => p.id);
-  const analyticsProviders = providersByType("analytics");
+  const paymentProviders: Provider[] = providersByType("payment");
+  const paymentIds = paymentProviders.map((p: Provider) => p.id);
+  const shippingProviders: Provider[] = providersByType("shipping");
+  const shippingIds = shippingProviders.map((p: Provider) => p.id);
+  const analyticsProviders: Provider[] = providersByType("analytics");
 
   useEffect(() => {
     const provider = searchParams.get("connected");
@@ -68,7 +68,7 @@ export default function StepOptions(): React.JSX.Element {
       </p>
       <div>
         <p className="font-medium">Payment Providers</p>
-        {paymentProviders.map((p) => (
+        {paymentProviders.map((p: Provider) => (
           <div key={p.id} className="flex items-center gap-2 text-sm">
             {p.name}
             {payment.includes(p.id) ? (
@@ -81,7 +81,7 @@ export default function StepOptions(): React.JSX.Element {
       </div>
       <div>
         <p className="font-medium">Shipping Providers</p>
-        {shippingProviders.map((p) => (
+        {shippingProviders.map((p: Provider) => (
           <div key={p.id} className="flex items-center gap-2 text-sm">
             {p.name}
             {shipping.includes(p.id) ? (
@@ -96,14 +96,16 @@ export default function StepOptions(): React.JSX.Element {
         <p className="font-medium">Analytics</p>
         <Select
           value={analyticsProvider}
-          onValueChange={(v) => setAnalyticsProvider(v === "none" ? "" : v)}
+          onValueChange={(v: string) =>
+            setAnalyticsProvider(v === "none" ? "" : v)
+          }
         >
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Select provider" />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="none">None</SelectItem>
-            {analyticsProviders.map((p) => (
+            {analyticsProviders.map((p: Provider) => (
               <SelectItem key={p.id} value={p.id}>
                 {p.name}
               </SelectItem>
@@ -114,7 +116,9 @@ export default function StepOptions(): React.JSX.Element {
           <Input
             className="mt-2"
             value={analyticsId}
-            onChange={(e) => setAnalyticsId(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setAnalyticsId(e.target.value)
+            }
             placeholder="Measurement ID"
           />
         )}

--- a/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
@@ -17,8 +17,7 @@ import {
 } from "@/components/atoms";
 import ProductPageBuilder from "@/components/cms/ProductPageBuilder";
 import { fillLocales } from "@i18n/fillLocales";
-import type { Page, PageComponent } from "@acme/types";
-import { historyStateSchema } from "@acme/types";
+import { type Page, type PageComponent, historyStateSchema } from "@acme/types";
 import { apiRequest } from "../lib/api";
 import { ulid } from "ulid";
 import { useEffect, useState } from "react";
@@ -75,12 +74,12 @@ export default function StepProductPage({
         `/cms/api/pages/${shopId}`,
       );
       if (data) {
-        const existing = productPageId
+        const existing: Page | undefined = productPageId
           ? data.find((p) => p.id === productPageId)
           : data.find((p) => p.slug === "product");
         if (existing) {
           setProductPageId(existing.id);
-          setProductComponents(existing.components);
+          setProductComponents(existing.components as PageComponent[]);
           if (typeof window !== "undefined") {
             localStorage.setItem(
               `page-builder-history-${existing.id}`,
@@ -88,7 +87,7 @@ export default function StepProductPage({
                 historyStateSchema.parse(
                   existing.history ?? {
                     past: [],
-                    present: existing.components,
+                    present: existing.components as PageComponent[],
                     future: [],
                   }
                 )
@@ -225,7 +224,7 @@ export default function StepProductPage({
             createdBy: "",
           } as Page
         }
-        onSave={async (fd) => {
+        onSave={async (fd: FormData) => {
           setIsSaving(true);
           setSaveError(null);
           const { data, error } = await apiRequest<{ id: string }>(
@@ -240,7 +239,7 @@ export default function StepProductPage({
             setSaveError(error);
           }
         }}
-        onPublish={async (fd) => {
+        onPublish={async (fd: FormData) => {
           setIsPublishing(true);
           setPublishError(null);
           fd.set("status", "published");


### PR DESCRIPTION
## Summary
- add explicit type imports and history parsing in configurator steps
- specify provider, event and FormData types in options, layout, hosting and navigation components

## Testing
- `pnpm test:cms` *(fails: Could not locate module @cms/actions/shops.server etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a595f2d2c8832f91d39ec641e6cf06