### PR TITLE
test(config): add loadShippingEnv invalid input test

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -24,7 +24,24 @@ describe("shipping env module", () => {
     });
   });
 
-  it("throws on invalid configuration", async () => {
+  it("loadShippingEnv throws on invalid variables", async () => {
+    const { loadShippingEnv } = await import("../shipping.ts");
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ UPS_KEY: 123 as unknown as string }),
+    ).toThrow("Invalid shipping environment variables");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        UPS_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("throws on invalid configuration during eager parse", async () => {
     process.env = {
       ...ORIGINAL_ENV,
       UPS_KEY: 123 as unknown as string,


### PR DESCRIPTION
## Summary
- test loadShippingEnv rejects invalid variables
- cover eager parse failure for shipping env

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_404 @types/chrome-launcher)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/config test packages/config/src/env/__tests__/shipping.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e543ef84832fb9ffc5bceaa98be7