### PR TITLE
fix: allow template app build without payment env vars

### DIFF
--- a/packages/config/src/env/payments.impl.ts
+++ b/packages/config/src/env/payments.impl.ts
@@ -9,12 +9,17 @@ export const paymentEnvSchema = z.object({
 
 const parsed = paymentEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  console.error(
-    "❌ Invalid payment environment variables:",
+  console.warn(
+    "⚠️ Invalid payment environment variables:",
     parsed.error.format(),
   );
-  throw new Error("Invalid payment environment variables");
 }
 
-export const paymentEnv = parsed.data;
+export const paymentEnv = parsed.success
+  ? parsed.data
+  : {
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+    };
 export type PaymentEnv = z.infer<typeof paymentEnvSchema>;

--- a/packages/template-app/src/app/cancelled/page.tsx
+++ b/packages/template-app/src/app/cancelled/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 
-export default function Cancelled() {
+function CancelledContent() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
   return (
@@ -15,5 +16,13 @@ export default function Cancelled() {
         </p>
       )}
     </div>
+  );
+}
+
+export default function Cancelled() {
+  return (
+    <Suspense>
+      <CancelledContent />
+    </Suspense>
   );
 }

--- a/packages/template-app/src/app/layout.tsx
+++ b/packages/template-app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // src/app/layout.tsx
 import { CartProvider } from "@platform-core/contexts/CartContext";
+import { CurrencyProvider } from "@platform-core/contexts/CurrencyContext";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import AnalyticsScripts from "./AnalyticsScripts";
@@ -29,7 +30,9 @@ export default function RootLayout({
       <body className="antialiased">
         {/* Global providers go here */}
         <AnalyticsScripts />
-        <CartProvider>{children}</CartProvider>
+        <CurrencyProvider>
+          <CartProvider>{children}</CartProvider>
+        </CurrencyProvider>
       </body>
     </html>
   );

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -6,10 +6,10 @@ import {
   getShopSettings,
   readShop,
 } from "@platform-core/repositories/shops.server";
-
-const SHOP_ID = "bcd";
 import CleaningInfo from "../../../components/CleaningInfo";
 import * as React from "react";
+
+const SHOP_ID = "bcd";
 
 export const metadata = { title: "Mobile Returns" };
 


### PR DESCRIPTION
## Summary
- avoid throwing when payment env vars missing and provide defaults
- add CurrencyProvider and Suspense wrappers in template app
- tidy returns mobile page imports

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/template-app build` *(fails: TypeError i.useRef is not a function at /account/returns/page)*

------
https://chatgpt.com/codex/tasks/task_e_68af655c1e64832fb9d196d6de79281a