### PR TITLE
fix: map i18n paths in ui tsconfig

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -25,7 +25,9 @@
       "@acme/types/*": ["../types/src/*"],
       "@ui": ["./src/index"],
       "@ui/*": ["./src/*"],
-      "@auth": ["types-compat/auth"]
+      "@auth": ["types-compat/auth"],
+      "@acme/i18n": ["../i18n/src/index"],
+      "@acme/i18n/*": ["../i18n/src/*"]
     }
   },
   "references": [


### PR DESCRIPTION
## Summary
- fix tsc module resolution for i18n by adding path mappings in the UI package

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeError: h.LRUCache is not a constructor)*
- `npx tsc -b packages/ui`


------
https://chatgpt.com/codex/tasks/task_e_68b7778649d8832fab4e4f4b1d64efd4