### PR TITLE
chore: fix i18n lint parsing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,19 @@ export default [
     },
   },
 
+  /* ▸ i18n package linting without TS project */
+  {
+    files: ["packages/i18n/**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: null,
+        projectService: false,
+        allowDefaultProject: true,
+      },
+    },
+  },
+
   /* ▸ Scripts directory override */
   {
     files: ["scripts/**/*.{ts,tsx,js,jsx}"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -67,6 +67,12 @@
       "@i18n/*": [
         "packages/i18n/src/*"
       ],
+      "@acme/i18n": [
+        "packages/i18n/src/index.ts"
+      ],
+      "@acme/i18n/*": [
+        "packages/i18n/src/*"
+      ],
       "@auth": [
         "packages/auth/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- allow linting i18n package without TypeScript project
- add base TypeScript path mapping for `@acme/i18n`

## Testing
- `pnpm exec eslint "packages/i18n/**/*.{ts,tsx,js,jsx}"`
- `npx tsc -p packages/i18n/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ac658c0a34832f84a40219526ef98e