### PR TITLE
test: add locales tests

### DIFF
--- a/packages/i18n/src/__tests__/locales.test.ts
+++ b/packages/i18n/src/__tests__/locales.test.ts
@@ -1,0 +1,27 @@
+import { assertLocales, resolveLocale } from "../locales";
+
+describe("assertLocales", () => {
+  it("throws on non-array values", () => {
+    expect(() => assertLocales(undefined as any)).toThrow(
+      "LOCALES must be a non-empty array"
+    );
+  });
+
+  it("throws on empty arrays", () => {
+    expect(() => assertLocales([] as any)).toThrow(
+      "LOCALES must be a non-empty array"
+    );
+  });
+
+  it("does not throw on non-empty arrays", () => {
+    expect(() => assertLocales(["en"])).not.toThrow();
+  });
+});
+
+describe("resolveLocale", () => {
+  it("returns supported locales and falls back to 'en'", () => {
+    expect(resolveLocale("de")).toBe("de");
+    expect(resolveLocale("fr" as any)).toBe("en");
+    expect(resolveLocale(undefined)).toBe("en");
+  });
+});


### PR DESCRIPTION
## Summary
- add locales unit tests for assertLocales and resolveLocale

## Testing
- `pnpm test packages/i18n` *(fails: Could not find task `packages/i18n`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc8ff834832fbdc88d32cceeb6a2