### PR TITLE
fix: guard plugin loader against client usage

### DIFF
--- a/packages/platform-core/src/plugins.ts
+++ b/packages/platform-core/src/plugins.ts
@@ -22,6 +22,9 @@ import type {
 
 let tsLoaderRegistered = false;
 async function importPluginModule(entry: string) {
+  if (typeof window !== "undefined") {
+    throw new Error("Plugins can only be loaded on the server");
+  }
   const abs = path.resolve(entry);
   if (/\.[mc]?ts$/.test(abs)) {
     if (!tsLoaderRegistered) {
@@ -29,7 +32,7 @@ async function importPluginModule(entry: string) {
       tsNode.register({ transpileOnly: true });
       tsLoaderRegistered = true;
     }
-    const req = createRequire(abs);
+    const req = createRequire(import.meta.url);
     return req(abs);
   }
   return import(pathToFileURL(abs).href);


### PR DESCRIPTION
## Summary
- avoid client-side invocation of plugin loader
- use `createRequire(import.meta.url)` to resolve plugin modules correctly

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@acme/email')*
- `pnpm --filter @acme/platform-core test`

------
https://chatgpt.com/codex/tasks/task_e_68b061e6600c832fb07696d373d77767