### PR TITLE
Use node fs in pricing repository to support Jest mocks

### DIFF
--- a/packages/platform-core/src/repositories/pricing.server.ts
+++ b/packages/platform-core/src/repositories/pricing.server.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { pricingSchema, type PricingMatrix } from "@acme/types";
-import { promises as fs } from "fs";
+import { promises as fs } from "node:fs";
 import * as path from "path";
 import { resolveDataRoot } from "../dataRoot";
 


### PR DESCRIPTION
## Summary
- use `node:fs` in pricing repository so tests can mock file operations

## Testing
- `pnpm exec jest packages/platform-core/src/repositories/__tests__/pricing.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace2460f74832fa70fd3cc76b6e4d9