### PR TITLE
test: cover login rate limit redis env

### DIFF
--- a/packages/config/__tests__/authEnv.test.ts
+++ b/packages/config/__tests__/authEnv.test.ts
@@ -46,4 +46,66 @@ describe("authEnv", () => {
     );
     expect(spy).toHaveBeenCalled();
   });
+
+  it("throws and logs when only LOGIN_RATE_LIMIT_REDIS_URL is set", async () => {
+    process.env = {
+      NODE_ENV: "production",
+      NEXTAUTH_SECRET: "nextauth",
+      SESSION_SECRET: "session",
+      LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(import("../src/env/auth")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        LOGIN_RATE_LIMIT_REDIS_TOKEN: { _errors: [expect.any(String)] },
+      }),
+    );
+  });
+
+  it("throws and logs when only LOGIN_RATE_LIMIT_REDIS_TOKEN is set", async () => {
+    process.env = {
+      NODE_ENV: "production",
+      NEXTAUTH_SECRET: "nextauth",
+      SESSION_SECRET: "session",
+      LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(import("../src/env/auth")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        LOGIN_RATE_LIMIT_REDIS_URL: { _errors: [expect.any(String)] },
+      }),
+    );
+  });
+
+  it("parses rate limit redis configuration when URL and token are provided", async () => {
+    process.env = {
+      NODE_ENV: "production",
+      NEXTAUTH_SECRET: "nextauth",
+      SESSION_SECRET: "session",
+      LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
+      LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const { authEnv } = await import("../src/env/auth");
+
+    expect(authEnv).toMatchObject({
+      LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
+      LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -355,14 +355,21 @@ describe("core env sub-schema integration", () => {
     }
   });
 
-  it("allows missing SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid", () => {
+  it("requires SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid", () => {
     const parsed = coreEnvSchema.safeParse({
       ...baseEnv,
       EMAIL_PROVIDER: "sendgrid",
     });
-    expect(parsed.success).toBe(true);
-    if (parsed.success) {
-      expect(parsed.data.SENDGRID_API_KEY).toBeUndefined();
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["SENDGRID_API_KEY"],
+            message: "Required",
+          }),
+        ]),
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary
- add tests for login rate limit redis env permutations
- align core env test with SendGrid API key requirement

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm run check:references` *(fails: Missing script `check:references`)*
- `pnpm test --filter @acme/config`


------
https://chatgpt.com/codex/tasks/task_e_68b826de5454832fb974ac6d1801dfa8