### PR TITLE
test(cms): add delete/unpublish blog post service tests

### DIFF
--- a/apps/cms/__tests__/services/blog/delete.test.ts
+++ b/apps/cms/__tests__/services/blog/delete.test.ts
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import { deletePost } from '../../../src/services/blog/posts/delete';
+
+jest.mock('../../../src/actions/common/auth', () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+jest.mock('../../../src/services/blog/config', () => ({
+  getConfig: jest.fn().mockResolvedValue({}),
+}));
+
+const repoDeletePost = jest.fn();
+
+jest.mock('@platform-core/repositories/blog.server', () => ({
+  deletePost: (...args: unknown[]) => repoDeletePost(...args),
+}));
+
+describe('deletePost', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves without error when repository succeeds', async () => {
+    repoDeletePost.mockResolvedValue(undefined);
+    const result = await deletePost('shop', '123');
+    expect(result).toEqual({ message: 'Post deleted' });
+    expect(repoDeletePost).toHaveBeenCalledWith({}, '123');
+  });
+
+  it('returns error when repository throws', async () => {
+    repoDeletePost.mockRejectedValue(new Error('fail'));
+    const result = await deletePost('shop', '123');
+    expect(result).toEqual({ error: 'Failed to delete post' });
+  });
+});
+

--- a/apps/cms/__tests__/services/blog/unpublish.test.ts
+++ b/apps/cms/__tests__/services/blog/unpublish.test.ts
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import { unpublishPost } from '../../../src/services/blog/posts/unpublish';
+
+jest.mock('../../../src/actions/common/auth', () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+jest.mock('../../../src/services/blog/config', () => ({
+  getConfig: jest.fn().mockResolvedValue({}),
+}));
+
+const repoUnpublishPost = jest.fn();
+
+jest.mock('@platform-core/repositories/blog.server', () => ({
+  unpublishPost: (...args: unknown[]) => repoUnpublishPost(...args),
+}));
+
+describe('unpublishPost', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves without error when repository succeeds', async () => {
+    repoUnpublishPost.mockResolvedValue(undefined);
+    const result = await unpublishPost('shop', '123');
+    expect(result).toEqual({ message: 'Post unpublished' });
+    expect(repoUnpublishPost).toHaveBeenCalledWith({}, '123');
+  });
+
+  it('returns error when repository throws', async () => {
+    repoUnpublishPost.mockRejectedValue(new Error('fail'));
+    const result = await unpublishPost('shop', '123');
+    expect(result).toEqual({ error: 'Failed to unpublish post' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for deleting and unpublishing blog posts
- cover success and repository failure paths

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @apps/cms test -- apps/cms` *(fails: test suite failures)*
- `pnpm --filter @apps/cms test apps/cms/__tests__/services/blog/delete.test.ts apps/cms/__tests__/services/blog/unpublish.test.ts` *(fails: global coverage threshold not met)*


------
https://chatgpt.com/codex/tasks/task_e_68b728a30224832fb7343be7e4eeb013