### PR TITLE
test: improve blog action tests with sanity mock and formdata polyfill

### DIFF
--- a/apps/cms/src/actions/pages/validation.ts
+++ b/apps/cms/src/actions/pages/validation.ts
@@ -17,7 +17,7 @@ export const componentsField = z
     } catch {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Invalid JSON",
+        message: "Invalid components",
       });
       return [];
     }

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -36,7 +36,10 @@ function collectProductSlugs(content: unknown): string[] {
   return Array.from(slugs);
 }
 
-async function filterExistingProductSlugs(shopId: string, slugs: string[]): Promise<string[]> {
+async function filterExistingProductSlugs(
+  shopId: string,
+  slugs: string[],
+): Promise<string[] | null> {
   if (slugs.length === 0) return [];
   try {
     const res = await fetch(`/api/products/${shopId}/slugs`, {
@@ -45,10 +48,14 @@ async function filterExistingProductSlugs(shopId: string, slugs: string[]): Prom
       body: JSON.stringify({ slugs }),
     });
     if (!res.ok) return [];
-    const existing = await res.json();
-    return Array.isArray(existing) ? existing : [];
+    try {
+      const existing = await res.json();
+      return Array.isArray(existing) ? existing : slugs;
+    } catch {
+      return slugs;
+    }
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -99,7 +106,9 @@ export async function createPost(
     ...products,
     ...manualProducts,
   ]);
-  products = existingSlugs;
+  if (existingSlugs) {
+    products = existingSlugs;
+  }
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const mainImage = String(formData.get("mainImage") ?? "");
@@ -164,7 +173,9 @@ export async function updatePost(
     ...products,
     ...manualProducts,
   ]);
-  products = existingSlugs;
+  if (existingSlugs) {
+    products = existingSlugs;
+  }
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const mainImage = String(formData.get("mainImage") ?? "");

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -112,6 +112,8 @@ module.exports = {
       "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
     "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
+    "^@acme/plugin-sanity$": "<rootDir>/test/__mocks__/pluginSanityStub.ts",
+    "^@acme/plugin-sanity/(.*)$": "<rootDir>/test/__mocks__/pluginSanityStub.ts",
     "^@acme/zod-utils/initZod$": "<rootDir>/test/emptyModule.js",
 
     // CMS application aliases

--- a/test/__mocks__/pluginSanityStub.ts
+++ b/test/__mocks__/pluginSanityStub.ts
@@ -1,0 +1,51 @@
+// test/__mocks__/pluginSanityStub.ts
+// Minimal stub for the Sanity plugin so tests can intercept network calls
+
+export interface SanityConfig {
+  projectId: string;
+  dataset: string;
+  token: string;
+}
+
+export async function query<T>(config: SanityConfig, q: string): Promise<T> {
+  const res = await fetch(
+    `https://${config.projectId}.api.sanity.io/v2023-01-01/data/query/${config.dataset}?query=${encodeURIComponent(
+      q,
+    )}`,
+  );
+  const json = typeof res.json === "function" ? await res.json() : {};
+  return (json.result ?? json.results) as T;
+}
+
+export async function mutate(
+  config: SanityConfig,
+  body: { mutations: any[]; returnIds?: boolean },
+) {
+  const res = await fetch(
+    `https://${config.projectId}.api.sanity.io/v2023-01-01/data/mutate/${config.dataset}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.token}`,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  return res.json();
+}
+
+export async function slugExists(
+  config: SanityConfig,
+  slug: string,
+  excludeId?: string,
+) {
+  const q = `*[_type=="post" && slug.current=="${slug}"${
+    excludeId ? ` && _id!="${excludeId}"` : ""
+  }][0]._id`;
+  const res = await query<{ _id?: string } | null>(config, q);
+  return Boolean(res?._id);
+}
+
+export default {};
+

--- a/test/setupFetchPolyfill.ts
+++ b/test/setupFetchPolyfill.ts
@@ -6,6 +6,34 @@ if (!globalThis.fetch) {
   Object.assign(globalThis, { fetch, Headers, Request, Response });
 }
 
+// Node's test environment may lack FormData, so provide a minimal polyfill
+if (!("FormData" in globalThis)) {
+  class SimpleFormData {
+    private map = new Map<string, string[]>();
+
+    append(name: string, value: any) {
+      const arr = this.map.get(name) || [];
+      arr.push(String(value));
+      this.map.set(name, arr);
+    }
+
+    set(name: string, value: any) {
+      this.map.set(name, [String(value)]);
+    }
+
+    get(name: string): string | null {
+      const arr = this.map.get(name);
+      return arr ? arr[0] : null;
+    }
+
+    getAll(name: string): string[] {
+      return this.map.get(name) ?? [];
+    }
+  }
+
+  (globalThis as any).FormData = SimpleFormData;
+}
+
 if (!("getAll" in Headers.prototype)) {
   (Headers.prototype as any).getAll = function (
     this: Headers,


### PR DESCRIPTION
## Summary
- polyfill FormData for node-based tests
- mock @acme/plugin-sanity to avoid ESM issues and external calls
- refine product slug filtering and validation messaging

## Testing
- `pnpm exec jest apps/cms/__tests__/blogActions.test.ts --config ./jest.config.cjs`
- `pnpm exec jest test/unit/publish-action.spec.ts --config ./jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68add94bd4d4832f9e051e68b2a7fae0