### PR TITLE
chore(cms): exclude tests from tsconfig

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -175,7 +175,10 @@
     "../../packages/**/__tests__/**",
     "../../test",
     "**/__mocks__/**",
-    "**/*.stories.*"
+    "**/*.stories.*",
+    "**/__tests__/**",
+    "**/*.test.*",
+    "**/*.spec.*"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
- ignore test files in CMS TypeScript config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot read file 'apps/shop-bcd/node_modules/tsconfig.base.json')*
- `pnpm run build:trace`

------
https://chatgpt.com/codex/tasks/task_e_68b0c4d92324832f81945458c615bb3f