### PR TITLE
test: validate deposit release env

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -201,7 +201,7 @@ describe("loadCoreEnv", () => {
       loadCoreEnv({
         ...baseEnv,
         DEPOSIT_RELEASE_ENABLED: "yes",
-        LATE_FEE_INTERVAL_MS: "fast",
+        DEPOSIT_RELEASE_INTERVAL_MS: "fast",
       } as NodeJS.ProcessEnv),
     ).toThrow("Invalid core environment variables");
     expect(errorSpy).toHaveBeenCalledWith(
@@ -211,7 +211,7 @@ describe("loadCoreEnv", () => {
       "  • DEPOSIT_RELEASE_ENABLED: must be true or false",
     );
     expect(errorSpy).toHaveBeenCalledWith(
-      "  • LATE_FEE_INTERVAL_MS: must be a number",
+      "  • DEPOSIT_RELEASE_INTERVAL_MS: must be a number",
     );
     errorSpy.mockRestore();
   });
@@ -364,7 +364,7 @@ describe("loadCoreEnv", () => {
       loadCoreEnv({
         ...baseEnv,
         DEPOSIT_RELEASE_ENABLED: "yes",
-        LATE_FEE_INTERVAL_MS: "fast",
+        DEPOSIT_RELEASE_INTERVAL_MS: "fast",
       } as unknown as NodeJS.ProcessEnv),
     ).toThrow("Invalid core environment variables");
     expect(errorSpy).toHaveBeenCalledWith(
@@ -374,7 +374,7 @@ describe("loadCoreEnv", () => {
       "  • DEPOSIT_RELEASE_ENABLED: must be true or false",
     );
     expect(errorSpy).toHaveBeenCalledWith(
-      "  • LATE_FEE_INTERVAL_MS: must be a number",
+      "  • DEPOSIT_RELEASE_INTERVAL_MS: must be a number",
     );
     errorSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- test loadCoreEnv throws/logs errors for invalid deposit release config

## Testing
- `pnpm --filter @acme/config test`
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b7189fcb24832fa4beaa8b8261ab15