### PR TITLE
fix: require domain name in shop definition

### DIFF
--- a/packages/platform-core/src/shops/index.d.ts
+++ b/packages/platform-core/src/shops/index.d.ts
@@ -47,11 +47,13 @@ export interface Shop {
  */
 export type SanityBlogConfig = Record<string, unknown>;
 /**
- * Placeholder type describing a shop domain.  The domain may include
- * a name and any other properties relevant to the domain configuration.
+ * Placeholder type describing a shop domain.  The domain must include a
+ * `name` and may include any other properties relevant to the domain
+ * configuration.
  */
 export interface ShopDomain {
-    name?: string;
+    /** Fully qualified domain name associated with the shop. */
+    name: string;
     [key: string]: any;
 }
 /**

--- a/packages/platform-core/src/shops/index.ts
+++ b/packages/platform-core/src/shops/index.ts
@@ -59,11 +59,13 @@ export interface Shop {
 export type SanityBlogConfig = Record<string, unknown>;
 
 /**
- * Placeholder type describing a shop domain.  The domain may include
- * a name and any other properties relevant to the domain configuration.
+ * Placeholder type describing a shop domain.  The domain must include a
+ * `name` field and may include any other properties relevant to the domain
+ * configuration.
  */
 export interface ShopDomain {
-  name?: string;
+  /** Fully qualified domain name associated with the shop. */
+  name: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary
- require domain name in `ShopDomain`

## Testing
- `pnpm test` *(fails: @acme/next-config#test exited with code 1)*
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm lint` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ddad2d58832f93a65694632b468b