### PR TITLE
fix tailwind-config ESLint parsing errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,19 @@ export default [
     },
   },
 
+  /* ▸ tailwind-config package linting without TS project */
+  {
+    files: ["packages/tailwind-config/**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: null,
+        projectService: false,
+        allowDefaultProject: true,
+      },
+    },
+  },
+
   /* ▸ Scripts directory override */
   {
     files: ["scripts/**/*.{ts,tsx,js,jsx}"],

--- a/packages/tailwind-config/tsconfig.test.json
+++ b/packages/tailwind-config/tsconfig.test.json
@@ -4,8 +4,9 @@
     "types": ["@testing-library/jest-dom", "jest", "node"],
     "noEmit": true,
     "module": "esnext",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "rootDir": "."
   },
-  "include": ["src/**/*"],
-  "exclude": ["__tests__"]
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": ["dist", ".turbo", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- include test files in tailwind-config tsconfig and adjust rootDir
- lint tailwind-config package without a TypeScript project

## Testing
- `pnpm install`
- `pnpm --filter @acme/tailwind-config build`
- `pnpm exec eslint "packages/tailwind-config/**/*.{ts,tsx,js,jsx}"`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc078588832f8ae900062c73a769