### PR TITLE
fix: annotate marketing template lookup

### DIFF
--- a/packages/email/src/templates.ts
+++ b/packages/email/src/templates.ts
@@ -3,7 +3,10 @@ import { createRequire } from "module";
 import type { ReactElement, ReactNode } from "react";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
-import { marketingEmailTemplates } from "@acme/email-templates";
+import {
+  marketingEmailTemplates,
+  type MarketingEmailTemplateVariant,
+} from "@acme/email-templates";
 
 // Use Node's createRequire with the current file path so this works when the
 // code is executed in a CommonJS context (e.g. ts-jest).
@@ -105,7 +108,9 @@ export function renderTemplate(
       return params[key] ?? "";
     });
   }
-  const variant = marketingEmailTemplates.find((t) => t.id === id);
+  const variant = (marketingEmailTemplates as MarketingEmailTemplateVariant[]).find(
+    (t) => t.id === id
+  );
   if (variant) {
     return renderToStaticMarkup(
       variant.make({


### PR DESCRIPTION
## Summary
- type marketing email templates lookup to avoid implicit any

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_404 @types/chrome-launcher)*
- `pnpm -r build` *(fails: TS2688 Cannot find type definition file for 'node')*
- `pnpm --filter @acme/email test` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e192f028832fa0f7d704d78c6e36