### PR TITLE
test(i18n): cover undefined values in fillLocales

### DIFF
--- a/packages/i18n/__tests__/fillLocales.test.ts
+++ b/packages/i18n/__tests__/fillLocales.test.ts
@@ -12,4 +12,12 @@ describe("fillLocales", () => {
       }
     }
   });
+
+  it("uses fallback for undefined values", () => {
+    const result = fillLocales(undefined, "Hi");
+    expect(Object.keys(result)).toEqual([...LOCALES]);
+    for (const locale of LOCALES) {
+      expect(result[locale]).toBe("Hi");
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- test fillLocales with undefined values to ensure fallback applies to all locales

## Testing
- `pnpm test packages/i18n` *(fails: Missing tasks in project)*
- `pnpm --filter @acme/i18n test packages/i18n/__tests__/fillLocales.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1f2157e7c832fbdc4bb51c277b56a