### PR TITLE
test: add useFSM hook tests

### DIFF
--- a/packages/platform-machine/src/__tests__/useFSM.test.ts
+++ b/packages/platform-machine/src/__tests__/useFSM.test.ts
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { useFSM } from "../useFSM";
+
+describe("useFSM", () => {
+  function TestComponent() {
+    const { state, send } = useFSM<
+      "idle" | "loading" | "success" | "fallback",
+      "FETCH" | "RESOLVE" | "UNKNOWN"
+    >("idle", [
+      { from: "idle", event: "FETCH", to: "loading" },
+      { from: "loading", event: "RESOLVE", to: "success" },
+    ]);
+
+    return React.createElement(
+      React.Fragment,
+      null,
+      React.createElement("span", { "data-testid": "state" }, state),
+      React.createElement(
+        "button",
+        { onClick: () => send("FETCH") },
+        "fetch"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => send("RESOLVE") },
+        "resolve"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => send("UNKNOWN", () => "fallback") },
+        "unknown"
+      )
+    );
+  }
+
+  it("handles transitions and fallback", () => {
+    render(React.createElement(TestComponent));
+    const state = screen.getByTestId("state");
+
+    expect(state.textContent).toBe("idle");
+    fireEvent.click(screen.getByText("fetch"));
+    expect(state.textContent).toBe("loading");
+    fireEvent.click(screen.getByText("resolve"));
+    expect(state.textContent).toBe("success");
+    fireEvent.click(screen.getByText("unknown"));
+    expect(state.textContent).toBe("fallback");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for useFSM hook with state transitions and fallback

## Testing
- `pnpm -r build` *(fails: Namespace 'Prisma' has no exported member 'InputJsonValue')*
- `pnpm --filter @acme/platform-machine test packages/platform-machine/src/__tests__/useFSM.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1f38d54d4832fbe3e0d28c893cbe8