### PR TITLE
fix: adjust inventory transaction parameters

### DIFF
--- a/packages/platform-core/src/repositories/inventory.sqlite.server.ts
+++ b/packages/platform-core/src/repositories/inventory.sqlite.server.ts
@@ -96,7 +96,8 @@ async function write(shop: string, items: InventoryItem[]): Promise<void> {
   const insert = db.prepare(
     "REPLACE INTO inventory (sku, productId, variantAttributes, quantity, lowStockThreshold, wearCount, wearAndTearLimit, maintenanceCycle) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
   );
-  const tx = db.transaction((records: SerializedInventoryItem[]) => {
+  const tx = db.transaction((...args: unknown[]) => {
+    const [records] = args as [SerializedInventoryItem[]];
     db.prepare("DELETE FROM inventory").run();
     for (const item of records) {
       insert.run(


### PR DESCRIPTION
## Summary
- fix TypeScript build error by accepting unknown args in SQLite inventory transaction and casting to typed records

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve './prisma')*
- `pnpm test` *(fails: @acme/theme test suite fails)*

------
https://chatgpt.com/codex/tasks/task_e_68b17c3e567c832f9aa578e89f590211