### PR TITLE
feat: export CMS pages to code scaffolding

### DIFF
--- a/apps/cms/src/app/api/git/export/route.ts
+++ b/apps/cms/src/app/api/git/export/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  return NextResponse.json({ ok: true });
+}

--- a/apps/cms/src/app/cms/shop/[shop]/pages/[pageId]/export/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/[pageId]/export/page.tsx
@@ -1,0 +1,3 @@
+export default function ExportPage() {
+  return <div>Export to Code</div>;
+}

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -48,4 +48,5 @@
   ,"cms.theme.library": "Theme Library"
   ,"cms.theme.saveToLibrary": "Save to Library"
  ,"cms.theme.importDesignSystem": "Import Design System"
+ ,"cms.export.toCode": "Export to Code"
 }

--- a/packages/types/src/page/page.ts
+++ b/packages/types/src/page/page.ts
@@ -110,6 +110,8 @@ export type HistoryState = z.infer<typeof historyStateSchema>;
 
 export interface Page {
   id: string;
+  /** Stable identifier used for code generation */
+  stableId: string;
   slug: string;
   status: "draft" | "published";
   components: PageComponent[];
@@ -127,6 +129,7 @@ export interface Page {
 export const pageSchema = z
   .object({
     id: z.string(),
+    stableId: z.string(),
     slug: z.string(),
     status: z.enum(["draft", "published"]),
     components: z.array(pageComponentSchema).default([]),

--- a/packages/ui/src/components/cms/page-builder/codegen/__tests__/next-templates.spec.ts
+++ b/packages/ui/src/components/cms/page-builder/codegen/__tests__/next-templates.spec.ts
@@ -1,0 +1,37 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+type Ctx = { client?: boolean; blocks?: string[]; title?: string };
+
+function render(tpl: string, ctx: Ctx): string {
+  let out = tpl;
+  out = out.replace("{{#if client}}'use client';\n{{/if}}\n", ctx.client ? "'use client';\n" : "");
+  out = out.replace(/{{#each blocks}}\n([\s\S]*?){{\/each}}\n/, ctx.blocks?.join("\n") + "\n" || "");
+  if (ctx.title) out = out.replace(/{{title}}/g, ctx.title);
+  return out;
+}
+
+describe("next app router templates", () => {
+  const dir = path.join(
+    process.cwd(),
+    "packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates",
+  );
+
+  it("adds use client for interactive blocks", async () => {
+    const tpl = await fs.readFile(path.join(dir, "page.tsx.hbs"), "utf8");
+    const out = render(tpl, { client: true, blocks: ["<p />"] });
+    expect(out).toContain("'use client'");
+  });
+
+  it("omits use client by default", async () => {
+    const tpl = await fs.readFile(path.join(dir, "page.tsx.hbs"), "utf8");
+    const out = render(tpl, { blocks: ["<p />"] });
+    expect(out).not.toContain("'use client'");
+  });
+
+  it("renders metadata title", async () => {
+    const tpl = await fs.readFile(path.join(dir, "metadata.ts.hbs"), "utf8");
+    const out = render(tpl, { title: "Hello" });
+    expect(out).toContain("Hello");
+  });
+});

--- a/packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates/metadata.ts.hbs
+++ b/packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates/metadata.ts.hbs
@@ -1,0 +1,5 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "{{title}}"
+};

--- a/packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates/page.tsx.hbs
+++ b/packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates/page.tsx.hbs
@@ -1,0 +1,20 @@
+{{#if client}}'use client';
+{{/if}}
+import { memo } from "react";
+
+interface PageProps {
+  children?: React.ReactNode;
+}
+
+function PageComponent({ children }: PageProps) {
+  return (
+    <>
+      {{#each blocks}}
+        {{this}}
+      {{/each}}
+      {children}
+    </>
+  );
+}
+
+export default memo(PageComponent);

--- a/packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates/segmentLayout.tsx.hbs
+++ b/packages/ui/src/components/cms/page-builder/codegen/next-app-router/templates/segmentLayout.tsx.hbs
@@ -1,0 +1,13 @@
+{{#if client}}'use client';
+{{/if}}
+import { memo } from "react";
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+function SegmentLayout({ children }: LayoutProps) {
+  return <section>{children}</section>;
+}
+
+export default memo(SegmentLayout);

--- a/test/e2e/export-to-code.spec.ts
+++ b/test/e2e/export-to-code.spec.ts
@@ -1,0 +1,7 @@
+// test/e2e/export-to-code.spec.ts
+
+describe("export to code", () => {
+  it("placeholder", () => {
+    expect(true).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add handlebars-style templates for Next App Router codegen
- scaffold CMS export route and page with placeholder API
- introduce stable page `stableId` and translation for "Export to Code"

## Testing
- `pnpm test` (fails: @acme/next-config tests)
- `pnpm e2e --spec test/e2e/export-to-code.spec.ts` (fails: Cypress executable missing)


------
https://chatgpt.com/codex/tasks/task_e_68b07db91a94832fbc50901cc20d6603