### PR TITLE
test(shop-bcd): add coverage for auth and content flows

### DIFF
--- a/apps/shop-bcd/__tests__/blog-pages.test.tsx
+++ b/apps/shop-bcd/__tests__/blog-pages.test.tsx
@@ -1,0 +1,119 @@
+// apps/shop-bcd/__tests__/blog-pages.test.tsx
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe("Blog listing page", () => {
+  test("renders posts when blog enabled", async () => {
+    jest.mock("@ui/components/cms/blocks/BlogListing", () => ({
+      __esModule: true,
+      default: jest.fn(() => null),
+    }));
+    jest.mock("@acme/sanity", () => ({
+      __esModule: true,
+      fetchPublishedPosts: jest
+        .fn()
+        .mockResolvedValue([
+          { title: "Hello", slug: "hello", excerpt: "Hi", products: ["p1"] },
+        ]),
+    }));
+    const { default: BlogPage } = await import(
+      "../src/app/[lang]/blog/page"
+    );
+    const BlogListing = (
+      await import("@ui/components/cms/blocks/BlogListing")
+    ).default as jest.Mock;
+    await BlogPage({ params: { lang: "en" } } as any);
+    expect(BlogListing).toHaveBeenCalledWith(
+      {
+        posts: [
+          {
+            title: "Hello",
+            excerpt: "Hi",
+            url: "/en/blog/hello",
+            shopUrl: "/en/product/p1",
+          },
+        ],
+      },
+      {},
+    );
+  });
+
+  test("calls notFound when blog disabled", async () => {
+    jest.doMock("../shop.json", () => ({
+      id: "bcd",
+      luxuryFeatures: { blog: false },
+      editorialBlog: {},
+    }));
+    const notFound = jest.fn();
+    jest.doMock("next/navigation", () => ({ notFound }));
+    const { default: BlogPage } = await import(
+      "../src/app/[lang]/blog/page"
+    );
+    await BlogPage({ params: { lang: "en" } } as any);
+    expect(notFound).toHaveBeenCalled();
+  });
+});
+
+describe("Blog post page", () => {
+  test("renders post when found", async () => {
+    jest.mock("@acme/sanity", () => ({
+      __esModule: true,
+      fetchPostBySlug: jest.fn().mockResolvedValue({
+        title: "Hello",
+        slug: "hello",
+        excerpt: "",
+        body: [],
+      }),
+    }));
+    jest.mock("@platform-core/components/blog/BlogPortableText", () => ({
+      BlogPortableText: jest.fn(() => null),
+    }));
+    const { default: BlogPostPage } = await import(
+      "../src/app/[lang]/blog/[slug]/page"
+    );
+    const res = await BlogPostPage({
+      params: { lang: "en", slug: "hello" },
+    } as any);
+    const { fetchPostBySlug } = await import("@acme/sanity");
+    expect((fetchPostBySlug as jest.Mock)).toHaveBeenCalledWith("bcd", "hello");
+    expect(res.type).toBe("article");
+  });
+
+  test("notFound when blog disabled", async () => {
+    jest.doMock("../shop.json", () => ({
+      id: "bcd",
+      luxuryFeatures: { blog: false },
+      editorialBlog: {},
+    }));
+    jest.mock("@acme/sanity", () => ({
+      __esModule: true,
+      fetchPostBySlug: jest.fn(),
+    }));
+    const notFound = jest.fn();
+    jest.doMock("next/navigation", () => ({ notFound }));
+    const { default: BlogPostPage } = await import(
+      "../src/app/[lang]/blog/[slug]/page"
+    );
+    await BlogPostPage({ params: { lang: "en", slug: "x" } } as any);
+    const { fetchPostBySlug } = await import("@acme/sanity");
+    expect(fetchPostBySlug).not.toHaveBeenCalled();
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  test("notFound when post missing", async () => {
+    jest.mock("@acme/sanity", () => ({
+      __esModule: true,
+      fetchPostBySlug: jest.fn().mockResolvedValue(null),
+    }));
+    const notFound = jest.fn();
+    jest.doMock("next/navigation", () => ({ notFound }));
+    const { default: BlogPostPage } = await import(
+      "../src/app/[lang]/blog/[slug]/page"
+    );
+    await BlogPostPage({ params: { lang: "en", slug: "missing" } } as any);
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/apps/shop-bcd/__tests__/login-api.test.ts
+++ b/apps/shop-bcd/__tests__/login-api.test.ts
@@ -1,0 +1,84 @@
+// apps/shop-bcd/__tests__/login-api.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  createCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn(),
+}));
+
+import { createCustomerSession, validateCsrfToken } from "@auth";
+import { POST } from "../src/app/api/login/route";
+
+function makeRequest(body: any, headers: Record<string, string> = {}) {
+  return new Request("http://example.com/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(() => jest.clearAllMocks());
+
+test("logs in valid customer", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "pass1" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(validateCsrfToken).toHaveBeenCalledWith("token");
+  expect(createCustomerSession).toHaveBeenCalledWith({
+    customerId: "cust1",
+    role: "customer",
+  });
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ ok: true });
+});
+
+test("rejects invalid CSRF token", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(false);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "pass1" },
+      { "x-csrf-token": "bad" },
+    ),
+  );
+  expect(res.status).toBe(403);
+  await expect(res.json()).resolves.toEqual({ error: "Invalid CSRF token" });
+});
+
+test("rejects invalid credentials", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "wrongpass" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(res.status).toBe(401);
+  const body = await res.json();
+  expect(body.error).toMatch(/invalid credentials/i);
+});
+
+test("rejects unauthorized role", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "admin1", password: "admin" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(res.status).toBe(403);
+  await expect(res.json()).resolves.toEqual({ error: "Unauthorized role" });
+});
+
+test("returns 400 for invalid body", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "short" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(res.status).toBe(400);
+});

