### PR TITLE
fix: stabilize jest browserslist

### DIFF
--- a/apps/shop-bcd/__tests__/account-profile-api.test.ts
+++ b/apps/shop-bcd/__tests__/account-profile-api.test.ts
@@ -1,4 +1,5 @@
 // apps/shop-bcd/__tests__/account-profile-api.test.ts
+jest.mock("@acme/zod-utils/initZod", () => ({}));
 jest.mock("@auth", () => ({
   __esModule: true,
   getCustomerSession: jest.fn(),

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,12 @@ const path = require("path");
 const { pathsToModuleNameMapper } = require("ts-jest");
 const ts = require("typescript");
 
+// Ensure Browserslist doesn't try to resolve config files from
+// temporary directories created during Jest transforms. This prevents
+// ENOENT errors when packages like `@babel/core` invoke Browserslist
+// while handling files compiled in non-existent temp paths.
+process.env.BROWSERSLIST = process.env.BROWSERSLIST || "defaults";
+
 /* ──────────────────────────────────────────────────────────────────────
  * 1️⃣  Resolve TS path aliases once so we don't hand-maintain 30+ maps
  * ──────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- prevent Browserslist ENOENT errors in Jest by defaulting BROWSERSLIST env
- stub `@acme/zod-utils/initZod` in account profile API test

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/account-profile-api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acdb3d9978832fa2f2e435839d79ff