### PR TITLE
chore: scope auth lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "turbo run lint",
     "lint:apps": "eslint \"apps/**/*.{ts,tsx}\" --ignore-pattern \"**/dist/**\"",
     "lint:all": "eslint \"{apps,packages,src}/**/*.{ts,tsx,js,jsx}\" --ignore-pattern \"**/dist/**\"",
+    "lint:auth": "pnpm exec eslint \"packages/auth/**/*.{ts,tsx,js,jsx}\" --ignore-pattern \"**/*.d.ts\" --ignore-pattern \"packages/auth/dist/**\"",
     "typecheck": "tsc -b --pretty",
     "test": "CI=true turbo run test",
     "test:coverage": "CI=true turbo run test -- --coverage",


### PR DESCRIPTION
## Summary
- add `lint:auth` script
- exclude `dist` and declaration files from auth linting

## Testing
- `pnpm run lint:auth` *(fails: Parsing error: packages/auth/__tests__/permissions.test.ts was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0417ec10832f87bcff22309d0565