### PR TITLE
Ensure republish removes upgrade metadata

### DIFF
--- a/scripts/src/republish-shop.js
+++ b/scripts/src/republish-shop.js
@@ -61,14 +61,16 @@ function saveHistory(root, id) {
 function republishShop(id, root) {
     if (root === void 0) { root = process.cwd(); }
     var upgradeFile = (0, node_path_1.join)(root, "data", "shops", id, "upgrade.json");
-    if ((0, node_fs_1.existsSync)(upgradeFile)) {
+    var hadUpgradeFile = (0, node_fs_1.existsSync)(upgradeFile);
+    if (hadUpgradeFile) {
         readUpgradeMeta(root, id);
+        (0, node_fs_1.unlinkSync)(upgradeFile);
     }
     saveHistory(root, id);
     run("pnpm", ["--filter", "apps/".concat(id), "build"]);
     run("pnpm", ["--filter", "apps/".concat(id), "deploy"]);
     updateStatus(root, id);
-    if ((0, node_fs_1.existsSync)(upgradeFile)) {
+    if (hadUpgradeFile && (0, node_fs_1.existsSync)(upgradeFile)) {
         (0, node_fs_1.unlinkSync)(upgradeFile);
     }
     var appDir = (0, node_path_1.join)(root, "apps", id);

--- a/scripts/src/republish-shop.ts
+++ b/scripts/src/republish-shop.ts
@@ -65,14 +65,16 @@ function saveHistory(root: string, id: string): void {
 
 export function republishShop(id: string, root = process.cwd()): void {
   const upgradeFile = join(root, "data", "shops", id, "upgrade.json");
-  if (existsSync(upgradeFile)) {
+  const hadUpgradeFile = existsSync(upgradeFile);
+  if (hadUpgradeFile) {
     readUpgradeMeta(root, id);
+    unlinkSync(upgradeFile);
   }
   saveHistory(root, id);
   run("pnpm", ["--filter", `apps/${id}`, "build"]);
   run("pnpm", ["--filter", `apps/${id}`, "deploy"]);
   updateStatus(root, id);
-  if (existsSync(upgradeFile)) {
+  if (hadUpgradeFile && existsSync(upgradeFile)) {
     unlinkSync(upgradeFile);
   }
   const appDir = join(root, "apps", id);


### PR DESCRIPTION
## Summary
- Delete `upgrade.json` before triggering build/deploy when republishing a shop
- Remove the file again after the process in case it is recreated

## Testing
- `pnpm test:cms test/integration/republish-shop.spec.ts`
- `pnpm test:cms scripts/__tests__/republish-shop.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae00ad4dd8832f8d693a0c04022180