### PR TITLE
fix checkout session cart parsing

### DIFF
--- a/apps/shop-bcd/src/api/checkout-session/route.ts
+++ b/apps/shop-bcd/src/api/checkout-session/route.ts
@@ -32,10 +32,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   let cart: CartState = {};
   try {
     const cartCookie = decodeCartCookie(rawCookie);
-    cart =
-      cartCookie && typeof cartCookie === "object"
-        ? (cartCookie as CartState)
-        : {};
+    if (typeof cartCookie === "string") {
+      cart = JSON.parse(cartCookie) as CartState;
+    } else if (cartCookie && typeof cartCookie === "object") {
+      cart = cartCookie as CartState;
+    } else {
+      cart = {};
+    }
   } catch {
     cart = {};
   }


### PR DESCRIPTION
## Summary
- parse stringified cart cookies before building checkout session

## Testing
- `npx jest apps/shop-bcd/__tests__/checkout-session.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af30e3c4e8832fad28bbe30c72fb0c