### PR TITLE
test: add auth env schema validation

### DIFF
--- a/packages/config/__tests__/authEnv.test.ts
+++ b/packages/config/__tests__/authEnv.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "@jest/globals";
+
+describe("authEnv", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("throws and logs when NEXTAUTH_SECRET is missing in production", async () => {
+    process.env = {
+      NODE_ENV: "production",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(import("../src/env/auth.impl")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/packages/config/__tests__/cmsEnv.test.ts
+++ b/packages/config/__tests__/cmsEnv.test.ts
@@ -11,6 +11,7 @@ describe("cmsEnv", () => {
 
   it("parses when required variables are present", async () => {
     process.env = {
+      NODE_ENV: "production",
       CMS_SPACE_URL: "https://example.com",
       CMS_ACCESS_TOKEN: "token",
       SANITY_API_VERSION: "2023-01-01",
@@ -26,6 +27,7 @@ describe("cmsEnv", () => {
 
   it("throws and logs when CMS_SPACE_URL is invalid", async () => {
     process.env = {
+      NODE_ENV: "production",
       CMS_SPACE_URL: "not-a-url",
       CMS_ACCESS_TOKEN: "token",
       SANITY_API_VERSION: "2023-01-01",
@@ -39,6 +41,7 @@ describe("cmsEnv", () => {
 
   it("throws and logs when required variables are missing", async () => {
     process.env = {
+      NODE_ENV: "production",
       CMS_SPACE_URL: "https://example.com",
     } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -12,6 +12,7 @@ describe("envSchema", () => {
   it("parses when required variables are present", async () => {
       process.env = {
         ...OLD_ENV,
+        NODE_ENV: "production",
         STRIPE_SECRET_KEY: "sk",
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
         CART_COOKIE_SECRET: "secret",
@@ -53,6 +54,7 @@ describe("envSchema", () => {
   it("throws when variables are missing", async () => {
     process.env = {
       ...OLD_ENV,
+      NODE_ENV: "production",
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
       CART_COOKIE_SECRET: "secret",


### PR DESCRIPTION
## Summary
- add test ensuring missing auth secrets throw and log
- run tests for config package in production mode

## Testing
- `pnpm --filter "@acme/config" test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1030aa4832fa61b361989dc93fc