### PR TITLE
test: expand ProductCard coverage

### DIFF
--- a/packages/platform-core/src/components/shop/ProductCard.tsx
+++ b/packages/platform-core/src/components/shop/ProductCard.tsx
@@ -12,7 +12,7 @@ interface PriceProps {
   currency?: string;
 }
 
-function Price({ amount, currency }: PriceProps) {
+export function Price({ amount, currency }: PriceProps) {
   const [ctxCurrency] = useCurrency();
   const cur = currency ?? ctxCurrency ?? "EUR";
   return <span>{formatPrice(amount, cur)}</span>;


### PR DESCRIPTION
## Summary
- test ProductCard with no media, image, and video variants
- verify Price component uses explicit currency prop or CurrencyContext fallback

## Testing
- `pnpm exec jest packages/platform-core/__tests__/productCard.test.tsx --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68b813221370832fbae05b9899d90032