### PR TITLE
chore: configure linting for scripts directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+node_modules/
+**/dist/**
+**/build/**
+**/.next/**
+**/coverage/**
+**/*.d.ts
+scripts/**/*.js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,11 @@
 // eslint.config.mjs
 import { FlatCompat } from "@eslint/eslintrc";
 import tsParser from "@typescript-eslint/parser"; // still needed for parser
+import tsPlugin from "@typescript-eslint/eslint-plugin";
 import boundaries from "eslint-plugin-boundaries";
 import importPlugin from "eslint-plugin-import";
 import { fixupPluginRules } from "@eslint/compat";
-import { dirname } from "path";
+import path, { dirname } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -18,6 +19,8 @@ export default [
       "**/dist/**",
       "packages/auth/dist/",
       "**/.next/**",
+      "**/build/**",
+      "**/coverage/**",
       "**/index.js",
       "packages/ui/src/**/*.js",
       "packages/ui/src/**/*.d.ts",
@@ -25,6 +28,7 @@ export default [
       "apps/*/src/**/*.js",
       "apps/*/src/**/*.d.ts",
       "apps/*/src/**/*.js.map",
+      "scripts/**/*.js",
       "**/*.d.ts",
     ],
     languageOptions: {
@@ -61,6 +65,20 @@ export default [
       ],
       // add more TS-only rules here
     },
+  },
+
+  /* ▸ Scripts directory override */
+  {
+    files: ["scripts/**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: [path.join(__dirname, "scripts/tsconfig.eslint.json")],
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: { "@typescript-eslint": tsPlugin },
+    rules: {},
   },
 
   /* ▸ Boundaries rules (unchanged) */

--- a/scripts/src/build-tokens.ts
+++ b/scripts/src/build-tokens.ts
@@ -1,5 +1,5 @@
 // /scripts/src/build-tokens.ts
-/* eslint-disable no-console */
+ 
 
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -163,8 +163,8 @@ if (process.argv[1] === __filename) {
       }).outputText;
 
       const sandbox: {
-        module: { exports: any };
-        exports: any;
+        module: { exports: Record<string, unknown> };
+        exports: Record<string, unknown>;
         require: NodeRequire;
       } = {
         module: { exports: {} },

--- a/scripts/tsconfig.eslint.json
+++ b/scripts/tsconfig.eslint.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+    "types": ["node"]
+  },
+  "include": [
+    "./**/*.ts",
+    "./**/*.tsx",
+    "./__tests__/**/*.ts",
+    "./__tests__/**/*.tsx"
+  ],
+  "exclude": ["./dist", "../node_modules"]
+}


### PR DESCRIPTION
## Summary
- ignore generated build outputs and declarations during lint
- add scripts-specific tsconfig for ESLint
- point ESLint at new config and clean up sandbox typing

## Testing
- `pnpm exec eslint scripts/src/build-tokens.ts --fix` *(fails: `.eslintignore` warning, no lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2464fde0832f835cf67747ed9391