### PR TITLE
fix module paths

### DIFF
--- a/apps/shop-bcd/__tests__/cart-api.test.ts
+++ b/apps/shop-bcd/__tests__/cart-api.test.ts
@@ -3,7 +3,7 @@ import {
   asSetCookieHeader,
   decodeCartCookie,
   encodeCartCookie,
-} from "@/lib/cartCookie";
+} from "@platform-core/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { DELETE, GET, PATCH, POST } from "../src/api/cart/route";
 

--- a/apps/shop-bcd/__tests__/cartApi.test.ts
+++ b/apps/shop-bcd/__tests__/cartApi.test.ts
@@ -1,5 +1,5 @@
 // apps/shop-bcd/__tests__/cartApi.test.ts
-import { encodeCartCookie } from "@/lib/cartCookie";
+import { encodeCartCookie } from "@platform-core/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { PATCH, POST } from "../src/api/cart/route";
 

--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -1,5 +1,5 @@
 // apps/shop-bcd/__tests__/checkout-session.test.ts
-import { encodeCartCookie } from "@/lib/cartCookie";
+import { encodeCartCookie } from "@platform-core/cartCookie";
 import { PRODUCTS } from "@platform-core/products";
 import { calculateRentalDays } from "@acme/date-utils";
 import { POST } from "../src/api/checkout-session/route";
@@ -28,7 +28,7 @@ const stripeCreate = stripe.checkout.sessions.create as jest.Mock;
 
 jest.mock("@platform-core/analytics", () => ({ trackEvent: jest.fn() }));
 jest.mock("@auth", () => ({ getCustomerSession: jest.fn(async () => null) }));
