### PR TITLE
chore: relax linting for env stubs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,5 +29,14 @@ module.exports = {
         "@typescript-eslint/no-var-requires": "off",
       },
     },
+    {
+      files: ["packages/config/src/env/*.js"],
+      rules: {
+        "import/extensions": "off",
+        "no-restricted-exports": "off",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": "off",
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- disable import extension & export restrictions for env stub files
- turn off unused-var linting for env stubs

## Testing
- `pnpm lint` *(fails: command  exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68af59edb760832f877d86a3e0b8d43e