### PR TITLE
test(shared-utils): add path helper tests

### DIFF
--- a/packages/shared-utils/__tests__/getShopFromPath.test.ts
+++ b/packages/shared-utils/__tests__/getShopFromPath.test.ts
@@ -1,0 +1,17 @@
+import { getShopFromPath } from "../src/getShopFromPath";
+
+describe("getShopFromPath", () => {
+  it("returns shop slug from valid path", () => {
+    expect(getShopFromPath("/cms/shop/my-shop/products")).toBe("my-shop");
+  });
+
+  it("returns undefined for missing shop segment or slug", () => {
+    expect(getShopFromPath("/cms/foo/bar")).toBeUndefined();
+    expect(getShopFromPath("/cms/shop")).toBeUndefined();
+    expect(getShopFromPath(undefined)).toBeUndefined();
+  });
+
+  it("handles paths with duplicate slashes", () => {
+    expect(getShopFromPath("/cms//shop//my-shop//foo")).toBe("my-shop");
+  });
+});

--- a/packages/shared-utils/__tests__/replaceShopInPath.test.ts
+++ b/packages/shared-utils/__tests__/replaceShopInPath.test.ts
@@ -1,0 +1,25 @@
+import { replaceShopInPath } from "../src/replaceShopInPath";
+
+describe("replaceShopInPath", () => {
+  it("replaces shop slug in a valid path", () => {
+    expect(replaceShopInPath("/cms/shop/old-shop/page", "new-shop")).toBe(
+      "/cms/shop/new-shop/page"
+    );
+  });
+
+  it("returns default path when missing shop segment or pathname", () => {
+    expect(replaceShopInPath("/cms/foo/bar", "new-shop")).toBe(
+      "/cms/shop/new-shop"
+    );
+    expect(replaceShopInPath(null, "new-shop")).toBe("/cms/shop/new-shop");
+  });
+
+  it("handles malformed paths with duplicate slashes or missing slug", () => {
+    expect(replaceShopInPath("/cms/shop", "new-shop")).toBe(
+      "/cms/shop/new-shop"
+    );
+    expect(replaceShopInPath("/cms//shop//old-shop", "new-shop")).toBe(
+      "/cms/shop/new-shop"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add getShopFromPath tests for valid, missing, and malformed CMS paths
- add replaceShopInPath tests covering slug replacement and fallback behaviour

## Testing
- `pnpm test packages/shared-utils` *(fails: Could not find task `packages/shared-utils`)*
- `pnpm --filter @acme/shared-utils test` *(fails: Could not locate module react mapped as /workspace/base-shop/node_modules/react)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ff61b78832f9789910e656dd072