### PR TITLE
test: cover rental order status updates

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/rentalOrders.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/rentalOrders.server.test.ts
@@ -1,0 +1,83 @@
+import { prisma } from "../../db";
+import {
+  markReceived,
+  markCleaning,
+  markRepair,
+  markQa,
+  markAvailable,
+  markLateFeeCharged,
+} from "../rentalOrders.server";
+
+jest.mock("@acme/date-utils", () => ({ nowIso: jest.fn() }));
+import { nowIso } from "@acme/date-utils";
+
+describe("rental orders status updates", () => {
+  const shop = "test-shop";
+  const sessionId = "session";
+  const order = { id: 1 } as unknown as any;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns updated order when update succeeds", async () => {
+    const updateMock = jest
+      .spyOn(prisma.rentalOrder, "update")
+      .mockResolvedValue(order);
+    (nowIso as jest.Mock).mockReturnValue("now");
+
+    await expect(markReceived(shop, sessionId)).resolves.toBe(order);
+    expect(updateMock).toHaveBeenNthCalledWith(1, {
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { status: "received", returnReceivedAt: "now" },
+    });
+
+    await expect(markCleaning(shop, sessionId)).resolves.toBe(order);
+    expect(updateMock).toHaveBeenNthCalledWith(2, {
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { status: "cleaning" },
+    });
+
+    await expect(markRepair(shop, sessionId)).resolves.toBe(order);
+    expect(updateMock).toHaveBeenNthCalledWith(3, {
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { status: "repair" },
+    });
+
+    await expect(markQa(shop, sessionId)).resolves.toBe(order);
+    expect(updateMock).toHaveBeenNthCalledWith(4, {
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { status: "qa" },
+    });
+
+    await expect(markAvailable(shop, sessionId)).resolves.toBe(order);
+    expect(updateMock).toHaveBeenNthCalledWith(5, {
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { status: "available" },
+    });
+
+    const amount = 10;
+    await expect(markLateFeeCharged(shop, sessionId, amount)).resolves.toBe(order);
+    expect(updateMock).toHaveBeenNthCalledWith(6, {
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { lateFeeCharged: amount },
+    });
+  });
+
+  it("returns null when update fails", async () => {
+    const updateMock = jest
+      .spyOn(prisma.rentalOrder, "update")
+      .mockRejectedValue(new Error("fail"));
+    (nowIso as jest.Mock).mockReturnValue("now");
+
+    await expect(markReceived(shop, sessionId)).resolves.toBeNull();
+    await expect(markCleaning(shop, sessionId)).resolves.toBeNull();
+    await expect(markRepair(shop, sessionId)).resolves.toBeNull();
+    await expect(markQa(shop, sessionId)).resolves.toBeNull();
+    await expect(markAvailable(shop, sessionId)).resolves.toBeNull();
+    await expect(markLateFeeCharged(shop, sessionId, 1)).resolves.toBeNull();
+
+    expect(updateMock).toHaveBeenCalledTimes(6);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test rental order status transitions for markReceived, markCleaning, markRepair, markQa, markAvailable, and markLateFeeCharged

## Testing
- `pnpm test packages/platform-core` *(fails: multiple existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc91d738832f8bfb2c95b9b76060