### PR TITLE
test: cover listFiles and diffDirectories edge cases

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -2,7 +2,12 @@ jest.mock('fs', () => require('memfs').fs);
 
 import path from 'path';
 import { vol } from 'memfs';
-import { extractSummary, gatherChanges, listFiles } from '../[shopId]';
+import {
+  extractSummary,
+  gatherChanges,
+  listFiles,
+  diffDirectories,
+} from '../[shopId]';
 
 describe('component helpers', () => {
   beforeEach(() => {
@@ -38,6 +43,17 @@ describe('component helpers', () => {
         path.join('sub', 'file2.txt'),
         path.join('sub', 'deeper', 'file3.txt'),
       ].sort());
+    });
+
+    it('returns empty array when directory does not exist', () => {
+      expect(listFiles('/no-such-dir')).toEqual([]);
+    });
+  });
+
+  describe('diffDirectories', () => {
+    it('detects files present in only one directory', () => {
+      vol.fromJSON({ '/a/only.txt': 'hello' });
+      expect(diffDirectories('/a', '/b')).toEqual(['only.txt']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add regression tests for listFiles handling missing directories
- cover diffDirectories when files exist in only one folder

## Testing
- `pnpm --filter @apps/api test`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed, apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7655e7fd8832fbb179ea0530c1e44