### PR TITLE
refactor configurator step hook

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/components/ShopPreview.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/components/ShopPreview.tsx
@@ -1,0 +1,18 @@
+interface ShopPreviewProps {
+  logo: string;
+  storeName: string;
+}
+
+export default function ShopPreview({ logo, storeName }: ShopPreviewProps) {
+  return (
+    <div className="flex items-center gap-2 rounded border p-2">
+      {logo ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={logo} alt="Logo preview" className="h-8 w-8 object-contain" />
+      ) : (
+        <div className="h-8 w-8 bg-gray-200" />
+      )}
+      <span>{storeName || "Store Name"}</span>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/configurator/steps/hooks/useConfiguratorStep.ts
+++ b/apps/cms/src/app/cms/configurator/steps/hooks/useConfiguratorStep.ts
@@ -1,0 +1,43 @@
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import type { ZodTypeAny } from "zod";
+import useStepCompletion from "../../hooks/useStepCompletion";
+
+interface Options<T> {
+  stepId: string;
+  schema?: ZodTypeAny;
+  values?: T;
+  prevStepId?: string;
+  nextStepId?: string;
+}
+
+export default function useConfiguratorStep<T>({
+  stepId,
+  schema,
+  values,
+  prevStepId,
+  nextStepId,
+}: Options<T>) {
+  const router = useRouter();
+  const [, markComplete] = useStepCompletion(stepId);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    if (schema && values) {
+      const parsed = schema.safeParse(values);
+      setErrors(parsed.success ? {} : parsed.error.flatten().fieldErrors);
+    }
+  }, [schema, values]);
+
+  const getError = (field: string) => errors[field]?.[0];
+  const isValid = Object.keys(errors).length === 0;
+
+  const goNext = () => {
+    if (nextStepId) router.push(`/cms/configurator/${nextStepId}`);
+  };
+  const goPrev = () => {
+    if (prevStepId) router.push(`/cms/configurator/${prevStepId}`);
+  };
+
+  return { router, markComplete, getError, isValid, goNext, goPrev, errors };
+}


### PR DESCRIPTION
## Summary
- add `useConfiguratorStep` hook to consolidate validation, navigation, and completion logic
- extract `ShopPreview` into dedicated component
- refactor `StepShopDetails` to compose new hook and component

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*


------
https://chatgpt.com/codex/tasks/task_e_68b6d8614154832fa2813de711d54860