### PR TITLE
Mock zod initialization in analytics tests

### DIFF
--- a/packages/email/src/__tests__/analytics.test.ts
+++ b/packages/email/src/__tests__/analytics.test.ts
@@ -1,4 +1,7 @@
 import { nowIso } from "@date-utils";
+// Stub the Zod initializer so tests don't attempt to execute the real module
+// during import, which can cause transform issues in Jest.
+jest.mock("@acme/zod-utils/initZod", () => ({}));
 
 process.env.CART_COOKIE_SECRET = "secret";
 


### PR DESCRIPTION
## Summary
- stub `@acme/zod-utils/initZod` in email analytics tests to avoid transform issues when importing the module

## Testing
- `pnpm test -- --runTestsByPath src/__tests__/analytics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace2d0c6c4832fa35f87540ad3fff8