### PR TITLE
feat: add page templates and apply script

### DIFF
--- a/data/templates/contact/pages/contact.json
+++ b/data/templates/contact/pages/contact.json
@@ -1,0 +1,10 @@
+{
+  "slug": "contact",
+  "title": { "en": "Contact" },
+  "components": [
+    {
+      "type": "ContactFormWithMap",
+      "mapSrc": "https://maps.example.com"
+    }
+  ]
+}

--- a/data/templates/hero/pages/home.json
+++ b/data/templates/hero/pages/home.json
@@ -1,0 +1,16 @@
+{
+  "slug": "home",
+  "title": { "en": "Home" },
+  "components": [
+    {
+      "type": "HeroBanner",
+      "slides": [
+        {
+          "src": "/hero/slide-1.jpg",
+          "headlineKey": "hero.slide1.headline",
+          "ctaKey": "hero.cta"
+        }
+      ]
+    }
+  ]
+}

--- a/data/templates/product-grid/pages/products.json
+++ b/data/templates/product-grid/pages/products.json
@@ -1,0 +1,11 @@
+{
+  "slug": "products",
+  "title": { "en": "Products" },
+  "components": [
+    {
+      "type": "ProductGrid",
+      "mode": "collection",
+      "quickView": true
+    }
+  ]
+}

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -12,6 +12,7 @@ pnpm quickstart-shop --id demo --theme base --template template-app --payment st
 ```
 
 Add `--seed` to copy sample products and inventory so the shop is immediately populated.
+Use `--pages-template <name>` to scaffold preset page layouts and push them to the CMS. Built-in templates include `hero`, `product-grid` and `contact`.
 
 ## 1. Create a shop
 
@@ -50,6 +51,7 @@ pnpm init-shop --brand "#663399" --tokens ./my-tokens.json
 To populate the new shop with sample data, run `pnpm init-shop --seed`.
 Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
 selected template without prompting for them.
+To scaffold predefined page layouts, pass `--pages-template <name>` (e.g. `hero`, `product-grid`, `contact`).
 Add `--auto-env` to skip prompts for provider environment variables. The wizard writes
 `TODO_*` placeholders to the new shop's `.env` file; replace them with real
 secrets before deploying.
@@ -70,6 +72,7 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 - `--name` – display name for the shop.
 - `--logo` – URL of the shop logo.
 - `--seed` – copy sample `products.json` and `inventory.json` into the new shop.
+- `--pages-template` – copy predefined page layouts from `data/templates/<name>/pages` and persist them via the CMS (templates: `hero`, `product-grid`, `contact`).
 - `--contact` – contact email for the shop.
 - `--config` – path to a JSON or TS file exporting options. Values from the file prefill the wizard and skip prompts.
 

--- a/scripts/src/apply-page-template.ts
+++ b/scripts/src/apply-page-template.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Copy page layouts from a template into a shop's data directory and
+ * persist them via the CMS HTTP API. Missing templates are ignored with a
+ * warning.
+ *
+ * @param shopId   Directory name of the shop (e.g. "shop-demo").
+ * @param template Template name under data/templates.
+ */
+export async function applyPageTemplate(
+  shopId: string,
+  template: string
+): Promise<void> {
+  const srcDir = join("data", "templates", template, "pages");
+  const destDir = join("data", "shops", shopId, "pages");
+  let files: string[];
+  try {
+    files = await fs.readdir(srcDir);
+  } catch (err) {
+    console.error(
+      `Page template \"${template}\" not found:`,
+      (err as Error).message
+    );
+    return;
+  }
+
+  await fs.mkdir(destDir, { recursive: true });
+
+  const cmsUrl = process.env.CMS_SPACE_URL;
+  const token = process.env.CMS_ACCESS_TOKEN;
+  const headers = token
+    ? { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+    : undefined;
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const srcPath = join(srcDir, file);
+    const destPath = join(destDir, file);
+    try {
+      const content = await fs.readFile(srcPath, "utf8");
+      await fs.writeFile(destPath, content, "utf8");
+      if (cmsUrl && headers) {
+        try {
+          const res = await fetch(`${cmsUrl}/shops/${shopId}/pages`, {
+            method: "POST",
+            headers,
+            body: content,
+          });
+          if (!res.ok) {
+            const text = await res.text().catch(() => "");
+            console.error(`Failed to persist ${file}: ${res.status} ${text}`);
+          }
+        } catch (err) {
+          console.error(`Failed to persist ${file}:`, err);
+        }
+      }
+    } catch (err) {
+      console.error(`Failed to apply page ${file}:`, err);
+    }
+  }
+}

