### PR TITLE
fix: align react runtime for tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -33,6 +33,10 @@ const tsPaths = tsconfig?.compilerOptions?.paths
 // Ensure a single React instance across the monorepo tests
 const reactPath = path.resolve(__dirname, "node_modules/react");
 const reactDomPath = path.resolve(__dirname, "node_modules/react-dom");
+const reactJsxRuntimePath = path.resolve(
+  __dirname,
+  "node_modules/react/jsx-runtime.js"
+);
 
 /* ──────────────────────────────────────────────────────────────────────
  * 2️⃣  Jest configuration proper
@@ -151,6 +155,8 @@ module.exports = {
     // map React to ensure hooks use the same instance during tests
     "^react$": reactPath,
     "^react-dom$": reactDomPath,
+    "^react/jsx-runtime$": reactJsxRuntimePath,
+    "^react/jsx-dev-runtime$": reactJsxRuntimePath,
     ...tsPaths,
   },
 

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -125,7 +125,8 @@ describe("DynamicRenderer", () => {
 
     expect(screen.getByText("bar")).toBeInTheDocument();
     expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ foo: "bar" })
+      expect.objectContaining({ foo: "bar" }),
+      undefined
     );
 
     spy.mockRestore();


### PR DESCRIPTION
## Summary
- ensure Jest resolves `react/jsx-runtime` and `react/jsx-dev-runtime` to the root React instance
- handle `component` call signature in `DynamicRenderer` runtime data test

## Testing
- `pnpm jest packages/ui/__tests__/DynamicRenderer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adbfe7b3f8832f8714e9cd168aca19