### PR TITLE
fix: ensure MediaFileItem has URL

### DIFF
--- a/packages/ui/src/components/cms/MediaFileItem.tsx
+++ b/packages/ui/src/components/cms/MediaFileItem.tsx
@@ -6,7 +6,13 @@ import { useState } from "react";
 import { Input } from "../atoms/shadcn";
 
 interface Props {
-  item: MediaItem;
+  /**
+   * The media item to render.  The generic {@link MediaItem} type marks the
+   * `url` property as optional, but this component relies on it being present
+   * (we can't display or replace a file without a URL).  Narrow the type here
+   * to guarantee that `url` is a defined string throughout the component.
+   */
+  item: MediaItem & { url: string };
   shop: string;
   onDelete: (url: string) => void;
   onReplace: (oldUrl: string, item: MediaItem) => void;


### PR DESCRIPTION
## Summary
- require MediaItem URL for MediaFileItem and document why

## Testing
- `pnpm --filter @acme/ui build` *(fails: 'item.media' is possibly 'undefined' in WishlistTemplate, etc.)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d35898f0832fb6b0d9272295dff6