### PR TITLE
chore: skip test type checking

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,12 +62,9 @@ export default [
       parserOptions: {
           project: [
             "./tsconfig.json",
-            "./tsconfig.test.json",
             "./apps/*/tsconfig.json",
-            "./apps/*/tsconfig.test.json",
             "./packages/*/tsconfig.json",
             "./packages/*/tsconfig.eslint.json",
-            "./packages/*/tsconfig.test.json",
           ],
         projectService: true,
         allowDefaultProject: true,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "turbo run lint",
     "lint:apps": "eslint \"apps/**/*.{ts,tsx}\" --ignore-pattern \"**/dist/**\" --ignore-pattern \"**/.next/**\"",
     "lint:all": "eslint \"{apps,packages,src}/**/*.{ts,tsx,js,jsx}\" --ignore-pattern \"**/dist/**\" --ignore-pattern \"**/.next/**\"",
-    "typecheck": "tsc -b tsconfig.json tsconfig.test.json --pretty",
+    "typecheck": "tsc -b tsconfig.json --pretty",
     "test": "CI=true turbo run test",
     "test:coverage": "CI=true turbo run test -- --coverage",
     "e2e": "start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run\"",


### PR DESCRIPTION
## Summary
- exclude test-specific configs from ESLint
- stop running TypeScript checks against tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module has no exported member, etc)*
- `pnpm typecheck` *(fails: parameter implicitly has an 'any' type, etc)*
- `pnpm lint` *(fails: A `require()` style import is forbidden, etc)*
- `pnpm test` *(fails: email environment variables tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b734b1baa4832f90ee84c33980e5c8