### PR TITLE
test(configurator): include env error in response

### DIFF
--- a/apps/cms/src/app/api/configurator/route.test.ts
+++ b/apps/cms/src/app/api/configurator/route.test.ts
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+const createNewShop = jest.fn();
+const validateShopEnv = jest.fn();
+
+jest.mock('@cms/actions/createShop.server', () => ({
+  __esModule: true,
+  createNewShop: (...args: any[]) => createNewShop(...args),
+}));
+
+jest.mock('@platform-core/configurator', () => ({
+  __esModule: true,
+  validateShopEnv: (...args: any[]) => validateShopEnv(...args),
+}));
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe('configurator route', () => {
+  it('returns envError while still succeeding when env validation fails', async () => {
+    createNewShop.mockResolvedValue({ ok: true });
+    validateShopEnv.mockImplementation(() => {
+      throw new Error('env failed');
+    });
+
+    const { POST } = await import('./route');
+
+    const req = { json: async () => ({ id: 'shop1' }) } as unknown as Request;
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.envError).toBe('env failed');
+    expect(body).toHaveProperty('deployment');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add configurator route test verifying env validation errors surface in response while request still succeeds

## Testing
- `pnpm test apps/cms/src/app/api/configurator/route.test.ts` *(fails: Could not find task)*
- `pnpm --filter @apps/cms test apps/cms/src/app/api/configurator/route.test.ts -- --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68af4826a1dc832f89e778aa24a449ff