### PR TITLE
Fix wizard route SSR test

### DIFF
--- a/apps/cms/__tests__/wizardRoute.test.ts
+++ b/apps/cms/__tests__/wizardRoute.test.ts
@@ -41,7 +41,10 @@ describe("wizard route", () => {
   it("renders wizard page for admin", async () => {
     jest.resetModules(); // ensure mocks are applied fresh
     await import("../../../test/resetNextMocks");
-
+    // Ensure React is loaded before invoking the server renderer. In some
+    // environments Jest's module cache can be cleared which leaves React
+    // undefined when `react-dom/server` evaluates.
+    await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const { default: WizardPage } = await import("../src/app/cms/wizard/page");
 


### PR DESCRIPTION
## Summary
- ensure React is imported before calling `react-dom/server` in wizard route test to prevent undefined access

## Testing
- `pnpm test:cms apps/cms/__tests__/wizardRoute.test.ts`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@babel/runtime/helpers/interopRequireDefault')*

------
https://chatgpt.com/codex/tasks/task_e_68b763d1511c832f8b5ae3fb22f10475