### PR TITLE
Fix cart API and enable AI catalog defaults

### DIFF
--- a/packages/platform-core/src/pricing/index.ts
+++ b/packages/platform-core/src/pricing/index.ts
@@ -4,7 +4,7 @@ import type { PricingMatrix, SKU } from "@acme/types";
 import { coverageCodeSchema, pricingSchema } from "@acme/types";
 import { promises as fs } from "node:fs";
 import * as path from "path";
-import { resolveDataRoot } from "./dataRoot";
+import { resolveDataRoot } from "../dataRoot";
 
 let cached: PricingMatrix | null = null;
 let rateCache: { base: string; rates: Record<string, number> } | null = null;

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -88,7 +88,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
         seo: {
           ...(parsed.data.seo ?? {}),
           aiCatalog: {
-            enabled: false,
+            enabled: true,
             fields: ["id", "title", "description", "price", "media"],
             pageSize: 50,
             ...((parsed.data.seo ?? {}).aiCatalog ?? {}),
@@ -103,7 +103,7 @@ export async function getShopSettings(shop: string): Promise<ShopSettings> {
     languages: DEFAULT_LANGUAGES,
     seo: {
       aiCatalog: {
-        enabled: false,
+        enabled: true,
         fields: ["id", "title", "description", "price", "media"],
         pageSize: 50,
       },

--- a/packages/platform-core/src/schemas/cart.ts
+++ b/packages/platform-core/src/schemas/cart.ts
@@ -1,9 +1,8 @@
 import { z } from "zod";
-import { skuSchema } from "@acme/types";
 
 export const postSchema = z
   .object({
-    sku: skuSchema.pick({ id: true }),
+    sku: z.object({ id: z.string() }),
     qty: z.coerce.number().int().min(1).default(1),
     // Optional size for SKUs that require it. Ensure non-empty when provided.
     size: z.string().min(1).optional(),

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -4,7 +4,7 @@ import {
   decodeCartCookie,
   type CartState,
 } from "@platform-core/cartCookie";
-import { createCartStore } from "@platform-core/cartStore";
+import { getCart } from "@platform-core/cartStore";
 import {
   convertCurrency,
   getPricing,
@@ -20,8 +20,7 @@ export const runtime = "edge";
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
   const cartId = decodeCartCookie(rawCookie);
-  const cartStore = createCartStore();
-  const cart = cartId ? ((await cartStore.getCart(cartId)) as CartState) : {};
+  const cart = cartId ? ((await getCart(cartId)) as CartState) : {};
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { getProductById } from "@platform-core/products";
+import { getProductById, PRODUCTS } from "@platform-core/products";
 import { readRepo } from "@platform-core/repositories/products.server";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import { trackEvent } from "@platform-core/analytics";
@@ -26,7 +26,22 @@ export async function GET(req: NextRequest) {
     return new NextResponse(null, { status: 404 });
   }
   const fields = (ai.fields?.length ? ai.fields : DEFAULT_FIELDS) as Field[];
-  const all = await readRepo<ProductPublication>(shop);
+  const publications = await readRepo<ProductPublication>(shop);
+  const all =
+    publications.length > 0
+      ? publications
+      : PRODUCTS.map(
+          (p) =>
+            ({
+              id: p.id,
+              sku: p.id,
+              title: p.title,
+              description: p.description,
+              price: p.price,
+              media: p.media,
+              updated_at: new Date(0).toISOString(),
+            }) as ProductPublication
+        );
 
   const lastModifiedDate = all.reduce((max, p) => {
     const d = p.updated_at ? new Date(p.updated_at) : new Date(0);


### PR DESCRIPTION
## Summary
- ensure platform-core PRODUCTS contain real catalogue data and expose pricing utilities
- refactor cart API and checkout session to use shared cart store
- enable AI catalog by default and provide static fallback

## Testing
- `pnpm jest packages/template-app/__tests__/checkout-session.test.ts packages/template-app/__tests__/cart.test.ts packages/template-app/__tests__/ai-catalog.test.ts --runInBand`
- `pnpm jest packages/platform-core/__tests__` *(fails: stock alerts & other suites timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68ade726d2ec832f93e9092329821848