### PR TITLE
feat: improve a11y and i18n for CMS flows

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
@@ -1,8 +1,15 @@
-export default function DesignSystemImportPage() {
+import { useTranslations } from "@i18n/useTranslations.server";
+
+export default async function DesignSystemImportPage() {
+  const t = await useTranslations("en");
   return (
     <div>
-      <h2 className="mb-4 text-xl font-semibold">Import Design System</h2>
-      <p className="text-sm">Paste design tokens JSON or enter npm package name.</p>
+      <h2 className="mb-4 text-xl font-semibold">
+        {t("cms.theme.importDesignSystem")}
+      </h2>
+      <p className="text-sm">
+        {t("cms.theme.importDesignSystem.help")}
+      </p>
     </div>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
@@ -6,28 +6,49 @@ import type { ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
 import SpecForm from "./components/SpecForm";
 import PreviewPane from "./components/PreviewPane";
 import { createDraft, finalize } from "./actions";
+import { useTranslations } from "@acme/i18n";
 
 export default function NewWizardPage() {
+  const t = useTranslations();
   const params = useParams<{ shop: string }>();
   const shop = params.shop;
   const [spec, setSpec] = useState<ScaffoldSpec | null>(null);
   const [draftId, setDraftId] = useState<string>("");
+  const [status, setStatus] = useState("");
 
   const handleNext = useCallback(
     async (s: ScaffoldSpec) => {
       const draft = await createDraft(shop, s);
       setSpec(s);
       setDraftId(draft.id);
-    },
-    [shop]
-  );
+      setStatus(t("wizard.status.previewReady"));
+      },
+      [shop, t]
+    );
 
-  const handleBack = useCallback(() => setSpec(null), []);
+  const handleBack = useCallback(() => {
+    setSpec(null);
+    setStatus(t("wizard.status.editing"));
+  }, [t]);
   const handleConfirm = useCallback(() => finalize(shop, draftId), [shop, draftId]);
 
   if (!spec) {
-    return <SpecForm onNext={handleNext} />;
+    return (
+      <>
+        <p aria-live="polite" className="sr-only">
+          {status}
+        </p>
+        <SpecForm onNext={handleNext} />
+      </>
+    );
   }
 
-  return <PreviewPane spec={spec} onBack={handleBack} onConfirm={handleConfirm} />;
+  return (
+    <>
+      <p aria-live="polite" className="sr-only">
+        {status}
+      </p>
+      <PreviewPane spec={spec} onBack={handleBack} onConfirm={handleConfirm} />
+    </>
+  );
 }

--- a/apps/cms/src/app/cms/themes/library/page.tsx
+++ b/apps/cms/src/app/cms/themes/library/page.tsx
@@ -1,6 +1,7 @@
 // apps/cms/src/app/cms/themes/library/page.tsx
 import Link from "next/link";
 import type { ThemeLibraryEntry } from "@acme/types/theme/ThemeLibrary";
+import { useTranslations } from "@i18n/useTranslations.server";
 
 async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
   const res = await fetch("/cms/api/themes", { cache: "no-store" });
@@ -9,10 +10,11 @@ async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
 }
 
 export default async function ThemeLibraryPage() {
+  const t = await useTranslations("en");
   const themes = await fetchThemes();
   return (
     <div>
-      <h2 className="mb-4 text-xl font-semibold">Theme Library</h2>
+      <h2 className="mb-4 text-xl font-semibold">{t("cms.theme.library")}</h2>
       <ul>
         {themes.map((t) => (
           <li key={t.id} className="mb-2">
@@ -21,7 +23,7 @@ export default async function ThemeLibraryPage() {
         ))}
       </ul>
       <p className="mt-4 text-sm">
-        <Link href="/cms">Back</Link>
+        <Link href="/cms">{t("wizard.back")}</Link>
       </p>
     </div>
   );

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -38,15 +38,26 @@
   "wizard.next": "Next",
   "cms.style.title": "Style",
   "cms.style.lowContrast": "Low contrast",
+  "cms.style.foreground": "Foreground",
+  "cms.style.background": "Background",
+  "cms.style.border": "Border",
+  "cms.style.fontFamily": "Font Family",
+  "cms.style.fontSize": "Font Size",
+  "cms.style.fontWeight": "Font Weight",
+  "cms.style.lineHeight": "Line Height",
+  "cms.style.colorPlaceholder": "token or #hex",
   "cms.image.url": "Image URL",
   "cms.image.upload": "Upload",
   "cms.image.alt": "Alt text",
   "cms.image.decorative": "Mark as decorative",
   "cms.image.altWarning": "Provide alt text or mark as decorative.",
   "cms.image.probing": "Checking image…",
-  "cms.image.probeError": "URL must point to an image"
-  ,"cms.theme.library": "Theme Library"
-  ,"cms.theme.saveToLibrary": "Save to Library"
- ,"cms.theme.importDesignSystem": "Import Design System"
- ,"cms.migrations.title": "Migrations"
+  "cms.image.probeError": "URL must point to an image",
+  "cms.theme.library": "Theme Library",
+  "cms.theme.saveToLibrary": "Save to Library",
+  "cms.theme.importDesignSystem": "Import Design System",
+  "cms.theme.importDesignSystem.help": "Paste design tokens JSON or enter npm package name.",
+  "cms.migrations.title": "Migrations",
+  "wizard.status.previewReady": "Preview ready",
+  "wizard.status.editing": "Editing page details"
 }

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -5,6 +5,7 @@ import type { PageComponent } from "@acme/types";
 import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";
+import { useTranslations } from "@acme/i18n";
 
 interface Props {
   component: PageComponent;
@@ -15,6 +16,7 @@ interface Props {
 }
 
 export default function StylePanel({ component, handleInput }: Props) {
+  const t = useTranslations();
   const overrides: StyleOverrides = component.styles
     ? JSON.parse(component.styles)
     : {};
@@ -38,46 +40,46 @@ export default function StylePanel({ component, handleInput }: Props) {
   return (
     <div className="space-y-2">
       <Input
-        label="Foreground"
+        label={t("cms.style.foreground")}
         value={color.fg ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.colorPlaceholder")}
         onChange={(e) => update("color", "fg", e.target.value)}
       />
       <Input
-        label="Background"
+        label={t("cms.style.background")}
         value={color.bg ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.colorPlaceholder")}
         onChange={(e) => update("color", "bg", e.target.value)}
       />
       <Input
-        label="Border"
+        label={t("cms.style.border")}
         value={color.border ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.colorPlaceholder")}
         onChange={(e) => update("color", "border", e.target.value)}
       />
       <Input
-        label="Font Family"
+        label={t("cms.style.fontFamily")}
         value={typography.fontFamily ?? ""}
         onChange={(e) => update("typography", "fontFamily", e.target.value)}
       />
       <Input
-        label="Font Size"
+        label={t("cms.style.fontSize")}
         value={typography.fontSize ?? ""}
         onChange={(e) => update("typography", "fontSize", e.target.value)}
       />
       <Input
-        label="Font Weight"
+        label={t("cms.style.fontWeight")}
         value={typography.fontWeight ?? ""}
         onChange={(e) => update("typography", "fontWeight", e.target.value)}
       />
       <Input
-        label="Line Height"
+        label={t("cms.style.lineHeight")}
         value={typography.lineHeight ?? ""}
         onChange={(e) => update("typography", "lineHeight", e.target.value)}
       />
       {warning && (
         <p role="alert" aria-live="polite" className="text-danger text-sm">
-          Low contrast
+          {t("cms.style.lowContrast")}
         </p>
       )}
     </div>

--- a/test/e2e/a11y-i18n.spec.ts
+++ b/test/e2e/a11y-i18n.spec.ts
@@ -1,0 +1,14 @@
+describe("A11y and i18n for new UIs", () => {
+  const shop = "abc";
+  it("shows translated labels", () => {
+    cy.visit("/cms/themes/library");
+    cy.contains("h2", "Theme Library").should("exist");
+    cy.contains("a", "Back").should("exist");
+
+    cy.visit(`/cms/shop/${shop}/import/design-system`);
+    cy.contains("h2", "Import Design System").should("exist");
+    cy.contains("p", "Paste design tokens JSON or enter npm package name.").should(
+      "exist",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- localize StylePanel controls and announce contrast warnings
- add live status messages to wizard and translate design system and theme pages
- cover translations with basic e2e test

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed, apps/cms build: Failed)*
- `pnpm e2e --spec test/e2e/a11y-i18n.spec.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b082f330dc832f8b3e0b49a7163930