### PR TITLE
fix headers iteration for csv upload route

### DIFF
--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -29,7 +29,10 @@ export async function POST(
     await mkdir(dir, { recursive: true });
     const filePath = path.join(dir, "products.csv");
 
-    const headers = Object.fromEntries<string>(req.headers.entries());
+    const headers: Record<string, string> = {};
+    req.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
     const busboy = Busboy({
       headers,
       limits: { fileSize: MAX_SIZE, files: 1 },


### PR DESCRIPTION
## Summary
- handle request headers without relying on `Headers.entries`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Parsing error files not found by project service)*
- `npx tsc -b apps/cms`
- `pnpm --filter @apps/cms test` *(fails: 3 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b15e320694832f8e93351e1a1efd2f