### PR TITLE
Defer Lighthouse import in SEO audit route

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -9,8 +9,9 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     // Allow importing/transpiling code from outside this app directory.
-    externalDir: true
+    externalDir: true,
   },
+  serverExternalPackages: ["lighthouse", "puppeteer", "yargs"],
   // Transpile linked workspace packages used by the CMS
   transpilePackages: [
     "@platform-core",

--- a/apps/cms/src/app/api/seo/audit/[shop]/route.ts
+++ b/apps/cms/src/app/api/seo/audit/[shop]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { validateShopName } from "@acme/lib";
-import lighthouse from "lighthouse";
 import isURL from "validator/lib/isURL";
 import {
   appendSeoAudit,
@@ -17,6 +16,8 @@ const TRUSTED_HOSTS = new Set(
 );
 
 async function runLighthouse(url: string): Promise<SeoAuditEntry> {
+  const { default: lighthouse } = await import("lighthouse");
+
   type Audit = {
     score?: number;
     scoreDisplayMode?: string;


### PR DESCRIPTION
## Summary
- dynamically load Lighthouse in SEO audit route
- keep heavy audit dependencies external to the CMS build

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Command failed with signal "SIGTERM")*
- `pnpm --filter @apps/cms build` *(fails: Exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b061c095d8832f819ee7be65ed239c