### PR TITLE
test: add fetchJson and buildResponse tests

### DIFF
--- a/packages/shared-utils/src/__tests__/buildResponse.test.ts
+++ b/packages/shared-utils/src/__tests__/buildResponse.test.ts
@@ -1,0 +1,15 @@
+import { buildResponse } from '../buildResponse';
+
+describe('buildResponse', () => {
+  it('decodes base64 body and rehydrates headers', async () => {
+    const text = 'hello world';
+    const body = Buffer.from(text).toString('base64');
+    const resp = buildResponse({
+      response: { status: 200, headers: { 'x-test': '1' }, body },
+    });
+
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get('x-test')).toBe('1');
+    await expect(resp.text()).resolves.toBe(text);
+  });
+});

--- a/packages/shared-utils/src/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/src/__tests__/fetchJson.test.ts
@@ -1,0 +1,45 @@
+import { fetchJson } from '../fetchJson';
+import { z } from 'zod';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches JSON and parses with schema', async () => {
+    const data = { message: 'ok' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(JSON.stringify(data)),
+    });
+
+    const schema = z.object({ message: z.string() });
+    await expect(fetchJson('https://example.com', undefined, schema)).resolves.toEqual(data);
+  });
+
+  it('throws status text for non-JSON error responses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Internal Server Error',
+      status: 500,
+      text: jest.fn().mockResolvedValue('not json'),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('Internal Server Error');
+  });
+
+  it('throws custom error message from payload', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+      status: 400,
+      text: jest.fn().mockResolvedValue(JSON.stringify({ error: 'Custom message' })),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('Custom message');
+  });
+});


### PR DESCRIPTION
## Summary
- test fetchJson for schema parsing, fallback status text, and custom error payloads
- test buildResponse for base64 body decoding and header rehydration

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Prisma.InputJsonValue missing in apps/cms build)*
- `pnpm test packages/shared-utils` *(fails: Missing task `packages/shared-utils`)*
- `pnpm exec jest packages/shared-utils`


------
https://chatgpt.com/codex/tasks/task_e_68b1e4af4eb0832f97739c53491f40d9