### PR TITLE
Add shared-utils CSRF and fetchJson tests

### DIFF
--- a/packages/shared-utils/src/fetchJson.test.ts
+++ b/packages/shared-utils/src/fetchJson.test.ts
@@ -1,0 +1,70 @@
+import { fetchJson } from './fetchJson';
+import { z } from 'zod';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns parsed data on success', async () => {
+    const data = { message: 'ok' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(JSON.stringify(data)),
+    });
+
+    await expect(fetchJson<typeof data>('https://example.com')).resolves.toEqual(data);
+  });
+
+  it('throws error for non-OK responses with JSON payload', async () => {
+    const payload = { error: 'Bad Request' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+      status: 400,
+      text: jest.fn().mockResolvedValue(JSON.stringify(payload)),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('Bad Request');
+  });
+
+  it('returns undefined when response body is invalid JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('not json'),
+    });
+
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+
+  it('propagates network errors', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network failure'));
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('Network failure');
+  });
+
+  it('returns undefined for unexpected content type', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('<html></html>'),
+      headers: { get: () => 'text/html' },
+    });
+
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+
+  it('validates data against provided schema', async () => {
+    const data = { message: 'ok' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(JSON.stringify(data)),
+    });
+    const schema = z.object({ message: z.string() });
+
+    await expect(fetchJson('https://example.com', undefined, schema)).resolves.toEqual(data);
+  });
+});

--- a/packages/shared-utils/src/getCsrfToken.test.ts
+++ b/packages/shared-utils/src/getCsrfToken.test.ts
@@ -1,0 +1,28 @@
+import { getCsrfToken } from './getCsrfToken';
+
+describe('getCsrfToken', () => {
+  afterEach(() => {
+    document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    jest.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).crypto;
+  });
+
+  it('returns token from cookie when present', () => {
+    document.cookie = 'csrf_token=cookie-token';
+    expect(getCsrfToken()).toBe('cookie-token');
+  });
+
+  it('generates and stores token when cookie missing', () => {
+    const mockCrypto = { randomUUID: jest.fn().mockReturnValue('generated-token') };
+    Object.defineProperty(globalThis, 'crypto', {
+      value: mockCrypto,
+      configurable: true,
+    });
+
+    const token = getCsrfToken();
+    expect(token).toBe('generated-token');
+    expect(document.cookie).toContain('csrf_token=generated-token');
+    expect(mockCrypto.randomUUID).toHaveBeenCalled();
+  });
+});

--- a/packages/shared-utils/tsconfig.json
+++ b/packages/shared-utils/tsconfig.json
@@ -12,6 +12,6 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "__tests__", ".turbo", "node_modules"],
+  "exclude": ["dist", "__tests__", ".turbo", "node_modules", "**/*.test.ts"],
   "references": []
 }


### PR DESCRIPTION
## Summary
- add unit tests for getCsrfToken retrieving/generating tokens
- add tests for fetchJson error and edge cases
- exclude test files from shared-utils build

## Testing
- `pnpm -r build` *(fails: ERR_INVALID_ARG_TYPE in apps/cms build)*
- `pnpm exec jest --runTestsByPath packages/shared-utils/src/getCsrfToken.test.ts packages/shared-utils/src/fetchJson.test.ts --config jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b045d001c4832f851c0fe917de131c