### PR TITLE
test: cover msw wizard progress handlers

### DIFF
--- a/packages/i18n/__tests__/msw.test.ts
+++ b/packages/i18n/__tests__/msw.test.ts
@@ -1,0 +1,53 @@
+import { server } from '../../../test/msw/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('msw default handlers', () => {
+  test('POST /cms/api/configurator', async () => {
+    const res = await fetch('http://localhost/cms/api/configurator', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true, message: 'default handler: OK' });
+  });
+
+  test('GET /cms/api/configurator/validate-env/:shop', async () => {
+    const res = await fetch(
+      'http://localhost/cms/api/configurator/validate-env/my-shop'
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true });
+  });
+
+  test('GET /cms/api/page-templates', async () => {
+    const res = await fetch('http://localhost/cms/api/page-templates');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+  });
+
+  test('GET /cms/api/wizard-progress', async () => {
+    const res = await fetch('http://localhost/cms/api/wizard-progress');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ state: {}, completed: {} });
+  });
+
+  test('PUT /cms/api/wizard-progress', async () => {
+    const res = await fetch('http://localhost/cms/api/wizard-progress', { method: 'PUT' });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({});
+  });
+
+  test('PATCH /cms/api/wizard-progress', async () => {
+    const res = await fetch('http://localhost/cms/api/wizard-progress', { method: 'PATCH' });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add MSW tests for CMS endpoints verifying default handlers

## Testing
- `pnpm --filter "@acme/i18n" test -- packages/i18n/__tests__/msw.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6f723576c832fb45940f60905197d