### PR TITLE
fix: guard pathname in CMS not-found

### DIFF
--- a/apps/cms/src/app/cms/not-found.client.tsx
+++ b/apps/cms/src/app/cms/not-found.client.tsx
@@ -4,7 +4,7 @@ import { usePathname } from "next/navigation";
 
 export default function CmsNotFound() {
   const pathname = usePathname();
-  const segments = pathname.split("/").filter(Boolean);
+  const segments = pathname?.split("/").filter(Boolean) ?? [];
   const shopIndex = segments.indexOf("shop");
   const shop = shopIndex >= 0 ? segments[shopIndex + 1] : null;
   const href = shop ? `/cms/shop/${shop}` : "/cms";


### PR DESCRIPTION
## Summary
- avoid runtime crash when pathname is null in CMS not-found page

## Testing
- `pnpm --filter cms test` *(fails: Package subpath './jest.preset.cjs' is not defined by "exports" in @acme/config/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5e842b60832f84f1fe1b93a1d9cb