### PR TITLE
Fix cart and order template type errors

### DIFF
--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -19,8 +19,8 @@ export function CartTemplate({
   className,
   ...props
 }: CartTemplateProps) {
-  const lines: (CartLine & { id: string })[] = Object.entries(cart).map(
-    ([id, line]) => ({ id, ...(line as any) })
+  const lines = (Object.entries(cart) as [string, CartLine][]).map(
+    ([id, line]) => ({ id, ...line })
   );
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -1,4 +1,4 @@
-import type { CartState } from "@acme/platform-core/cartCookie";
+import type { CartLine, CartState } from "@acme/platform-core/cartCookie";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Price } from "../atoms/Price";
@@ -15,7 +15,7 @@ export function OrderConfirmationTemplate({
   className,
   ...props
 }: OrderConfirmationTemplateProps) {
-  const lines = (Object.entries(cart) as [string, CartState[string]][]).map(
+  const lines = (Object.entries(cart) as [string, CartLine][]).map(
     ([id, line]) => ({ id, ...line })
   );
   const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);


### PR DESCRIPTION
## Summary
- correctly type cart line data when building cart lines to avoid `unknown` properties
- apply same fix for order confirmation template and import `CartLine`

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f3f54250832f8d68ce3cad41f7c1