### PR TITLE
test: ensure sendCampaignEmail renders templates

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -71,7 +71,7 @@ describe("sendCampaignEmail", () => {
 
     setupEnv();
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",
@@ -112,6 +112,34 @@ describe("sendCampaignEmail", () => {
         html: "<p>Hello</p>",
         text: "Hello",
       });
+    });
+
+    it("renders templates before sending", async () => {
+      mockSendgridSend = jest.fn().mockResolvedValue(undefined);
+      mockResendSend = jest.fn();
+      mockSendMail = jest.fn();
+      mockSanitizeHtml = jest.fn((html: string) => html);
+
+      setupEnv();
+
+      const { registerTemplate, sendCampaignEmail } = await import("../index");
+      registerTemplate("welcome", "<p>Hello {{name}}</p>");
+
+      await sendCampaignEmail({
+        to: "to@example.com",
+        subject: "Subject",
+        templateId: "welcome",
+        variables: { name: "Alice" },
+      });
+
+      expect(mockSendgridSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "to@example.com",
+          subject: "Subject",
+          html: "<p>Hello Alice</p>",
+          text: "Hello Alice",
+        })
+      );
     });
 
     it("falls back to alternate provider when primary fails", async () => {
@@ -188,7 +216,7 @@ describe("sendCampaignEmail", () => {
 
   it("throws when EMAIL_PROVIDER is invalid", async () => {
     const originalProvider = process.env.EMAIL_PROVIDER;
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     process.env.EMAIL_PROVIDER = "invalid";
     await expect(
       sendCampaignEmail({
@@ -212,7 +240,7 @@ describe("sendCampaignEmail", () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("../index");
+    const { sendCampaignEmail } = await import("../send");
     await sendCampaignEmail({
       to: "to@example.com",
       subject: "Subject",


### PR DESCRIPTION
## Summary
- add test for sendCampaignEmail to verify registered templates render before sending

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/email test packages/email/src/__tests__/send.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b800806ce0832fad114cab46632576