### PR TITLE
chore: ensure single react runtime in tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -33,6 +33,8 @@ const tsPaths = tsconfig?.compilerOptions?.paths
 // Ensure a single React instance across the monorepo tests
 const reactPath = path.resolve(__dirname, "node_modules/react");
 const reactDomPath = path.resolve(__dirname, "node_modules/react-dom");
+const reactJsxRuntimePath = require.resolve("react/jsx-runtime");
+const reactJsxDevRuntimePath = require.resolve("react/jsx-dev-runtime");
 
 /* ──────────────────────────────────────────────────────────────────────
  * 2️⃣  Jest configuration proper
@@ -151,6 +153,8 @@ module.exports = {
     // map React to ensure hooks use the same instance during tests
     "^react$": reactPath,
     "^react-dom$": reactDomPath,
+    "^react/jsx-runtime$": reactJsxRuntimePath,
+    "^react/jsx-dev-runtime$": reactJsxDevRuntimePath,
     ...tsPaths,
   },
 

--- a/test/emptyModule.js
+++ b/test/emptyModule.js
@@ -1,2 +1,3 @@
-/* Jest stub for type-only .d.ts imports */
-module.exports = {};
+/* Jest stub for modules without runtime behavior */
+const noop = () => {};
+module.exports = { default: noop, initZod: noop };


### PR DESCRIPTION
## Summary
- ensure jest resolves react runtime modules from root so tests use single React instance
- stub initZod in emptyModule to avoid runtime errors during tests

## Testing
- `npx jest packages/ui/__tests__/ContentPanel.test.tsx packages/ui/__tests__/ComponentEditor.test.tsx --config jest.config.cjs --runInBand --silent` *(fails: Unable to find a label with the text of: Width (Desktop))*

------
https://chatgpt.com/codex/tasks/task_e_68adbff0a3d8832fb40cde90bf4d4e16