### PR TITLE
chore: add js bridges for env configs

### DIFF
--- a/packages/config/scripts/generate-env-stubs.mjs
+++ b/packages/config/scripts/generate-env-stubs.mjs
@@ -1,19 +1,26 @@
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const envDir = path.join(__dirname, '..', 'src', 'env');
+const envDir = path.join(__dirname, "..", "src", "env");
 
 async function generate() {
   const entries = await fs.readdir(envDir);
-  const implFiles = entries.filter((f) => f.endsWith('.impl.ts'));
+  const implFiles = entries.filter((f) => f.endsWith(".impl.ts"));
   await Promise.all(
     implFiles.map(async (impl) => {
-      const base = impl.replace(/\.impl\.ts$/, '');
+      const base = impl.replace(/\.impl\.ts$/, "");
       const stubPath = path.join(envDir, `${base}.js`);
       const content = `export * from "./${base}.impl.js";\n`;
-      await fs.writeFile(stubPath, content, 'utf8');
+
+      const implStubPath = path.join(envDir, `${base}.impl.js`);
+      const implContent = `export * from './${base}.impl.ts';\n`;
+
+      await Promise.all([
+        fs.writeFile(stubPath, content, "utf8"),
+        fs.writeFile(implStubPath, implContent, "utf8"),
+      ]);
     })
   );
 }

--- a/packages/config/src/env/auth.impl.js
+++ b/packages/config/src/env/auth.impl.js
@@ -1,0 +1,1 @@
+export * from "./auth.impl.ts";

--- a/packages/config/src/env/cms.impl.js
+++ b/packages/config/src/env/cms.impl.js
@@ -1,0 +1,1 @@
+export * from "./cms.impl.ts";

--- a/packages/config/src/env/core.impl.js
+++ b/packages/config/src/env/core.impl.js
@@ -1,0 +1,1 @@
+export * from "./core.impl.ts";

--- a/packages/config/src/env/email.impl.js
+++ b/packages/config/src/env/email.impl.js
@@ -1,0 +1,1 @@
+export * from "./email.impl.ts";

--- a/packages/config/src/env/payments.impl.js
+++ b/packages/config/src/env/payments.impl.js
@@ -1,0 +1,1 @@
+export * from "./payments.impl.ts";

--- a/packages/config/src/env/shipping.impl.js
+++ b/packages/config/src/env/shipping.impl.js
@@ -1,0 +1,1 @@
+export * from "./shipping.impl.ts";

--- a/packages/zod-utils/src/zodErrorMap.js
+++ b/packages/zod-utils/src/zodErrorMap.js
@@ -1,0 +1,1 @@
+export * from "./zodErrorMap.ts";


### PR DESCRIPTION
## Summary
- add zodErrorMap.js that re-exports the TypeScript version
- generate `.impl.js` re-exports for all env config implementations
- update env stub generator to output `.impl.js` bridges alongside stubs

## Testing
- `pnpm install`
- `pnpm --filter @acme/config run build:stubs`
- `pnpm -r build` *(fails: Module '@ui' has no exported member 'ImagePicker')*


------
https://chatgpt.com/codex/tasks/task_e_68b0257682a8832fb8689f045eb52faa