### PR TITLE
test(config): add redis session store credential tests

### DIFF
--- a/packages/config/src/env/__tests__/auth.test.ts
+++ b/packages/config/src/env/__tests__/auth.test.ts
@@ -186,12 +186,13 @@ describe("auth env module", () => {
     await expect(import("../auth.ts")).rejects.toThrow(
       "Invalid auth environment variables",
     );
-    expect(errorSpy).toHaveBeenCalled();
-    const issues = errorSpy.mock.calls.at(-1)[1];
-    expect(issues).toEqual({
-      UPSTASH_REDIS_REST_TOKEN: { _errors: [expect.any(String)] },
-      _errors: [],
-    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      {
+        UPSTASH_REDIS_REST_TOKEN: { _errors: [expect.any(String)] },
+        _errors: [],
+      },
+    );
     errorSpy.mockRestore();
   });
 
@@ -209,12 +210,13 @@ describe("auth env module", () => {
     await expect(import("../auth.ts")).rejects.toThrow(
       "Invalid auth environment variables",
     );
-    expect(errorSpy).toHaveBeenCalled();
-    const issues = errorSpy.mock.calls.at(-1)[1];
-    expect(issues).toEqual({
-      UPSTASH_REDIS_REST_URL: { _errors: [expect.any(String)] },
-      _errors: [],
-    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      {
+        UPSTASH_REDIS_REST_URL: { _errors: [expect.any(String)] },
+        _errors: [],
+      },
+    );
     errorSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- add explicit tests for redis session store without Upstash token or URL

## Testing
- `pnpm test packages/config` *(fails: Could not find task `packages/config`)*
- `pnpm --filter @acme/config test` *(fails: core env sub-schema integration: allows missing SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid)*

------
https://chatgpt.com/codex/tasks/task_e_68b826dd6650832fbf995d21df52b940