### PR TITLE
fix shop repo generic constraint

### DIFF
--- a/packages/platform-core/src/repositories/shop.server.ts
+++ b/packages/platform-core/src/repositories/shop.server.ts
@@ -19,7 +19,7 @@ async function ensureDir(shop: string): Promise<void> {
   await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
 }
 
-export async function getShopById<T extends { id: string } = Shop>(
+export async function getShopById<T extends Shop = Shop>(
   shop: string
 ): Promise<T> {
   try {
@@ -36,7 +36,7 @@ export async function getShopById<T extends { id: string } = Shop>(
   }
 }
 
-export async function updateShopInRepo<T extends { id: string } = Shop>(
+export async function updateShopInRepo<T extends Shop = Shop>(
   shop: string,
   patch: Partial<T> & { id: string }
 ): Promise<T> {


### PR DESCRIPTION
## Summary
- fix generic constraints for shop repository helpers

## Testing
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@acme/config/env/core')*
- `pnpm test --filter @acme/platform-core`


------
https://chatgpt.com/codex/tasks/task_e_68a5c0e3a710832f8060deb05987f59b