### PR TITLE
Add tests for listShops error handling

### DIFF
--- a/apps/cms/src/lib/__tests__/listShops.test.ts
+++ b/apps/cms/src/lib/__tests__/listShops.test.ts
@@ -1,0 +1,24 @@
+import fs from "fs/promises";
+import { listShops } from "../listShops";
+
+describe("listShops", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns an empty array when directory is missing", async () => {
+    const err: NodeJS.ErrnoException = new Error("not found");
+    err.code = "ENOENT";
+    jest.spyOn(fs, "readdir").mockRejectedValueOnce(err);
+
+    await expect(listShops()).resolves.toEqual([]);
+  });
+
+  it("rethrows unexpected errors", async () => {
+    const err: NodeJS.ErrnoException = new Error("boom");
+    err.code = "EACCES";
+    jest.spyOn(fs, "readdir").mockRejectedValueOnce(err);
+
+    await expect(listShops()).rejects.toBe(err);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests validating listShops returns [] on ENOENT
- add test ensuring listShops rethrows unexpected errors

## Testing
- `pnpm test src/lib/__tests__/listShops.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af06134200832f9ee981f3338e151f