### PR TITLE
fix(cms): use node runtime for cart API

### DIFF
--- a/apps/cms/src/app/api/cart/route.ts
+++ b/apps/cms/src/app/api/cart/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
-export const runtime = "edge";
+// Use the Node.js runtime to avoid long edge compilation in development
+export const runtime = "nodejs";
 
 function empty() {
   return NextResponse.json({ ok: true, cart: {} });


### PR DESCRIPTION
## Summary
- avoid slow edge compilation for `/api/cart` by using Node.js runtime

## Testing
- `pnpm --filter cms test` *(fails: Package subpath './jest.preset.cjs' is not defined by exports)*
- `pnpm --filter cms lint` *(fails: Cannot find module '@next/eslint-plugin-next')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6662964c832fa15914e2daa9e50a