### PR TITLE
chore: include auth tsconfigs in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,12 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: ["./tsconfig.json", "./tsconfig.test.json"],
+        project: [
+          "./tsconfig.json",
+          "./tsconfig.test.json",
+          "./packages/*/tsconfig.json",
+          "./packages/*/tsconfig.test.json",
+        ],
         projectService: true,
         allowDefaultProject: true,
         sourceType: "module",


### PR DESCRIPTION
## Summary
- cover tsconfig files from packages in ESLint project settings

## Testing
- `pnpm eslint packages/auth` *(fails: Parsing error: was not found by the project service)*

------
https://chatgpt.com/codex/tasks/task_e_68ae041702cc832fb23608641b4829e9