### PR TITLE
test(platform-core): add shop accessors tests

### DIFF
--- a/packages/platform-core/src/shops/__tests__/index.test.ts
+++ b/packages/platform-core/src/shops/__tests__/index.test.ts
@@ -1,0 +1,70 @@
+import {
+  validateShopName,
+  getSanityConfig,
+  setSanityConfig,
+  getEditorialBlog,
+  setEditorialBlog,
+  getDomain,
+  setDomain,
+  type Shop,
+  type SanityBlogConfig,
+  type ShopDomain,
+} from "../index";
+
+describe("validateShopName", () => {
+  it("accepts valid names", () => {
+    expect(validateShopName(" store-name_123 ")).toBe("store-name_123");
+  });
+
+  it("rejects invalid names", () => {
+    for (const invalid of ["bad name", "bad/name", "bad@name"]) {
+      expect(() => validateShopName(invalid)).toThrow(/Invalid shop name/);
+    }
+  });
+});
+
+describe("sanityBlog accessors", () => {
+  it("adds and removes config", () => {
+    const shop: Shop = {};
+    expect(getSanityConfig(shop)).toBeUndefined();
+
+    const config: SanityBlogConfig = { projectId: "p", dataset: "d", token: "t" };
+    const withConfig = setSanityConfig(shop, config);
+    expect(getSanityConfig(withConfig)).toEqual(config);
+
+    const cleared = setSanityConfig(withConfig, undefined);
+    expect(getSanityConfig(cleared)).toBeUndefined();
+    expect("sanityBlog" in cleared).toBe(false);
+  });
+});
+
+describe("editorialBlog accessors", () => {
+  it("adds and removes editorial blog", () => {
+    const shop: Shop = {};
+    expect(getEditorialBlog(shop)).toBeUndefined();
+
+    const editorial = { enabled: true };
+    const withBlog = setEditorialBlog(shop, editorial);
+    expect(getEditorialBlog(withBlog)).toEqual(editorial);
+
+    const cleared = setEditorialBlog(withBlog, undefined);
+    expect(getEditorialBlog(cleared)).toBeUndefined();
+    expect("editorialBlog" in cleared).toBe(false);
+  });
+});
+
+describe("domain accessors", () => {
+  it("adds and removes domain", () => {
+    const shop: Shop = {};
+    expect(getDomain(shop)).toBeUndefined();
+
+    const domain: ShopDomain = { name: "shop.example.com" };
+    const withDomain = setDomain(shop, domain);
+    expect(getDomain(withDomain)).toEqual(domain);
+
+    const cleared = setDomain(withDomain, undefined);
+    expect(getDomain(cleared)).toBeUndefined();
+    expect("domain" in cleared).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add validation tests for shop names
- verify sanityBlog, editorialBlog, and domain accessors

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fchrome-launcher: Not Found - 404)*
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*
- `pnpm --filter @acme/platform-core test` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e7e25320832f858fadb8785f589d