### PR TITLE
chore: include plugin packages in tsconfig

### DIFF
--- a/packages/plugins/paypal/tsconfig.json
+++ b/packages/plugins/paypal/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": ".",
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/premier-shipping/tsconfig.json
+++ b/packages/plugins/premier-shipping/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": ".",
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["dist", "node_modules", "__tests__"]
+}

--- a/packages/plugins/sanity/index.ts
+++ b/packages/plugins/sanity/index.ts
@@ -53,7 +53,7 @@ export async function query<T>(config: SanityConfig, q: string): Promise<T> {
 }
 
 interface MutateBody {
-  mutations: Mutation<Record<string, any>>[];
+  mutations: Mutation<Record<string, unknown>>[];
   returnIds?: boolean;
 }
 

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -32,6 +32,9 @@
     { "path": "packages/theme" },
     { "path": "packages/configurator" },
     { "path": "packages/telemetry" },
+    { "path": "packages/plugins/paypal" },
+    { "path": "packages/plugins/premier-shipping" },
+    { "path": "packages/plugins/sanity" },
     { "path": "src" }
   ]
 }


### PR DESCRIPTION
## Summary
- include paypal and premier shipping plugins in TypeScript project
- fix explicit `any` in Sanity plugin

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'sku' does not exist on type)*
- `pnpm exec eslint "packages/plugins/**/*.{ts,tsx,js,jsx}" --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b1710988f4832fab4050a8f0baa8a3