### PR TITLE
fix(theme): run tests with root jest config

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "test": "rimraf dist && jest"
+    "test": "rimraf dist && jest --config ../../jest.config.cjs"
   },
   "dependencies": {
     "@acme/types": "workspace:*",

--- a/packages/theme/src/io/__tests__/ds-package-schema.spec.ts
+++ b/packages/theme/src/io/__tests__/ds-package-schema.spec.ts
@@ -1,4 +1,4 @@
-const { parseDsPackage } = require("../ds-package-schema");
+import { parseDsPackage } from "../ds-package-schema";
 
 describe("ds-package-schema", () => {
   it("parses tokens", () => {

--- a/packages/theme/src/io/__tests__/theme-schema.spec.ts
+++ b/packages/theme/src/io/__tests__/theme-schema.spec.ts
@@ -1,4 +1,4 @@
-const { parseTheme } = require("../theme-schema");
+import { parseTheme } from "../theme-schema";
 
 describe("themeLibrarySchema", () => {
   it("parses valid theme", () => {


### PR DESCRIPTION
## Summary
- use ESM imports in theme package tests
- run theme package tests with monorepo Jest config

## Testing
- `pnpm --filter @acme/theme test -- packages/theme`
- `pnpm -r build` *(fails: Cannot find module '/workspace/base-shop/packages/config/dist/env/auth')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f45c2fc0832f9e2d73bde4720dc1