### PR TITLE
test: mock heavy modules in shopPages404 to prevent timeout

### DIFF
--- a/apps/cms/__tests__/shopPages404.test.ts
+++ b/apps/cms/__tests__/shopPages404.test.ts
@@ -49,6 +49,19 @@ describe("CMS shop pages", () => {
         deleteMedia: jest.fn(),
       }));
 
+      // products page imports heavy server-only actions; mock them as well
+      jest.doMock("@cms/actions/products.server", () => ({
+        createDraft: jest.fn(),
+        deleteProduct: jest.fn(),
+        duplicateProduct: jest.fn(),
+      }));
+
+      // settings page imports auth options and shop actions; keep them light
+      jest.doMock("@cms/auth/options", () => ({}));
+      jest.doMock("@cms/actions/shops.server", () => ({
+        resetThemeOverride: jest.fn(),
+      }));
+
       // dynamic import of the page under test
       const mod = await import(route);
       const Page = mod.default as (args: {


### PR DESCRIPTION
## Summary
- mock product, shop, and auth server modules in CMS shop pages 404 test to avoid slow imports

## Testing
- `npx jest apps/cms/__tests__/shopPages404.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68add932c478832fa821d13f4bfaff23