### PR TITLE
test: expand json error coverage

### DIFF
--- a/packages/shared-utils/src/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/src/__tests__/fetchJson.test.ts
@@ -33,6 +33,35 @@ describe('fetchJson', () => {
     await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
   });
 
+  it('returns undefined for empty response bodies', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(''),
+    });
+
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+
+  it('propagates network failures', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network down'));
+    await expect(fetchJson('https://example.com')).rejects.toThrow(
+      'Network down',
+    );
+  });
+
+  it('throws status text when error response contains invalid JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: jest.fn().mockResolvedValue('{invalid'),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow(
+      'Bad Gateway',
+    );
+  });
+
   it('throws error message from JSON error payload', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: false,

--- a/packages/shared-utils/src/__tests__/parseJsonBody.test.ts
+++ b/packages/shared-utils/src/__tests__/parseJsonBody.test.ts
@@ -54,6 +54,14 @@ describe('parseJsonBody', () => {
     await expect(result.response.json()).resolves.toEqual({ error: 'Invalid JSON' });
   });
 
+  it('returns 400 for empty body', async () => {
+    const req = { text: jest.fn().mockResolvedValue('') } as unknown as Request;
+    const result = await parseJsonBody(req, schema, 1024);
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+    await expect(result.response.json()).resolves.toEqual({ error: 'Invalid JSON' });
+  });
+
   it('returns 400 when no body parser is available', async () => {
     const req = {} as Request;
     const result = await parseJsonBody(req, schema, 1024);


### PR DESCRIPTION
## Summary
- add fetchJson tests for network failures, invalid JSON, and empty responses
- cover empty body handling in parseJsonBody

## Testing
- `pnpm --filter @acme/shared-utils test packages/shared-utils/src/__tests__/fetchJson.test.ts packages/shared-utils/src/__tests__/parseJsonBody.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b7282986e8832fb9ac54e1b076d942