### PR TITLE
fix path aliases for shop-abc and add promote schedule

### DIFF
--- a/apps/shop-abc/shop.json
+++ b/apps/shop-abc/shop.json
@@ -48,5 +48,5 @@
     "returns": true,
     "premierDelivery": true
   },
-  "editorialBlog": { "enabled": true }
+  "editorialBlog": { "enabled": true, "promoteSchedule": "2025-01-01T00:00:00Z" }
 }

--- a/apps/shop-abc/tsconfig.json
+++ b/apps/shop-abc/tsconfig.json
@@ -42,6 +42,25 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@/*": ["src/*"],
+      "@/i18n/*": ["../../packages/i18n/src/*"],
+      "@i18n": ["../../packages/i18n/src/index"],
+      "@i18n/*": ["../../packages/i18n/src/*"],
+      "@ui/*": ["../../packages/ui/src/*"],
+      "@ui/src/*": ["../../packages/ui/src/*"],
+      "@platform-core": ["../../packages/platform-core/src/index"],
+      "@platform-core/*": ["../../packages/platform-core/src/*"],
+      "@acme/platform-core": ["../../packages/platform-core/src/index"],
+      "@acme/platform-core/*": ["../../packages/platform-core/src/*"],
+      "@auth": ["../../packages/auth/src/index", "../../packages/auth/src"],
+      "@auth/*": ["../../packages/auth/src/*"],
+      "@date-utils": ["../../packages/date-utils/src/index", "../../packages/date-utils/src"],
+      "@date-utils/*": ["../../packages/date-utils/src/*"],
+      "@shared-utils": ["../../packages/shared-utils/src/index", "../../packages/shared-utils/src"],
+      "@shared-utils/*": ["../../packages/shared-utils/src/*"],
+      "@acme/types": ["../../packages/types/src/index", "../../packages/types/src"],
+      "@acme/types/*": ["../../packages/types/src/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure `shop-abc` tsconfig with path aliases for internal packages and app sources
- include example `promoteSchedule` in shop configuration for blog promotion

## Testing
- `pnpm exec tsc -p apps/shop-abc/tsconfig.json --noEmit` *(fails: Output file has not been built from source file)*
- `pnpm --filter @apps/shop-abc test`

------
https://chatgpt.com/codex/tasks/task_e_68a6f838be98832f9e48ce1e2bb38517