### PR TITLE
fix ui tests for page schema and app shell

### DIFF
--- a/packages/types/src/page.d.ts
+++ b/packages/types/src/page.d.ts
@@ -1,0 +1,1 @@
+export * from "./page/index";

--- a/packages/types/src/page.ts
+++ b/packages/types/src/page.ts
@@ -1,0 +1,1 @@
+export * from "./page/index";

--- a/packages/ui/__tests__/appShell.test.tsx
+++ b/packages/ui/__tests__/appShell.test.tsx
@@ -1,11 +1,11 @@
-import { useLayout } from "@platform-core";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { AppShell } from "../components/templates/AppShell";
 
 jest.mock("next/navigation", () => ({
   usePathname: jest.fn(),
 }));
 
+import { useLayout } from "@platform-core";
+import { AppShell } from "../components/templates/AppShell";
 import { usePathname } from "next/navigation";
 
 function LayoutInfo() {


### PR DESCRIPTION
## Summary
- expose page types barrel to fix missing import
- mock `next/navigation` before platform-core import in `appShell` test

## Testing
- `pnpm exec jest packages/ui/__tests__/pageComponentSchema.test.ts packages/ui/__tests__/appShell.test.tsx --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68adbf623e1c832f947b350b89f61f2e