### PR TITLE
fix: use type-only import for CliEnv

### DIFF
--- a/scripts/src/migrate-cms.ts
+++ b/scripts/src/migrate-cms.ts
@@ -9,7 +9,8 @@
  */
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { CliEnvSchema, type CliEnv } from "./types/env";
+import { CliEnvSchema } from "./types/env";
+import type { CliEnv } from "./types/env";
 
 let env: CliEnv;
 try {


### PR DESCRIPTION
## Summary
- fix TS1484 by importing CliEnv as a type-only import

## Testing
- `pnpm exec eslint scripts/src/migrate-cms.ts`
- `pnpm exec tsc --noEmit scripts/src/migrate-cms.ts`
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit` *(fails: Output file has not been built from source)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b32cd60832fb28a2a41fc5a1b72