### PR TITLE
fix: allow deposit service fs mocking

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -6,7 +6,7 @@ import {
 } from "@platform-core/repositories/rentalOrders.server";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { logger } from "@platform-core/utils";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile } from "fs/promises";
 import { join } from "path";
 
 const DATA_ROOT = resolveDataRoot();


### PR DESCRIPTION
## Summary
- use `fs/promises` in `releaseDepositsService` so tests can mock `readdir`

## Testing
- `pnpm exec jest packages/platform-machine/__tests__/depositService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf1a42ee4832fba033406bd59304a