### PR TITLE
test(config): add email env parsing and error tests

### DIFF
--- a/packages/config/__tests__/emailEnv.test.ts
+++ b/packages/config/__tests__/emailEnv.test.ts
@@ -19,4 +19,30 @@ describe("emailEnv", () => {
     );
     expect(spy).toHaveBeenCalled();
   });
+
+  it("parses numeric strings and applies defaults", async () => {
+    process.env = {
+      GMAIL_USER: "a",
+      SMTP_URL: "https://smtp",
+      EMAIL_BATCH_SIZE: "10",
+    } as NodeJS.ProcessEnv;
+    const { emailEnv } = await import("../src/env/email");
+    expect(emailEnv.GMAIL_USER).toBe("a");
+    expect(emailEnv.SMTP_URL).toBe("https://smtp");
+    expect(emailEnv.EMAIL_BATCH_SIZE).toBe(10);
+    expect(emailEnv.EMAIL_PROVIDER).toBe("smtp");
+  });
+
+  it("throws and logs when EMAIL_BATCH_SIZE is non-numeric", async () => {
+    process.env = {
+      GMAIL_USER: "a",
+      SMTP_URL: "https://smtp",
+      EMAIL_BATCH_SIZE: "abc",
+    } as NodeJS.ProcessEnv;
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../src/env/email")).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add test for successful email env parsing with defaults
- add test covering invalid numeric email batch size

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/template-app build, packages/auth build, packages/email build, packages/lib build, packages/platform-machine build)*
- `pnpm --filter @acme/config build`
- `pnpm exec jest packages/config/__tests__/emailEnv.test.ts --runInBand --config packages/config/jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b5e34208fc832f9d22eb6eee59c0c6