### PR TITLE
Fix wizard summary step initialization

### DIFF
--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
+import { flushSync } from "react-dom";
 
 import { baseTokens, loadThemeTokens, type TokenMap } from "./tokenUtils";
 
@@ -65,7 +66,8 @@ export default function Wizard({ themes }: WizardProps): React.JSX.Element {
         // Determine starting step by counting completed steps
         const completed = json.completed || {};
         const idx = stepOrder.findIndex((s) => completed[s] !== "complete");
-        setStepIdx(idx === -1 ? stepOrder.length - 1 : idx);
+        const next = idx === -1 ? stepOrder.length - 1 : idx;
+        flushSync(() => setStepIdx(next));
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Summary
- ensure wizard resumes at correct step using flushSync when loading persisted progress

## Testing
- `pnpm --filter @apps/cms test __tests__/wizard-flow.integration.test.tsx`
- `pnpm -r build` *(fails: Next.js build worker exited with code: null and signal: SIGTRAP)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e07145a4832f92ff49100de860ee