### PR TITLE
test: load react before server render

### DIFF
--- a/apps/cms/__tests__/wizardPage.test.tsx
+++ b/apps/cms/__tests__/wizardPage.test.tsx
@@ -59,6 +59,10 @@ async function withRepo(cb: (dir: string) => Promise<void>): Promise<void> {
 describe("WizardPage", () => {
   it("renders placeholder content", async () => {
     await withRepo(async () => {
+      // Ensure React is loaded before invoking the server renderer.  In some
+      // environments Jest’s module cache can be cleared which leaves React
+      // undefined when `react-dom/server` evaluates.
+      await import("react");
       const { renderToStaticMarkup } = await import("react-dom/server");
       const { default: WizardPage } = await import(
         "../src/app/cms/wizard/page"


### PR DESCRIPTION
## Summary
- ensure React is loaded before using `react-dom/server` in Wizard page test

## Testing
- `pnpm test:cms apps/cms/__tests__/wizardPage.test.tsx`
- `pnpm -r build` *(fails: `setTheme` is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b756ef0620832fb9a1af11c936365e