### PR TITLE
test: load dotenv for jest and add CMS test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,5 @@ yarn-error.log*
 .env*
 !.env.example
 !apps/*/.env.local
+!apps/*/.env.test
 !apps/*/.env.production

--- a/apps/cms/.env.test
+++ b/apps/cms/.env.test
@@ -1,0 +1,8 @@
+# apps/cms/.env.test
+NEXTAUTH_URL=http://localhost:3006
+STRIPE_SECRET_KEY=sk_test_12345
+STRIPE_PUBLISHABLE_KEY=pk_test_12345
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_yourKey
+NEXTAUTH_SECRET="Zybn8rg2S47UnbB3zsyG+pIigj671YVeS86egWcxQGE="
+CART_COOKIE_SECRET=change-me-cart-secret
+SESSION_SECRET=change-me-session-secret

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -71,7 +71,7 @@ module.exports = {
   /* ------------------------------------------------------------------ */
   /* Global setup & polyfills                                           */
   /* ------------------------------------------------------------------ */
-  setupFiles: ["<rootDir>/test/setupFetchPolyfill.ts"],
+  setupFiles: ["dotenv/config", "<rootDir>/test/setupFetchPolyfill.ts"],
   setupFilesAfterEnv: [
     "<rootDir>/jest.setup.ts",
     "<rootDir>/test/polyfills/messageChannel.js",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "chromatic": "^13.0.1",
     "cross-env": "^7.0.3",
     "cross-fetch": "^4.1.0",
+    "dotenv": "^17.2.1",
     "cypress": "^14.5.0",
     "eslint": "^9.30.1",
     "eslint-config-next": "15.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       cypress:
         specifier: ^14.5.0
         version: 14.5.1
+      dotenv:
+        specifier: ^17.2.1
+        version: 17.2.1
       eslint:
         specifier: ^9.30.1
         version: 9.30.1(jiti@2.4.2)
@@ -6023,6 +6026,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -16897,6 +16904,8 @@ snapshots:
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
+
+  dotenv@17.2.1: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add `.env.test` for CMS with minimal secret placeholders
- load dotenv in Jest to read env vars
- unignore `.env.test` and add dotenv dependency

## Testing
- `pnpm -r build` *(fails: Prisma.InputJsonValue missing)*
- `pnpm --filter @apps/cms test` *(fails: 3 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e2f12b6c832fb8842abd9e1b773b