### PR TITLE
test: mock config in publish action tests

### DIFF
--- a/test/unit/publish-action.spec.ts
+++ b/test/unit/publish-action.spec.ts
@@ -9,6 +9,12 @@ function mockAuth() {
   }));
 }
 
+function mockConfig() {
+  jest.doMock("@acme/config", () => ({
+    env: { NODE_ENV: "test", NEXTAUTH_SECRET: "secret" },
+  }));
+}
+
 describe("publish page action", () => {
   afterEach(() => {
     jest.resetModules();
@@ -32,6 +38,7 @@ describe("publish page action", () => {
       })
     );
     mockAuth();
+    mockConfig();
     const { createPage } = await import(
       "../../apps/cms/src/actions/pages.server"
     );
@@ -55,6 +62,7 @@ describe("publish page action", () => {
       })
     );
     mockAuth();
+    mockConfig();
     const { createPage } = await import(
       "../../apps/cms/src/actions/pages.server"
     );


### PR DESCRIPTION
## Summary
- mock `@acme/config` in publish action unit tests
- provide `NEXTAUTH_SECRET` so auth secret module loads

## Testing
- `pnpm test:cms test/unit/publish-action.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68aef23699c0832fb3a04489f8175ecf