### PR TITLE
fix: narrow provider types

### DIFF
--- a/scripts/src/createShop/parse.ts
+++ b/scripts/src/createShop/parse.ts
@@ -1,6 +1,16 @@
 import { validateShopName } from "@acme/platform-core/shops";
 import type { CreateShopOptions } from "@acme/platform-core/createShop";
 
+const PAYMENT_PROVIDERS = ["stripe", "paypal"] as const;
+const SHIPPING_PROVIDERS = ["dhl", "ups", "premier-shipping"] as const;
+
+function parseList<T extends readonly string[]>(val: string, allowed: T): T[number][] {
+  return val
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is T[number] => (allowed as readonly string[]).includes(s));
+}
+
 /** Command line options for creating a shop.
  *
  * The CLI only collects a subset of the full `CreateShopOptions` defined by
@@ -69,10 +79,10 @@ export function parseArgs(argv: string[]): {
         templateProvided = true;
         break;
       case "payment":
-        opts.payment = val.split(",").filter(Boolean);
+        opts.payment = parseList(val, PAYMENT_PROVIDERS);
         break;
       case "shipping":
-        opts.shipping = val.split(",").filter(Boolean);
+        opts.shipping = parseList(val, SHIPPING_PROVIDERS);
         break;
       case "subscriptions":
         opts.enableSubscriptions = val === "" ? true : val !== "false";

--- a/scripts/src/createShop/prompts.ts
+++ b/scripts/src/createShop/prompts.ts
@@ -127,7 +127,7 @@ export async function gatherOptions(
             options.payment = ans
               .split(",")
               .map((s) => s.trim())
-              .filter((p) => providers.includes(p));
+              .filter((p) => providers.includes(p)) as Options["payment"];
             rl.close();
             resolve();
           }
@@ -151,7 +151,7 @@ export async function gatherOptions(
             options.shipping = ans
               .split(",")
               .map((s) => s.trim())
-              .filter((p) => providers.includes(p));
+              .filter((p) => providers.includes(p)) as Options["shipping"];
             rl.close();
             resolve();
           }


### PR DESCRIPTION
## Summary
- narrow create shop payment and shipping provider parsing
- ensure prompt assignments respect provider unions

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68a59d6e0798832f9c6dcfbca89b5a7c