### PR TITLE
Fix json repo import path and ThemeContext test

### DIFF
--- a/packages/platform-core/__tests__/repositories.test.ts
+++ b/packages/platform-core/__tests__/repositories.test.ts
@@ -11,7 +11,7 @@ import { nowIso } from "@date-utils";
 jest.setTimeout(20_000);
 
 /** The shape of the JSON-repository module we import dynamically */
-type JsonRepo = typeof import("../repositories/json.server");
+type JsonRepo = typeof import("../src/repositories/json.server");
 
 /**
  * Creates an isolated temp repo, runs `cb`, then restores CWD.
@@ -35,7 +35,7 @@ async function withRepo(
     PrismaClient: jest.fn().mockImplementation(() => ({})),
   }));
 
-  const repo: JsonRepo = await import("../repositories/json.server");
+  const repo: JsonRepo = await import("../src/repositories/json.server");
   try {
     await cb(repo, "test", dir);
   } finally {

--- a/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,5 +1,4 @@
-import { createRoot } from "react-dom/client";
-import { act } from "react";
+import { render } from "@testing-library/react";
 import { ThemeProvider, useTheme } from "../ThemeContext";
 
 // React 19 requires this flag for `act` to suppress environment warnings
@@ -39,23 +38,15 @@ describe("ThemeProvider fallback", () => {
       value: undefined,
     });
 
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-
-    const root = createRoot(container);
-    act(() => {
-      root.render(
-        <ThemeProvider>
-          <ThemeDisplay />
-        </ThemeProvider>
-      );
-    });
-
-    expect(container.querySelector("[data-testid='theme']")?.textContent).toBe(
-      "system"
+    const { getByTestId, unmount } = render(
+      <ThemeProvider>
+        <ThemeDisplay />
+      </ThemeProvider>
     );
+
+    expect(getByTestId("theme").textContent).toBe("system");
     expect(document.documentElement.style.colorScheme).toBe("light");
 
-    act(() => root.unmount());
+    unmount();
   });
 });


### PR DESCRIPTION
## Summary
- fix JsonRepo import path in repository tests
- update ThemeContext test to use @testing-library/react render

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `CI=true pnpm exec jest packages/platform-core/__tests__/repositories.test.ts --runInBand --config jest.config.cjs`
- `pnpm exec jest packages-platform-core/src/contexts/__tests__/ThemeContext.test.tsx --ci --runInBand --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b6f9118060832fbdea9143feae0525