### PR TITLE
feat(cms): centralize configurator step props

### DIFF
--- a/apps/cms/src/app/cms/configurator/Dashboard.tsx
+++ b/apps/cms/src/app/cms/configurator/Dashboard.tsx
@@ -18,8 +18,8 @@ import {
   getRequiredSteps,
   getSteps,
   steps as configuratorSteps,
-  type ConfiguratorStep,
 } from "./steps";
+import type { ConfiguratorStep } from "./types";
 
 const stepLinks: Record<string, string> = {
   create: "summary",

--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.tsx
@@ -19,7 +19,8 @@ export default function StepPage({ stepId }: Props) {
   const prev = list[idx - 1];
   const next = list[idx + 1];
 
-  const StepComponent = step.component as React.ComponentType<Record<string, unknown>>;
+  const StepComponent =
+    step.component as unknown as React.ComponentType<Record<string, unknown>>;
 
   return (
     <div className="space-y-4">

--- a/apps/cms/src/app/cms/configurator/steps.tsx
+++ b/apps/cms/src/app/cms/configurator/steps.tsx
@@ -19,76 +19,81 @@ import Link from "next/link";
 import type { StepStatus } from "../wizard/schema";
 import { cn } from "@ui/utils/style";
 import { Tooltip } from "@/components/atoms";
-
-export interface ConfiguratorStep {
-  id: string;
-  label: string;
-  component: React.ComponentType;
-  optional?: boolean;
-  /** IDs of steps that are recommended to complete before this step */
-  recommended?: string[];
-}
+import type { ConfiguratorStep } from "./types";
+import type { ConfiguratorStepProps } from "@/types/configurator";
 
 const stepList: ConfiguratorStep[] = [
   { id: "shop-details", label: "Shop Details", component: StepShopDetails },
   { id: "theme", label: "Theme", component: StepTheme },
   { id: "tokens", label: "Tokens", component: StepTokens },
   { id: "options", label: "Options", component: StepOptions },
-  { id: "navigation", label: "Navigation", component: StepNavigation },
+  {
+    id: "navigation",
+    label: "Navigation",
+    component: StepNavigation as unknown as React.ComponentType<ConfiguratorStepProps>,
+  },
   {
     id: "layout",
     label: "Layout",
-    component: StepLayout,
+    component: StepLayout as unknown as React.ComponentType<ConfiguratorStepProps>,
     recommended: ["navigation"],
   },
   {
     id: "home-page",
     label: "Home Page",
-    component: StepHomePage,
+    component: StepHomePage as unknown as React.ComponentType<ConfiguratorStepProps>,
     recommended: ["layout"],
   },
   {
     id: "checkout-page",
     label: "Checkout Page",
-    component: StepCheckoutPage,
+    component: StepCheckoutPage as unknown as React.ComponentType<ConfiguratorStepProps>,
     recommended: ["layout"],
   },
   {
     id: "shop-page",
     label: "Shop Page",
-    component: StepShopPage,
+    component: StepShopPage as unknown as React.ComponentType<ConfiguratorStepProps>,
     recommended: ["layout"],
   },
   {
     id: "product-page",
     label: "Product Page",
-    component: StepProductPage,
+    component: StepProductPage as unknown as React.ComponentType<ConfiguratorStepProps>,
     recommended: ["shop-page"],
   },
   {
     id: "additional-pages",
     label: "Additional Pages",
-    component: StepAdditionalPages,
+    component: StepAdditionalPages as unknown as React.ComponentType<ConfiguratorStepProps>,
     recommended: ["layout"],
   },
-  { id: "env-vars", label: "Environment Variables", component: StepEnvVars },
-  { id: "summary", label: "Summary", component: StepSummary },
+  {
+    id: "env-vars",
+    label: "Environment Variables",
+    component: StepEnvVars as unknown as React.ComponentType<ConfiguratorStepProps>,
+  },
+  {
+    id: "summary",
+    label: "Summary",
+    component: StepSummary as unknown as React.ComponentType<ConfiguratorStepProps>,
+  },
   {
     id: "import-data",
     label: "Import Data",
-    component: StepImportData,
+    component: StepImportData as unknown as React.ComponentType<ConfiguratorStepProps>,
     optional: true,
   },
   {
     id: "seed-data",
     label: "Seed Data",
-    component: StepSeedData,
+    component: StepSeedData as unknown as React.ComponentType<ConfiguratorStepProps>,
     optional: true,
   },
   {
     id: "hosting",
     label: "Hosting",
-    component: StepHosting,
+    component: StepHosting as unknown as React.ComponentType<ConfiguratorStepProps>,
     optional: true,
   },
 ];

--- a/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepOptions.tsx
@@ -14,8 +14,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useConfigurator } from "../ConfiguratorContext";
 import useStepCompletion from "../hooks/useStepCompletion";
 import { providersByType, type Provider } from "@acme/configurator/providers";
+import type { ConfiguratorStepProps } from "@/types/configurator";
 
-export default function StepOptions(): React.JSX.Element {
+export default function StepOptions(_: ConfiguratorStepProps): React.JSX.Element {
   const { state, update } = useConfigurator();
   const {
     shopId,

--- a/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
@@ -13,23 +13,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import useStepCompletion from "../hooks/useStepCompletion";
-
-interface Props {
-  shopId: string;
-  setShopId: (v: string) => void;
-  storeName: string;
-  setStoreName: (v: string) => void;
-  logo: string;
-  setLogo: (v: string) => void;
-  contactInfo: string;
-  setContactInfo: (v: string) => void;
-  type: "sale" | "rental";
-  setType: (v: "sale" | "rental") => void;
-  template: string;
-  setTemplate: (v: string) => void;
-  templates: string[];
-  errors?: Record<string, string[]>;
-}
+import type { ConfiguratorStepProps } from "@/types/configurator";
 
 export default function StepShopDetails({
   shopId,
@@ -46,7 +30,7 @@ export default function StepShopDetails({
   setTemplate,
   templates,
   errors = {},
-}: Props): React.JSX.Element {
+}: ConfiguratorStepProps): React.JSX.Element {
   const router = useRouter();
   const [, markComplete] = useStepCompletion("shop-details");
   const [validationErrors, setValidationErrors] = useState<Record<string, string[]>>({});

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -21,6 +21,7 @@ import { useThemeLoader } from "../hooks/useThemeLoader";
 import { STORAGE_KEY } from "../hooks/useConfiguratorPersistence";
 import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
 import DeviceSelector from "@ui/components/cms/DeviceSelector";
+import type { ConfiguratorStepProps } from "@/types/configurator";
 
 const colorPalettes: Array<{
   name: string;
@@ -68,17 +69,11 @@ function checkContrast(fg?: string, bg?: string): number {
   return getContrast(fg, bg);
 }
 
-interface Props {
-  themes: string[];
-  prevStepId?: string;
-  nextStepId?: string;
-}
-
 export default function StepTheme({
   themes,
   prevStepId,
   nextStepId,
-}: Props): React.JSX.Element {
+}: ConfiguratorStepProps): React.JSX.Element {
   const themeStyle = useThemeLoader();
   const { state, update, themeDefaults, setThemeOverrides } =
     useConfigurator();

--- a/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTokens.tsx
@@ -12,8 +12,9 @@ import { useState } from "react";
 import { type TokenMap } from "../../wizard/tokenUtils";
 import { useConfigurator } from "../ConfiguratorContext";
 import { useThemeLoader } from "../hooks/useThemeLoader";
+import type { ConfiguratorStepProps } from "@/types/configurator";
 
-export default function StepTokens(): React.JSX.Element {
+export default function StepTokens(_: ConfiguratorStepProps): React.JSX.Element {
   const themeStyle = useThemeLoader();
   const [, markComplete] = useStepCompletion("tokens");
   const router = useRouter();

--- a/apps/cms/src/app/cms/configurator/types.ts
+++ b/apps/cms/src/app/cms/configurator/types.ts
@@ -1,0 +1,11 @@
+import type { ComponentType } from "react";
+import type { ConfiguratorStepProps } from "@/types/configurator";
+
+export interface ConfiguratorStep {
+  id: string;
+  label: string;
+  component: ComponentType<ConfiguratorStepProps>;
+  optional?: boolean;
+  /** IDs of steps that are recommended to complete before this step */
+  recommended?: string[];
+}

--- a/apps/cms/src/types/configurator.ts
+++ b/apps/cms/src/types/configurator.ts
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+export interface ConfiguratorStepProps {
+  shopId: string;
+  setShopId: (v: string) => void;
+  storeName: string;
+  setStoreName: (v: string) => void;
+  logo: string;
+  setLogo: (v: string) => void;
+  contactInfo: string;
+  setContactInfo: (v: string) => void;
+  type: "sale" | "rental";
+  setType: (v: "sale" | "rental") => void;
+  template: string;
+  setTemplate: (v: string) => void;
+  templates: string[];
+  errors?: Record<string, string[]>;
+  themes: string[];
+  prevStepId?: string;
+  nextStepId?: string;
+  children?: ReactNode;
+}


### PR DESCRIPTION
## Summary
- add shared `ConfiguratorStepProps` and `ConfiguratorStep` types
- update configurator steps to accept unified props
- adjust step registry to use the shared prop typing

## Testing
- `pnpm install`
- `pnpm --filter @apps/cms build` *(fails: Interface 'PickerInput' incorrectly extends interface 'HTMLInputElement')*

------
https://chatgpt.com/codex/tasks/task_e_68b078fcae7c832fae832338ca1cfce8