### PR TITLE
type: add blog shop typings

### DIFF
--- a/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,7 +1,11 @@
 import { notFound } from "next/navigation";
 import { fetchPostBySlug } from "@acme/sanity";
 import { BlogPortableText } from "@/components/blog/BlogPortableText";
-import shop from "../../../../../shop.json";
+import type { Shop } from "@acme/types";
+import shopJson from "../../../../../shop.json";
+
+type BlogShop = Pick<Shop, "id" | "luxuryFeatures" | "editorialBlog">;
+const shop: BlogShop = shopJson;
 
 export default async function BlogPostPage({
   params,

--- a/apps/shop-abc/src/app/[lang]/blog/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/blog/page.tsx
@@ -1,7 +1,11 @@
 import BlogListing from "@ui/components/cms/blocks/BlogListing";
 import { fetchPublishedPosts } from "@acme/sanity";
 import { notFound } from "next/navigation";
-import shop from "../../../../shop.json";
+import type { Shop } from "@acme/types";
+import shopJson from "../../../../shop.json";
+
+type BlogShop = Pick<Shop, "id" | "luxuryFeatures" | "editorialBlog">;
+const shop: BlogShop = shopJson;
 
 export default async function BlogPage({ params }: { params: { lang: string } }) {
   if (!shop.luxuryFeatures.blog) {


### PR DESCRIPTION
## Summary
- ensure blog pages use typed shop config so `promoteSchedule` is recognized

## Testing
- `npx tsc -p apps/shop-abc/tsconfig.json --noEmit` *(fails: Output file '/workspace/base-shop/packages/ui/dist/src/components/account/index.d.ts' has not been built from source file '/workspace/base-shop/packages/ui/src/components/account/index.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68a725b153dc832fa5041952ab967caa