### PR TITLE
test: handle empty fetchJson response

### DIFF
--- a/packages/shared-utils/src/__tests__/http-utils.test.ts
+++ b/packages/shared-utils/src/__tests__/http-utils.test.ts
@@ -22,6 +22,15 @@ describe('fetchJson', () => {
     await expect(fetchJson('https://example.com', undefined, schema)).resolves.toEqual(data);
   });
 
+  it('returns undefined for empty response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(''),
+    });
+
+    await expect(fetchJson('https://example.com')).resolves.toBeUndefined();
+  });
+
   it('throws on invalid JSON', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- test fetchJson returns undefined when response text is empty

## Testing
- `pnpm exec jest packages/shared-utils/src/__tests__/http-utils.test.ts --config jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b741e07da8832fb3faab6aba26cf7c