### PR TITLE
Ensure Jest resolves React DOM client safely

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -70,7 +70,11 @@ function resolveReact() {
     const jsxDevRuntime = path.join(reactBase, 'jsx-dev-runtime.js');
     const domClient = path.join(reactDomBase, 'client.js');
 
-    if (fs.existsSync(jsxRuntime) && fs.existsSync(jsxDevRuntime)) {
+    if (
+      fs.existsSync(jsxRuntime) &&
+      fs.existsSync(jsxDevRuntime) &&
+      fs.existsSync(domClient)
+    ) {
       return {
         reactPath: reactBase,
         reactDomPath: reactDomBase,


### PR DESCRIPTION
## Summary
- verify `react-dom/client` file exists before mapping in Jest config

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_404 – @types/chrome-launcher)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/email-templates test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e5cca08c832f8b0b2b55f287d4c4