### PR TITLE
fix sendgrid provider to support error testing without API key

### DIFF
--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -56,8 +56,9 @@ export class SendgridProvider implements CampaignProvider {
 
   async send(options: CampaignOptions): Promise<void> {
     if (!apiKey) {
-      console.warn("Sendgrid API key is not configured; skipping email send");
-      return;
+      console.warn(
+        "Sendgrid API key is not configured; attempting to send email"
+      );
     }
     try {
       await sgMail.send({


### PR DESCRIPTION
## Summary
- allow Sendgrid provider to attempt sending when API key is missing, warning instead of skipping

## Testing
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm exec jest packages/email/src/providers/__tests__/sendgrid.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4515580832fb79faf7533b4cfe9