### PR TITLE
feat(config): validate sendgrid env and add tests

### DIFF
--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -22,6 +22,18 @@ if (!parsed.success) {
   );
   throw new Error("Invalid email environment variables");
 }
+if (parsed.data.EMAIL_PROVIDER === "sendgrid") {
+  const sendgrid = z
+    .object({ SENDGRID_API_KEY: z.string() })
+    .safeParse(parsed.data);
+  if (!sendgrid.success) {
+    console.error(
+      "❌ Invalid email environment variables:",
+      sendgrid.error.format(),
+    );
+    throw new Error("Invalid email environment variables");
+  }
+}
 
 export const emailEnv = parsed.data;
 export type EmailEnv = z.infer<typeof emailEnvSchema>;


### PR DESCRIPTION
## Summary
- validate SendGrid provider requires SENDGRID_API_KEY
- test invalid SMTP_URL and missing SendGrid key error paths

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/ui build: src/components/cms/ProductEditorForm.tsx(8,15): error TS2614: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants'. Did you mean to use 'import ProductWithVariants from "../../hooks/useProductEditorFormState"' instead?)*
- `pnpm --filter @acme/config test packages/config/src/env/__tests__/email.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b7376f9140832fb7f098536896f4e6