### PR TITLE
refactor: use scripts dist for publish

### DIFF
--- a/apps/shop-bcd/src/app/api/publish/route.ts
+++ b/apps/shop-bcd/src/app/api/publish/route.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import { NextResponse } from "next/server";
 import { requirePermission } from "@auth";
-import { republishShop } from "../../../../../../scripts/src/republish-shop";
+import { republishShop } from "@scripts/republish-shop";
 
 export const runtime = "nodejs";
 

--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -52,6 +52,13 @@
       "@shared-utils/*": [
         "../../packages/shared-utils/dist/*"
       ],
+      "@scripts": [
+        "../../scripts/dist/index",
+        "../../scripts/dist"
+      ],
+      "@scripts/*": [
+        "../../scripts/dist/*"
+      ],
       "@acme/types": [
         "../../packages/types/dist/index",
         "../../packages/types/dist"
@@ -110,6 +117,9 @@
     },
     {
       "path": "../../packages/zod-utils"
+    },
+    {
+      "path": "../../scripts"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- use scripts package alias in publish route
- link shop-bcd to scripts project and dist path

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `npx tsc -b apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_68af6fd1057c832fa331fe1986b7a5a3