### PR TITLE
fix: align blog post body types

### DIFF
--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function BlogPostPage({
       )}
       <h1 className="text-2xl font-bold">{post.title}</h1>
       {post.excerpt && <p className="text-muted">{post.excerpt}</p>}
-      {Array.isArray(post.body) ? (
+      {post.body ? (
         <div className="space-y-4">
           <BlogPortableText value={post.body} />
         </div>

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -5,7 +5,12 @@ import { getShopById } from "@platform-core/repositories/shop.server";
 import { sanityBlogConfigSchema, type SanityBlogConfig } from "@acme/types";
 import { nowIso } from "@date-utils";
 
-export interface ProductBlock {
+export interface PortableBlock {
+  _type: string;
+  [key: string]: unknown;
+}
+
+export interface ProductBlock extends PortableBlock {
   _type: "productReference";
   slug: string;
 }
@@ -14,7 +19,7 @@ export interface BlogPost {
   title: string;
   slug: string;
   excerpt?: string;
-  body?: (unknown | ProductBlock)[];
+  body?: PortableBlock[];
   mainImage?: string;
   author?: string;
   categories?: string[];


### PR DESCRIPTION
## Summary
- type blog body blocks to match BlogPortableText requirements
- display blog post body when present

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm test` *(fails: @acme/theme#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b19ac9831c832fad98de38e0a901ff