### PR TITLE
fix: ensure i18n messages align

### DIFF
--- a/apps/cms/src/app/[lang]/layout.tsx
+++ b/apps/cms/src/app/[lang]/layout.tsx
@@ -10,11 +10,15 @@ import { Locale, resolveLocale } from "@i18n/locales";
 import type { ReactNode } from "react";
 
 /** Eager-import the three locale JSON files so webpack can statically analyse them. */
-import de from "@i18n/de.json";
 import en from "@i18n/en.json";
-import it from "@i18n/it.json";
+import de_ from "@i18n/de.json";
+import it_ from "@i18n/it.json";
+import type { Messages } from "@/types/i18n";
 
-const MESSAGES: Record<Locale, typeof en> = { en, de, it };
+const de = de_ satisfies Messages ? de_ : de_;
+const it = it_ satisfies Messages ? it_ : it_;
+
+const MESSAGES: Record<Locale, Messages> = { en, de, it };
 
 /** Layout for every route under `/[lang]/*` */
 export default async function LocaleLayout({

--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
@@ -200,12 +200,8 @@ export function useThemeEditor({
     });
   };
 
-  interface PickerInput extends HTMLInputElement {
-    showPicker?: () => void;
-  }
-
   const handleTokenSelect = (token: string) => {
-    const input = overrideRefs.current[token] as PickerInput | null;
+    const input = overrideRefs.current[token] as HTMLInputElement | null;
     if (input) {
       input.scrollIntoView?.({ behavior: "smooth", block: "center" });
       input.focus();

--- a/apps/cms/src/app/cms/wizard/TokenInspector.tsx
+++ b/apps/cms/src/app/cms/wizard/TokenInspector.tsx
@@ -137,26 +137,30 @@ export default function TokenInspector({
     return () => window.removeEventListener("keydown", keyHandler);
   }, [inspectMode, selectedIndex]);
 
-  const child = children as React.ReactElement & {
-    ref?: React.Ref<HTMLDivElement>;
-  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const child = children as React.ReactElement<any>;
   return (
     <>
-      {React.cloneElement(child, {
-        ref: (node: HTMLDivElement) => {
-          previewRef.current = node;
-          const { ref } = child;
-          if (typeof ref === "function") {
-            ref(node);
-          } else if (ref && "current" in ref) {
-            (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
-          }
-        },
-        onPointerMove: handlePointerMove,
-        onClickCapture: handleClick,
-        onPointerLeave: handleLeave,
-        className: `${child.props.className ?? ""} ${inspectMode ? "cursor-crosshair" : ""}`,
-      })}
+      {React.cloneElement(
+        child,
+        {
+          ref: (node: HTMLDivElement) => {
+            previewRef.current = node;
+            const { ref } = child as unknown as {
+              ref?: React.Ref<HTMLDivElement>;
+            };
+            if (typeof ref === "function") {
+              ref(node);
+            } else if (ref && "current" in ref) {
+              (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+            }
+          },
+          onPointerMove: handlePointerMove,
+          onClickCapture: handleClick,
+          onPointerLeave: handleLeave,
+          className: `${child.props.className ?? ""} ${inspectMode ? "cursor-crosshair" : ""}`,
+        } as Record<string, unknown>
+      )}
       {selected && popoverPos && (
         <Popover
           open={popoverOpen}

--- a/apps/cms/src/types/i18n.ts
+++ b/apps/cms/src/types/i18n.ts
@@ -1,0 +1,3 @@
+import enJson from "@i18n/en.json";
+
+export type Messages = typeof enJson;

--- a/packages/i18n/src/de.json
+++ b/packages/i18n/src/de.json
@@ -48,8 +48,10 @@
   "cms.image.decorative": "Als dekorativ markieren",
   "cms.image.altWarning": "Alternativtext angeben oder als dekorativ markieren.",
   "cms.image.probing": "Bild wird geprüft…",
-  "cms.image.probeError": "URL muss auf ein Bild verweisen"
-  ,"cms.theme.library": "Theme-Bibliothek"
-  ,"cms.theme.saveToLibrary": "In Bibliothek speichern"
- ,"cms.theme.importDesignSystem": "Import Design System"
+  "cms.image.probeError": "URL muss auf ein Bild verweisen",
+  "cms.theme.library": "Theme-Bibliothek",
+  "cms.theme.saveToLibrary": "In Bibliothek speichern",
+  "cms.theme.importDesignSystem": "Import Design System",
+  "cms.migrations.title": "Migrationen",
+  "cms.export.title": "In Code exportieren"
 }

--- a/packages/i18n/src/it.json
+++ b/packages/i18n/src/it.json
@@ -48,8 +48,10 @@
   "cms.image.decorative": "Segna come decorativa",
   "cms.image.altWarning": "Fornisci un testo alternativo o segna come decorativa.",
   "cms.image.probing": "Verifica dell'immagine…",
-  "cms.image.probeError": "L'URL deve puntare a un'immagine"
-  ,"cms.theme.library": "Libreria temi"
-  ,"cms.theme.saveToLibrary": "Salva nella libreria"
- ,"cms.theme.importDesignSystem": "Import Design System"
+  "cms.image.probeError": "L'URL deve puntare a un'immagine",
+  "cms.theme.library": "Libreria temi",
+  "cms.theme.saveToLibrary": "Salva nella libreria",
+  "cms.theme.importDesignSystem": "Import Design System",
+  "cms.migrations.title": "Migrazioni",
+  "cms.export.title": "Esporta in codice"
 }

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export default function StylePanel({ component, handleInput }: Props) {
   const overrides: StyleOverrides = component.styles
-    ? JSON.parse(component.styles)
+    ? JSON.parse(String(component.styles))
     : {};
   const color = overrides.color ?? {};
   const typography = overrides.typography ?? {};


### PR DESCRIPTION
## Summary
- add shared Messages type for CMS i18n
- validate locale JSON with `satisfies`
- sync German and Italian messages with English
- adjust TypeScript typings to keep CMS build green

## Testing
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `CMS_ACCESS_TOKEN=foo SANITY_API_VERSION=2023-01-01 CMS_SPACE_URL=https://example.com pnpm --filter @apps/cms build` *(fails: useCurrency must be inside CurrencyProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b087b01ddc832f983235e19480cdb1