### PR TITLE
fix: include setSnapPosition dependency in usePageBuilderDnD

### DIFF
--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
@@ -145,7 +145,7 @@ export function usePageBuilderDnD({
         });
       }
     },
-    [dispatch, components, containerTypes, defaults, selectId]
+    [dispatch, components, containerTypes, defaults, selectId, setSnapPosition]
   );
 
   const handleDragStart = useCallback((ev: DragStartEvent) => {


### PR DESCRIPTION
## Summary
- include `setSnapPosition` in `usePageBuilderDnD`'s `handleDragEndInternal` dependency array

## Testing
- `pnpm exec eslint packages/ui/src`
- `pnpm test --filter @acme/ui` *(fails: moduleNameMapper/@auth config)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f9f1f820832fa1de3b8d9e9f267a