### PR TITLE
refactor: avoid explicit any in StepPage

### DIFF
--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -19,7 +19,7 @@ export default function StepPage({ stepId }: Props) {
   const prev = list[idx - 1];
   const next = list[idx + 1];
 
-  const StepComponent = step.component as React.ComponentType<any>;
+  const StepComponent = step.component as React.ComponentType<Record<string, unknown>>;
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- replace explicit `any` with `Record<string, unknown>` when typing step component

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Output file '/workspace/base-shop/packages/platform-core/dist/dataRoot.d.ts' has not been built from source file '/workspace/base-shop/packages/platform-core/src/dataRoot.ts')*
- `pnpm --filter @apps/cms lint --file src/app/cms/configurator/[stepId]/step-page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b0519bca28832fbe295eef982dc1d7