### PR TITLE
Add buildLineItemsForItem tests

### DIFF
--- a/packages/platform-core/src/checkout/lineItems.test.ts
+++ b/packages/platform-core/src/checkout/lineItems.test.ts
@@ -1,0 +1,51 @@
+import type { CartLine } from "../cart";
+
+jest.mock("../pricing", () => ({
+  priceForDays: jest.fn(),
+  convertCurrency: jest.fn(),
+}));
+
+import { priceForDays, convertCurrency } from "../pricing";
+import { buildLineItemsForItem } from "./lineItems";
+
+const priceForDaysMock = priceForDays as jest.MockedFunction<typeof priceForDays>;
+const convertCurrencyMock = convertCurrency as jest.MockedFunction<typeof convertCurrency>;
+
+describe("buildLineItemsForItem", () => {
+  beforeEach(() => {
+    priceForDaysMock.mockReset();
+    convertCurrencyMock.mockReset();
+  });
+
+  test("adds deposit line when sku.deposit > 0", async () => {
+    priceForDaysMock.mockResolvedValue(100);
+    convertCurrencyMock.mockImplementation((value: number) => Promise.resolve(value));
+
+    const item: CartLine = {
+      sku: { title: "Tent", deposit: 50 } as any,
+      qty: 1,
+    };
+
+    const lines = await buildLineItemsForItem(item, 3, 0, "USD");
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0].price_data?.product_data?.name).toBe("Tent");
+    expect(lines[1].price_data?.product_data?.name).toBe("Tent deposit");
+  });
+
+  test("only rental line when sku.deposit = 0", async () => {
+    priceForDaysMock.mockResolvedValue(100);
+    convertCurrencyMock.mockImplementation((value: number) => Promise.resolve(value));
+
+    const item: CartLine = {
+      sku: { title: "Bike", deposit: 0 } as any,
+      qty: 1,
+    };
+
+    const lines = await buildLineItemsForItem(item, 3, 0, "USD");
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].price_data?.product_data?.name).toBe("Bike");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for buildLineItemsForItem handling deposit vs non-deposit items
- stub priceForDays and convertCurrency to isolate line-item logic

## Testing
- `pnpm --filter @acme/platform-core test -- --runTestsByPath src/checkout/lineItems.test.ts --runInBand --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b81320f104832f9fb62eddb2494f2e