### PR TITLE
fix: stabilize wizard step loading

### DIFF
--- a/apps/cms/src/app/cms/wizard/Wizard.tsx
+++ b/apps/cms/src/app/cms/wizard/Wizard.tsx
@@ -1,6 +1,5 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import { flushSync } from "react-dom";
 
 import { baseTokens, loadThemeTokens, type TokenMap } from "./tokenUtils";
 
@@ -67,7 +66,7 @@ export default function Wizard({ themes }: WizardProps): React.JSX.Element {
         const completed = json.completed || {};
         const idx = stepOrder.findIndex((s) => completed[s] !== "complete");
         const next = idx === -1 ? stepOrder.length - 1 : idx;
-        flushSync(() => setStepIdx((cur) => (cur === 0 ? next : cur)));
+        setStepIdx((cur) => (cur === 0 ? next : cur));
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Summary
- fix wizard progress restoration by setting step index without `flushSync`

## Testing
- `pnpm test:cms apps/cms/__tests__/wizard-flow.integration.test.tsx`
- `pnpm test:cms apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b756d99768832f8e300a4f6608a458