### PR TITLE
fix: correct ZoomImage test import path

### DIFF
--- a/packages/ui/__tests__/ZoomImage.test.tsx
+++ b/packages/ui/__tests__/ZoomImage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { ZoomImage } from "../components/atoms/ZoomImage";
+import { ZoomImage } from "../src/components/atoms/ZoomImage";
 
 describe("ZoomImage", () => {
   it("toggles zoomed state on click", () => {


### PR DESCRIPTION
## Summary
- fix ZoomImage test module path

## Testing
- `pnpm exec jest __tests__/ZoomImage.test.tsx --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68acc8b4a44c832f9c1104a53887c466