### PR TITLE
fix: await dynamic imports in retry test

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -109,9 +109,13 @@ describe("sendCampaignEmail fallback and retry", () => {
       html: "<p>HTML</p>",
     });
 
-    await Promise.resolve();
+    // Await the next macrotask to allow dynamic imports in the email module
+    // to resolve before assertions run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(mockSendgridSend).toHaveBeenCalledTimes(1);
-    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+    expect(
+      timeoutSpy.mock.calls.some(([_, ms]) => ms === 100)
+    ).toBe(true);
 
     await promise;
 


### PR DESCRIPTION
## Summary
- stabilize campaign email retry test by waiting for dynamic imports

## Testing
- `pnpm --filter @acme/email test src/__tests__/send.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf126d9e0832fa958672e04e4b973