### PR TITLE
fix: exclude damage code from coverage list

### DIFF
--- a/apps/shop-bcd/src/api/return/route.ts
+++ b/apps/shop-bcd/src/api/return/route.ts
@@ -45,11 +45,8 @@ export async function POST(req: NextRequest) {
   }
 
   const shop = await readShop("bcd");
-  let coverageCodes =
+  const coverageCodes =
     session.metadata?.coverage?.split(",").filter(Boolean) ?? [];
-  if (shop.coverageIncluded && typeof damage === "string") {
-    coverageCodes = Array.from(new Set([...coverageCodes, damage]));
-  }
   const damageFee = await computeDamageFee(
     damage,
     deposit,


### PR DESCRIPTION
## Summary
- avoid adding reported damage into coverage code list when computing return refunds

## Testing
- `npx jest apps/shop-bcd/__tests__/return-api.test.ts --runInBand --testTimeout=20000`

------
https://chatgpt.com/codex/tasks/task_e_68add9a63070832fb3d0ab6a92154207