### PR TITLE
fix dynamic imports and default email provider

### DIFF
--- a/dist-types/src/send.js
+++ b/dist-types/src/send.js
@@ -34,11 +34,9 @@ const providers = {
     resend: new ResendProvider(),
 };
 const availableProviders = [...Object.keys(providers), "smtp"];
-if (!coreEnv.EMAIL_PROVIDER) {
-    console.error(`EMAIL_PROVIDER is not set. Available providers: ${availableProviders.join(", ")}`);
-}
-else if (!availableProviders.includes(coreEnv.EMAIL_PROVIDER)) {
-    throw new Error(`Unsupported EMAIL_PROVIDER "${coreEnv.EMAIL_PROVIDER}". Available providers: ${availableProviders.join(", ")}`);
+const providerName = coreEnv.EMAIL_PROVIDER ?? "smtp";
+if (!availableProviders.includes(providerName)) {
+    throw new Error(`Unsupported EMAIL_PROVIDER "${providerName}". Available providers: ${availableProviders.join(", ")}`);
 }
 /**
  * Send a campaign email using the configured provider.
@@ -84,7 +82,7 @@ export async function sendCampaignEmail(options) {
         });
     }
     const optsWithText = ensureText(opts);
-    const primary = coreEnv.EMAIL_PROVIDER ?? "";
+    const primary = providerName;
     const provider = providers[primary];
     // No configured provider – use Nodemailer directly
     if (!provider) {

--- a/packages/config/src/env/core.d.ts
+++ b/packages/config/src/env/core.d.ts
@@ -20,7 +20,7 @@ export declare const coreEnvBaseSchema: z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -74,7 +74,7 @@ export declare const coreEnvBaseSchema: z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -128,7 +128,7 @@ export declare const coreEnvBaseSchema: z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -184,7 +184,7 @@ export declare const coreEnvSchema: z.ZodEffects<z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -238,7 +238,7 @@ export declare const coreEnvSchema: z.ZodEffects<z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -292,7 +292,7 @@ export declare const coreEnvSchema: z.ZodEffects<z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -346,7 +346,7 @@ export declare const coreEnvSchema: z.ZodEffects<z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -400,7 +400,7 @@ export declare const coreEnvSchema: z.ZodEffects<z.ZodObject<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;
@@ -455,7 +455,7 @@ export declare const coreEnv: z.objectOutputType<{
     GA_API_SECRET: z.ZodOptional<z.ZodString>;
     SMTP_URL: z.ZodOptional<z.ZodString>;
     CAMPAIGN_FROM: z.ZodOptional<z.ZodString>;
-    EMAIL_PROVIDER: z.ZodOptional<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: z.ZodDefault<z.ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: z.ZodOptional<z.ZodString>;
     SENDGRID_MARKETING_KEY: z.ZodOptional<z.ZodString>;
     RESEND_API_KEY: z.ZodOptional<z.ZodString>;

--- a/packages/config/src/env/core.js
+++ b/packages/config/src/env/core.js
@@ -20,7 +20,7 @@ export const coreEnvBaseSchema = z.object({
     GA_API_SECRET: z.string().optional(),
     SMTP_URL: z.string().url().optional(),
     CAMPAIGN_FROM: z.string().optional(),
-    EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).optional(),
+    EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).default("smtp"),
     SENDGRID_API_KEY: z.string().optional(),
     SENDGRID_MARKETING_KEY: z.string().optional(),
     RESEND_API_KEY: z.string().optional(),

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -21,7 +21,7 @@ export const coreEnvBaseSchema = z.object({
   GA_API_SECRET: z.string().optional(),
   SMTP_URL: z.string().url().optional(),
   CAMPAIGN_FROM: z.string().optional(),
-  EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).optional(),
+  EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).default("smtp"),
   SENDGRID_API_KEY: z.string().optional(),
   SENDGRID_MARKETING_KEY: z.string().optional(),
   RESEND_API_KEY: z.string().optional(),

--- a/packages/config/src/index.d.ts
+++ b/packages/config/src/index.d.ts
@@ -18,7 +18,7 @@ export declare const env: import("zod").objectOutputType<{
     GA_API_SECRET: import("zod").ZodOptional<import("zod").ZodString>;
     SMTP_URL: import("zod").ZodOptional<import("zod").ZodString>;
     CAMPAIGN_FROM: import("zod").ZodOptional<import("zod").ZodString>;
-    EMAIL_PROVIDER: import("zod").ZodOptional<import("zod").ZodEnum<["sendgrid", "resend", "smtp"]>>;
+    EMAIL_PROVIDER: import("zod").ZodDefault<import("zod").ZodEnum<["sendgrid", "resend", "smtp"]>>;
     SENDGRID_API_KEY: import("zod").ZodOptional<import("zod").ZodString>;
     SENDGRID_MARKETING_KEY: import("zod").ZodOptional<import("zod").ZodString>;
     RESEND_API_KEY: import("zod").ZodOptional<import("zod").ZodString>;

--- a/packages/email/src/__tests__/sendInit.test.ts
+++ b/packages/email/src/__tests__/sendInit.test.ts
@@ -13,12 +13,10 @@ describe("EMAIL_PROVIDER validation", () => {
     delete process.env.EMAIL_PROVIDER;
   });
 
-  it("logs error when EMAIL_PROVIDER is unset", async () => {
+  it("does not log when EMAIL_PROVIDER is unset", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     await import("../send");
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("EMAIL_PROVIDER is not set")
-    );
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it("throws when EMAIL_PROVIDER is unsupported", async () => {

--- a/packages/email/src/send.js
+++ b/packages/email/src/send.js
@@ -34,11 +34,9 @@ const providers = {
     resend: new ResendProvider(),
 };
 const availableProviders = [...Object.keys(providers), "smtp"];
-if (!coreEnv.EMAIL_PROVIDER) {
-    console.error(`EMAIL_PROVIDER is not set. Available providers: ${availableProviders.join(", ")}`);
-}
-else if (!availableProviders.includes(coreEnv.EMAIL_PROVIDER)) {
-    throw new Error(`Unsupported EMAIL_PROVIDER "${coreEnv.EMAIL_PROVIDER}". Available providers: ${availableProviders.join(", ")}`);
+const providerName = coreEnv.EMAIL_PROVIDER ?? "smtp";
+if (!availableProviders.includes(providerName)) {
+    throw new Error(`Unsupported EMAIL_PROVIDER "${providerName}". Available providers: ${availableProviders.join(", ")}`);
 }
 /**
  * Send a campaign email using the configured provider.
@@ -84,7 +82,7 @@ export async function sendCampaignEmail(options) {
         });
     }
     const optsWithText = ensureText(opts);
-    const primary = coreEnv.EMAIL_PROVIDER ?? "";
+    const primary = providerName;
     const provider = providers[primary];
     // No configured provider – use Nodemailer directly
     if (!provider) {

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -58,13 +58,10 @@ const providers: Record<string, CampaignProvider> = {
 
 const availableProviders = [...Object.keys(providers), "smtp"];
 
-if (!coreEnv.EMAIL_PROVIDER) {
-  console.error(
-    `EMAIL_PROVIDER is not set. Available providers: ${availableProviders.join(", ")}`
-  );
-} else if (!availableProviders.includes(coreEnv.EMAIL_PROVIDER)) {
+const providerName = coreEnv.EMAIL_PROVIDER ?? "smtp";
+if (!availableProviders.includes(providerName)) {
   throw new Error(
-    `Unsupported EMAIL_PROVIDER "${coreEnv.EMAIL_PROVIDER}". Available providers: ${availableProviders.join(", ")}`
+    `Unsupported EMAIL_PROVIDER "${providerName}". Available providers: ${availableProviders.join(", ")}`
   );
 }
 
@@ -114,7 +111,7 @@ export async function sendCampaignEmail(
     });
   }
   const optsWithText = ensureText(opts);
-  const primary = coreEnv.EMAIL_PROVIDER ?? "";
+  const primary = providerName;
   const provider = providers[primary];
 
   // No configured provider – use Nodemailer directly

--- a/packages/platform-core/src/themeTokens/index.ts
+++ b/packages/platform-core/src/themeTokens/index.ts
@@ -44,20 +44,18 @@ export function loadThemeTokensNode(theme: string): TokenMap {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const requireFn: NodeRequire =
     typeof require !== "undefined" ? require : createRequire(import.meta.url);
-  try {
-    // attempt to load compiled module
-    const mod = requireFn(
-      /* webpackExclude: /(\.map$|\.d\.ts$|\.tsbuildinfo$)/ */
-      `@themes/${theme}/tailwind-tokens`
-    ) as { tokens: TokenMap };
-    return mod.tokens;
-  } catch {
-    const modPath = join("packages", "themes", theme, "tailwind-tokens.ts");
-    const srcPath = join("packages", "themes", theme, "src", "tailwind-tokens.ts");
-    if (existsSync(modPath)) return transpileTokens(modPath, requireFn);
-    if (existsSync(srcPath)) return transpileTokens(srcPath, requireFn);
-    return {};
+  const baseDir = join("packages", "themes", theme);
+  const candidates = [
+    join(baseDir, "tailwind-tokens.js"),
+    join(baseDir, "tailwind-tokens.ts"),
+    join(baseDir, "src", "tailwind-tokens.ts"),
+  ];
+  for (const file of candidates) {
+    if (existsSync(file)) {
+      return transpileTokens(file, requireFn);
+    }
   }
+  return {};
 }
 
 export async function loadThemeTokensBrowser(theme: string): Promise<TokenMap> {

--- a/packages/ui/src/components/ComponentPreview.js
+++ b/packages/ui/src/components/ComponentPreview.js
@@ -32,7 +32,10 @@ export default function ComponentPreview({ component, componentProps = {} }) {
                 globalThis.__UPGRADE_MOCKS__?.[p]) {
                 return globalThis.__UPGRADE_MOCKS__[p];
             }
-            const m = await import(p);
+            const m = await import(
+            /* webpackIgnore: true */
+            p
+            );
             return m[component.componentName] ?? m.default;
         };
         load(basePath)

--- a/packages/ui/src/components/ComponentPreview.tsx
+++ b/packages/ui/src/components/ComponentPreview.tsx
@@ -54,7 +54,10 @@ export default function ComponentPreview<
       ) {
         return globalThis.__UPGRADE_MOCKS__[p];
       }
-      const m = await import(p);
+      const m = await import(
+        /* webpackIgnore: true */
+        p
+      );
       return (m as Record<string, React.ComponentType>)[
         component.componentName
       ] ?? m.default;


### PR DESCRIPTION
## Summary
- avoid Next.js dynamic import warnings in ComponentPreview
- simplify theme token loading to remove critical require warning
- default EMAIL_PROVIDER to smtp and clean up validation

## Testing
- `pnpm --filter @acme/email exec jest src/__tests__/sendInit.test.ts --runInBand` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c7c5db0832f9649e66584a12285