### PR TITLE
fix(api): resolve tsc build errors

### DIFF
--- a/apps/api/src/routes/shop/[id]/publish-upgrade.ts
+++ b/apps/api/src/routes/shop/[id]/publish-upgrade.ts
@@ -55,8 +55,12 @@ export const onRequestPost = async ({
     const shopFile = path.join(root, "data", "shops", id, "shop.json");
     const pkgFile = path.join(appDir, "package.json");
 
-    const body = await request.json().catch(() => ({}));
-    const selected: string[] = Array.isArray(body.components) ? body.components : [];
+    const body = (await request.json().catch(() => ({}))) as {
+      components?: unknown;
+    };
+    const selected: string[] = Array.isArray(body.components)
+      ? (body.components as string[])
+      : [];
 
     const deps = JSON.parse(readFileSync(pkgFile, "utf8")).dependencies ?? {};
     const shop = JSON.parse(readFileSync(shopFile, "utf8"));

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,7 +4,19 @@
     "composite": true,
     "noEmit": false,
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "paths": {
+      "@acme/lib": ["../../packages/lib/dist/index.d.ts"],
+      "@acme/lib/*": ["../../packages/lib/dist/*"],
+      "@acme/config": ["../../packages/config/dist/index.d.ts"],
+      "@acme/config/*": ["../../packages/config/dist/*"],
+      "@acme/zod-utils": ["../../packages/zod-utils/dist/index.d.ts"],
+      "@acme/zod-utils/*": ["../../packages/zod-utils/dist/*"],
+      "@platform-core": ["../../packages/platform-core/dist/index.d.ts"],
+      "@platform-core/*": ["../../packages/platform-core/dist/*"],
+      "@acme/platform-core": ["../../packages/platform-core/dist/index.d.ts"],
+      "@acme/platform-core/*": ["../../packages/platform-core/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "turbo run dev --parallel",
     "dev:trace": "cross-env NODE_OPTIONS=\"--trace-uncaught --enable-source-maps\" pnpm --filter cms dev",
-      "build": "pnpm -r run clean && pnpm run build:tokens && pnpm run check:tailwind-preset && turbo run build",
+    "build": "pnpm -r run clean && pnpm run build:tokens && pnpm run check:tailwind-preset && turbo run build",
     "build:tokens": "tsx ./scripts/src/build-tokens.ts",
     "build:trace": "cross-env NODE_OPTIONS=\"--trace-uncaught --enable-source-maps\" pnpm --filter cms exec next build --debug",
     "start": "turbo run start --parallel",
@@ -141,6 +141,7 @@
     "@types/amphtml-validator": "^1.0.4",
     "@types/jest": "^29.5.14",
     "@types/jsdom": "^21.1.7",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.19.4",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^19.1.8",

--- a/packages/date-utils/tsconfig.json
+++ b/packages/date-utils/tsconfig.json
@@ -9,5 +9,13 @@
     "outDir": "dist",
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", ".turbo", "node_modules"]
+  "exclude": [
+    "dist",
+    ".turbo",
+    "node_modules",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/*.test.*",
+    "**/*.spec.*"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^20.19.4
         version: 20.19.4
@@ -4085,6 +4088,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
   '@types/keygrip@1.0.6':
     resolution: {integrity: sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==}
@@ -14529,6 +14535,11 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 24.0.10
 
   '@types/keygrip@1.0.6': {}
 


### PR DESCRIPTION
## Summary
- add missing `@types/jsonwebtoken`
- exclude test files from date-utils build
- use built package types in API tsconfig and type request body

## Testing
- `npx tsc -b apps/api`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bf30e84832fa3d898882a2598b9