### PR TITLE
test(config): validate payments env defaults

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -13,41 +13,40 @@ afterEach(() => {
 });
 
 describe("payments env defaults", () => {
-  it("warns and falls back to defaults when variables are malformed", () => {
-    process.env = {
-      STRIPE_SECRET_KEY: 123 as unknown as string,
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 456 as unknown as string,
-      STRIPE_WEBHOOK_SECRET: 789 as unknown as string,
-    } as NodeJS.ProcessEnv;
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    jest.resetModules();
-    const { paymentsEnv } = require("../payments.js");
-    expect(paymentsEnv).toEqual({
-      STRIPE_SECRET_KEY: "sk_test",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
-      STRIPE_WEBHOOK_SECRET: "whsec_test",
-    });
-    expect(warnSpy).toHaveBeenCalledWith(
-      "⚠️ Invalid payments environment variables:",
-      expect.any(Object),
-    );
-  });
-
-  it("warns and falls back to defaults when variables are empty strings", () => {
-    process.env = {
-      STRIPE_SECRET_KEY: "",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
-      STRIPE_WEBHOOK_SECRET: "",
-    } as NodeJS.ProcessEnv;
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    jest.resetModules();
-    const { paymentsEnv } = require("../payments.js");
-    expect(paymentsEnv).toEqual({
-      STRIPE_SECRET_KEY: "sk_test",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
-      STRIPE_WEBHOOK_SECRET: "whsec_test",
-    });
-    expect(warnSpy).toHaveBeenCalled();
-  });
+  it.each([
+    {
+      name: "malformed values",
+      env: {
+        STRIPE_SECRET_KEY: 123 as unknown as string,
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 456 as unknown as string,
+        STRIPE_WEBHOOK_SECRET: 789 as unknown as string,
+      },
+    },
+    {
+      name: "empty strings",
+      env: {
+        STRIPE_SECRET_KEY: "",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
+        STRIPE_WEBHOOK_SECRET: "",
+      },
+    },
+  ])(
+    "warns and falls back to defaults when variables are $name",
+    ({ env }) => {
+      process.env = env as NodeJS.ProcessEnv;
+      warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      jest.resetModules();
+      const { paymentsEnv } = require("../payments.js");
+      expect(paymentsEnv).toEqual({
+        STRIPE_SECRET_KEY: "sk_test",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+        STRIPE_WEBHOOK_SECRET: "whsec_test",
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "⚠️ Invalid payments environment variables:",
+        expect.any(Object),
+      );
+    },
+  );
 });
 


### PR DESCRIPTION
## Summary
- test payments env defaults for malformed and empty values

## Testing
- `pnpm install` *(fails: No matching version found for chrome-launcher@^0.16.0)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/config test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e5436490832f82b53792d3fbd93f