### PR TITLE
fix: add missing TS path aliases

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -18,6 +18,10 @@
     "paths": {
       "@acme/platform-core": ["../platform-core/src/index"],
       "@acme/platform-core/*": ["../platform-core/src/*"],
+      "@platform-core": ["../platform-core/src/index"],
+      "@platform-core/*": ["../platform-core/src/*"],
+      "@ui": ["./src/index"],
+      "@ui/*": ["./src/*"],
       "@acme/types": ["../types/src/index"],
       "@acme/types/*": ["../types/src/*"],
       "@auth": ["types-compat/auth"]


### PR DESCRIPTION
## Summary
- add `@ui` and `@platform-core` path aliases to UI package tsconfig

## Testing
- `npx tsc -b packages/ui`
- `npx tsc -b packages/auth`
- `npx tsc -b packages/configurator`


------
https://chatgpt.com/codex/tasks/task_e_68adece33c98832f99f890b4647eea0b