### PR TITLE
test: expand color utils coverage

### DIFF
--- a/packages/ui/src/utils/__tests__/colorUtils.test.ts
+++ b/packages/ui/src/utils/__tests__/colorUtils.test.ts
@@ -1,12 +1,29 @@
 import { hslToHex, hexToHsl, isHex, isHsl } from "../colorUtils";
 
 describe("colorUtils", () => {
-  test("hslToHex converts HSL to hex", () => {
-    expect(hslToHex("0 100% 50%")).toBe("#ff0000");
+  test.each([
+    ["#ff0000", "0 100% 50%"],
+    ["#00ff00", "120 100% 50%"],
+    ["#0000ff", "240 100% 50%"],
+    ["#777777", "0 0% 47%"],
+  ])("hexToHsl converts %s to %s", (hex, hsl) => {
+    expect(hexToHsl(hex)).toBe(hsl);
   });
 
-  test("hexToHsl converts hex to HSL", () => {
-    expect(hexToHsl("#00ff00")).toBe("120 100% 50%");
+  test.each([
+    ["0 100% 50%", "#ff0000"],
+    ["120 100% 50%", "#00ff00"],
+    ["240 100% 50%", "#0000ff"],
+    ["0 0% 47%", "#787878"],
+  ])("hslToHex converts %s to %s", (hsl, hex) => {
+    expect(hslToHex(hsl)).toBe(hex);
+  });
+
+  test("hsl and hex conversions are symmetric", () => {
+    const colors = ["#ff0000", "#00ff00", "#0000ff"];
+    colors.forEach((hex) => {
+      expect(hslToHex(hexToHsl(hex))).toBe(hex);
+    });
   });
 
   test("isHex validates hex colors", () => {


### PR DESCRIPTION
## Summary
- add hex and HSL conversion tests for primary colors and grayscale
- verify symmetry of hex/hsl transformations

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'parsed.error' is possibly 'undefined')*
- `pnpm --filter @acme/ui test packages/ui/src/utils/__tests__/colorUtils.test.ts -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b765fc3cb8832fbdb77d05fd1a62b1