### PR TITLE
fix(template-app): extract client-only returns components

### DIFF
--- a/packages/template-app/src/app/account/returns/ReturnForm.tsx
+++ b/packages/template-app/src/app/account/returns/ReturnForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+
+interface ReturnFormProps {
+  bagType?: string;
+  tracking?: boolean;
+}
+
+export default function ReturnForm({
+  bagType,
+  tracking: trackingEnabled,
+}: ReturnFormProps) {
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+  const [sessionId, setSessionId] = React.useState("");
+  const [labelUrl, setLabelUrl] = React.useState<string | null>(null);
+  const [trackingNumber, setTrackingNumber] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let stream: MediaStream | null = null;
+    let active = true;
+    async function init() {
+      if (!("BarcodeDetector" in window)) return;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+        });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+        const detector = new window.BarcodeDetector({
+          formats: ["qr_code"],
+        });
+        const scan = async () => {
+          if (!active || !videoRef.current) return;
+          try {
+            const codes = await detector.detect(videoRef.current);
+            if (codes.length > 0) {
+              const code = codes[0].rawValue;
+              setSessionId(code);
+              active = false;
+              stream?.getTracks().forEach((t) => t.stop());
+              return;
+            }
+          } catch {
+            /* noop */
+          }
+          requestAnimationFrame(scan);
+        };
+        requestAnimationFrame(scan);
+      } catch {
+        setError("Unable to access camera.");
+      }
+    }
+    init();
+    return () => {
+      active = false;
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLabelUrl(null);
+    setTrackingNumber(null);
+    try {
+      const res = await fetch("/api/returns/mobile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to create return");
+        return;
+      }
+      setLabelUrl(data.labelUrl ?? null);
+      setTrackingNumber(data.tracking ?? null);
+    } catch {
+      setError("Failed to create return");
+    }
+  };
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-xl font-semibold">Return Item</h1>
+      {bagType && <p>Please reuse the {bagType} bag for your return.</p>}
+      <video ref={videoRef} className="w-full max-w-md" />
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="w-full border p-2"
+          placeholder="Session ID"
+          value={sessionId}
+          onChange={(e) => setSessionId(e.target.value)}
+        />
+        <button type="submit" className="bg-primary px-4 py-2 text-white">
+          Submit
+        </button>
+      </form>
+      {labelUrl && trackingEnabled && (
+        <p>
+          <a
+            href={labelUrl}
+            className="text-blue-600 underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Print Label
+          </a>
+          {trackingNumber && (
+            <span className="block">Tracking: {trackingNumber}</span>
+          )}
+        </p>
+      )}
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}
+

--- a/packages/template-app/src/app/account/returns/page.tsx
+++ b/packages/template-app/src/app/account/returns/page.tsx
@@ -3,11 +3,11 @@ import {
   getReturnBagAndLabel,
 } from "@platform-core/returnLogistics";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import * as React from "react";
 
 const SHOP_ID = "bcd";
 import CleaningInfo from "../../../components/CleaningInfo";
 import shop from "../../../../shop.json";
+import ReturnForm from "./ReturnForm";
 
 export const metadata = { title: "Mobile Returns" };
 
