### PR TITLE
test(shared-utils): default debug level without env

### DIFF
--- a/packages/shared-utils/src/__tests__/logger.test.ts
+++ b/packages/shared-utils/src/__tests__/logger.test.ts
@@ -53,6 +53,13 @@ describe('logger', () => {
     expect(pinoMock).toHaveBeenCalledWith({ level: 'info' });
   });
 
+  it('defaults to debug when LOG_LEVEL and NODE_ENV are undefined', async () => {
+    const { logger } = await import('../logger');
+    logger.debug('msg');
+
+    expect(pinoMock).toHaveBeenCalledWith({ level: 'debug' });
+  });
+
   it('defaults to debug when NODE_ENV is not production', async () => {
     process.env.NODE_ENV = 'development';
     const { logger } = await import('../logger');


### PR DESCRIPTION
## Summary
- add test for logger defaulting to debug when LOG_LEVEL and NODE_ENV are unset

## Testing
- `pnpm exec jest packages/shared-utils/src/__tests__/logger.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b741e3fcb0832fba390b6fc398dcbf