### PR TITLE
test: add Image360Viewer interaction test

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/Image360Viewer.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/Image360Viewer.test.tsx
@@ -1,0 +1,26 @@
+import "../../../../../../test/resetNextMocks";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Image360Viewer } from "../Image360Viewer";
+
+// jsdom may not define PointerEvent
+if (typeof window !== "undefined" && !(window as any).PointerEvent) {
+  (window as any).PointerEvent = MouseEvent as any;
+}
+
+describe("Image360Viewer", () => {
+  it("changes frames when dragging horizontally and wraps index", () => {
+    const frames = ["/1.jpg", "/2.jpg"];
+    render(<Image360Viewer frames={frames} alt="test" />);
+    const img = screen.getByAltText("test");
+    const container = img.closest("div") as HTMLElement;
+
+    expect(img).toHaveAttribute("src", frames[0]);
+
+    fireEvent.pointerDown(container, { clientX: 100 });
+    fireEvent.pointerMove(container, { clientX: 111 });
+    expect(img).toHaveAttribute("src", frames[1]);
+
+    fireEvent.pointerMove(container, { clientX: 100 });
+    expect(img).toHaveAttribute("src", frames[0]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Image360Viewer to ensure frame index wraps on horizontal drags

## Testing
- `pnpm exec jest packages/ui/src/components/molecules/__tests__/Image360Viewer.test.tsx --config jest.config.cjs --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b765f9cc3c832f972f572d29af7cde