### PR TITLE
test(paypal): add config validation tests

### DIFF
--- a/packages/plugins/paypal/__tests__/index.test.ts
+++ b/packages/plugins/paypal/__tests__/index.test.ts
@@ -2,6 +2,58 @@ import plugin from "../index";
 import type { PaymentRegistry } from "@acme/types";
 
 describe("paypal plugin", () => {
+  it("parses valid custom config", () => {
+    const cfg = { clientId: "abc", secret: "xyz" };
+    expect(plugin.configSchema.parse(cfg)).toEqual(cfg);
+  });
+
+  it("rejects missing clientId/secret", () => {
+    expect(plugin.configSchema.safeParse({}).success).toBe(false);
+    expect(plugin.configSchema.safeParse({ clientId: "abc" }).success).toBe(
+      false
+    );
+    expect(plugin.configSchema.safeParse({ secret: "xyz" }).success).toBe(
+      false
+    );
+  });
+
+  it("registerPayments adds paypal handler using provided config", () => {
+    const registry: PaymentRegistry = {
+      add: jest.fn(),
+      get: jest.fn(),
+      list: jest.fn(),
+    };
+
+    const cfg = plugin.configSchema.parse({
+      clientId: "abc",
+      secret: "xyz",
+    });
+
+    plugin.registerPayments!(registry, cfg);
+
+    expect(registry.add).toHaveBeenCalledWith(
+      "paypal",
+      expect.objectContaining({
+        processPayment: expect.any(Function),
+      })
+    );
+  });
+
+  it("throws when given invalid config", () => {
+    const registry: PaymentRegistry = {
+      add: jest.fn(),
+      get: jest.fn(),
+      list: jest.fn(),
+    };
+
+    expect(() => {
+      const cfg = plugin.configSchema.parse({ clientId: "abc" } as any);
+      plugin.registerPayments!(registry, cfg);
+    }).toThrow();
+
+    expect(registry.add).not.toHaveBeenCalled();
+  });
+
   it("registerPayments adds paypal handler using default config when empty", () => {
     const registry: PaymentRegistry = {
       add: jest.fn(),


### PR DESCRIPTION
## Summary
- test paypal plugin config schema parses valid config
- test paypal plugin rejects invalid config and registers handler properly

## Testing
- `pnpm -r build` *(fails: Type 'Promise<PluginManager<...>>' is not assignable to type ...)*
- `pnpm test --filter packages/plugins/paypal` *(fails: No package found with name 'packages/plugins/paypal' in workspace)*
- `pnpm exec jest packages/plugins/paypal/__tests__/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5c43a6bf4832fbb57ddd0a065a314