### PR TITLE
test(api): add route tests

### DIFF
--- a/apps/api/__tests__/routes/components/[shopId].test.ts
+++ b/apps/api/__tests__/routes/components/[shopId].test.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createRequestHandler } from "../../test-utils";
+
+describe("components route", () => {
+  beforeAll(() => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "testsecret";
+  });
+
+  it("rejects requests without token", async () => {
+    const res = await request(createRequestHandler()).get("/components/abc");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns components for valid token", async () => {
+    const token = jwt.sign({}, "testsecret");
+    const res = await request(createRequestHandler())
+      .get("/components/abc")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ components: [] });
+  });
+});

--- a/apps/api/__tests__/routes/shop/[id]/publish-upgrade.test.ts
+++ b/apps/api/__tests__/routes/shop/[id]/publish-upgrade.test.ts
@@ -1,0 +1,22 @@
+import request from "supertest";
+import { createRequestHandler } from "../../../test-utils";
+
+describe("publish-upgrade route", () => {
+  beforeAll(() => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "testsecret";
+  });
+
+  it("rejects invalid shop id", async () => {
+    const res = await request(createRequestHandler()).post(
+      "/shop/ABC/publish-upgrade",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("requires bearer token", async () => {
+    const res = await request(createRequestHandler()).post(
+      "/shop/abc/publish-upgrade",
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/__tests__/test-utils.ts
+++ b/apps/api/__tests__/test-utils.ts
@@ -1,0 +1,55 @@
+import type { IncomingMessage, ServerResponse } from "http";
+import { onRequest as componentsHandler } from "../src/routes/components/[shopId]";
+import { onRequestPost as publishUpgradeHandler } from "../src/routes/shop/[id]/publish-upgrade";
+
+async function collectBody(req: IncomingMessage): Promise<Uint8Array | undefined> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) return undefined;
+  return Buffer.concat(chunks);
+}
+
+export function createRequestHandler() {
+  return async (req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url || "", "http://test");
+    const method = req.method || "GET";
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (Array.isArray(value)) headers.set(key, value.join(","));
+      else if (value !== undefined) headers.set(key, value);
+    }
+    const body = await collectBody(req);
+    const request = new Request(url.toString(), {
+      method,
+      headers,
+      body,
+    });
+
+    let response: Response | undefined;
+    if (method === "GET" && url.pathname.startsWith("/components/")) {
+      const shopId = url.pathname.split("/")[2];
+      response = await componentsHandler({ params: { shopId }, request });
+    } else if (
+      method === "POST" &&
+      url.pathname.startsWith("/shop/") &&
+      url.pathname.endsWith("/publish-upgrade")
+    ) {
+      const id = url.pathname.split("/")[2];
+      response = await publishUpgradeHandler({ params: { id }, request });
+    }
+
+    if (!response) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    res.statusCode = response.status;
+    response.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+    const text = await response.text();
+    res.end(text);
+  };
+}

--- a/apps/api/jest.config.cjs
+++ b/apps/api/jest.config.cjs
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const base = require("@acme/config/jest.preset.cjs");
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  roots: ["<rootDir>/apps/api/src", "<rootDir>/apps/api/__tests__"],
+  testEnvironment: "node",
+  setupFilesAfterEnv: [
+    "<rootDir>/apps/api/jest.setup.ts",
+  ],
+};

--- a/apps/api/jest.setup.ts
+++ b/apps/api/jest.setup.ts
@@ -1,0 +1,4 @@
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@apps/api",
+  "private": true,
+  "scripts": {
+    "test": "jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.3"
+  }
+}

--- a/apps/api/tsconfig.test.json
+++ b/apps/api/tsconfig.test.json
@@ -1,0 +1,10 @@
+// apps/api/tsconfig.test.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "noEmit": true,
+    "allowJs": true
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,11 +396,20 @@ importers:
         specifier: ^4.20.4
         version: 4.23.0(@cloudflare/workers-types@4.20250704.0)
 
+  apps/api:
+    devDependencies:
+      supertest:
+        specifier: ^6.3.3
+        version: 6.3.4
+
   apps/cms:
     dependencies:
       '@acme/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@acme/configurator':
+        specifier: workspace:*
+        version: link:../../packages/configurator
       '@acme/date-utils':
         specifier: workspace:*
         version: link:../../packages/date-utils
@@ -462,6 +471,8 @@ importers:
       next:
         specifier: 15.3.5
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409)
+
+  apps/dashboard: {}
 
   apps/shop-bcd:
     dependencies:
