### PR TITLE
test: stub zod init for jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -97,6 +97,7 @@ module.exports = {
       "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
     "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
+    "^@acme/zod-utils/initZod$": "<rootDir>/test/emptyModule.js",
 
     // CMS application aliases
     "^@/components/atoms/shadcn$":


### PR DESCRIPTION
## Summary
- stub `@acme/zod-utils/initZod` for Jest to avoid top-level await parse issues

## Testing
- `pnpm test:cms test/unit/revert-seo.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ace19d89d8832f9125a0e28fdce875