### PR TITLE
test: cover core env proxy and refinement

### DIFF
--- a/packages/config/__tests__/coreEnvProxy.test.ts
+++ b/packages/config/__tests__/coreEnvProxy.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, afterEach, expect } from "@jest/globals";
+
+const OLD_ENV = process.env;
+
+afterEach(() => {
+  jest.resetModules();
+  process.env = OLD_ENV;
+});
+
+describe("coreEnv proxy", () => {
+  it("supports the has trap", async () => {
+    process.env = { ...OLD_ENV, NODE_ENV: "test" } as NodeJS.ProcessEnv;
+    const { coreEnv } = await import("../src/env/core");
+    expect("NODE_ENV" in coreEnv).toBe(true);
+  });
+
+  it("invokes loadCoreEnv during import in production", async () => {
+    process.env = {
+      ...OLD_ENV,
+      NODE_ENV: "production",
+      CART_COOKIE_SECRET: "secret",
+      NEXTAUTH_SECRET: "nextauth",
+      SESSION_SECRET: "session",
+      CMS_SPACE_URL: "https://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2023-01-01",
+    } as NodeJS.ProcessEnv;
+    const core = await import("../src/env/core");
+    const spy = jest.spyOn(core, "loadCoreEnv");
+    // Accessing again shouldn't trigger loadCoreEnv if fail-fast ran on import.
+    core.coreEnv.NODE_ENV;
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/config/__tests__/coreEnvRefinement.test.ts
+++ b/packages/config/__tests__/coreEnvRefinement.test.ts
@@ -14,6 +14,8 @@ describe("coreEnvSchema refinement", () => {
       ...OLD_ENV,
       DEPOSIT_RELEASE_ENABLED: "notbool",
       REVERSE_LOGISTICS_INTERVAL_MS: "abc",
+      LATE_FEE_INTERVAL_MS: "abc",
+      DEPOSIT_RELEASE_FOO: "bar",
     } as NodeJS.ProcessEnv;
 
     const parsed = coreEnvSchema.safeParse(process.env);
@@ -23,6 +25,12 @@ describe("coreEnvSchema refinement", () => {
         expect.arrayContaining([
           expect.objectContaining({ path: ["DEPOSIT_RELEASE_ENABLED"] }),
           expect.objectContaining({ path: ["REVERSE_LOGISTICS_INTERVAL_MS"] }),
+          expect.objectContaining({ path: ["LATE_FEE_INTERVAL_MS"] }),
+        ]),
+      );
+      expect(parsed.error.issues).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ["DEPOSIT_RELEASE_FOO"] }),
         ]),
       );
     }

--- a/packages/config/__tests__/index.test.ts
+++ b/packages/config/__tests__/index.test.ts
@@ -22,10 +22,19 @@ describe("config package entry", () => {
       CMS_SPACE_URL: "https://example.com",
       CMS_ACCESS_TOKEN: "token",
       SANITY_API_VERSION: "2023-01-01",
+      NODE_ENV: "production",
     } as NodeJS.ProcessEnv;
 
     const { env } = await import("../src/index");
-    expect(env).toMatchObject({
+    expect({
+      STRIPE_SECRET_KEY: env.STRIPE_SECRET_KEY,
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+        env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+      CART_COOKIE_SECRET: env.CART_COOKIE_SECRET,
+      STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET,
+      NEXTAUTH_SECRET: env.NEXTAUTH_SECRET,
+      SESSION_SECRET: env.SESSION_SECRET,
+    }).toEqual({
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
       CART_COOKIE_SECRET: "secret",

--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -102,6 +102,7 @@ describe("core env module", () => {
     process.env = {
       ...ORIGINAL_ENV,
       ...baseEnv,
+      NODE_ENV: "production",
       DEPOSIT_RELEASE_ENABLED: "yes",
       LATE_FEE_INTERVAL_MS: "fast",
     } as NodeJS.ProcessEnv;


### PR DESCRIPTION
## Summary
- extend core env refinement test to cover late fee and unknown keys
- add tests for core env proxy `has` trap and production fail-fast behavior
- ensure core env module and index tests run under production env

## Testing
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e3456d7c832fa8f3fcd9e9752626