### PR TITLE
chore(eslint): ignore test folders

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,8 +31,11 @@ export default [
       "apps/*/src/**/*.d.ts",
       "apps/*/src/**/*.js.map",
       "scripts/**/*.js",
+      "**/__tests__/**",
       "**/*.d.ts",
     ],
+  },
+  {
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
@@ -182,7 +185,7 @@ export default [
 
   /* ▸ Test files relaxations */
   {
-    files: ["**/__tests__/**/*.{ts,tsx,js,jsx}", "**/*.test.{ts,tsx,js,jsx}"],
+    files: ["**/*.test.{ts,tsx,js,jsx}"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": "off",


### PR DESCRIPTION
## Summary
- ignore `__tests__` folders and declaration files in ESLint
- drop `__tests__` from test-specific config

## Testing
- `pnpm exec eslint "packages/zod-utils/**/*.{ts,tsx,js,jsx}"`
- `pnpm -r build` *(fails: packages/template-app build: Type error: Type 'MemoExoticComponent...' is not assignable to type 'ComponentType')*

------
https://chatgpt.com/codex/tasks/task_e_68b16cabd69c832f9b6cc67ba741aff5