### PR TITLE
test: run rental order tests in node env

### DIFF
--- a/packages/platform-core/__tests__/rentalOrders.test.ts
+++ b/packages/platform-core/__tests__/rentalOrders.test.ts
@@ -1,3 +1,5 @@
+/** @jest-environment node */
+
 jest.mock("../src/analytics", () => ({ trackOrder: jest.fn() }));
 import * as repo from "../src/repositories/rentalOrders.server";
 import { getOrdersForCustomer } from "../src/orders";


### PR DESCRIPTION
## Summary
- ensure rental order repository tests run in a Node environment so Prisma can operate

## Testing
- `pnpm exec jest packages/platform-core/__tests__/rentalOrders.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ade73091f4832fa32e5b22697d3f2e