### PR TITLE
fix(email): mark templates server-only and load react-dom dynamically

### DIFF
--- a/packages/email/src/index.js
+++ b/packages/email/src/index.js
@@ -1,8 +1,23 @@
+"use server";
+import "server-only";
+
 export { sendCampaignEmail } from "./send";
 export { registerTemplate, renderTemplate, clearTemplates } from "./templates";
 export { recoverAbandonedCarts, resolveAbandonedCartDelay } from "./abandonedCart";
 export { sendEmail } from "./sendEmail";
 export { resolveSegment, createContact, addToList, listSegments } from "./segments";
-export { createCampaign, listCampaigns, sendDueCampaigns, syncCampaignAnalytics, } from "./scheduler";
+export {
+  createCampaign,
+  listCampaigns,
+  sendDueCampaigns,
+  syncCampaignAnalytics,
+} from "./scheduler";
 export { setCampaignStore, fsCampaignStore } from "./storage";
-export { onSend, onOpen, onClick, emitSend, emitOpen, emitClick, } from "./hooks";
+export {
+  onSend,
+  onOpen,
+  onClick,
+  emitSend,
+  emitOpen,
+  emitClick,
+} from "./hooks";

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,3 +1,4 @@
+"use server";
 import "server-only";
 
 export type { CampaignOptions } from "./send";

--- a/packages/email/src/templates.js
+++ b/packages/email/src/templates.js
@@ -1,9 +1,15 @@
+"use server";
 import "server-only";
 import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import { marketingEmailTemplates } from "@acme/ui";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
+import { createRequire } from "module";
+
+const nodeRequire =
+  typeof require !== "undefined"
+    ? require
+    : createRequire(eval("import.meta.url"));
 const { window } = new JSDOM("");
 const DOMPurify = createDOMPurify(window);
 const templates = {};
@@ -26,6 +32,7 @@ export function clearTemplates() {
  * use the Handlebars-like syntax `{{variable}}`.
  */
 export function renderTemplate(id, params) {
+    const { renderToStaticMarkup } = nodeRequire("react-dom/server");
     const source = templates[id];
     if (source) {
         return source.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,8 +1,15 @@
+"use server";
+import "server-only";
 import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import { marketingEmailTemplates } from "@acme/ui";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
+import { createRequire } from "module";
+
+const nodeRequire =
+  typeof require !== "undefined"
+    ? require
+    : createRequire(eval("import.meta.url"));
 
 const { window } = new JSDOM("");
 const DOMPurify = createDOMPurify(window);
@@ -33,6 +40,7 @@ export function renderTemplate(
   id: string,
   params: Record<string, string>,
 ): string {
+  const { renderToStaticMarkup } = nodeRequire("react-dom/server");
   const source = templates[id];
   if (source) {
     return source.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {


### PR DESCRIPTION
## Summary
- mark `@acme/email` entry points as server-only modules
- dynamically require `react-dom/server` in email templates with Node compatibility

## Testing
- `pnpm lint --filter @acme/email`
- `pnpm --filter @acme/email test -- packages/email/src/__tests__/templates.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab1085a25c832fba02c365b6ad202f