### PR TITLE
test(configurator): verify build and deploy commands

### DIFF
--- a/packages/configurator/__tests__/cli.integration.test.ts
+++ b/packages/configurator/__tests__/cli.integration.test.ts
@@ -27,4 +27,52 @@ describe('configurator CLI integration', () => {
     expect(command).toBe('vite');
     expect(args).toEqual(['dev']);
   });
+
+  it('delegates to vite build and exits with code 0', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'configurator-cli-'));
+    const logFile = join(tempDir, 'spawn.json');
+    const stub = resolve(__dirname, 'spawnSync.stub.cjs');
+    const result = spawnSync(
+      'node',
+      ['--require', stub, 'bin/configurator.js', 'build'],
+      {
+        cwd: resolve(__dirname, '..'),
+        env: {
+          ...process.env,
+          STRIPE_SECRET_KEY: 'sk',
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk',
+          CART_COOKIE_SECRET: 'secret',
+          SPAWN_SYNC_LOG: logFile,
+        },
+      }
+    );
+    expect(result.status).toBe(0);
+    const { command, args } = JSON.parse(readFileSync(logFile, 'utf8'));
+    expect(command).toBe('vite');
+    expect(args).toEqual(['build']);
+  });
+
+  it('delegates to wrangler pages deploy .vercel/output/static and exits with code 0', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'configurator-cli-'));
+    const logFile = join(tempDir, 'spawn.json');
+    const stub = resolve(__dirname, 'spawnSync.stub.cjs');
+    const result = spawnSync(
+      'node',
+      ['--require', stub, 'bin/configurator.js', 'deploy'],
+      {
+        cwd: resolve(__dirname, '..'),
+        env: {
+          ...process.env,
+          STRIPE_SECRET_KEY: 'sk',
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk',
+          CART_COOKIE_SECRET: 'secret',
+          SPAWN_SYNC_LOG: logFile,
+        },
+      }
+    );
+    expect(result.status).toBe(0);
+    const { command, args } = JSON.parse(readFileSync(logFile, 'utf8'));
+    expect(command).toBe('wrangler');
+    expect(args).toEqual(['pages', 'deploy', '.vercel/output/static']);
+  });
 });


### PR DESCRIPTION
## Summary
- expand configurator CLI integration coverage for `build` and `deploy`

## Testing
- `pnpm install` *(fails: @types/chrome-launcher 404)*
- `pnpm -r build` *(fails: missing type definition file for 'node')*
- `pnpm exec jest packages/configurator/__tests__/cli.integration.test.ts` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e4f89bfc832fb7e92ee00d508e36