### PR TITLE
refactor: validate sanity config

### DIFF
--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { createClient } from "@sanity/client";
 import { getSanityConfig } from "@platform-core/shops";
 import { getShopById } from "@platform-core/repositories/shop.server";
-import type { SanityBlogConfig } from "@acme/types";
+import { sanityBlogConfigSchema, type SanityBlogConfig } from "@acme/types";
 import { nowIso } from "@date-utils";
 
 export interface ProductBlock {
@@ -27,7 +27,7 @@ export async function getConfig(shopId: string): Promise<SanityBlogConfig> {
   if (!config) {
     throw new Error(`Missing Sanity credentials for shop ${shopId}`);
   }
-  return config as any;
+  return sanityBlogConfigSchema.parse(config);
 }
 
 async function getClient(shopId: string) {


### PR DESCRIPTION
## Summary
- validate Sanity credentials using exported Zod schema instead of `any`

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Argument of type '(records: SerializedInventoryItem[]) => void' is not assignable to parameter of type '(...args: unknown[]) => unknown')
- `pnpm exec eslint packages/sanity/src/index.ts`
- `pnpm --filter @acme/sanity test` (fails: inventory import/export routes › imports inventory from json)


------
https://chatgpt.com/codex/tasks/task_e_68b17adac8ac832f9625f175ecd814eb