### PR TITLE
test: add provider stats mapping tests

### DIFF
--- a/packages/email/src/__tests__/stats.test.ts
+++ b/packages/email/src/__tests__/stats.test.ts
@@ -112,6 +112,32 @@ describe("normalizeProviderStats", () => {
       bounced: 5,
     });
   });
+
+  it("returns mapped stats for sendgrid provider", () => {
+    const raw = {
+      delivered: "1",
+      opens: "2",
+    };
+
+    expect(stats.normalizeProviderStats("sendgrid", raw)).toEqual(
+      mapSendGridStats(raw)
+    );
+  });
+
+  it("returns mapped stats for resend provider", () => {
+    const raw = {
+      delivered_count: "1",
+      opened_count: "2",
+    };
+
+    expect(stats.normalizeProviderStats("resend", raw)).toEqual(
+      mapResendStats(raw)
+    );
+  });
+
+  it("returns empty stats for other provider", () => {
+    expect(stats.normalizeProviderStats("other", undefined)).toEqual(emptyStats);
+  });
 });
 describe("normalizeProviderStats real module", () => {
   it("uses actual implementation for unknown providers", () => {


### PR DESCRIPTION
## Summary
- add tests ensuring `normalizeProviderStats` dispatches to SendGrid, Resend, or empty stats based on provider name

## Testing
- `pnpm --filter @acme/email test` *(fails: Cannot find module './runtime' ... and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b80c85a288832f8be2be548a89094c