### PR TITLE
fix: resolve publish location type mismatch

### DIFF
--- a/packages/ui/src/hooks/useProductEditorFormState.tsx
+++ b/packages/ui/src/hooks/useProductEditorFormState.tsx
@@ -19,10 +19,6 @@ interface ProductPublication {
   media: MediaItem[];
 }
 
-interface PublishLocation {
-  id: string;
-  requiredOrientation: string;
-}
 import { parseMultilingualInput } from "@acme/i18n/parseMultilingualInput";
 import {
   useCallback,
@@ -82,9 +78,8 @@ export function useProductEditorFormState(
   /* ---------- helpers ---------------------------------------------- */
   const { locations } = usePublishLocations();
   const requiredOrientation =
-    locations.find(
-      (l: PublishLocation) => l.id === publishTargets[0]
-    )?.requiredOrientation ?? "landscape";
+    locations.find((l) => l.id === publishTargets[0])?.requiredOrientation ??
+    "landscape";
 
   const { uploader } = useFileUpload({
     shop: init.shop,


### PR DESCRIPTION
## Summary
- avoid mismatched PublishLocation types by relying on inference when locating required orientation

## Testing
- `pnpm test --filter @acme/ui` *(fails: Cannot find module '@acme/i18n')*
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/config/env/core')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c026b77c832f96248f52e324d130