### PR TITLE
fix: enable synthetic default imports

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
       ""
     ],
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- allow synthetic default imports so libraries like @dnd-kit can use default React import under bundler resolution

## Testing
- `pnpm -r build` *(fails: packages/ui has existing TypeScript errors)*
- `pnpm run typecheck` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b730e2c434832fbe6ad71b9763cc38