### PR TITLE
test: stub initZod for jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -104,7 +104,7 @@ module.exports = {
       "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
     "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
-    "^@acme/zod-utils/initZod$": "<rootDir>/test/emptyModule.js",
+    "^@acme/zod-utils/initZod$": "<rootDir>/test/initZodStub.js",
 
     // CMS application aliases
     "^@/components/atoms/shadcn$":

--- a/test/initZodStub.js
+++ b/test/initZodStub.js
@@ -1,0 +1,4 @@
+// Jest stub for @acme/zod-utils/initZod
+module.exports = {
+  initZod: () => {},
+};


### PR DESCRIPTION
## Summary
- add a no-op initZod stub for tests
- map @acme/zod-utils/initZod to that stub in Jest config

## Testing
- `pnpm test:cms packages/template-app/__tests__/preview-route.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adc0291244832f8251c9a0ba92d6af