### PR TITLE
feat(cms): migrate configurator previews to next/image

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -25,6 +25,9 @@ const nextConfig = {
     "@acme/tailwind-config",
     "@acme/design-tokens"
   ],
+  images: {
+    remotePatterns: [{ protocol: "https", hostname: "**" }],
+  },
   webpack: (config, { isServer }) => {
     const nodeBuiltins = [
       "assert",

--- a/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
+++ b/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
@@ -18,6 +18,7 @@ import {
 import type { PageComponent } from "@acme/types";
 import { ulid } from "ulid";
 import { useState } from "react";
+import Image from "next/image";
 import type React from "react";
 
 interface Template {
@@ -90,9 +91,11 @@ export default function TemplateSelector({
             >
               <button type="button" className="w-full text-left">
                 <div className="flex items-center gap-2">
-                  <img
+                  <Image
                     src={t.preview}
                     alt={`${t.name} preview`}
+                    width={32}
+                    height={32}
                     className="h-8 w-8 rounded object-cover"
                   />
                   {t.name}
@@ -115,9 +118,12 @@ export default function TemplateSelector({
             </DialogTitle>
           </DialogHeader>
           {pendingTemplate?.preview && (
-            <img
+            <Image
               src={pendingTemplate.preview}
               alt={`${pendingTemplate.name} preview`}
+              width={800}
+              height={600}
+              sizes="100vw"
               className="w-full rounded"
             />
           )}

--- a/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepProductPage.tsx
@@ -24,6 +24,7 @@ import { useEffect, useState } from "react";
 import { Toast } from "@ui/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 
 interface Props {
   pageTemplates: Array<{
@@ -141,9 +142,11 @@ export default function StepProductPage({
             >
               <button type="button" className="w-full text-left">
                 <div className="flex items-center gap-2">
-                  <img
+                  <Image
                     src={t.preview}
                     alt={`${t.name} preview`}
+                    width={32}
+                    height={32}
                     className="h-8 w-8 rounded object-cover"
                   />
                   {t.name}
@@ -170,9 +173,12 @@ export default function StepProductPage({
             </DialogTitle>
           </DialogHeader>
           {pendingTemplate?.preview && (
-            <img
+            <Image
               src={pendingTemplate.preview}
               alt={`${pendingTemplate.name} preview`}
+              width={800}
+              height={600}
+              sizes="100vw"
               className="w-full rounded"
             />
           )}

--- a/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopPage.tsx
@@ -24,6 +24,7 @@ import { useState } from "react";
 import { Toast } from "@ui/components/atoms";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { STORAGE_KEY } from "../hooks/useConfiguratorPersistence";
 
 interface Props {
@@ -112,9 +113,11 @@ export default function StepShopPage({
             >
               <button type="button" className="w-full text-left">
                 <div className="flex items-center gap-2">
-                  <img
+                  <Image
                     src={t.preview}
                     alt={`${t.name} preview`}
+                    width={32}
+                    height={32}
                     className="h-8 w-8 rounded object-cover"
                   />
                   {t.name}
@@ -141,9 +144,12 @@ export default function StepShopPage({
             </DialogTitle>
           </DialogHeader>
           {pendingTemplate?.preview && (
-            <img
+            <Image
               src={pendingTemplate.preview}
               alt={`${pendingTemplate.name} preview`}
+              width={800}
+              height={600}
+              sizes="100vw"
               className="w-full rounded"
             />
           )}

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -15,6 +15,7 @@ import { getContrast } from "@ui/components/cms";
 import WizardPreview from "../../wizard/WizardPreview";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { useConfigurator } from "../ConfiguratorContext";
 import { useThemeLoader } from "../hooks/useThemeLoader";
 import { STORAGE_KEY } from "../hooks/useConfiguratorPersistence";
@@ -188,9 +189,11 @@ export default function StepTheme({
           {themes.map((t) => (
             <SelectItem key={t} value={t}>
               <div className="flex items-center gap-2">
-                <img
+                <Image
                   src={`/themes/${t}.svg`}
                   alt={`${t} preview`}
+                  width={24}
+                  height={24}
                   className="h-6 w-6 rounded object-cover"
                 />
                 {t}


### PR DESCRIPTION
## Summary
- replace `<img>` with Next.js `Image` for configurator template previews and dialogs
- allow remote https images via `images.remotePatterns`

## Testing
- `pnpm -r build` *(fails: Type 'RunnerResult' is not assignable to type...)*
- `pnpm test` *(fails: @acme/next-config#test)*
- `pnpm lint:apps` *(fails: Command failed with exit code 134: ESLint OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68b06cb388d4832fb2694337bc62ae37