### PR TITLE
Include template-app middleware in tsconfig

### DIFF
--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -65,6 +65,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "middleware.ts",
     "src/**/*",
     "src/**/*.json",
     ".next/types/**/*.ts"


### PR DESCRIPTION
## Summary
- include middleware file in template-app tsconfig so eslint can locate it

## Testing
- `pnpm install`
- `pnpm -r build` (fails: apps/cms build: Failed)
- `pnpm eslint packages/template-app/middleware.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b16802d504832fb98ed1b8f7cc31b9