### PR TITLE
test: stub core env in cms tests

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -24,7 +24,7 @@ module.exports = {
     "^@/components/(.*)$": "<rootDir>/test/__mocks__/componentStub.js",
     "^@/i18n/Translations$": "<rootDir>/test/emptyModule.js",
     "^@/(.*)$": "<rootDir>/apps/cms/src/$1",
-    "^packages/config/src/env/core\\.js$": "<rootDir>/packages/config/src/env/core.ts",
+    "^packages/config/src/env/core\\.js$": "<rootDir>/packages/config/src/env/__test__/core.stub.ts",
     "^packages/config/src/env/index\\.js$": "<rootDir>/packages/config/src/env/index.ts",
     "^packages/config/src/env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
     // TODO: map test-friendly stubs once available


### PR DESCRIPTION
## Summary
- stub `packages/config/src/env/core.js` in CMS Jest config to use test-friendly env schema

## Testing
- `pnpm exec jest apps/cms/__tests__/errorPages.test.tsx --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_68b7499e36cc832fb195df79b31f9873