### PR TITLE
fix: use node runtime for unsubscribe route

### DIFF
--- a/apps/cms/src/app/api/marketing/email/unsubscribe/route.ts
+++ b/apps/cms/src/app/api/marketing/email/unsubscribe/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { trackEvent } from "@platform-core/analytics";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");


### PR DESCRIPTION
## Summary
- ensure unsubscribe API route runs in Node.js runtime instead of edge



------
https://chatgpt.com/codex/tasks/task_e_68b0aa303408832f80a6d47dde3f81ae