### PR TITLE
Ensure theme tokens for SearchBar and expose script entry points

### DIFF
--- a/packages/ui/src/components/cms/blocks/SearchBar.tsx
+++ b/packages/ui/src/components/cms/blocks/SearchBar.tsx
@@ -69,6 +69,7 @@ export default function SearchBar({
       {results.length > 0 && (
         <ul
           className="bg-background absolute z-10 mt-1 w-full rounded-md border shadow"
+          data-token="--color-bg"
         >
           {results.map((r) => (
             <li
@@ -77,7 +78,7 @@ export default function SearchBar({
               className="text-fg hover:bg-accent hover:text-accent-foreground cursor-pointer px-3 py-1"
               data-token="--color-fg"
             >
-              {r.title}
+              <span>{r.title}</span>
             </li>
           ))}
         </ul>

--- a/scripts/diff-shadcn.ts
+++ b/scripts/diff-shadcn.ts
@@ -1,0 +1,1 @@
+import "./src/diff-shadcn";

--- a/scripts/migrate-cms.ts
+++ b/scripts/migrate-cms.ts
@@ -1,0 +1,1 @@
+import "./src/migrate-cms";

--- a/scripts/src/migrate-cms.ts
+++ b/scripts/src/migrate-cms.ts
@@ -3,14 +3,15 @@
  * Push page and shop schemas to a headless CMS.  This version closely follows
  * the original implementation from the base-shop repository, but uses a
  * simplified environment schema.  It reads JSON schema files from the
- * platform-core repositories and sends them to the CMS using the global
- * `fetch` API.  Any errors reading files or making HTTP requests are
+ * platform-core repositories and sends them to the CMS using the
+ * `cross-fetch` package.  Any errors reading files or making HTTP requests are
  * reported to stderr.
  */
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { CliEnvSchema } from "./types/env";
 import type { CliEnv } from "./types/env";
+import fetch from "cross-fetch";
 
 let env: CliEnv;
 try {


### PR DESCRIPTION
## Summary
- ensure SearchBar results carry fg/bg tokens
- expose diff-shadcn and migrate-cms scripts from `scripts/`
- migrate-cms uses `cross-fetch`

## Testing
- `npx jest packages/ui/__tests__/SearchBar.test.tsx test/unit/diff-shadcn.spec.ts test/unit/migrate-cms.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade2b0707c832fa25f9dc76be02b1d