### PR TITLE
test: ensure loadCoreEnv logs errors

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
-import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "../core.js";
+import {
+  coreEnvBaseSchema,
+  depositReleaseEnvRefinement,
+  loadCoreEnv,
+} from "../core.js";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
 
@@ -131,6 +135,27 @@ describe("core env module", () => {
   afterEach(() => {
     jest.resetModules();
     process.env = ORIGINAL_ENV;
+  });
+
+  it("loadCoreEnv logs detailed messages and throws on invalid configuration", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadCoreEnv({
+        ...baseEnv,
+        DEPOSIT_RELEASE_ENABLED: "yes",
+        LATE_FEE_INTERVAL_MS: "fast",
+      } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid core environment variables");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid core environment variables:",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "  • DEPOSIT_RELEASE_ENABLED: must be true or false",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "  • LATE_FEE_INTERVAL_MS: must be a number",
+    );
+    errorSpy.mockRestore();
   });
 
   it("logs detailed messages and throws on invalid configuration", () => {


### PR DESCRIPTION
## Summary
- add direct loadCoreEnv test for invalid env values

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found - 404)*
- `pnpm -r build` *(fails: tsc: not found)*
- `pnpm --filter @acme/config test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e54633ac832f940ab945bbbe7955