### PR TITLE
Handle missing tax rules in platform core

### DIFF
--- a/packages/platform-core/src/tax/index.ts
+++ b/packages/platform-core/src/tax/index.ts
@@ -18,8 +18,20 @@ let rulesCache: Record<string, number> | null = null;
 async function loadRules() {
   if (rulesCache) return rulesCache;
   const file = path.join(resolveDataRoot(), "..", "tax", "rules.json");
-  const buf = await fs.readFile(file, "utf8");
-  rulesCache = JSON.parse(buf) as Record<string, number>;
+  try {
+    const buf = await fs.readFile(file, "utf8");
+    rulesCache = JSON.parse(buf) as Record<string, number>;
+  } catch (err: any) {
+    // If the file is missing, fall back to an empty ruleset so tax
+    // calculations can proceed without configuration. This mirrors the
+    // behaviour in production where tax rules are optional for tests and
+    // local development environments.
+    if (err?.code === "ENOENT") {
+      rulesCache = {};
+    } else {
+      throw err;
+    }
+  }
   return rulesCache;
 }
 


### PR DESCRIPTION
## Summary
- avoid crash when `data/tax/rules.json` is missing by falling back to empty rules

## Testing
- `pnpm test` *(fails: Could not find module '@acme/config/dist/env/core.js' for @acme/next-config package)*

------
https://chatgpt.com/codex/tasks/task_e_68af0c920db0832fb97c050736509a7b