### PR TITLE
chore(ui): remove auth dependency

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,6 @@
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "dependencies": {
-    "@acme/auth": "workspace:^",
     "@acme/config": "workspace:*",
     "@acme/date-utils": "workspace:*",
     "@acme/i18n": "workspace:*",


### PR DESCRIPTION
## Summary
- remove unused `@acme/auth` dependency from `@acme/ui`

## Testing
- `pnpm --filter @acme/ui build`
- `pnpm test` *(fails: Cannot find module './env/core.js' from 'packages/config/src/index.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68aeda73af74832fbd5d73fd2395d099