### PR TITLE
fix: resolve eslint issues in UI components

### DIFF
--- a/packages/ui/src/components/atoms/shadcn/index.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.ts
@@ -32,4 +32,3 @@ export {
 } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";

--- a/packages/ui/src/components/cms/blocks/atoms.tsx
+++ b/packages/ui/src/components/cms/blocks/atoms.tsx
@@ -98,10 +98,10 @@ const atomEntries = {
   Spacer: { component: Spacer },
   CustomHtml: { component: CustomHtml },
   Button: { component: ButtonBlock },
-} satisfies Record<string, BlockRegistryEntry<any>>;
+} satisfies Record<string, BlockRegistryEntry<unknown>>;
 
 type AtomRegistry = {
-  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<any>;
+  -readonly [K in keyof typeof atomEntries]: BlockRegistryEntry<unknown>;
 };
 
 export const atomRegistry: AtomRegistry = Object.entries(atomEntries).reduce(


### PR DESCRIPTION
## Summary
- remove disallowed Accordion re-export from shadcn atoms index
- use `unknown` instead of `any` in CMS atom registry

## Testing
- `pnpm exec eslint packages/ui/src/components/atoms/shadcn/index.ts packages/ui/src/components/cms/blocks/atoms.tsx`
- `pnpm -r build` *(fails: apps/cms build: Failed, apps/shop-bcd build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b227aa5250832fab94f6062bee5e8a