### PR TITLE
refactor: use package imports for platform-core

### DIFF
--- a/apps/cms/__tests__/pages.test.ts
+++ b/apps/cms/__tests__/pages.test.ts
@@ -45,7 +45,7 @@ describe("page actions", () => {
       expect(result.page?.slug).toBe("home");
 
       const { getPages } = await import(
-        "../../../packages/platform-core/src/repositories/pages/index.server"
+        "@acme/platform-core/repositories/pages/index.server"
       );
       const pages = await getPages("test");
       expect(pages).toHaveLength(1);
@@ -60,7 +60,7 @@ describe("page actions", () => {
       jest.doMock("@acme/date-utils", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
-        "../../../packages/platform-core/src/repositories/pages/index.server"
+        "@acme/platform-core/repositories/pages/index.server"
       );
       const page = {
         id: "1",
@@ -99,7 +99,7 @@ describe("page actions", () => {
       jest.doMock("@acme/date-utils", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
-        "../../../packages/platform-core/src/repositories/pages/index.server"
+        "@acme/platform-core/repositories/pages/index.server"
       );
       const page = {
         id: "1",
@@ -144,7 +144,7 @@ describe("page actions", () => {
       jest.doMock("@acme/date-utils", () => ({ nowIso: () => now }));
       mockAuth();
       const repo = await import(
-        "../../../packages/platform-core/src/repositories/pages/index.server"
+        "@acme/platform-core/repositories/pages/index.server"
       );
       const page = {
         id: "1",

--- a/apps/cms/__tests__/products.test.ts
+++ b/apps/cms/__tests__/products.test.ts
@@ -1,6 +1,6 @@
 // apps/cms/__tests__/products.test.ts
 
-import type { ProductPublication } from "../../../packages/platform-core/src/products";
+import type { ProductPublication } from "@acme/platform-core/products";
 
 // Ensure auth options do not throw on import
 process.env.NEXTAUTH_SECRET = "test-secret";
@@ -106,7 +106,7 @@ describe("product actions", () => {
       expect(result.errors?.price).toEqual(["Invalid price"]);
 
       const { readRepo } = await import(
-        "../../../packages/platform-core/src/repositories/json.server"
+        "@acme/platform-core/repositories/json.server"
       );
       const repo = (await readRepo("test")) as ProductPublication[];
       expect(repo[0].price).toBe(0);
@@ -130,7 +130,7 @@ describe("product actions", () => {
       await duplicateProduct("test", prod.id);
 
       const { readRepo } = await import(
-        "../../../packages/platform-core/src/repositories/json.server"
+        "@acme/platform-core/repositories/json.server"
       );
       const repo = (await readRepo("test")) as ProductPublication[];
 
@@ -157,7 +157,7 @@ describe("product actions", () => {
       await deleteProduct("test", prod.id);
 
       const { readRepo } = await import(
-        "../../../packages/platform-core/src/repositories/json.server"
+        "@acme/platform-core/repositories/json.server"
       );
       const repo = (await readRepo("test")) as ProductPublication[];
 

--- a/apps/cms/__tests__/seoTimelineRevert.test.ts
+++ b/apps/cms/__tests__/seoTimelineRevert.test.ts
@@ -67,7 +67,7 @@ describe("SEO revert via timeline", () => {
       // Dynamic imports must come *after* jest.doMock + cwd swap
       const actions = await import("../src/actions/shops.server");
       const repo = await import(
-        "../../../packages/platform-core/src/repositories/settings.server"
+        "@acme/platform-core/repositories/settings.server"
       );
 
       /* ---------- initial update -------------------------------------- */

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -1,6 +1,6 @@
 // packages/template-app/__tests__/checkout-session.test.ts
-import { encodeCartCookie } from "../../platform-core/src/cartCookie";
-import { PRODUCTS } from "../../platform-core/src/products";
+import { encodeCartCookie } from "@acme/platform-core/cartCookie";
+import { PRODUCTS } from "@acme/platform-core/products";
 import { calculateRentalDays } from "@acme/date-utils";
 
 jest.mock("next/server", () => ({
@@ -14,18 +14,18 @@ jest.mock("@acme/stripe", () => ({
   stripe: { checkout: { sessions: { create: jest.fn() } } },
 }));
 
-jest.mock("../../platform-core/src/pricing", () => ({
+jest.mock("@acme/platform-core/pricing", () => ({
   priceForDays: jest.fn(async () => 10),
   convertCurrency: jest.fn(async (v: number) => v),
 }));
 
 jest.mock("@upstash/redis", () => ({ Redis: class {} }));
-jest.mock("@platform-core/analytics", () => ({ trackEvent: jest.fn() }));
-jest.mock("@platform-core/repositories/shops.server", () => ({
+jest.mock("@acme/platform-core/analytics", () => ({ trackEvent: jest.fn() }));
+jest.mock("@acme/platform-core/repositories/shops.server", () => ({
   readShop: jest.fn(async () => ({ coverageIncluded: true })),
 }));
 let mockCart: any;
-jest.mock("@platform-core/cartStore", () => ({
+jest.mock("@acme/platform-core/cartStore", () => ({
   getCart: jest.fn(async () => mockCart),
 }));
 

--- a/packages/template-app/__tests__/rental-return-flow.test.ts
+++ b/packages/template-app/__tests__/rental-return-flow.test.ts
@@ -16,7 +16,7 @@ if (typeof (Response as any).json !== "function") {
 
 async function withShop(
   cb: (
-    repo: typeof import("../../platform-core/src/repositories/rentalOrders.server")
+    repo: typeof import("@acme/platform-core/repositories/rentalOrders.server")
   ) => Promise<void>
 ) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "shop-"));
@@ -42,8 +42,8 @@ async function withShop(
   const cwd = process.cwd();
   process.chdir(dir);
   jest.resetModules();
-  const repo: typeof import("../../platform-core/src/repositories//rentalOrders.server") = await import(
-    "@platform-core/repositories/rentalOrders.server"
+  const repo: typeof import("@acme/platform-core/repositories/rentalOrders.server") = await import(
+    "@acme/platform-core/repositories/rentalOrders.server"
   );
   try {
     await cb(repo);
@@ -89,15 +89,15 @@ describe("rental order lifecycle", () => {
         }),
         { virtual: true }
       );
-      jest.doMock("@platform-core/orders/rentalAllocation", () => ({
+      jest.doMock("@acme/platform-core/orders/rentalAllocation", () => ({
         __esModule: true,
         reserveRentalInventory,
       }));
-      jest.doMock("@platform-core/repositories/inventory.server", () => ({
+      jest.doMock("@acme/platform-core/repositories/inventory.server", () => ({
         __esModule: true,
         readInventory,
       }));
-      jest.doMock("@platform-core/repositories/products.server", () => ({
+      jest.doMock("@acme/platform-core/repositories/products.server", () => ({
         __esModule: true,
         readRepo: readProducts,
       }));

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,7 @@
     "@acme/config": "workspace:*",
     "@acme/date-utils": "workspace:*",
     "@acme/i18n": "workspace:*",
-    "@acme/platform-core": "workspace:^",
+    "@acme/platform-core": "workspace:*",
     "@acme/shared-utils": "workspace:*",
     "@acme/telemetry": "workspace:*",
     "@acme/types": "workspace:*",

--- a/test/unit/page-schema.spec.ts
+++ b/test/unit/page-schema.spec.ts
@@ -1,5 +1,5 @@
 import Ajv from "ajv";
-import schema from "../../packages/platform-core/src/repositories/pages/schema.json";
+import schema from "@acme/platform-core/repositories/pages/schema.json";
 
 describe("page component discriminated union", () => {
   const ajv = new Ajv();

--- a/test/unit/publish-action.spec.ts
+++ b/test/unit/publish-action.spec.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import type { Page } from "../../packages/types/src/page";
+import type { Page } from "@acme/types/page";
 
 function mockAuth() {
   jest.doMock("next-auth", () => ({
@@ -24,7 +24,7 @@ describe("publish page action", () => {
   it("saves page with published status", async () => {
     const pages: Page[] = [];
     jest.doMock(
-      "../../packages/platform-core/src/repositories/pages/index.server",
+      "@acme/platform-core/repositories/pages/index.server",
       () => ({
         getPages: jest.fn().mockResolvedValue(pages),
         savePage: jest
@@ -53,7 +53,7 @@ describe("publish page action", () => {
 
   it("rejects invalid payload", async () => {
     jest.doMock(
-      "../../packages/platform-core/src/repositories/pages/index.server",
+      "@acme/platform-core/repositories/pages/index.server",
       () => ({
         getPages: jest.fn().mockResolvedValue([]),
         savePage: jest.fn(),


### PR DESCRIPTION
## Summary
- refactor tests to use `@acme/platform-core` package imports instead of relative paths
- pin UI package's platform-core dependency to `workspace:*`

## Testing
- `pnpm install`
- `pnpm -r --filter "./packages/**" build` *(fails: packages-template-app build: Failed; packages/ui build: Failed; packages/platform-machine build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b09bd6f268832f9800265993c08c2b