### PR TITLE
fix: remove server directive from email entry

### DIFF
--- a/packages/email/src/index.js
+++ b/packages/email/src/index.js
@@ -1,4 +1,3 @@
-"use server";
 import "server-only";
 
 export { sendCampaignEmail } from "./send";

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,4 +1,3 @@
-"use server";
 import "server-only";
 
 export type { CampaignOptions } from "./send";


### PR DESCRIPTION
## Summary
- fix: remove global "use server" directive from `@acme/email` index to satisfy Next.js

## Testing
- `npx eslint packages/email/src/index.ts`
- `pnpm --filter @acme/email test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab13422534832fbb54bb23a9e7a261