### PR TITLE
refactor: modularize shop editor

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/FilterMappings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/FilterMappings.tsx
@@ -1,0 +1,63 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/FilterMappings.tsx
+"use client";
+import { Button, Input } from "@/components/atoms/shadcn";
+import { ChangeEvent } from "react";
+
+interface Row {
+  key: string;
+  value: string;
+}
+
+interface Props {
+  mappings: Row[];
+  addMapping: () => void;
+  updateMapping: (index: number, field: "key" | "value", value: string) => void;
+  removeMapping: (index: number) => void;
+  errors: Record<string, string[]>;
+}
+
+export default function FilterMappings({
+  mappings,
+  addMapping,
+  updateMapping,
+  removeMapping,
+  errors,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span>Filter Mappings</span>
+      {mappings.map((row, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <Input
+            name="filterMappingsKey"
+            value={row.key}
+            placeholder="Filter"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              updateMapping(idx, "key", e.target.value)
+            }
+          />
+          <Input
+            name="filterMappingsValue"
+            value={row.value}
+            placeholder="Mapping"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              updateMapping(idx, "value", e.target.value)
+            }
+          />
+          <Button type="button" onClick={() => removeMapping(idx)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button type="button" onClick={addMapping}>
+        Add Mapping
+      </Button>
+      {errors.filterMappings && (
+        <span className="text-sm text-red-600">
+          {errors.filterMappings.join("; ")}
+        </span>
+      )}
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/LocaleOverrides.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/LocaleOverrides.tsx
@@ -1,0 +1,68 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/LocaleOverrides.tsx
+"use client";
+import { Button, Input } from "@/components/atoms/shadcn";
+import { ChangeEvent } from "react";
+
+interface Row {
+  key: string;
+  value: string;
+}
+
+interface Props {
+  overrides: Row[];
+  addOverride: () => void;
+  updateOverride: (index: number, field: "key" | "value", value: string) => void;
+  removeOverride: (index: number) => void;
+  errors: Record<string, string[]>;
+}
+
+export default function LocaleOverrides({
+  overrides,
+  addOverride,
+  updateOverride,
+  removeOverride,
+  errors,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span>Locale Overrides</span>
+      {overrides.map((row, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <Input
+            name="localeOverridesKey"
+            value={row.key}
+            placeholder="Field"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              updateOverride(idx, "key", e.target.value)
+            }
+          />
+          <select
+            name="localeOverridesValue"
+            value={row.value}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              updateOverride(idx, "value", e.target.value)
+            }
+            className="border p-2"
+          >
+            <option value="">Select locale</option>
+            <option value="en">en</option>
+            <option value="de">de</option>
+            <option value="it">it</option>
+          </select>
+          <Button type="button" onClick={() => removeOverride(idx)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button type="button" onClick={addOverride}>
+        Add Override
+      </Button>
+      {errors.localeOverrides && (
+        <span className="text-sm text-red-600">
+          {errors.localeOverrides.join("; ")}
+        </span>
+      )}
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/PriceOverrides.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/PriceOverrides.tsx
@@ -1,0 +1,64 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/PriceOverrides.tsx
+"use client";
+import { Button, Input } from "@/components/atoms/shadcn";
+import { ChangeEvent } from "react";
+
+interface Row {
+  key: string;
+  value: string;
+}
+
+interface Props {
+  overrides: Row[];
+  addOverride: () => void;
+  updateOverride: (index: number, field: "key" | "value", value: string) => void;
+  removeOverride: (index: number) => void;
+  errors: Record<string, string[]>;
+}
+
+export default function PriceOverrides({
+  overrides,
+  addOverride,
+  updateOverride,
+  removeOverride,
+  errors,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span>Price Overrides</span>
+      {overrides.map((row, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <Input
+            name="priceOverridesKey"
+            value={row.key}
+            placeholder="Locale"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              updateOverride(idx, "key", e.target.value)
+            }
+          />
+          <Input
+            type="number"
+            name="priceOverridesValue"
+            value={row.value}
+            placeholder="Price"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              updateOverride(idx, "value", e.target.value)
+            }
+          />
+          <Button type="button" onClick={() => removeOverride(idx)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button type="button" onClick={addOverride}>
+        Add Override
+      </Button>
+      {errors.priceOverrides && (
+        <span className="text-sm text-red-600">
+          {errors.priceOverrides.join("; ")}
+        </span>
+      )}
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ProviderSelect.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ProviderSelect.tsx
@@ -1,0 +1,48 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/ProviderSelect.tsx
+"use client";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
+import type { Provider } from "@acme/configurator/providers";
+
+interface Props {
+  trackingProviders: string[];
+  setTrackingProviders: Dispatch<SetStateAction<string[]>>;
+  errors: Record<string, string[]>;
+  shippingProviders: Provider[];
+}
+
+export default function ProviderSelect({
+  trackingProviders,
+  setTrackingProviders,
+  errors,
+  shippingProviders,
+}: Props) {
+  const handleTracking = (e: ChangeEvent<HTMLSelectElement>) => {
+    const selected = Array.from(e.target.selectedOptions).map((o) => o.value);
+    setTrackingProviders(selected);
+  };
+
+  return (
+    <label className="flex flex-col gap-1">
+      <span>Tracking Providers</span>
+      <select
+        multiple
+        name="trackingProviders"
+        value={trackingProviders}
+        onChange={handleTracking}
+        className="border p-2"
+      >
+        {shippingProviders.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      {errors.trackingProviders && (
+        <span className="text-sm text-red-600">
+          {errors.trackingProviders.join("; ")}
+        </span>
+      )}
+    </label>
+  );
+}
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/SEOSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/SEOSettings.tsx
@@ -3,25 +3,14 @@
 import { Input } from "@/components/atoms/shadcn";
 import type { Shop } from "@acme/types";
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
-import type { Provider } from "@acme/configurator/providers";
 
 interface Props {
   info: Shop;
   setInfo: Dispatch<SetStateAction<Shop>>;
-  trackingProviders: string[];
-  setTrackingProviders: Dispatch<SetStateAction<string[]>>;
   errors: Record<string, string[]>;
-  shippingProviders: Provider[];
 }
 
-export default function SEOSettings({
-  info,
-  setInfo,
-  trackingProviders,
-  setTrackingProviders,
-  errors,
-  shippingProviders,
-}: Props) {
+export default function SEOSettings({ info, setInfo, errors }: Props) {
   const handleFilters = (e: ChangeEvent<HTMLInputElement>) => {
     setInfo((prev) => ({
       ...prev,
@@ -29,48 +18,20 @@ export default function SEOSettings({
     }));
   };
 
-  const handleTracking = (e: ChangeEvent<HTMLSelectElement>) => {
-    const selected = Array.from(e.target.selectedOptions).map((o) => o.value);
-    setTrackingProviders(selected);
-  };
-
   return (
-    <>
-      <label className="flex flex-col gap-1">
-        <span>Catalog Filters (comma separated)</span>
-        <Input
-          className="border p-2"
-          name="catalogFilters"
-          value={info.catalogFilters.join(",")}
-          onChange={handleFilters}
-        />
-        {errors.catalogFilters && (
-          <span className="text-sm text-red-600">
-            {errors.catalogFilters.join("; ")}
-          </span>
-        )}
-      </label>
-      <label className="flex flex-col gap-1">
-        <span>Tracking Providers</span>
-        <select
-          multiple
-          name="trackingProviders"
-          value={trackingProviders}
-          onChange={handleTracking}
-          className="border p-2"
-        >
-          {shippingProviders.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-        {errors.trackingProviders && (
-          <span className="text-sm text-red-600">
-            {errors.trackingProviders.join("; ")}
-          </span>
-        )}
-      </label>
-    </>
+    <label className="flex flex-col gap-1">
+      <span>Catalog Filters (comma separated)</span>
+      <Input
+        className="border p-2"
+        name="catalogFilters"
+        value={info.catalogFilters.join(",")}
+        onChange={handleFilters}
+      />
+      {errors.catalogFilters && (
+        <span className="text-sm text-red-600">
+          {errors.catalogFilters.join("; ")}
+        </span>
+      )}
+    </label>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -2,14 +2,15 @@
 
 "use client";
 import { Button, Input } from "@/components/atoms/shadcn";
-import { updateShop } from "@cms/actions/shops.server";
-import { shopSchema } from "@cms/actions/schemas";
 import type { Shop } from "@acme/types";
-import { ChangeEvent, FormEvent, useMemo, useState } from "react";
 import GeneralSettings from "./GeneralSettings";
 import SEOSettings from "./SEOSettings";
 import ThemeTokens from "./ThemeTokens";
-import { providersByType } from "@acme/configurator/providers";
+import FilterMappings from "./FilterMappings";
+import PriceOverrides from "./PriceOverrides";
+import ProviderSelect from "./ProviderSelect";
+import LocaleOverrides from "./LocaleOverrides";
+import { useShopEditorForm } from "./useShopEditorForm";
 
 export { default as GeneralSettings } from "./GeneralSettings";
 export { default as SEOSettings } from "./SEOSettings";
@@ -22,195 +23,31 @@ interface Props {
 }
 
 export default function ShopEditor({ shop, initial, initialTrackingProviders }: Props) {
-  const [info, setInfo] = useState<Shop>(initial);
-  const [trackingProviders, setTrackingProviders] = useState<string[]>(
-    initialTrackingProviders,
-  );
-  const [saving, setSaving] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string[]>>({});
-  const [filterMappings, setFilterMappings] = useState<{ key: string; value: string }[]>(
-    Object.entries(initial.filterMappings ?? {}).map(([key, value]) => ({
-      key,
-      value: String(value),
-    })),
-  );
-  const [priceOverrides, setPriceOverrides] = useState<{ key: string; value: string }[]>(
-    Object.entries(initial.priceOverrides ?? {}).map(([key, value]) => ({
-      key,
-      value: String(value),
-    })),
-  );
-  const [localeOverrides, setLocaleOverrides] = useState<{ key: string; value: string }[]>(
-    Object.entries(initial.localeOverrides ?? {}).map(([key, value]) => ({
-      key,
-      value: String(value),
-    })),
-  );
-
-  const shippingProviders = providersByType("shipping");
-
-  const tokenRows = useMemo(() => {
-    const defaults = info.themeDefaults ?? {};
-    const overrides = info.themeOverrides ?? {};
-    const tokens = Array.from(
-      new Set([...Object.keys(defaults), ...Object.keys(overrides)]),
-    );
-    return tokens.map((token) => ({
-      token,
-      defaultValue: defaults[token],
-      overrideValue: overrides[token],
-    }));
-    // note: depends on info to update when tokens change
-  }, [info.themeDefaults, info.themeOverrides]);
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setInfo((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const addFilterMapping = () =>
-    setFilterMappings((prev) => [...prev, { key: "", value: "" }]);
-  const updateFilterMapping = (
-    index: number,
-    field: "key" | "value",
-    value: string,
-  ) =>
-    setFilterMappings((prev) =>
-      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
-    );
-  const removeFilterMapping = (index: number) =>
-    setFilterMappings((prev) => prev.filter((_, i) => i !== index));
-
-  const addPriceOverride = () =>
-    setPriceOverrides((prev) => [...prev, { key: "", value: "" }]);
-  const updatePriceOverride = (
-    index: number,
-    field: "key" | "value",
-    value: string,
-  ) =>
-    setPriceOverrides((prev) =>
-      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
-    );
-  const removePriceOverride = (index: number) =>
-    setPriceOverrides((prev) => prev.filter((_, i) => i !== index));
-
-  const addLocaleOverride = () =>
-    setLocaleOverrides((prev) => [...prev, { key: "", value: "" }]);
-  const updateLocaleOverride = (
-    index: number,
-    field: "key" | "value",
-    value: string,
-  ) =>
-    setLocaleOverrides((prev) =>
-      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
-    );
-  const removeLocaleOverride = (index: number) =>
-    setLocaleOverrides((prev) => prev.filter((_, i) => i !== index));
-
-  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setSaving(true);
-    const fd = new FormData(e.currentTarget);
-    const validationErrors: Record<string, string[]> = {};
-    const allowedLocales = ["en", "de", "it"];
-    if (filterMappings.some(({ key, value }) => !key.trim() || !value.trim())) {
-      validationErrors.filterMappings = [
-        "All filter mappings must have key and value",
-      ];
-    }
-    if (
-      priceOverrides.some(
-        ({ key, value }) => !key.trim() || value === "" || isNaN(Number(value)),
-      )
-    ) {
-      validationErrors.priceOverrides = [
-        "All price overrides require locale and numeric value",
-      ];
-    }
-    if (
-      localeOverrides.some(
-        ({ key, value }) => !key.trim() || !allowedLocales.includes(value),
-      )
-    ) {
-      validationErrors.localeOverrides = [
-        "All locale overrides require key and valid locale",
-      ];
-    }
-    if (Object.keys(validationErrors).length > 0) {
-      setErrors(validationErrors);
-      setSaving(false);
-      return;
-    }
-
-    const filterMappingsObj = Object.fromEntries(
-      filterMappings
-        .map(({ key, value }) => [key.trim(), value.trim()])
-        .filter(([k, v]) => k && v),
-    );
-    const priceOverridesObj = Object.fromEntries(
-      priceOverrides
-        .map(({ key, value }) => [key.trim(), Number(value)])
-        .filter(([k, v]) => k && !Number.isNaN(v)),
-    );
-    const localeOverridesObj = Object.fromEntries(
-      localeOverrides
-        .map(({ key, value }) => [key.trim(), value])
-        .filter(([k, v]) => k && v),
-    );
-
-    const entries = Array.from(
-      (fd as unknown as Iterable<[string, string]>),
-    ).filter(([k]) =>
-      ![
-        "filterMappingsKey",
-        "filterMappingsValue",
-        "priceOverridesKey",
-        "priceOverridesValue",
-        "localeOverridesKey",
-        "localeOverridesValue",
-      ].includes(k),
-    );
-    const data = Object.fromEntries(entries) as Record<string, string>;
-    const parsed = shopSchema.safeParse({
-      ...data,
-      trackingProviders: fd.getAll("trackingProviders"),
-      filterMappings: JSON.stringify(filterMappingsObj),
-      priceOverrides: JSON.stringify(priceOverridesObj),
-      localeOverrides: JSON.stringify(localeOverridesObj),
-    });
-    if (!parsed.success) {
-      setErrors(parsed.error.flatten().fieldErrors);
-      setSaving(false);
-      return;
-    }
-    const result = await updateShop(shop, fd);
-    if (result.errors) {
-      setErrors(result.errors);
-    } else if (result.shop) {
-      setInfo(result.shop);
-      setTrackingProviders(fd.getAll("trackingProviders") as string[]);
-      setFilterMappings(
-        Object.entries(result.shop.filterMappings ?? {}).map(([key, value]) => ({
-          key,
-          value: String(value),
-        })),
-      );
-      setPriceOverrides(
-        Object.entries(result.shop.priceOverrides ?? {}).map(([key, value]) => ({
-          key,
-          value: String(value),
-        })),
-      );
-      setLocaleOverrides(
-        Object.entries(result.shop.localeOverrides ?? {}).map(([key, value]) => ({
-          key,
-          value: String(value),
-        })),
-      );
-      setErrors({});
-    }
-    setSaving(false);
-  };
+  const form = useShopEditorForm({ shop, initial, initialTrackingProviders });
+  const {
+    info,
+    setInfo,
+    trackingProviders,
+    setTrackingProviders,
+    errors,
+    tokenRows,
+    saving,
+    filterMappings,
+    addFilterMapping,
+    updateFilterMapping,
+    removeFilterMapping,
+    priceOverrides,
+    addPriceOverride,
+    updatePriceOverride,
+    removePriceOverride,
+    localeOverrides,
+    addLocaleOverride,
+    updateLocaleOverride,
+    removeLocaleOverride,
+    handleChange,
+    shippingProviders,
+    onSubmit,
+  } = form;
 
   return (
     <form
@@ -219,136 +56,44 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
     >
       <Input type="hidden" name="id" value={info.id} />
       <GeneralSettings
-        info={info}
-        setInfo={setInfo}
-        errors={errors}
-        handleChange={handleChange}
+      info={info}
+      setInfo={setInfo}
+      errors={errors}
+      handleChange={handleChange}
       />
-      <SEOSettings
-        info={info}
-        setInfo={setInfo}
+      <SEOSettings info={info} setInfo={setInfo} errors={errors} />
+      <ProviderSelect
         trackingProviders={trackingProviders}
         setTrackingProviders={setTrackingProviders}
         errors={errors}
         shippingProviders={shippingProviders}
       />
-      <ThemeTokens
-        shop={shop}
-        tokenRows={tokenRows}
-        info={info}
+      <ThemeTokens shop={shop} tokenRows={tokenRows} info={info} errors={errors} />
+      <FilterMappings
+        mappings={filterMappings}
+        addMapping={addFilterMapping}
+        updateMapping={updateFilterMapping}
+        removeMapping={removeFilterMapping}
         errors={errors}
       />
-      <div className="flex flex-col gap-1">
-        <span>Filter Mappings</span>
-        {filterMappings.map((row, idx) => (
-          <div key={idx} className="flex items-center gap-2">
-            <Input
-              name="filterMappingsKey"
-              value={row.key}
-              placeholder="Filter"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                updateFilterMapping(idx, "key", e.target.value)
-              }
-            />
-            <Input
-              name="filterMappingsValue"
-              value={row.value}
-              placeholder="Mapping"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                updateFilterMapping(idx, "value", e.target.value)
-              }
-            />
-            <Button type="button" onClick={() => removeFilterMapping(idx)}>
-              Remove
-            </Button>
-          </div>
-        ))}
-        <Button type="button" onClick={addFilterMapping}>
-          Add Mapping
-        </Button>
-        {errors.filterMappings && (
-          <span className="text-sm text-red-600">
-            {errors.filterMappings.join("; ")}
-          </span>
-        )}
-      </div>
-      <div className="flex flex-col gap-1">
-        <span>Price Overrides</span>
-        {priceOverrides.map((row, idx) => (
-          <div key={idx} className="flex items-center gap-2">
-            <Input
-              name="priceOverridesKey"
-              value={row.key}
-              placeholder="Locale"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                updatePriceOverride(idx, "key", e.target.value)
-              }
-            />
-            <Input
-              type="number"
-              name="priceOverridesValue"
-              value={row.value}
-              placeholder="Price"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                updatePriceOverride(idx, "value", e.target.value)
-              }
-            />
-            <Button type="button" onClick={() => removePriceOverride(idx)}>
-              Remove
-            </Button>
-          </div>
-        ))}
-        <Button type="button" onClick={addPriceOverride}>
-          Add Override
-        </Button>
-        {errors.priceOverrides && (
-          <span className="text-sm text-red-600">
-            {errors.priceOverrides.join("; ")}
-          </span>
-        )}
-      </div>
-      <div className="flex flex-col gap-1">
-        <span>Locale Overrides</span>
-        {localeOverrides.map((row, idx) => (
-          <div key={idx} className="flex items-center gap-2">
-            <Input
-              name="localeOverridesKey"
-              value={row.key}
-              placeholder="Field"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                updateLocaleOverride(idx, "key", e.target.value)
-              }
-            />
-            <select
-              name="localeOverridesValue"
-              value={row.value}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                updateLocaleOverride(idx, "value", e.target.value)
-              }
-              className="border p-2"
-            >
-              <option value="">Select locale</option>
-              <option value="en">en</option>
-              <option value="de">de</option>
-              <option value="it">it</option>
-            </select>
-            <Button type="button" onClick={() => removeLocaleOverride(idx)}>
-              Remove
-            </Button>
-          </div>
-        ))}
-        <Button type="button" onClick={addLocaleOverride}>
-          Add Override
-        </Button>
-        {errors.localeOverrides && (
-          <span className="text-sm text-red-600">
-            {errors.localeOverrides.join("; ")}
-          </span>
-        )}
-      </div>
+      <PriceOverrides
+        overrides={priceOverrides}
+        addOverride={addPriceOverride}
+        updateOverride={updatePriceOverride}
+        removeOverride={removePriceOverride}
+        errors={errors}
+      />
+      <LocaleOverrides
+        overrides={localeOverrides}
+        addOverride={addLocaleOverride}
+        updateOverride={updateLocaleOverride}
+        removeOverride={removeLocaleOverride}
+        errors={errors}
+      />
       <Button className="bg-primary text-white" disabled={saving} type="submit">
         {saving ? "Saving…" : "Save"}
       </Button>
     </form>
   );
 }
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -1,0 +1,243 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+"use client";
+
+import { useMemo, useState, ChangeEvent, FormEvent } from "react";
+import { providersByType } from "@acme/configurator/providers";
+import type { Shop } from "@acme/types";
+import { shopSchema } from "@cms/actions/schemas";
+import { updateShop } from "@cms/actions/shops.server";
+
+interface MappingRow {
+  key: string;
+  value: string;
+}
+
+interface HookArgs {
+  shop: string;
+  initial: Shop;
+  initialTrackingProviders: string[];
+}
+
+export function useShopEditorForm({
+  shop,
+  initial,
+  initialTrackingProviders,
+}: HookArgs) {
+  const [info, setInfo] = useState<Shop>(initial);
+  const [trackingProviders, setTrackingProviders] = useState<string[]>(
+    initialTrackingProviders,
+  );
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [filterMappings, setFilterMappings] = useState<MappingRow[]>(
+    Object.entries(initial.filterMappings ?? {}).map(([key, value]) => ({
+      key,
+      value: String(value),
+    })),
+  );
+  const [priceOverrides, setPriceOverrides] = useState<MappingRow[]>(
+    Object.entries(initial.priceOverrides ?? {}).map(([key, value]) => ({
+      key,
+      value: String(value),
+    })),
+  );
+  const [localeOverrides, setLocaleOverrides] = useState<MappingRow[]>(
+    Object.entries(initial.localeOverrides ?? {}).map(([key, value]) => ({
+      key,
+      value: String(value),
+    })),
+  );
+
+  const shippingProviders = providersByType("shipping");
+
+  const tokenRows = useMemo(() => {
+    const defaults = info.themeDefaults ?? {};
+    const overrides = info.themeOverrides ?? {};
+    const tokens = Array.from(
+      new Set([...Object.keys(defaults), ...Object.keys(overrides)]),
+    );
+    return tokens.map((token) => ({
+      token,
+      defaultValue: defaults[token],
+      overrideValue: overrides[token],
+    }));
+  }, [info.themeDefaults, info.themeOverrides]);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setInfo((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // Filter mappings
+  const addFilterMapping = () =>
+    setFilterMappings((prev) => [...prev, { key: "", value: "" }]);
+  const updateFilterMapping = (
+    index: number,
+    field: "key" | "value",
+    value: string,
+  ) =>
+    setFilterMappings((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
+    );
+  const removeFilterMapping = (index: number) =>
+    setFilterMappings((prev) => prev.filter((_, i) => i !== index));
+
+  // Price overrides
+  const addPriceOverride = () =>
+    setPriceOverrides((prev) => [...prev, { key: "", value: "" }]);
+  const updatePriceOverride = (
+    index: number,
+    field: "key" | "value",
+    value: string,
+  ) =>
+    setPriceOverrides((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
+    );
+  const removePriceOverride = (index: number) =>
+    setPriceOverrides((prev) => prev.filter((_, i) => i !== index));
+
+  // Locale overrides
+  const addLocaleOverride = () =>
+    setLocaleOverrides((prev) => [...prev, { key: "", value: "" }]);
+  const updateLocaleOverride = (
+    index: number,
+    field: "key" | "value",
+    value: string,
+  ) =>
+    setLocaleOverrides((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
+    );
+  const removeLocaleOverride = (index: number) =>
+    setLocaleOverrides((prev) => prev.filter((_, i) => i !== index));
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData(e.currentTarget);
+    const validationErrors: Record<string, string[]> = {};
+    const allowedLocales = ["en", "de", "it"];
+    if (filterMappings.some(({ key, value }) => !key.trim() || !value.trim())) {
+      validationErrors.filterMappings = [
+        "All filter mappings must have key and value",
+      ];
+    }
+    if (
+      priceOverrides.some(
+        ({ key, value }) => !key.trim() || value === "" || isNaN(Number(value)),
+      )
+    ) {
+      validationErrors.priceOverrides = [
+        "All price overrides require locale and numeric value",
+      ];
+    }
+    if (
+      localeOverrides.some(
+        ({ key, value }) => !key.trim() || !allowedLocales.includes(value),
+      )
+    ) {
+      validationErrors.localeOverrides = [
+        "All locale overrides require key and valid locale",
+      ];
+    }
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      setSaving(false);
+      return;
+    }
+
+    const filterMappingsObj = Object.fromEntries(
+      filterMappings
+        .map(({ key, value }) => [key.trim(), value.trim()])
+        .filter(([k, v]) => k && v),
+    );
+    const priceOverridesObj = Object.fromEntries(
+      priceOverrides
+        .map(({ key, value }) => [key.trim(), Number(value)])
+        .filter(([k, v]) => k && !Number.isNaN(v)),
+    );
+    const localeOverridesObj = Object.fromEntries(
+      localeOverrides
+        .map(({ key, value }) => [key.trim(), value])
+        .filter(([k, v]) => k && v),
+    );
+
+    const entries = Array.from(
+      (fd as unknown as Iterable<[string, string]>),
+    ).filter(([k]) =>
+      ![
+        "filterMappingsKey",
+        "filterMappingsValue",
+        "priceOverridesKey",
+        "priceOverridesValue",
+        "localeOverridesKey",
+        "localeOverridesValue",
+      ].includes(k),
+    );
+    const data = Object.fromEntries(entries) as Record<string, string>;
+    const parsed = shopSchema.safeParse({
+      ...data,
+      trackingProviders: fd.getAll("trackingProviders"),
+      filterMappings: JSON.stringify(filterMappingsObj),
+      priceOverrides: JSON.stringify(priceOverridesObj),
+      localeOverrides: JSON.stringify(localeOverridesObj),
+    });
+    if (!parsed.success) {
+      setErrors(parsed.error.flatten().fieldErrors);
+      setSaving(false);
+      return;
+    }
+    const result = await updateShop(shop, fd);
+    if (result.errors) {
+      setErrors(result.errors);
+    } else if (result.shop) {
+      setInfo(result.shop);
+      setTrackingProviders(fd.getAll("trackingProviders") as string[]);
+      setFilterMappings(
+        Object.entries(result.shop.filterMappings ?? {}).map(([key, value]) => ({
+          key,
+          value: String(value),
+        })),
+      );
+      setPriceOverrides(
+        Object.entries(result.shop.priceOverrides ?? {}).map(([key, value]) => ({
+          key,
+          value: String(value),
+        })),
+      );
+      setLocaleOverrides(
+        Object.entries(result.shop.localeOverrides ?? {}).map(([key, value]) => ({
+          key,
+          value: String(value),
+        })),
+      );
+      setErrors({});
+    }
+    setSaving(false);
+  };
+
+  return {
+    info,
+    setInfo,
+    trackingProviders,
+    setTrackingProviders,
+    saving,
+    errors,
+    filterMappings,
+    addFilterMapping,
+    updateFilterMapping,
+    removeFilterMapping,
+    priceOverrides,
+    addPriceOverride,
+    updatePriceOverride,
+    removePriceOverride,
+    localeOverrides,
+    addLocaleOverride,
+    updateLocaleOverride,
+    removeLocaleOverride,
+    handleChange,
+    tokenRows,
+    shippingProviders,
+    onSubmit,
+  } as const;
+}
+


### PR DESCRIPTION
## Summary
- extract filter mappings, price overrides, locale overrides, and provider selection into their own components
- add `useShopEditorForm` hook to manage form state and validation
- simplify `ShopEditor` by composing new subcomponents

## Testing
- `pnpm test:cms apps/cms/__tests__/ShopEditor.test.tsx`
- `pnpm --filter @apps/cms lint` *(fails: Cannot find module '@next/eslint-plugin-next')*


------
https://chatgpt.com/codex/tasks/task_e_68ac49565464832fa1bb7746f4a7c8bb