### PR TITLE
refactor: use static plugin registry

### DIFF
--- a/packages/platform-core/src/plugins.d.ts
+++ b/packages/platform-core/src/plugins.d.ts
@@ -1,5 +1,6 @@
 import { PluginManager } from "./plugins/PluginManager";
 import type { PaymentPayload, ShippingRequest, WidgetProps, PaymentProvider, ShippingProvider, WidgetComponent, PaymentRegistry, ShippingRegistry, WidgetRegistry, PluginOptions, Plugin } from "@acme/types";
+export declare function loadPlugin(id: string): Promise<Plugin | undefined>;
 export interface LoadPluginsOptions {
     /** directories containing plugin packages */
     directories?: string[];


### PR DESCRIPTION
## Summary
- replace dynamic plugin resolution with explicit registry and `loadPlugin`
- update plugin loading to use registry and add `loadPlugin` export

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type error: Type '{ id: "shop-details"; label: "Shop Details"; component: StepShopDetails; }' is not assignable to type 'ComponentType<{}>')*
- `pnpm --filter @apps/cms build` *(fails: Type error: Type '{ id: "shop-details"; label: "Shop Details"; component: StepShopDetails; }' is not assignable to type 'ComponentType<{}>')*


------
https://chatgpt.com/codex/tasks/task_e_68b0792756c0832fb831393f0ee53197