### PR TITLE
test: cover dev auth env defaults

### DIFF
--- a/packages/config/src/env/__tests__/auth.test.ts
+++ b/packages/config/src/env/__tests__/auth.test.ts
@@ -23,6 +23,23 @@ describe("auth env module", () => {
     });
   });
 
+  it("defaults secrets in development", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv;
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.SESSION_SECRET;
+    delete process.env.PREVIEW_TOKEN_SECRET;
+    jest.resetModules();
+    const { authEnv } = await import("../auth.ts");
+    expect(authEnv).toMatchObject({
+      NEXTAUTH_SECRET: "dev-nextauth-secret",
+      SESSION_SECRET: "dev-session-secret",
+    });
+    expect(authEnv.PREVIEW_TOKEN_SECRET).toBeUndefined();
+  });
+
   it("throws on missing or invalid configuration", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- test that auth config defaults secrets in development mode

## Testing
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: packages/lib build: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee329d64832faf7850964bf51eb5