### PR TITLE
test: expand ImageGallery coverage

### DIFF
--- a/packages/platform-core/__tests__/imageGallery.test.tsx
+++ b/packages/platform-core/__tests__/imageGallery.test.tsx
@@ -3,7 +3,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import ImageGallery from "../src/components/pdp/ImageGallery";
 
 describe("ImageGallery", () => {
-  it("toggles zoom on click", () => {
+  it("returns null when items array is empty", () => {
+    const { container } = render(<ImageGallery items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an image and toggles zoom on click", () => {
     const items = [{ url: "/img.jpg", type: "image" as const, altText: "img" }];
     render(<ImageGallery items={items} />);
     const img = screen.getByAltText("img");
@@ -13,5 +18,17 @@ describe("ImageGallery", () => {
     expect(img.className).toContain("scale-125");
     fireEvent.click(figure);
     expect(img.className).not.toContain("scale-125");
+  });
+
+  it("renders video when thumbnail is clicked", () => {
+    const items = [
+      { url: "/img.jpg", type: "image" as const, altText: "img" },
+      { url: "/vid.mp4", type: "video" as const },
+    ];
+    const { container } = render(<ImageGallery items={items} />);
+    expect(container.querySelector("video")).toBeNull();
+    const videoThumb = screen.getByText("Video").closest("button")!;
+    fireEvent.click(videoThumb);
+    expect(container.querySelector("video")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add regression tests for ImageGallery behavior when given no items
- cover zoom toggle on single image
- verify video rendering when switching thumbnails

## Testing
- `pnpm --filter @acme/platform-core test __tests__/imageGallery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b73f3ce938832fb681b872b4507a33