### PR TITLE
test(tailwind-config): ensure preset exposes theme arrays

### DIFF
--- a/packages/tailwind-config/__tests__/preset.test.ts
+++ b/packages/tailwind-config/__tests__/preset.test.ts
@@ -13,3 +13,30 @@ it("exports preset and prints diagnostic message", async () => {
   );
   logSpy.mockRestore();
 });
+
+it("sets arrays and exposes theme mappings", async () => {
+  jest.resetModules();
+  const { default: preset } = await import("../src/index.ts");
+
+  expect(Array.isArray((preset as { plugins?: unknown[] }).plugins)).toBe(true);
+  expect(Array.isArray((preset as { presets?: unknown[] }).presets)).toBe(true);
+
+  const extend = (preset.theme?.extend ?? {}) as Record<string, any>;
+  expect(extend.textColor).toEqual(
+    expect.objectContaining({
+      "primary-foreground": "hsl(var(--color-primary-fg))",
+    })
+  );
+  expect(extend.fontFamily).toEqual(
+    expect.objectContaining({ sans: "var(--font-sans)", mono: "var(--font-mono)" })
+  );
+  expect(extend.spacing).toEqual(
+    expect.objectContaining({ 1: "var(--space-1)" })
+  );
+  expect(extend.borderRadius).toEqual(
+    expect.objectContaining({ sm: "var(--radius-sm)" })
+  );
+  expect(extend.boxShadow).toEqual(
+    expect.objectContaining({ sm: "var(--shadow-sm)" })
+  );
+});


### PR DESCRIPTION
## Summary
- extend tailwind-config preset tests to check plugins/presets arrays
- verify theme exposes textColor, fontFamily, spacing, borderRadius, and boxShadow mappings

## Testing
- `pnpm test --filter @acme/tailwind-config`
- `pnpm exec jest packages/tailwind-config/__tests__/preset.test.ts --config jest.config.cjs` *(fails: Jest global coverage threshold for lines (80%) not met: 62.5%)*


------
https://chatgpt.com/codex/tasks/task_e_68b5e3276698832f82f13f7138eba1e0