### PR TITLE
Ensure page-draft API returns validation errors for malformed components

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -121,13 +121,13 @@ export async function savePageDraft(
   const id = (formData.get("id") as string) || ulid();
   const compStr = formData.get("components");
   let components: PageComponents;
-  try {
-    components = componentsField.parse(
-      typeof compStr === "string" ? compStr : undefined
-    );
-  } catch {
+  const parsedComponents = componentsField.safeParse(
+    typeof compStr === "string" ? compStr : undefined
+  );
+  if (!parsedComponents.success) {
     return { errors: { components: ["Invalid components"] } };
   }
+  components = parsedComponents.data;
 
   let history = undefined;
   const historyStr = formData.get("history");


### PR DESCRIPTION
## Summary
- use safe Zod parsing for page draft components and return structured error when invalid

## Testing
- `pnpm test:cms apps/cms/__tests__/pages.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade1e462ec832f85370ec2b1f424dd