### PR TITLE
test(platform-core): verify return authorization helpers

### DIFF
--- a/packages/platform-core/__tests__/returnAuthorization.test.ts
+++ b/packages/platform-core/__tests__/returnAuthorization.test.ts
@@ -1,0 +1,35 @@
+/** @jest-environment node */
+
+jest.mock("../src/repositories/returnAuthorization.server", () => ({
+  addReturnAuthorization: jest.fn(),
+  readReturnAuthorizations: jest.fn(),
+}));
+
+describe("returnAuthorization", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("forwards repository results unchanged", async () => {
+    const { listReturnAuthorizations } = await import("../src/returnAuthorization");
+    const repo = await import("../src/repositories/returnAuthorization.server");
+    const list = [
+      { raId: "RA1", orderId: "o1", status: "pending", inspectionNotes: "" },
+    ];
+    (repo.readReturnAuthorizations as jest.Mock).mockResolvedValue(list);
+    const result = await listReturnAuthorizations();
+    expect(repo.readReturnAuthorizations).toHaveBeenCalled();
+    expect(result).toBe(list);
+  });
+
+  it("generates an RA-prefixed ID and persists via addReturnAuthorization", async () => {
+    const { createReturnAuthorization } = await import("../src/returnAuthorization");
+    const repo = await import("../src/repositories/returnAuthorization.server");
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(123456);
+    const ra = await createReturnAuthorization({ orderId: "o1" });
+    expect(ra.raId).toBe(`RA${(123456).toString(36).toUpperCase()}`);
+    expect(repo.addReturnAuthorization).toHaveBeenCalledWith(ra);
+    nowSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add return authorization tests to ensure listReturnAuthorizations delegates to the repository and createReturnAuthorization persists RA IDs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/returnAuthorization.test.ts` *(fails: coverage threshold not met)*
- `pnpm --filter @acme/platform-core test` *(fails: Could not locate module react)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1e08f48832fa9dc941f5ceb8526