### PR TITLE
feat(init-shop): auto-apply template defaults

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -31,9 +31,15 @@ pnpm init-shop
 - theme token overrides (`token=value` pairs)
  - environment variables like Stripe keys and CMS credentials
 
+Passing `--defaults` tells the wizard to prefill navigation links and pages
+from the selected template's `shop.json` when those fields exist. Any missing
+entries fall back to interactive prompts.
+
 After answering the prompts the wizard scaffolds `apps/shop-<id>` and writes your answers to `apps/shop-<id>/.env`.
 
 To populate the new shop with sample data, run `pnpm init-shop --seed`.
+Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
+selected template without prompting for them.
 
 Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages.
 

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -65,6 +65,7 @@ function ensureRuntime(): void {
 ensureRuntime();
 
 const seed = process.argv.includes("--seed");
+const useDefaults = process.argv.includes("--defaults");
 
 /**
  * Prompt the user for input. If the user does not provide an answer, return the default value.
@@ -280,6 +281,33 @@ async function promptThemeOverrides(): Promise<Record<string, string>> {
 }
 
 /**
+ * Load default navItems and pages from a template's shop.json if present.
+ * @param root Repository root directory.
+ * @param template Selected template name.
+ */
+function loadTemplateDefaults(
+  root: string,
+  template: string,
+): {
+  navItems?: CreateShopOptions["navItems"];
+  pages?: CreateShopOptions["pages"];
+} {
+  try {
+    const raw = readFileSync(join(root, "packages", template, "shop.json"), "utf8");
+    const data = JSON.parse(raw);
+    const defaults: {
+      navItems?: CreateShopOptions["navItems"];
+      pages?: CreateShopOptions["pages"];
+    } = {};
+    if (Array.isArray(data.navItems)) defaults.navItems = data.navItems;
+    if (Array.isArray(data.pages)) defaults.pages = data.pages;
+    return defaults;
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Main entry point for the init-shop CLI. Collects shop configuration
  * through prompts and calls createShop to scaffold a new shop. Validates
  * the resulting environment file and optionally sets up CI.
@@ -365,8 +393,15 @@ async function main(): Promise<void> {
       envVars[key] = await prompt(`${key}: `, envVars[key] ?? "");
     }
   }
-  const navItems = await promptNavItems();
-  const pages = await promptPages();
+  const templateDefaults = loadTemplateDefaults(rootDir, template);
+  const navItems =
+    useDefaults && templateDefaults.navItems
+      ? templateDefaults.navItems
+      : await promptNavItems();
+  const pages =
+    useDefaults && templateDefaults.pages
+      ? templateDefaults.pages
+      : await promptPages();
   const themeOverrides = await promptThemeOverrides();
   const ciAns = await prompt("Setup CI workflow? (y/N): ");
 


### PR DESCRIPTION
## Summary
- support `--defaults` flag in `init-shop` to use navItems and pages from template shop.json
- document template default sources and `--defaults` flag in setup guide

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68ac43a4de14832f94a91b15e7efbb27