### PR TITLE
refactor: move server directives to module scope

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -1,3 +1,5 @@
+"use server";
+
 // apps/cms/src/actions/blog.server.ts
 
 import {
@@ -24,7 +26,6 @@ export async function createPost(
   _prev: unknown,
   formData: FormData,
 ): Promise<{ message?: string; error?: string; id?: string }> {
-  "use server";
   return serviceCreatePost(shopId, formData);
 }
 
@@ -33,7 +34,6 @@ export async function updatePost(
   _prev: unknown,
   formData: FormData,
 ): Promise<{ message?: string; error?: string }> {
-  "use server";
   return serviceUpdatePost(shopId, formData);
 }
 
@@ -43,7 +43,6 @@ export async function publishPost(
   _prev?: unknown,
   formData?: FormData,
 ): Promise<{ message?: string; error?: string }> {
-  "use server";
   return servicePublishPost(shopId, id, formData);
 }
 
@@ -53,7 +52,6 @@ export async function unpublishPost(
   _prev?: unknown,
   _formData?: FormData,
 ): Promise<{ message?: string; error?: string }> {
-  "use server";
   return serviceUnpublishPost(shopId, id);
 }
 
@@ -61,7 +59,6 @@ export async function deletePost(
   shopId: string,
   id: string,
 ): Promise<{ message?: string; error?: string }> {
-  "use server";
   return serviceDeletePost(shopId, id);
 }
 

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -1,3 +1,5 @@
+"use server";
+
 // apps/cms/src/actions/shops.server.ts
 
 import {
@@ -23,7 +25,6 @@ export async function updateShop(
   shop: string,
   formData: FormData,
 ): Promise<{ shop?: Shop; errors?: Record<string, string[]> }> {
-  "use server";
   return serviceUpdateShop(shop, formData);
 }
 
@@ -35,7 +36,6 @@ export async function updateSeo(
   shop: string,
   formData: FormData,
 ) {
-  "use server";
   return serviceUpdateSeo(shop, formData);
 }
 
@@ -43,17 +43,14 @@ export async function generateSeo(
   shop: string,
   formData: FormData,
 ) {
-  "use server";
   return serviceGenerateSeo(shop, formData);
 }
 
 export async function revertSeo(shop: string, timestamp: string) {
-  "use server";
   return serviceRevertSeo(shop, timestamp);
 }
 
 export async function setFreezeTranslations(shop: string, freeze: boolean) {
-  "use server";
   return serviceSetFreezeTranslations(shop, freeze);
 }
 
@@ -61,27 +58,22 @@ export async function updateCurrencyAndTax(
   shop: string,
   formData: FormData,
 ) {
-  "use server";
   return serviceUpdateCurrencyAndTax(shop, formData);
 }
 
 export async function updateDeposit(shop: string, formData: FormData) {
-  "use server";
   return serviceUpdateDeposit(shop, formData);
 }
 
 export async function updateReverseLogistics(shop: string, formData: FormData) {
-  "use server";
   return serviceUpdateReverseLogistics(shop, formData);
 }
 
 export async function updateUpsReturns(shop: string, formData: FormData) {
-  "use server";
   return serviceUpdateUpsReturns(shop, formData);
 }
 
 export async function updateStockAlert(shop: string, formData: FormData) {
-  "use server";
   return serviceUpdateStockAlert(shop, formData);
 }
 
@@ -89,17 +81,14 @@ export async function updatePremierDelivery(
   shop: string,
   formData: FormData,
 ) {
-  "use server";
   return serviceUpdatePremierDelivery(shop, formData);
 }
 
 export async function updateAiCatalog(shop: string, formData: FormData) {
-  "use server";
   return serviceUpdateAiCatalog(shop, formData);
 }
 
 export async function resetThemeOverride(shop: string, token: string) {
-  "use server";
   return serviceResetThemeOverride(shop, token);
 }
 

--- a/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
@@ -1,3 +1,5 @@
+"use server";
+
 // apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
 import { listThemes } from "@platform-core/createShop";
 import { baseTokens, loadThemeTokens } from "@platform-core/themeTokens";
@@ -14,12 +16,10 @@ export async function savePreset(
   name: string,
   tokens: Record<string, string>,
 ) {
-  "use server";
   await saveThemePreset(shop, name, tokens);
 }
 
 export async function deletePreset(shop: string, name: string) {
-  "use server";
   await deleteThemePreset(shop, name);
 }
 


### PR DESCRIPTION
## Summary
- move "use server" directives to top of server action modules
- clean up inline server directives in CMS theme page

## Testing
- `pnpm -r build` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68af89a52348832f8b96f007808b3e58