### PR TITLE
Use Next.js Image and refine block typing

### DIFF
--- a/packages/ui/src/components/cms/media/UploadPanel.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.tsx
@@ -1,6 +1,7 @@
 // packages/ui/src/components/cms/media/UploadPanel.tsx
 "use client";
 
+import Image from "next/image";
 import { Input } from "../../atoms/shadcn";
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";
@@ -89,9 +90,11 @@ export default function UploadPanel({ shop, onUploaded }: UploadPanelProps): Rea
         {pendingFile && (isVideo || isValid !== null) && (
           <div className="space-y-2">
             {thumbnail && (
-              <img
+              <Image
                 src={thumbnail}
                 alt="preview"
+                width={80}
+                height={80}
                 className="h-20 w-20 rounded object-cover"
               />
             )}

--- a/packages/ui/src/components/cms/page-builder/Block.tsx
+++ b/packages/ui/src/components/cms/page-builder/Block.tsx
@@ -2,8 +2,7 @@
 import type { Locale } from "@acme/i18n/locales";
 import type { PageComponent } from "@acme/types";
 import DOMPurify from "dompurify";
-import { memo } from "react";
-import type { ComponentType } from "react";
+import { memo, type ComponentType } from "react";
 import "./animations.css";
 import { blockRegistry } from "../blocks";
 
@@ -18,13 +17,13 @@ function Block({ component, locale }: { component: PageComponent; locale: Locale
     const sanitized = DOMPurify.sanitize(value);
     return <div dangerouslySetInnerHTML={{ __html: sanitized }} />;
   }
-  const entry = blockRegistry[(component as any).type as keyof typeof blockRegistry];
+  const entry = blockRegistry[component.type as keyof typeof blockRegistry];
   if (!entry) return null;
-  const Comp = entry.component as ComponentType<any>;
+  const Comp = entry.component as ComponentType<Record<string, unknown>>;
 
   const {
-    id,
-    type,
+    id: _id,
+    type: _type,
     clickAction,
     href,
     animation,
@@ -34,6 +33,8 @@ function Block({ component, locale }: { component: PageComponent; locale: Locale
     href?: string;
     animation?: "none" | "fade" | "slide";
   };
+  void _id;
+  void _type;
 
   const compProps: Record<string, unknown> = { ...(props as Record<string, unknown>) };
   if (clickAction === "navigate" && href) compProps.href = href;


### PR DESCRIPTION
## Summary
- replace `<img>` with optimized `<Image>` in UploadPanel
- remove `any` usage and drop unused props in page builder Block component

## Testing
- `pnpm install`
- `pnpm --filter @acme/ui build`
- `npx eslint packages/ui/src/components/cms/media/UploadPanel.tsx packages/ui/src/components/cms/page-builder/Block.tsx`
- `pnpm --filter @acme/ui test` *(fails: inventory import/export routes › imports inventory from json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1723dfe64832fb9df3239cb850abc