### PR TITLE
refactor: address template-app lint errors

### DIFF
--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
   try {
     const sub = await stripe.subscriptions.update(user.stripeSubscriptionId, {
       items: [{ price: priceId }],
-      // @ts-ignore - `prorate` is deprecated but required for this flow
+      // @ts-expect-error - `prorate` is deprecated but required for this flow
       prorate: true,
     });
     await setStripeSubscriptionId(userId, sub.id, shopId);

--- a/packages/template-app/src/app/[lang]/checkout/page.tsx
+++ b/packages/template-app/src/app/[lang]/checkout/page.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // packages/template-app/src/app/[lang]/checkout/page.tsx
 import CheckoutForm from "@/components/checkout/CheckoutForm";
 import OrderSummary from "@/components/organisms/OrderSummary";

--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -1,6 +1,5 @@
-// @ts-nocheck
 // packages/template-app/src/app/[lang]/subscribe/page.tsx
-import { Locale, resolveLocale } from "@i18n/locales";
+import { resolveLocale } from "@i18n/locales";
 import { stripe } from "@acme/stripe";
 import { coreEnv } from "@acme/config/env/core";
 import { readShop } from "@platform-core/repositories/shops.server";
@@ -16,8 +15,8 @@ export default async function SubscribePage({
 }: {
   params: Promise<{ lang?: string }>;
 }) {
-  const { lang: rawLang } = await params;
-  const lang: Locale = resolveLocale(rawLang);
+  const { lang } = await params;
+  resolveLocale(lang);
   const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
   const shop = await readShop(shopId);
   if (!shop.subscriptionsEnabled) return notFound();
@@ -32,7 +31,7 @@ export default async function SubscribePage({
     const sub = await stripe.subscriptions.create({
       customer: session.customerId,
       items: [{ price: priceId }],
-      // `prorate` is deprecated but required for this flow
+      // @ts-expect-error - `prorate` is deprecated but required for this flow
       prorate: true,
       metadata: { userId: session.customerId, shop: shopId },
     });


### PR DESCRIPTION
## Summary
- remove @ts-nocheck usages in checkout and subscribe pages
- switch deprecated `prorate` usage to `@ts-expect-error`
- validate locale params without unused variables

## Testing
- `pnpm -r build` *(fails: apps/cms build: Failed)*
- `pnpm --filter=@acme/template-app build`
- `pnpm lint --filter=@acme/template-app`
- `pnpm test --filter=@acme/template-app`


------
https://chatgpt.com/codex/tasks/task_e_68b167c1ed6c832fa99b09e176c1505e