### PR TITLE
refactor: isolate sentry from client bundles

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -24,7 +24,7 @@ const nextConfig = {
     "@acme/tailwind-config",
     "@acme/design-tokens"
   ],
-  webpack: (config) => {
+  webpack: (config, { isServer }) => {
     const nodeBuiltins = [
       "assert",
       "buffer",
@@ -54,6 +54,11 @@ const nextConfig = {
       // Prevent optional Drizzle ORM dependency from being bundled
       "drizzle-orm": false,
     };
+
+    if (!isServer) {
+      config.resolve.alias["@sentry/node"] = false;
+      config.resolve.alias["@sentry/opentelemetry"] = false;
+    }
 
     for (const mod of nodeBuiltins) {
       config.resolve.alias[`node:${mod}`] = mod;

--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/actions/pages.server.ts
 
 import { LOCALES } from "@acme/i18n";
-import * as Sentry from "@sentry/node";
+import { captureException } from "@/utils/sentry.server";
 import type { Locale, Page, HistoryState } from "@acme/types";
 import { historyStateSchema } from "@acme/types";
 import { ulid } from "ulid";
@@ -52,7 +52,7 @@ export async function createPage(
       });
     }
     try {
-      Sentry.captureException(parsed.error, { extra: context });
+      await captureException(parsed.error, { extra: context });
     } catch {
       /* ignore sentry failure */
     }
@@ -89,7 +89,7 @@ export async function createPage(
     const saved = await savePageInService(shop, page, prev);
     return { page: saved };
   } catch (err) {
-    Sentry.captureException(err);
+    await captureException(err);
     throw err;
   }
 }
@@ -155,7 +155,7 @@ export async function savePageDraft(
     const saved = await savePageInService(shop, page, existing);
     return { page: saved };
   } catch (err) {
-    Sentry.captureException(err);
+    await captureException(err);
     throw err;
   }
 }
@@ -180,7 +180,7 @@ export async function updatePage(
       });
     }
     try {
-      Sentry.captureException(parsed.error, { extra: context });
+      await captureException(parsed.error, { extra: context });
     } catch {
       /* ignore sentry failure */
     }
@@ -227,7 +227,7 @@ export async function updatePage(
     const saved = await updatePageInService(shop, patch, previous);
     return { page: saved };
   } catch (err) {
-    Sentry.captureException(err);
+    await captureException(err);
     throw err;
   }
 }
@@ -241,7 +241,7 @@ export async function deletePage(shop: string, id: string): Promise<void> {
   try {
     await deletePageFromService(shop, id);
   } catch (err) {
-    Sentry.captureException(err);
+    await captureException(err);
     throw err;
   }
 }

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -13,7 +13,7 @@ import {
   writeRepo,
 } from "@platform-core/repositories/json.server";
 import { fillLocales } from "@i18n/fillLocales";
-import * as Sentry from "@sentry/node";
+import { captureException } from "@/utils/sentry.server";
 import type { Locale, ProductPublication, PublicationStatus } from "@acme/types";
 import { ensureAuthorized } from "./common/auth";
 import { redirect } from "next/navigation";
@@ -113,7 +113,7 @@ export async function updateProduct(
   if (!parsed.success) {
     const { fieldErrors } = parsed.error.flatten();
     const productId = String(formData.get("id") ?? "");
-    Sentry.captureException(parsed.error, { extra: { productId } });
+    await captureException(parsed.error, { extra: { productId } });
     return { errors: fieldErrors as Record<string, string[]> };
   }
 

--- a/apps/cms/src/utils/sentry.server.ts
+++ b/apps/cms/src/utils/sentry.server.ts
@@ -1,0 +1,19 @@
+let sentry: typeof import("@sentry/node") | undefined;
+
+export type CaptureContext = Parameters<
+  typeof import("@sentry/node")["captureException"]
+>[1];
+
+export async function captureException(
+  error: unknown,
+  context?: CaptureContext,
+): Promise<void> {
+  if (!sentry) {
+    sentry = await import(/* webpackIgnore: true */ "@sentry/node");
+  }
+  if (context) {
+    sentry.captureException(error, context);
+  } else {
+    sentry.captureException(error);
+  }
+}


### PR DESCRIPTION
## Summary
- lazily import `@sentry/node` from a server-only helper so browser bundles never see it
- wire product/page actions to use the new helper
- alias Sentry packages out of the client build in the CMS config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @typescript-eslint/no-unused-vars in StepProductPage.tsx)*
- `TSC_COMPILE_ON_ERROR=true pnpm -F cms build --no-lint` *(fails: Type error in seo audit route, no Sentry/OTel critical dependency warnings)*
- `pnpm -F cms test` *(fails: invalid CMS env vars)*
- `pnpm -F cms test src/actions/pages.server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b061d155dc832fa39561a0d64b3e40