### PR TITLE
fix prisma and build issues

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,6 +1,5 @@
 import { coreEnv } from "@acme/config/env/core";
 import type { PrismaClient } from "@prisma/client";
-import "./prisma";
 
 type RentalOrderStub = {
   shop?: string;

--- a/packages/platform-core/src/repositories/inventory.sqlite.server.ts
+++ b/packages/platform-core/src/repositories/inventory.sqlite.server.ts
@@ -96,9 +96,10 @@ async function write(shop: string, items: InventoryItem[]): Promise<void> {
   const insert = db.prepare(
     "REPLACE INTO inventory (sku, productId, variantAttributes, quantity, lowStockThreshold, wearCount, wearAndTearLimit, maintenanceCycle) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
   );
-  const tx = db.transaction((records: SerializedInventoryItem[]) => {
+  const tx = db.transaction((...records: unknown[]) => {
+    const [items] = records as [SerializedInventoryItem[]];
     db.prepare("DELETE FROM inventory").run();
-    for (const item of records) {
+    for (const item of items) {
       insert.run(
         item.sku,
         item.productId,
@@ -110,7 +111,7 @@ async function write(shop: string, items: InventoryItem[]): Promise<void> {
         item.maintenanceCycle ?? null,
       );
     }
-  });
+  }) as (records: SerializedInventoryItem[]) => void;
   tx(normalized);
 }
 

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -40,5 +40,5 @@
     { "path": "../themes/base" },
     { "path": "../zod-utils" }
   ],
-  "files": ["../../src/types/global.d.ts"]
+  "files": ["../../src/types/global.d.ts", "src/prisma.d.ts"]
 }

--- a/packages/template-app/src/app/account/returns/ReturnForm.tsx
+++ b/packages/template-app/src/app/account/returns/ReturnForm.tsx
@@ -30,7 +30,7 @@ export default function ReturnForm({
           videoRef.current.srcObject = stream;
           await videoRef.current.play();
         }
-        const detector = new window.BarcodeDetector({
+        const detector = new (window as any).BarcodeDetector({
           formats: ["qr_code"],
         });
         const scan = async () => {

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -39,7 +39,7 @@ export async function GET(req: NextRequest) {
               price: p.price,
               media: p.media,
               updated_at: new Date(0).toISOString(),
-            }) as ProductPublication
+            }) as unknown as ProductPublication
         );
 
   const lastModifiedDate = all.reduce((max, p) => {
@@ -69,7 +69,7 @@ export async function GET(req: NextRequest) {
   }
 
   const items = paged.map((p) => {
-    const sku: SKU | undefined = getProductById(p.sku);
+    const sku: SKU | null = getProductById(p.sku);
     const item: Record<string, unknown> = {};
     if (fields.includes("id")) item.id = p.id;
     if (fields.includes("title")) item.title = p.title;

--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -52,6 +52,9 @@
       ],
       "@date-utils/*": [
         "../date-utils/src/*"
+      ],
+      "better-sqlite3": [
+        "../platform-core/src/types/better-sqlite3"
       ]
     },
     "allowJs": true,
@@ -72,5 +75,8 @@
   ],
   "exclude": [
     "node_modules"
+  ],
+  "files": [
+    "../platform-core/src/prisma.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- remove runtime prisma stub import and rely on tsconfig for types
- fix sqlite repository transaction typing
- add prisma and better-sqlite3 typings to template app and cast browser APIs
- adjust AI catalog route types

## Testing
- `pnpm -r build` *(fails: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature)*
- `pnpm test` *(fails: @acme/theme:test)*

------
https://chatgpt.com/codex/tasks/task_e_68b17a05cae8832f9004514ef98de2e7