### PR TITLE
test: stabilize GiftCardBlock test with mocked currency context

### DIFF
--- a/packages/ui/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/__tests__/GiftCardBlock.test.tsx
@@ -1,6 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import GiftCardBlock from "../src/components/cms/blocks/GiftCardBlock";
 
+jest.mock("@acme/platform-core/components/shop/AddToCartButton.client", () => ({
+  __esModule: true,
+  default: () => <button>Purchase</button>,
+}));
+
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["EUR", jest.fn()],
+}));
+
 describe("GiftCardBlock", () => {
   it("exposes data-token attributes", () => {
     render(<GiftCardBlock denominations={[25, 50]} />);


### PR DESCRIPTION
## Summary
- mock AddToCartButton and CurrencyContext in GiftCardBlock test to avoid missing provider errors

## Testing
- `pnpm test:cms packages/ui/__tests__/GiftCardBlock.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acc8adafa8832fbcb4d5cd43ed558c