### PR TITLE
test: cover email provider stats

### DIFF
--- a/packages/email/src/providers/__tests__/resend.test.ts
+++ b/packages/email/src/providers/__tests__/resend.test.ts
@@ -6,9 +6,12 @@ describe("ResendProvider", () => {
     text: "Text",
   };
 
+  const realFetch = global.fetch;
+
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    global.fetch = realFetch;
     delete process.env.CAMPAIGN_FROM;
     delete process.env.RESEND_API_KEY;
   });
@@ -68,6 +71,44 @@ describe("ResendProvider", () => {
     await expect(promise).rejects.toMatchObject({
       message: "Unknown error",
       retryable: true,
+    });
+  });
+
+  describe("getCampaignStats", () => {
+    it("returns normalized stats on success", async () => {
+      process.env.RESEND_API_KEY = "rs";
+      const stats = { delivered: "1", opened_count: "2", clicked: 3 };
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve(stats),
+      }) as any;
+      const { ResendProvider } = await import("../resend");
+      const provider = new ResendProvider();
+      const { mapResendStats } = await import("../../stats");
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(
+        mapResendStats(stats)
+      );
+    });
+
+    it("returns empty stats when fetch rejects", async () => {
+      process.env.RESEND_API_KEY = "rs";
+      global.fetch = jest.fn().mockRejectedValue(new Error("fail")) as any;
+      const { ResendProvider } = await import("../resend");
+      const provider = new ResendProvider();
+      const { mapResendStats } = await import("../../stats");
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(
+        mapResendStats({})
+      );
+    });
+
+    it("returns empty stats when RESEND_API_KEY missing", async () => {
+      global.fetch = jest.fn();
+      const { ResendProvider } = await import("../resend");
+      const provider = new ResendProvider();
+      const { mapResendStats } = await import("../../stats");
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(
+        mapResendStats({})
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/email/src/providers/__tests__/sendgrid.test.ts
+++ b/packages/email/src/providers/__tests__/sendgrid.test.ts
@@ -6,9 +6,12 @@ describe("SendgridProvider", () => {
     text: "Text",
   };
 
+  const realFetch = global.fetch;
+
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    global.fetch = realFetch;
     delete process.env.CAMPAIGN_FROM;
     delete process.env.SENDGRID_API_KEY;
   });
@@ -63,6 +66,44 @@ describe("SendgridProvider", () => {
     await expect(promise).rejects.toMatchObject({
       message: "Unknown error",
       retryable: true,
+    });
+  });
+
+  describe("getCampaignStats", () => {
+    it("returns normalized stats on success", async () => {
+      process.env.SENDGRID_API_KEY = "key";
+      const stats = { delivered: "2", opens: "5", clicks: 1 };
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve(stats),
+      }) as any;
+      const { SendgridProvider } = await import("../sendgrid");
+      const provider = new SendgridProvider();
+      const { mapSendGridStats } = await import("../../stats");
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(
+        mapSendGridStats(stats)
+      );
+    });
+
+    it("returns empty stats when fetch rejects", async () => {
+      process.env.SENDGRID_API_KEY = "key";
+      global.fetch = jest.fn().mockRejectedValue(new Error("fail")) as any;
+      const { SendgridProvider } = await import("../sendgrid");
+      const provider = new SendgridProvider();
+      const { mapSendGridStats } = await import("../../stats");
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(
+        mapSendGridStats({})
+      );
+    });
+
+    it("returns empty stats when SENDGRID_API_KEY missing", async () => {
+      global.fetch = jest.fn();
+      const { SendgridProvider } = await import("../sendgrid");
+      const provider = new SendgridProvider();
+      const { mapSendGridStats } = await import("../../stats");
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(
+        mapSendGridStats({})
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- mock fetch in ResendProvider tests to cover stats success, failure, and missing API key cases
- add analogous SendgridProvider stats tests and restore global fetch between tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '...')*
- `pnpm --filter @acme/email exec jest packages/email/src/providers/__tests__/resend.test.ts packages/email/src/providers/__tests__/sendgrid.test.ts --config ../../jest.config.cjs` *(coverage threshold warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b73aba00d4832fb84544c4b3c004a1