### PR TITLE
refactor: simplify i18n imports

### DIFF
--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -3,7 +3,7 @@ import { localeSchema, sanityBlogConfigSchema } from "@acme/types";
 import { upgradeComponentSchema as pageComponentSchema } from "@acme/types";
 import { z } from "zod";
 import { slugify } from "@acme/shared-utils";
-import { fillLocales } from "@acme/i18n/fillLocales";
+import { fillLocales } from "@acme/i18n";
 import { defaultPaymentProviders } from "./defaultPaymentProviders";
 import { defaultShippingProviders } from "./defaultShippingProviders";
 import { defaultTaxProviders } from "./defaultTaxProviders";

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -1,7 +1,7 @@
 // packages/platform-core/repositories/settings.server.ts
 import "server-only";
 
-import { LOCALES } from "@acme/i18n/locales";
+import { LOCALES } from "@acme/i18n";
 import {
   shopSettingsSchema,
   type Locale,

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -33,8 +33,8 @@
       "better-sqlite3": ["src/types/better-sqlite3"],
 
       "@acme/config/env/*": ["../config/src/env/*"],
-      "@acme/i18n/fillLocales": ["../i18n/src/fillLocales.ts"],
-      "@acme/i18n/locales": ["../i18n/src/locales.ts"],
+      "@acme/i18n": ["../i18n/src/index.ts"],
+      "@acme/i18n/*": ["../i18n/src/*"],
       "@acme/email-templates": ["../email-templates/src/index.ts"]
     }
   },


### PR DESCRIPTION
## Summary
- use @acme/i18n root exports instead of subpaths
- add generic @acme/i18n path mapping in platform-core tsconfig

## Testing
- `pnpm -F @acme/platform-core build`


------
https://chatgpt.com/codex/tasks/task_e_68b76ec8ae04832f86033dc67751488f