### PR TITLE
test: page templates API routes

### DIFF
--- a/apps/cms/__tests__/pageTemplateNameRoute.test.ts
+++ b/apps/cms/__tests__/pageTemplateNameRoute.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+jest.setTimeout(20000);
+
+// Polyfill Response.json when missing
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    });
+}
+
+async function withTemplates(
+  files: Record<string, unknown>,
+  cb: () => Promise<void>
+): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pt-"));
+  const templatesDir = path.join(dir, "packages", "ui", "components", "templates");
+  await fs.mkdir(templatesDir, { recursive: true });
+  for (const [name, data] of Object.entries(files)) {
+    await fs.writeFile(
+      path.join(templatesDir, `${name}.json`),
+      JSON.stringify(data),
+      "utf8"
+    );
+  }
+  const cwd = process.cwd();
+  process.chdir(dir);
+  jest.resetModules();
+  try {
+    await cb();
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+describe("page template by name API route", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
+  it("returns template data when found", async () => {
+    await withTemplates({ home: { name: "Home", components: ["Hero"] } }, async () => {
+      const route = await import("../src/app/api/page-templates/[name]/route");
+      const res = await route.GET(new Request("http://localhost"), {
+        params: Promise.resolve({ name: "home" }),
+      });
+      const json = await res.json();
+      expect(json).toEqual({ name: "Home", components: ["Hero"] });
+    });
+  });
+
+  it("returns 404 when template missing", async () => {
+    await withTemplates({}, async () => {
+      const route = await import("../src/app/api/page-templates/[name]/route");
+      const res = await route.GET(new Request("http://localhost"), {
+        params: Promise.resolve({ name: "missing" }),
+      });
+      const json = await res.json();
+      expect(res.status).toBe(404);
+      expect(json).toEqual({ error: "Not found" });
+    });
+  });
+});

--- a/apps/cms/__tests__/pageTemplatesRoute.test.ts
+++ b/apps/cms/__tests__/pageTemplatesRoute.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+jest.setTimeout(20000);
+
+// Polyfill Response.json when missing
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    });
+}
+
+async function withTemplates(
+  files: Record<string, unknown>,
+  cb: () => Promise<void>
+): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pt-"));
+  const templatesDir = path.join(dir, "packages", "ui", "components", "templates");
+  await fs.mkdir(templatesDir, { recursive: true });
+  for (const [name, data] of Object.entries(files)) {
+    await fs.writeFile(
+      path.join(templatesDir, `${name}.json`),
+      JSON.stringify(data),
+      "utf8"
+    );
+  }
+  const cwd = process.cwd();
+  process.chdir(dir);
+  jest.resetModules();
+  try {
+    await cb();
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+describe("page templates list API route", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
+  it("returns template list", async () => {
+    await withTemplates(
+      {
+        home: { name: "Home", components: ["Hero"] },
+        contact: { components: [] },
+      },
+      async () => {
+        const route = await import("../src/app/api/page-templates/route");
+        const res = await route.GET();
+        const json = await res.json();
+        expect(json).toHaveLength(2);
+        expect(json).toEqual(
+          expect.arrayContaining([
+            { name: "Home", components: ["Hero"] },
+            { name: "contact", components: [] },
+          ])
+        );
+      }
+    );
+  });
+
+  it("handles fs errors", async () => {
+    await withTemplates({}, async () => {
+      jest.doMock("fs", () => {
+        const actual = jest.requireActual("fs");
+        return {
+          ...actual,
+          promises: {
+            ...actual.promises,
+            readdir: jest.fn().mockRejectedValue(new Error("boom")),
+          },
+        } as typeof actual;
+      });
+      const route = await import("../src/app/api/page-templates/route");
+      const res = await route.GET();
+      const json = await res.json();
+      expect(res.status).toBe(500);
+      expect(json).toEqual({ error: "boom" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for page templates list route
- add tests for page templates by-name route

## Testing
- `pnpm --filter @apps/cms test __tests__/pageTemplatesRoute.test.ts __tests__/pageTemplateNameRoute.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af6f688428832fa47d26713d9aa657