### PR TITLE
Fix checkout test to reference correct module paths

### DIFF
--- a/test/__tests__/checkout.test.tsx
+++ b/test/__tests__/checkout.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 process.env.STRIPE_SECRET_KEY = "sk_test_123";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_123";
 
-import CheckoutForm from "../../packages/ui/components/checkout/CheckoutForm";
+import CheckoutForm from "../../packages/ui/src/components/checkout/CheckoutForm";
 import { CurrencyProvider } from "@platform-core/contexts/CurrencyContext";
 import { isoDateInNDays } from "@acme/date-utils";
 import * as sharedUtils from "@acme/shared-utils";
@@ -43,7 +43,7 @@ jest.mock("@stripe/react-stripe-js", () => {
 });
 
 jest.mock("@platform-core/contexts/CurrencyContext", () =>
-  require("./__mocks__/currencyContextMock")
+  require("../__mocks__/currencyContextMock")
 );
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- fix CheckoutForm import path in checkout test
- point CurrencyContext mock to correct relative location

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build in template-app ran long; build step interrupted)*
- `pnpm exec jest test/__tests__/checkout.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b80000433c832fb542ce29ce2d7ed9