### PR TITLE
Fix CMS TypeScript errors

### DIFF
--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -13,10 +13,13 @@ import {
   writeRepo,
 } from "@platform-core/repositories/json.server";
 import { fillLocales } from "@i18n/fillLocales";
-import type { ProductPublication } from "@platform-core/products";
-import type { PublicationStatus } from "@acme/types";
 import * as Sentry from "@sentry/node";
-import type { Locale, MediaItem } from "@acme/types";
+import type {
+  Locale,
+  MediaItem,
+  ProductPublication,
+  PublicationStatus,
+} from "@acme/types";
 import { ensureAuthorized } from "./common/auth";
 import { redirect } from "next/navigation";
 import { ulid } from "ulid";
@@ -184,10 +187,7 @@ export async function promoteProduct(
   "use server";
   await ensureAuthorized();
 
-  const current = (await getProductById<ProductPublication>(
-    shop,
-    id,
-  )) as ProductPublication | null;
+  const current = await getProductById<ProductPublication>(shop, id);
   if (!current) throw new Error(`Product ${id} not found in ${shop}`);
 
   const status = nextStatus[current.status];

--- a/apps/cms/src/app/cms/shop/[shop]/themes/PresetControls.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/PresetControls.tsx
@@ -1,6 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/themes/PresetControls.tsx
 "use client";
 import { Button, Input } from "@/components/atoms/shadcn";
+import type { ChangeEvent } from "react";
 
 interface Props {
   presetName: string;
@@ -22,7 +23,7 @@ export default function PresetControls({
       <Input
         placeholder="Preset name"
         value={presetName}
-        onChange={(e) => setPresetName(e.target.value)}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setPresetName(e.target.value)}
       />
       <Button type="button" onClick={handleSavePreset} disabled={!presetName.trim()}>
         Save Preset

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -1,8 +1,7 @@
 // apps/cms/src/app/cms/wizard/schema.ts
 import { LOCALES } from "@acme/i18n";
 import { fillLocales } from "@i18n/fillLocales";
-import { pageComponentSchema } from "@acme/types/page";
-import { localeSchema, type Locale } from "@acme/types";
+import { pageComponentSchema, localeSchema, type Locale } from "@acme/types";
 import { ulid } from "ulid";
 import { z, type ZodType } from "zod";
 import { baseTokens } from "./tokenUtils";


### PR DESCRIPTION
## Summary
- correct import of `pageComponentSchema` from shared types
- type input change handler in `PresetControls`
- use typed `ProductPublication` for product promotion

## Testing
- `pnpm --filter @apps/cms test` *(fails: Package subpath './jest.preset.cjs' is not defined by "exports" in @acme/config)*
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm lint` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd84e404832fa639fc8b4fad173f