### PR TITLE
chore(test): disable babel in jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -52,17 +52,12 @@ module.exports = {
         tsconfig: "<rootDir>/tsconfig.test.json",
         useESM: true,
         diagnostics: false,
-        babelConfig: {
-        presets: [
-          [
-            "@babel/preset-env",
-            {
-              targets: { node: "current" },
-              ignoreBrowserslistConfig: true,
-            },
-          ],
-        ],
-        },
+        // Disable automatic Babel transpilation; ts-jest handles TypeScript
+        // compilation itself and Node 20 supports the necessary syntax.
+        // This prevents ts-jest from attempting to load `babel-jest`, which
+        // previously caused "createTransformer is not a function" errors when
+        // the module was missing or incompatible.
+        babelConfig: false,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- prevent ts-jest from loading babel-jest by disabling babel transpilation

## Testing
- `npx jest test/checkout.test.tsx --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ada1ece938832f9193ed2b47c1f7c8