### PR TITLE
refactor: alias ulid import to avoid duplicate identifier

### DIFF
--- a/packages/ui/src/components/cms/page-builder/state/layout/utils.ts
+++ b/packages/ui/src/components/cms/page-builder/state/layout/utils.ts
@@ -1,5 +1,5 @@
 import type { PageComponent } from "@acme/types";
-import { ulid } from "ulid";
+import { ulid as generateId } from "ulid";
 
 export function addAt(list: PageComponent[], index: number, item: PageComponent) {
   return [...list.slice(0, index), item, ...list.slice(index)];
@@ -49,7 +49,7 @@ export function removeComponent(list: PageComponent[], id: string): PageComponen
 }
 
 export function cloneWithNewIds(component: PageComponent): PageComponent {
-  const copy: PageComponent = { ...component, id: ulid() };
+  const copy: PageComponent = { ...component, id: generateId() };
   const childList = (component as { children?: PageComponent[] }).children;
   if (Array.isArray(childList)) {
     (copy as { children?: PageComponent[] }).children = childList.map((child) =>


### PR DESCRIPTION
## Summary
- alias `ulid` import in page builder state utils to prevent duplicate identifier errors

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/page-builder/state/layout/utils.ts` *(fails: hung)*
- `pnpm --filter @acme/ui test` *(fails: hung)*

------
https://chatgpt.com/codex/tasks/task_e_68ac53c4610c832fb0395928f2461265