### PR TITLE
test: expand date utilities coverage

### DIFF
--- a/packages/date-utils/src/__tests__/index.test.ts
+++ b/packages/date-utils/src/__tests__/index.test.ts
@@ -25,6 +25,9 @@ describe("isoDateInNDays", () => {
   it("returns ISO date string N days ahead", () => {
     expect(isoDateInNDays(3)).toBe("2025-01-04");
   });
+  it("returns ISO date string N days behind", () => {
+    expect(isoDateInNDays(-3)).toBe("2024-12-29");
+  });
 });
 
 describe("calculateRentalDays", () => {
@@ -39,6 +42,9 @@ describe("calculateRentalDays", () => {
   });
   it("returns 1 for past return dates", () => {
     expect(calculateRentalDays("2024-12-31")).toBe(1);
+  });
+  it("defaults to 1 when return date missing", () => {
+    expect(calculateRentalDays()).toBe(1);
   });
   it("throws on invalid date", () => {
     expect(() => calculateRentalDays("not-a-date")).toThrow("Invalid returnDate");


### PR DESCRIPTION
## Summary
- add negative-day test for isoDateInNDays
- assert calculateRentalDays handles missing returnDate

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/lib build: src/__tests__/generateMeta.test.ts(71,5): error TS2304: Cannot find name 'expect'.)*
- `pnpm test packages/date-utils` *(fails: Could not find task `packages/date-utils` in project)*
- `pnpm exec jest src/__tests__/index.test.ts --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b6fc8eca18832f9ea72a85fa8c2bc1