### PR TITLE
test: add stdin/stdout prompt tests

### DIFF
--- a/scripts/__tests__/prompt.test.ts
+++ b/scripts/__tests__/prompt.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+import { expect } from "@jest/globals";
+import { PassThrough, Writable } from "node:stream";
+
+class MockWritable extends Writable {
+  data: string[] = [];
+  _write(chunk: any, _encoding: string, cb: (error?: Error | null) => void) {
+    this.data.push(chunk.toString());
+    cb();
+  }
+}
+
+let stdinMock: PassThrough;
+let stdoutMock: MockWritable;
+
+jest.mock("node:process", () => ({
+  get stdin() {
+    return stdinMock;
+  },
+  get stdout() {
+    return stdoutMock;
+  },
+}));
+
+async function loadPromptModule() {
+  jest.resetModules();
+  stdinMock = new PassThrough();
+  stdoutMock = new MockWritable();
+  return await import("../src/utils/prompt.ts");
+}
+
+function feed(lines: string[]) {
+  const stream = stdinMock;
+  lines.forEach((line, idx) => {
+    setTimeout(() => stream.write(line + "\n"), idx * 10);
+  });
+  setTimeout(() => stream.end(), lines.length * 10);
+}
+
+describe("prompt utilities", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reads user input", async () => {
+    const { prompt } = await loadPromptModule();
+    const p = prompt("Question: ");
+    feed(["answer"]);
+    await expect(p).resolves.toBe("answer");
+  });
+
+  it("uses default when input empty", async () => {
+    const { prompt } = await loadPromptModule();
+    const p = prompt("Question: ", "def");
+    feed([""]);
+    await expect(p).resolves.toBe("def");
+  });
+
+  it("selects providers by number", async () => {
+    const { selectProviders } = await loadPromptModule();
+    const p = selectProviders("providers", ["A", "B", "C"]);
+    feed(["1,3"]);
+    const result = await p;
+    expect(result).toEqual(["A", "C"]);
+  });
+
+  it("selects option with validation", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { selectOption } = await loadPromptModule();
+    const p = selectOption("option", ["A", "B"], 0);
+    feed(["5", "2"]);
+    const result = await p;
+    expect(result).toBe("B");
+    expect(errorSpy).toHaveBeenCalledWith("Invalid option selection.");
+  });
+
+  it("validates URL input", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { promptUrl } = await loadPromptModule();
+    const p = promptUrl("URL: ");
+    feed(["bad", "https://example.com"]);
+    const result = await p;
+    expect(result).toBe("https://example.com");
+    expect(errorSpy).toHaveBeenCalledWith("Invalid URL.");
+  });
+
+  it("returns undefined for empty URL", async () => {
+    const { promptUrl } = await loadPromptModule();
+    const p = promptUrl("URL: ");
+    feed([""]);
+    const result = await p;
+    expect(result).toBeUndefined();
+  });
+
+  it("validates email input", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { promptEmail } = await loadPromptModule();
+    const p = promptEmail("Email: ");
+    feed(["bad", "user@example.com"]);
+    const result = await p;
+    expect(result).toBe("user@example.com");
+    expect(errorSpy).toHaveBeenCalledWith("Invalid email address.");
+  });
+
+  it("collects navigation items", async () => {
+    const { promptNavItems } = await loadPromptModule();
+    const p = promptNavItems();
+    feed(["Home", "/", "About", "/about", ""]);
+    const result = await p;
+    expect(result).toEqual([
+      { label: "Home", url: "/" },
+      { label: "About", url: "/about" },
+    ]);
+  });
+
+  it("collects pages", async () => {
+    const { promptPages } = await loadPromptModule();
+    const p = promptPages();
+    feed(["about", "About Us", "contact", "Contact", ""]);
+    const result = await p;
+    expect(result).toEqual([
+      { slug: "about", title: { en: "About Us" }, components: [] },
+      { slug: "contact", title: { en: "Contact" }, components: [] },
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive stdin/stdout-based tests for prompt utilities

## Testing
- `pnpm test scripts` *(fails: Could not find task `scripts`)*
- `pnpm exec jest scripts/__tests__/prompt.test.ts` *(fails: global coverage threshold for branches (80%) not met: 78.94%)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ffed4a8832f8f94bd68104b4442