### PR TITLE
fix: resolve zod shape error in core env

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -76,16 +76,13 @@ const baseEnvSchema = z
   })
   .passthrough();
 
-export const coreEnvBaseSchema = z
-  .object({
-    ...((authEnvSchema.innerType() as z.AnyZodObject).shape as z.ZodRawShape),
-    ...(cmsEnvSchema.shape as z.ZodRawShape),
-    ...((emailEnvSchema.innerType() as z.AnyZodObject).shape as z.ZodRawShape),
-    ...(paymentsEnvSchema.shape as z.ZodRawShape),
-    ...(shippingEnvSchema.shape as z.ZodRawShape),
-    ...(baseEnvSchema.shape as z.ZodRawShape),
-  })
-  .passthrough();
+export const coreEnvBaseSchema = authEnvSchema
+  .innerType()
+  .merge(cmsEnvSchema)
+  .merge(emailEnvSchema.innerType())
+  .merge(paymentsEnvSchema)
+  .merge(shippingEnvSchema)
+  .merge(baseEnvSchema);
 
 export function depositReleaseEnvRefinement(
   env: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- merge environment schemas instead of spreading raw shapes to avoid zod shape errors

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve '@babel/runtime/helpers/asyncToGenerator')*
- `pnpm test:cms apps/cms/src/app/api/configurator/__tests__/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b75465ab5c832fbfd01dcea676fd97