### PR TITLE
chore: close message ports after tests

### DIFF
--- a/test/polyfills/messageChannel.js
+++ b/test/polyfills/messageChannel.js
@@ -1,16 +1,22 @@
-// Polyfill to track MessagePorts created by React's scheduler
+// Polyfill MessageChannel so that React's scheduler ports don't keep Jest
+// alive or trigger "open handle" warnings.
 const { MessageChannel: NodeMessageChannel } = require("node:worker_threads");
 
+// Track MessagePorts so we can close them once the test suite finishes.
 const openPorts = [];
+
 class ManagedMessageChannel extends NodeMessageChannel {
   constructor(...args) {
     super(...args);
     openPorts.push(this.port1, this.port2);
+    // React never closes these ports, so unref both ends immediately to avoid
+    // keeping the Node.js event loop active.  Jest's open-handle detection
+    // still sees them as active until explicitly closed, so we collect them
+    // for cleanup after the tests complete.
+    this.port1.unref();
+    this.port2.unref();
   }
 }
-
-// Replace global MessageChannel with managed version
-global.MessageChannel = ManagedMessageChannel;
 
 function closeOpenPorts() {
   for (const port of openPorts.splice(0)) {
@@ -20,5 +26,9 @@ function closeOpenPorts() {
   }
 }
 
-afterEach(closeOpenPorts);
+// Replace the global MessageChannel with the managed version.
+global.MessageChannel = ManagedMessageChannel;
+
+// Close any remaining ports after all tests and right before process exit.
 afterAll(closeOpenPorts);
+process.on("exit", closeOpenPorts);


### PR DESCRIPTION
## Summary
- prevent React scheduler's MessageChannel from leaving open handles in Jest by tracking and closing ports at suite end

## Testing
- `npx jest packages/ui/__tests__/DataTable.test.tsx packages/ui/__tests__/Button.test.tsx --detectOpenHandles --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68ace15ae928832fa18d14c46456f134