### PR TITLE
Wrap CMS layout with CurrencyProvider

### DIFF
--- a/apps/cms/src/app/layout.tsx
+++ b/apps/cms/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // apps/cms/src/app/layout.tsx
 import { CartProvider } from "@/contexts/CartContext";
+import { CurrencyProvider } from "@/contexts/CurrencyContext";
 import { initTheme } from "@platform-core/utils";
 import "@acme/zod-utils/initZod";
 import type { Metadata } from "next";
@@ -38,7 +39,9 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         {/* Global providers go here */}
-        <CartProvider>{children}</CartProvider>
+        <CurrencyProvider>
+          <CartProvider>{children}</CartProvider>
+        </CurrencyProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap the CMS root layout in `CurrencyProvider` so `useCurrency` hooks are always within context

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm test:cms` *(fails: inventory import/export timeout, rental test expectations, media and products action timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68b219655de8832fa28863ee19e27ad3