### PR TITLE
refactor: replace any types in CMS blocks

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductCarousel.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductCarousel.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import ProductCarousel from "./ProductCarousel";
 import { PRODUCTS } from "@acme/platform-core/products";
+import type { SKU } from "@acme/types";
 
 const meta: Meta<typeof ProductCarousel> = {
   component: ProductCarousel,
-  args: { skus: PRODUCTS as any },
+  args: { skus: PRODUCTS as SKU[] },
 };
 export default meta;
 

--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -7,6 +7,7 @@ import React, {
   type JSXElementConstructor,
   type JSX as ReactJSX,
 } from "react";
+import NextImage, { type ImageProps as NextImageProps } from "next/image";
 import type { BlockRegistryEntry } from "./types";
 import Divider from "./Divider";
 import Spacer from "./Spacer";
@@ -23,7 +24,7 @@ const defaultPreview = "/window.svg";
 type IntrinsicTag = keyof ReactJSX.IntrinsicElements & string;
 
 /** Everything React can legally mount: intrinsic tag *or* React component. */
-export type ValidComponent = IntrinsicTag | JSXElementConstructor<any>;
+export type ValidComponent = IntrinsicTag | JSXElementConstructor<unknown>;
 
 /* ──────────────────────────────────────────────────────────────────────────
  * <Text>
@@ -61,10 +62,7 @@ export function Text<C extends React.ElementType = "p">({
  * <Image>
  * --------------------------------------------------------------------------*/
 export interface ImageProps
-  extends Omit<
-    React.ImgHTMLAttributes<HTMLImageElement>,
-    "src" | "alt" | "width" | "height"
-  > {
+  extends Omit<NextImageProps, "src" | "alt" | "width" | "height"> {
   src: string;
   alt?: string;
   width?: number;
@@ -79,7 +77,15 @@ export const Image = memo(function Image({
   ...rest
 }: ImageProps) {
   if (!src) return null;
-  return <img src={src} alt={alt} width={width} height={height} {...rest} />;
+  return (
+    <NextImage
+      src={src}
+      alt={alt}
+      width={width ?? 0}
+      height={height ?? 0}
+      {...rest}
+    />
+  );
 });
 
 /* ──────────────────────────────────────────────────────────────────────────
@@ -95,7 +101,7 @@ const atomEntries = {
 } as const;
 
 type AtomRegistry = {
-  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<any>;
+  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<unknown>;
 };
 
 export const atomRegistry: AtomRegistry = Object.entries(atomEntries).reduce(

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -10,7 +10,7 @@ const containerEntries = {
 } as const;
 
 type ContainerRegistry = {
-  -readonly [K in keyof typeof containerEntries]: BlockRegistryEntry<any>;
+  -readonly [K in keyof typeof containerEntries]: BlockRegistryEntry<unknown>;
 };
 
 export const containerRegistry: ContainerRegistry = Object.entries(

--- a/packages/ui/src/components/cms/blocks/index.ts
+++ b/packages/ui/src/components/cms/blocks/index.ts
@@ -113,6 +113,6 @@ export const blockRegistry = {
   ...moleculeRegistry,
   ...organismRegistry,
   ...overlayRegistry,
-} satisfies Record<string, BlockRegistryEntry<any>>;
+} satisfies Record<string, BlockRegistryEntry<unknown>>;
 
 export type BlockType = keyof typeof blockRegistry;

--- a/packages/ui/src/components/cms/blocks/layout.tsx
+++ b/packages/ui/src/components/cms/blocks/layout.tsx
@@ -10,7 +10,7 @@ const layoutEntries = {
 } as const;
 
 type LayoutRegistry = {
-  [K in keyof typeof layoutEntries]: BlockRegistryEntry<any>;
+  [K in keyof typeof layoutEntries]: BlockRegistryEntry<unknown>;
 };
 
 export const layoutRegistry = Object.fromEntries(

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -106,7 +106,7 @@ const moleculeEntries = {
   NewsletterForm: { component: NewsletterForm },
   PromoBanner: { component: PromoBanner },
   CategoryList: { component: CategoryList },
-} satisfies Record<string, BlockRegistryEntry<any>>;
+} satisfies Record<string, BlockRegistryEntry<unknown>>;
 
 export const moleculeRegistry = Object.fromEntries(
   Object.entries(moleculeEntries).map(([k, v]) => [

--- a/packages/ui/src/components/cms/blocks/organisms.tsx
+++ b/packages/ui/src/components/cms/blocks/organisms.tsx
@@ -101,7 +101,7 @@ const organismEntries = {
 } as const;
 
 type OrganismRegistry = {
-  [K in keyof typeof organismEntries]: BlockRegistryEntry<any>;
+  [K in keyof typeof organismEntries]: BlockRegistryEntry<unknown>;
 };
 
 export const organismRegistry = Object.fromEntries(

--- a/packages/ui/src/components/cms/blocks/overlays.tsx
+++ b/packages/ui/src/components/cms/blocks/overlays.tsx
@@ -8,7 +8,7 @@ const overlayEntries = {
 } as const;
 
 type OverlayRegistry = {
-  [K in keyof typeof overlayEntries]: BlockRegistryEntry<any>;
+  [K in keyof typeof overlayEntries]: BlockRegistryEntry<unknown>;
 };
 
 export const overlayRegistry = Object.fromEntries(


### PR DESCRIPTION
## Summary
- replace any casts in ProductCarousel stories with SKU typings
- use Next.js Image component in cms atom and tighten registry typings
- replace any with unknown across CMS block registries

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'sku' does not exist on type)*
- `pnpm lint --filter @acme/ui` *(no tasks in scope)*


------
https://chatgpt.com/codex/tasks/task_e_68b1723359b8832f88b3bb828d01f6e9