### PR TITLE
fix: handle node:module alias for Next.js

### DIFF
--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -29,6 +29,7 @@ export default withShopCode(coreEnv.SHOP_CODE, {
       "fs",
       "http",
       "https",
+      "module",
       "path",
       "stream",
       "string_decoder",


### PR DESCRIPTION
## Summary
- extend Next.js config aliases with `module` to resolve `node:module` imports

## Testing
- `pnpm --filter cms dev`
- `pnpm --filter @acme/next-config test` *(fails: Cannot find module '/workspace/base-shop/packages/config/dist/env/auth')*

------
https://chatgpt.com/codex/tasks/task_e_68ae059860b0832f968794e907c9cae8