### PR TITLE
Lazy-load OpenAI and gate deposit release service startup

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -156,7 +156,10 @@ export async function startDepositReleaseService(
   return () => timers.forEach((t) => clearInterval(t));
 }
 
-if (process.env.NODE_ENV !== "test") {
+// Avoid automatically starting the deposit release service when this module is
+// imported.  Production environments can opt-in by explicitly setting an
+// environment variable.
+if (process.env.RUN_DEPOSIT_RELEASE_SERVICE === "true") {
   startDepositReleaseService().catch((err) =>
     logger.error("failed to start deposit release service", { err }),
   );


### PR DESCRIPTION
## Summary
- Lazily import OpenAI in `generateMeta` so environments without the client or API key can still load the module
- Prevent deposit release service from auto-starting unless `RUN_DEPOSIT_RELEASE_SERVICE=true`

## Testing
- `pnpm test` *(fails: apps/cms/__tests__/products.test.ts – createDraftRecord creates placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68af03aec57c832fa28ad21b2cb4880e