### PR TITLE
fix: allow dashboard test project emit

### DIFF
--- a/apps/dashboard/tsconfig.test.json
+++ b/apps/dashboard/tsconfig.test.json
@@ -3,7 +3,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true,
     "allowJs": true,
     "jsx": "react-jsx"
   },


### PR DESCRIPTION
## Summary
- allow dashboard test TypeScript project to emit declarations

## Testing
- `pnpm typecheck` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*
- `pnpm --filter @apps/dashboard test`


------
https://chatgpt.com/codex/tasks/task_e_68b726aae5d0832fa5e187d325ee6036