### PR TITLE
fix: ensure tests run without prisma or ESM issues

### DIFF
--- a/packages/platform-core/src/repositories/json.server.ts
+++ b/packages/platform-core/src/repositories/json.server.ts
@@ -8,9 +8,19 @@
  * • saveShopSettings – write settings.json atomically
  * • diffHistory      – return patch history for settings.json
  * • products.server  – catalogue helpers (read/write/update/delete/…)
+ *
+ * The `readShop` helper pulls in a large dependency tree (including the
+ * Prisma client) so we lazily import it.  This keeps simple JSON repo
+ * consumers – such as unit tests that only touch product helpers – fast and
+ * self-contained.
  */
 
-export { readShop } from "./shops.server";
+import type { Shop } from "@acme/types";
+
+export async function readShop(shop: string): Promise<Shop> {
+  const mod = await import("./shops.server");
+  return mod.readShop(shop);
+}
 
 // Alias getShopSettings → readSettings so existing callers keep working.
 export { getShopSettings as readSettings } from "./settings.server";

--- a/packages/zod-utils/src/initZod.ts
+++ b/packages/zod-utils/src/initZod.ts
@@ -1,9 +1,11 @@
 // packages/zod-utils/src/initZod.ts
 // Small initializer that installs the friendly Zod error map.
-// Import it directly so Jest can transpile the module without
-// choking on top‑level `await`.
-// Import the TypeScript source so ts-jest can transpile it during tests.
-import { applyFriendlyZodMessages } from "./zodErrorMap";
+// Import it using `require` so that when this file is transpiled to
+// CommonJS (as happens under Jest) it does not emit any async `import`
+// helpers that rely on top-level `await`.  Using `require` keeps the
+// generated code synchronous and works in both ESM and CJS test runs.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { applyFriendlyZodMessages } = require("./zodErrorMap");
 
 export function initZod(): void {
   applyFriendlyZodMessages();


### PR DESCRIPTION
## Summary
- avoid emitting top-level `await` in zod setup by requiring the error map
- lazily import `readShop` to keep JSON repo tests lightweight
- mock Prisma and raise timeout in JSON repository tests
- stub init-shop env script in vault test to exercise vault command without Prisma

## Testing
- `pnpm exec jest packages/platform-core/__tests__/repositories.test.ts`
- `pnpm exec jest test/unit/init-shop/vault.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace200cfb0832fadf54bdfd61e3ea4