### PR TITLE
feat: add theme generator

### DIFF
--- a/doc/palette.md
+++ b/doc/palette.md
@@ -12,3 +12,16 @@ The base and dark themes share a minimal colour system built around WCAG AA cont
 | `--color-info` / `--color-info-fg` | `210 90% 96%` / `210 90% 35%` | `210 90% 35%` / `210 90% 96%` | 6.31, 6.31 |
 
 All contrast ratios were measured using the relative luminance method and meet WCAG AA for normal text.
+
+## Theme generator
+
+Use the `generate-theme` helper to build a token map based on a brand color. The
+script extends the base theme tokens and prints the full map as JSON:
+
+```bash
+pnpm ts-node scripts/src/generate-theme.ts '#336699'
+```
+
+During `init-shop` scaffolding you can provide a primary color when prompted.
+Any generated tokens are stored in `data/shops/<id>/shop.json` under
+`themeOverrides`.

--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -1,5 +1,11 @@
 // packages/platform-core/src/createShop/index.ts
-import { readdirSync, existsSync, readFileSync, writeFileSync } from "fs";
+import {
+  readdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "fs";
 import { join } from "path";
 import { genSecret } from "@acme/shared-utils";
 import { Prisma } from "@prisma/client";
@@ -60,6 +66,14 @@ export async function createShop(
   await prisma.shop.create({
     data: { id, data: shopData as unknown as Prisma.InputJsonValue },
   });
+
+  try {
+    const dir = join("data", "shops", id);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "shop.json"), JSON.stringify(shopData, null, 2));
+  } catch {
+    // ignore filesystem write errors
+  }
 
   if (prepared.pages.length) {
     await prisma.page.createMany({

--- a/scripts/src/generate-theme.ts
+++ b/scripts/src/generate-theme.ts
@@ -1,0 +1,79 @@
+import { loadBaseTokens } from "@acme/platform-core/createShop";
+
+function hexToRgb(hex: string): [number, number, number] {
+  let h = hex.replace(/^#/, "");
+  if (h.length === 3) {
+    h = h.split("").map((c) => c + c).join("");
+  }
+  if (!/^([0-9a-f]{6})$/i.test(h)) {
+    throw new Error("Invalid hex color");
+  }
+  const num = parseInt(h, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  const srgb = [r, g, b].map((v) => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * srgb[0] + 0.7152 * srgb[1] + 0.0722 * srgb[2];
+}
+
+export function generateThemeTokens(primary: string): Record<string, string> {
+  const base = loadBaseTokens();
+  const [r, g, b] = hexToRgb(primary);
+  const [h, s, l] = rgbToHsl(r, g, b);
+  const luminance = relativeLuminance(r, g, b);
+  const fg = luminance > 0.5 ? "0 0% 10%" : "0 0% 100%";
+  return {
+    ...base,
+    "--color-primary": `${h} ${s}% ${l}%`,
+    "--color-primary-fg": fg,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const color = process.argv[2];
+  if (!color) {
+    console.error(
+      "Usage: pnpm ts-node scripts/src/generate-theme.ts <hex-color>"
+    );
+    process.exit(1);
+  }
+  try {
+    const tokens = generateThemeTokens(color);
+    console.log(JSON.stringify(tokens, null, 2));
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add `generate-theme` script to derive tokens from a primary brand color
- allow `init-shop` to generate theme overrides using the helper
- persist theme overrides to `data/shops/<id>/shop.json`
- document theme generator usage

## Testing
- `pnpm exec eslint scripts/src/generate-theme.ts scripts/src/init-shop.ts packages/platform-core/src/createShop/index.ts test/unit/init-shop.spec.ts` *(no output)*
- `pnpm exec jest test/unit/init-shop.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ac3c5d108c832fb1ebdbe59fea485b