### PR TITLE
fix scripts tsconfig paths

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -24,15 +24,15 @@
 
     /* ───── workspace package resolution ───── */
     "paths": {
-      "@acme/platform-core": ["./packages/platform-core/src/index"],
+      "@acme/platform-core": ["packages/platform-core/src/index"],
       "@acme/platform-core/*": [
-        "./packages/platform-core/src/*",
-        "./packages/platform-core/src/*/index"
+        "packages/platform-core/src/*",
+        "packages/platform-core/src/*/index.ts"
       ],
-      "@acme/types": ["./packages/types/src/index"],
+      "@acme/types": ["packages/types/src/index"],
       "@acme/types/*": [
-        "./packages/types/src/*",
-        "./packages/types/src/*/index"
+        "packages/types/src/*",
+        "packages/types/src/*/index.ts"
       ]
     },
 


### PR DESCRIPTION
## Summary
- fix workspace module paths in scripts tsconfig

## Testing
- `pnpm exec tsc -b scripts/tsconfig.json --noEmit` *(fails: Cannot find module '@acme/config/env/core' etc.)*
- `pnpm test:cms -- test/unit/create-shop-cli.spec.ts test/unit/init-shop.spec.ts` *(fails: expected vs received, SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68a765b265c4832faff812bfdd622162