### PR TITLE
feat: add lint scripts across packages and enforce via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
       - run: pnpm install
-      - run: pnpm lint && pnpm test
+      - run: pnpm lint
+      - run: pnpm test
       - uses: codecov/codecov-action@v3
         with:
           files: ./coverage/lcov.info

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -5,7 +5,7 @@
     "dev": "cross-env next dev -p 3006",
     "build": "next build",
     "start": "next start -p 3006",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
     "dev:debug": "cross-env NODE_OPTIONS='--enable-source-maps --trace-uncaught --inspect' next dev -p 3006"
   },

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "@apps/dashboard",
   "private": true,
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
+    "lint": "eslint ."
   }
 }

--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev -p 3004",
     "build": "next build",
-    "start": "next start -p 3004"
+    "start": "next start -p 3004",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@themes/base": "workspace:*",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "build": "tsc -b",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "dependencies": {
     "iron-session": "^6.3.1",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -61,7 +61,8 @@
     "clean": "rimraf dist *.tsbuildinfo",
     "test": "jest packages/config/__tests__ packages/config/src/env/__tests__ --passWithNoTests --runInBand --config jest.preset.cjs",
     "fix:env": "node ./scripts/fix-config-env.mjs",
-    "verify:env": "node ./scripts/verify-config-env.mjs"
+    "verify:env": "node ./scripts/verify-config-env.mjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/zod-utils": "workspace:^"

--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -23,7 +23,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250702.0",

--- a/packages/date-utils/package.json
+++ b/packages/date-utils/package.json
@@ -13,7 +13,8 @@
     }
   },
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "date-fns": "^4.1.0",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -14,6 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint ."
   }
 }

--- a/packages/email-templates/package.json
+++ b/packages/email-templates/package.json
@@ -18,7 +18,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "peerDependencies": {
     "react": ">=19 <20",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/config": "workspace:*",

--- a/packages/eslint-plugin-ds/package.json
+++ b/packages/eslint-plugin-ds/package.json
@@ -5,11 +5,14 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs tests/no-raw-color.spec.ts",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "peerDependencies": {
     "eslint": "^9"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "build": "tsc -b",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "next": "^15.3.5"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -23,7 +23,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "next": "^15.3.5"

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -10,7 +10,8 @@
     "./next.config.mjs": "./next.config.mjs"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/config": "workspace:^",

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -120,7 +120,8 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "peerDependencies": {
     "react": ">=19 <20",

--- a/packages/platform-machine/package.json
+++ b/packages/platform-machine/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/stripe": "workspace:*",

--- a/packages/plugins/paypal/package.json
+++ b/packages/plugins/paypal/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "@acme/types": "workspace:*",
     "zod": "^3.25.73"
+  },
+  "scripts": {
+    "lint": "eslint ."
   }
 }

--- a/packages/plugins/sanity/package.json
+++ b/packages/plugins/sanity/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../../jest.config.cjs",
     "build": "tsc -b",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/types": "workspace:*",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -9,7 +9,8 @@
     }
   },
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@sanity/client": "^6.15.0",

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -18,7 +18,8 @@
     }
   },
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "pino": "^9.9.0"

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -9,7 +9,8 @@
     }
   },
   "scripts": {
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "stripe": "^18.2.1",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -15,6 +15,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint ."
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -5,11 +5,14 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "type": "module",
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "test": "rimraf dist && jest --config ../../jest.config.cjs"
+    "test": "rimraf dist && jest --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "exports": {
     ".": {

--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -13,7 +13,8 @@
     "start": "next start -p 3000",
     "test": "jest --ci --runInBand --detectOpenHandles --config jest.config.cjs",
     "fix:next-config": "node ./scripts/fix-template-next-config.mjs",
-    "verify:next-config": "node ./scripts/verify-template-next-config.mjs"
+    "verify:next-config": "node ./scripts/verify-template-next-config.mjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@themes/base": "workspace:*",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -5,11 +5,14 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "type": "module",
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "test": "rimraf dist && jest --config ../../jest.config.cjs"
+    "test": "rimraf dist && jest --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/types": "workspace:*",

--- a/packages/themes/abc/package.json
+++ b/packages/themes/abc/package.json
@@ -23,5 +23,8 @@
     },
     "./tokens.css": "./src/tokens.css"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint ."
+  }
 }

--- a/packages/themes/base/package.json
+++ b/packages/themes/base/package.json
@@ -18,5 +18,8 @@
     "./tokens.css": "./tokens.css",
     "./src/tokens.css": "./src/tokens.css"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint ."
+  }
 }

--- a/packages/themes/bcd/package.json
+++ b/packages/themes/bcd/package.json
@@ -23,5 +23,8 @@
     },
     "./tokens.css": "./src/tokens.css"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint ."
+  }
 }

--- a/packages/themes/brandx/package.json
+++ b/packages/themes/brandx/package.json
@@ -23,5 +23,8 @@
     },
     "./tokens.css": "./src/tokens.css"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint ."
+  }
 }

--- a/packages/themes/dark/package.json
+++ b/packages/themes/dark/package.json
@@ -23,5 +23,8 @@
     },
     "./tokens.css": "./src/tokens.css"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint ."
+  }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,8 @@
   ],
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "exports": {
     "./settings": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@acme/config": "workspace:*",

--- a/packages/zod-utils/package.json
+++ b/packages/zod-utils/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w",
-    "clean": "rimraf dist *.tsbuildinfo"
+    "clean": "rimraf dist *.tsbuildinfo",
+    "lint": "eslint ."
   },
   "dependencies": {
     "zod": "^3.23.8"

--- a/turbo.json
+++ b/turbo.json
@@ -3,17 +3,30 @@
   "tasks": {
     "dev": {
       "cache": false,
-      "dependsOn": ["^dev"]
+      "dependsOn": [
+        "^dev"
+      ]
     },
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**"
+      ]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": [
+        "^lint"
+      ]
+    },
     "test": {
       "dependsOn": [],
       "cache": false,
-      "outputs": ["coverage/**"]
+      "outputs": [
+        "coverage/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `lint` scripts to all workspace packages
- run lint task across dependencies via `turbo.json`
- run lint in CI to fail builds on lint errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @apps/shop-bcd@ build: `next build`)*
- `pnpm lint` *(fails: @apps/dashboard#lint: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b476ba76fc832fb313a1d5a694eaf8