### PR TITLE
test(email): ensure index sets email service and exposes API

### DIFF
--- a/packages/email/src/__tests__/index.test.ts
+++ b/packages/email/src/__tests__/index.test.ts
@@ -1,0 +1,44 @@
+import { jest } from "@jest/globals";
+
+const sendEmailMock = jest.fn();
+
+jest.mock("@acme/platform-core/services/emailService", () => ({
+  setEmailService: jest.fn(),
+}));
+
+jest.mock("../sendEmail", () => ({
+  sendEmail: sendEmailMock,
+}));
+
+jest.mock("../templates", () => ({
+  registerTemplate: jest.fn(),
+  renderTemplate: jest.fn(),
+  clearTemplates: jest.fn(),
+}));
+
+describe("email index", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("registers sendEmail with email service on import", async () => {
+    const { setEmailService } = require("@acme/platform-core/services/emailService");
+
+    await import("../index");
+
+    expect(setEmailService).toHaveBeenCalledWith({ sendEmail: sendEmailMock });
+  });
+
+  it("re-exports public API", async () => {
+    const mod = await import("../index");
+
+    expect(mod.sendCampaignEmail).toBeDefined();
+    expect(mod.registerTemplate).toBeDefined();
+    expect(mod.recoverAbandonedCarts).toBeDefined();
+    expect(mod.sendEmail).toBeDefined();
+    expect(mod.resolveSegment).toBeDefined();
+    expect(mod.createCampaign).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test for email index registering sendEmail with platform email service
- assert key functions are re-exported from package entry

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeError h.LRUCache is not a constructor)*
- `pnpm --filter @acme/email test --coverage=false packages/email/src/__tests__/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5e5a40924832f8e7494b1b254f662