### PR TITLE
chore: map foo env modules in Jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -103,6 +103,8 @@ module.exports = {
     "^\\./core\\.js$": "<rootDir>/packages/config/src/env/core.ts",
     "^\\./payments\\.js$": "<rootDir>/packages/config/src/env/payments.ts",
     "^\\./shipping\\.js$": "<rootDir>/packages/config/src/env/shipping.ts",
+    "^\\./foo\\.js$": "<rootDir>/packages/config/src/env/foo.impl.ts",
+    "^\\./foo\\.impl\\.ts$": "<rootDir>/packages/config/src/env/foo.impl.ts",
 
     // explicit barrels (no trailing segment)
     "^@platform-core$": "<rootDir>/packages/platform-core/src/index.ts",


### PR DESCRIPTION
## Summary
- map ./foo.js and ./foo.impl.ts to src/env/foo.impl.ts in Jest moduleNameMapper

## Testing
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68af59edac98832fbda14dbf670c6202