### PR TITLE
fix: resolve eslint parse errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,6 +128,22 @@ export default [
     },
   },
 
+  /* ▸ platform-core root files without TS project */
+  {
+    files: [
+      "packages/platform-core/defaultFilterMappings.ts",
+      "packages/platform-core/prisma/**/*.{ts,tsx,js,jsx}",
+    ],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: null,
+        projectService: false,
+        allowDefaultProject: true,
+      },
+    },
+  },
+
   /* ▸ Allow generated declaration files without a TS project */
   {
     files: ["**/dist/**/*.d.ts"],

--- a/packages/platform-core/src/analytics/index.ts
+++ b/packages/platform-core/src/analytics/index.ts
@@ -15,13 +15,11 @@ export interface AnalyticsProvider {
 }
 
 class NoopProvider implements AnalyticsProvider {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async track(_event: AnalyticsEvent): Promise<void> {}
 }
 
 class ConsoleProvider implements AnalyticsProvider {
   async track(event: AnalyticsEvent): Promise<void> {
-    // eslint-disable-next-line no-console
     console.log("analytics", event);
   }
 }
@@ -45,7 +43,8 @@ class GoogleAnalyticsProvider implements AnalyticsProvider {
   constructor(private measurementId: string, private apiSecret: string) {}
 
   async track(event: AnalyticsEvent): Promise<void> {
-    const { type, timestamp, ...params } = event;
+    const { type, ...params } = event;
+    delete (params as { timestamp?: string }).timestamp;
     const url =
       "https://www.google-analytics.com/mp/collect?measurement_id=" +
       encodeURIComponent(this.measurementId) +


### PR DESCRIPTION
## Summary
- allow linting platform-core root files without tsconfig
- omit unused timestamp in analytics

## Testing
- `pnpm --filter @acme/platform-core build`
- `pnpm exec eslint packages/platform-core/src/analytics/index.ts packages/platform-core/defaultFilterMappings.ts packages/platform-core/prisma/seed.ts`
- `pnpm test --filter @acme/platform-core`


------
https://chatgpt.com/codex/tasks/task_e_68b171875178832fad272655c8ded421