### PR TITLE
refactor quickstart shop orchestration

### DIFF
--- a/scripts/src/cli/parseQuickstartArgs.ts
+++ b/scripts/src/cli/parseQuickstartArgs.ts
@@ -1,0 +1,86 @@
+// scripts/src/cli/parseQuickstartArgs.ts
+// Parse CLI arguments for the quickstart script.
+
+export interface Flags {
+  id?: string;
+  theme?: string;
+  template?: string;
+  payment?: string[];
+  shipping?: string[];
+  seed?: boolean;
+  seedFull?: boolean;
+  brand?: string;
+  tokens?: string;
+  autoEnv?: boolean;
+  config?: string;
+  pagesTemplate?: string;
+  presets?: boolean;
+  autoPlugins?: boolean;
+}
+
+export function parseQuickstartArgs(argv: string[]): Flags {
+  const flags: Flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const [key, value] = arg.slice(2).split("=");
+      if (key === "seed") {
+        flags.seed = true;
+        continue;
+      }
+      if (key === "seed-full") {
+        flags.seedFull = true;
+        continue;
+      }
+      if (key === "auto-env") {
+        flags.autoEnv = true;
+        continue;
+      }
+      if (key === "presets") {
+        flags.presets = true;
+        continue;
+      }
+      if (key === "auto-plugins") {
+        flags.autoPlugins = true;
+        continue;
+      }
+      const val = value ?? argv[++i];
+      switch (key) {
+        case "id":
+        case "shop":
+          flags.id = val;
+          break;
+        case "theme":
+          flags.theme = val;
+          break;
+        case "template":
+          flags.template = val;
+          break;
+        case "pages-template":
+          flags.pagesTemplate = val;
+          break;
+        case "payment":
+          flags.payment = val ? val.split(",").map((s) => s.trim()) : [];
+          break;
+        case "shipping":
+          flags.shipping = val ? val.split(",").map((s) => s.trim()) : [];
+          break;
+        case "brand":
+          flags.brand = val;
+          break;
+        case "tokens":
+          flags.tokens = val;
+          break;
+        case "config":
+          flags.config = val;
+          break;
+        default:
+          console.error(`Unknown option --${key}`);
+          process.exit(1);
+      }
+    } else if (!flags.id) {
+      flags.id = arg;
+    }
+  }
+  return flags;
+}

--- a/scripts/src/cli/quickstartPrompts.ts
+++ b/scripts/src/cli/quickstartPrompts.ts
@@ -1,0 +1,108 @@
+// scripts/src/cli/quickstartPrompts.ts
+// Prompt helpers for quickstart-shop.
+
+import { join } from "node:path";
+import type { CreateShopOptions } from "@acme/platform-core/createShop";
+import {
+  listProviders,
+  type ProviderInfo,
+} from "@acme/platform-core/createShop/listProviders";
+import { selectOption, selectProviders } from "../utils/prompts";
+import {
+  listDirNames,
+  loadTemplateDefaults,
+  loadPresetDefaults,
+} from "../utils/templates";
+import type { Flags } from "./parseQuickstartArgs";
+
+export interface QuickstartPromptsResult {
+  theme: string;
+  template: string;
+  navItems?: CreateShopOptions["navItems"];
+  pages?: CreateShopOptions["pages"];
+  payment: string[];
+  shipping: string[];
+  paymentProviders: ProviderInfo[];
+  shippingProviders: ProviderInfo[];
+  pageTemplate?: string;
+}
+
+export async function quickstartPrompts(
+  args: Flags,
+  config: Partial<CreateShopOptions>,
+): Promise<QuickstartPromptsResult> {
+  const themes = listDirNames(join(process.cwd(), "packages", "themes"));
+  let theme = args.theme ?? (config.theme as string | undefined);
+  if (!theme) {
+    theme = await selectOption(
+      "theme",
+      themes,
+      Math.max(themes.indexOf("base"), 0),
+    );
+  }
+
+  const templates = listDirNames(join(process.cwd(), "packages")).filter((n) =>
+    n.startsWith("template-"),
+  );
+  let template = args.template ?? (config.template as string | undefined);
+  if (!template) {
+    template = await selectOption(
+      "template",
+      templates,
+      Math.max(templates.indexOf("template-app"), 0),
+    );
+  }
+
+  const templateDefaults = loadTemplateDefaults(template);
+  const presetDefaults = args.presets ? loadPresetDefaults() : {};
+  const navItems =
+    (config.navItems as CreateShopOptions["navItems"] | undefined) ??
+    templateDefaults.navItems ??
+    presetDefaults.navItems;
+  const pages =
+    (config.pages as CreateShopOptions["pages"] | undefined) ??
+    templateDefaults.pages ??
+    presetDefaults.pages;
+
+  const paymentProviders = await listProviders("payment");
+  let payment =
+    args.payment ??
+    (Array.isArray(config.payment) ? (config.payment as string[]) : undefined);
+  const shippingProviders = await listProviders("shipping");
+  let shipping =
+    args.shipping ??
+    (Array.isArray(config.shipping) ? (config.shipping as string[]) : undefined);
+
+  if (args.autoPlugins) {
+    payment = paymentProviders.map((p) => p.id);
+    shipping = shippingProviders.map((p) => p.id);
+  } else {
+    if (!payment || payment.length === 0) {
+      payment = await selectProviders(
+        "payment providers",
+        paymentProviders.map((p) => p.id),
+      );
+    }
+
+    if (!shipping || shipping.length === 0) {
+      shipping = await selectProviders(
+        "shipping providers",
+        shippingProviders.map((p) => p.id),
+      );
+    }
+  }
+
+  const pageTemplate = args.pagesTemplate ?? (args.presets ? "default" : undefined);
+
+  return {
+    theme,
+    template,
+    navItems,
+    pages,
+    payment: payment ?? [],
+    shipping: shipping ?? [],
+    paymentProviders,
+    shippingProviders,
+    pageTemplate,
+  };
+}

