### PR TITLE
chore: add test script to platform-core

### DIFF
--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -119,7 +119,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
## Summary
- add jest test script to platform-core package

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: plugins.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f37be7dc832fba85f52e1144af8e