### PR TITLE
chore(test): shim react-dom client

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -183,7 +183,7 @@ const config = {
     '^server-only$': ' /test/server-only-stub.ts',
     // Use resolved React paths to ensure a single instance across tests
     '^react$': reactPath,
-    '^react-dom/client$': reactDomClientPath,
+    '^react-dom/client$': '<rootDir>/test/reactDomClientShim.ts',
     '^react-dom$': reactDomPath,
     '^react/jsx-runtime$': reactJsxRuntimePath,
     '^react/jsx-dev-runtime$': reactJsxDevRuntimePath,

--- a/test/reactDomClientShim.ts
+++ b/test/reactDomClientShim.ts
@@ -1,0 +1,4 @@
+// test/reactDomClientShim.ts
+export * from "next/dist/compiled/react-dom/client.js";
+export { default } from "next/dist/compiled/react-dom/client.js";
+


### PR DESCRIPTION
## Summary
- map `react-dom/client` to a custom shim so Jest can resolve the module
- add `reactDomClientShim` that re-exports Next.js' compiled `react-dom` client

## Testing
- `pnpm -r build` *(fails: Cannot find name 'expect' in packages/lib tests)*
- `pnpm test` *(fails: @acme/configurator#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f7f89728832f9131178d0a372c57