### PR TITLE
fix: ignore type re-exports in component name map

### DIFF
--- a/scripts/src/component-names.ts
+++ b/scripts/src/component-names.ts
@@ -43,6 +43,7 @@ export function getComponentNameMap(componentsDir: string): Record<string, strin
       const file = resolveFile(dir, rel);
       if (!file) continue;
       for (const spec of specifiers) {
+        if (spec.startsWith("type ")) continue;
         let name = spec;
         if (spec.startsWith("default as ")) {
           name = spec.slice("default as ".length).trim();


### PR DESCRIPTION
## Summary
- ignore `type` specifiers when collecting component names to avoid overwriting components with type exports

## Testing
- `npx jest scripts/__tests__/component-names.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf3a7a710832fb27dd49b31237183