### PR TITLE
Fix template app preview token import and params typing

### DIFF
--- a/packages/template-app/src/app/globals.css
+++ b/packages/template-app/src/app/globals.css
@@ -1,5 +1,5 @@
 @config "../../../../tailwind.config.mjs";
 
-@import "@themes/base/tokens.css";
+@import "@themes/base/src/tokens.css";
 
 @import "tailwindcss";

--- a/packages/template-app/src/app/preview/[pageId]/page.tsx
+++ b/packages/template-app/src/app/preview/[pageId]/page.tsx
@@ -8,10 +8,10 @@ export default async function PreviewPage({
   params,
   searchParams,
 }: {
-  params: { pageId: string };
+  params: Promise<{ pageId: string }>;
   searchParams: { token?: string; upgrade?: string; device?: string; view?: string };
 }) {
-  const { pageId } = params;
+  const { pageId } = await params;
   const query = new URLSearchParams();
   if (searchParams.token) query.set("token", searchParams.token);
   if (searchParams.upgrade) query.set("upgrade", searchParams.upgrade);


### PR DESCRIPTION
## Summary
- update global stylesheet to import tokens from `@themes/base/src/tokens.css`
- adjust preview page to await Promise-based params in Next.js 15

## Testing
- `pnpm --filter @acme/template-app run build` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68aae81074b0832f96a412ae06a5be09