### PR TITLE
fix: address cms settings type errors

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
@@ -50,7 +50,7 @@ export default function GeneralSettings({
             <Checkbox
               name="blog"
               checked={info.luxuryFeatures.blog ?? false}
-              onCheckedChange={(v) =>
+              onCheckedChange={(v: boolean) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {
@@ -66,7 +66,7 @@ export default function GeneralSettings({
             <Checkbox
               name="contentMerchandising"
               checked={info.luxuryFeatures.contentMerchandising ?? false}
-              onCheckedChange={(v) =>
+              onCheckedChange={(v: boolean) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {
@@ -82,7 +82,7 @@ export default function GeneralSettings({
             <Checkbox
               name="raTicketing"
               checked={info.luxuryFeatures.raTicketing ?? false}
-              onCheckedChange={(v) =>
+              onCheckedChange={(v: boolean) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {
@@ -100,7 +100,7 @@ export default function GeneralSettings({
               type="number"
               name="fraudReviewThreshold"
               value={info.luxuryFeatures.fraudReviewThreshold}
-              onChange={(e) =>
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {
@@ -115,7 +115,7 @@ export default function GeneralSettings({
             <Checkbox
               name="requireStrongCustomerAuth"
               checked={info.luxuryFeatures.requireStrongCustomerAuth}
-              onCheckedChange={(v) =>
+              onCheckedChange={(v: boolean) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {
@@ -131,7 +131,7 @@ export default function GeneralSettings({
             <Checkbox
               name="strictReturnConditions"
               checked={info.luxuryFeatures.strictReturnConditions}
-              onCheckedChange={(v) =>
+              onCheckedChange={(v: boolean) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {
@@ -147,7 +147,7 @@ export default function GeneralSettings({
             <Checkbox
               name="trackingDashboard"
               checked={info.luxuryFeatures.trackingDashboard}
-              onCheckedChange={(v) =>
+              onCheckedChange={(v: boolean) =>
                 setInfo((prev) => ({
                   ...prev,
                   luxuryFeatures: {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -207,7 +207,10 @@ export default async function SettingsPage({
           <div className="mt-6">
             <CurrencyTaxEditor
               shop={shop}
-              initial={{ currency: settings.currency, taxRegion: settings.taxRegion }}
+              initial={{
+                currency: settings.currency ?? "",
+                taxRegion: settings.taxRegion ?? "",
+              }}
             />
           </div>
         </div>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Input } from "@/components/atoms/shadcn";
 import { updatePremierDelivery } from "@cms/actions/shops.server";
-import { FormEvent, useState } from "react";
+import { FormEvent, useState, type ChangeEvent } from "react";
 
 interface Props {
   shop: string;
@@ -65,7 +65,9 @@ export default function PremierDeliveryEditor({ shop, initial }: Props) {
             <Input
               name="regions"
               value={region}
-              onChange={(e) => updateRegion(i, e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                updateRegion(i, e.target.value)
+              }
             />
             <Button
               type="button"
@@ -90,7 +92,9 @@ export default function PremierDeliveryEditor({ shop, initial }: Props) {
             <Input
               name="windows"
               value={window}
-              onChange={(e) => updateWindow(i, e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                updateWindow(i, e.target.value)
+              }
             />
             <Button
               type="button"

--- a/apps/cms/src/app/cms/shop/[shop]/settings/returns/ReturnsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/returns/ReturnsEditor.tsx
@@ -38,7 +38,7 @@ export default function ReturnsEditor({ shop, initial }: Props) {
         <Checkbox
           name="enabled"
           checked={enabled}
-          onCheckedChange={(v) => setEnabled(Boolean(v))}
+          onCheckedChange={(v: boolean) => setEnabled(Boolean(v))}
         />
         <span>Enable UPS returns</span>
       </label>
@@ -49,7 +49,7 @@ export default function ReturnsEditor({ shop, initial }: Props) {
         <Checkbox
           name="bagEnabled"
           checked={bagEnabled}
-          onCheckedChange={(v) => setBagEnabled(Boolean(v))}
+          onCheckedChange={(v: boolean) => setBagEnabled(Boolean(v))}
         />
         <span>Provide return bags</span>
       </label>
@@ -57,7 +57,7 @@ export default function ReturnsEditor({ shop, initial }: Props) {
         <Checkbox
           name="homePickupEnabled"
           checked={pickupEnabled}
-          onCheckedChange={(v) => setPickupEnabled(Boolean(v))}
+          onCheckedChange={(v: boolean) => setPickupEnabled(Boolean(v))}
         />
         <span>Enable home pickup</span>
       </label>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor.tsx
@@ -39,7 +39,7 @@ export default function ReverseLogisticsEditor({ shop, initial }: Props) {
         <Checkbox
           name="enabled"
           checked={state.enabled}
-          onCheckedChange={(v) =>
+          onCheckedChange={(v: boolean) =>
             setState((s) => ({ ...s, enabled: Boolean(v) }))
           }
         />

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiCatalogSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState, type FormEvent, type ChangeEvent } from "react";
 import { Button, Checkbox, Input } from "@/components/atoms/shadcn";
 import { updateAiCatalog } from "@cms/actions/shops.server";
 import { formatTimestamp } from "@acme/date-utils";
@@ -58,7 +58,9 @@ export default function AiCatalogSettings({ shop, initial }: Props) {
         <Checkbox
           name="enabled"
           checked={state.enabled}
-          onCheckedChange={(v) => setState((s) => ({ ...s, enabled: Boolean(v) }))}
+          onCheckedChange={(v: boolean) =>
+            setState((s) => ({ ...s, enabled: Boolean(v) }))
+          }
         />
         <span>Enable AI catalog feed</span>
       </label>
@@ -85,7 +87,7 @@ export default function AiCatalogSettings({ shop, initial }: Props) {
           type="number"
           name="pageSize"
           value={state.pageSize}
-          onChange={(e) =>
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
             setState((s) => ({ ...s, pageSize: Number(e.target.value) }))
           }
         />

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiFeedPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiFeedPanel.tsx
@@ -2,8 +2,9 @@ import { formatTimestamp } from "@acme/date-utils";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 
 export default async function AiFeedPanel({ shop }: { shop: string }) {
-  const events = (await listEvents(shop))
-    .filter((e) => e.type === "ai_crawl")
+  const events = (await listEvents())
+    .filter((e: any) => e.shop === shop)
+    .filter((e: any) => e.type === "ai_crawl")
     .slice(-5)
     .reverse();
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
@@ -26,7 +26,7 @@ export default async function SeoSettingsPage({
   const { shop } = await params;
   const [settings, events] = await Promise.all([
     getSettings(shop),
-    listEvents(shop),
+    listEvents(),
   ]);
   const languages = settings.languages;
   const seo = settings.seo ?? {};
@@ -37,7 +37,8 @@ export default async function SeoSettingsPage({
     pageSize: 50,
   };
   const lastCrawl = events
-    .filter((e) => e.type === "ai_crawl")
+    .filter((e: any) => e.shop === shop)
+    .filter((e: any) => e.type === "ai_crawl")
     .map((e) => e.timestamp as string)
     .filter(Boolean)
     .sort()


### PR DESCRIPTION
## Summary
- add explicit types for checkbox and change handlers in CMS settings components
- adjust analytics event lookups to match no-arg signature
- provide default values for currency and tax region props

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm test:cms` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ed29f74832fbc2419e7955ce2f8