### PR TITLE
fix: map env js modules to ts sources

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -17,6 +17,10 @@ module.exports = {
     "^@/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@/i18n/Translations$": "<rootDir>/test/emptyModule.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
+    "^packages/config/src/env/core\\.js$": "<rootDir>/packages/config/src/env/core.impl.ts",
+    "^packages/config/src/env/index\\.js$": "<rootDir>/packages/config/src/env/index.ts",
+    "^packages/config/src/env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
+    // TODO: map test-friendly stubs once available
   },
   globals: {
     "ts-jest": {


### PR DESCRIPTION
## Summary
- map env JS modules to TS source files in cms Jest config

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Namespace '"/workspace/base-shop/node_modules/.pnpm/@prisma+client@6.14.0_typescript@5.8.3/node_modules/.prisma/client/default".Prisma' has no exported member 'InputJsonValue')
- `pnpm --filter @apps/cms test __tests__/products.test.ts` (fails: Exceeded timeout of 5000 ms for a test)

------
https://chatgpt.com/codex/tasks/task_e_68b1e2c7f6f0832f9986b68329919fb2