### PR TITLE
test: cover listSegments and segment filters

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -22,6 +22,48 @@ jest.mock("../providers/resend", () => ({
   ResendProvider: class {},
 }));
 
+const coreEnv: Record<string, any> = {};
+jest.mock("@acme/config/env/core", () => ({ coreEnv }));
+jest.mock("@acme/lib", () => ({ validateShopName: (s: string) => s }));
+
+describe("listSegments", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns empty list for unknown provider", async () => {
+    coreEnv.EMAIL_PROVIDER = "unknown";
+    const { listSegments } = await import("../segments");
+    await expect(listSegments()).resolves.toEqual([]);
+    delete coreEnv.EMAIL_PROVIDER;
+  });
+});
+
+describe("resolveSegment filters", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("ignores events without matching filter fields", async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify([
+        { id: "vips", filters: [{ field: "plan", value: "gold" }] },
+      ])
+    );
+    mockStat.mockResolvedValue({ mtimeMs: 1 });
+    mockListEvents.mockResolvedValue([
+      { email: "a@example.com", plan: "silver" },
+      { email: "b@example.com" },
+    ]);
+
+    const { resolveSegment } = await import("../segments");
+    const result = await resolveSegment("shop1", "vips");
+    expect(result).toEqual([]);
+  });
+});
+
 describe("resolveSegment caching", () => {
   beforeEach(() => {
     jest.resetModules();


### PR DESCRIPTION
## Summary
- add test ensuring unknown email provider yields no segments
- verify resolveSegment skips events with unmatched filters

## Testing
- `pnpm -r build` (fails: Error occurred prerendering page /en/product/green-sneaker)
- `pnpm --filter @acme/email test src/__tests__/segments.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b21e39b2f8832f9f1bdc9e7c6d478a