### PR TITLE
test(config): add env index tests

### DIFF
--- a/packages/config/src/env/__tests__/index.test.ts
+++ b/packages/config/src/env/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { z } from "zod";
+
+describe("env index module", () => {
+  const ORIGINAL_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("throws and logs on invalid env", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "test",
+      CART_COOKIE_SECRET: "",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("../index.ts")).rejects.toThrow(
+      "Invalid environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid environment variables:",
+      expect.objectContaining({
+        CART_COOKIE_SECRET: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("mergeEnvSchemas combines shapes", async () => {
+    const { mergeEnvSchemas } = await import("../index.ts");
+    const schemaA = z.object({ FOO: z.string() });
+    const schemaB = z.object({ BAR: z.number() });
+    const merged = mergeEnvSchemas(schemaA, schemaB);
+    expect(merged.shape).toHaveProperty("FOO");
+    expect(merged.shape).toHaveProperty("BAR");
+    expect(merged.safeParse({ FOO: "hello", BAR: 1 }).success).toBe(true);
+    expect(merged.safeParse({ FOO: "hello" }).success).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover env/index.ts error handling when env vars are invalid
- verify mergeEnvSchemas merges multiple schema shapes

## Testing
- `pnpm --filter @acme/config test`
- `pnpm install`
- `pnpm -r build` *(fails: Output file '/workspace/base-shop/packages/platform-core/dist/dataRoot.d.ts' has not been built from source file '/workspace/base-shop/packages/platform-core/src/dataRoot.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68b7341efb18832fb607e22c9e2bf61f