### PR TITLE
test: cover configurator msw handlers

### DIFF
--- a/test/msw/configurator.test.ts
+++ b/test/msw/configurator.test.ts
@@ -1,0 +1,29 @@
+import { server } from "./server";
+
+describe("msw configurator handlers", () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  test("POST /cms/api/configurator returns default message", async () => {
+    const res = await fetch("http://localhost/cms/api/configurator", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true, message: "default handler: OK" });
+  });
+
+  test("GET /cms/api/configurator/validate-env/:shop returns success", async () => {
+    const res = await fetch(
+      "http://localhost/cms/api/configurator/validate-env/my-shop"
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for default MSW configurator handlers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm exec jest test/msw/configurator.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b5e3469520832fbf119a5de0fef191