### PR TITLE
fix: remove unused setTheme and handle fieldErrors

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/hooks/useConfiguratorStep.ts
+++ b/apps/cms/src/app/cms/configurator/steps/hooks/useConfiguratorStep.ts
@@ -25,7 +25,8 @@ export default function useConfiguratorStep<T>({
   useEffect(() => {
     if (schema && values) {
       const parsed = schema.safeParse(values);
-      setErrors(parsed.success ? {} : parsed.error.flatten().fieldErrors);
+      const fieldErrors = parsed.error.flatten().fieldErrors;
+      setErrors(parsed.success ? {} : (fieldErrors as Record<string, string[]>));
     }
   }, [schema, values]);
 

--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeEditor.ts
@@ -24,7 +24,6 @@ export function useThemeEditor({
 }: Options) {
   const {
     theme,
-    setTheme,
     overrides,
     setOverrides,
     availableThemes,


### PR DESCRIPTION
## Summary
- remove unused `setTheme` parameter from theme editor hook
- cast Zod field errors to expected record type in configurator step hook

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@babel/runtime/helpers/interopRequireDefault')*

------
https://chatgpt.com/codex/tasks/task_e_68b75c3182e0832f94934a9269d6ed04