### PR TITLE
fix: call component editor hooks unconditionally

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -34,10 +34,10 @@ interface Props {
 }
 
 function ComponentEditor({ component, onChange, onResize }: Props) {
-  if (!component) return null;
-
   const { handleInput } = useComponentInputs(onChange);
   const { handleResize, handleFullSize } = useComponentResize(onResize);
+
+  if (!component) return null;
 
   return (
     <Accordion


### PR DESCRIPTION
## Summary
- ensure ComponentEditor hooks run every render by moving them before null guard

## Testing
- `pnpm exec eslint -c eslint.config.mjs packages/ui/src/components/cms/page-builder/ComponentEditor.tsx` *(fails: Cannot redefine plugin "import")*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server, among others)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f9c33f7c832fa72808d6b613c7e9