### PR TITLE
test(theme): add mergeExternalTokens tests

### DIFF
--- a/packages/theme/src/tokens/__tests__/mergeExternalTokens.test.ts
+++ b/packages/theme/src/tokens/__tests__/mergeExternalTokens.test.ts
@@ -1,0 +1,16 @@
+import { mergeExternalTokens } from '../mergeExternalTokens';
+
+describe('mergeExternalTokens', () => {
+  it('overrides base tokens with external tokens', () => {
+    const base = { color: 'red', size: 'medium' };
+    const external = { color: 'blue' };
+    const result = mergeExternalTokens(base, external);
+    expect(result).toEqual({ color: 'blue', size: 'medium' });
+  });
+
+  it('keeps base tokens when external overrides are missing', () => {
+    const base = { color: 'red', size: 'medium' };
+    const result = mergeExternalTokens(base, {});
+    expect(result).toEqual(base);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests verifying external tokens override base tokens
- ensure missing overrides retain original values

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported)*
- `pnpm test packages/theme` *(fails: Could not find task `packages/theme`)*
- `pnpm --filter @acme/theme test` *(fails: Could not locate module `react`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a19c38bc832fba8bfbbfeca1b54e