### PR TITLE
fix: address page builder hook warnings

### DIFF
--- a/packages/ui/src/components/cms/page-builder/TextBlock.tsx
+++ b/packages/ui/src/components/cms/page-builder/TextBlock.tsx
@@ -130,20 +130,22 @@ const TextBlock = memo(function TextBlock({
 
   const editor = useTextEditor(component, locale, editing);
 
+  const { id: componentId, text: componentText } = component;
+
   const finishEdit = useCallback(() => {
     if (!editor) return;
     dispatch({
       type: "update",
-      id: component.id,
+      id: componentId,
       patch: {
         text: {
-          ...(typeof component.text === "object" ? component.text : {}),
+          ...(typeof componentText === "object" ? componentText : {}),
           [locale]: editor.getHTML(),
         },
       } as Partial<TextComponent>,
     });
     setEditing(false);
-  }, [editor, dispatch, locale, component]);
+  }, [editor, dispatch, locale, componentId, componentText]);
 
   return (
     <div

--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderDnD.ts
@@ -14,6 +14,8 @@ import type { PageComponent } from "@acme/types";
 import type { Action } from "../state";
 import { snapToGrid } from "../gridSnap";
 
+const noop = () => {};
+
 function isPointerEvent(
   ev: Event | null | undefined
 ): ev is PointerEvent {
@@ -45,7 +47,7 @@ export function usePageBuilderDnD({
   selectId,
   gridSize = 1,
   canvasRef,
-  setSnapPosition = () => {},
+  setSnapPosition = noop,
 }: Params) {
   const sensors = useSensors(
     useSensor(PointerSensor),


### PR DESCRIPTION
## Summary
- ensure `finishEdit` relies on stable component id/text and tight deps
- provide stable default for `setSnapPosition` in page builder DnD hook

## Testing
- `pnpm --filter @acme/ui exec eslint src/components/cms/page-builder/TextBlock.tsx src/components/cms/page-builder/hooks/usePageBuilderDnD.ts` (configuration missing)
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/__tests__/usePageBuilderDnD.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a70012d788832fb289e9ef4cabc5c0