### PR TITLE
fix sanity blog config types

### DIFF
--- a/apps/cms/src/app/[lang]/checkout/page.tsx
+++ b/apps/cms/src/app/[lang]/checkout/page.tsx
@@ -41,7 +41,7 @@ export default async function CheckoutPage({
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-10 p-6">
       <OrderSummary />
-      <CheckoutForm locale={lang} taxRegion={settings.taxRegion} />
+      <CheckoutForm locale={lang} taxRegion={settings.taxRegion ?? ""} />
     </div>
   );
 }

--- a/packages/platform-core/src/shops/index.d.ts
+++ b/packages/platform-core/src/shops/index.d.ts
@@ -45,7 +45,12 @@ export interface Shop {
  * required by the CMS, but here it is left as an object with
  * arbitrary keys.
  */
-export type SanityBlogConfig = Record<string, unknown>;
+export interface SanityBlogConfig {
+    projectId: string;
+    dataset: string;
+    token: string;
+    [key: string]: unknown;
+}
 /**
  * Placeholder type describing a shop domain.  The domain must include a
  * `name` and may include any other properties relevant to the domain

--- a/packages/platform-core/src/shops/index.ts
+++ b/packages/platform-core/src/shops/index.ts
@@ -51,12 +51,18 @@ export interface Shop {
 }
 
 /**
- * Placeholder type describing the configuration of a Sanity blog.
- * In the full codebase this would include the specific fields
- * required by the CMS, but here it is left as an object with
- * arbitrary keys.
+ * Configuration required to connect a shop to a Sanity project.
+ * These fields mirror the shape used in the real application while
+ * still allowing additional properties.  Using an explicit interface
+ * keeps type‑checking in sync with the `@acme/types` package which
+ * expects these keys to exist.
  */
-export type SanityBlogConfig = Record<string, unknown>;
+export interface SanityBlogConfig {
+  projectId: string;
+  dataset: string;
+  token: string;
+  [key: string]: unknown;
+}
 
 /**
  * Placeholder type describing a shop domain.  The domain must include a


### PR DESCRIPTION
## Summary
- align SanityBlogConfig interface with expected fields
- handle missing tax region when rendering checkout

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm test` *(fails: command (@apps/cms) pnpm run test exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ede1e418832fa5426f285834fd9d