### PR TITLE
fix: map cms jest aliases correctly

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require("path");
 const base = require("@acme/config/jest.preset.cjs");
+const {
+  "^@/(.*)$": _unused,
+  "^../components/(.*)$": _unused2,
+  ...baseModuleNameMapper
+} = base.moduleNameMapper;
 
 /** @type {import('jest').Config} */
 module.exports = {
@@ -8,9 +13,9 @@ module.exports = {
   roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
   setupFilesAfterEnv: ["<rootDir>/apps/cms/jest.setup.tsx"],
   moduleNameMapper: {
-    ...base.moduleNameMapper,
-    "^../components/(.*)$": "<rootDir>/apps/cms/src/app/cms/configurator/components/$1",
+    ...baseModuleNameMapper,
     "^@/components/(.*)$": "<rootDir>/packages/ui/src/components/$1",
+    "^@/i18n/Translations$": "<rootDir>/test/emptyModule.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
   },
   globals: {


### PR DESCRIPTION
## Summary
- align CMS Jest config with UI component and i18n aliases
- ensure local alias order no longer overrides @/components

## Testing
- `pnpm --filter @apps/cms test -- __tests__/dashboardSkip.integration.test.tsx __tests__/dashboardRecommendations.integration.test.tsx`
- `pnpm --filter @apps/cms test -- __tests__/ThemeEditor.colors.test.tsx __tests__/wizard-flow.integration.test.tsx __tests__/wizardPreview.sanitize.test.tsx` *(fails: Unable to find an element with the alt text: malicious; Unable to find role="heading" and name "Import Data"; Unable to find role="button" "save" )*

------
https://chatgpt.com/codex/tasks/task_e_68adf4ac1dcc832f9e985f096d4a51c4