### PR TITLE
test: add CMS E2E coverage

### DIFF
--- a/test/e2e/blog-post-workflow.spec.ts
+++ b/test/e2e/blog-post-workflow.spec.ts
@@ -1,0 +1,63 @@
+// test/e2e/blog-post-workflow.spec.ts
+
+describe("Blog post workflow", () => {
+  const shopId = "abc";
+  const baseUrl = `/cms/blog/posts?shopId=${shopId}`;
+
+  beforeEach(() => {
+    cy.request("/api/auth/csrf").then(({ body }) => {
+      cy.request({
+        method: "POST",
+        url: "/api/auth/callback/credentials",
+        form: true,
+        followRedirect: true,
+        body: {
+          csrfToken: body.csrfToken,
+          email: "admin@example.com",
+          password: "admin",
+          callbackUrl: baseUrl,
+        },
+      });
+    });
+  });
+
+  it("creates, edits, publishes, unpublishes and deletes a post", () => {
+    cy.intercept("POST", "/cms/api/blog/posts", {
+      statusCode: 200,
+      body: { id: "1" },
+    }).as("createPost");
+
+    cy.visit(`/cms/blog/posts/new?shopId=${shopId}`);
+    cy.get('input[name="title"]').type("My Post");
+    cy.get('textarea[name="excerpt"]').type("Excerpt");
+    cy.contains("button", "Save").click();
+    cy.wait("@createPost");
+
+    cy.intercept("POST", "/cms/api/blog/posts/1", { statusCode: 200 }).as(
+      "editPost",
+    );
+    cy.visit(`/cms/blog/posts/1?shopId=${shopId}`);
+    cy.get('input[name="title"]').clear().type("Updated Post");
+    cy.contains("button", "Save").click();
+    cy.wait("@editPost");
+
+    cy.intercept("POST", "/cms/api/blog/posts/1/publish", { statusCode: 200 }).as(
+      "publishPost",
+    );
+    cy.contains("button", "Publish").click();
+    cy.wait("@publishPost");
+
+    cy.intercept("POST", "/cms/api/blog/posts/1/unpublish", {
+      statusCode: 200,
+    }).as("unpublishPost");
+    cy.contains("button", "Unpublish").click();
+    cy.wait("@unpublishPost");
+
+    cy.intercept("DELETE", "/cms/api/blog/posts/1", { statusCode: 200 }).as(
+      "deletePost",
+    );
+    cy.contains("button", "Delete").click();
+    cy.wait("@deletePost");
+  });
+});
+

--- a/test/e2e/media-library.spec.ts
+++ b/test/e2e/media-library.spec.ts
@@ -1,0 +1,53 @@
+// test/e2e/media-library.spec.ts
+
+describe("Media library", () => {
+  const shopId = "abc";
+
+  beforeEach(() => {
+    cy.request("/api/auth/csrf").then(({ body }) => {
+      cy.request({
+        method: "POST",
+        url: "/api/auth/callback/credentials",
+        form: true,
+        followRedirect: true,
+        body: {
+          csrfToken: body.csrfToken,
+          email: "admin@example.com",
+          password: "admin",
+          callbackUrl: `/cms/shop/${shopId}/media`,
+        },
+      });
+    });
+  });
+
+  it("uploads, renames and deletes a file", () => {
+    cy.visit(`/cms/shop/${shopId}/media`);
+
+    cy.intercept("POST", `/cms/api/media?shop=${shopId}`, {
+      statusCode: 200,
+      body: { url: `/uploads/${shopId}/test.txt` },
+    }).as("uploadFile");
+
+    cy.get('input[type="file"]').selectFile({
+      contents: "hello world",
+      fileName: "test.txt",
+    });
+    cy.wait("@uploadFile");
+
+    cy.intercept("POST", `/cms/api/media?shop=${shopId}`, {
+      statusCode: 200,
+      body: { url: `/uploads/${shopId}/test.txt`, altText: "renamed" },
+    }).as("renameFile");
+    cy.contains("Edit").click();
+    cy.get('input[placeholder="Alt text"]').clear().type("renamed");
+    cy.contains("button", "Save").click();
+    cy.wait("@renameFile");
+
+    cy.intercept("DELETE", `/cms/api/media?shop=${shopId}&file=*`).as(
+      "deleteFile",
+    );
+    cy.contains("Delete").click();
+    cy.wait("@deleteFile");
+  });
+});
+

