### PR TITLE
refactor: memoize canvas item inner component

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -29,7 +29,7 @@ type Props = {
   device?: DevicePreset;
 };
 
-const CanvasItemInner = memo(function CanvasItemInner({
+function CanvasItemInner({
   component,
   index,
   parentId,
@@ -358,7 +358,9 @@ const CanvasItemInner = memo(function CanvasItemInner({
       )}
     </div>
   );
-});
+}
+
+const MemoCanvasItemInner = memo(CanvasItemInner);
 
 const CanvasItem = memo(function CanvasItem({
   component,
@@ -393,7 +395,7 @@ const CanvasItem = memo(function CanvasItem({
   }
 
   return (
-    <CanvasItemInner
+    <MemoCanvasItemInner
       component={component}
       index={index}
       parentId={parentId}


### PR DESCRIPTION
## Summary
- refactor CanvasItem to memoize inner component separately so hooks are always invoked in a stable order

## Testing
- `pnpm -F ui test` *(fails: Could not locate module @cms/actions/shops.server mapped as: /workspace/base-shop/apps/cms/$1)*

------
https://chatgpt.com/codex/tasks/task_e_68a700d803a0832f993e6ba327b970b1