### PR TITLE
test: require sendgrid api key

### DIFF
--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -53,6 +53,28 @@ describe("email env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("throws and logs error when SENDGRID_API_KEY is missing", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      EMAIL_PROVIDER: "sendgrid",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    await expect(import("../email.ts")).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid email environment variables:",
+      expect.objectContaining({
+        SENDGRID_API_KEY: {
+          _errors: [expect.stringContaining("Required")],
+        },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("defaults EMAIL_PROVIDER to smtp when unset in development", async () => {
     process.env = { ...ORIGINAL_ENV, NODE_ENV: "development" } as NodeJS.ProcessEnv;
     jest.resetModules();

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -23,5 +23,15 @@ if (!parsed.success) {
   throw new Error("Invalid email environment variables");
 }
 
+if (
+  parsed.data.EMAIL_PROVIDER === "sendgrid" &&
+  !parsed.data.SENDGRID_API_KEY
+) {
+  console.error("❌ Invalid email environment variables:", {
+    SENDGRID_API_KEY: { _errors: ["Required"] },
+  });
+  throw new Error("Invalid email environment variables");
+}
+
 export const emailEnv = parsed.data;
 export type EmailEnv = z.infer<typeof emailEnvSchema>;


### PR DESCRIPTION
## Summary
- add failing test when SENDGRID_API_KEY missing for sendgrid provider
- enforce SENDGRID_API_KEY presence when EMAIL_PROVIDER=sendgrid

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b718a1b7e0832fbcd2d00cd49fa737