### PR TITLE
test: cover data root resolution edge cases

### DIFF
--- a/packages/platform-core/__tests__/resolveDataRoot.test.ts
+++ b/packages/platform-core/__tests__/resolveDataRoot.test.ts
@@ -8,6 +8,7 @@ describe("resolveDataRoot", () => {
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    delete process.env.DATA_ROOT;
   });
 
   it("walks up directories to find an existing data/shops folder", async () => {
@@ -51,9 +52,20 @@ describe("resolveDataRoot", () => {
     existsMock.mockReturnValue(false);
 
     const { resolveDataRoot } = await import("../src/dataRoot");
+    existsMock.mockClear();
     const dir = resolveDataRoot();
 
+    const calls = existsMock.mock.calls.map(([p]) => p);
+    const expectedCalls: string[] = [];
+    let current = startDir;
+    while (true) {
+      expectedCalls.push(path.join(current, "data", "shops"));
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+
     expect(dir).toBe(expected);
-    expect(existsMock).toHaveBeenCalled();
+    expect(calls).toEqual(expectedCalls);
   });
 });


### PR DESCRIPTION
## Summary
- test env override for resolveDataRoot
- test fallback and traversal to filesystem root when data/shops missing

## Testing
- `pnpm exec jest packages/platform-core/__tests__/resolveDataRoot.test.ts --coverage=false`
- `pnpm -r build` *(fails: src/seoAudit.ts Variable 'launch' is used before being assigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b72806f224832f95ca20699e1e091c