### PR TITLE
test: add tests for scripts

### DIFF
--- a/scripts/__tests__/build-tokens.test.ts
+++ b/scripts/__tests__/build-tokens.test.ts
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+import {
+  generateStaticCss,
+  generateDynamicCss,
+  generateThemeCss,
+} from "../../dist-scripts/build-tokens.js";
+
+describe("build-tokens", () => {
+  it("generates static css with dark variants", () => {
+    const css = generateStaticCss({
+      "--color": { light: "white", dark: "black" },
+      "--bg": { light: "green" },
+    });
+    expect(css).toContain(":root {");
+    expect(css).toContain("--color: white;");
+    expect(css).toContain("--color-dark: black;");
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("html.theme-dark");
+  });
+
+  it("generates dynamic css using variables", () => {
+    const css = generateDynamicCss({
+      "--color": { light: "white", dark: "black" },
+    });
+    expect(css).toContain("--color: var(--token-color, white);");
+    expect(css).toContain("--color-dark: var(--token-color-dark, black);");
+  });
+
+  it("generates theme css only when base token present", () => {
+    const css = generateThemeCss({
+      "--color": "white",
+      "--color-dark": "black",
+      "--orphan-dark": "red",
+    });
+    expect(css).toContain("--color: white;");
+    expect(css).toContain("--color-dark: black;");
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("html.theme-dark");
+    expect(css).not.toContain("--orphan-dark");
+  });
+});

