### PR TITLE
test: ensure exported tokens keys match source

### DIFF
--- a/packages/design-tokens/__tests__/exportedTokenMap.test.ts
+++ b/packages/design-tokens/__tests__/exportedTokenMap.test.ts
@@ -1,5 +1,5 @@
 import { exportedTokenMap } from "../src/exportedTokenMap.ts";
-import { tokens as sourceTokens } from "../../themes/base/src/tokens.ts";
+import { tokens } from "../../themes/base/src/tokens.ts";
 
 function mergeTokenMaps(
   ...maps: Array<Record<string, string>>
@@ -15,11 +15,17 @@ function mergeTokenMaps(
 describe("exportedTokenMap", () => {
   it("matches source token definitions", () => {
     const expected = Object.fromEntries(
-      Object.keys(sourceTokens)
+      Object.keys(tokens)
         .filter((k) => k in exportedTokenMap)
         .map((k) => [k, `var(${k})`])
     );
     expect(exportedTokenMap).toMatchObject(expected);
+  });
+
+  it("has no extra or missing keys", () => {
+    const exportedKeys = Object.keys(exportedTokenMap).sort();
+    const tokenKeys = Object.keys(tokens).sort();
+    expect(exportedKeys).toEqual(tokenKeys);
   });
 
   it("merges tokens with overrides", () => {


### PR DESCRIPTION
## Summary
- add test ensuring exported token map keys mirror base theme tokens

## Testing
- `pnpm install` *(fails: No matching version found for chrome-launcher@^0.16.0)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*
- `pnpm --filter @acme/design-tokens test` *(no tests executed; command produced no output)*
- `pnpm exec jest packages/design-tokens/__tests__/exportedTokenMap.test.ts` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e6a73d54832f9a874ed34e27b63f