### PR TITLE
fix replaceShopInPath fallback logic

### DIFF
--- a/packages/platform-core/src/utils/replaceShopInPath.ts
+++ b/packages/platform-core/src/utils/replaceShopInPath.ts
@@ -22,5 +22,8 @@ export function replaceShopInPath(
     }
     return "/" + segments.join("/");
   }
+  if (segments.length === 1 && segments[0] === "cms") {
+    return `/cms/shop/${shop}`;
+  }
   return pathname;
 }


### PR DESCRIPTION
## Summary
- ensure replaceShopInPath inserts shop segment when path is `/cms`

## Testing
- `pnpm -r build` *(fails: packages/email build: Failed)*
- `pnpm exec jest packages/platform-core/__tests__/replaceShopInPath.test.ts packages/platform-core/src/utils/path-helpers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b73415eee0832f804de9e416e167ff