### PR TITLE
feat(shared-utils): add build script and update entry points

### DIFF
--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -7,17 +7,21 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./logger": {
-      "types": "./dist/logger.d.ts",
       "import": "./dist/logger.js",
-      "require": "./dist/logger.js"
+      "default": "./dist/logger.js",
+      "types": "./dist/logger.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "lint": "eslint ."
   },


### PR DESCRIPTION
## Summary
- add TypeScript build script for shared-utils
- point package exports and types to compiled dist files

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/lib build: Failed)*
- `pnpm --filter @acme/shared-utils test` *(fails: ThemeEditor colors tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa2b0164832fa1f20e65f34b2672