### PR TITLE
fix: ensure media tests use file upload

### DIFF
--- a/apps/cms/src/actions/__tests__/media.server.test.ts
+++ b/apps/cms/src/actions/__tests__/media.server.test.ts
@@ -21,6 +21,8 @@ jest.mock('sharp', () => ({
   default: sharpMock,
 }));
 
+import { File } from 'node:buffer';
+
 import { uploadMedia, deleteMedia } from '../media.server';
 
 describe('uploadMedia', () => {
@@ -36,7 +38,7 @@ describe('uploadMedia', () => {
 
     const file = new File(['dummy'], 'portrait.jpg', { type: 'image/jpeg' });
     const formData = new FormData();
-    formData.set('file', file);
+    formData.append('file', file);
 
     await expect(uploadMedia('shop', formData)).rejects.toThrow(
       'Image orientation must be landscape',
@@ -46,7 +48,7 @@ describe('uploadMedia', () => {
   it('throws for invalid file type', async () => {
     const file = new File(['dummy'], 'file.txt', { type: 'text/plain' });
     const formData = new FormData();
-    formData.set('file', file);
+    formData.append('file', file);
 
     await expect(uploadMedia('shop', formData)).rejects.toThrow(
       'Invalid file type',


### PR DESCRIPTION
## Summary
- use `node:buffer` File and `FormData.append` in media server tests to ensure files are attached properly

## Testing
- `pnpm exec jest apps/cms/src/actions/__tests__/media.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0b7f7a770832f8414cc764c22b6bc