### PR TITLE
fix: specify types for wizard preview callbacks

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -50,7 +50,8 @@ export default function WizardPreview({
   const device = useMemo<DevicePreset>(() => {
     if (deviceProp) return deviceProp;
     const preset =
-      devicePresets.find((d) => d.id === deviceId) ?? devicePresets[0];
+      devicePresets.find((d: DevicePreset) => d.id === deviceId) ??
+      devicePresets[0];
     return orientation === "portrait"
       ? { ...preset, orientation }
       : {
@@ -295,7 +296,7 @@ export default function WizardPreview({
         <div className="flex justify-end gap-2">
           <DeviceSelector
             deviceId={deviceId}
-            onChange={(id) => {
+            onChange={(id: string) => {
               setDeviceId(id);
               setOrientation("portrait");
             }}
@@ -342,7 +343,7 @@ export default function WizardPreview({
       {selected && popoverPos && (
         <Popover
           open={popoverOpen}
-          onOpenChange={(o) => {
+          onOpenChange={(o: boolean) => {
             setPopoverOpen(o);
             if (!o) {
               setSelected(null);


### PR DESCRIPTION
## Summary
- specify DevicePreset type when finding preview devices
- annotate callback parameters in WizardPreview

## Testing
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` (fails: Cannot find module '@themes/base')
- `pnpm --filter @apps/cms test` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './jest.preset.cjs' is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a72611e0c0832fbfa152f40a4c02e2