### PR TITLE
fix: resolve type errors for dependencies

### DIFF
--- a/apps/cms/src/app/cms/wizard/preview/view/page.tsx
+++ b/apps/cms/src/app/cms/wizard/preview/view/page.tsx
@@ -53,11 +53,11 @@ export default async function PreviewView({
   const tokens = await loadThemeTokens(theme);
   const style = Object.fromEntries(Object.entries(tokens)) as CSSProperties;
 
-  const messagesMap = {
+  const messagesMap: Record<Locale, () => Promise<any>> = {
     en: () => import("@i18n/en.json"),
     de: () => import("@i18n/de.json"),
     it: () => import("@i18n/it.json"),
-  } as const;
+  };
   const messages = (await messagesMap[lang]()).default;
 
   return (

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -19,21 +19,22 @@
   },
   "dependencies": {
     "@acme/config": "workspace:*",
+    "@acme/platform-core": "workspace:^",
     "@acme/ui": "workspace:*",
     "@sendgrid/mail": "^8.1.5",
     "commander": "^11.1.0",
+    "dompurify": "^3.2.6",
+    "jsdom": "^26.1.0",
     "nodemailer": "^6.10.1",
     "pino": "^9.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "resend": "^3.5.0",
-    "sanitize-html": "^2.12.1",
-    "dompurify": "^3.2.6",
-    "jsdom": "^26.1.0",
-    "@acme/platform-core": "workspace:^"
+    "sanitize-html": "^2.12.1"
   },
   "devDependencies": {
-    "@types/sanitize-html": "^2.16.0",
-    "@types/dompurify": "^3.2.0"
+    "@types/dompurify": "^3.2.0",
+    "@types/jsdom": "^21.1.7",
+    "@types/sanitize-html": "^2.16.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,9 +10,11 @@
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "dependencies": {
-    "@acme/date-utils": "workspace:*",
+    "@acme/auth": "workspace:^",
     "@acme/config": "workspace:*",
+    "@acme/date-utils": "workspace:*",
     "@acme/i18n": "workspace:*",
+    "@acme/platform-core": "workspace:^",
     "@acme/shared-utils": "workspace:*",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
@@ -28,14 +30,13 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-joyride": "^2.9.3",
-    "shadcn-ui": "^0.9.5",
-    "@acme/platform-core": "workspace:^",
-    "@acme/auth": "workspace:^"
+    "shadcn-ui": "^0.9.5"
   },
   "peerDependencies": {
     "tailwindcss": "^4"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.5",
     "next": "^15.3.4",
     "typescript": "^5.8.3"
   }

--- a/packages/ui/src/components/cms/ProductsTable.client.tsx
+++ b/packages/ui/src/components/cms/ProductsTable.client.tsx
@@ -2,10 +2,7 @@
 
 "use client";
 
-import type {
-  ProductPublication,
-  PublicationStatus,
-} from "@acme/platform-core/products";
+import type { ProductPublication, PublicationStatus } from "@acme/types";
 import { useProductFilters } from "../../hooks/useProductFilters";
 import { formatCurrency } from "@acme/shared-utils";
 import Link from "next/link";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@types/sanitize-html':
         specifier: ^2.16.0
         version: 2.16.0
@@ -852,6 +855,9 @@ importers:
         specifier: ^4
         version: 4.1.11
     devDependencies:
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.5
       next:
         specifier: ^15.3.4
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4097,6 +4103,9 @@ packages:
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -4159,6 +4168,9 @@ packages:
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
+
+  '@types/qrcode@1.5.5':
+    resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -14549,6 +14561,12 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 24.0.10
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -14624,6 +14642,10 @@ snapshots:
       '@types/node': 24.0.10
       pg-protocol: 1.10.3
       pg-types: 2.2.0
+
+  '@types/qrcode@1.5.5':
+    dependencies:
+      '@types/node': 24.0.10
 
   '@types/qs@6.14.0': {}
 


### PR DESCRIPTION
## Summary
- add missing type packages for jsdom and qrcode
- reference product types from @acme/types
- type message loader map by locale

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm --filter @acme/email test` *(fails: Could not locate module @cms/actions/shops.server mapped)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/auth/options mapped)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad2aafc8832fb1b14f1e47f32cf6