### PR TITLE
fix: allow tests outside src

### DIFF
--- a/apps/api/tsconfig.test.json
+++ b/apps/api/tsconfig.test.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "types": ["jest", "node"],
     "noEmit": true,
-    "allowJs": true
+    "allowJs": true,
+    "rootDir": "."
   },
   "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/auth/tsconfig.test.json
+++ b/packages/auth/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/config/tsconfig.test.json
+++ b/packages/config/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/configurator/tsconfig.test.json
+++ b/packages/configurator/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/date-utils/tsconfig.test.json
+++ b/packages/date-utils/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["src/**/*", "__tests__/**/*"],
   "exclude": ["dist", ".turbo", "node_modules"]

--- a/packages/email-templates/tsconfig.test.json
+++ b/packages/email-templates/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["src/**/*", "__tests__/**/*"],
   "exclude": ["dist", ".turbo", "node_modules"]

--- a/packages/i18n/tsconfig.test.json
+++ b/packages/i18n/tsconfig.test.json
@@ -6,7 +6,8 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "types": ["@testing-library/jest-dom", "jest", "node", "react"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/platform-core/tsconfig.test.json
+++ b/packages/platform-core/tsconfig.test.json
@@ -6,7 +6,8 @@
     /* test environment types */
     "types": ["@testing-library/jest-dom", "jest", "node"],
     /* no JS output for tests */
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
 
   "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*"]

--- a/packages/shared-utils/tsconfig.test.json
+++ b/packages/shared-utils/tsconfig.test.json
@@ -3,7 +3,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": []


### PR DESCRIPTION
## Summary
- allow tests outside src for multiple packages by setting `rootDir` to project root in `tsconfig.test.json`
- restore inadvertently modified binaries in node_modules

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants')*
- `pnpm --filter @acme/email-templates test` *(fails: Jest encountered an unexpected token)*
- `pnpm --filter @apps/api test` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b730964bd0832f9d408dae18c91848