### PR TITLE
test: cover maintenance scheduler error handling

### DIFF
--- a/packages/platform-machine/src/__tests__/maintenanceScheduler.test.ts
+++ b/packages/platform-machine/src/__tests__/maintenanceScheduler.test.ts
@@ -1,0 +1,37 @@
+jest.mock("fs/promises", () => ({
+  readdir: jest.fn(),
+}));
+
+jest.mock("@platform-core/utils", () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+
+import { readdir } from "fs/promises";
+import { logger } from "@platform-core/utils";
+import { startMaintenanceScheduler } from "../maintenanceScheduler";
+
+describe("startMaintenanceScheduler", () => {
+  let timer: NodeJS.Timeout;
+  const readdirMock = readdir as unknown as jest.Mock;
+  const errorMock = logger.error as unknown as jest.Mock;
+
+  afterEach(() => {
+    if (timer) {
+      clearInterval(timer);
+    }
+    jest.clearAllMocks();
+  });
+
+  it("logs an error when runMaintenanceScan throws", async () => {
+    readdirMock.mockRejectedValueOnce(new Error("fail"));
+
+    timer = startMaintenanceScheduler();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errorMock).toHaveBeenCalledWith("maintenance scan failed", {
+      err: expect.any(Error),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test maintenance scheduler logs errors when scan fails

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/platform-machine test packages/platform-machine/src/__tests__/maintenanceScheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b220d48280832f8a854a86b3a92157