### PR TITLE
test(config): add core env refinement tests

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.impl";
+
+const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
+
+describe("core env refinement", () => {
+  it("reports invalid DEPOSIT_RELEASE_ENABLED", () => {
+    const parsed = schema.safeParse({ DEPOSIT_RELEASE_ENABLED: "yes" });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]).toMatchObject({
+        path: ["DEPOSIT_RELEASE_ENABLED"],
+        message: "must be true or false",
+      });
+    }
+  });
+
+  it("reports non-numeric LATE_FEE_INTERVAL_MS", () => {
+    const parsed = schema.safeParse({ LATE_FEE_INTERVAL_MS: "fast" });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]).toMatchObject({
+        path: ["LATE_FEE_INTERVAL_MS"],
+        message: "must be a number",
+      });
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- test DEPOSIT_RELEASE_ENABLED requires true/false
- test LATE_FEE_INTERVAL_MS requires numeric value

## Testing
- `pnpm exec jest packages/config/src/env/__tests__/core.test.ts --config packages/config/jest.preset.cjs`
- `pnpm -r build` *(fails: Next.js build worker exited with code: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68af68897e94832fbb74797ed34f6f9f