### PR TITLE
refactor: modularize product editor hooks

### DIFF
--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -8,3 +8,5 @@ export * from "./useTokenEditor";
 export * from "./usePreviewDevice";
 export * from "./useTokenColors";
 export * from "./useRemoteImageProbe";
+export * from "./useProductInputs";
+export * from "./useProductMediaManager";

--- a/packages/ui/src/hooks/useProductInputs.ts
+++ b/packages/ui/src/hooks/useProductInputs.ts
@@ -1,0 +1,122 @@
+"use client";
+
+// packages/ui/hooks/useProductInputs.ts
+import { parseMultilingualInput } from "@acme/i18n/parseMultilingualInput";
+import type { Locale } from "@acme/i18n";
+import type { ProductPublication } from "@acme/types";
+import {
+  useCallback,
+  useState,
+  type ChangeEvent,
+} from "react";
+
+export type ProductWithVariants = ProductPublication & {
+  variants: Record<string, string[]>;
+};
+
+export interface UseProductInputsResult {
+  product: ProductWithVariants;
+  setProduct: React.Dispatch<React.SetStateAction<ProductWithVariants>>;
+  handleChange: (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+  addVariantValue: (attr: string) => void;
+  removeVariantValue: (attr: string, index: number) => void;
+}
+
+export function useProductInputs(
+  init: ProductPublication & { variants?: Record<string, string[]> },
+  locales: readonly Locale[]
+): UseProductInputsResult {
+  const [product, setProduct] = useState<ProductWithVariants>({
+    ...init,
+    variants: init.variants ?? {},
+  });
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value } = e.target;
+      const parsed = parseMultilingualInput(name, locales);
+
+      setProduct((prev: ProductWithVariants) => {
+        if (parsed) {
+          const { field, locale } = parsed;
+          const realField = field === "desc" ? "description" : field;
+          const translations = (
+            prev[
+              realField as keyof Pick<ProductWithVariants, "title" | "description">
+            ] ?? {}
+          ) as Record<Locale, string>;
+          return {
+            ...prev,
+            [realField]: { ...translations, [locale]: value },
+          } as ProductWithVariants;
+        }
+
+        if (name === "price") {
+          return { ...prev, price: Number(value) };
+        }
+
+        if (name.startsWith("variant_")) {
+          const indexed = name.match(/^variant_(.+)_(\d+)$/);
+          if (indexed) {
+            const [, key, idxStr] = indexed;
+            const idx = Number(idxStr);
+            const existing = prev.variants[key] ?? [];
+            const next = [...existing];
+            next[idx] = value;
+            return {
+              ...prev,
+              variants: { ...prev.variants, [key]: next },
+            };
+          }
+
+          const key = name.replace(/^variant_/, "");
+          return {
+            ...prev,
+            variants: {
+              ...prev.variants,
+              [key]: value ? value.split(",").map((v) => v.trim()) : [""],
+            },
+          };
+        }
+
+        return prev;
+      });
+    },
+    [locales]
+  );
+
+  const addVariantValue = useCallback((attr: string) => {
+    setProduct((prev: ProductWithVariants) => ({
+      ...prev,
+      variants: {
+        ...prev.variants,
+        [attr]: [...(prev.variants[attr] ?? []), ""],
+      },
+    }));
+  }, []);
+
+  const removeVariantValue = useCallback((attr: string, index: number) => {
+    setProduct((prev: ProductWithVariants) => {
+      const values = prev.variants[attr] ?? [];
+      return {
+        ...prev,
+        variants: {
+          ...prev.variants,
+          [attr]: values.filter((_, i) => i !== index),
+        },
+      };
+    });
+  }, []);
+
+  return {
+    product,
+    setProduct,
+    handleChange,
+    addVariantValue,
+    removeVariantValue,
+  };
+}
+
+export default useProductInputs;

--- a/packages/ui/src/utils/__tests__/buildProductFormData.test.ts
+++ b/packages/ui/src/utils/__tests__/buildProductFormData.test.ts
@@ -1,0 +1,40 @@
+import type { ProductPublication } from "@acme/types";
+import type { Locale } from "@acme/i18n";
+import { buildProductFormData } from "../buildProductFormData";
+
+describe("buildProductFormData", () => {
+  it("creates FormData with product fields", () => {
+    const product: ProductPublication & { variants: Record<string, string[]> } = {
+      id: "p1",
+      sku: "sku1",
+      title: { en: "EN", de: "DE" },
+      description: { en: "Desc EN", de: "Desc DE" },
+      price: 100,
+      currency: "EUR",
+      media: [],
+      created_at: "2023-01-01",
+      updated_at: "2023-01-01",
+      shop: "shop",
+      status: "draft",
+      row_version: 1,
+      variants: { size: ["m", "l"] },
+    };
+
+    const locales: readonly Locale[] = ["en", "de"];
+    const fd = buildProductFormData(product, ["loc1"], locales);
+
+    const entries = Array.from(fd.entries());
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        ["id", "p1"],
+        ["title_en", "EN"],
+        ["desc_en", "Desc EN"],
+        ["title_de", "DE"],
+        ["desc_de", "Desc DE"],
+        ["price", "100"],
+        ["publish", "loc1"],
+        ["variant_size", "m,l"],
+      ])
+    );
+  });
+});

--- a/packages/ui/src/utils/buildProductFormData.ts
+++ b/packages/ui/src/utils/buildProductFormData.ts
@@ -1,0 +1,29 @@
+// packages/ui/utils/buildProductFormData.ts
+import type { Locale } from "@acme/i18n";
+import type { ProductWithVariants } from "../hooks/useProductInputs";
+
+export function buildProductFormData(
+  product: ProductWithVariants,
+  publishTargets: string[],
+  locales: readonly Locale[]
+): FormData {
+  const fd = new FormData();
+  fd.append("id", product.id);
+
+  locales.forEach((l: Locale) => {
+    fd.append(`title_${l}`, product.title[l]);
+    fd.append(`desc_${l}`, product.description[l]);
+  });
+
+  fd.append("price", String(product.price));
+  fd.append("media", JSON.stringify(product.media));
+  fd.append("publish", publishTargets.join(","));
+
+  Object.entries(product.variants).forEach(([k, vals]) => {
+    fd.append(`variant_${k}`, (vals as string[]).filter(Boolean).join(","));
+  });
+
+  return fd;
+}
+
+export default buildProductFormData;

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './style';
 export * from './colorUtils';
 export * from './devicePresets';
+export * from './buildProductFormData';


### PR DESCRIPTION
## Summary
- add `useProductInputs` for managing product text and variants
- extract media upload logic to `useProductMediaManager`
- move form data creation into `buildProductFormData`
- simplify `useProductEditorFormState` to orchestrate new helpers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm test` *(fails: Module /test/setupFetchPolyfill.ts in the setupFiles option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d86b1d88832f95680497c67c1e3f