### PR TITLE
fix: return JSON for components route

### DIFF
--- a/apps/api/src/routes/components/[shopId].ts
+++ b/apps/api/src/routes/components/[shopId].ts
@@ -143,7 +143,9 @@ export const onRequest = async ({
 
   const includeDiff = new URL(request.url).searchParams.has("diff");
   if (!includeDiff) {
-    return Response.json({ components });
+    return new Response(JSON.stringify({ components }), {
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   const appDir = path.join(root, "apps", `shop-${shopId}`);
@@ -158,7 +160,9 @@ export const onRequest = async ({
       path.join(templateDir, "src", "translations"),
     ),
   };
-  return Response.json({ components, configDiff });
+  return new Response(JSON.stringify({ components, configDiff }), {
+    headers: { "Content-Type": "application/json" },
+  });
 };
 
 export { extractSummary, gatherChanges, diffDirectories };


### PR DESCRIPTION
## Summary
- ensure components route returns JSON payloads with correct headers

## Testing
- `pnpm --filter @apps/api test`
- `pnpm -r build` *(fails: Cannot find name 'expect' in packages/lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b713935128832f9d341dfff0307177