### PR TITLE
test: add coverage for cart size edge cases

### DIFF
--- a/apps/cms/__tests__/api.cart.test.ts
+++ b/apps/cms/__tests__/api.cart.test.ts
@@ -30,4 +30,21 @@ describe("cart API", () => {
     const json = await res.json();
     expect(json).toEqual({ error: "Item not found" });
   });
+
+  it("handles SKU without sizes", async () => {
+    jest.doMock("@platform-core/products", () => ({
+      __esModule: true,
+      getProductById: () => ({ id: "foo", stock: 1 }),
+      PRODUCTS: [{ id: "foo", stock: 1 }],
+    }));
+
+    const { POST } = await import("../src/app/api/cart/route");
+    const res = await POST({
+      json: async () => ({ sku: { id: "foo" }, qty: 1 }),
+      cookies: { get: () => undefined },
+    } as unknown as Request);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
 });

--- a/packages/platform-core/__tests__/cartApi.missingSizes.test.ts
+++ b/packages/platform-core/__tests__/cartApi.missingSizes.test.ts
@@ -1,0 +1,26 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+describe("cart API edge runtime", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("throws when SKU is missing sizes", async () => {
+    jest.doMock("../src/products", () => ({
+      __esModule: true,
+      getProductById: () => ({ id: "foo", stock: 1 }),
+      PRODUCTS: [],
+    }));
+
+    const { POST } = await import("../src/cartApi");
+
+    await expect(
+      POST({
+        json: async () => ({ sku: { id: "foo" }, qty: 1 }),
+        cookies: { get: () => undefined },
+      } as unknown as NextRequest)
+    ).rejects.toThrow(/length/);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for CMS cart API to handle products lacking a `sizes` list
- add platform-core test exposing runtime error when `sku.sizes` is undefined

## Testing
- `pnpm --filter @acme/platform-core test -- __tests__/cartApi.missingSizes.test.ts`
- `pnpm --filter @apps/cms test -- __tests__/api.cart.test.ts`
- `pnpm -r build` *(fails: ENOENT for missing plugin directories)*

------
https://chatgpt.com/codex/tasks/task_e_68b3079144a0832fb4fdedc3e7a26f2f