### PR TITLE
fix: base64 encode cart cookie

### DIFF
--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -46,7 +46,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Size required" }, { status: 400 });
   }
   const cookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart: CartState = JSON.parse(decodeCartCookie(cookie) ?? "{}");
+  const cart: CartState = (decodeCartCookie(cookie) ?? {}) as CartState;
   const id = size ? `${sku.id}:${size}` : sku.id;
   const line = cart[id];
   const newQty = (line?.qty ?? 0) + qty;
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Insufficient stock" }, { status: 409 });
   }
 
-  cart[id] = { sku, size, qty: newQty };
+  cart[id] = { sku, qty: newQty, size };
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set(
@@ -75,7 +75,7 @@ export async function PATCH(req: NextRequest) {
 
   const { id, qty } = parsed.data;
   const cookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart: CartState = JSON.parse(decodeCartCookie(cookie) ?? "{}");
+  const cart: CartState = (decodeCartCookie(cookie) ?? {}) as CartState;
   const line = cart[id];
 
   if (!line) {
@@ -85,7 +85,7 @@ export async function PATCH(req: NextRequest) {
   if (qty === 0) {
     delete cart[id];
   } else {
-    cart[id] = { ...line, qty };
+    cart[id] = { sku: line.sku, qty, size: line.size };
   }
 
   const res = NextResponse.json({ ok: true, cart });
@@ -108,7 +108,7 @@ export async function DELETE(req: NextRequest) {
 
   const { id } = parsed.data;
   const cookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart: CartState = JSON.parse(decodeCartCookie(cookie) ?? "{}");
+  const cart: CartState = (decodeCartCookie(cookie) ?? {}) as CartState;
 
   if (!cart[id]) {
     return NextResponse.json({ error: "Item not in cart" }, { status: 404 });
@@ -126,6 +126,6 @@ export async function DELETE(req: NextRequest) {
 
 export async function GET(req: NextRequest) {
   const cookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart: CartState = JSON.parse(decodeCartCookie(cookie) ?? "{}");
+  const cart: CartState = (decodeCartCookie(cookie) ?? {}) as CartState;
   return NextResponse.json({ ok: true, cart });
 }

--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -29,15 +29,7 @@ const schema = z
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
-  const cookieValue = decodeCartCookie(rawCookie);
-  let cart: CartState = {};
-  if (cookieValue) {
-    try {
-      cart = JSON.parse(cookieValue) as CartState;
-    } catch {
-      cart = {};
-    }
-  }
+  const cart = (decodeCartCookie(rawCookie) ?? {}) as CartState;
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });

--- a/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/checkout/page.tsx
@@ -3,7 +3,7 @@ import CheckoutForm from "@ui/components/checkout/CheckoutForm";
 import OrderSummary from "@ui/components/organisms/OrderSummary";
 import { DeliveryScheduler } from "@ui/components/organisms";
 import { Locale, resolveLocale } from "@i18n/locales";
-import { CART_COOKIE, decodeCartCookie } from "@platform-core/cartCookie";
+import { CART_COOKIE, decodeCartCookie, type CartState } from "@platform-core/cartCookie";
 import { cookies } from "next/headers";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import shop from "../../../../shop.json";
@@ -27,7 +27,7 @@ export default async function CheckoutPage({
 
   /* ---------- read cart from cookie ---------- */
   const cookieStore = await cookies(); // ← await here
-  const cart = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
+  const cart = (decodeCartCookie(cookieStore.get(CART_COOKIE)?.value) ?? {}) as CartState;
 
   /* ---------- empty cart guard ---------- */
   if (!Object.keys(cart).length) {

--- a/packages/platform-core/src/cartCookie.d.ts
+++ b/packages/platform-core/src/cartCookie.d.ts
@@ -331,11 +331,12 @@ export declare const cartStateSchema: z.ZodRecord<z.ZodString, z.ZodObject<{
 /**
  * Serialize a cart ID into a signed cookie value.
  */
-export declare function encodeCartCookie(id: string): string;
+export declare function encodeCartCookie(value: string): string;
 /**
- * Verify and extract the cart ID from a signed cookie value.
- * Returns `null` when the cookie is missing or invalid.
+ * Verify and extract the payload from a signed cookie value. JSON payloads are
+ * parsed and returned as objects, otherwise the raw string is returned. Returns
+ * `null` when the cookie is missing or invalid.
  */
-export declare function decodeCartCookie(raw?: string | null): string | null;
+export declare function decodeCartCookie(raw?: string | null): unknown;
 /** Build the Set-Cookie header value for HTTP responses. */
 export declare function asSetCookieHeader(value: string): string;


### PR DESCRIPTION
## Summary
- base64url-encode cart cookie payloads and auto-parse JSON on decode
- operate on decoded cart objects in shop cart and checkout endpoints
- stabilize cart line serialization order

## Testing
- `pnpm exec jest packages/platform-core/__tests__/cartCookie.test.ts apps/shop-bcd/__tests__/cart-api.test.ts`
- `pnpm exec eslint packages/platform-core/src/cartCookie.ts apps/shop-bcd/src/api/cart/route.ts apps/shop-bcd/src/api/checkout-session/route.ts apps/shop-bcd/src/app/[lang]/checkout/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adf4878128832faf7ebab180626b20