### PR TITLE
feat(init-shop): add profile support and non-interactive mode

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -74,6 +74,10 @@ To prefill answers from an existing file, supply `--env-file <path>`.
 Keys in the file are merged before prompting—any variables already present are
 written directly to the generated `.env` and prompts for them are skipped. After
 validation the wizard warns about unused entries or missing required variables.
+To reuse answers across runs, create `profiles/<name>.json` and run
+`pnpm init-shop --profile <name>`. Profile values prefill the wizard. Combine
+with `--skip-prompts` to accept defaults for remaining questions and run
+non-interactively.
 
 Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,11 +42,14 @@ Example `shop.config.json`:
    `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
    contact email, shop type (`sale` or `rental`), and which theme and template to use. Payment and
    shipping providers are chosen from guided lists of available providers. It then
-  scaffolds `apps/shop-<id>` and prompts for environment variables like Stripe keys and CMS
-  credentials, writing them directly to `apps/shop-<id>/.env`. For scripted setups you can still
-  call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and `--contact` to skip those
-  prompts. Both `init-shop` and `create-shop` accept a `--seed` flag to copy sample
-  `products.json` and `inventory.json` from `data/templates/default` into the new shop.
+   scaffolds `apps/shop-<id>` and prompts for environment variables like Stripe keys and CMS
+   credentials, writing them directly to `apps/shop-<id>/.env`. For scripted setups you can still
+   call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and `--contact` to skip those
+   prompts. Both `init-shop` and `create-shop` accept a `--seed` flag to copy sample
+   `products.json` and `inventory.json` from `data/templates/default` into the new shop.
+   To reuse answers, place a JSON profile in `profiles/<name>.json` and run
+   `pnpm init-shop --profile <name>`. Combine with `--skip-prompts` to accept
+   defaults for any remaining questions and run non-interactively.
 
    ```bash
    pnpm create-shop <id> --name="Demo Shop" --logo=https://example.com/logo.png \
@@ -185,4 +188,3 @@ The Page Builder and `/edit-preview` route include a device menu with presets fo
 - Galaxy S8
 
 Switch between widths using the desktop/tablet/mobile buttons or the dropdown. The chosen preset resets to **Desktop 1280** when the page reloads.
-


### PR DESCRIPTION
## Summary
- allow init-shop to load defaults from named profiles
- add `--skip-prompts` flag for non-interactive runs
- document profile and non-interactive options

## Testing
- `pnpm exec eslint scripts/src/env.ts`
- `pnpm test` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68ac64d0968c832f9d3d3666c9d44cc1