### PR TITLE
feat(cms): add msw server for networked tests

### DIFF
--- a/apps/cms/__tests__/msw/handlers.ts
+++ b/apps/cms/__tests__/msw/handlers.ts
@@ -1,0 +1,49 @@
+import { rest } from "msw";
+import { baseTokens } from "../../src/app/cms/wizard/tokenUtils";
+
+export const handlers = [
+  rest.get("/cms/api/wizard-progress", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({ state: {}, completed: {} }))
+  ),
+  rest.put("/cms/api/wizard-progress", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({}))
+  ),
+  rest.patch("/cms/api/wizard-progress", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({}))
+  ),
+  rest.post("/cms/api/configurator", async (_req, res, ctx) =>
+    res(
+      ctx.status(201),
+      ctx.json({ id: "testshop", message: "shop created successfully" })
+    )
+  ),
+  rest.get("/cms/api/theme/list", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({ themes: ["base", "dark"] }))
+  ),
+  rest.get("/cms/api/theme/tokens", (req, res, ctx) => {
+    const name = req.url.searchParams.get("name");
+    // For tests we reuse base tokens regardless of theme name
+    return res(ctx.status(200), ctx.json(baseTokens));
+  }),
+  rest.get("/cms/api/products/slug/:slug", (_req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.json({
+        title: "Test",
+        price: 100,
+        stock: 1,
+        media: [{ url: "/image.png" }],
+      })
+    )
+  ),
+  rest.post(
+    "/cms/api/marketing/email/provider-webhooks/sendgrid",
+    (_req, res, ctx) => res(ctx.status(200), ctx.json({ received: true }))
+  ),
+  rest.post(
+    "/cms/api/marketing/email/provider-webhooks/resend",
+    (_req, res, ctx) => res(ctx.status(200), ctx.json({ received: true }))
+  ),
+];
+
+export { rest };

--- a/apps/cms/__tests__/msw/server.ts
+++ b/apps/cms/__tests__/msw/server.ts
@@ -1,0 +1,10 @@
+import { setupServer } from "msw/node";
+import { handlers, rest } from "./handlers";
+
+export const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+export { rest };

--- a/apps/cms/__tests__/wizard-navigation.test.tsx
+++ b/apps/cms/__tests__/wizard-navigation.test.tsx
@@ -3,7 +3,7 @@
 import { runWizard, templates, themes } from "./utils/wizardTestUtils";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { ResponseComposition, RestContext, RestRequest, rest } from "msw";
-import { server } from "../../../test/msw/server";
+import { server } from "./msw/server";
 import Wizard from "../src/app/cms/wizard/Wizard";
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/__tests__/wizard-save.test.tsx
+++ b/apps/cms/__tests__/wizard-save.test.tsx
@@ -3,7 +3,7 @@
 import { templates, themes, runWizard } from "./utils/wizardTestUtils";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { rest } from "msw";
-import { server } from "../../../test/msw/server";
+import { server } from "./msw/server";
 import Wizard from "../src/app/cms/wizard/Wizard";
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/__tests__/wizard-validation.test.tsx
+++ b/apps/cms/__tests__/wizard-validation.test.tsx
@@ -4,7 +4,7 @@ import { templates, themes } from "./utils/wizardTestUtils";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { baseTokens } from "../src/app/cms/wizard/tokenUtils";
 import { rest } from "msw";
-import { server } from "../../../test/msw/server";
+import { server } from "./msw/server";
 import Wizard from "../src/app/cms/wizard/Wizard";
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -13,6 +13,7 @@ module.exports = {
   roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
   setupFilesAfterEnv: [
     "<rootDir>/apps/cms/jest.setup.polyfills.ts",
+    "<rootDir>/apps/cms/__tests__/msw/server.ts",
     "<rootDir>/apps/cms/jest.setup.tsx",
   ],
   moduleNameMapper: {

--- a/apps/cms/jest.setup.polyfills.ts
+++ b/apps/cms/jest.setup.polyfills.ts
@@ -1,3 +1,9 @@
-import { File, Blob, FormData, fetch } from 'undici';
+import { TextDecoder, TextEncoder } from "node:util";
+
+(globalThis as any).TextDecoder ||= TextDecoder;
+(globalThis as any).TextEncoder ||= TextEncoder;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { File, Blob, FormData, fetch } = require("undici");
 
 Object.assign(global, { File, Blob, FormData, fetch });

--- a/apps/cms/jest.setup.tsx
+++ b/apps/cms/jest.setup.tsx
@@ -94,13 +94,3 @@ jest.mock("next/router", () => ({
     prefetch: jest.fn(),
   }),
 }));
-
-/* -------------------------------------------------------------------------- */
-/* 3 ·  MSW – Mock Service Worker                                             */
-/* -------------------------------------------------------------------------- */
-
-import { server } from "../../test/msw/server";
-
-beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- add dedicated MSW server and handlers for CMS tests
- hook MSW server into CMS Jest config and clean up setup files
- polyfill TextDecoder before loading undici

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Prisma.InputJsonValue type missing)*
- `pnpm --filter @apps/cms test -- apps/cms/__tests__/wizard-navigation.test.tsx apps/cms/__tests__/wizard-theme.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1e689c27c832f9c52cbb479605227