### PR TITLE
fix: resolve env imports for config package

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,8 +1,8 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-import { authEnvSchema } from "./auth.js";
-import { cmsEnvSchema } from "./cms.js";
-import { emailEnvSchema } from "./email.js";
+import { authEnvSchema } from "./auth";
+import { cmsEnvSchema } from "./cms";
+import { emailEnvSchema } from "./email";
 
 const isProd = process.env.NODE_ENV === "production";
 

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
-} from "./core.js";
-import { paymentEnvSchema } from "./payments.js";
-import { shippingEnvSchema } from "./shipping.js";
+} from "./core";
+import { paymentEnvSchema } from "./payments";
+import { shippingEnvSchema } from "./shipping";
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   k: infer I,
@@ -58,9 +58,9 @@ if (!parsed.success) {
 export const env = parsed.data;
 export type Env = z.infer<typeof envSchema>;
 
-export * from "./auth.js";
-export * from "./cms.js";
-export * from "./email.js";
-export * from "./core.js";
-export * from "./payments.js";
-export * from "./shipping.js";
+export * from "./auth";
+export * from "./cms";
+export * from "./email";
+export * from "./core";
+export * from "./payments";
+export * from "./shipping";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 // packages/config/src/index.ts
 // Re-export compiled env in a stable, root entry for all consumers.
-import { coreEnv } from "./env/core.js";
+import { coreEnv } from "./env/core";
 
 export const env = coreEnv;
-export type { CoreEnv as Env } from "./env/core.js";
+export type { CoreEnv as Env } from "./env/core";


### PR DESCRIPTION
## Summary
- fix config env imports to avoid missing module errors
- update env index/core to reference TS sources directly

## Testing
- `pnpm exec jest packages/config/__tests__/env.test.ts --config packages/config/jest.preset.cjs`
- `pnpm --filter cms dev:debug`


------
https://chatgpt.com/codex/tasks/task_e_68ae2c5e7880832fb03ab90cbead41f9