### PR TITLE
fix: map shared-utils path

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -103,6 +103,12 @@
       "@acme/shared-utils/*": [
         "packages/shared-utils/src/*"
       ],
+      "@shared-utils": [
+        "packages/shared-utils/src/index.ts"
+      ],
+      "@shared-utils/*": [
+        "packages/shared-utils/src/*"
+      ],
       "@acme/email": [
         "packages/email/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- map `@shared-utils` alias in base tsconfig so Jest can resolve the package

## Testing
- `npx jest apps/cms/__tests__/inventoryImportExport.test.ts --config jest.config.cjs --runInBand` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68acc84e611c832fb1916f8c9a1dd160