### PR TITLE
test(config): add shipping env validation

### DIFF
--- a/packages/config/__tests__/cmsEnv.test.ts
+++ b/packages/config/__tests__/cmsEnv.test.ts
@@ -40,6 +40,7 @@ describe("cmsEnv", () => {
   it("throws and logs when required variables are missing", async () => {
     process.env = {
       CMS_SPACE_URL: "https://example.com",
+      NODE_ENV: "production",
     } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     await expect(import("../src/env/cms.impl")).rejects.toThrow(

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -53,6 +53,7 @@ describe("envSchema", () => {
   it("throws when variables are missing", async () => {
     process.env = {
       ...OLD_ENV,
+      NODE_ENV: "production",
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
       CART_COOKIE_SECRET: "secret",

--- a/packages/config/__tests__/shippingEnv.test.ts
+++ b/packages/config/__tests__/shippingEnv.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "@jest/globals";
+
+describe("shippingEnv", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("parses when optional keys are valid strings", async () => {
+    process.env = {
+      TAXJAR_KEY: "tax",
+      UPS_KEY: "ups",
+      DHL_KEY: "dhl",
+    } as NodeJS.ProcessEnv;
+
+    const { shippingEnv } = await import("../src/env/shipping.impl");
+    expect(shippingEnv).toEqual({
+      TAXJAR_KEY: "tax",
+      UPS_KEY: "ups",
+      DHL_KEY: "dhl",
+    });
+  });
+
+  it("throws and logs when a key has an invalid type", async () => {
+    process.env = {
+      TAXJAR_KEY: "tax",
+      UPS_KEY: "ups",
+      // @ts-expect-error - intentionally invalid type to trigger schema failure
+      DHL_KEY: 123,
+    } as unknown as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../src/env/shipping.impl")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for shipping env parsing and failure
- ensure env and CMS tests run in production mode when expecting failures

## Testing
- `pnpm --filter "@acme/config" test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1056e88832f9c539b5139b3007c