### PR TITLE
feat: add full shop seeding

### DIFF
--- a/data/templates/default/navigation.json
+++ b/data/templates/default/navigation.json
@@ -1,0 +1,4 @@
+[
+  { "label": "Home", "href": "/" },
+  { "label": "Shop", "href": "/shop" }
+]

--- a/data/templates/default/pages.json
+++ b/data/templates/default/pages.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "home",
+    "slug": "",
+    "title": "Home",
+    "components": [],
+    "status": "draft",
+    "updatedAt": "1970-01-01T00:00:00.000Z"
+  }
+]

--- a/data/templates/default/pages/home.json
+++ b/data/templates/default/pages/home.json
@@ -1,0 +1,8 @@
+{
+  "id": "home",
+  "slug": "",
+  "title": "Home",
+  "components": [],
+  "status": "draft",
+  "updatedAt": "1970-01-01T00:00:00.000Z"
+}

--- a/data/templates/default/settings.json
+++ b/data/templates/default/settings.json
@@ -1,0 +1,8 @@
+{
+  "languages": ["en"],
+  "freezeTranslations": false,
+  "currency": "USD",
+  "taxRegion": "US",
+  "updatedAt": "",
+  "updatedBy": ""
+}

--- a/data/templates/default/shop.json
+++ b/data/templates/default/shop.json
@@ -1,0 +1,25 @@
+{
+  "id": "template",
+  "name": "Template Shop",
+  "type": "sale",
+  "catalogFilters": [],
+  "themeId": "base",
+  "themeDefaults": {},
+  "themeOverrides": {},
+  "themeTokens": {},
+  "filterMappings": {},
+  "priceOverrides": {},
+  "localeOverrides": {},
+  "navigation": [
+    { "label": "Home", "href": "/" },
+    { "label": "Shop", "href": "/shop" }
+  ],
+  "analyticsEnabled": false,
+  "shippingProviders": ["ups"],
+  "taxProviders": ["taxjar"],
+  "paymentProviders": ["stripe"],
+  "sanityBlog": null,
+  "enableEditorial": false,
+  "subscriptionsEnabled": false,
+  "rentalSubscriptions": []
+}

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -8,13 +8,13 @@
 For a one-liner that scaffolds a shop, validates the environment, and starts the dev server:
 
 ```bash
-pnpm quickstart-shop --id demo --theme base --template template-app --payment stripe --shipping ups --seed
+pnpm quickstart-shop --id demo --theme base --template template-app --payment stripe --shipping ups --seed-full
 ```
 
-Add `--seed` to copy sample products and inventory so the shop is immediately populated. The script also accepts `--config <file>` to prefill options and skip prompts:
+Add `--seed` to copy sample products and inventory. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings so the shop is immediately populated. The script also accepts `--config <file>` to prefill options and skip prompts:
 
 ```bash
-pnpm quickstart-shop --config ./shop.config.json --seed
+pnpm quickstart-shop --config ./shop.config.json --seed-full
 ```
 
 Example `shop.config.json`:
@@ -65,8 +65,7 @@ pnpm init-shop --brand "#663399" --tokens ./my-tokens.json
 
 `--brand` sets the primary brand color and `--tokens` merges additional token overrides from a JSON file.
 
-To populate the new shop with sample data, run `pnpm init-shop --seed`.
-Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
+To populate the new shop with sample data, run `pnpm init-shop --seed`. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings. Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
 selected template without prompting for them.
 Add `--auto-env` to skip prompts for provider environment variables. The wizard writes
 `TODO_*` placeholders to the new shop's `.env` file; replace them with real
@@ -88,6 +87,7 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 - `--name` – display name for the shop.
 - `--logo` – URL of the shop logo.
 - `--seed` – copy sample `products.json` and `inventory.json` into the new shop.
+- `--seed-full` – additionally copy `shop.json`, navigation defaults, page templates, and `settings.json`.
 - `--contact` – contact email for the shop.
 - `--config` – path to a JSON or TS file exporting options. Values from the file prefill the wizard and skip prompts.
 

