### PR TITLE
Ensure React 19 tests use compatible react-dom client shim

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -189,7 +189,7 @@ const config = {
     '^server-only$': ' /test/server-only-stub.ts',
     // Use resolved React paths to ensure a single instance across tests
     '^react$': reactPath,
-    '^react-dom/client$': reactDomClientPath,
+    '^react-dom/client$': ' /test/reactDomClientShim.ts',
     '^react-dom/client\\.js$': reactDomClientPath,
     '^react-dom$': reactDomPath,
     '^react/jsx-runtime$': reactJsxRuntimePath,

--- a/test/reactDomClientShim.ts
+++ b/test/reactDomClientShim.ts
@@ -1,10 +1,17 @@
+import * as ReactDOMClient from 'react-dom/client.js';
 import * as ReactDOM from 'react-dom';
 
-// Provide a compatible `createRoot` API for React 19.
+// Provide a compatible `createRoot` API for both React 18 and 19.
 export function createRoot(container: Element) {
+  if (typeof (ReactDOMClient as any).createRoot === 'function') {
+    return (ReactDOMClient as any).createRoot(container);
+  }
+
+  // Fallback for React versions that only expose `render`/`unmountComponentAtNode`.
   return {
-    render: (children: React.ReactNode) => ReactDOM.render(children, container),
-    unmount: () => ReactDOM.unmountComponentAtNode(container),
+    render: (children: React.ReactNode) =>
+      (ReactDOM as any).render(children, container),
+    unmount: () => (ReactDOM as any).unmountComponentAtNode(container),
   };
 }
 


### PR DESCRIPTION
## Summary
- add version-aware `createRoot` shim that supports React 18+ APIs
- map `react-dom/client` to the shim in Jest config

## Testing
- `pnpm exec jest packages/platform-core/__tests__/cartContext.test.tsx --config jest.config.cjs`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b71d8e78a4832fbbcbc5fcf02dc167