### PR TITLE
fix email template error handling

### DIFF
--- a/packages/email-templates/src/MarketingEmailTemplate.tsx
+++ b/packages/email-templates/src/MarketingEmailTemplate.tsx
@@ -23,7 +23,10 @@ export function MarketingEmailTemplate({
   ...props
 }: MarketingEmailTemplateProps) {
   if (!headline || content == null) {
-    return <></>;
+    throw new Error("headline and content are required");
+  }
+  if ((ctaLabel && !ctaHref) || (!ctaLabel && ctaHref)) {
+    throw new Error("ctaLabel and ctaHref must both be provided");
   }
 
   const showCta = Boolean(ctaLabel && ctaHref);

--- a/packages/email-templates/src/marketingEmailTemplates.tsx
+++ b/packages/email-templates/src/marketingEmailTemplates.tsx
@@ -13,14 +13,24 @@ export const marketingEmailTemplates: MarketingEmailTemplateVariant[] = [
     id: "basic",
     label: "Basic",
     buildSubject: (headline) => headline,
-    make: (props) => <MarketingEmailTemplate {...(props ?? {})} />,
+    make: (props) => {
+      if (!props || !props.headline || props.content == null) {
+        return <></>;
+      }
+      return <MarketingEmailTemplate {...(props ?? {})} />;
+    },
   },
   {
     id: "centered",
     label: "Centered",
     buildSubject: (headline) => headline,
-    make: (props) => (
-      <MarketingEmailTemplate {...(props ?? {})} className="text-center" />
-    ),
+    make: (props) => {
+      if (!props || !props.headline || props.content == null) {
+        return <></>;
+      }
+      return (
+        <MarketingEmailTemplate {...(props ?? {})} className="text-center" />
+      );
+    },
   },
 ];


### PR DESCRIPTION
## Summary
- guard marketing email variants against missing data so invalid input returns an empty fragment
- enforce required props in MarketingEmailTemplate by throwing for missing headline/content and mismatched CTA props

## Testing
- `pnpm --filter @acme/email-templates build`
- `pnpm --filter @acme/email-templates test -- --testPathPattern packages/email-templates`
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants')*


------
https://chatgpt.com/codex/tasks/task_e_68b7324c84a0832fbda9a681cc415116