### PR TITLE
chore: mark auth modules as server-only

### DIFF
--- a/apps/cms/src/actions/common/auth.ts
+++ b/apps/cms/src/actions/common/auth.ts
@@ -1,4 +1,5 @@
 // apps/cms/src/actions/common/auth.ts
+import "server-only";
 
 import { getServerSession } from "next-auth";
 import { authOptions } from "@cms/auth/options";

--- a/apps/cms/src/auth/options.ts
+++ b/apps/cms/src/auth/options.ts
@@ -1,4 +1,5 @@
 // apps/cms/src/auth/options.ts
+import "server-only";
 import argon2 from "argon2";
 import type { NextAuthOptions } from "next-auth";
 import type { JWT } from "next-auth/jwt";


### PR DESCRIPTION
## Summary
- mark auth options and ensureAuthorized modules as server-only to prevent client bundling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Build failed because of webpack errors)*
- `pnpm --filter @apps/cms lint` *(fails: React Hook useTranslations cannot be called in an async function)*
- `pnpm --filter @apps/cms test` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a0c71834832f8e1aef83603350e4