### PR TITLE
fix: make server actions async and adjust theme tokens

### DIFF
--- a/apps/cms/src/actions/blog.server.ts
+++ b/apps/cms/src/actions/blog.server.ts
@@ -13,11 +13,11 @@ import {
   type SanityPost,
 } from "../services/blog";
 
-export function getPosts(shopId: string): Promise<SanityPost[]> {
+export async function getPosts(shopId: string): Promise<SanityPost[]> {
   return serviceGetPosts(shopId);
 }
 
-export function getPost(shopId: string, id: string): Promise<SanityPost | null> {
+export async function getPost(shopId: string, id: string): Promise<SanityPost | null> {
   return serviceGetPost(shopId, id);
 }
 

--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -28,7 +28,7 @@ export async function updateShop(
   return serviceUpdateShop(shop, formData);
 }
 
-export function getSettings(shop: string) {
+export async function getSettings(shop: string): Promise<ShopSettings> {
   return serviceGetSettings(shop);
 }
 

--- a/apps/cms/src/app/cms/wizard/services/createShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/createShop.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { createShopOptionsSchema, type DeployStatusBase } from "@platform-core/createShop";
+import { createShopOptionsSchema } from "@platform-core/createShop/schema";
+import type { DeployStatusBase } from "@platform-core/createShop/deployTypes";
 import { validateShopName } from "@platform-core/shops";
 import type { WizardState } from "../schema";
 

--- a/packages/platform-core/src/themeTokens/index.ts
+++ b/packages/platform-core/src/themeTokens/index.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync } from "fs";
-import { join } from "path";
-import { runInNewContext } from "vm";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { runInNewContext } from "node:vm";
 import ts from "typescript";
 
 import {
@@ -55,7 +55,7 @@ export async function loadThemeTokensBrowser(theme: string): Promise<TokenMap> {
   if (!theme || theme === "base") return baseTokens;
   try {
     const mod = await import(
-      /* webpackExclude: /(\.map$|\.d\.ts$|\.tsbuildinfo$)/ */
+      /* webpackExclude: /(\.map$|\.d\.ts$|\.tsbuildinfo$|__tests__\/)/ */
       `@themes/${theme}`
     );
     if ("tokens" in mod) {


### PR DESCRIPTION
## Summary
- make `getSettings`, `getPosts`, and `getPost` async server actions
- avoid server-only imports in CMS wizard by using direct schema and token utilities
- mark theme token helpers with explicit node built-ins

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve 'module')*


------
https://chatgpt.com/codex/tasks/task_e_68afeff1be04832fbde3d9b0c440edbc