### PR TITLE
fix: correct SizeSelector import path

### DIFF
--- a/packages/platform-core/__tests__/sizeSelector.test.tsx
+++ b/packages/platform-core/__tests__/sizeSelector.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import SizeSelector from "../components/pdp/SizeSelector";
+import SizeSelector from "../src/components/pdp/SizeSelector";
 
 describe("SizeSelector", () => {
   it("calls onSelect with chosen size", () => {


### PR DESCRIPTION
## Summary
- fix SizeSelector test import path

## Testing
- `pnpm exec jest packages/platform-core/__tests__/sizeSelector.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acc8683d8c832f88489df7995a0e3c