### PR TITLE
test(ui): add css vars tests

### DIFF
--- a/packages/ui/src/utils/__tests__/cssVars.test.ts
+++ b/packages/ui/src/utils/__tests__/cssVars.test.ts
@@ -1,0 +1,31 @@
+import { cssVars } from "../style";
+
+describe("cssVars", () => {
+  it("maps color overrides to CSS variables", () => {
+    const vars = cssVars({
+      color: { bg: "--bg", fg: "--fg", border: "--border" },
+    });
+    expect(vars).toEqual({
+      "--color-bg": "var(--bg)",
+      "--color-fg": "var(--fg)",
+      "--color-border": "var(--border)",
+    });
+  });
+
+  it("maps typography overrides to CSS variables", () => {
+    const vars = cssVars({
+      typography: {
+        fontFamily: "--font-family",
+        fontSize: "--font-size",
+        fontWeight: "--font-weight",
+        lineHeight: "--line-height",
+      },
+    });
+    expect(vars).toEqual({
+      "--font-family": "var(--font-family)",
+      "--font-size": "var(--font-size)",
+      "--font-weight": "var(--font-weight)",
+      "--line-height": "var(--line-height)",
+    });
+  });
+});

--- a/packages/ui/src/utils/style/index.ts
+++ b/packages/ui/src/utils/style/index.ts
@@ -1,2 +1,3 @@
 export * from './boxProps';
 export * from './cn';
+export * from './cssVars';


### PR DESCRIPTION
## Summary
- export cssVars utility
- add tests for cssVars color and typography overrides

## Testing
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui`)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ff9169c832fb6a23a665f4526d1