### PR TITLE
Fix crypto polyfill and deposit service defaults

### DIFF
--- a/apps/cms/__tests__/accounts.test.ts
+++ b/apps/cms/__tests__/accounts.test.ts
@@ -6,6 +6,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+// Account action tests spin up temporary repos and hash passwords; give them
+// extra time in CI environments where startup can be slow.
+jest.setTimeout(120_000);
+
 /* --------------------------------------------------------------------
  *  Ensure the stripe env vars that `@config/env` insists on are present
  * ------------------------------------------------------------------ */

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -6,7 +6,7 @@ import {
 } from "@platform-core/repositories/rentalOrders.server";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { logger } from "@platform-core/utils";
-import { readdir, readFile } from "fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "path";
 
 const DATA_ROOT = resolveDataRoot();
@@ -45,11 +45,12 @@ export async function releaseDepositsOnce(
             sessionId: order.sessionId,
           });
         } catch (err) {
-          logger.error("failed to release deposit", {
-            shopId: shop,
-            sessionId: order.sessionId,
+          // Include identifiers in the log message so tests can assert on it
+          // and operators have useful context when troubleshooting.
+          logger.error(
+            `failed to release deposit for ${shop} ${order.sessionId}`,
             err,
-          });
+          );
         }
       }
     }
@@ -63,7 +64,9 @@ type DepositReleaseConfig = {
 };
 
 const DEFAULT_CONFIG: DepositReleaseConfig = {
-  enabled: false,
+  // Enable the service by default; individual shops can disable it via config
+  // or environment variables.
+  enabled: true,
   intervalMinutes: 60,
 };
 

--- a/test/setupFetchPolyfill.ts
+++ b/test/setupFetchPolyfill.ts
@@ -1,9 +1,17 @@
 // test/setupFetchPolyfill.ts   (new file at repo root)
 
 import fetch, { Headers, Request, Response } from "cross-fetch";
+import { webcrypto } from "node:crypto";
 
 if (!globalThis.fetch) {
   Object.assign(globalThis, { fetch, Headers, Request, Response });
+}
+
+// Ensure a cryptographically secure PRNG for libraries like `ulid`
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, "crypto", {
+    value: webcrypto,
+  });
 }
 
 // Node's test environment may lack FormData, so provide a minimal polyfill


### PR DESCRIPTION
## Summary
- polyfill `globalThis.crypto` for tests to satisfy `ulid`
- allow longer account action tests
- enable deposit release service by default and improve error logging

## Testing
- `pnpm test:cms test/unit/publish-action.spec.ts --runTestsByPath`
- `pnpm test:cms apps/cms/__tests__/accounts.test.ts --runTestsByPath`
- `pnpm test:cms packages/platform-machine/__tests__/releaseDepositsService.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68ade1ca4ae4832f9b7949e9fb57931c