### PR TITLE
test: add email service registration tests

### DIFF
--- a/packages/platform-core/src/services/__tests__/emailService.test.ts
+++ b/packages/platform-core/src/services/__tests__/emailService.test.ts
@@ -1,0 +1,22 @@
+import type { EmailService } from "../emailService";
+
+describe("emailService", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("throws if service is not registered", async () => {
+    const { getEmailService } = await import("../emailService");
+    expect(() => getEmailService()).toThrow("EmailService not registered");
+  });
+
+  it("returns the registered service", async () => {
+    const { setEmailService, getEmailService } = await import("../emailService");
+    const mockService: EmailService = {
+      sendEmail: jest.fn().mockResolvedValue(undefined),
+    };
+    setEmailService(mockService);
+    expect(getEmailService()).toBe(mockService);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests verifying email service must be registered
- ensure registered mock service is returned

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Export encountered an error on /returns/mobile/page)*
- `pnpm exec jest packages/platform-core/src/services/__tests__/emailService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af6886f354832fa28906d577b40e08