### PR TITLE
fix: clean up TextBlock callback deps

### DIFF
--- a/packages/ui/src/components/cms/page-builder/TextBlock.tsx
+++ b/packages/ui/src/components/cms/page-builder/TextBlock.tsx
@@ -143,7 +143,7 @@ const TextBlock = memo(function TextBlock({
       } as Partial<TextComponent>,
     });
     setEditing(false);
-  }, [editor, dispatch, component.id, locale, component]);
+  }, [editor, dispatch, locale, component]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- remove redundant useCallback dependency

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/page-builder/TextBlock.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server)*
- `pnpm run lint:all packages/ui/src/components/cms/page-builder/TextBlock.tsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fa03aea4832f93a16bed6651babc