### PR TITLE
fix eslint config for i18n tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,12 +47,16 @@ export default [
   /* ▸ Your repo-wide TypeScript rules (NO plugins key!) */
   {
     files: ["**/*.{ts,tsx}"],
+    ignores: ["**/*.d.ts"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: ["./tsconfig.json"],
-        projectService: true,
+        project: [
+          "./tsconfig.json",
+          "./packages/i18n/tsconfig.json"
+        ],
         allowDefaultProject: true,
+        tsconfigRootDir: __dirname,
         sourceType: "module",
         ecmaVersion: "latest",
         ecmaFeatures: { jsx: true },
@@ -113,6 +117,17 @@ export default [
   /* ▸ Test files relaxations */
   {
     files: ["**/__tests__/**/*.{ts,tsx,js,jsx}", "**/*.test.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: [
+          "./tsconfig.test.json",
+          "./packages/i18n/tsconfig.test.json"
+        ],
+        allowDefaultProject: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": "off",

--- a/packages/i18n/tsconfig.test.json
+++ b/packages/i18n/tsconfig.test.json
@@ -6,7 +6,9 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "types": ["@testing-library/jest-dom", "jest", "node", "react"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": []
 }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -29,6 +29,7 @@
     { "path": "packages/ui" },
     { "path": "packages/auth" },
     { "path": "packages/configurator" },
+    { "path": "packages/i18n" },
     { "path": "src" }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure i18n package tests are included in ESLint type checking
- add i18n package to solution-style TypeScript config

## Testing
- `pnpm exec eslint "packages/i18n/**/*.{ts,tsx,js,jsx}"`
- `pnpm --filter @acme/i18n exec jest packages/i18n/__tests__ --runInBand` *(fails: Jest encountered an unexpected token in packages/zod-utils)*

------
https://chatgpt.com/codex/tasks/task_e_68ac632b08c8832f8259558369220952