### PR TITLE
fix(config): add explicit .js extensions for NodeNext

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,8 +1,8 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-import { authEnvSchema } from "./auth";
-import { cmsEnvSchema } from "./cms";
-import { emailEnvSchema } from "./email";
+import { authEnvSchema } from "./auth.js";
+import { cmsEnvSchema } from "./cms.js";
+import { emailEnvSchema } from "./email.js";
 
 const isProd = process.env.NODE_ENV === "production";
 

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
-} from "./core";
-import { paymentEnvSchema } from "./payments";
-import { shippingEnvSchema } from "./shipping";
+} from "./core.js";
+import { paymentEnvSchema } from "./payments.js";
+import { shippingEnvSchema } from "./shipping.js";
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   k: infer I,
@@ -58,9 +58,9 @@ if (!parsed.success) {
 export const env = parsed.data;
 export type Env = z.infer<typeof envSchema>;
 
-export * from "./auth";
-export * from "./cms";
-export * from "./email";
-export * from "./core";
-export * from "./payments";
-export * from "./shipping";
+export * from "./auth.js";
+export * from "./cms.js";
+export * from "./email.js";
+export * from "./core.js";
+export * from "./payments.js";
+export * from "./shipping.js";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 // packages/config/src/index.ts
 // Re-export compiled env in a stable, root entry for all consumers.
-import { coreEnv } from "./env/core";
+import { coreEnv } from "./env/core.js";
 
 export const env = coreEnv;
-export type { CoreEnv as Env } from "./env/core";
+export type { CoreEnv as Env } from "./env/core.js";

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -11,6 +11,9 @@
     "rootDir": "src",
     "outDir": "dist",
 
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+
     /* let TS infer rootDir (same as package folder) */
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary
- use NodeNext module resolution in config package
- include explicit `.js` extensions in env exports so Node can resolve built files

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter template-app build` *(fails: Module not found: Can't resolve '@acme/i18n')*

------
https://chatgpt.com/codex/tasks/task_e_68ae327e26bc832f8d518e2bbaaf9add