### PR TITLE
fix: map cms jest alias

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -7,6 +7,12 @@ module.exports = {
   ...base,
   roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
   setupFilesAfterEnv: ["<rootDir>/apps/cms/jest.setup.tsx"],
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    "^../components/(.*)$": "<rootDir>/apps/cms/src/app/cms/configurator/components/$1",
+    "^@/components/(.*)$": "<rootDir>/packages/ui/src/components/$1",
+    "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
+  },
   globals: {
     "ts-jest": {
       tsconfig: path.resolve(__dirname, "tsconfig.test.json"),


### PR DESCRIPTION
## Summary
- map `@/` and relative component imports in CMS tests
- add focused mocks for StepHomePage tests

## Testing
- `pnpm --filter @apps/cms test -- __tests__/StepHomePage.toast.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68acda10baf0832fbcc37c22b2f716a0