### PR TITLE
fix: correct email cli bin path

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -12,7 +12,7 @@
     "./analytics": "./dist/analytics.js"
   },
   "bin": {
-    "email": "./dist/cli.js"
+    "email": "./src/cli.ts"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Summary
- fix email package bin path to use existing TypeScript CLI script

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/analytics.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68af85e51bc8832f89867bf009c388c2