### PR TITLE
test(email): cover segment recipient resolution

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -161,24 +161,27 @@ describe("scheduler", () => {
     expect(html).toContain("Rendered");
   });
 
-  test("createCampaign resolves recipients from segment", async () => {
+  test("createCampaign resolves recipients from segment without explicit recipients", async () => {
     (resolveSegment as jest.Mock).mockResolvedValue(["seg@example.com"]);
     const id = await createCampaign({
       shop,
-      recipients: [],
-      segment: "id",
+      segment: "test",
       subject: "Hi",
       body: "<p>Hi</p>",
     });
-    expect(resolveSegment).toHaveBeenCalledWith(shop, "id");
+    expect(resolveSegment).toHaveBeenCalledWith(shop, "test");
+    expect(sendCampaignEmail).toHaveBeenCalledWith({
+      to: "seg@example.com",
+      subject: "Hi",
+      html: expect.any(String),
+    });
     expect(typeof id).toBe("string");
   });
 
-  test("createCampaign rejects when required fields are missing", async () => {
+  test("createCampaign rejects when neither recipients nor segment provided", async () => {
     await expect(
       createCampaign({
         shop,
-        recipients: [],
         subject: "Hi",
         body: "<p>Hi</p>",
       }),


### PR DESCRIPTION
## Summary
- add test calling `createCampaign` with only `segment`
- ensure error thrown when neither recipients nor segment provided

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/email test packages/email/src/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b80c823080832fbb94f7b77ca5e05a