### PR TITLE
Add Jest coverage thresholds and CI upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
       - uses: pnpm/action-setup@v3
       - run: pnpm install
       - run: pnpm lint && pnpm test
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage/lcov.info
       - run: pnpm build
       - run: npx @cloudflare/next-on-pages deploy \
                --project-name=base-shop \

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -217,5 +217,11 @@ module.exports = {
   collectCoverage: true,
   coverageDirectory: "<rootDir>/coverage",
   coverageReporters: ["text", "text-summary", "lcov"],
+  coverageThreshold: {
+    global: {
+      lines: 80,
+      branches: 80,
+    },
+  },
   rootDir: ".", // each workspace already passes  --config ../../jest.config.cjs
 };

--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -11,4 +11,10 @@ module.exports = {
     "^\\.\\./core\\.js$": "<rootDir>/packages/config/src/env/core.ts",
     "^\\.\\./payments\\.js$": "<rootDir>/packages/config/src/env/payments.ts",
   },
+  coverageThreshold: {
+    global: {
+      lines: 60,
+      branches: 60,
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- enforce 80% coverage threshold in monorepo Jest config
- allow lower coverage in config package via custom preset
- upload lcov coverage reports in CI with Codecov

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Package path ./decode is not exported by entities)*
- `pnpm test` *(fails: @acme/eslint-plugin-ds#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b4719b0c94832fbe1f740b39942519