### PR TITLE
feat(platform-core): expose assertLocale

### DIFF
--- a/packages/platform-core/src/products.ts
+++ b/packages/platform-core/src/products.ts
@@ -35,6 +35,8 @@ export function getProductById(a: string, b?: string): any {
 // Non-conflicting re-exports are safe:
 
 
+export { assertLocale } from "./products/index";
+
 export async function getProducts(...args: any[]): Promise<any[]> {
   const fn = (server as any)?.getProducts;
   if (typeof fn === "function") return fn(...args);


### PR DESCRIPTION
## Summary
- re-export `assertLocale` from product facade so downstream tests can use it

## Testing
- `pnpm exec jest test/unit/locales-regression.spec.ts`
- `pnpm test` *(fails: @acme/next-config:test: command exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ace19010fc832f8945fea710f3d7bc