### PR TITLE
test: stub initZod in tests

### DIFF
--- a/test/emptyModule.js
+++ b/test/emptyModule.js
@@ -1,2 +1,14 @@
-/* Jest stub for type-only .d.ts imports */
-module.exports = {};
+/* Jest stub for type-only .d.ts imports.
+ *
+ * Some modules, such as `@acme/zod-utils/initZod`, are mapped to this file
+ * during tests.  Those modules expect an `initZod` function to exist, so we
+ * provide a no-op implementation here while still exporting an object for
+ * other generic stubs.
+ */
+
+module.exports = {
+  // Flag as an ES module so named imports work with Jest's ESM handling.
+  __esModule: true,
+  // Provide a noop function so calls like `initZod()` do not throw.
+  initZod: () => {},
+};


### PR DESCRIPTION
## Summary
- provide a noop initZod export for jest-mapped modules

## Testing
- `npx jest packages/platform-machine/__tests__/releaseDepositsService.test.ts packages/platform-machine/__tests__/lateFeeService.test.ts --runInBand --config jest.config.cjs` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68adc0354da0832f93971e092b25c38e