### PR TITLE
fix: resolve cms i18n and component paths in tests

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/atoms/shadcn";
 import PageBuilder from "@/components/cms/PageBuilder";
-import TemplateSelector from "../components/TemplateSelector";
+import TemplateSelector from "@/app/cms/configurator/components/TemplateSelector";
 import { fillLocales } from "@i18n/fillLocales";
 import {
   type Page,

--- a/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepNavigation.tsx
@@ -10,7 +10,7 @@ import { useThemeLoader } from "../hooks/useThemeLoader";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import { useState, useMemo } from "react";
 import DeviceSelector from "@ui/components/cms/DeviceSelector";
-import NavTemplateSelector from "../components/NavTemplateSelector";
+import NavTemplateSelector from "@/app/cms/configurator/components/NavTemplateSelector";
 
 interface NavItem {
   id: string;

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -120,6 +120,8 @@ module.exports = {
     // CMS application aliases
     "^@/components/atoms/shadcn$":
       "<rootDir>/test/__mocks__/shadcnDialogStub.tsx",
+    "^@/i18n/(.*)$": "<rootDir>/packages/i18n/src/$1",
+    "^@/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
 
     // context mocks


### PR DESCRIPTION
## Summary
- add Jest mappings for `@/i18n/*` and stub `@/components/*`
- update configurator steps to import internal components via absolute alias

## Testing
- `pnpm test:cms apps/cms/__tests__/stepValidators.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf4a0ec30832f90b5423f9309cb88