### PR TITLE
fix: close CLI prompt handles after use

### DIFF
--- a/scripts/src/utils/prompt.ts
+++ b/scripts/src/utils/prompt.ts
@@ -6,6 +6,10 @@ export async function prompt(question: string, def = ""): Promise<string> {
   const rl = readline.createInterface({ input, output });
   const answer = (await rl.question(question)).trim();
   rl.close();
+  // Ensure stdin/stdout don't keep the event loop alive in tests
+  // or after the prompt completes.
+  typeof (input as any).unref === "function" && (input as any).unref();
+  typeof (output as any).unref === "function" && (output as any).unref();
   return answer || def;
 }
 


### PR DESCRIPTION
## Summary
- unref stdin/stdout after closing readline prompts to let Jest exit cleanly

## Testing
- `npx jest test/unit/init-shop/provider.spec.ts --detectOpenHandles --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68af13a7c0dc832fb66af4741b95fa95