### PR TITLE
test: add config diff route test

### DIFF
--- a/apps/api/__tests__/routes/components/[shopId].test.ts
+++ b/apps/api/__tests__/routes/components/[shopId].test.ts
@@ -20,4 +20,16 @@ describe("components route", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ components: [] });
   });
+
+  it("returns config diff when requested", async () => {
+    const token = jwt.sign({}, "testsecret");
+    const res = await request(createRequestHandler())
+      .get("/components/abc?diff")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      components: [],
+      configDiff: { templates: [], translations: [] },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add test to ensure components route returns config diff when requested

## Testing
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a76ad990832f9b27589ba716c16a