### PR TITLE
Read analytics events from filesystem and make validate-env script CommonJS

### DIFF
--- a/dist-scripts/package.json
+++ b/dist-scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/dist-scripts/validate-env.js
+++ b/dist-scripts/validate-env.js
@@ -1,7 +1,9 @@
-import { envSchema } from "@config/src/env";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { ZodError } from "zod";
+// CommonJS build to ensure compatibility with Jest's runtime.
+const { envSchema } = require("@config/src/env");
+const { existsSync, readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { ZodError } = require("zod");
+
 const shopId = process.argv[2];
 if (!shopId) {
     console.error("Usage: pnpm validate-env <shopId>");

--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -4,8 +4,43 @@ import { DATA_ROOT } from "../dataRoot";
 import { validateShopName } from "../shops";
 import type { AnalyticsAggregates } from "../analytics";
 
+/**
+ * Read analytics events from newline-delimited JSON files. When a shop is
+ * provided only that shop's log is read, otherwise the logs for all shops are
+ * concatenated. Missing files or invalid JSON lines are ignored so callers do
+ * not need to handle errors.
+ */
 export async function listEvents(_shop?: string) {
-  return [] as any[];
+  const shops = _shop
+    ? [validateShopName(_shop)]
+    : await fs
+        .readdir(DATA_ROOT, { withFileTypes: true })
+        .then((entries) =>
+          entries.filter((e) => e.isDirectory()).map((e) => e.name)
+        )
+        .catch(() => []);
+
+  const events: any[] = [];
+  for (const shop of shops) {
+    const file = path.join(DATA_ROOT, shop, "analytics.jsonl");
+    let data = "";
+    try {
+      data = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of data.split(/\n+/)) {
+      const trimmed = line.trim();
+      if (!trimmed)
+        continue;
+      try {
+        events.push(JSON.parse(trimmed));
+      } catch {
+        // ignore malformed lines
+      }
+    }
+  }
+  return events;
 }
 
 export async function readAggregates(


### PR DESCRIPTION
## Summary
- read analytics events from newline-delimited files to support marketing segment resolution
- run validate-env script under Jest by converting to CommonJS and marking dist-scripts as CJS

## Testing
- `npx jest scripts/__tests__/validate-env.test.ts`
- `npx jest apps/cms/__tests__/marketingEmailApi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade25545b4832f8fe440f32dfe7664