### PR TITLE
fix: ignore dist declaration files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,6 +124,19 @@ export default [
     },
   },
 
+  /* ▸ Allow generated declaration files without a TS project */
+  {
+    files: ["**/dist/**/*.d.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: null,
+        projectService: false,
+        allowDefaultProject: true,
+      },
+    },
+  },
+
   /* ▸ Scripts directory override */
   {
     files: ["scripts/**/*.{ts,tsx,js,jsx}"],


### PR DESCRIPTION
## Summary
- configure ESLint to treat generated `.d.ts` in dist directories without requiring a tsconfig

## Testing
- `pnpm exec eslint "apps/api/**/*.{ts,tsx,js,jsx}" -f json`
- `pnpm -r build` *(fails: apps/cms build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cf1c0650832faa3d2e0c8d5c0b1b