### PR TITLE
refactor: modularize text block

### DIFF
--- a/packages/ui/src/components/cms/page-builder/TextBlockView.tsx
+++ b/packages/ui/src/components/cms/page-builder/TextBlockView.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { EditorContent, type Editor } from "@tiptap/react";
+import MenuBar from "./MenuBar";
+
+interface Guides {
+  x: number | null;
+  y: number | null;
+}
+
+interface Props {
+  selected: boolean;
+  attributes: Record<string, unknown>;
+  listeners: Record<string, unknown>;
+  setNodeRef: (node: HTMLDivElement | null) => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  isDragging: boolean;
+  style: React.CSSProperties;
+  guides: Guides;
+  snapping: boolean;
+  editor: Editor | null;
+  editing: boolean;
+  onStartEditing: () => void;
+  onFinishEditing: () => void;
+  startDrag: (e: React.PointerEvent) => void;
+  startResize: (e: React.PointerEvent) => void;
+  onSelect: () => void;
+  onRemove: () => void;
+  content: string;
+}
+
+const TextBlockView = ({
+  selected,
+  attributes,
+  listeners,
+  setNodeRef,
+  containerRef,
+  isDragging,
+  style,
+  guides,
+  snapping,
+  editor,
+  editing,
+  onStartEditing,
+  onFinishEditing,
+  startDrag,
+  startResize,
+  onSelect,
+  onRemove,
+  content,
+}: Props) => {
+  return (
+    <div
+      ref={(node) => {
+        setNodeRef(node);
+        containerRef.current = node;
+      }}
+      onClick={onSelect}
+      role="listitem"
+      aria-grabbed={isDragging}
+      tabIndex={0}
+      style={style}
+      className={
+        "relative rounded border" +
+        (selected ? " ring-2 ring-blue-500" : "") +
+        (snapping ? " border-primary" : "")
+      }
+    >
+      <div
+        className="absolute left-0 top-0 z-10 h-3 w-3 cursor-move bg-muted"
+        {...attributes}
+        {...listeners}
+        role="button"
+        tabIndex={0}
+        aria-grabbed={isDragging}
+        title="Drag or press space/enter to move"
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          onSelect();
+          startDrag(e);
+        }}
+      />
+      {(guides.x !== null || guides.y !== null) && (
+        <div className="pointer-events-none absolute inset-0 z-20">
+          {guides.x !== null && (
+            <div
+              className="absolute top-0 bottom-0 w-px bg-primary"
+              style={{ left: guides.x }}
+            />
+          )}
+          {guides.y !== null && (
+            <div
+              className="absolute left-0 right-0 h-px bg-primary"
+              style={{ top: guides.y }}
+            />
+          )}
+        </div>
+      )}
+      {editing ? (
+        <div onBlur={onFinishEditing} onClick={(e) => e.stopPropagation()}>
+          <MenuBar editor={editor} />
+          <EditorContent
+            editor={editor}
+            className="min-h-[1rem] outline-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onFinishEditing();
+              }
+            }}
+          />
+        </div>
+      ) : (
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            onStartEditing();
+          }}
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+      )}
+      {selected && (
+        <>
+          <div
+            onPointerDown={startResize}
+            className="absolute -top-1 -left-1 h-2 w-2 cursor-nwse-resize bg-primary"
+          />
+          <div
+            onPointerDown={startResize}
+            className="absolute -top-1 -right-1 h-2 w-2 cursor-nesw-resize bg-primary"
+          />
+          <div
+            onPointerDown={startResize}
+            className="absolute -bottom-1 -left-1 h-2 w-2 cursor-nesw-resize bg-primary"
+          />
+          <div
+            onPointerDown={startResize}
+            className="absolute -right-1 -bottom-1 h-2 w-2 cursor-nwse-resize bg-primary"
+          />
+        </>
+      )}
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute top-1 right-1 rounded bg-danger px-2 text-xs"
+        data-token="--color-danger"
+      >
+        <span className="text-danger-foreground" data-token="--color-danger-fg">
+          ×
+        </span>
+      </button>
+    </div>
+  );
+};
+
+export default TextBlockView;
+

