### PR TITLE
refactor: isolate email templates from UI

### DIFF
--- a/packages/email/src/send.js
+++ b/packages/email/src/send.js
@@ -6,7 +6,6 @@ import { SendgridProvider } from "./providers/sendgrid";
 import { ResendProvider } from "./providers/resend";
 import { ProviderError } from "./providers/types";
 import { hasProviderErrorFields } from "./providers/error";
-import { renderTemplate } from "./templates";
 function deriveText(html) {
     return html
         .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, "")
@@ -49,6 +48,7 @@ export async function sendCampaignEmail(options) {
     const { sanitize = true, ...rest } = options;
     let opts = { ...rest };
     if (opts.templateId) {
+        const { renderTemplate } = await import("./templates");
         opts.html = renderTemplate(opts.templateId, opts.variables ?? {});
     }
     if (sanitize && opts.html) {

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -7,7 +7,6 @@ import { ResendProvider } from "./providers/resend";
 import type { CampaignProvider } from "./providers/types";
 import { ProviderError } from "./providers/types";
 import { hasProviderErrorFields } from "./providers/error";
-import { renderTemplate } from "./templates";
 
 export interface CampaignOptions {
   /** Recipient email address */
@@ -78,6 +77,7 @@ export async function sendCampaignEmail(
   const { sanitize = true, ...rest } = options;
   let opts = { ...rest } as CampaignOptions;
   if (opts.templateId) {
+    const { renderTemplate } = await import("./templates");
     opts.html = renderTemplate(opts.templateId, opts.variables ?? {});
   }
   if (sanitize && opts.html) {

--- a/packages/email/src/templates.js
+++ b/packages/email/src/templates.js
@@ -1,6 +1,9 @@
 import "server-only";
 import * as React from "react";
-import { marketingEmailTemplates } from "@acme/ui";
+// Import the marketing email templates directly to avoid loading unrelated
+// components that depend on ESM-only modules (like @acme/auth) which Jest
+// cannot process in its CommonJS environment.
+import { marketingEmailTemplates } from "@acme/ui/components/templates";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 import { createRequire } from "module";

--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,6 +1,9 @@
 import "server-only";
 import * as React from "react";
-import { marketingEmailTemplates } from "@acme/ui";
+// Import only the email templates to avoid loading the entire UI library,
+// which pulls in components that rely on ESM-only modules and break under
+// Jest's CommonJS environment.
+import { marketingEmailTemplates } from "@acme/ui/components/templates";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 function renderToStaticMarkup(node: React.ReactNode): string {


### PR DESCRIPTION
## Summary
- import marketing email templates directly to avoid loading full UI package
- lazily import templates in campaign sender to prevent ESM issues during tests

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendgrid.test.ts`
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendInit.test.ts`
- `pnpm --filter @acme/email test packages/email/src/__tests__/segments.test.ts`
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendEmail.test.ts`
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendCampaignEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adc3d77e8c832fb793eaad8131dd65