### PR TITLE
refactor: lazy-load email module

### DIFF
--- a/apps/cms/src/actions/accounts.server.ts
+++ b/apps/cms/src/actions/accounts.server.ts
@@ -6,7 +6,6 @@ import type { Role } from "@cms/auth/roles";
 import type { CmsUser } from "@cms/auth/users";
 import argon2 from "argon2";
 import { ulid } from "ulid";
-import { sendEmail } from "@acme/email";
 import { readRbac, writeRbac } from "../lib/server/rbacStore";
 
 export interface PendingUser {
@@ -47,6 +46,7 @@ export async function approveAccount(formData: FormData): Promise<void> {
   db.roles[user.id] = roles.length <= 1 ? (roles[0] as Role) : roles;
   await writeRbac(db);
   delete PENDING_USERS[id];
+  const { sendEmail } = await import("@acme/email");
   await sendEmail(
     user.email,
     "Account approved",

--- a/apps/cms/src/app/api/campaigns/route.ts
+++ b/apps/cms/src/app/api/campaigns/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { sendCampaignEmail } from "@acme/email";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const { to, subject, body } = (await req.json().catch(() => ({}))) as {
@@ -13,6 +12,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   try {
+    const { sendCampaignEmail } = await import("@acme/email");
     await sendCampaignEmail({ to, subject, html: body });
     return NextResponse.json({ ok: true });
   } catch {

--- a/apps/cms/src/app/api/marketing/email/route.ts
+++ b/apps/cms/src/app/api/marketing/email/route.ts
@@ -1,16 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  createCampaign,
-  listCampaigns,
-  type Campaign,
-  renderTemplate,
-} from "@acme/email";
+import type { Campaign } from "@acme/email";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const shop = req.nextUrl.searchParams.get("shop");
   if (!shop)
     return NextResponse.json({ error: "Missing shop" }, { status: 400 });
+  const { listCampaigns } = await import("@acme/email");
   const campaigns: Campaign[] = await listCampaigns(shop);
   const events = await listEvents();
   const withMetrics = campaigns.map((c) => {
@@ -52,6 +48,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!shop || !subject || !body || (list.length === 0 && !segment)) {
     return NextResponse.json({ error: "Missing fields" }, { status: 400 });
   }
+  const { createCampaign, renderTemplate } = await import("@acme/email");
   let html = body;
   if (templateId) {
     html = renderTemplate(templateId, { subject, body });


### PR DESCRIPTION
## Summary
- import `@acme/email` lazily in campaign and marketing email API routes
- defer email dependency loading in account approval to avoid build-time evaluation

## Testing
- `pnpm install`
- `pnpm --filter @apps/cms build`


------
https://chatgpt.com/codex/tasks/task_e_68b77260e324832f85ca4707b728ff62