### PR TITLE
chore: include dashboard in tsconfig

### DIFF
--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@acme/config/tsconfig.app.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "../..",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@acme/types": ["../../packages/types/src/index.ts"],
+      "@acme/types/*": ["../../packages/types/src/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    { "path": "../../packages/types" }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./packages/types" },
     { "path": "./tsconfig.packages.json" },
     { "path": "./apps/cms" },
+    { "path": "./apps/dashboard" },
     { "path": "./apps/shop-bcd" },
     { "path": "./apps/api" },
     { "path": "packages/platform-core" },


### PR DESCRIPTION
## Summary
- add tsconfig for dashboard app
- register dashboard project in root tsconfig references

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build: Failed)*
- `pnpm exec eslint "apps/dashboard/**/*.{ts,tsx,js,jsx}"`


------
https://chatgpt.com/codex/tasks/task_e_68b0d08404d8832f95ea89fe428c07e6