### PR TITLE
Fix type mismatch for newsletter form block registry

### DIFF
--- a/packages/ui/src/components/cms/blocks/index.ts
+++ b/packages/ui/src/components/cms/blocks/index.ts
@@ -113,6 +113,6 @@ export const blockRegistry = {
   ...moleculeRegistry,
   ...organismRegistry,
   ...overlayRegistry,
-} satisfies Record<string, BlockRegistryEntry<unknown>>;
+} satisfies Record<string, BlockRegistryEntry<any>>;
 
 export type BlockType = keyof typeof blockRegistry;

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -106,7 +106,11 @@ const moleculeEntries = {
   NewsletterForm: { component: NewsletterForm },
   PromoBanner: { component: PromoBanner },
   CategoryList: { component: CategoryList },
-} satisfies Record<string, BlockRegistryEntry<unknown>>;
+} satisfies {
+  NewsletterForm: BlockRegistryEntry<NewsletterFormProps>;
+  PromoBanner: BlockRegistryEntry<PromoBannerProps>;
+  CategoryList: BlockRegistryEntry<CategoryCollectionTemplateProps>;
+};
 
 export const moleculeRegistry = Object.fromEntries(
   Object.entries(moleculeEntries).map(([k, v]) => [


### PR DESCRIPTION
## Summary
- ensure molecule block registry uses correct prop types for memoized components
- relax global block registry typing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/template-app build: Type error: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature)*
- `pnpm --filter @acme/ui build` *(fails: @acme/ui@0.1.0 build: `tsc -b`)*


------
https://chatgpt.com/codex/tasks/task_e_68b17f52ed34832f85788ba27dfdb110