### PR TITLE
fix: log error meta when releasing deposits

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -49,7 +49,7 @@ export async function releaseDepositsOnce(
           // and operators have useful context when troubleshooting.
           logger.error(
             `failed to release deposit for ${shop} ${order.sessionId}`,
-            err,
+            { err },
           );
         }
       }


### PR DESCRIPTION
## Summary
- ensure releaseDepositsService logs errors using structured metadata

## Testing
- `npx tsc -b packages/platform-machine` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `npx tsc -b packages/lib` *(fails: Module '@prisma/client' has no exported member 'Prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68adeca86a10832fb1b3bcd6035068e8