### PR TITLE
fix: correct ComponentPreview import in shop app

### DIFF
--- a/apps/shop-bcd/src/app/edit-preview/page.tsx
+++ b/apps/shop-bcd/src/app/edit-preview/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import ComponentPreview from "@ui/src/components/ComponentPreview";
+import ComponentPreview from "@ui/components/ComponentPreview";
 
 interface UpgradeComponent {
   file: string;

--- a/apps/shop-bcd/src/app/upgrade-preview/page.tsx
+++ b/apps/shop-bcd/src/app/upgrade-preview/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { exampleProps } from "./example-props";
-import ComponentPreview from "@ui/src/components/ComponentPreview";
+import ComponentPreview from "@ui/components/ComponentPreview";
 
 interface UpgradeComponent {
   file: string;


### PR DESCRIPTION
## Summary
- use existing `@ui/components` alias for `ComponentPreview` in shop preview pages

## Testing
- `pnpm install` *(fails: No matching version for chrome-launcher@^0.16.0)*
- `pnpm -r build` *(fails: Cannot find module 'chrome-launcher')*
- `pnpm test` *(fails: @apps/api#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ddebe498832f9bef571e27b93768