### PR TITLE
chore(test): harden React resolution

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -74,9 +74,7 @@ function resolveReact() {
     // Build full paths to runtime files and verify they exist.
     const jsxRuntime = path.join(reactBase, 'jsx-runtime.js');
     const jsxDevRuntime = path.join(reactBase, 'jsx-dev-runtime.js');
-    const domClient = require.resolve('react-dom/client', {
-      paths: [process.cwd()],
-    });
+    const domClient = path.join(reactDomBase, 'client.js');
 
     if (
       fs.existsSync(jsxRuntime) &&


### PR DESCRIPTION
## Summary
- ensure resolveReact falls back when React DOM client runtime is missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find name 'expect')*
- `pnpm test` *(fails: @acme/configurator#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b7013e555c832f9a6c68c525884779