### PR TITLE
chore: enable composite builds for utilities

### DIFF
--- a/packages/date-utils/package.json
+++ b/packages/date-utils/package.json
@@ -14,7 +14,7 @@
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "lint": "eslint ."
   },

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
     "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "lint": "eslint ."
   },

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -14,7 +14,7 @@
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
     "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "lint": "eslint ."
   },


### PR DESCRIPTION
## Summary
- switch date-utils build script to composite mode
- switch shared-utils build script to composite mode
- switch stripe build script to composite mode

## Testing
- `pnpm -r build` (fails: Variable 'launch' is used before being assigned.)

------
https://chatgpt.com/codex/tasks/task_e_68b7243efde0832fa345e47811ac0a61