### PR TITLE
fix: cast env vars to expected types

### DIFF
--- a/packages/lib/src/generateMeta.ts
+++ b/packages/lib/src/generateMeta.ts
@@ -77,7 +77,9 @@ export async function generateMeta(product: ProductData): Promise<GeneratedMeta>
     return fallback;
   }
 
-  const client = new OpenAIConstructor({ apiKey: env.OPENAI_API_KEY });
+    const client = new OpenAIConstructor({
+      apiKey: env.OPENAI_API_KEY as string,
+    });
 
   const prompt = `Generate SEO metadata for a product as JSON with keys title, description, alt.\n\nTitle: ${product.title}\nDescription: ${product.description}`;
 

--- a/packages/platform-core/src/analytics/index.ts
+++ b/packages/platform-core/src/analytics/index.ts
@@ -105,9 +105,14 @@ async function resolveProvider(shop: string): Promise<AnalyticsProvider> {
   }
   if (analytics?.provider === "ga") {
     const measurementId = analytics.id;
-    const apiSecret = process.env.GA_API_SECRET || coreEnv.GA_API_SECRET;
+    const apiSecret = (
+      process.env.GA_API_SECRET ?? coreEnv.GA_API_SECRET
+    ) as string | undefined;
     if (measurementId && apiSecret) {
-      const p = new GoogleAnalyticsProvider(measurementId, apiSecret);
+      const p = new GoogleAnalyticsProvider(
+        measurementId,
+        apiSecret as string,
+      );
       providerCache.set(shop, p);
       return p;
     }

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -19,7 +19,7 @@ function getSecret(): string {
   if (_secret) return _secret;
   const { CART_COOKIE_SECRET: secret } = loadCoreEnv();
   if (!secret) throw new Error("env.CART_COOKIE_SECRET is required");
-  _secret = secret;
+  _secret = secret as string;
   return _secret!; // non‑null assertion to satisfy the string return type
 }
 

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -40,13 +40,18 @@ export async function checkAndAlert(
 ): Promise<void> {
   const settings = await getShopSettings(shop);
   const envRecipients =
-    coreEnv.STOCK_ALERT_RECIPIENTS ?? coreEnv.STOCK_ALERT_RECIPIENT ?? "";
+    (coreEnv.STOCK_ALERT_RECIPIENTS as string | undefined) ??
+    (coreEnv.STOCK_ALERT_RECIPIENT as string | undefined) ??
+    "";
   const recipients = settings.stockAlert?.recipients?.length
     ? settings.stockAlert.recipients
     : envRecipients.split(",").map((r: string) => r.trim()).filter(Boolean);
-  const webhook = settings.stockAlert?.webhook ?? coreEnv.STOCK_ALERT_WEBHOOK;
+  const webhook =
+    (settings.stockAlert?.webhook as string | undefined) ??
+    (coreEnv.STOCK_ALERT_WEBHOOK as string | undefined);
   const defaultThreshold =
-    settings.stockAlert?.threshold ?? coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD;
+    settings.stockAlert?.threshold ??
+    (coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD as number | undefined);
 
   if (recipients.length === 0 && !webhook) return;
 

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -111,17 +111,25 @@ export async function resolveConfig(
   const envEnabled = process.env[envKey(shop, "ENABLED")];
   if (envEnabled !== undefined) {
     config.enabled = envEnabled !== "false";
-  } else if (coreEnv.LATE_FEE_ENABLED !== undefined) {
-    config.enabled = coreEnv.LATE_FEE_ENABLED;
-  }
+    } else if (
+      coreEnv.LATE_FEE_ENABLED !== undefined &&
+      coreEnv.LATE_FEE_ENABLED !== null
+    ) {
+      config.enabled = coreEnv.LATE_FEE_ENABLED as boolean;
+    }
 
-  const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
-  if (envInterval !== undefined) {
-    const num = Number(envInterval);
-    if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
-  } else if (coreEnv.LATE_FEE_INTERVAL_MS !== undefined) {
-    config.intervalMinutes = Math.round(coreEnv.LATE_FEE_INTERVAL_MS / 60000);
-  }
+    const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
+    if (envInterval !== undefined) {
+      const num = Number(envInterval);
+      if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
+    } else if (
+      coreEnv.LATE_FEE_INTERVAL_MS !== undefined &&
+      coreEnv.LATE_FEE_INTERVAL_MS !== null
+    ) {
+      config.intervalMinutes = Math.round(
+        (coreEnv.LATE_FEE_INTERVAL_MS as number) / 60000,
+      );
+    }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;
   if (override.intervalMinutes !== undefined)

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -99,27 +99,29 @@ async function resolveConfig(
   } catch {}
 
   const envEnabled = process.env[envKey(shop, "ENABLED")];
-  if (envEnabled !== undefined) {
-    config.enabled = envEnabled !== "false";
-  } else if (
-    coreEnv.DEPOSIT_RELEASE_ENABLED !== undefined &&
-    config.enabled === DEFAULT_CONFIG.enabled
-  ) {
-    config.enabled = coreEnv.DEPOSIT_RELEASE_ENABLED;
-  }
+    if (envEnabled !== undefined) {
+      config.enabled = envEnabled !== "false";
+    } else if (
+      coreEnv.DEPOSIT_RELEASE_ENABLED !== undefined &&
+      coreEnv.DEPOSIT_RELEASE_ENABLED !== null &&
+      config.enabled === DEFAULT_CONFIG.enabled
+    ) {
+      config.enabled = coreEnv.DEPOSIT_RELEASE_ENABLED as boolean;
+    }
 
   const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
-  if (envInterval !== undefined) {
-    const num = Number(envInterval);
-    if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
-  } else if (
-    coreEnv.DEPOSIT_RELEASE_INTERVAL_MS !== undefined &&
-    config.intervalMinutes === DEFAULT_CONFIG.intervalMinutes
-  ) {
-    config.intervalMinutes = Math.round(
-      coreEnv.DEPOSIT_RELEASE_INTERVAL_MS / 60000,
-    );
-  }
+    if (envInterval !== undefined) {
+      const num = Number(envInterval);
+      if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
+    } else if (
+      coreEnv.DEPOSIT_RELEASE_INTERVAL_MS !== undefined &&
+      coreEnv.DEPOSIT_RELEASE_INTERVAL_MS !== null &&
+      config.intervalMinutes === DEFAULT_CONFIG.intervalMinutes
+    ) {
+      config.intervalMinutes = Math.round(
+        (coreEnv.DEPOSIT_RELEASE_INTERVAL_MS as number) / 60000,
+      );
+    }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;
   if (override.intervalMinutes !== undefined)

--- a/packages/platform-machine/src/reverseLogisticsService.ts
+++ b/packages/platform-machine/src/reverseLogisticsService.ts
@@ -124,21 +124,27 @@ export async function resolveConfig(
   } catch {}
 
   const envEnabled = process.env[envKey(shop, "ENABLED")];
-  if (envEnabled !== undefined) {
-    config.enabled = envEnabled !== "false";
-  } else if (coreEnv.REVERSE_LOGISTICS_ENABLED !== undefined) {
-    config.enabled = coreEnv.REVERSE_LOGISTICS_ENABLED;
-  }
+    if (envEnabled !== undefined) {
+      config.enabled = envEnabled !== "false";
+    } else if (
+      coreEnv.REVERSE_LOGISTICS_ENABLED !== undefined &&
+      coreEnv.REVERSE_LOGISTICS_ENABLED !== null
+    ) {
+      config.enabled = coreEnv.REVERSE_LOGISTICS_ENABLED as boolean;
+    }
 
   const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
-  if (envInterval !== undefined) {
-    const num = Number(envInterval);
-    if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
-  } else if (coreEnv.REVERSE_LOGISTICS_INTERVAL_MS !== undefined) {
-    config.intervalMinutes = Math.round(
-      coreEnv.REVERSE_LOGISTICS_INTERVAL_MS / 60000
-    );
-  }
+    if (envInterval !== undefined) {
+      const num = Number(envInterval);
+      if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
+    } else if (
+      coreEnv.REVERSE_LOGISTICS_INTERVAL_MS !== undefined &&
+      coreEnv.REVERSE_LOGISTICS_INTERVAL_MS !== null
+    ) {
+      config.intervalMinutes = Math.round(
+        (coreEnv.REVERSE_LOGISTICS_INTERVAL_MS as number) / 60000,
+      );
+    }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;
   if (override.intervalMinutes !== undefined)

--- a/packages/template-app/src/api/checkout-session/route.ts
+++ b/packages/template-app/src/api/checkout-session/route.ts
@@ -47,8 +47,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     coverage?: string[];
   };
 
-  const shop = coreEnv.NEXT_PUBLIC_DEFAULT_SHOP || "shop";
-  const shopInfo = await readShop(shop);
+    const shop = (coreEnv.NEXT_PUBLIC_DEFAULT_SHOP as string | undefined) || "shop";
+    const shopInfo = await readShop(shop);
 
   const coverageCodes = Array.isArray(coverage) ? coverage : [];
   const lineItemsExtra: Stripe.Checkout.SessionCreateParams.LineItem[] = [];

--- a/packages/template-app/src/api/subscription/change/route.ts
+++ b/packages/template-app/src/api/subscription/change/route.ts
@@ -20,10 +20,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
   }
 
