### PR TITLE
feat(config): improve env error reporting

### DIFF
--- a/packages/config/src/env/core.js
+++ b/packages/config/src/env/core.js
@@ -1,6 +1,7 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-export const coreEnvBaseSchema = z.object({
+export const coreEnvBaseSchema = z
+  .object({
     NEXTAUTH_SECRET: z.string().min(1),
     PREVIEW_TOKEN_SECRET: z.string().optional(),
     UPGRADE_PREVIEW_TOKEN_SECRET: z.string().optional(),
@@ -32,53 +33,51 @@ export const coreEnvBaseSchema = z.object({
     CLOUDFLARE_API_TOKEN: z.string().optional(),
     LUXURY_FEATURES_RA_TICKETING: z.coerce.boolean().optional(),
     LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: z.coerce.number().optional(),
-    LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: z.coerce
-        .boolean()
-        .optional(),
+    LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: z.coerce.boolean().optional(),
     LUXURY_FEATURES_TRACKING_DASHBOARD: z.coerce.boolean().optional(),
     LUXURY_FEATURES_RETURNS: z.coerce.boolean().optional(),
     DEPOSIT_RELEASE_ENABLED: z
-        .string()
-        .refine((v) => v === "true" || v === "false", {
+      .string()
+      .refine((v) => v === "true" || v === "false", {
         message: "must be true or false",
-    })
-        .transform((v) => v === "true")
-        .optional(),
+      })
+      .transform((v) => v === "true")
+      .optional(),
     DEPOSIT_RELEASE_INTERVAL_MS: z
-        .string()
-        .refine((v) => !Number.isNaN(Number(v)), {
+      .string()
+      .refine((v) => !Number.isNaN(Number(v)), {
         message: "must be a number",
-    })
-        .transform((v) => Number(v))
-        .optional(),
+      })
+      .transform((v) => Number(v))
+      .optional(),
     REVERSE_LOGISTICS_ENABLED: z
-        .string()
-        .refine((v) => v === "true" || v === "false", {
+      .string()
+      .refine((v) => v === "true" || v === "false", {
         message: "must be true or false",
-    })
-        .transform((v) => v === "true")
-        .optional(),
+      })
+      .transform((v) => v === "true")
+      .optional(),
     REVERSE_LOGISTICS_INTERVAL_MS: z
-        .string()
-        .refine((v) => !Number.isNaN(Number(v)), {
+      .string()
+      .refine((v) => !Number.isNaN(Number(v)), {
         message: "must be a number",
-    })
-        .transform((v) => Number(v))
-        .optional(),
+      })
+      .transform((v) => Number(v))
+      .optional(),
     LATE_FEE_ENABLED: z
-        .string()
-        .refine((v) => v === "true" || v === "false", {
+      .string()
+      .refine((v) => v === "true" || v === "false", {
         message: "must be true or false",
-    })
-        .transform((v) => v === "true")
-        .optional(),
+      })
+      .transform((v) => v === "true")
+      .optional(),
     LATE_FEE_INTERVAL_MS: z
-        .string()
-        .refine((v) => !Number.isNaN(Number(v)), {
+      .string()
+      .refine((v) => !Number.isNaN(Number(v)), {
         message: "must be a number",
-    })
-        .transform((v) => Number(v))
-        .optional(),
+      })
+      .transform((v) => Number(v))
+      .optional(),
     OPENAI_API_KEY: z.string().optional(),
     SESSION_SECRET: z.string().min(1),
     COOKIE_DOMAIN: z.string().optional(),
@@ -92,45 +91,61 @@ export const coreEnvBaseSchema = z.object({
     SESSION_STORE: z.enum(["memory", "redis"]).optional(),
     UPSTASH_REDIS_REST_URL: z.string().url().optional(),
     UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
-}).passthrough();
+  })
+  .passthrough();
 export function depositReleaseEnvRefinement(env, ctx) {
-    for (const [key, value] of Object.entries(env)) {
-        const isDeposit = key.startsWith("DEPOSIT_RELEASE_");
-        const isReverse = key.startsWith("REVERSE_LOGISTICS_");
-        const isLateFee = key.startsWith("LATE_FEE_");
-        if (!isDeposit && !isReverse && !isLateFee)
-            continue;
-        if (key === "DEPOSIT_RELEASE_ENABLED" ||
-            key === "DEPOSIT_RELEASE_INTERVAL_MS" ||
-            key === "REVERSE_LOGISTICS_ENABLED" ||
-            key === "REVERSE_LOGISTICS_INTERVAL_MS" ||
-            key === "LATE_FEE_ENABLED" ||
-            key === "LATE_FEE_INTERVAL_MS")
-            continue;
-        if (key.includes("ENABLED")) {
-            if (value !== "true" && value !== "false") {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: [key],
-                    message: "must be true or false",
-                });
-            }
-        }
-        else if (key.includes("INTERVAL_MS")) {
-            if (Number.isNaN(Number(value))) {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: [key],
-                    message: "must be a number",
-                });
-            }
-        }
+  for (const [key, value] of Object.entries(env)) {
+    const isDeposit = key.startsWith("DEPOSIT_RELEASE_");
+    const isReverse = key.startsWith("REVERSE_LOGISTICS_");
+    const isLateFee = key.startsWith("LATE_FEE_");
+    if (!isDeposit && !isReverse && !isLateFee) continue;
+    if (
+      key === "DEPOSIT_RELEASE_ENABLED" ||
+      key === "DEPOSIT_RELEASE_INTERVAL_MS" ||
+      key === "REVERSE_LOGISTICS_ENABLED" ||
+      key === "REVERSE_LOGISTICS_INTERVAL_MS" ||
+      key === "LATE_FEE_ENABLED" ||
+      key === "LATE_FEE_INTERVAL_MS"
+    )
+      continue;
+    if (key.includes("ENABLED")) {
+      if (value !== "true" && value !== "false") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: "must be true or false",
+        });
+      }
+    } else if (key.includes("INTERVAL_MS")) {
+      if (Number.isNaN(Number(value))) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: "must be a number",
+        });
+      }
     }
