### PR TITLE
test: add msw server tests

### DIFF
--- a/test/msw/server.test.ts
+++ b/test/msw/server.test.ts
@@ -1,0 +1,57 @@
+import { server } from "./server";
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("msw server handlers", () => {
+  test("POST /cms/api/configurator returns default message", async () => {
+    const res = await fetch("http://localhost/cms/api/configurator", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true, message: "default handler: OK" });
+  });
+
+  test("GET /cms/api/configurator/validate-env/:shop returns success", async () => {
+    const res = await fetch(
+      "http://localhost/cms/api/configurator/validate-env/my-shop"
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true });
+  });
+
+  test("GET /cms/api/page-templates returns empty array", async () => {
+    const res = await fetch("http://localhost/cms/api/page-templates");
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+  });
+
+  test("GET /cms/api/wizard-progress returns default state", async () => {
+    const res = await fetch("http://localhost/cms/api/wizard-progress");
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ state: {}, completed: {} });
+  });
+
+  test("PUT /cms/api/wizard-progress returns empty object", async () => {
+    const res = await fetch("http://localhost/cms/api/wizard-progress", {
+      method: "PUT",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({});
+  });
+
+  test("PATCH /cms/api/wizard-progress returns empty object", async () => {
+    const res = await fetch("http://localhost/cms/api/wizard-progress", {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering shared MSW server handlers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find name 'expect' in packages/lib build)*
- `pnpm exec jest test/msw --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b6f7072850832fbd89ab13ffd2d9e3