### PR TITLE
fix cms action type errors and test imports

### DIFF
--- a/apps/cms/src/actions/deleteSanityConfig.ts
+++ b/apps/cms/src/actions/deleteSanityConfig.ts
@@ -12,7 +12,7 @@ export async function deleteSanityConfig(
   try {
     const shop = await getShopById(shopId);
     const updated = setSanityConfig(shop, undefined);
-    await updateShopInRepo(shopId, updated);
+    await updateShopInRepo(shopId, { ...updated, id: shopId });
     return { message: "Sanity disconnected" };
   } catch (err) {
     console.error("Failed to disconnect Sanity", err);

--- a/apps/cms/src/actions/pages/service.spec.ts
+++ b/apps/cms/src/actions/pages/service.spec.ts
@@ -1,19 +1,22 @@
 import { getPages, savePage, updatePage, deletePage } from "./service";
 import type { Page } from "@acme/types";
+import { describe, expect, it, jest } from "@jest/globals";
 
 jest.mock("@platform-core/repositories/pages/index.server", () => ({
   getPages: jest.fn().mockResolvedValue([]),
   savePage: jest
     .fn()
-    .mockImplementation((_s, p) => Promise.resolve(p)),
+    .mockImplementation((_s: string, p: Page) => Promise.resolve(p)),
   updatePage: jest
     .fn()
-    .mockImplementation((_s, p) => Promise.resolve({ ...(p as any) })),
+    .mockImplementation((_s: string, p: Page) =>
+      Promise.resolve({ ...(p as Page) })
+    ),
   deletePage: jest.fn().mockResolvedValue(undefined),
 }));
 
 const repo = jest.requireMock(
-  "@platform-core/repositories/pages/index.server"
+  "@platform-core/repositories/pages/index.server",
 );
 
 describe("pages service", () => {
@@ -29,8 +32,8 @@ describe("pages service", () => {
   });
 
   it("calls repository updatePage", async () => {
-    const patch = { id: "p1", updatedAt: "now" } as any;
-    const prev = { id: "p1", updatedAt: "now" } as any;
+    const patch = { id: "p1", updatedAt: "now" } as Page;
+    const prev = { id: "p1", updatedAt: "now" } as Page;
     await updatePage("shop1", patch, prev);
     expect(repo.updatePage).toHaveBeenCalledWith("shop1", patch, prev);
   });
@@ -40,3 +43,4 @@ describe("pages service", () => {
     expect(repo.deletePage).toHaveBeenCalledWith("shop1", "p1");
   });
 });
+

--- a/apps/cms/src/actions/pages/validation.spec.ts
+++ b/apps/cms/src/actions/pages/validation.spec.ts
@@ -5,6 +5,7 @@ import {
   emptyTranslated,
   componentsField,
 } from "./validation";
+import { describe, expect, it } from "@jest/globals";
 
 describe("pages validation", () => {
   it("creates empty translated object for all locales", () => {

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -13,7 +13,8 @@ import {
   writeRepo,
 } from "@platform-core/repositories/json.server";
 import { fillLocales } from "@i18n/fillLocales";
-import type { ProductPublication, PublicationStatus } from "@platform-core/products";
+import type { ProductPublication } from "@platform-core/products";
+import type { PublicationStatus } from "@acme/types";
 import * as Sentry from "@sentry/node";
 import type { Locale, MediaItem } from "@acme/types";
 import { ensureAuthorized } from "./common/auth";
@@ -85,7 +86,9 @@ export async function updateProduct(
   "use server";
   await ensureAuthorized();
 
-  const formEntries = Object.fromEntries(formData.entries());
+  // Node's FormData type doesn't declare `entries`, but the object itself is
+  // iterable. Casting to `any` lets us collect key/value pairs safely.
+  const formEntries = Object.fromEntries(formData as any);
   const locales = await getLocales(shop);
   const title: Record<Locale, string> = {} as Record<Locale, string>;
   const description: Record<Locale, string> = {} as Record<Locale, string>;

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -80,7 +80,7 @@ export async function saveSanityConfig(
       console.error("[saveSanityConfig] failed to schedule promotion", err);
     }
   }
-  await updateShopInRepo(shopId, updated);
+  await updateShopInRepo(shopId, { ...updated, id: shopId });
 
   return { message: "Sanity connected" };
 }


### PR DESCRIPTION
## Summary
- import PublicationStatus type from shared types and handle FormData iteration
- include shop id when updating Sanity config
- wire up jest globals and types for page action tests

## Testing
- `pnpm test:cms` *(fails: Could not locate module @cms/actions/shops.server)*
- `npx tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Could not find a declaration file for module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a59faffec0832fa608b810b74557a2