### PR TITLE
test(email): add listCampaigns store forwarding test

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -52,6 +52,18 @@ describe("scheduler", () => {
     (listEvents as jest.Mock).mockResolvedValue([]);
   });
 
+  test("listCampaigns forwards arguments to the campaign store", async () => {
+    const data: Campaign[] = [];
+    const readCampaigns = jest.fn().mockResolvedValue(data);
+    const getCampaignStore = jest.fn().mockReturnValue({ readCampaigns });
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock("../storage", () => ({ __esModule: true, getCampaignStore }));
+      const { listCampaigns } = await import("../scheduler");
+      await expect(listCampaigns(shop)).resolves.toBe(data);
+      expect(readCampaigns).toHaveBeenCalledWith(shop);
+    });
+  });
+
   test("filterUnsubscribed skips unsubscribed recipients", async () => {
     const past = new Date(now.getTime() - 1000).toISOString();
     memory[shop] = [


### PR DESCRIPTION
## Summary
- add unit test verifying listCampaigns forwards shop argument to the campaign store

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Output file '/workspace/base-shop/packages/platform-core/dist/dataRoot.d.ts' has not been built)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/scheduler.test.ts` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b8007dea38832fb94c147018d25e89