### PR TITLE
test(api): cover invalid bearer token

### DIFF
--- a/apps/api/__tests__/routes/shop/[id]/publish-upgrade.test.ts
+++ b/apps/api/__tests__/routes/shop/[id]/publish-upgrade.test.ts
@@ -19,4 +19,12 @@ describe("publish-upgrade route", () => {
     );
     expect(res.status).toBe(401);
   });
+
+  it("rejects invalid bearer token", async () => {
+    const res = await request(createRequestHandler())
+      .post("/shop/abc/publish-upgrade")
+      .set("Authorization", "Bearer invalid");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Forbidden" });
+  });
 });


### PR DESCRIPTION
## Summary
- add test for publish-upgrade route to return 403 when Authorization token is invalid

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Package path ./decode is not exported from package entities)*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a76e4f14832f80f0492ae971ef30