### PR TITLE
fix: include snap position in drag end deps

### DIFF
--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
@@ -145,7 +145,7 @@ export function usePageBuilderDnD({
         });
       }
     },
-    [dispatch, components, containerTypes, defaults, selectId]
+    [dispatch, components, containerTypes, defaults, selectId, setSnapPosition]
   );
 
   const handleDragStart = useCallback((ev: DragStartEvent) => {


### PR DESCRIPTION
## Summary
- include `setSnapPosition` in drag end callback dependencies to satisfy lint rule

## Testing
- `pnpm lint:all` *(fails: Parsing error in template-app files)*
- `pnpm test --filter @acme/ui` *(fails: Cannot find module '@date-utils' in preview-upgrade tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f9f87510832faa077e97886501b8