### PR TITLE
test: mock customer profile module

### DIFF
--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -2,9 +2,10 @@
 jest.mock("@auth", () => ({
   __esModule: true,
   getCustomerSession: jest.fn(),
+  hasPermission: jest.fn(),
 }));
 
-jest.mock("@platform-core", () => ({
+jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile: jest.fn(),
 }));
@@ -15,7 +16,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 import { getCustomerSession } from "@auth";
-import { getCustomerProfile } from "@platform-core";
+import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
 import ProfilePage from "@ui/src/components/account/Profile";
 import ProfileForm from "@ui/src/components/account/ProfileForm";
 import { redirect } from "next/navigation";

--- a/packages/ui/__tests__/Profile.test.tsx
+++ b/packages/ui/__tests__/Profile.test.tsx
@@ -5,13 +5,13 @@ jest.mock("@auth", () => ({
   hasPermission: jest.fn(),
 }));
 
-jest.mock("@platform-core", () => ({
+jest.mock("@acme/platform-core/customerProfiles", () => ({
   __esModule: true,
   getCustomerProfile: jest.fn(),
 }));
 
 import { getCustomerSession, hasPermission } from "@auth";
-import { getCustomerProfile } from "@platform-core";
+import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
 import ProfilePage from "../src/components/account/Profile";
 
 describe("ProfilePage permissions", () => {


### PR DESCRIPTION
## Summary
- fix account profile tests by mocking auth permissions and platform-core customerProfiles via `@acme` path
- ensure Profile component tests use same mock to avoid prisma import

## Testing
- `npx jest apps/shop-bcd/__tests__/account-profile.test.tsx`
- `npx jest packages/ui/__tests__/Profile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acdb2a87e8832f80970649dd24e389