### PR TITLE
fix plugin and i18n loading

### DIFF
--- a/apps/shop-bcd/src/app/api/publish/route.ts
+++ b/apps/shop-bcd/src/app/api/publish/route.ts
@@ -2,10 +2,12 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import { NextResponse } from "next/server";
 import { requirePermission } from "@auth";
+import { createRequire } from "module";
 // The republish utility lives in the top-level scripts directory and isn't
-// published as a package. Import it via a relative path so the build can
-// resolve it without relying on a workspace alias.
-import { republishShop } from "../../../../../../scripts/src/republish-shop";
+// published as a package. Load it via `createRequire` so the build can
+// resolve the CommonJS module without relying on a workspace alias.
+const require = createRequire(import.meta.url);
+const { republishShop } = require("../../../../../../scripts/src/republish-shop.js") as typeof import("../../../../../../scripts/src/republish-shop");
 
 export const runtime = "nodejs";
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -15,7 +15,7 @@
       "import": "./dist/*.js",
       "default": "./dist/*.js"
     },
-    "./*.json": "./*.json"
+    "./*.json": "./dist/*.json"
   },
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -45,7 +45,7 @@ export default withShopCode(coreEnv.SHOP_CODE, {
     config.resolve.alias = {
       ...config.resolve.alias,
       "@": path.resolve(__dirname, "../template-app/src"),
-      "@i18n": path.resolve(__dirname, "../i18n"),
+      "@i18n": path.resolve(__dirname, "../i18n/src"),
     };
     for (const mod of nodeBuiltins) {
       config.resolve.alias[`node:${mod}`] = mod;


### PR DESCRIPTION
## Summary
- load CMS republish script via `createRequire`
- expose dist locale JSONs from i18n package and update alias
- search for plugins from workspace root and import via file URLs

## Testing
- `pnpm --filter @apps/shop-bcd build` *(fails: Cannot read properties of null (reading 'useContext'))*


------
https://chatgpt.com/codex/tasks/task_e_68af7e5aef90832fb894be5a0aa68445