### PR TITLE
fix: use node module specifier for createRequire imports

### DIFF
--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 import type { ReactElement, ReactNode } from "react";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";

--- a/packages/zod-utils/src/initZod.ts
+++ b/packages/zod-utils/src/initZod.ts
@@ -6,8 +6,7 @@
 // async `import` helpers that rely on top-level `await`. Using
 // `createRequire` keeps the generated code synchronous and works in
 // both ESM and CJS test runs.
-import { createRequire } from "module";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { createRequire } from "node:module";
 const { applyFriendlyZodMessages } = createRequire(import.meta.url)(
   "./zodErrorMap"
 );

--- a/scripts/src/createShop/parse.ts
+++ b/scripts/src/createShop/parse.ts
@@ -1,6 +1,6 @@
 import { validateShopName } from "@acme/platform-core/shops";
 import type { CreateShopOptions } from "@acme/platform-core/createShop";
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 import { resolve, extname } from "path";
 import { readFileSync } from "fs";
 

--- a/test/integration/publish-api.spec.ts
+++ b/test/integration/publish-api.spec.ts
@@ -1,4 +1,4 @@
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";


### PR DESCRIPTION
## Summary
- use `node:module` specifier for `createRequire` to avoid bundler resolution issues

## Testing
- `pnpm exec eslint packages/zod-utils/src/initZod.ts`
- `pnpm exec eslint packages/email/src/templates.ts scripts/src/createShop/parse.ts test/integration/publish-api.spec.ts` *(fails: Definition for rule 'n/no-deprecated-api' was not found)*
- `pnpm test:cms` *(fails: scheduler › sends due campaigns and marks them as sent, media actions › listMedia throws when dir missing, product actions › createDraftRecord creates placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68ae02975a44832fb5eb90848c6e14d3