### PR TITLE
test: expand zod error map coverage

### DIFF
--- a/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
+++ b/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
-import { applyFriendlyZodMessages } from "../zodErrorMap";
+import { applyFriendlyZodMessages, friendlyErrorMap } from "../zodErrorMap";
+
+test("applyFriendlyZodMessages sets global error map", () => {
+  const original = z.getErrorMap();
+  expect(original).not.toBe(friendlyErrorMap);
+  applyFriendlyZodMessages();
+  expect(z.getErrorMap()).toBe(friendlyErrorMap);
+  z.setErrorMap(original);
+});
 
 describe("friendly zod error messages", () => {
   const defaultMap = z.getErrorMap();
@@ -24,6 +32,20 @@ describe("friendly zod error messages", () => {
     const result = schema.safeParse(123);
     expect(result.success).toBe(false);
     expect(result.error.issues[0].message).toBe("Expected string");
+  });
+
+  test("invalid_type number", () => {
+    const schema = z.number();
+    const result = schema.safeParse("123");
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe("Expected number");
+  });
+
+  test("invalid_type array", () => {
+    const schema = z.array(z.string());
+    const result = schema.safeParse("not-an-array");
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe("Expected array");
   });
 
   test("invalid_enum_value", () => {


### PR DESCRIPTION
## Summary
- add tests for friendly error map global update
- cover invalid_type for number and array inputs

## Testing
- `pnpm install` *(fails: @types/chrome-launcher not in registry)*
- `pnpm -r build` *(fails: tsc: not found)*
- `pnpm exec jest packages/zod-utils/src/__tests__/zodErrorMap.test.ts --coverage` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e7e3e694832fb4e255da3334e15a