### PR TITLE
fix auth tests by removing entities override

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,8 +204,7 @@
       "domhandler": "5.0.3",
       "domutils": "3.1.0",
       "htmlparser2>entities": "4.5.0",
-      "dom-serializer>entities": "4.5.0",
-      "entities": "4.5.0"
+      "dom-serializer>entities": "4.5.0"
     },
     "onlyBuiltDependencies": [
       "@prisma/client",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,6 @@ overrides:
   domutils: 3.1.0
   htmlparser2>entities: 4.5.0
   dom-serializer>entities: 4.5.0
-  entities: 4.5.0
 
 importers:
 
@@ -6129,6 +6128,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -17034,6 +17037,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.2:
@@ -20473,7 +20478,7 @@ snapshots:
 
   parse5@7.3.0:
     dependencies:
-      entities: 4.5.0
+      entities: 6.0.1
 
   parseley@0.12.1:
     dependencies:


### PR DESCRIPTION
## Summary
- allow parse5 to install its required entities@6 dependency

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve './email.js')*
- `pnpm --filter @acme/auth test -- packages/auth`
- `pnpm --filter @acme/config test -- packages/config` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b47af74ad4832fbd6b9da1ebd856a1