### PR TITLE
refactor: extract theme editor hooks

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/ThemeEditorForm.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/ThemeEditorForm.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@ui/components/atoms/shadcn";
+import StyleEditor from "@ui/components/cms/StyleEditor";
+import Image from "next/image";
+import DeviceSelector from "@ui/components/cms/DeviceSelector";
+import WizardPreview from "../../wizard/WizardPreview";
+import { getContrast } from "@ui/components/cms";
+import type { TokenMap } from "@ui/hooks/useTokenEditor";
+import type { DevicePreset } from "@ui/utils/devicePresets";
+
+const MIN_CONTRAST = 4.5;
+
+function checkContrast(fg?: string, bg?: string): number {
+  if (!fg || !bg) return MIN_CONTRAST;
+  return getContrast(fg, bg);
+}
+
+interface ThemeEditorFormProps {
+  themes: string[];
+  theme: string;
+  onThemeChange: (v: string) => void;
+  colorPalettes: Array<{ name: string; colors: Record<string, string> }>;
+  palette: string;
+  setPalette: (name: string) => void;
+  themeOverrides: Record<string, string>;
+  themeDefaults: Record<string, string>;
+  onTokensChange: (tokens: TokenMap) => void;
+  onReset: () => void;
+  deviceId: string;
+  orientation: "portrait" | "landscape";
+  setDeviceId: (id: string) => void;
+  toggleOrientation: () => void;
+  device: DevicePreset;
+  themeStyle: React.CSSProperties;
+}
+
+export default function ThemeEditorForm({
+  themes,
+  theme,
+  onThemeChange,
+  colorPalettes,
+  palette,
+  setPalette,
+  themeOverrides,
+  themeDefaults,
+  onTokensChange,
+  onReset,
+  deviceId,
+  orientation,
+  setDeviceId,
+  toggleOrientation,
+  device,
+  themeStyle,
+}: ThemeEditorFormProps): React.JSX.Element {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Select Theme</h2>
+
+      <Select value={theme} onValueChange={onThemeChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select theme" />
+        </SelectTrigger>
+        <SelectContent>
+          {themes.map((t) => (
+            <SelectItem key={t} value={t}>
+              <div className="flex items-center gap-2">
+                <Image
+                  src={`/themes/${t}.svg`}
+                  alt={`${t} preview`}
+                  width={24}
+                  height={24}
+                  className="h-6 w-6 rounded object-cover"
+                />
+                {t}
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <div className="space-y-2">
+        <h3 className="font-medium">Color Palette</h3>
+        <div className="flex flex-wrap gap-2">
+          {colorPalettes.map((p) => {
+            const c1 = checkContrast(p.colors["--color-fg"], p.colors["--color-bg"]);
+            const c2 = checkContrast(
+              p.colors["--color-primary-fg"],
+              p.colors["--color-primary"]
+            );
+            const warn = c1 < MIN_CONTRAST || c2 < MIN_CONTRAST;
+            return (
+              <div key={p.name} className="relative">
+                <Button
+                  variant={p.name === palette ? "default" : "outline"}
+                  onClick={() => setPalette(p.name)}
+                  className="h-10 w-10 p-0"
+                  aria-label={p.name}
+                >
+                  <div className="flex h-full w-full flex-wrap overflow-hidden rounded">
+                    {Object.values(p.colors).map((c, i) => (
+                      <span
+                        key={i}
+                        className="h-1/2 w-1/2"
+                        style={{ backgroundColor: `hsl(${c})` }}
+                      />
+                    ))}
+                  </div>
+                </Button>
+                {warn && (
+                  <span className="absolute -top-1 -right-1 rounded bg-amber-100 px-1 text-xs text-amber-800">
+                    Low contrast
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <StyleEditor
+        tokens={themeOverrides}
+        baseTokens={themeDefaults}
+        onChange={onTokensChange}
+      />
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onReset}>
+          Reset to defaults
+        </Button>
+        <DeviceSelector
+          deviceId={deviceId}
+          orientation={orientation}
+          setDeviceId={setDeviceId}
+          toggleOrientation={toggleOrientation}
+        />
+      </div>
+
+      <WizardPreview style={themeStyle} device={device} />
+    </div>
+  );
+}
+

--- a/apps/cms/src/app/cms/configurator/steps/hooks/useThemePalette.ts
+++ b/apps/cms/src/app/cms/configurator/steps/hooks/useThemePalette.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { TokenMap } from "@ui/hooks/useTokenEditor";
+import { useConfigurator } from "../../ConfiguratorContext";
+import { STORAGE_KEY } from "../../hooks/useConfiguratorPersistence";
+
+const colorPalettes: Array<{ name: string; colors: Record<string, string> }> = [
+  {
+    name: "Base",
+    colors: {
+      "--color-bg": "0 0% 100%",
+      "--color-fg": "0 0% 10%",
+      "--color-primary": "220 90% 56%",
+      "--color-primary-fg": "0 0% 100%",
+      "--color-accent": "260 83% 67%",
+      "--color-muted": "0 0% 88%",
+    },
+  },
+  {
+    name: "Dark",
+    colors: {
+      "--color-bg": "0 0% 4%",
+      "--color-fg": "0 0% 93%",
+      "--color-primary": "220 90% 66%",
+      "--color-primary-fg": "0 0% 100%",
+      "--color-accent": "260 83% 67%",
+      "--color-muted": "0 0% 60%",
+    },
+  },
+  {
+    name: "Forest",
+    colors: {
+      "--color-bg": "0 0% 100%",
+      "--color-fg": "0 0% 10%",
+      "--color-primary": "160 80% 40%",
+      "--color-primary-fg": "0 0% 100%",
+      "--color-accent": "200 90% 45%",
+      "--color-muted": "0 0% 88%",
+    },
+  },
+];
+
+export function useThemePalette() {
+  const { themeDefaults, themeOverrides, setThemeOverrides } = useConfigurator();
+  const [palette, setPalette] = useState(colorPalettes[0].name);
+
+  const applyPalette = useCallback(
+    (name: string) => {
+      const cp = colorPalettes.find((c) => c.name === name);
+      if (!cp) return;
+      setThemeOverrides((prev) => {
+        const next = { ...prev };
+        Object.entries(cp.colors).forEach(([k, v]) => {
+          if (themeDefaults[k] !== v) {
+            next[k] = v;
+          } else {
+            delete next[k];
+          }
+        });
+        return next;
+      });
+    },
+    [themeDefaults, setThemeOverrides]
+  );
+
+  const handleTokenChange = useCallback(
+    (tokens: TokenMap) => {
+      setThemeOverrides(
+        Object.fromEntries(
+          Object.entries(tokens).filter(([k, v]) => themeDefaults[k] !== v)
+        ) as Record<string, string>
+      );
+    },
+    [setThemeOverrides, themeDefaults]
+  );
+
+  const handleReset = useCallback(() => {
+    setPalette(colorPalettes[0].name);
+    setThemeOverrides({});
+    if (typeof window !== "undefined") {
+      try {
+        const json = localStorage.getItem(STORAGE_KEY);
+        if (json) {
+          const data = JSON.parse(json);
+          data.themeOverrides = {};
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+          window.dispatchEvent(new CustomEvent("configurator:update"));
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [setThemeOverrides]);
+
+  useEffect(() => {
+    applyPalette(palette);
+  }, [palette, applyPalette]);
+
+  return {
+    colorPalettes,
+    palette,
+    setPalette,
+    themeOverrides,
+    themeDefaults,
+    handleTokenChange,
+    handleReset,
+  };
+}
+

--- a/apps/cms/src/app/cms/configurator/steps/hooks/useThemePreviewDevice.ts
+++ b/apps/cms/src/app/cms/configurator/steps/hooks/useThemePreviewDevice.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { devicePresets, type DevicePreset } from "@ui/utils/devicePresets";
+
+export function useThemePreviewDevice() {
+  const [deviceId, setDeviceIdState] = useState(devicePresets[0].id);
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">("portrait");
+
+  const device = useMemo<DevicePreset>(() => {
+    const preset =
+      devicePresets.find((d: DevicePreset) => d.id === deviceId) ?? devicePresets[0];
+    return orientation === "portrait"
+      ? { ...preset, orientation }
+      : {
+          ...preset,
+          width: preset.height,
+          height: preset.width,
+          orientation,
+        };
+  }, [deviceId, orientation]);
+
+  const setDeviceId = (id: string) => {
+    setDeviceIdState(id);
+    setOrientation("portrait");
+  };
+
+  const toggleOrientation = () =>
+    setOrientation((o) => (o === "portrait" ? "landscape" : "portrait"));
+
+  return { deviceId, orientation, setDeviceId, toggleOrientation, device };
+}
+


### PR DESCRIPTION
## Summary
- extract palette logic into useThemePalette hook
- add useThemePreviewDevice for device preview state
- refactor Theme step into presentational ThemeEditorForm

## Testing
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm test` *(fails: @acme/eslint-plugin-ds#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d85fcb38832f84e80a276d04bd0b