### PR TITLE
fix: explicit env exports

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -16,10 +16,35 @@
       "import": "./dist/env/index.js",
       "default": "./dist/env/index.js"
     },
-    "./env/*": {
-      "types": "./dist/env/*.d.ts",
-      "import": "./dist/env/*.js",
-      "default": "./dist/env/*.js"
+    "./env/core": {
+      "types": "./dist/env/core.d.ts",
+      "import": "./dist/env/core.js",
+      "default": "./dist/env/core.js"
+    },
+    "./env/auth": {
+      "types": "./dist/env/auth.d.ts",
+      "import": "./dist/env/auth.js",
+      "default": "./dist/env/auth.js"
+    },
+    "./env/cms": {
+      "types": "./dist/env/cms.d.ts",
+      "import": "./dist/env/cms.js",
+      "default": "./dist/env/cms.js"
+    },
+    "./env/email": {
+      "types": "./dist/env/email.d.ts",
+      "import": "./dist/env/email.js",
+      "default": "./dist/env/email.js"
+    },
+    "./env/payments": {
+      "types": "./dist/env/payments.d.ts",
+      "import": "./dist/env/payments.js",
+      "default": "./dist/env/payments.js"
+    },
+    "./env/shipping": {
+      "types": "./dist/env/shipping.d.ts",
+      "import": "./dist/env/shipping.js",
+      "default": "./dist/env/shipping.js"
     },
     "./jest.preset.cjs": "./jest.preset.cjs",
     "./tsconfig.app.json": "./tsconfig.app.json"

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,8 +1,8 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-import { authEnvSchema } from "./auth.js";
-import { cmsEnvSchema } from "./cms.js";
-import { emailEnvSchema } from "./email.js";
+import { authEnvSchema } from "./auth";
+import { cmsEnvSchema } from "./cms";
+import { emailEnvSchema } from "./email";
 
 const isProd = process.env.NODE_ENV === "production";
 

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -3,9 +3,9 @@ import { z, type AnyZodObject } from "zod";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
-} from "./core.js";
-import { paymentEnvSchema } from "./payments.js";
-import { shippingEnvSchema } from "./shipping.js";
+} from "./core";
+import { paymentEnvSchema } from "./payments";
+import { shippingEnvSchema } from "./shipping";
 
 type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
   k: infer I,
@@ -52,9 +52,9 @@ if (!parsed.success) {
 export const env = parsed.data;
 export type Env = z.infer<typeof envSchema>;
 
-export * from "./auth.js";
-export * from "./cms.js";
-export * from "./email.js";
-export * from "./core.js";
-export * from "./payments.js";
-export * from "./shipping.js";
+export * from "./auth";
+export * from "./cms";
+export * from "./email";
+export * from "./core";
+export * from "./payments";
+export * from "./shipping";

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -12,8 +12,8 @@
     "outDir": "dist",
     "allowJs": true,
 
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
 
     /* let TS infer rootDir (same as package folder) */
     "types": ["node"]


### PR DESCRIPTION
## Summary
- reference TS env modules directly and remove .js suffix
- explicitly map env exports in config package
- use bundler module resolution for config build

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '/workspace/base-shop/packages/config/dist/env/auth')*
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1c88534832f9b1bc8f772766675