### PR TITLE
fix: correct return authorization repository import

### DIFF
--- a/packages/platform-core/src/returnAuthorization.d.ts
+++ b/packages/platform-core/src/returnAuthorization.d.ts
@@ -1,5 +1,5 @@
 import type { ReturnAuthorization } from "@acme/types";
-import { getReturnAuthorization } from "./repositories/returnAuthorization.server.js";
+import { getReturnAuthorization } from "./repositories/returnAuthorization.server";
 export { getTrackingStatus, type TrackingStatusRequest, type TrackingStatus, type TrackingStep, } from "./shipping/index.js";
 export { getReturnAuthorization };
 export declare function listReturnAuthorizations(): Promise<ReturnAuthorization[]>;

--- a/packages/platform-core/src/returnAuthorization.ts
+++ b/packages/platform-core/src/returnAuthorization.ts
@@ -3,7 +3,7 @@ import {
   addReturnAuthorization,
   readReturnAuthorizations,
   getReturnAuthorization,
-} from "./repositories/returnAuthorization.server.js";
+} from "./repositories/returnAuthorization.server";
 export {
   getTrackingStatus,
   type TrackingStatusRequest,


### PR DESCRIPTION
## Summary
- fix return authorization repository import path

## Testing
- `pnpm --filter @acme/platform-core lint` (fails: None of the selected packages has a "lint" script)
- `pnpm test --filter @acme/platform-core`
- `pnpm --filter @acme/platform-core build`


------
https://chatgpt.com/codex/tasks/task_e_68ab24891d38832fb4bc84f8b39d7dcf