### PR TITLE
test(auth): cover hasPermission for unknown roles

### DIFF
--- a/packages/auth/__tests__/permissions.test.ts
+++ b/packages/auth/__tests__/permissions.test.ts
@@ -1,5 +1,5 @@
 import { PERMISSIONS, isPermission } from "../src/types/permissions";
-import { hasPermission } from "../src/permissions";
+import { hasPermission, ROLE_PERMISSIONS } from "../src/permissions";
 
 describe("isPermission", () => {
   for (const perm of PERMISSIONS) {
@@ -41,5 +41,11 @@ describe("hasPermission", () => {
 
   it("viewer cannot view orders", () => {
     expect(hasPermission("viewer", "view_orders")).toBe(false);
+  });
+
+  it("returns false for roles not in ROLE_PERMISSIONS", () => {
+    const unknownRole = "ghost" as any;
+    expect((ROLE_PERMISSIONS as Record<string, unknown>)[unknownRole]).toBeUndefined();
+    expect(hasPermission(unknownRole, "view_products")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- test hasPermission with a role that isn't configured in ROLE_PERMISSIONS

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher 404)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/auth test` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e53ef0f0832f87239bfa0600c7c0