### PR TITLE
fix: ensure platform-core tests use local React

### DIFF
--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -127,6 +127,10 @@
     "react": ">=19 <20",
     "react-dom": ">=19 <20"
   },
+  "devDependencies": {
+    "react": "19.2.0-canary-3fbfb9ba-20250409",
+    "react-dom": "19.2.0-canary-3fbfb9ba-20250409"
+  },
   "dependencies": {
     "@acme/config": "workspace:^",
     "@acme/date-utils": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,15 +728,16 @@ importers:
       next:
         specifier: ^15.3.5
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409)
+      ulid:
+        specifier: ^3.0.1
+        version: 3.0.1
+    devDependencies:
       react:
         specifier: 19.2.0-canary-3fbfb9ba-20250409
         version: 19.2.0-canary-3fbfb9ba-20250409
       react-dom:
         specifier: 19.2.0-canary-3fbfb9ba-20250409
         version: 19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409)
-      ulid:
-        specifier: ^3.0.1
-        version: 3.0.1
 
   packages/platform-machine:
     dependencies:


### PR DESCRIPTION
## Summary
- add `react` and `react-dom` dev deps for `@acme/platform-core`
- install packages to ensure a single React instance during tests

## Testing
- `pnpm exec jest packages/platform-core/src/contexts/__tests__/CartContext.test.tsx packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx --config jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b71d376f4c832fb19efcab27678cbc