--- a/scripts/src/env.ts
+++ b/scripts/src/env.ts
@@ -21,6 +21,7 @@ import {
 import { promptThemeOverrides } from "./utils/theme";
 
 const seed = process.argv.includes("--seed");
+const seedFull = process.argv.includes("--seed-full");
 const useDefaults = process.argv.includes("--defaults");
 const autoEnv = process.argv.includes("--auto-env");
 
@@ -224,7 +225,9 @@ export async function initShop(): Promise<void> {
 
   try {
     await createShop(prefixedId, options);
-    if (seed) {
+    if (seedFull) {
+      seedShop(prefixedId, undefined, true);
+    } else if (seed) {
       seedShop(prefixedId);
     }
     try {

--- a/scripts/src/quickstart-shop.ts
+++ b/scripts/src/quickstart-shop.ts
@@ -145,6 +145,7 @@ interface Flags {
   payment?: string[];
   shipping?: string[];
   seed?: boolean;
+  seedFull?: boolean;
   brand?: string;
   tokens?: string;
   autoEnv?: boolean;
@@ -159,6 +160,10 @@ function parseArgs(argv: string[]): Flags {
       const [key, value] = arg.slice(2).split("=");
       if (key === "seed") {
         flags.seed = true;
+        continue;
+      }
+      if (key === "seed-full") {
+        flags.seedFull = true;
         continue;
       }
       if (key === "auto-env") {
@@ -343,7 +348,9 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  if (args.seed) {
+  if (args.seedFull) {
+    seedShop(prefixedId, undefined, true);
+  } else if (args.seed) {
     seedShop(prefixedId);
   }
 

--- a/scripts/src/seedShop.ts
+++ b/scripts/src/seedShop.ts
@@ -1,4 +1,4 @@
-import { copyFileSync } from "node:fs";
+import { copyFileSync, cpSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -8,12 +8,42 @@ import { join } from "node:path";
  * @param shopId - Directory name of the shop (e.g. "shop-demo").
  * @param template - Template name under data/templates. Defaults to "default".
  */
-export function seedShop(shopId: string, template = "default"): void {
+export function seedShop(
+  shopId: string,
+  template = "default",
+  full = false,
+): void {
   const srcDir = join("data", "templates", template);
   const destDir = join("data", "shops", shopId);
   try {
-    copyFileSync(join(srcDir, "products.json"), join(destDir, "products.json"));
-    copyFileSync(join(srcDir, "inventory.json"), join(destDir, "inventory.json"));
+    const baseFiles = ["products.json", "inventory.json"];
+    for (const file of baseFiles) {
+      const src = join(srcDir, file);
+      if (existsSync(src)) {
+        copyFileSync(src, join(destDir, file));
+      }
+    }
+    if (full) {
+      const extraFiles = [
+        "shop.json",
+        "settings.json",
+        "navigation.json",
+        "pages.json",
+      ];
+      const extraDirs = ["navigation", "pages"];
+      for (const file of extraFiles) {
+        const src = join(srcDir, file);
+        if (existsSync(src)) {
+          copyFileSync(src, join(destDir, file));
+        }
+      }
+      for (const dir of extraDirs) {
+        const src = join(srcDir, dir);
+        if (existsSync(src)) {
+          cpSync(src, join(destDir, dir), { recursive: true });
+        }
+      }
+    }
   } catch (err) {
     console.error(`Failed to seed shop data: ${(err as Error).message}`);
   }


### PR DESCRIPTION
## Summary
- allow seeding optional shop files like navigation, pages, and settings
- add `--seed-full` flag to `init-shop` and `quickstart-shop`
- document richer seeding and expand default template

## Testing
- `pnpm lint` *(fails: Unexpected any. Specify a different type)*
- `pnpm test` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_68ac576c76f0832fa60a4c66feb7eec3