### PR TITLE
Fix lighthouse ESM config import for tests

### DIFF
--- a/functions/__tests__/seoAudit.test.ts
+++ b/functions/__tests__/seoAudit.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import seoAudit from '../src/seoAudit';
-import { runSeoAudit } from '../../scripts/seo-audit';
+import { runSeoAudit } from '@acme/lib/seoAudit';
 import { trackEvent } from '@platform-core/analytics';
 import { sendCampaignEmail } from '@acme/email';
 
@@ -35,7 +35,7 @@ jest.mock('node:fs', () => {
   };
 });
 
-jest.mock('../../scripts/seo-audit', () => ({ runSeoAudit: jest.fn() }));
+jest.mock('@acme/lib/seoAudit', () => ({ runSeoAudit: jest.fn() }));
 jest.mock('@platform-core/analytics', () => ({ trackEvent: jest.fn() }));
 jest.mock('@acme/email', () => ({ sendCampaignEmail: jest.fn() }));
 jest.mock('@platform-core/dataRoot', () => ({ DATA_ROOT: '/data' }));

--- a/packages/lib/src/seoAudit.ts
+++ b/packages/lib/src/seoAudit.ts
@@ -1,5 +1,4 @@
 import type { RunnerResult } from "lighthouse";
-import desktopConfig from "lighthouse/core/config/desktop-config.js";
 
 export interface SeoAuditResult {
   score: number;
@@ -42,11 +41,21 @@ export async function runSeoAudit(url: string): Promise<SeoAuditResult> {
   } catch {
     // ignore; handled below
   }
+  let desktopConfig: any;
+  try {
+    const mod = await import("lighthouse/core/config/desktop-config.js");
+    desktopConfig = (mod as any)?.default ?? mod;
+  } catch {
+    // ignore; handled below
+  }
   if (typeof launch !== "function") {
     throw new Error("chrome-launcher launch function not available");
   }
   if (typeof lighthouseFn !== "function") {
     throw new Error("lighthouse is not a function");
+  }
+  if (!desktopConfig) {
+    throw new Error("lighthouse desktop config not available");
   }
 
   const chrome = await launch({ chromeFlags: ["--headless"] });


### PR DESCRIPTION
## Summary
- load Lighthouse desktop config dynamically to support ESM
- update SEO audit tests to mock new import path

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed)*
- `pnpm exec jest functions/__tests__/seoAudit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8002ce614832f98412787da52eebc