### PR TITLE
fix: correct utils import paths in platform-core tests

### DIFF
--- a/packages/platform-core/__tests__/getShopFromPath.test.ts
+++ b/packages/platform-core/__tests__/getShopFromPath.test.ts
@@ -1,5 +1,5 @@
 // packages/platform-core/__tests__/getShopFromPath.test.ts
-import { getShopFromPath } from "../utils/getShopFromPath";
+import { getShopFromPath } from "../src/utils/getShopFromPath";
 
 describe("getShopFromPath", () => {
   it("extracts shop slug from typical cms paths", () => {

--- a/packages/platform-core/__tests__/replaceShopInPath.test.ts
+++ b/packages/platform-core/__tests__/replaceShopInPath.test.ts
@@ -1,5 +1,5 @@
 // packages/platform-core/__tests__/replaceShopInPath.test.ts
-import { replaceShopInPath } from "../utils/replaceShopInPath";
+import { replaceShopInPath } from "../src/utils/replaceShopInPath";
 
 describe("replaceShopInPath", () => {
   it("replaces the existing shop segment", () => {


### PR DESCRIPTION
## Summary
- fix failing platform-core tests by importing `getShopFromPath` and `replaceShopInPath` from `src/utils`

## Testing
- `pnpm test:cms packages/platform-core/__tests__/getShopFromPath.test.ts packages/platform-core/__tests__/replaceShopInPath.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acc8f3bbe8832fa1f2460fae2dcb4d