### PR TITLE
fix: mark ProductCarousel as client

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductCarousel.js
+++ b/packages/ui/src/components/cms/blocks/ProductCarousel.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { jsx as _jsx } from "react/jsx-runtime";
 import { ProductCarousel as BaseCarousel, } from "../../organisms/ProductCarousel";
 import { PRODUCTS } from "@acme/platform-core/products";

--- a/packages/ui/src/components/cms/blocks/ProductCarousel.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductCarousel.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ProductCarousel as BaseCarousel,
   type ProductCarouselProps as BaseProps,


### PR DESCRIPTION
## Summary
- mark CMS ProductCarousel as a client component so its hooks run correctly

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/blocks/ProductCarousel.tsx packages/ui/src/components/cms/blocks/ProductCarousel.js`
- `pnpm --filter @acme/ui test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `pnpm --filter @acme/ui build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*


------
https://chatgpt.com/codex/tasks/task_e_68ab35db063c832fbab89d2fec2504c4