### PR TITLE
Fix import path in Text atom test

### DIFF
--- a/packages/ui/__tests__/Text.test.tsx
+++ b/packages/ui/__tests__/Text.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { Text } from "../components/cms/blocks/atoms";
+import { Text } from "../src/components/cms/blocks/atoms";
 
 describe("Text atom", () => {
   it("renders provided text", () => {


### PR DESCRIPTION
## Summary
- correct Text atom test to import from src directory

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/Text.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68acc8e22814832fa8233c761ae7da06