### PR TITLE
test: handle JSON parse failure in Sendgrid stats

### DIFF
--- a/packages/email/src/__tests__/sendgrid.test.ts
+++ b/packages/email/src/__tests__/sendgrid.test.ts
@@ -112,6 +112,17 @@ describe("SendgridProvider", () => {
       const provider = new SendgridProvider();
       await expect(provider.getCampaignStats("1")).resolves.toEqual(emptyStats);
     });
+
+    it("returns empty stats on JSON parse failure", async () => {
+      process.env.SENDGRID_API_KEY = "sg";
+      global.fetch = jest.fn().mockResolvedValue({
+        json: jest.fn().mockRejectedValue(new Error("bad")),
+      });
+      const { SendgridProvider } = await import("../providers/sendgrid");
+      const { emptyStats } = await import("../stats");
+      const provider = new SendgridProvider();
+      await expect(provider.getCampaignStats("1")).resolves.toEqual(emptyStats);
+    });
   });
 
   describe("createContact", () => {


### PR DESCRIPTION
## Summary
- test Sendgrid getCampaignStats resilience to JSON parse errors

## Testing
- `pnpm install`
- `pnpm -F @acme/email build`
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendgrid.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8008236fc832fa2727e739deb5c82