### PR TITLE
chore(config): default stripe env vars

### DIFF
--- a/packages/config/src/env/payments.impl.ts
+++ b/packages/config/src/env/payments.impl.ts
@@ -2,9 +2,12 @@ import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
 export const paymentEnvSchema = z.object({
-  STRIPE_SECRET_KEY: z.string().min(1),
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
-  STRIPE_WEBHOOK_SECRET: z.string().min(1),
+  STRIPE_SECRET_KEY: z.string().min(1).default("sk_test"),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z
+    .string()
+    .min(1)
+    .default("pk_test"),
+  STRIPE_WEBHOOK_SECRET: z.string().min(1).default("whsec_test"),
 });
 
 const parsed = paymentEnvSchema.safeParse(process.env);
@@ -17,9 +20,5 @@ if (!parsed.success) {
 
 export const paymentEnv = parsed.success
   ? parsed.data
-  : {
-      STRIPE_SECRET_KEY: "sk_test",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
-      STRIPE_WEBHOOK_SECRET: "whsec_test",
-    };
+  : paymentEnvSchema.parse({});
 export type PaymentEnv = z.infer<typeof paymentEnvSchema>;


### PR DESCRIPTION
## Summary
- provide default payment env vars so builds don't warn when missing

## Testing
- `pnpm -r build` *(fails: Import trace for requested module: packages/platform-core/src/customerProfiles.ts > ...)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68af8a941f4c832fbda73eb38f04d14b