### PR TITLE
Refactor BlockItem into composable hooks

### DIFF
--- a/packages/ui/src/components/cms/page-builder/BlockChildren.tsx
+++ b/packages/ui/src/components/cms/page-builder/BlockChildren.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
+import type { Locale } from "@acme/i18n/locales";
+import type { PageComponent } from "@acme/types";
+import CanvasItem from "./CanvasItem";
+import type { Action } from "./state";
+import type { DevicePreset } from "../../../utils/devicePresets";
+
+interface Props {
+  component: PageComponent;
+  childComponents?: PageComponent[];
+  selectedId: string | null;
+  onSelectId: (id: string) => void;
+  dispatch: React.Dispatch<Action>;
+  locale: Locale;
+  gridEnabled?: boolean;
+  gridCols: number;
+  viewport: "desktop" | "tablet" | "mobile";
+  device?: DevicePreset;
+  isOver: boolean;
+  setDropRef: (node: HTMLDivElement | null) => void;
+}
+
+export default function BlockChildren({
+  component,
+  childComponents,
+  selectedId,
+  onSelectId,
+  dispatch,
+  locale,
+  gridEnabled = false,
+  gridCols,
+  viewport,
+  device,
+  isOver,
+  setDropRef,
+}: Props) {
+  if (!childComponents || childComponents.length === 0) return null;
+  const childIds = childComponents.map((c) => c.id);
+  return (
+    <SortableContext
+      id={`context-${component.id}`}
+      items={childIds}
+      strategy={rectSortingStrategy}
+    >
+      <div
+        ref={setDropRef}
+        id={`container-${component.id}`}
+        role="list"
+        aria-dropeffect="move"
+        className="border-muted m-2 flex flex-col gap-4 border border-dashed p-2"
+      >
+        {isOver && (
+          <div
+            data-placeholder
+            className="border-primary bg-primary/10 ring-primary h-4 w-full rounded border-2 border-dashed ring-2"
+          />
+        )}
+        {childComponents.map((child, i) => (
+          <CanvasItem
+            key={child.id}
+            component={child}
+            index={i}
+            parentId={component.id}
+            selectedId={selectedId}
+            onSelectId={onSelectId}
+            onRemove={() => dispatch({ type: "remove", id: child.id })}
+            dispatch={dispatch}
+            locale={locale}
+            gridEnabled={gridEnabled}
+            gridCols={gridCols}
+            viewport={viewport}
+            device={device}
+          />
+        ))}
+      </div>
+    </SortableContext>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/BlockResizer.tsx
+++ b/packages/ui/src/components/cms/page-builder/BlockResizer.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+interface Props {
+  selected: boolean;
+  startResize: (e: React.PointerEvent) => void;
+  startSpacing: (
+    e: React.PointerEvent,
+    type: "margin" | "padding",
+    side: "top" | "bottom" | "left" | "right",
+  ) => void;
+}
+
+export default function BlockResizer({
+  selected,
+  startResize,
+  startSpacing,
+}: Props) {
+  if (!selected) return null;
+  return (
+    <>
+      <div
+        onPointerDown={startResize}
+        className="bg-primary absolute -top-1 -left-1 h-2 w-2 cursor-nwse-resize"
+      />
+      <div
+        onPointerDown={startResize}
+        className="bg-primary absolute -top-1 -right-1 h-2 w-2 cursor-nesw-resize"
+      />
+      <div
+        onPointerDown={startResize}
+        className="bg-primary absolute -bottom-1 -left-1 h-2 w-2 cursor-nesw-resize"
+      />
+      <div
+        onPointerDown={startResize}
+        className="bg-primary absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "margin", "top")}
+        className="bg-primary absolute -top-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "margin", "bottom")}
+        className="bg-primary absolute -bottom-2 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "margin", "left")}
+        className="bg-primary absolute top-1/2 -left-2 h-4 w-1 -translate-y-1/2 cursor-w-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "margin", "right")}
+        className="bg-primary absolute top-1/2 -right-2 h-4 w-1 -translate-y-1/2 cursor-e-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "padding", "top")}
+        className="bg-primary absolute top-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-n-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "padding", "bottom")}
+        className="bg-primary absolute bottom-0 left-1/2 h-1 w-4 -translate-x-1/2 cursor-s-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "padding", "left")}
+        className="bg-primary absolute top-1/2 left-0 h-4 w-1 -translate-y-1/2 cursor-w-resize"
+      />
+      <div
+        onPointerDown={(e) => startSpacing(e, "padding", "right")}
+        className="bg-primary absolute top-1/2 right-0 h-4 w-1 -translate-y-1/2 cursor-e-resize"
+      />
+    </>
+  );
+}
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -45,3 +45,5 @@ export { default as usePageBuilderState } from "./hooks/usePageBuilderState";
 export { default as usePageBuilderDnD } from "./hooks/usePageBuilderDnD";
 export { default as useCanvasDrag } from "./useCanvasDrag";
 export { default as useCanvasResize } from "./useCanvasResize";
+export { default as useBlockDimensions } from "./useBlockDimensions";
+export { default as useBlockDnD } from "./useBlockDnD";

--- a/packages/ui/src/components/cms/page-builder/useBlockDimensions.ts
+++ b/packages/ui/src/components/cms/page-builder/useBlockDimensions.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import type { PageComponent } from "@acme/types";
+
+interface Options {
+  component: PageComponent;
+  viewport: "desktop" | "tablet" | "mobile";
+}
+
+export default function useBlockDimensions({
+  component,
+  viewport,
+}: Options) {
+  const widthKey =
+    viewport === "desktop"
+      ? "widthDesktop"
+      : viewport === "tablet"
+        ? "widthTablet"
+        : "widthMobile";
+  const heightKey =
+    viewport === "desktop"
+      ? "heightDesktop"
+      : viewport === "tablet"
+        ? "heightTablet"
+        : "heightMobile";
+  const widthVal =
+    (component[widthKey as keyof PageComponent] as string | undefined) ??
+    component.width;
+  const heightVal =
+    (component[heightKey as keyof PageComponent] as string | undefined) ??
+    component.height;
+  const marginKey =
+    viewport === "desktop"
+      ? "marginDesktop"
+      : viewport === "tablet"
+        ? "marginTablet"
+        : "marginMobile";
+  const paddingKey =
+    viewport === "desktop"
+      ? "paddingDesktop"
+      : viewport === "tablet"
+        ? "paddingTablet"
+        : "paddingMobile";
+  const marginVal =
+    (component[marginKey as keyof PageComponent] as string | undefined) ??
+    component.margin;
+  const paddingVal =
+    (component[paddingKey as keyof PageComponent] as string | undefined) ??
+    component.padding;
+
+  return {
+    widthKey,
+    heightKey,
+    widthVal,
+    heightVal,
+    marginKey,
+    paddingKey,
+    marginVal,
+    paddingVal,
+  } as const;
+}
+

--- a/packages/ui/src/components/cms/page-builder/useBlockDnD.ts
+++ b/packages/ui/src/components/cms/page-builder/useBlockDnD.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRef } from "react";
+import useSortableBlock from "./useSortableBlock";
+
+export default function useBlockDnD(
+  id: string,
+  index: number,
+  parentId: string | undefined,
+) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const sortable = useSortableBlock(id, index, parentId);
+
+  const setNodeRef = (node: HTMLDivElement | null) => {
+    sortable.setNodeRef(node);
+    containerRef.current = node;
+  };
+
+  return { ...sortable, setNodeRef, containerRef } as const;
+}
+


### PR DESCRIPTION
## Summary
- extract width, height, margin and padding logic into `useBlockDimensions`
- wrap sortable setup with `useBlockDnD`
- isolate resizer controls and child rendering into `BlockResizer` and `BlockChildren`
- streamline `BlockItem` to compose new hooks and components

## Testing
- `pnpm lint --filter @acme/ui`
- `pnpm test --filter @acme/ui` *(fails: command exited with status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51517f14832fa0638ddea43d76af