### PR TITLE
fix tailwind preset nesting

### DIFF
--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -55,7 +55,6 @@ const preset = {
     },
   },
   plugins: [],
-  presets: [],
 } as const;
 
 // Additional diagnostics


### PR DESCRIPTION
## Summary
- remove `presets` key from custom Tailwind preset to avoid recursive merging

## Testing
- `pnpm test --filter @acme/tailwind-config`
- `pnpm lint --filter @acme/tailwind-config`
- `pnpm check:tailwind-preset` *(fails: ReferenceError __filename is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1cecfcb8832fb6f7a8c687221a56