### PR TITLE
test: add marketing email template error cases

### DIFF
--- a/packages/email-templates/__tests__/marketingEmailTemplates.error.test.tsx
+++ b/packages/email-templates/__tests__/marketingEmailTemplates.error.test.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { marketingEmailTemplates } from "@acme/email-templates";
+
+describe("marketingEmailTemplates error handling", () => {
+  it("returns empty fragment for invalid props and echoes headline", () => {
+    marketingEmailTemplates.forEach((variant) => {
+      const result = variant.make({ content: <p /> } as any);
+      expect(result.type).toBe(React.Fragment);
+      expect(result.props.children).toBeUndefined();
+
+      const headline = "Sample";
+      expect(variant.buildSubject(headline)).toBe(headline);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for marketing email template variants to ensure invalid props return an empty fragment
- cover `buildSubject` for each variant

## Testing
- `pnpm --filter @acme/email-templates exec jest packages/email-templates/__tests__/marketingEmailTemplates.error.test.tsx --config ../../jest.config.cjs --coverage` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b71a5c9800832f9cd7248e8ac0a3ba