### PR TITLE
test: add middleware security header test

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+
+describe("middleware security headers", () => {
+  it("adds expected security headers", () => {
+    const mockRequest = {} as NextRequest;
+    const response = middleware(mockRequest);
+
+    const expectedHeaders = [
+      "Content-Security-Policy",
+      "Cross-Origin-Embedder-Policy",
+      "Cross-Origin-Opener-Policy",
+      "Permissions-Policy",
+      "Strict-Transport-Security",
+      "X-Frame-Options",
+      "Referrer-Policy",
+      "X-Content-Type-Options",
+      "X-Download-Options",
+    ];
+
+    for (const header of expectedHeaders) {
+      expect(response.headers.get(header)).not.toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add tests verifying middleware adds expected security headers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm exec jest __tests__/middleware.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b72be36e30832fa32b2d05e0710bdd