### PR TITLE
feat(cms): type not-found return element

### DIFF
--- a/apps/cms/src/app/not-found.tsx
+++ b/apps/cms/src/app/not-found.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
+import type { ReactElement } from "react";
 
-export default function NotFound() {
+// This function must return a JSX element.
+export default function NotFound(): ReactElement {
   return (
     <div className="flex h-screen flex-col items-center justify-center gap-4">
       <h1 className="text-3xl font-bold">404 – Page not found</h1>


### PR DESCRIPTION
## Summary
- type CMS not-found to return ReactElement

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm build` *(fails: Failed to fetch `Geist` from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_68b4acd3b7d0832fb48120bc0e664735