### PR TITLE
refactor: extract cart types

### DIFF
--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/cartStore.js",
       "default": "./dist/cartStore.js"
     },
+    "./cart": {
+      "types": "./dist/cart/index.d.ts",
+      "import": "./dist/cart/index.js",
+      "default": "./dist/cart/index.js"
+    },
     "./returnAuthorization": {
       "types": "./dist/returnAuthorization.d.ts",
       "import": "./dist/returnAuthorization.js",

--- a/packages/platform-core/src/cart/cartLine.d.ts
+++ b/packages/platform-core/src/cart/cartLine.d.ts
@@ -1,0 +1,6 @@
+import type { SKU } from "@acme/types";
+export interface CartLine {
+  sku: SKU;
+  qty: number;
+  size?: string;
+}

--- a/packages/platform-core/src/cart/cartLine.ts
+++ b/packages/platform-core/src/cart/cartLine.ts
@@ -1,0 +1,7 @@
+import type { SKU } from "@acme/types";
+
+export interface CartLine {
+  sku: SKU;
+  qty: number;
+  size?: string;
+}

--- a/packages/platform-core/src/cart/cartState.d.ts
+++ b/packages/platform-core/src/cart/cartState.d.ts
@@ -1,0 +1,2 @@
+import type { CartLine } from "./cartLine";
+export type CartState = Record<string, CartLine>;

--- a/packages/platform-core/src/cart/cartState.ts
+++ b/packages/platform-core/src/cart/cartState.ts
@@ -1,0 +1,3 @@
+import type { CartLine } from "./cartLine";
+
+export type CartState = Record<string, CartLine>;

--- a/packages/platform-core/src/cart/index.d.ts
+++ b/packages/platform-core/src/cart/index.d.ts
@@ -1,0 +1,2 @@
+export type { CartLine } from "./cartLine";
+export type { CartState } from "./cartState";

--- a/packages/platform-core/src/cart/index.ts
+++ b/packages/platform-core/src/cart/index.ts
@@ -1,0 +1,2 @@
+export type { CartLine } from "./cartLine";
+export type { CartState } from "./cartState";

--- a/packages/platform-core/src/cartApi.ts
+++ b/packages/platform-core/src/cartApi.ts
@@ -4,8 +4,8 @@ import {
   CART_COOKIE,
   decodeCartCookie,
   encodeCartCookie,
-  type CartState,
 } from "./cartCookie";
+import type { CartState } from "./cart";
 import { createCartStore } from "./cartStore";
 import { getProductById, PRODUCTS } from "./products";
 import type { NextRequest } from "next/server";

--- a/packages/platform-core/src/cartCookie.d.ts
+++ b/packages/platform-core/src/cartCookie.d.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+export type { CartLine, CartState } from "./cart";
 export declare const CART_COOKIE = "__Host-CART_ID";
 /**
  * Schema for one cart line.  We keep the schema definition simple and
@@ -327,8 +328,6 @@ export declare const cartStateSchema: z.ZodRecord<z.ZodString, z.ZodObject<{
     qty: number;
     size?: string | undefined;
 }>>;
-export type CartLine = z.infer<typeof cartLineSchema>;
-export type CartState = z.infer<typeof cartStateSchema>;
 /**
  * Serialize a cart ID into a signed cookie value.
  */

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 import { coreEnv } from "@acme/config/env/core";
 import { skuSchema } from "@acme/types";
 
+export type { CartLine, CartState } from "./cart";
+
 /* ------------------------------------------------------------------
  * Cookie constants
  * ------------------------------------------------------------------ */
@@ -38,9 +40,6 @@ export const cartLineSchema = z
  * Schema for the full cart, keyed by `${sku.id}` or `${sku.id}:${size}`.
  */
 export const cartStateSchema = z.record(z.string(), cartLineSchema);
-
-export type CartLine = z.infer<typeof cartLineSchema>;
-export type CartState = z.infer<typeof cartStateSchema>;
 
 /* ------------------------------------------------------------------
  * Helper functions

--- a/packages/platform-core/src/cartStore.d.ts
+++ b/packages/platform-core/src/cartStore.d.ts
@@ -1,5 +1,5 @@
 import { Redis } from "@upstash/redis";
-import type { CartState } from "./cartCookie";
+import type { CartState } from "./cart";
 import type { SKU } from "@acme/types";
 /** Abstraction for cart storage backends */
 export interface CartStore {

--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -1,6 +1,6 @@
 import { Redis } from "@upstash/redis";
 import { coreEnv } from "@acme/config/env/core";
-import type { CartState } from "./cartCookie";
+import type { CartState } from "./cart";
 import type { SKU } from "@acme/types";
 import { MemoryCartStore } from "./cartStore/memoryStore";
 import { RedisCartStore } from "./cartStore/redisStore";

--- a/packages/platform-core/src/cartStore/memoryStore.d.ts
+++ b/packages/platform-core/src/cartStore/memoryStore.d.ts
@@ -1,4 +1,4 @@
-import type { CartState } from "../cartCookie";
+import type { CartState } from "../cart";
 import type { SKU } from "@acme/types";
 import type { CartStore } from "../cartStore";
 /** In-memory implementation of CartStore */

--- a/packages/platform-core/src/cartStore/memoryStore.ts
+++ b/packages/platform-core/src/cartStore/memoryStore.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 
-import type { CartState } from "../cartCookie";
+import type { CartState } from "../cart";
 import type { SKU } from "@acme/types";
 import type { CartStore } from "../cartStore";
 

--- a/packages/platform-core/src/cartStore/redisStore.d.ts
+++ b/packages/platform-core/src/cartStore/redisStore.d.ts
@@ -1,5 +1,5 @@
 import type { Redis } from "@upstash/redis";
-import type { CartState } from "../cartCookie";
+import type { CartState } from "../cart";
 import type { SKU } from "@acme/types";
 import type { CartStore } from "../cartStore";
 /** Redis-backed implementation of CartStore */

--- a/packages/platform-core/src/cartStore/redisStore.ts
+++ b/packages/platform-core/src/cartStore/redisStore.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import type { Redis } from "@upstash/redis";
 
-import type { CartState } from "../cartCookie";
+import type { CartState } from "../cart";
 import type { SKU } from "@acme/types";
 import type { CartStore } from "../cartStore";
 

--- a/packages/platform-core/src/checkout/session.ts
+++ b/packages/platform-core/src/checkout/session.ts
@@ -4,7 +4,7 @@ import { trackEvent } from "../analytics";
 import { getTaxRate } from "../tax";
 import { calculateRentalDays } from "@acme/date-utils";
 import { stripe } from "@acme/stripe";
-import type { CartLine, CartState } from "../cartCookie";
+import type { CartLine, CartState } from "../cart";
 import type Stripe from "stripe";
 
 /** Build the two Stripe line-items (rental + deposit) for a single cart item. */

--- a/packages/platform-core/src/contexts/CartContext.d.ts
+++ b/packages/platform-core/src/contexts/CartContext.d.ts
@@ -1,4 +1,4 @@
-import { type CartState } from "../cartCookie";
+import { type CartState } from "../cart";
 import type { SKU } from "@acme/types";
 import { type ReactNode } from "react";
 type Action = {

--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -1,7 +1,7 @@
 // packages/platform-core/src/contexts/CartContext.tsx
 "use client";
 
-import { type CartState } from "../cartCookie";
+import { type CartState } from "../cart";
 
 import type { SKU } from "@acme/types";
 import {


### PR DESCRIPTION
## Summary
- define CartLine and CartState in new `src/cart` modules
- re-export cart types from `cart` index and `cartCookie`
- update package exports and cart code to use new modules

## Testing
- `pnpm --filter @acme/platform-core build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @acme/platform-core test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4957ef88832fabbacf9793e4d0c3