### PR TITLE
chore: lint design tokens package

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,21 +1,2 @@
-// eslint.config.js
-import { fixupPluginRules } from "@eslint/compat";
-import reactHooks from "eslint-plugin-react-hooks";
-
-export default [
-  {
-    ignores: [
-      "**/dist/**",
-      "**/.next/**",
-      "**/index.js",
-    ],
-    plugins: {
-      "react-hooks": fixupPluginRules(reactHooks),
-    },
-    rules: {
-      // Re-export the legacy preset rules but with
-      // getSource() → sourceCode.getText() rewired.
-      ...reactHooks.configs.recommended.rules,
-    },
-  },
-];
+import config from "./eslint.config.mjs";
+export default config;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,8 @@ export default [
       parser: tsParser,
       parserOptions: {
         project: ["./tsconfig.json"],
+        projectService: true,
+        allowDefaultProject: true,
         sourceType: "module",
         ecmaVersion: "latest",
       },

--- a/packages/design-tokens/__tests__/preset.test.ts
+++ b/packages/design-tokens/__tests__/preset.test.ts
@@ -1,9 +1,9 @@
 import { jest } from "@jest/globals";
 
 describe("design tokens preset", () => {
-  it("exports preset configuration", () => {
+  it("exports preset configuration", async () => {
     jest.resetModules();
-    const preset = require("../src/index.ts").default;
+    const preset = (await import("../src/index.ts")).default;
 
     // ensure color tokens exist
     expect(preset.theme?.extend?.colors?.bg).toBe("hsl(var(--color-bg))");

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "rootDir": ".",
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["index.ts", "src/**/*", "__tests__/**/*"],
+  "exclude": ["dist", ".turbo", "node_modules"],
+  "references": [{ "path": "../types" }]
+}

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -4,7 +4,7 @@
 
   "compilerOptions": {
     "composite": true,
-    "noEmit": false, // referenced projects must not disable emit
+    "noEmit": false // referenced projects must not disable emit
   },
 
   "files": [],
@@ -19,6 +19,7 @@
     { "path": "packages/themes/bcd" },
     { "path": "packages/config" },
     { "path": "packages/email" },
+    { "path": "packages/design-tokens" },
     { "path": "packages/ui" },
     { "path": "packages/auth" },
     { "path": "packages/configurator" },


### PR DESCRIPTION
## Summary
- add a tsconfig and workspace reference for design-tokens
- re-export `eslint.config.mjs` and enable projectService so the package is linted
- convert design token preset test to ESM import

## Testing
- `pnpm exec eslint "packages/design-tokens/**/*.{ts,tsx,js,jsx}" --fix`
- `pnpm --filter @acme/design-tokens test -- packages/design-tokens/__tests__/preset.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a6ff507adc832f87261ccfc8d28fde