### PR TITLE
chore: exclude tests from shop-bcd typecheck

### DIFF
--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -50,6 +50,8 @@
     "node_modules",
     "../../apps-script",
     "src/routes/preview/[pageId].ts",
-    ".next"
+    ".next",
+    "../../packages/**/__tests__/**",
+    "../../test"
   ]
 }

--- a/packages/config/tsconfig.app.json
+++ b/packages/config/tsconfig.app.json
@@ -22,5 +22,12 @@
     "types": ["node", "react", "react-dom"],
     "skipLibCheck": true
   },
-  "exclude": ["dist", "node_modules", "../../apps-script"]
+  "exclude": [
+    "dist",
+    "node_modules",
+    "../../apps-script",
+    "**/__mocks__/**",
+    "**/__tests__/**",
+    "../../test"
+  ]
 }


### PR DESCRIPTION
## Summary
- avoid typechecking unit tests by excluding test directories from shop-bcd's tsconfig
- extend shared tsconfig app preset to ignore test and mock folders across apps

## Testing
- `npx tsc -p apps/shop-bcd/tsconfig.json --noEmit` *(fails: Found 244 errors in 98 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c0576038832f91c3fe722e124260