### PR TITLE
test: load init-shop modules dynamically

### DIFF
--- a/test/unit/init-shop/runtime.spec.ts
+++ b/test/unit/init-shop/runtime.spec.ts
@@ -20,6 +20,23 @@ describe('init-shop wizard - runtime checks', () => {
         if (p === 'node:child_process') {
           return { execSync: () => '10.0.0' };
         }
+        if (p.includes('./runtime')) {
+          const runtimeSrc = fs.readFileSync(
+            path.join(__dirname, '../../../scripts/src/runtime.ts'),
+            'utf8'
+          );
+          const transpiledRuntime = ts.transpileModule(runtimeSrc, {
+            compilerOptions: {
+              module: ts.ModuleKind.CommonJS,
+              esModuleInterop: true,
+            },
+          }).outputText;
+          const runtimeSandbox: any = { ...sandbox };
+          runtimeSandbox.module = { exports: {} };
+          runtimeSandbox.exports = runtimeSandbox.module.exports;
+          runInNewContext(transpiledRuntime, runtimeSandbox);
+          return runtimeSandbox.module.exports;
+        }
         return {};
       },
     };
@@ -53,6 +70,23 @@ describe('init-shop wizard - runtime checks', () => {
       require: (p: string) => {
         if (p === 'node:child_process') {
           return { execSync: () => '9.0.0' };
+        }
+        if (p.includes('./runtime')) {
+          const runtimeSrc = fs.readFileSync(
+            path.join(__dirname, '../../../scripts/src/runtime.ts'),
+            'utf8'
+          );
+          const transpiledRuntime = ts.transpileModule(runtimeSrc, {
+            compilerOptions: {
+              module: ts.ModuleKind.CommonJS,
+              esModuleInterop: true,
+            },
+          }).outputText;
+          const runtimeSandbox: any = { ...sandbox };
+          runtimeSandbox.module = { exports: {} };
+          runtimeSandbox.exports = runtimeSandbox.module.exports;
+          runInNewContext(transpiledRuntime, runtimeSandbox);
+          return runtimeSandbox.module.exports;
         }
         return {};
       },

--- a/test/unit/init-shop/theme.spec.ts
+++ b/test/unit/init-shop/theme.spec.ts
@@ -151,7 +151,7 @@ describe('init-shop wizard - theme', () => {
             }),
           };
         }
-        if (p.includes('./generate-theme')) {
+        if (p.includes('generate-theme')) {
           return {
             generateThemeTokens: () => ({
               '--color-primary': '210 60% 40%',
@@ -180,6 +180,100 @@ describe('init-shop wizard - theme', () => {
               sanity: ['SANITY_PROJECT_ID', 'SANITY_DATASET', 'SANITY_TOKEN'],
             },
           };
+        }
+        if (p.includes('./utils/providers')) {
+          return {
+            listProviders: jest.fn((kind: string) =>
+              Promise.resolve(
+                kind === 'payment'
+                  ? [
+                      {
+                        id: 'stripe',
+                        name: 'stripe',
+                        envVars: [
+                          'STRIPE_SECRET_KEY',
+                          'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+                          'STRIPE_WEBHOOK_SECRET',
+                        ],
+                      },
+                      {
+                        id: 'paypal',
+                        name: 'paypal',
+                        envVars: ['PAYPAL_CLIENT_ID', 'PAYPAL_SECRET'],
+                      },
+                    ]
+                  : [
+                      { id: 'dhl', name: 'dhl', envVars: [] },
+                      { id: 'ups', name: 'ups', envVars: [] },
+                    ]
+              )
+            ),
+            listPlugins: jest.fn(() => [
+              {
+                id: 'sanity',
+                packageName: '@acme/plugin-sanity',
+                envVars: [
+                  'SANITY_PROJECT_ID',
+                  'SANITY_DATASET',
+                  'SANITY_TOKEN',
+                ],
+              },
+            ]),
+          };
+        }
+        if (p.includes('./apply-page-template')) {
+          return { applyPageTemplate: jest.fn() };
+        }
+        if (p.includes('./utils/prompt') || p.endsWith('/prompt')) {
+          const promptSrc = fs.readFileSync(
+            path.join(__dirname, '../../../scripts/src/utils/prompt.ts'),
+            'utf8'
+          );
+          const transpiledPrompt = ts.transpileModule(promptSrc, {
+            compilerOptions: {
+              module: ts.ModuleKind.CommonJS,
+              esModuleInterop: true,
+            },
+          }).outputText;
+          const promptSandbox: any = { ...sandbox };
+          promptSandbox.module = { exports: {} };
+          promptSandbox.exports = promptSandbox.module.exports;
+          runInNewContext(transpiledPrompt, promptSandbox);
+          return promptSandbox.module.exports;
+        }
+        if (p.includes('./utils/theme')) {
+          const themeSrc = fs.readFileSync(
+            path.join(__dirname, '../../../scripts/src/utils/theme.ts'),
+            'utf8'
+          );
+          const transpiledTheme = ts.transpileModule(themeSrc, {
+            compilerOptions: {
+              module: ts.ModuleKind.CommonJS,
+              esModuleInterop: true,
+            },
+          }).outputText;
+          const themeSandbox: any = { ...sandbox };
+          themeSandbox.module = { exports: {} };
+          themeSandbox.exports = themeSandbox.module.exports;
+          runInNewContext(transpiledTheme, themeSandbox);
+          return themeSandbox.module.exports;
+        }
+        if (p.includes('./env')) {
+          const envSrc = fs.readFileSync(
+            path.join(__dirname, '../../../scripts/src/env.ts'),
+            'utf8'
+          );
+          const transpiledEnv = ts.transpileModule(envSrc, {
+            compilerOptions: {
+              module: ts.ModuleKind.CommonJS,
+              esModuleInterop: true,
+            },
+          }).outputText;
+          const envSandbox: any = { ...sandbox };
+          envSandbox.module = { exports: {} };
+          envSandbox.exports = envSandbox.module.exports;
+          runInNewContext(transpiledEnv, envSandbox);
+          return envSandbox.module.exports;
         }
         if (p.includes('./runtime')) {
           return { ensureRuntime: jest.fn() };


### PR DESCRIPTION
## Summary
- mock and transpile init-shop dependencies in unit tests
- exercise runtime checks without missing module errors

## Testing
- `pnpm test:cms test/unit/init-shop/theme.spec.ts`
- `pnpm test:cms test/unit/init-shop/env.spec.ts`
- `pnpm test:cms test/unit/init-shop/runtime.spec.ts`
- `pnpm test:cms` *(fails: missing modules like '@/components/cms/StyleEditor', '@prisma/client', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68adbf3c5bd0832f964b146e76309919