### PR TITLE
test: verify inventory backend selection

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/inventory.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/inventory.backendSelection.test.ts
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+
+const mockSqlite = {
+  read: jest.fn(),
+  write: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockJson = {
+  read: jest.fn(),
+  write: jest.fn(),
+  update: jest.fn(),
+};
+
+jest.mock('../inventory.sqlite.server', () => ({
+  sqliteInventoryRepository: mockSqlite,
+}));
+
+jest.mock('../inventory.json.server', () => ({
+  jsonInventoryRepository: mockJson,
+}));
+
+describe('inventory repository backend selection', () => {
+  const origBackend = process.env.INVENTORY_BACKEND;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.INVENTORY_BACKEND;
+    } else {
+      process.env.INVENTORY_BACKEND = origBackend;
+    }
+  });
+
+  it('uses sqlite repository when INVENTORY_BACKEND="sqlite"', async () => {
+    process.env.INVENTORY_BACKEND = 'sqlite';
+    const { inventoryRepository } = await import('../inventory.server');
+    const mutate = jest.fn();
+
+    await inventoryRepository.read('shop');
+    await inventoryRepository.write('shop', []);
+    await inventoryRepository.update('shop', 'sku', {}, mutate);
+
+    expect(mockSqlite.read).toHaveBeenCalledWith('shop');
+    expect(mockSqlite.write).toHaveBeenCalledWith('shop', []);
+    expect(mockSqlite.update).toHaveBeenCalledWith('shop', 'sku', {}, mutate);
+    expect(mockJson.read).not.toHaveBeenCalled();
+  });
+
+  it('defaults to JSON repository when INVENTORY_BACKEND is not "sqlite"', async () => {
+    delete process.env.INVENTORY_BACKEND;
+    const { inventoryRepository } = await import('../inventory.server');
+    const mutate = jest.fn();
+
+    await inventoryRepository.read('shop');
+    await inventoryRepository.write('shop', []);
+    await inventoryRepository.update('shop', 'sku', {}, mutate);
+
+    expect(mockJson.read).toHaveBeenCalledWith('shop');
+    expect(mockJson.write).toHaveBeenCalledWith('shop', []);
+    expect(mockJson.update).toHaveBeenCalledWith('shop', 'sku', {}, mutate);
+    expect(mockSqlite.read).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test inventory repository selects sqlite or json backend based on INVENTORY_BACKEND
- ensure read, write, and update delegate to the chosen repository

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: cannot find module 'file:///workspace/base-shop/apps/cms/packages/plugins')*
- `pnpm exec jest packages/platform-core/src/repositories/__tests__/inventory.backendSelection.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b81328a720832f9e0e396296b670cb