### PR TITLE
fix: stub CMS component imports in Jest

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/apps/cms/jest.setup.tsx"],
   moduleNameMapper: {
     ...baseModuleNameMapper,
-    "^@/components/(.*)$": "<rootDir>/packages/ui/src/components/$1",
+    "^@/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@/i18n/Translations$": "<rootDir>/test/emptyModule.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
   },


### PR DESCRIPTION
## Summary
- stub `@/components/*` to a generic component mock for CMS tests

## Testing
- `pnpm exec jest --config apps/cms/jest.config.cjs apps/cms/__tests__/wizardPreview.sanitize.test.tsx`
- `pnpm exec jest --config apps/cms/jest.config.cjs apps/cms/__tests__/wizard-validation.test.tsx` *(fails: ignores invalid progress state)*

------
https://chatgpt.com/codex/tasks/task_e_68adf7c19158832fafe35a8ad660ef8f