### PR TITLE
test: canonicalize temp dir in settings repo tests

### DIFF
--- a/packages/platform-core/__tests__/settingsRepo.test.ts
+++ b/packages/platform-core/__tests__/settingsRepo.test.ts
@@ -15,14 +15,15 @@ async function withRepo(
   ) => Promise<void>
 ): Promise<void> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "settings-"));
-  const shopDir = path.join(dir, "data", "shops", "test");
+  const realDir = await fs.realpath(dir);
+  const shopDir = path.join(realDir, "data", "shops", "test");
   await fs.mkdir(shopDir, { recursive: true });
   const cwd = process.cwd();
-  process.chdir(dir);
+  process.chdir(realDir);
   jest.resetModules();
   const repo = await import("../src/repositories/settings.server");
   try {
-    await cb(repo, "test", dir);
+    await cb(repo, "test", realDir);
   } finally {
     process.chdir(cwd);
   }


### PR DESCRIPTION
## Summary
- resolve temporary repository directory to its real path before running settings repository tests
- prevents macOS path symlink (`/var` vs `/private/var`) from causing rename assertions to fail

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @apps/cms@ build: `next build`)*
- `pnpm --filter @acme/platform-core exec jest __tests__/settingsRepo.test.ts --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b800203fc4832f8a888f5a4e7c1f7b