### PR TITLE
fix checkShopExists import for server test

### DIFF
--- a/packages/lib/src/checkShopExists.server.js
+++ b/packages/lib/src/checkShopExists.server.js
@@ -1,6 +1,6 @@
 // packages/lib/checkShopExists.server.ts
 import "server-only";
-import { promises as fs } from "fs";
+import { promises as fs } from "node:fs";
 import * as path from "path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "./validateShopName";

--- a/packages/lib/src/checkShopExists.server.ts
+++ b/packages/lib/src/checkShopExists.server.ts
@@ -1,7 +1,7 @@
 // packages/lib/checkShopExists.server.ts
 import "server-only";
 
-import { promises as fs } from "fs";
+import { promises as fs } from "node:fs";
 import * as path from "path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "./validateShopName";


### PR DESCRIPTION
## Summary
- use `node:fs` in `checkShopExists` so tests can mock filesystem

## Testing
- `pnpm --filter=@acme/lib test -- __tests__/checkShopExists.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68accc99370c832f908805dacb632e7b