### PR TITLE
test(auth): add memory session store ttl test

### DIFF
--- a/packages/auth/src/__tests__/memoryStore.test.ts
+++ b/packages/auth/src/__tests__/memoryStore.test.ts
@@ -1,0 +1,40 @@
+import { MemorySessionStore } from "../memoryStore";
+import type { SessionRecord } from "../store";
+
+describe("MemorySessionStore", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("expires sessions and returns only active sessions", async () => {
+    const store = new MemorySessionStore(1);
+    const expired: SessionRecord = {
+      sessionId: "s1",
+      customerId: "c1",
+      userAgent: "agent",
+      createdAt: new Date(),
+    };
+    await store.set(expired);
+
+    jest.advanceTimersByTime(500);
+    const active: SessionRecord = {
+      sessionId: "s2",
+      customerId: "c1",
+      userAgent: "agent",
+      createdAt: new Date(),
+    };
+    await store.set(active);
+
+    jest.advanceTimersByTime(600);
+
+    await expect(store.get(expired.sessionId)).resolves.toBeNull();
+    await expect(store.list("c1")).resolves.toEqual([active]);
+    await expect(store.get(active.sessionId)).resolves.toEqual(active);
+    await expect(store.list("c1")).resolves.toEqual([active]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for MemorySessionStore to ensure expired sessions are omitted from results

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Next.js build worker exited with code 1)
- `pnpm --filter @acme/auth test packages/auth/src/__tests__/memoryStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af6885f690832fbf1e128cbb1f8ca0