### PR TITLE
fix: handle optional cart fields

### DIFF
--- a/packages/ui/src/components/cms/page-builder/state/actions/helpers.ts
+++ b/packages/ui/src/components/cms/page-builder/state/actions/helpers.ts
@@ -190,6 +190,3 @@ export function moveComponent(
   if (!item) return list;
   return addComponent(without, to.parentId, to.index, item);
 }
-
-// ulid import for cloneWithNewIds
-import { ulid } from "ulid";

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -22,7 +22,10 @@ export function CartTemplate({
   const lines = (Object.entries(cart) as [string, CartLine][]).map(
     ([id, line]) => ({ id, ...line })
   );
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const subtotal = lines.reduce(
+    (s, l) => s + (l.sku.price ?? 0) * l.qty,
+    0,
+  );
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
   if (!lines.length) {
@@ -48,19 +51,19 @@ export function CartTemplate({
             <tr key={line.id} className="border-b last:border-0">
               <td className="py-2">
                 <div className="flex items-center gap-4">
-                  {line.sku.media[0] && (
+                  {line.sku.media?.[0] && (
                     <div className="relative hidden h-12 w-12 sm:block">
-                      {line.sku.media[0].type === "image" ? (
+                      {line.sku.media?.[0].type === "image" ? (
                         <Image
-                          src={line.sku.media[0].url}
-                          alt={line.sku.title}
+                          src={line.sku.media?.[0].url ?? ""}
+                          alt={line.sku.title ?? ""}
                           fill
                           sizes="3rem"
                           className="rounded-md object-cover"
                         />
                       ) : (
                         <video
-                          src={line.sku.media[0].url}
+                          src={line.sku.media?.[0].url ?? ""}
                           className="h-full w-full rounded-md object-cover"
                           muted
                           playsInline
@@ -84,7 +87,7 @@ export function CartTemplate({
                 />
               </td>
               <td className="text-right">
-                <Price amount={line.sku.price * line.qty} />
+                <Price amount={(line.sku.price ?? 0) * line.qty} />
               </td>
               {onRemove && (
                 <td className="text-right">

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -18,7 +18,10 @@ export function OrderConfirmationTemplate({
   const lines = (Object.entries(cart) as [string, CartLine][]).map(
     ([id, line]) => ({ id, ...line })
   );
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const subtotal = lines.reduce(
+    (s, l) => s + (l.sku.price ?? 0) * l.qty,
+    0,
+  );
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
   return (
@@ -52,7 +55,7 @@ export function OrderConfirmationTemplate({
               </td>
               <td>{l.qty}</td>
               <td className="text-right">
-                <Price amount={l.sku.price * l.qty} />
+                <Price amount={(l.sku.price ?? 0) * l.qty} />
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- remove duplicate `ulid` import in page builder helpers
- guard cart templates against missing media, price, or title data

## Testing
- `npx tsc -b apps/cms` *(fails: File not listed in project and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac526049e4832f926d9519698d0959