### PR TITLE
test: add API error-handling coverage

### DIFF
--- a/apps/cms/__tests__/api.cart.test.ts
+++ b/apps/cms/__tests__/api.cart.test.ts
@@ -17,4 +17,17 @@ describe("cart API", () => {
     const json = await res.json();
     expect(json).toEqual({ ok: true, cart: {} });
   });
+
+  it("returns 404 for unknown sku", async () => {
+    const { POST } = await import("../src/app/api/cart/route");
+    const req = new Request("http://test.local/api/cart", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sku: { id: "missing" }, qty: 1 }),
+    }) as any;
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json).toEqual({ error: "Item not found" });
+  });
 });

--- a/apps/cms/__tests__/api.shops.test.ts
+++ b/apps/cms/__tests__/api.shops.test.ts
@@ -27,4 +27,16 @@ describe("shops API", () => {
     expect(json).toEqual(["shop-a", "shop-b"]);
     (process.env as Record<string, string>).NODE_ENV = prev as string;
   });
+
+  it("handles listShops error", async () => {
+    jest.doMock("../src/lib/listShops", () => ({
+      __esModule: true,
+      listShops: jest.fn().mockRejectedValue(new Error("boom")),
+    }));
+    const { GET } = await import("../src/app/api/shops/route");
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json).toHaveProperty("error");
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test for unknown SKU in cart API
- ensure shop listing route reports errors

## Testing
- `pnpm test:cms` *(fails: packages/template-app/__tests__/rental.test.ts, apps/cms/__tests__/products.test.ts, apps/cms/__tests__/wizard-flow.integration.test.tsx, packages/email/src/scheduler.test.ts, packages/platform-core/src/shipping/index.test.ts, packages/platform-core/__tests__/plugins.test.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3039b1728832f9c7263c5ceef7e58