### PR TITLE
chore: align platform-core tsconfig with repo

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -1,13 +1,43 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
+    "composite": true,
     "declaration": true,
-    "outDir": "dist",
+    "declarationMap": true,
+    "noEmit": false,
     "rootDir": "src",
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "jsx": "react-jsx",
     "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "baseUrl": ".",
+    "paths": {
+      "@acme/ui": ["types-compat/ui"],
+      "@acme/ui/*": ["types-compat/ui"],
+      "@acme/email": ["types-compat/email"],
+      "@acme/email/*": ["types-compat/email"]
+    }
   },
-  "include": ["src"]
+  "include": [
+    "src*",
+    "src*.json",
+    "src/**/*",
+    "src/**/*.json"
+  ],
+  "references": [
+    { "path": "../config" },
+    { "path": "../date-utils" },
+    { "path": "../i18n" },
+    { "path": "../shared-utils" },
+    { "path": "../stripe" },
+    { "path": "../types" },
+    { "path": "../themes/base" },
+    { "path": "../zod-utils" }
+  ],
+  "files": ["../../src/types/global.d.ts"]
 }

--- a/packages/platform-core/types-compat/ui.d.ts
+++ b/packages/platform-core/types-compat/ui.d.ts
@@ -1,0 +1,3 @@
+declare module "@acme/ui" {
+  export type Placeholder = unknown;
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -43,10 +43,6 @@ declare module "react" {
 
 declare module "better-sqlite3";
 
-declare module "@acme/plugin-sanity" {
-  export * from "../../packages/plugins/sanity/index.ts";
-}
-
 declare module "validator/lib/isURL" {
   export default function isURL(
     str: string,


### PR DESCRIPTION
## Summary
- align platform-core tsconfig with repo settings
- drop unused plugin-sanity declaration
- stub @acme/ui types for platform-core

## Testing
- `pnpm --filter @acme/platform-core run build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*


------
https://chatgpt.com/codex/tasks/task_e_68aadea3e5a4832fb5c98cd8d420a98b