### PR TITLE
test: add CMS env validation tests

### DIFF
--- a/packages/config/__tests__/cmsEnv.test.ts
+++ b/packages/config/__tests__/cmsEnv.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "@jest/globals";
+
+describe("cmsEnv", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("parses when required variables are present", async () => {
+    process.env = {
+      CMS_SPACE_URL: "https://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2023-01-01",
+    } as NodeJS.ProcessEnv;
+
+    const { cmsEnv } = await import("../src/env/cms.impl");
+    expect(cmsEnv).toEqual({
+      CMS_SPACE_URL: "https://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2023-01-01",
+    });
+  });
+
+  it("throws and logs when CMS_SPACE_URL is invalid", async () => {
+    process.env = {
+      CMS_SPACE_URL: "not-a-url",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2023-01-01",
+    } as NodeJS.ProcessEnv;
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../src/env/cms.impl")).rejects.toThrow(
+      "Invalid CMS environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("throws and logs when required variables are missing", async () => {
+    process.env = {
+      CMS_SPACE_URL: "https://example.com",
+    } as NodeJS.ProcessEnv;
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../src/env/cms.impl")).rejects.toThrow(
+      "Invalid CMS environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -17,6 +17,9 @@ describe("envSchema", () => {
         STRIPE_WEBHOOK_SECRET: "whsec",
         NEXTAUTH_SECRET: "nextauth",
         SESSION_SECRET: "session",
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "2023-01-01",
       } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");
@@ -28,6 +31,9 @@ describe("envSchema", () => {
         STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET!,
         NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET!,
         SESSION_SECRET: process.env.SESSION_SECRET!,
+        CMS_SPACE_URL: process.env.CMS_SPACE_URL!,
+        CMS_ACCESS_TOKEN: process.env.CMS_ACCESS_TOKEN!,
+        SANITY_API_VERSION: process.env.SANITY_API_VERSION!,
       });
       expect(parsed).toEqual({
         STRIPE_SECRET_KEY: "sk",
@@ -36,6 +42,9 @@ describe("envSchema", () => {
         STRIPE_WEBHOOK_SECRET: "whsec",
         NEXTAUTH_SECRET: "nextauth",
         SESSION_SECRET: "session",
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "2023-01-01",
         EMAIL_PROVIDER: "smtp",
       });
   });
@@ -49,6 +58,9 @@ describe("envSchema", () => {
       STRIPE_WEBHOOK_SECRET: "whsec",
       NEXTAUTH_SECRET: "nextauth",
       SESSION_SECRET: "session",
+      CMS_SPACE_URL: "https://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2023-01-01",
     } as NodeJS.ProcessEnv;
 
     const { envSchema } = await import("../src/env");

--- a/packages/config/__tests__/index.test.ts
+++ b/packages/config/__tests__/index.test.ts
@@ -19,6 +19,9 @@ describe("config package entry", () => {
       STRIPE_WEBHOOK_SECRET: "whsec",
       NEXTAUTH_SECRET: "nextauth",
       SESSION_SECRET: "session",
+      CMS_SPACE_URL: "https://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2023-01-01",
     } as NodeJS.ProcessEnv;
 
     const { env } = await import("../src/index");

--- a/packages/config/src/env/cms.impl.ts
+++ b/packages/config/src/env/cms.impl.ts
@@ -2,9 +2,9 @@ import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
 export const cmsEnvSchema = z.object({
-  CMS_SPACE_URL: z.string().url().optional(),
-  CMS_ACCESS_TOKEN: z.string().optional(),
-  SANITY_API_VERSION: z.string().optional(),
+  CMS_SPACE_URL: z.string().url(),
+  CMS_ACCESS_TOKEN: z.string(),
+  SANITY_API_VERSION: z.string(),
 });
 
 const parsed = cmsEnvSchema.safeParse(process.env);


### PR DESCRIPTION
## Summary
- require CMS env vars in schema
- add cms env tests for valid and invalid configurations
- update existing env tests to include CMS settings

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68af6f662e2c832fb23327ce79dbc7ca