### PR TITLE
test: add CMS middleware access tests

### DIFF
--- a/apps/cms/src/__tests__/middleware.test.ts
+++ b/apps/cms/src/__tests__/middleware.test.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+import { getToken } from "next-auth/jwt";
+import { canRead, canWrite } from "@auth/rbac";
+
+jest.mock("../auth/secret", () => ({ authSecret: "test-secret" }));
+jest.mock("next-auth/jwt", () => ({ getToken: jest.fn() }));
+jest.mock("@auth/rbac", () => ({ canRead: jest.fn(), canWrite: jest.fn() }));
+
+const getTokenMock = getToken as jest.MockedFunction<typeof getToken>;
+const canReadMock = canRead as jest.MockedFunction<typeof canRead>;
+const canWriteMock = canWrite as jest.MockedFunction<typeof canWrite>;
+
+describe("middleware", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns NextResponse.next for static asset paths", async () => {
+    getTokenMock.mockResolvedValue(null);
+
+    const req = new NextRequest("http://example.com/_next/static/chunk.js");
+    const res = await middleware(req);
+
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("rewrites roles without read access to /403", async () => {
+    getTokenMock.mockResolvedValue({ role: "viewer" } as any);
+    canReadMock.mockReturnValue(false);
+
+    const req = new NextRequest("http://example.com/cms");
+    const res = await middleware(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get("x-middleware-rewrite")).toBe("http://example.com/403");
+  });
+
+  it("blocks viewer roles from write routes", async () => {
+    getTokenMock.mockResolvedValue({ role: "viewer" } as any);
+    canReadMock.mockReturnValue(true);
+    canWriteMock.mockReturnValue(false);
+
+    const req = new NextRequest(
+      "http://example.com/cms/shop/test-shop/products/1/edit",
+    );
+    const res = await middleware(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get("x-middleware-rewrite")).toBe(
+      "http://example.com/403?shop=test-shop",
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- test middleware static asset passthrough
- test 403 rewrite for roles without read access
- test blocking viewer roles from write routes

## Testing
- `pnpm --filter @apps/cms test apps/cms/src/__tests__/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af060b63bc832fa0e1fb0253638cd7