### PR TITLE
refactor: modularize theme editor hooks

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/__tests__/useThemeEditor.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/__tests__/useThemeEditor.test.ts
@@ -10,15 +10,25 @@ jest.mock("../../../../wizard/previewTokens", () => ({
   savePreviewTokens: jest.fn(),
 }));
 
-jest.mock("../useThemePresets", () => ({
-  useThemePresets: jest.fn().mockReturnValue({
-    availableThemes: ["base"],
-    tokensByThemeState: { base: { color: "#fff" } },
-    presetThemes: [],
-    presetName: "",
-    setPresetName: jest.fn(),
-    handleSavePreset: jest.fn(),
-    handleDeletePreset: jest.fn(),
+jest.mock("../useThemePresetManager", () => ({
+  useThemePresetManager: jest.fn((args) => {
+    const React = require("react");
+    const [theme, setTheme] = React.useState(args.initialTheme);
+    const [overrides, setOverrides] = React.useState(args.initialOverrides);
+    return {
+      theme,
+      setTheme,
+      overrides,
+      setOverrides,
+      availableThemes: args.themes,
+      tokensByThemeState: args.tokensByTheme,
+      presetThemes: [],
+      presetName: "",
+      setPresetName: jest.fn(),
+      handleSavePreset: jest.fn(),
+      handleDeletePreset: jest.fn(),
+      handleThemeChange: jest.fn(),
+    };
   }),
 }));
 

--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemePresetManager.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemePresetManager.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, type ChangeEvent } from "react";
+import { useThemePresets } from "./useThemePresets";
+
+interface Options {
+  shop: string;
+  themes: string[];
+  tokensByTheme: Record<string, Record<string, string>>;
+  initialTheme: string;
+  initialOverrides: Record<string, string>;
+  presets: string[];
+}
+
+export function useThemePresetManager({
+  shop,
+  themes,
+  tokensByTheme,
+  initialTheme,
+  initialOverrides,
+  presets,
+}: Options) {
+  const [theme, setTheme] = useState(initialTheme);
+  const [overrides, setOverrides] = useState<Record<string, string>>(initialOverrides);
+  const [, setThemeDefaults] = useState<Record<string, string>>(tokensByTheme[initialTheme]);
+
+  const {
+    availableThemes,
+    tokensByThemeState,
+    presetThemes,
+    presetName,
+    setPresetName,
+    handleSavePreset,
+    handleDeletePreset,
+  } = useThemePresets({
+    shop,
+    initialThemes: themes,
+    initialTokensByTheme: tokensByTheme,
+    presets,
+    theme,
+    overrides,
+    setTheme,
+    setOverrides,
+    setThemeDefaults,
+  });
+
+  const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const newTheme = e.target.value;
+    setTheme(newTheme);
+    setOverrides({});
+    setThemeDefaults(tokensByThemeState[newTheme]);
+  };
+
+  return {
+    theme,
+    setTheme,
+    overrides,
+    setOverrides,
+    availableThemes,
+    tokensByThemeState,
+    presetThemes,
+    presetName,
+    setPresetName,
+    handleSavePreset,
+    handleDeletePreset,
+    handleThemeChange,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `useThemePresetManager` for preset integration and theme switching
- add `useThemeTokenSync` to handle patching and preview persistence
- compose new hooks inside `useThemeEditor` and adjust tests

## Testing
- `pnpm test:cms` *(fails: Module /test/setupFetchPolyfill.ts in the setupFiles option was not found)*
- `pnpm test` *(fails: @acme/email-templates:test: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d866e03c832fa4916d566d35ebf0