### PR TITLE
fix: correct shadcn path in ui tests

### DIFF
--- a/packages/ui/__tests__/Button.test.tsx
+++ b/packages/ui/__tests__/Button.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { Button } from "../components/atoms/shadcn";
+import { Button } from "../src/components/atoms/shadcn";
 
 describe("Button", () => {
   it("handles click events", () => {

--- a/packages/ui/__tests__/Input.test.tsx
+++ b/packages/ui/__tests__/Input.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { Input } from "../components/atoms/shadcn";
+import { Input } from "../src/components/atoms/shadcn";
 
 describe("Input", () => {
   it("handles change events", () => {


### PR DESCRIPTION
## Summary
- fix broken imports in button and input tests

## Testing
- `pnpm exec jest packages/ui/__tests__/Input.test.tsx packages/ui/__tests__/Button.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68accca1079c832fb5224e17d2e10644