### PR TITLE
fix: resolve cms build lint errors

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -80,6 +80,8 @@ const nextConfig = {
       ...(config.resolve.alias ?? {}),
       "@": path.resolve(__dirname, "src"),
       "drizzle-orm": false,
+      "entities/decode": "entities/lib/decode.js",
+      "entities/escape": "entities/lib/escape.js",
 
       // EXACT-MATCH ALIASES — do NOT shadow subpaths like `react/jsx-runtime`
       react$: REACT_INDEX,

--- a/apps/cms/src/app/api/cart/route.ts
+++ b/apps/cms/src/app/api/cart/route.ts
@@ -78,7 +78,6 @@ export async function PUT(req: NextRequest) {
     res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
     return res;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("[api/cart:PUT] error", err);
     return NextResponse.json(
       { ok: false, error: (err as Error).message },
@@ -136,7 +135,6 @@ export async function POST(req: NextRequest) {
     res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
     return res;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("[api/cart:POST] error", err);
     return NextResponse.json(
       { ok: false, error: (err as Error).message },
@@ -173,7 +171,6 @@ export async function PATCH(req: NextRequest) {
     res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
     return res;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("[api/cart:PATCH] error", err);
     return NextResponse.json(
       { ok: false, error: (err as Error).message },
@@ -210,7 +207,6 @@ export async function DELETE(req: NextRequest) {
     res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
     return res;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("[api/cart:DELETE] error", err);
     return NextResponse.json(
       { ok: false, error: (err as Error).message },
@@ -231,7 +227,6 @@ export async function GET(req: NextRequest) {
     res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
     return res;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("[api/cart:GET] error", err);
     return NextResponse.json(
       { ok: false, error: (err as Error).message },

--- a/apps/cms/src/app/api/shops/route.ts
+++ b/apps/cms/src/app/api/shops/route.ts
@@ -9,7 +9,6 @@ export async function GET() {
     const shops = await listShops();
     return NextResponse.json(shops);
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error("[api/shops:GET] error", err);
     return NextResponse.json(
       { error: (err as Error).message },

--- a/apps/cms/src/instrumentation.node.ts
+++ b/apps/cms/src/instrumentation.node.ts
@@ -2,13 +2,12 @@
 export async function register() {
   // Dev-focused, noisy on purpose
   process.on("uncaughtException", (err: unknown) => {
-    const e = err as Error;
-    // eslint-disable-next-line no-console
-    console.error("[instrumentation] uncaughtException\n", e?.stack ?? e);
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error("[instrumentation] uncaughtException\n", e.stack ?? e);
   });
   process.on("unhandledRejection", (reason: unknown) => {
-    const e = reason as any;
-    // eslint-disable-next-line no-console
-    console.error("[instrumentation] unhandledRejection\n", e?.stack ?? e);
+    const e =
+      reason instanceof Error ? reason : new Error(String(reason));
+    console.error("[instrumentation] unhandledRejection\n", e.stack ?? e);
   });
 }


### PR DESCRIPTION
## Summary
- remove unnecessary eslint-disable comments from cart and shop API routes
- add type-safe error handling in cms instrumentation
- alias entities decode/escape paths in Next config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module 'packages/plugins/sanity/index.js')*
- `pnpm --filter @apps/cms build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a758b5f8832f9027d9096a31d8bd