### PR TITLE
test: cover device preset fallback

### DIFF
--- a/packages/ui/src/utils/__tests__/devicePresets.test.ts
+++ b/packages/ui/src/utils/__tests__/devicePresets.test.ts
@@ -26,4 +26,15 @@ describe("devicePresets data", () => {
       expect(preset.type).toBe(type);
     });
   });
+
+  it("returns the correct preset for a valid type", () => {
+    const expected = devicePresets.find((p) => p.type === "tablet");
+    const preset = getLegacyPreset("tablet");
+    expect(preset).toEqual(expected);
+  });
+
+  it("falls back to the default preset for an unknown type", () => {
+    const preset = getLegacyPreset("unknown" as any);
+    expect(preset).toEqual(devicePresets[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- test device preset retrieval for valid type
- ensure getLegacyPreset falls back to default for unknown type

## Testing
- `pnpm -r build` *(fails: apps/cms build: Type error: 'parsed.error' is possibly 'undefined')*
- `pnpm --filter @acme/ui test src/utils/__tests__/devicePresets.test.ts -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b765fd55f0832fa5ce3ca66c227497