### PR TITLE
Handle default re-exports in component name mapping

### DIFF
--- a/scripts/__tests__/component-names.test.ts
+++ b/scripts/__tests__/component-names.test.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
 import { getComponentNameMap } from "../src/component-names";
 
 describe("component name resolution", () => {
@@ -20,5 +22,14 @@ describe("component name resolution", () => {
       "FormField",
     );
     expect(map["ThemeToggle.tsx"]).toBe("ThemeToggle");
+  });
+
+  it("infers names for default exports without alias", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "components-"));
+    fs.writeFileSync(path.join(tmp, "index.ts"), 'export { default } from "./Foo";');
+    fs.writeFileSync(path.join(tmp, "Foo.tsx"), "export default function Foo() { return null; }");
+    const map = getComponentNameMap(tmp);
+    expect(map["Foo.tsx"]).toBe("Foo");
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 });

--- a/scripts/src/component-names.ts
+++ b/scripts/src/component-names.ts
@@ -72,6 +72,8 @@ export function getComponentNameMap(componentsDir: string): Record<string, strin
         let name = spec;
         if (spec.startsWith("default as ")) {
           name = spec.slice("default as ".length).trim();
+        } else if (spec === "default") {
+          name = path.parse(file).name;
         } else if (spec.includes(" as ")) {
           name = spec.split(/\s+as\s+/)[1];
         }


### PR DESCRIPTION
## Summary
- handle `export { default } from` in component name map
- test default export name inference

## Testing
- `pnpm exec jest scripts/__tests__/component-names.test.ts --coverage=false`
- `pnpm -r build` *(fails: command terminated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68b808b3e6bc832f8b2025126d780fad