### PR TITLE
Fix Browserslist error in seedShop unit test

### DIFF
--- a/test/unit/seedShop.spec.ts
+++ b/test/unit/seedShop.spec.ts
@@ -1,10 +1,12 @@
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { seedShop } from '../../scripts/src/seedShop';
 
 describe('seedShop', () => {
-  it('copies template data into shop directory', () => {
+  it('copies template data into shop directory', async () => {
+    process.env.BROWSERSLIST ??= 'defaults';
+    const { seedShop } = await import('../../scripts/src/seedShop');
+
     const root = mkdtempSync(join(tmpdir(), 'seed-shop-'));
     // Create template files
     const templateDir = join(root, 'data', 'templates', 'default');


### PR DESCRIPTION
## Summary
- ensure Browserslist config is set before importing `seedShop` in the test

## Testing
- `pnpm exec jest test/unit/seedShop.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace1aaf454832fb5917788df71a3b6