### PR TITLE
Fix Jest parsing for config env modules

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -120,7 +120,12 @@ module.exports = {
     "^@platform-core/(.*)$": "<rootDir>/packages/platform-core/src/$1",
     "^@ui/src/(.*)$": "<rootDir>/packages/ui/src/$1",
       "^@config/src/env$": "<rootDir>/packages/config/src/env/index.ts",
+      "^@config/src/env/(.*)$":
+        "<rootDir>/packages/config/src/env/$1.impl.ts",
       "^@config/src/(.*)$": "<rootDir>/packages/config/src/$1",
+    "^@acme/config/env$": "<rootDir>/packages/config/src/env/index.ts",
+    "^@acme/config/env/(.*)$":
+      "<rootDir>/packages/config/src/env/$1.impl.ts",
     "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
     "^@acme/plugin-sanity$": "<rootDir>/test/__mocks__/pluginSanityStub.ts",


### PR DESCRIPTION
## Summary
- map `@config/src/env/*` and `@acme/config/env/*` imports to their TypeScript implementations in `moduleNameMapper`

## Testing
- `pnpm --filter @apps/cms test -- __tests__/shopPages404.test.ts`
- `pnpm -r build` *(fails: Unexpected any & require() lint errors in apps/cms build)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68b0460a6948832f8bc6f8e3fbf1df28