@@ -27,122 +27,5 @@ export default async function ReturnsPage() {
       <ReturnForm bagType={bagType} tracking={tracking} />
       {shop.showCleaningTransparency && <CleaningInfo />}
     </>
-  );
-}
-
-interface ReturnFormProps {
-  bagType?: string;
-  tracking?: boolean;
-}
-
-function ReturnForm({ bagType, tracking: trackingEnabled }: ReturnFormProps) {
-  "use client";
-
-  const videoRef = React.useRef<HTMLVideoElement>(null);
-  const [sessionId, setSessionId] = React.useState("");
-  const [labelUrl, setLabelUrl] = React.useState<string | null>(null);
-  const [trackingNumber, setTrackingNumber] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    let stream: MediaStream | null = null;
-    let active = true;
-    async function init() {
-      if (!("BarcodeDetector" in window)) return;
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: "environment" },
-        });
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play();
-        }
-        const detector = new window.BarcodeDetector({
-          formats: ["qr_code"],
-        });
-        const scan = async () => {
-          if (!active || !videoRef.current) return;
-          try {
-            const codes = await detector.detect(videoRef.current);
-            if (codes.length > 0) {
-              const code = codes[0].rawValue;
-              setSessionId(code);
-              active = false;
-              stream?.getTracks().forEach((t) => t.stop());
-              return;
-            }
-          } catch {
-            /* noop */
-          }
-          requestAnimationFrame(scan);
-        };
-        requestAnimationFrame(scan);
-      } catch {
-        setError("Unable to access camera.");
-      }
-    }
-    init();
-    return () => {
-      active = false;
-      stream?.getTracks().forEach((t) => t.stop());
-    };
-  }, []);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    setLabelUrl(null);
-    setTrackingNumber(null);
-    try {
-      const res = await fetch("/api/returns/mobile", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || "Failed to create return");
-        return;
-      }
-      setLabelUrl(data.labelUrl ?? null);
-      setTrackingNumber(data.tracking ?? null);
-    } catch {
-      setError("Failed to create return");
-    }
-  };
-
-  return (
-    <div className="space-y-4 p-6">
-      <h1 className="text-xl font-semibold">Return Item</h1>
-      {bagType && <p>Please reuse the {bagType} bag for your return.</p>}
-      <video ref={videoRef} className="w-full max-w-md" />
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <input
-          className="w-full border p-2"
-          placeholder="Session ID"
-          value={sessionId}
-          onChange={(e) => setSessionId(e.target.value)}
-        />
-        <button type="submit" className="bg-primary px-4 py-2 text-white">
-          Submit
-        </button>
-      </form>
-      {labelUrl && trackingEnabled && (
-        <p>
-          <a
-            href={labelUrl}
-            className="text-blue-600 underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Print Label
-          </a>
-          {trackingNumber && (
-            <span className="block">Tracking: {trackingNumber}</span>
-          )}
-        </p>
-      )}
-      {error && <p className="text-red-600">{error}</p>}
-    </div>
   );
 }

