### PR TITLE
refactor: remove any from API routes

### DIFF
--- a/apps/cms/src/app/api/seo/audit/[shop]/route.ts
+++ b/apps/cms/src/app/api/seo/audit/[shop]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { validateShopName } from "@acme/lib";
 import lighthouse from "lighthouse";
+import type { CliFlags, RunnerResult } from "lighthouse";
 import isURL from "validator/lib/isURL";
 import {
   appendSeoAudit,
@@ -17,14 +18,12 @@ const TRUSTED_HOSTS = new Set(
 );
 
 async function runLighthouse(url: string): Promise<SeoAuditEntry> {
-  const result = (await lighthouse(
-    url,
-    {
-      onlyCategories: ["seo"],
-      chromeFlags: ["--headless"],
-      preset: "desktop",
-    } as any,
-  )) as { lhr: any } | undefined;
+  const flags: CliFlags = {
+    onlyCategories: ["seo"],
+    chromeFlags: ["--headless"],
+    preset: "desktop",
+  };
+  const result: RunnerResult | undefined = await lighthouse(url, flags);
   if (!result) {
     throw new Error("Failed to run Lighthouse");
   }

--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import { mkdir, unlink } from "fs/promises";
 import path from "path";
 import { Readable } from "stream";
+import type { ReadableStream } from "stream/web";
 import Busboy from "busboy";
 import { fileTypeFromBuffer } from "file-type/core";
 import { resolveDataRoot } from "@platform-core/dataRoot";
@@ -29,7 +30,7 @@ export async function POST(
     const filePath = path.join(dir, "products.csv");
 
     const busboy = Busboy({
-      headers: Object.fromEntries(req.headers as any),
+      headers: Object.fromEntries(req.headers.entries()),
       limits: { fileSize: MAX_SIZE, files: 1 },
     });
 
@@ -115,7 +116,7 @@ export async function POST(
       });
 
       if (req.body) {
-        Readable.fromWeb(req.body as any).pipe(busboy);
+        Readable.fromWeb(req.body as ReadableStream).pipe(busboy);
       } else {
         resolved = true;
         resolve(NextResponse.json({ error: "No body" }, { status: 400 }));


### PR DESCRIPTION
## Summary
- use typed Lighthouse flags and result in SEO audit API
- convert headers/streams to typed values in CSV upload API

## Testing
- `pnpm exec eslint apps/cms/src/app/api/seo/audit/[shop]/route.ts apps/cms/src/app/api/upload-csv/[shop]/route.ts`
- `pnpm -r build` *(fails: Unexpected any in unrelated StepProductPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b05164664c832f8608f4d74e25373c