### PR TITLE
test: validate email env schema

### DIFF
--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+
+describe("email env module", () => {
+  const ORIGINAL_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("logs formatted errors and throws on invalid configuration", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      EMAIL_PROVIDER: "invalid" as unknown as NodeJS.ProcessEnv[string],
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../email.ts")).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid email environment variables:",
+      expect.objectContaining({
+        EMAIL_PROVIDER: {
+          _errors: [expect.stringContaining("Invalid enum value")],
+        },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying email env validation logs formatted errors and throws

## Testing
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: useCurrency must be inside CurrencyProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b21e362358832fbc081f682771a781