### PR TITLE
fix: align component types and shop patch id

### DIFF
--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -115,6 +115,7 @@ export async function writeShop(
   const themeTokens = { ...themeDefaults, ...themeOverrides } as Record<string, string>;
   const updated = await updateShopInRepo<Shop>(shop, {
     ...patch,
+    id: patch.id,
     themeDefaults,
     themeOverrides,
     themeTokens,

--- a/packages/ui/src/components/cms/page-builder/TextBlock.tsx
+++ b/packages/ui/src/components/cms/page-builder/TextBlock.tsx
@@ -3,7 +3,7 @@
 import type { Locale } from "@acme/i18n/locales";
 import { CSS } from "@dnd-kit/utilities";
 import { EditorContent } from "@tiptap/react";
-import type { PageComponent } from "@acme/types";
+import type { TextComponent as BaseTextComponent } from "@acme/types";
 import { memo, useCallback, useRef, useState } from "react";
 import DOMPurify from "dompurify";
 import MenuBar from "./MenuBar";
@@ -13,10 +13,10 @@ import useCanvasResize from "./useCanvasResize";
 import useCanvasDrag from "./useCanvasDrag";
 import type { Action } from "./state";
 
-type TextComponent = Extract<
-  PageComponent,
-  { type: "Text" }
-> & { text?: string | Record<string, string>; [key: string]: unknown };
+type TextComponent = BaseTextComponent & {
+  text?: string | Record<string, string>;
+  [key: string]: unknown;
+};
 
 const TextBlock = memo(function TextBlock({
   component,


### PR DESCRIPTION
## Summary
- use explicit TextComponent type to avoid `never` in TextBlock
- ensure shop patch object always includes required id before updating

## Testing
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@acme/types')*
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/config/env/core')*
- `pnpm --filter @acme/ui test` *(fails: plugin invalid config error)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c0ce33ac832f8b87d52da7613fc4