### PR TITLE
docs: add per-package agent notes

### DIFF
--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# auth — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Authentication utilities and session helpers.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/configurator/AGENTS.md
+++ b/packages/configurator/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# configurator — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+CLI for generating configuration files.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/date-utils/AGENTS.md
+++ b/packages/date-utils/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# date-utils — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Date and time helper functions.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# design-tokens — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Shared design tokens for styling.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/email-templates/AGENTS.md
+++ b/packages/email-templates/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# email-templates — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Reusable email template components.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/email/AGENTS.md
+++ b/packages/email/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# email — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Email sending utilities.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/eslint-plugin-ds/AGENTS.md
+++ b/packages/eslint-plugin-ds/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# eslint-plugin-ds — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+ESLint rules for the design system.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/i18n/AGENTS.md
+++ b/packages/i18n/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# i18n — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Internationalization helpers and message formatting.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/lib/AGENTS.md
+++ b/packages/lib/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# lib — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Common library helpers.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/platform-core/AGENTS.md
+++ b/packages/platform-core/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# platform-core — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Core services for the platform.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/platform-machine/AGENTS.md
+++ b/packages/platform-machine/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# platform-machine — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Machine-oriented platform utilities.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/sanity/AGENTS.md
+++ b/packages/sanity/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# sanity — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Sanity CMS integration helpers.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/shared-utils/AGENTS.md
+++ b/packages/shared-utils/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# shared-utils — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Utilities shared across packages.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/stripe/AGENTS.md
+++ b/packages/stripe/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# stripe — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Stripe API integration utilities.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/tailwind-config/AGENTS.md
+++ b/packages/tailwind-config/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# tailwind-config — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Tailwind CSS base configuration.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/telemetry/AGENTS.md
+++ b/packages/telemetry/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# telemetry — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Telemetry and analytics helpers.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/template-app/AGENTS.md
+++ b/packages/template-app/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# template-app — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Starter application template.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/theme/AGENTS.md
+++ b/packages/theme/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# theme — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Theming helpers and default theme.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# types — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Shared TypeScript type definitions.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# ui — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+UI component library.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`

--- a/packages/zod-utils/AGENTS.md
+++ b/packages/zod-utils/AGENTS.md
@@ -1,15 +1,7 @@
-# config — Agent Notes
+# zod-utils — Agent Notes
 
 ## Purpose
-Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
-
-## Regenerating Stubs
-Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
-## Tooling
-- **Next.js** loads the `*.js` stubs for runtime configuration.
-- **Jest** resolves the stubs so tests run without a custom transformer.
-- **ESLint** reads configuration from the stubs for consistent linting.
+Helpers for working with Zod schemas.
 
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`


### PR DESCRIPTION
## Summary
- add AGENTS.md to each TypeScript package describing build contract and maintenance steps
- document stub regeneration and build expectations for config package

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm test` *(fails: command exited 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b8231f510c832f9086fd5d2e7f4cf0