### PR TITLE
test(config): add non-string shipping env tests

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -201,5 +201,43 @@ describe("shipping env module", () => {
     );
     errorSpy.mockRestore();
   });
+
+  it("loadShippingEnv logs and throws on numeric UPS_KEY", async () => {
+    const { loadShippingEnv } = await import("../shipping.ts");
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() => loadShippingEnv({ UPS_KEY: 123 } as any)).toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        UPS_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("logs and throws during eager parse when UPS_KEY is non-string", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      UPS_KEY: 123 as unknown as string,
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../shipping.ts")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        UPS_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- test loadShippingEnv numeric UPS_KEY logs and throws
- test eager shipping env parse fails on non-string UPS_KEY

## Testing
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b734330eb0832f95ffbbee49d44263