### PR TITLE
fix: resolve internal packages from source

### DIFF
--- a/apps/shop-bcd/src/app/api/publish/route.ts
+++ b/apps/shop-bcd/src/app/api/publish/route.ts
@@ -7,7 +7,7 @@ import { createRequire } from "module";
 // published as a package. Load it via `createRequire` so the build can
 // resolve the CommonJS module without relying on a workspace alias.
 const require = createRequire(import.meta.url);
-const { republishShop } = require("../../../../../../scripts/src/republish-shop.js") as typeof import("../../../../../../scripts/src/republish-shop");
+const { republishShop } = require("../../../../../../scripts/src/republish-shop") as typeof import("../../../../../../scripts/src/republish-shop");
 
 export const runtime = "nodejs";
 

--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -8,63 +8,99 @@
       "@/*": [
         "./dist/*",
         "../../packages/ui/dist/src/*",
-        "../../packages/i18n/dist/*"
+        "../../packages/i18n/dist/*",
+        "../../packages/ui/src/*",
+        "../../packages/i18n/src/*"
       ],
       "@ui/*": [
-        "../../packages/ui/dist/src/*"
+        "../../packages/ui/dist/src/*",
+        "../../packages/ui/src/*"
       ],
       "@ui/src/*": [
-        "../../packages/ui/dist/src/*"
+        "../../packages/ui/dist/src/*",
+        "../../packages/ui/src/*"
+      ],
+      "@i18n": [
+        "../../packages/i18n/dist/index",
+        "../../packages/i18n/src/index.ts"
       ],
       "@i18n/*": [
-        "../../packages/i18n/dist/*"
+        "../../packages/i18n/dist/*",
+        "../../packages/i18n/src/*"
+      ],
+      "@acme/i18n": [
+        "../../packages/i18n/dist/index",
+        "../../packages/i18n/src/index.ts"
+      ],
+      "@acme/i18n/*": [
+        "../../packages/i18n/dist/*",
+        "../../packages/i18n/src/*"
       ],
       "@platform-core": [
-        "../../packages/platform-core/dist/index"
+        "../../packages/platform-core/dist/index",
+        "../../packages/platform-core/src/index.ts"
       ],
       "@platform-core/*": [
-        "../../packages/platform-core/dist/*"
+        "../../packages/platform-core/dist/*",
+        "../../packages/platform-core/src/*"
       ],
       "@acme/platform-core": [
-        "../../packages/platform-core/dist/index"
+        "../../packages/platform-core/dist/index",
+        "../../packages/platform-core/src/index.ts"
       ],
       "@acme/platform-core/*": [
-        "../../packages/platform-core/dist/*"
+        "../../packages/platform-core/dist/*",
+        "../../packages/platform-core/src/*"
       ],
       "@auth": [
         "../../packages/auth/dist/index",
-        "../../packages/auth/dist"
+        "../../packages/auth/dist",
+        "../../packages/auth/src/index.ts",
+        "../../packages/auth/src"
       ],
       "@auth/*": [
-        "../../packages/auth/dist/*"
+        "../../packages/auth/dist/*",
+        "../../packages/auth/src/*"
       ],
       "@date-utils": [
         "../../packages/date-utils/dist/index",
-        "../../packages/date-utils/dist"
+        "../../packages/date-utils/dist",
+        "../../packages/date-utils/src/index.ts",
+        "../../packages/date-utils/src"
       ],
       "@date-utils/*": [
-        "../../packages/date-utils/dist/*"
+        "../../packages/date-utils/dist/*",
+        "../../packages/date-utils/src/*"
       ],
       "@shared-utils": [
         "../../packages/shared-utils/dist/index",
-        "../../packages/shared-utils/dist"
+        "../../packages/shared-utils/dist",
+        "../../packages/shared-utils/src/index.ts",
+        "../../packages/shared-utils/src"
       ],
       "@shared-utils/*": [
-        "../../packages/shared-utils/dist/*"
+        "../../packages/shared-utils/dist/*",
+        "../../packages/shared-utils/src/*"
       ],
       "@scripts": [
         "../../scripts/dist/index",
-        "../../scripts/dist"
+        "../../scripts/dist",
+        "../../scripts/src/index.ts",
+        "../../scripts/src"
       ],
       "@scripts/*": [
-        "../../scripts/dist/*"
+        "../../scripts/dist/*",
+        "../../scripts/src/*"
       ],
       "@acme/types": [
         "../../packages/types/dist/index",
-        "../../packages/types/dist"
+        "../../packages/types/dist",
+        "../../packages/types/src/index.ts",
+        "../../packages/types/src"
       ],
       "@acme/types/*": [
-        "../../packages/types/dist/*"
+        "../../packages/types/dist/*",
+        "../../packages/types/src/*"
       ]
     },
     "module": "ESNext",


### PR DESCRIPTION
## Summary
- include source directories in shop-bcd tsconfig paths so TypeScript can resolve workspace packages without a prior build
- load republish-shop script from its TypeScript source instead of a non-existent JS build

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm --filter @apps/shop-bcd build`


------
https://chatgpt.com/codex/tasks/task_e_68b76c9dc08c832fa9b126c269d82362