### PR TITLE
Add tests for auth helpers

### DIFF
--- a/apps/cms/src/auth/__tests__/secret.test.ts
+++ b/apps/cms/src/auth/__tests__/secret.test.ts
@@ -16,6 +16,14 @@ describe("auth secret", () => {
     );
   });
 
+  it("throws when NEXTAUTH_SECRET is empty", async () => {
+    (process.env as Record<string, string>).NEXTAUTH_SECRET = "";
+    jest.doMock("@acme/config", () => ({ env: process.env }));
+    await expect(import("../secret")).rejects.toThrow(
+      "NEXTAUTH_SECRET is not set",
+    );
+  });
+
   it("exports the NEXTAUTH_SECRET value", async () => {
     (process.env as Record<string, string>).NEXTAUTH_SECRET = "test-secret";
     jest.doMock("@acme/config", () => ({ env: process.env }));

--- a/packages/auth/__tests__/roles.test.ts
+++ b/packages/auth/__tests__/roles.test.ts
@@ -49,4 +49,16 @@ describe("extendRoles", () => {
     expect(isRole("author")).toBe(true);
     expect(isRole("reader")).toBe(true);
   });
+
+  it("adds write roles to both write and read lists", () => {
+    extendRoles({ write: ["editor"] });
+    expect(WRITE_ROLES).toContain("editor");
+    expect(READ_ROLES).toContain("editor");
+  });
+
+  it("adds read roles only to the read list", () => {
+    extendRoles({ read: ["guest"] });
+    expect(READ_ROLES).toContain("guest");
+    expect(WRITE_ROLES).not.toContain("guest");
+  });
 });

--- a/packages/platform-core/__tests__/users.lookup.test.ts
+++ b/packages/platform-core/__tests__/users.lookup.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { getUserByEmail, getUserById } from "../src/users";
+import { prisma } from "../src/db";
+
+type StoreUser = {
+  id: string;
+  email: string;
+  passwordHash: string;
+  role: string;
+  resetToken: string | null;
+  resetTokenExpiresAt: Date | null;
+  emailVerified: boolean;
+};
+
+const store: Record<string, StoreUser> = {};
+let shouldThrow = false;
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(async ({ where }) => {
+        if (shouldThrow) throw new Error("db error");
+        if ("id" in where) return store[where.id] ?? null;
+        if ("email" in where)
+          return (
+            Object.values(store).find((u) => u.email === where.email) ?? null
+          );
+        return null;
+      }),
+    },
+  },
+}));
+
+const findUniqueMock = (prisma as any).user.findUnique as jest.Mock;
+
+beforeEach(() => {
+  findUniqueMock.mockClear();
+  shouldThrow = false;
+  for (const key in store) delete store[key];
+});
+
+describe("user lookup", () => {
+  const user: StoreUser = {
+    id: "u1",
+    email: "u1@example.com",
+    passwordHash: "hash",
+    role: "customer",
+    resetToken: null,
+    resetTokenExpiresAt: null,
+    emailVerified: false,
+  };
+
+  it("finds user by id", async () => {
+    store[user.id] = user;
+    await expect(getUserById("u1")).resolves.toEqual(user);
+  });
+
+  it("finds user by email", async () => {
+    store[user.id] = user;
+    await expect(getUserByEmail("u1@example.com")).resolves.toEqual(user);
+  });
+
+  it("returns null when user not found", async () => {
+    await expect(getUserById("missing")).resolves.toBeNull();
+    await expect(getUserByEmail("missing@example.com")).resolves.toBeNull();
+  });
+
+  it("propagates backend errors", async () => {
+    shouldThrow = true;
+    await expect(getUserById("u1")).rejects.toThrow("db error");
+    await expect(getUserByEmail("u1@example.com")).rejects.toThrow("db error");
+  });
+});


### PR DESCRIPTION
## Summary
- cover secret export edge cases when auth secret is empty
- verify role extension adds fallback read/write permissions
- exercise user lookup helpers with success, null, and error paths

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `pnpm exec jest packages/auth/__tests__/roles.test.ts packages/platform-core/__tests__/users.lookup.test.ts apps/cms/src/auth/__tests__/secret.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af78a003a4832f87cb77024a735369