### PR TITLE
test: mock currency context with acme alias

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx
@@ -4,7 +4,7 @@ import type { SKU } from "@acme/types";
 import "@testing-library/jest-dom";
 import "../../../../../../test/resetNextMocks";
 
-jest.mock("@platform-core/contexts/CurrencyContext", () => ({
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
   useCurrency: () => ["USD", jest.fn()],
 }));
 


### PR DESCRIPTION
## Summary
- mock @acme currency context in ProductCard tests so USD formatting is used

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/ProductCard.test.tsx`
- `pnpm --filter @acme/ui test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68ade4436250832fa40cc08fe657369b