### PR TITLE
test: add subscription usage tests

### DIFF
--- a/packages/platform-core/src/__tests__/subscriptionUsage.test.ts
+++ b/packages/platform-core/src/__tests__/subscriptionUsage.test.ts
@@ -1,0 +1,69 @@
+/** @jest-environment node */
+
+jest.mock("../db", () => ({
+  prisma: { subscriptionUsage: { findUnique: jest.fn(), upsert: jest.fn() } },
+}));
+
+import { prisma } from "../db";
+import { getSubscriptionUsage, incrementSubscriptionUsage } from "../subscriptionUsage";
+
+const store: Record<string, any> = {};
+const findUniqueMock = prisma.subscriptionUsage.findUnique as jest.Mock;
+const upsertMock = prisma.subscriptionUsage.upsert as jest.Mock;
+
+describe("subscriptionUsage", () => {
+  const shop = "shop1";
+  const customerId = "customer1";
+  const month = "2023-10";
+
+  beforeEach(() => {
+    Object.keys(store).forEach((k) => delete store[k]);
+    findUniqueMock.mockReset();
+    upsertMock.mockReset();
+
+    findUniqueMock.mockImplementation(({ where }: any) => {
+      const key = JSON.stringify(where.shop_customerId_month);
+      return store[key] ?? null;
+    });
+    upsertMock.mockImplementation(({ where, create, update }: any) => {
+      const key = JSON.stringify(where.shop_customerId_month);
+      if (store[key]) {
+        store[key].shipments += update.shipments.increment;
+      } else {
+        store[key] = { ...create };
+      }
+      return store[key];
+    });
+  });
+
+  it("retrieves existing records", async () => {
+    const key = JSON.stringify({ shop, customerId, month });
+    store[key] = { id: "1", shop, customerId, month, shipments: 5 };
+
+    const record = await getSubscriptionUsage(shop, customerId, month);
+
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { shop_customerId_month: { shop, customerId, month } },
+    });
+    expect(record).toEqual({ id: "1", shop, customerId, month, shipments: 5 });
+  });
+
+  it("creates and increments shipments", async () => {
+    await incrementSubscriptionUsage(shop, customerId, month, 1);
+    expect(upsertMock).toHaveBeenCalledWith({
+      where: { shop_customerId_month: { shop, customerId, month } },
+      create: { shop, customerId, month, shipments: 1 },
+      update: { shipments: { increment: 1 } },
+    });
+
+    await incrementSubscriptionUsage(shop, customerId, month, 2);
+    expect(upsertMock).toHaveBeenLastCalledWith({
+      where: { shop_customerId_month: { shop, customerId, month } },
+      create: { shop, customerId, month, shipments: 2 },
+      update: { shipments: { increment: 2 } },
+    });
+
+    const record = await getSubscriptionUsage(shop, customerId, month);
+    expect(record?.shipments).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for retrieving and updating subscription usage

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported from package entities)*
- `pnpm test packages/platform-core` *(fails: Could not find task `packages/platform-core` in project)*
- `pnpm exec jest packages/platform-core/src/__tests__/subscriptionUsage.test.ts` *(fails: global coverage threshold for lines (80%) not met: 66.66%)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1a28ac4832f9b893e495d7c523d