### PR TITLE
test: cover subscription usage increments

### DIFF
--- a/packages/platform-core/src/__tests__/subscriptionUsage.test.ts
+++ b/packages/platform-core/src/__tests__/subscriptionUsage.test.ts
@@ -48,22 +48,36 @@ describe("subscriptionUsage", () => {
     expect(record).toEqual({ id: "1", shop, customerId, month, shipments: 5 });
   });
 
-  it("creates and increments shipments", async () => {
-    await incrementSubscriptionUsage(shop, customerId, month, 1);
+  it("uses default count and increments with custom values", async () => {
+    // no existing record returns null
+    expect(await getSubscriptionUsage(shop, customerId, month)).toBeNull();
+
+    // default increment when no count is provided
+    await incrementSubscriptionUsage(shop, customerId, month);
     expect(upsertMock).toHaveBeenCalledWith({
       where: { shop_customerId_month: { shop, customerId, month } },
       create: { shop, customerId, month, shipments: 1 },
       update: { shipments: { increment: 1 } },
     });
+    expect(await getSubscriptionUsage(shop, customerId, month)).toEqual({
+      shop,
+      customerId,
+      month,
+      shipments: 1,
+    });
 
+    // custom increment
     await incrementSubscriptionUsage(shop, customerId, month, 2);
     expect(upsertMock).toHaveBeenLastCalledWith({
       where: { shop_customerId_month: { shop, customerId, month } },
       create: { shop, customerId, month, shipments: 2 },
       update: { shipments: { increment: 2 } },
     });
-
-    const record = await getSubscriptionUsage(shop, customerId, month);
-    expect(record?.shipments).toBe(3);
+    expect(await getSubscriptionUsage(shop, customerId, month)).toEqual({
+      shop,
+      customerId,
+      month,
+      shipments: 3,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add tests for default and custom subscription usage increments
- ensure prisma.subscriptionUsage is mocked

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build aborted)*
- `pnpm exec jest packages/platform-core/src/__tests__/subscriptionUsage.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8131b065c832fb504309e1c5fb345