### PR TITLE
Fix CurrencyContext React 19 hook error normalization

### DIFF
--- a/packages/platform-core/src/contexts/CurrencyContext.tsx
+++ b/packages/platform-core/src/contexts/CurrencyContext.tsx
@@ -48,10 +48,14 @@ export function useCurrency() {
     if (!ctx) throw new Error("useCurrency must be inside CurrencyProvider");
     return ctx;
   } catch (err) {
-    // React throws "Invalid hook call" when hooks run outside a component.
-    // Tests invoke this hook directly, so normalize that error into the
+    // React throws different errors when hooks run outside a component.
+    // Tests invoke this hook directly, so normalize those errors into the
     // expected provider usage message.
-    if (err instanceof Error && err.message.includes("Invalid hook call")) {
+    if (
+      err instanceof Error &&
+      (err.message.includes("Invalid hook call") ||
+        err.message.includes("reading 'useContext'"))
+    ) {
       throw new Error("useCurrency must be inside CurrencyProvider");
     }
     throw err;


### PR DESCRIPTION
## Summary
- normalize React 19's hook error messages when CurrencyContext is used outside of its provider

## Testing
- `pnpm exec jest --runInBand --detectOpenHandles --config jest.config.cjs --runTestsByPath packages/platform-core/__tests__/currencyContext.test.tsx --coverage=false`
- `pnpm -F @acme/platform-core lint` *(fails: Unexpected any in cartStore.ts)*
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned in packages/lib/src/seoAudit.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b71d9aa138832f9d1ad4dce29e14c6