### PR TITLE
fix: correct json repository imports

### DIFF
--- a/packages/platform-core/src/repositories/json.server.ts
+++ b/packages/platform-core/src/repositories/json.server.ts
@@ -10,13 +10,13 @@
  * • products.server  – catalogue helpers (read/write/update/delete/…)
  */
 
-export { readShop } from "./dist/repositories/shops.server.js";
+export { readShop } from "./shops.server.js";
 
 // Alias getShopSettings → readSettings so existing callers keep working.
-export { getShopSettings as readSettings } from "./dist/repositories/settings.server.js";
+export { getShopSettings as readSettings } from "./settings.server.js";
 
-export * from "./dist/repositories/products.server.js";
-export * from "./dist/repositories/inventory.server.js";
+export * from "./products.server.js";
+export * from "./inventory.server.js";
 export * from "./pricing.server.js";
 export * from "./returnLogistics.server.js";
 
@@ -24,6 +24,6 @@ export {
   diffHistory,
   getShopSettings,
   saveShopSettings,
-} from "./dist/repositories/settings.server.js";
-export type { SettingsDiffEntry } from "./dist/repositories/settings.server.js";
+} from "./settings.server.js";
+export type { SettingsDiffEntry } from "./settings.server.js";
 export { getShopById, updateShopInRepo } from "./shop.server.js";


### PR DESCRIPTION
## Summary
- fix barrel file to import local repository modules instead of compiled output

## Testing
- `pnpm --filter @acme/platform-core run build` *(fails: Module '@prisma/client' has no exported member 'Prisma'; Cannot find module 'better-sqlite3')*


------
https://chatgpt.com/codex/tasks/task_e_68aae1235e64832fae9cc8d7e607c059