### PR TITLE
test: add MemorySessionStore TTL tests

### DIFF
--- a/packages/auth/src/__tests__/memoryStore.test.ts
+++ b/packages/auth/src/__tests__/memoryStore.test.ts
@@ -2,6 +2,16 @@ import { MemorySessionStore } from "../memoryStore";
 import type { SessionRecord } from "../store";
 
 describe("MemorySessionStore", () => {
+  const createRecord = (
+    sessionId: string,
+    customerId = "c1"
+  ): SessionRecord => ({
+    sessionId,
+    customerId,
+    userAgent: "agent",
+    createdAt: new Date(),
+  });
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(0);
@@ -11,30 +21,50 @@ describe("MemorySessionStore", () => {
     jest.useRealTimers();
   });
 
-  it("expires sessions and returns only active sessions", async () => {
+  it("returns a session before it expires", async () => {
     const store = new MemorySessionStore(1);
-    const expired: SessionRecord = {
-      sessionId: "s1",
-      customerId: "c1",
-      userAgent: "agent",
-      createdAt: new Date(),
-    };
+    const record = createRecord("s1");
+    await store.set(record);
+
+    await expect(store.get(record.sessionId)).resolves.toEqual(record);
+  });
+
+  it("removes expired sessions on get", async () => {
+    const store = new MemorySessionStore(1);
+    const record = createRecord("s1");
+    await store.set(record);
+
+    jest.advanceTimersByTime(1001);
+
+    await expect(store.get(record.sessionId)).resolves.toBeNull();
+    await expect(store.list(record.customerId)).resolves.toEqual([]);
+  });
+
+  it("lists only active sessions for a customer", async () => {
+    const store = new MemorySessionStore(1);
+    const expired = createRecord("s1");
     await store.set(expired);
 
     jest.advanceTimersByTime(500);
-    const active: SessionRecord = {
-      sessionId: "s2",
-      customerId: "c1",
-      userAgent: "agent",
-      createdAt: new Date(),
-    };
+
+    const active = createRecord("s2");
+    const otherCustomer = createRecord("s3", "c2");
     await store.set(active);
+    await store.set(otherCustomer);
 
     jest.advanceTimersByTime(600);
 
-    await expect(store.get(expired.sessionId)).resolves.toBeNull();
-    await expect(store.list("c1")).resolves.toEqual([active]);
-    await expect(store.get(active.sessionId)).resolves.toEqual(active);
     await expect(store.list("c1")).resolves.toEqual([active]);
   });
+
+  it("deletes sessions", async () => {
+    const store = new MemorySessionStore(1);
+    const record = createRecord("s1");
+    await store.set(record);
+
+    await store.delete(record.sessionId);
+
+    await expect(store.get(record.sessionId)).resolves.toBeNull();
+  });
 });
+


### PR DESCRIPTION
## Summary
- expand MemorySessionStore tests to cover TTL behaviour, active listing, and deletions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Namespace "Prisma" has no exported member 'InputJsonValue')*
- `pnpm test packages/auth` *(fails: Could not find task `packages/auth` in project)*
- `pnpm --filter @acme/auth exec jest --config ../../jest.config.cjs packages/auth/src/__tests__/memoryStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1e4a5b374832fbb254922468fc6f3