### PR TITLE
feat(config): add env stub generator

### DIFF
--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -1,0 +1,9 @@
+# @acme/config
+
+## Environment stubs
+
+This package uses implementation files suffixed with `.impl.ts` under `src/env/`.
+Run `pnpm run build:stubs` to generate matching `.js` re-export files
+whenever you add or modify these implementations.
+
+The command is also executed automatically during `pnpm run build`.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,7 +27,8 @@
   "files": ["dist"],
   "sideEffects": false,
   "scripts": {
-    "prebuild": "pnpm --filter @acme/zod-utils run build",
+    "build:stubs": "node ./scripts/generate-env-stubs.mjs",
+    "prebuild": "pnpm run build:stubs && pnpm --filter @acme/zod-utils run build",
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w",
     "clean": "rimraf dist *.tsbuildinfo",

--- a/packages/config/scripts/generate-env-stubs.mjs
+++ b/packages/config/scripts/generate-env-stubs.mjs
@@ -1,0 +1,20 @@
+import { readdir, writeFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const envDir = join(__dirname, '..', 'src', 'env');
+
+const entries = await readdir(envDir, { withFileTypes: true }).catch(() => []);
+
+await Promise.all(
+  entries
+    .filter((e) => e.isFile() && e.name.endsWith('.impl.ts'))
+    .map(async (e) => {
+      const base = e.name.replace(/\.impl\.ts$/, '');
+      const stubPath = join(envDir, `${base}.js`);
+      const content = `export * from "./${base}.impl.js";\nexport { default } from "./${base}.impl.js";\n`;
+      await writeFile(stubPath, content);
+    }),
+);


### PR DESCRIPTION
## Summary
- add script to generate env re-export stubs
- run stub generation before building config package
- document stub script usage

## Testing
- `pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68af59edb508832f9545370e3cadb74c