### PR TITLE
feat(config): require sendgrid api key for sendgrid provider

### DIFF
--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -75,7 +75,7 @@ describe("email env module", () => {
   });
 
   it(
-    "does not throw when SENDGRID_API_KEY is missing for sendgrid provider",
+    "throws and logs error when SENDGRID_API_KEY is missing for sendgrid provider",
     async () => {
       process.env = {
         ...ORIGINAL_ENV,
@@ -85,9 +85,17 @@ describe("email env module", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
       jest.resetModules();
-      const { emailEnv } = await import("../email.ts");
-      expect(errorSpy).not.toHaveBeenCalled();
-      expect(emailEnv).toMatchObject({ EMAIL_PROVIDER: "sendgrid" });
+      await expect(import("../email.ts")).rejects.toThrow(
+        "Invalid email environment variables",
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        "❌ Invalid email environment variables:",
+        expect.objectContaining({
+          SENDGRID_API_KEY: {
+            _errors: [expect.stringContaining("Required")],
+          },
+        }),
+      );
       errorSpy.mockRestore();
     },
   );

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -79,7 +79,7 @@ const baseEnvSchema = z
 export const coreEnvBaseSchema = authEnvSchema
   .innerType()
   .merge(cmsEnvSchema)
-  .merge(emailEnvSchema)
+  .merge(emailEnvSchema.innerType())
   .merge(paymentsEnvSchema)
   .merge(shippingEnvSchema)
   .merge(baseEnvSchema);

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -13,6 +13,15 @@ export const emailEnvSchema = z
     RESEND_API_KEY: z.string().optional(),
     EMAIL_BATCH_SIZE: z.coerce.number().optional(),
     EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),
+  })
+  .superRefine((env, ctx) => {
+    if (env.EMAIL_PROVIDER === "sendgrid" && !env.SENDGRID_API_KEY) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["SENDGRID_API_KEY"],
+        message: "Required",
+      });
+    }
   });
 
 const parsed = emailEnvSchema.safeParse(process.env);


### PR DESCRIPTION
## Summary
- require SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid
- align core schema merge with refined email env
- update tests for sendgrid API key requirement

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed, apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b809326d90832f80b284f953619e20