### PR TITLE
fix: hydrate translations without internals error

### DIFF
--- a/packages/i18n/__tests__/hydration.test.tsx
+++ b/packages/i18n/__tests__/hydration.test.tsx
@@ -1,6 +1,5 @@
 // packages/i18n/__tests__/hydration.test.tsx
 import { hydrateRoot } from "react-dom/client";
-import { renderToString } from "react-dom/server";
 import React from "react";
 import { TranslationsProvider, useTranslations } from "../src/Translations";
 
@@ -15,6 +14,8 @@ describe("TranslationsProvider hydration", () => {
   }
 
   it("hydrates without warnings", async () => {
+    const { renderToString } = await import("react-dom/server");
+
     const html = renderToString(
       <TranslationsProvider messages={{ greet: "Hallo" }}>
         <Greeting />


### PR DESCRIPTION
## Summary
- load `renderToString` during the test so React internals are initialized before use

## Testing
- `pnpm exec jest packages/i18n/__tests__/hydration.test.tsx --runTestsByPath --config jest.config.cjs`
- `pnpm -r build` *(fails: packages/ui build: ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b73a082f70832f958c2cb142524119