### PR TITLE
test: add env stubs for CMS

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -14,6 +14,8 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/apps/cms/jest.setup.tsx"],
   moduleNameMapper: {
     ...baseModuleNameMapper,
+    "^packages/config/src/env/cms\\.impl\\.ts$": "<rootDir>/packages/config/src/env/__test__/cms.stub.ts",
+    "^packages/config/src/env/core\\.impl\\.ts$": "<rootDir>/packages/config/src/env/__test__/core.stub.ts",
     "^@/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@/i18n/Translations$": "<rootDir>/test/emptyModule.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",

--- a/packages/config/src/env/__test__/cms.stub.ts
+++ b/packages/config/src/env/__test__/cms.stub.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const cmsEnvSchema = z.object({
+  CMS_SPACE_URL: z.string().url(),
+  CMS_ACCESS_TOKEN: z.string(),
+  SANITY_API_VERSION: z.string(),
+});
+
+const defaults = {
+  CMS_SPACE_URL: "https://cms.example.com",
+  CMS_ACCESS_TOKEN: "test-token",
+  SANITY_API_VERSION: "2021-10-21",
+} as const;
+
+export const cmsEnv = cmsEnvSchema.parse(defaults);
+export type CmsEnv = typeof cmsEnv;

--- a/packages/config/src/env/__test__/core.stub.ts
+++ b/packages/config/src/env/__test__/core.stub.ts
@@ -1,0 +1,48 @@
+import os from "os";
+import path from "path";
+import { z } from "zod";
+
+export const coreEnvSchema = z.object({
+  NEXTAUTH_SECRET: z.string(),
+  SESSION_SECRET: z.string(),
+  CMS_ADMIN_EMAIL: z.string().email(),
+  CMS_ADMIN_PASSWORD: z.string(),
+  CMS_SPACE_URL: z.string().url(),
+  CMS_ACCESS_TOKEN: z.string(),
+  SANITY_API_VERSION: z.string(),
+  EMAIL_PROVIDER: z.enum(["sendgrid", "resend", "smtp"]).default("smtp"),
+  SMTP_URL: z.string().url(),
+  NEXT_PUBLIC_BASE_URL: z.string().url(),
+  DATABASE_URL: z.string(),
+  CMS_MEDIA_DIR: z.string(),
+  CART_COOKIE_SECRET: z.string(),
+  NEXT_PUBLIC_DEFAULT_SHOP: z.string(),
+  NEXT_PUBLIC_SHOP_ID: z.string(),
+});
+
+export const coreEnvBaseSchema = coreEnvSchema;
+
+// No-op refinement for tests
+export function depositReleaseEnvRefinement(): void {}
+
+const tmp = os.tmpdir();
+const defaults = {
+  NEXTAUTH_SECRET: "test-secret",
+  SESSION_SECRET: "test-session-secret",
+  CMS_ADMIN_EMAIL: "admin@example.com",
+  CMS_ADMIN_PASSWORD: "password",
+  CMS_SPACE_URL: "https://cms.example.com",
+  CMS_ACCESS_TOKEN: "test-token",
+  SANITY_API_VERSION: "2021-10-21",
+  EMAIL_PROVIDER: "smtp" as const,
+  SMTP_URL: "smtp://localhost:2525",
+  NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  DATABASE_URL: `file:${path.join(tmp, "db.sqlite")}`,
+  CMS_MEDIA_DIR: path.join(tmp, "cms-media"),
+  CART_COOKIE_SECRET: "cart-secret",
+  NEXT_PUBLIC_DEFAULT_SHOP: "shop",
+  NEXT_PUBLIC_SHOP_ID: "shop",
+};
+
+export const coreEnv = coreEnvSchema.parse(defaults);
+export type CoreEnv = typeof coreEnv;


### PR DESCRIPTION
## Summary
- add test env shims for core and cms env loaders with safe defaults
- map cms and core env implementations to test shims in cms jest config

## Testing
- `pnpm install`
- `pnpm --filter @acme/config run build:stubs`
- `pnpm --filter @acme/config build`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed; apps/cms build: Failed)*
- `pnpm --filter @apps/cms test` *(fails: 3 failed, 2 skipped, 116 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e2e1151c832f81b8332f8793814d