### PR TITLE
chore(test): ignore msw server for coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -201,6 +201,7 @@ const config = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs', 'node', 'd.ts'],
   collectCoverage: true,
   coverageDirectory: ' /coverage',
+  coveragePathIgnorePatterns: [' /test/msw/'],
   coverageReporters: ['text', 'text-summary', 'lcov'],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
## Summary
- avoid collecting coverage for test MSW server

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm test` *(fails: @acme/configurator#test exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68b718a4afa0832fb2ea58bbfba0d8ee