### PR TITLE
refactor: clarify state transition variable

### DIFF
--- a/packages/platform-machine/src/__tests__/useFSM.test.ts
+++ b/packages/platform-machine/src/__tests__/useFSM.test.ts
@@ -16,23 +16,23 @@ describe("useFSM", () => {
     expect(result.current).not.toBeNull();
     expect(result.current?.state).toBe("idle");
 
-    let next: string;
+    let nextState: string;
     act(() => {
-      next = result.current!.send("FETCH");
+      nextState = result.current!.send("FETCH");
     });
-    expect(next).toBe("loading");
-    expect(result.current?.state).toBe(next);
+    expect(nextState).toBe("loading");
+    expect(result.current?.state).toBe(nextState);
 
     act(() => {
-      next = result.current!.send("RESOLVE");
+      nextState = result.current!.send("RESOLVE");
     });
-    expect(next).toBe("success");
-    expect(result.current?.state).toBe(next);
+    expect(nextState).toBe("success");
+    expect(result.current?.state).toBe(nextState);
 
     act(() => {
-      next = result.current!.send("UNKNOWN", () => "fallback");
+      nextState = result.current!.send("UNKNOWN", () => "fallback");
     });
-    expect(next).toBe("fallback");
-    expect(result.current?.state).toBe(next);
+    expect(nextState).toBe("fallback");
+    expect(result.current?.state).toBe(nextState);
   });
 });


### PR DESCRIPTION
## Summary
- clarify useFSM test state transition variable

## Testing
- `pnpm exec jest packages/platform-machine/src/__tests__/useFSM.test.ts --runInBand --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b71ebacb28832fb279df2051af8365