### PR TITLE
test: add useFSM hook tests

### DIFF
--- a/packages/platform-machine/src/__tests__/useFSM.test.ts
+++ b/packages/platform-machine/src/__tests__/useFSM.test.ts
@@ -1,50 +1,38 @@
-import React from "react";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useFSM } from "../useFSM";
 
 describe("useFSM", () => {
-  function TestComponent() {
-    const { state, send } = useFSM<
-      "idle" | "loading" | "success" | "fallback",
-      "FETCH" | "RESOLVE" | "UNKNOWN"
-    >("idle", [
-      { from: "idle", event: "FETCH", to: "loading" },
-      { from: "loading", event: "RESOLVE", to: "success" },
-    ]);
-
-    return React.createElement(
-      React.Fragment,
-      null,
-      React.createElement("span", { "data-testid": "state" }, state),
-      React.createElement(
-        "button",
-        { onClick: () => send("FETCH") },
-        "fetch"
-      ),
-      React.createElement(
-        "button",
-        { onClick: () => send("RESOLVE") },
-        "resolve"
-      ),
-      React.createElement(
-        "button",
-        { onClick: () => send("UNKNOWN", () => "fallback") },
-        "unknown"
-      )
-    );
-  }
-
   it("handles transitions and fallback", () => {
-    render(React.createElement(TestComponent));
-    const state = screen.getByTestId("state");
+    const { result } = renderHook(() =>
+      useFSM<
+        "idle" | "loading" | "success" | "fallback",
+        "FETCH" | "RESOLVE" | "UNKNOWN"
+      >("idle", [
+        { from: "idle", event: "FETCH", to: "loading" },
+        { from: "loading", event: "RESOLVE", to: "success" },
+      ])
+    );
 
-    expect(state.textContent).toBe("idle");
-    fireEvent.click(screen.getByText("fetch"));
-    expect(state.textContent).toBe("loading");
-    fireEvent.click(screen.getByText("resolve"));
-    expect(state.textContent).toBe("success");
-    fireEvent.click(screen.getByText("unknown"));
-    expect(state.textContent).toBe("fallback");
+    expect(result.current).not.toBeNull();
+    expect(result.current?.state).toBe("idle");
+
+    let next: string;
+    act(() => {
+      next = result.current!.send("FETCH");
+    });
+    expect(next).toBe("loading");
+    expect(result.current?.state).toBe(next);
+
+    act(() => {
+      next = result.current!.send("RESOLVE");
+    });
+    expect(next).toBe("success");
+    expect(result.current?.state).toBe(next);
+
+    act(() => {
+      next = result.current!.send("UNKNOWN", () => "fallback");
+    });
+    expect(next).toBe("fallback");
+    expect(result.current?.state).toBe(next);
   });
 });
-


### PR DESCRIPTION
## Summary
- add tests for useFSM hook, covering state transitions and fallback

## Testing
- `pnpm test packages/platform-machine` *(fails: Could not find task `packages/platform-machine`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc933784832f83ac4396cd8b011b