### PR TITLE
Fix cart cookie parsing in checkout API route

### DIFF
--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -31,8 +31,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const rawCookie = req.cookies.get(CART_COOKIE)?.value;
   let cart: CartState = {};
   try {
-    const cartJson = decodeCartCookie(rawCookie);
-    cart = cartJson ? (JSON.parse(cartJson) as CartState) : {};
+    const cartCookie = decodeCartCookie(rawCookie);
+    cart =
+      cartCookie && typeof cartCookie === "object"
+        ? (cartCookie as CartState)
+        : {};
   } catch {
     cart = {};
   }


### PR DESCRIPTION
## Summary
- avoid double-parsing decoded cart cookie in checkout session route

## Testing
- `pnpm exec jest --config jest.config.cjs --runTestsByPath functions/themes/\[theme\]/__tests__/cart-checkout-integration.test.ts`
- `pnpm test` *(fails: Cannot find module '/workspace/base-shop/packages/next-config/node_modules/@acme/config/dist/env/core.js')*


------
https://chatgpt.com/codex/tasks/task_e_68af0fce48bc832faef665f20ce2750e