--- a/scripts/src/env.ts
+++ b/scripts/src/env.ts
@@ -8,6 +8,7 @@ import { readdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { validateShopEnv, readEnvFile } from "@acme/platform-core/configurator";
 import { seedShop } from "./seedShop";
+import { applyPageTemplate } from "./apply-page-template";
 import { listProviders, listPlugins } from "./utils/providers";
 import {
   prompt,
@@ -23,6 +24,14 @@ import { promptThemeOverrides } from "./utils/theme";
 const seed = process.argv.includes("--seed");
 const useDefaults = process.argv.includes("--defaults");
 const autoEnv = process.argv.includes("--auto-env");
+const pagesTemplateIndex = process.argv.indexOf("--pages-template");
+const pagesTemplates =
+  pagesTemplateIndex !== -1
+    ? process.argv[pagesTemplateIndex + 1]
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
 
 function listDirNames(path: string): string[] {
   return readdirSync(path, { withFileTypes: true })
@@ -32,13 +41,16 @@ function listDirNames(path: string): string[] {
 
 function loadTemplateDefaults(
   root: string,
-  template: string,
+  template: string
 ): {
   navItems?: CreateShopOptions["navItems"];
   pages?: CreateShopOptions["pages"];
 } {
   try {
-    const raw = readFileSync(join(root, "packages", template, "shop.json"), "utf8");
+    const raw = readFileSync(
+      join(root, "packages", template, "shop.json"),
+      "utf8"
+    );
     const data = JSON.parse(raw);
     const defaults: {
       navItems?: CreateShopOptions["navItems"];
@@ -76,7 +88,8 @@ export async function initShop(): Promise<void> {
     }
   }
 
-  const rawId = (config.id as string | undefined) ?? (await prompt("Shop ID: "));
+  const rawId =
+    (config.id as string | undefined) ?? (await prompt("Shop ID: "));
   let shopId: string;
   try {
     shopId = validateShopName(rawId);
@@ -108,10 +121,10 @@ export async function initShop(): Promise<void> {
       : await selectOption(
           "theme",
           themes,
-          Math.max(themes.indexOf("base"), 0),
+          Math.max(themes.indexOf("base"), 0)
         );
   const templates = listDirNames(join(rootDir, "packages")).filter((n) =>
-    n.startsWith("template-"),
+    n.startsWith("template-")
   );
   const template =
     config.template && templates.includes(config.template)
@@ -119,7 +132,7 @@ export async function initShop(): Promise<void> {
       : await selectOption(
           "template",
           templates,
-          Math.max(templates.indexOf("template-app"), 0),
+          Math.max(templates.indexOf("template-app"), 0)
         );
   const paymentMeta = (await listProviders("payment")) as (
     | { id: "stripe"; name: string; envVars: readonly string[] }
@@ -129,7 +142,7 @@ export async function initShop(): Promise<void> {
     ? (config.payment as ("stripe" | "paypal")[])
     : await selectProviders<"stripe" | "paypal">(
         "payment providers",
-        paymentMeta.map((p) => p.id) as ("stripe" | "paypal")[],
+        paymentMeta.map((p) => p.id) as ("stripe" | "paypal")[]
       );
   const shippingMeta = (await listProviders("shipping")) as (
     | { id: "dhl"; name: string; envVars: readonly string[] }
@@ -140,11 +153,7 @@ export async function initShop(): Promise<void> {
     ? (config.shipping as ("dhl" | "ups" | "premier-shipping")[])
     : await selectProviders<"dhl" | "ups" | "premier-shipping">(
         "shipping providers",
-        shippingMeta.map((p) => p.id) as (
-          | "dhl"
-          | "ups"
-          | "premier-shipping"
-        )[],
+        shippingMeta.map((p) => p.id) as ("dhl" | "ups" | "premier-shipping")[]
       );
   const allPluginMeta = listPlugins(rootDir);
   type ProviderMeta = {
@@ -156,16 +165,22 @@ export async function initShop(): Promise<void> {
     string,
     { packageName?: string; envVars: readonly string[] }
   >();
-  for (const m of [...paymentMeta, ...shippingMeta, ...allPluginMeta] as ProviderMeta[]) {
+  for (const m of [
+    ...paymentMeta,
+    ...shippingMeta,
+    ...allPluginMeta,
+  ] as ProviderMeta[]) {
     pluginMap.set(m.id, { packageName: m.packageName, envVars: m.envVars });
   }
   const selectedPlugins = new Set<string>([...payment, ...shipping]);
-  const optionalPlugins = allPluginMeta.filter((p) => !selectedPlugins.has(p.id));
+  const optionalPlugins = allPluginMeta.filter(
+    (p) => !selectedPlugins.has(p.id)
+  );
   let extra: string[] = Array.isArray(config.plugins) ? config.plugins : [];
   if (!extra.length && optionalPlugins.length) {
     extra = await selectProviders(
       "plugins",
-      optionalPlugins.map((p) => p.id),
+      optionalPlugins.map((p) => p.id)
     );
   }
   extra.forEach((id) => selectedPlugins.add(id));
@@ -201,8 +216,12 @@ export async function initShop(): Promise<void> {
         : "n"
       : await prompt("Setup CI workflow? (y/N): ");
 
-  const { id: _id, plugins: _plugins, setupCI: _setupCI, ...restConfig } =
-    config as Record<string, unknown>;
+  const {
+    id: _id,
+    plugins: _plugins,
+    setupCI: _setupCI,
+    ...restConfig
+  } = config as Record<string, unknown>;
   void _id;
   void _plugins;
   void _setupCI;
@@ -226,6 +245,9 @@ export async function initShop(): Promise<void> {
     await createShop(prefixedId, options);
     if (seed) {
       seedShop(prefixedId);
+    }
+    for (const t of pagesTemplates) {
+      await applyPageTemplate(prefixedId, t);
     }
     try {
       const pkgPath = join("apps", prefixedId, "package.json");
@@ -254,7 +276,7 @@ export async function initShop(): Promise<void> {
     envPath,
     Object.entries(finalEnv)
       .map(([k, v]) => `${k}=${v}`)
-      .join("\n") + "\n",
+      .join("\n") + "\n"
   );
 
   let validationError: unknown;
@@ -278,12 +300,12 @@ export async function initShop(): Promise<void> {
 
   if (autoEnv) {
     console.warn(
-      `\nWARNING: placeholder environment variables were written to apps/${prefixedId}/.env. Replace any TODO_* values with real secrets before deployment.`,
+      `\nWARNING: placeholder environment variables were written to apps/${prefixedId}/.env. Replace any TODO_* values with real secrets before deployment.`
     );
   }
 
   console.log(
-    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Review data/shops/${prefixedId}/shop.json\n  - Use the CMS Page Builder to lay out your pages\n  - Run: pnpm --filter @apps/${prefixedId} dev`,
+    `\nNext steps:\n  - Review apps/${prefixedId}/.env\n  - Review data/shops/${prefixedId}/shop.json\n  - Use the CMS Page Builder to lay out your pages\n  - Run: pnpm --filter @apps/${prefixedId} dev`
   );
 }
 


### PR DESCRIPTION
## Summary
- add `apply-page-template` helper to copy template layouts and persist to CMS
- integrate `--pages-template` option into shop scaffolding scripts
- document available page layout templates and usage

## Testing
- `pnpm test` *(fails: @acme/next-config#test)*
- `pnpm lint` *(fails: @apps/cms#lint)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55f5a2a8832f994fd64e82c26c4e