### PR TITLE
test(cms): add middleware bypass tests

### DIFF
--- a/apps/cms/__tests__/middleware.integration.test.ts
+++ b/apps/cms/__tests__/middleware.integration.test.ts
@@ -141,4 +141,26 @@ describe("middleware integration", () => {
       "http://localhost/403?shop=foo"
     );
   });
+
+  it("allows viewers with read access to /cms", async () => {
+    getToken.mockResolvedValueOnce({ role: "viewer" } as JWT);
+    canRead.mockReturnValueOnce(true);
+
+    const req = createRequest("/cms");
+    const res = await middleware(req);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("bypasses auth for Next.js static assets", async () => {
+    getToken.mockResolvedValueOnce(null);
+
+    const req = createRequest("/_next/static/chunk.js");
+    const res = await middleware(req);
+
+    expect(next).toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
 });


### PR DESCRIPTION
## Summary
- add integration test for viewer with read access hitting /cms
- add integration test confirming _next/static bypasses auth

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/middleware.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af6f62f9d0832f9aa92b0be2fe1965