### PR TITLE
refactor: fix prisma stub typing

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,32 +1,53 @@
-/// <reference path="./prisma.d.ts" />
+import "./prisma";
 import { coreEnv } from "@acme/config/env/core";
 import type { PrismaClient } from "@prisma/client";
 
-let prisma: PrismaClient;
+type RentalOrderStub = {
+  shop?: string;
+  customerId?: string;
+  sessionId?: string;
+  trackingNumber?: string;
+  [key: string]: unknown;
+};
 
-if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
-  // In tests (or when no database URL is provided) fall back to an in-memory stub
-  const rentalOrders: any[] = [];
-  prisma = {
+type FindManyArgs = {
+  where?: { shop?: string; customerId?: string };
+};
+
+type UpdateArgs = {
+  where:
+    | { shop_sessionId: { shop: string; sessionId: string } }
+    | { shop_trackingNumber: { shop: string; trackingNumber: string } };
+  data: Partial<RentalOrderStub>;
+};
+
+type CreateArgs = {
+  data: RentalOrderStub;
+};
+
+function createStubPrisma(): PrismaClient {
+  const rentalOrders: RentalOrderStub[] = [];
+
+  return {
     rentalOrder: {
-      findMany: async ({ where }: any) =>
+      findMany: async ({ where }: FindManyArgs) =>
         rentalOrders.filter((o) => {
           if (where?.shop && o.shop !== where.shop) return false;
           if (where?.customerId && o.customerId !== where.customerId) return false;
           return true;
         }),
-      create: async ({ data }: any) => {
+      create: async ({ data }: CreateArgs) => {
         rentalOrders.push({ ...data });
         return data;
       },
-      update: async ({ where, data }: any) => {
-        let order;
-        if (where?.shop_sessionId) {
+      update: async ({ where, data }: UpdateArgs) => {
+        let order: RentalOrderStub | undefined;
+        if ("shop_sessionId" in where) {
           const { shop, sessionId } = where.shop_sessionId;
           order = rentalOrders.find(
             (o) => o.shop === shop && o.sessionId === sessionId,
           );
-        } else if (where?.shop_trackingNumber) {
+        } else {
           const { shop, trackingNumber } = where.shop_trackingNumber;
           order = rentalOrders.find(
             (o) => o.shop === shop && o.trackingNumber === trackingNumber,
@@ -38,54 +59,26 @@ if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
       },
     },
     shop: {
-      findUnique: async () => ({ data: {} }),
+      findUnique: async () => ({ data: {} as Record<string, unknown> }),
     },
   } as unknown as PrismaClient;
+}
+
+let prisma: PrismaClient;
+
+if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
+  // In tests (or when no database URL is provided) fall back to an in-memory stub
+  prisma = createStubPrisma();
 } else {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { PrismaClient } = require("@prisma/client") as typeof import("@prisma/client");
+    const { PrismaClient: RealPrismaClient } = await import("@prisma/client");
     const databaseUrl = coreEnv.DATABASE_URL;
-    prisma = new PrismaClient({
+    prisma = new RealPrismaClient({
       datasources: { db: { url: databaseUrl } },
     });
   } catch {
     // If Prisma client cannot be loaded, fall back to the in-memory stub
-    const rentalOrders: any[] = [];
-    prisma = {
-      rentalOrder: {
-        findMany: async ({ where }: any) =>
-          rentalOrders.filter((o) => {
-            if (where?.shop && o.shop !== where.shop) return false;
-            if (where?.customerId && o.customerId !== where.customerId) return false;
-            return true;
-          }),
-        create: async ({ data }: any) => {
-          rentalOrders.push({ ...data });
-          return data;
-        },
-        update: async ({ where, data }: any) => {
-          let order;
-          if (where?.shop_sessionId) {
-            const { shop, sessionId } = where.shop_sessionId;
-            order = rentalOrders.find(
-              (o) => o.shop === shop && o.sessionId === sessionId,
-            );
-          } else if (where?.shop_trackingNumber) {
-            const { shop, trackingNumber } = where.shop_trackingNumber;
-            order = rentalOrders.find(
-              (o) => o.shop === shop && o.trackingNumber === trackingNumber,
-            );
-          }
-          if (!order) throw new Error("Order not found");
-          Object.assign(order, data);
-          return order;
-        },
-      },
-      shop: {
-        findUnique: async () => ({ data: {} }),
-      },
-    } as unknown as PrismaClient;
+    prisma = createStubPrisma();
   }
 }
 

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -11,7 +11,7 @@ import { incrementSubscriptionUsage } from "./subscriptionUsage";
 type Order = RentalOrder;
 
 function normalize(order: DbRentalOrder): Order {
-  const o: any = { ...order };
+  const o: Record<string, unknown> = { ...order };
   Object.keys(o).forEach((k) => {
     if (o[k] === null) o[k] = undefined;
   });


### PR DESCRIPTION
## Summary
- replace Prisma triple-slash reference with module import
- add typed in-memory Prisma stub and use dynamic import for real client
- remove `any` usage in `normalize`

## Testing
- `pnpm exec eslint packages/platform-core/src/db.ts packages-platform-core/src/orders.ts && echo 'Lint passed'`
- `pnpm -r build` *(fails: Property 'sku' does not exist on type ...)*
- `pnpm test` *(fails: ERROR run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68b17163ab14832fa6203af6f6845466