@@ -2640,6 +2651,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2867,6 +2882,9 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@paralleldrive/cuid2@2.2.2':
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
 
   '@paulirish/trace_engine@0.0.19':
     resolution: {integrity: sha512-3tjEzXBBtU83DkCJAdU2UwBBunspiwTCn+Y5jOxm592cfEuLr/T7Lcn+QhRerVqkSik2mnjN4X6NgHZjI9Biwg==}
@@ -4974,6 +4992,9 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
 
@@ -5578,6 +5599,9 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
@@ -5629,6 +5653,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   core-js-compat@3.43.0:
     resolution: {integrity: sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==}
@@ -5944,6 +5971,9 @@ packages:
 
   devtools-protocol@0.0.1312386:
     resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -6752,6 +6782,9 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
@@ -6913,6 +6946,9 @@ packages:
   formdata-node@4.4.1:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
+
+  formidable@2.1.5:
+    resolution: {integrity: sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==}
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
@@ -8359,6 +8395,10 @@ packages:
   metaviewport-parser@0.3.0:
     resolution: {integrity: sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
   micro@9.3.5-canary.3:
     resolution: {integrity: sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==}
     engines: {node: '>= 8.0.0'}
@@ -8379,6 +8419,11 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -10268,9 +10313,19 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  superagent@8.1.2:
+    resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
+    engines: {node: '>=6.4.0 <13 || >=14'}
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
+
+  supertest@6.3.4:
+    resolution: {integrity: sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==}
+    engines: {node: '>=6.4.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -13021,6 +13076,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.3.5':
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -13305,6 +13362,10 @@ snapshots:
       '@otplib/plugin-thirty-two': 12.0.1
 
   '@panva/hkdf@1.2.1': {}
+
+  '@paralleldrive/cuid2@2.2.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@paulirish/trace_engine@0.0.19': {}
 
@@ -15759,6 +15820,8 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
+  asap@2.0.6: {}
+
   asn1.js@4.10.1:
     dependencies:
       bn.js: 4.12.2
@@ -16385,6 +16448,8 @@ snapshots:
 
   commondir@1.0.1: {}
 
+  component-emitter@1.3.1: {}
+
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
@@ -16428,6 +16493,8 @@ snapshots:
   cookie@0.5.0: {}
 
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
 
   core-js-compat@3.43.0:
     dependencies:
@@ -16792,6 +16859,11 @@ snapshots:
   devtools-protocol@0.0.1232444: {}
 
   devtools-protocol@0.0.1312386: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   diff-sequences@29.6.3: {}
 
@@ -17727,6 +17799,8 @@ snapshots:
 
   fast-redact@3.5.0: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-uri@3.0.6: {}
 
   fastq@1.19.1:
@@ -17918,6 +17992,13 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
+
+  formidable@2.1.5:
+    dependencies:
+      '@paralleldrive/cuid2': 2.2.2
+      dezalgo: 1.0.4
+      once: 1.4.0
+      qs: 6.14.0
 
   forwarded-parse@2.1.2: {}
 
@@ -19710,6 +19791,8 @@ snapshots:
 
   metaviewport-parser@0.3.0: {}
 
+  methods@1.1.2: {}
+
   micro@9.3.5-canary.3:
     dependencies:
       arg: 4.1.0
@@ -19731,6 +19814,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime@2.6.0: {}
 
   mime@3.0.0: {}
 
@@ -21881,7 +21966,29 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.0
 
+  superagent@8.1.2:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.1(supports-color@8.1.1)
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.4
+      formidable: 2.1.5
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   superstruct@2.0.2: {}
+
+  supertest@6.3.4:
+    dependencies:
+      methods: 1.1.2
+      superagent: 8.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@5.5.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add supertest-based tests for components and publish-upgrade routes
- wire up jest config and setup for api workspace
- expose `pnpm test` script in apps/api workspace

## Testing
- `pnpm --filter @apps/api test`
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported from package entities)*

------
https://chatgpt.com/codex/tasks/task_e_68b47583ba00832fbe8da54cc01443c1