### PR TITLE
map config env imports for jest tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -96,6 +96,14 @@ module.exports = {
     // use TypeScript implementation for data root helper during tests
     "^\\./dataRoot\\.js$": "<rootDir>/packages/platform-core/src/dataRoot.ts",
 
+    // map config package relative ESM imports to TypeScript sources
+    "^\\./auth\\.js$": "<rootDir>/packages/config/src/env/auth.ts",
+    "^\\./cms\\.js$": "<rootDir>/packages/config/src/env/cms.ts",
+    "^\\./email\\.js$": "<rootDir>/packages/config/src/env/email.ts",
+    "^\\./core\\.js$": "<rootDir>/packages/config/src/env/core.ts",
+    "^\\./payments\\.js$": "<rootDir>/packages/config/src/env/payments.ts",
+    "^\\./shipping\\.js$": "<rootDir>/packages/config/src/env/shipping.ts",
+
     // explicit barrels (no trailing segment)
     "^@platform-core$": "<rootDir>/packages/platform-core/src/index.ts",
     "^@ui/src$": "<rootDir>/packages/ui/src/index.ts",


### PR DESCRIPTION
## Summary
- map config env `.js` specifiers to TypeScript sources in Jest config

## Testing
- `npx jest packages/template-app/__tests__/rental-return-flow.test.ts`
- `npx jest packages/email/src/__tests__/sendCampaignEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aef25005d8832f9af85133aaed920d