### PR TITLE
test: use jsdom env for app tests

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -10,6 +10,7 @@ const {
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
+  testEnvironment: "jsdom",
   roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
   setupFilesAfterEnv: [
     "<rootDir>/apps/cms/jest.setup.polyfills.ts",

--- a/apps/dashboard/jest.config.cjs
+++ b/apps/dashboard/jest.config.cjs
@@ -5,6 +5,7 @@ const { "^@/(.*)$": _unused, ...baseModuleNameMapper } = base.moduleNameMapper;
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
+  testEnvironment: "jsdom",
   roots: ["<rootDir>/apps/dashboard/src", "<rootDir>/apps/dashboard/__tests__"],
   moduleNameMapper: {
     ...baseModuleNameMapper,


### PR DESCRIPTION
## Summary
- ensure dashboard app tests run in jsdom
- ensure cms app tests run in jsdom

## Testing
- `pnpm -r build` (fails: Cannot find name 'expect' in packages/lib)
- `pnpm --filter @apps/cms test -- apps/cms` (fails: Unable to find role="heading" and name "Summary")
- `pnpm --filter @apps/dashboard test -- apps/dashboard` (fails: coverage threshold not met for branches)


------
https://chatgpt.com/codex/tasks/task_e_68b713f43854832f8478b9ccc69a8e53