### PR TITLE
chore: remove shop-abc references

### DIFF
--- a/apps/shop-bcd/middleware.ts
+++ b/apps/shop-bcd/middleware.ts
@@ -1,5 +1,3 @@
-// apps/shop-abc/middleware.ts
-
 import { NextResponse, type NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {

--- a/apps/shop-bcd/src/api/cart/route.ts
+++ b/apps/shop-bcd/src/api/cart/route.ts
@@ -1,4 +1,3 @@
-// apps/shop-abc/src/app/api/cart/route.ts
 import "@acme/zod-utils/initZod";
 
 import {

--- a/scripts/__tests__/setup-ci.test.ts
+++ b/scripts/__tests__/setup-ci.test.ts
@@ -43,7 +43,7 @@ describe("setup-ci script", () => {
         throw new Error(`EXIT:${code}`);
       }) as never);
 
-    process.argv = ["node", "setup-ci", "abc"];
+    process.argv = ["node", "setup-ci", "bcd"];
 
     await import("../src/setup-ci");
 
@@ -51,8 +51,8 @@ describe("setup-ci script", () => {
     expect(readMock).toHaveBeenCalled();
     expect(writeMock).toHaveBeenCalledTimes(1);
     const [wfPath, content] = writeMock.mock.calls[0];
-    expect(wfPath).toBe(path.join(".github", "workflows", "shop-abc.yml"));
-      expect(content).toContain("shop-abc");
+    expect(wfPath).toBe(path.join(".github", "workflows", "shop-bcd.yml"));
+      expect(content).toContain("shop-bcd");
       expect(content).toContain("STRIPE_SECRET_KEY: sk");
       expect(content).toContain("STRIPE_WEBHOOK_SECRET: whsec");
       expect(exitMock).not.toHaveBeenCalled();
@@ -81,7 +81,7 @@ describe("setup-ci script", () => {
       .spyOn(fs, "writeFileSync")
       .mockImplementation(() => {});
 
-    process.argv = ["node", "setup-ci", "abc"];
+    process.argv = ["node", "setup-ci", "bcd"];
 
     await import("../src/setup-ci");
 
@@ -104,11 +104,11 @@ describe("setup-ci script", () => {
         throw new Error(`EXIT:${code}`);
       }) as never);
 
-    process.argv = ["node", "setup-ci", "abc"];
+    process.argv = ["node", "setup-ci", "bcd"];
 
     await expect(import("../src/setup-ci")).rejects.toThrow("EXIT:1");
     expect(errorSpy).toHaveBeenCalledWith(
-      `Missing ${path.join("apps", "shop-abc", ".env")}`
+      `Missing ${path.join("apps", "shop-bcd", ".env")}`
     );
     expect(writeMock).not.toHaveBeenCalled();
     expect(exitMock).toHaveBeenCalledWith(1);
@@ -132,7 +132,7 @@ describe("setup-ci script", () => {
         throw new Error(`EXIT:${code}`);
       }) as never);
 
-    process.argv = ["node", "setup-ci", "abc"];
+    process.argv = ["node", "setup-ci", "bcd"];
 
     await expect(import("../src/setup-ci")).rejects.toThrow("EXIT:1");
     expect(errorSpy).toHaveBeenCalled();

--- a/scripts/__tests__/validate-env.test.ts
+++ b/scripts/__tests__/validate-env.test.ts
@@ -17,7 +17,7 @@ describe("validate-env script", () => {
 
     beforeEach(() => {
       jest.resetModules();
-      process.argv = ["node", "validate-env", "abc"];
+      process.argv = ["node", "validate-env", "bcd"];
       process.env.STRIPE_SECRET_KEY = "sk";
       process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
       process.env.CART_COOKIE_SECRET = "secret";
@@ -91,7 +91,7 @@ describe("validate-env script", () => {
     await import("../../dist-scripts/validate-env.js").catch(() => {});
 
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(errorSpy).toHaveBeenCalledWith("Missing apps/shop-abc/.env");
+    expect(errorSpy).toHaveBeenCalledWith("Missing apps/shop-bcd/.env");
     expect(logSpy).not.toHaveBeenCalled();
   });
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -48,7 +48,6 @@
     { "path": "./packages/types/tsconfig.test.json" },
     { "path": "./packages/ui/tsconfig.test.json" },
     { "path": "./packages/i18n/tsconfig.test.json" },
-    { "path": "./apps/cms/tsconfig.test.json" },
-    { "path": "./apps/shop-abc/tsconfig.test.json" }
+    { "path": "./apps/cms/tsconfig.test.json" }
   ]
 }


### PR DESCRIPTION
## Summary
- remove obsolete shop-abc entry from tsconfig.test.json
- update tests to reference shop-bcd and drop shop-abc paths
- tidy middleware and cart route comments

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm exec jest scripts/__tests__/validate-env.test.ts scripts/__tests__/setup-ci.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af6ff26610832f92c05cc5a3c231e6