### PR TITLE
test: cover premier shipping scenarios

### DIFF
--- a/packages/platform-core/src/shipping/__tests__/index.test.ts
+++ b/packages/platform-core/src/shipping/__tests__/index.test.ts
@@ -99,7 +99,7 @@ describe('getShippingRate', () => {
     ).rejects.toThrow('Premier delivery not configured');
   });
 
-  it('validates region/window for non-premier providers', async () => {
+  it('validates region/window/carrier for non-premier providers', async () => {
     await expect(
       getShippingRate({
         provider: 'ups',
@@ -108,6 +108,7 @@ describe('getShippingRate', () => {
         weight: 5,
         region: 'eligible',
         window: 'morning',
+        carrier: 'ups',
       }),
     ).rejects.toThrow('Premier delivery not configured');
   });
@@ -157,6 +158,20 @@ describe('getShippingRate', () => {
           carrier: 'dhl',
         }),
       ).rejects.toThrow('Carrier not supported');
+    });
+
+    it('returns rate for valid config', async () => {
+      const result = await getShippingRate({
+        ...base,
+        region: 'eligible',
+        window: 'morning',
+        carrier: 'ups',
+      });
+      expect(result).toEqual({
+        rate: 0,
+        surcharge: 5,
+        serviceLabel: 'Premier Delivery',
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- extend non-premier provider validation to include carrier
- add success-path test for premier delivery configuration

## Testing
- `pnpm --filter @acme/platform-core exec jest src/shipping/__tests__/index.test.ts --runTestsByPath --config ../../jest.config.cjs --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b81325cdac832fb1c170d43f50a0a5