### PR TITLE
chore(cms): move rbacStore to server namespace

### DIFF
--- a/apps/cms/__tests__/accounts.test.ts
+++ b/apps/cms/__tests__/accounts.test.ts
@@ -94,7 +94,7 @@ describe("account actions", () => {
       }));
 
       const actions = await import("../src/actions/accounts.server");
-      const { readRbac } = await import("../src/lib/rbacStore");
+      const { readRbac } = await import("../src/lib/server/rbacStore");
 
       await actions.requestAccount(
         fd({ name: "C", email: "c@example.com", password: "pw" })

--- a/apps/cms/__tests__/authOptions.test.ts
+++ b/apps/cms/__tests__/authOptions.test.ts
@@ -6,7 +6,7 @@
 /* -------------------------------------------------------------------------- */
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-const rbacStorePath = require.resolve("../src/lib/rbacStore");
+const rbacStorePath = require.resolve("../src/lib/server/rbacStore");
 const { ROLE_PERMISSIONS } = require("@auth/permissions");
 /* eslint-enable @typescript-eslint/no-var-requires */
 

--- a/apps/cms/__tests__/createShopActions.test.tsx
+++ b/apps/cms/__tests__/createShopActions.test.tsx
@@ -193,7 +193,7 @@ describe("rbac actions persistence", () => {
       const { inviteUser } = await import(
         /* webpackIgnore: true */ "../src/actions/rbac.server.ts"
       );
-      const { readRbac } = await import("../src/lib/rbacStore");
+      const { readRbac } = await import("../src/lib/server/rbacStore");
 
       await inviteUser(
         fd({
@@ -224,7 +224,7 @@ describe("rbac actions persistence", () => {
       const { updateUserRoles } = await import(
         /* webpackIgnore: true */ "../src/actions/rbac.server.ts"
       );
-      const { readRbac } = await import("../src/lib/rbacStore");
+      const { readRbac } = await import("../src/lib/server/rbacStore");
 
       const form = fd({ id: "2", roles: ["admin", "viewer"] });
       await updateUserRoles(form);

--- a/apps/cms/__tests__/rbacPermissions.integration.test.tsx
+++ b/apps/cms/__tests__/rbacPermissions.integration.test.tsx
@@ -80,7 +80,7 @@ describe("PermissionsPage storefront roles", () => {
       const { updateRolePermissions } = await import(
         "../src/actions/rbac.server"
       );
-      const { readRbac } = await import("../src/lib/rbacStore");
+      const { readRbac } = await import("../src/lib/server/rbacStore");
 
       const form = new FormData();
       form.append("role", "customer");

--- a/apps/cms/__tests__/rbacStore.test.ts
+++ b/apps/cms/__tests__/rbacStore.test.ts
@@ -20,7 +20,7 @@ afterEach(() => jest.resetAllMocks());
 describe("rbacStore", () => {
   it("readRbac returns defaults when file missing", async () => {
     await withTempDir(async () => {
-      const { readRbac } = await import("../src/lib/rbacStore");
+      const { readRbac } = await import("../src/lib/server/rbacStore");
       const db = await readRbac();
       expect(db.users["1"].email).toBe("admin@example.com");
       expect(db.roles["1"]).toBe("admin");
@@ -30,7 +30,7 @@ describe("rbacStore", () => {
 
   it("writeRbac persists modified db", async () => {
     await withTempDir(async (dir) => {
-      const { readRbac, writeRbac } = await import("../src/lib/rbacStore");
+      const { readRbac, writeRbac } = await import("../src/lib/server/rbacStore");
       const db = await readRbac();
       db.users["6"] = {
         id: "6",
@@ -49,7 +49,7 @@ describe("rbacStore", () => {
 
   it("updates permissions for roles", async () => {
     await withTempDir(async (dir) => {
-      const { readRbac, writeRbac } = await import("../src/lib/rbacStore");
+      const { readRbac, writeRbac } = await import("../src/lib/server/rbacStore");
       const db = await readRbac();
       db.permissions.admin = [PERMISSIONS[0]];
       await writeRbac(db);

--- a/apps/cms/src/actions/__tests__/rbac.server.test.ts
+++ b/apps/cms/src/actions/__tests__/rbac.server.test.ts
@@ -1,11 +1,11 @@
 /** @jest-environment node */
 
-jest.mock('../../lib/rbacStore', () => ({
+jest.mock('../../lib/server/rbacStore', () => ({
   readRbac: jest.fn(),
 }));
 
 import { listUsers } from '../rbac.server';
-import { readRbac } from '../../lib/rbacStore';
+import { readRbac } from '../../lib/server/rbacStore';
 
 describe('listUsers', () => {
   beforeEach(() => {

--- a/apps/cms/src/actions/accounts.server.ts
+++ b/apps/cms/src/actions/accounts.server.ts
@@ -7,7 +7,7 @@ import type { CmsUser } from "@cms/auth/users";
 import argon2 from "argon2";
 import { ulid } from "ulid";
 import { sendEmail } from "@acme/email";
-import { readRbac, writeRbac } from "../lib/rbacStore";
+import { readRbac, writeRbac } from "../lib/server/rbacStore";
 
 export interface PendingUser {
   id: string;

--- a/apps/cms/src/actions/createShop.server.test.ts
+++ b/apps/cms/src/actions/createShop.server.test.ts
@@ -11,7 +11,7 @@ jest.mock("@platform-core/db", () => ({
   },
 }));
 
-jest.mock("../lib/rbacStore", () => ({
+jest.mock("../lib/server/rbacStore", () => ({
   readRbac: jest.fn(),
   writeRbac: jest.fn(),
 }));
@@ -27,7 +27,7 @@ describe("createNewShop", () => {
 
   it("Successful shop creation with RBAC update for new user", async () => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/rbacStore");
+    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
 
     const deployResult = { status: "ok" } as any;
@@ -52,7 +52,7 @@ describe("createNewShop", () => {
     { current: "Viewer", expected: ["Viewer", "ShopAdmin"] },
   ])("Existing role array vs single role %#", async ({ current, expected }) => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/rbacStore");
+    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
 
     (createShop as jest.Mock).mockResolvedValue({});
@@ -71,7 +71,7 @@ describe("createNewShop", () => {
 
   it("Failure writing RBAC → verify rollback deletes created entities and throws", async () => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/rbacStore");
+    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
     const { prisma } = await import("@platform-core/db");
 
@@ -95,7 +95,7 @@ describe("createNewShop", () => {
 
   it("Ensure user without id skips RBAC update", async () => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/rbacStore");
+    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
 
     const deployResult = { status: "ok" } as any;

--- a/apps/cms/src/actions/createShop.server.ts
+++ b/apps/cms/src/actions/createShop.server.ts
@@ -7,7 +7,7 @@ import {
   type DeployStatusBase,
 } from "@platform-core/createShop";
 import { prisma } from "@platform-core/db";
-import { readRbac, writeRbac } from "../lib/rbacStore";
+import { readRbac, writeRbac } from "../lib/server/rbacStore";
 import { ensureAuthorized } from "./common/auth";
 
 export async function createNewShop(

--- a/apps/cms/src/actions/rbac.server.ts
+++ b/apps/cms/src/actions/rbac.server.ts
@@ -6,7 +6,7 @@ import type { CmsUser } from "@cms/auth/users";
 import type { Permission } from "@auth";
 import argon2 from "argon2";
 import { ulid } from "ulid";
-import { readRbac, writeRbac } from "../lib/rbacStore";
+import { readRbac, writeRbac } from "../lib/server/rbacStore";
 
 export interface UserWithRoles extends CmsUser {
   roles: Role | Role[];

--- a/apps/cms/src/app/cms/page.tsx
+++ b/apps/cms/src/app/cms/page.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/atoms/shadcn";
 import { approveAccount, listPendingUsers } from "@cms/actions/accounts.server";
 import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
-import { readRbac } from "@cms/lib/rbacStore";
+import { readRbac } from "@cms/lib/server/rbacStore";
 import type { ReactNode } from "react";
 import { DashboardTemplate } from "@ui/components/templates";
 import type { Metadata } from "next";

--- a/apps/cms/src/app/cms/rbac/permissions/page.tsx
+++ b/apps/cms/src/app/cms/rbac/permissions/page.tsx
@@ -5,7 +5,7 @@ import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
 import type { Permission } from "@auth";
 import { PERMISSIONS } from "@auth/types/permissions";
-import { readRbac } from "@cms/lib/rbacStore";
+import { readRbac } from "@cms/lib/server/rbacStore";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 

--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -3,7 +3,7 @@ import argon2 from "argon2";
 import type { NextAuthOptions } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
-import { readRbac as defaultReadRbac } from "../lib/rbacStore";
+import { readRbac as defaultReadRbac } from "../lib/server/rbacStore";
 
 import { logger } from "@acme/shared-utils";
 

--- a/apps/cms/src/lib/server/rbacStore.ts
+++ b/apps/cms/src/lib/server/rbacStore.ts
@@ -1,4 +1,6 @@
-// apps/cms/src/lib/rbacStore.ts
+import "server-only";
+
+// apps/cms/src/lib/server/rbacStore.ts
 
 import type { CmsUser } from "@acme/types";
 import type { Permission } from "@auth";
@@ -6,7 +8,7 @@ import { ROLE_PERMISSIONS } from "@auth/permissions";
 import * as fsSync from "fs";
 import { promises as fs } from "fs";
 import * as path from "path";
-import type { Role } from "../auth/roles";
+import type { Role } from "../../auth/roles";
 
 export interface RbacDB {
   users: Record<string, CmsUser>;


### PR DESCRIPTION
## Summary
- move rbacStore into a dedicated server namespace
- mark rbacStore as server-only and update relative imports

## Testing
- `pnpm -r build` *(fails: Build failed because of webpack errors)*
- `pnpm --filter @apps/cms test` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a0a08db4832f91ceb707fe09e70b