### PR TITLE
fix: include types index in tsconfig

### DIFF
--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "noEmit": false,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "module": "ESNext",
     "moduleResolution": "Bundler",
@@ -15,6 +15,7 @@
     "skipLibCheck": true
   },
   "include": [
+    "index.ts",
     "src/**/*",
     "src/**/*.json"
   ]


### PR DESCRIPTION
## Summary
- include root index file in types package tsconfig
- set rootDir to project root so the index is recognized

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'sku' does not exist on type in packages/template-app)*

------
https://chatgpt.com/codex/tasks/task_e_68b171b25c84832f8e47925958e8c2aa