### PR TITLE
fix: resolve cms test paths and react setup

### DIFF
--- a/apps/cms/__tests__/api.cart.test.ts
+++ b/apps/cms/__tests__/api.cart.test.ts
@@ -13,7 +13,9 @@ afterEach(() => {
 describe("cart API", () => {
   it("returns empty cart", async () => {
     const { GET } = await import("../src/app/api/cart/route");
-    const res = await GET();
+    const res = await GET({
+      cookies: { get: () => undefined },
+    } as any);
     const json = await res.json();
     expect(json).toEqual({ ok: true, cart: {} });
   });

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -33,6 +33,8 @@
   "devDependencies": {
     "@types/busboy": "^1.5.4",
     "cross-env": "^7.0.3",
-    "next": "15.3.5"
+    "next": "15.3.5",
+    "react": "19.2.0-canary-3fbfb9ba-20250409",
+    "react-dom": "19.2.0-canary-3fbfb9ba-20250409"
   }
 }

--- a/apps/cms/src/actions/__tests__/createShop.server.test.ts
+++ b/apps/cms/src/actions/__tests__/createShop.server.test.ts
@@ -11,7 +11,7 @@ jest.mock("@platform-core/db", () => ({
   },
 }));
 
-jest.mock("../lib/server/rbacStore", () => ({
+jest.mock("../../lib/server/rbacStore", () => ({
   readRbac: jest.fn(),
   writeRbac: jest.fn(),
 }));
@@ -27,7 +27,7 @@ describe("createNewShop", () => {
 
   it("Successful shop creation with RBAC update for new user", async () => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
+    const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
 
     const deployResult = { status: "ok" } as any;
@@ -52,7 +52,7 @@ describe("createNewShop", () => {
     { current: "Viewer", expected: ["Viewer", "ShopAdmin"] },
   ])("Existing role array vs single role %#", async ({ current, expected }) => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
+    const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
 
     (createShop as jest.Mock).mockResolvedValue({});
@@ -71,7 +71,7 @@ describe("createNewShop", () => {
 
   it("Failure writing RBAC → verify rollback deletes created entities and throws", async () => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
+    const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
     const { prisma } = await import("@platform-core/db");
 
@@ -95,7 +95,7 @@ describe("createNewShop", () => {
 
   it("Ensure user without id skips RBAC update", async () => {
     const { createShop } = await import("@platform-core/createShop");
-    const { readRbac, writeRbac } = await import("../lib/server/rbacStore");
+    const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
     const { ensureAuthorized } = await import("./common/auth");
 
     const deployResult = { status: "ok" } as any;

--- a/apps/cms/src/app/api/launch-shop/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/launch-shop/__tests__/route.test.ts
@@ -24,27 +24,27 @@ const deployShop = jest.fn();
 const seedShop = jest.fn();
 const getRequiredSteps = jest.fn();
 
-jest.mock('../../cms/wizard/services/createShop', () => ({
+jest.mock('../../../cms/wizard/services/createShop', () => ({
   __esModule: true,
   createShop: (...args: any[]) => createShop(...args),
 }));
 
-jest.mock('../../cms/wizard/services/initShop', () => ({
+jest.mock('../../../cms/wizard/services/initShop', () => ({
   __esModule: true,
   initShop: (...args: any[]) => initShop(...args),
 }));
 
-jest.mock('../../cms/wizard/services/deployShop', () => ({
+jest.mock('../../../cms/wizard/services/deployShop', () => ({
   __esModule: true,
   deployShop: (...args: any[]) => deployShop(...args),
 }));
 
-jest.mock('../../cms/wizard/services/seedShop', () => ({
+jest.mock('../../../cms/wizard/services/seedShop', () => ({
   __esModule: true,
   seedShop: (...args: any[]) => seedShop(...args),
 }));
 
-jest.mock('../../cms/configurator/steps', () => ({
+jest.mock('../../../cms/configurator/steps', () => ({
   __esModule: true,
   getRequiredSteps: (...args: any[]) => getRequiredSteps(...args),
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,6 +483,12 @@ importers:
       next:
         specifier: 15.3.5
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409)
+      react:
+        specifier: 19.2.0-canary-3fbfb9ba-20250409
+        version: 19.2.0-canary-3fbfb9ba-20250409
+      react-dom:
+        specifier: 19.2.0-canary-3fbfb9ba-20250409
+        version: 19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409)
 
   apps/dashboard: {}
 

--- a/test/setupFetchPolyfill.ts
+++ b/test/setupFetchPolyfill.ts
@@ -2,6 +2,7 @@
 
 import fetch, { Headers, Request, Response } from "cross-fetch";
 import { webcrypto } from "node:crypto";
+import React from "react";
 
 if (!globalThis.fetch) {
   Object.assign(globalThis, { fetch, Headers, Request, Response });
@@ -63,3 +64,32 @@ if (!("getAll" in Headers.prototype)) {
     return value ? [value] : [];
   };
 }
+
+// React 19 renamed some internal fields used by react-dom. Jest loads test
+// modules before `setupFilesAfterEnv`, so ensure both the old and new
+// properties exist on the React instance that `react-dom` will import.
+if (
+  (React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE &&
+  !(React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+) {
+  (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED =
+    (React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+} else if (
+  (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED &&
+  !(React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE
+) {
+  (React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE =
+    (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+}
+
+// The experimental React builds used in this repo may not provide `act`.
+// Testing libraries rely on it, so polyfill a minimal thenable version.
+if (!(React as any).act) {
+  (React as any).act = (callback: () => void | Promise<void>) => {
+    const result = callback();
+    return result && typeof (result as any).then === "function"
+      ? result
+      : Promise.resolve(result);
+  };
+}
+


### PR DESCRIPTION
## Summary
- ensure React 19 internals are patched before tests run
- include React dependencies for CMS app and fix missing request in cart API test
- correct relative paths in CMS unit tests

## Testing
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm test:cms` *(fails: packages/config/src/env/__tests__/core.test.ts: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68b727929830832fa2e7b7e90b57b570