### PR TITLE
Wrap useSearchParams with Suspense on cancelled pages

### DIFF
--- a/apps/cms/src/app/cancelled/page.tsx
+++ b/apps/cms/src/app/cancelled/page.tsx
@@ -2,9 +2,10 @@
 
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 
-export default function Cancelled() {
+function CancelledContent() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
   return (
@@ -17,5 +18,13 @@ export default function Cancelled() {
         </p>
       )}
     </div>
+  );
+}
+
+export default function Cancelled() {
+  return (
+    <Suspense>
+      <CancelledContent />
+    </Suspense>
   );
 }

--- a/apps/shop-bcd/src/app/[lang]/cancelled/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/cancelled/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 
-export default function Cancelled() {
+function CancelledContent() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
   return (
@@ -15,5 +16,13 @@ export default function Cancelled() {
         </p>
       )}
     </div>
+  );
+}
+
+export default function Cancelled() {
+  return (
+    <Suspense>
+      <CancelledContent />
+    </Suspense>
   );
 }

--- a/apps/shop-bcd/src/app/cancelled/page.tsx
+++ b/apps/shop-bcd/src/app/cancelled/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 
-export default function Cancelled() {
+function CancelledContent() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
   return (
@@ -15,5 +16,13 @@ export default function Cancelled() {
         </p>
       )}
     </div>
+  );
+}
+
+export default function Cancelled() {
+  return (
+    <Suspense>
+      <CancelledContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap useSearchParams with Suspense in cancelled pages to satisfy Next.js requirements

## Testing
- `pnpm install`
- `CMS_SPACE_URL=https://example.com CMS_ACCESS_TOKEN=bar SANITY_API_VERSION=2023-01-01 pnpm -r build` *(fails: Cannot find module packages/plugins/sanity and other plugin issues)*

------
https://chatgpt.com/codex/tasks/task_e_68af7be8af84832fbb01d074a3c4f6dd