### PR TITLE
chore(ui): exclude tests from typecheck

### DIFF
--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -4,5 +4,5 @@
     "types": ["@testing-library/jest-dom", "jest", "node"],
     "noEmit": true
   },
-  "include": ["src/**/*", "__tests__/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- stop typechecking package ui tests by removing them from tsconfig

## Testing
- `pnpm --filter @acme/ui exec tsc -p tsconfig.test.json` *(fails: File ... is not listed within the file list)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f4487b08832f9ddf4c5e8e52442c