### PR TITLE
feat: decouple email service from platform core

### DIFF
--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,11 +1,15 @@
 import "server-only";
+import { setEmailService } from "@acme/platform-core/services/emailService";
+import { sendEmail } from "./sendEmail";
+
+setEmailService({ sendEmail });
 
 export type { CampaignOptions } from "./send";
 export { sendCampaignEmail } from "./send";
 export { registerTemplate, renderTemplate, clearTemplates } from "./templates";
 export type { AbandonedCart } from "./abandonedCart";
 export { recoverAbandonedCarts, resolveAbandonedCartDelay } from "./abandonedCart";
-export { sendEmail } from "./sendEmail";
+export { sendEmail };
 export { resolveSegment, createContact, addToList, listSegments } from "./segments";
 export {
   createCampaign,

--- a/packages/platform-core/__tests__/tracking-dashboard.test.ts
+++ b/packages/platform-core/__tests__/tracking-dashboard.test.ts
@@ -1,7 +1,5 @@
 import { jest } from "@jest/globals";
 import type { TrackingStatus } from "../src/shipping";
-
-jest.mock("@acme/email", () => ({ sendEmail: jest.fn() }));
 jest.mock("../src/shipping", () => ({
   getTrackingStatus: jest.fn(async () => ({
     status: "Delivered",
@@ -48,7 +46,7 @@ describe("tracking dashboard", () => {
   });
 
   test("notifies on status change", async () => {
-    const sendEmail = (await import("@acme/email")).sendEmail as jest.Mock;
+    const sendEmail = jest.fn();
     global.fetch = jest
       .fn<Promise<any>, any>()
       .mockResolvedValue({ ok: true, json: async () => ({}) } as any) as any;
@@ -61,6 +59,7 @@ describe("tracking dashboard", () => {
       { id: "1", type: "shipment", provider: "ups", trackingNumber: "1" },
       "old",
       "new",
+      { sendEmail },
     );
     expect(sendEmail).toHaveBeenCalled();
     expect(fetch).toHaveBeenCalled();

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -132,7 +132,6 @@
     "@acme/plugin-sanity": "workspace:^",
     "@acme/shared-utils": "workspace:^",
     "@acme/stripe": "workspace:^",
-    "@acme/email": "workspace:^",
     "@acme/types": "workspace:^",
     "@prisma/client": "^6.14.0",
     "@themes/base": "workspace:^",

--- a/packages/platform-core/src/services/emailService.ts
+++ b/packages/platform-core/src/services/emailService.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+export interface EmailService {
+  sendEmail(to: string, subject: string, body: string): Promise<void>;
+}
+
+let service: EmailService | undefined;
+
+export function setEmailService(svc: EmailService): void {
+  service = svc;
+}
+
+export function getEmailService(): EmailService {
+  if (!service) {
+    throw new Error("EmailService not registered");
+  }
+  return service;
+}

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { coreEnv } from "@acme/config/env/core";
 import { DATA_ROOT } from "../dataRoot";
-import { sendEmail } from "@acme/email";
+import { type EmailService, getEmailService } from "./emailService";
 import { promises as fs } from "fs";
 import * as path from "path";
 import type { InventoryItem } from "@acme/types";
@@ -34,6 +34,7 @@ async function writeLog(shop: string, log: Record<string, number>): Promise<void
 export async function checkAndAlert(
   shop: string,
   items: InventoryItem[],
+  email: EmailService = getEmailService(),
 ): Promise<void> {
   const settings = await getShopSettings(shop);
   const envRecipients =
@@ -80,7 +81,7 @@ export async function checkAndAlert(
 
   for (const r of recipients) {
     try {
-      await sendEmail(r, subject, body);
+      await email.sendEmail(r, subject, body);
     } catch (err) {
       console.error("Failed to send stock alert", err);
     }

--- a/packages/platform-core/src/tracking/index.ts
+++ b/packages/platform-core/src/tracking/index.ts
@@ -1,7 +1,7 @@
 // packages/platform-core/src/tracking/index.ts
 
 import { getTrackingStatus, type TrackingStatus } from "../shipping";
-import { sendEmail } from "@acme/email";
+import { type EmailService, getEmailService } from "../services/emailService";
 
 export interface TrackingItem {
   id: string;
@@ -61,11 +61,12 @@ export async function notifyStatusChange(
   item: TrackingItem,
   previous: string | null,
   current: string | null,
+  email: EmailService = getEmailService(),
 ): Promise<void> {
   if (previous === current) return;
   const message = `Tracking update for ${item.id}: ${current ?? "unknown"}`;
   if (contact.email) {
-    await sendEmail(contact.email, "Tracking update", message);
+    await email.sendEmail(contact.email, "Tracking update", message);
   }
   if (contact.phone) {
     await sendSms(contact.phone, message);

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -19,8 +19,6 @@
     "paths": {
       "@acme/ui": ["types-compat/ui"],
       "@acme/ui/*": ["types-compat/ui"],
-      "@acme/email": ["types-compat/email"],
-      "@acme/email/*": ["types-compat/email"],
       "better-sqlite3": ["src/types/better-sqlite3"]
     }
   },

--- a/packages/platform-core/types-compat/email.d.ts
+++ b/packages/platform-core/types-compat/email.d.ts
@@ -1,3 +1,0 @@
-declare module "@acme/email" {
-  export function sendEmail(to: string, subject: string, body: string): Promise<void>;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,9 +618,6 @@ importers:
       '@acme/date-utils':
         specifier: workspace:^
         version: link:../date-utils
-      '@acme/email':
-        specifier: workspace:^
-        version: link:../email
       '@acme/i18n':
         specifier: workspace:^
         version: link:../i18n


### PR DESCRIPTION
## Summary
- remove direct @acme/email dependency from platform-core and introduce an EmailService interface
- refactor tracking and stock alert modules to use EmailService via injection
- register the email service implementation from @acme/email

## Testing
- `pnpm test --filter @acme/platform-core` *(no tests found)*
- `pnpm test --filter @acme/email` *(fails: ReferenceError import after Jest teardown)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda70e0e4832f912544c92697004e