### PR TITLE
fix ai imports

### DIFF
--- a/packages/lib/src/seoAudit.ts
+++ b/packages/lib/src/seoAudit.ts
@@ -1,6 +1,4 @@
-import lighthouse from "lighthouse";
 import type { RunnerResult } from "lighthouse";
-import chromeLauncher from "chrome-launcher";
 import desktopConfig from "lighthouse/core/config/desktop-config.js";
 
 export interface SeoAuditResult {
@@ -13,9 +11,47 @@ export interface SeoAuditResult {
  * recommendations for failing audits.
  */
 export async function runSeoAudit(url: string): Promise<SeoAuditResult> {
-  const chrome = await chromeLauncher.launch({ chromeFlags: ["--headless"] });
+  // Resolve the `launch` function from chrome-launcher lazily to support both
+  // CommonJS and ESM versions of the library. This mirrors how generateMeta
+  // resolves the OpenAI client above.
+  let lighthouseFn: typeof import("lighthouse").default;
   try {
-    const result: RunnerResult | undefined = await lighthouse(
+    const mod = await import("lighthouse");
+    lighthouseFn =
+      typeof (mod as any).default === "function"
+        ? (mod as any).default
+        : typeof (mod as any).default?.default === "function"
+          ? (mod as any).default.default
+          : typeof mod === "function"
+            ? (mod as any)
+            : undefined;
+  } catch {
+    // ignore; handled below
+  }
+  let launch: typeof import("chrome-launcher").launch;
+  try {
+    const mod = await import("chrome-launcher");
+    launch =
+      typeof (mod as any).launch === "function"
+        ? (mod as any).launch
+        : typeof (mod as any).default?.launch === "function"
+          ? (mod as any).default.launch
+          : typeof (mod as any).default?.default?.launch === "function"
+            ? (mod as any).default.default.launch
+            : undefined;
+  } catch {
+    // ignore; handled below
+  }
+  if (typeof launch !== "function") {
+    throw new Error("chrome-launcher launch function not available");
+  }
+  if (typeof lighthouseFn !== "function") {
+    throw new Error("lighthouse is not a function");
+  }
+
+  const chrome = await launch({ chromeFlags: ["--headless"] });
+  try {
+    const result: RunnerResult | undefined = await lighthouseFn(
       url,
       {
         port: chrome.port,


### PR DESCRIPTION
## Summary
- handle multiple export styles of OpenAI SDK in generateMeta
- resolve chrome-launcher and lighthouse dynamically for compatibility

## Testing
- `pnpm exec jest packages/lib/src/__tests__/generateMeta.test.ts packages/lib/__tests__/generateMeta.test.ts packages/lib/__tests__/seoAudit.test.ts --runTestsByPath --config jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b6f05d24a8832fb5f9d98d115c24d5