### PR TITLE
chore(configurator): use monorepo jest config

### DIFF
--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "test": "jest",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs packages/configurator",
     "lint": "eslint .",
     "prepack": "pnpm run build"
   },


### PR DESCRIPTION
## Summary
- ensure configurator tests use monorepo Jest config

## Testing
- `pnpm install`
- `pnpm -r build` (fails: packages/lib build: Variable 'launch' is used before being assigned)
- `pnpm --filter @acme/configurator test`


------
https://chatgpt.com/codex/tasks/task_e_68b718162d50832fa0e93340c5444e46