### PR TITLE
chore: fix implicit any for provider arrays

### DIFF
--- a/scripts/src/cli/quickstartPrompts.ts
+++ b/scripts/src/cli/quickstartPrompts.ts
@@ -64,11 +64,11 @@ export async function quickstartPrompts(
     templateDefaults.pages ??
     presetDefaults.pages;
 
-  const paymentProviders = await listProviders("payment");
+  const paymentProviders: ProviderInfo[] = await listProviders("payment");
   let payment =
     args.payment ??
     (Array.isArray(config.payment) ? (config.payment as string[]) : undefined);
-  const shippingProviders = await listProviders("shipping");
+  const shippingProviders: ProviderInfo[] = await listProviders("shipping");
   let shipping =
     args.shipping ??
     (Array.isArray(config.shipping) ? (config.shipping as string[]) : undefined);


### PR DESCRIPTION
## Summary
- explicitly type payment and shipping provider arrays to avoid implicit any errors in quickstart prompts

## Testing
- `pnpm -r build` *(fails: ProductPublication & { variants?: Record<string, string[]> | undefined; }' is missing required properties)*
- `pnpm exec jest test/unit/create-shop-cli.spec.ts` *(fails: Cannot find module './runtime' from 'test/unit/create-shop-cli.spec.ts')*
- `pnpm exec eslint scripts/src/cli/quickstartPrompts.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b770118690832fa3c879c95f338551