### PR TITLE
Use permissive BlockRegistryEntry type for CMS blocks

### DIFF
--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -64,7 +64,7 @@ export default async function OrdersPage({
           trackingNumber: o.trackingNumber,
         });
         shippingSteps = ship.steps as OrderStep[];
-        status = ship.status;
+        status = ship.status as string | null;
         const ret = await getReturnTrackingStatus({
           provider,
           trackingNumber: o.trackingNumber,

--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -101,7 +101,7 @@ const atomEntries = {
 } as const;
 
 type AtomRegistry = {
-  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<unknown>;
+  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<any>;
 };
 
 export const atomRegistry: AtomRegistry = Object.entries(atomEntries).reduce(

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -10,7 +10,7 @@ const containerEntries = {
 } as const;
 
 type ContainerRegistry = {
-  -readonly [K in keyof typeof containerEntries]: BlockRegistryEntry<unknown>;
+  -readonly [K in keyof typeof containerEntries]: BlockRegistryEntry<any>;
 };
 
 export const containerRegistry: ContainerRegistry = Object.entries(

--- a/packages/ui/src/components/cms/blocks/index.ts
+++ b/packages/ui/src/components/cms/blocks/index.ts
@@ -113,6 +113,6 @@ export const blockRegistry = {
   ...moleculeRegistry,
   ...organismRegistry,
   ...overlayRegistry,
-} satisfies Record<string, BlockRegistryEntry<unknown>>;
+} satisfies Record<string, BlockRegistryEntry<any>>;
 
 export type BlockType = keyof typeof blockRegistry;


### PR DESCRIPTION
## Summary
- widen BlockRegistryEntry use to `any` for block registries
- cast shipping status to `string | null` in account orders page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'unknown[]' is not assignable to type 'PortableBlock[]')*
- `pnpm build --filter @acme/ui`


------
https://chatgpt.com/codex/tasks/task_e_68b188b08474832f9907ae9144d0ebe3