### PR TITLE
chore(tsconfig): add configurator path aliases

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -145,6 +145,12 @@
       "@acme/config/*": [
         "packages/config/src/*"
       ],
+      "@acme/configurator": [
+        "packages/configurator/src/index.ts"
+      ],
+      "@acme/configurator/*": [
+        "packages/configurator/src/*"
+      ],
       "@acme/next-config": [
         "packages/next-config/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- add @acme/configurator path aliases to tsconfig base

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module not found: Package path ./decode is not exported from package)
- `npx tsc -b apps/cms/tsconfig.build.json`

------
https://chatgpt.com/codex/tasks/task_e_68b47aaecd38832f9edfe539e0c2ebde