### PR TITLE
test: fallback language in sitemap

### DIFF
--- a/packages/template-app/__tests__/sitemap.test.ts
+++ b/packages/template-app/__tests__/sitemap.test.ts
@@ -19,6 +19,26 @@ describe("sitemap generation", () => {
     process.env.NEXT_PUBLIC_SHOP_ID = "shop1";
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("falls back to English when no languages are configured", async () => {
+    getShopSettingsMock.mockResolvedValueOnce({});
+    const { default: sitemap } = await import("../src/app/sitemap");
+    const entries = (await sitemap()) as MetadataRoute.Sitemap;
+    expect(getShopSettingsMock).toHaveBeenCalledWith("shop1");
+    expect(readRepoMock).toHaveBeenCalledWith("shop1");
+    const home = entries.find((e) => e.url === "https://example.com/en");
+    expect(home?.alternates?.languages).toEqual({
+      en: "https://example.com/en",
+    });
+    const product = entries.find((e) => e.url.endsWith("/product/shoe"));
+    expect(product?.alternates?.languages).toEqual({
+      en: "https://example.com/en/product/shoe",
+    });
+  });
+
   it("builds URLs with hreflang alternates", async () => {
     const { default: sitemap } = await import("../src/app/sitemap");
     const entries = (await sitemap()) as MetadataRoute.Sitemap;


### PR DESCRIPTION
## Summary
- add test for sitemap when shop settings lack languages
- cover existing behavior for custom languages

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2304 Cannot find name 'expect')*
- `pnpm --filter @acme/template-app test` *(fails: expected 200 received 404 in AI catalogue API test)*
- `pnpm --filter @acme/template-app exec jest __tests__/sitemap.test.ts --runInBand --detectOpenHandles` *(fails: coverage threshold for lines 60% not met 55.82%)*

------
https://chatgpt.com/codex/tasks/task_e_68b705218308832f958a7adf5b43aa1b