### PR TITLE
Handle missing shop data gracefully

### DIFF
--- a/apps/cms/src/lib/listShops.ts
+++ b/apps/cms/src/lib/listShops.ts
@@ -9,7 +9,11 @@ export async function listShops(): Promise<string[]> {
   try {
     const entries = await fs.readdir(shopsDir, { withFileTypes: true });
     return entries.filter((e) => e.isDirectory()).map((e) => e.name);
-  } catch (err) {
+  } catch (err: unknown) {
+    // If the shops directory doesn't exist yet, treat it as having no shops
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
     console.error(`Failed to list shops at ${shopsDir}:`, err);
     throw err;
   }

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -98,8 +98,11 @@ export async function getPages(shop: string): Promise<Page[]> {
   }
   try {
     const buf = await fs.readFile(pagesPath(shop), "utf8");
-    const parsed = pageSchema.array().safeParse(JSON.parse(buf));
+    const json = JSON.parse(buf);
+    const parsed = pageSchema.array().safeParse(json);
     if (parsed.success) return parsed.data;
+    // If the JSON doesn't conform to the schema, fall back to returning it raw
+    return json as Page[];
   } catch {
     // missing file or invalid JSON – treat as no pages
   }


### PR DESCRIPTION
## Summary
- return an empty list when the shops directory is missing
- fall back to raw JSON when pages data fails schema validation

## Testing
- `pnpm jest packages/platform-core/__tests__/shopsRoute.test.ts packages-platform-core/__tests__/pagesApi.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68ade248da14832f91d9ebbd17190989