### PR TITLE
test: add hooks open and click listeners

### DIFF
--- a/packages/email/src/__tests__/hooks.test.ts
+++ b/packages/email/src/__tests__/hooks.test.ts
@@ -1,0 +1,25 @@
+import { onOpen, onClick, emitOpen, emitClick } from "../hooks";
+
+jest.mock("@platform-core/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+describe("hooks", () => {
+  it("invokes open and click listeners with shop and payload", async () => {
+    const shop = "test-shop";
+    const payload = { campaign: "spring" };
+    const openListener = jest.fn();
+    const clickListener = jest.fn();
+
+    onOpen(openListener);
+    onClick(clickListener);
+
+    await emitOpen(shop, payload);
+    await emitClick(shop, payload);
+
+    expect(openListener).toHaveBeenCalledTimes(1);
+    expect(openListener).toHaveBeenCalledWith(shop, payload);
+    expect(clickListener).toHaveBeenCalledTimes(1);
+    expect(clickListener).toHaveBeenCalledWith(shop, payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests ensuring `emitOpen` and `emitClick` trigger registered listeners

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: useCurrency must be inside CurrencyProvider)*
- `pnpm --filter @acme/email test -- src/__tests__/hooks.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b21e378b94832f8295c4a1206810dc