### PR TITLE
chore(platform-core): remove sanity reference

### DIFF
--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -35,8 +35,7 @@
       "@acme/config/env/*": ["../config/src/env/*"],
       "@acme/i18n/fillLocales": ["../i18n/src/fillLocales.ts"],
       "@acme/i18n/locales": ["../i18n/src/locales.ts"],
-      "@acme/email-templates": ["../email-templates/src/index.ts"],
-      "@acme/sanity": ["../sanity/src/index.ts"]
+      "@acme/email-templates": ["../email-templates/src/index.ts"]
     }
   },
   "include": ["src*", "src*.json", "src/**/*", "src/**/*.json"],
@@ -49,8 +48,7 @@
     { "path": "../types" },
     { "path": "../themes/base" },
     { "path": "../zod-utils" },
-    { "path": "../email-templates" },
-    { "path": "../sanity" }
+    { "path": "../email-templates" }
   ],
   "files": ["../../src/types/global.d.ts", "src/prisma.d.ts"]
 }


### PR DESCRIPTION
## Summary
- remove unused `@acme/sanity` path alias and project reference from `platform-core`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68b6d97c2bc4832fa2e108ba6cd692fc