### PR TITLE
test: verify msw handlers

### DIFF
--- a/test/unit/mswHandlers.test.ts
+++ b/test/unit/mswHandlers.test.ts
@@ -1,0 +1,57 @@
+import { server } from "../msw/server";
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("msw handlers", () => {
+  test("POST /cms/api/configurator", async () => {
+    const res = await fetch("http://localhost/cms/api/configurator", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true, message: "default handler: OK" });
+  });
+
+  test("GET /cms/api/configurator/validate-env/:shop", async () => {
+    const res = await fetch(
+      "http://localhost/cms/api/configurator/validate-env/my-shop"
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true });
+  });
+
+  test("GET /cms/api/page-templates", async () => {
+    const res = await fetch("http://localhost/cms/api/page-templates");
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+  });
+
+  test("GET /cms/api/wizard-progress", async () => {
+    const res = await fetch("http://localhost/cms/api/wizard-progress");
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ state: {}, completed: {} });
+  });
+
+  test("PUT /cms/api/wizard-progress", async () => {
+    const res = await fetch("http://localhost/cms/api/wizard-progress", {
+      method: "PUT",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({});
+  });
+
+  test("PATCH /cms/api/wizard-progress", async () => {
+    const res = await fetch("http://localhost/cms/api/wizard-progress", {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering default MSW handlers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: require() style import is forbidden)*
- `pnpm test` *(fails: @acme/theme test suite failed)*
- `pnpm test:cms test/unit/mswHandlers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1095f78832fb5bcfd07ec247cb8