### PR TITLE
test: polyfill File global for Jest

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -29,10 +29,12 @@ mutableEnv.SESSION_SECRET ||= "test-session-secret";
 import "@testing-library/jest-dom";
 import "cross-fetch/polyfill";
 import { TextDecoder, TextEncoder } from "node:util";
+import { File } from "node:buffer";
 
 /** Node’s `util` encoders/decoders are required by React-DOM’s server renderer */
 (globalThis as any).TextEncoder ||= TextEncoder;
 (globalThis as any).TextDecoder ||= TextDecoder;
+(globalThis as any).File ||= File;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { FormData: UndiciFormData } = require("undici");
 (globalThis as any).FormData ||= UndiciFormData;


### PR DESCRIPTION
## Summary
- polyfill global File in Jest setup for Node environment

## Testing
- `pnpm -r build` *(fails: '_type' is assigned a value but never used...')*
- `pnpm test:cms apps/cms/src/actions/__tests__/media.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0449e67bc832f85a39082f61df5d2