### PR TITLE
chore(eslint): ignore test files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,9 @@ export default [
       "scripts/**/*.js",
       "**/__tests__/**",
       "**/*.d.ts",
+      "**/jest.setup.{ts,tsx}",
+      "**/*.test.{ts,tsx,js,jsx}",
+      "**/*.spec.{ts,tsx,js,jsx}",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- exclude Jest setup and test/spec files from eslint scanning

## Testing
- `pnpm exec eslint "apps/cms/**/*.{ts,tsx,js,jsx}"`
- `pnpm test` *(fails: @acme/theme#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b16f80df54832f90b6fc6a0e7891e1