### PR TITLE
test(shared-utils): verify buildResponse decoding

### DIFF
--- a/packages/shared-utils/src/__tests__/buildResponse.test.ts
+++ b/packages/shared-utils/src/__tests__/buildResponse.test.ts
@@ -1,15 +1,28 @@
-import { buildResponse } from '../buildResponse';
+import { buildResponse, type ProxyResponse } from '../buildResponse';
 
 describe('buildResponse', () => {
-  it('decodes base64 body and rehydrates headers', async () => {
+  it('decodes base64 body and preserves multiple headers', async () => {
     const text = 'hello world';
     const body = Buffer.from(text).toString('base64');
-    const resp = buildResponse({
-      response: { status: 200, headers: { 'x-test': '1' }, body },
-    });
+    const proxyResponse: ProxyResponse = {
+      response: {
+        status: 202,
+        headers: {
+          'x-test': '1',
+          'content-type': 'text/plain',
+          'x-other': '2',
+        },
+        body,
+      },
+    };
 
-    expect(resp.status).toBe(200);
+    const resp = buildResponse(proxyResponse);
+
+    expect(resp.status).toBe(202);
     expect(resp.headers.get('x-test')).toBe('1');
+    expect(resp.headers.get('content-type')).toBe('text/plain');
+    expect(resp.headers.get('x-other')).toBe('2');
     await expect(resp.text()).resolves.toBe(text);
   });
 });
+


### PR DESCRIPTION
## Summary
- add test ensuring `buildResponse` decodes base64 body and rehydrates multiple headers

## Testing
- `pnpm test packages/shared-utils` *(fails: Missing tasks in project)*
- `pnpm exec jest packages/shared-utils/src/__tests__/buildResponse.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6fc98c7e8832fbded62aa25a8b16e