### PR TITLE
fix(shop): ensure writeShop uses overridable readShop

### DIFF
--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -95,6 +95,7 @@ export async function writeShop(
   shop: string,
   patch: Partial<Shop> & { id: string }
 ): Promise<Shop> {
+  const { readShop } = await import("./shops.server");
   const current = await readShop(shop);
   const themeDefaults = {
     ...(current.themeDefaults ?? {}),


### PR DESCRIPTION
## Summary
- load readShop dynamically in writeShop so tests can mock it

## Testing
- `pnpm -r build`
- `pnpm --filter @acme/platform-core exec jest src/repositories/__tests__/shops.server.test.ts --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8000adc24832fa2de1b97aa662db4