### PR TITLE
feat: harden accessibility and i18n

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/import/design-system/page.tsx
@@ -1,30 +1,34 @@
 "use client";
 import { useEffect } from "react";
 import { track } from "@acme/telemetry";
+import { useTranslations } from "@acme/i18n";
 
 export default function DesignSystemImportPage() {
   useEffect(() => {
     track("designsystem:import:view", {});
   }, []);
+  const t = useTranslations();
   return (
     <div>
-      <h2 className="mb-4 text-xl font-semibold">Import Design System</h2>
-      <p className="text-sm">Paste design tokens JSON or enter npm package name.</p>
+      <h2 className="mb-4 text-xl font-semibold">{t("cms.theme.importDesignSystem")}</h2>
+      <p className="text-sm">{t("cms.theme.importDesc")}</p>
       <p className="mt-2 text-xs">
         <a
           href="/docs/design-system-package-import"
           className="text-blue-600 hover:underline"
           target="_blank"
+          rel="noopener noreferrer"
         >
-          Package import guide
+          {t("cms.theme.packageGuide")}
         </a>{" "}
-        and{" "}
+        {t("cms.and")}{" "}
         <a
           href="/docs/theme-lifecycle-and-library"
           className="text-blue-600 hover:underline"
           target="_blank"
+          rel="noopener noreferrer"
         >
-          theme library tips
+          {t("cms.theme.libraryTips")}
         </a>
         .
       </p>

--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
@@ -7,12 +7,14 @@ import type { ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
 import SpecForm from "./components/SpecForm";
 import PreviewPane from "./components/PreviewPane";
 import { createDraft, finalize } from "./actions";
+import { useTranslations } from "@acme/i18n";
 
 export default function NewWizardPage() {
   const params = useParams<{ shop: string }>();
   const shop = params.shop;
   const [spec, setSpec] = useState<ScaffoldSpec | null>(null);
   const [draftId, setDraftId] = useState<string>("");
+  const t = useTranslations();
 
   const handleNext = useCallback(
     async (s: ScaffoldSpec) => {
@@ -31,8 +33,18 @@ export default function NewWizardPage() {
   }, [shop, draftId]);
 
   if (!spec) {
-    return <SpecForm onNext={handleNext} />;
+    return (
+      <>
+        <h1 className="sr-only">{t("wizard.spec.title")}</h1>
+        <SpecForm onNext={handleNext} />
+      </>
+    );
   }
 
-  return <PreviewPane spec={spec} onBack={handleBack} onConfirm={handleConfirm} />;
+  return (
+    <>
+      <h1 className="sr-only">{t("wizard.preview.title")}</h1>
+      <PreviewPane spec={spec} onBack={handleBack} onConfirm={handleConfirm} />
+    </>
+  );
 }

--- a/apps/cms/src/app/cms/themes/library/page.tsx
+++ b/apps/cms/src/app/cms/themes/library/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { track } from "@acme/telemetry";
 import type { ThemeLibraryEntry } from "@acme/types/theme/ThemeLibrary";
+import { useTranslations } from "@i18n/useTranslations";
 
 async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
   const res = await fetch("/cms/api/themes", { cache: "no-store" });
@@ -11,10 +12,11 @@ async function fetchThemes(): Promise<ThemeLibraryEntry[]> {
 
 export default async function ThemeLibraryPage() {
   track("themes:library:view", {});
+  const t = await useTranslations("en");
   const themes = await fetchThemes();
   return (
     <div>
-      <h2 className="mb-4 text-xl font-semibold">Theme Library</h2>
+      <h2 className="mb-4 text-xl font-semibold">{t("cms.theme.library")}</h2>
       <ul>
         {themes.map((t) => (
           <li key={t.id} className="mb-2">
@@ -23,7 +25,7 @@ export default async function ThemeLibraryPage() {
         ))}
       </ul>
       <p className="mt-4 text-sm">
-        <Link href="/cms">Back</Link>
+        <Link href="/cms">{t("cms.back")}</Link>
       </p>
     </div>
   );

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -38,16 +38,30 @@
   "wizard.next": "Next",
   "cms.style.title": "Style",
   "cms.style.lowContrast": "Low contrast",
+  "cms.style.foreground": "Foreground",
+  "cms.style.background": "Background",
+  "cms.style.border": "Border",
+  "cms.style.fontFamily": "Font Family",
+  "cms.style.fontSize": "Font Size",
+  "cms.style.fontWeight": "Font Weight",
+  "cms.style.lineHeight": "Line Height",
+  "cms.style.colorPlaceholder": "token or #hex",
   "cms.image.url": "Image URL",
   "cms.image.upload": "Upload",
   "cms.image.alt": "Alt text",
   "cms.image.decorative": "Mark as decorative",
   "cms.image.altWarning": "Provide alt text or mark as decorative.",
   "cms.image.probing": "Checking image…",
-  "cms.image.probeError": "URL must point to an image"
-  ,"cms.theme.library": "Theme Library"
-  ,"cms.theme.saveToLibrary": "Save to Library"
- ,"cms.theme.importDesignSystem": "Import Design System"
- ,"cms.migrations.title": "Migrations"
- ,"cms.export.title": "Export to Code"
+  "cms.image.probeError": "URL must point to an image",
+  "cms.theme.library": "Theme Library",
+  "cms.theme.saveToLibrary": "Save to Library",
+  "cms.theme.importDesignSystem": "Import Design System",
+  "cms.theme.importDesc": "Paste design tokens JSON or enter npm package name.",
+  "cms.theme.packageGuide": "Package import guide",
+  "cms.theme.libraryTips": "theme library tips",
+  "cms.and": "and",
+  "cms.back": "Back",
+  "cms.migrations.title": "Migrations",
+  "cms.export.title": "Export to Code"
 }
+

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -5,6 +5,7 @@ import type { PageComponent } from "@acme/types";
 import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
 import { track } from "@acme/telemetry";
+import { useTranslations } from "@acme/i18n";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";
 
 interface Props {
@@ -22,6 +23,7 @@ export default function StylePanel({ component, handleInput }: Props) {
   const color = overrides.color ?? {};
   const typography = overrides.typography ?? {};
   const warning = color.fg && color.bg ? useContrastWarnings(color.fg, color.bg) : null;
+  const t = useTranslations();
 
   const update = (group: "color" | "typography", key: string, value: string) => {
     const next: StyleOverrides = {
@@ -40,46 +42,46 @@ export default function StylePanel({ component, handleInput }: Props) {
   return (
     <div className="space-y-2">
       <Input
-        label="Foreground"
+        label={t("cms.style.foreground")}
         value={color.fg ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.colorPlaceholder")}
         onChange={(e) => update("color", "fg", e.target.value)}
       />
       <Input
-        label="Background"
+        label={t("cms.style.background")}
         value={color.bg ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.colorPlaceholder")}
         onChange={(e) => update("color", "bg", e.target.value)}
       />
       <Input
-        label="Border"
+        label={t("cms.style.border")}
         value={color.border ?? ""}
-        placeholder="token or #hex"
+        placeholder={t("cms.style.colorPlaceholder")}
         onChange={(e) => update("color", "border", e.target.value)}
       />
       <Input
-        label="Font Family"
+        label={t("cms.style.fontFamily")}
         value={typography.fontFamily ?? ""}
         onChange={(e) => update("typography", "fontFamily", e.target.value)}
       />
       <Input
-        label="Font Size"
+        label={t("cms.style.fontSize")}
         value={typography.fontSize ?? ""}
         onChange={(e) => update("typography", "fontSize", e.target.value)}
       />
       <Input
-        label="Font Weight"
+        label={t("cms.style.fontWeight")}
         value={typography.fontWeight ?? ""}
         onChange={(e) => update("typography", "fontWeight", e.target.value)}
       />
       <Input
-        label="Line Height"
+        label={t("cms.style.lineHeight")}
         value={typography.lineHeight ?? ""}
         onChange={(e) => update("typography", "lineHeight", e.target.value)}
       />
       {warning && (
-        <p role="alert" aria-live="polite" className="text-danger text-sm">
-          Low contrast
+        <p role="status" aria-live="polite" className="text-danger text-sm">
+          {t("cms.style.lowContrast")}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- localize style panel controls and announce low contrast warnings
- add translated step headings for wizard, theme library, and design-system import pages
- supply new i18n strings for CMS styling and design system guidance

## Testing
- `pnpm -r build` *(fails: module not found)*
- `pnpm e2e --spec test/e2e/a11y-i18n.spec.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0905f2780832fa6331a893fbd8882