### PR TITLE
chore: add missing test tsconfigs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "turbo run lint",
     "lint:apps": "eslint \"apps/**/*.{ts,tsx}\" --ignore-pattern \"**/dist/**\" --ignore-pattern \"**/.next/**\"",
     "lint:all": "eslint \"{apps,packages,src}/**/*.{ts,tsx,js,jsx}\" --ignore-pattern \"**/dist/**\" --ignore-pattern \"**/.next/**\"",
-    "typecheck": "tsc -b --pretty",
+    "typecheck": "tsc -b tsconfig.json tsconfig.test.json --pretty",
     "test": "CI=true turbo run test",
     "test:coverage": "CI=true turbo run test -- --coverage",
     "e2e": "start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run\"",

--- a/packages/email/tsconfig.test.json
+++ b/packages/email/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/eslint-plugin-ds/tsconfig.test.json
+++ b/packages/eslint-plugin-ds/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/next-config/tsconfig.test.json
+++ b/packages/next-config/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/paypal/tsconfig.test.json
+++ b/packages/plugins/paypal/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/premier-shipping/tsconfig.test.json
+++ b/packages/plugins/premier-shipping/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/sanity/tsconfig.test.json
+++ b/packages/plugins/sanity/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/sanity/tsconfig.test.json
+++ b/packages/sanity/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/stripe/tsconfig.test.json
+++ b/packages/stripe/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/telemetry/tsconfig.test.json
+++ b/packages/telemetry/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/theme/tsconfig.test.json
+++ b/packages/theme/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/zod-utils/tsconfig.test.json
+++ b/packages/zod-utils/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests", "__tests__", "*.ts", "*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -49,6 +49,17 @@
     { "path": "./packages/types/tsconfig.test.json" },
     { "path": "./packages/ui/tsconfig.test.json" },
     { "path": "./packages/i18n/tsconfig.test.json" },
+      { "path": "./packages/email/tsconfig.test.json" },
+      { "path": "./packages/eslint-plugin-ds/tsconfig.test.json" },
+      { "path": "./packages/next-config/tsconfig.test.json" },
+      { "path": "./packages/plugins/paypal/tsconfig.test.json" },
+      { "path": "./packages/plugins/premier-shipping/tsconfig.test.json" },
+      { "path": "./packages/plugins/sanity/tsconfig.test.json" },
+      { "path": "./packages/sanity/tsconfig.test.json" },
+      { "path": "./packages/stripe/tsconfig.test.json" },
+      { "path": "./packages/telemetry/tsconfig.test.json" },
+      { "path": "./packages/theme/tsconfig.test.json" },
+      { "path": "./packages/zod-utils/tsconfig.test.json" },
     { "path": "./apps/cms/tsconfig.test.json" },
     { "path": "./apps/dashboard/tsconfig.test.json" }
   ]


### PR DESCRIPTION
## Summary
- add tsconfig.test.json for packages lacking test configs
- reference root base config in new test tsconfigs
- run typecheck against project and test configs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported from package /workspace/base-shop/node_modules/.pnpm/parse5@7.3.0/node_modules/entities)*
- `pnpm typecheck` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b475652f80832fa4f4804a265dae4b