### PR TITLE
feat(ui): isolate account components

### DIFF
--- a/apps/shop-bcd/__tests__/account-orders.test.tsx
+++ b/apps/shop-bcd/__tests__/account-orders.test.tsx
@@ -1,12 +1,12 @@
 // apps/shop-bcd/__tests__/account-orders.test.tsx
-jest.mock("@ui/components/account/Orders", () => ({
+jest.mock("@ui/account", () => ({
   __esModule: true,
-  default: jest.fn(() => null),
-  metadata: { title: "Orders" },
+  OrdersPage: jest.fn(() => null),
+  ordersMetadata: { title: "Orders" },
 }));
 
 import OrdersPage, { metadata } from "../src/app/account/orders/page";
-import Orders from "@ui/components/account/Orders";
+import { OrdersPage as Orders } from "@ui/account";
 import shop from "../shop.json";
 
 describe("/account/orders page", () => {

--- a/apps/shop-bcd/__tests__/account-profile.test.tsx
+++ b/apps/shop-bcd/__tests__/account-profile.test.tsx
@@ -17,8 +17,7 @@ jest.mock("next/navigation", () => ({
 
 import { getCustomerSession } from "@auth";
 import { getCustomerProfile } from "@acme/platform-core/customerProfiles";
-import ProfilePage from "@ui/src/components/account/Profile";
-import ProfileForm from "@ui/src/components/account/ProfileForm";
+import { ProfilePage, ProfileForm } from "@ui/account";
 import { redirect } from "next/navigation";
 
 describe("/account/profile", () => {

--- a/apps/shop-bcd/src/app/account/orders/page.tsx
+++ b/apps/shop-bcd/src/app/account/orders/page.tsx
@@ -1,5 +1,8 @@
 // apps/shop-bcd/src/app/account/orders/page.tsx
-import Orders, { metadata } from "@ui/components/account/Orders";
+import {
+  OrdersPage as Orders,
+  ordersMetadata as metadata,
+} from "@ui/account";
 import shop from "../../../../shop.json";
 
 export { metadata };

--- a/apps/shop-bcd/src/app/account/profile/page.tsx
+++ b/apps/shop-bcd/src/app/account/profile/page.tsx
@@ -1,3 +1,5 @@
 // apps/shop-bcd/src/app/account/profile/page.tsx
-export { metadata } from "@ui/components/account/Profile";
-export { default } from "@ui/components/account/Profile";
+export {
+  profileMetadata as metadata,
+  ProfilePage as default,
+} from "@ui/account";

--- a/apps/shop-bcd/src/app/account/sessions/page.tsx
+++ b/apps/shop-bcd/src/app/account/sessions/page.tsx
@@ -1,3 +1,6 @@
 // apps/shop-bcd/src/app/account/sessions/page.tsx
-export { metadata, revoke } from "@ui/components/account/Sessions";
-export { default } from "@ui/components/account/Sessions";
+export {
+  sessionsMetadata as metadata,
+  revoke,
+  SessionsPage as default,
+} from "@ui/account";

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -1,4 +1,5 @@
 // packages/auth/src/session.ts
+import "server-only";
 import { cookies, headers } from "next/headers";
 import { sealData, unsealData } from "iron-session";
 import { randomUUID } from "crypto";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./account": {
+      "types": "./dist/account.d.ts",
+      "import": "./dist/account.js"
+    }
+  },
   "scripts": {
     "build": "tsc -b",
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"

--- a/packages/ui/src/account.ts
+++ b/packages/ui/src/account.ts
@@ -1,0 +1,3 @@
+// packages/ui/src/account.ts
+// Entry point for account-related components that depend on server APIs
+export * from "./components/account";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,5 +1,3 @@
-export * from "./account";
-export * from "./cms";
 export * from "./atoms";
 export * from "./molecules";
 export * from "./organisms";


### PR DESCRIPTION
## Summary
- drop server-only account and CMS exports from UI barrel
- add @ui/account entry for account components
- mark session utilities as server-only

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68af89aa9af4832fa1df8c4332371efc