### PR TITLE
test: stabilize theme context tests

### DIFF
--- a/packages/platform-core/__tests__/themeContext.test.tsx
+++ b/packages/platform-core/__tests__/themeContext.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ThemeProvider, useTheme } from "../src/contexts/ThemeContext";
 
 function Buttons() {
@@ -13,13 +13,30 @@ function Buttons() {
 }
 
 describe("ThemeContext", () => {
+  beforeAll(() => {
+    // jsdom doesn't implement matchMedia, but our context expects it.
+    // Provide a minimal stub so effects don't error during tests.
+    window.matchMedia =
+      window.matchMedia ||
+      ((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      } as unknown as MediaQueryList));
+  });
+
   afterEach(() => {
     document.documentElement.className = "";
     localStorage.clear();
   });
 
-  it("applies classes to <html> element", () => {
-    const { getByText } = render(
+  it("applies classes to <html> element", async () => {
+    render(
       <ThemeProvider>
         <Buttons />
       </ThemeProvider>
@@ -27,19 +44,20 @@ describe("ThemeContext", () => {
 
     const html = document.documentElement;
     expect(html.className).toBe("");
-    fireEvent.click(getByText("dark"));
+    fireEvent.click(await screen.findByText("dark"));
     expect(html.classList.contains("theme-dark")).toBe(true);
-    fireEvent.click(getByText("brandx"));
+    fireEvent.click(await screen.findByText("brandx"));
     expect(html.classList.contains("theme-dark")).toBe(false);
     expect(html.classList.contains("theme-brandx")).toBe(true);
   });
 
-  it("matches snapshot on initial render", () => {
+  it("matches snapshot on initial render", async () => {
     const { asFragment } = render(
       <ThemeProvider>
         <div>Hello</div>
       </ThemeProvider>
     );
+    await screen.findByText("Hello");
     expect(asFragment()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary
- stub `matchMedia` in theme context tests
- wait for buttons before firing events

## Testing
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @acme/platform-core test -- __tests__/themeContext.test.tsx` *(fails: coverage threshold for branches not met: 57.89%)*
- `pnpm exec jest packages/platform-core/__tests__/themeContext.test.tsx --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68b71d47d1c8832fb4b22156920cb89f