### PR TITLE
docs: document configuration stubs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS
+
+## Required scripts
+
+- Run `pnpm install` to install dependencies.
+- Build all packages before starting any app: `pnpm -r build`.
+- Regenerate config stubs after editing `.impl.ts` files: `pnpm run build:stubs`.
+

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS
+
+This package exposes configuration files through generated JavaScript stubs.
+Each config file has a TypeScript implementation in a sibling `*.impl.ts`
+file. The corresponding `*.js` stub simply re-exports the compiled
+implementation.
+
+## Regenerating stubs
+
+Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the
+JavaScript stubs.
+
+## Tooling
+
+- **Next.js** loads the `*.js` stubs for runtime configuration.
+- **Jest** resolves the stubs so tests run without a custom transformer.
+- **ESLint** reads configuration from the stubs for consistent linting.
+


### PR DESCRIPTION
## Summary
- document JS stub pattern for @acme/config and list regeneration command
- outline required repo scripts including building before running apps

## Testing
- `pnpm --filter @acme/config lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68af59eda898832f973f0693f30ff293