### PR TITLE
test: add dashboard upgrade page test

### DIFF
--- a/apps/dashboard/__tests__/Upgrade.test.tsx
+++ b/apps/dashboard/__tests__/Upgrade.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Upgrade from "../src/pages/Upgrade";
+import { useRouter } from "next/router";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+describe("Upgrade page", () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ query: { id: "shop1" } });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockReset();
+    global.fetch = originalFetch;
+  });
+
+  it("loads components, toggles selection, and publishes", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          core: [
+            { file: "CompA.tsx", componentName: "CompA" },
+            { file: "CompB.tsx", componentName: "CompB" },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, text: async () => "" });
+
+    render(<Upgrade />);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/shop/shop1/component-diff"
+    );
+
+    await screen.findByText("core");
+
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("CompA"));
+    expect(screen.getByText("CompA.tsx")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /publish upgrade/i })
+    );
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/shop/shop1/publish-upgrade",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ components: ["CompA.tsx"] }),
+        })
+      )
+    );
+
+    await screen.findByText("Upgrade published successfully.");
+  });
+});

--- a/apps/dashboard/jest.config.cjs
+++ b/apps/dashboard/jest.config.cjs
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const base = require("@acme/config/jest.preset.cjs");
+const { "^@/(.*)$": _unused, ...baseModuleNameMapper } = base.moduleNameMapper;
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  roots: ["<rootDir>/apps/dashboard/src", "<rootDir>/apps/dashboard/__tests__"],
+  moduleNameMapper: {
+    ...baseModuleNameMapper,
+    "^@/(.*)$": "<rootDir>/apps/dashboard/src/$1",
+    "^entities/decode$": "<rootDir>/node_modules/entities/lib/decode.js",
+  },
+};

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@apps/dashboard",
+  "private": true,
+  "scripts": {
+    "test": "jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs"
+  }
+}

--- a/apps/dashboard/tsconfig.test.json
+++ b/apps/dashboard/tsconfig.test.json
@@ -1,0 +1,11 @@
+// apps/dashboard/tsconfig.test.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom", "jest", "node"],
+    "noEmit": true,
+    "allowJs": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -48,6 +48,7 @@
     { "path": "./packages/types/tsconfig.test.json" },
     { "path": "./packages/ui/tsconfig.test.json" },
     { "path": "./packages/i18n/tsconfig.test.json" },
-    { "path": "./apps/cms/tsconfig.test.json" }
+    { "path": "./apps/cms/tsconfig.test.json" },
+    { "path": "./apps/dashboard/tsconfig.test.json" }
   ]
 }


### PR DESCRIPTION
## Summary
- add Jest/RTL test for dashboard upgrade page
- configure dashboard workspace for Jest
- link dashboard test config to root test setup

## Testing
- `pnpm -r build` *(fails: Package subpath './decode' is not defined by "exports" in entities)*
- `pnpm --filter @apps/dashboard test` *(fails: Package subpath './decode' is not defined by "exports" in entities)*

------
https://chatgpt.com/codex/tasks/task_e_68b47194f740832fbe3455dddec9219d