### PR TITLE
refactor: fix sidebar nav links

### DIFF
--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -101,34 +101,30 @@ function Sidebar({ role, pathname: pathnameProp }: SidebarProps) {
     }
   }, []);
 
+  const handleClick = () => {
+    console.log("step 1: create shop link clicked");
+  };
+
   return (
     <aside className="w-56 shrink-0 border-r border-muted">
       <h1 className="px-4 py-6 text-lg font-semibold tracking-tight">CMS</h1>
       <nav>
         <ul className="flex flex-col gap-1 px-2">
-          {navItems.map(({ href, label, icon, title, fullHref, active }) => {
-            const handleClick =
-              label === "Create Shop"
-                ? () => {
-                    console.log("step 1: create shop link clicked");
-                  }
-                : undefined;
-            return (
-              <li key={href}>
-                <Link href={fullHref} legacyBehavior>
-                  <a
-                    onClick={handleClick}
-                    aria-current={active ? "page" : undefined}
-                    className={`focus-visible:ring-primary flex items-center gap-2 rounded-md px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none ${active ? "bg-primary/10 font-medium" : "hover:bg-muted"}`}
-                    title={title}
-                  >
-                    <span aria-hidden="true">{icon}</span>
-                    {label}
-                  </a>
-                </Link>
-              </li>
-            );
-          })}
+          {navItems.map(({ label, icon, title, fullHref, active }) => (
+            <li key={fullHref}>
+              <Link href={fullHref} legacyBehavior>
+                <a
+                  aria-current={active ? "page" : undefined}
+                  title={title}
+                  className={`focus-visible:ring-primary flex items-center gap-2 rounded-md px-3 py-2 text-sm focus-visible:ring-2 focus-visible:outline-none ${active ? "bg-primary/10 font-medium" : "hover:bg-muted"}`}
+                  {...(label === "Create Shop" ? { onClick: handleClick } : {})}
+                >
+                  <span>{icon}</span>
+                  {label}
+                </a>
+              </Link>
+            </li>
+          ))}
         </ul>
       </nav>
     </aside>

--- a/packages/ui/src/components/cms/Sidebar.stories.tsx
+++ b/packages/ui/src/components/cms/Sidebar.stories.tsx
@@ -5,9 +5,11 @@ const meta: Meta<typeof Sidebar> = {
   component: Sidebar,
   args: {
     role: "admin",
+    pathname: "/cms",
   },
   argTypes: {
     role: { control: "text" },
+    pathname: { control: "text" },
   },
 };
 export default meta;


### PR DESCRIPTION
## Summary
- render sidebar nav items with proper anchors and aria-current
- only attach create shop click handler when needed
- pass pathname in sidebar story

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm exec jest packages/ui/__tests__/Sidebar.test.tsx --runInBand --detectOpenHandles --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b72890bddc832fa219709e70f9431f