### PR TITLE
test: ensure deselection removes selected components

### DIFF
--- a/apps/dashboard/__tests__/Upgrade.test.tsx
+++ b/apps/dashboard/__tests__/Upgrade.test.tsx
@@ -44,6 +44,12 @@ describe("Upgrade page", () => {
     await user.click(screen.getByLabelText("CompA"));
     expect(screen.getByText("CompA.tsx")).toBeInTheDocument();
 
+    await user.click(screen.getByLabelText("CompA"));
+    expect(screen.queryByText("CompA.tsx")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("CompA"));
+    expect(screen.getByText("CompA.tsx")).toBeInTheDocument();
+
     await user.click(
       screen.getByRole("button", { name: /publish upgrade/i })
     );


### PR DESCRIPTION
## Summary
- extend Upgrade page test to toggle component selection off and on

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @apps/dashboard test -- apps/dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b72b1cbd0c832fab8d6cd6691e7e29