--- a/packages/template-app/src/app/returns/mobile/Scanner.tsx
+++ b/packages/template-app/src/app/returns/mobile/Scanner.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import * as React from "react";
+
+interface ScannerProps {
+  allowedZips: string[];
+}
+
+export default function Scanner({ allowedZips }: ScannerProps) {
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+  const [result, setResult] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [zip, setZip] = React.useState("");
+  const [done, setDone] = React.useState(false);
+
+  async function finalize(sessionId: string) {
+    try {
+      await fetch("/api/returns/mobile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(zip ? { sessionId, zip } : { sessionId }),
+      });
+      setDone(true);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to record return.");
+    }
+  }
+
+  React.useEffect(() => {
+    let stream: MediaStream | null = null;
+    let active = true;
+    async function init() {
+      if (!("BarcodeDetector" in window)) {
+        setError("Scanning not supported on this device.");
+        return;
+      }
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+        });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+        const detector = new (window as any).BarcodeDetector({
+          formats: ["qr_code", "code_128", "ean_13", "upc_a"],
+        });
+        const scan = async () => {
+          if (!active || !videoRef.current) return;
+          try {
+            const codes = await detector.detect(videoRef.current);
+            if (codes.length > 0) {
+              const code = codes[0].rawValue;
+              setResult(code);
+              active = false;
+              stream?.getTracks().forEach((t) => t.stop());
+              if (allowedZips.length === 0) {
+                await finalize(code);
+              }
+              return;
+            }
+          } catch (err) {
+            console.error(err);
+          }
+          requestAnimationFrame(scan);
+        };
+        requestAnimationFrame(scan);
+      } catch (err) {
+        setError("Unable to access camera.");
+      }
+    }
+    init();
+    return () => {
+      active = false;
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, [allowedZips]);
+
+  if (done) {
+    return (
+      <div className="space-y-4 p-6">
+        <p>Return recorded.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-xl font-semibold">Scan to mark return</h1>
+      {!result && <video ref={videoRef} className="w-full max-w-md" />}
+      {result && allowedZips.length > 0 && (
+        <div className="space-y-2">
+          <p>Scanned: {result}</p>
+          <label className="flex flex-col gap-1">
+            Home pickup ZIP
+            <select
+              className="border p-2"
+              value={zip}
+              onChange={(e) => setZip(e.target.value)}
+            >
+              <option value="">Select ZIP</option>
+              {allowedZips.map((z) => (
+                <option key={z} value={z}>
+                  {z}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            className="bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+            disabled={!zip}
+            onClick={() => result && finalize(result)}
+          >
+            Finalize
+          </button>
+        </div>
+      )}
+      {result && allowedZips.length === 0 && <p>Processing...</p>}
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}
+

--- a/packages/template-app/src/app/returns/mobile/page.tsx
+++ b/packages/template-app/src/app/returns/mobile/page.tsx
@@ -7,7 +7,7 @@ import {
   readShop,
 } from "@platform-core/repositories/shops.server";
 import CleaningInfo from "../../../components/CleaningInfo";
-import * as React from "react";
+import Scanner from "./Scanner";
 
 const SHOP_ID = "bcd";
 
@@ -31,122 +31,5 @@ export default async function MobileReturnPage() {
       <Scanner allowedZips={allowed} />
       {shop.showCleaningTransparency && <CleaningInfo />}
     </>
-  );
-}
-
-function Scanner({ allowedZips }: { allowedZips: string[] }) {
-  "use client";
-  const videoRef = React.useRef<HTMLVideoElement>(null);
-  const [result, setResult] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
-  const [zip, setZip] = React.useState("");
-  const [done, setDone] = React.useState(false);
-
-  async function finalize(sessionId: string) {
-    try {
-      await fetch("/api/returns/mobile", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(zip ? { sessionId, zip } : { sessionId }),
-      });
-      setDone(true);
-    } catch (err) {
-      console.error(err);
-      setError("Failed to record return.");
-    }
-  }
-
-  React.useEffect(() => {
-    let stream: MediaStream | null = null;
-    let active = true;
-    async function init() {
-      if (!("BarcodeDetector" in window)) {
-        setError("Scanning not supported on this device.");
-        return;
-      }
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: "environment" },
-        });
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play();
-        }
-        const detector = new (window as any).BarcodeDetector({
-          formats: ["qr_code", "code_128", "ean_13", "upc_a"],
-        });
-        const scan = async () => {
-          if (!active || !videoRef.current) return;
-          try {
-            const codes = await detector.detect(videoRef.current);
-            if (codes.length > 0) {
-              const code = codes[0].rawValue;
-              setResult(code);
-              active = false;
-              stream?.getTracks().forEach((t) => t.stop());
-              if (allowedZips.length === 0) {
-                await finalize(code);
-              }
-              return;
-            }
-          } catch (err) {
-            console.error(err);
-          }
-          requestAnimationFrame(scan);
-        };
-        requestAnimationFrame(scan);
-      } catch (err) {
-        setError("Unable to access camera.");
-      }
-    }
-    init();
-    return () => {
-      active = false;
-      stream?.getTracks().forEach((t) => t.stop());
-    };
-  }, [allowedZips]);
-
-  if (done) {
-    return (
-      <div className="space-y-4 p-6">
-        <p>Return recorded.</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-4 p-6">
-      <h1 className="text-xl font-semibold">Scan to mark return</h1>
-      {!result && <video ref={videoRef} className="w-full max-w-md" />}
-      {result && allowedZips.length > 0 && (
-        <div className="space-y-2">
-          <p>Scanned: {result}</p>
-          <label className="flex flex-col gap-1">
-            Home pickup ZIP
-            <select
-              className="border p-2"
-              value={zip}
-              onChange={(e) => setZip(e.target.value)}
-            >
-              <option value="">Select ZIP</option>
-              {allowedZips.map((z) => (
-                <option key={z} value={z}>
-                  {z}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button
-            className="bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
-            disabled={!zip}
-            onClick={() => result && finalize(result)}
-          >
-            Finalize
-          </button>
-        </div>
-      )}
-      {result && allowedZips.length === 0 && <p>Processing...</p>}
-      {error && <p className="text-red-600">{error}</p>}
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix build error on account returns page by moving client logic into `ReturnForm`
- do the same for mobile returns page using a new `Scanner` component

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/email build: tsconfig rootDir error)*
- `pnpm --filter @acme/template-app build`


------
https://chatgpt.com/codex/tasks/task_e_68af6811c490832f908aea1cc46a9030