### PR TITLE
test: supply base URL for email scheduler

### DIFF
--- a/packages/email/src/scheduler.test.ts
+++ b/packages/email/src/scheduler.test.ts
@@ -47,7 +47,8 @@ describe("sendDueCampaigns retry logic", () => {
     process.env.CAMPAIGN_FROM = "campaign@example.com";
     process.env.EMAIL_BATCH_DELAY_MS = "0";
     process.env.EMAIL_BATCH_SIZE = "100";
-    process.env.NEXT_PUBLIC_BASE_URL = "";
+    // Provide a valid URL to satisfy core environment validation
+    process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
     mockSendMail = jest.fn();
   };
 


### PR DESCRIPTION
## Summary
- set NEXT_PUBLIC_BASE_URL in scheduler tests to a valid URL

## Testing
- `pnpm install`
- `pnpm exec jest packages/email/src/scheduler.test.ts` *(fails: timeout and coverage threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e490949c832fbe06532d5a5f11a4