### PR TITLE
Fix CurrencyContext Jest alias and test expectations

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -118,13 +118,13 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
 
     // context mocks
-    "^@platform-core/contexts/ThemeContext$":
+    "^@platform-core/contexts/ThemeContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/themeContextMock.tsx",
-    "^@platform-core/contexts/CurrencyContext$":
+    "^@platform-core/contexts/CurrencyContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
-    "^@acme/platform-core/contexts/ThemeContext$":
+    "^@acme/platform-core/contexts/ThemeContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/themeContextMock.tsx",
-    "^@acme/platform-core/contexts/CurrencyContext$":
+    "^@acme/platform-core/contexts/CurrencyContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
 
     // email provider client mocks

--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -125,7 +125,8 @@ describe("DynamicRenderer", () => {
 
     expect(screen.getByText("bar")).toBeInTheDocument();
     expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ foo: "bar" })
+      expect.objectContaining({ foo: "bar" }),
+      undefined
     );
 
     spy.mockRestore();


### PR DESCRIPTION
## Summary
- handle `.js`-suffixed context imports in Jest config so mocks resolve
- adjust DynamicRenderer runtimeData test to allow extra call argument

## Testing
- `pnpm -F @acme/ui test packages/ui/__tests__/DynamicRenderer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68adc71953e8832faa89f5be84480167