### PR TITLE
fix: improve product preview validity

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -18,6 +18,8 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
     let active = true;
     async function load() {
       setLoading(true);
+      setProduct(null);
+      onValidChange?.(false);
       try {
         const res = await fetch(
           `/api/products?slug=${encodeURIComponent(slug)}`
@@ -41,7 +43,7 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
     load();
     return () => {
       active = false;
-      onValidChange?.(true);
+      onValidChange?.(false);
     };
   }, [slug, onValidChange]);
 


### PR DESCRIPTION
## Summary
- reset product preview validity while fetching
- clear product data when refetching and mark invalid on unmount

## Testing
- `pnpm test:cms apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx`
- `pnpm -r build` *(fails: apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b043c84dbc832f98bd158209e99b1d