### PR TITLE
fix: adjust date-utils path to package root

### DIFF
--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -37,13 +37,10 @@ export async function checkAndAlert(
 ): Promise<void> {
   const settings = await getShopSettings(shop);
   const envRecipients =
-    coreEnv.STOCK_ALERT_RECIPIENTS ?? coreEnv.STOCK_ALERT_RECIPIENT;
+    coreEnv.STOCK_ALERT_RECIPIENTS ?? coreEnv.STOCK_ALERT_RECIPIENT ?? "";
   const recipients = settings.stockAlert?.recipients?.length
     ? settings.stockAlert.recipients
-    : envRecipients
-        ?.split(",")
-        .map((r) => r.trim())
-        .filter(Boolean) ?? [];
+    : envRecipients.split(",").map((r) => r.trim()).filter(Boolean);
   const webhook = settings.stockAlert?.webhook ?? coreEnv.STOCK_ALERT_WEBHOOK;
   const defaultThreshold =
     settings.stockAlert?.threshold ?? coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -110,16 +110,16 @@
         "packages/sanity/*"
       ],
       "@acme/date-utils": [
-        "packages/date-utils/src/index.ts"
+        "packages/date-utils"
       ],
       "@acme/date-utils/*": [
-        "packages/date-utils/src/*"
+        "packages/date-utils/*"
       ],
       "@date-utils": [
-        "packages/date-utils/src/index.ts"
+        "packages/date-utils"
       ],
       "@date-utils/*": [
-        "packages/date-utils/src/*"
+        "packages/date-utils/*"
       ],
       "@acme/configurator": [
         "packages/configurator"


### PR DESCRIPTION
## Summary
- point `@acme/date-utils` TypeScript path to the package root to avoid rootDir errors
- default stock alert env recipients to an empty string to satisfy strict typing

## Testing
- `pnpm -F @acme/platform-core build` *(fails: Module '@prisma/client' has no exported member 'Prisma'; Cannot find module '@acme/email')*


------
https://chatgpt.com/codex/tasks/task_e_68a7710b7e90832fa4adbca855004a01