### PR TITLE
fix(configurator): make CLI tests work with Jest

### DIFF
--- a/packages/configurator/__tests__/bin.test.ts
+++ b/packages/configurator/__tests__/bin.test.ts
@@ -10,6 +10,8 @@ describe("configurator bin", () => {
   beforeEach(() => {
     jest.resetModules();
     spawnSyncMock.mockReset();
+    // Mock a successful child process result
+    spawnSyncMock.mockReturnValue({ status: 0 });
     exitSpy = jest
       .spyOn(process, "exit")
       .mockImplementation(((code?: number) => {}) as any);
@@ -26,7 +28,7 @@ describe("configurator bin", () => {
   });
 
   it("runs the CLI", async () => {
-    await import("../bin/configurator.js");
+    await import("../bin/configurator.cjs");
     expect(spawnSyncMock).toHaveBeenCalledWith("vite", ["dev"], {
       stdio: "inherit",
       shell: true,
@@ -40,7 +42,7 @@ describe("configurator bin", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    await import("../bin/configurator.js");
+    await import("../bin/configurator.cjs");
 
     expect(process.exitCode).toBeUndefined();
     expect(errorSpy).not.toHaveBeenCalled();

--- a/packages/configurator/__tests__/cli.integration.test.ts
+++ b/packages/configurator/__tests__/cli.integration.test.ts
@@ -10,7 +10,7 @@ describe('configurator CLI integration', () => {
     const stub = resolve(__dirname, 'spawnSync.stub.cjs');
     const result = spawnSync(
       'node',
-      ['--require', stub, 'bin/configurator.js', 'dev'],
+      ['--require', stub, 'bin/configurator.cjs', 'dev'],
       {
         cwd: resolve(__dirname, '..'),
         env: {
@@ -34,7 +34,7 @@ describe('configurator CLI integration', () => {
     const stub = resolve(__dirname, 'spawnSync.stub.cjs');
     const result = spawnSync(
       'node',
-      ['--require', stub, 'bin/configurator.js', 'build'],
+      ['--require', stub, 'bin/configurator.cjs', 'build'],
       {
         cwd: resolve(__dirname, '..'),
         env: {
@@ -58,7 +58,7 @@ describe('configurator CLI integration', () => {
     const stub = resolve(__dirname, 'spawnSync.stub.cjs');
     const result = spawnSync(
       'node',
-      ['--require', stub, 'bin/configurator.js', 'deploy'],
+      ['--require', stub, 'bin/configurator.cjs', 'deploy'],
       {
         cwd: resolve(__dirname, '..'),
         env: {

--- a/packages/configurator/bin/configurator.cjs
+++ b/packages/configurator/bin/configurator.cjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-// packages/configurator/bin/configurator.js
+// packages/configurator/bin/configurator.cjs
 
-import { spawnSync } from "node:child_process";
+// Use CommonJS so Jest can execute this file without ESM support
+const { spawnSync } = require("node:child_process");
 
 const required = [
   "STRIPE_SECRET_KEY",

--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "bin": {
-    "configurator": "bin/configurator.js"
+    "configurator": "bin/configurator.cjs"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- use CommonJS for configurator CLI to avoid Jest ESM parsing issues
- point package bin and tests to new `.cjs` file
- mock spawnSync return value in unit tests

## Testing
- `pnpm exec jest packages/configurator/__tests__/bin.test.ts packages/configurator/__tests__/cli.integration.test.ts --config jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68b6ecd26888832f9c634c1e5a7f4b40