### PR TITLE
feat(email-templates): relax marketing template validations

### DIFF
--- a/packages/email-templates/src/MarketingEmailTemplate.tsx
+++ b/packages/email-templates/src/MarketingEmailTemplate.tsx
@@ -23,14 +23,10 @@ export function MarketingEmailTemplate({
   ...props
 }: MarketingEmailTemplateProps) {
   if (!headline || content == null) {
-    throw new Error("MarketingEmailTemplate: headline and content are required");
+    return <></>;
   }
 
-  if ((ctaLabel && !ctaHref) || (!ctaLabel && ctaHref)) {
-    throw new Error(
-      "MarketingEmailTemplate: ctaLabel and ctaHref must both be provided",
-    );
-  }
+  const showCta = Boolean(ctaLabel && ctaHref);
 
   return (
     <div
@@ -51,14 +47,17 @@ export function MarketingEmailTemplate({
       <div className="space-y-4 p-6">
         <h1 className="text-xl font-bold">{headline}</h1>
         <div className="leading-6">{content}</div>
-        {ctaLabel && ctaHref && (
+        {showCta && (
           <div className="text-center">
             <a
               href={ctaHref}
               className="bg-primary inline-block rounded-md px-4 py-2 font-medium"
               data-token="--color-primary"
             >
-              <span className="text-primary-foreground" data-token="--color-primary-fg">
+              <span
+                className="text-primary-foreground"
+                data-token="--color-primary-fg"
+              >
                 {ctaLabel}
               </span>
             </a>

--- a/packages/email-templates/src/marketingEmailTemplates.tsx
+++ b/packages/email-templates/src/marketingEmailTemplates.tsx
@@ -13,24 +13,14 @@ export const marketingEmailTemplates: MarketingEmailTemplateVariant[] = [
     id: "basic",
     label: "Basic",
     buildSubject: (headline) => headline,
-    make: (props) => {
-      try {
-        return <MarketingEmailTemplate {...props} />;
-      } catch {
-        return <></>;
-      }
-    },
+    make: (props) => <MarketingEmailTemplate {...(props ?? {})} />,
   },
   {
     id: "centered",
     label: "Centered",
     buildSubject: (headline) => headline,
-    make: (props) => {
-      try {
-        return <MarketingEmailTemplate {...props} className="text-center" />;
-      } catch {
-        return <></>;
-      }
-    },
+    make: (props) => (
+      <MarketingEmailTemplate {...(props ?? {})} className="text-center" />
+    ),
   },
 ];


### PR DESCRIPTION
## Summary
- avoid throwing when marketing email data is incomplete
- simplify template registry

## Testing
- `pnpm --filter @acme/email-templates exec jest packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx packages/email-templates/__tests__/marketingEmailTemplates.test.tsx --runInBand --config ../../jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68b7191c1984832f9548d1561a759848