### PR TITLE
test: add assertLocales coverage

### DIFF
--- a/packages/i18n/__tests__/locales.test.ts
+++ b/packages/i18n/__tests__/locales.test.ts
@@ -1,0 +1,19 @@
+import { assertLocales } from "@acme/i18n";
+
+describe("assertLocales", () => {
+  it("throws on non-array values", () => {
+    expect(() => assertLocales(undefined as any)).toThrow(
+      "LOCALES must be a non-empty array"
+    );
+  });
+
+  it("throws on empty arrays", () => {
+    expect(() => assertLocales([] as any)).toThrow(
+      "LOCALES must be a non-empty array"
+    );
+  });
+
+  it("does not throw on non-empty arrays", () => {
+    expect(() => assertLocales(["en"])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests verifying assertLocales behavior for invalid and valid inputs

## Testing
- `pnpm --filter @acme/i18n test -- packages/i18n`


------
https://chatgpt.com/codex/tasks/task_e_68b1f213c27c832f9bac002856bbd11f