### PR TITLE
refactor: remove explicit any from platform-core

### DIFF
--- a/packages/platform-core/src/plugins/PluginManager.ts
+++ b/packages/platform-core/src/plugins/PluginManager.ts
@@ -31,12 +31,18 @@ class MapRegistry<T> {
 }
 
 export interface PluginMetadata<
-  T extends Plugin<any, any, any, any, any, any, any> = Plugin,
+  C extends Record<string, unknown> = Record<string, unknown>,
+  PPay extends PaymentPayload = PaymentPayload,
+  SReq extends ShippingRequest = ShippingRequest,
+  WProp extends WidgetProps = WidgetProps,
+  P extends PaymentProvider<PPay> = PaymentProvider<PPay>,
+  S extends ShippingProvider<SReq> = ShippingProvider<SReq>,
+  W extends WidgetComponent<WProp> = WidgetComponent<WProp>,
 > {
   id: string;
   name?: string;
   description?: string;
-  plugin: T;
+  plugin: Plugin<C, PPay, SReq, WProp, P, S, W>;
 }
 
 export class PluginManager<
@@ -52,7 +58,7 @@ export class PluginManager<
   readonly widgets = new MapRegistry<W>();
   private plugins = new Map<
     string,
-    PluginMetadata<Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>>
+    PluginMetadata<Record<string, unknown>, PPay, SReq, WProp, P, S, W>
   >();
 
   addPlugin<C extends Record<string, unknown>>(
@@ -62,30 +68,26 @@ export class PluginManager<
       id: plugin.id,
       name: plugin.name,
       description: plugin.description,
-      plugin: plugin as unknown as Plugin<
-        Record<string, unknown>,
-        PPay,
-        SReq,
-        WProp,
-        P,
-        S,
-        W
-      >,
+      plugin,
     });
   }
 
   getPlugin(
     id: string,
   ):
-    | PluginMetadata<
-        Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>
-      >
+    | PluginMetadata<Record<string, unknown>, PPay, SReq, WProp, P, S, W>
     | undefined {
     return this.plugins.get(id);
   }
 
   listPlugins(): PluginMetadata<
-    Plugin<Record<string, unknown>, PPay, SReq, WProp, P, S, W>
+    Record<string, unknown>,
+    PPay,
+    SReq,
+    WProp,
+    P,
+    S,
+    W
   >[] {
     return Array.from(this.plugins.values());
   }

--- a/packages/platform-core/src/products.ts
+++ b/packages/platform-core/src/products.ts
@@ -1,19 +1,23 @@
 // Compat facade for product lookups used by both UI and server.
 /* Broad types on purpose; tighten when real models land. */
-export type SKU = any;
-export type Locale = any;
-export type ProductPublication = any;
+export type { Locale, ProductPublication } from "@acme/types";
 
 // Pull in the real product dataset and helpers. This keeps existing imports
 // like `@platform-core/products` working while ensuring the in-memory list
 // actually contains catalogue data.
+import type { SKU as BaseSKU } from "@acme/types";
 import * as base from "./products/index";
 
+/**
+ * Compatibility SKU type that allows optional `sku` field for legacy access.
+ */
+export type SKU = BaseSKU & { sku?: string };
+
 /** Simple in-memory list for legacy/sync call sites (stories, demos, cart sync path). */
-export const PRODUCTS: any[] = [...base.PRODUCTS];
+export const PRODUCTS: SKU[] = [...base.PRODUCTS];
 
 /** Quick slug lookup for demos. */
-export function getProductBySlug(slug: string): any | null {
+export function getProductBySlug(slug: string): SKU | null {
   return base.getProductBySlug(slug) ?? null;
 }
 
@@ -21,9 +25,12 @@ export function getProductBySlug(slug: string): any | null {
  *  - getProductById(id)            -> sync (legacy) from PRODUCTS
  *  - getProductById(shop, id)      -> async via server impl
  */
-export function getProductById(id: string): any | null;
-export function getProductById(shop: string, id: string): Promise<any | null>;
-export function getProductById(a: string, b?: string): any {
+export function getProductById(id: string): SKU | null;
+export function getProductById(shop: string, id: string): Promise<SKU | null>;
+export function getProductById(
+  a: string,
+  b?: string,
+): SKU | null | Promise<SKU | null> {
   if (typeof b === "undefined") {
     // Legacy sync path: look up in local PRODUCTS
     return base.getProductById(a) ?? null;
@@ -37,9 +44,9 @@ export function getProductById(a: string, b?: string): any {
 
 export { assertLocale } from "./products/index";
 
-export async function getProducts(..._args: any[]): Promise<any[]> {
+export async function getProducts(..._args: unknown[]): Promise<SKU[]> {
   return [...base.PRODUCTS];
 }
-export async function searchProducts(..._args: any[]): Promise<any[]> {
+export async function searchProducts(..._args: unknown[]): Promise<SKU[]> {
   return [];
 }


### PR DESCRIPTION
## Summary
- tighten PluginMetadata typing and clean plugin registry plumbing
- replace loose product facades with typed SKU helpers

## Testing
- `pnpm -r build` *(fails: Property 'sku' does not exist on type)*
- `pnpm --filter @acme/platform-core build`


------
https://chatgpt.com/codex/tasks/task_e_68b171542508832f890b4cc5a1b2b831