### PR TITLE
fix: use server.node render in i18n hydration test

### DIFF
--- a/packages/i18n/__tests__/hydration.test.tsx
+++ b/packages/i18n/__tests__/hydration.test.tsx
@@ -1,5 +1,6 @@
 // packages/i18n/__tests__/hydration.test.tsx
 import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server.node";
 import React from "react";
 import { TranslationsProvider, useTranslations } from "../src/Translations";
 
@@ -14,8 +15,6 @@ describe("TranslationsProvider hydration", () => {
   }
 
   it("hydrates without warnings", async () => {
-    const { renderToString } = await import("react-dom/server");
-
     const html = renderToString(
       <TranslationsProvider messages={{ greet: "Hallo" }}>
         <Greeting />


### PR DESCRIPTION
## Summary
- import `renderToString` from `react-dom/server.node` for predictable SSR

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build failed)*
- `pnpm --filter @acme/i18n build`
- `pnpm --filter @acme/i18n lint`
- `pnpm exec jest packages/i18n/__tests__/hydration.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b7ffc2e30c832fa18822e87b42cd06