### PR TITLE
fix cms api shops compile hang

### DIFF
--- a/apps/cms/__tests__/api.shops.test.ts
+++ b/apps/cms/__tests__/api.shops.test.ts
@@ -14,7 +14,7 @@ describe("shops API", () => {
   it("returns list from listShops", async () => {
     const prev = process.env.NODE_ENV;
     (process.env as Record<string, string>).NODE_ENV = "development";
-    jest.doMock("../src/app/cms/listShops", () => ({
+    jest.doMock("../src/lib/listShops", () => ({
       __esModule: true,
       listShops: jest
         .fn<Promise<string[]>, []>()

--- a/apps/cms/__tests__/listShops.test.ts
+++ b/apps/cms/__tests__/listShops.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { listShops } from "../src/app/cms/listShops";
+import { listShops } from "../src/lib/listShops";
 
 describe("listShops", () => {
   it("returns empty list when no shops", async () => {

--- a/apps/cms/src/app/api/shops/route.ts
+++ b/apps/cms/src/app/api/shops/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { listShops } from "../../cms/listShops";
+import { listShops } from "../../../lib/listShops";
 
 export const runtime = "nodejs";
 

--- a/apps/cms/src/app/cms/dashboard/page.tsx
+++ b/apps/cms/src/app/cms/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function DashboardIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/app/cms/live/page.tsx
+++ b/apps/cms/src/app/cms/live/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/atoms/shadcn";
 import fsSync from "fs";
 import fs from "fs/promises";
 import path from "path";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export const metadata = {
   title: "Live shops · Base-Shop",

--- a/apps/cms/src/app/cms/marketing/page.tsx
+++ b/apps/cms/src/app/cms/marketing/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 import type { AnalyticsEvent } from "@platform-core/analytics";
 

--- a/apps/cms/src/app/cms/media/page.tsx
+++ b/apps/cms/src/app/cms/media/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/media/page.tsx
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function MediaIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/app/cms/orders/page.tsx
+++ b/apps/cms/src/app/cms/orders/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/orders/page.tsx
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function OrdersIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/app/cms/pages/page.tsx
+++ b/apps/cms/src/app/cms/pages/page.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/pages/page.tsx
 
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function PagesIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/app/cms/products/page.tsx
+++ b/apps/cms/src/app/cms/products/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/products/page.tsx
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function ProductsIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/app/cms/settings/page.tsx
+++ b/apps/cms/src/app/cms/settings/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/settings/page.tsx
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function SettingsIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/app/cms/shop/page.tsx
+++ b/apps/cms/src/app/cms/shop/page.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/shop/page.tsx
 
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export const metadata = {
   title: "Choose shop · Base-Shop",

--- a/apps/cms/src/app/cms/themes/page.tsx
+++ b/apps/cms/src/app/cms/themes/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/themes/page.tsx
 import Link from "next/link";
-import { listShops } from "../listShops";
+import { listShops } from "../../../lib/listShops";
 
 export default async function ThemesIndexPage() {
   const shops = await listShops();

--- a/apps/cms/src/lib/listShops.ts
+++ b/apps/cms/src/lib/listShops.ts
@@ -1,4 +1,4 @@
-// apps/cms/src/app/cms/listShops.ts
+// apps/cms/src/lib/listShops.ts
 
 import fs from "fs/promises";
 import { resolveDataRoot } from "@platform-core/dataRoot";


### PR DESCRIPTION
## Summary
- move listShops helper out of the app router to avoid pulling in all CMS pages when building `/api/shops`
- update imports to new lib location and adjust tests

## Testing
- `pnpm --filter @apps/cms test` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './jest.preset.cjs' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac620f1dd8832fa0ee170734cec539