### PR TITLE
feat: add design system eslint plugin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - run: pnpm install
+      - run: pnpm lint

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import tsParser from "@typescript-eslint/parser"; // still needed for parser
 import tsPlugin from "@typescript-eslint/eslint-plugin";
 import boundaries from "eslint-plugin-boundaries";
 import importPlugin from "eslint-plugin-import";
+import dsPlugin from "@acme/eslint-plugin-ds";
 import { fixupPluginRules } from "@eslint/compat";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -72,6 +73,15 @@ export default [
         { argsIgnorePattern: "^_" },
       ],
       // add more TS-only rules here
+    },
+  },
+
+  /* ▸ Design system token enforcement */
+  {
+    plugins: { ds: dsPlugin },
+    rules: {
+      "ds/no-raw-color": "error",
+      "ds/no-raw-font": "error",
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-testing-library": "^7.5.3",
+    "@acme/eslint-plugin-ds": "workspace:*",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lighthouse": "^11.5.0",

--- a/packages/eslint-plugin-ds/package.json
+++ b/packages/eslint-plugin-ds/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@acme/eslint-plugin-ds",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs tests/no-raw-color.spec.ts",
+    "clean": "rimraf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "eslint": "^9"
+  }
+}

--- a/packages/eslint-plugin-ds/src/index.ts
+++ b/packages/eslint-plugin-ds/src/index.ts
@@ -1,0 +1,10 @@
+import noRawColor from "./rules/no-raw-color.js";
+import noRawFont from "./rules/no-raw-font.js";
+
+export const rules = {
+  "no-raw-color": noRawColor,
+  "no-raw-font": noRawFont,
+};
+
+const plugin = { rules };
+export default plugin;

--- a/packages/eslint-plugin-ds/src/rules/no-raw-color.ts
+++ b/packages/eslint-plugin-ds/src/rules/no-raw-color.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- rule uses loose node typing */
+import type { Rule } from "eslint";
+
+const HEX_COLOR = /#(?:[0-9a-fA-F]{3,4}){1,2}\b/;
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow raw hex colors outside of the design token system",
+    },
+    schema: [],
+    messages: {
+      noRawColor: "Use color tokens instead of raw color '{{color}}'.",
+    },
+  },
+  create(context) {
+    function report(value: string, node: any) {
+      const match = value.match(HEX_COLOR);
+      if (match) {
+        context.report({
+          node: (node as unknown) as any,
+          messageId: "noRawColor",
+          data: { color: match[0] },
+        });
+      }
+    }
+
+    return {
+      Literal(node: any) {
+        if (typeof node.value === "string") {
+          report(node.value, node);
+        }
+      },
+      TemplateElement(node: any) {
+        report(node.value.raw, node);
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-ds/src/rules/no-raw-font.ts
+++ b/packages/eslint-plugin-ds/src/rules/no-raw-font.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, ds/no-raw-font -- defining disallowed fonts and loose typing */
+import type { Rule } from "eslint";
+
+const DISALLOWED_FONTS = [
+  "arial",
+  "helvetica",
+  "times",
+  "courier",
+  "sans-serif",
+  "serif",
+  "monospace",
+];
+
+function containsDisallowed(value: string): string | undefined {
+  if (value.includes("var(")) return undefined;
+  const lower = value.toLowerCase();
+  return DISALLOWED_FONTS.find((f) => lower.includes(f));
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow raw font stacks outside of the design token system",
+    },
+    schema: [],
+    messages: {
+      noRawFont: "Use typography tokens instead of raw font stack '{{font}}'.",
+    },
+  },
+  create(context) {
+    function report(value: string, node: any) {
+      const font = containsDisallowed(value);
+      if (font) {
+        context.report({
+          node: (node as unknown) as any,
+          messageId: "noRawFont",
+          data: { font },
+        });
+      }
+    }
+
+    return {
+      Literal(node: any) {
+        if (typeof node.value === "string") {
+          report(node.value, node);
+        }
+      },
+      TemplateElement(node: any) {
+        report(node.value.raw, node);
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-ds/tests/no-raw-color.spec.ts
+++ b/packages/eslint-plugin-ds/tests/no-raw-color.spec.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "eslint";
+import rule from "../src/rules/no-raw-color";
+
+(globalThis as any).structuredClone =
+  (globalThis as any).structuredClone ||
+  ((value: unknown) => JSON.parse(JSON.stringify(value)));
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2020, sourceType: "module" },
+});
+
+tester.run("no-raw-color", rule, {
+  valid: [
+    { code: "const color = 'var(--color-primary)';" },
+    { code: "const color = tokens.colors.primary;" },
+  ],
+  invalid: [
+    {
+      code: "const bad = '#fff';",
+      errors: [{ messageId: "noRawColor" }],
+    },
+    {
+      code: "const tmpl = `color: #000000;`;",
+      errors: [{ messageId: "noRawColor" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-ds/tsconfig.json
+++ b/packages/eslint-plugin-ds/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "NodeNext",
+    "target": "ES2022",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "strict": true,
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["dist", "tests"]
+}


### PR DESCRIPTION
## Summary
- add lint workflow to run ESLint in CI
- introduce `@acme/eslint-plugin-ds` with rules banning raw hex colors and font stacks
- wire plugin into repo-wide ESLint config

## Testing
- `pnpm --filter @acme/eslint-plugin-ds build`
- `pnpm exec eslint packages/eslint-plugin-ds/src/index.ts packages/eslint-plugin-ds/src/rules/no-raw-color.ts packages/eslint-plugin-ds/src/rules/no-raw-font.ts`
- `pnpm --filter @acme/eslint-plugin-ds test`


------
https://chatgpt.com/codex/tasks/task_e_68b07980d564832f850976425590df6f