### PR TITLE
test: cover resend provider list errors

### DIFF
--- a/packages/email/src/providers/__tests__/resendProvider.test.ts
+++ b/packages/email/src/providers/__tests__/resendProvider.test.ts
@@ -1,0 +1,25 @@
+import { ResendProvider } from "../resend";
+
+describe("ResendProvider segmentation error handling", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("resolves when addToList fetch rejects", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    (global as any).fetch = jest.fn(() => Promise.reject(new Error("fail")));
+    const provider = new ResendProvider();
+    await expect(provider.addToList("c1", "l1")).resolves.toBeUndefined();
+  });
+
+  it("returns [] when listSegments json rejects", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.reject(new Error("bad")),
+    });
+    const provider = new ResendProvider();
+    await expect(provider.listSegments()).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ResendProvider addToList and listSegments error handling

## Testing
- `pnpm -r build` *(fails: useCurrency must be inside CurrencyProvider)*
- `pnpm exec jest packages/email/src/providers/__tests__/resendProvider.test.ts --config jest.config.cjs --runInBand --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b21e3e3e6c832f9296a21b1dca9e67