### PR TITLE
docs: add TSDoc comments to shipping and email hooks

### DIFF
--- a/packages/email/src/hooks.ts
+++ b/packages/email/src/hooks.ts
@@ -11,26 +11,98 @@ const sendListeners: HookHandler[] = [];
 const openListeners: HookHandler[] = [];
 const clickListeners: HookHandler[] = [];
 
+/**
+ * Register a listener that runs whenever an email is sent.
+ *
+ * @param listener - Handler invoked with the shop ID and payload.
+ *
+ * @example
+ * ```ts
+ * onSend(async (shop, payload) => {
+ *   console.log(`Email sent for ${shop}`, payload);
+ * });
+ * ```
+ */
 export function onSend(listener: HookHandler): void {
   sendListeners.push(listener);
 }
 
+/**
+ * Register a listener that runs when an email is opened.
+ *
+ * @param listener - Handler invoked with the shop ID and payload.
+ *
+ * @example
+ * ```ts
+ * onOpen(async (shop, payload) => {
+ *   console.log(`Email opened for ${shop}`, payload);
+ * });
+ * ```
+ */
 export function onOpen(listener: HookHandler): void {
   openListeners.push(listener);
 }
 
+/**
+ * Register a listener that runs when a link in an email is clicked.
+ *
+ * @param listener - Handler invoked with the shop ID and payload.
+ *
+ * @example
+ * ```ts
+ * onClick(async (shop, payload) => {
+ *   console.log(`Email link clicked for ${shop}`, payload);
+ * });
+ * ```
+ */
 export function onClick(listener: HookHandler): void {
   clickListeners.push(listener);
 }
 
+/**
+ * Trigger all registered send listeners.
+ *
+ * @param shop - Identifier for the shop.
+ * @param payload - Context about the email campaign.
+ * @returns A promise that resolves once every listener has completed.
+ *
+ * @example
+ * ```ts
+ * await emitSend("my-shop", { campaign: "spring" });
+ * ```
+ */
 export async function emitSend(shop: string, payload: HookPayload): Promise<void> {
   await Promise.all(sendListeners.map((fn) => fn(shop, payload)));
 }
 
+/**
+ * Trigger all registered open listeners.
+ *
+ * @param shop - Identifier for the shop.
+ * @param payload - Context about the email campaign.
+ * @returns A promise that resolves once every listener has completed.
+ *
+ * @example
+ * ```ts
+ * await emitOpen("my-shop", { campaign: "spring" });
+ * ```
+ */
 export async function emitOpen(shop: string, payload: HookPayload): Promise<void> {
   await Promise.all(openListeners.map((fn) => fn(shop, payload)));
 }
 
+/**
+ * Trigger all registered click listeners.
+ *
+ * @param shop - Identifier for the shop.
+ * @param payload - Context about the email campaign.
+ * @returns A promise that resolves once every listener has completed.
+ *
+ * @example
+ * ```ts
+ * await emitClick("my-shop", { campaign: "spring" });
+ * ```
+ */
 export async function emitClick(shop: string, payload: HookPayload): Promise<void> {
   await Promise.all(clickListeners.map((fn) => fn(shop, payload)));
 }

--- a/packages/platform-core/src/shipping.ts
+++ b/packages/platform-core/src/shipping.ts
@@ -5,6 +5,21 @@ export interface TrackingStatus {
   [key: string]: unknown;
 }
 
+/**
+ * Fetches tracking information for a shipment.
+ *
+ * @param arg - Object containing the shipping `provider` and its `trackingNumber`.
+ * @returns A promise that resolves with the tracking status.
+ *
+ * @example
+ * ```ts
+ * const status = await getTrackingStatus({
+ *   provider: "ups",
+ *   trackingNumber: "1Z12345"
+ * });
+ * console.log(status.status);
+ * ```
+ */
 export async function getTrackingStatus(arg: { provider: Carrier; trackingNumber: string }): Promise<TrackingStatus> {
   // TODO: real provider implementations
   return { status: "unknown", provider: arg.provider, trackingNumber: arg.trackingNumber };


### PR DESCRIPTION
## Summary
- document shipping tracking API usage
- add examples for email hook registration and emit functions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build and apps/shop-bcd build)*
- `pnpm lint` *(fails: Cannot find module '@next/eslint-plugin-next')*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc063350832fadf222bc23a35133