### PR TITLE
fix: alias node:module in cms config

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -31,6 +31,7 @@ const nextConfig = {
       "fs",
       "http",
       "https",
+      "module",
       "path",
       "stream",
       "string_decoder",


### PR DESCRIPTION
## Summary
- fix UnhandledSchemeError in CMS by mapping `node:module` to `module`

## Testing
- `pnpm --filter @apps/cms lint` *(fails: command hung)*
- `pnpm --filter @apps/cms test` *(fails: 4 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11968614832fb507fbaca3bda363