### PR TITLE
test: add design token preset assertions

### DIFF
--- a/packages/design-tokens/__tests__/preset.test.ts
+++ b/packages/design-tokens/__tests__/preset.test.ts
@@ -1,17 +1,31 @@
 import { jest } from "@jest/globals";
 
 describe("design tokens preset", () => {
+  const assertTokens = (config: any) => {
+    expect(config.theme?.extend?.colors?.bg).toBe("hsl(var(--color-bg))");
+    expect(config.theme?.extend?.fontFamily?.sans).toBe("var(--font-sans)");
+    expect(config.theme?.extend?.fontFamily?.mono).toBe("var(--font-mono)");
+    expect(config.theme?.extend?.spacing?.["1"]).toBe("var(--space-1)");
+    expect(config.theme?.extend?.spacing?.["2"]).toBe("var(--space-2)");
+    expect(config.theme?.extend?.spacing?.["3"]).toBe("var(--space-3)");
+    expect(config.theme?.extend?.spacing?.["4"]).toBe("var(--space-4)");
+    expect(config.theme?.extend?.borderRadius?.sm).toBe("var(--radius-sm)");
+    expect(config.theme?.extend?.borderRadius?.md).toBe("var(--radius-md)");
+    expect(config.theme?.extend?.borderRadius?.lg).toBe("var(--radius-lg)");
+    expect(config.theme?.extend?.boxShadow?.sm).toBe("var(--shadow-sm)");
+    expect(config.theme?.extend?.boxShadow?.md).toBe("var(--shadow-md)");
+    expect(config.theme?.extend?.boxShadow?.lg).toBe("var(--shadow-lg)");
+  };
+
   it("exports preset configuration", async () => {
     jest.resetModules();
     const preset = (await import("../src/index.ts")).default;
 
-    // ensure color tokens exist
-    expect(preset.theme?.extend?.colors?.bg).toBe("hsl(var(--color-bg))");
+    assertTokens(preset);
 
-    // if preset is a function, calling it should return same config
     if (typeof preset === "function") {
       const result = preset();
-      expect(result.theme?.extend?.colors?.bg).toBe("hsl(var(--color-bg))");
+      assertTokens(result);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add tests verifying design token preset exposes CSS variables for fonts, spacing, radii, and shadows

## Testing
- `pnpm test --filter @acme/design-tokens` *(no tasks executed)*
- `pnpm exec jest packages/design-tokens/__tests__/preset.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b5e326c914832faf58acec79fb83c3