### PR TITLE
fix: tighten marketing discount and tracking typing

### DIFF
--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest) {
   ]);
   const counts: Record<string, number> = {};
   for (const e of events) {
-    if (e.type === "discount_redeemed") {
+    if (e.type === "discount_redeemed" && typeof e.code === "string") {
       const code = e.code;
       counts[code] = (counts[code] || 0) + 1;
     }

--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -64,7 +64,9 @@ export default async function OrdersPage({
           trackingNumber: o.trackingNumber,
         });
         shippingSteps = ship.steps as OrderStep[];
-        status = ship.status;
+        if (typeof ship.status === "string") {
+          status = ship.status;
+        }
         const ret = await getReturnTrackingStatus({
           provider,
           trackingNumber: o.trackingNumber,


### PR DESCRIPTION
## Summary
- guard against undefined discount codes when counting redemptions
- ensure tracking status is a string before assigning

## Testing
- `pnpm -r build` *(fails: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature)*
- `pnpm test` *(fails: Exceeded timeout of 5000 ms for a test)*

------
https://chatgpt.com/codex/tasks/task_e_68b17f6a1b28832fadf3a933a8225ac6