### PR TITLE
fix: add date-utils project reference in platform-core

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -21,5 +21,8 @@
     "src*.json",
     "src/**/*",
     "src/**/*.json"
+  ],
+  "references": [
+    { "path": "../date-utils" }
   ]
 }


### PR DESCRIPTION
## Summary
- add project reference to date-utils in platform-core tsconfig

## Testing
- `pnpm --filter @acme/platform-core build` *(fails: Module '@prisma/client' has no exported member 'Prisma', '@acme/email' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7711ba3c8832f9dcb249b432b9d65