### PR TITLE
Handle missing shops directory

### DIFF
--- a/apps/cms/__tests__/listShops.test.ts
+++ b/apps/cms/__tests__/listShops.test.ts
@@ -21,11 +21,11 @@ describe("listShops", () => {
     await fs.rm(dir, { recursive: true, force: true });
   });
 
-  it("throws when data/shops is missing", async () => {
+  it("returns empty list when data/shops is missing", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "shops-"));
     const spy = jest.spyOn(process, "cwd").mockReturnValue(dir);
 
-    await expect(listShops()).rejects.toThrow();
+    await expect(listShops()).resolves.toEqual([]);
 
     spy.mockRestore();
     await fs.rm(dir, { recursive: true, force: true });

--- a/apps/cms/src/lib/listShops.ts
+++ b/apps/cms/src/lib/listShops.ts
@@ -10,14 +10,11 @@ export async function listShops(): Promise<string[]> {
     const entries = await fs.readdir(shopsDir, { withFileTypes: true });
     return entries.filter((e) => e.isDirectory()).map((e) => e.name);
   } catch (err: unknown) {
-    // Surface configuration errors clearly: the absence of the `data/shops`
-    // directory means we cannot determine available shops.  Upstream code and
-    // tests expect this to be treated as an exceptional situation rather than
-    // silently returning an empty list.
+    // If the shops directory hasn't been created yet, treat it as having
+    // no shops rather than throwing. This allows callers to handle the empty
+    // state gracefully.
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      const message = `Shops directory not found at ${shopsDir}`;
-      console.error(message);
-      throw new Error(message);
+      return [];
     }
     console.error(`Failed to list shops at ${shopsDir}:`, err);
     throw err;


### PR DESCRIPTION
## Summary
- return an empty list when `data/shops` directory is missing
- adjust listShops tests for new empty-directory behavior

## Testing
- `npx jest apps/cms/__tests__/listShops.test.ts apps/cms/__tests__/api.shops.test.ts packages/platform-core/__tests__/shopsRoute.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ae009d4148832f9ab143df206a68de