### PR TITLE
fix: remove disallowed accordion export

### DIFF
--- a/packages/ui/src/components/atoms/shadcn/index.d.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.d.ts
@@ -6,5 +6,4 @@ export { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSepa
 export { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";
 //# sourceMappingURL=index.d.ts.map

--- a/packages/ui/src/components/atoms/shadcn/index.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.ts
@@ -32,4 +32,3 @@ export {
 } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";


### PR DESCRIPTION
## Summary
- remove Accordion re-export from atoms to satisfy path restrictions

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Property 'sku' does not exist on type)


------
https://chatgpt.com/codex/tasks/task_e_68b171ea36fc832fbb94fab56474a917