### PR TITLE
fix: add .js extensions to env imports

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,8 +1,8 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-import { authEnvSchema } from "./auth";
-import { cmsEnvSchema } from "./cms";
-import { emailEnvSchema } from "./email";
+import { authEnvSchema } from "./auth.js";
+import { cmsEnvSchema } from "./cms.js";
+import { emailEnvSchema } from "./email.js";
 
 const isProd = process.env.NODE_ENV === "production";
 

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
-} from "./core";
-import { paymentEnvSchema } from "./payments";
-import { shippingEnvSchema } from "./shipping";
+} from "./core.js";
+import { paymentEnvSchema } from "./payments.js";
+import { shippingEnvSchema } from "./shipping.js";
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   k: infer I,
@@ -58,9 +58,9 @@ if (!parsed.success) {
 export const env = parsed.data;
 export type Env = z.infer<typeof envSchema>;
 
-export * from "./auth";
-export * from "./cms";
-export * from "./email";
-export * from "./core";
-export * from "./payments";
-export * from "./shipping";
+export * from "./auth.js";
+export * from "./cms.js";
+export * from "./email.js";
+export * from "./core.js";
+export * from "./payments.js";
+export * from "./shipping.js";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 // packages/config/src/index.ts
 // Re-export compiled env in a stable, root entry for all consumers.
-import { coreEnv } from "./env/core";
+import { coreEnv } from "./env/core.js";
 
 export const env = coreEnv;
-export type { CoreEnv as Env } from "./env/core";
+export type { CoreEnv as Env } from "./env/core.js";


### PR DESCRIPTION
## Summary
- add .js extensions to env module imports
- ensure env index re-exports compiled modules

## Testing
- `npx tsc -b apps/cms` *(fails: packages/email-templates rootDir errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af16361f08832f811106d2dd3af4de