### PR TITLE
Handle Configurator validation safely and fix override typing

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/hooks/useConfiguratorStep.ts
+++ b/apps/cms/src/app/cms/configurator/steps/hooks/useConfiguratorStep.ts
@@ -25,8 +25,12 @@ export default function useConfiguratorStep<T>({
   useEffect(() => {
     if (schema && values) {
       const parsed = schema.safeParse(values);
-      const fieldErrors = parsed.error.flatten().fieldErrors;
-      setErrors(parsed.success ? {} : (fieldErrors as Record<string, string[]>));
+      if (parsed.success) {
+        setErrors({});
+      } else {
+        const fieldErrors = parsed.error.flatten().fieldErrors;
+        setErrors(fieldErrors as Record<string, string[]>);
+      }
     }
   }, [schema, values]);
 

--- a/apps/cms/src/app/cms/shop/[shop]/themes/useThemeTokenSync.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/useThemeTokenSync.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from "react";
 import { patchShopTheme } from "../../../wizard/services/patchTheme";
 import { savePreviewTokens } from "../../../wizard/previewTokens";
 
@@ -9,7 +9,7 @@ interface Args {
   theme: string;
   overrides: Record<string, string>;
   tokensByThemeState: Record<string, Record<string, string>>;
-  setOverrides: (next: Record<string, string>) => void;
+  setOverrides: Dispatch<SetStateAction<Record<string, string>>>;
 }
 
 export function useThemeTokenSync({


### PR DESCRIPTION
## Summary
- avoid accessing parsed.error when schema parsing succeeds
- allow useThemeTokenSync to accept state updater functions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68b7665295a8832fa674282855548cdb