### PR TITLE
fix: mark countdown timer as client component

### DIFF
--- a/packages/ui/src/components/cms/blocks/CountdownTimer.js
+++ b/packages/ui/src/components/cms/blocks/CountdownTimer.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { jsx as _jsx } from "react/jsx-runtime";
 import { useEffect, useMemo, useState } from "react";
 import { parseTargetDate, getTimeRemaining, formatDuration, } from "@acme/date-utils";

--- a/packages/ui/src/components/cms/blocks/CountdownTimer.tsx
+++ b/packages/ui/src/components/cms/blocks/CountdownTimer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useMemo, useState } from "react";
 import {
   parseTargetDate,


### PR DESCRIPTION
## Summary
- mark CountdownTimer block as a client component

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/blocks/CountdownTimer.tsx packages/ui/src/components/cms/blocks/CountdownTimer.js`
- `pnpm --filter @acme/ui test` *(fails: SyntaxError: Cannot use import statement outside a module in packages/zod-utils/src/zodErrorMap.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e20484c832fab1b63144dd0c55c