### PR TITLE
test(configurator): add integration test for CLI

### DIFF
--- a/packages/configurator/__tests__/cli.integration.test.ts
+++ b/packages/configurator/__tests__/cli.integration.test.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+describe('configurator CLI integration', () => {
+  it('delegates to vite dev and exits with code 0', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'configurator-cli-'));
+    const logFile = join(tempDir, 'spawn.json');
+    const stub = resolve(__dirname, 'spawnSync.stub.cjs');
+    const result = spawnSync(
+      'node',
+      ['--require', stub, 'bin/configurator.js', 'dev'],
+      {
+        cwd: resolve(__dirname, '..'),
+        env: {
+          ...process.env,
+          STRIPE_SECRET_KEY: 'sk',
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk',
+          CART_COOKIE_SECRET: 'secret',
+          SPAWN_SYNC_LOG: logFile,
+        },
+      }
+    );
+    expect(result.status).toBe(0);
+    const { command, args } = JSON.parse(readFileSync(logFile, 'utf8'));
+    expect(command).toBe('vite');
+    expect(args).toEqual(['dev']);
+  });
+});

--- a/packages/configurator/__tests__/spawnSync.stub.cjs
+++ b/packages/configurator/__tests__/spawnSync.stub.cjs
@@ -1,0 +1,6 @@
+const fs = require('node:fs');
+const cp = require('node:child_process');
+cp.spawnSync = (command, args, options) => {
+  fs.writeFileSync(process.env.SPAWN_SYNC_LOG, JSON.stringify({ command, args, options }));
+  return { status: 0 };
+};


### PR DESCRIPTION
## Summary
- add integration test spawning configurator CLI and verifying it delegates to `vite dev`
- stub `child_process.spawnSync` via require hook inside spawned process

## Testing
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm --filter @acme/configurator build`
- `pnpm exec jest packages/configurator/__tests__/cli.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4e7ca54832f95220e2c2ece203d