### PR TITLE
Use package entry imports in Tailwind config

### DIFF
--- a/packages/tailwind-config/tailwind.config.mjs
+++ b/packages/tailwind-config/tailwind.config.mjs
@@ -1,8 +1,10 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import tokens from "../design-tokens/index.ts";
-import preset from "./src/index.ts";
+import tokens from "@acme/design-tokens";
+import preset from "@acme/tailwind-config";
+import forms from "@tailwindcss/forms";
+import containerQueries from "@tailwindcss/container-queries";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,10 +25,7 @@ const config = {
     "!**/dist",
     "!**/.next",
   ],
-  plugins: [
-    require("@tailwindcss/forms"),
-    require("@tailwindcss/container-queries"),
-  ],
+  plugins: [forms, containerQueries],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- load design tokens and preset via their package entry points
- use ESM imports for Tailwind plugins

## Testing
- `pnpm exec prettier packages/tailwind-config/tailwind.config.mjs --write`
- `pnpm exec eslint packages/tailwind-config/tailwind.config.mjs`
- `pnpm --filter @acme/tailwind-config build`
- `pnpm --filter @acme/tailwind-config test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ce1873c832fbeefaf1da3534a02