### PR TITLE
test: stub StyleEditor for cms tests

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.test-utils.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test-utils.tsx
@@ -16,7 +16,7 @@ jest.mock(
   "@/components/cms/StyleEditor",
   () => {
     const React = require("react");
-    function MockStyleEditor({ tokens, baseTokens, onChange, focusToken }: any) {
+    function MockStyleEditor({ tokens = {}, baseTokens = {}, onChange, focusToken }: any) {
       const ref = React.useRef<HTMLDivElement | null>(null);
       React.useEffect(() => {
         if (!focusToken) return;
@@ -59,6 +59,10 @@ jest.mock(
   }),
   { virtual: true }
 );
+jest.mock("../src/app/cms/wizard/PreviewDeviceSelector", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
 jest.mock("../src/app/cms/wizard/WizardPreview", () => ({
   __esModule: true,
   default: ({ onTokenSelect }: any) => (

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -120,6 +120,8 @@ module.exports = {
     // CMS application aliases
     "^@/components/atoms/shadcn$":
       "<rootDir>/test/__mocks__/shadcnDialogStub.tsx",
+    "^@/components/cms/StyleEditor$":
+      "<rootDir>/test/__mocks__/componentStub.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
 
     // context mocks


### PR DESCRIPTION
## Summary
- stub cms StyleEditor alias for Jest
- harden ThemeEditor tests by mocking PreviewDeviceSelector

## Testing
- `pnpm test:cms apps/cms/__tests__/ThemeEditor.colors.test.tsx apps/cms/__tests__/ThemeEditor.reload.test.tsx apps/cms/__tests__/ThemeEditor.presets.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/^save$/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68adf4b83dcc832fb2ba2069b2a0b068