### PR TITLE
Fix CurrencyContext mock resolution and ComponentEditor tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -118,13 +118,13 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
 
     // context mocks
-    "^@platform-core/contexts/ThemeContext$":
+    "^@platform-core/contexts/ThemeContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/themeContextMock.tsx",
-    "^@platform-core/contexts/CurrencyContext$":
+    "^@platform-core/contexts/CurrencyContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
-    "^@acme/platform-core/contexts/ThemeContext$":
+    "^@acme/platform-core/contexts/ThemeContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/themeContextMock.tsx",
-    "^@acme/platform-core/contexts/CurrencyContext$":
+    "^@acme/platform-core/contexts/CurrencyContext(?:\\.js)?$":
       "<rootDir>/test/__mocks__/currencyContextMock.tsx",
 
     // email provider client mocks

--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -9,30 +9,31 @@ describe("ComponentEditor", () => {
       type: "Image",
     } as PageComponent;
     const onResize = jest.fn();
-    const { getByLabelText, getAllByText } = render(
+    const { getByLabelText, getAllByText, getByText } = render(
       <ComponentEditor
         component={component}
         onChange={() => {}}
         onResize={onResize}
       />
     );
-    fireEvent.change(getByLabelText("Width (Desktop)"), {
+    fireEvent.click(getByText("Layout"));
+    fireEvent.change(getByLabelText("Width (Desktop)", { exact: false }), {
       target: { value: "200" },
     });
     expect(onResize).toHaveBeenCalledWith({ widthDesktop: "200" });
     fireEvent.click(getAllByText("Full width")[0]);
     expect(onResize).toHaveBeenCalledWith({ widthDesktop: "100%" });
-    fireEvent.change(getByLabelText("Height (Desktop)"), {
+    fireEvent.change(getByLabelText("Height (Desktop)", { exact: false }), {
       target: { value: "300" },
     });
     expect(onResize).toHaveBeenCalledWith({ heightDesktop: "300" });
     fireEvent.click(getAllByText("Full height")[0]);
     expect(onResize).toHaveBeenCalledWith({ heightDesktop: "100%" });
-    fireEvent.change(getByLabelText("Margin (Desktop)"), {
+    fireEvent.change(getByLabelText("Margin (Desktop)", { exact: false }), {
       target: { value: "10px" },
     });
     expect(onResize).toHaveBeenCalledWith({ marginDesktop: "10px" });
-    fireEvent.change(getByLabelText("Padding (Desktop)"), {
+    fireEvent.change(getByLabelText("Padding (Desktop)", { exact: false }), {
       target: { value: "5px" },
     });
     expect(onResize).toHaveBeenCalledWith({ paddingDesktop: "5px" });
@@ -46,11 +47,16 @@ describe("ComponentEditor", () => {
       maxItems: 5,
     } as PageComponent;
     const onChange = jest.fn();
-    const { getByLabelText } = render(
+    const { getByLabelText, getByText } = render(
       <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
     );
-    fireEvent.change(getByLabelText("Min Items"), { target: { value: "2" } });
-    fireEvent.change(getByLabelText("Max Items"), { target: { value: "6" } });
+    fireEvent.click(getByText("Content"));
+    fireEvent.change(getByLabelText("Min Items", { exact: false }), {
+      target: { value: "2" },
+    });
+    fireEvent.change(getByLabelText("Max Items", { exact: false }), {
+      target: { value: "6" },
+    });
     expect(onChange).toHaveBeenCalledWith({ minItems: 2 });
     expect(onChange).toHaveBeenCalledWith({ maxItems: 6 });
   });
@@ -63,12 +69,17 @@ describe("ComponentEditor", () => {
       maxItems: 5,
     } as PageComponent;
     const onChange = jest.fn();
-    const { getByLabelText } = render(
+    const { getByLabelText, getByText } = render(
       <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
     );
-    fireEvent.change(getByLabelText("Min Items"), { target: { value: "6" } });
+    fireEvent.click(getByText("Content"));
+    fireEvent.change(getByLabelText("Min Items", { exact: false }), {
+      target: { value: "6" },
+    });
     expect(onChange).toHaveBeenNthCalledWith(1, { minItems: 6, maxItems: 6 });
-    fireEvent.change(getByLabelText("Max Items"), { target: { value: "0" } });
+    fireEvent.change(getByLabelText("Max Items", { exact: false }), {
+      target: { value: "0" },
+    });
     expect(onChange).toHaveBeenNthCalledWith(2, { maxItems: 0, minItems: 0 });
   });
 
@@ -77,15 +88,14 @@ describe("ComponentEditor", () => {
       id: "1",
       type: "Image",
     } as PageComponent;
-    const { findByPlaceholderText } = render(
+    const { findByPlaceholderText, getByText } = render(
       <ComponentEditor
         component={component}
         onChange={() => {}}
         onResize={() => {}}
       />
     );
-    await act(async () => {
-      expect(await findByPlaceholderText("src")).toBeInTheDocument();
-    });
+    fireEvent.click(getByText("Content"));
+    expect(await findByPlaceholderText("src")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- handle `@acme/platform-core` context mocks with optional `.js` extension so Jest resolves them
- expand accordion panels and use fuzzy label matching in ComponentEditor tests

## Testing
- `npx jest packages/ui/__tests__/ContentPanel.test.tsx packages/ui/__tests__/ComponentEditor.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68adc7405014832f9ca7c8a8f98994f3