### PR TITLE
test: expand shipping env loader coverage

### DIFF
--- a/packages/config/__tests__/shippingEnv.test.ts
+++ b/packages/config/__tests__/shippingEnv.test.ts
@@ -38,4 +38,31 @@ describe("shippingEnv", () => {
     );
     expect(spy).toHaveBeenCalled();
   });
+
+  it("loadShippingEnv parses valid UPS_KEY", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const env = loadShippingEnv({ UPS_KEY: "x" } as NodeJS.ProcessEnv);
+    expect(env).toEqual({ UPS_KEY: "x" });
+  });
+
+  it("loadShippingEnv throws and logs on invalid UPS_KEY", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ UPS_KEY: 123 as any } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid shipping environment variables");
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("legacy parse throws and logs on invalid UPS_KEY", async () => {
+    process.env = {
+      UPS_KEY: 123 as any,
+    } as unknown as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../src/env/shipping")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- test loadShippingEnv with valid UPS_KEY
- ensure loadShippingEnv logs and throws on invalid UPS_KEY
- verify legacy shippingEnv parse logs and throws on invalid UPS_KEY

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm --filter @acme/config test` *(fails: config package entry re-exports core env and core env module errors)*
- `pnpm exec jest packages/config/__tests__/shippingEnv.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b5e344b934832f9a365453b6db3377