### PR TITLE
feat: add text-summary coverage report

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -215,6 +215,6 @@ module.exports = {
   ],
   collectCoverage: true,
   coverageDirectory: "<rootDir>/coverage",
-  coverageReporters: ["text", "lcov"],
+  coverageReporters: ["text", "text-summary", "lcov"],
   rootDir: ".", // each workspace already passes  --config ../../jest.config.cjs
 };


### PR DESCRIPTION
## Summary
- include text-summary reporter in Jest coverage settings

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '/workspace/base-shop/packages/config/dist/env/auth')*
- `pnpm test` *(fails: @acme/next-config#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b202cd42e0832f9fcc16b22292d66b