### PR TITLE
test: map CJS config env stubs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -181,6 +181,7 @@ const config = {
     '^@acme/zod-utils/initZod$': ' /test/emptyModule.js',
     '^\\./env/(.*)\\.js$': ' /packages/config/src/env/$1.ts',
     '^\\./(auth|cms|email|core|payments|shipping)\\.js$': ' /packages/config/src/env/$1.ts',
+    '^\\.\\./(auth|cms|email|core|payments|shipping)\\.js$': ' /packages/config/src/env/$1.ts',
     '^@/components/atoms/shadcn$': ' /test/__mocks__/shadcnDialogStub.tsx',
     '^@/i18n/(.*)$': ' /packages/i18n/src/$1',
     '^@/components/(.*)$': ' /test/__mocks__/componentStub.js',


### PR DESCRIPTION
## Summary
- map @acme/config JS stubs for CJS tests in root Jest config

## Testing
- `pnpm jest packages/config/src/env/__tests__/payments-env.test.ts`
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fff60de4832f8f34e1f981b00553