### PR TITLE
test: cart cookie parsing and expiration

### DIFF
--- a/packages/platform-core/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/__tests__/cartCookie.test.ts
@@ -1,4 +1,3 @@
-// packages/platform-core/__tests__/cartCookie.test.ts
 import {
   asSetCookieHeader,
   CART_COOKIE,
@@ -7,22 +6,28 @@ import {
 } from "../src/cartCookie";
 
 describe("cart cookie helpers", () => {
-  it("encodes and decodes the cart id", () => {
-    const id = "test-id";
-    const encoded = encodeCartCookie(id);
-    expect(decodeCartCookie(encoded)).toBe(id);
+  it("parses valid cookie data", () => {
+    const data = { id: "test" };
+    const encoded = encodeCartCookie(JSON.stringify(data));
+    expect(decodeCartCookie(encoded)).toEqual(data);
   });
 
-  it("decodeCartCookie handles invalid input", () => {
+  it("handles malformed or missing cookie", () => {
     expect(decodeCartCookie("bad" as any)).toBeNull();
     expect(decodeCartCookie(null)).toBeNull();
   });
 
-  it("formats Set-Cookie header", () => {
+  it("sets cookie with expiration", () => {
     const encoded = "value";
-
     expect(asSetCookieHeader(encoded)).toBe(
       `${CART_COOKIE}=${encoded}; Path=/; Max-Age=${60 * 60 * 24 * 30}; SameSite=Strict; Secure; HttpOnly`
+    );
+  });
+
+  it("sets cookie without expiration", () => {
+    const encoded = "value";
+    expect(asSetCookieHeader(encoded, null)).toBe(
+      `${CART_COOKIE}=${encoded}; Path=/; SameSite=Strict; Secure; HttpOnly`
     );
   });
 });

--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -82,6 +82,12 @@ export function decodeCartCookie(raw?: string | null): unknown {
 }
 
 /** Build the Set‑Cookie header value for HTTP responses. */
-export function asSetCookieHeader(value: string): string {
-  return `${CART_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE}; SameSite=Strict; Secure; HttpOnly`;
+export function asSetCookieHeader(
+  value: string,
+  maxAge: number | null = MAX_AGE
+): string {
+  const parts = [`${CART_COOKIE}=${value}`, "Path=/"];
+  if (maxAge !== null) parts.push(`Max-Age=${maxAge}`);
+  parts.push("SameSite=Strict", "Secure", "HttpOnly");
+  return parts.join("; ");
 }


### PR DESCRIPTION
## Summary
- add tests for cart cookie parsing and headers with optional expiration
- allow omitting Max-Age when constructing Set-Cookie headers

## Testing
- `npm test packages/platform-core` *(fails: Could not find task `packages-platform-core` in project)*
- `pnpm --filter @acme/platform-core exec jest __tests__/cartCookie.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b7654fed1c832f8e913af58845a681