### PR TITLE
fix: allow server components in template pages

### DIFF
--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -1,6 +1,8 @@
 // /packages/tailwind-config/src/index.ts
 
-import type { Config } from "tailwindcss";
+// Avoid direct dependency on Tailwind's ESM-only type declarations
+// to keep this package CommonJS compatible.
+type Config = Record<string, unknown>;
 
 /* ------------------------------------------------------------
  *  Runtime diagnostics — confirm the preset really loads

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 // @ts-nocheck
 // packages/template-app/src/app/[lang]/checkout/page.tsx
 import CheckoutForm from "@/components/checkout/CheckoutForm";

--- a/packages/template-app/src/app/account/returns/page.tsx
+++ b/packages/template-app/src/app/account/returns/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import {
   getReturnLogistics,
   getReturnBagAndLabel,

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import {
   getReturnLogistics,
   getReturnBagAndLabel,


### PR DESCRIPTION
## Summary
- remove `use client` directive from template app pages that rely on server-only features
- avoid importing Tailwind CSS ESM types so tailwind-config stays CommonJS compatible

## Testing
- `pnpm --filter @acme/tailwind-config build`
- `NEXTAUTH_SECRET=foo SESSION_SECRET=bar CART_COOKIE_SECRET=baz pnpm --filter @acme/template-app build` *(fails: Module not found: Can't resolve '@acme/email')*


------
https://chatgpt.com/codex/tasks/task_e_68ae29e76bb4832f9018a1b3b9f6c413