### PR TITLE
test: add deposit release misc env ignore

### DIFF
--- a/packages/config/src/env/__tests__/depositReleaseEnvRefinement.test.ts
+++ b/packages/config/src/env/__tests__/depositReleaseEnvRefinement.test.ts
@@ -117,4 +117,10 @@ describe("depositReleaseEnvRefinement", () => {
     );
     expect(ctx.addIssue).not.toHaveBeenCalled();
   });
+
+  it("ignores DEPOSIT_RELEASE keys without a recognized suffix", () => {
+    const ctx = { addIssue: jest.fn() } as unknown as z.RefinementCtx;
+    depositReleaseEnvRefinement({ DEPOSIT_RELEASE_MISC: "foo" }, ctx);
+    expect(ctx.addIssue).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- test depositReleaseEnvRefinement ignores keys without expected suffix

## Testing
- `pnpm --filter @acme/config test`
- `pnpm --filter @acme/configurator test -- packages/configurator` *(fails: global coverage threshold for branches (80%) not met: 47.36%)*

------
https://chatgpt.com/codex/tasks/task_e_68b73ac5e290832f877ed1f56f589e61