### PR TITLE
test: expand seo coverage

### DIFF
--- a/packages/template-app/__tests__/structured-data.test.ts
+++ b/packages/template-app/__tests__/structured-data.test.ts
@@ -1,5 +1,7 @@
 import { getStructuredData, serializeJsonLd } from "../src/lib/seo";
 
+jest.mock("@acme/config/env/core", () => ({ coreEnv: {} }));
+
 describe("getStructuredData", () => {
   test("builds product schema", () => {
     const data = getStructuredData({
@@ -26,6 +28,14 @@ describe("getStructuredData", () => {
         reviewCount: 20,
       },
     });
+  });
+
+  test("builds product schema without optional fields", () => {
+    const data = getStructuredData({ type: "Product", name: "Simple" });
+    expect(data).toMatchObject({ "@type": "Product", name: "Simple" });
+    expect(data).not.toHaveProperty("brand");
+    expect(data).not.toHaveProperty("offers");
+    expect(data).not.toHaveProperty("aggregateRating");
   });
 
   test("builds webpage schema", () => {


### PR DESCRIPTION
## Summary
- add tests for SEO image overrides and canonical fallbacks
- cover structured data defaults when optional fields missing

## Testing
- `pnpm exec jest packages/template-app/__tests__/seo-get.test.ts packages/template-app/__tests__/structured-data.test.ts --config packages/template-app/jest.config.cjs --coverage`
- `pnpm test --filter @acme/template-app -- --coverage` *(fails: authEnvSchema.merge is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b741f044c8832f8d04495b5b1bc5b3