### PR TITLE
test: add forbidden token case

### DIFF
--- a/apps/api/__tests__/routes/components/[shopId].test.ts
+++ b/apps/api/__tests__/routes/components/[shopId].test.ts
@@ -12,9 +12,18 @@ describe("components route", () => {
     expect(res.status).toBe(403);
   });
 
+  it("rejects requests with invalid token", async () => {
+    const token = jwt.sign({}, "wrongsecret");
+    const res = await request(createRequestHandler())
+      .get("/components/abc")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Forbidden" });
+  });
+
   it("returns 400 for invalid shop id", async () => {
     const res = await request(createRequestHandler()).get(
-      "/components/INVALID_ID"
+      "/components/INVALID$ID"
     );
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ error: "Invalid shop id" });


### PR DESCRIPTION
## Summary
- verify components endpoint rejects invalid bearer tokens
- use unmistakably invalid shop id in failing test

## Testing
- `pnpm -r build` *(fails: Module not found: Package path ./decode is not exported from package entities)*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa26f0c0832f9f16f0f798b84c3b