### PR TITLE
Include CMS env variables in core env tests

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -3,9 +3,18 @@ import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.impl";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
 
+const baseEnv = {
+  CMS_SPACE_URL: "https://example.com",
+  CMS_ACCESS_TOKEN: "token",
+  SANITY_API_VERSION: "v1",
+};
+
 describe("core env refinement", () => {
   it("reports invalid DEPOSIT_RELEASE_ENABLED", () => {
-    const parsed = schema.safeParse({ DEPOSIT_RELEASE_ENABLED: "yes" });
+    const parsed = schema.safeParse({
+      ...baseEnv,
+      DEPOSIT_RELEASE_ENABLED: "yes",
+    });
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
       expect(parsed.error.issues[0]).toMatchObject({
@@ -16,7 +25,10 @@ describe("core env refinement", () => {
   });
 
   it("reports non-numeric LATE_FEE_INTERVAL_MS", () => {
-    const parsed = schema.safeParse({ LATE_FEE_INTERVAL_MS: "fast" });
+    const parsed = schema.safeParse({
+      ...baseEnv,
+      LATE_FEE_INTERVAL_MS: "fast",
+    });
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
       expect(parsed.error.issues[0]).toMatchObject({


### PR DESCRIPTION
## Summary
- add minimal CMS env values in core env tests to ensure targeted validation

## Testing
- `pnpm -r build` (fails: Unexpected any in apps/cms)
- `pnpm --filter @acme/config test`
- `pnpm exec jest packages/config/src/env/__tests__/core.test.ts --config packages/config/jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b04cfee748832f944fbc3b047dafc9