### PR TITLE
fix postcss configs and campaign analytics lookup

### DIFF
--- a/apps/api/postcss.config.cjs
+++ b/apps/api/postcss.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require("../../postcss.config.cjs");

--- a/apps/dashboard/postcss.config.cjs
+++ b/apps/dashboard/postcss.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require("../../postcss.config.cjs");

--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -35,8 +35,12 @@ export async function emitClick(shop: string, payload: HookPayload): Promise<voi
   await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
 }
 
+let analyticsMod: Promise<typeof import("@platform-core/analytics")> | null = null;
 async function track(shop: string, data: AnalyticsEvent): Promise<void> {
-  const { trackEvent } = await import("@platform-core/analytics");
+  if (!analyticsMod) {
+    analyticsMod = import("@platform-core/analytics");
+  }
+  const { trackEvent } = await analyticsMod;
   await trackEvent(shop, data);
 }
 

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -50,7 +50,7 @@ async function filterUnsubscribed(
   shop: string,
   recipients: string[],
 ): Promise<string[]> {
-  const events: AnalyticsEvent[] = await listEvents().catch(
+  const events: AnalyticsEvent[] = await listEvents(shop).catch(
     (): AnalyticsEvent[] => [],
   );
   const unsub = new Set(


### PR DESCRIPTION
## Summary
- add root postcss config loader for api and dashboard apps
- resolve email segments from analytics events and cache analytics import
- read analytics event log per shop

## Testing
- `pnpm exec jest test/unit/postcss-config.spec.ts packages/email/src/__tests__/campaign-integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade29b2804832fa27c8760d7d96739