### PR TITLE
Refactor plugin loading helpers

### DIFF
--- a/packages/platform-core/src/plugins/env.ts
+++ b/packages/platform-core/src/plugins/env.ts
@@ -1,0 +1,64 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+import type { LoadPluginsOptions } from "../plugins";
+
+function unique<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}
+
+export function findPluginsDir(start: string): string {
+  let dir = start;
+  while (true) {
+    const candidate = path.join(dir, "packages", "plugins");
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return candidate;
+    dir = parent;
+  }
+}
+
+export async function resolvePluginEnvironment({
+  directories = [],
+  plugins = [],
+  configFile,
+}: LoadPluginsOptions = {}) {
+  const workspaceDir = findPluginsDir(process.cwd());
+
+  const envDirs = process.env.PLUGIN_DIRS
+    ? process.env.PLUGIN_DIRS.split(path.delimiter).filter(Boolean)
+    : [];
+
+  const configDirs: string[] = [];
+  const configPlugins: string[] = [];
+  const configPaths = [
+    configFile,
+    process.env.PLUGIN_CONFIG,
+    path.join(process.cwd(), "plugins.config.json"),
+  ].filter(Boolean) as string[];
+
+  for (const cfgPath of configPaths) {
+    try {
+      const cfg = JSON.parse(await readFile(cfgPath, "utf8"));
+      if (Array.isArray(cfg.directories)) configDirs.push(...cfg.directories);
+      if (Array.isArray(cfg.plugins)) configPlugins.push(...cfg.plugins);
+      break;
+    } catch {
+      /* ignore invalid config */
+    }
+  }
+
+  const searchDirs = unique([
+    workspaceDir,
+    ...envDirs,
+    ...configDirs,
+    ...directories,
+  ]);
+
+  const pluginDirs = [...configPlugins, ...plugins].map((p) =>
+    path.resolve(p)
+  );
+
+  return { searchDirs, pluginDirs };
+}
+

--- a/packages/platform-core/src/plugins/resolvers.ts
+++ b/packages/platform-core/src/plugins/resolvers.ts
@@ -1,0 +1,109 @@
+import { readFile, stat } from "fs/promises";
+import { createRequire } from "module";
+import path from "path";
+import { pathToFileURL } from "url";
+import { logger } from "../utils";
+
+// Use __filename if available (CommonJS), otherwise derive from import.meta.url
+const req = createRequire(
+  typeof __filename !== "undefined" ? __filename : eval("import.meta.url")
+);
+
+function unique<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    const s = await stat(p);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function exportsToCandidates(
+  dir: string,
+  exportsField: unknown
+): string[] {
+  const candidates: string[] = [];
+  if (!exportsField) return candidates;
+
+  try {
+    if (typeof exportsField === "string") {
+      candidates.push(path.resolve(dir, exportsField));
+      return candidates;
+    }
+    const root = (exportsField as Record<string, unknown>)["."] ?? exportsField;
+
+    if (typeof root === "string") {
+      candidates.push(path.resolve(dir, root));
+      return candidates;
+    }
+
+    if (root && typeof root === "object") {
+      const entryObj = root as Record<string, string>;
+      if (entryObj.import) candidates.push(path.resolve(dir, entryObj.import));
+      if (entryObj.default)
+        candidates.push(path.resolve(dir, entryObj.default));
+      if (entryObj.require)
+        candidates.push(path.resolve(dir, entryObj.require));
+    }
+  } catch {
+    // ignore malformed exports
+  }
+  return candidates;
+}
+
+export async function resolvePluginEntry(dir: string): Promise<{
+  entryPath: string | null;
+  isModule: boolean;
+}> {
+  try {
+    const pkgPath = path.join(dir, "package.json");
+    const rawPkg = await readFile(pkgPath, "utf8");
+    const pkg = JSON.parse(rawPkg) as {
+      type?: string;
+      main?: string;
+      module?: string;
+      exports?: unknown;
+    };
+    const isModule = pkg.type === "module";
+
+    // Candidates (compiled JS only)
+    const candidates = unique(
+      [
+        ...(pkg.main ? [pkg.main] : []),
+        ...(pkg.module ? [pkg.module] : []),
+        ...exportsToCandidates(dir, pkg.exports),
+        "dist/index.mjs",
+        "dist/index.js",
+        "dist/index.cjs",
+        "index.mjs",
+        "index.js",
+        "index.cjs",
+      ].map((p) => path.resolve(dir, p))
+    );
+
+    for (const candidate of candidates) {
+      if (await fileExists(candidate)) {
+        return {
+          entryPath: candidate,
+          isModule: isModule || /\.mjs$/.test(candidate),
+        };
+      }
+    }
+    return { entryPath: null, isModule };
+  } catch (err) {
+    logger.error("Failed to read plugin package.json", { plugin: dir, err });
+    return { entryPath: null, isModule: false };
+  }
+}
+
+export async function importByType(entryPath: string, isModule: boolean) {
+  if (isModule || /\.mjs$/.test(entryPath)) {
+    return import(pathToFileURL(entryPath).href);
+  }
+  return req(entryPath);
+}
+


### PR DESCRIPTION
## Summary
- extract filesystem resolution helpers into plugins/resolvers
- move directory and env handling into plugins/env
- simplify plugins.ts to delegate to env and resolvers

## Testing
- `pnpm -r build` *(fails: TypeError: h.LRUCache is not a constructor)*
- `pnpm --filter @acme/platform-core test` *(fails: Could not locate module react)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b2288510832fab94998eb3e49e4a