### PR TITLE
fix: map parent env stubs for tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -181,6 +181,7 @@ const config = {
     '^@acme/zod-utils/initZod$': ' /test/emptyModule.js',
     '^\\./env/(.*)\\.js$': ' /packages/config/src/env/$1.ts',
     '^\\./(auth|cms|email|core|payments|shipping)\\.js$': ' /packages/config/src/env/$1.ts',
+    '^\\.\\./(auth|cms|email|core|payments|shipping)\\.js$': ' /packages/config/src/env/$1.ts',
     '^@/components/atoms/shadcn$': ' /test/__mocks__/shadcnDialogStub.tsx',
     '^@/i18n/(.*)$': ' /packages/i18n/src/$1',
     '^@/components/(.*)$': ' /test/__mocks__/componentStub.js',


### PR DESCRIPTION
## Summary
- map parent relative env stubs to TypeScript sources in Jest config so individual tests import compiled code

## Testing
- `pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68b80016cfec832f821aa05ebc9e9341