### PR TITLE
Handle FormData without entries

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -6,6 +6,7 @@ import type { Locale, Page, HistoryState } from "@acme/types";
 import { historyStateSchema } from "@acme/types";
 import { ulid } from "ulid";
 import { nowIso } from "@acme/date-utils";
+import { formDataToObject } from "../utils/formData";
 
 import { env } from "@acme/config";
 import { ensureAuthorized } from "./common/auth";
@@ -42,9 +43,7 @@ export async function createPage(
       ? idField.trim()
       : ulid();
 
-  const parsed = createSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = createSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     const context = { shop, id };
     if (env.NODE_ENV === "development") {
@@ -183,9 +182,7 @@ export async function updatePage(
 ): Promise<{ page?: Page; errors?: Record<string, string[]> }> {
   await ensureAuthorized();
 
-  const parsed = updateSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = updateSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     const context = { shop, id: formData.get("id") || undefined };
     if (env.NODE_ENV === "development") {

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -19,6 +19,7 @@ import { ensureAuthorized } from "./common/auth";
 import { redirect } from "next/navigation";
 import { ulid } from "ulid";
 import { nowIso } from "@acme/date-utils";
+import { formDataToObject } from "../utils/formData";
 
 /* -------------------------------------------------------------------------- */
 /*  Helpers                                                                    */
@@ -84,9 +85,9 @@ export async function updateProduct(
   "use server";
   await ensureAuthorized();
 
-  // Collect key/value pairs from the incoming form data. Node's FormData
-  // provides an `entries()` iterator for this purpose.
-  const formEntries = Object.fromEntries(formData.entries());
+  // Collect key/value pairs from the incoming form data. Use a helper that
+  // supports environments where `FormData.entries()` may be unavailable.
+  const formEntries = formDataToObject(formData);
   const locales = await getLocales(shop);
   const title: Record<Locale, string> = {} as Record<Locale, string>;
   const description: Record<Locale, string> = {} as Record<Locale, string>;

--- a/apps/cms/src/services/shops/validation.ts
+++ b/apps/cms/src/services/shops/validation.ts
@@ -11,6 +11,7 @@ import {
   parsePriceOverrides,
   parseLocaleOverrides,
 } from "./formData";
+import { formDataEntries, formDataToObject } from "../../utils/formData";
 
 export type { ShopForm };
 
@@ -21,7 +22,7 @@ export function parseShopForm(formData: FormData): {
   const themeDefaultsRaw = formData.get("themeDefaults") as string | null;
   const themeOverridesRaw = formData.get("themeOverrides") as string | null;
 
-  const entries = Array.from(formData.entries()).filter(
+  const entries = Array.from(formDataEntries(formData)).filter(
     ([k]) =>
       ![
         "filterMappingsKey",
@@ -67,9 +68,7 @@ export function parseSeoForm(formData: FormData): {
   data?: z.infer<typeof seoSchema>;
   errors?: Record<string, string[]>;
 } {
-  const parsed = seoSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = seoSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
   }
@@ -89,9 +88,7 @@ export function parseGenerateSeoForm(formData: FormData): {
   data?: z.infer<typeof generateSchema>;
   errors?: Record<string, string[]>;
 } {
-  const parsed = generateSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = generateSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
   }
@@ -109,9 +106,7 @@ export function parseCurrencyTaxForm(formData: FormData): {
   data?: z.infer<typeof currencyTaxSchema>;
   errors?: Record<string, string[]>;
 } {
-  const parsed = currencyTaxSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = currencyTaxSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
   }
@@ -129,9 +124,7 @@ export function parseDepositForm(formData: FormData): {
   data?: z.infer<typeof depositSchema>;
   errors?: Record<string, string[]>;
 } {
-  const parsed = depositSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = depositSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
   }
@@ -149,9 +142,7 @@ export function parseReverseLogisticsForm(formData: FormData): {
   data?: z.infer<typeof reverseLogisticsSchema>;
   errors?: Record<string, string[]>;
 } {
-  const parsed = reverseLogisticsSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = reverseLogisticsSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
   }
@@ -174,9 +165,7 @@ export function parseUpsReturnsForm(formData: FormData): {
   data?: z.infer<typeof returnsSchema>;
   errors?: Record<string, string[]>;
 } {
-  const parsed = returnsSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  const parsed = returnsSchema.safeParse(formDataToObject(formData));
   if (!parsed.success) {
     return { errors: parsed.error.flatten().fieldErrors };
   }

--- a/apps/cms/src/utils/formData.ts
+++ b/apps/cms/src/utils/formData.ts
@@ -1,0 +1,23 @@
+export function formDataEntries(
+  formData: FormData,
+): Iterable<[string, FormDataEntryValue]> {
+  if (typeof (formData as any).entries === "function") {
+    return (formData as any).entries();
+  }
+  if (typeof (formData as any)[Symbol.iterator] === "function") {
+    return (formData as any)[Symbol.iterator]();
+  }
+  const entries: [string, FormDataEntryValue][] = [];
+  if (typeof (formData as any).forEach === "function") {
+    (formData as any).forEach((value: FormDataEntryValue, key: string) => {
+      entries.push([key, value]);
+    });
+  }
+  return entries;
+}
+
+export function formDataToObject(
+  formData: FormData,
+): Record<string, FormDataEntryValue> {
+  return Object.fromEntries(formDataEntries(formData));
+}


### PR DESCRIPTION
## Summary
- add `formDataToObject` utility to read FormData in environments missing `entries`
- use the helper in page and product actions
- update shop form validations to rely on the new helper

## Testing
- `pnpm jest apps/cms/src/actions/pages.server.test.ts`
- `pnpm jest apps/cms/src/services/shops/__tests__/validation.test.ts`
- `pnpm test:cms` *(fails: scheduler test timeout; media test missing directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd74512c832f840ddda98f691316