### PR TITLE
test: verify production core env load

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -384,6 +384,21 @@ describe("core env module", () => {
     parseSpy.mockRestore();
   });
 
+  it("parses env once during module load in production", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      ...baseEnv,
+      NODE_ENV: "production",
+      CART_COOKIE_SECRET: "secret",
+    } as NodeJS.ProcessEnv;
+    jest.resetModules();
+    const mod = await import("../core.ts");
+    const parseSpy = jest.spyOn(mod.coreEnvSchema, "safeParse");
+    expect(mod.coreEnv.CMS_SPACE_URL).toBe("https://example.com");
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
+  });
+
   it("triggers proxy traps without reparsing in production", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- add test ensuring core env loads only once during production import

## Testing
- `pnpm --filter @acme/config test`
- `pnpm --filter @acme/configurator test -- packages/configurator`


------
https://chatgpt.com/codex/tasks/task_e_68b73ac6bf74832f990c053b722fbf45