### PR TITLE
test: cover product repo error paths

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/products.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/products.server.test.ts
@@ -1,0 +1,57 @@
+import { jest } from "@jest/globals";
+
+describe("products repository error cases", () => {
+  const shop = "demo";
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.DATA_ROOT = "/tmp/data";
+  });
+
+  it("readRepo returns empty array when file read fails", async () => {
+    const readFile = jest.fn().mockRejectedValue(new Error("fail"));
+    jest.doMock("fs", () => ({ promises: { readFile } }));
+    const { readRepo } = await import("../products.server");
+    await expect(readRepo(shop)).resolves.toEqual([]);
+    expect(readFile).toHaveBeenCalled();
+  });
+
+  it("updateProductInRepo throws when id not found", async () => {
+    const readFile = jest.fn().mockResolvedValue("[]");
+    const writeFile = jest.fn();
+    const mkdir = jest.fn();
+    const rename = jest.fn();
+    jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+    const { updateProductInRepo } = await import("../products.server");
+    await expect(updateProductInRepo(shop, { id: "2" })).rejects.toThrow(
+      "Product 2 not found in demo",
+    );
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("deleteProductFromRepo throws when product absent", async () => {
+    const readFile = jest.fn().mockResolvedValue('[{"id":"1"}]');
+    const writeFile = jest.fn();
+    const mkdir = jest.fn();
+    const rename = jest.fn();
+    jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+    const { deleteProductFromRepo } = await import("../products.server");
+    await expect(deleteProductFromRepo(shop, "2")).rejects.toThrow(
+      "Product 2 not found in demo",
+    );
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("duplicateProductInRepo throws when original missing", async () => {
+    const readFile = jest.fn().mockResolvedValue("[]");
+    const writeFile = jest.fn();
+    const mkdir = jest.fn();
+    const rename = jest.fn();
+    jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+    const { duplicateProductInRepo } = await import("../products.server");
+    await expect(duplicateProductInRepo(shop, "1")).rejects.toThrow(
+      "Product 1 not found in demo",
+    );
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `readRepo` failing to read file
- ensure update, delete, and duplicate operations throw when product IDs are missing

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/src/repositories/__tests__/products.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b813294b04832f88d4d8bd5b6e10c1