### PR TITLE
test: set CMS env in next-config tests

### DIFF
--- a/packages/next-config/__tests__/index.test.mjs
+++ b/packages/next-config/__tests__/index.test.mjs
@@ -2,6 +2,10 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
+process.env.CMS_SPACE_URL = 'https://example.com';
+process.env.CMS_ACCESS_TOKEN = 'test-token';
+process.env.SANITY_API_VERSION = '2023-05-31';
+
 const moduleUrl = new URL('../index.mjs', import.meta.url);
 const freshImport = () => import(`${moduleUrl.href}?t=${Date.now()}&r=${Math.random()}`);
 


### PR DESCRIPTION
## Summary
- set placeholder CMS environment variables for next-config tests

## Testing
- `pnpm --filter @acme/next-config test`

------
https://chatgpt.com/codex/tasks/task_e_68b0b7ab1cf4832f8381910bd3e616b3