### PR TITLE
fix DataTable test import path

### DIFF
--- a/packages/ui/__tests__/DataTable.test.tsx
+++ b/packages/ui/__tests__/DataTable.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import DataTable, { type Column } from "../components/cms/DataTable";
+import DataTable, { type Column } from "../src/components/cms/DataTable";
 
 interface Row {
   name: string;


### PR DESCRIPTION
## Summary
- fix DataTable test to import component from src path

## Testing
- `pnpm exec jest packages/ui/__tests__/DataTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b7231e9800832f8756a3d7ee691388