### PR TITLE
feat: scaffold new locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "seo:audit": "tsx scripts/seo-audit.ts",
     "validate-env": "ts-node scripts/src/validate-env.ts",
     "check:locales": "ts-node scripts/src/check-locales.ts",
+    "add-locale": "tsx scripts/src/add-locale.ts",
     "check:tailwind-preset": "tsx scripts/check-tailwind-preset.ts",
     "shadcn:diff": "ts-node scripts/diff-shadcn.ts",
     "tailwind:check": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest test/unit/tailwind-build.spec.ts test/unit/postcss-config.spec.ts test/unit/tailwind-postcss.spec.ts",

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,0 +1,13 @@
+# @acme/i18n
+
+## Adding a locale
+
+Run `pnpm add-locale <code>` from the repository root.
+
+This command:
+
+- appends the locale code to [`src/locales.ts`](src/locales.ts)
+- creates a translation stub at [`src/<code>.json`](src)
+- updates internal imports so the new locale is recognised
+
+Fill in the generated JSON file with translations and commit the changes.

--- a/scripts/src/add-locale.ts
+++ b/scripts/src/add-locale.ts
@@ -1,0 +1,70 @@
+// scripts/src/add-locale.ts
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+function usage(): never {
+  console.error("Usage: pnpm add-locale <code>");
+  process.exit(1);
+}
+
+function main() {
+  const code = process.argv[2];
+  if (!code || !/^[a-z]{2}$/i.test(code)) usage();
+  const locale = code.toLowerCase();
+
+  const root = process.cwd();
+  const i18nSrc = path.join(root, "packages", "i18n", "src");
+
+  // Update locales.ts
+  const localesPath = path.join(i18nSrc, "locales.ts");
+  const localesSrc = readFileSync(localesPath, "utf8");
+  const match = localesSrc.match(/LOCALES = \[([^\]]*)\] as const;/);
+  if (!match) {
+    console.error("Could not locate LOCALES array in locales.ts");
+    process.exit(1);
+  }
+  const list = match[1]
+    .split(",")
+    .map((s) => s.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+  if (list.includes(locale)) {
+    console.log(`Locale '${locale}' already present.`);
+  } else {
+    list.push(locale);
+    list.sort();
+    const arrayStr = `[${list.map((l) => `"${l}"`).join(", ")}]`;
+    const updated = localesSrc.replace(
+      /LOCALES = \[[^\]]*\] as const;/,
+      `LOCALES = ${arrayStr} as const;`
+    );
+    writeFileSync(localesPath, updated);
+  }
+
+  // Update useTranslations.server.ts regex
+  const serverPath = path.join(i18nSrc, "useTranslations.server.ts");
+  if (existsSync(serverPath)) {
+    let serverSrc = readFileSync(serverPath, "utf8");
+    const regex = /webpackInclude: \/\(([^)]+)\)\.json\$\//;
+    const localesPattern = list.join("|");
+    if (regex.test(serverSrc)) {
+      serverSrc = serverSrc.replace(
+        regex,
+        `webpackInclude: /(${localesPattern})\\.json$/`
+      );
+      writeFileSync(serverPath, serverSrc);
+    }
+  }
+
+  // Create translation stub
+  const templatePath = path.join(i18nSrc, "en.json");
+  const template = JSON.parse(readFileSync(templatePath, "utf8")) as Record<string, string>;
+  const stub = Object.fromEntries(Object.keys(template).map((k) => [k, ""]));
+  const target = path.join(i18nSrc, `${locale}.json`);
+  if (!existsSync(target)) {
+    writeFileSync(target, JSON.stringify(stub, null, 2) + "\n");
+  }
+
+  console.log(`Added locale '${locale}'.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `add-locale` script to generate locale stubs and update wiring
- document adding locales in i18n package

## Testing
- `npx jest packages/i18n/__tests__/i18n.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ac328d70f0832f99a81bf193f8626b