### PR TITLE
Adjust ui tests for translated placeholders

### DIFF
--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -96,6 +96,9 @@ describe("ComponentEditor", () => {
       />
     );
     fireEvent.click(getByText("Content"));
-    expect(await findByPlaceholderText("src")).toBeInTheDocument();
+    // Image source field uses translation keys as placeholders
+    expect(
+      await findByPlaceholderText("cms.image.url")
+    ).toBeInTheDocument();
   });
 });

--- a/packages/ui/__tests__/Image.test.tsx
+++ b/packages/ui/__tests__/Image.test.tsx
@@ -8,7 +8,9 @@ describe("Image atom", () => {
     );
     const img = container.querySelector("img");
     expect(img).toBeInTheDocument();
-    expect(img?.getAttribute("src")).toBe("/a.jpg");
+    // Next.js <Image> rewrites the src attribute; ensure original path is preserved
+    // within the generated URL
+    expect(img?.getAttribute("src")).toContain("url=%2Fa.jpg");
     expect(img?.getAttribute("alt")).toBe("a");
   });
 });

--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -32,7 +32,8 @@ describe("block editors", () => {
       "ImageBlockEditor",
       ImageBlockEditor,
       { type: "Image", src: "", alt: "" },
-      "alt",
+      // Image editor placeholders use translation keys
+      "cms.image.alt",
     ],
     [
       "GalleryEditor",


### PR DESCRIPTION
## Summary
- update ComponentEditor and block editor tests for translated image placeholders
- adapt Image atom test for Next.js rewritten src

## Testing
- `pnpm exec jest packages/ui/__tests__/ComponentEditor.test.tsx packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx packages/ui/__tests__/Image.test.tsx --config jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa56eb04832fb44b303c39257615