### PR TITLE
refactor: unify coverage ignore patterns in jest config

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -201,9 +201,8 @@ const config = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs', 'node', 'd.ts'],
   collectCoverage: true,
   coverageDirectory: ' /coverage',
-  coveragePathIgnorePatterns: [' /test/msw/'],
-  coverageReporters: ['text', 'text-summary', 'lcov'],
   coveragePathIgnorePatterns: [
+    ' /test/msw/',
     '<rootDir>/test/msw/server.ts',
     '<rootDir>/test/mswServer.ts',
     '<rootDir>/test/resetNextMocks.ts',
@@ -213,6 +212,7 @@ const config = {
     '<rootDir>/test/polyfills/',
     '<rootDir>/test/__mocks__/',
   ],
+  coverageReporters: ['text', 'text-summary', 'lcov'],
   coverageThreshold: {
     global: {
       lines: 80,


### PR DESCRIPTION
## Summary
- merge coveragePathIgnorePatterns into a single array in jest config

## Testing
- `pnpm --filter @acme/shared-utils test packages/shared-utils` *(fails: global coverage threshold for branches (80%) not met: 70.83%)*

------
https://chatgpt.com/codex/tasks/task_e_68b720e35b0c832f85a22e99e4af895a