### PR TITLE
test: cover shops repository paths

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/shops.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/shops.server.test.ts
@@ -45,6 +45,26 @@ describe("shops repository", () => {
   });
 
   describe("readShop", () => {
+    it("returns shop from Prisma when available", async () => {
+      const dbData = {
+        id: "db-shop",
+        name: "DB Shop",
+        catalogFilters: [],
+        themeId: "base",
+        filterMappings: {},
+        themeDefaults: { color: "green" },
+        themeOverrides: { color: "blue" },
+      };
+      findUnique.mockResolvedValue({ data: dbData });
+
+      const result = await readShop("db-shop");
+
+      expect(result.name).toBe("DB Shop");
+      expect(result.themeDefaults).toEqual({ color: "green" });
+      expect(readFile).not.toHaveBeenCalled();
+      expect(loadTokens).not.toHaveBeenCalled();
+    });
+
     it("falls back to filesystem when Prisma fails", async () => {
       findUnique.mockRejectedValue(new Error("db fail"));
       const fileData = {
@@ -68,6 +88,7 @@ describe("shops repository", () => {
         "/data/root/shop1/shop.json",
         "utf8",
       );
+      expect(loadTokens).not.toHaveBeenCalled();
     });
 
     it("returns empty shop with defaults when db and fs fail", async () => {


### PR DESCRIPTION
## Summary
- add prisma success case to shops repository tests
- assert filesystem fallback and default shop logic
- ensure theme tokens load only when defaults absent

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: core env sub-schema integration allows missing SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid)*
- `pnpm exec jest packages/platform-core/src/repositories/__tests__/shops.server.test.ts --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68b8132c2aa4832f9e154ea7e7b47d1c