### PR TITLE
test(email): cover provider errors

### DIFF
--- a/packages/email/src/providers/__tests__/resend.test.ts
+++ b/packages/email/src/providers/__tests__/resend.test.ts
@@ -1,0 +1,74 @@
+describe("ResendProvider", () => {
+  const options = {
+    to: "to@example.com",
+    subject: "Subject",
+    html: "<p>HTML</p>",
+    text: "Text",
+  };
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.CAMPAIGN_FROM;
+    delete process.env.RESEND_API_KEY;
+  });
+
+  function setupEnv() {
+    process.env.RESEND_API_KEY = "rs";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+  }
+
+  it("resolves on success", async () => {
+    setupEnv();
+    const { send } = require("resend");
+    send.mockResolvedValueOnce(undefined);
+    const { ResendProvider } = await import("../resend");
+    const provider = new ResendProvider();
+    await expect(provider.send(options)).resolves.toBeUndefined();
+  });
+
+  it("wraps 400 errors as non-retryable ProviderError", async () => {
+    setupEnv();
+    const { send } = require("resend");
+    const err = { message: "Bad Request", statusCode: 400 };
+    send.mockRejectedValueOnce(err);
+    const { ResendProvider } = await import("../resend");
+    const provider = new ResendProvider();
+    const { ProviderError } = require("../types");
+    const promise = provider.send(options);
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      message: "Bad Request",
+      retryable: false,
+    });
+  });
+
+  it("marks 500 errors as retryable", async () => {
+    setupEnv();
+    const { send } = require("resend");
+    const err = { message: "Server Error", statusCode: 500 };
+    send.mockRejectedValueOnce(err);
+    const { ResendProvider } = await import("../resend");
+    const provider = new ResendProvider();
+    const { ProviderError } = require("../types");
+    const promise = provider.send(options);
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({ retryable: true });
+  });
+
+  it("wraps unexpected errors in ProviderError", async () => {
+    setupEnv();
+    const { send } = require("resend");
+    send.mockRejectedValueOnce("boom");
+    const { ResendProvider } = await import("../resend");
+    const provider = new ResendProvider();
+    const { ProviderError } = require("../types");
+    const promise = provider.send(options);
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      message: "Unknown error",
+      retryable: true,
+    });
+  });
+});
+

--- a/packages/email/src/providers/__tests__/sendgrid.test.ts
+++ b/packages/email/src/providers/__tests__/sendgrid.test.ts
@@ -1,0 +1,69 @@
+describe("SendgridProvider", () => {
+  const options = {
+    to: "to@example.com",
+    subject: "Subject",
+    html: "<p>HTML</p>",
+    text: "Text",
+  };
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.CAMPAIGN_FROM;
+    delete process.env.SENDGRID_API_KEY;
+  });
+
+  it("resolves on success", async () => {
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+    const sgMail = require("@sendgrid/mail").default;
+    sgMail.send.mockResolvedValueOnce(undefined);
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.send(options)).resolves.toBeUndefined();
+  });
+
+  it("wraps 400 errors as non-retryable ProviderError", async () => {
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+    const sgMail = require("@sendgrid/mail").default;
+    const err = Object.assign(new Error("Bad Request"), { code: 400 });
+    sgMail.send.mockRejectedValueOnce(err);
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    const { ProviderError } = require("../types");
+    const promise = provider.send(options);
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      message: "Bad Request",
+      retryable: false,
+    });
+  });
+
+  it("marks 500 errors as retryable", async () => {
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+    const sgMail = require("@sendgrid/mail").default;
+    const err = Object.assign(new Error("Server Error"), { code: 500 });
+    sgMail.send.mockRejectedValueOnce(err);
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    const { ProviderError } = require("../types");
+    const promise = provider.send(options);
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({ retryable: true });
+  });
+
+  it("wraps unexpected errors in ProviderError", async () => {
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+    const sgMail = require("@sendgrid/mail").default;
+    sgMail.send.mockRejectedValueOnce("boom");
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    const { ProviderError } = require("../types");
+    const promise = provider.send(options);
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      message: "Unknown error",
+      retryable: true,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Sendgrid provider tests for success, retryable, non-retryable, and unknown errors
- add Resend provider tests for success, retryable, non-retryable, and unknown errors

## Testing
- `pnpm test packages/email` *(fails: Missing tasks in project)*
- `npx jest packages/email/src/providers/__tests__/sendgrid.test.ts packages/email/src/providers/__tests__/resend.test.ts --config jest.config.cjs --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_68b202f02ee0832f87b3476cd442c4a3