### PR TITLE
test: validate payments env

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -12,6 +12,22 @@ afterEach(() => {
   jest.resetModules();
 });
 
+describe("payments env", () => {
+  it("returns provided values without warnings", () => {
+    const env = {
+      STRIPE_SECRET_KEY: "sk_live_123",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_123",
+      STRIPE_WEBHOOK_SECRET: "whsec_live_123",
+    };
+    process.env = env as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual(env);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("payments env defaults", () => {
   it.each([
     {


### PR DESCRIPTION
## Summary
- add test to ensure paymentsEnv uses provided env vars without warnings

## Testing
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: Cannot find name 'expect' in packages/lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee357d5c832f9b2a9b90dba40419