### PR TITLE
Ensure publish API removes upgrade metadata

### DIFF
--- a/apps/shop-bcd/src/app/api/publish/route.ts
+++ b/apps/shop-bcd/src/app/api/publish/route.ts
@@ -18,6 +18,7 @@ export async function POST() {
     const { id } = JSON.parse(raw) as { id: string };
     const root = join(process.cwd(), "..", "..");
     republishShop(id, root);
+    await fs.rm(join(root, "data", "shops", id, "upgrade.json"), { force: true });
     return NextResponse.json({ status: "ok" });
   } catch (err) {
     console.error("Publish failed", err);


### PR DESCRIPTION
## Summary
- remove `upgrade.json` after republishing a shop

## Testing
- `pnpm jest test/integration/publish-api.spec.ts`
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae021154e4832fbb07a1aa99daea56