### PR TITLE
test: ensure core env includes cms vars

### DIFF
--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "@jest/globals";
+import { coreEnvBaseSchema } from "../src/env/core.impl";
 
 describe("envSchema", () => {
   const OLD_ENV = process.env;
@@ -59,5 +60,32 @@ describe("envSchema", () => {
     } as Record<string, string>;
 
     expect(() => envSchema.parse(invalid)).toThrow();
+  });
+});
+
+describe("coreEnvBaseSchema", () => {
+  it("parses valid CMS variables", () => {
+    const parsed = coreEnvBaseSchema.parse({
+      CMS_SPACE_URL: "https://cms.example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "v1",
+    });
+
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        CMS_SPACE_URL: "https://cms.example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "v1",
+      }),
+    );
+  });
+
+  it("fails to parse invalid CMS variables", () => {
+    expect(() =>
+      coreEnvBaseSchema.parse({
+        CMS_SPACE_URL: "not-a-url",
+        CMS_ACCESS_TOKEN: "token",
+      }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add tests for `coreEnvBaseSchema` to verify CMS variables merge
- assert invalid CMS variables fail to parse

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68af6f67b008832f9eb0b34ec5aef289