### PR TITLE
feat: add theme library infrastructure

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -19,6 +19,7 @@
     "@acme/plugin-sanity": "workspace:*",
     "@acme/shared-utils": "workspace:*",
     "@acme/zod-utils": "workspace:^",
+    "@acme/theme": "workspace:*",
     "@sendgrid/eventwebhook": "^7.2.7",
     "@themes/base": "workspace:*",
     "busboy": "^1.6.0",

--- a/apps/cms/src/app/[lang]/layout.tsx
+++ b/apps/cms/src/app/[lang]/layout.tsx
@@ -14,7 +14,11 @@ import de from "@i18n/de.json";
 import en from "@i18n/en.json";
 import it from "@i18n/it.json";
 
-const MESSAGES: Record<Locale, typeof en> = { en, de, it };
+const MESSAGES: Record<Locale, typeof en> = {
+  en,
+  de: de as typeof en,
+  it: it as typeof en,
+};
 
 /** Layout for every route under `/[lang]/*` */
 export default async function LocaleLayout({

--- a/apps/cms/src/app/api/themes/[themeId]/route.ts
+++ b/apps/cms/src/app/api/themes/[themeId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseThemeLibraryEntry } from "@acme/theme";
+import { themeLibrary } from "../store";
+
+function findIndex(id: string) {
+  return themeLibrary.findIndex((t) => t.id === id);
+}
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ themeId: string }> },
+) {
+  const { themeId } = await context.params;
+  const idx = findIndex(themeId);
+  if (idx === -1) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(themeLibrary[idx]);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ themeId: string }> },
+) {
+  try {
+    const { themeId } = await context.params;
+    const idx = findIndex(themeId);
+    if (idx === -1)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const body = await req.json();
+    const updated = { ...themeLibrary[idx], ...body };
+    const entry = parseThemeLibraryEntry(updated);
+    themeLibrary[idx] = entry;
+    return NextResponse.json(entry);
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 },
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: Promise<{ themeId: string }> },
+) {
+  const { themeId } = await context.params;
+  const idx = findIndex(themeId);
+  if (idx === -1) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  themeLibrary.splice(idx, 1);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/cms/src/app/api/themes/route.ts
+++ b/apps/cms/src/app/api/themes/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseThemeLibraryEntry } from "@acme/theme";
+import { themeLibrary } from "./store";
+
+export async function GET() {
+  return NextResponse.json(themeLibrary);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const entry = parseThemeLibraryEntry(body);
+    themeLibrary.push(entry);
+    return NextResponse.json(entry);
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/cms/src/app/api/themes/store.ts
+++ b/apps/cms/src/app/api/themes/store.ts
@@ -1,0 +1,3 @@
+import type { ThemeLibraryEntry } from "@acme/types/theme/ThemeLibrary";
+
+export const themeLibrary: ThemeLibraryEntry[] = [];

--- a/apps/cms/src/app/cms/shop/[shop]/settings/theme/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/theme/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default async function ShopThemeSettingsPage({
+  params,
+}: {
+  params: Promise<{ shop: string }>;
+}) {
+  const { shop } = await params;
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Theme Settings – {shop}</h2>
+      <p className="text-sm">
+        <Link href="/cms/themes/library" className="text-primary underline">
+          Open theme library
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/themes/library/page.tsx
+++ b/apps/cms/src/app/cms/themes/library/page.tsx
@@ -1,0 +1,22 @@
+import { themeLibrary } from "../../../api/themes/store";
+
+export default function ThemeLibraryPage() {
+  const themes = themeLibrary;
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Theme Library</h2>
+      <ul className="space-y-2">
+        {themes.map((t) => (
+          <li key={t.id} className="flex items-center gap-2">
+            <span
+              className="inline-block h-4 w-4 rounded"
+              style={{ backgroundColor: t.brandColor }}
+            />
+            <span>{t.name}</span>
+          </li>
+        ))}
+        {themes.length === 0 && <li>No themes.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -37,5 +37,6 @@
   "wizard.back": "Back",
   "wizard.next": "Next",
   "cms.style.title": "Style",
-  "cms.style.lowContrast": "Low contrast"
+  "cms.style.lowContrast": "Low contrast",
+  "cms.theme.library": "Theme Library"
 }

--- a/packages/platform-core/prisma/migrations/2025-08-28-themes/migration.sql
+++ b/packages/platform-core/prisma/migrations/2025-08-28-themes/migration.sql
@@ -1,0 +1,9 @@
+-- Migration for theme library table
+CREATE TABLE IF NOT EXISTS ThemeLibrary (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  brandColor TEXT NOT NULL,
+  createdBy TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1,
+  theme JSON NOT NULL
+);

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@acme/theme",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": ["src"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf dist *.tsbuildinfo",
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+  },
+  "dependencies": {
+    "zod": "^3.25.73",
+    "@acme/types": "workspace:*"
+  },
+  "exports": {
+    "./io/*": {
+      "types": "./src/io/*.ts",
+      "import": "./src/io/*.ts",
+      "default": "./src/io/*.ts"
+    },
+    "./*": {
+      "types": "./src/*.ts",
+      "import": "./src/*.ts",
+      "default": "./src/*.ts"
+    },
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./io/theme-schema";

--- a/packages/theme/src/io/__tests__/theme-schema.spec.ts
+++ b/packages/theme/src/io/__tests__/theme-schema.spec.ts
@@ -1,0 +1,19 @@
+import { parseThemeLibraryEntry } from "../theme-schema";
+
+describe("theme-library schema", () => {
+  it("parses valid entry", () => {
+    const entry = parseThemeLibraryEntry({
+      id: "1",
+      name: "Default",
+      brandColor: "#ffffff",
+      createdBy: "tester",
+      version: 1,
+      theme: { "--color-primary": "0 0% 0%" },
+    });
+    expect(entry.name).toBe("Default");
+  });
+
+  it("rejects missing fields", () => {
+    expect(() => parseThemeLibraryEntry({} as any)).toThrow();
+  });
+});

--- a/packages/theme/src/io/theme-schema.ts
+++ b/packages/theme/src/io/theme-schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const themeMetadataSchema = z.object({
+  name: z.string().min(1),
+  brandColor: z.string().min(1),
+  createdBy: z.string().min(1),
+  version: z.number().int().min(1),
+});
+
+export const themeLibraryEntrySchema = themeMetadataSchema.extend({
+  id: z.string().min(1),
+  theme: z.record(z.any()),
+});
+
+export type ThemeLibraryEntry = z.infer<typeof themeLibraryEntrySchema>;
+
+export function parseThemeLibraryEntry(data: unknown): ThemeLibraryEntry {
+  return themeLibraryEntrySchema.parse(data);
+}

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", ".turbo", "node_modules", "src/**/__tests__/**"],
+  "references": [{ "path": "../types" }]
+}

--- a/packages/theme/tsconfig.test.json
+++ b/packages/theme/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom", "jest", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "src/**/*.json", "__tests__/**/*"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,6 +29,11 @@
       "import": "./src/settings/*.ts",
       "default": "./src/settings/*.ts"
     },
+    "./theme/*": {
+      "types": "./src/theme/*.ts",
+      "import": "./src/theme/*.ts",
+      "default": "./src/theme/*.ts"
+    },
     "./*": {
       "types": "./src/*.ts",
       "import": "./src/*.ts",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,3 +29,4 @@ export * from "./shop-seo";
 export * from "./shop-locale";
 export * from "./shop-theme";
 export type { StyleOverrides } from "./style/StyleOverrides";
+export * from "./theme/ThemeLibrary";

--- a/packages/types/src/theme/ThemeLibrary.ts
+++ b/packages/types/src/theme/ThemeLibrary.ts
@@ -1,0 +1,11 @@
+export interface ThemeMetadata {
+  name: string;
+  brandColor: string;
+  createdBy: string;
+  version: number;
+}
+
+export interface ThemeLibraryEntry extends ThemeMetadata {
+  id: string;
+  theme: Record<string, unknown>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       '@acme/shared-utils':
         specifier: workspace:*
         version: link:../../packages/shared-utils
+      '@acme/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
       '@acme/zod-utils':
         specifier: workspace:^
         version: link:../../packages/zod-utils
@@ -755,6 +758,15 @@ importers:
       next:
         specifier: ^15.3.4
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  packages/theme:
+    dependencies:
+      '@acme/types':
+        specifier: workspace:*
+        version: link:../types
+      zod:
+        specifier: 3.25.73
+        version: 3.25.73
 
   packages/themes/abc: {}
 

--- a/test/e2e/theme-library.spec.ts
+++ b/test/e2e/theme-library.spec.ts
@@ -1,0 +1,21 @@
+describe("Theme library API", () => {
+  const base = "/cms/api/themes";
+  const sample = {
+    id: "theme-1",
+    name: "Sample",
+    brandColor: "#000000",
+    createdBy: "tester",
+    version: 1,
+    theme: {},
+  };
+
+  it("creates, updates and deletes an entry", () => {
+    cy.request("POST", base, sample).its("status").should("eq", 200);
+    cy.request(base).its("body").should("deep.include", sample);
+    cy.request(`${base}/${sample.id}`).its("body.name").should("eq", sample.name);
+    cy.request("PATCH", `${base}/${sample.id}`, { name: "Updated" });
+    cy.request(`${base}/${sample.id}`).its("body.name").should("eq", "Updated");
+    cy.request("DELETE", `${base}/${sample.id}`).its("status").should("eq", 200);
+    cy.request(base).its("body").should("deep.equal", []);
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -73,6 +73,18 @@
       "@acme/i18n/*": [
         "packages/i18n/src/*"
       ],
+      "@theme": [
+        "packages/theme/src/index.ts"
+      ],
+      "@theme/*": [
+        "packages/theme/src/*"
+      ],
+      "@acme/theme": [
+        "packages/theme/src/index.ts"
+      ],
+      "@acme/theme/*": [
+        "packages/theme/src/*"
+      ],
       "@auth": [
         "packages/auth/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- implement theme library API routes for listing and managing themes
- introduce theme schema and shared types
- add CMS pages and migration for theme library

## Testing
- `pnpm -r build` *(fails: Type 'RunnerResult' is not assignable to type ...)*
- `pnpm exec jest packages/theme/src/io/__tests__/theme-schema.spec.ts --runInBand`
- `pnpm e2e --spec test/e2e/theme-library.spec.ts` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b06ae7f140832fb3f961b30fb3f8ff