### PR TITLE
fix: handle optional product fields

### DIFF
--- a/packages/ui/src/components/organisms/ProductCard.tsx
+++ b/packages/ui/src/components/organisms/ProductCard.tsx
@@ -40,6 +40,7 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
     ref
   ) => {
     const { classes, style } = boxProps({ width, height, padding, margin });
+    const media = product.media?.[0];
     return (
       <div
         ref={ref}
@@ -51,19 +52,19 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
         )}
         {...props}
       >
-        {showImage && product.media[0] && (
+        {showImage && media && (
           <div className="relative aspect-square">
-            {product.media[0].type === "image" ? (
+            {media.type === "image" ? (
               <Image
-                src={product.media[0].url}
-                alt={product.title}
+                src={media.url ?? ""}
+                alt={media.alt ?? product.title ?? ""}
                 fill
                 sizes="(min-width: 640px) 25vw, 50vw"
                 className="rounded-md object-cover"
               />
             ) : (
               <video
-                src={product.media[0].url}
+                src={media.url ?? ""}
                 className="h-full w-full rounded-md object-cover"
                 muted
                 playsInline
@@ -71,8 +72,8 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
             )}
           </div>
         )}
-        <h3 className="font-medium">{product.title}</h3>
-        {showPrice && (
+        <h3 className="font-medium">{product.title ?? ""}</h3>
+        {showPrice && product.price != null && (
           <Price amount={product.price} className="font-semibold" />
         )}
         {onAddToCart && (

--- a/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
+++ b/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
@@ -35,8 +35,10 @@ export function StickyAddToCartBar({
       {...props}
     >
       <div className="flex flex-col">
-        <span className="text-sm">{product.title}</span>
-        <Price amount={product.price} className="font-semibold" />
+        <span className="text-sm">{product.title ?? ""}</span>
+        {product.price != null && (
+          <Price amount={product.price} className="font-semibold" />
+        )}
       </div>
       {onAddToCart && (
         <Button onClick={() => onAddToCart(product)}>{ctaLabel}</Button>


### PR DESCRIPTION
## Summary
- guard against missing media and price fields in ProductCard
- safely render title and price in StickyAddToCartBar

## Testing
- `pnpm --filter @acme/ui build` *(fails: Type 'undefined' is not assignable to type 'number'...)*
- `pnpm --filter @acme/ui test` *(fails: Configuration error: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d3296b04832faf7e2564b098b7f1