### PR TITLE
fix: display actual image url in preview

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/MainImageField.tsx
+++ b/apps/cms/src/app/cms/blog/posts/MainImageField.tsx
@@ -21,6 +21,7 @@ export default function MainImageField({ value, onChange }: Props) {
           alt="Main image"
           width={128}
           height={128}
+          unoptimized
           className="h-32 w-auto rounded object-cover"
         />
       )}


### PR DESCRIPTION
## Summary
- ensure CMS main image preview uses the raw image url

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid CMS environment variables)*
- `pnpm test:cms apps/cms/src/app/cms/blog/posts/__tests__/MainImageField.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0b988074c832faea2c2291258f596