### PR TITLE
fix: resolve lints in email package

### DIFF
--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -149,7 +149,10 @@ export class SendgridProvider implements CampaignProvider {
       });
       const json = await res.json().catch(() => ({}));
       const segments = Array.isArray(json?.result) ? json.result : [];
-      return segments.map((s: any) => ({ id: s.id, name: s.name }));
+      return segments.map((s: { id: string; name?: string }) => ({
+        id: s.id,
+        name: s.name,
+      }));
     } catch {
       return [];
     }

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -123,15 +123,8 @@ export async function createCampaign(opts: {
   sendAt?: string;
   templateId?: string | null;
 }): Promise<string> {
-  let {
-    shop,
-    recipients = [],
-    subject,
-    body,
-    segment,
-    sendAt,
-    templateId,
-  } = opts;
+  let { shop, recipients = [] } = opts;
+  const { subject, body, segment, sendAt, templateId } = opts;
   shop = validateShopName(shop);
   if (recipients.length === 0 && segment) {
     const { resolveSegment } = await import("./segments");

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -123,7 +123,7 @@ export async function resolveSegment(
       const email = e.email;
       if (
         (e.type === `segment:${id}` ||
-          (e.type === "segment" && (e as any).segment === id)) &&
+          (e.type === "segment" && (e as { segment?: string }).segment === id)) &&
         typeof email === "string"
       ) {
         emails.add(email);


### PR DESCRIPTION
## Summary
- remove `any` types in email package and use explicit typings
- use `const` for immutable values in `createCampaign`

## Testing
- `pnpm exec eslint packages/email/src/providers/sendgrid.ts packages/email/src/scheduler.ts packages/email/src/segments.ts`
- `pnpm --filter @acme/email test -- --passWithNoTests`
- `pnpm -r build` *(fails: Argument of type '(records: SerializedInventoryItem[]) => void' is not assignable to parameter of type '(...args: unknown[]) => unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68b17b13274c832fb5e3f7e6661c683b