### PR TITLE
test(config): add empty STRIPE_SECRET_KEY fallback test

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -94,6 +94,26 @@ describe("payments env defaults", () => {
     );
   });
 
+  it("warns and falls back to defaults when STRIPE_SECRET_KEY is empty", () => {
+    process.env = {
+      STRIPE_SECRET_KEY: "",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_123",
+      STRIPE_WEBHOOK_SECRET: "whsec_live_123",
+    } as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "⚠️ Invalid payments environment variables:",
+      expect.any(Object),
+    );
+  });
+
   it.each([
     {
       name: "malformed values",
@@ -177,7 +197,7 @@ describe("payments env defaults", () => {
     );
 
   it(
-    "warns and falls back to defaults when STRIPE_SECRET_KEY is empty",
+    "warns and falls back to defaults when STRIPE_SECRET_KEY is empty (ts import)",
     async () => {
       process.env = {
         STRIPE_SECRET_KEY: "",


### PR DESCRIPTION
## Summary
- test fallback to default payments env when STRIPE_SECRET_KEY is empty and warning is logged

## Testing
- `pnpm --filter @packages/config test packages/config/src/env` *(fails: No projects matched the filters)*
- `pnpm --filter @acme/config test packages/config/src/env`

------
https://chatgpt.com/codex/tasks/task_e_68b7599104e8832f9791a346b5bf0986