### PR TITLE
feat: add design system import scaffolding

### DIFF
--- a/apps/cms/src/app/api/ds/import/route.ts
+++ b/apps/cms/src/app/api/ds/import/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseDsPackage } from "@acme/theme";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  let data: unknown;
+  if (typeof body.npm === "string") {
+    try {
+      const res = await fetch(`https://unpkg.com/${body.npm}`);
+      data = await res.json();
+    } catch {
+      return NextResponse.json({ error: "Failed to fetch package" }, { status: 400 });
+    }
+  } else if (body.json) {
+    data = body.json;
+  } else {
+    return NextResponse.json({ error: "No input provided" }, { status: 400 });
+  }
+
+  const parsed = parseDsPackage(data);
+  return NextResponse.json(parsed);
+}

--- a/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
@@ -1,0 +1,8 @@
+export default function DesignSystemImportPage() {
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Import Design System</h2>
+      <p className="text-sm">Paste design tokens JSON or enter npm package name.</p>
+    </div>
+  );
+}

--- a/packages/i18n/src/de.json
+++ b/packages/i18n/src/de.json
@@ -51,4 +51,5 @@
   "cms.image.probeError": "URL muss auf ein Bild verweisen"
   ,"cms.theme.library": "Theme-Bibliothek"
   ,"cms.theme.saveToLibrary": "In Bibliothek speichern"
+ ,"cms.theme.importDesignSystem": "Import Design System"
 }

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -47,4 +47,5 @@
   "cms.image.probeError": "URL must point to an image"
   ,"cms.theme.library": "Theme Library"
   ,"cms.theme.saveToLibrary": "Save to Library"
+ ,"cms.theme.importDesignSystem": "Import Design System"
 }

--- a/packages/i18n/src/it.json
+++ b/packages/i18n/src/it.json
@@ -51,4 +51,5 @@
   "cms.image.probeError": "L'URL deve puntare a un'immagine"
   ,"cms.theme.library": "Libreria temi"
   ,"cms.theme.saveToLibrary": "Salva nella libreria"
+ ,"cms.theme.importDesignSystem": "Import Design System"
 }

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./io/theme-schema";
+export * from "./io/ds-package-schema";
+export * from "./tokens/mergeExternalTokens";

--- a/packages/theme/src/io/__tests__/ds-package-schema.spec.ts
+++ b/packages/theme/src/io/__tests__/ds-package-schema.spec.ts
@@ -1,0 +1,12 @@
+const { parseDsPackage } = require("../ds-package-schema");
+
+describe("ds-package-schema", () => {
+  it("parses tokens", () => {
+    const ds = parseDsPackage({ tokens: { color: "#fff" } });
+    expect(ds.tokens.color).toBe("#fff");
+  });
+
+  it("throws on invalid package", () => {
+    expect(() => parseDsPackage({})).toThrow();
+  });
+});

--- a/packages/theme/src/io/ds-package-schema.ts
+++ b/packages/theme/src/io/ds-package-schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { externalDsSchema } from "@acme/types/ds/ExternalDs";
+
+export { externalDsSchema };
+export type ExternalDs = z.infer<typeof externalDsSchema>;
+
+export function parseDsPackage(data: unknown): ExternalDs {
+  return externalDsSchema.parse(data);
+}

--- a/packages/theme/src/tokens/mergeExternalTokens.ts
+++ b/packages/theme/src/tokens/mergeExternalTokens.ts
@@ -1,0 +1,6 @@
+export function mergeExternalTokens(
+  base: Record<string, string>,
+  external: Record<string, string>,
+): Record<string, string> {
+  return { ...base, ...external };
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,6 +39,16 @@
       "import": "./src/theme/*.ts",
       "default": "./src/theme/*.ts"
     },
+    "./ds": {
+      "types": "./src/ds/index.ts",
+      "import": "./src/ds/index.ts",
+      "default": "./src/ds/index.ts"
+    },
+    "./ds/*": {
+      "types": "./src/ds/*.ts",
+      "import": "./src/ds/*.ts",
+      "default": "./src/ds/*.ts"
+    },
     "./*": {
       "types": "./src/*.ts",
       "import": "./src/*.ts",

--- a/packages/types/src/ds/ExternalDs.ts
+++ b/packages/types/src/ds/ExternalDs.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const externalDsSchema = z
+  .object({
+    tokens: z.record(z.string()),
+  })
+  .strict();
+
+export type ExternalDs = z.infer<typeof externalDsSchema>;

--- a/packages/types/src/ds/index.ts
+++ b/packages/types/src/ds/index.ts
@@ -1,0 +1,1 @@
+export * from "./ExternalDs";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,4 +29,5 @@ export * from "./shop-seo";
 export * from "./shop-locale";
 export * from "./shop-theme";
 export type { StyleOverrides } from "./style/StyleOverrides";
+export * from "./ds";
 export * from "./theme";

--- a/test/e2e/ds-import.spec.ts
+++ b/test/e2e/ds-import.spec.ts
@@ -1,0 +1,7 @@
+describe("Design system import", () => {
+  const shop = "abc";
+  it("shows import form", () => {
+    cy.visit(`/cms/shop/${shop}/import/design-system`);
+    cy.contains("Import Design System").should("exist");
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold design system import API and CMS page
- add external design system schema and token merge helper
- seed i18n strings and tests for ds package parsing

## Testing
- `pnpm -r build` *(fails: Type error in apps/cms configurator step)*
- `pnpm --filter @acme/theme test` *(fails: Jest failed to parse TypeScript exports)*
- `pnpm e2e --spec test/e2e/ds-import.spec.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b079696774832f88abbe634cae297c