### PR TITLE
fix: infer generic in loyalty hub story

### DIFF
--- a/packages/ui/src/components/templates/LoyaltyHubTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/LoyaltyHubTemplate.stories.tsx
@@ -1,29 +1,57 @@
-import { type Meta, type StoryObj } from "@storybook/react";
-import { LoyaltyHubTemplate } from "./LoyaltyHubTemplate";
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
 
+import type { Column } from "../organisms/DataTable";
+import {
+  LoyaltyHubTemplate,
+  type LoyaltyHubTemplateProps,
+} from "./LoyaltyHubTemplate";
+
+/* ------------------------------------------------------------------ *
+ *  Row model & mock data
+ * ------------------------------------------------------------------ */
 interface HistoryRow {
   date: string;
   action: string;
   amount: number;
 }
 
-const meta: Meta<typeof LoyaltyHubTemplate> = {
-  component: LoyaltyHubTemplate,
+const stats = [
+  { label: "Points", value: 1200 },
+  { label: "Tier", value: "Gold" },
+];
+
+const progress = { current: 600, goal: 1000, label: "Progress" };
+
+const historyRows: HistoryRow[] = [
+  { date: "2023-01-01", action: "Earned", amount: 100 },
+  { date: "2023-01-02", action: "Spent", amount: -50 },
+];
+
+const historyColumns: Column<HistoryRow>[] = [
+  { header: "Date", render: (row) => row.date },
+  { header: "Action", render: (row) => row.action },
+  { header: "Amount", render: (row) => row.amount },
+];
+
+/* ------------------------------------------------------------------ *
+ *  Generic-aware wrapper
+ * ------------------------------------------------------------------ */
+const LoyaltyHubForHistory: React.FC<LoyaltyHubTemplateProps<HistoryRow>> = (
+  props,
+) => <LoyaltyHubTemplate<HistoryRow> {...props} />;
+
+/* ------------------------------------------------------------------ *
+ *  Storybook meta
+ * ------------------------------------------------------------------ */
+const meta: Meta<typeof LoyaltyHubForHistory> = {
+  title: "Templates/Loyalty Hub",
+  component: LoyaltyHubForHistory,
   args: {
-    stats: [
-      { label: "Points", value: 1200 },
-      { label: "Tier", value: "Gold" },
-    ],
-    progress: { current: 600, goal: 1000, label: "Progress" },
-    historyRows: [
-      { date: "2023-01-01", action: "Earned", amount: 100 },
-      { date: "2023-01-02", action: "Spent", amount: -50 },
-    ],
-    historyColumns: [
-      { header: "Date", render: (row: HistoryRow) => row.date },
-      { header: "Action", render: (row: HistoryRow) => row.action },
-      { header: "Amount", render: (row: HistoryRow) => row.amount },
-    ],
+    stats,
+    progress,
+    historyRows,
+    historyColumns,
   },
   argTypes: {
     stats: { control: "object" },
@@ -32,6 +60,10 @@ const meta: Meta<typeof LoyaltyHubTemplate> = {
     historyColumns: { control: "object" },
   },
 };
+
 export default meta;
 
-export const Default: StoryObj<typeof LoyaltyHubTemplate> = {};
+/* ------------------------------------------------------------------ *
+ *  Stories
+ * ------------------------------------------------------------------ */
+export const Default: StoryObj<typeof LoyaltyHubForHistory> = {};


### PR DESCRIPTION
## Summary
- add generic-aware wrapper for LoyaltyHubTemplate story to satisfy Column typing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type error in ComponentPreview.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b17f3968b8832faa379bd454e33a9b