### PR TITLE
feat: set tsconfig path for template app

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 // packages/config/src/index.ts
 // Re-export compiled env in a stable, root entry for all consumers.
-import { coreEnv } from "./env/core";
+import { coreEnv } from "./env/core.js";
 
 export const env = coreEnv;
-export type { CoreEnv as Env } from "./env/core";
+export type { CoreEnv as Env } from "./env/core.js";

--- a/packages/template-app/next.config.mjs
+++ b/packages/template-app/next.config.mjs
@@ -15,6 +15,10 @@ import baseConfig from "@acme/next-config/next.config.mjs";
 const config = {
   // Spread the settings from the shared config to preserve its behaviour.
   ...baseConfig,
+  typescript: {
+    ...(baseConfig.typescript ?? {}),
+    tsconfigPath: "./tsconfig.json",
+  },
   // Override or extend any fields here.  In this case we need to
   // transpile additional internal packages so that Next.js can import
   // their untranspiled source code from `node_modules`.

--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -32,6 +32,13 @@
       "@acme/platform-core/*": [
         "../platform-core/src/*"
       ],
+      "@acme/config": [
+        "../config/dist/index"
+      ],
+      "@acme/config/*": [
+        "./src/env/*.impl.ts",
+        "../config/dist/*"
+      ],
       "@auth": [
         "../auth/src/index",
         "../auth/src"


### PR DESCRIPTION
## Summary
- ensure template-app uses its own tsconfig
- map `@acme/config/*` to compiled package and local env overrides
- fix config package entry to use explicit .js extension

## Testing
- `pnpm --filter @acme/template-app build` *(fails: Module '"@prisma/client"' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68af59edbc5c832faa36854c7a1e4d50