--- a/apps/shop-bcd/__tests__/logout.test.ts
+++ b/apps/shop-bcd/__tests__/logout.test.ts
@@ -1,0 +1,24 @@
+// apps/shop-bcd/__tests__/logout.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  destroyCustomerSession: jest.fn(),
+}));
+
+import { destroyCustomerSession } from "@auth";
+import { GET } from "../src/app/logout/route";
+
+afterEach(() => jest.clearAllMocks());
+
+test("destroys session and redirects to home", async () => {
+  const req = new Request("http://example.com/logout");
+  const res = await GET(req as any);
+  expect(destroyCustomerSession).toHaveBeenCalled();
+  expect(res.status).toBe(307);
+  expect(res.headers.get("location")).toBe("/");
+});
+
+test("propagates errors from session destroy", async () => {
+  (destroyCustomerSession as jest.Mock).mockRejectedValueOnce(new Error("boom"));
+  const req = new Request("http://example.com/logout");
+  await expect(GET(req as any)).rejects.toThrow("boom");
+});

--- a/apps/shop-bcd/__tests__/search-api.test.ts
+++ b/apps/shop-bcd/__tests__/search-api.test.ts
@@ -1,0 +1,45 @@
+// apps/shop-bcd/__tests__/search-api.test.ts
+jest.mock("@acme/sanity", () => ({
+  __esModule: true,
+  fetchPublishedPosts: jest.fn(),
+}));
+
+import { fetchPublishedPosts } from "@acme/sanity";
+import { GET } from "../src/app/api/search/route";
+import { PRODUCTS } from "@platform-core/products";
+
+function makeRequest(q: string) {
+  return new Request(`http://example.com/api/search?q=${encodeURIComponent(q)}`);
+}
+
+afterEach(() => jest.clearAllMocks());
+
+test("returns matching products and posts", async () => {
+  (fetchPublishedPosts as jest.Mock).mockResolvedValue([
+    { title: "Summer Style", slug: "summer" },
+  ]);
+  const product = PRODUCTS[0];
+  const q = product.title.slice(0, 3).toLowerCase();
+  const res = await GET(makeRequest(q) as any);
+  expect(fetchPublishedPosts).toHaveBeenCalledWith("bcd");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.results).toEqual(
+    expect.arrayContaining([
+      { type: "product", title: product.title, slug: product.slug },
+      { type: "post", title: "Summer Style", slug: "summer" },
+    ]),
+  );
+});
+
+test("ignores blog posts when fetch fails", async () => {
+  (fetchPublishedPosts as jest.Mock).mockRejectedValue(new Error("fail"));
+  const product = PRODUCTS[0];
+  const q = product.title.slice(0, 3).toLowerCase();
+  const res = await GET(makeRequest(q) as any);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.results).toEqual([
+    { type: "product", title: product.title, slug: product.slug },
+  ]);
+});

--- a/apps/shop-bcd/__tests__/shipping-rate.test.ts
+++ b/apps/shop-bcd/__tests__/shipping-rate.test.ts
@@ -1,0 +1,75 @@
+// apps/shop-bcd/__tests__/shipping-rate.test.ts
+jest.mock("@platform-core/shipping/index", () => ({
+  __esModule: true,
+  getShippingRate: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/settings.server", () => ({
+  __esModule: true,
+  getShopSettings: jest.fn().mockResolvedValue({}),
+}));
+
+import { getShippingRate } from "@platform-core/shipping/index";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import { POST } from "../src/app/api/shipping-rate/route";
+
+function makeRequest(body: any) {
+  return new Request("http://example.com/api/shipping-rate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(() => jest.clearAllMocks());
+
+test("returns shipping rate for valid request", async () => {
+  (getShippingRate as jest.Mock).mockResolvedValue(42);
+  const res = await POST(
+    makeRequest({
+      provider: "dhl",
+      fromPostalCode: "1000",
+      toPostalCode: "2000",
+      weight: 1,
+    }) as any,
+  );
+  expect(getShippingRate).toHaveBeenCalledWith({
+    provider: "dhl",
+    fromPostalCode: "1000",
+    toPostalCode: "2000",
+    weight: 1,
+    region: undefined,
+    window: undefined,
+    carrier: undefined,
+    premierDelivery: undefined,
+  });
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ rate: 42 });
+});
+
+test("validates required fields for premier-shipping", async () => {
+  const res = await POST(
+    makeRequest({
+      provider: "premier-shipping",
+      fromPostalCode: "1000",
+      toPostalCode: "2000",
+      weight: 1,
+    }) as any,
+  );
+  expect(res.status).toBe(400);
+  expect(getShippingRate).not.toHaveBeenCalled();
+});
+
+test("returns 500 when provider throws", async () => {
+  (getShippingRate as jest.Mock).mockRejectedValueOnce(new Error("oops"));
+  const res = await POST(
+    makeRequest({
+      provider: "dhl",
+      fromPostalCode: "1",
+      toPostalCode: "2",
+      weight: 1,
+    }) as any,
+  );
+  expect(res.status).toBe(500);
+  await expect(res.json()).resolves.toEqual({ error: "oops" });
+});


### PR DESCRIPTION
## Summary
- add unit tests for login API and logout route
- cover shipping-rate and search APIs
- test blog listing and post pages for success and error states

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__ --config apps/shop-bcd/jest.config.cjs` (fails: Module /test/setupFetchPolyfill.ts not found)

------
https://chatgpt.com/codex/tasks/task_e_68b6d83feb68832f88798be11f173676