### PR TITLE
Fix FilterBar uncontrolled values causing test hang

### DIFF
--- a/packages/platform-core/src/components/shop/FilterBar.tsx
+++ b/packages/platform-core/src/components/shop/FilterBar.tsx
@@ -22,16 +22,16 @@ export interface FilterBarProps {
 
 export default function FilterBar({
   definitions,
-  values: externalValues = {},
+  values: externalValues,
   onChange,
 }: FilterBarProps) {
-  const [values, setValues] = useState<Filters>(externalValues);
+  const [values, setValues] = useState<Filters>(externalValues ?? {});
   const deferred = useDeferredValue(values);
 
   // Keep internal state in sync when parent updates its values (e.g. after a
   // reload where values are read from the URL).
   useEffect(() => {
-    setValues(externalValues);
+    setValues(externalValues ?? {});
   }, [externalValues]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stabilize FilterBar's internal state when no `values` prop is provided
- prevent infinite re-render loops that caused tests to hang

## Testing
- `npx jest packages/platform-core/__tests__/filterBar.test.tsx --runInBand --config ./jest.config.cjs`
- `pnpm exec eslint packages/platform-core/src/components/shop/FilterBar.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ade7c73964832fb33df371c0041d9c