### PR TITLE
test: ensure sendCampaignEmail uses provided text

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -92,6 +92,32 @@ describe("sendCampaignEmail", () => {
     });
   });
 
+  it("forwards provided text without deriving from HTML", async () => {
+    mockSendgridSend = jest.fn().mockResolvedValue(undefined);
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
+    mockSanitizeHtml = jest.fn();
+
+    setupEnv();
+
+    const { sendCampaignEmail } = await import("../index");
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>Hello <strong>world</strong></p>",
+      text: "Custom text",
+      sanitize: false,
+    });
+
+    expect(mockSanitizeHtml).not.toHaveBeenCalled();
+    expect(mockSendgridSend).toHaveBeenCalledWith({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>Hello <strong>world</strong></p>",
+      text: "Custom text",
+    });
+  });
+
     it("sanitizes HTML and derives text", async () => {
       mockSendgridSend = jest.fn().mockResolvedValue(undefined);
       mockResendSend = jest.fn();


### PR DESCRIPTION
## Summary
- add test to confirm sendCampaignEmail doesn't derive text when provided

## Testing
- `pnpm exec jest packages/email/src/__tests__/send.test.ts --config jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b806204f2c832f925baa9f107be4e1