### PR TITLE
Enable ESLint to parse JSX in JS files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,15 +12,20 @@ const __dirname = dirname(__filename);
 const compat = new FlatCompat({ baseDirectory: __dirname });
 
 export default [
-  /* ▸ Global ignores ─ JS/JSX are skipped entirely */
+  /* ▸ Global setup */
   {
     ignores: [
       "**/dist/**",
       "**/.next/**",
       "**/index.js",
-      "**/*.js",
-      "**/*.jsx",
     ],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
   },
 
   /* ▸ Next.js presets (bring in @typescript-eslint plugin once) */
@@ -37,6 +42,7 @@ export default [
         allowDefaultProject: true,
         sourceType: "module",
         ecmaVersion: "latest",
+        ecmaFeatures: { jsx: true },
       },
     },
     rules: {
@@ -76,7 +82,6 @@ export default [
   /* ▸ Enforce UI component layering */
   {
     files: ["packages/ui/**/*.{ts,tsx}"],
-    plugins: { import: fixupPluginRules(importPlugin) },
     rules: {
       "import/no-restricted-paths": [
         "error",


### PR DESCRIPTION
## Summary
- allow JSX to be parsed in .js/.jsx sources
- include JSX support for TypeScript rules

## Testing
- `pnpm exec eslint 'apps/cms/src/app/(auth)/login/LoginForm.js'`
- `pnpm exec eslint 'apps/cms/src/app/cms/wizard/tokenUtils.js'`


------
https://chatgpt.com/codex/tasks/task_e_68a7264c4540832f8533086cc4bb1b8b