### PR TITLE
test(api): verify publish-upgrade success

### DIFF
--- a/apps/api/__tests__/routes/shop/[id]/publish-upgrade.test.ts
+++ b/apps/api/__tests__/routes/shop/[id]/publish-upgrade.test.ts
@@ -1,9 +1,42 @@
 import request from "supertest";
-import { createRequestHandler } from "../../../test-utils";
+import jwt from "jsonwebtoken";
+
+jest.mock("fs", () => ({
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}));
+jest.mock("child_process", () => ({ spawn: jest.fn() }));
+
+import { readFileSync, writeFileSync } from "fs";
+import { spawn } from "child_process";
+import { server, rest } from "../../../../../../test/msw/server";
+
+let createRequestHandler: typeof import("../../../test-utils").createRequestHandler;
 
 describe("publish-upgrade route", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "testsecret";
+    ({ createRequestHandler } = await import("../../../test-utils"));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    server.use(rest.all(/.*/, (req) => req.passthrough()));
+    (readFileSync as jest.Mock).mockImplementation((p: any) => {
+      if (String(p).endsWith("package.json")) {
+        return JSON.stringify({ dependencies: {} });
+      }
+      if (String(p).endsWith("shop.json")) {
+        return JSON.stringify({});
+      }
+      return "{}";
+    });
+    (writeFileSync as jest.Mock).mockImplementation(() => {});
+    (spawn as jest.Mock).mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown) => ({
+        on: (_evt: string, cb: (code: number) => void) => cb(0),
+      }),
+    );
   });
 
   it("rejects invalid shop id", async () => {
@@ -18,5 +51,15 @@ describe("publish-upgrade route", () => {
       "/shop/abc/publish-upgrade",
     );
     expect(res.status).toBe(401);
+  });
+
+  it("publishes upgrade for valid token and shop id", async () => {
+    const token = jwt.sign({}, "testsecret");
+    const res = await request(createRequestHandler())
+      .post("/shop/valid-id/publish-upgrade")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
   });
 });


### PR DESCRIPTION
## Summary
- add success case for publish-upgrade route
- mock fs and child_process to avoid real IO

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Package path ./decode is not exported from package entities)*
- `pnpm exec jest "apps/api/__tests__/routes/shop/\[id\]/publish-upgrade.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68b5a76d637c832f8ba343f268c3f934