### PR TITLE
fix(cms): remove any cast from StepProductPage

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
@@ -85,7 +85,7 @@ export default function StepProductPage({
               `page-builder-history-${existing.id}`,
               JSON.stringify(
                 historyStateSchema.parse(
-                  (existing as any).history ?? {
+                  existing.history ?? {
                     past: [],
                     present: existing.components as PageComponent[],
                     future: [],


### PR DESCRIPTION
## Summary
- remove `any` cast when reading page history

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @apps/cms@ build)*

------
https://chatgpt.com/codex/tasks/task_e_68b04f5717d0832f884e2bd76f222127