### PR TITLE
feat(design-tokens): add Jest test script

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "pnpm exec jest --ci --runInBand --config ../../jest.config.cjs"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest test script to design-tokens package

## Testing
- `pnpm install` *(fails: @types/chrome-launcher not found)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/design-tokens test` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e6a682ac832f99dce8cb294c78af