### PR TITLE
refactor: tighten types in rental and checkout endpoints

### DIFF
--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const shopInfo = await readShop(shop);
 
   const coverageCodes = Array.isArray(coverage) ? coverage : [];
-  let lineItemsExtra: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
+  const lineItemsExtra: Stripe.Checkout.SessionCreateParams.LineItem[] = [];
   let metadataExtra: Record<string, string> = {};
   let subtotalExtra = 0;
   let depositAdjustment = 0;

--- a/packages/template-app/src/api/rental/route.ts
+++ b/packages/template-app/src/api/rental/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
       ]);
     for (const { sku, from, to } of orderItems) {
       const skuInfo = products.find(
-        (p: any) => p.id === sku || p.slug === sku || p.sku === sku,
+        (p: SKU) => p.id === sku || p.slug === sku || p.sku === sku,
       );
       if (!skuInfo) continue;
       const items = inventory.filter((i) => i.sku === sku);


### PR DESCRIPTION
## Summary
- use const for Stripe checkout extra line items
- tighten SKU typing in rental route

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Type error in DynamicRenderer.tsx)
- `pnpm exec eslint packages/template-app/src/api/checkout-session/route.ts packages/template-app/src/api/rental/route.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b16ee02488832fbb17596f29dda531