### PR TITLE
fix: address analytics typings

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
@@ -89,7 +89,7 @@ export default function StepShopPage({
           <SelectItem
             value="blank"
             asChild
-            onSelect={(e: Event) => {
+            onSelect={(e) => {
               e.preventDefault();
               setSelectOpen(false);
               setPendingTemplate({ name: "blank", components: [], preview: "" });
@@ -104,7 +104,7 @@ export default function StepShopPage({
               key={t.name}
               value={t.name}
               asChild
-              onSelect={(e: Event) => {
+              onSelect={(e) => {
                 e.preventDefault();
                 setSelectOpen(false);
                 setPendingTemplate(t);

--- a/apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor.tsx
@@ -30,8 +30,8 @@ export default function CurrencyTaxEditor({ shop, initial }: Props) {
       setErrors(result.errors);
     } else if (result.settings) {
       setState({
-        currency: result.settings.currency,
-        taxRegion: result.settings.taxRegion,
+        currency: result.settings.currency ?? state.currency,
+        taxRegion: result.settings.taxRegion ?? state.taxRegion,
       });
       setErrors({});
     }

--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -1,3 +1,30 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { DATA_ROOT } from "../dataRoot";
+import { validateShopName } from "../shops";
+import type { AnalyticsAggregates } from "../analytics";
+
 export async function listEvents(_shop?: string) {
   return [] as any[];
+}
+
+export async function readAggregates(
+  shop: string
+): Promise<AnalyticsAggregates> {
+  const file = path.join(
+    DATA_ROOT,
+    validateShopName(shop),
+    "analytics-aggregates.json"
+  );
+  try {
+    const buf = await fs.readFile(file, "utf8");
+    return JSON.parse(buf) as AnalyticsAggregates;
+  } catch {
+    return {
+      page_view: {},
+      order: {},
+      discount_redeemed: {},
+      ai_crawl: {},
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- handle optional currency and tax region values
- fix shop template selection events
- expose analytics aggregates reader

## Testing
- `npx tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Cannot find module '@i18n/de.json')*
- `pnpm test:cms` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a6bb88ac832f8e4e8d9aacdc7082