### PR TITLE
fix: remove deprecated Prisma InputJsonValue

### DIFF
--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -6,7 +6,6 @@ import { pageSchema, type Page } from "@acme/types";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { prisma } from "../../db";
-import type { Prisma } from "@prisma/client";
 import { validateShopName } from "../../shops/index";
 import { DATA_ROOT } from "../../dataRoot";
 import { nowIso } from "@acme/date-utils";
@@ -119,12 +118,12 @@ export async function savePage(
   try {
     await prisma.page.upsert({
       where: { id: page.id },
-      update: { data: page as unknown as Prisma.InputJsonValue, slug: page.slug },
+      update: { data: page as unknown as Record<string, unknown>, slug: page.slug },
       create: {
         id: page.id,
         shopId: shop,
         slug: page.slug,
-        data: page as unknown as Prisma.InputJsonValue,
+        data: page as unknown as Record<string, unknown>,
       },
     });
   } catch {
@@ -172,7 +171,7 @@ export async function updatePage(
     await prisma.page.update({
       where: { id: patch.id },
       data: {
-        data: updated as unknown as Prisma.InputJsonValue,
+        data: updated as unknown as Record<string, unknown>,
         slug: updated.slug,
       },
     });


### PR DESCRIPTION
## Summary
- avoid Prisma InputJsonValue by storing page JSON as generic record

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '/workspace/base-shop/packages/config/dist/env/auth')
- `pnpm test` (fails: @acme/next-config#test)


------
https://chatgpt.com/codex/tasks/task_e_68b1f4fb76ec832fb27e591736b0b7a1