### PR TITLE
fix: build core env schema without merge

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -76,14 +76,16 @@ const baseEnvSchema = z
   })
   .passthrough();
 
-export const coreEnvBaseSchema = (
-  authEnvSchema.innerType() as z.AnyZodObject
-)
-  .merge(cmsEnvSchema)
-  .merge(emailEnvSchema.innerType() as z.AnyZodObject)
-  .merge(paymentsEnvSchema)
-  .merge(shippingEnvSchema)
-  .merge(baseEnvSchema);
+export const coreEnvBaseSchema = z
+  .object({
+    ...((authEnvSchema.innerType() as z.AnyZodObject).shape as z.ZodRawShape),
+    ...(cmsEnvSchema.shape as z.ZodRawShape),
+    ...((emailEnvSchema.innerType() as z.AnyZodObject).shape as z.ZodRawShape),
+    ...(paymentsEnvSchema.shape as z.ZodRawShape),
+    ...(shippingEnvSchema.shape as z.ZodRawShape),
+    ...(baseEnvSchema.shape as z.ZodRawShape),
+  })
+  .passthrough();
 
 export function depositReleaseEnvRefinement(
   env: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- construct core env schema by combining shapes rather than chaining `merge`

## Testing
- `pnpm --filter @acme/config build`
- `pnpm exec jest apps/cms/__tests__/inventoryImportJsonRoute.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b749b740c4832fb5dd951b42f5e2c9