### PR TITLE
feat: allow theme overrides via cli flags

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -33,6 +33,14 @@ pnpm init-shop
 
 After answering the prompts the wizard scaffolds `apps/shop-<id>` and writes your answers to `apps/shop-<id>/.env`.
 
+To skip the theme prompts, provide overrides via flags:
+
+```bash
+pnpm init-shop --brand "#663399" --tokens ./my-tokens.json
+```
+
+`--brand` sets the primary brand color and `--tokens` merges additional token overrides from a JSON file.
+
 To populate the new shop with sample data, run `pnpm init-shop --seed`.
 
 Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages.

--- a/docs/theming-advanced.md
+++ b/docs/theming-advanced.md
@@ -85,3 +85,13 @@ useEffect(() => {
   };
 }, []);
 ```
+
+## CLI overrides
+
+Theme tokens can also be supplied when creating a shop:
+
+```bash
+pnpm init-shop --brand "#663399" --tokens ./tokens.json
+```
+
+`--brand` generates tokens for the primary color while `--tokens` loads additional overrides from a JSON file.

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -250,6 +250,37 @@ async function promptPages(): Promise<CreateShopOptions["pages"]> {
  */
 async function promptThemeOverrides(): Promise<Record<string, string>> {
   const overrides: Record<string, string> = {};
+  const argv = process.argv.slice(2);
+  const brandIndex = argv.indexOf("--brand");
+  const tokensIndex = argv.indexOf("--tokens");
+
+  const brandArg = brandIndex !== -1 ? argv[brandIndex + 1] : undefined;
+  const tokensFile = tokensIndex !== -1 ? argv[tokensIndex + 1] : undefined;
+
+  if (brandArg || tokensFile) {
+    if (brandArg) {
+      try {
+        const base = loadBaseTokens();
+        const tokens = generateThemeTokens(brandArg);
+        for (const [k, v] of Object.entries(tokens)) {
+          if (base[k] !== v) overrides[k] = v;
+        }
+      } catch {
+        console.error("Invalid color format.");
+      }
+    }
+    if (tokensFile) {
+      try {
+        const content = readFileSync(tokensFile, "utf8");
+        const json = JSON.parse(content) as Record<string, string>;
+        Object.assign(overrides, json);
+      } catch {
+        console.error("Failed to load token overrides from file.");
+      }
+    }
+    return overrides;
+  }
+
   const brand = await prompt(
     "Primary brand color (hex, blank to skip): "
   );

--- a/test/unit/init-shop.spec.ts
+++ b/test/unit/init-shop.spec.ts
@@ -208,5 +208,213 @@ describe('init-shop wizard', () => {
 
     expect(sandbox.console.error).not.toHaveBeenCalled();
   });
+
+  it('supports theme overrides via CLI flags', async () => {
+    const questions: string[] = [];
+    const answers = [
+      'demo',
+      'Demo Shop',
+      'https://example.com/logo.png',
+      'contact@example.com',
+      '',
+      '1',
+      '1',
+      '1,2',
+      '1',
+      '1',
+      'sk',
+      'pk',
+      'whsec',
+      'client',
+      'secret',
+      'proj',
+      'dataset',
+      'token',
+      'Home',
+      '/',
+      'Shop',
+      '/shop',
+      '',
+      'about',
+      'About Us',
+      '',
+      'n',
+    ];
+    const createShop = jest.fn();
+    const envParse = jest.fn((env: Record<string, string>) => env);
+    let envContent = '';
+    let pkgContent = '{"dependencies":{}}';
+    const validateShopEnv = jest.fn(() => {
+      const env: Record<string, string> = {};
+      for (const line of envContent.split(/\n+/)) {
+        const [k, ...r] = line.split('=');
+        if (k) env[k] = r.join('=');
+      }
+      envParse(env);
+    });
+
+    const sandbox: any = {
+      exports: {},
+      module: { exports: {} },
+      process: {
+        version: 'v20.0.0',
+        exit: jest.fn(),
+        cwd: () => path.join(__dirname, '..', '..'),
+        argv: [
+          'node',
+          'init-shop',
+          '--brand',
+          '#336699',
+          '--tokens',
+          'overrides.json',
+        ],
+      },
+      console: { log: jest.fn(), error: jest.fn() },
+      URL,
+      require: (p: string) => {
+        if (p === 'node:fs') {
+          return {
+            existsSync: () => true,
+            readdirSync: (dir: string) => {
+              if (dir.includes('packages/plugins')) {
+                return [
+                  { name: 'paypal', isDirectory: () => true },
+                  { name: 'sanity', isDirectory: () => true },
+                ];
+              }
+              return [
+                { name: 'base', isDirectory: () => true },
+                { name: 'template-app', isDirectory: () => true },
+              ];
+            },
+            readFileSync: (fp: string) => {
+              if (fp.endsWith('apps/shop-demo/package.json')) return pkgContent;
+              if (fp.includes('packages/plugins/paypal/package.json'))
+                return '{"name":"@acme/plugin-paypal"}';
+              if (fp.includes('packages/plugins/sanity/package.json'))
+                return '{"name":"@acme/plugin-sanity"}';
+              if (fp === 'overrides.json')
+                return '{"--color-bg":"0 0% 0%"}';
+              return '';
+            },
+            writeFileSync: (fp: string, c: string) => {
+              if (fp.endsWith('.env')) envContent = c;
+              else if (fp.endsWith('package.json')) pkgContent = c;
+            },
+          };
+        }
+        if (p === 'node:path') return require('node:path');
+        if (p === 'node:child_process') {
+          return { spawnSync: jest.fn(), execSync: () => '10.0.0' };
+        }
+        if (p === 'node:readline/promises') {
+          return {
+            createInterface: () => ({
+              question: (q: string) => {
+                questions.push(q);
+                return Promise.resolve(answers.shift()!);
+              },
+              close: () => undefined,
+            }),
+          };
+        }
+        if (p.includes('@acme/platform-core/createShop/listProviders')) {
+          return {
+            listProviders: jest.fn((kind: string) =>
+              Promise.resolve(
+                kind === 'payment'
+                  ? [
+                      {
+                        id: 'stripe',
+                        name: 'stripe',
+                        envVars: [
+                          'STRIPE_SECRET_KEY',
+                          'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+                          'STRIPE_WEBHOOK_SECRET',
+                        ],
+                      },
+                      {
+                        id: 'paypal',
+                        name: 'paypal',
+                        envVars: ['PAYPAL_CLIENT_ID', 'PAYPAL_SECRET'],
+                      },
+                    ]
+                  : [
+                      { id: 'dhl', name: 'dhl', envVars: [] },
+                      { id: 'ups', name: 'ups', envVars: [] },
+                    ]
+              )
+            ),
+          };
+        }
+        if (p.includes('@acme/platform-core/createShop')) {
+          return {
+            createShop,
+            loadBaseTokens: () => ({
+              '--color-primary': '100 50% 50%',
+              '--color-primary-fg': '0 0% 10%',
+            }),
+          };
+        }
+        if (p.includes('./generate-theme')) {
+          return {
+            generateThemeTokens: () => ({
+              '--color-primary': '210 60% 40%',
+              '--color-primary-fg': '0 0% 100%',
+            }),
+          };
+        }
+        if (p.includes('./seedShop')) {
+          return { seedShop: jest.fn() };
+        }
+        if (p.includes('@acme/platform-core/configurator')) {
+          return {
+            validateShopEnv,
+            readEnvFile: () => ({
+              STRIPE_SECRET_KEY: '',
+              NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: '',
+              STRIPE_WEBHOOK_SECRET: '',
+            }),
+            pluginEnvVars: {
+              stripe: [
+                'STRIPE_SECRET_KEY',
+                'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+                'STRIPE_WEBHOOK_SECRET',
+              ],
+              paypal: ['PAYPAL_CLIENT_ID', 'PAYPAL_SECRET'],
+              sanity: ['SANITY_PROJECT_ID', 'SANITY_DATASET', 'SANITY_TOKEN'],
+            },
+          };
+        }
+        return require(p);
+      },
+    };
+
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../scripts/src/init-shop.ts'),
+      'utf8'
+    );
+    const transpiled = ts.transpileModule(src, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, esModuleInterop: true },
+    }).outputText;
+
+    const promise = runInNewContext(transpiled, sandbox);
+    await promise;
+
+    expect(createShop).toHaveBeenCalledWith(
+      'shop-demo',
+      expect.objectContaining({
+        themeOverrides: {
+          '--color-primary': '210 60% 40%',
+          '--color-primary-fg': '0 0% 100%',
+          '--color-bg': '0 0% 0%',
+        },
+      })
+    );
+
+    expect(questions.some((q) => q.includes('Primary brand color'))).toBe(
+      false
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- allow specifying theme overrides via `--brand` and `--tokens` flags
- document non-interactive theme override usage
- test CLI theme override flags

## Testing
- `pnpm exec jest test/unit/init-shop.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac43a6d8d8832f92e497952452885a