### PR TITLE
test: add dashboard and shop e2e specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
       - run: pnpm install
       - run: pnpm lint && pnpm test
       - run: pnpm build
+      - run: pnpm e2e:dashboard
+      - run: pnpm e2e:shop
       - run: npx @cloudflare/next-on-pages deploy \
                --project-name=base-shop \
                --branch=${{ github.ref_name }}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3006",
+    baseUrl: process.env.CYPRESS_BASE_URL || "http://localhost:3006",
     supportFile: false,
     specPattern: "cypress/e2e/**/*.cy.ts",
   },

--- a/cypress/e2e/dashboard-signin.cy.ts
+++ b/cypress/e2e/dashboard-signin.cy.ts
@@ -1,0 +1,10 @@
+describe("Dashboard sign in", () => {
+  it("logs in via the login page and redirects", () => {
+    const callbackUrl = "/cms";
+    cy.visit(`/login?callbackUrl=${callbackUrl}`);
+    cy.get('input[name="email"]').type("admin@example.com");
+    cy.get('input[name="password"]').type("admin");
+    cy.contains("button", "Continue").click();
+    cy.location("pathname", { timeout: 10000 }).should("eq", callbackUrl);
+  });
+});

--- a/cypress/e2e/shop-customer.cy.ts
+++ b/cypress/e2e/shop-customer.cy.ts
@@ -1,0 +1,9 @@
+describe("Shop customer login", () => {
+  it("shows an error for invalid credentials", () => {
+    cy.visit("/login");
+    cy.get('input[name="customerId"]').type("cust1");
+    cy.get('input[name="password"]').type("pass1pass");
+    cy.contains("button", "Login").click();
+    cy.contains("Invalid credentials");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "test:coverage": "CI=true turbo run test -- --coverage",
     "e2e": "start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run\"",
     "e2e:open": "start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress open\"",
+    "e2e:dashboard": "start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run --spec cypress/e2e/dashboard-signin.cy.ts\"",
+    "e2e:shop": "start-server-and-test \"sh -c 'pnpm --filter @apps/shop-bcd build && pnpm --filter @apps/shop-bcd start -- --port 3004'\" http://localhost:3004 \"CYPRESS_BASE_URL=http://localhost:3004 pnpm exec cypress run --spec cypress/e2e/shop-customer.cy.ts\"",
     "i18n:extract": "next-intl extract",
     "i18n:check": "ts-node scripts/check-i18n-schemas.ts",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Summary
- add Cypress specs for dashboard login and shop customer login flow
- allow base URL overrides in Cypress config for per-app testing
- run dashboard and shop suites in CI after building apps

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages build: Failed)*
- `pnpm lint` *(fails: run failed)*
- `pnpm test` *(fails: ERR_PACKAGE_PATH_NOT_EXPORTED)*
- `pnpm e2e:dashboard` *(fails: build exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b471979ba8832fb013a7bb950fc5e7