### PR TITLE
Fix FormData parsing and deposit release logging

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -43,9 +43,7 @@ export async function createPage(
       : ulid();
 
   const parsed = createSchema.safeParse(
-    Object.fromEntries(
-      formData as unknown as Iterable<[string, FormDataEntryValue]>
-    )
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     const context = { shop, id };
@@ -186,9 +184,7 @@ export async function updatePage(
   await ensureAuthorized();
 
   const parsed = updateSchema.safeParse(
-    Object.fromEntries(
-      formData as unknown as Iterable<[string, FormDataEntryValue]>
-    )
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     const context = { shop, id: formData.get("id") || undefined };

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -84,9 +84,9 @@ export async function updateProduct(
   "use server";
   await ensureAuthorized();
 
-  // Node's FormData type doesn't declare `entries`, but the object itself is
-  // iterable. Casting to `any` lets us collect key/value pairs safely.
-  const formEntries = Object.fromEntries(formData as any);
+  // Collect key/value pairs from the incoming form data. Node's FormData
+  // provides an `entries()` iterator for this purpose.
+  const formEntries = Object.fromEntries(formData.entries());
   const locales = await getLocales(shop);
   const title: Record<Locale, string> = {} as Record<Locale, string>;
   const description: Record<Locale, string> = {} as Record<Locale, string>;

--- a/apps/cms/src/services/shops/validation.ts
+++ b/apps/cms/src/services/shops/validation.ts
@@ -21,9 +21,7 @@ export function parseShopForm(formData: FormData): {
   const themeDefaultsRaw = formData.get("themeDefaults") as string | null;
   const themeOverridesRaw = formData.get("themeOverrides") as string | null;
 
-  const entries = Array.from(
-    formData as unknown as Iterable<[string, FormDataEntryValue]>
-  ).filter(
+  const entries = Array.from(formData.entries()).filter(
     ([k]) =>
       ![
         "filterMappingsKey",
@@ -70,9 +68,7 @@ export function parseSeoForm(formData: FormData): {
   errors?: Record<string, string[]>;
 } {
   const parsed = seoSchema.safeParse(
-    Object.fromEntries(
-      formData as unknown as Iterable<[string, FormDataEntryValue]>
-    )
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
@@ -94,9 +90,7 @@ export function parseGenerateSeoForm(formData: FormData): {
   errors?: Record<string, string[]>;
 } {
   const parsed = generateSchema.safeParse(
-    Object.fromEntries(
-      formData as unknown as Iterable<[string, FormDataEntryValue]>
-    )
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
@@ -116,7 +110,7 @@ export function parseCurrencyTaxForm(formData: FormData): {
   errors?: Record<string, string[]>;
 } {
   const parsed = currencyTaxSchema.safeParse(
-    Object.fromEntries(formData as unknown as Iterable<[string, FormDataEntryValue]>)
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
@@ -136,7 +130,7 @@ export function parseDepositForm(formData: FormData): {
   errors?: Record<string, string[]>;
 } {
   const parsed = depositSchema.safeParse(
-    Object.fromEntries(formData as unknown as Iterable<[string, FormDataEntryValue]>)
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
@@ -156,7 +150,7 @@ export function parseReverseLogisticsForm(formData: FormData): {
   errors?: Record<string, string[]>;
 } {
   const parsed = reverseLogisticsSchema.safeParse(
-    Object.fromEntries(formData as unknown as Iterable<[string, FormDataEntryValue]>)
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
@@ -181,7 +175,7 @@ export function parseUpsReturnsForm(formData: FormData): {
   errors?: Record<string, string[]>;
 } {
   const parsed = returnsSchema.safeParse(
-    Object.fromEntries(formData as unknown as Iterable<[string, FormDataEntryValue]>)
+    Object.fromEntries(formData.entries())
   );
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -51,6 +51,12 @@ export async function releaseDepositsOnce(
             `failed to release deposit for ${shop} ${order.sessionId}`,
             { err },
           );
+          // Also log via console.error so tests and simple environments can
+          // detect failures without pino parsing.
+          console.error(
+            `failed to release deposit for ${shop} ${order.sessionId}`,
+            err,
+          );
         }
       }
     }

--- a/packages/template-app/src/api/rental/route.ts
+++ b/packages/template-app/src/api/rental/route.ts
@@ -35,7 +35,9 @@ export async function POST(req: NextRequest) {
         readProducts<SKU>(SHOP_ID),
       ]);
     for (const { sku, from, to } of orderItems) {
-      const skuInfo = products.find((p) => p.id === sku || p.slug === sku);
+      const skuInfo = products.find(
+        (p: any) => p.id === sku || p.slug === sku || p.sku === sku,
+      );
       if (!skuInfo) continue;
       const items = inventory.filter((i) => i.sku === sku);
       await reserveRentalInventory(SHOP_ID, items, skuInfo, from, to);


### PR DESCRIPTION
## Summary
- parse FormData using `entries()` in CMS actions and shop validation helpers
- log deposit release failures with `console.error`
- look up products by `sku` when reserving rental inventory

## Testing
- `pnpm test` *(fails: @acme/next-config#test module not found)*
- `pnpm jest test/unit/publish-action.spec.ts packages/platform-machine/__tests__/releaseDepositsService.test.ts packages/template-app/__tests__/rental.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf0fdcd50832f9b3e7ec6542196a8