### PR TITLE
fix breadcrumbs test import path

### DIFF
--- a/packages/ui/__tests__/Breadcrumbs.test.tsx
+++ b/packages/ui/__tests__/Breadcrumbs.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import Breadcrumbs from "../components/molecules/Breadcrumbs";
+import Breadcrumbs from "../src/components/molecules/Breadcrumbs";
 
 describe("Breadcrumbs", () => {
   it("renders anchors and separators", () => {


### PR DESCRIPTION
## Summary
- fix Breadcrumbs test import path

## Testing
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '@shared-utils')*
- `npx jest packages/ui/__tests__/Breadcrumbs.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68acc8bbcb20832f932884d488ddf467