### PR TITLE
test: ensure missing cms vars throw

### DIFF
--- a/packages/config/src/env/__tests__/cms.test.ts
+++ b/packages/config/src/env/__tests__/cms.test.ts
@@ -53,7 +53,7 @@ describe("cms env module", () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.resetModules();
     await expect(import("../cms.ts")).rejects.toThrow(
-      "Invalid CMS environment variables",
+      "Invalid CMS environment variables"
     );
     expect(errorSpy).toHaveBeenCalledWith(
       "❌ Invalid CMS environment variables:",
@@ -61,7 +61,51 @@ describe("cms env module", () => {
         CMS_SPACE_URL: { _errors: [expect.any(String)] },
         CMS_ACCESS_TOKEN: { _errors: [expect.any(String)] },
         SANITY_API_VERSION: { _errors: [expect.any(String)] },
-      }),
+      })
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("throws when CMS_SPACE_URL is missing in production", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2024-01-01",
+    } as NodeJS.ProcessEnv;
+    delete process.env.CMS_SPACE_URL;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../cms.ts")).rejects.toThrow(
+      "Invalid CMS environment variables"
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid CMS environment variables:",
+      expect.objectContaining({
+        CMS_SPACE_URL: { _errors: [expect.any(String)] },
+      })
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("throws when CMS_ACCESS_TOKEN is missing in production", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      CMS_SPACE_URL: "https://cms.example.com",
+      SANITY_API_VERSION: "2024-01-01",
+    } as NodeJS.ProcessEnv;
+    delete process.env.CMS_ACCESS_TOKEN;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../cms.ts")).rejects.toThrow(
+      "Invalid CMS environment variables"
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid CMS environment variables:",
+      expect.objectContaining({
+        CMS_ACCESS_TOKEN: { _errors: [expect.any(String)] },
+      })
     );
     errorSpy.mockRestore();
   });
@@ -77,13 +121,13 @@ describe("cms env module", () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.resetModules();
     await expect(import("../cms.ts")).rejects.toThrow(
-      "Invalid CMS environment variables",
+      "Invalid CMS environment variables"
     );
     expect(errorSpy).toHaveBeenCalledWith(
       "❌ Invalid CMS environment variables:",
       expect.objectContaining({
         SANITY_API_VERSION: { _errors: [expect.any(String)] },
-      }),
+      })
     );
     errorSpy.mockRestore();
   });
@@ -99,7 +143,7 @@ describe("cms env module", () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.resetModules();
     await expect(import("../cms.ts")).rejects.toThrow(
-      "Invalid CMS environment variables",
+      "Invalid CMS environment variables"
     );
     expect(errorSpy).toHaveBeenCalledWith(
       "❌ Invalid CMS environment variables:",
@@ -107,9 +151,8 @@ describe("cms env module", () => {
         CMS_SPACE_URL: { _errors: [expect.any(String)] },
         CMS_ACCESS_TOKEN: { _errors: [expect.any(String)] },
         SANITY_API_VERSION: { _errors: [expect.any(String)] },
-      }),
+      })
     );
     errorSpy.mockRestore();
   });
 });
-


### PR DESCRIPTION
## Summary
- add tests to verify missing CMS_SPACE_URL or CMS_ACCESS_TOKEN in production triggers console error and throws

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`
- `pnpm --filter @acme/config lint` *(fails: require() import and no-explicit-any issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b727ff30f0832fb55a599509e0a06b