### PR TITLE
Refactor wizard preview into composable hooks

### DIFF
--- a/apps/cms/__tests__/wizardPreview.sanitize.test.tsx
+++ b/apps/cms/__tests__/wizardPreview.sanitize.test.tsx
@@ -30,15 +30,6 @@ jest.mock(
   () => ({ devicePresets: [{ id: "d", type: "desktop", width: 100, height: 100 }] }),
   { virtual: true }
 );
-jest.mock("@ui/components/common/DeviceSelector", () => ({ __esModule: true, default: () => null }), {
-  virtual: true,
-});
-jest.mock("@radix-ui/react-icons", () => ({ ReloadIcon: () => null }), {
-  virtual: true,
-});
-jest.mock("@ui/hooks", () => ({ usePreviewDevice: () => ["d", jest.fn()] }), {
-  virtual: true,
-});
 jest.mock("@platform-core/themeTokens", () => ({
   baseTokens: {},
   loadThemeTokensBrowser: () => ({}),

--- a/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
@@ -5,8 +5,10 @@
 import { Button, Input } from "@ui/components/atoms/shadcn";
 import { LOCALES } from "@acme/i18n";
 import type { Locale } from "@acme/types";
-import React from "react";
+import React, { useState } from "react";
 import WizardPreview from "../../wizard/WizardPreview";
+import PreviewDeviceSelector from "../../wizard/PreviewDeviceSelector";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 
@@ -60,6 +62,7 @@ export default function StepSummary({
   const languages = LOCALES as readonly Locale[];
   const [, markComplete] = useStepCompletion("summary");
   const router = useRouter();
+  const [device, setDevice] = useState<DevicePreset>(devicePresets[0]);
 
   return (
     <div className="space-y-4">
@@ -153,7 +156,8 @@ export default function StepSummary({
 
       {result && <p className="text-sm">{result}</p>}
 
-      <WizardPreview style={themeStyle} />
+      <PreviewDeviceSelector onChange={setDevice} />
+      <WizardPreview style={themeStyle} device={device} />
 
       <div className="flex justify-end">
         <Button

--- a/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
@@ -3,6 +3,9 @@
 import { Button } from "@/components/atoms/shadcn";
 import StyleEditor from "@ui/components/cms/StyleEditor";
 import WizardPreview from "../../wizard/WizardPreview";
+import TokenInspector from "../../wizard/TokenInspector";
+import PreviewDeviceSelector from "../../wizard/PreviewDeviceSelector";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -17,6 +20,7 @@ export default function StepTokens(): React.JSX.Element {
   const { themeDefaults, themeOverrides, setThemeOverrides } = useConfigurator();
   const tokens = { ...themeDefaults, ...themeOverrides } as TokenMap;
   const [selected, setSelected] = useState<string | null>(null);
+  const [device, setDevice] = useState<DevicePreset>(devicePresets[0]);
 
   const handleChange = (next: TokenMap) => {
     const overrides: TokenMap = { ...next };
@@ -33,11 +37,10 @@ export default function StepTokens(): React.JSX.Element {
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Customize Tokens</h2>
-      <WizardPreview
-        style={previewStyle}
-        inspectMode
-        onTokenSelect={(t) => setSelected(t)}
-      />
+      <PreviewDeviceSelector onChange={setDevice} />
+      <TokenInspector inspectMode onTokenSelect={(t) => setSelected(t)}>
+        <WizardPreview style={previewStyle} device={device} />
+      </TokenInspector>
       {selected && (
         <StyleEditor
           tokens={themeOverrides}

--- a/apps/cms/src/app/cms/shop/[shop]/themes/PreviewPane.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/PreviewPane.tsx
@@ -3,6 +3,9 @@
 import { useState, useRef, useEffect, type CSSProperties } from "react";
 import StyleEditor from "@/components/cms/StyleEditor";
 import WizardPreview from "../../../wizard/WizardPreview";
+import TokenInspector from "../../../wizard/TokenInspector";
+import PreviewDeviceSelector from "../../../wizard/PreviewDeviceSelector";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import { type TokenMap } from "../../../wizard/tokenUtils";
 
 interface Props {
@@ -20,6 +23,7 @@ export default function PreviewPane({
 }: Props) {
   const [selectedToken, setSelectedToken] = useState<string | null>(null);
   const styleEditorRef = useRef<HTMLDivElement | null>(null);
+  const [device, setDevice] = useState<DevicePreset>(devicePresets[0]);
 
   useEffect(() => {
     if (selectedToken) {
@@ -32,11 +36,10 @@ export default function PreviewPane({
 
   return (
     <>
-      <WizardPreview
-        style={style}
-        inspectMode
-        onTokenSelect={(t) => setSelectedToken(t)}
-      />
+      <PreviewDeviceSelector onChange={setDevice} />
+      <TokenInspector inspectMode onTokenSelect={(t) => setSelectedToken(t)}>
+        <WizardPreview style={style} device={device} />
+      </TokenInspector>
       {selectedToken && (
         <div ref={styleEditorRef}>
           <StyleEditor

--- a/apps/cms/src/app/cms/shop/[shop]/themes/ThemePreview.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/ThemePreview.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react";
 import InlineColorPicker from "./InlineColorPicker";
 import WizardPreview from "../../../wizard/WizardPreview";
+import TokenInspector from "../../../wizard/TokenInspector";
+import PreviewDeviceSelector from "../../../wizard/PreviewDeviceSelector";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import type { CSSProperties } from "react";
 
 interface Picker {
@@ -30,6 +33,7 @@ export default function ThemePreview({
   onTokenSelect,
 }: Props) {
   const [picker, setPicker] = useState<Picker | null>(null);
+  const [device, setDevice] = useState<DevicePreset>(devicePresets[0]);
 
   const handleTokenClick = (
     token: string,
@@ -68,11 +72,13 @@ export default function ThemePreview({
           onClose={handlePickerClose}
         />
       )}
-      <WizardPreview
-        style={previewTokens as CSSProperties}
-        inspectMode
-        onTokenSelect={handleTokenClick}
-      />
+      <PreviewDeviceSelector onChange={setDevice} />
+      <TokenInspector inspectMode onTokenSelect={handleTokenClick}>
+        <WizardPreview
+          style={previewTokens as CSSProperties}
+          device={device}
+        />
+      </TokenInspector>
     </>
   );
 }

--- a/apps/cms/src/app/cms/wizard/PreviewDeviceSelector.tsx
+++ b/apps/cms/src/app/cms/wizard/PreviewDeviceSelector.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Button } from "@ui/components/atoms";
+import DeviceSelector from "@ui/components/common/DeviceSelector";
+import { ReloadIcon } from "@radix-ui/react-icons";
+import { usePreviewDevice } from "@ui/src/hooks/usePreviewDevice";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
+
+interface Props {
+  onChange?: (device: DevicePreset) => void;
+}
+
+export default function PreviewDeviceSelector({ onChange }: Props) {
+  const [deviceId, setDeviceId] = usePreviewDevice(devicePresets[0].id);
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
+    "portrait"
+  );
+
+  const device = useMemo<DevicePreset>(() => {
+    const preset =
+      devicePresets.find((d: DevicePreset) => d.id === deviceId) ??
+      devicePresets[0];
+    return orientation === "portrait"
+      ? { ...preset, orientation }
+      : {
+          ...preset,
+          width: preset.height,
+          height: preset.width,
+          orientation,
+        };
+  }, [deviceId, orientation]);
+
+  useEffect(() => {
+    onChange?.(device);
+  }, [device, onChange]);
+
+  return (
+    <div className="flex justify-end gap-2">
+      <DeviceSelector
+        deviceId={deviceId}
+        onChange={(id: string) => {
+          setDeviceId(id);
+          setOrientation("portrait");
+        }}
+        showLegacyButtons
+      />
+      <Button
+        variant="outline"
+        onClick={() =>
+          setOrientation((o) => (o === "portrait" ? "landscape" : "portrait"))
+        }
+        aria-label="Rotate"
+      >
+        <ReloadIcon
+          className={orientation === "landscape" ? "rotate-90" : ""}
+        />
+      </Button>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/wizard/TokenInspector.tsx
+++ b/apps/cms/src/app/cms/wizard/TokenInspector.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@ui/components/atoms";
+
+interface Props {
+  inspectMode?: boolean;
+  onTokenSelect?: (token: string, coords: { x: number; y: number }) => void;
+  children: React.ReactElement;
+}
+
+export default function TokenInspector({
+  inspectMode = false,
+  onTokenSelect,
+  children,
+}: Props) {
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const tokenElsRef = useRef<HTMLElement[]>([]);
+  const [hoverEl, setHoverEl] = useState<HTMLElement | null>(null);
+  const [selected, setSelected] = useState<{ el: HTMLElement; token: string } | null>(
+    null
+  );
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [popoverPos, setPopoverPos] = useState<{ x: number; y: number } | null>(
+    null
+  );
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  useEffect(() => {
+    if (!hoverEl || selected?.el === hoverEl) return;
+    const prev = hoverEl.style.outline;
+    hoverEl.style.outline = "2px solid #3b82f6";
+    return () => {
+      hoverEl.style.outline = prev;
+    };
+  }, [hoverEl, selected]);
+
+  useEffect(() => {
+    if (!selected || !popoverOpen) return;
+    const el = selected.el;
+    const prevOutline = el.style.outline;
+    const prevAnimation = el.style.animation;
+    el.style.outline = "2px solid #3b82f6";
+    el.style.animation = "wizard-outline 1s ease-in-out infinite";
+    return () => {
+      el.style.outline = prevOutline;
+      el.style.animation = prevAnimation;
+    };
+  }, [selected, popoverOpen]);
+
+  useEffect(() => {
+    const styleEl = document.createElement("style");
+    styleEl.textContent =
+      "@keyframes wizard-outline{0%,100%{outline-color:#3b82f6;}50%{outline-color:#93c5fd;}}";
+    document.head.appendChild(styleEl);
+    return () => {
+      document.head.removeChild(styleEl);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!inspectMode || !previewRef.current) return;
+    tokenElsRef.current = Array.from(
+      previewRef.current.querySelectorAll("[data-token]")
+    ) as HTMLElement[];
+  }, [inspectMode, children]);
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!inspectMode || popoverOpen) return;
+    const el = (e.target as HTMLElement).closest(
+      "[data-token]"
+    ) as HTMLElement | null;
+    setHoverEl(el);
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!inspectMode) return;
+    const el = (e.target as HTMLElement).closest(
+      "[data-token]"
+    ) as HTMLElement | null;
+    if (!el) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const token = el.getAttribute("data-token");
+    if (!token) return;
+    const rect = el.getBoundingClientRect();
+    setSelected({ el, token });
+    setPopoverPos({ x: rect.left + rect.width / 2, y: rect.bottom });
+    setPopoverOpen(true);
+    const idx = tokenElsRef.current.indexOf(el);
+    if (idx >= 0) setSelectedIndex(idx);
+  };
+
+  const handleLeave = () => {
+    if (!inspectMode || popoverOpen) return;
+    setHoverEl(null);
+  };
+
+  const selectByIndex = (idx: number) => {
+    const els = tokenElsRef.current;
+    if (!els.length) return;
+    const el = els[idx];
+    const token = el.getAttribute("data-token");
+    if (!token) return;
+    const rect = el.getBoundingClientRect();
+    setSelected({ el, token });
+    setPopoverPos({ x: rect.left + rect.width / 2, y: rect.bottom });
+    setPopoverOpen(true);
+    setSelectedIndex(idx);
+  };
+
+  useEffect(() => {
+    if (!inspectMode) return;
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.altKey && e.key === "ArrowRight") {
+        e.preventDefault();
+        const next =
+          selectedIndex + 1 < tokenElsRef.current.length
+            ? selectedIndex + 1
+            : 0;
+        selectByIndex(next);
+      } else if (e.altKey && e.key === "ArrowLeft") {
+        e.preventDefault();
+        const prev =
+          selectedIndex - 1 >= 0
+            ? selectedIndex - 1
+            : tokenElsRef.current.length - 1;
+        selectByIndex(prev);
+      }
+    };
+    window.addEventListener("keydown", keyHandler);
+    return () => window.removeEventListener("keydown", keyHandler);
+  }, [inspectMode, selectedIndex]);
+
+  return (
+    <>
+      {React.cloneElement(children, {
+        ref: (node: HTMLDivElement) => {
+          previewRef.current = node;
+          const { ref } = children as any;
+          if (typeof ref === "function") ref(node);
+          else if (ref)
+            (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        },
+        onPointerMove: handlePointerMove,
+        onClickCapture: handleClick,
+        onPointerLeave: handleLeave,
+        className: `${children.props.className ?? ""} ${inspectMode ? "cursor-crosshair" : ""}`,
+      })}
+      {selected && popoverPos && (
+        <Popover
+          open={popoverOpen}
+          onOpenChange={(o: boolean) => {
+            setPopoverOpen(o);
+            if (!o) {
+              setSelected(null);
+              setSelectedIndex(-1);
+            }
+          }}
+        >
+          <PopoverAnchor asChild>
+            <div
+              style={{
+                position: "fixed",
+                left: popoverPos.x,
+                top: popoverPos.y,
+              }}
+            />
+          </PopoverAnchor>
+          <PopoverContent side="top" align="center">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs">{selected.token}</span>
+              <Button
+                className="px-2 py-1 text-xs"
+                onClick={() => onTokenSelect?.(selected.token, popoverPos)}
+              >
+                Jump to editor
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+}

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -2,12 +2,6 @@
 
 "use client";
 
-import {
-  Button,
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-} from "@ui/components/atoms";
 import { blockRegistry } from "@ui/components/cms/blocks";
 import { Footer, Header, SideNav } from "@ui/components/organisms";
 import { AppShell } from "@ui/components/templates";
@@ -15,20 +9,13 @@ import TranslationsProvider from "@/i18n/Translations";
 import enMessages from "@i18n/en.json";
 import type { PageComponent } from "@acme/types";
 import DOMPurify from "dompurify";
-import React, { useEffect, useRef, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, forwardRef } from "react";
 import { STORAGE_KEY } from "../configurator/hooks/useConfiguratorPersistence";
-import { loadPreviewTokens, PREVIEW_TOKENS_EVENT } from "./previewTokens";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
-import DeviceSelector from "@ui/components/common/DeviceSelector";
-import { ReloadIcon } from "@radix-ui/react-icons";
-import { usePreviewDevice } from "@ui/hooks";
+import usePreviewTokens from "./usePreviewTokens";
 
 interface Props {
   style: React.CSSProperties;
-  /** Enable inspection mode to highlight tokenised elements */
-  inspectMode?: boolean;
-  /** Called when a tokenised element is clicked */
-  onTokenSelect?: (token: string, coords: { x: number; y: number }) => void;
   device?: DevicePreset;
 }
 
@@ -37,53 +24,14 @@ interface Props {
  * The preview reads wizard state from localStorage (keyed by `STORAGE_KEY`)
  * so it always shows the latest edits without needing a full refresh.
  */
-export default function WizardPreview({
-  style,
-  inspectMode = false,
-  onTokenSelect,
-  device: deviceProp,
-}: Props): React.JSX.Element {
-  const [deviceId, setDeviceId] = usePreviewDevice(devicePresets[0].id);
-  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
-    "portrait"
-  );
-  const device = useMemo<DevicePreset>(() => {
-    if (deviceProp) return deviceProp;
-    const preset =
-      devicePresets.find((d: DevicePreset) => d.id === deviceId) ??
-      devicePresets[0];
-    return orientation === "portrait"
-      ? { ...preset, orientation }
-      : {
-          ...preset,
-          width: preset.height,
-          height: preset.width,
-          orientation,
-        };
-  }, [deviceId, orientation, deviceProp]);
-  const viewport: "desktop" | "tablet" | "mobile" = device.type;
+const WizardPreview = forwardRef<HTMLDivElement, Props>(function WizardPreview(
+  { style, device: deviceProp },
+  ref,
+) {
   const [components, setComponents] = useState<PageComponent[]>([]);
-  const [themeStyle, setThemeStyle] = useState<React.CSSProperties>(() => ({
-    ...style,
-    ...loadPreviewTokens(),
-  }));
-  const [hoverEl, setHoverEl] = useState<HTMLElement | null>(null);
-  const [selected, setSelected] = useState<{
-    el: HTMLElement;
-    token: string;
-  } | null>(null);
-  const [popoverOpen, setPopoverOpen] = useState(false);
-  const [popoverPos, setPopoverPos] = useState<{ x: number; y: number } | null>(
-    null
-  );
-  const [selectedIndex, setSelectedIndex] = useState(-1);
-  const tokenElsRef = useRef<HTMLElement[]>([]);
-  const previewRef = useRef<HTMLDivElement | null>(null);
+  const tokens = usePreviewTokens();
+  const device = deviceProp ?? devicePresets[0];
 
-  /* ------------------------------------------------------------------ */
-  /*             Sync wizard state from localStorage                    */
-  /*  Re-sync when localStorage changes or when a custom event fires.   */
-  /* ------------------------------------------------------------------ */
   useEffect(() => {
     const load = () => {
       try {
@@ -107,145 +55,15 @@ export default function WizardPreview({
     };
   }, []);
 
-  /* ------------------------------------------------------------------ */
-  /*                  Theme token subscription                           */
-  /* ------------------------------------------------------------------ */
-  useEffect(() => {
-    const handle = () => {
-      setThemeStyle((prev) => ({ ...prev, ...loadPreviewTokens() }));
-    };
-    handle();
-    window.addEventListener("storage", handle);
-    window.addEventListener(PREVIEW_TOKENS_EVENT, handle);
-    return () => {
-      window.removeEventListener("storage", handle);
-      window.removeEventListener(PREVIEW_TOKENS_EVENT, handle);
-    };
-  }, []);
-
-  useEffect(() => {
-    setThemeStyle((prev) => ({ ...prev, ...style }));
-  }, [style]);
-
-  /* ------------------------------------------------------------------ */
-  /*                         Helpers                                    */
-  /* ------------------------------------------------------------------ */
-
-  const containerStyle = {
-    ...themeStyle,
-    width: `${device.width}px`,
-    height: `${device.height}px`,
-  };
-
-  /* ------------------------------------------------------------------ */
-  /*                         Inspect mode                               */
-  /* ------------------------------------------------------------------ */
-
-  useEffect(() => {
-    if (!hoverEl || selected?.el === hoverEl) return;
-    const prev = hoverEl.style.outline;
-    hoverEl.style.outline = "2px solid #3b82f6";
-    return () => {
-      hoverEl.style.outline = prev;
-    };
-  }, [hoverEl, selected]);
-
-  useEffect(() => {
-    if (!selected || !popoverOpen) return;
-    const el = selected.el;
-    const prevOutline = el.style.outline;
-    const prevAnimation = el.style.animation;
-    el.style.outline = "2px solid #3b82f6";
-    el.style.animation = "wizard-outline 1s ease-in-out infinite";
-    return () => {
-      el.style.outline = prevOutline;
-      el.style.animation = prevAnimation;
-    };
-  }, [selected, popoverOpen]);
-
-  useEffect(() => {
-    const styleEl = document.createElement("style");
-    styleEl.textContent =
-      "@keyframes wizard-outline{0%,100%{outline-color:#3b82f6;}50%{outline-color:#93c5fd;}}";
-    document.head.appendChild(styleEl);
-    return () => {
-      document.head.removeChild(styleEl);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!inspectMode || !previewRef.current) return;
-    tokenElsRef.current = Array.from(
-      previewRef.current.querySelectorAll("[data-token]")
-    ) as HTMLElement[];
-  }, [components, inspectMode]);
-
-  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!inspectMode || popoverOpen) return;
-    const el = (e.target as HTMLElement).closest(
-      "[data-token]"
-    ) as HTMLElement | null;
-    setHoverEl(el);
-  };
-
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!inspectMode) return;
-    const el = (e.target as HTMLElement).closest(
-      "[data-token]"
-    ) as HTMLElement | null;
-    if (!el) return;
-    e.preventDefault();
-    e.stopPropagation();
-    const token = el.getAttribute("data-token");
-    if (!token) return;
-    const rect = el.getBoundingClientRect();
-    setSelected({ el, token });
-    setPopoverPos({ x: rect.left + rect.width / 2, y: rect.bottom });
-    setPopoverOpen(true);
-    const idx = tokenElsRef.current.indexOf(el);
-    if (idx >= 0) setSelectedIndex(idx);
-  };
-
-  const handleLeave = () => {
-    if (!inspectMode || popoverOpen) return;
-    setHoverEl(null);
-  };
-
-  const selectByIndex = (idx: number) => {
-    const els = tokenElsRef.current;
-    if (!els.length) return;
-    const el = els[idx];
-    const token = el.getAttribute("data-token");
-    if (!token) return;
-    const rect = el.getBoundingClientRect();
-    setSelected({ el, token });
-    setPopoverPos({ x: rect.left + rect.width / 2, y: rect.bottom });
-    setPopoverOpen(true);
-    setSelectedIndex(idx);
-  };
-
-  useEffect(() => {
-    if (!inspectMode) return;
-    const keyHandler = (e: KeyboardEvent) => {
-      if (e.altKey && e.key === "ArrowRight") {
-        e.preventDefault();
-        const next =
-          selectedIndex + 1 < tokenElsRef.current.length
-            ? selectedIndex + 1
-            : 0;
-        selectByIndex(next);
-      } else if (e.altKey && e.key === "ArrowLeft") {
-        e.preventDefault();
-        const prev =
-          selectedIndex - 1 >= 0
-            ? selectedIndex - 1
-            : tokenElsRef.current.length - 1;
-        selectByIndex(prev);
-      }
-    };
-    window.addEventListener("keydown", keyHandler);
-    return () => window.removeEventListener("keydown", keyHandler);
-  }, [inspectMode, selectedIndex]);
+  const containerStyle = useMemo(
+    () => ({
+      ...tokens,
+      ...style,
+      width: `${device.width}px`,
+      height: `${device.height}px`,
+    }),
+    [tokens, style, device],
+  );
 
   /** Renders a single block component */
   function Block({ component }: { component: PageComponent }) {
@@ -286,93 +104,26 @@ export default function WizardPreview({
     return <Comp {...props} locale="en" />;
   }
 
-  /* ------------------------------------------------------------------ */
-  /*                             Render                                 */
-  /* ------------------------------------------------------------------ */
   return (
-    <div className="space-y-2">
-      {/* viewport switcher */}
-      {!deviceProp && (
-        <div className="flex justify-end gap-2">
-          <DeviceSelector
-            deviceId={deviceId}
-            onChange={(id: string) => {
-              setDeviceId(id);
-              setOrientation("portrait");
-            }}
-            showLegacyButtons
-          />
-          <Button
-            variant="outline"
-            onClick={() =>
-              setOrientation((o) =>
-                o === "portrait" ? "landscape" : "portrait"
-              )
-            }
-            aria-label="Rotate"
-          >
-            <ReloadIcon
-              className={orientation === "landscape" ? "rotate-90" : ""}
-            />
-          </Button>
-        </div>
-      )}
-
-      {/* live preview */}
-      <div
-        ref={previewRef}
-        style={containerStyle}
-        className={`mx-auto rounded border ${inspectMode ? "cursor-crosshair" : ""}`}
-        data-token="--color-bg"
-        onPointerMove={handlePointerMove}
-        onClickCapture={handleClick}
-        onPointerLeave={handleLeave}
-      >
-        <TranslationsProvider messages={enMessages}>
-          <AppShell
-            header={<Header locale="en" />}
-            sideNav={<SideNav />}
-            footer={<Footer />}
-          >
-            {components.map((c) => (
-              <Block key={c.id} component={c} />
-            ))}
-          </AppShell>
-        </TranslationsProvider>
-      </div>
-      {selected && popoverPos && (
-        <Popover
-          open={popoverOpen}
-          onOpenChange={(o: boolean) => {
-            setPopoverOpen(o);
-            if (!o) {
-              setSelected(null);
-              setSelectedIndex(-1);
-            }
-          }}
+    <div
+      ref={ref}
+      style={containerStyle}
+      className="mx-auto rounded border"
+      data-token="--color-bg"
+    >
+      <TranslationsProvider messages={enMessages}>
+        <AppShell
+          header={<Header locale="en" />}
+          sideNav={<SideNav />}
+          footer={<Footer />}
         >
-          <PopoverAnchor asChild>
-            <div
-              style={{
-                position: "fixed",
-                left: popoverPos.x,
-                top: popoverPos.y,
-              }}
-            />
-          </PopoverAnchor>
-          <PopoverContent side="top" align="center">
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-xs">{selected.token}</span>
-              <Button
-                className="px-2 py-1 text-xs"
-                onClick={() => onTokenSelect?.(selected.token, popoverPos)}
-              >
-                Jump to editor
-              </Button>
-            </div>
-          </PopoverContent>
-        </Popover>
-      )}
+          {components.map((c) => (
+            <Block key={c.id} component={c} />
+          ))}
+        </AppShell>
+      </TranslationsProvider>
     </div>
   );
-}
+});
+
+export default WizardPreview;

--- a/apps/cms/src/app/cms/wizard/usePreviewTokens.ts
+++ b/apps/cms/src/app/cms/wizard/usePreviewTokens.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadPreviewTokens, PREVIEW_TOKENS_EVENT } from "./previewTokens";
+
+export default function usePreviewTokens() {
+  const [tokens, setTokens] = useState<Record<string, string>>(() => loadPreviewTokens());
+
+  useEffect(() => {
+    const handle = () => {
+      setTokens(loadPreviewTokens());
+    };
+    handle();
+    window.addEventListener("storage", handle);
+    window.addEventListener(PREVIEW_TOKENS_EVENT, handle);
+    return () => {
+      window.removeEventListener("storage", handle);
+      window.removeEventListener(PREVIEW_TOKENS_EVENT, handle);
+    };
+  }, []);
+
+  return tokens;
+}


### PR DESCRIPTION
## Summary
- move preview token subscription into dedicated `usePreviewTokens` hook
- extract device controls and inspect-mode popover into `PreviewDeviceSelector` and `TokenInspector`
- simplify `WizardPreview` to a pure preview shell and update wizard step components

## Testing
- `pnpm test:cms` *(fails: fireEvent.click can't find Save button; SyntaxError in zod error map)*

------
https://chatgpt.com/codex/tasks/task_e_68ac49554664832f9ebcaf417f39ae94