### PR TITLE
test: cover numeric zod error map branches

### DIFF
--- a/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
+++ b/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
@@ -69,6 +69,20 @@ describe("friendly zod error messages", () => {
     expect(result.error.issues[0].message).toBe("Must be at most 2 characters");
   });
 
+  test("too_small number", () => {
+    const schema = z.number().min(1);
+    const result = schema.safeParse(0);
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe("Number must be greater than or equal to 1");
+  });
+
+  test("too_big number", () => {
+    const schema = z.number().max(1);
+    const result = schema.safeParse(2);
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe("Number must be less than or equal to 1");
+  });
+
   test("too_small array", () => {
     const schema = z.array(z.string()).min(2);
     const result = schema.safeParse(["a"]);


### PR DESCRIPTION
## Summary
- test numeric branches in zod error map for too_small and too_big numbers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build: Failed, apps/shop-bcd build: Failed)*
- `pnpm --filter @packages/zod-utils test packages/zod-utils` *(fails: No projects matched the filters in "/workspace/base-shop")*
- `pnpm --filter @acme/zod-utils exec jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b75994df28832fb1626dec7b8f5312