### PR TITLE
feat: streamline environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Configuration and usage examples for both are documented in [doc/machine.md](doc
 
 # Environment Variables
 
-After running `pnpm create-shop <id>`, configure `apps/shop-<id>/.env` with:
+After running `pnpm create-shop <id>`, the wizard generates `.env` and `.env.template` under
+`apps/shop-<id>/`, validates the variables, and can pull secrets from an external vault by passing
+`--vault-cmd <cmd>` (the command receives each variable name). Configure the resulting `.env` with:
 
 - `STRIPE_SECRET_KEY` – secret key used by the Stripe server SDK
 - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` – public key for the Stripe client SDK

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -158,17 +158,20 @@ Scaffolded apps/shop-demo
 
 The wizard captures common environment variables and writes them to `apps/shop-<id>/.env`.
 
-If you used `--auto-env`, this file contains placeholder values like `TODO_API_KEY`.
-If you passed `--env-file`, any matching keys from that file are copied directly
-and unused entries are reported during validation. Placeholders and missing
-variables must be replaced with real credentials before deployment.
+After scaffolding, the wizard writes both `.env` and `.env.template` to `apps/shop-<id>/`.
+The template lists all variables required by your chosen providers. If you used `--auto-env`,
+`.env` contains placeholder values like `TODO_API_KEY`. Supplying `--env-file` copies matching keys
+from that file, and `--vault-cmd <cmd>` invokes the given command with each variable name to retrieve
+secrets from an external vault. Placeholders and missing variables must be replaced with real
+credentials before deployment.
+
+The wizard validates the environment immediately. Rerun the check manually any time after editing:
 
 ```bash
 pnpm validate-env <id>
 ```
 
-`validate-env` parses the `.env` file and exits with an error if any required variable is missing or malformed.
-You can edit the file later and rerun `pnpm validate-env <id>` to confirm everything is set up.
+`validate-env` parses the `.env` file and exits with an error if a required variable is missing or malformed.
 
 ## 3. Run the shop
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,7 +43,10 @@ Example `shop.config.json`:
    contact email, shop type (`sale` or `rental`), and which theme and template to use. Payment and
    shipping providers are chosen from guided lists of available providers. It then
    scaffolds `apps/shop-<id>` and prompts for environment variables like Stripe keys and CMS
-   credentials, writing them directly to `apps/shop-<id>/.env`. For scripted setups you can still
+   credentials, writing them directly to `apps/shop-<id>/.env` and generating a matching
+   `.env.template` with the required keys. The wizard validates the environment immediately and
+   can fetch secrets from an external vault by providing `--vault-cmd <cmd>` (the command is invoked
+   with each variable name). For scripted setups you can still
    call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and `--contact` to skip those
    prompts. Both `init-shop` and `create-shop` accept a `--seed` flag to copy sample
    `products.json` and `inventory.json` from `data/templates/default` into the new shop.
@@ -59,12 +62,13 @@ Example `shop.config.json`:
 2. **Run the app**
 
    ```bash
-   pnpm validate-env <id>
    cd apps/shop-<id>
    pnpm dev
    ```
 
-   Open http://localhost:3000 to view the site. Pages hot-reload on save.
+   The wizard already validated your environment variables. Rerun `pnpm validate-env <id>` after
+   editing `.env` if you need to re-check. Open http://localhost:3000 to view the site. Pages
+   hot-reload on save.
 
 3. _(Optional)_ Each Next.js app must provide its own `postcss.config.cjs` that forwards to the repo root configuration so Tailwind resolves correctly. After updating Tailwind or any CSS utilities, run `pnpm tailwind:check` to verify the build.
 

--- a/test/unit/init-shop/vault.spec.ts
+++ b/test/unit/init-shop/vault.spec.ts
@@ -1,0 +1,187 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import ts from 'typescript';
+import { runInNewContext } from 'vm';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('init-shop wizard - vault', () => {
+  it('fetches secrets using --vault-cmd', async () => {
+    const questions: string[] = [];
+    const answers = [
+      'demo',
+      'Demo Shop',
+      'https://example.com/logo.png',
+      'contact@example.com',
+      '',
+      '1',
+      '1',
+      '1,2',
+      '1',
+      '1',
+      'Home',
+      '/',
+      'Shop',
+      '/shop',
+      '',
+      'about',
+      'About Us',
+      '',
+      '#336699',
+      '',
+      'n',
+    ];
+    const createShop = jest.fn();
+    const envParse = jest.fn((env: Record<string, string>) => env);
+    let envContent = '';
+    let pkgContent = '{"dependencies":{}}';
+    let templateContent = '';
+    const execSync = jest.fn((cmd: string) => {
+      if (cmd.startsWith('vault')) return 'vault-secret';
+      return '10.0.0';
+    });
+    const validateShopEnv = jest.fn(() => {
+      const env: Record<string, string> = {};
+      for (const line of envContent.split(/\n+/)) {
+        const [k, ...r] = line.split('=');
+        if (k) env[k] = r.join('=');
+      }
+      envParse(env);
+    });
+
+    const sandbox: any = {
+      exports: {},
+      module: { exports: {} },
+      process: {
+        version: 'v20.0.0',
+        exit: jest.fn(),
+        cwd: () => path.join(__dirname, '..', '..', '..'),
+        argv: ['node', 'init-shop', '--vault-cmd', 'vault'],
+      },
+      console: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+      URL,
+      require: (p: string) => {
+        if (p === 'node:fs') {
+          return {
+            existsSync: () => true,
+            readdirSync: (dir: string) => {
+              if (dir.includes('packages/plugins')) {
+                return [
+                  { name: 'paypal', isDirectory: () => true },
+                  { name: 'sanity', isDirectory: () => true },
+                ];
+              }
+              return [
+                { name: 'base', isDirectory: () => true },
+                { name: 'template-app', isDirectory: () => true },
+              ];
+            },
+            readFileSync: (fp: string) => {
+              if (fp.endsWith('apps/shop-demo/package.json')) return pkgContent;
+              if (fp.includes('packages/plugins/paypal/package.json'))
+                return '{"name":"@acme/plugin-paypal"}';
+              if (fp.includes('packages/plugins/sanity/package.json'))
+                return '{"name":"@acme/plugin-sanity"}';
+              return '';
+            },
+            writeFileSync: (fp: string, c: string) => {
+              if (fp.endsWith('.env')) envContent = c;
+              else if (fp.endsWith('.env.template')) templateContent = c;
+              else if (fp.endsWith('package.json')) pkgContent = c;
+            },
+          };
+        }
+        if (p === 'node:path') return require('node:path');
+        if (p === 'node:child_process') {
+          return { spawnSync: jest.fn(), execSync };
+        }
+        if (p === 'node:readline/promises') {
+          return {
+            createInterface: () => ({
+              question: (q: string) => {
+                questions.push(q);
+                return Promise.resolve(answers.shift()!);
+              },
+              close: () => undefined,
+            }),
+          };
+        }
+        if (p.includes('@acme/platform-core/createShop/listProviders')) {
+          return {
+            listProviders: jest.fn((kind: string) =>
+              Promise.resolve(
+                kind === 'payment'
+                  ? [
+                      {
+                        id: 'stripe',
+                        name: 'stripe',
+                        envVars: [
+                          'STRIPE_SECRET_KEY',
+                          'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+                          'STRIPE_WEBHOOK_SECRET',
+                        ],
+                      },
+                      {
+                        id: 'paypal',
+                        name: 'paypal',
+                        envVars: ['PAYPAL_CLIENT_ID', 'PAYPAL_SECRET'],
+                      },
+                    ]
+                  : [
+                      { id: 'dhl', name: 'dhl', envVars: [] },
+                      { id: 'ups', name: 'ups', envVars: [] },
+                    ]
+              )
+            ),
+          };
+        }
+        if (p.includes('@acme/platform-core/createShop')) {
+          return {
+            createShop,
+            loadBaseTokens: () => ({
+              '--color-primary': '100 50% 50%',
+              '--color-primary-fg': '0 0% 10%',
+            }),
+          };
+        }
+        if (p.includes('./generate-theme')) {
+          return {
+            generateThemeTokens: () => ({
+              '--color-primary': '210 60% 40%',
+              '--color-primary-fg': '0 0% 100%',
+            }),
+          };
+        }
+        if (p.includes('./seedShop')) {
+          return { seedShop: jest.fn() };
+        }
+        if (p.includes('@acme/platform-core/configurator')) {
+          return {
+            validateShopEnv,
+            readEnvFile: () => ({}),
+          };
+        }
+        return require(p);
+      },
+    };
+
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../scripts/src/init-shop.ts'),
+      'utf8'
+    );
+    const transpiled = ts.transpileModule(src, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, esModuleInterop: true },
+    }).outputText;
+
+    const promise = runInNewContext(transpiled, sandbox);
+    await promise;
+
+    expect(execSync).toHaveBeenCalledWith('vault STRIPE_SECRET_KEY', { encoding: 'utf8' });
+    expect(envParse).toHaveBeenCalledWith(
+      expect.objectContaining({ STRIPE_SECRET_KEY: 'vault-secret' })
+    );
+    expect(templateContent).toContain('STRIPE_SECRET_KEY=');
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow init-shop to fetch secrets via `--vault-cmd`
- write `.env.template` when scaffolding shops
- document integrated validation and vault support

## Testing
- `pnpm lint` *(fails: run failed)*
- `pnpm exec eslint scripts/src/env.ts test/unit/init-shop/vault.spec.ts docs/install.md doc/setup.md README.md`
- `pnpm test` *(fails: @apps/cms#test)*

------
https://chatgpt.com/codex/tasks/task_e_68ac66d433d4832fafd7d96e338703bf