### PR TITLE
test: validate custom env issues

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
-import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.js";
+import {
+  coreEnvBaseSchema,
+  coreEnvSchema,
+  depositReleaseEnvRefinement,
+} from "../core.js";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
 
@@ -45,6 +49,42 @@ describe("core env refinement", () => {
           expect.objectContaining({
             path: ["LATE_FEE_BAD_ENABLED"],
             message: "must be true or false",
+          }),
+        ]),
+      );
+    }
+  });
+
+  it("reports custom issue for invalid ENABLED variable", () => {
+    const parsed = coreEnvSchema.safeParse({
+      ...baseEnv,
+      DEPOSIT_RELEASE_FOO_ENABLED: "notbool",
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["DEPOSIT_RELEASE_FOO_ENABLED"],
+            message: "must be true or false",
+          }),
+        ]),
+      );
+    }
+  });
+
+  it("reports custom issue for invalid INTERVAL_MS variable", () => {
+    const parsed = coreEnvSchema.safeParse({
+      ...baseEnv,
+      REVERSE_LOGISTICS_BAR_INTERVAL_MS: "soon",
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["REVERSE_LOGISTICS_BAR_INTERVAL_MS"],
+            message: "must be a number",
           }),
         ]),
       );


### PR DESCRIPTION
## Summary
- add tests for invalid ENABLED and INTERVAL_MS env variables

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_404 @types/chrome-launcher)*
- `pnpm -r build` *(fails: TS2688 Cannot find type definition file for 'node')*
- `pnpm --filter @acme/config test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e544d038832f97ccad0438ee0d04