### PR TITLE
fix: address missing hook dependencies

### DIFF
--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -29,7 +29,7 @@ export async function POST(
     const filePath = path.join(dir, "products.csv");
 
     const busboy = Busboy({
-      headers: Object.fromEntries(req.headers as any),
+      headers: Object.fromEntries(req.headers),
       limits: { fileSize: MAX_SIZE, files: 1 },
     });
 
@@ -115,7 +115,7 @@ export async function POST(
       });
 
       if (req.body) {
-        Readable.fromWeb(req.body as any).pipe(busboy);
+        Readable.fromWeb(req.body).pipe(busboy);
       } else {
         resolved = true;
         resolve(NextResponse.json({ error: "No body" }, { status: 400 }));

--- a/apps/cms/src/app/cms/blog/sanity/connect/useSanityConnection.ts
+++ b/apps/cms/src/app/cms/blog/sanity/connect/useSanityConnection.ts
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/blog/sanity/connect/useSanityConnection.ts
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormState } from "react-dom";
 import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
 import { defaultDataset } from "./constants";
@@ -39,7 +39,7 @@ export function useSanityConnection(
   const [verifyError, setVerifyError] = useState("");
   const creatingDatasetRef = useRef(false);
 
-  async function verify() {
+  const verify = useCallback(async () => {
     if (!projectId || !token || !dataset) {
       return;
     }
@@ -80,28 +80,18 @@ export function useSanityConnection(
       setVerifyError("Invalid Sanity credentials");
       setVerifyStatus("error");
     }
-  }
+  }, [projectId, token, dataset]);
 
   useEffect(() => {
-    if (projectId && token) {
-      void verify();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (projectId && token && dataset) {
-      void verify();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataset]);
+    void verify();
+  }, [verify]);
 
   useEffect(() => {
     if (state.message && creatingDatasetRef.current) {
       void verify();
       creatingDatasetRef.current = false;
     }
-  }, [state.message]);
+  }, [state.message, verify]);
 
   function handleDatasetSubmit() {
     creatingDatasetRef.current =

--- a/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
+++ b/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
@@ -67,7 +67,7 @@ export default function TemplateSelector({
           <SelectItem
             value="blank"
             asChild
-            onSelect={(e: React.SyntheticEvent) => {
+            onSelect={(e: React.SyntheticEvent<unknown>) => {
               e.preventDefault();
               setSelectOpen(false);
               setPendingTemplate({ name: "blank", components: [], preview: "" });
@@ -82,7 +82,7 @@ export default function TemplateSelector({
               key={t.name}
               value={t.name}
               asChild
-              onSelect={(e: React.SyntheticEvent) => {
+              onSelect={(e: React.SyntheticEvent<unknown>) => {
                 e.preventDefault();
                 setSelectOpen(false);
                 setPendingTemplate(t);

--- a/apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
@@ -73,7 +73,7 @@ export function useConfiguratorPersistence(
       .catch(() => {
         /* ignore */
       });
-  }, [setState]);
+  }, [setState, onInvalid]);
 
   /* Persist whenever the state changes */
   useEffect(() => {
@@ -86,7 +86,8 @@ export function useConfiguratorPersistence(
       } catch {
         /* ignore quota */
       }
-      const { completed, ...data } = state;
+      const { completed: _completed, ...data } = state;
+      void _completed;
       fetch("/cms/api/wizard-progress", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },

--- a/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from "@ui/components/atoms/shadcn";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import useStepCompletion from "../hooks/useStepCompletion";
 
@@ -51,21 +51,25 @@ export default function StepShopDetails({
   const [, markComplete] = useStepCompletion("shop-details");
   const [validationErrors, setValidationErrors] = useState<Record<string, string[]>>({});
 
-  const schema = z
-    .object({
-      id: z
-        .string()
-        .min(1, "Required")
-        .regex(/^[a-z0-9-]+$/, {
-          message: "Lowercase letters, numbers, and dashes only",
-        }),
-      name: z.string().min(1, "Required"),
-      logo: z.string().url("Invalid URL"),
-      contactInfo: z.string().min(1, "Required"),
-      type: z.enum(["sale", "rental"]),
-      template: z.string().min(1, "Required"),
-    })
-    .strict();
+  const schema = useMemo(
+    () =>
+      z
+        .object({
+          id: z
+            .string()
+            .min(1, "Required")
+            .regex(/^[a-z0-9-]+$/, {
+              message: "Lowercase letters, numbers, and dashes only",
+            }),
+          name: z.string().min(1, "Required"),
+          logo: z.string().url("Invalid URL"),
+          contactInfo: z.string().min(1, "Required"),
+          type: z.enum(["sale", "rental"]),
+          template: z.string().min(1, "Required"),
+        })
+        .strict(),
+    [],
+  );
 
   useEffect(() => {
     const parsed = schema.safeParse({
@@ -81,7 +85,7 @@ export default function StepShopDetails({
     } else {
       setValidationErrors({});
     }
-  }, [shopId, storeName, logo, contactInfo, type, template]);
+  }, [schema, shopId, storeName, logo, contactInfo, type, template]);
 
   const getError = (field: string) =>
     validationErrors[field]?.[0] || errors[field]?.[0];


### PR DESCRIPTION
## Summary
- refactor Sanity connection verify flow using `useCallback`
- include missing dependencies and memoized schema in configurator hooks
- clean up lingering `any` usage causing build failures

## Testing
- `pnpm -r build` *(fails: Type 'RunnerResult' is not assignable to type {...})*
- `pnpm --filter @apps/cms test` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b062011f9c832f89441dbccb7f42a0