### PR TITLE
chore: ignore __mocks__ directories in ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,7 @@ export default [
       "apps/*/src/**/*.js.map",
       "scripts/**/*.js",
       "**/__tests__/**",
+      "**/__mocks__/**",
       "**/*.test.*",
       "**/*.spec.*",
       "**/*.d.ts",


### PR DESCRIPTION
## Summary
- ignore `__mocks__` directories in ESLint config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Argument of type '(records: SerializedInventoryItem[]) => void' is not assignable to parameter of type '(...args: unknown[]) => unknown'.)*
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint:all` *(fails: 32 problems (29 errors, 3 warnings))*
- `pnpm exec eslint packages/email/src/providers` *(fails: sendgrid.ts: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b277ae4832fa46f80db4e2e0f57