### PR TITLE
fix ts errors in shop bcd

### DIFF
--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -39,9 +39,7 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const parsed = await parseJsonBody<
-    Required<z.infer<typeof schema>>
-  >(req, schema, "1mb");
+  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
   if (parsed.success === false) {
     return parsed.response;
   }

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -1,9 +1,6 @@
 // apps/shop-bcd/src/app/api/shipping-rate/route.ts
 import "@acme/zod-utils/initZod";
-import {
-  getShippingRate,
-  type ShippingRateRequest,
-} from "@platform-core/shipping";
+import { getShippingRate } from "@platform-core/shipping";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import shop from "../../../../shop.json";
 import type { NextRequest } from "next/server";
@@ -44,7 +41,7 @@ export async function POST(req: NextRequest) {
   }
 
   const body = parsed.data;
-  let premierDelivery: ShippingRateRequest["premierDelivery"];
+  let premierDelivery: Parameters<typeof getShippingRate>[0]["premierDelivery"];
   let provider = body.provider;
   if (body.provider === "premier-shipping") {
     const settings = await getShopSettings(shop.id);

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -1,9 +1,6 @@
 // apps/shop-bcd/src/app/api/tax/route.ts
 import "@acme/zod-utils/initZod";
-import {
-  calculateTax,
-  type TaxCalculationRequest,
-} from "@platform-core/tax";
+import { calculateTax } from "@platform-core/tax";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -27,8 +24,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const body: TaxCalculationRequest = parsed.data;
-    const tax = await calculateTax(body);
+    const tax = await calculateTax({ provider: "taxjar", ...parsed.data });
     return NextResponse.json({ tax });
   } catch (err) {
     return NextResponse.json(

--- a/apps/shop-bcd/src/app/preview/[pageId]/page.tsx
+++ b/apps/shop-bcd/src/app/preview/[pageId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { pageSchema } from "@acme/types";
+import { pageSchema, type Page, type PageComponent } from "@acme/types";
 import type { Locale } from "@i18n/locales";
 import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
 import PreviewClient from "./PreviewClient";
@@ -27,7 +27,8 @@ export default async function PreviewPage({
   if (!res.ok) {
     throw new Error("Failed to load preview");
   }
-  const page = pageSchema.parse(await res.json());
+  const page: Page = pageSchema.parse(await res.json());
+  const components = page.components as PageComponent[];
   const locale = (Object.keys(page.seo.title)[0] || "en") as Locale;
   const init = searchParams.device ?? searchParams.view;
   const initialDeviceId = (() => {
@@ -43,7 +44,7 @@ export default async function PreviewPage({
 
   return (
     <PreviewClient
-      components={page.components}
+      components={components}
       locale={locale}
       initialDeviceId={initialDeviceId}
     />


### PR DESCRIPTION
## Summary
- fix parseJsonBody usage in account profile route
- fix shipping-rate import and types
- ensure tax route builds TaxCalculationRequest properly
- cast page components for preview client

## Testing
- `pnpm typecheck` *(fails: Referenced project '/workspace/base-shop/apps/cms' must have setting "composite": true)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f80b203c832fb8a910eae0ac13cf