### PR TITLE
fix: map config env js imports for Jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -117,6 +117,11 @@ module.exports = {
     "^@acme/plugin-sanity/(.*)$": "<rootDir>/test/__mocks__/pluginSanityStub.ts",
     "^@acme/zod-utils/initZod$": "<rootDir>/test/emptyModule.js",
 
+    // resolve relative .js imports within packages/config/env to their .ts sources
+    "^\\./env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
+    "^\\./(auth|cms|email|core|payments|shipping)\\.js$":
+      "<rootDir>/packages/config/src/env/$1.ts",
+
     // CMS application aliases
     "^@/components/atoms/shadcn$":
       "<rootDir>/test/__mocks__/shadcnDialogStub.tsx",


### PR DESCRIPTION
## Summary
- map .js imports in config env to their TypeScript sources for Jest

## Testing
- `pnpm test:cms packages/platform-core/__tests__/pagesApi.test.ts -t 'pages API route'` *(fails: run hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68aef2ea9898832fb71cd5ca902c75c6