### PR TITLE
fix env type exports

### DIFF
--- a/data/shops/default/analytics-aggregates.json
+++ b/data/shops/default/analytics-aggregates.json
@@ -1,1 +1,1 @@
-{"page_view":{},"order":{},"discount_redeemed":{},"ai_crawl":{"2025-08-27":3,"2025-08-28":9}}
+{"page_view":{},"order":{},"discount_redeemed":{},"ai_crawl":{"2025-08-27":3,"2025-08-28":9,"2025-08-29":3}}

--- a/packages/config/__tests__/envIndexFailure.test.ts
+++ b/packages/config/__tests__/envIndexFailure.test.ts
@@ -20,7 +20,7 @@ jest.mock("../src/env/core", () => ({
 }));
 
 jest.mock("../src/env/payments", () => ({
-  paymentEnvSchema: z.object({
+  paymentsEnvSchema: z.object({
     STRIPE_SECRET_KEY: z.string().min(1),
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
@@ -50,7 +50,7 @@ describe("env index failure", () => {
       CMS_SPACE_URL: "not-a-url",
       CMS_ACCESS_TOKEN: "",
       SANITY_API_VERSION: "",
-      // payment
+      // payments
       STRIPE_SECRET_KEY: "",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
       STRIPE_WEBHOOK_SECRET: "",

--- a/packages/config/__tests__/paymentsEnv.test.ts
+++ b/packages/config/__tests__/paymentsEnv.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@jest/globals";
 
-describe("paymentEnv", () => {
+describe("paymentsEnv", () => {
   const OLD_ENV = process.env;
 
   afterEach(() => {
@@ -16,12 +16,12 @@ describe("paymentEnv", () => {
 
     const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
-    const { paymentEnv, paymentEnvSchema } = await import("../src/env/payments");
+    const { paymentsEnv, paymentsEnvSchema } = await import("../src/env/payments");
 
     expect(spy).toHaveBeenCalledWith(
-      "⚠️ Invalid payment environment variables:",
+      "⚠️ Invalid payments environment variables:",
       expect.anything(),
     );
-    expect(paymentEnv).toEqual(paymentEnvSchema.parse({}));
+    expect(paymentsEnv).toEqual(paymentsEnvSchema.parse({}));
   });
 });

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -4,7 +4,7 @@ import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
 } from "./core.js";
-import { paymentEnvSchema } from "./payments.js";
+import { paymentsEnvSchema } from "./payments.js";
 import { shippingEnvSchema } from "./shipping.js";
 
 type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
@@ -35,7 +35,7 @@ export const mergeEnvSchemas = <T extends readonly AnyZodObject[]>(
 
 const mergedEnvSchema = mergeEnvSchemas(
   coreEnvBaseSchema,
-  paymentEnvSchema,
+  paymentsEnvSchema,
   shippingEnvSchema,
 );
 

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -1,7 +1,7 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
-export const paymentEnvSchema = z.object({
+export const paymentsEnvSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1).default("sk_test"),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z
     .string()
@@ -10,15 +10,15 @@ export const paymentEnvSchema = z.object({
   STRIPE_WEBHOOK_SECRET: z.string().min(1).default("whsec_test"),
 });
 
-const parsed = paymentEnvSchema.safeParse(process.env);
+const parsed = paymentsEnvSchema.safeParse(process.env);
 if (!parsed.success) {
   console.warn(
-    "⚠️ Invalid payment environment variables:",
+    "⚠️ Invalid payments environment variables:",
     parsed.error.format(),
   );
 }
 
-export const paymentEnv = parsed.success
+export const paymentsEnv = parsed.success
   ? parsed.data
-  : paymentEnvSchema.parse({});
-export type PaymentEnv = z.infer<typeof paymentEnvSchema>;
+  : paymentsEnvSchema.parse({});
+export type PaymentsEnv = z.infer<typeof paymentsEnvSchema>;

--- a/packages/stripe/src/index.js
+++ b/packages/stripe/src/index.js
@@ -1,6 +1,6 @@
 // packages/stripe/src/index.ts
 import "server-only";
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import Stripe from "stripe";
 /**
  * Edge-friendly Stripe client.
@@ -13,7 +13,7 @@ import Stripe from "stripe";
  * `apiVersion` line and Stripe will default to the newest version whenever
  * you bump the SDK.
  */
-export const stripe = new Stripe(paymentEnv.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(paymentsEnv.STRIPE_SECRET_KEY, {
     apiVersion: "2025-06-30.basil",
     httpClient: Stripe.createFetchHttpClient(),
 });

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,7 +1,7 @@
 // packages/stripe/src/index.ts
 import "server-only";
 
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import Stripe from "stripe";
 
 /**
@@ -15,7 +15,7 @@ import Stripe from "stripe";
  * `apiVersion` line and Stripe will default to the newest version whenever
  * you bump the SDK.
  */
-export const stripe = new Stripe(paymentEnv.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(paymentsEnv.STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
   httpClient: Stripe.createFetchHttpClient(),
 });

--- a/packages/template-app/src/api/billing/webhook/route.ts
+++ b/packages/template-app/src/api/billing/webhook/route.ts
@@ -1,6 +1,6 @@
 // packages/template-app/src/api/billing/webhook/route.ts
 import { stripe } from "@acme/stripe";
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { setStripeSubscriptionId } from "@platform-core/repositories/users";
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     event = stripe.webhooks.constructEvent(
       body,
       signature,
-      paymentEnv.STRIPE_WEBHOOK_SECRET,
+      paymentsEnv.STRIPE_WEBHOOK_SECRET,
     );
   } catch {
     return new NextResponse("Invalid signature", { status: 400 });

--- a/packages/template-app/src/api/stripe-webhook/route.ts
+++ b/packages/template-app/src/api/stripe-webhook/route.ts
@@ -2,7 +2,7 @@
 
 import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { stripe } from "@acme/stripe";
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
     event = stripe.webhooks.constructEvent(
       body,
       signature,
-      paymentEnv.STRIPE_WEBHOOK_SECRET
+      paymentsEnv.STRIPE_WEBHOOK_SECRET
     );
   } catch {
     return new NextResponse("Invalid signature", { status: 400 });


### PR DESCRIPTION
## Summary
- fix env type aliases to reference schema identifiers
- rename payments env exports to plural and update imports

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS5083 Cannot read file 'apps/shop-bcd/node_modules/tsconfig.base.json')*
- `pnpm --filter @acme/config test`
- `pnpm --filter @acme/stripe exec jest packages/stripe --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs`
- `pnpm --filter @acme/template-app test` *(fails: 1 failed, 10 passed, 11 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b2147b9f30832f9a349d8b50529588