### PR TITLE
Ensure deploy info directory exists

### DIFF
--- a/packages/platform-core/src/createShop/deploymentAdapter.ts
+++ b/packages/platform-core/src/createShop/deploymentAdapter.ts
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "child_process";
 import { join } from "path";
-import { writeFileSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
 
 import type { DeployShopResult } from "./deployTypes";
 
@@ -38,7 +38,9 @@ export class CloudflareDeploymentAdapter implements ShopDeploymentAdapter {
 
   writeDeployInfo(id: string, info: DeployShopResult): void {
     try {
-      const file = join("data", "shops", id, "deploy.json");
+      const dir = join("data", "shops", id);
+      mkdirSync(dir, { recursive: true });
+      const file = join(dir, "deploy.json");
       writeFileSync(file, JSON.stringify(info, null, 2));
     } catch {
       // ignore write errors


### PR DESCRIPTION
## Summary
- ensure deployment adapter creates shop directory before writing deploy info

## Testing
- `pnpm -r build` (failed: Next.js build failure)
- `pnpm -F platform-core build`
- `pnpm exec jest packages/platform-core/__tests__/deployShop.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8121652f4832f9ea97260cc3d083a