### PR TITLE
Ensure MediaManager dropzone is accessible in tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,5 @@
 // /jest.config.cjs   ← keep this exact filename
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 
 /**
  * Monorepo-wide Jest config (CommonJS so Node can load it without
@@ -122,6 +122,7 @@ module.exports = {
     "^@sendgrid/mail$": "<rootDir>/packages/email/src/providers/__mocks__/@sendgrid/mail.ts",
 
     // component stubs – structure isn’t under test
+    "^@ui/components/cms/MediaManager$": "<rootDir>/packages/ui/src/components/cms/MediaManager.tsx",
     "^@ui/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@ui/atoms/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@ui/molecules/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",

--- a/packages/ui/src/components/cms/media/UploadPanel.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.tsx
@@ -3,7 +3,7 @@
 
 import { Input } from "../../atoms/shadcn";
 import type { ImageOrientation, MediaItem } from "@acme/types";
-import { useMediaUpload } from "../../../hooks/useMediaUpload";
+import { useMediaUpload } from "@ui/hooks/useMediaUpload";
 import { ChangeEvent, ReactElement, useState } from "react";
 
 interface UploadPanelProps {
@@ -37,7 +37,7 @@ export default function UploadPanel({ shop, onUploaded }: UploadPanelProps): Rea
     requiredOrientation: REQUIRED_ORIENTATION,
     onUploaded,
   });
-  const isVideo = pendingFile?.type.startsWith("video/") ?? false;
+  const isVideo = pendingFile?.type?.startsWith("video/") ?? false;
 
   return (
     <div className="space-y-2">

--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -79,7 +79,7 @@ export function useFileUpload(
   const feedbackId = "uploader-feedback";
 
   /* ---------- orientation check ----------------------------------- */
-  const isVideo = pendingFile?.type.startsWith("video/") ?? false;
+  const isVideo = pendingFile?.type?.startsWith("video/") ?? false;
   const { actual, isValid: orientationValid } = useImageOrientationValidation(
     isVideo ? null : pendingFile,
     requiredOrientation


### PR DESCRIPTION
## Summary
- use `@ui` alias for `useMediaUpload` in UploadPanel
- guard pending file type checks with optional chaining
- map `@ui/components/cms/MediaManager` to real component in Jest config

## Testing
- `pnpm exec eslint packages/ui/src/components/cms/media/UploadPanel.tsx packages/ui/src/hooks/useFileUpload.tsx jest.config.cjs`
- `pnpm exec jest packages/ui/__tests__/MediaManager.a11y.test.tsx --no-cache`


------
https://chatgpt.com/codex/tasks/task_e_68adbfc41e94832fa6a5dfc865e86eed