### PR TITLE
Handle non-File entries in uploadMedia

### DIFF
--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -81,8 +81,11 @@ export async function uploadMedia(
 ): Promise<MediaItem> {
   await ensureAuthorized();
 
-  const file = formData.get("file");
-  if (!(file instanceof File)) throw new Error("No file provided");
+  const fileEntry = formData.get("file");
+  if (!fileEntry || typeof fileEntry === "string") {
+    throw new Error("No file provided");
+  }
+  const file = fileEntry as File;
 
   const title = formData.get("title")?.toString();
   const altText = formData.get("altText")?.toString();


### PR DESCRIPTION
## Summary
- avoid strict `File` instance check in `uploadMedia`
- ensure FormData non-file values trigger `No file provided` error

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Unexpected any in StepProductPage.tsx)*
- `pnpm --filter @apps/cms test` *(fails: Invalid CMS environment variables; `src/actions/__tests__/media.server.test.ts` passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d0c9974832fb70a16a612836314