### PR TITLE
fix: set Node runtime for shops API

### DIFF
--- a/apps/cms/src/app/api/shops/route.ts
+++ b/apps/cms/src/app/api/shops/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { listShops } from "../../cms/listShops";
 
+export const runtime = "nodejs";
+
 export async function GET() {
   try {
     const shops = await listShops();


### PR DESCRIPTION
## Summary
- specify Node runtime for /api/shops route to avoid edge build hang

## Testing
- `pnpm --filter @apps/cms test __tests__/api.shops.test.ts __tests__/listShops.test.ts` *(fails: Package subpath './jest.preset.cjs' is not defined)*
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '@next/eslint-plugin-next')*


------
https://chatgpt.com/codex/tasks/task_e_68ac41707978832faa8ba569a9aa9f2d