### PR TITLE
test(cms): add segment builder integration tests

### DIFF
--- a/apps/cms/__tests__/segmentBuilder.integration.test.ts
+++ b/apps/cms/__tests__/segmentBuilder.integration.test.ts
@@ -1,0 +1,103 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+
+jest.doMock("@platform-core/analytics", () => ({
+  __esModule: true,
+  trackEvent: jest.fn(),
+}));
+jest.doMock("@platform-core/repositories/analytics.server", () => ({
+  __esModule: true,
+  listEvents: jest.fn(),
+}));
+jest.doMock("@acme/lib", () => ({
+  __esModule: true,
+  validateShopName: (s: string) => s,
+}));
+
+process.env.CMS_SPACE_URL = "https://example.com";
+process.env.CMS_ACCESS_TOKEN = "token";
+process.env.SANITY_API_VERSION = "2023-01-01";
+
+const ResponseWithJson = Response as unknown as typeof Response & {
+  json?: (data: unknown, init?: ResponseInit) => Response;
+};
+if (typeof ResponseWithJson.json !== "function") {
+  ResponseWithJson.json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+describe("segments API", () => {
+  const shop = "segint";
+  const shopDir = path.join(DATA_ROOT, shop);
+
+  beforeEach(async () => {
+    await fs.rm(shopDir, { recursive: true, force: true });
+    await fs.mkdir(shopDir, { recursive: true });
+  });
+
+  test("creates, lists, and deletes segments", async () => {
+    const { GET, POST, DELETE } = await import("../src/app/api/segments/route");
+
+    const createRes = await POST({
+      json: async () => ({
+        shop,
+        id: "vip",
+        name: "VIP",
+        filters: [{ field: "type", value: "purchase" }],
+      }),
+    } as unknown as NextRequest);
+    expect(createRes.status).toBe(200);
+
+    const listRes = await GET({
+      nextUrl: new URL(`http://example.com?shop=${shop}`),
+    } as unknown as NextRequest);
+    expect(listRes.status).toBe(200);
+    const listData = await listRes.json();
+    expect(listData.segments).toEqual([
+      { id: "vip", name: "VIP", filters: [{ field: "type", value: "purchase" }] },
+    ]);
+
+    const delRes = await DELETE({
+      nextUrl: new URL(`http://example.com?shop=${shop}&id=vip`),
+    } as unknown as NextRequest);
+    expect(delRes.status).toBe(200);
+
+    const afterDelete = await GET({
+      nextUrl: new URL(`http://example.com?shop=${shop}`),
+    } as unknown as NextRequest);
+    const afterData = await afterDelete.json();
+    expect(afterData.segments).toEqual([]);
+  });
+
+  test("validates missing shop on GET", async () => {
+    const { GET } = await import("../src/app/api/segments/route");
+    const res = await GET({
+      nextUrl: new URL("http://example.com"),
+    } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing shop" });
+  });
+
+  test("validates segment payload on POST", async () => {
+    const { POST } = await import("../src/app/api/segments/route");
+    const res = await POST({ json: async () => ({}) } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      shop: ["Required"],
+      id: ["Required"],
+      filters: ["Required"],
+    });
+  });
+
+  test("validates missing id on DELETE", async () => {
+    const { DELETE } = await import("../src/app/api/segments/route");
+    const res = await DELETE({
+      nextUrl: new URL(`http://example.com?shop=${shop}`),
+    } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing id" });
+  });
+});

--- a/apps/cms/src/app/api/segments/route.ts
+++ b/apps/cms/src/app/api/segments/route.ts
@@ -54,3 +54,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   await writeSegments(shop, segments);
   return NextResponse.json({ ok: true });
 }
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const shopParam = req.nextUrl.searchParams.get("shop");
+  const idParam = req.nextUrl.searchParams.get("id");
+  const shopParsed = z.string().min(1).safeParse(shopParam);
+  if (!shopParsed.success) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 400 });
+  }
+  const idParsed = z.string().min(1).safeParse(idParam);
+  if (!idParsed.success) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
+  const segments = await readSegments(shopParsed.data);
+  const idx = segments.findIndex((s) => s.id === idParsed.data);
+  if (idx >= 0) {
+    segments.splice(idx, 1);
+    await writeSegments(shopParsed.data, segments);
+  }
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- support deleting CMS segments via API
- cover segment creation, listing, and validation with integration tests

## Testing
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `pnpm --filter @apps/cms test __tests__/segmentBuilder.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af78b8262c832fa3bfc0a0e69d2179