### PR TITLE
test: add access denied page link tests

### DIFF
--- a/apps/cms/src/app/403/__tests__/page.test.tsx
+++ b/apps/cms/src/app/403/__tests__/page.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+}));
+
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import AccessDenied from "../page";
+
+const mockSearch = useSearchParams as jest.MockedFunction<typeof useSearchParams>;
+
+describe("AccessDenied page", () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it("links to shop products when shop param provided", () => {
+    mockSearch.mockReturnValue(
+      new URLSearchParams("shop=my-shop") as unknown as ReadonlyURLSearchParams
+    );
+
+    render(<AccessDenied />);
+    const link = screen.getByRole("link", { name: /Back to catalogue/i });
+    expect(link).toHaveAttribute("href", "/cms/shop/my-shop/products");
+  });
+
+  it("defaults link to /products when no shop param", () => {
+    mockSearch.mockReturnValue(
+      new URLSearchParams() as unknown as ReadonlyURLSearchParams
+    );
+
+    render(<AccessDenied />);
+    const link = screen.getByRole("link", { name: /Back to catalogue/i });
+    expect(link).toHaveAttribute("href", "/products");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add component test verifying AccessDenied link uses shop param

## Testing
- `pnpm --filter @apps/cms test src/app/403/__tests__/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af061875b4832f86b55d13bcbdc237