### PR TITLE
docs: expand contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,10 +2,19 @@
 
 Contributions are welcome! Please open an issue or pull request with improvements.
 
-## Guidelines
+## Formatting
 
-- Use `pnpm` for package management.
-- Run `pnpm lint` and `pnpm test` before submitting changes.
-- Follow existing code style and naming conventions.
-- Write clear commit messages and include tests when adding features.
+Use [pnpm](https://pnpm.io) for package management. The repository uses Prettier and ESLint with semicolons, double quotes, two-space indentation, an 80-character line width, and the Tailwind CSS plugin. Run [`pnpm lint`](../package.json#L24) to check formatting and lint rules, or [`pnpm format`](../package.json#L37) to automatically apply fixes.
+
+## Commit Messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Start messages with a type such as `feat:` or `fix:` and write in the present tense with a concise subject line under 72 characters.
+
+## Branching
+
+Create branches from `main` and name them descriptively (e.g., `feat/login-form` or `fix/cart-redirect`). Push your branch and open a pull request against `main`.
+
+## Linting and Tests
+
+Before submitting changes, run [`pnpm lint`](../package.json#L24) and [`pnpm test`](../package.json#L28) to ensure the codebase is formatted correctly and the test suite passes.
 


### PR DESCRIPTION
## Summary
- document formatting conventions and automation
- outline commit message and branch guidelines
- add lint and test steps with pnpm command links

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@acme/email')*
- `pnpm lint` *(fails: command /workspace/base-shop/apps/cms ... exited (1))*
- `pnpm test` *(terminated: run failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc0244b4832fb1277917dd69e498