### PR TITLE
feat(config): allow sendgrid without API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ After running `pnpm create-shop <id>`, the wizard generates `.env` and `.env.tem
 - `DEPOSIT_RELEASE_INTERVAL_MS` – interval in milliseconds for running the refund service
 - `LOG_LEVEL` – controls logging output (`error`, `warn`, `info`, `debug`; defaults to `info`)
 - `EMAIL_PROVIDER` – campaign email provider (`smtp`, `sendgrid`, or `resend`)
-- `SENDGRID_API_KEY` – API key for SendGrid when using the SendGrid provider
+- `SENDGRID_API_KEY` – optional API key for SendGrid when using the SendGrid provider
 - `SENDGRID_MARKETING_KEY` – API key for SendGrid marketing endpoints (contact management and segments)
 - `RESEND_API_KEY` – API key for Resend when using the Resend provider (requires `emails.send`, `contacts.write`, `contacts.read`, and `segments.read` scopes)
 - `SENDGRID_WEBHOOK_PUBLIC_KEY` – public key to verify SendGrid event webhook signatures

--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -75,7 +75,7 @@ describe("email env module", () => {
   });
 
   it(
-    "throws and logs error when SENDGRID_API_KEY is missing for sendgrid provider",
+    "does not throw when SENDGRID_API_KEY is missing for sendgrid provider",
     async () => {
       process.env = {
         ...ORIGINAL_ENV,
@@ -85,17 +85,9 @@ describe("email env module", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
       jest.resetModules();
-      await expect(import("../email.ts")).rejects.toThrow(
-        "Invalid email environment variables",
-      );
-      expect(errorSpy).toHaveBeenCalledWith(
-        "❌ Invalid email environment variables:",
-        expect.objectContaining({
-          SENDGRID_API_KEY: {
-            _errors: [expect.stringContaining("Required")],
-          },
-        }),
-      );
+      const { emailEnv } = await import("../email.ts");
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(emailEnv).toMatchObject({ EMAIL_PROVIDER: "sendgrid" });
       errorSpy.mockRestore();
     },
   );

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -79,7 +79,7 @@ const baseEnvSchema = z
 export const coreEnvBaseSchema = authEnvSchema
   .innerType()
   .merge(cmsEnvSchema)
-  .merge(emailEnvSchema.innerType())
+  .merge(emailEnvSchema)
   .merge(paymentsEnvSchema)
   .merge(shippingEnvSchema)
   .merge(baseEnvSchema);

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -13,15 +13,6 @@ export const emailEnvSchema = z
     RESEND_API_KEY: z.string().optional(),
     EMAIL_BATCH_SIZE: z.coerce.number().optional(),
     EMAIL_BATCH_DELAY_MS: z.coerce.number().optional(),
-  })
-  .superRefine((env, ctx) => {
-    if (env.EMAIL_PROVIDER === "sendgrid" && !env.SENDGRID_API_KEY) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["SENDGRID_API_KEY"],
-        message: "Required",
-      });
-    }
   });
 
 const parsed = emailEnvSchema.safeParse(process.env);

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -28,7 +28,7 @@ Node versions.
 The email package relies on several environment variables when sending
 campaigns or managing contacts:
 
-- `SENDGRID_API_KEY` – used to send mail via the SendGrid provider
+- `SENDGRID_API_KEY` – optional API key used to send mail via the SendGrid provider
 - `SENDGRID_MARKETING_KEY` – grants access to SendGrid marketing APIs for
   contact and segment management
 - `RESEND_API_KEY` – used by the Resend provider and must include `emails.send`,


### PR DESCRIPTION
## Summary
- make SENDGRID_API_KEY optional for SendGrid email provider
- update docs and tests for optional SendGrid API key

## Testing
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b826403a34832f9bcd7d82b42ca6d1