### PR TITLE
test(config): add invalid smtp url test

### DIFF
--- a/packages/config/__tests__/emailEnv.test.ts
+++ b/packages/config/__tests__/emailEnv.test.ts
@@ -1,0 +1,22 @@
+import { expect } from "@jest/globals";
+
+describe("emailEnv", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("throws and logs when SMTP_URL is invalid", async () => {
+    process.env = {
+      SMTP_URL: "notaurl",
+    } as NodeJS.ProcessEnv;
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../src/env/email.impl")).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for invalid SMTP_URL in email env schema

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Error: A `require()` style import is forbidden)*
- `pnpm --filter "@acme/config" test` *(fails: envSchema and cmsEnv tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c1048dc8832f9091836b87fbbb73