### PR TITLE
fix: allow tailwind preset check script to run in CommonJS environments

### DIFF
--- a/scripts/check-tailwind-preset.ts
+++ b/scripts/check-tailwind-preset.ts
@@ -1,13 +1,12 @@
 import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
 import preset from "../packages/tailwind-config/src/index.ts";
 
 // Build a `require` function that works in both ESM and CJS environments.
-// `__filename` is available in CommonJS, while `import.meta.url` works in ESM.
+// `__filename` is available in CommonJS. When unavailable (e.g. ESM execution
+// without transpilation), fall back to the current working directory which
+// still allows Node's resolver to locate packages in this monorepo.
 const nodeRequire = createRequire(
-  typeof __filename !== "undefined"
-    ? __filename
-    : fileURLToPath(import.meta.url)
+  typeof __filename !== "undefined" ? __filename : process.cwd() + "/"
 );
 
 let resolvedPresetPath = "<unresolved>";


### PR DESCRIPTION
## Summary
- avoid `import.meta.url` in `check-tailwind-preset.ts`
- support running the script under CommonJS by falling back to `process.cwd()`

## Testing
- `pnpm exec jest scripts/__tests__/check-tailwind-preset.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aef3204e68832f90a0fcc4ed113404