### PR TITLE
test: cover stripe env fallbacks

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -111,26 +111,70 @@ describe("payments env defaults", () => {
         STRIPE_WEBHOOK_SECRET: "",
       },
     },
-  ])(
-    "warns and falls back to defaults when variables are $name (ts import)",
-    async ({ env }) => {
-      process.env = env as unknown as NodeJS.ProcessEnv;
-      warnSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
-      jest.resetModules();
-      const { paymentsEnv } = await import("../payments.ts");
-      expect(paymentsEnv).toEqual({
-        STRIPE_SECRET_KEY: "sk_test",
-        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
-        STRIPE_WEBHOOK_SECRET: "whsec_test",
-      });
-      expect(warnSpy).toHaveBeenCalledWith(
-        "⚠️ Invalid payments environment variables:",
-        expect.any(Object),
-      );
-    },
-  );
+    ])(
+      "warns and falls back to defaults when variables are $name (ts import)",
+      async ({ env }) => {
+        process.env = env as unknown as NodeJS.ProcessEnv;
+        warnSpy = jest
+          .spyOn(console, "warn")
+          .mockImplementation(() => {});
+        jest.resetModules();
+        const { paymentsEnv } = await import("../payments.ts");
+        expect(paymentsEnv).toEqual({
+          STRIPE_SECRET_KEY: "sk_test",
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+          STRIPE_WEBHOOK_SECRET: "whsec_test",
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+          "⚠️ Invalid payments environment variables:",
+          expect.any(Object),
+        );
+      },
+    );
+
+    it.each([
+      {
+        name: "STRIPE_SECRET_KEY",
+        env: {
+          STRIPE_SECRET_KEY: "sk_live_123",
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
+          STRIPE_WEBHOOK_SECRET: "",
+        },
+      },
+      {
+        name: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+        env: {
+          STRIPE_SECRET_KEY: "",
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_123",
+          STRIPE_WEBHOOK_SECRET: "",
+        },
+      },
+      {
+        name: "STRIPE_WEBHOOK_SECRET",
+        env: {
+          STRIPE_SECRET_KEY: "",
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
+          STRIPE_WEBHOOK_SECRET: "whsec_live_123",
+        },
+      },
+    ])(
+      "warns and falls back to defaults when only $name is valid",
+      async ({ env }) => {
+        process.env = env as NodeJS.ProcessEnv;
+        warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+        jest.resetModules();
+        const { paymentsEnv } = await import("../payments.ts");
+        expect(paymentsEnv).toEqual({
+          STRIPE_SECRET_KEY: "sk_test",
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+          STRIPE_WEBHOOK_SECRET: "whsec_test",
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+          "⚠️ Invalid payments environment variables:",
+          expect.any(Object),
+        );
+      },
+    );
 
   it(
     "warns and falls back to defaults when STRIPE_SECRET_KEY is empty",


### PR DESCRIPTION
## Summary
- expand payments env tests to cover cases where only one Stripe variable is valid

## Testing
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants'.)*
- `pnpm --filter @acme/auth test` *(fails: Jest encountered an unexpected token in packages/config/src/env/core.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b739b0d374832fbfb3115a023696eb