### PR TITLE
test: expand return API coverage

### DIFF
--- a/packages/template-app/__tests__/return.test.ts
+++ b/packages/template-app/__tests__/return.test.ts
@@ -28,6 +28,12 @@ describe("/api/return", () => {
     const refundCreate = jest.fn();
     const computeDamageFee = jest.fn(async () => 20);
 
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest
+        .fn()
+        .mockResolvedValue({ returnsEnabled: true, coverageIncluded: true }),
+    }));
     jest.doMock(
       "@acme/stripe",
       () => ({
@@ -69,6 +75,12 @@ describe("/api/return", () => {
       .mockResolvedValue({ metadata: {} } as SessionSubset);
     const refundCreate = jest.fn();
 
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest
+        .fn()
+        .mockResolvedValue({ returnsEnabled: true, coverageIncluded: true }),
+    }));
     jest.doMock(
       "@acme/stripe",
       () => ({
@@ -101,5 +113,204 @@ describe("/api/return", () => {
       ok: false,
       message: "No deposit found",
     });
+  });
+
+  test("returns 403 when returns disabled", async () => {
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: false }),
+    }));
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn(),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess" }),
+    } as unknown as NextRequest);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Returns disabled" });
+  });
+
+  test("returns 404 when order not found", async () => {
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true }),
+    }));
+    const markReturned = jest
+      .fn<Promise<RentalOrder | null>, []>()
+      .mockResolvedValue(null);
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned,
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess" }),
+    } as unknown as NextRequest);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Order not found" });
+  });
+
+  test("home pickup disabled when setting false", async () => {
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true }),
+    }));
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn(),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+    jest.doMock("@platform-core/returnLogistics", () => ({
+      __esModule: true,
+      getReturnBagAndLabel: jest
+        .fn()
+        .mockResolvedValue({ homePickupZipCodes: ["12345"] }),
+    }));
+    jest.doMock("@platform-core/repositories/settings.server", () => ({
+      __esModule: true,
+      getShopSettings: jest
+        .fn()
+        .mockResolvedValue({ returnService: { homePickupEnabled: false } }),
+    }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ zip: "12345", date: "2023-01-01", time: "10:00" }),
+    } as unknown as NextRequest);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Home pickup disabled" });
+  });
+
+  test("rejects ZIP not eligible for pickup", async () => {
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true }),
+    }));
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn(),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+    jest.doMock("@platform-core/returnLogistics", () => ({
+      __esModule: true,
+      getReturnBagAndLabel: jest
+        .fn()
+        .mockResolvedValue({ homePickupZipCodes: ["99999"] }),
+    }));
+    jest.doMock("@platform-core/repositories/settings.server", () => ({
+      __esModule: true,
+      getShopSettings: jest
+        .fn()
+        .mockResolvedValue({ returnService: { homePickupEnabled: true } }),
+    }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ zip: "12345", date: "2023-01-01", time: "10:00" }),
+    } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "ZIP not eligible" });
+  });
+
+  test("schedules valid home pickup", async () => {
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true }),
+    }));
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn(),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+    jest.doMock("@platform-core/returnLogistics", () => ({
+      __esModule: true,
+      getReturnBagAndLabel: jest
+        .fn()
+        .mockResolvedValue({ homePickupZipCodes: ["12345"] }),
+    }));
+    jest.doMock("@platform-core/repositories/settings.server", () => ({
+      __esModule: true,
+      getShopSettings: jest
+        .fn()
+        .mockResolvedValue({ returnService: { homePickupEnabled: true } }),
+    }));
+
+    const log = jest.spyOn(console, "log").mockImplementation(() => {});
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({} as Response);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+
+    const { POST } = await import("../src/api/return/route");
+    const appt = { zip: "12345", date: "2023-01-01", time: "10:00" };
+    const res = await POST({ json: async () => appt } as unknown as NextRequest);
+
+    expect(log).toHaveBeenCalledWith("pickup scheduled", appt);
+    expect(fetchMock).toHaveBeenCalledWith("https://carrier.invalid/pickup", {
+      method: "POST",
+      body: JSON.stringify(appt),
+    });
+    expect(await res.json()).toEqual({ ok: true });
+    log.mockRestore();
+  });
+
+  test("returns 400 for invalid request", async () => {
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: jest.fn().mockResolvedValue({ returnsEnabled: true }),
+    }));
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      markReturned: jest.fn(),
+      markRefunded: jest.fn(),
+      addOrder: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { checkout: { sessions: { retrieve: jest.fn() } }, refunds: { create: jest.fn() } },
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({ json: async () => ({}) } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid request" });
   });
 });


### PR DESCRIPTION
## Summary
- add coverage for disabled returns and missing orders
- exercise home pickup flows including valid and error paths
- verify invalid requests respond with 400

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Can't resolve 'fs')
- `npx jest packages/template-app/__tests__/return.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0a722d100832f8e0111e2b5419e53