### PR TITLE
Relax email env validation

### DIFF
--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -75,7 +75,7 @@ describe("email env module", () => {
   });
 
   it(
-    "throws and logs structured error when SENDGRID_API_KEY is missing for sendgrid provider",
+    "does not throw when SENDGRID_API_KEY is missing for sendgrid provider",
     async () => {
       process.env = {
         ...ORIGINAL_ENV,
@@ -85,23 +85,15 @@ describe("email env module", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
       jest.resetModules();
-      await expect(import("../email.ts")).rejects.toThrow(
-        "Invalid email environment variables",
-      );
-      expect(errorSpy).toHaveBeenCalledWith(
-        "❌ Invalid email environment variables:",
-        expect.objectContaining({
-          SENDGRID_API_KEY: {
-            _errors: [expect.stringContaining("Required")],
-          },
-        }),
-      );
+      const { emailEnv } = await import("../email.ts");
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(emailEnv).toMatchObject({ EMAIL_PROVIDER: "sendgrid" });
       errorSpy.mockRestore();
     },
   );
 
   it(
-    "throws an error when RESEND_API_KEY is missing for resend provider",
+    "does not throw when RESEND_API_KEY is missing for resend provider",
     async () => {
       process.env = {
         ...ORIGINAL_ENV,
@@ -110,17 +102,10 @@ describe("email env module", () => {
       const errorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      await expect(import("../email.ts")).rejects.toThrow(
-        "Invalid email environment variables",
-      );
-      expect(errorSpy).toHaveBeenCalledWith(
-        "❌ Invalid email environment variables:",
-        expect.objectContaining({
-          RESEND_API_KEY: {
-            _errors: [expect.stringContaining("Required")],
-          },
-        }),
-      );
+      jest.resetModules();
+      const { emailEnv } = await import("../email.ts");
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(emailEnv).toMatchObject({ EMAIL_PROVIDER: "resend" });
       errorSpy.mockRestore();
     },
   );

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -79,7 +79,7 @@ const baseEnvSchema = z
 export const coreEnvBaseSchema = authEnvSchema
   .innerType()
   .merge(cmsEnvSchema)
-  .merge(emailEnvSchema.innerType())
+  .merge(emailEnvSchema)
   .merge(paymentsEnvSchema)
   .merge(shippingEnvSchema)
   .merge(baseEnvSchema);

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -13,22 +13,6 @@ export const emailEnvSchema = z
     RESEND_API_KEY: z.string().optional(),
     EMAIL_BATCH_SIZE: z.coerce.number().optional(),
     EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),
-  })
-  .superRefine((env, ctx) => {
-    if (env.EMAIL_PROVIDER === "sendgrid" && !env.SENDGRID_API_KEY) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Required",
-        path: ["SENDGRID_API_KEY"],
-      });
-    }
-    if (env.EMAIL_PROVIDER === "resend" && !env.RESEND_API_KEY) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Required",
-        path: ["RESEND_API_KEY"],
-      });
-    }
   });
 
 const parsed = emailEnvSchema.safeParse(process.env);
@@ -38,18 +22,6 @@ if (!parsed.success) {
     parsed.error.format()
   );
   throw new Error("Invalid email environment variables");
-}
-if (parsed.data.EMAIL_PROVIDER === "sendgrid") {
-  const sendgrid = z
-    .object({ SENDGRID_API_KEY: z.string() })
-    .safeParse(parsed.data);
-  if (!sendgrid.success) {
-    console.error(
-      "❌ Invalid email environment variables:",
-      sendgrid.error.format(),
-    );
-    throw new Error("Invalid email environment variables");
-  }
 }
 
 export const emailEnv = parsed.data;


### PR DESCRIPTION
## Summary
- allow missing API keys for sendgrid and resend
- adjust core env schema merge
- update tests for relaxed email env validation

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/config test`
- `pnpm exec jest packages/email/src/__tests__/send.test.ts --runInBand` *(fails: Cannot find module '../utils/args' from 'test/unit/init-shop/env.spec.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b7fee0f570832fa5c941611fd507a7