### PR TITLE
chore: remove unused eslint disable in StepTheme

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -225,7 +225,6 @@ export default function StepTheme({
                   <div className="flex h-full w-full flex-wrap overflow-hidden rounded">
                     {Object.values(p.colors).map((c, i) => (
                       <span
-                        // eslint-disable-next-line react/no-array-index-key
                         key={i}
                         className="h-1/2 w-1/2"
                         style={{ backgroundColor: `hsl(${c})` }}


### PR DESCRIPTION
## Summary
- remove obsolete `react/no-array-index-key` eslint-disable from StepTheme

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'RunnerResult' is not assignable to type ...)*
- `pnpm lint --filter @apps/cms`


------
https://chatgpt.com/codex/tasks/task_e_68b06cbe39b4832fb0eca33f1f642479