### PR TITLE
refactor: replace require and add types

### DIFF
--- a/apps/cms/src/__tests__/cmsAccess.integration.test.tsx
+++ b/apps/cms/src/__tests__/cmsAccess.integration.test.tsx
@@ -94,7 +94,7 @@ describe("/cms access", () => {
   });
 
   it("returns 403 for roles without read access", async () => {
-    const { canRead } = require("@auth/rbac") as {
+    const { canRead } = (await import("@auth/rbac")) as {
       canRead: jest.Mock;
       canWrite: jest.Mock;
     };


### PR DESCRIPTION
## Summary
- use dynamic import instead of require in cms access test
- add specific response types in Cloudflare domain provisioning

## Testing
- `pnpm -r build` *(fails: apps/cms build: 'completed' is assigned a value but never used)*
- `pnpm --filter @apps/cms lint` *(fails: Unexpected any in upload-csv route)*
- `pnpm --filter @apps/cms test` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b05c86e448832fbc87c108a8907806