### PR TITLE
test: cover optional core env vars

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -147,6 +147,25 @@ describe("core env refinement", () => {
       message: "must be true or false",
     });
   });
+
+  it("skips base keys and accepts valid custom deposit values", () => {
+    const ctx = { addIssue: jest.fn() } as unknown as z.RefinementCtx;
+    depositReleaseEnvRefinement(
+      {
+        DEPOSIT_RELEASE_ENABLED: "true",
+        DEPOSIT_RELEASE_INTERVAL_MS: "1000",
+        REVERSE_LOGISTICS_ENABLED: "false",
+        REVERSE_LOGISTICS_INTERVAL_MS: "2000",
+        LATE_FEE_ENABLED: "true",
+        LATE_FEE_INTERVAL_MS: "3000",
+        DEPOSIT_RELEASE_FOO_ENABLED: "true",
+        REVERSE_LOGISTICS_BAR_INTERVAL_MS: "4000",
+        LATE_FEE_BAZ_ENABLED: "false",
+      },
+      ctx,
+    );
+    expect(ctx.addIssue).not.toHaveBeenCalled();
+  });
 });
 
 describe("core env defaults", () => {
@@ -487,6 +506,73 @@ describe("loadCoreEnv", () => {
       CART_COOKIE_SECRET: "dev-cart-secret",
     });
     expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("coerces optional export, phase, luxury and stock alert vars", () => {
+    const env = loadCoreEnv({
+      ...baseEnv,
+      OUTPUT_EXPORT: "true",
+      NEXT_PUBLIC_PHASE: "beta",
+      LUXURY_FEATURES_RA_TICKETING: "",
+      LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: "5",
+      LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: "true",
+      LUXURY_FEATURES_TRACKING_DASHBOARD: "",
+      LUXURY_FEATURES_RETURNS: "true",
+      STOCK_ALERT_RECIPIENTS: "a@a.com,b@b.com",
+      STOCK_ALERT_WEBHOOK: "https://example.com/hook",
+      STOCK_ALERT_DEFAULT_THRESHOLD: "10",
+      STOCK_ALERT_RECIPIENT: "alert@example.com",
+    } as unknown as NodeJS.ProcessEnv);
+    expect(env).toMatchObject({
+      OUTPUT_EXPORT: true,
+      NEXT_PUBLIC_PHASE: "beta",
+      LUXURY_FEATURES_RA_TICKETING: false,
+      LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: 5,
+      LUXURY_FEATURES_REQUIRE_STRONG_CUSTOMER_AUTH: true,
+      LUXURY_FEATURES_TRACKING_DASHBOARD: false,
+      LUXURY_FEATURES_RETURNS: true,
+      STOCK_ALERT_RECIPIENTS: "a@a.com,b@b.com",
+      STOCK_ALERT_WEBHOOK: "https://example.com/hook",
+      STOCK_ALERT_DEFAULT_THRESHOLD: 10,
+      STOCK_ALERT_RECIPIENT: "alert@example.com",
+    });
+  });
+
+  it("logs issues and throws for invalid optional vars", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadCoreEnv({
+        ...baseEnv,
+        NEXT_PUBLIC_PHASE: 123 as unknown as string,
+        LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD: "abc",
+        STOCK_ALERT_RECIPIENTS: 456 as unknown as string,
+        STOCK_ALERT_WEBHOOK: "not-a-url",
+        STOCK_ALERT_DEFAULT_THRESHOLD: "oops",
+        STOCK_ALERT_RECIPIENT: "not-an-email",
+      } as unknown as NodeJS.ProcessEnv),
+    ).toThrow("Invalid core environment variables");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid core environment variables:",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("NEXT_PUBLIC_PHASE"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("LUXURY_FEATURES_FRAUD_REVIEW_THRESHOLD"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("STOCK_ALERT_RECIPIENTS"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("STOCK_ALERT_WEBHOOK"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("STOCK_ALERT_DEFAULT_THRESHOLD"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("STOCK_ALERT_RECIPIENT"),
+    );
     errorSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- add coverage for optional core env flags and stock alerts
- ensure deposit refinement skips base keys and accepts valid custom vars

## Testing
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: Module '../../hooks/useProductEditorFormState' has no exported member 'ProductWithVariants' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b734215428832f841de8d702589011