### PR TITLE
chore: ignore jest polyfill setup in lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,7 @@ export default [
       "**/*.test.*",
       "**/*.spec.*",
       "**/*.d.ts",
-      "**/jest.setup.{ts,tsx}",
+      "**/jest.setup*.{ts,tsx}",
       "**/*.test.{ts,tsx,js,jsx}",
       "**/*.spec.{ts,tsx,js,jsx}",
     ],


### PR DESCRIPTION
## Summary
- prevent ESLint from parsing `jest.setup.polyfills.ts`

## Testing
- `pnpm -r build`
- `pnpm exec eslint "apps/cms/**/*.{ts,tsx,js,jsx}"`


------
https://chatgpt.com/codex/tasks/task_e_68b22760a4e4832f9a4bfa3628465b64