### PR TITLE
test(cms): add locale layout fallback test

### DIFF
--- a/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
+++ b/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import LocaleLayout from "../layout";
+
+jest.mock("@ui/components/layout/Footer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="footer" />,
+}));
+
+const HeaderMock = jest.fn(({ lang }: { lang: string }) => (
+  <div data-testid="header">{lang}</div>
+));
+
+jest.mock("@ui/components/layout/Header", () => ({
+  __esModule: true,
+  default: HeaderMock,
+}));
+
+jest.mock("@i18n/Translations", () => ({
+  __esModule: true,
+  TranslationsProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+describe("LocaleLayout", () => {
+  afterEach(() => HeaderMock.mockClear());
+
+  it("renders with provided lang", async () => {
+    const element = await LocaleLayout({
+      children: <div />,
+      params: Promise.resolve({ lang: "de" }),
+    });
+    render(element);
+    expect(screen.getByTestId("header")).toHaveTextContent("de");
+  });
+
+  it("defaults to 'en' when lang param is missing", async () => {
+    const element = await LocaleLayout({
+      children: <div />,
+      params: Promise.resolve({}),
+    });
+    render(element);
+    expect(screen.getByTestId("header")).toHaveTextContent("en");
+  });
+});


### PR DESCRIPTION
## Summary
- add component test for [lang] layout verifying default locale fallback

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'setTheme' is assigned a value but never used)*
- `pnpm test apps/cms` *(fails: Missing tasks in project)*
- `pnpm test --filter @apps/cms` *(fails: 7 failed, 126 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b75836f210832fac7808823b57ed87