### PR TITLE
test: add server translation fallback test

### DIFF
--- a/packages/i18n/__tests__/useTranslations.server.test.ts
+++ b/packages/i18n/__tests__/useTranslations.server.test.ts
@@ -1,0 +1,9 @@
+import { useTranslations } from "../src/useTranslations.server";
+
+describe("useTranslations (server)", () => {
+  it("returns translations and falls back to key", async () => {
+    const t = await useTranslations("de");
+    expect(t("nav.home")).toBe("Startseite");
+    expect(t("missing.key")).toBe("missing.key");
+  });
+});


### PR DESCRIPTION
## Summary
- test useTranslations on the server for known translation and fallback behavior

## Testing
- `pnpm test packages/i18n` *(fails: Could not find task `packages/i18n` in project)*
- `pnpm test __tests__/useTranslations.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1f217641c832f85796ead8b076133