### PR TITLE
test(design-tokens): cover token map merging

### DIFF
--- a/packages/design-tokens/__tests__/exportedTokenMap.test.ts
+++ b/packages/design-tokens/__tests__/exportedTokenMap.test.ts
@@ -1,0 +1,49 @@
+import { exportedTokenMap } from "../src/exportedTokenMap.ts";
+import { tokens as sourceTokens } from "../../themes/base/src/tokens.ts";
+
+function mergeTokenMaps(
+  ...maps: Array<Record<string, string>>
+): Record<string, string> {
+  return maps.reduce<Record<string, string>>((acc, map) => {
+    for (const [key, value] of Object.entries(map)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+}
+
+describe("exportedTokenMap", () => {
+  it("matches source token definitions", () => {
+    const expected = Object.fromEntries(
+      Object.keys(sourceTokens)
+        .filter((k) => k in exportedTokenMap)
+        .map((k) => [k, `var(${k})`])
+    );
+    expect(exportedTokenMap).toMatchObject(expected);
+  });
+
+  it("merges tokens with overrides", () => {
+    const overrides = {
+      "--color-bg": "var(--custom-bg)",
+      "--new-token": "var(--new-token)",
+    };
+    const merged = mergeTokenMaps(exportedTokenMap, overrides);
+    expect(merged["--color-bg"]).toBe("var(--custom-bg)");
+    expect(merged["--new-token"]).toBe("var(--new-token)");
+    expect(merged["--color-fg"]).toBe(exportedTokenMap["--color-fg"]);
+  });
+
+  it("handles duplicate keys by overriding with last value", () => {
+    const first = { "--color-bg": "var(--first-bg)" };
+    const second = { "--color-bg": "var(--second-bg)" };
+    const merged = mergeTokenMaps(first, second);
+    expect(merged["--color-bg"]).toBe("var(--second-bg)");
+  });
+
+  it("uses valid CSS variable formatting", () => {
+    for (const value of Object.values(exportedTokenMap)) {
+      expect(value).toMatch(/^var\(--[a-z0-9-]+\)$/);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests validating exported token map against base theme tokens
- cover token map merging, duplicate overrides, and CSS variable formatting

## Testing
- `pnpm exec jest packages/design-tokens` *(fails: Module /test/setupFetchPolyfill.ts in the setupFiles option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d84217c8832fa218c5bc25d3c5bb