-  const shopId =
-    req.nextUrl.searchParams.get("shop") ||
-    coreEnv.NEXT_PUBLIC_SHOP_ID ||
-    "shop";
+    const shopId =
+      req.nextUrl.searchParams.get("shop") ||
+      (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) ||
+      "shop";
   const shop = await readShop(shopId);
   if (!shop.subscriptionsEnabled) {
     return NextResponse.json(

--- a/packages/template-app/src/app/AnalyticsScripts.tsx
+++ b/packages/template-app/src/app/AnalyticsScripts.tsx
@@ -5,7 +5,7 @@ import {
 import { coreEnv } from "@acme/config/env/core";
 
 export default async function AnalyticsScripts() {
-  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "default";
   const [settings, shopData] = await Promise.all([
     getShopSettings(shop),
     readShop(shop),

--- a/packages/template-app/src/app/[lang]/subscribe/page.tsx
+++ b/packages/template-app/src/app/[lang]/subscribe/page.tsx
@@ -17,7 +17,7 @@ export default async function SubscribePage({
 }) {
   const { lang } = await params;
   resolveLocale(lang);
-  const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
+    const shopId = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "shop";
   const shop = await readShop(shopId);
   if (!shop.subscriptionsEnabled) return notFound();
 

--- a/packages/template-app/src/app/account/swaps/page.tsx
+++ b/packages/template-app/src/app/account/swaps/page.tsx
@@ -27,8 +27,9 @@ export default async function SwapPage() {
   const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
   const cart: CartState =
     typeof cartId === "string" ? await getCart(cartId) : {};
-  const session = await getCustomerSession();
-  const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
+    const session = await getCustomerSession();
+    const shopId =
+      (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "shop";
   const shop = await readShop(shopId);
   if (!shop.subscriptionsEnabled) return notFound();
   const planId = session?.customerId
@@ -57,7 +58,7 @@ export default async function SwapPage() {
     const cartId = decodeCartCookie(cookieStore.get(CART_COOKIE)?.value);
     const session = await getCustomerSession();
     if (typeof cartId !== "string" || !session?.customerId) return;
-    const shopId = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
+    const shopId = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "shop";
     const shop = await readShop(shopId);
     if (!shop.subscriptionsEnabled) return;
     const planId = await getUserPlan(shopId, session.customerId);

--- a/packages/template-app/src/app/api/ai/catalog/route.ts
+++ b/packages/template-app/src/app/api/ai/catalog/route.ts
@@ -18,7 +18,7 @@ function parseIntOr(val: string | null, def: number): number {
 }
 
 export async function GET(req: NextRequest) {
-  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
+    const shop = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "default";
   const settings = await getShopSettings(shop);
   const ai = settings.seo?.aiCatalog;
   if (!ai?.enabled) {

--- a/packages/template-app/src/app/api/preview-token/route.ts
+++ b/packages/template-app/src/app/api/preview-token/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: Request) {
   if (!pageId) {
     return NextResponse.json({ error: "Missing pageId" }, { status: 400 });
   }
-  const secret = coreEnv.UPGRADE_PREVIEW_TOKEN_SECRET;
+    const secret = coreEnv.UPGRADE_PREVIEW_TOKEN_SECRET as string | undefined;
   if (!secret) {
     return NextResponse.json(
       { error: "Token secret not configured" },

--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -2,7 +2,9 @@ import type { MetadataRoute } from "next";
 import { coreEnv } from "@acme/config/env/core";
 
 export default function robots(): MetadataRoute.Robots {
-  const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+    const base =
+      (coreEnv.NEXT_PUBLIC_BASE_URL as string | undefined) ||
+      "http://localhost:3000";
   return {
     rules: [
       { userAgent: "*", allow: "/" },

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -6,8 +6,11 @@ import type { ProductPublication } from "@acme/types";
 import { nowIso } from "@date-utils";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const base = coreEnv.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "shop";
+    const base =
+      (coreEnv.NEXT_PUBLIC_BASE_URL as string | undefined) ||
+      "http://localhost:3000";
+    const shop =
+      (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "shop";
   const now = nowIso();
 
   const [settings, products] = await Promise.all([

--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -33,7 +33,7 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<ExtendedSeoProps> = {}
 ): Promise<NextSeoProps> {
-  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
+    const shop = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "default";
   const { getShopSettings } = await import(
     "@platform-core/repositories/shops.server"
   );

--- a/packages/template-app/src/routes/preview/[pageId].ts
+++ b/packages/template-app/src/routes/preview/[pageId].ts
@@ -5,8 +5,8 @@ import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "crypto";
 import { coreEnv } from "@acme/config/env/core";
 
-const secret = coreEnv.PREVIEW_TOKEN_SECRET;
-const upgradeSecret = coreEnv.UPGRADE_PREVIEW_TOKEN_SECRET;
+const secret = coreEnv.PREVIEW_TOKEN_SECRET as string | undefined;
+const upgradeSecret = coreEnv.UPGRADE_PREVIEW_TOKEN_SECRET as string | undefined;
 
 function verify(
   id: string,
@@ -37,7 +37,7 @@ export const onRequest = async ({
   } else if (!verify(pageId, token, secret)) {
     return new Response("Unauthorized", { status: 401 });
   }
-  const shop = coreEnv.NEXT_PUBLIC_SHOP_ID || "default";
+  const shop = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "default";
   const pages = await getPages(shop);
   const page = pages.find((p) => p.id === pageId);
   if (!page) return new Response("Not Found", { status: 404 });


### PR DESCRIPTION
## Summary
- add explicit string casts for cookie secret and GA API secret
- type stock alert configuration and various template app env lookups
- normalize env-driven service configs for deposit, reverse logistics, and late fees

## Testing
- `pnpm -r build` *(fails: Module '"../../hooks/useProductEditorFormState"' has no exported member 'ProductWithVariants'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b748334c84832faa4f61d2e30fb51e