### PR TITLE
test(config): warn on invalid stripe key types

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -65,6 +65,35 @@ describe("payments env defaults", () => {
     },
   );
 
+  it("warns with formatted errors when variables have invalid types", () => {
+    process.env = {
+      STRIPE_SECRET_KEY: 123 as unknown as string,
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 456 as unknown as string,
+      STRIPE_WEBHOOK_SECRET: 789 as unknown as string,
+    } as unknown as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "⚠️ Invalid payments environment variables:",
+      {
+        _errors: [],
+        STRIPE_SECRET_KEY: { _errors: ["Expected string, received number"] },
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: {
+          _errors: ["Expected string, received number"],
+        },
+        STRIPE_WEBHOOK_SECRET: {
+          _errors: ["Expected string, received number"],
+        },
+      },
+    );
+  });
+
   it(
     "warns and falls back to defaults when STRIPE_SECRET_KEY is empty",
     async () => {


### PR DESCRIPTION
## Summary
- add test verifying payments env handles invalid stripe key types

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @acme/ui build errors)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b734240ac8832fb78ba794e883e293