### PR TITLE
test: add stock status tests

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/StockStatus.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/StockStatus.test.tsx
@@ -1,0 +1,19 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import { StockStatus } from "../StockStatus";
+
+describe("StockStatus", () => {
+  it("renders in-stock state", () => {
+    render(<StockStatus inStock />);
+    const span = screen.getByText("In stock");
+    expect(span).toHaveAttribute("data-token", "--color-success");
+    expect(span).toHaveClass("text-success");
+  });
+
+  it("renders out-of-stock state", () => {
+    render(<StockStatus inStock={false} />);
+    const span = screen.getByText("Out of stock");
+    expect(span).toHaveAttribute("data-token", "--color-danger");
+    expect(span).toHaveClass("text-danger");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for StockStatus component covering in-stock and out-of-stock states

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/__tests__/StockStatus.test.tsx -- --coverage` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b765f89794832faabeb572f9698e58