### PR TITLE
docs: add codex troubleshooting note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,5 @@
 - Run `pnpm install` to install dependencies.
 - Build all packages before starting any app: `pnpm -r build`.
 - Regenerate config stubs after editing `.impl.ts` files: `pnpm run build:stubs`.
+- If `pnpm run dev` fails with an `array.length` error, run the appropriate Codex command to retrieve detailed failure logs.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ before running.
 Apps Script code lives under `apps-script/` and compiles with its own `tsconfig.json`.
 Next.js projects exclude this folder to avoid type conflicts with DOM typings.
 
+## Troubleshooting
+
+- If `pnpm run dev` fails with an `array.length` error, run the appropriate Codex command to retrieve detailed failure information.
+
 ## Notes
 
 See [docs/lighthouse.md](docs/lighthouse.md) for running Lighthouse audits.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -238,3 +238,4 @@ See [doc/machine.md](./machine.md#deposit-release-service) for more details and 
 - **"Theme 'X' not found" or "Template 'Y' not found"** – ensure the names match directories in `packages/themes` or `packages/`.
 - **`validate-env` fails** – verify `apps/shop-<id>/.env` contains all variables listed in the error. Missing values will stop the script.
 - **Node or pnpm version errors** – check you are running Node.js ≥20 and pnpm 10.x. Version mismatches can cause dependency resolution issues.
+- **`pnpm dev` throws an `array.length` error** – run the relevant Codex command to gather detailed logs about the failure.

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,6 +70,8 @@ Example `shop.config.json`:
    editing `.env` if you need to re-check. Open http://localhost:3000 to view the site. Pages
    hot-reload on save.
 
+   If `pnpm dev` fails with an `array.length` error, run the relevant Codex command to inspect detailed logs explaining the failure.
+
 3. _(Optional)_ Each Next.js app must provide its own `postcss.config.cjs` that forwards to the repo root configuration so Tailwind resolves correctly. After updating Tailwind or any CSS utilities, run `pnpm tailwind:check` to verify the build.
 
 ### Example


### PR DESCRIPTION
## Summary
- document how to use Codex when `pnpm run dev` hits an `array.length` error

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68af72f351dc832fb51a7a4dfa3ae5be