### PR TITLE
Fix middleware integration test with RBAC and config mocks

### DIFF
--- a/apps/cms/__tests__/middleware.integration.test.ts
+++ b/apps/cms/__tests__/middleware.integration.test.ts
@@ -5,6 +5,23 @@ import type { JWT } from "next-auth/jwt";
 import { middleware } from "../src/middleware";
 
 /* -------------------------------------------------------------------------- */
+/* Mock RBAC helpers so importing middleware doesn't pull in JSON modules.   */
+/* -------------------------------------------------------------------------- */
+jest.mock("@auth/rbac", () => ({
+  __esModule: true,
+  canRead: jest.fn(() => true),
+  canWrite: jest.fn(() => true),
+}));
+
+/* -------------------------------------------------------------------------- */
+/* Provide minimal env config to satisfy auth secret lookup.                  */
+/* -------------------------------------------------------------------------- */
+jest.mock("@acme/config", () => ({
+  __esModule: true,
+  env: { NEXTAUTH_SECRET: "test" },
+}));
+
+/* -------------------------------------------------------------------------- */
 /* Mock `next-auth/jwt` *completely* so the ESM-only `jose` bundle never      */
 /* reaches Jest.  We expose only the symbol(s) our middleware touches.        */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- mock `@auth/rbac` to avoid JSON import assertions in middleware test
- stub `@acme/config` env so auth secret lookup works during testing

## Testing
- `pnpm test:cms -- apps/cms/__tests__/middleware.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acda96a954832faf5cb0fb75ac84ce