### PR TITLE
test: improve late fee service coverage

### DIFF
--- a/packages/platform-machine/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/__tests__/lateFeeService.test.ts
@@ -1,3 +1,25 @@
+describe("chargeLateFeesOnce", () => {
+  it("continues when shop policy cannot be loaded", async () => {
+    const { setupLateFeeTest } = await import("./helpers/lateFee");
+    const mocks = await setupLateFeeTest({ orders: [] });
+    mocks.readFile.mockRejectedValue(new Error("no policy"));
+    jest.doMock("@acme/config/env/core", () => ({
+      __esModule: true,
+      coreEnv: {},
+      loadCoreEnv: () => ({}),
+    }));
+
+    const { chargeLateFeesOnce } = await import("../src/lateFeeService");
+    try {
+      await chargeLateFeesOnce();
+    } finally {
+      mocks.restore();
+    }
+
+    expect(mocks.readOrders).not.toHaveBeenCalled();
+  });
+});
+
 describe("resolveConfig", () => {
   const OLD_ENV = process.env;
 
@@ -64,6 +86,32 @@ describe("resolveConfig", () => {
     delete process.env.LATE_FEE_ENABLED_SHOP;
   });
 
+  it("falls back to core env values", async () => {
+    const readFile = jest.fn().mockResolvedValue("{}");
+    jest.doMock("fs/promises", () => ({
+      __esModule: true,
+      readFile,
+      readdir: jest.fn(),
+    }));
+    jest.doMock("@platform-core/utils", () => ({
+      __esModule: true,
+      logger: { error: jest.fn(), info: jest.fn() },
+    }));
+    jest.doMock("@acme/config/env/core", () => ({
+      __esModule: true,
+      coreEnv: { LATE_FEE_ENABLED: true, LATE_FEE_INTERVAL_MS: 180000 },
+      loadCoreEnv: () => ({
+        LATE_FEE_ENABLED: true,
+        LATE_FEE_INTERVAL_MS: 180000,
+      }),
+    }));
+
+    const mod = await import("../src/lateFeeService");
+    const cfg = await mod.resolveConfig("shop", "/data");
+
+    expect(cfg).toEqual({ enabled: true, intervalMinutes: 3 });
+  });
+
   it("applies passed overrides", async () => {
     const readFile = jest.fn().mockResolvedValue("{}");
     jest.doMock("fs/promises", () => ({
@@ -93,6 +141,7 @@ describe("resolveConfig", () => {
 
 describe("startLateFeeService", () => {
   const OLD_ENV = process.env;
+  let error: jest.Mock;
 
   beforeEach(() => {
     jest.resetModules();
@@ -106,9 +155,10 @@ describe("startLateFeeService", () => {
       __esModule: true,
       resolveDataRoot: () => "/data",
     }));
+    error = jest.fn();
     jest.doMock("@platform-core/utils", () => ({
       __esModule: true,
-      logger: { error: jest.fn(), info: jest.fn() },
+      logger: { error, info: jest.fn() },
     }));
   });
 
@@ -162,6 +212,86 @@ describe("startLateFeeService", () => {
     stop();
     expect(clearSpy).toHaveBeenCalledWith(111 as any);
 
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+  });
+
+  it("logs errors from chargeLateFeesOnce", async () => {
+    const readdir = jest.fn().mockResolvedValue(["shop"]);
+    const readFile = jest.fn().mockImplementation((path: string) => {
+      if (path.endsWith("shop/settings.json"))
+        return Promise.resolve(
+          JSON.stringify({ lateFeeService: { enabled: true, intervalMinutes: 1 } }),
+        );
+      if (path.endsWith("shop/shop.json"))
+        return Promise.resolve(
+          JSON.stringify({ lateFeePolicy: { feeAmount: 5 } }),
+        );
+      return Promise.reject(new Error("not found"));
+    });
+    jest.doMock("fs/promises", () => ({ __esModule: true, readdir, readFile }));
+    const setSpy = jest
+      .spyOn(global, "setInterval")
+      .mockImplementation(() => 111 as any);
+    const clearSpy = jest
+      .spyOn(global, "clearInterval")
+      .mockImplementation(() => undefined as any);
+
+    const err = new Error("boom");
+    jest.doMock("@platform-core/repositories/rentalOrders.server", () => ({
+      __esModule: true,
+      readOrders: jest.fn().mockRejectedValue(err),
+      markLateFeeCharged: jest.fn(),
+    }));
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: {
+        checkout: { sessions: { retrieve: jest.fn() } },
+        paymentIntents: { create: jest.fn() },
+      },
+    }));
+
+    const mod = await import("../src/lateFeeService");
+    const stop = await mod.startLateFeeService();
+
+    expect(error).toHaveBeenCalledWith("late fee processing failed", {
+      shopId: "shop",
+      err,
+    });
+
+    stop();
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+  });
+
+  it("returns early when shop settings are inaccessible", async () => {
+    const readdir = jest.fn().mockResolvedValue(["shop"]);
+    const readFile = jest.fn().mockImplementation((path: string) => {
+      if (path.endsWith("shop/settings.json"))
+        return Promise.resolve(
+          JSON.stringify({ lateFeeService: { enabled: true, intervalMinutes: 1 } }),
+        );
+      if (path.endsWith("shop/shop.json"))
+        return Promise.reject(new Error("denied"));
+      return Promise.reject(new Error("not found"));
+    });
+    jest.doMock("fs/promises", () => ({ __esModule: true, readdir, readFile }));
+
+    const mod = await import("../src/lateFeeService");
+    const chargeSpy = jest.spyOn(mod, "chargeLateFeesOnce").mockResolvedValue();
+    const setSpy = jest
+      .spyOn(global, "setInterval")
+      .mockImplementation(() => 111 as any);
+    const clearSpy = jest
+      .spyOn(global, "clearInterval")
+      .mockImplementation(() => undefined as any);
+
+    const stop = await mod.startLateFeeService();
+
+    expect(chargeSpy).not.toHaveBeenCalled();
+    expect(setSpy).not.toHaveBeenCalled();
+
+    stop();
     setSpy.mockRestore();
     clearSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- add coverage for chargeLateFeesOnce when shop policy load fails
- verify resolveConfig falls back to core env values
- ensure startLateFeeService logs errors and handles missing shop settings

## Testing
- `pnpm test packages/platform-machine` *(fails: Could not find task)*
- `pnpm exec jest packages/platform-machine/__tests__/lateFeeService.test.ts --config jest.config.cjs --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b73f7abcd0832f9a15cef8a6adc404