### PR TITLE
fix: address lint warnings in CMS modules

### DIFF
--- a/apps/cms/src/__tests__/cmsAccess.integration.test.tsx
+++ b/apps/cms/src/__tests__/cmsAccess.integration.test.tsx
@@ -44,6 +44,7 @@ jest.mock("next/server", () => ({
 import { getToken as mockedGetToken } from "next-auth/jwt";
 import { NextResponse } from "next/server";
 import { render, screen } from "@testing-library/react";
+import { canRead } from "@auth/rbac";
 
 const getToken = mockedGetToken as jest.MockedFunction<
   typeof import("next-auth/jwt").getToken
@@ -51,6 +52,7 @@ const getToken = mockedGetToken as jest.MockedFunction<
 const redirect = NextResponse.redirect as jest.Mock;
 const next = NextResponse.next as jest.Mock;
 const rewrite = NextResponse.rewrite as jest.Mock;
+const canReadMock = canRead as jest.Mock;
 
 function createRequest(path: string) {
   const url = new URL(`http://localhost${path}`) as URL & { clone(): URL };
@@ -94,11 +96,7 @@ describe("/cms access", () => {
   });
 
   it("returns 403 for roles without read access", async () => {
-    const { canRead } = require("@auth/rbac") as {
-      canRead: jest.Mock;
-      canWrite: jest.Mock;
-    };
-    canRead.mockReturnValueOnce(false);
+    canReadMock.mockReturnValueOnce(false);
     getToken.mockResolvedValueOnce({ role: "stranger" } as JWT);
 
     const res = await middleware(createRequest("/cms"));

--- a/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
@@ -85,7 +85,12 @@ export default function StepProductPage({
               `page-builder-history-${existing.id}`,
               JSON.stringify(
                 historyStateSchema.parse(
-                  (existing as any).history ?? {
+                  (
+                    existing as {
+                      history?: unknown;
+                      components: PageComponent[];
+                    }
+                  ).history ?? {
                     past: [],
                     present: existing.components as PageComponent[],
                     future: [],


### PR DESCRIPTION
## Summary
- replace forbidden `require` with typed import in CMS access test
- tighten Cloudflare Pages provisioning types
- remove `any` from StepProductPage history parsing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Unexpected any in other files)*
- `pnpm exec eslint apps/cms/src/__tests__/cmsAccess.integration.test.tsx apps/cms/src/actions/cloudflare.server.ts apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx`
- `pnpm --filter @apps/cms test` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b05105da18832f8505afea2b4f8ab0