### PR TITLE
chore(api): exclude tests from typechecking

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -19,5 +19,12 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/__mocks__/**",
+    "**/__tests__/**",
+    "**/*.spec.*",
+    "**/*.test.*"
+  ]
 }


### PR DESCRIPTION
## Summary
- avoid type checking for test files in API app

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/ui build: src/components/cms/ProductEditorForm.tsx(8,15): error TS2614: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants'. Did you mean to use 'import ProductWithVariants from "../../hooks/useProductEditorFormState"' instead?)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f19f334832fb331bdfa392f210d