### PR TITLE
test: validate production auth secrets

### DIFF
--- a/packages/config/src/env/__tests__/auth.test.ts
+++ b/packages/config/src/env/__tests__/auth.test.ts
@@ -62,6 +62,28 @@ describe("auth env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("throws when required secrets are empty", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      NEXTAUTH_SECRET: "",
+      SESSION_SECRET: "",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../auth.ts")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        NEXTAUTH_SECRET: { _errors: [expect.any(String)] },
+        SESSION_SECRET: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws when SESSION_STORE is invalid", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- test invalid auth environment secrets are rejected in production

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants')*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b7342ddf30832fb65b354135181ef6