### PR TITLE
Fix checkout session cart parsing

### DIFF
--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -29,7 +29,13 @@ const schema = z
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
-  const cart = (decodeCartCookie(rawCookie) ?? {}) as CartState;
+  let cart: CartState = {};
+  try {
+    const cartJson = decodeCartCookie(rawCookie);
+    cart = cartJson ? (JSON.parse(cartJson) as CartState) : {};
+  } catch {
+    cart = {};
+  }
 
   if (!Object.keys(cart).length) {
     return NextResponse.json({ error: "Cart is empty" }, { status: 400 });


### PR DESCRIPTION
## Summary
- parse decoded cart cookie JSON before creating checkout session

## Testing
- `npx jest apps/shop-bcd/__tests__/checkout-session.test.ts`
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd5daa48832fb909261711444893