### PR TITLE
fix: address template-app TypeScript issues

### DIFF
--- a/packages/template-app/src/api/rental/route.ts
+++ b/packages/template-app/src/api/rental/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
       ]);
     for (const { sku, from, to } of orderItems) {
       const skuInfo = products.find(
-        (p: SKU) => p.id === sku || p.slug === sku || p.sku === sku,
+        (p: SKU) => p.id === sku || p.slug === sku,
       );
       if (!skuInfo) continue;
       const items = inventory.filter((i) => i.sku === sku);

--- a/packages/template-app/src/components/DynamicRenderer.tsx
+++ b/packages/template-app/src/components/DynamicRenderer.tsx
@@ -48,7 +48,7 @@ const registry: Partial<
   HeroBanner,
   ValueProps,
   ReviewsCarousel,
-  ProductGrid,
+  ProductGrid: (ProductGrid as unknown as React.ComponentType<Record<string, unknown>>),
   Gallery,
   ContactForm,
   ContactFormWithMap,

--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -1,6 +1,13 @@
 import { LOCALES, type Locale } from "@i18n/locales";
 import type { ShopSettings } from "@acme/types";
-import type { LinkTag, NextSeoProps } from "next-seo";
+import type { NextSeoProps } from "next-seo";
+
+/** Minimal representation of a link tag for Next SEO */
+type LinkTag = {
+  rel: string;
+  href: string;
+  hrefLang?: string;
+};
 import { coreEnv } from "@acme/config/env/core";
 
 interface OpenGraphImageProps {


### PR DESCRIPTION
## Summary
- cast ProductGrid to generic component for dynamic registry
- remove unused SKU field check in rental API
- replace missing LinkTag type with local interface

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: route.test.ts was not found by the project service)*

------
https://chatgpt.com/codex/tasks/task_e_68b1707870d0832fa02d7918e09320fc