### PR TITLE
fix: type theme parameter in ShopThemePage

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
@@ -36,7 +36,7 @@ export default async function ShopThemePage({
   const tokensByTheme = {
     ...Object.fromEntries(
       await Promise.all(
-        builtInThemes.map(async (t) => [t, { ...baseTokens, ...(await loadThemeTokens(t)) }])
+        builtInThemes.map(async (t: string) => [t, { ...baseTokens, ...(await loadThemeTokens(t)) }])
       )
     ),
     ...presets,


### PR DESCRIPTION
## Summary
- type theme identifier in theme token map to avoid implicit any

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/shop/[shop]/themes/page.tsx`
- `pnpm exec tsc -p apps/cms/tsconfig.json --noEmit` *(fails: Cannot find module '@themes/base' and other missing types)*
- `pnpm test:cms "apps/cms/src/app/cms/shop/[shop]/themes/__tests__/components.test.tsx"` *(no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_68a765f17910832f875372d84c1071b6