### PR TITLE
test: add MiniCart client error tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/MiniCart.client.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/MiniCart.client.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MiniCart } from "../MiniCart.client";
+
+jest.mock("@platform-core/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+const mockUseCart = jest.fn();
+jest.mock("@platform-core/contexts/CartContext", () => ({
+  useCart: () => mockUseCart(),
+}));
+
+describe("MiniCart client", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows empty state when cart is empty", async () => {
+    mockUseCart.mockReturnValue([{}, jest.fn()]);
+    render(<MiniCart trigger={<button>Cart</button>} />);
+
+    await userEvent.click(screen.getByText("Cart"));
+    expect(await screen.findByText("Cart is empty.")).toBeInTheDocument();
+  });
+
+  it("renders subtotal and displays toast when dispatch errors occur", async () => {
+    const dispatch = jest.fn().mockRejectedValue(new Error("fail"));
+    mockUseCart.mockReturnValue([
+      {
+        "sku1:m": {
+          sku: { id: "sku1", title: "Item", price: 10, sizes: [] },
+          qty: 1,
+          size: "m",
+        },
+      },
+      dispatch,
+    ]);
+
+    render(<MiniCart trigger={<button>Cart</button>} />);
+    await userEvent.click(screen.getByText("Cart"));
+
+    expect(await screen.findByText("$10.00")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /increase quantity/i })
+    );
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "setQty",
+      id: "sku1:m",
+      qty: 2,
+    });
+    expect(await screen.findByText("fail")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "×" }));
+
+    await userEvent.click(screen.getByRole("button", { name: /remove/i }));
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1:m" });
+    expect(await screen.findByText("fail")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add MiniCart client tests covering empty cart and dispatch error handling

## Testing
- `pnpm -r build` *(fails: Error: 'setTheme' is assigned a value but never used)*
- `pnpm --filter @acme/ui test --coverage` *(fails: Cannot find module '../utils/args' from 'test/unit/init-shop/env.spec.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b7597bebb8832f8f77ee27299323fa