### PR TITLE
test: add cms env fallback test

### DIFF
--- a/packages/config/__tests__/cmsEnv.test.ts
+++ b/packages/config/__tests__/cmsEnv.test.ts
@@ -25,6 +25,20 @@ describe("cmsEnv", () => {
     });
   });
 
+  it("uses fallback values in development", async () => {
+    process.env = {
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv;
+
+    const { cmsEnv } = await import("../src/env/cms");
+
+    expect(cmsEnv).toEqual({
+      CMS_SPACE_URL: "https://cms.example.com",
+      CMS_ACCESS_TOKEN: "placeholder-token",
+      SANITY_API_VERSION: "2021-10-21",
+    });
+  });
+
   it("throws and logs when CMS_SPACE_URL is invalid", async () => {
     process.env = {
       NODE_ENV: "production",


### PR DESCRIPTION
## Summary
- add test for cms env fallback values in development

## Testing
- `pnpm install`
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test` *(fails: core env module, config package entry)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e33fdb30832fb85e21ec181aecda