### PR TITLE
test: cover getProductById variations

### DIFF
--- a/packages/platform-core/__tests__/products.test.ts
+++ b/packages/platform-core/__tests__/products.test.ts
@@ -1,10 +1,31 @@
 // packages/platform-core/__tests__/products.test.ts
 
-import { getProductBySlug, PRODUCTS } from "../src/products/index";
+import { getProductBySlug, getProductById, PRODUCTS } from "../src/products";
 
 describe("getProductBySlug", () => {
   it("returns the matching product", () => {
     const slug = PRODUCTS[0].slug;
     expect(getProductBySlug(slug)).toEqual(PRODUCTS[0]);
+  });
+});
+
+describe("getProductById", () => {
+  const inStock = PRODUCTS.find((p) => p.stock > 0)!;
+  const outOfStock = PRODUCTS.find((p) => p.stock === 0)!;
+
+  it("returns the item when in stock", () => {
+    expect(getProductById(inStock.id)).toEqual(inStock);
+  });
+
+  it("returns null when stock is 0", () => {
+    expect(getProductById(outOfStock.id)).toBeNull();
+  });
+
+  it("returns the item when in stock via async lookup", async () => {
+    await expect(getProductById("shop", inStock.id)).resolves.toEqual(inStock);
+  });
+
+  it("returns null when stock is 0 via async lookup", async () => {
+    await expect(getProductById("shop", outOfStock.id)).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- test getProductById using both legacy and async signatures
- verify out-of-stock SKUs return null

## Testing
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/__tests__/products.test.ts --runInBand --config ../../jest.config.cjs`
- `pnpm -r build` *(fails: Property 'merge' does not exist on type 'ZodEffects'...)*

------
https://chatgpt.com/codex/tasks/task_e_68b73f325014832fb05ea8ec971b2a94