### PR TITLE
fix(pricing): ensure fs module can be mocked

### DIFF
--- a/packages/platform-core/src/pricing.ts
+++ b/packages/platform-core/src/pricing.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { PricingMatrix, SKU } from "@acme/types";
 import { coverageCodeSchema, pricingSchema } from "@acme/types";
-import { promises as fs } from "fs";
+import { promises as fs } from "node:fs";
 import * as path from "path";
 import { resolveDataRoot } from "./dataRoot";
 


### PR DESCRIPTION
## Summary
- import fs from `node:fs` so jest mocks work in pricing utilities

## Testing
- `pnpm exec jest packages/platform-core/__tests__/pricing.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade27dda28832fb0894faf8726e4e0