### PR TITLE
fix: adjust useCallback dependencies

### DIFF
--- a/packages/ui/src/components/cms/page-builder/TextBlock.tsx
+++ b/packages/ui/src/components/cms/page-builder/TextBlock.tsx
@@ -143,7 +143,7 @@ const TextBlock = memo(function TextBlock({
       } as Partial<TextComponent>,
     });
     setEditing(false);
-  }, [editor, dispatch, component.id, locale, component]);
+  }, [editor, dispatch, locale, component]);
 
   return (
     <div

--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
@@ -145,7 +145,7 @@ export function usePageBuilderDnD({
         });
       }
     },
-    [dispatch, components, containerTypes, defaults, selectId]
+    [dispatch, components, containerTypes, defaults, selectId, setSnapPosition]
   );
 
   const handleDragStart = useCallback((ev: DragStartEvent) => {


### PR DESCRIPTION
## Summary
- fix exhaustive-deps lint warnings for TextBlock and page builder DnD hook

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/page-builder/TextBlock.tsx packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts`
- `pnpm test --filter=@acme/ui`


------
https://chatgpt.com/codex/tasks/task_e_68a6f9905280832fba8ea9fd9f9541f2