### PR TITLE
feat: add inventory CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,21 +78,23 @@ STOCK_ALERT_RECIPIENT=alerts@example.com
 
 ### Import / export
 
-Inventory can be round-tripped as JSON or CSV through the CMS API.
+Inventory can be round-tripped as JSON or CSV using the `inventory` CLI, which wraps the CMS API.
 
 Export inventory:
 
 ```bash
-curl "http://localhost:3000/cms/api/data/demo/inventory/export?format=csv" -o inventory.csv
-curl "http://localhost:3000/cms/api/data/demo/inventory/export" -o inventory.json
+pnpm inventory export demo --file inventory.csv
+pnpm inventory export demo --file inventory.json
 ```
 
 Import inventory:
 
 ```bash
-curl -X POST -F "file=@inventory.csv;type=text/csv" http://localhost:3000/cms/api/data/demo/inventory/import
-curl -X POST -F "file=@inventory.json;type=application/json" http://localhost:3000/cms/api/data/demo/inventory/import
+pnpm inventory import demo --file inventory.csv
+pnpm inventory import demo --file inventory.json
 ```
+
+The underlying API endpoints remain available if you prefer using `curl`.
 
 CSV files use headers to define variant attributes:
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lh:checkout": "lighthouse http://localhost:3000/en/checkout --chrome-flags=\"--headless\" --only-categories=performance,accessibility,best-practices,seo --preset=desktop",
     "seo:audit": "tsx scripts/seo-audit.ts",
     "validate-env": "ts-node scripts/src/validate-env.ts",
+    "inventory": "ts-node scripts/src/inventory.ts",
     "quickstart-shop": "ts-node scripts/src/quickstart-shop.ts",
     "check:locales": "ts-node scripts/src/check-locales.ts",
     "add-locale": "tsx scripts/src/add-locale.ts",

--- a/scripts/src/inventory.ts
+++ b/scripts/src/inventory.ts
@@ -1,0 +1,70 @@
+// scripts/src/inventory.ts
+// Inventory import/export helper calling CMS API endpoints.
+import { readFile, writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { parseArgs } from "node:util";
+
+interface Options {
+  file: string;
+  url?: string;
+}
+
+async function importInventory(shop: string, file: string, base: string): Promise<void> {
+  const buf = await readFile(file);
+  const contentType = file.endsWith(".csv") ? "text/csv" : "application/json";
+  const form = new FormData();
+  form.append("file", new Blob([buf], { type: contentType }), basename(file));
+  const res = await fetch(`${base}/cms/api/data/${shop}/inventory/import`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Import failed: ${res.status} ${text}`);
+  }
+  console.log(`Imported inventory from ${file}`);
+}
+
+async function exportInventory(shop: string, file: string, base: string): Promise<void> {
+  const format = file.endsWith(".csv") ? "csv" : "json";
+  const url = `${base}/cms/api/data/${shop}/inventory/export${
+    format === "csv" ? "?format=csv" : ""
+  }`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Export failed: ${res.status} ${text}`);
+  }
+  const data = Buffer.from(await res.arrayBuffer());
+  await writeFile(file, data);
+  console.log(`Saved inventory to ${file}`);
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      file: { type: "string", short: "f" },
+      url: { type: "string" },
+    },
+    allowPositionals: true,
+  });
+  const [cmd, shop] = positionals;
+  if (!cmd || !shop || typeof values.file !== "string") {
+    console.error("Usage: pnpm inventory <import|export> <shop> --file <path> [--url <baseUrl>]");
+    process.exit(1);
+  }
+  const base = (values.url || process.env.CMS_BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+  if (cmd === "import") {
+    await importInventory(shop, values.file, base);
+  } else if (cmd === "export") {
+    await exportInventory(shop, values.file, base);
+  } else {
+    console.error(`Unknown command: ${cmd}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script wrapping CMS inventory import/export endpoints
- expose inventory command in package.json
- document new CLI usage for inventory import/export

## Testing
- `pnpm lint` *(fails: Could not find module '@next/eslint-plugin-next')*
- `pnpm test:cms` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55f1b108832f968b55a12d4cca79