### PR TITLE
fix(template-app): use node runtime for cart api

### DIFF
--- a/packages/template-app/src/api/cart/route.ts
+++ b/packages/template-app/src/api/cart/route.ts
@@ -1,2 +1,15 @@
 // packages/template-app/src/api/cart/route.ts
-export { runtime, DELETE, GET, PATCH, POST, PUT } from "@platform-core/cartApi";
+//
+// Re-export the cart API handlers from `@platform-core/cartApi` but
+// explicitly opt into the Node.js runtime. The shared cart API defaults to
+// the edge runtime which can cause development hangs when Node-specific
+// modules (e.g. `crypto`) are required during compilation. By importing the
+// handlers and setting `runtime` here, the template app avoids those edge
+// limitations while keeping the implementation centralized.
+
+import { DELETE, GET, PATCH, POST, PUT } from "@platform-core/cartApi";
+
+export { DELETE, GET, PATCH, POST, PUT };
+
+// Run this route using the Node.js runtime to ensure full Node API support.
+export const runtime = "nodejs";


### PR DESCRIPTION
## Summary
- ensure template-app cart API runs on Node.js runtime to avoid edge compilation hang

## Testing
- `pnpm --filter @acme/template-app build` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/dist/env/core.js')*


------
https://chatgpt.com/codex/tasks/task_e_68ac72b55478832fb9bdd354594e59c4