### PR TITLE
fix(ui): align Tag variant classes and jest aliases

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -116,6 +116,10 @@ module.exports = {
       "<rootDir>/test/__mocks__/themeContextMock.tsx",
     "^@platform-core/contexts/CurrencyContext$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
+    "^@acme/platform-core/contexts/ThemeContext$":
+      "<rootDir>/test/__mocks__/themeContextMock.tsx",
+    "^@acme/platform-core/contexts/CurrencyContext$":
+      "<rootDir>/test/__mocks__/currencyContextMock.tsx",
 
     // email provider client mocks
     "^resend$": "<rootDir>/packages/email/src/providers/__mocks__/resend.ts",

--- a/packages/ui/src/components/atoms/Tag.js
+++ b/packages/ui/src/components/atoms/Tag.js
@@ -26,6 +26,6 @@ export const Tag = React.forwardRef(({ className, variant = "default", children,
         warning: "--color-warning-fg",
         destructive: "--color-danger-fg",
     };
-    return (_jsx("span", { ref: ref, "data-token": bgTokens[variant], className: cn("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium", bgClasses[variant], className), ...props, children: _jsx("span", { className: textClasses[variant], "data-token": textTokens[variant], children: children }) }));
+    return (_jsx("span", { ref: ref, "data-token": bgTokens[variant], "data-token-fg": textTokens[variant], className: cn("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium", bgClasses[variant], textClasses[variant], className), ...props, children: children }));
 });
 Tag.displayName = "Tag";

--- a/packages/ui/src/components/atoms/Tag.tsx
+++ b/packages/ui/src/components/atoms/Tag.tsx
@@ -35,16 +35,16 @@ export const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
       <span
         ref={ref}
         data-token={bgTokens[variant]}
+        data-token-fg={textTokens[variant]}
         className={cn(
           "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
           bgClasses[variant],
+          textClasses[variant],
           className
         )}
         {...props}
       >
-        <span className={textClasses[variant]} data-token={textTokens[variant]}>
-          {children}
-        </span>
+        {children}
       </span>
     );
   }


### PR DESCRIPTION
## Summary
- ensure Tag applies text color classes on its root element
- mock ThemeContext and CurrencyContext for @acme aliases in Jest config

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/Chip.test.tsx packages/ui/__tests__/CanvasItem.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adbffc460c832fbf5e94739d493c2d