### PR TITLE
test: add initZod error map tests

### DIFF
--- a/packages/zod-utils/src/__tests__/initZod.test.ts
+++ b/packages/zod-utils/src/__tests__/initZod.test.ts
@@ -1,0 +1,37 @@
+const setErrorMap = jest.fn();
+
+jest.mock("zod", () => ({
+  z: { setErrorMap },
+}));
+
+jest.mock("../zodErrorMap.js", () => ({
+  friendlyErrorMap: jest.fn(() => ({ message: "ok" })),
+}));
+
+import { friendlyErrorMap } from "../zodErrorMap.js";
+
+describe("initZod", () => {
+  const orig = process.env.ZOD_ERROR_MAP_OFF;
+
+  afterEach(() => {
+    process.env.ZOD_ERROR_MAP_OFF = orig;
+    jest.resetModules();
+    setErrorMap.mockReset();
+    (friendlyErrorMap as jest.Mock).mockClear();
+  });
+
+  test("registers friendly error map by default", async () => {
+    delete process.env.ZOD_ERROR_MAP_OFF;
+    await import("../initZod");
+    expect(setErrorMap).toHaveBeenCalledTimes(1);
+    const handler = setErrorMap.mock.calls[0][0];
+    handler({} as any, { defaultError: "err" });
+    expect(friendlyErrorMap).toHaveBeenCalled();
+  });
+
+  test("skips when ZOD_ERROR_MAP_OFF=1", async () => {
+    process.env.ZOD_ERROR_MAP_OFF = "1";
+    await import("../initZod");
+    expect(setErrorMap).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for initZod ensuring friendly error map is installed by default and skipped when `ZOD_ERROR_MAP_OFF` is set

## Testing
- `pnpm test packages/zod-utils` *(fails: Missing tasks in project)*
- `pnpm exec jest packages/zod-utils --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b59ffa7368832fb164b758d2442686