### PR TITLE
feat(email-templates): validate required props

### DIFF
--- a/packages/email-templates/__tests__/marketingEmailTemplates.error.test.tsx
+++ b/packages/email-templates/__tests__/marketingEmailTemplates.error.test.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
+import { render } from "@testing-library/react";
 import { marketingEmailTemplates } from "@acme/email-templates";
 
 describe("marketingEmailTemplates error handling", () => {
-  it("returns empty fragment for invalid props and echoes headline", () => {
+  it("throws for invalid props and echoes headline", () => {
     marketingEmailTemplates.forEach((variant) => {
-      const result = variant.make({ content: <p /> } as any);
-      expect(result.type).toBe(React.Fragment);
-      expect(result.props.children).toBeUndefined();
+      expect(() =>
+        render(variant.make({ content: <p /> } as any)),
+      ).toThrow("headline and content are required");
 
       const headline = "Sample";
       expect(variant.buildSubject(headline)).toBe(headline);

--- a/packages/email-templates/src/MarketingEmailTemplate.js
+++ b/packages/email-templates/src/MarketingEmailTemplate.js
@@ -1,4 +1,61 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 export function MarketingEmailTemplate({ logoSrc, headline, content, ctaLabel, ctaHref, footer, className, ...props }) {
-    return (_jsxs("div", { className: `mx-auto w-full max-w-xl overflow-hidden rounded-md border text-sm${className ? ` ${className}` : ""}`, ...props, children: [logoSrc && (_jsx("div", { className: "bg-muted p-6 text-center", "data-token": "--color-muted", children: _jsx("img", { src: logoSrc, alt: "logo", width: 40, height: 40, style: { margin: "0 auto", height: "40px", width: "auto" } }) })), _jsxs("div", { className: "space-y-4 p-6", children: [_jsx("h1", { className: "text-xl font-bold", children: headline }), _jsx("div", { className: "leading-6", children: content }), ctaLabel && ctaHref && (_jsx("div", { className: "text-center", children: _jsx("a", { href: ctaHref, className: "bg-primary inline-block rounded-md px-4 py-2 font-medium", "data-token": "--color-primary", children: _jsx("span", { className: "text-primary-foreground", "data-token": "--color-primary-fg", children: ctaLabel }) }) }))] }), footer && (_jsx("div", { className: "bg-muted border-t p-4 text-center text-xs text-muted", "data-token": "--color-muted", children: footer }))] }));
+  if (!headline || content == null) {
+    throw new Error("headline and content are required");
+  }
+  const hasCtaLabel = Boolean(ctaLabel);
+  const hasCtaHref = Boolean(ctaHref);
+  if (hasCtaLabel !== hasCtaHref) {
+    throw new Error("ctaLabel and ctaHref must both be provided");
+  }
+  const showCta = hasCtaLabel && hasCtaHref;
+  return (
+    _jsxs("div", {
+      className: `mx-auto w-full max-w-xl overflow-hidden rounded-md border text-sm${className ? ` ${className}` : ""}`,
+      ...props,
+      children: [
+        logoSrc &&
+          _jsx("div", {
+            className: "bg-muted p-6 text-center",
+            "data-token": "--color-muted",
+            children: _jsx("img", {
+              src: logoSrc,
+              alt: "logo",
+              width: 40,
+              height: 40,
+              style: { margin: "0 auto", height: "40px", width: "auto" },
+            }),
+          }),
+        _jsxs("div", {
+          className: "space-y-4 p-6",
+          children: [
+            _jsx("h1", { className: "text-xl font-bold", children: headline }),
+            _jsx("div", { className: "leading-6", children: content }),
+            showCta &&
+              _jsx("div", {
+                className: "text-center",
+                children: _jsx("a", {
+                  href: ctaHref,
+                  className:
+                    "bg-primary inline-block rounded-md px-4 py-2 font-medium",
+                  "data-token": "--color-primary",
+                  children: _jsx("span", {
+                    className: "text-primary-foreground",
+                    "data-token": "--color-primary-fg",
+                    children: ctaLabel,
+                  }),
+                }),
+              }),
+          ],
+        }),
+        footer &&
+          _jsx("div", {
+            className:
+              "bg-muted border-t p-4 text-center text-xs text-muted",
+            "data-token": "--color-muted",
+            children: footer,
+          }),
+      ],
+    })
+  );
 }

--- a/packages/email-templates/src/MarketingEmailTemplate.tsx
+++ b/packages/email-templates/src/MarketingEmailTemplate.tsx
@@ -23,10 +23,17 @@ export function MarketingEmailTemplate({
   ...props
 }: MarketingEmailTemplateProps) {
   if (!headline || content == null) {
-    return <></>;
+    throw new Error("headline and content are required");
   }
 
-  const showCta = Boolean(ctaLabel && ctaHref);
+  const hasCtaLabel = Boolean(ctaLabel);
+  const hasCtaHref = Boolean(ctaHref);
+
+  if (hasCtaLabel !== hasCtaHref) {
+    throw new Error("ctaLabel and ctaHref must both be provided");
+  }
+
+  const showCta = hasCtaLabel && hasCtaHref;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- enforce required headline/content and paired CTA props in marketing email template
- update template error handling test to assert thrown errors

## Testing
- `pnpm --filter @acme/email-templates test -- --runTestsByPath packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx packages/email-templates/__tests__/marketingEmailTemplates.test.tsx packages/email-templates/__tests__/marketingEmailTemplates.error.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7323c891c832f996f5ad36132d84c