### PR TITLE
fix: avoid conditional hook calls

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -34,10 +34,10 @@ interface Props {
 }
 
 function ComponentEditor({ component, onChange, onResize }: Props) {
-  if (!component) return null;
-
   const { handleInput } = useComponentInputs(onChange);
   const { handleResize, handleFullSize } = useComponentResize(onResize);
+
+  if (!component) return null;
 
   return (
     <Accordion


### PR DESCRIPTION
## Summary
- avoid conditional `useComponentInputs` and `useComponentResize` hooks when component is null

## Testing
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fa0d4d94832f975e95e509d7c2d6