### PR TITLE
fix env schema merge

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -154,6 +154,7 @@ const config = {
     '^\\./env/core\\.js$': ' /packages/config/src/env/core.ts',
     '^\\./payments\\.js$': ' /packages/config/src/env/payments.ts',
     '^\\./shipping\\.js$': ' /packages/config/src/env/shipping.ts',
+    '^\\./mergeEnvSchemas\\.js$': ' /packages/config/src/env/mergeEnvSchemas.ts',
     '^\\./foo\\.js$': ' /packages/config/src/env/foo.impl.ts',
     '^\\./foo\\.impl\\.ts$': ' /packages/config/src/env/foo.impl.ts',
     '^@platform-core$': ' /packages/platform-core/src/index.ts',

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -6,6 +6,7 @@ import { cmsEnvSchema } from "./cms.js";
 import { emailEnvSchema } from "./email.js";
 import { paymentsEnvSchema } from "./payments.js";
 import { shippingEnvSchema } from "./shipping.js";
+import { mergeEnvSchemas } from "./mergeEnvSchemas.js";
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -76,12 +77,14 @@ const baseEnvSchema = z
   })
   .passthrough();
 
-export const coreEnvBaseSchema = authEnvSchema
-  .merge(cmsEnvSchema)
-  .merge(emailEnvSchema)
-  .merge(paymentsEnvSchema)
-  .merge(shippingEnvSchema)
-  .merge(baseEnvSchema);
+export const coreEnvBaseSchema = mergeEnvSchemas(
+  authEnvSchema,
+  cmsEnvSchema,
+  emailEnvSchema,
+  paymentsEnvSchema,
+  shippingEnvSchema,
+  baseEnvSchema
+);
 
 export function depositReleaseEnvRefinement(
   env: Record<string, unknown>,

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -1,31 +1,12 @@
 // packages/config/src/env/index.ts
 import "@acme/zod-utils/initZod";
-import { z, type AnyZodObject } from "zod";
+import { z } from "zod";
 import { coreEnvBaseSchema, depositReleaseEnvRefinement } from "./core.js";
 import { paymentsEnvSchema } from "./payments.js";
 import { shippingEnvSchema } from "./shipping.js";
+import { mergeEnvSchemas } from "./mergeEnvSchemas.js";
 
-type UnionToIntersection<U> = (
-  U extends unknown ? (k: U) => void : never
-) extends (k: infer I) => void
-  ? I
-  : never;
-
-type MergedShape<T extends readonly AnyZodObject[]> = UnionToIntersection<
-  {
-    [K in keyof T]: T[K] extends z.ZodObject<infer S extends z.ZodRawShape>
-      ? S
-      : never;
-  }[number]
-> &
-  z.ZodRawShape;
-
-export const mergeEnvSchemas = <T extends readonly AnyZodObject[]>(
-  ...schemas: T
-): z.ZodObject<MergedShape<T>> =>
-  schemas.reduce((acc, s) => acc.merge(s), z.object({})) as z.ZodObject<
-    MergedShape<T>
-  >;
+export { mergeEnvSchemas };
 
 const mergedEnvSchema = mergeEnvSchemas(
   coreEnvBaseSchema,

--- a/packages/config/src/env/mergeEnvSchemas.js
+++ b/packages/config/src/env/mergeEnvSchemas.js
@@ -1,0 +1,2 @@
+// packages/config/src/env/mergeEnvSchemas.js
+export * from "./mergeEnvSchemas.ts";

--- a/packages/config/src/env/mergeEnvSchemas.ts
+++ b/packages/config/src/env/mergeEnvSchemas.ts
@@ -1,0 +1,43 @@
+import {
+  z,
+  type ZodTypeAny,
+  ZodEffects,
+  type AnyZodObject,
+} from "zod";
+
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+type UnwrapEffects<T extends ZodTypeAny> = T extends ZodEffects<infer U>
+  ? UnwrapEffects<U>
+  : T;
+
+type MergedShape<T extends readonly ZodTypeAny[]> = UnionToIntersection<
+  {
+    [K in keyof T]: UnwrapEffects<T[K]> extends z.ZodObject<
+      infer S extends z.ZodRawShape
+    >
+      ? S
+      : never;
+  }[number]
+> &
+  z.ZodRawShape;
+
+function unwrap(schema: ZodTypeAny): AnyZodObject {
+  let current: ZodTypeAny = schema;
+  while (current instanceof ZodEffects) {
+    current = current._def.schema;
+  }
+  return current as AnyZodObject;
+}
+
+export const mergeEnvSchemas = <T extends readonly ZodTypeAny[]>(
+  ...schemas: T
+): z.ZodObject<MergedShape<T>> =>
+  schemas.reduce<AnyZodObject>(
+    (acc, schema) => acc.merge(unwrap(schema)),
+    z.object({})
+  ) as z.ZodObject<MergedShape<T>>;


### PR DESCRIPTION
## Summary
- add utility to merge environment schemas while unwrapping Zod effects
- use mergeEnvSchemas when composing core env schema
- map mergeEnvSchemas stub in Jest config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Argument of type '{}' is not assignable to parameter of type 'string')*
- `pnpm --filter @acme/template-app exec jest packages/template-app/__tests__/ai-catalog.test.ts --runInBand --coverage=false`
- `pnpm --filter @acme/config test` *(fails: email env module missing RESEND_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b7407e51c8832f9d61878c2df70e1c