### PR TITLE
test: cover fetchJson HTTP status fallback

### DIFF
--- a/packages/shared-utils/src/__tests__/http-utils.test.ts
+++ b/packages/shared-utils/src/__tests__/http-utils.test.ts
@@ -53,6 +53,19 @@ describe('fetchJson', () => {
 
     await expect(fetchJson('https://example.com')).rejects.toThrow('Internal Server Error');
   });
+
+  it('falls back to status code when status text is empty', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 418,
+      statusText: '',
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify({ message: 'teapot' })
+      ),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('HTTP 418');
+  });
 });
 
 describe('buildResponse', () => {


### PR DESCRIPTION
## Summary
- add test ensuring `fetchJson` falls back to HTTP status code when no status text

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'merge' does not exist on type 'ZodEffects')*
- `pnpm exec jest --config ../../jest.config.cjs src/__tests__/http-utils.test.ts --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_68b741df9f10832fb8be73085e856983