### PR TITLE
test: cover reverse logistics events

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/reverseLogisticsEvents.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/reverseLogisticsEvents.server.test.ts
@@ -6,40 +6,92 @@ jest.mock("../../db", () => ({
     },
   },
 }));
+jest.mock("@acme/date-utils", () => ({
+  nowIso: jest.fn(() => "now"),
+}));
 
 import { prisma } from "../../db";
-import {
-  reverseLogisticsEvents,
-  listEvents,
-} from "../reverseLogisticsEvents.server";
+import { nowIso } from "@acme/date-utils";
+import { recordEvent, listEvents } from "../reverseLogisticsEvents.server";
 
 describe("reverse logistics events repository", () => {
   const create = prisma.reverseLogisticsEvent.create as jest.Mock;
   const findMany = prisma.reverseLogisticsEvent.findMany as jest.Mock;
+  const nowIsoMock = nowIso as jest.Mock;
 
   beforeEach(() => {
     create.mockReset();
     findMany.mockReset();
+    nowIsoMock.mockClear();
   });
 
-  it("emits typed events", async () => {
-    await reverseLogisticsEvents.cleaning("shop1", "session1", "time");
+  it("records event with provided createdAt", async () => {
+    await recordEvent("shop1", "session1", "received", "time");
+    expect(nowIsoMock).not.toHaveBeenCalled();
     expect(create).toHaveBeenCalledWith({
       data: {
         shop: "shop1",
         sessionId: "session1",
-        event: "cleaning",
+        event: "received",
         createdAt: "time",
       },
     });
   });
 
-  it("lists events for a shop", async () => {
-    findMany.mockResolvedValue([]);
-    await listEvents("demo");
+  it("records event with default createdAt", async () => {
+    nowIsoMock.mockReturnValue("mocked");
+    await recordEvent("shop1", "session1", "qa");
+    expect(nowIsoMock).toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        shop: "shop1",
+        sessionId: "session1",
+        event: "qa",
+        createdAt: "mocked",
+      },
+    });
+  });
+
+  it("returns events ordered by createdAt", async () => {
+    const events = [
+      {
+        id: "2",
+        shop: "demo",
+        sessionId: "b",
+        event: "qa",
+        createdAt: "2023-01-02",
+      },
+      {
+        id: "1",
+        shop: "demo",
+        sessionId: "a",
+        event: "received",
+        createdAt: "2023-01-01",
+      },
+    ];
+    findMany.mockResolvedValue(
+      [...events].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    );
+    const result = await listEvents("demo");
     expect(findMany).toHaveBeenCalledWith({
       where: { shop: "demo" },
       orderBy: { createdAt: "asc" },
     });
+    expect(result).toEqual([
+      {
+        id: "1",
+        shop: "demo",
+        sessionId: "a",
+        event: "received",
+        createdAt: "2023-01-01",
+      },
+      {
+        id: "2",
+        shop: "demo",
+        sessionId: "b",
+        event: "qa",
+        createdAt: "2023-01-02",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add tests for recordEvent default timestamp and explicit timestamp
- ensure listEvents returns records sorted by createdAt

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/platform-core test` *(fails: core env test, releaseDepositsService)*
- `pnpm --filter @acme/platform-core exec jest src/repositories/__tests__/reverseLogisticsEvents.server.test.ts --config ../../jest.config.cjs --runInBand` *(coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b8132a85a4832fb5c7bbeacdbebe4c