### PR TITLE
test: cover sanity server actions

### DIFF
--- a/apps/cms/src/__tests__/sanity.server.test.ts
+++ b/apps/cms/src/__tests__/sanity.server.test.ts
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+
+import { connectSanity, createSanityPost } from "../actions/sanity.server";
+import { verifyCredentials, publishPost } from "@acme/plugin-sanity";
+
+jest.mock("@acme/plugin-sanity", () => ({
+  __esModule: true,
+  verifyCredentials: jest.fn(),
+  publishPost: jest.fn(),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("connectSanity", () => {
+  it("passes parsed config to verifyCredentials", async () => {
+    const fd = new FormData();
+    fd.set("projectId", "p");
+    fd.set("dataset", "d");
+    fd.set("token", "t");
+
+    await connectSanity(fd);
+
+    expect(verifyCredentials).toHaveBeenCalledWith({
+      projectId: "p",
+      dataset: "d",
+      token: "t",
+    });
+  });
+});
+
+describe("createSanityPost", () => {
+  it("invokes publishPost on valid JSON", async () => {
+    const fd = new FormData();
+    fd.set("projectId", "p");
+    fd.set("dataset", "d");
+    fd.set("token", "t");
+    fd.set("post", JSON.stringify({ title: "Hi" }));
+
+    await createSanityPost(fd);
+
+    expect(publishPost).toHaveBeenCalledWith(
+      { projectId: "p", dataset: "d", token: "t" },
+      { title: "Hi" }
+    );
+  });
+
+  it("throws when JSON payload is malformed", async () => {
+    const fd = new FormData();
+    fd.set("projectId", "p");
+    fd.set("dataset", "d");
+    fd.set("token", "t");
+    fd.set("post", "{invalid");
+
+    await expect(createSanityPost(fd)).rejects.toThrow();
+    expect(publishPost).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for `connectSanity` and `createSanityPost`
- verify config parsing and publishing behavior

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'RentalOrder')*
- `pnpm test apps/cms` *(missing task)*
- `pnpm test --filter @apps/cms` *(fails: DatasetStep.test.tsx)*
- `pnpm --filter @apps/cms test -- apps/cms/src/__tests__/sanity.server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b1ecd04c20832fb00e41d143d9a58f