### PR TITLE
fix: resolve config module for scripts build

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -33,7 +33,9 @@
       "@acme/types/*": [
         "packages/types/src/*",
         "packages/types/src/*/index.ts"
-      ]
+      ],
+      "@config/src/env": ["packages/config/src/env/index.ts"],
+      "@config/src/*": ["packages/config/src/*"]
     },
 
     /* ───── keep imports extension-less ───── */


### PR DESCRIPTION
## Summary
- add path alias so scripts can import config env schema

## Testing
- `npx tsc -b scripts`
- `npx tsc -b src`
- `npx jest scripts/__tests__/setup-ci.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aded41abec832fbc65afc7528dfd55