### PR TITLE
fix: resolve components path for ui tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -114,6 +114,8 @@ module.exports = {
       "<rootDir>/packages/platform-core/src/repositories/$1",
     "^../packages/ui/components/(.*)$":
       "<rootDir>/packages/ui/src/components/$1",
+    "^../components/(.*)$":
+      "<rootDir>/packages/ui/src/components/$1",
 
     // fixture JSON moved during the Turbo-repo migration
     "^functions/data/rental/(.*)$":


### PR DESCRIPTION
## Summary
- map `../components/*` imports to `packages/ui/src/components` so Jest resolves VideoPlayer and other UI atoms correctly

## Testing
- `npx jest packages/ui/__tests__/VideoPlayer.test.tsx --config jest.config.cjs`
- `npx jest packages/ui/__tests__/Button.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68acc88c8708832f9fdcf67b4c43900a