### PR TITLE
test(configurator): add providersByType tests

### DIFF
--- a/packages/configurator/__tests__/providers.test.ts
+++ b/packages/configurator/__tests__/providers.test.ts
@@ -1,0 +1,18 @@
+import { providers, providersByType } from "../src/providers";
+
+describe("providersByType", () => {
+  it.each(["payment", "shipping", "analytics"] as const)(
+    "returns only %s providers",
+    (type) => {
+      const result = providersByType(type);
+      expect(result).toHaveLength(
+        providers.filter((p) => p.type === type).length
+      );
+      expect(result.every((p) => p.type === type)).toBe(true);
+    }
+  );
+
+  it("returns empty array for unknown type", () => {
+    expect(providersByType("unknown" as any)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- test providersByType returns correct providers for each type and handles unknown types

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Failed to collect page data for /api/campaigns)
- `pnpm exec jest packages/configurator/__tests__/providers.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5aee897d0832fbcea93a97d29b6dc