### PR TITLE
refactor: tighten cms test typings

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps.tsx
+++ b/apps/cms/src/app/cms/configurator/steps.tsx
@@ -23,7 +23,7 @@ import { Tooltip } from "@/components/atoms";
 export interface ConfiguratorStep {
   id: string;
   label: string;
-  component: React.ComponentType<any>;
+  component: React.ComponentType;
   optional?: boolean;
   /** IDs of steps that are recommended to complete before this step */
   recommended?: string[];

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -93,7 +93,8 @@ export default function InventoryForm({ shop, initial }: Props) {
     setAttributes((prev) => prev.filter((a) => a !== attr));
     setItems((prev) =>
       prev.map((i) => {
-        const { [attr]: _, ...rest } = i.variantAttributes;
+        const rest = { ...i.variantAttributes };
+        delete rest[attr];
         return { ...i, variantAttributes: rest };
       })
     );

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -1,28 +1,28 @@
 import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { z } from "zod";
 
 jest.mock(
   "@/components/atoms/shadcn",
-  () => {
-    const React = require("react");
-    return {
-      __esModule: true,
-      Button: ({ children, ...props }: any) => (
-        <button {...props}>{children}</button>
-      ),
-      Input: ({ ...props }: any) => <input {...props} />,
-      Table: ({ children }: any) => <table>{children}</table>,
-      TableBody: ({ children }: any) => <tbody>{children}</tbody>,
-      TableCell: ({ children, ...props }: any) => <td {...props}>{children}</td>,
-      TableHead: ({ children }: any) => <th>{children}</th>,
-      TableHeader: ({ children }: any) => <thead>{children}</thead>,
-      TableRow: ({ children }: any) => <tr>{children}</tr>,
-    };
-  },
+  () => ({
+    __esModule: true,
+    Button: ({ children, ...props }: ComponentProps<"button">) => (
+      <button {...props}>{children}</button>
+    ),
+    Input: (props: ComponentProps<"input">) => <input {...props} />,
+    Table: ({ children }: ComponentProps<"table">) => <table>{children}</table>,
+    TableBody: ({ children }: ComponentProps<"tbody">) => <tbody>{children}</tbody>,
+    TableCell: ({ children, ...props }: ComponentProps<"td">) => (
+      <td {...props}>{children}</td>
+    ),
+    TableHead: ({ children }: ComponentProps<"th">) => <th>{children}</th>,
+    TableHeader: ({ children }: ComponentProps<"thead">) => <thead>{children}</thead>,
+    TableRow: ({ children }: ComponentProps<"tr">) => <tr>{children}</tr>,
+  }),
   { virtual: true }
 );
 
 jest.mock("@acme/types", () => {
-  const { z } = require("zod");
   const inventoryItemSchema = z
     .object({
       sku: z.string(),
@@ -49,9 +49,9 @@ describe("InventoryForm", () => {
   ];
 
   beforeEach(() => {
-    (global as any).fetch = jest
+    globalThis.fetch = jest
       .fn()
-      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch;
   });
 
   it("adds and deletes rows", () => {
@@ -65,7 +65,7 @@ describe("InventoryForm", () => {
   });
 
   it("adds attribute columns and persists values", async () => {
-    (window as any).prompt = jest.fn().mockReturnValue("material");
+    window.prompt = jest.fn().mockReturnValue("material") as unknown as typeof window.prompt;
     render(<InventoryForm shop="test" initial={initial} />);
     fireEvent.click(screen.getByText("Add attribute"));
     expect(screen.getByText("material")).toBeInTheDocument();

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts
@@ -1,7 +1,8 @@
 import { validateInventoryItems } from "../useInventoryValidation";
+import { z } from "zod";
+import type { InventoryItem } from "@acme/types";
 
 jest.mock("@acme/types", () => {
-  const { z } = require("zod");
   const inventoryItemSchema = z
     .object({
       sku: z.string(),
@@ -36,7 +37,7 @@ describe("validateInventoryItems", () => {
         productId: "sku1",
         variantAttributes: {},
         quantity: -1,
-      } as any,
+      } as unknown as InventoryItem,
     ]);
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/greater than or equal to 0/i);

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiFeedPanel.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/AiFeedPanel.tsx
@@ -1,14 +1,22 @@
 import { formatTimestamp } from "@acme/date-utils";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 
+interface EventRecord {
+  shop?: string;
+  type?: string;
+  timestamp?: string;
+  status?: unknown;
+}
+
 export default async function AiFeedPanel({ shop }: { shop: string }) {
-  const events = (await listEvents())
-    .filter((e: any) => e.shop === shop)
-    .filter((e: any) => e.type === "ai_crawl")
+  const events = (await listEvents()) as EventRecord[];
+  const filtered = events
+    .filter((e) => e.shop === shop)
+    .filter((e) => e.type === "ai_crawl")
     .slice(-5)
     .reverse();
 
-  if (events.length === 0) {
+  if (filtered.length === 0) {
     return (
       <div className="space-y-2 text-sm">
         <h4 className="font-medium">Recent AI Feed Requests</h4>
@@ -18,15 +26,15 @@ export default async function AiFeedPanel({ shop }: { shop: string }) {
   }
 
   return (
-  <div className="space-y-2 text-sm">
-    <h4 className="font-medium">Recent AI Feed Requests</h4>
-    <ul className="space-y-1">
-      {events.map((e, idx) => (
-        <li key={idx}>
-          {formatTimestamp(e.timestamp as string)} – {String(e.status)}
-        </li>
-      ))}
-    </ul>
-  </div>
+    <div className="space-y-2 text-sm">
+      <h4 className="font-medium">Recent AI Feed Requests</h4>
+      <ul className="space-y-1">
+        {filtered.map((e, idx) => (
+          <li key={idx}>
+            {formatTimestamp(e.timestamp as string)} – {String(e.status)}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/page.tsx
@@ -18,6 +18,12 @@ interface Params {
   shop: string;
 }
 
+interface EventRecord {
+  shop?: string;
+  type?: string;
+  timestamp?: string;
+}
+
 export default async function SeoSettingsPage({
   params,
 }: {
@@ -36,9 +42,9 @@ export default async function SeoSettingsPage({
     fields: ["id", "title", "description", "price", "media"],
     pageSize: 50,
   };
-  const lastCrawl = events
-    .filter((e: any) => e.shop === shop)
-    .filter((e: any) => e.type === "ai_crawl")
+  const lastCrawl = (events as EventRecord[])
+    .filter((e) => e.shop === shop)
+    .filter((e) => e.type === "ai_crawl")
     .map((e) => e.timestamp as string)
     .filter(Boolean)
     .sort()

--- a/apps/cms/src/app/cms/shop/[shop]/themes/__tests__/components.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/__tests__/components.test.tsx
@@ -1,16 +1,17 @@
 import { render, fireEvent } from "@testing-library/react";
+import type { ComponentProps } from "react";
 
 jest.mock(
   "@/components/atoms/shadcn",
   () => ({
-    Button: (props: any) => <button {...props} />,
-    Input: (props: any) => <input {...props} />,
+    Button: (props: ComponentProps<"button">) => <button {...props} />,
+    Input: (props: ComponentProps<"input">) => <input {...props} />,
   }),
   { virtual: true },
 );
 
-const ThemeSelector = require("../ThemeSelector").default;
-const PresetControls = require("../PresetControls").default;
+import ThemeSelector from "../ThemeSelector";
+import PresetControls from "../PresetControls";
 
 describe("ThemeSelector", () => {
   it("calls onChange when value changes", () => {

--- a/apps/cms/src/app/cms/shop/[shop]/themes/__tests__/useThemeEditor.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/__tests__/useThemeEditor.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { useThemeEditor } from "../useThemeEditor";
+import { patchShopTheme } from "../../../../wizard/services/patchTheme";
 
 jest.mock("../../../../wizard/services/patchTheme", () => ({
   patchShopTheme: jest.fn().mockResolvedValue(undefined),
@@ -43,7 +44,6 @@ describe("useThemeEditor", () => {
     act(() => {
       jest.runAllTimers();
     });
-    const { patchShopTheme } = require("../../../../wizard/services/patchTheme");
     expect(patchShopTheme).toHaveBeenCalledWith("shop1", {
       themeOverrides: { color: "#000" },
       themeDefaults: {},

--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
@@ -200,13 +200,17 @@ export function useThemeEditor({
     });
   };
 
+  interface PickerInput extends HTMLInputElement {
+    showPicker?: () => void;
+  }
+
   const handleTokenSelect = (token: string) => {
-    const input = overrideRefs.current[token];
+    const input = overrideRefs.current[token] as PickerInput | null;
     if (input) {
       input.scrollIntoView?.({ behavior: "smooth", block: "center" });
       input.focus();
-      (input as any).showPicker?.();
-      if (!(input as any).showPicker) {
+      input.showPicker?.();
+      if (!input.showPicker) {
         input.click();
       }
     }

--- a/apps/cms/src/app/cms/wizard/TokenInspector.tsx
+++ b/apps/cms/src/app/cms/wizard/TokenInspector.tsx
@@ -137,16 +137,20 @@ export default function TokenInspector({
     return () => window.removeEventListener("keydown", keyHandler);
   }, [inspectMode, selectedIndex]);
 
-  const child = children as React.ReactElement<any>;
+  const child = children as React.ReactElement & {
+    ref?: React.Ref<HTMLDivElement>;
+  };
   return (
     <>
       {React.cloneElement(child, {
         ref: (node: HTMLDivElement) => {
           previewRef.current = node;
-          const { ref } = child as any;
-          if (typeof ref === "function") ref(node);
-          else if (ref)
+          const { ref } = child;
+          if (typeof ref === "function") {
+            ref(node);
+          } else if (ref && "current" in ref) {
             (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+          }
         },
         onPointerMove: handlePointerMove,
         onClickCapture: handleClick,

--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -34,7 +34,7 @@ export default function Wizard({ themes }: WizardProps): React.JSX.Element {
   // --------------------------------------------------------------
   // Progress helpers
   // --------------------------------------------------------------
-  const persist = (data: any) =>
+  const persist = (data: Record<string, unknown>) =>
     fetch("/cms/api/wizard-progress", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -91,10 +91,10 @@ export default function Wizard({ themes }: WizardProps): React.JSX.Element {
     };
   }, [theme]);
 
-  const style = useMemo(() => {
-    const s: React.CSSProperties = {};
+  const style = useMemo<Record<string, string>>(() => {
+    const s: Record<string, string> = {};
     Object.entries(tokens).forEach(([k, v]) => {
-      (s as any)[k] = v;
+      s[k] = v;
     });
     return s;
   }, [tokens]);


### PR DESCRIPTION
## Summary
- replace `any` with explicit React types in CMS theme tests and utilities
- switch `require` calls to ES imports for better type checking
- add stricter typings for various CMS panels and wizard helpers

## Testing
- `pnpm -r build` *(fails: Unexpected any / require usage across apps/cms)*
- `pnpm --filter @apps/cms test` *(fails: Wizard locale flow & navigation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0486196f0832fb1453a423df2d8ac