### PR TITLE
test: cover invalid shipping env scenarios

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -115,6 +115,30 @@ describe("shipping env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("loadShippingEnv throws when process.env has invalid variables", async () => {
+    // import with a valid env so the eager parse doesn't throw
+    process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
+    jest.resetModules();
+    const { loadShippingEnv } = await import("../shipping.ts");
+    process.env = {
+      ...ORIGINAL_ENV,
+      UPS_KEY: 123 as unknown as string,
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() => loadShippingEnv()).toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        UPS_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws on invalid configuration during eager parse", async () => {
     process.env = {
       ...ORIGINAL_ENV,
@@ -152,6 +176,27 @@ describe("shipping env module", () => {
       "❌ Invalid shipping environment variables:",
       expect.objectContaining({
         DHL_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("throws on invalid TAXJAR_KEY during eager parse", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      TAXJAR_KEY: 123 as unknown as string,
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../shipping.ts")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        TAXJAR_KEY: { _errors: [expect.any(String)] },
       }),
     );
     errorSpy.mockRestore();


### PR DESCRIPTION
## Summary
- test loadShippingEnv with invalid process.env data
- ensure eager parse fails for invalid TAXJAR_KEY

## Testing
- `pnpm --filter @acme/config test`
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b72802e148832f92f425bf4d085c68