### PR TITLE
test: expand reverse logistics service coverage

### DIFF
--- a/packages/platform-machine/src/reverseLogisticsService.ts
+++ b/packages/platform-machine/src/reverseLogisticsService.ts
@@ -103,7 +103,7 @@ function envKey(shop: string, key: string): string {
   return `REVERSE_LOGISTICS_${key}_${shop.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
 }
 
-async function resolveConfig(
+export async function resolveConfig(
   shop: string,
   dataRoot: string,
   override: Partial<ReverseLogisticsConfig> = {}


### PR DESCRIPTION
## Summary
- extend reverse logistics service tests to cover all event statuses and parse failures
- verify config resolution priority and service scheduling
- expose `resolveConfig` for testing

## Testing
- `pnpm --filter @acme/platform-machine exec jest src/__tests__/reverseLogisticsService.test.ts --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b22515fd30832f925180cef6e01f28