-jest.mock("@/lib/cartCookie", () => ({
+jest.mock("@platform-core/cartCookie", () => ({
   CART_COOKIE: "__Host-CART_ID",
   encodeCartCookie: (cart: any) => JSON.stringify(cart),
   decodeCartCookie: (raw: string) => (raw ? JSON.parse(raw) : {}),

--- a/apps/shop-bcd/src/api/cart/route.d.ts
+++ b/apps/shop-bcd/src/api/cart/route.d.ts
@@ -5,11 +5,11 @@ export declare function POST(req: NextRequest): Promise<NextResponse<{
     error: string;
 }> | NextResponse<{
     ok: boolean;
-    cart: import("@/lib/cartCookie").CartState;
+    cart: import("@platform-core/cartCookie").CartState;
 }>>;
 export declare function PATCH(req: NextRequest): Promise<NextResponse<{
     error: string;
 }> | NextResponse<{
     ok: boolean;
-    cart: import("@/lib/cartCookie").CartState;
+    cart: import("@platform-core/cartCookie").CartState;
 }>>;

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -7,8 +7,8 @@ import {
   decodeCartCookie,
   encodeCartCookie,
   type CartState,
-} from "@/lib/cartCookie";
-import { getProductById, PRODUCTS } from "@/lib/products";
+} from "@platform-core/cartCookie";
+import { getProductById, PRODUCTS } from "@platform-core/products";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { postSchema, patchSchema } from "@platform-core/schemas/cart";

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -5,7 +5,7 @@ import {
   CART_COOKIE,
   decodeCartCookie,
   type CartState,
-} from "@/lib/cartCookie";
+} from "@platform-core/cartCookie";
 import { getCustomerSession } from "@auth";
 import { createCheckoutSession } from "@platform-core/checkout/session";
 import shop from "../../../shop.json";

--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { fetchPostBySlug } from "@acme/sanity";
-import { BlogPortableText } from "@/components/blog/BlogPortableText";
+import { BlogPortableText } from "@platform-core/components/blog/BlogPortableText";
 import type { Shop } from "@acme/types";
 import shopJson from "../../../../../shop.json";
 

--- a/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
@@ -1,9 +1,9 @@
 // apps/shop-bcd/src/app/[lang]/checkout/page.tsx
-import CheckoutForm from "@/components/checkout/CheckoutForm";
-import OrderSummary from "@/components/organisms/OrderSummary";
+import CheckoutForm from "@ui/components/checkout/CheckoutForm";
+import OrderSummary from "@ui/components/organisms/OrderSummary";
 import { DeliveryScheduler } from "@ui/components/organisms";
-import { Locale, resolveLocale } from "@/i18n/locales";
-import { CART_COOKIE, decodeCartCookie } from "@/lib/cartCookie";
+import { Locale, resolveLocale } from "@i18n/locales";
+import { CART_COOKIE, decodeCartCookie } from "@platform-core/cartCookie";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import shop from "../../../../shop.json";

--- a/apps/shop-bcd/src/app/[lang]/layout.tsx
+++ b/apps/shop-bcd/src/app/[lang]/layout.tsx
@@ -1,7 +1,7 @@
 // apps/shop-bcd/src/app/[lang]/layout.tsx
 
-import Footer from "@/components/layout/Footer";
-import Header from "@/components/layout/Header";
+import Footer from "@ui/components/layout/Footer";
+import Header from "@ui/components/layout/Header";
 import TranslationsProvider from "@i18n/Translations";
 import { Locale, resolveLocale } from "@i18n/locales";
 import { DefaultSeo } from "next-seo";

--- a/apps/shop-bcd/src/app/[lang]/page.client.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.client.tsx
@@ -4,7 +4,7 @@
 import DynamicRenderer from "@ui/components/DynamicRenderer";
 import type { PageComponent } from "@acme/types";
 import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
-import type { Locale } from "@/i18n/locales";
+import type { Locale } from "@i18n/locales";
 
 export default function Home({
   components,

--- a/apps/shop-bcd/src/app/[lang]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/page.tsx
@@ -5,7 +5,7 @@ import shop from "../../../shop.json";
 import Home from "./page.client";
 import { fetchPublishedPosts } from "@acme/sanity";
 import type { BlogPost } from "@ui/components/cms/blocks/BlogListing";
-import { Locale, resolveLocale } from "@/i18n/locales";
+import { Locale, resolveLocale } from "@i18n/locales";
 
 async function loadComponents(): Promise<PageComponent[]> {
   try {

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -1,5 +1,5 @@
 // apps/shop-bcd/src/app/[lang]/shop/page.tsx
-import { PRODUCTS } from "@/lib/products";
+import { PRODUCTS } from "@platform-core/products";
 import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
 import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";

--- a/apps/shop-bcd/src/app/api/search/route.ts
+++ b/apps/shop-bcd/src/app/api/search/route.ts
@@ -1,6 +1,6 @@
 // apps/shop-bcd/src/app/api/search/route.ts
 import { NextResponse } from "next/server";
-import { PRODUCTS } from "@/lib/products";
+import { PRODUCTS } from "@platform-core/products";
 import { fetchPublishedPosts } from "@acme/sanity";
 import shop from "../../../../shop.json";
 

--- a/apps/shop-bcd/src/app/layout.tsx
+++ b/apps/shop-bcd/src/app/layout.tsx
@@ -1,6 +1,6 @@
 // src/app/layout.tsx
 import "./globals.css";
-import { CartProvider } from "@/contexts/CartContext";
+import { CartProvider } from "@platform-core/contexts/CartContext";
 import { initTheme } from "@platform-core/utils";
 import "@acme/zod-utils/initZod";
 import { initPlugins } from "@platform-core/plugins";

--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -1,5 +1,38 @@
 {
   "extends": "@acme/config/tsconfig.app.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*",
+        "../../packages/ui/src/*",
+        "../../packages/i18n/src/*"
+      ],
+      "@ui/*": ["../../packages/ui/src/*"],
+      "@ui/src/*": ["../../packages/ui/src/*"],
+      "@i18n/*": ["../../packages/i18n/src/*"],
+      "@platform-core": ["../../packages/platform-core/src/index"],
+      "@platform-core/*": ["../../packages/platform-core/src/*"],
+      "@acme/platform-core": ["../../packages/platform-core/src/index"],
+      "@acme/platform-core/*": ["../../packages/platform-core/src/*"],
+      "@auth": [
+        "../../packages/auth/src/index",
+        "../../packages/auth/src"
+      ],
+      "@auth/*": ["../../packages/auth/src/*"],
+      "@date-utils": [
+        "../../packages/date-utils/src/index",
+        "../../packages/date-utils/src"
+      ],
+      "@date-utils/*": ["../../packages/date-utils/src/*"],
+      "@shared-utils": [
+        "../../packages/shared-utils/src/index",
+        "../../packages/shared-utils/src"
+      ],
+      "@shared-utils/*": ["../../packages/shared-utils/src/*"]
+    }
+  },
   "include": ["src/**/*", ".next/types/**/*.ts", "shop.json"],
   "exclude": [
     "dist",


### PR DESCRIPTION
## Summary
- configure shop-bcd TypeScript paths to resolve shared packages
- replace stale `@/` imports with proper package aliases
- adjust tests for new module locations

## Testing
- `CI=true pnpm exec jest apps/shop-bcd --runInBand` *(fails: Could not locate module @auth, @acme/stripe)*

------
https://chatgpt.com/codex/tasks/task_e_68a59dac6890832fb2f8d7d1f496e211