### PR TITLE
feat: allow init-shop to auto fill env vars

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -50,6 +50,9 @@ pnpm init-shop --brand "#663399" --tokens ./my-tokens.json
 To populate the new shop with sample data, run `pnpm init-shop --seed`.
 Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
 selected template without prompting for them.
+Add `--auto-env` to skip prompts for provider environment variables. The wizard writes
+`TODO_*` placeholders to the new shop's `.env` file; replace them with real
+secrets before deploying.
 
 Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages.
 
@@ -126,6 +129,9 @@ Scaffolded apps/shop-demo
 ## 2. Review environment variables
 
 The wizard captures common environment variables and writes them to `apps/shop-<id>/.env`.
+
+If you used `--auto-env`, this file contains placeholder values like `TODO_API_KEY`.
+These placeholders must be replaced with real credentials before deployment.
 
 ```bash
 pnpm validate-env <id>

--- a/scripts/src/init-shop.ts
+++ b/scripts/src/init-shop.ts
@@ -66,6 +66,7 @@ ensureRuntime();
 
 const seed = process.argv.includes("--seed");
 const useDefaults = process.argv.includes("--defaults");
+const autoEnv = process.argv.includes("--auto-env");
 
 /**
  * Prompt the user for input. If the user does not provide an answer, return the default value.
@@ -421,7 +422,11 @@ async function main(): Promise<void> {
   for (const id of selectedPlugins) {
     const vars = pluginMap.get(id)?.envVars ?? [];
     for (const key of vars) {
-      envVars[key] = await prompt(`${key}: `, envVars[key] ?? "");
+      if (autoEnv) {
+        envVars[key] = envVars[key] ?? `TODO_${key}`;
+      } else {
+        envVars[key] = await prompt(`${key}: `, envVars[key] ?? "");
+      }
     }
   }
   const templateDefaults = loadTemplateDefaults(rootDir, template);
@@ -510,6 +515,12 @@ async function main(): Promise<void> {
     console.error("\nEnvironment validation failed:\n", validationError);
   } else {
     console.log("\nEnvironment variables look valid.");
+  }
+
+  if (autoEnv) {
+    console.warn(
+      `\nWARNING: placeholder environment variables were written to apps/${prefixedId}/.env. Replace any TODO_* values with real secrets before deployment.`,
+    );
   }
 
   console.log(


### PR DESCRIPTION
## Summary
- add `--auto-env` option to `init-shop` to skip env prompts and write TODO placeholders
- warn users that placeholders must be replaced before deploy
- document `--auto-env` usage and limitations in setup guide

## Testing
- `pnpm test` *(fails: @apps/cms#test command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68ac468f53e8832f905f21db16823fed