### PR TITLE
fix type errors in shop-bcd

### DIFF
--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -39,10 +39,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
-  if (parsed.success === false) {
-    return parsed.response;
-  }
+  const parsed = await parseJsonBody(req, schema, "1mb");
+  if (!parsed.success) return parsed.response;
 
   await updateCustomerProfile(session.customerId, parsed.data);
   const profile = await getCustomerProfile(session.customerId);

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -35,10 +35,8 @@ const schema = z
   });
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
-  if (parsed.success === false) {
-    return parsed.response;
-  }
+  const parsed = await parseJsonBody(req, schema, "1mb");
+  if (!parsed.success) return parsed.response;
 
   const body = parsed.data;
   let premierDelivery: Parameters<typeof getShippingRate>[0]["premierDelivery"];

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -18,13 +18,11 @@ const schema = z
   .strict();
 
 export async function POST(req: NextRequest) {
-  const parsed = await parseJsonBody<z.infer<typeof schema>>(req, schema, "1mb");
-  if (parsed.success === false) {
-    return parsed.response;
-  }
+  const parsed = await parseJsonBody(req, schema, "1mb");
+  if (!parsed.success) return parsed.response;
 
   try {
-    const tax = await calculateTax({ provider: "taxjar", ...parsed.data });
+    const tax = await calculateTax(parsed.data);
     return NextResponse.json({ tax });
   } catch (err) {
     return NextResponse.json(

--- a/apps/shop-bcd/src/app/preview/[pageId]/page.tsx
+++ b/apps/shop-bcd/src/app/preview/[pageId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { pageSchema, type Page, type PageComponent } from "@acme/types";
+import { pageSchema, type PageComponent } from "@acme/types";
 import type { Locale } from "@i18n/locales";
 import { devicePresets, getLegacyPreset } from "@ui/utils/devicePresets";
 import PreviewClient from "./PreviewClient";
@@ -27,7 +27,7 @@ export default async function PreviewPage({
   if (!res.ok) {
     throw new Error("Failed to load preview");
   }
-  const page: Page = pageSchema.parse(await res.json());
+  const page = pageSchema.parse(await res.json());
   const components = page.components as PageComponent[];
   const locale = (Object.keys(page.seo.title)[0] || "en") as Locale;
   const init = searchParams.device ?? searchParams.view;


### PR DESCRIPTION
## Summary
- remove explicit generics when parsing API request bodies and rely on zod inference
- pass validated data to shipping, tax, and profile handlers
- ensure preview page supplies typed components to client renderer

## Testing
- `pnpm test` *(fails: command .../packages/next-config exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a725a1b4c8832fbba2ad53d6a4b707