### PR TITLE
fix cms path aliases

### DIFF
--- a/apps/cms/src/app/[lang]/shop/page.tsx
+++ b/apps/cms/src/app/[lang]/shop/page.tsx
@@ -1,5 +1,5 @@
 // apps/cms/src/app/[lang]/shop/page.tsx
-import { PRODUCTS } from "@/lib/products";
+import { PRODUCTS } from "@platform-core/lib/products";
 import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
 import ShopClient from "./ShopClient.client";

--- a/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/return-logistics/page.tsx
@@ -1,5 +1,5 @@
 import { checkShopExists } from "@acme/lib";
-import { readReturnLogistics } from "@platform-core/src/repositories/returnLogistics.server";
+import { readReturnLogistics } from "@platform-core/repositories/returnLogistics.server";
 import { notFound } from "next/navigation";
 import ReturnLogisticsForm from "./ReturnLogisticsForm";
 

--- a/apps/cms/src/app/cms/shop/[shop]/upgrade-preview/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/upgrade-preview/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { requirePermission } from "@auth";
 import { useEffect, useState } from "react";
 import type { UpgradeComponent } from "@acme/types/upgrade";
-import ComponentPreview from "@ui/src/components/ComponentPreview";
+import ComponentPreview from "@ui/components/ComponentPreview";
 import { z } from "zod";
 
 export const metadata: Metadata = {

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -40,11 +40,23 @@
       "@/i18n/*": [
         "../../packages/i18n/src/*"
       ],
+      "@i18n": [
+        "../../packages/i18n/src/index.ts"
+      ],
+      "@i18n/*": [
+        "../../packages/i18n/src/*"
+      ],
       "@ui/*": [
         "../../packages/ui/src/*"
       ],
       "@ui": [
         "../../packages/ui/src/index.ts"
+      ],
+      "@acme/ui": [
+        "../../packages/ui/src/index.ts"
+      ],
+      "@acme/ui/*": [
+        "../../packages/ui/src/*"
       ],
       "@auth": [
         "../../packages/auth/src/index.ts"


### PR DESCRIPTION
## Summary
- restore `@i18n` and `@acme/ui` path aliases in CMS tsconfig
- correct several CMS imports to use existing package paths

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm --filter @apps/cms test` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './jest.preset.cjs' is not defined by "exports" in @acme/config/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e9e9b7c0832fbab78a0bc2cf1fe6