### PR TITLE
fix(config): include ESM extensions in env imports

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,8 +1,8 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-import { authEnvSchema } from "./auth";
-import { cmsEnvSchema } from "./cms";
-import { emailEnvSchema } from "./email";
+import { authEnvSchema } from "./auth.js";
+import { cmsEnvSchema } from "./cms.js";
+import { emailEnvSchema } from "./email.js";
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -135,7 +135,7 @@ const parsed = coreEnvSchema.safeParse(process.env);
 // specific path is provided.
 if (!parsed.success) {
   console.error("❌ Invalid core environment variables:");
-  parsed.error.issues.forEach((issue) => {
+  parsed.error.issues.forEach((issue: z.ZodIssue) => {
     const path =
       issue.path && issue.path.length > 0 ? issue.path.join(".") : "(root)";
     console.error(`  • ${path}: ${issue.message}`);

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
-} from "./core";
-import { paymentEnvSchema } from "./payments";
-import { shippingEnvSchema } from "./shipping";
+} from "./core.js";
+import { paymentEnvSchema } from "./payments.js";
+import { shippingEnvSchema } from "./shipping.js";
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   k: infer I,
@@ -58,9 +58,9 @@ if (!parsed.success) {
 export const env = parsed.data;
 export type Env = z.infer<typeof envSchema>;
 
-export * from "./auth";
-export * from "./cms";
-export * from "./email";
-export * from "./core";
-export * from "./payments";
-export * from "./shipping";
+export * from "./auth.js";
+export * from "./cms.js";
+export * from "./email.js";
+export * from "./core.js";
+export * from "./payments.js";
+export * from "./shipping.js";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 // packages/config/src/index.ts
 // Re-export compiled env in a stable, root entry for all consumers.
-import { coreEnv } from "./env/core";
+import { coreEnv } from "./env/core.js";
 
 export const env = coreEnv;
-export type { CoreEnv as Env } from "./env/core";
+export type { CoreEnv as Env } from "./env/core.js";


### PR DESCRIPTION
## Summary
- fix config package ESM import paths by adding `.js` extensions
- ensure Zod issue parameter typed

## Testing
- `pnpm --filter @acme/config build`
- `NEXTAUTH_SECRET=dev SESSION_SECRET=dev CART_COOKIE_SECRET=dev SHOP_CODE=dev pnpm --filter @acme/template-app build` *(fails: module not found '@acme/i18n')*

------
https://chatgpt.com/codex/tasks/task_e_68ae27adf21c832f8468986a4ac07e3b