### PR TITLE
test(ui): add rating stars tests

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx
@@ -1,0 +1,22 @@
+import "../../../../../../test/resetNextMocks";
+import { render } from "@testing-library/react";
+import { RatingStars } from "../RatingStars";
+
+describe("RatingStars", () => {
+  it.each([
+    { rating: 3.2, filled: 3 },
+    { rating: 4.8, filled: 5 },
+    { rating: 0, filled: 0 },
+  ])("renders correct stars for rating %p", ({ rating, filled }) => {
+    const { container } = render(<RatingStars rating={rating} />);
+    const stars = container.querySelectorAll("svg");
+    expect(stars).toHaveLength(5);
+    stars.forEach((star, index) => {
+      if (index < filled) {
+        expect(star).toHaveClass("fill-yellow-500");
+      } else {
+        expect(star).toHaveClass("fill-muted");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for RatingStars to verify rounding and class application

## Testing
- `pnpm test packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx -- --coverage` *(fails: Missing tasks in project)*
- `pnpm exec jest packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx --coverage` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b765f7b134832fa10b71e072d87a80