### PR TITLE
chore: move email routes to node runtime

### DIFF
--- a/apps/cms/src/app/api/marketing/email/click/route.ts
+++ b/apps/cms/src/app/api/marketing/email/click/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { emitClick } from "@acme/email";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
@@ -19,6 +18,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   if (shop && campaign) {
+    const { emitClick } = await import("@acme/email");
     await emitClick(shop, { campaign });
   }
 

--- a/apps/cms/src/app/api/marketing/email/open/route.ts
+++ b/apps/cms/src/app/api/marketing/email/open/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from "next/server";
-import { emitOpen } from "@acme/email";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 // 1x1 transparent gif
 const pixel = Uint8Array.from(
@@ -15,6 +14,7 @@ export async function GET(req: NextRequest) {
   const shop = params.get("shop");
   const campaign = params.get("campaign");
   if (shop && campaign) {
+    const { emitOpen } = await import("@acme/email");
     await emitOpen(shop, { campaign });
   }
   return new Response(pixel, {


### PR DESCRIPTION
## Summary
- use the node runtime for marketing email tracking routes
- lazily load `@acme/email` in those handlers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Build failed because of webpack errors)*
- `pnpm test:cms` *(fails: Exceeded timeout of 5000 ms for a test)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a0bbc7f4832fb02be151b2fe8ead