### PR TITLE
test(config): handle missing NEXTAUTH_SECRET

### DIFF
--- a/packages/config/src/env/__tests__/auth.test.ts
+++ b/packages/config/src/env/__tests__/auth.test.ts
@@ -106,6 +106,27 @@ describe("auth env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("throws when NEXTAUTH_SECRET is missing", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      SESSION_SECRET: "session-secret",
+    } as NodeJS.ProcessEnv;
+    delete process.env.NEXTAUTH_SECRET;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../auth.ts")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        NEXTAUTH_SECRET: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws when SESSION_STORE is invalid", async () => {
     process.env = {
       ...ORIGINAL_ENV,

--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -355,14 +355,20 @@ describe("core env sub-schema integration", () => {
     }
   });
 
-  it("allows missing SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid", () => {
+  it("requires SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid", () => {
     const parsed = coreEnvSchema.safeParse({
       ...baseEnv,
+      NEXTAUTH_SECRET: "test-nextauth-secret",
+      SESSION_SECRET: "test-session-secret",
       EMAIL_PROVIDER: "sendgrid",
     });
-    expect(parsed.success).toBe(true);
-    if (parsed.success) {
-      expect(parsed.data.SENDGRID_API_KEY).toBeUndefined();
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ["SENDGRID_API_KEY"] }),
+        ]),
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary
- ensure missing `NEXTAUTH_SECRET` in production throws and logs formatted error
- check Sendgrid API key requirement in core env schema

## Testing
- `pnpm test packages/config` *(fails: Could not find task `packages/config`)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b826dfa670832f8e67119a72f69e73