--- a/packages/ui/src/components/cms/page-builder/index.ts
+++ b/packages/ui/src/components/cms/page-builder/index.ts
@@ -49,3 +49,5 @@ export { default as useCanvasDrag } from "./useCanvasDrag";
 export { default as useCanvasResize } from "./useCanvasResize";
 export { default as useBlockDimensions } from "./useBlockDimensions";
 export { default as useBlockDnD } from "./useBlockDnD";
+export { default as useBlockTransform } from "./useBlockTransform";
+export { default as useLocalizedTextEditor } from "./useLocalizedTextEditor";

--- a/packages/ui/src/components/cms/page-builder/useBlockTransform.ts
+++ b/packages/ui/src/components/cms/page-builder/useBlockTransform.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import type { RefObject } from "react";
+import useCanvasResize from "./useCanvasResize";
+import useCanvasDrag from "./useCanvasDrag";
+import type { Action } from "./state";
+
+interface Options {
+  widthKey: string;
+  heightKey: string;
+  widthVal?: string;
+  heightVal?: string;
+  dispatch: React.Dispatch<Action>;
+  gridEnabled?: boolean;
+  gridCols: number;
+  containerRef: RefObject<HTMLDivElement | null>;
+  disabled?: boolean;
+}
+
+export default function useBlockTransform(
+  componentId: string,
+  {
+    widthKey,
+    heightKey,
+    widthVal,
+    heightVal,
+    dispatch,
+    gridEnabled = false,
+    gridCols,
+    containerRef,
+    disabled = false,
+  }: Options,
+) {
+  const {
+    startResize,
+    guides: resizeGuides,
+    snapping: resizeSnapping,
+  } = useCanvasResize({
+    componentId,
+    widthKey,
+    heightKey,
+    widthVal,
+    heightVal,
+    dispatch,
+    gridEnabled,
+    gridCols,
+    containerRef,
+    disabled,
+  });
+
+  const {
+    startDrag,
+    guides: dragGuides,
+    snapping: dragSnapping,
+  } = useCanvasDrag({
+    componentId,
+    dispatch,
+    gridEnabled,
+    gridCols,
+    containerRef,
+    disabled,
+  });
+
+  const guides =
+    resizeGuides.x !== null || resizeGuides.y !== null
+      ? resizeGuides
+      : dragGuides;
+  const snapping = resizeSnapping || dragSnapping;
+
+  return { startResize, startDrag, guides, snapping } as const;
+}
+

--- a/packages/ui/src/components/cms/page-builder/useLocalizedTextEditor.ts
+++ b/packages/ui/src/components/cms/page-builder/useLocalizedTextEditor.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { Locale } from "@acme/i18n/locales";
+import type { TextComponent as BaseTextComponent } from "@acme/types";
+import useTextEditor from "./useTextEditor";
+
+type TextComponent = BaseTextComponent & {
+  text?: string | Record<string, string>;
+};
+
+export default function useLocalizedTextEditor(
+  component: TextComponent,
+  locale: Locale,
+) {
+  const [editing, setEditing] = useState(false);
+  const editor = useTextEditor(component, locale, editing);
+
+  const startEditing = useCallback(() => {
+    setEditing(true);
+  }, []);
+
+  const finishEditing = useCallback(() => {
+    if (!editor) return null;
+    setEditing(false);
+    return {
+      text: {
+        ...(typeof component.text === "object" ? component.text : {}),
+        [locale]: editor.getHTML(),
+      },
+    } as Partial<TextComponent>;
+  }, [editor, component, locale]);
+
+  return { editor, editing, startEditing, finishEditing } as const;
+}
+


### PR DESCRIPTION
## Summary
- refactor TextBlock to delegate rendering to TextBlockView and hooks
- add useBlockTransform for drag/resize pairing
- add useLocalizedTextEditor for locale-aware editing

## Testing
- `pnpm --filter @acme/ui build` *(fails: Project references may not form a circular graph)*
- `pnpm --filter @acme/ui test` *(fails: setupFiles module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d8680eb8832fac1eed559d9f018b