### PR TITLE
Ensure upgrade file removed after republish

### DIFF
--- a/scripts/src/republish-shop.ts
+++ b/scripts/src/republish-shop.ts
@@ -65,8 +65,7 @@ function saveHistory(root: string, id: string): void {
 
 export function republishShop(id: string, root = process.cwd()): void {
   const upgradeFile = join(root, "data", "shops", id, "upgrade.json");
-  const hadUpgradeFile = existsSync(upgradeFile);
-  if (hadUpgradeFile) {
+  if (existsSync(upgradeFile)) {
     readUpgradeMeta(root, id);
     unlinkSync(upgradeFile);
   }
@@ -74,7 +73,7 @@ export function republishShop(id: string, root = process.cwd()): void {
   run("pnpm", ["--filter", `apps/${id}`, "build"]);
   run("pnpm", ["--filter", `apps/${id}`, "deploy"]);
   updateStatus(root, id);
-  if (hadUpgradeFile && existsSync(upgradeFile)) {
+  if (existsSync(upgradeFile)) {
     unlinkSync(upgradeFile);
   }
   const appDir = join(root, "apps", id);


### PR DESCRIPTION
## Summary
- Always remove `upgrade.json` after republishing a shop to avoid stale upgrade artifacts

## Testing
- `pnpm -r build`
- `pnpm exec jest test/integration/publish-api.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b808c6756c832f965b8ca10d44cea6