### PR TITLE
Fix path and image handling in UI tests

### DIFF
--- a/packages/ui/__tests__/HeroBanner.test.tsx
+++ b/packages/ui/__tests__/HeroBanner.test.tsx
@@ -53,8 +53,8 @@ describe("HeroBanner", () => {
 
   it("uses navigation buttons with provided slides", () => {
     const slides: Slide[] = [
-      { src: "a.jpg", alt: "a", headlineKey: "a.head", ctaKey: "a.cta" },
-      { src: "b.jpg", alt: "b", headlineKey: "b.head", ctaKey: "b.cta" },
+      { src: "/a.jpg", alt: "a", headlineKey: "a.head", ctaKey: "a.cta" },
+      { src: "/b.jpg", alt: "b", headlineKey: "b.head", ctaKey: "b.cta" },
     ];
     Object.assign(translations, {
       "a.head": "Alpha",

--- a/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
+++ b/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 import ImageUploaderWithOrientationCheck from "../components/cms/ImageUploaderWithOrientationCheck";
-import { useImageOrientationValidation } from "../hooks/useImageOrientationValidation";
+import { useImageOrientationValidation } from "@ui/hooks/useImageOrientationValidation";
 
 jest.mock("@ui/hooks/useImageOrientationValidation");
 


### PR DESCRIPTION
## Summary
- use repository path alias for `useImageOrientationValidation`
- ensure HeroBanner test uses absolute image URLs

## Testing
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @/components/cms/StyleEditor)*

------
https://chatgpt.com/codex/tasks/task_e_68adbfdf6430832fa6c26f8e3549518d