### PR TITLE
Render toast inside MiniCart dialog

### DIFF
--- a/packages/ui/src/components/organisms/MiniCart.client.tsx
+++ b/packages/ui/src/components/organisms/MiniCart.client.tsx
@@ -126,13 +126,13 @@ export function MiniCart({ trigger, width = "w-80" }: MiniCartProps) {
               </div>
             </div>
           )}
+          <Toast
+            open={toast.open}
+            onClose={() => setToast((t) => ({ ...t, open: false }))}
+            message={toast.message}
+          />
         </DialogContent>
       </Dialog>
-      <Toast
-        open={toast.open}
-        onClose={() => setToast((t) => ({ ...t, open: false }))}
-        message={toast.message}
-      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Render toast inside MiniCart dialog content so its close button stays accessible

## Testing
- `pnpm -r build` *(fails: Next.js build errors)*
- `pnpm --filter @acme/ui test` *(fails: Jest unexpected token)*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/MiniCart.client.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b764e7a1d0832fa0f849fc72d671a1