### PR TITLE
docs: document package management

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 ## Getting Started
 - [Install](./install.md)
 - [Setup](./setup.md)
+- [Package management](./package-management.md)
 - [CMS guide](./cms.md)
 - [Storybook](./storybook.md)
 - [Permissions](./permissions.md)

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -1,0 +1,20 @@
+# Package Management
+
+## Workspace layout
+The monorepo uses **pnpm workspaces** to organize applications and shared packages. Patterns in `pnpm-workspace.yaml` include `apps/**` for app sources, `apps-script`, `packages/**`, and special entries such as `packages/platform-machine` and `packages/plugins/sanity`.
+
+## Turbo tasks
+[Turborepo](https://turbo.build) coordinates common tasks across the workspace. The `turbo.json` config defines pipelines for `dev`, `build`, `lint`, and `test`, enabling caching and dependency-aware execution.
+
+## Scripts
+Use these `package.json` scripts for day‑to‑day development:
+
+- `pnpm dev` – runs `turbo run dev --parallel` to start all apps in development. Build packages first with `pnpm -r build`.
+- `pnpm build` – cleans and builds every package, regenerates tokens, and checks the Tailwind preset.
+- `pnpm lint` – runs lint rules on all projects.
+- `pnpm test` – executes unit tests; run before pushing or in CI.
+- `pnpm quickstart-shop` – scaffolds a new shop with optional seeding for rapid demos.
+
+## Reproducible builds
+The workspace pins transitive dependencies via `pnpm` **overrides** and compiles a curated list of native modules listed in `onlyBuiltDependencies`. These settings ensure consistent, reproducible builds across environments.
+


### PR DESCRIPTION
## Summary
- add package management guide detailing workspace layout, Turbo pipelines, scripts, and reproducible build settings
- link the new guide from the docs index

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported from package entities)*

------
https://chatgpt.com/codex/tasks/task_e_68b4701c5d78832fb89db461c0b54c50