### PR TITLE
chore(api): add @acme/lib declaration stub

### DIFF
--- a/apps/api/src/types/acme-lib.d.ts
+++ b/apps/api/src/types/acme-lib.d.ts
@@ -1,0 +1,3 @@
+declare module '@acme/lib' {
+  export function validateShopName(name: string): string;
+}


### PR DESCRIPTION
## Summary
- add type declaration for `@acme/lib` so the API route can import it without TypeScript errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: Argument of type '{}' is not assignable to parameter of type 'string')*
- `pnpm exec tsc -p apps/api/tsconfig.json`
- `pnpm --filter @apps/api test` *(fails: coverage threshold for branches not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b74aef6590832f819a94055b5650d4