### PR TITLE
test(config): add cms defaults test

### DIFF
--- a/packages/config/src/env/__tests__/cms.test.ts
+++ b/packages/config/src/env/__tests__/cms.test.ts
@@ -25,6 +25,47 @@ describe("cms env module", () => {
     });
   });
 
+  it("uses defaults in development when variables are missing", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv;
+    delete process.env.CMS_SPACE_URL;
+    delete process.env.CMS_ACCESS_TOKEN;
+    delete process.env.SANITY_API_VERSION;
+    jest.resetModules();
+    const { cmsEnv } = await import("../cms.ts");
+    expect(cmsEnv).toMatchObject({
+      CMS_SPACE_URL: "https://cms.example.com",
+      CMS_ACCESS_TOKEN: "placeholder-token",
+      SANITY_API_VERSION: "2021-10-21",
+    });
+  });
+
+  it("throws when required values are missing in production", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+    } as NodeJS.ProcessEnv;
+    delete process.env.CMS_SPACE_URL;
+    delete process.env.CMS_ACCESS_TOKEN;
+    delete process.env.SANITY_API_VERSION;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../cms.ts")).rejects.toThrow(
+      "Invalid CMS environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid CMS environment variables:",
+      expect.objectContaining({
+        CMS_SPACE_URL: { _errors: [expect.any(String)] },
+        CMS_ACCESS_TOKEN: { _errors: [expect.any(String)] },
+        SANITY_API_VERSION: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws on malformed configuration", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- add test ensuring CMS env defaults apply in development
- verify missing production CMS env vars raise errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find name 'expect')*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ee3399d0832f920cb09afb305552