### PR TITLE
fix: align cart type imports and tighten product filter types

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./src/index";
 export { ExampleProps } from "./src/ExampleProps";
 export { historyStateSchema } from "./src/page/page";
+export type { CartLine, CartState } from "./src/Cart";

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -1,6 +1,6 @@
 export * from "./ApiError";
 export * from "./Blog";
-export * from "./Cart";
+export type { CartLine, CartState } from "./Cart";
 export * from "./CmsUser";
 export * from "./constants";
 export * from "./ImageOrientation";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./ApiError";
 export * from "./Blog";
-export * from "./Cart";
+export type { CartLine, CartState } from "./Cart";
 export * from "./CmsUser";
 export * from "./constants";
 export * from "./ImageOrientation";

--- a/packages/ui/src/components/cms/blocks/ProductFilter.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductFilter.tsx
@@ -5,6 +5,8 @@ import { useProductFilters } from "../../../hooks/useProductFilters";
 import { PRODUCTS } from "@acme/platform-core/products";
 import type { SKU } from "@acme/types";
 
+type FilterSku = SKU & { id: string; title: string };
+
 export interface ProductFilterProps {
   showSize?: boolean;
   showColor?: boolean;
@@ -16,17 +18,19 @@ export default function ProductFilter({
   showColor = true,
   showPrice = true,
 }: ProductFilterProps) {
-  const { filteredRows } = useProductFilters<SKU>(PRODUCTS);
+  const { filteredRows } = useProductFilters<FilterSku>(
+    PRODUCTS as FilterSku[],
+  );
 
   const sizes = useMemo(() => {
     const s = new Set<string>();
-    filteredRows.forEach((p: SKU) => p.sizes?.forEach((sz: string) => s.add(sz)));
+    filteredRows.forEach((p) => p.sizes?.forEach((sz: string) => s.add(sz)));
     return Array.from(s).sort();
   }, [filteredRows]);
 
   const colors = useMemo(() => {
     const s = new Set<string>();
-    filteredRows.forEach((p: SKU) => {
+    filteredRows.forEach((p) => {
       const c = p.id.split("-")[0];
       if (c) s.add(c);
     });
@@ -34,7 +38,7 @@ export default function ProductFilter({
   }, [filteredRows]);
 
   const priceBounds = useMemo(() => {
-    const prices = filteredRows.map((p: SKU) => p.price ?? 0);
+    const prices = filteredRows.map((p) => p.price ?? 0);
     const min = prices.length ? Math.min(...prices) : 0;
     const max = prices.length ? Math.max(...prices) : 0;
     return [min, max];
@@ -46,7 +50,7 @@ export default function ProductFilter({
   const [maxPrice, setMaxPrice] = useState(priceBounds[1]);
 
   const results = useMemo(() => {
-    return filteredRows.filter((p: SKU) => {
+    return filteredRows.filter((p) => {
       const sizeMatch = !size || p.sizes?.includes(size);
       const colorMatch = !color || p.id.includes(color);
       const price = p.price ?? 0;

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 // server component
 import { readShop } from "@acme/platform-core/repositories/json.server";
 import { CART_COOKIE, decodeCartCookie } from "@acme/platform-core/cartCookie";
-import type { CartState, CartLine } from "@acme/types";
+import type { CartLine, CartState } from "@acme/platform-core/cart";
 import { createCartStore } from "@acme/platform-core/cartStore";
 import { cookies } from "next/headers";
 import HeaderClient from "./HeaderClient.client";

--- a/packages/ui/src/components/organisms/MiniCart.stories.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.stories.tsx
@@ -1,6 +1,7 @@
 import { CartProvider, useCart } from "@acme/platform-core/contexts/CartContext";
 import { type Meta, type StoryObj } from "@storybook/react";
-import type { CartLine, CartState, SKU } from "@acme/types";
+import type { CartLine, CartState } from "@acme/platform-core/cart";
+import type { SKU } from "@acme/types";
 import * as React from "react";
 import { Button } from "../atoms/shadcn";
 import { MiniCart } from "./MiniCart.client";

--- a/packages/ui/src/components/templates/CartTemplate.d.ts
+++ b/packages/ui/src/components/templates/CartTemplate.d.ts
@@ -1,4 +1,4 @@
-import type { CartState } from "@acme/types";
+import type { CartState } from "@acme/platform-core/cart";
 import * as React from "react";
 export interface CartTemplateProps extends React.HTMLAttributes<HTMLDivElement> {
     cart: CartState;

--- a/packages/ui/src/components/templates/CartTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from "@storybook/react";
-import type { CartState } from "@acme/types";
+import type { CartState } from "@acme/platform-core/cart";
 import { CartTemplate } from "./CartTemplate";
 
 const cart: CartState = {

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -1,4 +1,4 @@
-import type { CartLine, CartState } from "@acme/types";
+import type { CartLine, CartState } from "@acme/platform-core/cart";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.d.ts
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.d.ts
@@ -1,4 +1,4 @@
-import type { CartState } from "@acme/types";
+import type { CartState } from "@acme/platform-core/cart";
 import * as React from "react";
 export interface OrderConfirmationTemplateProps extends React.HTMLAttributes<HTMLDivElement> {
     orderId: string;

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from "@storybook/react";
-import type { CartState } from "@acme/types";
+import type { CartState } from "@acme/platform-core/cart";
 import { OrderConfirmationTemplate } from "./OrderConfirmationTemplate";
 
 const cart: CartState = {

--- a/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
+++ b/packages/ui/src/components/templates/OrderConfirmationTemplate.tsx
@@ -1,4 +1,4 @@
-import type { CartLine, CartState } from "@acme/types";
+import type { CartLine, CartState } from "@acme/platform-core/cart";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Price } from "../atoms/Price";


### PR DESCRIPTION
## Summary
- re-export cart types from @acme/types
- switch UI components to cart types from @acme/platform-core
- ensure ProductFilter works with SKUs that include id and title

## Testing
- `npx tsc -b packages/types`
- `npx tsc -b packages/ui`
- `pnpm --filter @acme/ui test` *(fails: Cannot find module './auth.js' in packages/config/src/env/core.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aedf4609b4832fa6d36c21563f33e2