### PR TITLE
feat: add page template application option

### DIFF
--- a/data/templates/contact/pages/contact.json
+++ b/data/templates/contact/pages/contact.json
@@ -1,0 +1,13 @@
+{
+  "id": "contact",
+  "slug": "contact",
+  "title": "Contact",
+  "components": [
+    {
+      "id": "contact-form",
+      "type": "ContactFormWithMap"
+    }
+  ],
+  "status": "draft",
+  "updatedAt": "1970-01-01T00:00:00.000Z"
+}

--- a/data/templates/hero/pages/home.json
+++ b/data/templates/hero/pages/home.json
@@ -1,0 +1,20 @@
+{
+  "id": "home",
+  "slug": "",
+  "title": "Home",
+  "components": [
+    {
+      "id": "hero",
+      "type": "HeroBanner",
+      "slides": [
+        {
+          "src": "/hero/slide-1.jpg",
+          "headlineKey": "hero.slide1.headline",
+          "ctaKey": "hero.cta"
+        }
+      ]
+    }
+  ],
+  "status": "draft",
+  "updatedAt": "1970-01-01T00:00:00.000Z"
+}

--- a/data/templates/product-grid/pages/products.json
+++ b/data/templates/product-grid/pages/products.json
@@ -1,0 +1,13 @@
+{
+  "id": "products",
+  "slug": "products",
+  "title": "Products",
+  "components": [
+    {
+      "id": "grid",
+      "type": "ProductGrid"
+    }
+  ],
+  "status": "draft",
+  "updatedAt": "1970-01-01T00:00:00.000Z"
+}

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -11,7 +11,7 @@ For a one-liner that scaffolds a shop, validates the environment, and starts the
 pnpm quickstart-shop --id demo --theme base --template template-app --payment stripe --shipping ups --seed-full
 ```
 
-Add `--seed` to copy sample products and inventory. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings so the shop is immediately populated. The script also accepts `--config <file>` to prefill options and skip prompts:
+Add `--seed` to copy sample products and inventory. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings so the shop is immediately populated. Pass `--pages-template <name>` to apply predefined page layouts (`hero`, `product-grid`, `contact`). The script also accepts `--config <file>` to prefill options and skip prompts:
 
 ```bash
 pnpm quickstart-shop --config ./shop.config.json --seed-full
@@ -65,7 +65,7 @@ pnpm init-shop --brand "#663399" --tokens ./my-tokens.json
 
 `--brand` sets the primary brand color and `--tokens` merges additional token overrides from a JSON file.
 
-To populate the new shop with sample data, run `pnpm init-shop --seed`. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings. Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
+To populate the new shop with sample data, run `pnpm init-shop --seed`. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings. Provide `--pages-template <name>` to copy predefined page layouts (`hero`, `product-grid`, `contact`). Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
 selected template without prompting for them.
 Add `--auto-env` to skip prompts for provider environment variables. The wizard writes
 `TODO_*` placeholders to the new shop's `.env` file; replace them with real

--- a/scripts/src/apply-page-template.ts
+++ b/scripts/src/apply-page-template.ts
@@ -1,0 +1,28 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { savePage } from "@acme/platform-core/repositories/pages";
+import type { Page } from "@acme/types";
+
+/**
+ * Copy page layouts from a template into a shop and persist them.
+ * @param shopId - Directory name of the shop (e.g. "shop-demo").
+ * @param template - Template name under data/templates.
+ */
+export async function applyPageTemplate(
+  shopId: string,
+  template: string,
+): Promise<void> {
+  const srcDir = join("data", "templates", template, "pages");
+  try {
+    const files = readdirSync(srcDir).filter((f) => f.endsWith(".json"));
+    for (const file of files) {
+      const raw = readFileSync(join(srcDir, file), "utf8");
+      const page = JSON.parse(raw) as Page;
+      await savePage(shopId, page);
+    }
+  } catch (err) {
+    console.error(
+      `Failed to apply page template: ${(err as Error).message}`,
+    );
+  }
+}

--- a/scripts/src/env.ts
+++ b/scripts/src/env.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { validateShopEnv, readEnvFile } from "@acme/platform-core/configurator";
 import { seedShop } from "./seedShop";
 import { listProviders, listPlugins } from "./utils/providers";
+import { applyPageTemplate } from "./apply-page-template";
 import {
   prompt,
   selectProviders,
@@ -24,6 +25,9 @@ const seed = process.argv.includes("--seed");
 const seedFull = process.argv.includes("--seed-full");
 const useDefaults = process.argv.includes("--defaults");
 const autoEnv = process.argv.includes("--auto-env");
+const pagesTemplateIndex = process.argv.indexOf("--pages-template");
+const pagesTemplate =
+  pagesTemplateIndex !== -1 ? process.argv[pagesTemplateIndex + 1] : undefined;
 
 function listDirNames(path: string): string[] {
   return readdirSync(path, { withFileTypes: true })
@@ -272,6 +276,10 @@ export async function initShop(): Promise<void> {
   } catch (err) {
     console.error("Failed to create shop:", (err as Error).message);
     process.exit(1);
+  }
+
+  if (pagesTemplate) {
+    await applyPageTemplate(prefixedId, pagesTemplate);
   }
 
   const envPath = join("apps", prefixedId, ".env");

--- a/scripts/src/quickstart-shop.ts
+++ b/scripts/src/quickstart-shop.ts
@@ -25,6 +25,7 @@ import {
 import { listProviders } from "@acme/platform-core/createShop/listProviders";
 import { seedShop } from "./seedShop";
 import { generateThemeTokens } from "./generate-theme";
+import { applyPageTemplate } from "./apply-page-template";
 
 /** Ensure Node.js and pnpm meet minimum requirements. */
 function ensureRuntime(): void {
@@ -150,6 +151,7 @@ interface Flags {
   tokens?: string;
   autoEnv?: boolean;
   config?: string;
+  pagesTemplate?: string;
 }
 
 function parseArgs(argv: string[]): Flags {
@@ -181,6 +183,9 @@ function parseArgs(argv: string[]): Flags {
           break;
         case "template":
           flags.template = val;
+          break;
+        case "pages-template":
+          flags.pagesTemplate = val;
           break;
         case "payment":
           flags.payment = val ? val.split(",").map((s) => s.trim()) : [];
@@ -352,6 +357,10 @@ async function main(): Promise<void> {
     seedShop(prefixedId, undefined, true);
   } else if (args.seed) {
     seedShop(prefixedId);
+  }
+
+  if (args.pagesTemplate) {
+    await applyPageTemplate(prefixedId, args.pagesTemplate);
   }
 
   if (args.autoEnv) {


### PR DESCRIPTION
## Summary
- add script to apply page template files via CMS
- provide hero, product grid, and contact page templates
- support `--pages-template` in quickstart and init shop commands

## Testing
- `pnpm exec eslint scripts/src/apply-page-template.ts scripts/src/quickstart-shop.ts scripts/src/env.ts doc/setup.md`
- `pnpm test` *(fails: @acme/next-config:test exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5d381b68832f9ac96adab40f9c46