### PR TITLE
test: verifyMfa bypasses update when enabled

### DIFF
--- a/packages/auth/src/__tests__/mfa.test.ts
+++ b/packages/auth/src/__tests__/mfa.test.ts
@@ -59,6 +59,22 @@ describe("mfa", () => {
     expect(result).toBe(true);
   });
 
+  it("verifyMfa resolves true without updating when already enabled", async () => {
+    const { verifyMfa } = await import("../mfa");
+    findUnique.mockResolvedValue({
+      customerId: "cust",
+      secret: "secret",
+      enabled: true,
+    });
+    verify.mockReturnValue(true);
+
+    const result = await verifyMfa("cust", "123456");
+
+    expect(verify).toHaveBeenCalledWith({ token: "123456", secret: "secret" });
+    expect(update).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
   it("verifyMfa rejects invalid tokens without enabling", async () => {
     const { verifyMfa } = await import("../mfa");
     findUnique.mockResolvedValue({


### PR DESCRIPTION
## Summary
- add test for verifyMfa when MFA already enabled

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed)*
- `pnpm exec jest --runTestsByPath packages/auth/src/__tests__/mfa.test.ts --config jest.config.cjs --runInBand --detectOpenHandles --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b5aee60878832f80ae9e6c4b47a2f2