### PR TITLE
fix inventory validation test zod initialization

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts
@@ -1,8 +1,8 @@
 import { validateInventoryItems } from "../useInventoryValidation";
-import { z } from "zod";
 import type { InventoryItem } from "@acme/types";
 
 jest.mock("@acme/types", () => {
+  const { z } = require("zod");
   const inventoryItemSchema = z
     .object({
       sku: z.string(),


### PR DESCRIPTION
## Summary
- fix zod mock initialization in inventoryValidation test to avoid ReferenceError

## Testing
- `npx jest "apps/cms/src/app/cms/shop/\\[shop\\]/data/inventory/__tests__/inventoryValidation.test.ts" --config jest.config.cjs --runInBand`
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb4795d4832fbf0530e48340d5e9