--- a/scripts/__tests__/diff-shadcn.test.ts
+++ b/scripts/__tests__/diff-shadcn.test.ts
@@ -1,0 +1,48 @@
+/** @jest-environment node */
+
+const spawnMock = jest.fn();
+const existsMock = jest.fn();
+
+jest.mock("node:child_process", () => ({
+  spawnSync: (...args: unknown[]) => spawnMock(...args),
+}));
+jest.mock("node:fs", () => ({
+  existsSync: (...args: unknown[]) => existsMock(...args),
+}));
+
+describe("diff-shadcn script", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    spawnMock.mockReset();
+    existsMock.mockReset();
+  });
+
+  it("spawns diff for existing upstream component", async () => {
+    existsMock.mockImplementation((p: unknown) =>
+      typeof p === "string" && p.includes("button.tsx")
+    );
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await import("../diff-shadcn.ts");
+    expect(spawnMock).toHaveBeenCalledWith(
+      "diff",
+      expect.arrayContaining([
+        "-u",
+        expect.stringContaining("button.tsx"),
+        expect.stringContaining("button.tsx"),
+      ]),
+      { stdio: "inherit" }
+    );
+    logSpy.mockRestore();
+  });
+
+  it("logs error when upstream component missing", async () => {
+    existsMock.mockReturnValue(false);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await import("../diff-shadcn.ts");
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Missing upstream component")
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/scripts/__tests__/generate-meta.test.ts
+++ b/scripts/__tests__/generate-meta.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+
+const readFileMock = jest.fn();
+const generateMetaMock = jest.fn();
+
+jest.mock("node:fs", () => ({
+  promises: { readFile: (...args: unknown[]) => readFileMock(...args) },
+}));
+jest.mock("@acme/lib/generateMeta", () => ({
+  generateMeta: (...args: unknown[]) => generateMetaMock(...args),
+}));
+
+describe("generate-meta script", () => {
+  const originalArgv = process.argv.slice();
+
+  beforeEach(() => {
+    jest.resetModules();
+    readFileMock.mockReset();
+    generateMetaMock.mockReset();
+    process.argv = originalArgv.slice();
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+  });
+
+  it("outputs meta for provided product file", async () => {
+    const scriptPath = require("path").resolve(__dirname, "..", "generate-meta.ts");
+    process.argv[1] = scriptPath;
+    process.argv[2] = "product.json";
+    const result = { title: "Test" };
+    readFileMock.mockResolvedValue("{\"name\":\"test\"}");
+    generateMetaMock.mockResolvedValue(result);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await import("../generate-meta.ts");
+    expect(readFileMock).toHaveBeenCalledWith("product.json", "utf8");
+    expect(generateMetaMock).toHaveBeenCalledWith({ name: "test" });
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(result, null, 2));
+    logSpy.mockRestore();
+  });
+
+  it("exits when input path missing", async () => {
+    const scriptPath = require("path").resolve(__dirname, "..", "generate-meta.ts");
+    process.argv[1] = scriptPath;
+    delete process.argv[2];
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+    readFileMock.mockResolvedValue("{}");
+    generateMetaMock.mockResolvedValue({});
+    await import("../generate-meta.ts");
+    expect(errorSpy).toHaveBeenCalledWith("Usage: generate-meta.ts ");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/scripts/__tests__/migrate-cms.test.ts
+++ b/scripts/__tests__/migrate-cms.test.ts
@@ -1,0 +1,78 @@
+/** @jest-environment node */
+
+const readFileMock = jest.fn();
+const fetchMock = jest.fn();
+
+jest.mock("node:fs/promises", () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args),
+}));
+jest.mock("cross-fetch", () => (
+  (...args: unknown[]) => fetchMock(...args)
+));
+
+describe("migrate-cms script", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    readFileMock.mockReset();
+    fetchMock.mockReset();
+    process.env = {
+      ...originalEnv,
+      CMS_SPACE_URL: "https://cms.example",
+      CMS_ACCESS_TOKEN: "token",
+    } as NodeJS.ProcessEnv;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("pushes page and shop schemas", async () => {
+    readFileMock.mockResolvedValueOnce("{}" ).mockResolvedValueOnce("{}" );
+    fetchMock.mockResolvedValue({ ok: true });
+    await import("../migrate-cms.ts");
+    await new Promise(setImmediate);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cms.example/schemas/page",
+      expect.objectContaining({ method: "PUT" })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cms.example/schemas/shop",
+      expect.objectContaining({ method: "PUT" })
+    );
+  });
+
+  it("logs error when fetch fails", async () => {
+    readFileMock.mockResolvedValue("{}" );
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => "bad" })
+      .mockResolvedValue({ ok: true });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await import("../migrate-cms.ts");
+    await new Promise(setImmediate);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to push page:"),
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("exits on invalid environment", async () => {
+    process.env = {}; // missing required vars
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit ${code}`);
+      }) as any);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../migrate-cms.ts")).rejects.toThrow("exit 1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Invalid environment variables:\n",
+      expect.anything()
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/scripts/__tests__/seo-audit.test.ts
+++ b/scripts/__tests__/seo-audit.test.ts
@@ -1,0 +1,53 @@
+/** @jest-environment node */
+
+const runSeoAuditMock = jest.fn();
+
+jest.mock("@acme/lib/seoAudit", () => ({
+  runSeoAudit: (...args: unknown[]) => runSeoAuditMock(...args),
+}));
+
+describe("seo-audit script", () => {
+  const originalArgv = process.argv.slice();
+
+  beforeEach(() => {
+    jest.resetModules();
+    runSeoAuditMock.mockReset();
+    process.argv = originalArgv.slice();
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+  });
+
+  it("runs audit for provided url", async () => {
+    const scriptPath = require("path").resolve(__dirname, "..", "seo-audit.ts");
+    process.argv[1] = scriptPath;
+    process.argv[2] = "https://example.com";
+    const result = { ok: true };
+    runSeoAuditMock.mockResolvedValue(result);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await import("../seo-audit.ts");
+    await Promise.resolve();
+    expect(runSeoAuditMock).toHaveBeenCalledWith("https://example.com");
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(result));
+    logSpy.mockRestore();
+  });
+
+  it("exits on audit error", async () => {
+    const scriptPath = require("path").resolve(__dirname, "..", "seo-audit.ts");
+    process.argv[1] = scriptPath;
+    runSeoAuditMock.mockRejectedValue(new Error("fail"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit ${code}`);
+      }) as any);
+    await expect(import("../seo-audit.ts")).rejects.toThrow("exit 1");
+    await Promise.resolve();
+    expect(errorSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for token builder, shadcn diff, CMS migration, meta generation, and SEO audit scripts

## Testing
- `pnpm -r build` *(fails: Variable 'launch' is used before being assigned)*
- `pnpm exec jest --runInBand scripts/__tests__/build-tokens.test.ts scripts/__tests__/diff-shadcn.test.ts scripts/__tests__/migrate-cms.test.ts scripts/__tests__/generate-meta.test.ts scripts/__tests__/seo-audit.test.ts` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b72be83c54832fba25ed358fceb81e