### PR TITLE
fix react-dom client mapping for tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -191,7 +191,8 @@ const config = {
     '^server-only$': ' /test/server-only-stub.ts',
     // Use resolved React paths to ensure a single instance across tests
     '^react$': reactPath,
-    '^react-dom/client$': '<rootDir>/test/reactDomClientShim.ts',
+    '^react-dom/client$': reactDomClientPath,
+    '^react-dom/client\\.js$': reactDomClientPath,
     '^react-dom$': reactDomPath,
     '^react/jsx-runtime$': reactJsxRuntimePath,
     '^react/jsx-dev-runtime$': reactJsxDevRuntimePath,


### PR DESCRIPTION
## Summary
- ensure jest maps `react-dom/client` and `react-dom/client.js` directly to installed React DOM

## Testing
- `pnpm exec jest packages/platform-core/__tests__/productCard.test.tsx packages/platform-core/__tests__/layoutContext.test.tsx --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b7006e31f4832f992b4d7118da8ba4