### PR TITLE
fix: add page type to builder route

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/pages/[page]/builder/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/pages/[page]/builder/page.tsx
@@ -2,6 +2,7 @@
 
 import { updatePage } from "@cms/actions/pages.server";
 import { getPages } from "@platform-core/repositories/pages/index.server";
+import type { Page } from "@acme/types";
 import dynamic from "next/dynamic";
 import { notFound } from "next/navigation";
 import type PageBuilderComponent from "@ui/components/cms/PageBuilder";
@@ -25,7 +26,7 @@ export default async function PageBuilderRoute({
   params: Promise<Params>;
 }) {
   const { shop, page: slug } = await params;
-  const pages = await getPages(shop);
+  const pages: Page[] = await getPages(shop);
   const current = pages.find((p) => p.slug === slug);
   if (!current) return notFound();
 


### PR DESCRIPTION
## Summary
- fix implicit any in page builder route

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Argument of type 'ProductPublication...' in packages/ui useProductEditorFormState.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b770b1d2f0832fa58e83d28ee5c276