### PR TITLE
fix: update wizard draft creation arguments

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/wizard/new/page.tsx
@@ -18,7 +18,7 @@ export default function NewWizardPage() {
 
   const handleNext = useCallback(
     async (s: ScaffoldSpec) => {
-      const draft = await createDraft(shop, s);
+      const draft = await createDraft({ shop, spec: s });
       track("wizard:createDraft", { shop });
       setSpec(s);
       setDraftId(draft.id);
@@ -29,7 +29,7 @@ export default function NewWizardPage() {
   const handleBack = useCallback(() => setSpec(null), []);
   const handleConfirm = useCallback(() => {
     track("wizard:finalize", { shop });
-    return finalize(shop, draftId);
+    return finalize({ shop, draftId });
   }, [shop, draftId]);
 
   if (!spec) {


### PR DESCRIPTION
## Summary
- pass shop and spec as object to `createDraft`
- send object to `finalize` for consistent API usage

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build: Failed, apps/shop-bcd build: Failed)*
- `pnpm run build:trace` *(fails: Invalid CMS environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b713f810832f8b11e5cff223ebf2