+  }
 }
-export const coreEnvSchema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
+export const coreEnvSchema = coreEnvBaseSchema.superRefine(
+  depositReleaseEnvRefinement
+);
 const parsed = coreEnvSchema.safeParse(process.env);
+// When validation fails, provide a detailed, human-readable report of each
+// invalid variable.  The default `ZodError.format()` returns a nested object
+// which logs as `[object Object]`, making it hard to identify the culprit.
+// To improve visibility, iterate over `parsed.error.issues` and output the
+// path and message for every issue.  The "(root)" label is used when no
+// specific path is provided.
 if (!parsed.success) {
-    console.error("❌ Invalid core environment variables:", parsed.error.format());
-    throw new Error("Invalid core environment variables");
+  console.error("❌ Invalid core environment variables:");
+  parsed.error.issues.forEach((issue) => {
+    const path =
+      issue.path && issue.path.length > 0 ? issue.path.join(".") : "(root)";
+    console.error(`  • ${path}: ${issue.message}`);
+  });
+  // Uncomment the next line to log the full formatted error object for debugging:
+  // console.error(JSON.stringify(parsed.error.format(), null, 2));
+  throw new Error("Invalid core environment variables");
 }
 export const coreEnv = parsed.data;

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,103 +1,103 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
-export const coreEnvBaseSchema = z.object({
-  NEXTAUTH_SECRET: z.string().min(1),
-  PREVIEW_TOKEN_SECRET: z.string().optional(),
-  UPGRADE_PREVIEW_TOKEN_SECRET: z.string().optional(),
-  NODE_ENV: z.enum(["development", "test", "production"]).optional(),
-  OUTPUT_EXPORT: z.coerce.boolean().optional(),
-  NEXT_PUBLIC_PHASE: z.string().optional(),
-  NEXT_PUBLIC_DEFAULT_SHOP: z.string().optional(),
-  NEXT_PUBLIC_SHOP_ID: z.string().optional(),
-  SHOP_CODE: z.string().optional(),
-  CART_COOKIE_SECRET: z.string().min(1),
-  CART_TTL: z.coerce.number().optional(),
-  CMS_SPACE_URL: z.string().url().optional(),
-  CMS_ACCESS_TOKEN: z.string().optional(),
-  CHROMATIC_PROJECT_TOKEN: z.string().optional(),
-  GMAIL_USER: z.string().optional(),
-  GMAIL_PASS: z.string().optional(),
-  GA_API_SECRET: z.string().optional(),
-  SMTP_URL: z.string().url().optional(),
-  CAMPAIGN_FROM: z.string().optional(),
-  EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).default("smtp"),
-  SENDGRID_API_KEY: z.string().optional(),
-  SENDGRID_MARKETING_KEY: z.string().optional(),
-  RESEND_API_KEY: z.string().optional(),
-  EMAIL_BATCH_SIZE: z.coerce.number().optional(),
-  EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),
-  DATABASE_URL: z.string().optional(),
-  SANITY_API_VERSION: z.string().optional(),
-  CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
-  CLOUDFLARE_API_TOKEN: z.string().optional(),
-  LUXURY_FEATURES_RA_TICKETING: z.coerce.boolean().optional(),
-  LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: z.coerce.number().optional(),
-  LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: z.coerce
-    .boolean()
-    .optional(),
-  LUXURY_FEATURES_TRACKING_DASHBOARD: z.coerce.boolean().optional(),
-  LUXURY_FEATURES_RETURNS: z.coerce.boolean().optional(),
-  DEPOSIT_RELEASE_ENABLED: z
-    .string()
-    .refine((v) => v === "true" || v === "false", {
-      message: "must be true or false",
-    })
-    .transform((v) => v === "true")
-    .optional(),
-  DEPOSIT_RELEASE_INTERVAL_MS: z
-    .string()
-    .refine((v) => !Number.isNaN(Number(v)), {
-      message: "must be a number",
-    })
-    .transform((v) => Number(v))
-    .optional(),
-  REVERSE_LOGISTICS_ENABLED: z
-    .string()
-    .refine((v) => v === "true" || v === "false", {
-      message: "must be true or false",
-    })
-    .transform((v) => v === "true")
-    .optional(),
-  REVERSE_LOGISTICS_INTERVAL_MS: z
-    .string()
-    .refine((v) => !Number.isNaN(Number(v)), {
-      message: "must be a number",
-    })
-    .transform((v) => Number(v))
-    .optional(),
-  LATE_FEE_ENABLED: z
-    .string()
-    .refine((v) => v === "true" || v === "false", {
-      message: "must be true or false",
-    })
-    .transform((v) => v === "true")
-    .optional(),
-  LATE_FEE_INTERVAL_MS: z
-    .string()
-    .refine((v) => !Number.isNaN(Number(v)), {
-      message: "must be a number",
-    })
-    .transform((v) => Number(v))
-    .optional(),
-  OPENAI_API_KEY: z.string().optional(),
-  SESSION_SECRET: z.string().min(1),
-  COOKIE_DOMAIN: z.string().optional(),
-  LOGIN_RATE_LIMIT_REDIS_URL: z.string().url().optional(),
-  LOGIN_RATE_LIMIT_REDIS_TOKEN: z.string().optional(),
-  NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
-  STOCK_ALERT_RECIPIENTS: z.string().optional(),
-  STOCK_ALERT_WEBHOOK: z.string().url().optional(),
-  STOCK_ALERT_DEFAULT_THRESHOLD: z.coerce.number().optional(),
-  STOCK_ALERT_RECIPIENT: z.string().email().optional(),
-  SESSION_STORE: z.enum(["memory", "redis"]).optional(),
-  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
-  UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
-}).passthrough();
+export const coreEnvBaseSchema = z
+  .object({
+    NEXTAUTH_SECRET: z.string().min(1),
+    PREVIEW_TOKEN_SECRET: z.string().optional(),
+    UPGRADE_PREVIEW_TOKEN_SECRET: z.string().optional(),
+    NODE_ENV: z.enum(["development", "test", "production"]).optional(),
+    OUTPUT_EXPORT: z.coerce.boolean().optional(),
+    NEXT_PUBLIC_PHASE: z.string().optional(),
+    NEXT_PUBLIC_DEFAULT_SHOP: z.string().optional(),
+    NEXT_PUBLIC_SHOP_ID: z.string().optional(),
+    SHOP_CODE: z.string().optional(),
+    CART_COOKIE_SECRET: z.string().min(1),
+    CART_TTL: z.coerce.number().optional(),
+    CMS_SPACE_URL: z.string().url().optional(),
+    CMS_ACCESS_TOKEN: z.string().optional(),
+    CHROMATIC_PROJECT_TOKEN: z.string().optional(),
+    GMAIL_USER: z.string().optional(),
+    GMAIL_PASS: z.string().optional(),
+    GA_API_SECRET: z.string().optional(),
+    SMTP_URL: z.string().url().optional(),
+    CAMPAIGN_FROM: z.string().optional(),
+    EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).default("smtp"),
+    SENDGRID_API_KEY: z.string().optional(),
+    SENDGRID_MARKETING_KEY: z.string().optional(),
+    RESEND_API_KEY: z.string().optional(),
+    EMAIL_BATCH_SIZE: z.coerce.number().optional(),
+    EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),
+    DATABASE_URL: z.string().optional(),
+    SANITY_API_VERSION: z.string().optional(),
+    CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
+    CLOUDFLARE_API_TOKEN: z.string().optional(),
+    LUXURY_FEATURES_RA_TICKETING: z.coerce.boolean().optional(),
+    LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: z.coerce.number().optional(),
+    LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: z.coerce.boolean().optional(),
+    LUXURY_FEATURES_TRACKING_DASHBOARD: z.coerce.boolean().optional(),
+    LUXURY_FEATURES_RETURNS: z.coerce.boolean().optional(),
+    DEPOSIT_RELEASE_ENABLED: z
+      .string()
+      .refine((v) => v === "true" || v === "false", {
+        message: "must be true or false",
+      })
+      .transform((v) => v === "true")
+      .optional(),
+    DEPOSIT_RELEASE_INTERVAL_MS: z
+      .string()
+      .refine((v) => !Number.isNaN(Number(v)), {
+        message: "must be a number",
+      })
+      .transform((v) => Number(v))
+      .optional(),
+    REVERSE_LOGISTICS_ENABLED: z
+      .string()
+      .refine((v) => v === "true" || v === "false", {
+        message: "must be true or false",
+      })
+      .transform((v) => v === "true")
+      .optional(),
+    REVERSE_LOGISTICS_INTERVAL_MS: z
+      .string()
+      .refine((v) => !Number.isNaN(Number(v)), {
+        message: "must be a number",
+      })
+      .transform((v) => Number(v))
+      .optional(),
+    LATE_FEE_ENABLED: z
+      .string()
+      .refine((v) => v === "true" || v === "false", {
+        message: "must be true or false",
+      })
+      .transform((v) => v === "true")
+      .optional(),
+    LATE_FEE_INTERVAL_MS: z
+      .string()
+      .refine((v) => !Number.isNaN(Number(v)), {
+        message: "must be a number",
+      })
+      .transform((v) => Number(v))
+      .optional(),
+    OPENAI_API_KEY: z.string().optional(),
+    SESSION_SECRET: z.string().min(1),
+    COOKIE_DOMAIN: z.string().optional(),
+    LOGIN_RATE_LIMIT_REDIS_URL: z.string().url().optional(),
+    LOGIN_RATE_LIMIT_REDIS_TOKEN: z.string().optional(),
+    NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
+    STOCK_ALERT_RECIPIENTS: z.string().optional(),
+    STOCK_ALERT_WEBHOOK: z.string().url().optional(),
+    STOCK_ALERT_DEFAULT_THRESHOLD: z.coerce.number().optional(),
+    STOCK_ALERT_RECIPIENT: z.string().email().optional(),
+    SESSION_STORE: z.enum(["memory", "redis"]).optional(),
+    UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+    UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+  })
+  .passthrough();
 
 export function depositReleaseEnvRefinement(
   env: Record<string, unknown>,
-  ctx: z.RefinementCtx,
+  ctx: z.RefinementCtx
 ): void {
   for (const [key, value] of Object.entries(env)) {
     const isDeposit = key.startsWith("DEPOSIT_RELEASE_");
@@ -134,12 +134,25 @@ export function depositReleaseEnvRefinement(
 }
 
 export const coreEnvSchema = coreEnvBaseSchema.superRefine(
-  depositReleaseEnvRefinement,
+  depositReleaseEnvRefinement
 );
 
 const parsed = coreEnvSchema.safeParse(process.env);
+// When validation fails, provide a detailed, human-readable report of each
+// invalid variable.  The default `ZodError.format()` returns a nested object
+// which logs as `[object Object]`, making it hard to identify the culprit.
+// To improve visibility, iterate over `parsed.error.issues` and output the
+// path and message for every issue.  The "(root)" label is used when no
+// specific path is provided.
 if (!parsed.success) {
-  console.error("❌ Invalid core environment variables:", parsed.error.format());
+  console.error("❌ Invalid core environment variables:");
+  parsed.error.issues.forEach((issue) => {
+    const path =
+      issue.path && issue.path.length > 0 ? issue.path.join(".") : "(root)";
+    console.error(`  • ${path}: ${issue.message}`);
+  });
+  // Uncomment the next line to log the full formatted error object for debugging:
+  // console.error(JSON.stringify(parsed.error.format(), null, 2));
   throw new Error("Invalid core environment variables");
 }
 


### PR DESCRIPTION
## Summary
- make core env validation errors list each invalid variable
- compile runtime JS to match TS changes

## Testing
- `pnpm exec jest packages/config/__tests__/env.test.ts --config packages/config/jest.preset.cjs` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2e02bd8c832fb70a7656daeeb81d