### PR TITLE
refactor: remove dynamic require in theme utils

### DIFF
--- a/packages/platform-core/src/createShop/themeUtils.ts
+++ b/packages/platform-core/src/createShop/themeUtils.ts
@@ -21,11 +21,9 @@ export function loadBaseTokens(): Record<string, string> {
   const sandbox: {
     module: { exports: Record<string, unknown> };
     exports: Record<string, unknown>;
-    require: NodeRequire;
   } = {
     module: { exports: {} },
     exports: {},
-    require,
   };
   sandbox.exports = sandbox.module.exports;
   runInNewContext(transpiled, sandbox);


### PR DESCRIPTION
## Summary
- avoid dynamic require in createShop themeUtils to remove critical dependency warning

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module 'file:///workspace/base-shop/packages/plugins/sanity/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b050c90588832f9c7342ec9e24e5eb