### PR TITLE
test: stabilize deposit and theme context tests

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,5 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
 import { ThemeProvider, useTheme } from "../ThemeContext";
+
+// React 19 requires this flag for `act` to suppress environment warnings
+// when not using a test renderer.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 function ThemeDisplay() {
   const { theme } = useTheme();
@@ -34,13 +39,23 @@ describe("ThemeProvider fallback", () => {
       value: undefined,
     });
 
-    render(
-      <ThemeProvider>
-        <ThemeDisplay />
-      </ThemeProvider>
-    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
 
-    expect(screen.getByTestId("theme").textContent).toBe("system");
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ThemeProvider>
+          <ThemeDisplay />
+        </ThemeProvider>
+      );
+    });
+
+    expect(container.querySelector("[data-testid='theme']")?.textContent).toBe(
+      "system"
+    );
     expect(document.documentElement.style.colorScheme).toBe("light");
+
+    act(() => root.unmount());
   });
 });


### PR DESCRIPTION
## Summary
- stub zod initialization to avoid top-level await parsing issues
- use React DOM `createRoot` for theme context tests
- isolate deposit service tests from Prisma and filesystem

## Testing
- `CI=true pnpm exec jest packages/platform-machine/__tests__/depositService.test.ts packages-platform-core/src/contexts/__tests__/ThemeContext.test.tsx --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68ace253dc88832faf73196265d0c34b