### PR TITLE
Fix ImageGallery test import and behavior

### DIFF
--- a/packages/platform-core/__tests__/imageGallery.test.tsx
+++ b/packages/platform-core/__tests__/imageGallery.test.tsx
@@ -1,15 +1,22 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import ImageGallery from "../components/pdp/ImageGallery";
+import ImageGallery from "../src/components/pdp/ImageGallery";
 
 describe("ImageGallery", () => {
-  it("toggles zoom on click", () => {
-    render(<ImageGallery src="/img.jpg" alt="img" />);
-    const img = screen.getByAltText("img");
-    const figure = img.closest("figure")!;
-    expect(img.className).not.toContain("scale-125");
-    fireEvent.click(figure);
-    expect(img.className).toContain("scale-125");
-    fireEvent.click(figure);
-    expect(img.className).not.toContain("scale-125");
+  it("switches images when thumbnails are clicked", () => {
+    const items = [
+      { type: "image" as const, url: "/img1.jpg", altText: "img1" },
+      { type: "image" as const, url: "/img2.jpg", altText: "img2" },
+    ];
+
+    render(<ImageGallery items={items} />);
+
+    // First image is shown initially
+    expect(screen.getByAltText("img1")).toBeInTheDocument();
+
+    // Click the second thumbnail
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    // Now the second image should be displayed
+    expect(screen.getByAltText("img2")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update ImageGallery unit test to match new component API
- verify thumbnails switch the main image

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest packages/platform-core/__tests__/imageGallery.test.tsx --config jest.config.cjs` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8a503b0832fac17e4ae269e4ecf