### PR TITLE
chore: verify react-dom client.js in jest config

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -68,7 +68,7 @@ function resolveReact() {
     // Build full paths to runtime files and verify they exist.
     const jsxRuntime = path.join(reactBase, 'jsx-runtime.js');
     const jsxDevRuntime = path.join(reactBase, 'jsx-dev-runtime.js');
-    const domClient = require.resolve('react-dom/client');
+    const domClient = path.join(reactDomBase, 'client.js');
 
     if (
       fs.existsSync(jsxRuntime) &&


### PR DESCRIPTION
## Summary
- ensure resolveReact checks for react-dom/client.js before mapping

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find name 'expect')
- `pnpm test` (fails: SyntaxError: Unexpected token 'export')

------
https://chatgpt.com/codex/tasks/task_e_68b6f7dac644832f8fbfb98399418ed3