### PR TITLE
fix: mock header correctly in layout tests

### DIFF
--- a/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
+++ b/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
@@ -8,14 +8,15 @@ jest.mock("@ui/components/layout/Footer", () => ({
   default: () => <div data-testid="footer" />,
 }));
 
-const HeaderMock = jest.fn(({ lang }: { lang: string }) => (
-  <div data-testid="header">{lang}</div>
-));
-
 jest.mock("@ui/components/layout/Header", () => ({
   __esModule: true,
-  default: HeaderMock,
+  default: jest.fn(({ lang }: { lang: string }) => (
+    <div data-testid="header">{lang}</div>
+  )),
 }));
+
+const HeaderMock =
+  jest.requireMock("@ui/components/layout/Header").default as jest.Mock;
 
 jest.mock("@i18n/Translations", () => ({
   __esModule: true,


### PR DESCRIPTION
## Summary
- fix layout test header mock initialization

## Testing
- `pnpm -r build` *(fails: Type error: 'parsed.error' is possibly 'undefined')*
- `pnpm test:cms` *(fails: SyntaxError Unexpected token 'export' in packages/config)*
- `pnpm exec jest --runTestsByPath apps/cms/src/app/'[lang]'/__tests__/layout.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b763e4afb8832fa6770d0389a2ce6a