### PR TITLE
test(platform-core): verify features flags

### DIFF
--- a/packages/platform-core/src/__tests__/features.test.ts
+++ b/packages/platform-core/src/__tests__/features.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+describe("features flags", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [
+      {
+        LUXURY_FEATURES_RA_TICKETING: true,
+        LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: 3,
+        LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: true,
+        LUXURY_FEATURES_TRACKING_DASHBOARD: false,
+        LUXURY_FEATURES_RETURNS: true,
+      },
+      {
+        raTicketing: true,
+        fraudReviewThreshold: 3,
+        requireStrongCustomerAuth: true,
+        trackingDashboard: false,
+        returns: true,
+      },
+    ],
+    [
+      {
+        LUXURY_FEATURES_RA_TICKETING: false,
+        LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: 8,
+        LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: false,
+        LUXURY_FEATURES_TRACKING_DASHBOARD: true,
+        LUXURY_FEATURES_RETURNS: false,
+      },
+      {
+        raTicketing: false,
+        fraudReviewThreshold: 8,
+        requireStrongCustomerAuth: false,
+        trackingDashboard: true,
+        returns: false,
+      },
+    ],
+  ])("maps env flags to features object", async (env, expected) => {
+    jest.doMock("@acme/config/env/core", () => ({
+      loadCoreEnv: () => env,
+    }));
+
+    const { features } = await import("../features");
+    expect(features).toEqual(expected);
+  });
+
+  it("uses defaults when env missing", async () => {
+    jest.doMock("@acme/config/env/core", () => ({
+      loadCoreEnv: () => ({}),
+    }));
+
+    const { features } = await import("../features");
+    expect(features).toEqual({
+      raTicketing: false,
+      fraudReviewThreshold: 0,
+      requireStrongCustomerAuth: false,
+      trackingDashboard: false,
+      returns: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for platform-core feature flags and defaults

## Testing
- `pnpm test packages/platform-core` *(fails: Could not find task `packages/platform-core` in project)*
- `pnpm --filter @acme/platform-core test -- src/__tests__/features.test.ts` *(fails: Jest coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1a63ab4832fa3915dbc5aa11c84