### PR TITLE
refactor: normalize env module imports

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -139,6 +139,9 @@ module.exports = {
     "^\\./env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
     "^\\./(auth|cms|email|core|payments|shipping)\\.js$":
       "<rootDir>/packages/config/src/env/$1.ts",
+    "^\\.\\./(auth|cms|email|core|payments|shipping)\\.js$":
+      "<rootDir>/packages/config/src/env/$1.ts",
+    "^\.\./src/env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
 
     // CMS application aliases
     "^@/components/atoms/shadcn$":

--- a/packages/config/__tests__/authEnv.test.ts
+++ b/packages/config/__tests__/authEnv.test.ts
@@ -16,7 +16,7 @@ describe("authEnv", () => {
 
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/auth")).rejects.toThrow(
+    await expect(import("../src/env/auth.js")).rejects.toThrow(
       "Invalid auth environment variables",
     );
     expect(spy).toHaveBeenCalled();

--- a/packages/config/__tests__/cmsEnv.test.ts
+++ b/packages/config/__tests__/cmsEnv.test.ts
@@ -17,7 +17,7 @@ describe("cmsEnv", () => {
       SANITY_API_VERSION: "2023-01-01",
     } as NodeJS.ProcessEnv;
 
-    const { cmsEnv } = await import("../src/env/cms");
+    const { cmsEnv } = await import("../src/env/cms.js");
     expect(cmsEnv).toEqual({
       CMS_SPACE_URL: "https://example.com",
       CMS_ACCESS_TOKEN: "token",
@@ -33,7 +33,7 @@ describe("cmsEnv", () => {
       SANITY_API_VERSION: "2023-01-01",
     } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../src/env/cms")).rejects.toThrow(
+    await expect(import("../src/env/cms.js")).rejects.toThrow(
       "Invalid CMS environment variables",
     );
     expect(spy).toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe("cmsEnv", () => {
       NODE_ENV: "production",
     } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../src/env/cms")).rejects.toThrow(
+    await expect(import("../src/env/cms.js")).rejects.toThrow(
       "Invalid CMS environment variables",
     );
     expect(spy).toHaveBeenCalled();

--- a/packages/config/__tests__/coreEnvRefinement.test.ts
+++ b/packages/config/__tests__/coreEnvRefinement.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 
 describe("coreEnvSchema refinement", () => {
   it("reports invalid env variables", async () => {
-    const { coreEnvSchema } = await import("../src/env/core");
+    const { coreEnvSchema } = await import("../src/env/core.js");
     process.env = {
       ...OLD_ENV,
       DEPOSIT_RELEASE_ENABLED: "notbool",

--- a/packages/config/__tests__/emailEnv.test.ts
+++ b/packages/config/__tests__/emailEnv.test.ts
@@ -14,7 +14,7 @@ describe("emailEnv", () => {
       SMTP_URL: "notaurl",
     } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../src/env/email")).rejects.toThrow(
+    await expect(import("../src/env/email.js")).rejects.toThrow(
       "Invalid email environment variables",
     );
     expect(spy).toHaveBeenCalled();

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@jest/globals";
-import { coreEnvBaseSchema } from "../src/env/core";
+import { coreEnvBaseSchema } from "../src/env/core.js";
 
 describe("envSchema", () => {
   const OLD_ENV = process.env;
@@ -24,7 +24,7 @@ describe("envSchema", () => {
         SANITY_API_VERSION: "2023-01-01",
       } as NodeJS.ProcessEnv;
 
-    const { envSchema } = await import("../src/env");
+    const { envSchema } = await import("../src/env/index.js");
       const parsed = envSchema.parse({
         STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY!,
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
@@ -66,7 +66,7 @@ describe("envSchema", () => {
       SANITY_API_VERSION: "2023-01-01",
     } as NodeJS.ProcessEnv;
 
-    const { envSchema } = await import("../src/env");
+    const { envSchema } = await import("../src/env/index.js");
 
     const invalid = {
       STRIPE_SECRET_KEY: "sk",

--- a/packages/config/__tests__/envIndexFailure.test.ts
+++ b/packages/config/__tests__/envIndexFailure.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@jest/globals";
 import { z } from "zod";
 
 // Mock env modules to expose schemas without validating process.env.
-jest.mock("../src/env/cms", () => ({
+jest.mock("../src/env/cms.js", () => ({
   cmsEnvSchema: z.object({
     CMS_SPACE_URL: z.string().url(),
     CMS_ACCESS_TOKEN: z.string().min(1),
@@ -10,7 +10,7 @@ jest.mock("../src/env/cms", () => ({
   }),
 }));
 
-jest.mock("../src/env/core", () => ({
+jest.mock("../src/env/core.js", () => ({
   coreEnvBaseSchema: z.object({
     CMS_SPACE_URL: z.string().url(),
     CMS_ACCESS_TOKEN: z.string().min(1),
@@ -19,15 +19,15 @@ jest.mock("../src/env/core", () => ({
   depositReleaseEnvRefinement: () => {},
 }));
 
-jest.mock("../src/env/payments", () => ({
-  paymentEnvSchema: z.object({
+jest.mock("../src/env/payments.js", () => ({
+  paymentsEnvSchema: z.object({
     STRIPE_SECRET_KEY: z.string().min(1),
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
   }),
 }));
 
-jest.mock("../src/env/shipping", () => ({
+jest.mock("../src/env/shipping.js", () => ({
   shippingEnvSchema: z.object({
     TAXJAR_KEY: z.string(),
   }),
@@ -50,7 +50,7 @@ describe("env index failure", () => {
       CMS_SPACE_URL: "not-a-url",
       CMS_ACCESS_TOKEN: "",
       SANITY_API_VERSION: "",
-      // payment
+      // payments
       STRIPE_SECRET_KEY: "",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
       STRIPE_WEBHOOK_SECRET: "",
@@ -62,7 +62,7 @@ describe("env index failure", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    await expect(import("../src/env/index")).rejects.toThrow(
+    await expect(import("../src/env/index.js")).rejects.toThrow(
       "Invalid environment variables",
     );
     expect(errorSpy).toHaveBeenCalled();

--- a/packages/config/__tests__/paymentsEnv.test.ts
+++ b/packages/config/__tests__/paymentsEnv.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@jest/globals";
 
-describe("paymentEnv", () => {
+describe("paymentsEnv", () => {
   const OLD_ENV = process.env;
 
   afterEach(() => {
@@ -16,12 +16,14 @@ describe("paymentEnv", () => {
 
     const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
-    const { paymentEnv, paymentEnvSchema } = await import("../src/env/payments");
+    const { paymentsEnv, paymentsEnvSchema } = await import(
+      "../src/env/payments.js"
+    );
 
     expect(spy).toHaveBeenCalledWith(
-      "⚠️ Invalid payment environment variables:",
+      "⚠️ Invalid payments environment variables:",
       expect.anything(),
     );
-    expect(paymentEnv).toEqual(paymentEnvSchema.parse({}));
+    expect(paymentsEnv).toEqual(paymentsEnvSchema.parse({}));
   });
 });

--- a/packages/config/__tests__/shippingEnv.test.ts
+++ b/packages/config/__tests__/shippingEnv.test.ts
@@ -16,7 +16,7 @@ describe("shippingEnv", () => {
       DHL_KEY: "dhl",
     } as NodeJS.ProcessEnv;
 
-    const { shippingEnv } = await import("../src/env/shipping");
+    const { shippingEnv } = await import("../src/env/shipping.js");
     expect(shippingEnv).toEqual({
       TAXJAR_KEY: "tax",
       UPS_KEY: "ups",
@@ -33,7 +33,7 @@ describe("shippingEnv", () => {
     } as unknown as NodeJS.ProcessEnv;
 
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../src/env/shipping")).rejects.toThrow(
+    await expect(import("../src/env/shipping.js")).rejects.toThrow(
       "Invalid shipping environment variables",
     );
     expect(spy).toHaveBeenCalled();

--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
-import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core";
+import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.js";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
 

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { authEnvSchema } from "./auth.js";
 import { cmsEnvSchema } from "./cms.js";
 import { emailEnvSchema } from "./email.js";
+import { paymentsEnvSchema } from "./payments.js";
+import { shippingEnvSchema } from "./shipping.js";
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -82,6 +84,8 @@ const baseEnvSchema = z
 export const coreEnvBaseSchema = authEnvSchema
   .merge(cmsEnvSchema)
   .merge(emailEnvSchema)
+  .merge(paymentsEnvSchema)
+  .merge(shippingEnvSchema)
   .merge(baseEnvSchema);
 
 export function depositReleaseEnvRefinement(

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -4,7 +4,7 @@ import {
   coreEnvBaseSchema,
   depositReleaseEnvRefinement,
 } from "./core.js";
-import { paymentEnvSchema } from "./payments.js";
+import { paymentsEnvSchema } from "./payments.js";
 import { shippingEnvSchema } from "./shipping.js";
 
 type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
@@ -35,7 +35,7 @@ export const mergeEnvSchemas = <T extends readonly AnyZodObject[]>(
 
 const mergedEnvSchema = mergeEnvSchemas(
   coreEnvBaseSchema,
-  paymentEnvSchema,
+  paymentsEnvSchema,
   shippingEnvSchema,
 );
 

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -1,7 +1,7 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
-export const paymentEnvSchema = z.object({
+export const paymentsEnvSchema = z.object({
   STRIPE_SECRET_KEY: z.string().min(1).default("sk_test"),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z
     .string()
@@ -10,15 +10,15 @@ export const paymentEnvSchema = z.object({
   STRIPE_WEBHOOK_SECRET: z.string().min(1).default("whsec_test"),
 });
 
-const parsed = paymentEnvSchema.safeParse(process.env);
+const parsed = paymentsEnvSchema.safeParse(process.env);
 if (!parsed.success) {
   console.warn(
-    "⚠️ Invalid payment environment variables:",
+    "⚠️ Invalid payments environment variables:",
     parsed.error.format(),
   );
 }
 
-export const paymentEnv = parsed.success
+export const paymentsEnv = parsed.success
   ? parsed.data
-  : paymentEnvSchema.parse({});
-export type PaymentEnv = z.infer<typeof paymentEnvSchema>;
+  : paymentsEnvSchema.parse({});
+export type PaymentsEnv = z.infer<typeof paymentsEnvSchema>;

--- a/packages/stripe/src/index.js
+++ b/packages/stripe/src/index.js
@@ -1,6 +1,6 @@
 // packages/stripe/src/index.ts
 import "server-only";
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import Stripe from "stripe";
 /**
  * Edge-friendly Stripe client.
@@ -13,7 +13,7 @@ import Stripe from "stripe";
  * `apiVersion` line and Stripe will default to the newest version whenever
  * you bump the SDK.
  */
-export const stripe = new Stripe(paymentEnv.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(paymentsEnv.STRIPE_SECRET_KEY, {
     apiVersion: "2025-06-30.basil",
     httpClient: Stripe.createFetchHttpClient(),
 });

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,7 +1,7 @@
 // packages/stripe/src/index.ts
 import "server-only";
 
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import Stripe from "stripe";
 
 /**
@@ -15,7 +15,7 @@ import Stripe from "stripe";
  * `apiVersion` line and Stripe will default to the newest version whenever
  * you bump the SDK.
  */
-export const stripe = new Stripe(paymentEnv.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(paymentsEnv.STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
   httpClient: Stripe.createFetchHttpClient(),
 });

--- a/packages/template-app/src/api/billing/webhook/route.ts
+++ b/packages/template-app/src/api/billing/webhook/route.ts
@@ -1,6 +1,6 @@
 // packages/template-app/src/api/billing/webhook/route.ts
 import { stripe } from "@acme/stripe";
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { setStripeSubscriptionId } from "@platform-core/repositories/users";
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     event = stripe.webhooks.constructEvent(
       body,
       signature,
-      paymentEnv.STRIPE_WEBHOOK_SECRET,
+      paymentsEnv.STRIPE_WEBHOOK_SECRET,
     );
   } catch {
     return new NextResponse("Invalid signature", { status: 400 });

--- a/packages/template-app/src/api/stripe-webhook/route.ts
+++ b/packages/template-app/src/api/stripe-webhook/route.ts
@@ -2,7 +2,7 @@
 
 import { handleStripeWebhook } from "@platform-core/stripe-webhook";
 import { stripe } from "@acme/stripe";
-import { paymentEnv } from "@acme/config/env/payments";
+import { paymentsEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
     event = stripe.webhooks.constructEvent(
       body,
       signature,
-      paymentEnv.STRIPE_WEBHOOK_SECRET
+      paymentsEnv.STRIPE_WEBHOOK_SECRET
     );
   } catch {
     return new NextResponse("Invalid signature", { status: 400 });


### PR DESCRIPTION
## Summary
- normalize env imports to use explicit `.js` extensions and plural `payments` naming
- include payments and shipping in core env schema
- update tests and tooling to resolve new module specifiers

## Testing
- `pnpm -r build` *(fails: apps/cms build: Failed; apps/shop-bcd build: Failed)*
- `pnpm --filter @acme/config test`
- `pnpm --filter @acme/stripe test` *(fails: /api/rental › POST creates order with deposit and return date)*

------
https://chatgpt.com/codex/tasks/task_e_68b21831d478832fba50dfd17c8bc5d0