### PR TITLE
test(config): ensure payments env falls back to defaults

### DIFF
--- a/packages/config/__tests__/paymentsEnv.test.ts
+++ b/packages/config/__tests__/paymentsEnv.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "@jest/globals";
+
+describe("paymentEnv", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("falls back to defaults and warns on invalid env", async () => {
+    process.env = {
+      STRIPE_SECRET_KEY: "",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { paymentEnv, paymentEnvSchema } = await import("../src/env/payments.impl");
+
+    expect(spy).toHaveBeenCalledWith(
+      "⚠️ Invalid payment environment variables:",
+      expect.anything(),
+    );
+    expect(paymentEnv).toEqual(paymentEnvSchema.parse({}));
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for payments env fallback and warning

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Error A `require()` style import is forbidden...)
- `pnpm --filter "@acme/config" test` (fails: 2 failed, 2 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b0c1077164832f9311a21a78b4f805