### PR TITLE
Fix ColorSwatch test import path

### DIFF
--- a/packages/ui/__tests__/ColorSwatch.test.tsx
+++ b/packages/ui/__tests__/ColorSwatch.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { ColorSwatch } from "../components/atoms/ColorSwatch";
+import { ColorSwatch } from "../src/components/atoms/ColorSwatch";
 
 describe("ColorSwatch", () => {
   it("applies background color", () => {


### PR DESCRIPTION
## Summary
- fix ColorSwatch unit test import path

## Testing
- `node ../../node_modules/jest/bin/jest.js --config ../../jest.config.cjs __tests__/ColorSwatch.test.tsx --runInBand --forceExit`

------
https://chatgpt.com/codex/tasks/task_e_68acc8d17398832fbf1468e6b7311f05