### PR TITLE
fix: add ProductPublication typings to product handlers

### DIFF
--- a/apps/cms/src/app/api/products/route.ts
+++ b/apps/cms/src/app/api/products/route.ts
@@ -54,16 +54,16 @@ export async function GET(req: NextRequest) {
 
   if (slug) {
     const product = catalogue.find(
-      (p) => p.sku === slug || p.id === slug,
+      (p: ProductPublication) => p.sku === slug || p.id === slug,
     );
     if (!product)
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(toSku(product));
   }
 
-  let matches = catalogue;
+  let matches: ProductPublication[] = catalogue;
   if (query) {
-    matches = matches.filter((p) => {
+    matches = matches.filter((p: ProductPublication) => {
       const title = p.title?.en ?? Object.values(p.title ?? {})[0] ?? "";
       return title.toLowerCase().includes(query);
     });


### PR DESCRIPTION
## Summary
- ensure `catalogue.find` and `matches.filter` callbacks use `ProductPublication`
- type the `matches` array as `ProductPublication[]`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build worker exited with code: 1; argument of type `ProductPublication & { variants?: Record<string, string[]> | undefined; }` is missing properties)*

------
https://chatgpt.com/codex/tasks/task_e_68b770e53f98832f9065695f66fb5bcc