### PR TITLE
test(scripts): cover listPlugins plugin env vars

### DIFF
--- a/scripts/__tests__/providers.test.ts
+++ b/scripts/__tests__/providers.test.ts
@@ -1,0 +1,49 @@
+import { listPlugins } from "../src/utils/providers";
+import { pluginEnvVars } from "@acme/platform-core/configurator";
+
+const fsMock = {
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+};
+
+jest.mock("node:fs", () => fsMock);
+
+describe("listPlugins", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns plugin metadata with env vars even when package.json is missing", () => {
+    const dirent = (name: string) => ({ name, isDirectory: () => true });
+    fsMock.readdirSync.mockReturnValue([dirent("stripe"), dirent("paypal")]);
+    fsMock.readFileSync.mockImplementation((p: string) => {
+      if (p.includes("stripe")) {
+        return JSON.stringify({ name: "@acme/stripe-plugin" });
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const plugins = listPlugins("/root");
+
+    expect(plugins).toEqual([
+      {
+        id: "stripe",
+        packageName: "@acme/stripe-plugin",
+        envVars: pluginEnvVars.stripe,
+      },
+      {
+        id: "paypal",
+        packageName: undefined,
+        envVars: pluginEnvVars.paypal,
+      },
+    ]);
+  });
+
+  it("falls back gracefully when plugins directory cannot be read", () => {
+    fsMock.readdirSync.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    expect(listPlugins("/root")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- test listPlugins env var mapping and missing package.json handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Package path ./decode is not exported from package /workspace/base-shop/node_modules/.pnpm/node_modules/entities)*
- `pnpm test scripts` *(fails: Could not find task `scripts` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a2d4fb1c832f83ef41c7fb73488e