### PR TITLE
chore: add missing type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,8 @@
     "playwright": "^1.53.1",
     "plop": "^4.0.1",
     "polished": "^4.3.1",
+    "@types/jsdom": "^21.1.7",
+    "@types/qrcode": "^1.5.5",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.13",
     "react-server-dom-webpack": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,9 +242,15 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@types/node':
         specifier: ^20.19.4
         version: 20.19.4
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.5
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8


### PR DESCRIPTION
## Summary
- install @types/jsdom
- install @types/qrcode

## Testing
- `pnpm exec tsc -p packages/email/tsconfig.json --noEmit` (fails: Cannot find modules built from platform-core)
- `pnpm exec tsc -p packages/ui/tsconfig.json --noEmit` (fails: Cannot find modules built from platform-core)
- `pnpm --filter @acme/email test packages/email/src/__tests__/templates.test.ts` (fails: Could not locate module @acme/ui)
- `pnpm --filter @acme/ui test packages/ui/__tests__/MfaSetup.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a6dd239354832f9e159e72014bb8f0