### PR TITLE
chore: move eslint ignores to config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,0 @@
-node_modules/
-**/dist/**
-**/build/**
-**/.next/**
-**/coverage/**
-**/*.d.ts
-scripts/**/*.js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default [
   /* ▸ Global setup */
   {
     ignores: [
+      "node_modules/",
       "**/dist/**",
       "packages/auth/dist/",
       "**/.next/**",


### PR DESCRIPTION
## Summary
- drop legacy `.eslintignore`
- configure ESLint ignores in `eslint.config.mjs`

## Testing
- `pnpm exec eslint scripts/check-tailwind-preset.ts --fix` *(fails: Parsing error: file was not found by the project service)*
- `pnpm exec eslint "scripts/**/*.{ts,tsx,js,jsx}" --fix` *(fails: process terminated after no output)*

------
https://chatgpt.com/codex/tasks/task_e_68ab28baf5f4832f9e980893f5529eca