### PR TITLE
test(config): validate session store

### DIFF
--- a/packages/config/src/env/__tests__/auth.test.ts
+++ b/packages/config/src/env/__tests__/auth.test.ts
@@ -60,6 +60,30 @@ describe("auth env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("throws when SESSION_STORE is invalid", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      NEXTAUTH_SECRET: "next-secret",
+      SESSION_SECRET: "session-secret",
+      SESSION_STORE: "postgres",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../auth.ts")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        SESSION_STORE: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws when optional URLs are invalid", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- add unit test for invalid SESSION_STORE values in auth env

## Testing
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned in packages/lib)*

------
https://chatgpt.com/codex/tasks/task_e_68b7189e7bf0832f919e0d6b9cdf76a5