### PR TITLE
fix: align tests with React 19 and correct auth path

### DIFF
--- a/apps/cms/__tests__/sectionIndexPages.test.ts
+++ b/apps/cms/__tests__/sectionIndexPages.test.ts
@@ -1,8 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 
 // Some pages pull in heavy server-only modules which can slow down
 // the initial dynamic import. Increase the Jest timeout so the test has
@@ -11,8 +9,10 @@ jest.setTimeout(20_000);
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: (props: any) =>
-    React.createElement("a", { href: props.href }, props.children),
+  default: (props: any) => {
+    const React = require("react");
+    return React.createElement("a", { href: props.href }, props.children);
+  },
 }));
 
 async function withRepo(cb: (dir: string) => Promise<void>): Promise<void> {
@@ -33,6 +33,7 @@ async function withRepo(cb: (dir: string) => Promise<void>): Promise<void> {
 describe("CMS section index pages", () => {
   it("lists shops with links", async () => {
     await withRepo(async () => {
+      const { renderToStaticMarkup } = await import("react-dom/server");
       const sections = [
         ["products", "products"],
         ["pages", "pages"],
@@ -51,6 +52,7 @@ describe("CMS section index pages", () => {
 
   it("shows message when no shops exist", async () => {
     await withRepo(async (dir) => {
+      const { renderToStaticMarkup } = await import("react-dom/server");
       await fs.rm(path.join(dir, "data", "shops", "foo"), {
         recursive: true,
         force: true,

--- a/apps/cms/__tests__/wizardRoute.test.ts
+++ b/apps/cms/__tests__/wizardRoute.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 /* ------------------------------------------------------------------ */
 /*  Environment setup                                                 */

--- a/apps/cms/src/actions/__tests__/createShop.server.test.ts
+++ b/apps/cms/src/actions/__tests__/createShop.server.test.ts
@@ -28,7 +28,7 @@ describe("createNewShop", () => {
   it("Successful shop creation with RBAC update for new user", async () => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("./common/auth");
+    const { ensureAuthorized } = await import("../common/auth");
 
     const deployResult = { status: "ok" } as any;
     (createShop as jest.Mock).mockResolvedValue(deployResult);
@@ -53,7 +53,7 @@ describe("createNewShop", () => {
   ])("Existing role array vs single role %#", async ({ current, expected }) => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("./common/auth");
+    const { ensureAuthorized } = await import("../common/auth");
 
     (createShop as jest.Mock).mockResolvedValue({});
     (readRbac as jest.Mock).mockResolvedValue({
@@ -72,7 +72,7 @@ describe("createNewShop", () => {
   it("Failure writing RBAC → verify rollback deletes created entities and throws", async () => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("./common/auth");
+    const { ensureAuthorized } = await import("../common/auth");
     const { prisma } = await import("@platform-core/db");
 
     (createShop as jest.Mock).mockResolvedValue({});
@@ -96,7 +96,7 @@ describe("createNewShop", () => {
   it("Ensure user without id skips RBAC update", async () => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("./common/auth");
+    const { ensureAuthorized } = await import("../common/auth");
 
     const deployResult = { status: "ok" } as any;
     (createShop as jest.Mock).mockResolvedValue(deployResult);


### PR DESCRIPTION
## Summary
- require React within Next.js link mock to avoid module reset issues in section index page tests
- import React DOM server on demand in tests
- use type-only ReactNode import in wizard route test
- fix relative auth import in createShop server test

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Error: 'setTheme' is assigned a value but never used)*
- `pnpm exec jest apps/cms/__tests__/sectionIndexPages.test.ts apps/cms/__tests__/wizardRoute.test.ts apps/cms/src/actions/__tests__/createShop.server.test.ts --runInBand` *(fails: global suite with unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b757106fa8832fad7d9e03b82d93bb