### PR TITLE
chore: alias shared utils in next config

### DIFF
--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -32,6 +32,8 @@ export default withShopCode(coreEnv.SHOP_CODE, {
       "@ui": path.resolve(__dirname, "../ui/src"),
       // Allow imports like "@platform-core/components/…" to resolve to packages/platform-core/src
       "@platform-core": path.resolve(__dirname, "../platform-core/src"),
+      // Allow imports like "@shared-utils" to resolve to packages/shared-utils/src
+      "@shared-utils": path.resolve(__dirname, "../shared-utils/src"),
     };
 
     // Map built-in node modules consistently (unchanged)


### PR DESCRIPTION
## Summary
- add webpack alias for `@shared-utils` to point to `packages/shared-utils/src`

## Testing
- `pnpm install` (fails: ERR_PNPM_FETCH_404 for @types/chrome-launcher)
- `pnpm -r build` (fails: build errors in plugin packages)
- `pnpm --filter next-config test`

------
https://chatgpt.com/codex/tasks/task_e_68b6de0e351c832fa1d958815b72bc41