### PR TITLE
chore: add api cart debug logs

### DIFF
--- a/apps/cms/src/app/api/cart/route.ts
+++ b/apps/cms/src/app/api/cart/route.ts
@@ -2,27 +2,29 @@ import { NextResponse } from "next/server";
 
 // Use the Node.js runtime to avoid long edge compilation in development
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-function empty() {
+function empty(method: string) {
+  console.log(`[api/cart] ${method} called`);
   return NextResponse.json({ ok: true, cart: {} });
 }
 
 export async function GET() {
-  return empty();
+  return empty("GET");
 }
 
 export async function POST() {
-  return empty();
+  return empty("POST");
 }
 
 export async function PUT() {
-  return empty();
+  return empty("PUT");
 }
 
 export async function PATCH() {
-  return empty();
+  return empty("PATCH");
 }
 
 export async function DELETE() {
-  return empty();
+  return empty("DELETE");
 }


### PR DESCRIPTION
## Summary
- log methods when `/api/cart` endpoints are invoked

## Testing
- `pnpm --filter cms lint`
- `pnpm --filter cms test` *(fails: ERR_PACKAGE_PATH_NOT_EXPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67e192e8832fb3ef34960fb5c4b4