### PR TITLE
Fix core env schema merge and stabilize CMS layout

### DIFF
--- a/apps/cms/src/app/[lang]/layout.tsx
+++ b/apps/cms/src/app/[lang]/layout.tsx
@@ -3,6 +3,7 @@ import "../globals.css";
 
 import Footer from "@ui/components/layout/Footer";
 import Header from "@ui/components/layout/Header";
+import { Suspense } from "react";
 
 import { TranslationsProvider } from "@i18n/Translations";
 import { Locale, resolveLocale } from "@i18n/locales";
@@ -34,7 +35,9 @@ export default async function LocaleLayout({
 
   return (
     <TranslationsProvider messages={messages}>
-      <Header lang={locale} />
+      <Suspense fallback={null}>
+        <Header lang={locale} />
+      </Suspense>
       <main className="min-h-[calc(100vh-8rem)]">{children}</main>
       <Footer />
     </TranslationsProvider>

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -76,9 +76,13 @@ const baseEnvSchema = z
   })
   .passthrough();
 
-export const coreEnvBaseSchema = (
-  authEnvSchema.innerType() as z.AnyZodObject
-)
+// Begin with an empty object and merge each schema in sequence. Casting the
+// inner types ensures we only merge the raw object shapes and avoid carrying
+// over any Zod effects or refinements. This prevents runtime failures when
+// `merge` receives a schema without a `shape` definition.
+export const coreEnvBaseSchema = z
+  .object({})
+  .merge(authEnvSchema.innerType() as z.AnyZodObject)
   .merge(cmsEnvSchema)
   .merge(emailEnvSchema.innerType() as z.AnyZodObject)
   .merge(paymentsEnvSchema)


### PR DESCRIPTION
## Summary
- avoid zod merge runtime crash by merging env schemas onto an empty object
- wrap CMS layout header in `<Suspense>` to prevent sync render suspension

## Testing
- `pnpm --filter @acme/config test`
- `pnpm --filter @apps/cms test apps/cms/__tests__/i18nPages.test.ts`
- `pnpm -r build` *(fails: Argument of type '{}' is not assignable to parameter of type 'string')*


------
https://chatgpt.com/codex/tasks/task_e_68b74945e1f8832fbb0ccdd50d736923