### PR TITLE
build(cms): transpile design tokens and tailwind config

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -20,7 +20,9 @@ const nextConfig = {
     "@acme/shared-utils",
     "@acme/types",
     "@shared-utils",
-    "@date-utils"
+    "@date-utils",
+    "@acme/tailwind-config",
+    "@acme/design-tokens"
   ],
   webpack: (config) => {
     const nodeBuiltins = [


### PR DESCRIPTION
## Summary
- transpile `@acme/tailwind-config` and `@acme/design-tokens` in the CMS next config

## Testing
- `pnpm lint --filter @apps/cms` *(fails: Cannot find module '@next/eslint-plugin-next')*
- `pnpm --filter @apps/cms test --runTestsByPath __tests__/wizard-flow.integration.test.tsx` *(fails: Unable to find role="heading" and name "Summary")*

------
https://chatgpt.com/codex/tasks/task_e_68ae22718c3c832f804c125c30b4582a