### PR TITLE
fix: use shared ProductPublication

### DIFF
--- a/packages/ui/src/hooks/useProductEditorFormState.d.ts
+++ b/packages/ui/src/hooks/useProductEditorFormState.d.ts
@@ -1,13 +1,5 @@
 import type { Locale } from "@acme/i18n";
-import type { MediaItem } from "@acme/types";
-interface ProductPublication {
-    id: string;
-    shop: string;
-    title: Record<Locale, string>;
-    description: Record<Locale, string>;
-    price: number;
-    media: MediaItem[];
-}
+import type { ProductPublication } from "@acme/types";
 import { type ChangeEvent, type FormEvent, type ReactElement } from "react";
 export type ProductWithVariants = ProductPublication & {
     variants: Record<string, string[]>;

--- a/packages/ui/src/hooks/useProductEditorFormState.tsx
+++ b/packages/ui/src/hooks/useProductEditorFormState.tsx
@@ -12,16 +12,7 @@ import {
   useState,
   type FormEvent,
 } from "react";
-import type { MediaItem } from "@acme/types";
-
-export interface ProductPublication {
-  id: string;
-  shop: string;
-  title: Record<Locale, string>;
-  description: Record<Locale, string>;
-  price: number;
-  media: MediaItem[];
-}
+import type { ProductPublication } from "@acme/types";
 
 export interface ProductSaveResult {
   product?: ProductPublication & { variants?: Record<string, string[]> };


### PR DESCRIPTION
## Summary
- import ProductPublication from shared `@acme/types`
- remove local ProductPublication interface in product editor form
- sync generated declaration to reference shared type

## Testing
- `pnpm -r build` (fails: h.LRUCache is not a constructor)
- `pnpm --filter @acme/ui test` (fails: Jest encountered an unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_68b76d01d03c832f9713a3e279399fca