### PR TITLE
fix: specify babel node targets for tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -42,6 +42,9 @@ module.exports = {
         tsconfig: "<rootDir>/tsconfig.test.json",
         useESM: true,
         diagnostics: false,
+        babelConfig: {
+          presets: [["@babel/preset-env", { targets: { node: "current" } }]],
+        },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- configure ts-jest to compile using Node target so browserslist no longer searches for missing package.json

## Testing
- `pnpm test:cms apps/cms/__tests__/storageUtils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68acdac6ec2c832fa1f49df0a7381902