### PR TITLE
fix: add empty presets array to Tailwind config

### DIFF
--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -58,6 +58,10 @@ const preset: Config = {
     },
   },
   plugins: [],
+  // Tailwind’s loader expects `presets` to be an array. Without this property,
+  // it tries to read `.length` of `undefined` during `next build`, causing
+  // “Cannot read properties of undefined (reading 'length')”.
+  presets: [],
 };
 
 // Additional diagnostics


### PR DESCRIPTION
## Summary
- ensure Tailwind preset exports an empty `presets` array to avoid `.length` errors during Next.js builds

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: Failed)*
- `pnpm --filter @acme/tailwind-config build`


------
https://chatgpt.com/codex/tasks/task_e_68b19ed00f84832f935d3fd72fc255ee