### PR TITLE
fix: resolve TypeScript errors in UI components

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -55,24 +55,6 @@ const PageBuilder = memo(function PageBuilder({
     }
   }, [onSave]);
   const {
-    state,
-    components,
-    dispatch,
-    selectedId,
-    setSelectedId,
-    gridCols,
-    setGridCols,
-    liveMessage,
-    clearHistory,
-  } = usePageBuilderState({
-    page,
-    history: historyProp,
-    onChange,
-    onSaveShortcut: handleSaveShortcut,
-    onTogglePreview: togglePreview,
-    onRotateDevice: rotateDevice,
-  });
-  const {
     deviceId,
     setDeviceId,
     orientation,
@@ -95,6 +77,24 @@ const PageBuilder = memo(function PageBuilder({
     showGrid,
     toggleGrid,
   } = usePageBuilderControls();
+  const {
+    state,
+    components,
+    dispatch,
+    selectedId,
+    setSelectedId,
+    gridCols,
+    setGridCols,
+    liveMessage,
+    clearHistory,
+  } = usePageBuilderState({
+    page,
+    history: historyProp,
+    onChange,
+    onSaveShortcut: handleSaveShortcut,
+    onTogglePreview: togglePreview,
+    onRotateDevice: rotateDevice,
+  });
   const [publishCount, setPublishCount] = useState(0);
   const prevId = useRef(page.id);
   const pathname = usePathname() ?? "";

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -22,7 +22,10 @@ export function CartTemplate({
   const lines = (Object.entries(cart) as [string, CartLine][]).map(
     ([id, line]) => ({ id, ...line })
   );
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const subtotal = lines.reduce(
+    (s, l) => s + (l.sku.price ?? 0) * l.qty,
+    0,
+  );
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
   if (!lines.length) {
@@ -44,62 +47,65 @@ export function CartTemplate({
           </tr>
         </thead>
         <tbody>
-          {lines.map((line) => (
-            <tr key={line.id} className="border-b last:border-0">
-              <td className="py-2">
-                <div className="flex items-center gap-4">
-                  {line.sku.media[0] && (
-                    <div className="relative hidden h-12 w-12 sm:block">
-                      {line.sku.media[0].type === "image" ? (
-                        <Image
-                          src={line.sku.media[0].url}
-                          alt={line.sku.title}
-                          fill
-                          sizes="3rem"
-                          className="rounded-md object-cover"
-                        />
-                      ) : (
-                        <video
-                          src={line.sku.media[0].url}
-                          className="h-full w-full rounded-md object-cover"
-                          muted
-                          playsInline
-                        />
-                      )}
-                    </div>
-                  )}
-                  {line.sku.title}
-                  {line.size && (
-                    <span className="ml-1 text-xs text-muted" data-token="--color-muted">
-                      ({line.size})
-                    </span>
-                  )}
-                </div>
-              </td>
-              <td>
-                <QuantityInput
-                  value={line.qty}
-                  onChange={(v) => onQtyChange?.(line.id, v)}
-                  className="justify-center"
-                />
-              </td>
-              <td className="text-right">
-                <Price amount={line.sku.price * line.qty} />
-              </td>
-              {onRemove && (
-                <td className="text-right">
-                  <button
-                    type="button"
-                    onClick={() => onRemove(line.id)}
-                    className="text-danger hover:underline"
-                    data-token="--color-danger"
-                  >
-                    Remove
-                  </button>
+          {lines.map((line) => {
+            const media = line.sku.media?.[0];
+            return (
+              <tr key={line.id} className="border-b last:border-0">
+                <td className="py-2">
+                  <div className="flex items-center gap-4">
+                    {media && (
+                      <div className="relative hidden h-12 w-12 sm:block">
+                        {media.type === "image" ? (
+                          <Image
+                            src={media.url}
+                            alt={line.sku.title ?? ""}
+                            fill
+                            sizes="3rem"
+                            className="rounded-md object-cover"
+                          />
+                        ) : (
+                          <video
+                            src={media.url}
+                            className="h-full w-full rounded-md object-cover"
+                            muted
+                            playsInline
+                          />
+                        )}
+                      </div>
+                    )}
+                    {line.sku.title}
+                    {line.size && (
+                      <span className="ml-1 text-xs text-muted" data-token="--color-muted">
+                        ({line.size})
+                      </span>
+                    )}
+                  </div>
                 </td>
-              )}
-            </tr>
-          ))}
+                <td>
+                  <QuantityInput
+                    value={line.qty}
+                    onChange={(v) => onQtyChange?.(line.id, v)}
+                    className="justify-center"
+                  />
+                </td>
+                <td className="text-right">
+                  <Price amount={(line.sku.price ?? 0) * line.qty} />
+                </td>
+                {onRemove && (
+                  <td className="text-right">
+                    <button
+                      type="button"
+                      onClick={() => onRemove(line.id)}
+                      className="text-danger hover:underline"
+                      data-token="--color-danger"
+                    >
+                      Remove
+                    </button>
+                  </td>
+                )}
+              </tr>
+            );
+          })}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -18,7 +18,10 @@ export function OrderConfirmationTemplate({
   const lines = (Object.entries(cart) as [string, CartLine][]).map(
     ([id, line]) => ({ id, ...line })
   );
-  const subtotal = lines.reduce((s, l) => s + l.sku.price * l.qty, 0);
+  const subtotal = lines.reduce(
+    (s, l) => s + (l.sku.price ?? 0) * l.qty,
+    0,
+  );
   const deposit = lines.reduce((s, l) => s + (l.sku.deposit ?? 0) * l.qty, 0);
 
   return (
@@ -52,7 +55,7 @@ export function OrderConfirmationTemplate({
               </td>
               <td>{l.qty}</td>
               <td className="text-right">
-                <Price amount={l.sku.price * l.qty} />
+                <Price amount={(l.sku.price ?? 0) * l.qty} />
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- reorder PageBuilder hooks to avoid using controls before their declaration
- guard cart and order templates against optional sku fields

## Testing
- `npx tsc -b packages/ui` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `npx tsc -p packages/ui/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ac572d4498832f94f5ab6095ce0edc