### PR TITLE
fix(email): isolate react-dom server rendering

### DIFF
--- a/packages/email/src/index.js
+++ b/packages/email/src/index.js
@@ -1,3 +1,6 @@
+"use server";
+import "server-only";
+
 export { sendCampaignEmail } from "./send";
 export { registerTemplate, renderTemplate, clearTemplates } from "./templates";
 export { recoverAbandonedCarts, resolveAbandonedCartDelay } from "./abandonedCart";

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,3 +1,6 @@
+"use server";
+import "server-only";
+
 export type { CampaignOptions } from "./send";
 export { sendCampaignEmail } from "./send";
 export { registerTemplate, renderTemplate, clearTemplates } from "./templates";

--- a/packages/email/src/templates.js
+++ b/packages/email/src/templates.js
@@ -1,8 +1,10 @@
+"use server";
+import "server-only";
 import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import { marketingEmailTemplates } from "@acme/ui";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
+const { renderToStaticMarkup } = await import("react-dom/server");
 const { window } = new JSDOM("");
 const DOMPurify = createDOMPurify(window);
 const templates = {};

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,8 +1,10 @@
+"use server";
+import "server-only";
 import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import { marketingEmailTemplates } from "@acme/ui";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
+const { renderToStaticMarkup } = await import("react-dom/server");
 
 const { window } = new JSDOM("");
 const DOMPurify = createDOMPurify(window);


### PR DESCRIPTION
## Summary
- ensure email entry points are treated as server modules
- load `react-dom/server` dynamically in templates to keep it out of client bundles

## Testing
- `pnpm --filter @acme/email test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68aaf1c388bc832f8c0d3129ac705141