--- a/test/e2e/plugin-management.spec.ts
+++ b/test/e2e/plugin-management.spec.ts
@@ -1,0 +1,51 @@
+// test/e2e/plugin-management.spec.ts
+
+describe("Plugin management", () => {
+  beforeEach(() => {
+    cy.request("/api/auth/csrf").then(({ body }) => {
+      cy.request({
+        method: "POST",
+        url: "/api/auth/callback/credentials",
+        form: true,
+        followRedirect: true,
+        body: {
+          csrfToken: body.csrfToken,
+          email: "admin@example.com",
+          password: "admin",
+          callbackUrl: "/cms/plugins",
+        },
+      });
+    });
+  });
+
+  it("installs, enables and removes a plugin", () => {
+    cy.intercept("GET", "/cms/api/plugins", {
+      statusCode: 200,
+      body: { plugins: [] },
+    }).as("listPlugins");
+    cy.intercept("POST", "/cms/api/plugins/install", {
+      statusCode: 200,
+      body: { id: "demo", name: "Demo" },
+    }).as("installPlugin");
+    cy.intercept("PATCH", "/cms/api/plugins/demo", {
+      statusCode: 200,
+      body: { enabled: true },
+    }).as("enablePlugin");
+    cy.intercept("DELETE", "/cms/api/plugins/demo", {
+      statusCode: 200,
+    }).as("removePlugin");
+
+    cy.visit("/cms/plugins");
+    cy.wait("@listPlugins");
+
+    cy.contains("button", "Install plugin").click();
+    cy.wait("@installPlugin");
+
+    cy.get('input[type="checkbox"]').check({ force: true });
+    cy.wait("@enablePlugin");
+
+    cy.contains("button", "Remove").click();
+    cy.wait("@removePlugin");
+  });
+});
+

--- a/test/e2e/rbac-restrictions.spec.ts
+++ b/test/e2e/rbac-restrictions.spec.ts
@@ -1,0 +1,51 @@
+// test/e2e/rbac-restrictions.spec.ts
+
+describe("RBAC restrictions", () => {
+  const shopId = "abc";
+
+  function signIn(email: string, password: string, callbackUrl: string) {
+    cy.request("/api/auth/csrf").then(({ body }) => {
+      cy.request({
+        method: "POST",
+        url: "/api/auth/callback/credentials",
+        form: true,
+        followRedirect: true,
+        body: {
+          csrfToken: body.csrfToken,
+          email,
+          password,
+          callbackUrl,
+        },
+      });
+    });
+  }
+
+  it("blocks viewer from accessing settings", () => {
+    const url = `/cms/shop/${shopId}/settings`;
+    signIn("viewer@example.com", "viewer", url);
+    cy.visit(url);
+    cy.contains("403").should("be.visible");
+  });
+
+  it("blocks catalog manager from theme editor", () => {
+    const url = `/cms/shop/${shopId}/themes`;
+    signIn("catalogmanager@example.com", "catalogmanager", url);
+    cy.visit(url);
+    cy.contains("403").should("be.visible");
+  });
+
+  it("blocks theme editor from products page", () => {
+    const url = `/cms/shop/${shopId}/products`;
+    signIn("themeeditor@example.com", "themeeditor", url);
+    cy.visit(url);
+    cy.contains("403").should("be.visible");
+  });
+
+  it("allows shop admin to access settings", () => {
+    const url = `/cms/shop/${shopId}/settings`;
+    signIn("shopadmin@example.com", "shopadmin", url);
+    cy.visit(url);
+    cy.contains("Settings – ${shopId}").should("be.visible");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add blog post workflow spec
- cover media library operations
- check RBAC restrictions for various roles
- test plugin install/enable/remove flow

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68af78aa9ac8832f847cf739c25df96d