### PR TITLE
Fix core env schema merging and email provider validation

### DIFF
--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -22,6 +22,13 @@ export const emailEnvSchema = z
         path: ["SENDGRID_API_KEY"],
       });
     }
+    if (env.EMAIL_PROVIDER === "resend" && !env.RESEND_API_KEY) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Required",
+        path: ["RESEND_API_KEY"],
+      });
+    }
   });
 
 const parsed = emailEnvSchema.safeParse(process.env);


### PR DESCRIPTION
## Summary
- correctly merge env schemas and preserve custom refinements in core config
- require `RESEND_API_KEY` when `EMAIL_PROVIDER` is `resend`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants')*
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b7414b2480832f80c0b2e8c52f2775