### PR TITLE
fix: stabilize wizard page server render test

### DIFF
--- a/apps/cms/__tests__/wizardPage.test.tsx
+++ b/apps/cms/__tests__/wizardPage.test.tsx
@@ -63,7 +63,11 @@ describe("WizardPage", () => {
       // environments Jest’s module cache can be cleared which leaves React
       // undefined when `react-dom/server` evaluates.
       await import("react");
-      const { renderToStaticMarkup } = await import("react-dom/server");
+      // Use the CommonJS build of `react-dom/server`. Loading it via `require`
+      // avoids crashes in environments where the ESM loader is missing the
+      // legacy `exports` object the module expects.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { renderToStaticMarkup } = require("react-dom/server");
       const { default: WizardPage } = await import(
         "../src/app/cms/wizard/page"
       );


### PR DESCRIPTION
## Summary
- load `react-dom/server` using CommonJS `require` to avoid runtime crash

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type error: 'parsed.error' is possibly 'undefined')*
- `pnpm --filter @apps/cms test apps/cms/__tests__/wizardPage.test.tsx` *(fails: Jest coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b763c1c318832f9f94c46aeaf45ad6