### PR TITLE
fix(TestimonialSlider): remove decorative quotes

### DIFF
--- a/packages/ui/src/components/cms/blocks/TestimonialSlider.js
+++ b/packages/ui/src/components/cms/blocks/TestimonialSlider.js
@@ -13,5 +13,5 @@ export default function TestimonialSlider({ testimonials = [], minItems, maxItem
     if (!list.length || list.length < (minItems ?? 0))
         return null;
     const t = list[i % list.length];
-    return (_jsxs("section", { className: "space-y-2 text-center", children: [_jsxs("blockquote", { className: "italic", children: ["\u201C", t.quote, "\u201D"] }), t.name && _jsxs("footer", { className: "text-sm text-muted", children: ["\u2014 ", t.name] })] }));
+    return (_jsxs("section", { className: "space-y-2 text-center", children: [_jsxs("blockquote", { className: "italic", children: [t.quote] }), t.name && _jsxs("footer", { className: "text-sm text-muted", children: ["\u2014 ", t.name] })] }));
 }

--- a/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
+++ b/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
@@ -27,7 +27,7 @@ export default function TestimonialSlider({
   const t = list[i % list.length];
   return (
     <section className="space-y-2 text-center">
-      <blockquote className="italic">“{t.quote}”</blockquote>
+      <blockquote className="italic">{t.quote}</blockquote>
       {t.name && <footer className="text-sm text-muted">— {t.name}</footer>}
     </section>
   );


### PR DESCRIPTION
## Summary
- remove decorative quotes from TestimonialSlider so plain text is available for queries
- update compiled component accordingly

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/TestimonialSlider.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adbf760d7c832fab71e33209144cd8