### PR TITLE
fix: correct ProductVariantSelector test import

### DIFF
--- a/packages/ui/__tests__/ProductVariantSelector.test.tsx
+++ b/packages/ui/__tests__/ProductVariantSelector.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { ProductVariantSelector } from "../components/organisms/ProductVariantSelector";
+import { ProductVariantSelector } from "../src/components/organisms/ProductVariantSelector";
 
 describe("ProductVariantSelector", () => {
   it("calls change handlers", () => {


### PR DESCRIPTION
## Summary
- fix unit test import for ProductVariantSelector to point to source component

## Testing
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned in packages/lib/src/seoAudit.ts)*
- `pnpm exec jest packages/ui/__tests__/ProductVariantSelector.test.tsx --runInBand --detectOpenHandles`

------
https://chatgpt.com/codex/tasks/task_e_68b722d26dac832fbcc110a964a691e7