### PR TITLE
fix CMS step validator test by avoiding heavy imports

### DIFF
--- a/apps/cms/__tests__/stepValidators.test.ts
+++ b/apps/cms/__tests__/stepValidators.test.ts
@@ -1,6 +1,15 @@
-import { validators } from "../src/app/cms/configurator/hooks/useStepCompletion";
-import { wizardStateSchema } from "../src/app/cms/wizard/schema";
-import { fillLocales } from "@i18n/fillLocales";
+jest.mock("../src/app/cms/configurator/ConfiguratorContext", () => ({
+  useConfigurator: () => ({
+    state: { completed: {} },
+    markStepComplete: jest.fn(),
+    resetDirty: jest.fn(),
+  }),
+}));
+
+// Use require to ensure mocks are applied before module evaluation
+const { validators } = require("../src/app/cms/configurator/hooks/useStepCompletion");
+const { wizardStateSchema } = require("../src/app/cms/wizard/schema");
+const { fillLocales } = require("@i18n/fillLocales");
 
 describe("step validators", () => {
   const base = wizardStateSchema.parse({});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -98,6 +98,10 @@ module.exports = {
     // email provider client mocks
     "^resend$": "<rootDir>/packages/email/src/providers/__mocks__/resend.ts",
     "^@sendgrid/mail$": "<rootDir>/packages/email/src/providers/__mocks__/@sendgrid/mail.ts",
+    // database client mock – avoid pulling Prisma in unit tests
+    "^@prisma/client$": "<rootDir>/test/__mocks__/prismaClient.ts",
+    // app-level @/* aliases not present in base tsconfig
+    "^@/i18n/(.*)$": "<rootDir>/packages/i18n/src/$1",
 
     // component stubs – structure isn’t under test
     "^@ui/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",

--- a/packages/zod-utils/src/initZod.ts
+++ b/packages/zod-utils/src/initZod.ts
@@ -1,13 +1,24 @@
 // packages/zod-utils/src/initZod.ts
 // Small initializer that installs the friendly Zod error map.
-// Load the map lazily via dynamic import so Jest's CommonJS parser
-// doesn't choke on the ESM build artifact.
-const { applyFriendlyZodMessages } = await import("./zodErrorMap.js");
+//
+// Jest's configuration for some packages runs in a CommonJS context
+// where top-level `await` is not supported.  The original implementation
+// used top-level `await` with a dynamic import, which caused Jest to bail
+// out before any tests executed.  To keep the lazy loading behaviour
+// without relying on top-level `await`, perform the dynamic import inside
+// an async function and fire it immediately.  The returned promise is
+// intentionally ignored – we only need the side-effect of installing the
+// error map.
 
-export function initZod(): void {
+async function loadFriendlyMessages() {
+  const { applyFriendlyZodMessages } = await import("./zodErrorMap.js");
   applyFriendlyZodMessages();
 }
 
-// Initialize immediately when this module is imported. The export
-// remains so callers can re-run if needed.
+export function initZod(): void {
+  void loadFriendlyMessages();
+}
+
+// Initialize immediately when this module is imported. The export remains
+// so callers can re-run if needed.
 initZod();

--- a/test/__mocks__/prismaClient.ts
+++ b/test/__mocks__/prismaClient.ts
@@ -1,0 +1,3 @@
+export class PrismaClient {
+  // Minimal mock: no-op methods used in tests can be added here if needed
+}


### PR DESCRIPTION
## Summary
- avoid top-level await in zod utils to work under Jest CJS
- mock Prisma client and CMS configurator to keep tests light
- add jest mappings for Prisma and @/i18n aliases

## Testing
- `pnpm --filter @apps/cms test stepValidators.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acdab743e8832fb5748a6eb63ceb79