### PR TITLE
fix: correct BlogListing test import path

### DIFF
--- a/packages/ui/__tests__/BlogListing.test.tsx
+++ b/packages/ui/__tests__/BlogListing.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import BlogListing from "../components/cms/blocks/BlogListing";
+import BlogListing from "../src/components/cms/blocks/BlogListing";
 
 describe("BlogListing", () => {
   it("renders post titles and excerpts", () => {


### PR DESCRIPTION
## Summary
- fix BlogListing test import path

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/BlogListing.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68acc8ca5cf0832fa41c6094a69dc5a8