### PR TITLE
test: add deploy and upgrade shop route tests

### DIFF
--- a/apps/cms/__tests__/upgradeShopRoute.test.ts
+++ b/apps/cms/__tests__/upgradeShopRoute.test.ts
@@ -1,0 +1,79 @@
+
+// Polyfill Response.json if missing
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    });
+}
+
+jest.mock("@auth", () => ({
+  requirePermission: jest.fn(),
+}));
+
+jest.mock("child_process", () => ({
+  spawnSync: jest.fn(),
+}));
+
+describe("upgrade-shop API route", () => {
+  let requirePermission: jest.Mock;
+  let spawnSync: jest.Mock;
+  let chdirSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ({ requirePermission } = require("@auth"));
+    ({ spawnSync } = require("child_process"));
+    spawnSync.mockReset();
+    requirePermission.mockReset();
+    chdirSpy = jest.spyOn(process, "chdir").mockImplementation((_path: string) => {});
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+  });
+
+  it("returns 200 and runs upgrade when authorized", async () => {
+    requirePermission.mockResolvedValueOnce(undefined);
+    spawnSync.mockReturnValueOnce({ status: 0 });
+
+    const route = await import("../src/app/api/upgrade-shop/route");
+
+    const req = { json: async () => ({ shop: "shop-1" }) } as any;
+    const res = await route.POST(req);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ status: "ok" });
+    expect(spawnSync).toHaveBeenCalledWith("pnpm", ["tsx", "scripts/src/upgrade-shop.ts", "shop-1"]);
+  });
+
+  it("returns 401 when permission check fails", async () => {
+    requirePermission.mockRejectedValueOnce(new Error("nope"));
+    const route = await import("../src/app/api/upgrade-shop/route");
+    const req = { json: async () => ({ shop: "shop-1" }) } as any;
+    const res = await route.POST(req);
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when shop is missing", async () => {
+    requirePermission.mockResolvedValueOnce(undefined);
+    const route = await import("../src/app/api/upgrade-shop/route");
+    const req = { json: async () => ({}) } as any;
+    const res = await route.POST(req);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "shop required" });
+  });
+
+  it("returns 500 when upgrade fails", async () => {
+    requirePermission.mockResolvedValueOnce(undefined);
+    spawnSync.mockReturnValueOnce({ status: 1 });
+    const route = await import("../src/app/api/upgrade-shop/route");
+    const req = { json: async () => ({ shop: "shop-1" }) } as any;
+    const res = await route.POST(req);
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Upgrade failed" });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration tests for deploy-shop API route covering auth and invalid input
- add upgrade-shop route tests including spawnSync failures and missing shop

## Testing
- `pnpm --filter @apps/cms test deployShopRoute.test.ts upgradeShopRoute.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af78a71204832fa986730b3833db6d