### PR TITLE
test(config): cover malformed CMS_SPACE_URL in production

### DIFF
--- a/packages/config/src/env/__tests__/cms.test.ts
+++ b/packages/config/src/env/__tests__/cms.test.ts
@@ -197,6 +197,26 @@ describe("cms env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("throws when CMS_SPACE_URL is malformed in production", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      CMS_SPACE_URL: "not-a-url",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2024-01-01",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../cms.ts")).rejects.toThrow(
+      "Invalid CMS environment variables"
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid CMS environment variables:",
+      { CMS_SPACE_URL: { _errors: [expect.any(String)] }, _errors: [] }
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws when CMS_SPACE_URL is malformed and tokens are missing", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- add production test for malformed CMS_SPACE_URL to exercise error logging

## Testing
- `pnpm -r build` (fails: Project references may not form a circular graph)
- `pnpm --filter @acme/config test` (fails: core env sub-schema integration)
- `pnpm exec jest packages/config/src/env/__tests__/cms.test.ts --runInBand --config packages/config/jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8278d8fa8832f99fd35c9a85c58ca