### PR TITLE
refactor: use Next Image component in CMS blog posts

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/MainImageField.tsx
+++ b/apps/cms/src/app/cms/blog/posts/MainImageField.tsx
@@ -1,4 +1,5 @@
 import { Button, ImagePicker } from "@ui";
+import Image from "next/image";
 
 interface Props {
   value: string;
@@ -15,7 +16,13 @@ export default function MainImageField({ value, onChange }: Props) {
         </Button>
       </ImagePicker>
       {value && (
-        <img src={value} alt="Main image" className="h-32 w-auto rounded object-cover" />
+        <Image
+          src={value}
+          alt="Main image"
+          width={128}
+          height={128}
+          className="h-32 w-auto rounded object-cover"
+        />
       )}
     </div>
   );

--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { SKU } from "@acme/types";
 import { formatCurrency } from "@acme/shared-utils";
+import Image from "next/image";
 
 export interface Props {
   slug: string;
@@ -56,9 +57,11 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
   return (
     <div className="flex gap-2 border p-2">
       {product.media?.[0] && (
-        <img
+        <Image
           src={product.media[0].url}
           alt={product.title}
+          width={64}
+          height={64}
           className="h-16 w-16 object-cover"
         />
       )}

--- a/apps/cms/src/app/cms/blog/posts/RichTextEditor.tsx
+++ b/apps/cms/src/app/cms/blog/posts/RichTextEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Button, Input, ImagePicker } from "@ui";
+import Image from "next/image";
 import {
   EditorProvider,
   PortableTextEditable,
@@ -144,9 +145,11 @@ function ProductSearch({
                   }
                 >
                   {imageUrl && (
-                    <img
+                    <Image
                       src={imageUrl}
                       alt={p.title}
+                      width={32}
+                      height={32}
                       className="h-8 w-8 object-cover"
                     />
                   )}


### PR DESCRIPTION
## Summary
- replace raw img elements in CMS blog components with Next.js Image for automatic optimization

## Testing
- `pnpm -r build` *(fails: @apps/cms build: Unexpected any. Specify a different type)*
- `pnpm test` *(fails: @acme/auth#test command exited with code 137)*

------
https://chatgpt.com/codex/tasks/task_e_68b0517409dc832fb2a57f0837c646b2