### PR TITLE
fix: use workspace React

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -26,6 +26,8 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     externalDir: true,
+    // Use React from node_modules to avoid version mismatches
+    prebundledReact: false,
   },
 
   // Keep heavy Node-only libs external on the server bundle


### PR DESCRIPTION
## Summary
- disable Next.js prebundled React in CMS to ensure workspace React 19.1.0 is used

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Package path ./decode not exported from parse5)*
- `pnpm test` *(fails: @acme/eslint-plugin-ds#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c4a21a0832f983b6d4e3863da8b