### PR TITLE
test(template-app): expand sitemap coverage

### DIFF
--- a/packages/template-app/__tests__/sitemap.test.ts
+++ b/packages/template-app/__tests__/sitemap.test.ts
@@ -1,9 +1,7 @@
 import type { MetadataRoute } from "next";
 
-const getShopSettingsMock = jest.fn().mockResolvedValue({ languages: ["en", "de"] });
-const readRepoMock = jest.fn().mockResolvedValue([
-  { id: "p1", slug: "shoe", updated_at: "2024-01-01T00:00:00Z" },
-]);
+const getShopSettingsMock = jest.fn();
+const readRepoMock = jest.fn();
 
 jest.mock("@platform-core/repositories/settings.server", () => ({
   getShopSettings: getShopSettingsMock,
@@ -13,43 +11,82 @@ jest.mock("@platform-core/repositories/products.server", () => ({
   readRepo: readRepoMock,
 }));
 
-describe("sitemap generation", () => {
-  beforeAll(() => {
-    process.env.NEXT_PUBLIC_BASE_URL = "https://example.com";
-    process.env.NEXT_PUBLIC_SHOP_ID = "shop1";
-  });
+jest.mock("@acme/config/env/core", () => ({
+  coreEnv: {
+    get NEXT_PUBLIC_BASE_URL() {
+      return process.env.NEXT_PUBLIC_BASE_URL as string | undefined;
+    },
+    get NEXT_PUBLIC_SHOP_ID() {
+      return process.env.NEXT_PUBLIC_SHOP_ID as string | undefined;
+    },
+  },
+}));
 
+const ORIGINAL_ENV = process.env;
+
+describe("sitemap generation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
   });
 
-  it("falls back to English when no languages are configured", async () => {
+  it("uses defaults when env vars, languages, and slug are missing", async () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.NEXT_PUBLIC_SHOP_ID;
+
     getShopSettingsMock.mockResolvedValueOnce({});
+    readRepoMock.mockResolvedValueOnce([
+      { id: "p1", updated_at: "2024-01-01T00:00:00Z" },
+    ]);
+
     const { default: sitemap } = await import("../src/app/sitemap");
     const entries = (await sitemap()) as MetadataRoute.Sitemap;
+
+    expect(getShopSettingsMock).toHaveBeenCalledWith("shop");
+    expect(readRepoMock).toHaveBeenCalledWith("shop");
+
+    const home = entries.find((e) => e.url === "http://localhost:3000/en");
+    expect(home?.alternates?.languages).toEqual({
+      en: "http://localhost:3000/en",
+    });
+
+    const product = entries.find(
+      (e) => e.url === "http://localhost:3000/en/product/p1"
+    );
+    expect(product?.alternates?.languages).toEqual({
+      en: "http://localhost:3000/en/product/p1",
+    });
+  });
+
+  it("builds URLs with hreflang alternates for multiple languages", async () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://example.com";
+    process.env.NEXT_PUBLIC_SHOP_ID = "shop1";
+
+    getShopSettingsMock.mockResolvedValueOnce({ languages: ["en", "de"] });
+    readRepoMock.mockResolvedValueOnce([
+      { id: "p1", slug: "shoe", updated_at: "2024-01-01T00:00:00Z" },
+    ]);
+
+    const { default: sitemap } = await import("../src/app/sitemap");
+    const entries = (await sitemap()) as MetadataRoute.Sitemap;
+
     expect(getShopSettingsMock).toHaveBeenCalledWith("shop1");
     expect(readRepoMock).toHaveBeenCalledWith("shop1");
+
     const home = entries.find((e) => e.url === "https://example.com/en");
     expect(home?.alternates?.languages).toEqual({
       en: "https://example.com/en",
+      de: "https://example.com/de",
     });
-    const product = entries.find((e) => e.url.endsWith("/product/shoe"));
+
+    const product = entries.find(
+      (e) => e.url === "https://example.com/en/product/shoe"
+    );
     expect(product?.alternates?.languages).toEqual({
       en: "https://example.com/en/product/shoe",
+      de: "https://example.com/de/product/shoe",
     });
-  });
-
-  it("builds URLs with hreflang alternates", async () => {
-    const { default: sitemap } = await import("../src/app/sitemap");
-    const entries = (await sitemap()) as MetadataRoute.Sitemap;
-    expect(getShopSettingsMock).toHaveBeenCalledWith("shop1");
-    expect(readRepoMock).toHaveBeenCalledWith("shop1");
-    const home = entries.find((e) => e.url === "https://example.com/en");
-    expect(home?.alternates?.languages?.de).toBe("https://example.com/de");
-    const product = entries.find((e) => e.url.endsWith("/product/shoe"));
-    expect(product?.alternates?.languages?.de).toBe(
-      "https://example.com/de/product/shoe"
-    );
   });
 });
 


### PR DESCRIPTION
## Summary
- mock config env to avoid schema issues
- test default env vars, language fallback, and slug fallback in sitemap
- verify hreflang alternates for multiple languages

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'merge' does not exist on type 'ZodEffects...')*
- `pnpm test packages/template-app -- --coverage` *(fails: Could not find task `packages/template-app` in project)*
- `pnpm --filter @acme/template-app test __tests__/sitemap.test.ts -- --coverage` *(fails: Jest "global" coverage threshold for branches (60%) not met: 28.57%)*

------
https://chatgpt.com/codex/tasks/task_e_68b741ec9388832fbbdaa665b0e6ecf3