### PR TITLE
feat(wizard): add navigation presets

### DIFF
--- a/apps/cms/src/app/cms/configurator/components/NavTemplateSelector.tsx
+++ b/apps/cms/src/app/cms/configurator/components/NavTemplateSelector.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import type React from "react";
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/atoms/shadcn";
+import { ulid } from "ulid";
+
+interface TemplateNavItem {
+  label: string;
+  url: string;
+  children?: TemplateNavItem[];
+}
+
+interface NavItem {
+  id: string;
+  label: string;
+  url: string;
+  children?: NavItem[];
+}
+
+interface NavTemplate {
+  name: string;
+  items: TemplateNavItem[];
+}
+
+interface Props {
+  templates: NavTemplate[];
+  onSelect: (items: NavItem[]) => void;
+}
+
+function withIds(items: TemplateNavItem[]): NavItem[] {
+  return items.map((i) => ({
+    id: ulid(),
+    label: i.label,
+    url: i.url,
+    children: i.children ? withIds(i.children) : undefined,
+  }));
+}
+
+export default function NavTemplateSelector({
+  templates,
+  onSelect,
+}: Props): React.JSX.Element {
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="flex items-end gap-2">
+      <Select value={value} onValueChange={setValue}>
+        <SelectTrigger className="w-full md:w-64">
+          <SelectValue placeholder="Navigation preset" />
+        </SelectTrigger>
+        <SelectContent>
+          {templates.map((t) => (
+            <SelectItem key={t.name} value={t.name}>
+              {t.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        disabled={!value}
+        onClick={() => {
+          const tpl = templates.find((t) => t.name === value);
+          if (tpl) onSelect(withIds(tpl.items));
+        }}
+      >
+        Apply
+      </Button>
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
@@ -10,6 +10,7 @@ import { useThemeLoader } from "../hooks/useThemeLoader";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import { useState, useMemo } from "react";
 import DeviceSelector from "@ui/components/cms/DeviceSelector";
+import NavTemplateSelector from "../components/NavTemplateSelector";
 
 interface NavItem {
   id: string;
@@ -17,6 +18,34 @@ interface NavItem {
   url: string;
   children?: NavItem[];
 }
+
+const navTemplates = [
+  {
+    name: "Basic Shop",
+    items: [
+      { label: "Home", url: "/" },
+      { label: "Shop", url: "/shop" },
+      { label: "Contact", url: "/contact" },
+    ],
+  },
+  {
+    name: "Mega Menu",
+    items: [
+      { label: "Home", url: "/" },
+      {
+        label: "Shop",
+        url: "/shop",
+        children: [
+          { label: "Men", url: "/shop/men" },
+          { label: "Women", url: "/shop/women" },
+          { label: "Accessories", url: "/shop/accessories" },
+        ],
+      },
+      { label: "About", url: "/about" },
+      { label: "Contact", url: "/contact" },
+    ],
+  },
+];
 
 export default function StepNavigation(): React.JSX.Element {
   const { state, update } = useConfigurator();
@@ -45,6 +74,7 @@ export default function StepNavigation(): React.JSX.Element {
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Navigation</h2>
+      <NavTemplateSelector templates={navTemplates} onSelect={setNavItems} />
       <div className="flex flex-col gap-6 md:flex-row">
         <div className="flex-1">
           <NavigationEditor items={navItems} onChange={setNavItems} />

--- a/doc/cms.md
+++ b/doc/cms.md
@@ -42,7 +42,7 @@ Admins can scaffold and launch a shop directly from the CMS at `/cms/wizard`. Th
 1. **Shop details** – provide the shop ID, display name, logo URL, contact email and choose whether it's for sales or rentals.
 2. **Options** – select the starter template and theme.
 3. **Theme tokens** – tweak design tokens to match your brand. See [advanced theming](../docs/theming-advanced.md) for details.
-4. **Navigation** – build the header navigation tree.
+4. **Navigation** – build the header navigation tree or start from prebuilt presets.
 5. **Page layouts** – configure home, shop, product and checkout pages and any optional additional pages.
 6. **Environment** – supply required environment variables.
 7. **Seed/Import data** – seed example products or import existing data.

--- a/packages/ui/src/components/templates/about.json
+++ b/packages/ui/src/components/templates/about.json
@@ -1,0 +1,7 @@
+{
+  "name": "About",
+  "components": [
+    { "type": "HeroBanner" },
+    { "type": "TextBlock" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add NavTemplateSelector to apply preset navigation trees
- expose basic and mega menu presets in navigation step
- include example About page template and update wizard docs

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/configurator/components/NavTemplateSelector.tsx apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx`
- `pnpm --filter @apps/cms test` *(fails: Package subpath './jest.preset.cjs' is not defined)*
- `pnpm --filter @acme/ui test` *(fails: aborted during jest startup)*

------
https://chatgpt.com/codex/tasks/task_e_68ac64ee8e38832f88ba2278b532e363