### PR TITLE
Add React Testing Library coverage for Cart and Currency contexts

### DIFF
--- a/packages/platform-core/__tests__/CartContext.test.tsx
+++ b/packages/platform-core/__tests__/CartContext.test.tsx
@@ -1,4 +1,4 @@
-// packages/platform-core/__tests__/cartContext.test.tsx
+// packages/platform-core/__tests__/CartContext.test.tsx
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CartProvider, useCart } from "../src/contexts/CartContext";
@@ -14,19 +14,11 @@ function TestComponent() {
     <div>
       <span data-testid="qty">{line?.qty ?? 0}</span>
 
-      <button
-        onClick={() => dispatch({ type: "add", sku: PRODUCTS[0], size })}
-      >
+      <button onClick={() => dispatch({ type: "add", sku: PRODUCTS[0], size })}>
         add
       </button>
-      <button onClick={() => dispatch({ type: "remove", id })}>
-        remove
-      </button>
-      <button
-        onClick={() => dispatch({ type: "setQty", id, qty: 0 })}
-      >
-        set
-      </button>
+      <button onClick={() => dispatch({ type: "remove", id })}>remove</button>
+      <button onClick={() => dispatch({ type: "setQty", id, qty: 0 })}>set</button>
     </div>
   );
 }
@@ -78,4 +70,16 @@ describe("CartContext actions", () => {
     fireEvent.click(remove);
     await waitFor(() => expect(qty.textContent).toBe("0"));
   });
+
+  it("throws when used outside provider", () => {
+    function Naked() {
+      useCart();
+      return null;
+    }
+    const orig = console.error;
+    console.error = () => {};
+    expect(() => render(<Naked />)).toThrow("inside CartProvider");
+    console.error = orig;
+  });
 });
+

--- a/packages/platform-core/__tests__/CurrencyContext.test.tsx
+++ b/packages/platform-core/__tests__/CurrencyContext.test.tsx
@@ -1,4 +1,4 @@
-// packages/platform-core/__tests__/currencyContext.test.tsx
+// packages/platform-core/__tests__/CurrencyContext.test.tsx
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { CurrencyProvider, useCurrency } from "../src/contexts/CurrencyContext";
@@ -28,10 +28,10 @@ describe("CurrencyContext", () => {
   });
 
   it("throws when used outside provider", () => {
-    // Suppress expected error output
     const orig = console.error;
     console.error = () => {};
     expect(() => useCurrency()).toThrow("inside CurrencyProvider");
     console.error = orig;
   });
 });
+


### PR DESCRIPTION
## Summary
- test cart context actions and error handling with CartProvider
- verify currency switching and hook usage guard in CurrencyProvider

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @acme/platform-core test` *(fails: Jest encountered an unexpected token in @acme/config)*
- `pnpm exec jest packages/platform-core/__tests__/CartContext.test.tsx packages/platform-core/__tests__/CurrencyContext.test.tsx --config jest.config.cjs --runInBand` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b724cee024832f9a4d091f871d8629