### PR TITLE
refactor: load zod error map synchronously

### DIFF
--- a/packages/zod-utils/src/initZod.js
+++ b/packages/zod-utils/src/initZod.js
@@ -1,9 +1,16 @@
 // packages/zod-utils/src/initZod.ts
 // Small initializer that installs the friendly Zod error map.
-// Import it directly so Jest can transpile the module without
-// relying on top-level `await`.
-import { applyFriendlyZodMessages } from "./zodErrorMap.js";
+// Import it using Node's `createRequire` so that when this file is
+// transpiled to CommonJS (as happens under Jest) it does not emit any
+// async `import` helpers that rely on top-level `await`. Using
+// `createRequire` keeps the generated code synchronous and works in
+// both ESM and CJS test runs.
+import { createRequire } from "module";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { applyFriendlyZodMessages } = createRequire(import.meta.url)("./zodErrorMap.js");
 export function initZod() {
     applyFriendlyZodMessages();
 }
+// Initialize immediately when this module is imported. The export
+// remains so callers can re-run if needed.
 initZod();

--- a/packages/zod-utils/src/initZod.ts
+++ b/packages/zod-utils/src/initZod.ts
@@ -1,12 +1,16 @@
 // packages/zod-utils/src/initZod.ts
 /* istanbul ignore file */
 // Small initializer that installs the friendly Zod error map.
-// Import it using `require` so that when this file is transpiled to
-// CommonJS (as happens under Jest) it does not emit any async `import`
-// helpers that rely on top-level `await`.  Using `require` keeps the
-// generated code synchronous and works in both ESM and CJS test runs.
+// Import it using Node's `createRequire` so that when this file is
+// transpiled to CommonJS (as happens under Jest) it does not emit any
+// async `import` helpers that rely on top-level `await`. Using
+// `createRequire` keeps the generated code synchronous and works in
+// both ESM and CJS test runs.
+import { createRequire } from "module";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { applyFriendlyZodMessages } = require("./zodErrorMap");
+const { applyFriendlyZodMessages } = createRequire(import.meta.url)(
+  "./zodErrorMap"
+);
 
 export function initZod(): void {
   applyFriendlyZodMessages();


### PR DESCRIPTION
## Summary
- load zod error map using Node's `createRequire` to avoid top-level `await`
- update compiled JS version to match

## Testing
- `npx jest apps/cms/__tests__/seoTimelineRevert.test.ts --runInBand --config jest.config.cjs` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68ad618c8120832fb8b75a89c6375c24