### PR TITLE
test: verify security headers in middleware

### DIFF
--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { middleware } from "../middleware";
 
 describe("middleware security headers", () => {
-  it("sets cross-origin and permissions policy headers", () => {
+  it("sets expected security headers", () => {
     const request = new NextRequest("http://example.com");
     const response = middleware(request);
 
@@ -15,5 +15,15 @@ describe("middleware security headers", () => {
     expect(response.headers.get("Cross-Origin-Embedder-Policy")).toBe(
       "require-corp",
     );
+    expect(response.headers.get("Content-Security-Policy")).toBe(
+      "default-src 'self'; object-src 'none'; form-action 'self'; frame-ancestors 'none'",
+    );
+    expect(response.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains; preload",
+    );
+    expect(response.headers.get("X-Frame-Options")).toBe("deny");
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Download-Options")).toBe("noopen");
   });
 });


### PR DESCRIPTION
## Summary
- test middleware for CSP, HSTS, X-Frame-Options, Referrer-Policy, X-Content-Type-Options, and X-Download-Options headers

## Testing
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported from package entities)*
- `NODE_OPTIONS=--experimental-vm-modules pnpm exec jest test/middleware.test.ts` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a7671608832fb5009de55b57c41e