### PR TITLE
refactor: extract form data helpers

### DIFF
--- a/apps/cms/src/services/shops/__tests__/formData.test.ts
+++ b/apps/cms/src/services/shops/__tests__/formData.test.ts
@@ -1,0 +1,41 @@
+import {
+  parseFilterMappings,
+  parsePriceOverrides,
+  parseLocaleOverrides,
+} from "../formData";
+
+describe("form data helpers", () => {
+  it("parses filter mappings", () => {
+    const formData = new FormData();
+    formData.append("filterMappingsKey", "brand");
+    formData.append("filterMappingsValue", "Brand");
+    formData.append("filterMappingsKey", "color");
+    formData.append("filterMappingsValue", "Color");
+
+    expect(parseFilterMappings(formData)).toBe(
+      JSON.stringify({ brand: "Brand", color: "Color" }),
+    );
+  });
+
+  it("parses price overrides", () => {
+    const formData = new FormData();
+    formData.append("priceOverridesKey", "USD");
+    formData.append("priceOverridesValue", "10");
+    formData.append("priceOverridesKey", "EUR");
+    formData.append("priceOverridesValue", "9");
+
+    expect(parsePriceOverrides(formData)).toBe(
+      JSON.stringify({ USD: 10, EUR: 9 }),
+    );
+  });
+
+  it("parses locale overrides", () => {
+    const formData = new FormData();
+    formData.append("localeOverridesKey", "en");
+    formData.append("localeOverridesValue", "de");
+
+    expect(parseLocaleOverrides(formData)).toBe(
+      JSON.stringify({ en: "de" }),
+    );
+  });
+});

--- a/apps/cms/src/services/shops/formData.ts
+++ b/apps/cms/src/services/shops/formData.ts
@@ -1,0 +1,37 @@
+export function parseFilterMappings(formData: FormData): string {
+  const keys = formData.getAll("filterMappingsKey").map(String);
+  const values = formData.getAll("filterMappingsValue").map(String);
+  return JSON.stringify(
+    Object.fromEntries(
+      keys
+        .map((k, i) => [k.trim(), values[i]?.trim() ?? ""])
+        .filter(([k, v]) => k && v),
+    ),
+  );
+}
+
+export function parsePriceOverrides(formData: FormData): string {
+  const keys = formData.getAll("priceOverridesKey").map(String);
+  const values = formData
+    .getAll("priceOverridesValue")
+    .map((v) => Number(v));
+  return JSON.stringify(
+    Object.fromEntries(
+      keys
+        .map((k, i) => [k.trim(), values[i]])
+        .filter(([k, v]) => k && !Number.isNaN(v)),
+    ),
+  );
+}
+
+export function parseLocaleOverrides(formData: FormData): string {
+  const keys = formData.getAll("localeOverridesKey").map(String);
+  const values = formData.getAll("localeOverridesValue").map(String);
+  return JSON.stringify(
+    Object.fromEntries(
+      keys
+        .map((k, i) => [k.trim(), values[i]?.trim() ?? ""])
+        .filter(([k, v]) => k && v),
+    ),
+  );
+}

--- a/apps/cms/src/services/shops/validation.ts
+++ b/apps/cms/src/services/shops/validation.ts
@@ -6,6 +6,11 @@ import {
   aiCatalogFieldSchema,
 } from "@acme/types";
 import { shopSchema, type ShopForm } from "../../actions/schemas";
+import {
+  parseFilterMappings,
+  parsePriceOverrides,
+  parseLocaleOverrides,
+} from "./formData";
 
 export type { ShopForm };
 
@@ -15,35 +20,6 @@ export function parseShopForm(formData: FormData): {
 } {
   const themeDefaultsRaw = formData.get("themeDefaults") as string | null;
   const themeOverridesRaw = formData.get("themeOverrides") as string | null;
-  const filterKeys = formData.getAll("filterMappingsKey").map(String);
-  const filterValues = formData.getAll("filterMappingsValue").map(String);
-  const filterMappings = JSON.stringify(
-    Object.fromEntries(
-      filterKeys
-        .map((k, i) => [k.trim(), filterValues[i]?.trim() ?? ""])
-        .filter(([k, v]) => k && v),
-    ),
-  );
-  const priceKeys = formData.getAll("priceOverridesKey").map(String);
-  const priceValues = formData
-    .getAll("priceOverridesValue")
-    .map((v) => Number(v));
-  const priceOverrides = JSON.stringify(
-    Object.fromEntries(
-      priceKeys
-        .map((k, i) => [k.trim(), priceValues[i]])
-        .filter(([k, v]) => k && !Number.isNaN(v)),
-    ),
-  );
-  const localeKeys = formData.getAll("localeOverridesKey").map(String);
-  const localeValues = formData.getAll("localeOverridesValue").map(String);
-  const localeOverrides = JSON.stringify(
-    Object.fromEntries(
-      localeKeys
-        .map((k, i) => [k.trim(), localeValues[i]?.trim() ?? ""])
-        .filter(([k, v]) => k && v),
-    ),
-  );
 
   const entries = Array.from(
     formData as unknown as Iterable<[string, FormDataEntryValue]>
@@ -64,9 +40,9 @@ export function parseShopForm(formData: FormData): {
     themeDefaults: themeDefaultsRaw ?? "{}",
     themeOverrides: themeOverridesRaw ?? "{}",
     trackingProviders: formData.getAll("trackingProviders"),
-    filterMappings,
-    priceOverrides,
-    localeOverrides,
+    filterMappings: parseFilterMappings(formData),
+    priceOverrides: parsePriceOverrides(formData),
+    localeOverrides: parseLocaleOverrides(formData),
   });
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };


### PR DESCRIPTION
## Summary
- extract filter, price, and locale overrides parsing into helpers
- simplify `parseShopForm` to use helpers
- add tests for form data parsers

## Testing
- `pnpm test:cms apps/cms/src/services/shops/__tests__/formData.test.ts apps/cms/src/services/shops/__tests__/validation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac49592544832fa35750b5ea5792a8