### PR TITLE
fix settings language defaults

### DIFF
--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -56,42 +56,46 @@ function diffSettings(
 export async function getShopSettings(shop: string): Promise<ShopSettings> {
   try {
     const buf = await fs.readFile(settingsPath(shop), "utf8");
-    const parsed = shopSettingsSchema.safeParse(JSON.parse(buf));
+    const parsed = shopSettingsSchema
+      .deepPartial()
+      .safeParse(JSON.parse(buf));
     if (parsed.success) {
+      const data = parsed.data as Partial<ShopSettings>;
       return {
         freezeTranslations: false,
-        ...(parsed.data.analytics ? { analytics: parsed.data.analytics } : {}),
-        currency: parsed.data.currency ?? "EUR",
-        taxRegion: parsed.data.taxRegion ?? "",
-        ...parsed.data,
+        ...(data.analytics ? { analytics: data.analytics } : {}),
+        currency: data.currency ?? "EUR",
+        taxRegion: data.taxRegion ?? "",
+        ...data,
+        languages: data.languages ?? DEFAULT_LANGUAGES,
         depositService: {
           enabled: false,
           intervalMinutes: 60,
-          ...(parsed.data.depositService ?? {}),
+          ...(data.depositService ?? {}),
         },
         reverseLogisticsService: {
           enabled: false,
           intervalMinutes: 60,
-          ...(parsed.data.reverseLogisticsService ?? {}),
+          ...(data.reverseLogisticsService ?? {}),
         },
         returnService: {
           upsEnabled: false,
           bagEnabled: false,
           homePickupEnabled: false,
-          ...(parsed.data.returnService ?? {}),
+          ...(data.returnService ?? {}),
         },
-        premierDelivery: parsed.data.premierDelivery,
+        premierDelivery: data.premierDelivery,
         stockAlert: {
           recipients: [],
-          ...(parsed.data.stockAlert ?? {}),
+          ...(data.stockAlert ?? {}),
         },
         seo: {
-          ...(parsed.data.seo ?? {}),
+          ...(data.seo ?? {}),
           aiCatalog: {
             enabled: true,
             fields: ["id", "title", "description", "price", "media"],
             pageSize: 50,
-            ...((parsed.data.seo ?? {}).aiCatalog ?? {}),
+            ...((data.seo ?? {}).aiCatalog ?? {}),
           },
         },
       } as ShopSettings;


### PR DESCRIPTION
## Summary
- parse settings with deepPartial to allow missing fields
- default languages to LOCALES when not provided

## Testing
- `pnpm --filter @acme/platform-core test src/repositories/__tests__/settings.server.test.ts` *(fails: Jest: "global" coverage threshold for branches (80%) not met: 59.52%)*
- `pnpm --filter @acme/platform-core run build` *(fails: Project references may not form a circular graph)*
- `pnpm run check:references` *(fails: Missing script: check:references)*


------
https://chatgpt.com/codex/tasks/task_e_68b827536888832fb569050d9bd2ab88