### PR TITLE
refactor: throw env errors instead of exiting

### DIFF
--- a/packages/config/src/env/core.js
+++ b/packages/config/src/env/core.js
@@ -131,6 +131,6 @@ export const coreEnvSchema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefi
 const parsed = coreEnvSchema.safeParse(process.env);
 if (!parsed.success) {
     console.error("❌ Invalid core environment variables:", parsed.error.format());
-    process.exit(1);
+    throw new Error("Invalid core environment variables");
 }
 export const coreEnv = parsed.data;

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -52,7 +52,7 @@ export const envSchema = mergedEnvSchema.superRefine(
 const parsed = envSchema.safeParse(process.env);
 if (!parsed.success) {
   console.error("❌ Invalid environment variables:", parsed.error.format());
-  process.exit(1);
+  throw new Error("Invalid environment variables");
 }
 
 export const env = parsed.data;

--- a/packages/config/src/env/payments.js
+++ b/packages/config/src/env/payments.js
@@ -8,6 +8,6 @@ export const paymentEnvSchema = z.object({
 const parsed = paymentEnvSchema.safeParse(process.env);
 if (!parsed.success) {
     console.error("❌ Invalid payment environment variables:", parsed.error.format());
-    process.exit(1);
+    throw new Error("Invalid payment environment variables");
 }
 export const paymentEnv = parsed.data;

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -13,7 +13,7 @@ if (!parsed.success) {
     "❌ Invalid payment environment variables:",
     parsed.error.format(),
   );
-  process.exit(1);
+  throw new Error("Invalid payment environment variables");
 }
 
 export const paymentEnv = parsed.data;

--- a/packages/config/src/env/shipping.js
+++ b/packages/config/src/env/shipping.js
@@ -8,6 +8,6 @@ export const shippingEnvSchema = z.object({
 const parsed = shippingEnvSchema.safeParse(process.env);
 if (!parsed.success) {
     console.error("❌ Invalid shipping environment variables:", parsed.error.format());
-    process.exit(1);
+    throw new Error("Invalid shipping environment variables");
 }
 export const shippingEnv = parsed.data;

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -13,7 +13,7 @@ if (!parsed.success) {
     "❌ Invalid shipping environment variables:",
     parsed.error.format(),
   );
-  process.exit(1);
+  throw new Error("Invalid shipping environment variables");
 }
 
 export const shippingEnv = parsed.data;


### PR DESCRIPTION
## Summary
- avoid `process.exit` in env config modules
- throw errors for invalid env values

## Testing
- `pnpm test` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './jest.preset.cjs' is not defined by "exports" in /workspace/base-shop/apps/cms/node_modules/@acme/config/package.json)*
- `pnpm lint` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68ab4771bffc832f9762c4929bc21387