### PR TITLE
fix: await draftMode in product page

### DIFF
--- a/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
+++ b/apps/shop-abc/src/app/[lang]/product/[slug]/page.tsx
@@ -84,7 +84,9 @@ export default async function ProductDetailPage({
 }: {
   params: { slug: string; lang: string };
 }) {
-  const { isEnabled } = draftMode();
+  // draftMode in Next.js may be asynchronous, returning a promise that resolves to
+  // the current draft state. Await it so we can safely read `isEnabled`.
+  const { isEnabled } = await draftMode();
   const product = await getProduct(
     params.slug,
     params.lang as Locale,


### PR DESCRIPTION
## Summary
- await `draftMode()` in product page to properly read draft state

## Testing
- `pnpm test --filter @apps/shop-abc`

------
https://chatgpt.com/codex/tasks/task_e_68a72fcb9830832fb94cba9388fa65ba