### PR TITLE
Refactor CanvasItem to avoid conditional hook calls

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -14,20 +14,7 @@ import useCanvasDrag from "./useCanvasDrag";
 import useCanvasSpacing from "./useCanvasSpacing";
 import type { DevicePreset } from "../../../utils/devicePresets";
 
-const CanvasItem = memo(function CanvasItem({
-  component,
-  index,
-  parentId,
-  selectedId,
-  onSelectId,
-  onRemove,
-  dispatch,
-  locale,
-  gridEnabled = false,
-  gridCols,
-  viewport,
-  device,
-}: {
+type Props = {
   component: PageComponent;
   index: number;
   parentId: string | undefined;
@@ -40,25 +27,22 @@ const CanvasItem = memo(function CanvasItem({
   gridCols: number;
   viewport: "desktop" | "tablet" | "mobile";
   device?: DevicePreset;
-}) {
-  if (component.type === "Text") {
-    return (
-      <TextBlock
-        component={component as TextComponent}
-        index={index}
-        parentId={parentId}
-        selectedId={selectedId}
-        onSelectId={onSelectId}
-        onRemove={onRemove}
-        dispatch={dispatch}
-        locale={locale}
-        gridEnabled={gridEnabled}
-        gridCols={gridCols}
-        viewport={viewport}
-      />
-    );
-  }
+};
 
+const CanvasItemInner = memo(function CanvasItemInner({
+  component,
+  index,
+  parentId,
+  selectedId,
+  onSelectId,
+  onRemove,
+  dispatch,
+  locale,
+  gridEnabled = false,
+  gridCols,
+  viewport,
+  device,
+}: Props) {
   const selected = selectedId === component.id;
   const {
     attributes,
@@ -76,14 +60,14 @@ const CanvasItem = memo(function CanvasItem({
     viewport === "desktop"
       ? "widthDesktop"
       : viewport === "tablet"
-      ? "widthTablet"
-      : "widthMobile";
+        ? "widthTablet"
+        : "widthMobile";
   const heightKey =
     viewport === "desktop"
       ? "heightDesktop"
       : viewport === "tablet"
-      ? "heightTablet"
-      : "heightMobile";
+        ? "heightTablet"
+        : "heightMobile";
   const widthVal =
     (component[widthKey as keyof PageComponent] as string | undefined) ??
     component.width;
@@ -94,14 +78,14 @@ const CanvasItem = memo(function CanvasItem({
     viewport === "desktop"
       ? "marginDesktop"
       : viewport === "tablet"
-      ? "marginTablet"
-      : "marginMobile";
+        ? "marginTablet"
+        : "marginMobile";
   const paddingKey =
     viewport === "desktop"
       ? "paddingDesktop"
       : viewport === "tablet"
-      ? "paddingTablet"
-      : "paddingMobile";
+        ? "paddingTablet"
+        : "paddingMobile";
   const marginVal =
     (component[marginKey as keyof PageComponent] as string | undefined) ??
     component.margin;
@@ -201,14 +185,14 @@ const CanvasItem = memo(function CanvasItem({
         ...(component.left ? { left: component.left } : {}),
       }}
       className={
-        "relative rounded border hover:border-dashed hover:border-primary" +
+        "hover:border-primary relative rounded border hover:border-dashed" +
         (selected ? " ring-2 ring-blue-500" : "") +
         (snapping ? " border-primary" : "") +
-        ((isOver || isDragging) ? " border-dashed border-primary" : "")
+        (isOver || isDragging ? " border-primary border-dashed" : "")
       }
     >
       <div
-        className="absolute left-0 top-0 z-10 h-3 w-3 cursor-move bg-muted"
+        className="bg-muted absolute top-0 left-0 z-10 h-3 w-3 cursor-move"
         {...attributes}
         {...listeners}
         role="button"
@@ -223,25 +207,31 @@ const CanvasItem = memo(function CanvasItem({
       />
       <div className="pointer-events-none absolute inset-0 z-20">
         <div
-          className="absolute top-0 bottom-0 w-px bg-primary transition-opacity duration-150"
+          className="bg-primary absolute top-0 bottom-0 w-px transition-opacity duration-150"
           style={{ left: guides.x ?? 0, opacity: guides.x !== null ? 1 : 0 }}
         />
         {distances.x !== null && (
           <div
-            className="absolute -top-4 rounded bg-black/75 px-1 text-[10px] font-mono text-white shadow transition-opacity duration-150 dark:bg-white/75 dark:text-black"
-            style={{ left: (guides.x ?? 0) + 4, opacity: guides.x !== null ? 1 : 0 }}
+            className="absolute -top-4 rounded bg-black/75 px-1 font-mono text-[10px] text-white shadow transition-opacity duration-150 dark:bg-white/75 dark:text-black"
+            style={{
+              left: (guides.x ?? 0) + 4,
+              opacity: guides.x !== null ? 1 : 0,
+            }}
           >
             {Math.round(distances.x)}
           </div>
         )}
         <div
-          className="absolute left-0 right-0 h-px bg-primary transition-opacity duration-150"
+          className="bg-primary absolute right-0 left-0 h-px transition-opacity duration-150"
           style={{ top: guides.y ?? 0, opacity: guides.y !== null ? 1 : 0 }}
         />
         {distances.y !== null && (
           <div
-            className="absolute -left-4 rounded bg-black/75 px-1 text-[10px] font-mono text-white shadow transition-opacity duration-150 dark:bg-white/75 dark:text-black"
-            style={{ top: (guides.y ?? 0) + 4, opacity: guides.y !== null ? 1 : 0 }}
+            className="absolute -left-4 rounded bg-black/75 px-1 font-mono text-[10px] text-white shadow transition-opacity duration-150 dark:bg-white/75 dark:text-black"
+            style={{
+              top: (guides.y ?? 0) + 4,
+              opacity: guides.y !== null ? 1 : 0,
+            }}
           >
             {Math.round(distances.y)}
           </div>
@@ -250,7 +240,7 @@ const CanvasItem = memo(function CanvasItem({
       <Block component={component} locale={locale} />
       {spacingOverlay && (
         <div
-          className="pointer-events-none absolute z-30 bg-primary/20"
+          className="bg-primary/20 pointer-events-none absolute z-30"
           style={{
             top: spacingOverlay.top,
             left: spacingOverlay.left,
@@ -260,67 +250,67 @@ const CanvasItem = memo(function CanvasItem({
         />
       )}
       {showOverlay && (
-        <div className="pointer-events-none absolute -top-5 left-0 z-30 rounded bg-black/75 px-1 text-[10px] font-mono text-white shadow dark:bg-white/75 dark:text-black">
-          {Math.round(overlayWidth)}×{Math.round(overlayHeight)} | {Math.round(overlayLeft)},{" "}
-          {Math.round(overlayTop)}
+        <div className="pointer-events-none absolute -top-5 left-0 z-30 rounded bg-black/75 px-1 font-mono text-[10px] text-white shadow dark:bg-white/75 dark:text-black">
+          {Math.round(overlayWidth)}×{Math.round(overlayHeight)} |{" "}
+          {Math.round(overlayLeft)}, {Math.round(overlayTop)}
         </div>
       )}
       {selected && (
         <>
           <div
             onPointerDown={startResize}
-            className="absolute -top-1 -left-1 h-2 w-2 cursor-nwse-resize bg-primary"
+            className="bg-primary absolute -top-1 -left-1 h-2 w-2 cursor-nwse-resize"
           />
           <div
             onPointerDown={startResize}
-            className="absolute -top-1 -right-1 h-2 w-2 cursor-nesw-resize bg-primary"
+            className="bg-primary absolute -top-1 -right-1 h-2 w-2 cursor-nesw-resize"
           />
           <div
             onPointerDown={startResize}
-            className="absolute -bottom-1 -left-1 h-2 w-2 cursor-nesw-resize bg-primary"
+            className="bg-primary absolute -bottom-1 -left-1 h-2 w-2 cursor-nesw-resize"
           />
           <div
             onPointerDown={startResize}
-            className="absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize bg-primary"
+            className="bg-primary absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "margin", "top")}
-            className="absolute -top-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize bg-primary"
+            className="bg-primary absolute -top-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "margin", "bottom")}
-            className="absolute -bottom-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize bg-primary"
+            className="bg-primary absolute -bottom-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "margin", "left")}
-            className="absolute -left-2 top-1/2 w-1 h-4 -translate-y-1/2 cursor-w-resize bg-primary"
+            className="bg-primary absolute top-1/2 -left-2 h-4 w-1 -translate-y-1/2 cursor-w-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "margin", "right")}
-            className="absolute -right-2 top-1/2 w-1 h-4 -translate-y-1/2 cursor-e-resize bg-primary"
+            className="bg-primary absolute top-1/2 -right-2 h-4 w-1 -translate-y-1/2 cursor-e-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "padding", "top")}
-            className="absolute top-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize bg-primary"
+            className="bg-primary absolute top-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "padding", "bottom")}
-            className="absolute bottom-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize bg-primary"
+            className="bg-primary absolute bottom-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "padding", "left")}
-            className="absolute left-0 top-1/2 w-1 h-4 -translate-y-1/2 cursor-w-resize bg-primary"
+            className="bg-primary absolute top-1/2 left-0 h-4 w-1 -translate-y-1/2 cursor-w-resize"
           />
           <div
             onPointerDown={(e) => startSpacing(e, "padding", "right")}
-            className="absolute right-0 top-1/2 w-1 h-4 -translate-y-1/2 cursor-e-resize bg-primary"
+            className="bg-primary absolute top-1/2 right-0 h-4 w-1 -translate-y-1/2 cursor-e-resize"
           />
         </>
       )}
       <button
         type="button"
         onClick={onRemove}
-        className="absolute top-1 right-1 rounded bg-danger px-2 text-xs"
+        className="bg-danger absolute top-1 right-1 rounded px-2 text-xs"
         data-token="--color-danger"
       >
         <span className="text-danger-foreground" data-token="--color-danger-fg">
@@ -338,37 +328,85 @@ const CanvasItem = memo(function CanvasItem({
             id={`container-${component.id}`}
             role="list"
             aria-dropeffect="move"
-            className="m-2 flex flex-col gap-4 border border-dashed border-muted p-2"
+            className="border-muted m-2 flex flex-col gap-4 border border-dashed p-2"
           >
             {isOver && (
               <div
                 data-placeholder
-                className="h-4 w-full rounded border-2 border-dashed border-primary bg-primary/10 ring-2 ring-primary"
+                className="border-primary bg-primary/10 ring-primary h-4 w-full rounded border-2 border-dashed ring-2"
               />
             )}
-            {children!.map(
-              (child: PageComponent, i: number) => (
-                <CanvasItem
-                  key={child.id}
-                  component={child}
-                  index={i}
-                  parentId={component.id}
-                  selectedId={selectedId}
-                  onSelectId={onSelectId}
-                  onRemove={() => dispatch({ type: "remove", id: child.id })}
-                  dispatch={dispatch}
-                  locale={locale}
-                  gridEnabled={gridEnabled}
-                  gridCols={gridCols}
-                  viewport={viewport}
-                  device={device}
-                />
-              )
-            )}
+            {children!.map((child: PageComponent, i: number) => (
+              <CanvasItem
+                key={child.id}
+                component={child}
+                index={i}
+                parentId={component.id}
+                selectedId={selectedId}
+                onSelectId={onSelectId}
+                onRemove={() => dispatch({ type: "remove", id: child.id })}
+                dispatch={dispatch}
+                locale={locale}
+                gridEnabled={gridEnabled}
+                gridCols={gridCols}
+                viewport={viewport}
+                device={device}
+              />
+            ))}
           </div>
         </SortableContext>
       )}
     </div>
+  );
+});
+
+const CanvasItem = memo(function CanvasItem({
+  component,
+  index,
+  parentId,
+  selectedId,
+  onSelectId,
+  onRemove,
+  dispatch,
+  locale,
+  gridEnabled = false,
+  gridCols,
+  viewport,
+  device,
+}: Props) {
+  if (component.type === "Text") {
+    return (
+      <TextBlock
+        component={component as TextComponent}
+        index={index}
+        parentId={parentId}
+        selectedId={selectedId}
+        onSelectId={onSelectId}
+        onRemove={onRemove}
+        dispatch={dispatch}
+        locale={locale}
+        gridEnabled={gridEnabled}
+        gridCols={gridCols}
+        viewport={viewport}
+      />
+    );
+  }
+
+  return (
+    <CanvasItemInner
+      component={component}
+      index={index}
+      parentId={parentId}
+      selectedId={selectedId}
+      onSelectId={onSelectId}
+      onRemove={onRemove}
+      dispatch={dispatch}
+      locale={locale}
+      gridEnabled={gridEnabled}
+      gridCols={gridCols}
+      viewport={viewport}
+      device={device}
+    />
   );
 });
 


### PR DESCRIPTION
## Summary
- Refactor CanvasItem to wrap hook-based logic in `CanvasItemInner`
- Use top-level `CanvasItem` wrapper to select between `TextBlock` and `CanvasItemInner` ensuring consistent hook ordering

## Testing
- `npx eslint -c eslint.config.mjs packages/ui/src/components/cms/page-builder/CanvasItem.tsx` *(failed: Cannot find package '@typescript-eslint/parser')*
- `pnpm --filter @acme/ui test` *(failed: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f9d00fec832f94125cf77a0b92ad