### PR TITLE
feat: add validation for marketing email templates

### DIFF
--- a/packages/email-templates/src/MarketingEmailTemplate.tsx
+++ b/packages/email-templates/src/MarketingEmailTemplate.tsx
@@ -22,6 +22,16 @@ export function MarketingEmailTemplate({
   className,
   ...props
 }: MarketingEmailTemplateProps) {
+  if (!headline || content == null) {
+    throw new Error("MarketingEmailTemplate: headline and content are required");
+  }
+
+  if ((ctaLabel && !ctaHref) || (!ctaLabel && ctaHref)) {
+    throw new Error(
+      "MarketingEmailTemplate: ctaLabel and ctaHref must both be provided",
+    );
+  }
+
   return (
     <div
       className={`mx-auto w-full max-w-xl overflow-hidden rounded-md border text-sm${className ? ` ${className}` : ""}`}

--- a/packages/email-templates/src/marketingEmailTemplates.tsx
+++ b/packages/email-templates/src/marketingEmailTemplates.tsx
@@ -13,14 +13,24 @@ export const marketingEmailTemplates: MarketingEmailTemplateVariant[] = [
     id: "basic",
     label: "Basic",
     buildSubject: (headline) => headline,
-    make: (props) => <MarketingEmailTemplate {...props} />,
+    make: (props) => {
+      try {
+        return <MarketingEmailTemplate {...props} />;
+      } catch {
+        return <></>;
+      }
+    },
   },
   {
     id: "centered",
     label: "Centered",
     buildSubject: (headline) => headline,
-    make: (props) => (
-      <MarketingEmailTemplate {...props} className="text-center" />
-    ),
+    make: (props) => {
+      try {
+        return <MarketingEmailTemplate {...props} className="text-center" />;
+      } catch {
+        return <></>;
+      }
+    },
   },
 ];


### PR DESCRIPTION
## Summary
- validate headline/content presence and CTA pairing in `MarketingEmailTemplate`
- guard marketing template variants against missing data

## Testing
- `pnpm exec jest packages/email-templates/__tests__/marketingEmailTemplates.test.tsx --config jest.config.cjs --coverage=false`
- `pnpm exec jest packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx --config jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b6ede8be48832fb7dff03d9864f147