### PR TITLE
test: add generateMeta default tests

### DIFF
--- a/packages/lib/src/generateMeta.ts
+++ b/packages/lib/src/generateMeta.ts
@@ -109,7 +109,7 @@ export async function generateMeta(product: ProductData): Promise<GeneratedMeta>
         content = (output as { text: string }).text;
       }
       if (content) {
-        data = JSON.parse(content);
+        data = { ...data, ...JSON.parse(content) };
       }
     }
   } catch {


### PR DESCRIPTION
## Summary
- merge partial OpenAI metadata with defaults
- add tests for full, partial, and empty metadata outputs

## Testing
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed, apps/cms build: Failed)*
- `npm test packages/lib` *(fails: Could not find task `packages/lib` in project)*
- `pnpm exec jest packages/lib/__tests__/generateMeta.test.ts packages/lib/src/__tests__/generateMeta.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b7654ae628832f92c040a2adb7f931