### PR TITLE
test: expand configurator CLI coverage

### DIFF
--- a/packages/configurator/__tests__/bin.test.ts
+++ b/packages/configurator/__tests__/bin.test.ts
@@ -36,11 +36,87 @@ describe("configurator bin", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it("errors when required env vars are missing", async () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+    delete process.env.CART_COOKIE_SECRET;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await import("../bin/configurator.cjs");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Missing required environment variables: STRIPE_SECRET_KEY, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, CART_COOKIE_SECRET",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+  });
+
+  it("propagates spawnSync exit code", async () => {
+    spawnSyncMock.mockReturnValue({ status: 2 });
+
+    await import("../bin/configurator.cjs");
+
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it("runs build", async () => {
+    process.argv = ["node", "configurator", "build"];
+
+    await import("../bin/configurator.cjs");
+
+    expect(spawnSyncMock).toHaveBeenCalledWith("vite", ["build"], {
+      stdio: "inherit",
+      shell: true,
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs deploy", async () => {
+    process.argv = ["node", "configurator", "deploy"];
+
+    await import("../bin/configurator.cjs");
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "wrangler",
+      ["pages", "deploy", ".vercel/output/static"],
+      {
+        stdio: "inherit",
+        shell: true,
+      },
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits with usage for unsupported command", async () => {
+    process.argv = ["node", "configurator", "wat"];
+    const logSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation(() => {});
+
+    await import("../bin/configurator.cjs");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "Usage: pnpm configurator <dev|build|deploy>",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
   it("exits cleanly when dist index resolves", async () => {
     jest.mock("../dist/index.js", () => ({}), { virtual: true });
     const errorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
+
+    // Ensure env vars are set for this test
+    process.env.STRIPE_SECRET_KEY = "sk";
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk";
+    process.env.CART_COOKIE_SECRET = "secret";
 
     await import("../bin/configurator.cjs");
 


### PR DESCRIPTION
## Summary
- add tests for missing env vars and spawn exit codes in configurator CLI
- cover build, deploy, and unsupported commands

## Testing
- `pnpm --filter @acme/configurator test`
- `pnpm install`
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants')*

------
https://chatgpt.com/codex/tasks/task_e_68b73425c3dc832f86ad89001bf4a558