### PR TITLE
chore: exclude build output from linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,14 +51,15 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: [
-          "./tsconfig.json",
-          "./tsconfig.test.json",
-          "./apps/*/tsconfig.json",
-          "./apps/*/tsconfig.test.json",
-          "./packages/*/tsconfig.json",
-          "./packages/*/tsconfig.test.json",
-        ],
+          project: [
+            "./tsconfig.json",
+            "./tsconfig.test.json",
+            "./apps/*/tsconfig.json",
+            "./apps/*/tsconfig.test.json",
+            "./packages/*/tsconfig.json",
+            "./packages/*/tsconfig.eslint.json",
+            "./packages/*/tsconfig.test.json",
+          ],
         projectService: true,
         allowDefaultProject: true,
         sourceType: "module",

--- a/packages/template-app/tsconfig.eslint.json
+++ b/packages/template-app/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", ".next"]
+}


### PR DESCRIPTION
## Summary
- ignore package-specific lint tsconfigs for generated build output
- add template app eslint tsconfig excluding `.next`

## Testing
- `pnpm eslint packages/template-app/src/app/upgrade-preview/page.tsx && echo 'Lint OK'`
- `pnpm -r build` *(fails: apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b168055734832f8f44f424b9d8be8c