### PR TITLE
fix: correct ProductEditorForm test mock path

### DIFF
--- a/packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../PublishLocationSelector", () => ({
   default: () => <div data-testid="publish-selector" />,
 }));
 
-jest.mock("../../hooks/useProductEditorFormState");
+jest.mock("../../../hooks/useProductEditorFormState");
 
 describe("ProductEditorForm", () => {
   it("renders fields and submits via hook", () => {


### PR DESCRIPTION
## Summary
- fix the ProductEditorForm test by pointing the jest mock to the proper hooks path

## Testing
- `pnpm -r build` *(fails: setTheme is assigned a value but never used)*
- `pnpm exec jest packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx --config jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b758bad340832f8ddd7205dfbc0035