### PR TITLE
test(config): run env tests in node runtime

### DIFF
--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -6,6 +6,13 @@ const base = require("../../jest.config.cjs");
 module.exports = {
   ...base,
   rootDir: path.resolve(__dirname, "../.."),
+  // Use a plain Node environment for configuration tests. These tests don't
+  // depend on DOM APIs and running them under jsdom pulls in additional
+  // transitive dependencies like `parse5`, which in turn requires the
+  // `entities/decode` subpath that isn't exported in older versions.  Using the
+  // Node environment avoids that resolution path entirely and prevents
+  // `ERR_PACKAGE_PATH_NOT_EXPORTED` errors when running unit tests.
+  testEnvironment: "node",
   moduleNameMapper: {
     ...base.moduleNameMapper,
     "^\\.\\./core\\.js$": "<rootDir>/packages/config/src/env/core.ts",


### PR DESCRIPTION
## Summary
- run config package tests using Node test environment to avoid parse5 `entities/decode` resolution issues

## Testing
- `pnpm --filter @acme/config exec jest src/env/__tests__/payments-env.test.ts --runInBand --config jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b4a18e8a34832fb18d42124dd90db0