### PR TITLE
fix tests by polyfilling File in Node environment

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -34,8 +34,9 @@ import { TextDecoder, TextEncoder } from "node:util";
 (globalThis as any).TextEncoder ||= TextEncoder;
 (globalThis as any).TextDecoder ||= TextDecoder;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { FormData: UndiciFormData } = require("undici");
+const { File: UndiciFile, FormData: UndiciFormData } = require("undici");
 (globalThis as any).FormData ||= UndiciFormData;
+(globalThis as any).File ||= UndiciFile;
 
 /**
  * React 19+ uses `MessageChannel` internally for suspense & streaming.


### PR DESCRIPTION
## Summary
- polyfill global File using undici in jest setup to support Node-based tests

## Testing
- `pnpm test:cms apps/cms/src/actions/__tests__/media.server.test.ts`
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0439e5ad8832fa6a4b1e36a384799