### PR TITLE
test(shared-utils): add logger tests

### DIFF
--- a/packages/shared-utils/__tests__/logger.test.ts
+++ b/packages/shared-utils/__tests__/logger.test.ts
@@ -1,0 +1,39 @@
+import { jest } from "@jest/globals";
+
+const baseLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
+const pinoMock = jest.fn(() => baseLogger);
+
+jest.mock("pino", () => ({ __esModule: true, default: pinoMock }));
+
+describe("logger", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    Object.values(baseLogger).forEach((fn) => fn.mockClear());
+    pinoMock.mockClear();
+    delete process.env.LOG_LEVEL;
+  });
+
+  it("forwards messages and metadata and respects LOG_LEVEL", async () => {
+    process.env.LOG_LEVEL = "warn";
+    const { logger } = await import("../src/logger");
+    const meta = { test: true };
+
+    logger.error("error msg", meta);
+    logger.warn("warn msg", meta);
+    logger.info("info msg", meta);
+    logger.debug("debug msg", meta);
+
+    expect(baseLogger.error).toHaveBeenCalledWith(meta, "error msg");
+    expect(baseLogger.warn).toHaveBeenCalledWith(meta, "warn msg");
+    expect(baseLogger.info).toHaveBeenCalledWith(meta, "info msg");
+    expect(baseLogger.debug).toHaveBeenCalledWith(meta, "debug msg");
+
+    expect(pinoMock).toHaveBeenCalledWith({ level: "warn" });
+  });
+});


### PR DESCRIPTION
## Summary
- add logger.test.ts verifying pino wrapper forwards message & metadata and honors LOG_LEVEL

## Testing
- `pnpm test packages/shared-utils` *(fails: Missing tasks in project: Could not find task `packages/shared-utils` in project)*
- `pnpm --filter @acme/shared-utils test` *(fails: Could not locate module react mapped as /workspace/base-shop/node_modules/react)*
- `pnpm exec jest packages/shared-utils/__tests__/logger.test.ts --config jest.config.cjs` *(fails: global coverage threshold for branches (80%) not met: 12.5%)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ff75094832f8322bd2883f417ac