### PR TITLE
fix: add email pkg build dependency

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -15,6 +15,7 @@
     "email": "./dist/cli.js"
   },
   "scripts": {
+    "build": "tsc -b",
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "dependencies": {

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -132,6 +132,7 @@
     "@acme/plugin-sanity": "workspace:^",
     "@acme/shared-utils": "workspace:^",
     "@acme/stripe": "workspace:^",
+    "@acme/email": "workspace:^",
     "@acme/types": "workspace:^",
     "@prisma/client": "^6.14.0",
     "@themes/base": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,9 @@ importers:
       '@acme/date-utils':
         specifier: workspace:^
         version: link:../date-utils
+      '@acme/email':
+        specifier: workspace:^
+        version: link:../email
       '@acme/i18n':
         specifier: workspace:^
         version: link:../i18n


### PR DESCRIPTION
## Summary
- include `@acme/email` in platform-core dependencies
- add build script to email package so its dist files are generated

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 NEXTAUTH_SECRET=abc SESSION_SECRET=def CART_COOKIE_SECRET=ghi pnpm --filter template-app build` *(fails: Fatal JavaScript invalid size error)*

------
https://chatgpt.com/codex/tasks/task_e_68aed4f64568832f97cd3df20e9aacd8