### PR TITLE
fix: tighten csv upload types and persistence hook

### DIFF
--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -29,7 +29,7 @@ export async function POST(
     const filePath = path.join(dir, "products.csv");
 
     const busboy = Busboy({
-      headers: Object.fromEntries(req.headers as any),
+      headers: Object.fromEntries(req.headers.entries()),
       limits: { fileSize: MAX_SIZE, files: 1 },
     });
 
@@ -115,7 +115,7 @@ export async function POST(
       });
 
       if (req.body) {
-        Readable.fromWeb(req.body as any).pipe(busboy);
+        Readable.fromWeb(req.body).pipe(busboy);
       } else {
         resolved = true;
         resolve(NextResponse.json({ error: "No body" }, { status: 400 }));

--- a/apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts
@@ -86,7 +86,8 @@ export function useConfiguratorPersistence(
       } catch {
         /* ignore quota */
       }
-      const { completed, ...data } = state;
+      const { completed: _completed, ...data } = state;
+      void _completed;
       fetch("/cms/api/wizard-progress", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- replace any casting in CSV upload route
- silence unused completed state in configurator persistence

## Testing
- `pnpm eslint apps/cms/src/app/api/upload-csv/[shop]/route.ts apps/cms/src/app/cms/configurator/hooks/useConfiguratorPersistence.ts`
- `pnpm -r build` *(fails: Type 'RunnerResult' is not assignable to type...)*
- `pnpm --filter cms test` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b061948778832f8cfb8e3193626a68