### PR TITLE
test: fix LayoutPanel test and currency context mapping

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -116,6 +116,10 @@ module.exports = {
       "<rootDir>/test/__mocks__/themeContextMock.tsx",
     "^@platform-core/contexts/CurrencyContext$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
+    "^@acme/platform-core/contexts/ThemeContext$":
+      "<rootDir>/test/__mocks__/themeContextMock.tsx",
+    "^@acme/platform-core/contexts/CurrencyContext$":
+      "<rootDir>/test/__mocks__/currencyContextMock.tsx",
 
     // email provider client mocks
     "^resend$": "<rootDir>/packages/email/src/providers/__mocks__/resend.ts",

--- a/packages/ui/__tests__/LayoutPanel.test.tsx
+++ b/packages/ui/__tests__/LayoutPanel.test.tsx
@@ -30,7 +30,7 @@ test("updates width via handleResize", () => {
       handleFullSize={() => {}}
     />
   );
-  fireEvent.change(screen.getByLabelText("Width (Desktop)"), {
+  fireEvent.change(screen.getByLabelText(/Width \(Desktop\)/), {
     target: { value: "200" },
   });
   expect(handleResize).toHaveBeenCalledWith("widthDesktop", "200");


### PR DESCRIPTION
## Summary
- mock `@acme/platform-core` context paths in Jest config
- relax LayoutPanel label query to handle tooltip text

## Testing
- `pnpm --filter @acme/ui test -- __tests__/LayoutPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adbfcd5084832fada3d80ea1d365f0