### PR TITLE
fix: type history columns for Loyalty Hub story

### DIFF
--- a/packages/ui/src/components/templates/LoyaltyHubTemplate.stories.tsx
+++ b/packages/ui/src/components/templates/LoyaltyHubTemplate.stories.tsx
@@ -28,11 +28,11 @@ const historyRows: HistoryRow[] = [
   { date: "2023-01-02", action: "Spent", amount: -50 },
 ];
 
-const historyColumns: Column<HistoryRow>[] = [
-  { header: "Date", render: (row) => row.date },
-  { header: "Action", render: (row) => row.action },
-  { header: "Amount", render: (row) => row.amount },
-];
+const historyColumns = [
+  { header: "Date", render: (row: HistoryRow) => row.date },
+  { header: "Action", render: (row: HistoryRow) => row.action },
+  { header: "Amount", render: (row: HistoryRow) => row.amount },
+] satisfies Column<HistoryRow>[];
 
 /* ------------------------------------------------------------------ *
  *  Generic-aware wrapper


### PR DESCRIPTION
## Summary
- ensure LoyaltyHubTemplate story's history columns honor row type

## Testing
- `pnpm --filter @acme/ui build` (fails: BlockRegistryEntry<unknown>)
- `pnpm --filter @acme/ui test` (fails: Exceeded timeout of 20000 ms for a test)

------
https://chatgpt.com/codex/tasks/task_e_68b18914f364832f83cbfd0863d81a39