### PR TITLE
docs: document Cloudflare Next.js config

### DIFF
--- a/docs/nextjs-config.md
+++ b/docs/nextjs-config.md
@@ -1,0 +1,25 @@
+# Next.js configuration
+
+Cloudflare Pages requires a few non‑default Next.js options. The project's [`next.config.mjs`](../next.config.mjs) applies them.
+
+## Cloudflare‑specific options
+
+- `images.unoptimized: true` — Cloudflare Pages cannot use the Next.js Image Optimization API.
+- `output: "standalone"` — required so `@cloudflare/next-on-pages` can package the app.
+- Server builds enable source maps only outside development (`config.devtool = "source-map"`) to avoid the "Improper devtool" warning.
+- Webpack aliases map `node:` builtin module specifiers (for example `node:stream` or `node:crypto`) to their standard names to prevent `UnhandledSchemeError` during the build.
+
+## Extending Node builtin aliases
+
+When a new `node:` import is introduced, add its module name to the `nodeBuiltins` array in `next.config.mjs`:
+
+```js
+const nodeBuiltins = [
+  "assert",
+  "buffer",
+  // ...existing builtins
+  "vm", // add new builtins here
+];
+```
+
+Webpack will automatically alias `node:vm` to `vm`, letting Cloudflare's environment resolve it correctly.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,6 +5,8 @@
 - **Node.js** v20 or newer
 - **pnpm** v10 (repo uses pnpm@10.12.1)
 
+See [Next.js configuration](./nextjs-config.md) for Cloudflare-specific framework options.
+
 For a one-liner that scaffolds a shop, validates the environment, and starts the dev server:
 
 ```bash


### PR DESCRIPTION
## Summary
- document Cloudflare-specific Next.js configuration and node: builtin aliasing
- link the new Next.js config guide from the setup docs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module 'react/jsx-runtime')*


------
https://chatgpt.com/codex/tasks/task_e_68b4701b8ac4832fae2add7e1b14fdad