### PR TITLE
test: cover rental inventory allocation edge cases

### DIFF
--- a/packages/template-app/__tests__/rental-post.test.ts
+++ b/packages/template-app/__tests__/rental-post.test.ts
@@ -97,4 +97,123 @@ describe("/api/rental POST", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
   });
+
+  test("skips inventory reservation when allocation disabled", async () => {
+    const retrieve = jest
+      .fn<
+        Promise<{ metadata: { depositTotal: string; returnDate: string; items: string } }>,
+        [string]
+      >()
+      .mockResolvedValue({
+        metadata: {
+          depositTotal: "50",
+          returnDate: "2030-01-02",
+          items: JSON.stringify([
+            { sku: "sku1", from: "2025-01-01", to: "2025-01-05" },
+          ]),
+        },
+      });
+    mockStripe({ checkout: { sessions: { retrieve } }, refunds: { create: jest.fn() } });
+    const addOrder = jest.fn();
+    mockRentalRepo({ addOrder });
+    const reserveRentalInventory = jest.fn();
+    const readInventory = jest
+      .fn()
+      .mockResolvedValue([{ sku: "sku1", quantity: 1, variantAttributes: {} }]);
+    const readProducts = jest.fn().mockResolvedValue([{ id: "sku1" }]);
+    jest.doMock("@platform-core/orders/rentalAllocation", () => ({
+      __esModule: true,
+      reserveRentalInventory,
+    }));
+    jest.doMock("@platform-core/repositories/inventory.server", () => ({
+      __esModule: true,
+      readInventory,
+    }));
+    jest.doMock("@platform-core/repositories/products.server", () => ({
+      __esModule: true,
+      readRepo: readProducts,
+    }));
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: async () => ({
+        rentalInventoryAllocation: false,
+        coverageIncluded: true,
+      }),
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+
+    const { POST } = await import("../src/api/rental/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess" }),
+    } as any);
+    expect(readInventory).not.toHaveBeenCalled();
+    expect(readProducts).not.toHaveBeenCalled();
+    expect(reserveRentalInventory).not.toHaveBeenCalled();
+    expect(addOrder).toHaveBeenCalledWith("bcd", "sess", 50, "2030-01-02");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("skips reserving inventory for unknown SKUs", async () => {
+    const retrieve = jest
+      .fn<
+        Promise<{ metadata: { depositTotal: string; returnDate: string; items: string } }>,
+        [string]
+      >()
+      .mockResolvedValue({
+        metadata: {
+          depositTotal: "50",
+          returnDate: "2030-01-02",
+          items: JSON.stringify([
+            { sku: "sku1", from: "2025-01-01", to: "2025-01-05" },
+            { sku: "missing", from: "2025-01-01", to: "2025-01-05" },
+          ]),
+        },
+      });
+    mockStripe({ checkout: { sessions: { retrieve } }, refunds: { create: jest.fn() } });
+    const addOrder = jest.fn();
+    mockRentalRepo({ addOrder });
+    const reserveRentalInventory = jest.fn();
+    const readInventory = jest.fn().mockResolvedValue([
+      { sku: "sku1", quantity: 1, variantAttributes: {} },
+      { sku: "missing", quantity: 1, variantAttributes: {} },
+    ]);
+    const readProducts = jest.fn().mockResolvedValue([{ id: "sku1" }]);
+    jest.doMock("@platform-core/orders/rentalAllocation", () => ({
+      __esModule: true,
+      reserveRentalInventory,
+    }));
+    jest.doMock("@platform-core/repositories/inventory.server", () => ({
+      __esModule: true,
+      readInventory,
+    }));
+    jest.doMock("@platform-core/repositories/products.server", () => ({
+      __esModule: true,
+      readRepo: readProducts,
+    }));
+    jest.doMock("@platform-core/repositories/shops.server", () => ({
+      __esModule: true,
+      readShop: async () => ({
+        rentalInventoryAllocation: true,
+        coverageIncluded: true,
+      }),
+    }));
+    jest.doMock("@platform-core/pricing", () => ({ computeDamageFee: jest.fn() }));
+
+    const { POST } = await import("../src/api/rental/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess" }),
+    } as any);
+    expect(reserveRentalInventory).toHaveBeenCalledTimes(1);
+    expect(reserveRentalInventory).toHaveBeenCalledWith(
+      "bcd",
+      [{ sku: "sku1", quantity: 1, variantAttributes: {} }],
+      { id: "sku1" },
+      "2025-01-01",
+      "2025-01-05",
+    );
+    expect(addOrder).toHaveBeenCalledWith("bcd", "sess", 50, "2030-01-02");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
 });


### PR DESCRIPTION
## Summary
- skip inventory reservation when rental inventory allocation is disabled
- ignore items with unknown SKUs during inventory reservation

## Testing
- `pnpm -r build` (fails: Type error: 'parsed.error' is possibly 'undefined')
- `pnpm exec jest packages/template-app/__tests__/rental-post.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b76777f250832fbe3f4dab96c442b6