### PR TITLE
test: add sanity action tests

### DIFF
--- a/apps/cms/src/actions/__tests__/sanity.server.test.ts
+++ b/apps/cms/src/actions/__tests__/sanity.server.test.ts
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+
+jest.mock("@acme/plugin-sanity", () => ({
+  verifyCredentials: jest.fn(),
+  publishPost: jest.fn(),
+}));
+
+import { connectSanity, createSanityPost } from "../sanity.server";
+import { verifyCredentials, publishPost } from "@acme/plugin-sanity";
+
+describe("connectSanity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses empty strings when required fields are missing", async () => {
+    (verifyCredentials as jest.Mock).mockResolvedValue("ok");
+    const formData = new FormData();
+    const result = await connectSanity(formData);
+    expect(result).toBe("ok");
+    expect(verifyCredentials).toHaveBeenCalledWith({
+      projectId: "",
+      dataset: "",
+      token: "",
+    });
+  });
+});
+
+describe("createSanityPost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws on invalid post JSON", async () => {
+    const formData = new FormData();
+    formData.append("post", "{invalid");
+    await expect(createSanityPost(formData)).rejects.toThrow();
+    expect(publishPost).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for sanity actions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'setTheme' is assigned a value but never used)*
- `pnpm test apps/cms` *(fails: Could not find task `apps/cms` in project)*
- `pnpm --filter @apps/cms test` *(fails: multiple test failures)*
- `pnpm exec jest apps/cms/src/actions/__tests__/sanity.server.test.ts --config apps/cms/jest.config.cjs` *(fails: Jest "global" coverage threshold for branches (60%) not met: 58.33%)*

------
https://chatgpt.com/codex/tasks/task_e_68b75834daf0832fae8e987781a6c67c