### PR TITLE
test: add marketing email sender tests

### DIFF
--- a/functions/__tests__/marketing-email-sender.test.ts
+++ b/functions/__tests__/marketing-email-sender.test.ts
@@ -1,0 +1,25 @@
+import { onScheduled, sendScheduledCampaigns } from "../marketing-email-sender";
+import { sendDueCampaigns } from "@acme/email";
+
+jest.mock("@acme/email", () => ({
+  sendDueCampaigns: jest.fn(),
+}));
+
+describe("marketing-email-sender", () => {
+  const sendDueCampaignsMock = sendDueCampaigns as jest.Mock;
+
+  beforeEach(() => {
+    sendDueCampaignsMock.mockClear();
+  });
+
+  it("calls sendDueCampaigns from onScheduled", async () => {
+    await onScheduled();
+    expect(sendDueCampaignsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls sendDueCampaigns from sendScheduledCampaigns", async () => {
+    await sendScheduledCampaigns();
+    expect(sendDueCampaignsMock).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for marketing email sender verifying sendDueCampaigns is invoked

## Testing
- `pnpm test functions` (fails: Could not find task `functions` in project)
- `pnpm exec jest functions/__tests__/marketing-email-sender.test.ts` (fails: global coverage threshold for lines (80%) not met: 64.7%)

------
https://chatgpt.com/codex/tasks/task_e_68b59ffb0280832fa2b1dfe0aee1b44f