### PR TITLE
test: cover auth env defaults and prod errors

### DIFF
--- a/packages/config/__tests__/authEnv.test.ts
+++ b/packages/config/__tests__/authEnv.test.ts
@@ -9,9 +9,34 @@ describe("authEnv", () => {
     jest.restoreAllMocks();
   });
 
+  it("uses development defaults for secrets", async () => {
+    process.env = {
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv;
+
+    const { authEnv } = await import("../src/env/auth");
+
+    expect(authEnv.NEXTAUTH_SECRET).toBe("dev-nextauth-secret");
+    expect(authEnv.SESSION_SECRET).toBe("dev-session-secret");
+  });
+
   it("throws and logs when NEXTAUTH_SECRET is missing in production", async () => {
     process.env = {
       NODE_ENV: "production",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(import("../src/env/auth")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("throws and logs when SESSION_SECRET is missing in production", async () => {
+    process.env = {
+      NODE_ENV: "production",
+      NEXTAUTH_SECRET: "x",
     } as NodeJS.ProcessEnv;
 
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- test auth env falls back to development secrets
- test missing SESSION_SECRET in production errors and logs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeError: h.LRUCache is not a constructor)*
- `pnpm --filter @acme/config test` *(fails: Test Suites: 2 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e33f06c0832f846217474b9baea6