### PR TITLE
fix: correct searchParams type for pickup page

### DIFF
--- a/packages/template-app/src/app/returns/pickup/page.tsx
+++ b/packages/template-app/src/app/returns/pickup/page.tsx
@@ -12,8 +12,9 @@ export const metadata = { title: "Schedule pickup" };
 export default async function PickupPage({
   searchParams,
 }: {
-  searchParams?: { zip?: string };
+  searchParams: Promise<{ zip?: string }>;
 }) {
+  const { zip = "" } = await searchParams;
   const [info, settings, shop] = await Promise.all([
     getReturnBagAndLabel(),
     getShopSettings(SHOP_ID),
@@ -22,7 +23,6 @@ export default async function PickupPage({
   const allowed = settings.returnService?.homePickupEnabled
     ? info.homePickupZipCodes
     : [];
-  const zip = searchParams?.zip || "";
   const isAllowed = zip ? allowed.includes(zip) : false;
   return (
     <div className="p-6 space-y-4">


### PR DESCRIPTION
## Summary
- handle async `searchParams` for returns pickup page by awaiting its value

## Testing
- `pnpm --filter @acme/template-app run build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68aaede8fbf8832f91c0afe342bc84e1