### PR TITLE
test(sendgrid): handle fetch failures

### DIFF
--- a/packages/email/src/providers/__tests__/sendgridProvider.test.ts
+++ b/packages/email/src/providers/__tests__/sendgridProvider.test.ts
@@ -1,0 +1,71 @@
+describe("SendgridProvider additional cases", () => {
+  const options = {
+    to: "to@example.com",
+    subject: "Subject",
+    html: "<p>HTML</p>",
+    text: "Text",
+  };
+  const realFetch = global.fetch;
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    global.fetch = realFetch;
+    delete process.env.CAMPAIGN_FROM;
+    delete process.env.SENDGRID_API_KEY;
+    delete process.env.SENDGRID_MARKETING_KEY;
+  });
+
+  it("wraps non-Error sgMail.send rejections", async () => {
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+    const sgMail = require("@sendgrid/mail").default;
+    sgMail.send.mockRejectedValueOnce("boom");
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    const { ProviderError } = require("../types");
+    await expect(provider.send(options)).rejects.toBeInstanceOf(ProviderError);
+  });
+
+  it("getCampaignStats returns emptyStats on fetch failure", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const { emptyStats } = await import("../../stats");
+    const provider = new SendgridProvider();
+    await expect(provider.getCampaignStats("1")).resolves.toEqual(emptyStats);
+  });
+
+  it("createContact returns empty string when fetch rejects", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.createContact("user@example.com")).resolves.toBe("");
+  });
+
+  it("addToList resolves even when fetch rejects", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.addToList("cid", "lid")).resolves.toBeUndefined();
+  });
+
+  it("listSegments returns [] when fetch rejects", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.listSegments()).resolves.toEqual([]);
+  });
+
+  it("listSegments returns [] when json fails", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      json: () => Promise.reject(new Error("bad")),
+    }) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.listSegments()).resolves.toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add coverage for Sendgrid provider failure paths
- ensure fetch failures return safe defaults

## Testing
- `pnpm --filter @acme/email test -- packages/email/src/providers/__tests__/sendgridProvider.test.ts`
- `pnpm -r build` *(fails: useCurrency must be inside CurrencyProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b21e3f6d20832fb0337c1f7d5fa2f3