### PR TITLE
Use next/image for MFA QR code

### DIFF
--- a/packages/ui/src/components/account/MfaSetup.tsx
+++ b/packages/ui/src/components/account/MfaSetup.tsx
@@ -2,6 +2,7 @@
 
 // packages/ui/src/components/account/MfaSetup.tsx
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import QRCode from "qrcode";
 import { getCsrfToken } from "@acme/shared-utils";
 
@@ -62,7 +63,14 @@ export default function MfaSetup() {
       {secret && (
         <div>
           {qrCode && (
-            <img src={qrCode} alt="MFA QR Code" className="mb-2" />
+            <Image
+              src={qrCode}
+              alt="MFA QR Code"
+              className="mb-2"
+              width={256}
+              height={256}
+              unoptimized
+            />
           )}
           <p className="mb-2">Secret: {secret}</p>
           <form onSubmit={verify} className="space-y-2">


### PR DESCRIPTION
## Summary
- use Next.js Image component for MFA setup QR code to satisfy lint rule

## Testing
- `pnpm exec eslint packages/ui/src/components/account/MfaSetup.tsx -f json`
- `pnpm -r build` *(fails: Property 'sku' does not exist on type ... in packages/template-app)*
- `pnpm --filter @acme/ui test` *(fails: inventory import/export routes imports inventory from json timeout)*
- `pnpm --filter @acme/ui exec jest src/components/account/MfaChallenge.test.tsx --runTestsByPath --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b171d0dfb8832fa03ab3c761004aae