### PR TITLE
Add rental pricing fixture and mock heavy deps in email tests

### DIFF
--- a/functions/data/rental/pricing.json
+++ b/functions/data/rental/pricing.json
@@ -1,0 +1,12 @@
+{
+  "baseDailyRate": 100,
+  "durationDiscounts": [
+    { "minDays": 7, "rate": 0.9 },
+    { "minDays": 30, "rate": 0.8 }
+  ],
+  "damageFees": {
+    "scuff": 5,
+    "default": "deposit"
+  },
+  "coverage": {}
+}

--- a/test/unit/email.spec.ts
+++ b/test/unit/email.spec.ts
@@ -1,3 +1,5 @@
+jest.mock("@acme/zod-utils/initZod", () => ({}));
+
 describe("sendEmail", () => {
   const OLD_ENV = process.env;
 
@@ -22,7 +24,7 @@ describe("sendEmail", () => {
       createTransport: () => ({ sendMail }),
     }));
 
-    const { sendEmail } = await import("@acme/email");
+    const { sendEmail } = await import("../../packages/email/src/sendEmail");
     await sendEmail("a@b.com", "Hello", "World");
     expect(sendMail).toHaveBeenCalledWith({
       from: "test@example.com",
@@ -50,7 +52,7 @@ describe("sendEmail", () => {
     }));
 
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    const { sendEmail } = await import("@acme/email");
+    const { sendEmail } = await import("../../packages/email/src/sendEmail");
     await expect(
       sendEmail("a@b.com", "Hello", "World")
     ).rejects.toThrow("failure");
@@ -64,16 +66,16 @@ describe("sendEmail", () => {
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
     } as NodeJS.ProcessEnv;
-    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const info = jest.fn();
     jest.doMock("nodemailer", () => ({
       __esModule: true,
       default: { createTransport: jest.fn() },
       createTransport: jest.fn(),
     }));
+    jest.doMock("pino", () => () => ({ info }));
 
-    const { sendEmail } = await import("@acme/email");
+    const { sendEmail } = await import("../../packages/email/src/sendEmail");
     await sendEmail("a@b.com", "Hi", "There");
-    expect(consoleSpy).toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    expect(info).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- mock zod init and pino in email tests
- add rental pricing configuration fixture

## Testing
- `pnpm test:cms test/unit/email.spec.ts`
- `pnpm test:cms 'functions/themes/\[theme\]/__tests__/rental-return-integration.test.ts'` *(fails: Cannot find module '.prisma/client/index-browser')*


------
https://chatgpt.com/codex/tasks/task_e_68ace213845c832fba12b46dafa32775