--- a/scripts/src/shop/createShopAndSeed.ts
+++ b/scripts/src/shop/createShopAndSeed.ts
@@ -1,0 +1,62 @@
+// scripts/src/shop/createShopAndSeed.ts
+// Create a shop, optionally seed it, apply page templates, and write env files.
+
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createShop,
+  type CreateShopOptions,
+} from "@acme/platform-core/createShop";
+import { readEnvFile } from "@acme/platform-core/configurator";
+import type { ProviderInfo } from "@acme/platform-core/createShop/listProviders";
+import type { Flags } from "../cli/parseQuickstartArgs";
+import { seedShop } from "../seedShop";
+import { applyPageTemplate } from "../apply-page-template";
+
+export async function createShopAndSeed(
+  prefixedId: string,
+  options: CreateShopOptions,
+  flags: Flags,
+  pageTemplate: string | undefined,
+  paymentProviders: ProviderInfo[],
+  shippingProviders: ProviderInfo[],
+): Promise<void> {
+  await createShop(prefixedId, options);
+
+  if (flags.seedFull) {
+    seedShop(prefixedId, undefined, true);
+  } else if (flags.seed) {
+    seedShop(prefixedId);
+  }
+
+  if (pageTemplate) {
+    await applyPageTemplate(prefixedId, pageTemplate);
+  }
+
+  if (flags.autoEnv) {
+    const envVars = new Set<string>();
+    const providerMap = new Map<string, readonly string[]>();
+    paymentProviders.forEach((p) => providerMap.set(p.id, p.envVars));
+    shippingProviders.forEach((p) => providerMap.set(p.id, p.envVars));
+    for (const id of [...options.payment, ...options.shipping]) {
+      const vars = providerMap.get(id) ?? [];
+      vars.forEach((v) => envVars.add(v));
+    }
+    const envPath = join("apps", prefixedId, ".env");
+    let existing: Record<string, string> = {};
+    if (existsSync(envPath)) {
+      existing = readEnvFile(envPath);
+    }
+    for (const key of envVars) {
+      if (!existing[key]) {
+        existing[key] = process.env[key] ?? `TODO_${key}`;
+      }
+    }
+    writeFileSync(
+      envPath,
+      Object.entries(existing)
+        .map(([k, v]) => `${k}=${v}`)
+        .join("\n") + "\n",
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract CLI argument parsing into parseQuickstartArgs
- factor prompt and provider selection logic into quickstartPrompts
- encapsulate shop creation, seeding, and env setup in createShopAndSeed
- simplify quickstart-shop to orchestrate new helpers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm test --filter scripts` *(fails: No package found with name 'scripts')*
- `pnpm exec jest scripts/__tests__/prompt.test.ts` *(fails: Module /test/setupFetchPolyfill.ts in the setupFiles option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d854dfbc832fb2a843c9e2ca0a25