### PR TITLE
refactor: validate CMS env vars

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,6 +21,9 @@ mutableEnv.CART_COOKIE_SECRET ||= "test-cart-secret"; // cart cookie signing
 mutableEnv.STRIPE_WEBHOOK_SECRET ||= "whsec_test"; // dummy Stripe webhook secret
 mutableEnv.NEXTAUTH_SECRET ||= "test-nextauth-secret";
 mutableEnv.SESSION_SECRET ||= "test-session-secret";
+mutableEnv.CMS_SPACE_URL ||= "https://cms.example.com";
+mutableEnv.CMS_ACCESS_TOKEN ||= "cms-access-token";
+mutableEnv.SANITY_API_VERSION ||= "2023-01-01";
 
 /* -------------------------------------------------------------------------- */
 /* 2.  Polyfills missing from the JSDOM / Node test runtime                    */

--- a/packages/config/src/env/cms.impl.ts
+++ b/packages/config/src/env/cms.impl.ts
@@ -2,18 +2,19 @@ import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
 export const cmsEnvSchema = z.object({
-  CMS_SPACE_URL: z.string().url().default("https://cms.example.com"),
-  CMS_ACCESS_TOKEN: z.string().default("cms-access-token"),
-  SANITY_API_VERSION: z.string().default("2023-01-01"),
+  CMS_SPACE_URL: z.string().url(),
+  CMS_ACCESS_TOKEN: z.string().min(1),
+  SANITY_API_VERSION: z.string().min(1),
 });
 
 const parsed = cmsEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  console.warn(
-    "⚠️ Invalid CMS environment variables:",
+  console.error(
+    "❌ Invalid CMS environment variables:",
     parsed.error.format(),
   );
+  throw new Error("Invalid CMS environment variables");
 }
 
-export const cmsEnv = parsed.success ? parsed.data : cmsEnvSchema.parse({});
+export const cmsEnv = parsed.data;
 export type CmsEnv = z.infer<typeof cmsEnvSchema>;


### PR DESCRIPTION
## Summary
- require CMS env variables and throw when invalid
- seed default CMS env values in Jest setup for tests

## Testing
- `pnpm --filter @acme/config run build:stubs`
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: Invalid CMS environment variables in apps/cms)*

------
https://chatgpt.com/codex/tasks/task_e_68b044ab4818832fb33b7145e7046c29