### PR TITLE
fix(ui): export cms components

### DIFF
--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./atoms";
 export * from "./molecules";
 export * from "./organisms";
 export * from "./templates";
+export * from "./cms";
 export { default as DynamicRenderer } from "./DynamicRenderer";
 export { default as ThemeToggle } from "./ThemeToggle";
 export { default as ComponentPreview } from "./ComponentPreview";


### PR DESCRIPTION
## Summary
- export CMS components from @ui so apps can access ImagePicker

## Testing
- `pnpm --filter @acme/ui build`
- `npx tsc -b apps/cms`
- `pnpm --filter @acme/ui test -- src/components/cms/page-builder/__tests__/ImagePicker.test.tsx`
- `pnpm --filter @apps/cms test` *(fails: wizard-flow.integration.test.tsx, wizard-navigation.test.tsx, wizard-theme.test.tsx, ProductPreview.spec.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b03110d7b0832f965dade955e1a560