### PR TITLE
test: return authorization

### DIFF
--- a/packages/platform-core/src/__tests__/returnAuthorization.test.ts
+++ b/packages/platform-core/src/__tests__/returnAuthorization.test.ts
@@ -1,0 +1,35 @@
+/** @jest-environment node */
+
+jest.mock("../repositories/returnAuthorization.server", () => ({
+  addReturnAuthorization: jest.fn(),
+  readReturnAuthorizations: jest.fn(),
+}));
+
+describe("returnAuthorization", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("builds RA IDs and delegates to addReturnAuthorization", async () => {
+    const { createReturnAuthorization } = await import("../returnAuthorization");
+    const repo = await import("../repositories/returnAuthorization.server");
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(123456);
+    const ra = await createReturnAuthorization({ orderId: "o1" });
+    expect(ra.raId).toBe(`RA${(123456).toString(36).toUpperCase()}`);
+    expect(repo.addReturnAuthorization).toHaveBeenCalledWith(ra);
+    nowSpy.mockRestore();
+  });
+
+  it("delegates to readReturnAuthorizations", async () => {
+    const { listReturnAuthorizations } = await import("../returnAuthorization");
+    const repo = await import("../repositories/returnAuthorization.server");
+    const list = [
+      { raId: "RA1", orderId: "o1", status: "pending", inspectionNotes: "" },
+    ];
+    (repo.readReturnAuthorizations as jest.Mock).mockResolvedValue(list);
+    const result = await listReturnAuthorizations();
+    expect(repo.readReturnAuthorizations).toHaveBeenCalled();
+    expect(result).toBe(list);
+  });
+});


### PR DESCRIPTION
## Summary
- add return authorization tests to ensure ID generation and delegation

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module not found: Package path ./decode is not exported from package entities)
- `pnpm --filter @acme/platform-core test` (fails: Could not locate module react)

------
https://chatgpt.com/codex/tasks/task_e_68b5a1a4c13c832f94de66865ee6eebf