### PR TITLE
test: fix Text atom import

### DIFF
--- a/packages/ui/__tests__/Text.test.tsx
+++ b/packages/ui/__tests__/Text.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import { Text } from "../src/components/cms/blocks/atoms";
+// Text is exported from the block registry's barrel file, so we can import it
+// directly from the `blocks` entry point rather than reaching into the file
+// system. This mirrors how consumers would access the component and avoids
+// brittle relative paths that omit the `src` directory.
+import { Text } from "../src/components/cms/blocks";
 
 describe("Text atom", () => {
   it("renders provided text", () => {


### PR DESCRIPTION
## Summary
- fix Text atom test to import from `blocks` barrel instead of deep relative path

## Testing
- `pnpm --filter @acme/ui test __tests__/Text.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acce76d608832f8d858582db9cf583