### PR TITLE
test: cover openai import error fs

### DIFF
--- a/packages/lib/__tests__/generateMeta.test.ts
+++ b/packages/lib/__tests__/generateMeta.test.ts
@@ -205,6 +205,7 @@ describe("generateMeta", () => {
   });
 
   it("returns fallback when __OPENAI_IMPORT_ERROR__ is true", async () => {
+    configEnv.OPENAI_API_KEY = "key";
     (globalThis as any).__OPENAI_IMPORT_ERROR__ = true;
     try {
       const result = await generateMeta({
@@ -220,6 +221,8 @@ describe("generateMeta", () => {
       });
       expect(responsesCreateMock).not.toHaveBeenCalled();
       expect(imagesGenerateMock).not.toHaveBeenCalled();
+      expect(mkdirMock).not.toHaveBeenCalled();
+      expect(writeFileMock).not.toHaveBeenCalled();
     } finally {
       delete (globalThis as any).__OPENAI_IMPORT_ERROR__;
     }


### PR DESCRIPTION
## Summary
- assert OpenAI import error path skips filesystem writes

## Testing
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm exec jest packages/lib/__tests__/generateMeta.test.ts --config jest.config.cjs --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_68b72806161c832f810ef67fb1cf97a9