### PR TITLE
fix(ts): loosen cms block types

### DIFF
--- a/packages/ui/src/components/account/Orders.tsx
+++ b/packages/ui/src/components/account/Orders.tsx
@@ -65,7 +65,7 @@ export default async function OrdersPage({
         });
         shippingSteps = ship.steps as OrderStep[];
         if (typeof ship.status === "string") {
-          status = ship.status;
+          status = ship.status as string;
         }
         const ret = await getReturnTrackingStatus({
           provider,

--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -101,7 +101,7 @@ const atomEntries = {
 } as const;
 
 type AtomRegistry = {
-  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<unknown>;
+  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<any>;
 };
 
 export const atomRegistry: AtomRegistry = Object.entries(atomEntries).reduce(

--- a/packages/ui/src/components/cms/blocks/containers.tsx
+++ b/packages/ui/src/components/cms/blocks/containers.tsx
@@ -10,7 +10,7 @@ const containerEntries = {
 } as const;
 
 type ContainerRegistry = {
-  -readonly [K in keyof typeof containerEntries]: BlockRegistryEntry<unknown>;
+  -readonly [K in keyof typeof containerEntries]: BlockRegistryEntry<any>;
 };
 
 export const containerRegistry: ContainerRegistry = Object.entries(

--- a/packages/ui/src/components/cms/blocks/index.ts
+++ b/packages/ui/src/components/cms/blocks/index.ts
@@ -113,6 +113,6 @@ export const blockRegistry = {
   ...moleculeRegistry,
   ...organismRegistry,
   ...overlayRegistry,
-} satisfies Record<string, BlockRegistryEntry<unknown>>;
+} satisfies Record<string, BlockRegistryEntry<any>>;
 
 export type BlockType = keyof typeof blockRegistry;


### PR DESCRIPTION
## Summary
- cast shipping status in Orders page
- relax BlockRegistryEntry generics to accept typed CMS blocks

## Testing
- `pnpm -r build` *(fails: Type 'unknown[]' is not assignable to type 'PortableBlock[]')*
- `pnpm --filter @acme/ui build`


------
https://chatgpt.com/codex/tasks/task_e_68b18ad8d3d4832f9d1f69db500b2a43