### PR TITLE
test: validate loadCoreEnv error logging

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -3,6 +3,7 @@ import {
   coreEnvBaseSchema,
   coreEnvSchema,
   depositReleaseEnvRefinement,
+  loadCoreEnv,
 } from "../core.js";
 
 const schema = coreEnvBaseSchema.superRefine(depositReleaseEnvRefinement);
@@ -218,6 +219,29 @@ describe("core env module", () => {
     );
     expect(errorSpy).toHaveBeenCalledWith(
       "  • CART_COOKIE_SECRET: Required",
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+describe("loadCoreEnv", () => {
+  it("throws and logs issues for invalid env values", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadCoreEnv({
+        ...baseEnv,
+        DEPOSIT_RELEASE_ENABLED: "yes",
+        LATE_FEE_INTERVAL_MS: "fast",
+      } as unknown as NodeJS.ProcessEnv),
+    ).toThrow("Invalid core environment variables");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid core environment variables:",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "  • DEPOSIT_RELEASE_ENABLED: must be true or false",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "  • LATE_FEE_INTERVAL_MS: must be a number",
     );
     errorSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- extend core env tests to call `loadCoreEnv` with invalid env vars
- verify loadCoreEnv throws and logs individual issue messages

## Testing
- `pnpm install` *(fails: @types/chrome-launcher not found)*
- `npx -y jest packages/config/src/env/__tests__/core.test.ts --runInBand --config packages/config/jest.preset.cjs` *(fails: Cannot find module 'ts-jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b6e8ed4784832fb209452007b17ae8