### PR TITLE
Fix rental deposit tests

### DIFF
--- a/packages/platform-machine/__tests__/depositService.test.ts
+++ b/packages/platform-machine/__tests__/depositService.test.ts
@@ -77,7 +77,7 @@ describe("releaseDepositsOnce", () => {
     }));
 
     const readdir = jest.fn().mockResolvedValue(["test"]);
-    jest.doMock("fs/promises", () => ({ __esModule: true, readdir }));
+    jest.doMock("node:fs/promises", () => ({ __esModule: true, readdir }));
 
     const { releaseDepositsOnce } = await import(
       "@acme/platform-machine/releaseDepositsService"

--- a/packages/template-app/__tests__/rental-return-flow.test.ts
+++ b/packages/template-app/__tests__/rental-return-flow.test.ts
@@ -3,7 +3,6 @@ import { jest } from "@jest/globals";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveDataRoot } from "@platform-core/dataRoot";
 
 process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
@@ -24,8 +23,8 @@ async function withShop(
   await fs.mkdir(path.join(dir, "data", "shops", "bcd"), { recursive: true });
   await fs.mkdir(path.join(dir, "data", "rental"), { recursive: true });
   await fs.copyFile(
-    path.resolve(resolveDataRoot(), "..", "rental", "pricing.json"),
-    path.join(dir, "data", "rental", "pricing.json")
+    path.resolve(__dirname, "../../../data/rental/pricing.json"),
+    path.join(dir, "data", "rental", "pricing.json"),
   );
   await fs.writeFile(
     path.join(dir, "data", "shops", "bcd", "shop.json"),


### PR DESCRIPTION
## Summary
- use __dirname to copy pricing data in rental return test
- mock `node:fs/promises` in deposit service test

## Testing
- `npx jest packages/template-app/__tests__/rental-return-flow.test.ts packages/platform-machine/__tests__/depositService.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af0c9e034c832fb3b9bfbb98e1467c