### PR TITLE
docs(cms): clarify NotFound wrapper

### DIFF
--- a/apps/cms/src/app/cms/not-found.tsx
+++ b/apps/cms/src/app/cms/not-found.tsx
@@ -2,8 +2,9 @@ import { type ReactElement } from "react";
 import CmsNotFound from "./not-found.client";
 
 /**
- * NotFound renders the CMS dashboard 404 page.  It wraps the client‑side
- * `CmsNotFound` component and ensures Next.js receives a valid React element.
+ * NotFound renders the CMS dashboard 404 page.
+ * Returning a bare component causes Next.js build failures, so this wrapper
+ * ensures Next.js receives a valid React element.
  */
 export default function NotFound(): ReactElement {
   return <CmsNotFound />;


### PR DESCRIPTION
## Summary
- clarify why the CMS 404 NotFound component wraps `CmsNotFound`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve './cms.js')*
- `pnpm --filter @apps/cms build` *(fails: Module parse failed in @acme/configurator)*

------
https://chatgpt.com/codex/tasks/task_e_68b4acd156c0832fad04b23dd9959839