### PR TITLE
test(configurator): add exit fallback test

### DIFF
--- a/packages/configurator/__tests__/bin.test.ts
+++ b/packages/configurator/__tests__/bin.test.ts
@@ -62,6 +62,19 @@ describe("configurator bin", () => {
     expect(exitSpy).toHaveBeenCalledWith(2);
   });
 
+  it("falls back to exit code 1 when spawnSync status is undefined", async () => {
+    spawnSyncMock.mockReturnValue({ status: undefined });
+
+    await import("../bin/configurator.cjs");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).toHaveBeenCalledWith("vite", ["dev"], {
+      stdio: "inherit",
+      shell: true,
+    });
+  });
+
   it("runs build", async () => {
     process.argv = ["node", "configurator", "build"];
 


### PR DESCRIPTION
## Summary
- test spawnSync status undefined to ensure exit code defaults to 1

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed, apps/cms build: Failed)*
- `pnpm exec jest packages/configurator/__tests__/bin.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b7ff5cd77c832fadf1acbf8e220ecd