### PR TITLE
test(config): validate core env refinement errors

### DIFF
--- a/packages/config/__tests__/coreEnvRefinement.test.ts
+++ b/packages/config/__tests__/coreEnvRefinement.test.ts
@@ -1,0 +1,30 @@
+import { expect, describe, it, afterEach } from "@jest/globals";
+
+const OLD_ENV = process.env;
+
+afterEach(() => {
+  jest.resetModules();
+  process.env = OLD_ENV;
+});
+
+describe("coreEnvSchema refinement", () => {
+  it("reports invalid env variables", async () => {
+    const { coreEnvSchema } = await import("../src/env/core.impl");
+    process.env = {
+      ...OLD_ENV,
+      DEPOSIT_RELEASE_ENABLED: "notbool",
+      REVERSE_LOGISTICS_INTERVAL_MS: "abc",
+    } as NodeJS.ProcessEnv;
+
+    const parsed = coreEnvSchema.safeParse(process.env);
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ["DEPOSIT_RELEASE_ENABLED"] }),
+          expect.objectContaining({ path: ["REVERSE_LOGISTICS_INTERVAL_MS"] }),
+        ]),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for coreEnvSchema error reporting on invalid variables

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: A `require()` style import is forbidden at apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts:5:17)*
- `pnpm --filter "@acme/config" test` *(fails: env.test.ts and cmsEnv.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c101e700832f8ec25d83eec7d244