### PR TITLE
test: ensure shipping env loads without error

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -8,6 +8,25 @@ describe("shipping env module", () => {
     process.env = ORIGINAL_ENV;
   });
 
+  it("imports shipping.ts without error when env is valid", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      TAXJAR_KEY: "tax",
+      UPS_KEY: "ups",
+      DHL_KEY: "dhl",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    const { shippingEnv } = await import("../shipping.ts");
+    expect(shippingEnv).toEqual({
+      TAXJAR_KEY: "tax",
+      UPS_KEY: "ups",
+      DHL_KEY: "dhl",
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it("parses valid configuration", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- add regression test verifying shipping env module imports cleanly when process.env is valid

## Testing
- `pnpm -r build` (fails: packages/ui build errors)
- `pnpm --filter @acme/configurator test -- packages/configurator` (fails: coverage thresholds not met)

------
https://chatgpt.com/codex/tasks/task_e_68b73ac93b10832f9e6d5ea82cd23760