### PR TITLE
test: ensure resolveDataRoot fallback

### DIFF
--- a/packages/email/src/cli.ts
+++ b/packages/email/src/cli.ts
@@ -16,7 +16,7 @@ interface Campaign {
   sentAt?: string;
 }
 
-function resolveDataRoot(): string {
+export function resolveDataRoot(): string {
   let dir = process.cwd();
   while (true) {
     const candidate = path.join(dir, "data", "shops");


### PR DESCRIPTION
## Summary
- mock fs.existsSync in email cli tests
- verify resolveDataRoot falls back to cwd/data/shops

## Testing
- `pnpm --filter @acme/email build`
- `pnpm exec jest packages/email/src/__tests__/cli.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b80c811d20832f8a7a1fc0c26839f9