### PR TITLE
fix GiftCardBlock test to mock currency correctly

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import GiftCardBlock from "../GiftCardBlock";
 
-jest.mock("@platform-core/components/shop/AddToCartButton.client", () => ({
+jest.mock("@acme/platform-core/components/shop/AddToCartButton.client", () => ({
   __esModule: true,
   default: () => <button>Purchase</button>,
 }));
-jest.mock("@platform-core/contexts/CurrencyContext", () => ({
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
   useCurrency: () => ["USD", jest.fn()],
 }));
 


### PR DESCRIPTION
## Summary
- ensure GiftCardBlock test mocks currency context via the `@acme` path

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ade43a3548832f83acd9f5bc3f8e43