### PR TITLE
test: add helper tests for components route

### DIFF
--- a/apps/api/__tests__/routes/components/helpers.test.ts
+++ b/apps/api/__tests__/routes/components/helpers.test.ts
@@ -1,0 +1,73 @@
+jest.mock('fs', () => require('memfs').fs);
+
+import path from 'path';
+import { vol } from 'memfs';
+import {
+  extractSummary,
+  gatherChanges,
+  diffDirectories,
+} from '../../../src/routes/components/[shopId]';
+
+describe('helpers', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  describe('extractSummary', () => {
+    it('returns first non-comment line', () => {
+      const log = '# heading\n\nFirst line\nSecond line';
+      expect(extractSummary(log)).toBe('First line');
+    });
+  });
+
+  describe('gatherChanges', () => {
+    const root = '/root';
+
+    it('handles missing shop.json', () => {
+      expect(gatherChanges('abc', root)).toEqual([]);
+    });
+
+    it('handles version bumps and changelog summaries', () => {
+      vol.fromJSON({
+        [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
+          componentVersions: { '@scope/pkg': '1.0.0' },
+        }),
+        [`${root}/packages/pkg/package.json`]: JSON.stringify({
+          name: '@scope/pkg',
+          version: '1.1.0',
+        }),
+        [`${root}/packages/pkg/CHANGELOG.md`]: '# Changelog\n\nAdded feature\nMore',
+      });
+
+      const changes = gatherChanges('abc', root);
+      expect(changes).toEqual([
+        {
+          name: '@scope/pkg',
+          from: '1.0.0',
+          to: '1.1.0',
+          summary: 'Added feature',
+          changelog: path.join('packages', 'pkg', 'CHANGELOG.md'),
+        },
+      ]);
+    });
+  });
+
+  describe('diffDirectories', () => {
+    it('detects added, removed, and modified files', () => {
+      vol.fromJSON({
+        '/a/only-a.txt': 'A',
+        '/a/common.txt': 'same',
+        '/a/changed.txt': 'old',
+        '/b/only-b.txt': 'B',
+        '/b/common.txt': 'same',
+        '/b/changed.txt': 'new',
+      });
+
+      const diff = diffDirectories('/a', '/b');
+      expect(diff.sort()).toEqual(
+        ['only-a.txt', 'only-b.txt', 'changed.txt'].sort(),
+      );
+    });
+  });
+});
+

--- a/apps/api/src/routes/components/[shopId].ts
+++ b/apps/api/src/routes/components/[shopId].ts
@@ -161,3 +161,5 @@ export const onRequest = async ({
   return Response.json({ components, configDiff });
 };
 
+export { extractSummary, gatherChanges, diffDirectories };
+


### PR DESCRIPTION
## Summary
- expose helper utilities from components route for unit testing
- add unit tests for component helper functions: extractSummary, gatherChanges, and diffDirectories

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found - 404)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @apps/api test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e0e180c4832f90d4a8e5f7b73e0c