### PR TITLE
test(shared-utils): cover HTTP 500 fallback

### DIFF
--- a/packages/shared-utils/src/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/src/__tests__/fetchJson.test.ts
@@ -60,5 +60,16 @@ describe('fetchJson', () => {
       'Internal Server Error',
     );
   });
+
+  it('throws HTTP status code when status text is empty', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: '',
+      text: jest.fn().mockResolvedValue(JSON.stringify({ message: 'oops' })),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('HTTP 500');
+  });
 });
 


### PR DESCRIPTION
## Summary
- test fetchJson for HTTP 500 when status text is empty

## Testing
- `pnpm --filter @acme/shared-utils test packages/shared-utils` *(fails: global coverage threshold for branches (80%) not met: 72.91%)*

------
https://chatgpt.com/codex/tasks/task_e_68b720ddfac0832f8bc6cbb035b3e482