### PR TITLE
chore(test): ignore shared helpers from coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -202,6 +202,16 @@ const config = {
   collectCoverage: true,
   coverageDirectory: ' /coverage',
   coverageReporters: ['text', 'text-summary', 'lcov'],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/test/msw/server.ts',
+    '<rootDir>/test/mswServer.ts',
+    '<rootDir>/test/resetNextMocks.ts',
+    '<rootDir>/test/setupFetchPolyfill.ts',
+    '<rootDir>/test/setupTests.ts',
+    '<rootDir>/test/reactDomClientShim.ts',
+    '<rootDir>/test/polyfills/',
+    '<rootDir>/test/__mocks__/',
+  ],
   coverageThreshold: {
     global: {
       lines: 80,


### PR DESCRIPTION
## Summary
- exclude common test helpers from global coverage

## Testing
- `npm run test:coverage` *(fails: `@acme/next-config:test` command exited (9))*

------
https://chatgpt.com/codex/tasks/task_e_68b7195154a8832f96c554cb65625607