### PR TITLE
fix: resolve cms tsconfig paths

### DIFF
--- a/apps/cms/src/types/validator.d.ts
+++ b/apps/cms/src/types/validator.d.ts
@@ -1,0 +1,5 @@
+declare module "validator/lib/isURL" {
+  import validator from "validator";
+  const isURL: typeof validator.isURL;
+  export default isURL;
+}

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -21,16 +21,27 @@
     ],
     "paths": {
       "@/*": [
-        "./dist/*"
+        "./src/*"
       ],
       "@cms/*": [
-        "./dist/*"
+        "./src/*"
       ],
-      "@i18n/*": [
-        "./src/i18n/*"
+      "@/components/*": [
+        "../../packages/ui/src/components/*"
+      ],
+      "@/lib/*": [
+        "./src/lib/*",
+        "../../packages/ui/src/lib/*",
+        "../../packages/platform-core/src/*"
+      ],
+      "@/contexts/*": [
+        "../../packages/platform-core/src/contexts/*"
+      ],
+      "@/i18n/*": [
+        "../../packages/i18n/src/*"
       ],
       "@ui/*": [
-        "../../packages/ui/dist/*"
+        "../../packages/ui/src/*"
       ],
       "@ui": [
         "../../packages/ui/src/index.ts"
@@ -39,73 +50,73 @@
         "../../packages/auth/src/index.ts"
       ],
       "@auth/*": [
-        "../../packages/auth/dist/*"
+        "../../packages/auth/src/*"
       ],
       "@acme/lib": [
         "../../packages/lib/src/index.ts"
       ],
       "@acme/lib/*": [
-        "../../packages/lib/dist/*"
+        "../../packages/lib/src/*"
       ],
       "@acme/shared-utils": [
         "../../packages/shared-utils/src/index.ts"
       ],
       "@acme/shared-utils/*": [
-        "../../packages/shared-utils/dist/*"
+        "../../packages/shared-utils/src/*"
       ],
       "@acme/types": [
         "../../packages/types/src/index.ts"
       ],
       "@acme/types/*": [
-        "../../packages/types/dist/*"
+        "../../packages/types/src/*"
       ],
       "@shared-utils": [
         "../../packages/shared-utils/src/index.ts"
       ],
       "@shared-utils/*": [
-        "../../packages/shared-utils/dist/*"
+        "../../packages/shared-utils/src/*"
       ],
       "@date-utils": [
         "../../packages/date-utils/src/index.ts"
       ],
       "@date-utils/*": [
-        "../../packages/date-utils/dist/*"
+        "../../packages/date-utils/src/*"
       ],
       "@platform-core": [
         "../../packages/platform-core/src/index.ts"
       ],
       "@platform-core/*": [
-        "../../packages/platform-core/dist/*"
+        "../../packages/platform-core/src/*"
       ],
       "@acme/platform-core": [
         "../../packages/platform-core/src/index.ts"
       ],
       "@acme/platform-core/*": [
-        "../../packages/platform-core/dist/*"
+        "../../packages/platform-core/src/*"
       ],
       "@acme/email": [
         "../../packages/email/src/index.ts"
       ],
       "@acme/email/*": [
-        "../../packages/email/dist/*"
+        "../../packages/email/src/*"
       ],
       "@acme/config": [
         "../../packages/config/src/index.ts"
       ],
       "@acme/config/*": [
-        "../../packages/config/dist/*"
+        "../../packages/config/src/*"
       ],
       "@acme/i18n": [
         "../../packages/i18n/src/index.ts"
       ],
       "@acme/i18n/*": [
-        "../../packages/i18n/dist/*"
+        "../../packages/i18n/src/*"
       ],
       "@acme/configurator": [
         "../../packages/configurator/src/index.ts"
       ],
       "@acme/configurator/*": [
-        "../../packages/configurator/dist/*"
+        "../../packages/configurator/src/*"
       ]
     },
     "module": "ESNext",


### PR DESCRIPTION
## Summary
- align CMS tsconfig paths with source packages
- declare validator isURL module for TypeScript

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm --filter @apps/cms test` *(fails: Package subpath './jest.preset.cjs' is not defined by "exports")*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4f9fe54832f9bbf6e25f95e3baf