### PR TITLE
refactor: modularize style tokens

### DIFF
--- a/packages/ui/src/components/cms/style/ColorToken.tsx
+++ b/packages/ui/src/components/cms/style/ColorToken.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ColorInput } from "../index";
+import type { TokenInfo, TokenMap } from "../../../hooks/useTokenEditor";
+import { useTokenColors } from "../../../hooks/useTokenColors";
+import { ReactElement } from "react";
+
+interface ColorTokenProps extends TokenInfo {
+  tokens: TokenMap;
+  baseTokens: TokenMap;
+  setToken: (key: string, value: string) => void;
+}
+
+export function ColorToken({
+  key: tokenKey,
+  value,
+  defaultValue,
+  isOverridden,
+  tokens,
+  baseTokens,
+  setToken,
+}: ColorTokenProps): ReactElement {
+  const warning = useTokenColors(tokenKey, value, tokens, baseTokens);
+
+  return (
+    <label
+      key={tokenKey}
+      data-token-key={tokenKey}
+      className={`flex flex-col gap-1 text-sm ${
+        isOverridden ? "border-l-2 border-l-info pl-2" : ""
+      }`}
+      data-token={isOverridden ? "--color-info" : undefined}
+    >
+      <span className="flex items-center gap-2">
+        <span className="w-40 flex-shrink-0">{tokenKey}</span>
+        <ColorInput value={value} onChange={(val) => setToken(tokenKey, val)} />
+        {isOverridden && (
+          <button
+            type="button"
+            className="rounded border px-2 py-1 text-xs"
+            onClick={() => setToken(tokenKey, defaultValue ?? "")}
+          >
+            Reset
+          </button>
+        )}
+      </span>
+      {defaultValue && (
+        <span className="text-xs text-muted-foreground">
+          Default: {defaultValue}
+        </span>
+      )}
+      {warning && (
+        <span className="text-xs text-danger" data-token="--color-danger">
+          Low contrast ({warning.contrast.toFixed(2)}:1)
+          {warning.suggestion ? ` – try ${warning.suggestion}` : ""}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/packages/ui/src/components/cms/style/FontToken.tsx
+++ b/packages/ui/src/components/cms/style/FontToken.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { FontSelect } from "../index";
+import type { TokenInfo } from "../../../hooks/useTokenEditor";
+import type { ChangeEvent, ReactElement } from "react";
+
+interface FontTokenProps extends TokenInfo {
+  options: string[];
+  type: "mono" | "sans";
+  googleFonts: string[];
+  setToken: (key: string, value: string) => void;
+  handleUpload: (type: "sans" | "mono", e: ChangeEvent<HTMLInputElement>) => void;
+  setGoogleFont: (type: "sans" | "mono", name: string) => void;
+}
+
+export function FontToken({
+  key: tokenKey,
+  value,
+  defaultValue,
+  isOverridden,
+  options,
+  type,
+  googleFonts,
+  setToken,
+  handleUpload,
+  setGoogleFont,
+}: FontTokenProps): ReactElement {
+  return (
+    <label
+      key={tokenKey}
+      data-token-key={tokenKey}
+      className={`flex flex-col gap-1 text-sm ${
+        isOverridden ? "border-l-2 border-l-info pl-2" : ""
+      }`}
+      data-token={isOverridden ? "--color-info" : undefined}
+    >
+      <span className="flex items-center gap-2">
+        <span className="w-40 flex-shrink-0">{tokenKey}</span>
+        <FontSelect
+          value={value}
+          options={options}
+          onChange={(val) => setToken(tokenKey, val)}
+          onUpload={(e) => handleUpload(type, e)}
+        />
+        {isOverridden && (
+          <button
+            type="button"
+            className="rounded border px-2 py-1 text-xs"
+            onClick={() => setToken(tokenKey, defaultValue ?? "")}
+          >
+            Reset
+          </button>
+        )}
+        <select
+          className="rounded border p-1"
+          onChange={(e) => {
+            if (e.target.value) {
+              setGoogleFont(type, e.target.value);
+              e.target.value = "";
+            }
+          }}
+        >
+          <option value="">Google Fonts</option>
+          {googleFonts.map((f: string) => (
+            <option key={f} value={f} style={{ fontFamily: f }}>
+              {f}
+            </option>
+          ))}
+        </select>
+      </span>
+      {defaultValue && (
+        <span className="text-xs text-muted-foreground">
+          Default: {defaultValue}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/packages/ui/src/components/cms/style/RangeToken.tsx
+++ b/packages/ui/src/components/cms/style/RangeToken.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { RangeInput } from "../index";
+import type { TokenInfo } from "../../../hooks/useTokenEditor";
+import { ReactElement } from "react";
+
+interface RangeTokenProps extends TokenInfo {
+  setToken: (key: string, value: string) => void;
+}
+
+export function RangeToken({
+  key: tokenKey,
+  value,
+  defaultValue,
+  isOverridden,
+  setToken,
+}: RangeTokenProps): ReactElement {
+  return (
+    <label
+      key={tokenKey}
+      data-token-key={tokenKey}
+      className={`flex items-center gap-2 text-sm ${
+        isOverridden ? "border-l-2 border-l-info pl-2" : ""
+      }`}
+      data-token={isOverridden ? "--color-info" : undefined}
+    >
+      <span className="w-40 flex-shrink-0">{tokenKey}</span>
+      <RangeInput value={value} onChange={(val) => setToken(tokenKey, val)} />
+      {isOverridden && (
+        <button
+          type="button"
+          className="rounded border px-2 py-1 text-xs"
+          onClick={() => setToken(tokenKey, defaultValue ?? "")}
+        >
+          Reset
+        </button>
+      )}
+      {defaultValue && (
+        <span className="text-xs text-muted-foreground">
+          Default: {defaultValue}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/packages/ui/src/components/cms/style/TextToken.tsx
+++ b/packages/ui/src/components/cms/style/TextToken.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Input } from "../../atoms/shadcn";
+import type { TokenInfo } from "../../../hooks/useTokenEditor";
+import { ReactElement, ChangeEvent } from "react";
+
+interface TextTokenProps extends TokenInfo {
+  setToken: (key: string, value: string) => void;
+}
+
+export function TextToken({
+  key: tokenKey,
+  value,
+  defaultValue,
+  isOverridden,
+  setToken,
+}: TextTokenProps): ReactElement {
+  return (
+    <label
+      key={tokenKey}
+      data-token-key={tokenKey}
+      className={`flex items-center gap-2 text-sm ${
+        isOverridden ? "border-l-2 border-l-info pl-2" : ""
+      }`}
+      data-token={isOverridden ? "--color-info" : undefined}
+    >
+      <span className="w-40 flex-shrink-0">{tokenKey}</span>
+      <Input
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setToken(tokenKey, e.target.value)
+        }
+      />
+      {isOverridden && (
+        <button
+          type="button"
+          className="rounded border px-2 py-1 text-xs"
+          onClick={() => setToken(tokenKey, defaultValue ?? "")}
+        >
+          Reset
+        </button>
+      )}
+      {defaultValue && (
+        <span className="text-xs text-muted-foreground">
+          Default: {defaultValue}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from "./useProductEditorFormState";
 export * from "./useProductFilters";
 export * from "./useTokenEditor";
 export * from "./usePreviewDevice";
+export * from "./useTokenColors";

--- a/packages/ui/src/hooks/useTokenColors.ts
+++ b/packages/ui/src/hooks/useTokenColors.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import type { TokenMap } from "./useTokenEditor";
+import { getContrast, suggestContrastColor } from "../components/cms/ColorInput";
+
+export interface ContrastWarning {
+  contrast: number;
+  suggestion: string | null;
+}
+
+export function useTokenColors(
+  key: string,
+  value: string,
+  tokens: TokenMap,
+  baseTokens: TokenMap
+): ContrastWarning | null {
+  return useMemo(() => {
+    let pairKey = "";
+    if (key.startsWith("--color-bg")) {
+      pairKey = `--color-fg${key.slice("--color-bg".length)}`;
+    } else if (key.startsWith("--color-fg")) {
+      pairKey = `--color-bg${key.slice("--color-fg".length)}`;
+    } else if (key.endsWith("-fg")) {
+      pairKey = key.slice(0, -3);
+    } else {
+      const candidate = `${key}-fg`;
+      if (
+        tokens[candidate as keyof TokenMap] !== undefined ||
+        baseTokens[candidate as keyof TokenMap] !== undefined
+      ) {
+        pairKey = candidate;
+      }
+    }
+    const pairVal = pairKey
+      ? tokens[pairKey as keyof TokenMap] ??
+        baseTokens[pairKey as keyof TokenMap]
+      : undefined;
+    if (pairVal) {
+      const contrast = getContrast(value, pairVal);
+      if (contrast < 4.5) {
+        const suggestion = suggestContrastColor(value, pairVal);
+        return { contrast, suggestion };
+      }
+    }
+    return null;
+  }, [key, value, tokens, baseTokens]);
+}


### PR DESCRIPTION
## Summary
- extract color contrast helpers into `useTokenColors` hook
- split token inputs into `ColorToken`, `FontToken`, `RangeToken`, and `TextToken` components
- simplify `Tokens.tsx` to orchestrate specialized components

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/src/components/cms/style/Tokens.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ac495092fc832f8f6f3fc3cca30fa8