### PR TITLE
Transpile @acme/config in template app

### DIFF
--- a/packages/template-app/next.config.mjs
+++ b/packages/template-app/next.config.mjs
@@ -18,7 +18,12 @@ const config = {
   // Override or extend any fields here.  In this case we need to
   // transpile additional internal packages so that Next.js can import
   // their untranspiled source code from `node_modules`.
-  transpilePackages: ["@acme/ui", "@acme/platform-core"],
+  transpilePackages: [
+    "@acme/ui",
+    "@acme/platform-core",
+    "@acme/config",
+    "@acme/zod-utils", // needed by @acme/config/env/auth.ts
+  ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- ensure Next.js transpiles `@acme/config` and its `@acme/zod-utils` dependency in the template app config

## Testing
- `pnpm lint --filter @acme/template-app`
- `pnpm test --filter @acme/template-app`


------
https://chatgpt.com/codex/tasks/task_e_68ae30f7a2e0832f93a68900258266ac