### PR TITLE
test: cover spawnSync error in configurator bin

### DIFF
--- a/packages/configurator/__tests__/bin.test.ts
+++ b/packages/configurator/__tests__/bin.test.ts
@@ -62,6 +62,23 @@ describe("configurator bin", () => {
     expect(exitSpy).toHaveBeenCalledWith(2);
   });
 
+  it("handles spawnSync errors", async () => {
+    const error = new Error("fail");
+    spawnSyncMock.mockReturnValue({ status: null, error });
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await import("../bin/configurator.cjs");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    if (errorSpy.mock.calls.length > 0) {
+      expect(errorSpy).toHaveBeenCalledWith(error);
+    }
+
+    errorSpy.mockRestore();
+  });
+
   it("runs build", async () => {
     process.argv = ["node", "configurator", "build"];
 


### PR DESCRIPTION
## Summary
- add test verifying configurator exits on spawnSync error

## Testing
- `pnpm --filter @acme/configurator test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff5f43ac832fbe66484b99f6dcd2