### PR TITLE
test(auth): handle missing mfa record

### DIFF
--- a/packages/auth/src/__tests__/mfa.test.ts
+++ b/packages/auth/src/__tests__/mfa.test.ts
@@ -75,6 +75,17 @@ describe("mfa", () => {
     expect(result).toBe(false);
   });
 
+  it("verifyMfa returns false when record is missing", async () => {
+    const { verifyMfa } = await import("../mfa");
+    findUnique.mockResolvedValue(null);
+
+    const result = await verifyMfa("cust", "123456");
+
+    expect(verify).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
   it("isMfaEnabled reflects enabled state", async () => {
     const { isMfaEnabled } = await import("../mfa");
     findUnique.mockResolvedValueOnce({ customerId: "cust", enabled: true });


### PR DESCRIPTION
## Summary
- cover `verifyMfa` when no MFA record exists

## Testing
- `pnpm -r build` *(fails: TypeError: h.LRUCache is not a constructor)*
- `pnpm --filter @acme/auth test src/__tests__/mfa.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5aee570d8832f82c3334b93813116