### PR TITLE
fix: avoid top-level await in env config

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,4 +1,5 @@
-import "@acme/zod-utils/initZod";
+import { initZod } from "@acme/zod-utils/initZod";
+initZod();
 import { z } from "zod";
 import { authEnvSchema } from "./auth";
 import { cmsEnvSchema } from "./cms";


### PR DESCRIPTION
## Summary
- import and invoke `initZod` directly instead of relying on side-effect import to prevent top-level await issues in tests

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/config.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ace2756a3c832f8a31ba853512a246