### PR TITLE
test: cover resend provider edge cases

### DIFF
--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -1,9 +1,16 @@
-const { Resend, send } = require("resend");
+let Resend: any;
+let send: any;
+const originalFetch = global.fetch;
 
 describe("ResendProvider", () => {
+  beforeEach(() => {
+    ({ Resend, send } = require("resend"));
+  });
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
     delete process.env.RESEND_API_KEY;
     delete process.env.CAMPAIGN_FROM;
   });
@@ -45,5 +52,101 @@ describe("ResendProvider", () => {
     );
 
     global.fetch = originalFetch;
+  });
+
+  it("throws ProviderError on non-OK responses", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    process.env.CAMPAIGN_FROM = "from@example.com";
+    const err = { message: "Bad Request", statusCode: 400 };
+    send.mockRejectedValueOnce(err);
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    const promise = provider.send({
+      to: "t@example.com",
+      subject: "s",
+      html: "<p>h</p>",
+      text: "t",
+    });
+    const { ProviderError } = require("../providers/types");
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({ retryable: false });
+  });
+
+  it("logs warning when API key missing", async () => {
+    process.env.CAMPAIGN_FROM = "from@example.com";
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await provider.send({
+      to: "t@example.com",
+      subject: "s",
+      html: "<p>h</p>",
+      text: "t",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Resend API key is not configured; skipping email send"
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("getCampaignStats returns fallback on fetch failure", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    const { emptyStats } = await import("../stats");
+    await expect(provider.getCampaignStats("1")).resolves.toEqual(emptyStats);
+  });
+
+  it("createContact returns empty string when fetch rejects", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await expect(provider.createContact("user@example.com")).resolves.toBe("");
+  });
+
+  it("addToList resolves even when fetch rejects", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await expect(provider.addToList("cid", "lid")).resolves.toBeUndefined();
+  });
+
+  it("listSegments returns [] when fetch rejects", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await expect(provider.listSegments()).resolves.toEqual([]);
+  });
+
+  it("listSegments handles data arrays", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({ data: [{ id: "1", name: "Test" }] }),
+    }) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await expect(provider.listSegments()).resolves.toEqual([
+      { id: "1", name: "Test" },
+    ]);
+  });
+
+  it("listSegments handles segments arrays", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({ segments: [{ id: "1", name: "Test" }] }),
+    }) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await expect(provider.listSegments()).resolves.toEqual([
+      { id: "1", name: "Test" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- expand resend provider tests for error paths, API key warnings, stats fallback, and segment parsing

## Testing
- `pnpm -r build` *(fails: TypeError LRUCache is not a constructor)*
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__/resend.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5a940d8832fa354487ad37ebe3b