### PR TITLE
test: ensure redis cart store falls back on exec failures

### DIFF
--- a/packages/platform-core/__tests__/cartStore/redis.test.ts
+++ b/packages/platform-core/__tests__/cartStore/redis.test.ts
@@ -7,6 +7,8 @@ process.env.CART_COOKIE_SECRET = "test";
 jest.mock("@upstash/redis", () => ({ Redis: jest.fn() }));
 
 import { createCartStore } from "../../src/cartStore";
+import { RedisCartStore } from "../../src/cartStore/redisStore";
+import type { CartStore } from "../../src/cartStore";
 
 describe("RedisCartStore", () => {
   const hsetMock = jest.fn();
@@ -46,6 +48,135 @@ describe("RedisCartStore", () => {
     await store.setCart("abc", { test: 1 } as any);
     expect(expireMock).toHaveBeenCalledWith("abc", 1);
     expect(expireMock).toHaveBeenLastCalledWith("abc:sku", 1);
+  });
+  const makeFallback = (): jest.Mocked<CartStore> => ({
+    createCart: jest.fn().mockResolvedValue("fb"),
+    getCart: jest.fn().mockResolvedValue({} as any),
+    setCart: jest.fn().mockResolvedValue(undefined),
+    deleteCart: jest.fn().mockResolvedValue(undefined),
+    incrementQty: jest.fn().mockResolvedValue({} as any),
+    setQty: jest.fn().mockResolvedValue({} as any),
+    removeItem: jest.fn().mockResolvedValue({} as any),
+  });
+
+  class FakeRedis {
+    data: Record<string, Record<string, any>> = {};
+    async hset(key: string, value: Record<string, any>) {
+      this.data[key] = { ...(this.data[key] || {}), ...value };
+      return 1;
+    }
+    async hgetall<T>(key: string): Promise<T> {
+      return (this.data[key] || {}) as T;
+    }
+    async expire() {
+      return 1;
+    }
+    async del(key: string) {
+      delete this.data[key];
+      return 1;
+    }
+    async hdel(key: string, field: string) {
+      if (this.data[key]?.[field] !== undefined) {
+        delete this.data[key][field];
+        return 1;
+      }
+      return 0;
+    }
+    async hincrby(key: string, field: string, n: number) {
+      const cur = Number(this.data[key]?.[field] || 0) + n;
+      this.data[key] = { ...(this.data[key] || {}), [field]: cur };
+      return cur;
+    }
+    async hexists(key: string, field: string) {
+      return this.data[key]?.[field] !== undefined ? 1 : 0;
+    }
+  }
+
+  it("enters fallback mode after repeated Redis failures", async () => {
+    const fallback = makeFallback();
+    const hset = jest.fn().mockRejectedValue(new Error("fail"));
+    const expire = jest.fn().mockRejectedValue(new Error("fail"));
+    const store = new RedisCartStore({ hset, expire } as any, 1, fallback);
+
+    await store.createCart();
+    await store.createCart();
+    await store.createCart();
+    await store.createCart();
+
+    expect(hset).toHaveBeenCalledTimes(2);
+    expect(fallback.createCart).toHaveBeenCalledTimes(4);
+  });
+
+  it("falls back when createCart fails", async () => {
+    const fallback = makeFallback();
+    const hset = jest.fn().mockRejectedValue(new Error("boom"));
+    const expire = jest.fn();
+    const store = new RedisCartStore({ hset, expire } as any, 1, fallback);
+    await store.createCart();
+    expect(fallback.createCart).toHaveBeenCalled();
+  });
+
+  it("falls back when getCart fails", async () => {
+    const fallback = makeFallback();
+    const hgetall = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({});
+    const store = new RedisCartStore({ hgetall } as any, 1, fallback);
+    await store.getCart("id");
+    expect(fallback.getCart).toHaveBeenCalledWith("id");
+  });
+
+  it("falls back when setCart fails", async () => {
+    const fallback = makeFallback();
+    const del = jest.fn().mockResolvedValue(undefined);
+    const store = new RedisCartStore({ del } as any, 1, fallback);
+    await store.setCart("id", {} as any);
+    expect(fallback.setCart).toHaveBeenCalledWith("id", {} as any);
+  });
+
+  it("falls back when incrementQty fails", async () => {
+    const fallback = makeFallback();
+    const hincrby = jest.fn().mockResolvedValue(undefined);
+    const store = new RedisCartStore({ hincrby } as any, 1, fallback);
+    await store.incrementQty("id", { id: "sku" } as any, 1);
+    expect(fallback.incrementQty).toHaveBeenCalled();
+  });
+
+  it("falls back when setQty fails", async () => {
+    const fallback = makeFallback();
+    const hexists = jest.fn().mockResolvedValue(undefined);
+    const store = new RedisCartStore({ hexists } as any, 1, fallback);
+    await store.setQty("id", "sku", 1);
+    expect(fallback.setQty).toHaveBeenCalled();
+  });
+
+  it("falls back when removeItem fails", async () => {
+    const fallback = makeFallback();
+    const hdel = jest.fn().mockResolvedValue(undefined);
+    const store = new RedisCartStore({ hdel } as any, 1, fallback);
+    await store.removeItem("id", "sku");
+    expect(fallback.removeItem).toHaveBeenCalled();
+  });
+
+  it("performs operations successfully when Redis succeeds", async () => {
+    const client = new FakeRedis();
+    const fallback = makeFallback();
+    const store = new RedisCartStore(client as any, 1, fallback);
+    const sku = { id: "sku" } as any;
+
+    const id = await store.createCart();
+    await store.setCart(id, { [sku.id]: { sku, qty: 1 } });
+    expect(await store.getCart(id)).toEqual({ [sku.id]: { sku, qty: 1 } });
+    await store.incrementQty(id, sku, 2);
+    expect(await store.getCart(id)).toEqual({ [sku.id]: { sku, qty: 3 } });
+    await store.setQty(id, sku.id, 5);
+    expect(await store.getCart(id)).toEqual({ [sku.id]: { sku, qty: 5 } });
+    await store.removeItem(id, sku.id);
+    expect(await store.getCart(id)).toEqual({});
+    expect(
+      Object.values(fallback).every((fn) => !(fn as jest.Mock).mock.calls.length)
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- test fallback mode activation after repeated Redis errors
- cover RedisCartStore operations delegating to fallback when exec fails
- verify successful cart operations with a fake Redis client

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed; apps/cms build: Failed)*
- `pnpm exec jest __tests__/cartStore/redis.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8131f2664832faa5ee07df75da7ba