### PR TITLE
feat(theme-library): add theme library API and types

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -18,6 +18,7 @@
     "@acme/next-config": "workspace:*",
     "@acme/plugin-sanity": "workspace:*",
     "@acme/shared-utils": "workspace:*",
+    "@acme/theme": "workspace:*",
     "@acme/zod-utils": "workspace:^",
     "@sendgrid/eventwebhook": "^7.2.7",
     "@themes/base": "workspace:*",

--- a/apps/cms/src/app/api/themes/[themeId]/route.ts
+++ b/apps/cms/src/app/api/themes/[themeId]/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { themeLibrarySchema, type ThemeLibraryEntry } from "@acme/theme";
+
+const LIB_PATH = path.join(process.cwd(), "data", "themes", "library.json");
+
+async function readLibrary(): Promise<ThemeLibraryEntry[]> {
+  try {
+    const buf = await fs.readFile(LIB_PATH, "utf8");
+    return JSON.parse(buf) as ThemeLibraryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeLibrary(themes: ThemeLibraryEntry[]) {
+  await fs.mkdir(path.dirname(LIB_PATH), { recursive: true });
+  await fs.writeFile(LIB_PATH, JSON.stringify(themes, null, 2), "utf8");
+}
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ themeId: string }> },
+) {
+  const { themeId } = await context.params;
+  const themes = await readLibrary();
+  const theme = themes.find((t) => t.id === themeId);
+  if (!theme) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(theme);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ themeId: string }> },
+) {
+  try {
+    const { themeId } = await context.params;
+    const body = await req.json();
+    const themes = await readLibrary();
+    const idx = themes.findIndex((t) => t.id === themeId);
+    if (idx === -1)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const merged = { ...themes[idx], ...body, id: themeId };
+    const parsed = themeLibrarySchema.parse(merged);
+    themes[idx] = parsed;
+    await writeLibrary(themes);
+    return NextResponse.json(parsed);
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 },
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: Promise<{ themeId: string }> },
+) {
+  const { themeId } = await context.params;
+  const themes = await readLibrary();
+  const idx = themes.findIndex((t) => t.id === themeId);
+  if (idx === -1) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  themes.splice(idx, 1);
+  await writeLibrary(themes);
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/cms/src/app/api/themes/route.ts
+++ b/apps/cms/src/app/api/themes/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { themeLibrarySchema, type ThemeLibraryEntry } from "@acme/theme";
+
+const LIB_PATH = path.join(process.cwd(), "data", "themes", "library.json");
+
+async function readLibrary(): Promise<ThemeLibraryEntry[]> {
+  try {
+    const buf = await fs.readFile(LIB_PATH, "utf8");
+    return JSON.parse(buf) as ThemeLibraryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeLibrary(themes: ThemeLibraryEntry[]) {
+  await fs.mkdir(path.dirname(LIB_PATH), { recursive: true });
+  await fs.writeFile(LIB_PATH, JSON.stringify(themes, null, 2), "utf8");
+}
+
+export async function GET() {
+  const themes = await readLibrary();
+  return NextResponse.json(themes);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = themeLibrarySchema.parse({
+      ...body,
+      id: body.id ?? crypto.randomUUID(),
+    });
+    const themes = await readLibrary();
+    themes.push(parsed);
+    await writeLibrary(themes);
+    return NextResponse.json(parsed, { status: 201 });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/page.tsx
@@ -10,6 +10,7 @@ import {
   deleteThemePreset,
 } from "@platform-core/repositories/themePresets.server";
 import ThemeEditor from "./ThemeEditor";
+import Link from "next/link";
 
 export async function savePreset(
   shop: string,
@@ -45,6 +46,11 @@ export default async function ShopThemePage({
   return (
     <div>
       <h2 className="mb-4 text-xl font-semibold">Theme</h2>
+      <p className="mb-4 text-sm">
+        <Link href="/cms/themes/library" className="text-primary underline">
+          Theme Library
+        </Link>
+      </p>
       <ThemeEditor
         shop={shop}
         themes={themes}

--- a/apps/cms/src/app/cms/themes/library/page.tsx
+++ b/apps/cms/src/app/cms/themes/library/page.tsx
@@ -1,0 +1,28 @@
+// apps/cms/src/app/cms/themes/library/page.tsx
+import Link from "next/link";
+import type { ThemeLibraryEntry } from "@acme/types/theme/ThemeLibrary";
+
+async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
+  const res = await fetch("/cms/api/themes", { cache: "no-store" });
+  if (!res.ok) return [];
+  return (await res.json()) as ThemeLibraryEntry[];
+}
+
+export default async function ThemeLibraryPage() {
+  const themes = await fetchThemes();
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Theme Library</h2>
+      <ul>
+        {themes.map((t) => (
+          <li key={t.id} className="mb-2">
+            {t.name}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-4 text-sm">
+        <Link href="/cms">Back</Link>
+      </p>
+    </div>
+  );
+}

--- a/packages/i18n/src/de.json
+++ b/packages/i18n/src/de.json
@@ -49,4 +49,6 @@
   "cms.image.altWarning": "Alternativtext angeben oder als dekorativ markieren.",
   "cms.image.probing": "Bild wird geprüft…",
   "cms.image.probeError": "URL muss auf ein Bild verweisen"
+  ,"cms.theme.library": "Theme-Bibliothek"
+  ,"cms.theme.saveToLibrary": "In Bibliothek speichern"
 }

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -45,4 +45,6 @@
   "cms.image.altWarning": "Provide alt text or mark as decorative.",
   "cms.image.probing": "Checking image…",
   "cms.image.probeError": "URL must point to an image"
+  ,"cms.theme.library": "Theme Library"
+  ,"cms.theme.saveToLibrary": "Save to Library"
 }

--- a/packages/i18n/src/it.json
+++ b/packages/i18n/src/it.json
@@ -49,4 +49,6 @@
   "cms.image.altWarning": "Fornisci un testo alternativo o segna come decorativa.",
   "cms.image.probing": "Verifica dell'immagine…",
   "cms.image.probeError": "L'URL deve puntare a un'immagine"
+  ,"cms.theme.library": "Libreria temi"
+  ,"cms.theme.saveToLibrary": "Salva nella libreria"
 }

--- a/packages/platform-core/prisma/migrations/2025-08-28-themes/migration.sql
+++ b/packages/platform-core/prisma/migrations/2025-08-28-themes/migration.sql
@@ -1,0 +1,9 @@
+-- packages/platform-core/prisma/migrations/2025-08-28-themes/migration.sql
+CREATE TABLE IF NOT EXISTS "ThemeLibrary" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "brandColor" TEXT NOT NULL,
+  "createdBy" TEXT NOT NULL,
+  "version" INTEGER NOT NULL DEFAULT 1,
+  "data" JSONB NOT NULL DEFAULT '{}'
+);

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@acme/theme",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "type": "module",
+  "files": ["src"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf dist *.tsbuildinfo",
+    "test": "rimraf dist && jest"
+  },
+  "dependencies": {
+    "@acme/types": "workspace:*",
+    "zod": "^3.25.73"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./io/theme-schema";

--- a/packages/theme/src/io/__tests__/theme-schema.spec.ts
+++ b/packages/theme/src/io/__tests__/theme-schema.spec.ts
@@ -1,0 +1,21 @@
+const { parseTheme } = require("../theme-schema");
+
+describe("themeLibrarySchema", () => {
+  it("parses valid theme", () => {
+    const theme = parseTheme({
+      id: "test",
+      name: "Test Theme",
+      brandColor: "#fff",
+      createdBy: "tester",
+      version: 1,
+      themeDefaults: {},
+      themeOverrides: {},
+      themeTokens: {},
+    });
+    expect(theme.name).toBe("Test Theme");
+  });
+
+  it("throws on invalid theme", () => {
+    expect(() => parseTheme({})).toThrow();
+  });
+});

--- a/packages/theme/src/io/theme-schema.ts
+++ b/packages/theme/src/io/theme-schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { themeLibrarySchema } from "@acme/types/theme/ThemeLibrary";
+
+export { themeLibrarySchema };
+export type ThemeLibraryEntry = z.infer<typeof themeLibrarySchema>;
+
+export function parseTheme(data: unknown): ThemeLibraryEntry {
+  return themeLibrarySchema.parse(data);
+}

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,0 +1,19 @@
+// packages/theme/tsconfig.json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", ".turbo", "node_modules", "src/**/__tests__/**"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,6 +29,16 @@
       "import": "./src/settings/*.ts",
       "default": "./src/settings/*.ts"
     },
+    "./theme": {
+      "types": "./src/theme/index.ts",
+      "import": "./src/theme/index.ts",
+      "default": "./src/theme/index.ts"
+    },
+    "./theme/*": {
+      "types": "./src/theme/*.ts",
+      "import": "./src/theme/*.ts",
+      "default": "./src/theme/*.ts"
+    },
     "./*": {
       "types": "./src/*.ts",
       "import": "./src/*.ts",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,3 +29,4 @@ export * from "./shop-seo";
 export * from "./shop-locale";
 export * from "./shop-theme";
 export type { StyleOverrides } from "./style/StyleOverrides";
+export * from "./theme";

--- a/packages/types/src/theme/ThemeLibrary.ts
+++ b/packages/types/src/theme/ThemeLibrary.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const themeLibrarySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    brandColor: z.string(),
+    createdBy: z.string(),
+    version: z.number().default(1),
+    themeDefaults: z.record(z.string()).default({}),
+    themeOverrides: z.record(z.string()).default({}),
+    themeTokens: z.record(z.string()).default({}),
+  })
+  .strict();
+
+export type ThemeLibraryEntry = z.infer<typeof themeLibrarySchema>;

--- a/packages/types/src/theme/index.ts
+++ b/packages/types/src/theme/index.ts
@@ -1,0 +1,1 @@
+export * from "./ThemeLibrary";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       '@acme/shared-utils':
         specifier: workspace:*
         version: link:../../packages/shared-utils
+      '@acme/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
       '@acme/zod-utils':
         specifier: workspace:^
         version: link:../../packages/zod-utils
@@ -755,6 +758,15 @@ importers:
       next:
         specifier: ^15.3.4
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  packages/theme:
+    dependencies:
+      '@acme/types':
+        specifier: workspace:*
+        version: link:../types
+      zod:
+        specifier: 3.25.73
+        version: 3.25.73
 
   packages/themes/abc: {}
 

--- a/test/e2e/theme-library.spec.ts
+++ b/test/e2e/theme-library.spec.ts
@@ -1,0 +1,27 @@
+// test/e2e/theme-library.spec.ts
+
+describe("Theme library API", () => {
+  const baseUrl = "/cms/api/themes";
+  it("creates, fetches and deletes themes", () => {
+    const theme = {
+      name: "Spec Theme",
+      brandColor: "#000",
+      createdBy: "tester",
+      version: 1,
+      themeDefaults: {},
+      themeOverrides: {},
+      themeTokens: {},
+    };
+    cy.request("POST", baseUrl, theme).then((res) => {
+      expect(res.status).to.eq(201);
+      const id = res.body.id;
+      cy.request(baseUrl)
+        .its("body")
+        .should("deep.include", { ...theme, id });
+      cy.request(`${baseUrl}/${id}`)
+        .its("body")
+        .should("deep.include", { ...theme, id });
+      cy.request("DELETE", `${baseUrl}/${id}`).its("status").should("eq", 204);
+    });
+  });
+});

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -29,6 +29,7 @@
     { "path": "packages/design-tokens" },
     { "path": "packages/ui" },
     { "path": "packages/auth" },
+    { "path": "packages/theme" },
     { "path": "packages/configurator" },
     { "path": "src" }
   ]


### PR DESCRIPTION
## Summary
- add theme library schema and parser
- expose theme library REST endpoints and basic CMS library page
- wire up translations, migration, and theme link

## Testing
- `pnpm --filter @acme/theme build`
- `pnpm --filter @apps/cms build` *(fails: TypeScript error in seo audit route)*
- `pnpm test --filter @acme/theme` *(fails: Babel parse error)*
- `pnpm e2e -- --spec test/e2e/theme-library.spec.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b073f35d40832fb626e545ed3e97ac