### PR TITLE
fix design tokens lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,6 +68,19 @@ export default [
     },
   },
 
+  /* ▸ design-tokens uses generated dist files; lint without TS project */
+  {
+    files: ["packages/design-tokens/**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: null,
+        projectService: false,
+        allowDefaultProject: true,
+      },
+    },
+  },
+
   /* ▸ Scripts directory override */
   {
     files: ["scripts/**/*.{ts,tsx,js,jsx}"],

--- a/packages/design-tokens/dist/src/index.js
+++ b/packages/design-tokens/dist/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-console
 console.log("[@acme/design-tokens] preset loaded");
 /**
  * Tailwind preset shared across all workspace packages.

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,7 +1,6 @@
 // packages/design-tokens/src/index.ts
 import type { Config } from "tailwindcss";
 
-// eslint-disable-next-line no-console
 console.log("[@acme/design-tokens] preset loaded");
 
 /**


### PR DESCRIPTION
## Summary
- allow design-tokens package to lint without a TypeScript project
- drop unused eslint-disable comment from design-tokens preset

## Testing
- `pnpm exec eslint "packages/design-tokens/**/*.{ts,tsx,js,jsx}" && echo "eslint ok"`


------
https://chatgpt.com/codex/tasks/task_e_68ac62a6f24c832f84b1b86b09792664