### PR TITLE
test(config): validate SMTP_URL format

### DIFF
--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -55,6 +55,29 @@ describe("email env module", () => {
     expect(emailEnv.EMAIL_BATCH_DELAY_MS).toBeUndefined();
   });
 
+  it("reports invalid SMTP_URL", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      SMTP_URL: "not-a-url",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../email.ts")).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid email environment variables:",
+      expect.objectContaining({
+        SMTP_URL: {
+          _errors: [expect.stringContaining("Invalid url")],
+        },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("reports non-numeric EMAIL_BATCH_SIZE", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- test email env for invalid SMTP_URL and expect errors

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found - 404)*
- `pnpm -r build` *(fails: @acme/configurator@0.0.0 build: `tsc -b`)*
- `pnpm --filter @acme/config test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e542894c832fbbfead9ffdc385ef