### PR TITLE
Fix shipping env import and make cart store factory testable

### DIFF
--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -96,7 +96,16 @@ export function createCartStore(options: CartStoreOptions = {}): CartStore {
 let _defaultStore: CartStore | null = null;
 export const getDefaultCartStore = (): CartStore => {
   if (_defaultStore) return _defaultStore;
-  _defaultStore = createCartStore();
+  // In tests, `createCartStore` is spied via the module export.
+  // Access through `module.exports` when available so the spy is hit.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const factory =
+    typeof module !== "undefined" &&
+    (module as any).exports?.createCartStore
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ((module as any).exports.createCartStore as typeof createCartStore)
+      : createCartStore;
+  _defaultStore = factory();
   return _defaultStore;
 };
 

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -1,9 +1,6 @@
 // packages/platform-core/src/shipping/index.ts
 
-import { loadShippingEnv } from "@acme/config/env/shipping";
-
-
-const shippingEnv = loadShippingEnv();
+import { shippingEnv } from "@acme/config/env/shipping";
 export interface ShippingRateRequest {
   provider: "ups" | "dhl" | "premier-shipping";
   fromPostalCode: string;

--- a/packages/platform-core/src/shipping/ups.ts
+++ b/packages/platform-core/src/shipping/ups.ts
@@ -1,7 +1,4 @@
-import { loadShippingEnv } from "@acme/config/env/shipping";
-
-
-const shippingEnv = loadShippingEnv();
+import { shippingEnv } from "@acme/config/env/shipping";
 export async function createReturnLabel(
   _sessionId: string,
 ): Promise<{ trackingNumber: string; labelUrl: string }> {


### PR DESCRIPTION
## Summary
- reference `shippingEnv` directly instead of `loadShippingEnv`
- allow tests to spy on cart store factory when creating default store

## Testing
- `pnpm exec jest packages/platform-core/src/shipping/__tests__/index.test.ts packages/platform-core/src/__tests__/cartStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6f94b0fdc832f9d8142a6da808ee3