### PR TITLE
feat: harden a11y and i18n for cms flows

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
@@ -1,23 +1,30 @@
-export default function DesignSystemImportPage() {
+import { useTranslations as getTranslations } from "@acme/i18n/useTranslations";
+
+export default async function DesignSystemImportPage() {
+  const t = await getTranslations("en");
   return (
     <div>
-      <h2 className="mb-4 text-xl font-semibold">Import Design System</h2>
-      <p className="text-sm">Paste design tokens JSON or enter npm package name.</p>
+      <h2 className="mb-4 text-xl font-semibold">{t("cms.theme.importDesignSystem")}</h2>
+      <p className="text-sm">
+        {t("cms.theme.importDesignSystem.description")}
+      </p>
       <p className="mt-2 text-xs">
         <a
           href="/docs/design-system-package-import"
           className="text-blue-600 hover:underline"
           target="_blank"
+          rel="noopener noreferrer"
         >
-          Package import guide
+          {t("cms.theme.importDesignSystem.packageGuide")}
         </a>{" "}
-        and{" "}
+        {t("common.and")}{" "}
         <a
           href="/docs/theme-lifecycle-and-library"
           className="text-blue-600 hover:underline"
           target="_blank"
+          rel="noopener noreferrer"
         >
-          theme library tips
+          {t("cms.theme.importDesignSystem.themeLibraryTips")}
         </a>
         .
       </p>

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/components/PreviewPane.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/components/PreviewPane.tsx
@@ -9,9 +9,10 @@ interface Props {
   spec: ScaffoldSpec;
   onBack: () => void;
   onConfirm: () => void;
+  t: (key: string) => string;
 }
 
-export default function PreviewPane({ spec, onBack, onConfirm }: Props) {
+export default function PreviewPane({ spec, onBack, onConfirm, t }: Props) {
   const [deviceId, setDeviceId] = useState("desktop");
   const handleDevice = useCallback((id: string) => setDeviceId(id), []);
   const handleBack = useCallback(() => onBack(), [onBack]);
@@ -22,8 +23,8 @@ export default function PreviewPane({ spec, onBack, onConfirm }: Props) {
       <DeviceSelector deviceId={deviceId} onChange={handleDevice} />
       <PreviewRenderer spec={spec} deviceId={deviceId} />
       <div className="flex gap-2">
-        <button onClick={handleBack}>Back</button>
-        <button onClick={handleConfirm}>Create</button>
+        <button onClick={handleBack}>{t("wizard.back")}</button>
+        <button onClick={handleConfirm}>{t("wizard.confirm")}</button>
       </div>
     </div>
   );

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/components/SpecForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/components/SpecForm.tsx
@@ -5,9 +5,10 @@ import type { ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
 
 interface Props {
   onNext: (spec: ScaffoldSpec) => void;
+  t: (key: string) => string;
 }
 
-export default function SpecForm({ onNext }: Props) {
+export default function SpecForm({ onNext, t }: Props) {
   const [layout, setLayout] = useState<"default" | "sidebar">("default");
   const [sections, setSections] = useState("");
   const [hero, setHero] = useState("");
@@ -58,29 +59,31 @@ export default function SpecForm({ onNext }: Props) {
   return (
     <form onSubmit={submit} className="flex flex-col gap-4">
       <label className="flex flex-col">
-        Layout
+        {t("wizard.spec.layout")}
         <select value={layout} onChange={handleLayout}>
-          <option value="default">Default</option>
-          <option value="sidebar">Sidebar</option>
+          <option value="default">{t("wizard.spec.layout.default")}</option>
+          <option value="sidebar">{t("wizard.spec.layout.sidebar")}</option>
         </select>
       </label>
       <label className="flex flex-col">
-        Sections
+        {t("wizard.spec.sections")}
         <input
           value={sections}
           onChange={handleSections}
-          placeholder="intro,features"
+          placeholder={t("wizard.spec.sections.placeholder")}
         />
       </label>
       <label className="flex flex-col">
-        Hero
-        <input value={hero} onChange={handleHero} placeholder="Welcome" />
+        {t("wizard.spec.hero")}
+        <input value={hero} onChange={handleHero} placeholder={t("wizard.spec.hero.placeholder")}
+        />
       </label>
       <label className="flex flex-col">
-        Call to action
-        <input value={cta} onChange={handleCta} placeholder="Start" />
+        {t("wizard.spec.cta")}
+        <input value={cta} onChange={handleCta} placeholder={t("wizard.spec.cta.placeholder")}
+        />
       </label>
-      <button type="submit">Next</button>
+      <button type="submit">{t("wizard.next")}</button>
     </form>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 import { useParams } from "next/navigation";
 import type { ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
+import { useTranslations } from "@acme/i18n";
 import SpecForm from "./components/SpecForm";
 import PreviewPane from "./components/PreviewPane";
 import { createDraft, finalize } from "./actions";
@@ -12,6 +13,7 @@ export default function NewWizardPage() {
   const shop = params.shop;
   const [spec, setSpec] = useState<ScaffoldSpec | null>(null);
   const [draftId, setDraftId] = useState<string>("");
+  const t = useTranslations();
 
   const handleNext = useCallback(
     async (s: ScaffoldSpec) => {
@@ -26,8 +28,10 @@ export default function NewWizardPage() {
   const handleConfirm = useCallback(() => finalize(shop, draftId), [shop, draftId]);
 
   if (!spec) {
-    return <SpecForm onNext={handleNext} />;
+    return <SpecForm onNext={handleNext} t={t} />;
   }
 
-  return <PreviewPane spec={spec} onBack={handleBack} onConfirm={handleConfirm} />;
+  return (
+    <PreviewPane spec={spec} onBack={handleBack} onConfirm={handleConfirm} t={t} />
+  );
 }

--- a/apps/cms/src/app/cms/themes/library/page.tsx
+++ b/apps/cms/src/app/cms/themes/library/page.tsx
@@ -1,6 +1,7 @@
 // apps/cms/src/app/cms/themes/library/page.tsx
 import Link from "next/link";
 import type { ThemeLibraryEntry } from "@acme/types/theme/ThemeLibrary";
+import { useTranslations as getTranslations } from "@acme/i18n/useTranslations";
 
 async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
   const res = await fetch("/cms/api/themes", { cache: "no-store" });
@@ -9,19 +10,20 @@ async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
 }
 
 export default async function ThemeLibraryPage() {
+  const t = await getTranslations("en");
   const themes = await fetchThemes();
   return (
     <div>
-      <h2 className="mb-4 text-xl font-semibold">Theme Library</h2>
+      <h2 className="mb-4 text-xl font-semibold">{t("cms.theme.library")}</h2>
       <ul>
-        {themes.map((t) => (
-          <li key={t.id} className="mb-2">
-            {t.name}
+        {themes.map((tItem) => (
+          <li key={tItem.id} className="mb-2">
+            {tItem.name}
           </li>
         ))}
       </ul>
       <p className="mt-4 text-sm">
-        <Link href="/cms">Back</Link>
+        <Link href="/cms">{t("wizard.back")}</Link>
       </p>
     </div>
   );

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -32,22 +32,39 @@
   "wizard.spec.sections": "Sections",
   "wizard.spec.hero": "Hero",
   "wizard.spec.cta": "Call to action",
+  "wizard.spec.layout.default": "Default",
+  "wizard.spec.layout.sidebar": "Sidebar",
+  "wizard.spec.sections.placeholder": "intro,features",
+  "wizard.spec.hero.placeholder": "Welcome",
+  "wizard.spec.cta.placeholder": "Start",
   "wizard.preview.title": "Preview",
   "wizard.confirm": "Create Page",
   "wizard.back": "Back",
   "wizard.next": "Next",
   "cms.style.title": "Style",
   "cms.style.lowContrast": "Low contrast",
+  "cms.style.foreground": "Foreground",
+  "cms.style.background": "Background",
+  "cms.style.border": "Border",
+  "cms.style.fontFamily": "Font Family",
+  "cms.style.fontSize": "Font Size",
+  "cms.style.fontWeight": "Font Weight",
+  "cms.style.lineHeight": "Line Height",
+  "cms.style.tokenOrHex": "token or #hex",
   "cms.image.url": "Image URL",
   "cms.image.upload": "Upload",
   "cms.image.alt": "Alt text",
   "cms.image.decorative": "Mark as decorative",
   "cms.image.altWarning": "Provide alt text or mark as decorative.",
   "cms.image.probing": "Checking image…",
-  "cms.image.probeError": "URL must point to an image"
-  ,"cms.theme.library": "Theme Library"
-  ,"cms.theme.saveToLibrary": "Save to Library"
- ,"cms.theme.importDesignSystem": "Import Design System"
- ,"cms.migrations.title": "Migrations"
- ,"cms.export.title": "Export to Code"
+  "cms.image.probeError": "URL must point to an image",
+  "cms.theme.library": "Theme Library",
+  "cms.theme.saveToLibrary": "Save to Library",
+  "cms.theme.importDesignSystem": "Import Design System",
+  "cms.theme.importDesignSystem.description": "Paste design tokens JSON or enter npm package name.",
+  "cms.theme.importDesignSystem.packageGuide": "Package import guide",
+  "cms.theme.importDesignSystem.themeLibraryTips": "theme library tips",
+  "common.and": "and",
+  "cms.migrations.title": "Migrations",
+  "cms.export.title": "Export to Code"
 }

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -4,6 +4,7 @@
 import type { PageComponent } from "@acme/types";
 import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
+import { useTranslations } from "@acme/i18n";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
 }
 
 export default function StylePanel({ component, handleInput }: Props) {
+  const t = useTranslations();
   const overrides: StyleOverrides = component.styles
     ? JSON.parse(component.styles)
     : {};
@@ -38,46 +40,46 @@ export default function StylePanel({ component, handleInput }: Props) {
   return (
     <div className="space-y-2">
       <Input
-        label="Foreground"
+        label={t("cms.style.foreground")}
         value={color.fg ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.tokenOrHex")}
         onChange={(e) => update("color", "fg", e.target.value)}
       />
       <Input
-        label="Background"
+        label={t("cms.style.background")}
         value={color.bg ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.tokenOrHex")}
         onChange={(e) => update("color", "bg", e.target.value)}
       />
       <Input
-        label="Border"
+        label={t("cms.style.border")}
         value={color.border ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.tokenOrHex")}
         onChange={(e) => update("color", "border", e.target.value)}
       />
       <Input
-        label="Font Family"
+        label={t("cms.style.fontFamily")}
         value={typography.fontFamily ?? ""}
         onChange={(e) => update("typography", "fontFamily", e.target.value)}
       />
       <Input
-        label="Font Size"
+        label={t("cms.style.fontSize")}
         value={typography.fontSize ?? ""}
         onChange={(e) => update("typography", "fontSize", e.target.value)}
       />
       <Input
-        label="Font Weight"
+        label={t("cms.style.fontWeight")}
         value={typography.fontWeight ?? ""}
         onChange={(e) => update("typography", "fontWeight", e.target.value)}
       />
       <Input
-        label="Line Height"
+        label={t("cms.style.lineHeight")}
         value={typography.lineHeight ?? ""}
         onChange={(e) => update("typography", "lineHeight", e.target.value)}
       />
       {warning && (
         <p role="alert" aria-live="polite" className="text-danger text-sm">
-          Low contrast
+          {t("cms.style.lowContrast")}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- localize and label StylePanel inputs with contrast warnings
- wire wizard pages through i18n
- translate theme library and design system import screens

## Testing
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed; apps/cms build: Failed)*
- `pnpm test test/e2e/a11y-i18n.spec.ts` *(fails: Could not find task)*

------
https://chatgpt.com/codex/tasks/task_e_68b0860682c8832fbed47fc3ac095188