### PR TITLE
Refactor reverse logistics service for testability

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -131,6 +131,7 @@ module.exports = {
       "<rootDir>/packages/config/src/env/$1.ts",
     "^@acme/config$": "<rootDir>/packages/config/src/env/index.ts",
     "^@acme/config/(.*)$": "<rootDir>/packages/config/src/$1",
+    "^@acme/platform-machine/src/(.*)$": "<rootDir>/packages/platform-machine/src/$1",
     "^@acme/plugin-sanity$": "<rootDir>/test/__mocks__/pluginSanityStub.ts",
     "^@acme/plugin-sanity/(.*)$": "<rootDir>/test/__mocks__/pluginSanityStub.ts",
     "^@acme/zod-utils/initZod$": "<rootDir>/test/emptyModule.js",


### PR DESCRIPTION
## Summary
- export and enhance reverse logistics configuration resolution
- allow injection and error logging in reverse logistics service
- add test path alias for platform-machine source files

## Testing
- `pnpm exec jest packages/platform-machine/__tests__/reverseLogisticsService.test.ts --runTestsByPath --config jest.config.cjs --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_68b2241fef08832fbc72c6d26da9ce7f