### PR TITLE
test: map cms module aliases

### DIFF
--- a/apps/cms/__tests__/ThemeEditor.test-utils.tsx
+++ b/apps/cms/__tests__/ThemeEditor.test-utils.tsx
@@ -16,7 +16,12 @@ jest.mock(
   "@/components/cms/StyleEditor",
   () => {
     const React = require("react");
-    function MockStyleEditor({ tokens, baseTokens, onChange, focusToken }: any) {
+    function MockStyleEditor({
+      tokens = {},
+      baseTokens = {},
+      onChange,
+      focusToken,
+    }: any) {
       const ref = React.useRef<HTMLDivElement | null>(null);
       React.useEffect(() => {
         if (!focusToken) return;
@@ -30,7 +35,7 @@ jest.mock(
       return (
         <div ref={ref}>
           {Object.entries(baseTokens).map(([k, defaultValue]: any) => {
-            const val = tokens[k] || defaultValue;
+            const val = (tokens as any)[k] || defaultValue;
             return (
               <label key={k} data-token-key={k}>
                 <input
@@ -38,7 +43,7 @@ jest.mock(
                   type="color"
                   value={val}
                   onChange={(e) =>
-                    onChange({ ...tokens, [k]: e.target.value })
+                    onChange({ ...(tokens as any), [k]: e.target.value })
                   }
                 />
               </label>

--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -5,14 +5,26 @@ const base = require("@acme/config/jest.preset.cjs");
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
-  roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
+  roots: [
+    "<rootDir>/apps/cms/src",
+    "<rootDir>/apps/cms/__tests__",
+    "<rootDir>/packages/ui/src",
+  ],
   setupFilesAfterEnv: ["<rootDir>/apps/cms/jest.setup.tsx"],
-  moduleNameMapper: {
-    ...base.moduleNameMapper,
-    "^../components/(.*)$": "<rootDir>/apps/cms/src/app/cms/configurator/components/$1",
-    "^@/components/(.*)$": "<rootDir>/packages/ui/src/components/$1",
-    "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
-  },
+  moduleNameMapper: (() => {
+    const mapper = { ...base.moduleNameMapper };
+    delete mapper["^@/(.*)$"];
+    return {
+      ...mapper,
+      "^@/components/atoms$": "<rootDir>/test/__mocks__/componentStub.js",
+      "^@/components/cms/StyleEditor$":
+        "<rootDir>/test/__mocks__/componentStub.js",
+      "^@/components/(.*)$": "<rootDir>/packages/ui/src/components/$1",
+      "^@ui/hooks$": "<rootDir>/test/__mocks__/componentStub.js",
+      "^@ui/hooks/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
+      "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
+    };
+  })(),
   globals: {
     "ts-jest": {
       tsconfig: path.resolve(__dirname, "tsconfig.test.json"),


### PR DESCRIPTION
## Summary
- restructure CMS Jest moduleNameMapper so CMS-only aliases resolve
- stub StyleEditor and UI hooks during tests

## Testing
- `pnpm test __tests__/ThemeEditor.colors.test.tsx` *(fails: Element type is invalid: expected a string or a class/function but got undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68adf498c5fc832fa0553b4f98106479