### PR TITLE
feat: add telemetry for cms flows

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -19,6 +19,7 @@
     "@acme/plugin-sanity": "workspace:*",
     "@acme/shared-utils": "workspace:*",
     "@acme/theme": "workspace:*",
+    "@acme/telemetry": "workspace:*",
     "@acme/zod-utils": "workspace:^",
     "@sendgrid/eventwebhook": "^7.2.7",
     "@themes/base": "workspace:*",

--- a/apps/cms/src/app/api/git/export/route.ts
+++ b/apps/cms/src/app/api/git/export/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { track } from "@acme/telemetry";
 
 export const runtime = "nodejs";
 
@@ -6,5 +7,6 @@ export async function POST(_req: NextRequest) {
   if (!process.env.GITHUB_TOKEN) {
     return NextResponse.json({ error: "GITHUB_TOKEN missing" }, { status: 501 });
   }
+  track("git:export", {});
   return NextResponse.json({ url: "https://example.com/pr/1" });
 }

--- a/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
@@ -1,4 +1,11 @@
+"use client";
+import { useEffect } from "react";
+import { track } from "@acme/telemetry";
+
 export default function DesignSystemImportPage() {
+  useEffect(() => {
+    track("designsystem:import:view", {});
+  }, []);
   return (
     <div>
       <h2 className="mb-4 text-xl font-semibold">Import Design System</h2>

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useParams } from "next/navigation";
+import { track } from "@acme/telemetry";
 import type { ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
 import SpecForm from "./components/SpecForm";
 import PreviewPane from "./components/PreviewPane";
@@ -16,6 +17,7 @@ export default function NewWizardPage() {
   const handleNext = useCallback(
     async (s: ScaffoldSpec) => {
       const draft = await createDraft(shop, s);
+      track("wizard:createDraft", { shop });
       setSpec(s);
       setDraftId(draft.id);
     },
@@ -23,7 +25,10 @@ export default function NewWizardPage() {
   );
 
   const handleBack = useCallback(() => setSpec(null), []);
-  const handleConfirm = useCallback(() => finalize(shop, draftId), [shop, draftId]);
+  const handleConfirm = useCallback(() => {
+    track("wizard:finalize", { shop });
+    return finalize(shop, draftId);
+  }, [shop, draftId]);
 
   if (!spec) {
     return <SpecForm onNext={handleNext} />;

--- a/apps/cms/src/app/cms/themes/library/page.tsx
+++ b/apps/cms/src/app/cms/themes/library/page.tsx
@@ -1,5 +1,6 @@
 // apps/cms/src/app/cms/themes/library/page.tsx
 import Link from "next/link";
+import { track } from "@acme/telemetry";
 import type { ThemeLibraryEntry } from "@acme/types/theme/ThemeLibrary";
 
 async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
@@ -9,6 +10,7 @@ async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
 }
 
 export default async function ThemeLibraryPage() {
+  track("themes:library:view", {});
   const themes = await fetchThemes();
   return (
     <div>

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@acme/telemetry",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "type": "module",
+  "files": ["src"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf dist *.tsbuildinfo",
+    "test": "rimraf dist && jest --config ../../jest.config.cjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/telemetry/src/__tests__/telemetry.spec.ts
+++ b/packages/telemetry/src/__tests__/telemetry.spec.ts
@@ -1,0 +1,55 @@
+import { jest } from "@jest/globals";
+
+describe("telemetry", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_ENABLE_TELEMETRY;
+    delete process.env.NEXT_PUBLIC_TELEMETRY_SAMPLE_RATE;
+    delete process.env.NODE_ENV;
+  });
+
+  test("strips PII", async () => {
+    const mod = await import("../index");
+    expect(
+      mod.__stripPII({ email: "a@b.com", ok: 1, userName: "bob" })
+    ).toEqual({ ok: 1 });
+  });
+
+  test("disabled when env flag false", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "false";
+    process.env.NODE_ENV = "production";
+    const mod = await import("../index");
+    mod.track("event", { a: 1 });
+    expect(mod.__buffer.length).toBe(0);
+  });
+
+  test("sampling limits events", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "true";
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_TELEMETRY_SAMPLE_RATE = "0.5";
+    const mod = await import("../index");
+    const rand = jest.spyOn(Math, "random").mockReturnValue(0.6);
+    mod.track("event1");
+    expect(mod.__buffer.length).toBe(0);
+    rand.mockReturnValue(0.4);
+    mod.track("event2");
+    expect(mod.__buffer.length).toBe(1);
+  });
+
+  test("flush retries on failure", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "true";
+    process.env.NODE_ENV = "production";
+    const mod = await import("../index");
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    mod.track("event", { foo: "bar" });
+    await mod.__flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mod.__buffer.length).toBe(0);
+  });
+});

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,72 @@
+// packages/telemetry/src/index.ts
+export interface TelemetryEvent {
+  name: string;
+  payload?: Record<string, unknown>;
+  ts: number;
+}
+
+const BUFFER: TelemetryEvent[] = [];
+const FLUSH_INTERVAL = 5000; // 5 seconds
+const MAX_RETRIES = 3;
+
+const SAMPLE_RATE = Number(
+  process.env.NEXT_PUBLIC_TELEMETRY_SAMPLE_RATE ?? "1"
+);
+const ENABLED =
+  process.env.NEXT_PUBLIC_ENABLE_TELEMETRY === "true" &&
+  (process.env.NODE_ENV === "production" || process.env.FORCE_TELEMETRY === "true");
+const ENDPOINT = process.env.NEXT_PUBLIC_TELEMETRY_ENDPOINT ?? "/api/telemetry";
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+function stripPII(payload: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const piiRegex = /(email|name|phone|address|password|token|id)/i;
+  for (const [key, value] of Object.entries(payload)) {
+    if (!piiRegex.test(key)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+async function flush() {
+  if (!BUFFER.length) return;
+  const events = BUFFER.splice(0, BUFFER.length);
+  let attempts = 0;
+  while (attempts < MAX_RETRIES) {
+    try {
+      await fetch(ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(events),
+      });
+      break;
+    } catch {
+      attempts++;
+      if (attempts >= MAX_RETRIES) {
+        BUFFER.unshift(...events); // restore
+      }
+    }
+  }
+}
+
+function scheduleFlush() {
+  if (timer) return;
+  timer = setTimeout(async () => {
+    timer = null;
+    await flush();
+  }, FLUSH_INTERVAL);
+}
+
+export function track(name: string, payload: Record<string, unknown> = {}) {
+  if (!ENABLED) return;
+  if (Math.random() > SAMPLE_RATE) return;
+  BUFFER.push({ name, payload: stripPII(payload), ts: Date.now() });
+  scheduleFlush();
+}
+
+// For testing purposes
+export const __buffer = BUFFER;
+export const __flush = flush;
+export const __stripPII = stripPII;

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,17 @@
+// packages/telemetry/tsconfig.json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", ".turbo", "node_modules", "src/**/__tests__/**"],
+  "references": []
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
     "@acme/platform-core": "workspace:^",
     "@acme/shared-utils": "workspace:*",
     "@acme/types": "workspace:*",
+    "@acme/telemetry": "workspace:*",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-icons": "^1.3.2",

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -4,6 +4,7 @@
 import type { PageComponent } from "@acme/types";
 import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
+import { track } from "@acme/telemetry";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";
 
 interface Props {
@@ -33,6 +34,7 @@ export default function StylePanel({ component, handleInput }: Props) {
       next.typography = { ...typography, [key]: value };
     }
     handleInput("styles", JSON.stringify(next));
+    track("stylepanel:update", { group, key });
   };
 
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       '@acme/shared-utils':
         specifier: workspace:*
         version: link:../../packages/shared-utils
+      '@acme/telemetry':
+        specifier: workspace:*
+        version: link:../../packages/telemetry
       '@acme/theme':
         specifier: workspace:*
         version: link:../../packages/theme
@@ -740,6 +743,8 @@ importers:
 
   packages/tailwind-config: {}
 
+  packages/telemetry: {}
+
   packages/template-app:
     dependencies:
       '@acme/config':
@@ -814,6 +819,9 @@ importers:
       '@acme/shared-utils':
         specifier: workspace:*
         version: link:../shared-utils
+      '@acme/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
       '@acme/types':
         specifier: workspace:*
         version: link:../types

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -31,6 +31,7 @@
     { "path": "packages/auth" },
     { "path": "packages/theme" },
     { "path": "packages/configurator" },
+    { "path": "packages/telemetry" },
     { "path": "src" }
   ]
 }


### PR DESCRIPTION
## Summary
- add @acme/telemetry package with buffered, sampled, env-gated events and PII stripping
- wire telemetry into CMS wizard, style panel, design system import, theme library and git export flows
- include unit tests for telemetry

## Testing
- `pnpm exec jest packages/telemetry/src/__tests__/telemetry.spec.ts --config jest.config.cjs`
- `pnpm -r build` *(fails: Next.js build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b086664498832fab6123f0021e3199