### PR TITLE
fix: guard zod init and template imports

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,5 +1,4 @@
-import { initZod } from "@acme/zod-utils/initZod";
-initZod();
+import "@acme/zod-utils/initZod";
 import { z } from "zod";
 import { authEnvSchema } from "./auth";
 import { cmsEnvSchema } from "./cms";

--- a/packages/email/src/templates.js
+++ b/packages/email/src/templates.js
@@ -1,6 +1,4 @@
 import "server-only";
-import * as React from "react";
-import { marketingEmailTemplates } from "@acme/ui";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 import { createRequire } from "module";
@@ -9,6 +7,15 @@ const nodeRequire =
   typeof require !== "undefined"
     ? require
     : createRequire(eval("import.meta.url"));
+const React = nodeRequire("react");
+let marketingEmailTemplates = [];
+try {
+  marketingEmailTemplates =
+    (nodeRequire("@acme/ui").marketingEmailTemplates ?? []);
+}
+catch {
+  // Ignore if @acme/ui is unavailable
+}
 const { window } = new JSDOM("");
 const DOMPurify = createDOMPurify(window);
 const templates = {};
@@ -31,13 +38,13 @@ export function clearTemplates() {
  * use the Handlebars-like syntax `{{variable}}`.
  */
 export function renderTemplate(id, params) {
-    const { renderToStaticMarkup } = nodeRequire("react-dom/server");
     const source = templates[id];
     if (source) {
         return source.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {
             return params[key] ?? "";
         });
     }
+    const { renderToStaticMarkup } = nodeRequire("react-dom/server");
     const variant = marketingEmailTemplates.find((t) => t.id === id);
     if (variant) {
         return renderToStaticMarkup(variant.render({


### PR DESCRIPTION
## Summary
- avoid calling a stubbed `initZod` by importing it for side effects only
- safely require React and templates in email renderer without `@acme/ui`

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendCampaignEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adbf1a6988832facbb1ae301e7b52f