### PR TITLE
refactor: remove any types from generateMeta

### DIFF
--- a/packages/lib/src/generateMeta.ts
+++ b/packages/lib/src/generateMeta.ts
@@ -47,7 +47,7 @@ export async function generateMeta(product: ProductData): Promise<GeneratedMeta>
     return fallback;
   }
 
-  let OpenAI: any;
+  let OpenAI: typeof import("openai").default;
   try {
     OpenAI = (await import("openai")).default;
   } catch {
@@ -71,8 +71,18 @@ export async function generateMeta(product: ProductData): Promise<GeneratedMeta>
   try {
     const first = text.output?.[0];
     if (first && "content" in first) {
-      const output = first.content?.[0];
-      const content = typeof output === "string" ? output : (output as any)?.text;
+      const output: unknown = first.content?.[0];
+      let content: string | undefined;
+      if (typeof output === "string") {
+        content = output;
+      } else if (
+        typeof output === "object" &&
+        output !== null &&
+        "text" in output &&
+        typeof (output as { text?: unknown }).text === "string"
+      ) {
+        content = (output as { text: string }).text;
+      }
       if (content) {
         data = JSON.parse(content);
       }


### PR DESCRIPTION
## Summary
- use typed `OpenAI` client import
- safely parse response content without `any`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: tsc -b)*
- `pnpm -F @acme/lib test` *(fails: inventory import/export routes imports inventory from json)*
- `pnpm eslint packages/lib/src/generateMeta.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b17b00b150832fab23a9d895415210