### PR TITLE
fix types settings export mapping

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,6 +21,7 @@
       "import": "./dist/env/*.js",
       "default": "./dist/env/*.js"
     },
+    "./jest.preset.cjs": "./jest.preset.cjs",
     "./tsconfig.app.json": "./tsconfig.app.json"
   },
   "files": ["dist"],

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,6 +19,16 @@
     "clean": "rimraf dist *.tsbuildinfo"
   },
   "exports": {
+    "./settings": {
+      "types": "./src/settings/index.ts",
+      "import": "./src/settings/index.ts",
+      "default": "./src/settings/index.ts"
+    },
+    "./settings/*": {
+      "types": "./src/settings/*.ts",
+      "import": "./src/settings/*.ts",
+      "default": "./src/settings/*.ts"
+    },
     "./*": {
       "types": "./src/*.ts",
       "import": "./src/*.ts",


### PR DESCRIPTION
## Summary
- expose `settings` modules from `@acme/types`
- export `jest.preset.cjs` from `@acme/config`

## Testing
- `pnpm test` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/dist/env/core.js')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68acc8ec8af0832fb5e7af3b025a05de