### PR TITLE
Fix config path resolution in TypeScript builds

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -21,6 +21,8 @@
       "@acme/ui/*": ["types-compat/ui"],
       "@acme/platform-core": ["src/index.ts"],
       "@acme/platform-core/*": ["src/*"],
+      "@acme/config": ["../config/src/index.ts"],
+      "@acme/config/*": ["../config/src/*"],
       "better-sqlite3": ["src/types/better-sqlite3"]
     }
   },

--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -40,6 +40,9 @@
       "@config": ["packages/config/src/env/index.ts"],
       "@config/*": ["packages/config/src/env/*"],
 
+      "@acme/config": ["packages/config/src/index.ts"],
+      "@acme/config/*": ["packages/config/src/*"],
+
       /* date utilities */
       "@date-utils": ["packages/date-utils/src/index.ts"],
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -139,6 +139,12 @@
       "@date-utils/*": [
         "packages/date-utils/src/*"
       ],
+      "@acme/config": [
+        "packages/config/src/index.ts"
+      ],
+      "@acme/config/*": [
+        "packages/config/src/*"
+      ],
       "@acme/configurator": [
         "packages/configurator/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- map `@acme/config` and subpaths to source files in shared tsconfig
- add config path alias to platform-core to resolve shipping env
- expose config path alias in platform-machine for consistency

## Testing
- `npx tsc -b packages/platform-core`
- `pnpm -r build` *(fails: Next.js build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2270c268c832fadd7b408a2b52916