### PR TITLE
test: map .js imports for core env tests

### DIFF
--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -6,4 +6,8 @@ const base = require("../../jest.config.cjs");
 module.exports = {
   ...base,
   rootDir: path.resolve(__dirname, "../.."),
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    "^\\.\\./core\\.js$": "<rootDir>/packages/config/src/env/core.ts",
+  },
 };

--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
-import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core";
+import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.js";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
 
@@ -107,7 +107,7 @@ describe("core env module", () => {
     } as NodeJS.ProcessEnv;
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.resetModules();
-    expect(() => require("../core")).toThrow(
+    expect(() => require("../core.js")).toThrow(
       "Invalid core environment variables",
     );
     expect(errorSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- use explicit `.js` extension in core env test imports
- map `../core.js` to the TypeScript source in config's Jest preset

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: useCurrency must be inside CurrencyProvider)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b214186140832fae16fd0d797f9d32