### PR TITLE
test(ui): add Avatar component tests

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/Avatar.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Avatar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { Avatar } from "../Avatar";
+import "../../../../../../test/resetNextMocks";
+
+describe("Avatar", () => {
+  it("renders an image when src is provided", () => {
+    render(<Avatar src="/avatar.jpg" alt="User avatar" />);
+    const img = screen.getByAltText("User avatar");
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "/avatar.jpg");
+  });
+
+  it("renders fallback content when no src is provided", () => {
+    render(<Avatar alt="Jane" fallback="FB" />);
+    expect(screen.getByText("FB")).toBeInTheDocument();
+  });
+
+  it("displays first initial from alt when no fallback is provided", () => {
+    render(<Avatar alt="John Doe" />);
+    expect(screen.getByText("J")).toBeInTheDocument();
+  });
+
+  it("applies size and shape classes", () => {
+    render(
+      <Avatar
+        src="/avatar.jpg"
+        alt="User avatar"
+        size={64}
+        className="rounded-none"
+      />
+    );
+    const img = screen.getByAltText("User avatar");
+    expect(img).toHaveStyle({ width: "64px", height: "64px" });
+    expect(img).toHaveClass("rounded-full");
+    expect(img).toHaveClass("rounded-none");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Avatar component handling image, fallback, initials, and size/shape classes

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: terminated due to time constraints)*
- `pnpm --filter @apps/cms test -- apps/cms`


------
https://chatgpt.com/codex/tasks/task_e_68b72899b17c832f9ed593208b5a2074