### PR TITLE
fix cms build lint errors

### DIFF
--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -94,12 +94,13 @@ const WizardPreview = forwardRef<HTMLDivElement, Props>(function WizardPreview(
     if (!Comp) return null;
 
     /* Remove metadata fields before spreading props */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
       id: _id,
       type: _type,
       ...props
     } = component as Record<string, unknown>;
+    void _id;
+    void _type;
 
     return <Comp {...props} locale="en" />;
   }

--- a/apps/cms/src/app/cms/wizard/preview/view/page.tsx
+++ b/apps/cms/src/app/cms/wizard/preview/view/page.tsx
@@ -53,7 +53,10 @@ export default async function PreviewView({
   const tokens = await loadThemeTokens(theme);
   const style = Object.fromEntries(Object.entries(tokens)) as CSSProperties;
 
-  const messagesMap: Record<Locale, () => Promise<any>> = {
+  const messagesMap: Record<
+    Locale,
+    () => Promise<{ default: Record<string, string> }>
+  > = {
     en: () => import("@i18n/en.json"),
     de: () => import("@i18n/de.json"),
     it: () => import("@i18n/it.json"),

--- a/apps/cms/src/app/cms/wizard/services/createShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/createShop.ts
@@ -5,6 +5,12 @@ import type { DeployStatusBase } from "@platform-core/createShop/deployTypes";
 import { validateShopName } from "@platform-core/shops";
 import type { WizardState } from "../schema";
 
+interface SerializedNavItem {
+  label: string;
+  url: string;
+  children?: SerializedNavItem[];
+}
+
 export interface CreateResult {
   ok: boolean;
   deployment?: DeployStatusBase;
@@ -14,7 +20,7 @@ export interface CreateResult {
 
 function serializeNavItems(
   items: WizardState["navItems"]
-): { label: string; url: string; children?: any[] }[] {
+): SerializedNavItem[] {
   return items.map(
     ({ label, url, children }: WizardState["navItems"][number]) => ({
       label,

--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -8,6 +8,12 @@ import {
 import { validateShopName } from "@platform-core/shops";
 import type { WizardState } from "../schema";
 
+interface SerializedNavItem {
+  label: string;
+  url: string;
+  children?: SerializedNavItem[];
+}
+
 export interface SubmitResult {
   ok: boolean;
   deployment?: DeployStatusBase;
@@ -17,7 +23,7 @@ export interface SubmitResult {
 
 function serializeNavItems(
   items: WizardState["navItems"]
-): { label: string; url: string; children?: any[] }[] {
+): SerializedNavItem[] {
   return items.map(
     ({ label, url, children }: WizardState["navItems"][number]) => ({
       label,

--- a/apps/cms/src/app/cms/wizard/tokenUtils.ts
+++ b/apps/cms/src/app/cms/wizard/tokenUtils.ts
@@ -1,6 +1,4 @@
 // apps/cms/src/app/cms/wizard/tokenUtils.ts
-/* eslint-disable import/consistent-type-specifier-style */
-
 import { tokens as baseTokensSrc, type TokenMap as ThemeTokenMap } from "@themes/base";
 
 function typedEntries<T extends object>(obj: T): [keyof T, T[keyof T]][] {

--- a/apps/cms/src/services/blog.ts
+++ b/apps/cms/src/services/blog.ts
@@ -17,17 +17,21 @@ import { nowIso } from "@date-utils";
 
 function collectProductSlugs(content: unknown): string[] {
   const slugs = new Set<string>();
-  const walk = (node: any) => {
-    if (!node) return;
+  const walk = (node: unknown): void => {
+    if (node == null) return;
     if (Array.isArray(node)) {
       node.forEach(walk);
       return;
     }
     if (typeof node === "object") {
-      if (node._type === "productReference" && typeof node.slug === "string") {
-        slugs.add(node.slug);
+      const record = node as Record<string, unknown>;
+      if (
+        record._type === "productReference" &&
+        typeof record.slug === "string"
+      ) {
+        slugs.add(record.slug);
       }
-      for (const value of Object.values(node)) {
+      for (const value of Object.values(record)) {
         walk(value);
       }
     }

--- a/apps/cms/src/services/shops/seoService.ts
+++ b/apps/cms/src/services/shops/seoService.ts
@@ -75,13 +75,18 @@ export async function generateSeo(
   return { generated: result };
 }
 
+interface DiffEntry {
+  timestamp: string;
+  diff: Partial<ShopSettings>;
+}
+
 export async function revertSeo(shop: string, timestamp: string) {
   await authorize();
-  const history = await fetchDiffHistory(shop);
-  const sorted = history.sort((a: any, b: any) =>
+  const history = (await fetchDiffHistory(shop)) as DiffEntry[];
+  const sorted = history.sort((a, b) =>
     a.timestamp.localeCompare(b.timestamp),
   );
-  const idx = sorted.findIndex((e: any) => e.timestamp === timestamp);
+  const idx = sorted.findIndex((e) => e.timestamp === timestamp);
   if (idx === -1) throw new Error("Version not found");
   let state: ShopSettings = {
     languages: [] as Locale[],


### PR DESCRIPTION
## Summary
- improve CMS wizard preview translation typing
- type-safe serialization of nav items in shop creation and submission
- fix misc CMS lint warnings and tighten types

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: A Node.js module is loaded ('crypto' at line 2) which is not supported in the Edge Runtime.)*

------
https://chatgpt.com/codex/tasks/task_e_68b042782b7c832fa612e01cd1959a26