### PR TITLE
refactor: replace raw black hex in InlineColorPicker

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/InlineColorPicker.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/InlineColorPicker.tsx
@@ -43,6 +43,7 @@ export default function InlineColorPicker({
   };
 
   const displayValue = isHsl(value) ? hslToHex(value) : value;
+  const defaultHex = isHsl(defaultValue) ? hslToHex(defaultValue) : defaultValue;
 
   return (
     <div className="fixed inset-0 z-50" onClick={handleClose}>
@@ -55,7 +56,7 @@ export default function InlineColorPicker({
           ref={inputRef}
           type="color"
           aria-label={token}
-          value={isHex(displayValue) ? displayValue : "#000000"}
+          value={isHex(displayValue) ? displayValue : defaultHex}
           onChange={handleChange}
           onBlur={handleClose}
         />


### PR DESCRIPTION
## Summary
- derive fallback color from default token instead of `#000000` in InlineColorPicker

## Testing
- `pnpm exec eslint apps/cms/src/app/cms/shop/[shop]/themes/InlineColorPicker.tsx`
- `pnpm test:cms` *(fails: product actions createDraftRecord creates placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68b082819e28832fbb55334dd56d7cce