### PR TITLE
test(config): add resend provider missing key coverage

### DIFF
--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -79,6 +79,31 @@ describe("email env module", () => {
   );
 
   it(
+    "logs second error block when RESEND_API_KEY is missing for resend provider",
+    async () => {
+      process.env = {
+        ...ORIGINAL_ENV,
+        EMAIL_PROVIDER: "resend",
+      } as NodeJS.ProcessEnv;
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      await expect(import("../email.ts")).rejects.toThrow(
+        "Invalid email environment variables",
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        "❌ Invalid email environment variables:",
+        expect.objectContaining({
+          RESEND_API_KEY: {
+            _errors: [expect.stringContaining("Required")],
+          },
+        }),
+      );
+      errorSpy.mockRestore();
+    },
+  );
+
+  it(
     "reports multiple errors for invalid SMTP_URL and non-numeric EMAIL_BATCH_SIZE",
     async () => {
       process.env = {


### PR DESCRIPTION
## Summary
- add a test verifying configuration fails when EMAIL_PROVIDER=resend and RESEND_API_KEY is missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/ui build: error TS2322: Type 'string | null'...)*
- `pnpm --filter @acme/config test` *(fails: email env module tests expecting missing API keys to throw)*
- `pnpm --filter @acme/auth test` *(fails: Jest encountered an unexpected token in packages/config/src/env/core.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b739b04a64832fb6094bf19dc243ff