### PR TITLE
test: silence console error in theme service tests

### DIFF
--- a/apps/cms/src/services/shops/__tests__/themeService.test.ts
+++ b/apps/cms/src/services/shops/__tests__/themeService.test.ts
@@ -17,6 +17,14 @@ jest.mock("../theme", () => ({
 }));
 
 describe("theme service", () => {
+  beforeAll(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
   it("returns validation errors", async () => {
     const fd = new FormData();
     fd.append("id", "test");


### PR DESCRIPTION
## Summary
- suppress console.error output in theme service tests to keep logs clean

## Testing
- `pnpm test:cms apps/cms/src/services/shops/__tests__/themeService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adbe9b7c30832fa55daa26aa3c36a9