### PR TITLE
test: add account approval edge cases

### DIFF
--- a/apps/cms/src/actions/__tests__/accounts.server.test.ts
+++ b/apps/cms/src/actions/__tests__/accounts.server.test.ts
@@ -1,0 +1,66 @@
+/** @jest-environment node */
+
+jest.mock('../../lib/server/rbacStore', () => ({
+  readRbac: jest.fn(),
+  writeRbac: jest.fn(),
+}));
+
+jest.mock('@acme/email', () => ({
+  sendEmail: jest.fn(),
+}));
+
+jest.mock('argon2', () => ({
+  hash: jest.fn().mockResolvedValue('hashed'),
+}));
+
+import { approveAccount, requestAccount, listPendingUsers } from '../accounts.server';
+import { readRbac, writeRbac } from '../../lib/server/rbacStore';
+import { sendEmail } from '@acme/email';
+
+describe('approveAccount', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('throws error when id does not exist in PENDING_USERS', async () => {
+    const form = new FormData();
+    form.set('id', 'missing');
+    form.append('roles', 'viewer');
+
+    await expect(approveAccount(form)).rejects.toThrow('pending user not found');
+    expect(readRbac).not.toHaveBeenCalled();
+    expect(writeRbac).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { roles: ['admin'], expected: 'admin' },
+    { roles: ['editor', 'viewer'], expected: ['editor', 'viewer'] },
+  ])('role array length %#', async ({ roles, expected }) => {
+    const requestForm = new FormData();
+    requestForm.set('name', 'Alice');
+    requestForm.set('email', 'alice@example.com');
+    requestForm.set('password', 'secret');
+    await requestAccount(requestForm);
+
+    const [pending] = await listPendingUsers();
+    const approveForm = new FormData();
+    approveForm.set('id', pending.id);
+    roles.forEach((r) => approveForm.append('roles', r));
+
+    (readRbac as jest.Mock).mockResolvedValue({
+      users: {},
+      roles: {},
+      permissions: {},
+    });
+
+    await approveAccount(approveForm);
+
+    expect(writeRbac).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roles: { [pending.id]: expected },
+      })
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for account approval failure and role coercion

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript project references are not fully supported. Attempting to build in incremental mode.)*
- `pnpm --filter @apps/cms test` *(fails: marketingEmailApi.test.ts timeout, createShop.server.test.ts module not found)*
- `pnpm --filter @apps/cms test src/actions/__tests__/accounts.server.test.ts` *(fails: coverage threshold for branches not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b758323cb4832faa9d383a6561ec53