### PR TITLE
test(eslint-plugin-ds): add rule tests for raw font stacks

### DIFF
--- a/packages/eslint-plugin-ds/package.json
+++ b/packages/eslint-plugin-ds/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc -b",
-    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs tests/no-raw-color.spec.ts",
+    "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs tests/no-raw-color.spec.ts tests/no-raw-font.spec.ts",
     "clean": "rimraf dist *.tsbuildinfo",
     "lint": "eslint ."
   },

--- a/packages/eslint-plugin-ds/tests/no-raw-font.spec.ts
+++ b/packages/eslint-plugin-ds/tests/no-raw-font.spec.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "eslint";
+import rule from "../src/rules/no-raw-font";
+
+(globalThis as any).structuredClone =
+  (globalThis as any).structuredClone ||
+  ((value: unknown) => JSON.parse(JSON.stringify(value)));
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2020, sourceType: "module" },
+});
+
+tester.run("no-raw-font", rule, {
+  valid: [
+    { code: "const font = 'var(--font-body)';" },
+    { code: "const font = tokens.typography.body;" },
+  ],
+  invalid: [
+    {
+      code: "const bad = 'Arial';",
+      errors: [{ messageId: "noRawFont" }],
+    },
+    {
+      code: "const tmpl = `font-family: Helvetica, sans-serif;`;",
+      errors: [{ messageId: "noRawFont" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add no-raw-font RuleTester spec covering token fonts vs raw stacks
- expand eslint-plugin-ds test script to run both color and font rule tests

## Testing
- `pnpm -r build` *(fails: Type error in apps/shop-bcd build)*
- `pnpm --filter eslint-plugin-ds test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c4396604832f9f505a6d1dbeb1ce