### PR TITLE
chore: ignore test files in lint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,8 @@ module.exports = {
     "**/.next/**", // Next.js build output
     "**/index.js",
     "**/*.d.ts",
+    "**/*.test.*",
+    "**/*.spec.*",
   ],
   overrides: [
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,8 @@ export default [
       "apps/*/src/**/*.js.map",
       "scripts/**/*.js",
       "**/__tests__/**",
+      "**/*.test.*",
+      "**/*.spec.*",
       "**/*.d.ts",
     ],
   },
@@ -184,13 +186,6 @@ export default [
   },
 
   /* ▸ Test files relaxations */
-  {
-    files: ["**/*.test.{ts,tsx,js,jsx}"],
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-    },
-  },
 
   /* ▸ Enforce UI component layering */
   {


### PR DESCRIPTION
## Summary
- ignore `.test` and `.spec` files in ESLint configs to prevent parser errors

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b172063114832faa379f42aef2fc1b