### PR TITLE
chore(email): mark package server-only

### DIFF
--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 export type { CampaignOptions } from "./send";
 export { sendCampaignEmail } from "./send";
 export { registerTemplate, renderTemplate, clearTemplates } from "./templates";

--- a/packages/email/src/templates.js
+++ b/packages/email/src/templates.js
@@ -1,3 +1,4 @@
+import "server-only";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { marketingEmailTemplates } from "@acme/ui";


### PR DESCRIPTION
## Summary
- mark email entry points as server-only

## Testing
- `pnpm --filter @acme/email test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68aaf1c388bc832f8c0d3129ac705141