### PR TITLE
test: ensure payments env handles valid stripe keys

### DIFF
--- a/packages/config/__tests__/paymentsEnv.test.ts
+++ b/packages/config/__tests__/paymentsEnv.test.ts
@@ -9,6 +9,25 @@ describe("paymentsEnv", () => {
     jest.restoreAllMocks();
   });
 
+  it("parses valid Stripe keys without warnings", async () => {
+    process.env = {
+      STRIPE_SECRET_KEY: "sk_test_123",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_456",
+      STRIPE_WEBHOOK_SECRET: "whsec_789",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { paymentsEnv } = await import("../src/env/payments");
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test_123",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_456",
+      STRIPE_WEBHOOK_SECRET: "whsec_789",
+    });
+  });
+
   it("falls back to defaults and warns on invalid env", async () => {
     process.env = {
       STRIPE_SECRET_KEY: "",


### PR DESCRIPTION
## Summary
- add test verifying paymentsEnv returns provided Stripe keys and logs no warnings

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm --filter @acme/config test` *(fails: core env module; config package entry)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3431328832fa095cc1fd2e15d65