### PR TITLE
test(shared-utils): add unit tests

### DIFF
--- a/packages/shared-utils/src/buildResponse.test.ts
+++ b/packages/shared-utils/src/buildResponse.test.ts
@@ -1,0 +1,28 @@
+import { buildResponse, type ProxyResponse } from './buildResponse';
+
+describe('buildResponse', () => {
+  it('creates a Response with decoded body, status and headers', async () => {
+    const proxy: ProxyResponse = {
+      response: {
+        status: 201,
+        headers: { 'x-test': '1', 'content-type': 'text/plain' },
+        body: Buffer.from('hello world').toString('base64'),
+      },
+    };
+    const res = buildResponse(proxy);
+    expect(res.status).toBe(201);
+    expect(res.headers.get('x-test')).toBe('1');
+    await expect(res.text()).resolves.toBe('hello world');
+  });
+
+  it('handles empty body and default headers', async () => {
+    const proxy: ProxyResponse = {
+      response: { status: 204, headers: {} },
+    };
+    const res = buildResponse(proxy);
+    expect(res.status).toBe(204);
+    expect([...res.headers.entries()]).toEqual([]);
+    await expect(res.text()).resolves.toBe('');
+  });
+});
+

--- a/packages/shared-utils/src/fetchJson.test.ts
+++ b/packages/shared-utils/src/fetchJson.test.ts
@@ -1,0 +1,43 @@
+import { fetchJson } from './fetchJson';
+import { z } from 'zod';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    // @ts-expect-error - jest mock
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('parses JSON when request succeeds', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(JSON.stringify({ msg: 'hi' })),
+    });
+    const schema = z.object({ msg: z.string() });
+    await expect(
+      fetchJson('https://example.com', undefined, schema),
+    ).resolves.toEqual({ msg: 'hi' });
+  });
+
+  it('throws with error message on HTTP failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: jest.fn().mockResolvedValue(JSON.stringify({ error: 'boom' })),
+    });
+    await expect(fetchJson('https://example.com')).rejects.toThrow('boom');
+  });
+
+  it('returns undefined when response is not JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('not-json'),
+    });
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+});
+

--- a/packages/shared-utils/src/genSecret.test.ts
+++ b/packages/shared-utils/src/genSecret.test.ts
@@ -1,0 +1,21 @@
+import { genSecret } from './genSecret';
+
+describe('genSecret', () => {
+  const original = globalThis.crypto;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'crypto', { value: original });
+  });
+
+  it('returns deterministic hex string for mocked bytes', () => {
+    const mock = {
+      getRandomValues: (arr: Uint8Array) => {
+        arr.set([0xde, 0xad, 0xbe, 0xef]);
+        return arr;
+      },
+    } as Crypto;
+    Object.defineProperty(globalThis, 'crypto', { value: mock });
+    expect(genSecret(4)).toBe('deadbeef');
+  });
+});
+

--- a/packages/shared-utils/src/getCsrfToken.node.test.ts
+++ b/packages/shared-utils/src/getCsrfToken.node.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+import { getCsrfToken } from './getCsrfToken';
+
+describe('getCsrfToken on server', () => {
+  it('returns undefined when document is not available', () => {
+    expect(getCsrfToken()).toBeUndefined();
+  });
+});
+

--- a/packages/shared-utils/src/slugify.test.ts
+++ b/packages/shared-utils/src/slugify.test.ts
@@ -1,0 +1,12 @@
+import slugify from './slugify';
+
+describe('slugify', () => {
+  it('creates slugs from plain text', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('handles accents and punctuation', () => {
+    expect(slugify('Crème_brûlée!')).toBe('creme-brulee');
+  });
+});
+

--- a/packages/shared-utils/src/toggleItem.test.ts
+++ b/packages/shared-utils/src/toggleItem.test.ts
@@ -1,0 +1,12 @@
+import { toggleItem } from './toggleItem';
+
+describe('toggleItem', () => {
+  it('adds item when missing', () => {
+    expect(toggleItem([1, 2], 3)).toEqual([1, 2, 3]);
+  });
+
+  it('removes item when present', () => {
+    expect(toggleItem([1, 2, 3], 2)).toEqual([1, 3]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add fetchJson tests covering success, HTTP error and invalid JSON
- verify buildResponse decodes body and respects defaults
- extend coverage for genSecret, getCsrfToken, toggleItem and slugify utilities

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm --filter @acme/shared-utils test` *(fails: Cannot find module '../utils/args' from 'test/unit/init-shop/env.spec.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b71ff81868832fbe93e6f7919c0a47