### PR TITLE
fix: adjust template-app not-found page to server component

### DIFF
--- a/packages/template-app/src/app/not-found.tsx
+++ b/packages/template-app/src/app/not-found.tsx
@@ -1,6 +1,4 @@
 // packages/template-app/src/app/not-found.tsx
-"use client";
-
 import { Error404Template } from "@ui/components/templates/Error404Template";
 
 export default function NotFound() {


### PR DESCRIPTION
## Summary
- remove unnecessary `use client` directive from template-app not-found page to allow prerendering

## Testing
- `pnpm --filter @acme/template-app run build`
- `pnpm --filter @acme/template-app test` *(fails: 2 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b49a529ce8832faea7e487af76091f