### PR TITLE
fix email tsconfig paths

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -10,7 +10,9 @@
     "baseUrl": ".",
     "paths": {
       "@date-utils": ["types-compat/date-utils"],
-      "@acme/ui": ["types-compat/ui"]
+      "@acme/ui": ["types-compat/ui"],
+      "@platform-core": ["../platform-core/src"],
+      "@platform-core/*": ["../platform-core/src/*"]
     }
   },
   "include": ["src", "types-compat/**/*.d.ts"],


### PR DESCRIPTION
## Summary
- map `@platform-core` modules in email package tsconfig so imports resolve correctly

## Testing
- `npx tsc -p packages/email/tsconfig.json --noEmit`
- `pnpm --filter @acme/email test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a594143bc8832fa99f65b9f53f3047