### PR TITLE
Fix ESLint issues in email package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,9 @@ export default [
       "apps/*/src/**/*.js",
       "apps/*/src/**/*.d.ts",
       "apps/*/src/**/*.js.map",
+      "packages/email/src/**/*.js",
+      "packages/email/src/**/*.d.ts",
+      "packages/email/src/**/*.d.ts.map",
       "scripts/**/*.js",
       "**/*.d.ts",
     ],
@@ -50,7 +53,7 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: ["./tsconfig.json"],
+        project: ["./tsconfig.json", "./packages/email/tsconfig.eslint.json"],
         projectService: true,
         allowDefaultProject: true,
         sourceType: "module",

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -144,8 +144,10 @@ export class SendgridProvider implements CampaignProvider {
         headers: { Authorization: `Bearer ${key}` },
       });
       const json = await res.json().catch(() => ({}));
-      const segments = Array.isArray(json?.result) ? json.result : [];
-      return segments.map((s: any) => ({ id: s.id, name: s.name }));
+      const segments: { id: string; name?: string }[] = Array.isArray(json?.result)
+        ? json.result
+        : [];
+      return segments.map((s) => ({ id: s.id, name: s.name }));
     } catch {
       return [];
     }

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -123,15 +123,8 @@ export async function createCampaign(opts: {
   sendAt?: string;
   templateId?: string | null;
 }): Promise<string> {
-  let {
-    shop,
-    recipients = [],
-    subject,
-    body,
-    segment,
-    sendAt,
-    templateId,
-  } = opts;
+  let { shop, recipients = [] } = opts;
+  const { subject, body, segment, sendAt, templateId } = opts;
   shop = validateShopName(shop);
   if (recipients.length === 0 && segment) {
     recipients = await resolveSegment(shop, segment);

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -76,7 +76,7 @@ export async function sendCampaignEmail(
   options: CampaignOptions
 ): Promise<void> {
   const { sanitize = true, ...rest } = options;
-  let opts = { ...rest } as CampaignOptions;
+  const opts = { ...rest } as CampaignOptions;
   if (opts.templateId) {
     opts.html = renderTemplate(opts.templateId, opts.variables ?? {});
   }
@@ -151,7 +151,6 @@ async function sendWithRetry(
   maxRetries = 3
 ): Promise<void> {
   let attempt = 0;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
       await provider.send(options);

--- a/packages/email/tsconfig.eslint.json
+++ b/packages/email/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "types-compat/**/*.d.ts"],
+  "exclude": []
+}

--- a/packages/email/types-compat/jsdom.d.ts
+++ b/packages/email/types-compat/jsdom.d.ts
@@ -1,6 +1,6 @@
 declare module "jsdom" {
   export class JSDOM {
-    constructor(html?: string, options?: any);
-    window: any;
+    constructor(html?: string, options?: unknown);
+    window: unknown;
   }
 }

--- a/packages/email/types-compat/ui.d.ts
+++ b/packages/email/types-compat/ui.d.ts
@@ -1,3 +1,3 @@
 declare module "@acme/ui" {
-  export const marketingEmailTemplates: any[];
+  export const marketingEmailTemplates: unknown[];
 }


### PR DESCRIPTION
## Summary
- ignore generated email sources and extend lint config for email package
- fix lint warnings in email providers and scheduler
- replace `any` usages with stricter typings

## Testing
- `pnpm exec eslint packages/email/src/providers/sendgrid.ts`
- `pnpm exec eslint packages/email/src/scheduler.ts`
- `pnpm exec eslint packages/email/src/send.ts`
- `pnpm exec eslint packages/email/types-compat/jsdom.d.ts`
- `pnpm exec eslint packages/email/types-compat/ui.d.ts`
- `pnpm --filter @acme/email test` *(fails: Cannot find module '@acme/i18n/parseMultilingualInput')*

------
https://chatgpt.com/codex/tasks/task_e_68ac63045f58832fa0e5d970711b9deb