### PR TITLE
chore: ensure client boundaries and edge runtimes

### DIFF
--- a/apps/cms/src/app/api/blog/slug/route.ts
+++ b/apps/cms/src/app/api/blog/slug/route.ts
@@ -4,6 +4,8 @@ import { getShopById } from "@platform-core/repositories/shop.server";
 import { getSanityConfig } from "@platform-core/shops";
 import { ensureAuthorized } from "@cms/actions/common/auth";
 
+export const runtime = "edge";
+
 const apiVersion =
   (env.SANITY_API_VERSION as string | undefined) ?? "2021-10-21";
 

--- a/apps/cms/src/app/api/marketing/email/click/route.ts
+++ b/apps/cms/src/app/api/marketing/email/click/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { emitClick } from "@acme/email";
 
+export const runtime = "edge";
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
   const campaign = req.nextUrl.searchParams.get("campaign");

--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest } from "next/server";
 import { emitOpen } from "@acme/email";
 
+export const runtime = "edge";
+
 // 1x1 transparent gif
-const pixel = Buffer.from(
-  "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
-  "base64"
+const pixel = Uint8Array.from(
+  atob("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="),
+  (c) => c.charCodeAt(0)
 );
 
 export async function GET(req: NextRequest) {

--- a/apps/cms/src/app/api/marketing/email/unsubscribe/route.ts
+++ b/apps/cms/src/app/api/marketing/email/unsubscribe/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { trackEvent } from "@platform-core/analytics";
 
+export const runtime = "edge";
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
   const email = req.nextUrl.searchParams.get("email");

--- a/apps/cms/src/app/api/sanity/verify/route.ts
+++ b/apps/cms/src/app/api/sanity/verify/route.ts
@@ -1,5 +1,7 @@
 import { verifyCredentials } from "@acme/plugin-sanity";
 
+export const runtime = "edge";
+
 interface VerifyRequest {
   projectId: string;
   dataset?: string;

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/actions.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/actions.ts
@@ -1,13 +1,25 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { scaffoldSpecSchema, type ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
+import { scaffoldSpecSchema } from "@acme/types/page/ScaffoldSpec";
+import { z } from "zod";
 
-export async function createDraft(shop: string, spec: ScaffoldSpec) {
-  const parsed = scaffoldSpecSchema.parse(spec);
-  return { id: `draft-${Date.now()}`, spec: parsed, shop };
+const createDraftSchema = z.object({
+  shop: z.string(),
+  spec: scaffoldSpecSchema,
+});
+
+export async function createDraft(input: z.infer<typeof createDraftSchema>) {
+  const { shop, spec } = createDraftSchema.parse(input);
+  return { id: `draft-${Date.now()}`, spec, shop };
 }
 
-export async function finalize(shop: string, draftId: string) {
+const finalizeSchema = z.object({
+  shop: z.string(),
+  draftId: z.string(),
+});
+
+export async function finalize(input: z.infer<typeof finalizeSchema>) {
+  const { shop, draftId } = finalizeSchema.parse(input);
   redirect(`/cms/shop/${shop}/pages/${draftId}/builder`);
 }

--- a/packages/ui/src/components/atoms/Chip.tsx
+++ b/packages/ui/src/components/atoms/Chip.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Tag, TagProps } from "./Tag";

--- a/packages/ui/src/components/atoms/Toast.tsx
+++ b/packages/ui/src/components/atoms/Toast.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 

--- a/packages/ui/src/components/cms/DeviceSelector.tsx
+++ b/packages/ui/src/components/cms/DeviceSelector.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import {
   Button,

--- a/packages/ui/src/components/cms/page-builder/Block.tsx
+++ b/packages/ui/src/components/cms/page-builder/Block.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { Locale } from "@acme/i18n/locales";
 import type { PageComponent } from "@acme/types";
 import DOMPurify from "dompurify";

--- a/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/FormBuilderEditor.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { FormField, FormFieldOption } from "@acme/types";
 import {
   Button,

--- a/packages/ui/src/components/cms/page-builder/ImageSliderEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImageSliderEditor.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { ImageSliderComponent } from "@acme/types";
 import { Button, Input } from "../../atoms/shadcn";
 import ImagePicker from "./ImagePicker";

--- a/packages/ui/src/components/cms/page-builder/MenuBar.tsx
+++ b/packages/ui/src/components/cms/page-builder/MenuBar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { Editor } from "@tiptap/react";
 import { Button } from "../../atoms/shadcn";
 

--- a/packages/ui/src/components/cms/page-builder/PricingTableEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/PricingTableEditor.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { ChangeEvent } from "react";
 import type { PricingTableComponent } from "@acme/types";
 import { Button, Input, Textarea } from "../../atoms/shadcn";

--- a/packages/ui/src/components/cms/page-builder/TabsEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/TabsEditor.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { TabsComponent } from "@acme/types";
 import { Button, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../atoms/shadcn";
 

--- a/packages/ui/src/components/common/DeviceSelector.tsx
+++ b/packages/ui/src/components/common/DeviceSelector.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { DesktopIcon, LaptopIcon, MobileIcon } from "@radix-ui/react-icons";
 import {
   Button,

--- a/packages/ui/src/components/molecules/MediaSelector.tsx
+++ b/packages/ui/src/components/molecules/MediaSelector.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import * as React from "react";
 

--- a/packages/ui/src/components/molecules/PaginationControl.tsx
+++ b/packages/ui/src/components/molecules/PaginationControl.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Button } from "../atoms/shadcn";

--- a/packages/ui/src/components/molecules/QuantityInput.tsx
+++ b/packages/ui/src/components/molecules/QuantityInput.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 

--- a/packages/ui/src/components/organisms/AccountPanel.tsx
+++ b/packages/ui/src/components/organisms/AccountPanel.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";

--- a/packages/ui/src/components/organisms/ProductCard.tsx
+++ b/packages/ui/src/components/organisms/ProductCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import * as React from "react";
 import type { SKU } from "@acme/types";

--- a/packages/ui/src/components/organisms/ProductVariantSelector.tsx
+++ b/packages/ui/src/components/organisms/ProductVariantSelector.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { ColorSwatch } from "../atoms/ColorSwatch";

--- a/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
+++ b/packages/ui/src/components/organisms/StickyAddToCartBar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Button } from "../atoms/shadcn";

--- a/packages/ui/src/components/templates/CartTemplate.tsx
+++ b/packages/ui/src/components/templates/CartTemplate.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { CartLine, CartState } from "@acme/platform-core/cart";
 import Image from "next/image";
 import * as React from "react";

--- a/packages/ui/src/components/templates/Error404Template.tsx
+++ b/packages/ui/src/components/templates/Error404Template.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Button } from "../atoms/shadcn";

--- a/packages/ui/src/components/templates/Error500Template.tsx
+++ b/packages/ui/src/components/templates/Error500Template.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Button } from "../atoms/shadcn";

--- a/packages/ui/src/components/templates/FeaturedProductTemplate.tsx
+++ b/packages/ui/src/components/templates/FeaturedProductTemplate.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";

--- a/packages/ui/src/components/templates/ProductDetailTemplate.tsx
+++ b/packages/ui/src/components/templates/ProductDetailTemplate.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";

--- a/packages/ui/src/components/templates/ProductMediaGalleryTemplate.tsx
+++ b/packages/ui/src/components/templates/ProductMediaGalleryTemplate.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cn } from "../../utils/style";
 import { Button } from "../atoms/shadcn";

--- a/packages/ui/src/components/templates/WishlistTemplate.tsx
+++ b/packages/ui/src/components/templates/WishlistTemplate.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import * as React from "react";
 import { cn } from "../../utils/style";


### PR DESCRIPTION
## Summary
- mark interactive UI components with `use client`
- add zod-validated inputs for wizard draft server actions
- run email tracking and sanity verification routes on the Edge

## Testing
- `pnpm -r build` *(fails: Output file '/workspace/base-shop/packages/platform-core/dist/dataRoot.d.ts' has not been built from source file '/workspace/base-shop/packages/platform-core/src/dataRoot.ts')*
- `pnpm test packages/ui/src/__tests__/rsc-boundaries.spec.tsx` *(fails: Could not find task packages/ui/src/__tests__/rsc-boundaries.spec.tsx in project)*
- `pnpm test:e2e test/e2e/next15-boundaries.spec.ts` *(fails: Command "test:e2e" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0867795e0832f81a714f39d129e79