### PR TITLE
Extend timeout for CMS section index pages test

### DIFF
--- a/apps/cms/__tests__/sectionIndexPages.test.ts
+++ b/apps/cms/__tests__/sectionIndexPages.test.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+// Some pages pull in heavy server-only modules which can slow down
+// the initial dynamic import. Increase the Jest timeout so the test has
+// enough time to complete without failing.
+jest.setTimeout(20_000);
+
 jest.mock("next/link", () => ({
   __esModule: true,
   default: (props: any) =>


### PR DESCRIPTION
## Summary
- increase Jest timeout for section index page tests to accommodate slow dynamic imports

## Testing
- `pnpm test:cms apps/cms/__tests__/sectionIndexPages.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae007e3eb0832fa56f6b3dcab1795a