### PR TITLE
chore: expand UI and platform-core aliases

### DIFF
--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -30,6 +30,8 @@ export default withShopCode(coreEnv.SHOP_CODE, {
       // === NEW ALIASES ===
       // Allow imports like "@ui/components/…" to resolve to packages/ui/src
       "@ui": path.resolve(__dirname, "../ui/src"),
+      // Support existing "@ui/src" imports
+      "@ui/src": path.resolve(__dirname, "../ui/src"),
       // Allow imports like "@platform-core/components/…" to resolve to packages/platform-core/src
       "@platform-core": path.resolve(__dirname, "../platform-core/src"),
       // Allow imports like "@shared-utils" to resolve to packages/shared-utils/src


### PR DESCRIPTION
## Summary
- ensure UI and platform-core aliases resolve to src directories
- add explicit `@ui/src` alias for existing imports

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found - 404)*
- `pnpm -r build` *(fails: Cannot find module 'chrome-launcher')*

------
https://chatgpt.com/codex/tasks/task_e_68b6df5bcf94832fac54f71968b784e4