### PR TITLE
Add comprehensive generateMeta tests

### DIFF
--- a/packages/lib/__tests__/generateMeta.test.ts
+++ b/packages/lib/__tests__/generateMeta.test.ts
@@ -1,7 +1,23 @@
+import path from "path";
 import { promises as fs } from "fs";
 
+const configEnv = { OPENAI_API_KEY: "key" } as { OPENAI_API_KEY: string | undefined };
 jest.mock("@acme/config", () => ({
-  env: { OPENAI_API_KEY: undefined },
+  env: configEnv,
+}));
+
+const responsesCreateMock = jest.fn().mockResolvedValue({
+  output: [{ content: [{ text: '{"title":"T","description":"D","alt":"A"}' }] }],
+});
+const imagesGenerateMock = jest.fn().mockResolvedValue({
+  data: [{ b64_json: Buffer.from("img").toString("base64") }],
+});
+const OpenAIConstructorMock = jest.fn().mockImplementation(() => ({
+  responses: { create: responsesCreateMock },
+  images: { generate: imagesGenerateMock },
+}));
+jest.mock("openai", () => ({
+  default: OpenAIConstructorMock,
 }));
 
 jest.mock("fs", () => ({
@@ -20,11 +36,41 @@ describe("generateMeta", () => {
   afterEach(() => {
     writeFileMock.mockReset();
     mkdirMock.mockReset();
+    responsesCreateMock.mockReset();
+    imagesGenerateMock.mockReset();
+    OpenAIConstructorMock.mockReset();
+  });
+
+  it("generates metadata and image using OpenAI", async () => {
+    configEnv.OPENAI_API_KEY = "key";
+
+    const result = await generateMeta({
+      id: "123",
+      title: "Title",
+      description: "Desc",
+    });
+
+    const dir = path.join(process.cwd(), "public", "og");
+    const file = path.join(dir, "123.png");
+
+    expect(responsesCreateMock).toHaveBeenCalled();
+    expect(imagesGenerateMock).toHaveBeenCalled();
+
+    expect(mkdirMock).toHaveBeenCalledWith(dir, { recursive: true });
+    expect(writeFileMock).toHaveBeenCalledWith(file, Buffer.from("img"));
+
+    expect(result).toEqual({
+      title: "T",
+      description: "D",
+      alt: "A",
+      image: "/og/123.png",
+    });
   });
 
   it("returns fallback metadata when no API key in production", async () => {
     const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";
+    configEnv.OPENAI_API_KEY = undefined;
 
     try {
       const result = await generateMeta({
@@ -44,6 +90,34 @@ describe("generateMeta", () => {
       expect(writeFileMock).not.toHaveBeenCalled();
     } finally {
       process.env.NODE_ENV = originalEnv;
+      configEnv.OPENAI_API_KEY = "key";
+    }
+  });
+
+  it("returns deterministic metadata in tests without API key", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+    configEnv.OPENAI_API_KEY = undefined;
+
+    try {
+      const result = await generateMeta({
+        id: "123",
+        title: "Title",
+        description: "Desc",
+      });
+
+      expect(result).toEqual({
+        title: "AI title",
+        description: "AI description",
+        alt: "alt",
+        image: "/og/123.png",
+      });
+
+      expect(mkdirMock).not.toHaveBeenCalled();
+      expect(writeFileMock).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+      configEnv.OPENAI_API_KEY = "key";
     }
   });
 });


### PR DESCRIPTION
## Summary
- expand generateMeta tests for OpenAI generation
- cover production and test fallbacks

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/campaigns)*
- `pnpm --filter @acme/lib test` *(fails: Module /test/setupFetchPolyfill.ts in the setupFiles option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60a8dce10832fb44db088b5702fd5