### PR TITLE
test(api): handle unknown route 404

### DIFF
--- a/apps/api/__tests__/request-handler.test.ts
+++ b/apps/api/__tests__/request-handler.test.ts
@@ -1,0 +1,30 @@
+import { Readable } from "stream";
+import type { IncomingMessage, ServerResponse } from "http";
+import { createRequestHandler } from "./test-utils";
+
+describe("createRequestHandler", () => {
+  it("returns 404 for unknown routes", async () => {
+    const handler = createRequestHandler();
+
+    const req = new Readable({
+      read() {
+        this.push(null);
+      },
+    }) as unknown as IncomingMessage;
+    req.url = "/unknown";
+    req.method = "GET";
+    req.headers = {};
+
+    const end = jest.fn();
+    const res = {
+      statusCode: 200,
+      setHeader: jest.fn(),
+      end,
+    } as unknown as ServerResponse;
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(end).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test api request handler returns 404 and ends response for unknown routes

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned, Variable 'lighthouseFn' is used before being assigned)*
- `pnpm --filter @apps/api test` *(fails: global coverage threshold for branches (60%) not met: 35.32%)*

------
https://chatgpt.com/codex/tasks/task_e_68b727fbc024832f827e306e6a91f3fb