### PR TITLE
Allow publish-upgrade route tests to bypass MSW

### DIFF
--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -35,6 +35,8 @@ export const handlers = [
   rest.patch("/cms/api/wizard-progress", (_req, res, ctx) =>
     res(ctx.status(200), ctx.json({}))
   ),
+  // Allow API route tests to hit local handlers without mocking
+  rest.post("*/shop/:id/publish-upgrade", (req) => req.passthrough()),
 ];
 
 export const server = setupServer(...handlers);


### PR DESCRIPTION
## Summary
- let publish-upgrade route tests bypass MSW network interception so they can exercise real handlers

## Testing
- `pnpm exec jest --testPathPattern=publish-upgrade.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8006abf6c832f9fa2d0853a7b1c22