### PR TITLE
fix: load template-app next config synchronously

### DIFF
--- a/packages/template-app/dev-defaults.mjs
+++ b/packages/template-app/dev-defaults.mjs
@@ -1,0 +1,6 @@
+process.env.NEXTAUTH_SECRET ??= "dev-nextauth-secret";
+process.env.SESSION_SECRET ??= "dev-session-secret";
+process.env.CART_COOKIE_SECRET ??= "dev-cart-secret";
+process.env.CMS_SPACE_URL ??= "https://cms.example.com";
+process.env.CMS_ACCESS_TOKEN ??= "placeholder-token";
+process.env.SANITY_API_VERSION ??= "2021-10-21";


### PR DESCRIPTION
## Summary
- load development env defaults before importing shared next config
- statically import shared next config and merge template overrides

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma' in apps/cms build)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cd88d27c832f8243550d3809b87b