### PR TITLE
fix email provider config from env

### DIFF
--- a/packages/email/src/config.ts
+++ b/packages/email/src/config.ts
@@ -4,7 +4,15 @@ import { z } from "zod";
 const emailSchema = z.string().email();
 
 export function getDefaultSender(): string {
-  const sender = coreEnv.CAMPAIGN_FROM || coreEnv.GMAIL_USER;
+  // Prefer reading directly from process.env to allow tests or runtime code
+  // to set environment variables after the initial configuration module has
+  // been imported. Falling back to values from `coreEnv` preserves the existing
+  // behaviour when variables are static.
+  const sender =
+    process.env.CAMPAIGN_FROM ||
+    process.env.GMAIL_USER ||
+    coreEnv.CAMPAIGN_FROM ||
+    coreEnv.GMAIL_USER;
   if (!sender) {
     throw new Error(
       "Default sender email is required. Set CAMPAIGN_FROM or GMAIL_USER."

--- a/packages/email/src/providers/resend.ts
+++ b/packages/email/src/providers/resend.ts
@@ -14,6 +14,8 @@ import {
 } from "../stats";
 import { getDefaultSender } from "../config";
 
+const apiKey = process.env.RESEND_API_KEY || coreEnv.RESEND_API_KEY;
+
 interface ProviderOptions {
   /**
     * When true, perform a lightweight API request to verify credentials. The
@@ -29,13 +31,13 @@ export class ResendProvider implements CampaignProvider {
   readonly ready: Promise<void>;
 
   constructor(options: ProviderOptions = {}) {
-    if (coreEnv.RESEND_API_KEY) {
-      this.client = new Resend(coreEnv.RESEND_API_KEY);
+    if (apiKey) {
+      this.client = new Resend(apiKey);
 
       if (options.sanityCheck) {
         this.ready = fetch("https://api.resend.com/domains", {
           headers: {
-            Authorization: `Bearer ${coreEnv.RESEND_API_KEY}`,
+            Authorization: `Bearer ${apiKey}`,
           },
         }).then((res) => {
           if (!res.ok) {
@@ -88,11 +90,11 @@ export class ResendProvider implements CampaignProvider {
   }
 
   async getCampaignStats(id: string): Promise<CampaignStats> {
-    if (!coreEnv.RESEND_API_KEY) return mapResendStats({});
+    if (!apiKey) return mapResendStats({});
     try {
       const res = await fetch(`https://api.resend.com/campaigns/${id}/stats`, {
         headers: {
-          Authorization: `Bearer ${coreEnv.RESEND_API_KEY}`,
+          Authorization: `Bearer ${apiKey}`,
         },
       });
       const json: ResendStatsResponse = await res
@@ -105,12 +107,12 @@ export class ResendProvider implements CampaignProvider {
   }
 
   async createContact(email: string): Promise<string> {
-    if (!coreEnv.RESEND_API_KEY) return "";
+    if (!apiKey) return "";
     try {
       const res = await fetch("https://api.resend.com/contacts", {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${coreEnv.RESEND_API_KEY}`,
+          Authorization: `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ email }),
@@ -123,11 +125,11 @@ export class ResendProvider implements CampaignProvider {
   }
 
   async addToList(contactId: string, listId: string): Promise<void> {
-    if (!coreEnv.RESEND_API_KEY) return;
+    if (!apiKey) return;
     await fetch(`https://api.resend.com/segments/${listId}/contacts`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${coreEnv.RESEND_API_KEY}`,
+        Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ contact_id: contactId }),
@@ -135,10 +137,10 @@ export class ResendProvider implements CampaignProvider {
   }
 
   async listSegments(): Promise<{ id: string; name?: string }[]> {
-    if (!coreEnv.RESEND_API_KEY) return [];
+    if (!apiKey) return [];
     try {
       const res = await fetch("https://api.resend.com/segments", {
-        headers: { Authorization: `Bearer ${coreEnv.RESEND_API_KEY}` },
+        headers: { Authorization: `Bearer ${apiKey}` },
       });
       const json: {
         data?: ResendSegment[];

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -11,6 +11,10 @@ import {
 } from "../stats";
 import { getDefaultSender } from "../config";
 
+const apiKey = process.env.SENDGRID_API_KEY || coreEnv.SENDGRID_API_KEY;
+const marketingKey =
+  process.env.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_MARKETING_KEY;
+
 interface ProviderOptions {
   /**
    * When true, the constructor will make a lightweight API request to verify
@@ -30,14 +34,14 @@ export class SendgridProvider implements CampaignProvider {
   readonly ready: Promise<void>;
 
   constructor(options: ProviderOptions = {}) {
-    if (coreEnv.SENDGRID_API_KEY) {
-      sgMail.setApiKey(coreEnv.SENDGRID_API_KEY);
+    if (apiKey) {
+      sgMail.setApiKey(apiKey);
     }
 
-    if (options.sanityCheck && coreEnv.SENDGRID_API_KEY) {
+    if (options.sanityCheck && apiKey) {
       this.ready = fetch("https://api.sendgrid.com/v3/user/profile", {
         headers: {
-          Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+          Authorization: `Bearer ${apiKey}`,
         },
       }).then((res) => {
         if (!res.ok) {
@@ -84,13 +88,13 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async getCampaignStats(id: string): Promise<CampaignStats> {
-    if (!coreEnv.SENDGRID_API_KEY) return mapSendGridStats({});
+    if (!apiKey) return mapSendGridStats({});
     try {
       const res = await fetch(
         `https://api.sendgrid.com/v3/campaigns/${id}/stats`,
         {
           headers: {
-            Authorization: `Bearer ${coreEnv.SENDGRID_API_KEY}`,
+            Authorization: `Bearer ${apiKey}`,
           },
         }
       );
@@ -104,7 +108,7 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async createContact(email: string): Promise<string> {
-    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    const key = marketingKey || apiKey;
     if (!key) return "";
     try {
       const res = await fetch("https://api.sendgrid.com/v3/marketing/contacts", {
@@ -124,7 +128,7 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async addToList(contactId: string, listId: string): Promise<void> {
-    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    const key = marketingKey || apiKey;
     if (!key) return;
     await fetch(`https://api.sendgrid.com/v3/marketing/lists/${listId}/contacts`, {
       method: "PUT",
@@ -137,7 +141,7 @@ export class SendgridProvider implements CampaignProvider {
   }
 
   async listSegments(): Promise<{ id: string; name?: string }[]> {
-    const key = coreEnv.SENDGRID_MARKETING_KEY || coreEnv.SENDGRID_API_KEY;
+    const key = marketingKey || apiKey;
     if (!key) return [];
     try {
       const res = await fetch("https://api.sendgrid.com/v3/marketing/segments", {

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -58,7 +58,12 @@ const providers: Record<string, CampaignProvider> = {
 
 const availableProviders = [...Object.keys(providers), "smtp"];
 
-const providerName = coreEnv.EMAIL_PROVIDER ?? "smtp";
+// Read provider preference directly from `process.env` first so tests or
+// runtime code that mutate environment variables after the config module has
+// loaded can still influence the chosen provider. Fall back to the value
+// parsed in `coreEnv` for normal runtime behaviour.
+const providerName =
+  process.env.EMAIL_PROVIDER || coreEnv.EMAIL_PROVIDER || "smtp";
 if (!availableProviders.includes(providerName)) {
   throw new Error(
     `Unsupported EMAIL_PROVIDER "${providerName}". Available providers: ${availableProviders.join(", ")}`


### PR DESCRIPTION
## Summary
- allow email defaults to read from process.env at runtime
- respect EMAIL_PROVIDER and provider API keys from environment variables

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendCampaignEmail.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ade2bb8f9c832f8abe466d97258c66