### PR TITLE
fix ThemeToggle theme context import

### DIFF
--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DesktopIcon, MoonIcon, SunIcon } from "@radix-ui/react-icons";
-import { useTheme, Theme } from "@acme/platform-core/contexts/ThemeContext";
+import { useTheme, Theme } from "@platform-core/contexts/ThemeContext";
 import type { ComponentType, KeyboardEvent } from "react";
 
 const themes: Theme[] = ["base", "dark", "system"];


### PR DESCRIPTION
## Summary
- fix ThemeToggle to import ThemeContext from `@platform-core`

## Testing
- `pnpm exec jest packages/ui/__tests__/ThemeToggle.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ade399b854832fbe1876ba016e453c