### PR TITLE
test(configurator): handle dist success

### DIFF
--- a/packages/configurator/__tests__/bin.test.ts
+++ b/packages/configurator/__tests__/bin.test.ts
@@ -14,6 +14,7 @@ describe("configurator bin", () => {
       .spyOn(process, "exit")
       .mockImplementation(((code?: number) => {}) as any);
 
+    process.exitCode = undefined;
     process.argv = ["node", "configurator", "dev"];
     process.env.STRIPE_SECRET_KEY = "sk";
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
@@ -31,6 +32,20 @@ describe("configurator bin", () => {
       shell: true,
     });
     expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits cleanly when dist index resolves", async () => {
+    jest.mock("../dist/index.js", () => ({}), { virtual: true });
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await import("../bin/configurator.js");
+
+    expect(process.exitCode).toBeUndefined();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- test configurator bin handles dist index resolution without errors

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found - 404)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/configurator test packages/configurator/__tests__/bin.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e708787c832f86d94980d2f65f9c