### PR TITLE
test: cover shipping env invalid cases

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -63,6 +63,23 @@ describe("shipping env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("loadShippingEnv throws on non-string TAXJAR_KEY", async () => {
+    const { loadShippingEnv } = await import("../shipping.ts");
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ TAXJAR_KEY: 123 as unknown as string }),
+    ).toThrow("Invalid shipping environment variables");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        TAXJAR_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("loadShippingEnv throws on non-string values", async () => {
     const { loadShippingEnv } = await import("../shipping.ts");
     const errorSpy = jest
@@ -97,6 +114,27 @@ describe("shipping env module", () => {
       "❌ Invalid shipping environment variables:",
       expect.objectContaining({
         UPS_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("throws on invalid DHL_KEY during eager parse", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      DHL_KEY: 123 as unknown as string,
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../shipping.ts")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        DHL_KEY: { _errors: [expect.any(String)] },
       }),
     );
     errorSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add test for non-string TAXJAR_KEY to loadShippingEnv
- cover DHL_KEY parsing error during module import

## Testing
- `pnpm --filter @acme/config exec jest src/env/__tests__/shipping.test.ts --runInBand --config jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b718a38544832f9e2978fa684da0ce