### PR TITLE
fix: restore SendGrid mapping in webhook tests

### DIFF
--- a/apps/cms/__tests__/emailProviderWebhooks.test.ts
+++ b/apps/cms/__tests__/emailProviderWebhooks.test.ts
@@ -8,10 +8,14 @@ jest.mock("@platform-core/analytics", () => ({
   trackEvent: jest.fn(),
 }));
 
-jest.mock("@acme/email/analytics", () => ({
-  __esModule: true,
-  mapResendEvent: jest.fn(),
-}));
+jest.mock("@acme/email/analytics", () => {
+  const actual = jest.requireActual("@acme/email/analytics");
+  return {
+    __esModule: true,
+    ...actual,
+    mapResendEvent: jest.fn(),
+  };
+});
 
 const ResponseWithJson = Response as unknown as typeof Response & {
   json?: (data: unknown, init?: ResponseInit) => Response;


### PR DESCRIPTION
## Summary
- preserve actual SendGrid mapper when mocking email analytics

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build: Failed)*
- `pnpm --filter @apps/cms test apps/cms/__tests__/emailProviderWebhooks.test.ts`
- `pnpm exec eslint apps/cms/__tests__/emailProviderWebhooks.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b763fccf54832fb602c6192e6bb89f