### PR TITLE
fix: allow mocking publish locations fs

### DIFF
--- a/apps/cms/src/app/api/publish-locations/route.ts
+++ b/apps/cms/src/app/api/publish-locations/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { promises as fs } from "fs";
+import { promises as fs } from "node:fs";
 import { join } from "path";
 
 export async function GET() {


### PR DESCRIPTION
## Summary
- use node:fs in publish-locations route so tests can mock file reads

## Testing
- `pnpm --filter @apps/cms test __tests__/api.create-shop.test.ts`
- `pnpm --filter @apps/cms test` *(fails: Could not locate module @/components/atoms, others)*

------
https://chatgpt.com/codex/tasks/task_e_68ade209959c832f90af130f5c5b04a7