### PR TITLE
test: expand parseMultilingualInput invalid cases

### DIFF
--- a/packages/i18n/__tests__/parseMultilingualInput.test.ts
+++ b/packages/i18n/__tests__/parseMultilingualInput.test.ts
@@ -16,5 +16,7 @@ describe("parseMultilingualInput", () => {
 
   it("returns null for invalid input", () => {
     expect(parseMultilingualInput("foo_en", locales)).toBeNull();
+    expect(parseMultilingualInput("title_fr", locales)).toBeNull();
+    expect(parseMultilingualInput("titleen", locales)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- extend parseMultilingualInput invalid input coverage for unsupported locales and missing underscore

## Testing
- `pnpm test packages/i18n` *(fails: Could not find task `packages/i18n`)*
- `pnpm --filter @acme/i18n test` *(fails: test suite triggered unrelated tests and many failed)*
- `cd packages/i18n && pnpm test parseMultilingualInput.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b1f2167d30832f8f149b482e933d08