### PR TITLE
Fix component map overriding exports

### DIFF
--- a/scripts/src/component-names.ts
+++ b/scripts/src/component-names.ts
@@ -51,7 +51,9 @@ export function getComponentNameMap(componentsDir: string): Record<string, strin
           name = spec.split(/\s+as\s+/)[1];
         }
         const key = path.relative(componentsDir, file).replace(/\\/g, "/");
-        map.set(key, name);
+        if (!map.has(key)) {
+          map.set(key, name);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- prevent component name map from overwriting earlier exported names when multiple exports come from a single file

## Testing
- `npx jest scripts/__tests__/component-names.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68aef33f3190832fbccaaa6ec28b6eb9