### PR TITLE
fix(template-app): server-side 404 and remove font fetch

### DIFF
--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -23,7 +23,9 @@
     "@acme/tailwind-config": "workspace:*",
     "@acme/stripe": "workspace:*",
     "@acme/date-utils": "workspace:*",
-    "@acme/config": "workspace:*"
+    "@acme/config": "workspace:*",
+    "react": "workspace:^",
+    "react-dom": "workspace:^"
   },
   "devDependencies": {
     "next": "^15.3.5"

--- a/packages/template-app/src/app/layout.tsx
+++ b/packages/template-app/src/app/layout.tsx
@@ -2,18 +2,8 @@
 import { CartProvider } from "@platform-core/contexts/CartContext";
 import { CurrencyProvider } from "@platform-core/contexts/CurrencyContext";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import AnalyticsScripts from "./AnalyticsScripts";
 import "./globals.css";
-
-const geistSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-geist-sans",
-});
-const geistMono = Geist_Mono({
-  subsets: ["latin"],
-  variable: "--font-geist-mono",
-});
 
 export const metadata: Metadata = {
   title: "Base-Shop",
@@ -26,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html lang="en">
       <body className="antialiased">
         {/* Global providers go here */}
         <AnalyticsScripts />

--- a/packages/template-app/src/app/not-found.tsx
+++ b/packages/template-app/src/app/not-found.tsx
@@ -1,6 +1,4 @@
 // packages/template-app/src/app/not-found.tsx
-"use client";
-
 import { Error404Template } from "@ui/components/templates/Error404Template";
 import { type ReactElement } from "react";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -808,6 +808,12 @@ importers:
       '@themes/base':
         specifier: workspace:*
         version: link:../themes/base
+      react:
+        specifier: 19.2.0-canary-3fbfb9ba-20250409
+        version: 19.2.0-canary-3fbfb9ba-20250409
+      react-dom:
+        specifier: 19.2.0-canary-3fbfb9ba-20250409
+        version: 19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409)
     devDependencies:
       next:
         specifier: ^15.3.5


### PR DESCRIPTION
## Summary
- make the template app 404 page a server component
- drop Google font imports from template layout to avoid external fetches
- declare React dependencies for template app build

## Testing
- `pnpm install`
- `cd packages/template-app && pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9b20f0c832fb9264c460cc643ad