### PR TITLE
test: add generateMeta fallback test

### DIFF
--- a/packages/lib/__tests__/generateMeta.test.ts
+++ b/packages/lib/__tests__/generateMeta.test.ts
@@ -1,0 +1,43 @@
+import { promises as fs } from "fs";
+
+jest.mock("@acme/config", () => ({
+  env: { OPENAI_API_KEY: undefined },
+}));
+
+jest.mock("fs", () => ({
+  promises: {
+    writeFile: jest.fn(),
+    mkdir: jest.fn(),
+  },
+}));
+
+import { generateMeta } from "../src/generateMeta";
+
+describe("generateMeta", () => {
+  const writeFileMock = fs.writeFile as jest.Mock;
+  const mkdirMock = fs.mkdir as jest.Mock;
+
+  afterEach(() => {
+    writeFileMock.mockReset();
+    mkdirMock.mockReset();
+  });
+
+  it("returns deterministic metadata and image path when no API key", async () => {
+    const result = await generateMeta({
+      id: "123",
+      title: "Title",
+      description: "Desc",
+    });
+
+    expect(result).toEqual({
+      title: "AI title",
+      description: "AI description",
+      alt: "alt",
+      image: "/og/123.png",
+    });
+
+    expect(mkdirMock).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add generateMeta unit test to ensure deterministic output when OpenAI API key is missing

## Testing
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported)*
- `pnpm test packages/lib` *(fails: Could not find task `packages/lib` in project)*
- `npx jest packages/lib/__tests__/generateMeta.test.ts` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1a006c0832fa47b0efcb35cca42