### PR TITLE
fix failing cms tests for server rendering

### DIFF
--- a/apps/cms/__tests__/sectionIndexPages.test.ts
+++ b/apps/cms/__tests__/sectionIndexPages.test.ts
@@ -1,19 +1,20 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 
 // Some pages pull in heavy server-only modules which can slow down
 // the initial dynamic import. Increase the Jest timeout so the test has
 // enough time to complete without failing.
 jest.setTimeout(20_000);
 
-jest.mock("next/link", () => ({
-  __esModule: true,
-  default: (props: any) =>
-    React.createElement("a", { href: props.href }, props.children),
-}));
+jest.mock("next/link", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: (props: any) =>
+      React.createElement("a", { href: props.href }, props.children),
+  };
+});
 
 async function withRepo(cb: (dir: string) => Promise<void>): Promise<void> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "sections-"));
@@ -33,6 +34,8 @@ async function withRepo(cb: (dir: string) => Promise<void>): Promise<void> {
 describe("CMS section index pages", () => {
   it("lists shops with links", async () => {
     await withRepo(async () => {
+      await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
       const sections = [
         ["products", "products"],
         ["pages", "pages"],
@@ -59,6 +62,8 @@ describe("CMS section index pages", () => {
         recursive: true,
         force: true,
       });
+      await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
       const { default: Page } = await import("../src/app/cms/products/page");
       const html = renderToStaticMarkup(await Page());
       expect(html).toContain("No shops found.");

--- a/apps/cms/__tests__/wizardRoute.test.ts
+++ b/apps/cms/__tests__/wizardRoute.test.ts
@@ -41,7 +41,7 @@ describe("wizard route", () => {
   it("renders wizard page for admin", async () => {
     jest.resetModules(); // ensure mocks are applied fresh
     await import("../../../test/resetNextMocks");
-
+    await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const { default: WizardPage } = await import("../src/app/cms/wizard/page");
 

--- a/apps/cms/src/actions/__tests__/createShop.server.test.ts
+++ b/apps/cms/src/actions/__tests__/createShop.server.test.ts
@@ -16,7 +16,7 @@ jest.mock("../../lib/server/rbacStore", () => ({
   writeRbac: jest.fn(),
 }));
 
-jest.mock("../common/auth", () => ({
+jest.mock("../common/auth.ts", () => ({
   ensureAuthorized: jest.fn(),
 }));
 
@@ -28,7 +28,7 @@ describe("createNewShop", () => {
   it("Successful shop creation with RBAC update for new user", async () => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("../common/auth");
+    const { ensureAuthorized } = await import("../common/auth.ts");
 
     const deployResult = { status: "ok" } as any;
     (createShop as jest.Mock).mockResolvedValue(deployResult);
@@ -59,7 +59,7 @@ describe("createNewShop", () => {
       const { readRbac, writeRbac } = await import(
         "../../lib/server/rbacStore"
       );
-      const { ensureAuthorized } = await import("../common/auth");
+      const { ensureAuthorized } = await import("../common/auth.ts");
 
       (createShop as jest.Mock).mockResolvedValue({});
       (readRbac as jest.Mock).mockResolvedValue({
@@ -85,7 +85,7 @@ describe("createNewShop", () => {
   it("Failure writing RBAC → verify rollback deletes created entities and throws", async () => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("../common/auth");
+    const { ensureAuthorized } = await import("../common/auth.ts");
     const { prisma } = await import("@platform-core/db");
 
     (createShop as jest.Mock).mockResolvedValue({});
@@ -109,7 +109,7 @@ describe("createNewShop", () => {
   it("Ensure user without id skips RBAC update", async () => {
     const { createShop } = await import("@platform-core/createShop");
     const { readRbac, writeRbac } = await import("../../lib/server/rbacStore");
-    const { ensureAuthorized } = await import("../common/auth");
+    const { ensureAuthorized } = await import("../common/auth.ts");
 
     const deployResult = { status: "ok" } as any;
     (createShop as jest.Mock).mockResolvedValue(deployResult);


### PR DESCRIPTION
## Summary
- re-import React after module resets in CMS section index tests and mock next/link dynamically
- load React before server rendering in wizard route test
- correct createShop test auth import path

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/tailwind-config, packages/i18n, packages/shared-utils, packages/types)*
- `pnpm exec jest apps/cms/__tests__/sectionIndexPages.test.ts apps/cms/src/actions/__tests__/createShop.server.test.ts apps/cms/__tests__/wizardRoute.test.ts --runInBand --config ./jest.config.cjs --collectCoverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b762f19b58832f9f693a4aaa2fbf81