### PR TITLE
fix: allow configurator CLI tests to mock child process

### DIFF
--- a/packages/configurator/src/index.ts
+++ b/packages/configurator/src/index.ts
@@ -1,5 +1,5 @@
 import { envSchema } from "@acme/config/env";
-import { spawnSync } from "child_process";
+import { spawnSync } from "node:child_process";
 
 try {
   envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- use `node:child_process` import so CLI tests mock spawnSync

## Testing
- `npx jest packages/configurator/__tests__/cli.test.ts`
- `pnpm lint --filter @acme/configurator`

------
https://chatgpt.com/codex/tasks/task_e_68add9d565b0832fb9b07c54431c84a3