### PR TITLE
test: verify email service registration

### DIFF
--- a/packages/platform-core/__tests__/emailService.test.ts
+++ b/packages/platform-core/__tests__/emailService.test.ts
@@ -1,0 +1,22 @@
+import type { EmailService } from "../src/services/emailService";
+
+describe("emailService", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("throws if service is not registered", async () => {
+    const { getEmailService } = await import("../src/services/emailService");
+    expect(() => getEmailService()).toThrow("EmailService not registered");
+  });
+
+  it("returns the registered service", async () => {
+    const { setEmailService, getEmailService } = await import("../src/services/emailService");
+    const mockService: EmailService = {
+      sendEmail: jest.fn().mockResolvedValue(undefined),
+    };
+    setEmailService(mockService);
+    expect(getEmailService()).toBe(mockService);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests ensuring email service requires registration

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/platform-core test` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e0deb5ac832fa40e9d79be156ab4