### PR TITLE
fix(ui): use altText for media

### DIFF
--- a/packages/ui/src/components/cms/blocks/FeaturedProductBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FeaturedProductBlock.tsx
@@ -53,7 +53,7 @@ export default function FeaturedProductBlock({
           {media.type === "image" ? (
             <Image
               src={media.url}
-              alt={media.alt ?? product.title ?? ""}
+              alt={media.altText ?? product.title ?? ""}
               fill
               sizes="(min-width: 768px) 50vw, 100vw"
               className="rounded-md object-cover"

--- a/packages/ui/src/components/organisms/ProductCard.tsx
+++ b/packages/ui/src/components/organisms/ProductCard.tsx
@@ -57,7 +57,7 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
             {media.type === "image" ? (
               <Image
                 src={media.url ?? ""}
-                alt={media.alt ?? product.title ?? ""}
+                alt={media.altText ?? product.title ?? ""}
                 fill
                 sizes="(min-width: 640px) 25vw, 50vw"
                 className="rounded-md object-cover"


### PR DESCRIPTION
## Summary
- fix TypeScript media property references by using `altText` instead of `alt`

## Testing
- `pnpm --filter @acme/ui build` *(fails: 'line.sku' is of type 'unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68a6dd1a19c0832f9217f3bfc38087a0