### PR TITLE
chore: polyfill web APIs for CMS tests

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -11,7 +11,10 @@ const {
 module.exports = {
   ...base,
   roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
-  setupFilesAfterEnv: ["<rootDir>/apps/cms/jest.setup.tsx"],
+  setupFilesAfterEnv: [
+    "<rootDir>/apps/cms/jest.setup.polyfills.ts",
+    "<rootDir>/apps/cms/jest.setup.tsx",
+  ],
   moduleNameMapper: {
     ...baseModuleNameMapper,
     "^@/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",

--- a/apps/cms/jest.setup.polyfills.ts
+++ b/apps/cms/jest.setup.polyfills.ts
@@ -1,0 +1,3 @@
+import { File, Blob, FormData, fetch } from 'undici';
+
+Object.assign(global, { File, Blob, FormData, fetch });


### PR DESCRIPTION
## Summary
- add jest polyfill setup for File, Blob, FormData and fetch
- ensure CMS Jest config loads polyfills before existing setup

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Namespace 'Prisma' has no exported member 'InputJsonValue')*
- `pnpm --filter @apps/cms test apps/cms/src/actions/__tests__/media.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1e2fcc7d0832f986580c478b21547