### PR TITLE
chore: remove typescript eslint disables

### DIFF
--- a/packages/platform-core/src/analytics/index.js
+++ b/packages/platform-core/src/analytics/index.js
@@ -7,12 +7,11 @@ import { validateShopName } from "../shops";
 import { getShopSettings, readShop } from "../repositories/shops.server";
 import { coreEnv } from "@acme/config/env/core";
 class NoopProvider {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async track(_event) { }
 }
 class ConsoleProvider {
     async track(event) {
-        // eslint-disable-next-line no-console
+         
         console.log("analytics", event);
     }
 }

--- a/packages/platform-core/src/themeTokens/index.js
+++ b/packages/platform-core/src/themeTokens/index.js
@@ -26,7 +26,6 @@ export function loadThemeTokensNode(theme) {
     if (!theme || theme === "base")
         return {};
     // obtain a `require` function in both CJS and ESM environments
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const requireFn = typeof require !== "undefined" ? require : createRequire(import.meta.url);
     try {
         // attempt to load compiled module


### PR DESCRIPTION
## Summary
- remove now-unnecessary `@typescript-eslint` disable directives from platform-core JS files

## Testing
- `pnpm exec eslint "packages/platform-core/**/*.{ts,tsx,js,jsx}" --fix`
- `pnpm run lint:all` *(fails: Parsing error: Unexpected token <)*
- `pnpm test` *(fails: command exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f8f68dc8832f916ad4af9f2d4127