### PR TITLE
fix: use explicit .js env specifiers

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -139,6 +139,8 @@ module.exports = {
     "^\\./env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
     "^\\./(auth|cms|email|core|payments|shipping)\\.js$":
       "<rootDir>/packages/config/src/env/$1.ts",
+    "^\\.\\./(auth|cms|email|core|payments|shipping)\\.js$":
+      "<rootDir>/packages/config/src/env/$1.ts",
 
     // CMS application aliases
     "^@/components/atoms/shadcn$":

--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
-import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core";
+import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.js";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
 
@@ -107,7 +107,7 @@ describe("core env module", () => {
     } as NodeJS.ProcessEnv;
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.resetModules();
-    expect(() => require("../core")).toThrow(
+    expect(() => require("../core.js")).toThrow(
       "Invalid core environment variables",
     );
     expect(errorSpy).toHaveBeenCalledWith(

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -1,8 +1,8 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
-import { authEnvSchema } from "./auth";
-import { cmsEnvSchema } from "./cms";
-import { emailEnvSchema } from "./email";
+import { authEnvSchema } from "./auth.js";
+import { cmsEnvSchema } from "./cms.js";
+import { emailEnvSchema } from "./email.js";
 
 const isProd = process.env.NODE_ENV === "production";
 

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -3,9 +3,9 @@ import { z, type AnyZodObject } from "zod";
 import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
-} from "./core";
-import { paymentEnvSchema } from "./payments";
-import { shippingEnvSchema } from "./shipping";
+} from "./core.js";
+import { paymentEnvSchema } from "./payments.js";
+import { shippingEnvSchema } from "./shipping.js";
 
 type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
   k: infer I,
@@ -50,11 +50,12 @@ if (!parsed.success) {
 }
 
 export const env = parsed.data;
-export type Env = z.infer<typeof envSchema>;
 
-export * from "./auth";
-export * from "./cms";
-export * from "./email";
-export * from "./core";
-export * from "./payments";
-export * from "./shipping";
+export * from "./auth.js";
+export * from "./cms.js";
+export * from "./email.js";
+export * from "./core.js";
+export * from "./payments.js";
+export * from "./shipping.js";
+
+export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
## Summary
- use .js extensions for env imports and re-exports
- align tests and jest mapping with .js relative specifiers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: ENOENT no such file or directory, open '/workspace/base-shop/apps/shop-shop1/package.json')*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b20b6b6bd0832fa1798111cb37aae8