### PR TITLE
Fix page history and build-tokens CLI detection

### DIFF
--- a/apps/cms/__tests__/pages.test.ts
+++ b/apps/cms/__tests__/pages.test.ts
@@ -118,6 +118,7 @@ describe("page actions", () => {
         past: [],
         present: [{ id: "c1", type: "HeroBanner" }],
         future: [],
+        gridCols: 12,
       };
       const fd = new FormData();
       fd.append("id", page.id);

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -1,7 +1,13 @@
 // /scripts/build-tokens.ts
  
 
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,6 +33,10 @@ const tokensPath = path.resolve(
   "tokens.js"
 );
 const { tokens } = require(tokensPath) as { tokens: TokenMap };
+
+const isDirectRun =
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === realpathSync(__filename);
 
 /* -------------------------------------------------------------------------- */
 /*  Base theme                                                                */
@@ -90,7 +100,7 @@ export function generateDynamicCss(map: TokenMap): string {
   return css;
 }
 
-if (process.argv[1] === __filename) {
+if (isDirectRun) {
   const baseDir = path.resolve(
     __dirname,
   "..",
@@ -145,7 +155,7 @@ export function generateThemeCss(map: Record<string, string>): string {
   return css;
 }
 
-if (process.argv[1] === __filename) {
+if (isDirectRun) {
   async function buildThemeCss(): Promise<void> {
     const themesDir = path.resolve(__dirname, "..", "packages", "themes");
     const themes = readdirSync(themesDir, { withFileTypes: true })


### PR DESCRIPTION
## Summary
- account for grid column state in page history tests
- robustly detect direct execution in build-tokens script to handle symlinks

## Testing
- `pnpm jest apps/cms/__tests__/pages.test.ts --testTimeout=30000`
- `pnpm jest test/integration/build-tokens.integration.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade2732988832f938bd0954a4860a7