### PR TITLE
Fix ReviewsCarousel test text matching

### DIFF
--- a/packages/ui/__tests__/ReviewsCarousel.test.tsx
+++ b/packages/ui/__tests__/ReviewsCarousel.test.tsx
@@ -34,14 +34,14 @@ describe("ReviewsCarousel", () => {
     expect(
       screen.getByText(/Anna quote/).closest("blockquote")
     ).toHaveAttribute("data-token", "--color-fg");
-    expect(screen.getByText(/Anna/).parentElement).toHaveAttribute(
+    expect(screen.getByText(/—\s*Anna/)).toHaveAttribute(
       "data-token",
       "--color-muted"
     );
     act(() => {
       jest.advanceTimersByTime(8000);
     });
-    expect(screen.getByText("Luca quote")).toBeInTheDocument();
+    expect(screen.getByText(/Luca quote/)).toBeInTheDocument();
   });
 
   it("renders provided reviews", () => {


### PR DESCRIPTION
## Summary
- refine name selector in ReviewsCarousel test to avoid duplicate text matches
- use regex to match rotated review quote

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/ReviewsCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adbf9f94a4832f933d5cc5e97b5055