### PR TITLE
test: cover ai catalog disabled

### DIFF
--- a/packages/template-app/__tests__/ai-catalog.test.ts
+++ b/packages/template-app/__tests__/ai-catalog.test.ts
@@ -1,5 +1,6 @@
 // packages/template-app/__tests__/ai-catalog.test.ts
 import { GET } from "../src/app/api/ai/catalog/route";
+import * as settings from "@platform-core/repositories/settings.server";
 
 describe("AI catalogue API", () => {
   beforeAll(() => {
@@ -38,5 +39,14 @@ describe("AI catalogue API", () => {
       })
     );
     expect(second.status).toBe(304);
+  });
+
+  test("returns 404 when AI catalog disabled", async () => {
+    const spy = jest
+      .spyOn(settings, "getShopSettings")
+      .mockResolvedValue({ seo: { aiCatalog: { enabled: false } } } as any);
+    const res = await GET(createRequest("http://localhost/api/ai/catalog"));
+    expect(res.status).toBe(404);
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add test for AI catalog API when disabled

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve 'fs')*
- `pnpm exec jest packages/template-app/__tests__/ai-catalog.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0a72f0134832fa0d7e8f0215def37