### PR TITLE
test: add component helper tests

### DIFF
--- a/apps/api/src/routes/components/[shopId].ts
+++ b/apps/api/src/routes/components/[shopId].ts
@@ -165,5 +165,5 @@ export const onRequest = async ({
   });
 };
 
-export { extractSummary, gatherChanges, diffDirectories };
+export { extractSummary, gatherChanges, diffDirectories, listFiles };
 

--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -1,0 +1,43 @@
+jest.mock('fs', () => require('memfs').fs);
+
+import path from 'path';
+import { vol } from 'memfs';
+import { extractSummary, gatherChanges, listFiles } from '../[shopId]';
+
+describe('component helpers', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  describe('extractSummary', () => {
+    it('returns empty string when changelog has only comments', () => {
+      const log = '# heading\n\n  # another comment\n';
+      expect(extractSummary(log)).toBe('');
+    });
+  });
+
+  describe('gatherChanges', () => {
+    const root = '/tmp';
+
+    it('handles malformed shop.json gracefully', () => {
+      vol.fromJSON({ [`${root}/data/shops/abc/shop.json`]: '{"componentVersions"' });
+      expect(gatherChanges('abc', root)).toEqual([]);
+    });
+  });
+
+  describe('listFiles', () => {
+    it('recursively collects nested file paths', () => {
+      vol.fromJSON({
+        '/dir/file1.txt': 'a',
+        '/dir/sub/file2.txt': 'b',
+        '/dir/sub/deeper/file3.txt': 'c',
+      });
+      const files = listFiles('/dir').sort();
+      expect(files).toEqual([
+        'file1.txt',
+        path.join('sub', 'file2.txt'),
+        path.join('sub', 'deeper', 'file3.txt'),
+      ].sort());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export listFiles from components route helper
- test extractSummary with comment-only changelog
- test gatherChanges with malformed shop.json
- test listFiles nested recursion

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @apps/api exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68b727fcc1f0832fae617805cfb993d5