### PR TITLE
fix: ensure Shop type for sanity config updates

### DIFF
--- a/apps/cms/src/actions/deleteSanityConfig.ts
+++ b/apps/cms/src/actions/deleteSanityConfig.ts
@@ -1,6 +1,7 @@
 // apps/cms/src/actions/deleteSanityConfig.ts
 "use server";
 
+import type { Shop } from "@acme/types";
 import { getShopById, updateShopInRepo } from "@platform-core/repositories/shop.server";
 import { setSanityConfig } from "@platform-core/shops";
 import { ensureAuthorized } from "./common/auth";
@@ -11,7 +12,7 @@ export async function deleteSanityConfig(
   await ensureAuthorized();
   try {
     const shop = await getShopById(shopId);
-    const updated = setSanityConfig(shop, undefined);
+    const updated = setSanityConfig(shop, undefined) as Shop;
     await updateShopInRepo(shopId, { ...updated, id: shopId });
     return { message: "Sanity disconnected" };
   } catch (err) {

--- a/apps/cms/src/actions/saveSanityConfig.ts
+++ b/apps/cms/src/actions/saveSanityConfig.ts
@@ -62,7 +62,7 @@ export async function saveSanityConfig(
   const updated = setEditorialBlog(setSanityConfig(shop, config), {
     enabled: editorialEnabled,
     ...(promoteSchedule ? { promoteSchedule } : {}),
-  });
+  }) as Shop;
   updated.luxuryFeatures = {
     ...(updated.luxuryFeatures ?? {}),
     blog: editorialEnabled,


### PR DESCRIPTION
## Summary
- fix TypeScript mismatch by casting Sanity config changes to `Shop`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type error in packages/template-app)*
- `pnpm --filter @apps/cms test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b17f75b720832fbc9395d14c6b64f0