### PR TITLE
test(email): cover unknown provider stats

### DIFF
--- a/packages/email/src/__tests__/stats.test.ts
+++ b/packages/email/src/__tests__/stats.test.ts
@@ -113,3 +113,9 @@ describe("normalizeProviderStats", () => {
     });
   });
 });
+describe("normalizeProviderStats real module", () => {
+  it("uses actual implementation for unknown providers", () => {
+    const { normalizeProviderStats, emptyStats } = jest.requireActual("../stats");
+    expect(normalizeProviderStats("unknown", undefined)).toEqual({ ...emptyStats });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure normalizeProviderStats handles unknown providers with real implementation

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm exec jest packages/email/src/__tests__/stats.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b80083bd58832f8e36ac4e3ea5e110