### PR TITLE
test(configurator): ensure bin logs import failure

### DIFF
--- a/packages/configurator/__tests__/bin.test.ts
+++ b/packages/configurator/__tests__/bin.test.ts
@@ -1,0 +1,30 @@
+const err = new Error("boom");
+
+jest.mock("../dist/index.js", () => {
+  throw err;
+}, { virtual: true });
+
+describe("configurator bin", () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("logs and sets exit code when dist import fails", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    let p: Promise<unknown>;
+
+    jest.isolateModules(() => {
+      p = import("../bin/configurator.js");
+    });
+
+    await p.catch(() => {});
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to load the compiled configurator module:",
+      expect.anything(),
+    );
+    expect(process.exitCode).toBe(1);
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- test bin script to log errors when compiled module fails to load

## Testing
- `pnpm exec jest packages/configurator/__tests__/bin.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4e70ea8832fbb11541d2ff3a89b