### PR TITLE
fix: correct component import paths in UI tests

### DIFF
--- a/packages/ui/__tests__/ARViewer.test.tsx
+++ b/packages/ui/__tests__/ARViewer.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { ARViewer } from "../components/atoms/ARViewer";
+import { ARViewer } from "../src/components/atoms/ARViewer";
 
 const scriptSrc =
   "https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js";

--- a/packages/ui/__tests__/Chip.test.tsx
+++ b/packages/ui/__tests__/Chip.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { Chip } from "../components/atoms/Chip";
-import { Tag } from "../components/atoms/Tag";
+import { Chip } from "../src/components/atoms/Chip";
+import { Tag } from "../src/components/atoms/Tag";
 
 describe("Chip", () => {
   it("calls onRemove when remove button clicked", () => {

--- a/packages/ui/__tests__/DataTable.test.tsx
+++ b/packages/ui/__tests__/DataTable.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import DataTable, { type Column } from "../components/cms/DataTable";
+import DataTable, { type Column } from "../src/components/cms/DataTable";
 
 interface Row {
   name: string;

--- a/packages/ui/__tests__/Image.test.tsx
+++ b/packages/ui/__tests__/Image.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { Image } from "../components/cms/blocks/atoms";
+import { Image } from "../src/components/cms/blocks/atoms";
 
 describe("Image atom", () => {
   it("renders an img element", () => {

--- a/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
+++ b/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
-import ImageUploaderWithOrientationCheck from "../components/cms/ImageUploaderWithOrientationCheck";
+import ImageUploaderWithOrientationCheck from "../src/components/cms/ImageUploaderWithOrientationCheck";
 import { useImageOrientationValidation } from "@ui/hooks/useImageOrientationValidation";
 
 jest.mock("@ui/hooks/useImageOrientationValidation");

--- a/packages/ui/__tests__/MediaSelector.test.tsx
+++ b/packages/ui/__tests__/MediaSelector.test.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import {
   MediaItem,
   MediaSelector,
-} from "../components/molecules/MediaSelector";
+} from "../src/components/molecules/MediaSelector";
 
 describe("MediaSelector", () => {
   const items: MediaItem[] = [

--- a/packages/ui/__tests__/PaginationDot.test.tsx
+++ b/packages/ui/__tests__/PaginationDot.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { PaginationDot } from "../components/atoms/PaginationDot";
+import { PaginationDot } from "../src/components/atoms/PaginationDot";
 
 describe("PaginationDot", () => {
   it("uses muted background by default", () => {

--- a/packages/ui/__tests__/ProductVariantSelector.test.tsx
+++ b/packages/ui/__tests__/ProductVariantSelector.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { ProductVariantSelector } from "../components/organisms/ProductVariantSelector";
+import { ProductVariantSelector } from "../src/components/organisms/ProductVariantSelector";
 
 describe("ProductVariantSelector", () => {
   it("calls change handlers", () => {

--- a/packages/ui/__tests__/TestimonialSlider.test.tsx
+++ b/packages/ui/__tests__/TestimonialSlider.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, act } from "@testing-library/react";
-import TestimonialSlider from "../components/cms/blocks/TestimonialSlider";
+import TestimonialSlider from "../src/components/cms/blocks/TestimonialSlider";
 
 describe("TestimonialSlider", () => {
   beforeEach(() => {

--- a/packages/ui/__tests__/VideoPlayer.test.tsx
+++ b/packages/ui/__tests__/VideoPlayer.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { VideoPlayer } from "../components/atoms/VideoPlayer";
+import { VideoPlayer } from "../src/components/atoms/VideoPlayer";
 
 describe("VideoPlayer", () => {
   it("renders video element with provided class names", () => {

--- a/packages/ui/__tests__/appShell.test.tsx
+++ b/packages/ui/__tests__/appShell.test.tsx
@@ -5,7 +5,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 import { useLayout } from "@platform-core";
-import { AppShell } from "../components/templates/AppShell";
+import { AppShell } from "../src/components/templates/AppShell";
 import { usePathname } from "next/navigation";
 
 function LayoutInfo() {


### PR DESCRIPTION
## Summary
- fix failing VideoPlayer test by importing from src folder
- ensure all UI tests import components from src paths

## Testing
- `pnpm -r build` (failed: Variable 'launch' is used before being assigned)
- `pnpm -F @acme/ui test __tests__/DataTable.test.tsx __tests__/Chip.test.tsx __tests__/ProductVariantSelector.test.tsx __tests__/ImageUploaderWithOrientationCheck.test.tsx __tests__/PaginationDot.test.tsx __tests__/TestimonialSlider.test.tsx __tests__/VideoPlayer.test.tsx __tests__/Image.test.tsx __tests__/appShell.test.tsx __tests__/MediaSelector.test.tsx __tests__/ARViewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b7229c28d4832fb4005924710ad953