### PR TITLE
fix: avoid conditional hook calls in CanvasItem

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
+++ b/packages/ui/src/components/cms/page-builder/CanvasItem.tsx
@@ -43,6 +43,24 @@ const CanvasItem = memo(function CanvasItemComponent({
   viewport,
   device,
 }: Props) {
+  if (component.type === "Text") {
+    return (
+      <TextBlock
+        component={component as TextComponent}
+        index={index}
+        parentId={parentId}
+        selectedId={selectedId}
+        onSelectId={onSelectId}
+        onRemove={onRemove}
+        dispatch={dispatch}
+        locale={locale}
+        gridEnabled={gridEnabled}
+        gridCols={gridCols}
+        viewport={viewport}
+      />
+    );
+  }
+
   const selected = selectedId === component.id;
   const {
     attributes,
@@ -162,24 +180,6 @@ const CanvasItem = memo(function CanvasItemComponent({
   const children = (component as { children?: PageComponent[] }).children;
   const hasChildren = Array.isArray(children);
   const childIds = hasChildren ? children!.map((c) => c.id) : [];
-
-  if (component.type === "Text") {
-    return (
-      <TextBlock
-        component={component as TextComponent}
-        index={index}
-        parentId={parentId}
-        selectedId={selectedId}
-        onSelectId={onSelectId}
-        onRemove={onRemove}
-        dispatch={dispatch}
-        locale={locale}
-        gridEnabled={gridEnabled}
-        gridCols={gridCols}
-        viewport={viewport}
-      />
-    );
-  }
 
   return (
     <div


### PR DESCRIPTION
## Summary
- avoid calling CanvasItem hooks conditionally by returning early for text components

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/page-builder/CanvasItem.tsx` *(fails: ConfigError: Key "plugins": Cannot redefine plugin "import".)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @cms/actions/shops.server mapped as /workspace/base-shop/apps/cms/$1)*

------
https://chatgpt.com/codex/tasks/task_e_68a707a180f4832f8b7a517250e4fd44