### PR TITLE
fix misc ts errors and add missing type decls

### DIFF
--- a/apps/cms/src/lib/analytics.ts
+++ b/apps/cms/src/lib/analytics.ts
@@ -37,9 +37,11 @@ export function buildMetrics(
         (campaignSalesCountByDay[day] || 0) + 1;
     } else if (e.type === "discount_redeemed") {
       const code = e.code;
-      const entry = discountByCodeByDay[day] || {};
-      entry[code] = (entry[code] || 0) + 1;
-      discountByCodeByDay[day] = entry;
+      if (code) {
+        const entry = discountByCodeByDay[day] || {};
+        entry[code] = (entry[code] || 0) + 1;
+        discountByCodeByDay[day] = entry;
+      }
     }
   }
 

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -54,7 +54,7 @@ async function filterExistingProductSlugs(shopId: string, slugs: string[]): Prom
 
 async function getConfig(shopId: string): Promise<SanityConfig> {
   const shop = await getShopById(shopId);
-  const sanity = getSanityConfig(shop);
+  const sanity = getSanityConfig(shop) as SanityConfig | undefined;
   if (!sanity) {
     throw new Error(`Missing Sanity config for shop ${shopId}`);
   }

--- a/apps/cms/src/services/shops/validation.ts
+++ b/apps/cms/src/services/shops/validation.ts
@@ -45,7 +45,9 @@ export function parseShopForm(formData: FormData): {
     ),
   );
 
-  const entries = Array.from(formData.entries()).filter(
+  const entries = Array.from(
+    formData as unknown as Iterable<[string, FormDataEntryValue]>
+  ).filter(
     ([k]) =>
       ![
         "filterMappingsKey",
@@ -54,8 +56,8 @@ export function parseShopForm(formData: FormData): {
         "priceOverridesValue",
         "localeOverridesKey",
         "localeOverridesValue",
-      ].includes(k),
-  );
+      ].includes(k)
+  ) as [string, FormDataEntryValue][];
 
   const parsed = shopSchema.safeParse({
     ...Object.fromEntries(entries),

--- a/packages/email/types-compat/jsdom.d.ts
+++ b/packages/email/types-compat/jsdom.d.ts
@@ -1,0 +1,6 @@
+declare module "jsdom" {
+  export class JSDOM {
+    constructor(html?: string, options?: any);
+    window: any;
+  }
+}

--- a/packages/platform-core/src/analytics.ts
+++ b/packages/platform-core/src/analytics.ts
@@ -1,3 +1,4 @@
-export type { AnalyticsEvent } from "./analytics/index";
+// Expose the analytics helpers and types consumed by the CMS and shops.
+export type { AnalyticsEvent, AnalyticsAggregates } from "./analytics/index";
 export { trackEvent, trackPageView, trackOrder } from "./analytics/index";
 

--- a/packages/platform-core/src/utils.ts
+++ b/packages/platform-core/src/utils.ts
@@ -6,6 +6,12 @@ export function replaceShopInPath(pathname: string, nextShop: string): string {
   return pathname.includes("/shops/") ? pathname.replace(/\/shops\/[^/]+/, `/shops/${nextShop}`) : pathname;
 }
 
+// Re-export the client theme initialiser used by various apps.  In the
+// real project this lives in `src/utils/initTheme.ts`, but this file acts as
+// the public entry point for `@platform-core/utils`, so we surface it here as
+// well.
+export { initTheme } from "./utils/initTheme";
+
 
 export const logger = {
   info: (...a: any[]) => console.log(...a),

--- a/packages/ui/src/components/account/Profile.tsx
+++ b/packages/ui/src/components/account/Profile.tsx
@@ -1,6 +1,6 @@
 // packages/ui/src/components/account/Profile.tsx
 import { getCustomerSession, hasPermission } from "@auth";
-import { getCustomerProfile } from "@acme/platform-core";
+import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
 import ProfileForm from "./ProfileForm";
 import { redirect } from "next/navigation";
 import Link from "next/link";

--- a/packages/ui/src/components/cms/ProductsTable.client.tsx
+++ b/packages/ui/src/components/cms/ProductsTable.client.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import {
+import type {
   ProductPublication,
   PublicationStatus,
 } from "@acme/platform-core/products";

--- a/packages/ui/src/components/cms/ShopSelector.tsx
+++ b/packages/ui/src/components/cms/ShopSelector.tsx
@@ -72,7 +72,7 @@ export default function ShopSelector() {
     );
 
   return (
-    <Select value={selected} onValueChange={changeShop}>
+    <Select value={selected ?? undefined} onValueChange={changeShop}>
       <SelectTrigger className="w-36">
         <SelectValue placeholder="Select shop" />
       </SelectTrigger>

--- a/packages/ui/src/components/cms/blocks/SearchBar.tsx
+++ b/packages/ui/src/components/cms/blocks/SearchBar.tsx
@@ -34,7 +34,7 @@ export default function SearchBar({
         const url = new URL("/api/products", origin);
         url.searchParams.set("q", query);
         const shop = getShopFromPath(
-          typeof window !== "undefined" ? window.location.pathname : undefined
+          typeof window !== "undefined" ? window.location.pathname : ""
         );
         if (shop) url.searchParams.set("shop", shop);
         const res = await fetch(url.toString(), { signal: controller.signal });

--- a/packages/ui/types-compat.qrcode.d.ts
+++ b/packages/ui/types-compat.qrcode.d.ts
@@ -1,0 +1,5 @@
+declare module "qrcode" {
+  export function toDataURL(text: string): Promise<string>;
+  const _default: { toDataURL: typeof toDataURL };
+  export default _default;
+}


### PR DESCRIPTION
## Summary
- export initTheme and analytics aggregates from platform-core
- tighten CMS analytics and shop form parsing types
- add missing jsdom and qrcode type shims
- fix various UI imports and props

## Testing
- `pnpm typecheck` (fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)
- `pnpm test` (fails: @acme/next-config#test exited with error)


------
https://chatgpt.com/codex/tasks/task_e_68a59e3ecbd8832f85b50bae0fd1c84c