### PR TITLE
fix: drop configurator path aliases

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -61,12 +61,7 @@
       "@acme/i18n": ["../../packages/i18n/src/index.ts"],
       "@acme/i18n/*": ["../../packages/i18n/src/*"],
       "@acme/zod-utils": ["../../packages/zod-utils/src/index.ts"],
-      "@acme/zod-utils/*": ["../../packages/zod-utils/src/*"],
-
-      /* Map the exact subpath to the source file that exists */
-      "@acme/configurator/providers": [
-        "../../packages/configurator/src/providers.ts"
-      ]
+      "@acme/zod-utils/*": ["../../packages/zod-utils/src/*"]
     },
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -145,12 +145,6 @@
       "@acme/config/*": [
         "packages/config/src/*"
       ],
-      "@acme/configurator": [
-        "packages/configurator/src/index.ts"
-      ],
-      "@acme/configurator/*": [
-        "packages/configurator/src/*"
-      ],
       "@acme/next-config": [
         "packages/next-config/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- remove `@acme/configurator` path overrides so TypeScript uses package exports
- clean up CMS tsconfig paths to stop pointing at configurator source

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Package path ./decode is not exported from package parse5)*
- `npx rimraf packages/configurator/dist packages/configurator/tsconfig.tsbuildinfo apps/cms/dist && npx tsc -b apps/cms/tsconfig.build.json`


------
https://chatgpt.com/codex/tasks/task_e_68b477406638832fa4e806866ecf03d8