### PR TITLE
fix: stabilize ImagePicker tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { MediaItem } from "@acme/types";
-import useFileUpload from "../../../hooks/useFileUpload";
+import useFileUpload from "@ui/hooks/useFileUpload";
 import Image from "next/image";
 import { memo, useEffect, useState, type ChangeEvent } from "react";
 import {
@@ -13,7 +13,7 @@ import {
   DialogTrigger,
   Input,
 } from "../../atoms/shadcn";
-import { Loader } from "../../atoms";
+import { Loader } from "../../atoms/Loader";
 import useMediaLibrary from "./useMediaLibrary";
 
 interface Props {

--- a/packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx
@@ -13,7 +13,10 @@ jest.mock("@ui/hooks/useFileUpload", () => () => ({
   error: "",
 }));
 
-jest.mock("next/navigation", () => ({ usePathname: () => "/shop" }));
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/cms/shop/abc",
+  useSearchParams: () => new URLSearchParams(),
+}));
 jest.mock("next/image", () => (props: any) => <img {...props} />);
 
 describe("ImagePicker", () => {

--- a/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
+++ b/packages/ui/src/components/cms/page-builder/useMediaLibrary.ts
@@ -1,5 +1,5 @@
 "use client";
-import { getShopFromPath } from "@acme/platform-core/utils";
+import { getShopFromPath } from "@acme/platform-core/utils/getShopFromPath";
 import type { MediaItem } from "@acme/types";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";


### PR DESCRIPTION
## Summary
- import Loader directly in ImagePicker to avoid loading unrelated atoms
- mock next/navigation more completely in ImagePicker tests and use CMS path
- use new getShopFromPath util in useMediaLibrary

## Testing
- `npx jest packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68adbe5741f4832f9410a0ca8e186788