### PR TITLE
fix tests by using JSDOM FormData

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -40,8 +40,14 @@ import { File } from "node:buffer";
 (globalThis as any).File ||= File;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { File: UndiciFile, FormData: UndiciFormData } = require("undici");
-(globalThis as any).FormData ||= UndiciFormData;
 (globalThis as any).File ||= UndiciFile;
+// Use JSDOM's FormData/File when available so form submissions work in tests
+if (typeof window !== "undefined") {
+  (globalThis as any).FormData = window.FormData;
+  (globalThis as any).File = window.File;
+} else {
+  (globalThis as any).FormData ||= UndiciFormData;
+}
 
 /**
  * React 19+ uses `MessageChannel` internally for suspense & streaming.


### PR DESCRIPTION
## Summary
- ensure Jest uses JSDOM's `FormData` and `File` when available so form submissions in tests work

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '/workspace/base-shop/packages/config/dist/env/auth')*
- `pnpm test:cms apps/cms/__tests__/ShopEditor.test.tsx apps/cms/__tests__/DatasetStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1fb57cca4832f9877a23fc71cb211