### PR TITLE
test: cover auth secret env handling

### DIFF
--- a/apps/cms/src/auth/__tests__/secret.test.ts
+++ b/apps/cms/src/auth/__tests__/secret.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+const OLD_ENV = { ...process.env };
+
+afterEach(() => {
+  jest.resetModules();
+  process.env = { ...OLD_ENV };
+});
+
+describe("auth secret", () => {
+  it("throws when NEXTAUTH_SECRET is missing", async () => {
+    delete (process.env as Record<string, string | undefined>).NEXTAUTH_SECRET;
+    jest.doMock("@acme/config", () => ({ env: process.env }));
+    await expect(import("../secret")).rejects.toThrow(
+      "NEXTAUTH_SECRET is not set",
+    );
+  });
+
+  it("exports the NEXTAUTH_SECRET value", async () => {
+    (process.env as Record<string, string>).NEXTAUTH_SECRET = "test-secret";
+    jest.doMock("@acme/config", () => ({ env: process.env }));
+    const { authSecret } = await import("../secret");
+    expect(authSecret).toBe("test-secret");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for auth secret requiring NEXTAUTH_SECRET env

## Testing
- `pnpm --filter @apps/cms test apps/cms/src/auth/__tests__/secret.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af06111bf8832f88d81e1b2b0e8108