### PR TITLE
fix: add empty content array to tailwind preset

### DIFF
--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -9,6 +9,8 @@ console.log(
 );
 
 const preset = {
+  // This preset only provides design tokens, so no files need to be scanned
+  content: [],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- avoid invalid array length errors by adding empty `content` array to the shared Tailwind preset

## Testing
- `pnpm test` *(fails: Cannot find module './auth.js' from packages/config/src/env/core.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1560d280832f9485669d286eecd3