### PR TITLE
test: await component render in upgrade preview test

### DIFF
--- a/apps/shop-bcd/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-bcd/__tests__/upgradePreview.test.tsx
@@ -33,7 +33,8 @@ describe("upgrade preview page", () => {
     render(<UpgradePreviewPage />);
 
     await screen.findByText("Breadcrumbs");
-    expect(await screen.findByTestId("new-comp")).toBeInTheDocument();
+    const newComp = await screen.findByTestId("new-comp");
+    expect(newComp).toBeInTheDocument();
     expect(screen.queryByTestId("old-comp")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /compare/i }));


### PR DESCRIPTION
## Summary
- Ensure upgrade preview waits for component render by storing `new-comp` element from `findByTestId`

## Testing
- `pnpm test:cms apps/shop-bcd/__tests__/upgradePreview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af13cf5058832f80617e15365aed3b