### PR TITLE
chore: allow dynamic prisma require

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -72,8 +72,8 @@ if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
   prisma = createStubPrisma();
 } else {
   try {
-    const { PrismaClient } =
-      require("@prisma/client") as typeof import("@prisma/client");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PrismaClient } = require("@prisma/client") as typeof import("@prisma/client");
 
     const databaseUrl = coreEnv.DATABASE_URL;
     prisma = new PrismaClient({


### PR DESCRIPTION
## Summary
- disable eslint no-require-imports rule for dynamic Prisma client load in platform-core

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Argument of type '(records: SerializedInventoryItem[]) => void' is not assignable to parameter of type '(...args: unknown[]) => unknown')*
- `npx eslint packages/platform-core/src/db.ts`
- `npx jest packages/platform-core/__tests__/rentalOrders.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b17aea8e04832f850769b83663c6e0