### PR TITLE
fix: resolve tailwind-config eslint parsing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,19 @@ export default [
     },
   },
 
+  /* ▸ tailwind-config package linting without TS project */
+  {
+    files: ["packages/tailwind-config/**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: null,
+        projectService: false,
+        allowDefaultProject: true,
+      },
+    },
+  },
+
   /* ▸ i18n package linting without TS project */
   {
     files: ["packages/i18n/**/*.{ts,tsx,js,jsx}"],

--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -7,7 +7,6 @@ type Config = Record<string, unknown>;
 /* ------------------------------------------------------------
  *  Runtime diagnostics — confirm the preset really loads
  * ------------------------------------------------------------ */
-// eslint-disable-next-line no-console
 console.log(
   `[@acme/tailwind-config] ✅  preset imported (cwd: ${process.cwd()})`
 );
@@ -62,14 +61,16 @@ const preset: Config = {
 };
 
 // Additional diagnostics
-// eslint-disable-next-line no-console
 console.log("[@acme/tailwind-config] preset keys", Object.keys(preset));
-// eslint-disable-next-line no-console
+const presetWithNested = preset as {
+  plugins?: unknown;
+  presets?: unknown;
+};
 console.log(
   "[@acme/tailwind-config] has nested",
   {
-    plugins: Array.isArray((preset as any).plugins),
-    presets: Array.isArray((preset as any).presets),
+    plugins: Array.isArray(presetWithNested.plugins),
+    presets: Array.isArray(presetWithNested.presets),
   }
 );
 

--- a/packages/tailwind-config/tsconfig.test.json
+++ b/packages/tailwind-config/tsconfig.test.json
@@ -4,8 +4,9 @@
     "types": ["@testing-library/jest-dom", "jest", "node"],
     "noEmit": true,
     "module": "esnext",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "rootDir": "."
   },
-  "include": ["src/**/*"],
-  "exclude": ["__tests__"]
+  "include": ["src/**/*", "__tests__/**/*", "dist/**/*.d.ts"],
+  "exclude": [".turbo", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add flat config override to lint tailwind-config without TypeScript project
- include tests and dist types in tailwind-config tsconfig for linting
- drop unnecessary any casts in Tailwind preset diagnostics

## Testing
- `pnpm exec eslint "packages/tailwind-config/**/*.{ts,tsx,js,jsx}"`
- `pnpm exec jest packages/tailwind-config/__tests__/preset.test.ts`
- `pnpm -r build` *(fails: TypeScript project references are not fully supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c8e8b96c832fbed7ed6d70805875