### PR TITLE
test: cover resolveLocale fallbacks

### DIFF
--- a/packages/i18n/__tests__/locales.test.ts
+++ b/packages/i18n/__tests__/locales.test.ts
@@ -1,4 +1,4 @@
-import { assertLocales } from "@acme/i18n";
+import { assertLocales, resolveLocale } from "@acme/i18n";
 
 describe("assertLocales", () => {
   it("throws on non-array values", () => {
@@ -15,5 +15,13 @@ describe("assertLocales", () => {
 
   it("does not throw on non-empty arrays", () => {
     expect(() => assertLocales(["en"])).not.toThrow();
+  });
+});
+
+describe("resolveLocale", () => {
+  it("returns supported locales and falls back to 'en'", () => {
+    expect(resolveLocale("de")).toBe("de");
+    expect(resolveLocale("fr")).toBe("en");
+    expect(resolveLocale(undefined)).toBe("en");
   });
 });


### PR DESCRIPTION
## Summary
- add resolveLocale tests for supported, unsupported and undefined inputs

## Testing
- `pnpm --filter @acme/i18n test packages/i18n/__tests__/locales.test.ts` *(fails: Jest: "global" coverage threshold for branches (80%) not met: 50%)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f720a3b4832fbe2c5f9750bf80b1