### PR TITLE
fix: use bundler module resolution for scripts

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -17,7 +17,7 @@
     /* ───── language / module target ───── */
     "module": "esnext",
     "target": "ES2017",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
 
     /* ───── Node typings only ───── */
     "types": ["node"],


### PR DESCRIPTION
## Summary
- enable bundler-based module resolution for scripts to support `@acme/platform-core` subpath imports

## Testing
- `pnpm exec tsc -p scripts/tsconfig.json` *(fails: Output file has not been built from source)*
- `npx jest test/unit/init-shop.spec.ts` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a72bc29100832f84c2f86b73552289