### PR TITLE
test: cover optional checkout metadata fields

### DIFF
--- a/packages/platform-core/src/checkout/metadata.test.ts
+++ b/packages/platform-core/src/checkout/metadata.test.ts
@@ -1,0 +1,34 @@
+import { buildCheckoutMetadata } from './metadata';
+
+describe('buildCheckoutMetadata', () => {
+  const base = {
+    subtotal: 100,
+    depositTotal: 50,
+    rentalDays: 3,
+    discount: 0,
+    currency: 'USD',
+    taxRate: 0.2,
+    taxAmount: 20,
+  };
+
+  test('includes optional keys when provided', () => {
+    const result = buildCheckoutMetadata({
+      ...base,
+      sizes: 'M,L',
+      clientIp: '203.0.113.1',
+      extra: { foo: 'bar' },
+    });
+
+    expect(result.sizes).toBe('M,L');
+    expect(result.client_ip).toBe('203.0.113.1');
+    expect(result.foo).toBe('bar');
+  });
+
+  test('omits optional keys when not provided', () => {
+    const result = buildCheckoutMetadata(base);
+
+    expect(result).not.toHaveProperty('sizes');
+    expect(result).not.toHaveProperty('client_ip');
+    expect(result).not.toHaveProperty('foo');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for buildCheckoutMetadata verifying optional sizes, clientIp, and extra metadata

## Testing
- `pnpm -r build` *(fails: Property 'merge' does not exist ...)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/checkout/metadata.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b73f3bde1c832f81096475ba509c23