### PR TITLE
stub Prisma client to allow builds without generated schema

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,5 +1,5 @@
 import { loadCoreEnv } from "@acme/config/env/core";
-import type { PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "./prisma-client";
 
 
 const coreEnv = loadCoreEnv();
@@ -73,8 +73,8 @@ if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
   prisma = createStubPrisma();
 } else {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { PrismaClient } = require("@prisma/client") as typeof import("@prisma/client");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PrismaClient } = (eval("require") as any)("@prisma/client");
 
     const databaseUrl = coreEnv.DATABASE_URL;
     prisma = new PrismaClient({

--- a/packages/platform-core/src/prisma-client.ts
+++ b/packages/platform-core/src/prisma-client.ts
@@ -1,0 +1,3 @@
+export interface PrismaClient {
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- avoid direct `@prisma/client` import by using a local PrismaClient interface
- require Prisma dynamically so builds don't fail when client isn't generated

## Testing
- `pnpm -r build` *(fails: Type error in useProductEditorFormState.tsx)*
- `pnpm --filter @acme/platform-core build`


------
https://chatgpt.com/codex/tasks/task_e_68b76927e53c832fa68afdb78ef122cf