### PR TITLE
test: disable browserslist config lookup

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -49,7 +49,15 @@ module.exports = {
         useESM: true,
         diagnostics: false,
         babelConfig: {
-          presets: [["@babel/preset-env", { targets: { node: "current" } }]],
+        presets: [
+          [
+            "@babel/preset-env",
+            {
+              targets: { node: "current" },
+              ignoreBrowserslistConfig: true,
+            },
+          ],
+        ],
         },
       },
     ],


### PR DESCRIPTION
## Summary
- prevent @babel/preset-env from resolving Browserslist config in Jest

## Testing
- `pnpm --filter @apps/cms test -- __tests__/ConfirmationStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ace1c205fc832f8c736e1c861ee595