### PR TITLE
fix: resolve duplicate config exports

### DIFF
--- a/packages/platform-machine/src/index.ts
+++ b/packages/platform-machine/src/index.ts
@@ -1,6 +1,18 @@
 export * from "./fsm";
 export * from "./releaseDepositsService";
-export * from "./reverseLogisticsService";
-export * from "./lateFeeService";
+
+export {
+  writeReverseLogisticsEvent,
+  processReverseLogisticsEventsOnce,
+  resolveConfig,
+  startReverseLogisticsService,
+} from "./reverseLogisticsService";
+
+export {
+  chargeLateFeesOnce,
+  resolveConfig as resolveLateFeeConfig,
+  startLateFeeService,
+} from "./lateFeeService";
+
 export * from "./useFSM";
 export * from "./maintenanceScheduler";


### PR DESCRIPTION
## Summary
- resolve duplicate `resolveConfig` exports in platform-machine index by aliasing late fee service

## Testing
- `pnpm --filter @acme/platform-machine build`
- `pnpm --filter @acme/platform-machine exec jest __tests__/reverseLogisticsService.test.ts --runInBand --config ../../jest.config.cjs` *(fails: Cannot find module 'undici')*
- `pnpm -r build` *(fails: apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d88423ec832f8deac9376eaae531