### PR TITLE
fix: avoid server action requirement in email templates

### DIFF
--- a/packages/email/src/templates.js
+++ b/packages/email/src/templates.js
@@ -1,4 +1,3 @@
-"use server";
 import "server-only";
 import * as React from "react";
 import { marketingEmailTemplates } from "@acme/ui";

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,4 +1,3 @@
-"use server";
 import "server-only";
 import * as React from "react";
 import { marketingEmailTemplates } from "@acme/ui";


### PR DESCRIPTION
## Summary
- remove `use server` directive from shared email templates to prevent Next.js from treating helpers as Server Actions

## Testing
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__/templates.test.ts --runInBand` *(fails: SyntaxError in test file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab16dd1740832faeafe821d5bb08eb