### PR TITLE
feat: preload env vars from file

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -53,6 +53,10 @@ selected template without prompting for them.
 Add `--auto-env` to skip prompts for provider environment variables. The wizard writes
 `TODO_*` placeholders to the new shop's `.env` file; replace them with real
 secrets before deploying.
+To prefill answers from an existing file, supply `--env-file <path>`.
+Keys in the file are merged before prompting—any variables already present are
+written directly to the generated `.env` and prompts for them are skipped. After
+validation the wizard warns about unused entries or missing required variables.
 
 Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages.
 
@@ -131,7 +135,9 @@ Scaffolded apps/shop-demo
 The wizard captures common environment variables and writes them to `apps/shop-<id>/.env`.
 
 If you used `--auto-env`, this file contains placeholder values like `TODO_API_KEY`.
-These placeholders must be replaced with real credentials before deployment.
+If you passed `--env-file`, any matching keys from that file are copied directly
+and unused entries are reported during validation. Placeholders and missing
+variables must be replaced with real credentials before deployment.
 
 ```bash
 pnpm validate-env <id>


### PR DESCRIPTION
## Summary
- add `--env-file` flag to init-shop script to preload env vars
- warn about unused or missing env vars after validation
- document env file loading and warnings

## Testing
- `pnpm exec eslint scripts/src/env.ts && echo 'eslint:ok'`
- `pnpm test` *(fails: @apps/cms#test)*
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit` *(fails: Output file ... has not been built from source)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55eb11d0832fafe1bb92e71e989c