### PR TITLE
test: cover ai catalog branches

### DIFF
--- a/packages/template-app/__tests__/ai-catalog.test.ts
+++ b/packages/template-app/__tests__/ai-catalog.test.ts
@@ -1,10 +1,46 @@
 // packages/template-app/__tests__/ai-catalog.test.ts
+
+jest.mock("@platform-core/repositories/settings.server", () => ({
+  getShopSettings: jest.fn(),
+}));
+jest.mock("@platform-core/repositories/products.server", () => ({
+  readRepo: jest.fn(),
+}));
+jest.mock("@platform-core/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
 import { GET } from "../src/app/api/ai/catalog/route";
-import * as settings from "@platform-core/repositories/settings.server";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import { readRepo } from "@platform-core/repositories/products.server";
+import { trackEvent } from "@platform-core/analytics";
+
+const getShopSettingsMock = jest.mocked(getShopSettings);
+const readRepoMock = jest.mocked(readRepo);
+const trackEventMock = jest.mocked(trackEvent);
 
 describe("AI catalogue API", () => {
   beforeAll(() => {
     process.env.NEXT_PUBLIC_SHOP_ID = "abc";
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getShopSettingsMock.mockResolvedValue({
+      seo: { aiCatalog: { enabled: true, fields: ["id", "title"], pageSize: 2 } },
+    } as any);
+    readRepoMock.mockResolvedValue([
+      {
+        id: "p1",
+        sku: "p1",
+        title: "Product 1",
+        description: "desc",
+        price: 123,
+        media: ["img"],
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    ] as any);
+    trackEventMock.mockResolvedValue(undefined as any);
   });
 
   function createRequest(url: string, headers: Record<string, string> = {}) {
@@ -14,39 +50,62 @@ describe("AI catalogue API", () => {
     } as any;
   }
 
-  test("returns product metadata", async () => {
+  test("returns filtered product metadata and tracks 200 response", async () => {
     const res = await GET(
-      createRequest("http://localhost/api/ai/catalog?limit=1&page=1")
+      createRequest("http://localhost/api/ai/catalog?page=foo&limit=-1")
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(Array.isArray(body.items)).toBe(true);
-    expect(body.items.length).toBeLessThanOrEqual(1);
-    const item = body.items[0];
-    expect(item).toHaveProperty("id");
-    expect(item).toHaveProperty("title");
-    expect(item).toHaveProperty("description");
-    expect(item).toHaveProperty("price");
-    expect(item).toHaveProperty("media");
+    expect(body.page).toBe(1);
+    expect(body.items).toEqual([{ id: "p1", title: "Product 1" }]);
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith("abc", {
+      type: "ai_crawl",
+      page: "1",
+      status: 200,
+      items: 1,
+    });
   });
 
-  test("responds 304 when not modified", async () => {
-    const first = await GET(createRequest("http://localhost/api/ai/catalog"));
-    const lm = first.headers.get("Last-Modified")!;
-    const second = await GET(
+  test("uses If-Modified-Since older than last modified and returns 200", async () => {
+    const ims = new Date("2023-12-31T23:59:59Z").toUTCString();
+    const res = await GET(
       createRequest("http://localhost/api/ai/catalog", {
-        "If-Modified-Since": lm,
+        "If-Modified-Since": ims,
       })
     );
-    expect(second.status).toBe(304);
+    expect(res.status).toBe(200);
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith("abc", {
+      type: "ai_crawl",
+      page: "1",
+      status: 200,
+      items: 1,
+    });
+  });
+
+  test("returns 304 when If-Modified-Since newer than last modified", async () => {
+    const ims = new Date("2024-01-02T00:00:00Z").toUTCString();
+    const res = await GET(
+      createRequest("http://localhost/api/ai/catalog", {
+        "If-Modified-Since": ims,
+      })
+    );
+    expect(res.status).toBe(304);
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith("abc", {
+      type: "ai_crawl",
+      page: "1",
+      status: 304,
+    });
   });
 
   test("returns 404 when AI catalog disabled", async () => {
-    const spy = jest
-      .spyOn(settings, "getShopSettings")
-      .mockResolvedValue({ seo: { aiCatalog: { enabled: false } } } as any);
+    getShopSettingsMock.mockResolvedValueOnce({
+      seo: { aiCatalog: { enabled: false } },
+    } as any);
     const res = await GET(createRequest("http://localhost/api/ai/catalog"));
     expect(res.status).toBe(404);
-    spy.mockRestore();
   });
 });
+


### PR DESCRIPTION
## Summary
- add comprehensive AI catalog API tests
- mock settings, repository, and analytics for deterministic responses
- verify Last-Modified handling and analytics tracking

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find name 'expect' in packages/lib build)*
- `pnpm --filter @acme/template-app test -- ai-catalog.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b70520b38c832faa43c207630e64b8