### PR TITLE
test: stabilize email and late fee tests

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -1,27 +1,30 @@
 import { ProviderError } from "../providers/types";
 
-let sendgridSendMock: jest.Mock;
-let resendSendMock: jest.Mock;
-let sendMailMock: jest.Mock;
+// Prefix mock variables with `mock` so Jest's hoisted `jest.mock`
+// factory functions can safely reference them.
+let mockSendgridSend: jest.Mock;
+let mockResendSend: jest.Mock;
+let mockSendMail: jest.Mock;
 
 jest.mock("nodemailer", () => ({
   __esModule: true,
   default: {
     createTransport: jest.fn(() => ({
-      sendMail: (...args: any[]) => sendMailMock(...args),
+      // Forward calls to the test-controlled mock implementation.
+      sendMail: (...args: any[]) => mockSendMail(...args),
     })),
   },
 }));
 
 jest.mock("../providers/sendgrid", () => ({
   SendgridProvider: jest.fn().mockImplementation(() => ({
-    send: (...args: any[]) => sendgridSendMock(...args),
+    send: (...args: any[]) => mockSendgridSend(...args),
   })),
 }));
 
 jest.mock("../providers/resend", () => ({
   ResendProvider: jest.fn().mockImplementation(() => ({
-    send: (...args: any[]) => resendSendMock(...args),
+    send: (...args: any[]) => mockResendSend(...args),
   })),
 }));
 
@@ -29,6 +32,11 @@ jest.mock("../scheduler", () => ({}));
 jest.mock("@platform-core/analytics", () => ({
   trackEvent: jest.fn(),
 }));
+// The templates module imports `@acme/ui`, which in turn pulls in many
+// dependencies (including JSON imports with `assert` attributes) that
+// Jest cannot parse in this test environment. Stub the module to avoid
+// loading the real UI package.
+jest.mock("@acme/ui", () => ({ marketingEmailTemplates: [] }));
 
 describe("sendCampaignEmail fallback and retry", () => {
   const setupEnv = () => {
@@ -50,11 +58,11 @@ describe("sendCampaignEmail fallback and retry", () => {
   });
 
   it("falls back to alternate provider when primary fails", async () => {
-    sendgridSendMock = jest
+    mockSendgridSend = jest
       .fn()
       .mockRejectedValue(new ProviderError("fail", false));
-    resendSendMock = jest.fn().mockResolvedValue(undefined);
-    sendMailMock = jest.fn();
+    mockResendSend = jest.fn().mockResolvedValue(undefined);
+    mockSendMail = jest.fn();
 
     setupEnv();
 
@@ -65,16 +73,16 @@ describe("sendCampaignEmail fallback and retry", () => {
       html: "<p>HTML</p>",
     });
 
-    expect(sendgridSendMock).toHaveBeenCalledTimes(1);
-    expect(resendSendMock).toHaveBeenCalledTimes(1);
-    expect(sendMailMock).not.toHaveBeenCalled();
-    expect(sendgridSendMock).toHaveBeenCalledWith({
+    expect(mockSendgridSend).toHaveBeenCalledTimes(1);
+    expect(mockResendSend).toHaveBeenCalledTimes(1);
+    expect(mockSendMail).not.toHaveBeenCalled();
+    expect(mockSendgridSend).toHaveBeenCalledWith({
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
       text: "HTML",
     });
-    expect(resendSendMock).toHaveBeenCalledWith({
+    expect(mockResendSend).toHaveBeenCalledWith({
       to: "to@example.com",
       subject: "Subject",
       html: "<p>HTML</p>",
@@ -84,12 +92,12 @@ describe("sendCampaignEmail fallback and retry", () => {
 
   it("retries with exponential backoff on retryable error", async () => {
     const timeoutSpy = jest.spyOn(global, "setTimeout");
-    sendgridSendMock = jest
+    mockSendgridSend = jest
       .fn()
       .mockRejectedValueOnce(new ProviderError("temporary", true))
       .mockResolvedValueOnce(undefined);
-    resendSendMock = jest.fn();
-    sendMailMock = jest.fn();
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
 
     setupEnv();
 
@@ -102,24 +110,24 @@ describe("sendCampaignEmail fallback and retry", () => {
     });
 
     await Promise.resolve();
-    expect(sendgridSendMock).toHaveBeenCalledTimes(1);
+    expect(mockSendgridSend).toHaveBeenCalledTimes(1);
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
 
     await promise;
 
-    expect(sendgridSendMock).toHaveBeenCalledTimes(2);
-    expect(sendgridSendMock.mock.calls[0][0].text).toBe("HTML");
-    expect(sendgridSendMock.mock.calls[1][0].text).toBe("HTML");
-    expect(resendSendMock).not.toHaveBeenCalled();
+    expect(mockSendgridSend).toHaveBeenCalledTimes(2);
+    expect(mockSendgridSend.mock.calls[0][0].text).toBe("HTML");
+    expect(mockSendgridSend.mock.calls[1][0].text).toBe("HTML");
+    expect(mockResendSend).not.toHaveBeenCalled();
     timeoutSpy.mockRestore();
   });
 
   it("logs provider, campaign, and recipient on failure", async () => {
-    sendgridSendMock = jest
+    mockSendgridSend = jest
       .fn()
       .mockRejectedValue(new ProviderError("fail", false));
-    resendSendMock = jest.fn().mockResolvedValue(undefined);
-    sendMailMock = jest.fn();
+    mockResendSend = jest.fn().mockResolvedValue(undefined);
+    mockSendMail = jest.fn();
 
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 

--- a/packages/platform-machine/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/__tests__/lateFeeService.test.ts
@@ -77,7 +77,10 @@ describe("chargeLateFeesOnce", () => {
       throw new Error("not found");
     });
     const readdir = jest.fn().mockResolvedValue(["test"]);
-    jest.doMock("node:fs/promises", () => ({
+    // Mock filesystem helpers used by the service. The implementation
+    // imports from "fs/promises" (without the "node:" prefix), so the
+    // mock must match that specifier exactly.
+    jest.doMock("fs/promises", () => ({
       __esModule: true,
       readFile,
       readdir,
@@ -142,7 +145,8 @@ describe("chargeLateFeesOnce", () => {
       throw new Error("not found");
     });
     const readdir = jest.fn().mockResolvedValue(["test"]);
-    jest.doMock("node:fs/promises", () => ({
+    // Ensure the second test also mocks the correct module specifier.
+    jest.doMock("fs/promises", () => ({
       __esModule: true,
       readFile,
       readdir,


### PR DESCRIPTION
## Summary
- rename test mocks with `mock` prefix to satisfy Jest ESM restrictions
- stub `@acme/ui` in email tests to avoid heavy imports
- mock `fs/promises` correctly in late fee tests to prevent timeouts

## Testing
- `npx jest packages/email/src/__tests__/send.test.ts -c jest.config.cjs`
- `npx jest packages/platform-machine/__tests__/lateFeeService.test.ts -c jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68ace1efa778832fb585fe11cc0c8e37