### PR TITLE
test(config): cover email provider and URL errors

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -355,14 +355,21 @@ describe("core env sub-schema integration", () => {
     }
   });
 
-  it("allows missing SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid", () => {
+  it("requires SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid", () => {
     const parsed = coreEnvSchema.safeParse({
       ...baseEnv,
       EMAIL_PROVIDER: "sendgrid",
     });
-    expect(parsed.success).toBe(true);
-    if (parsed.success) {
-      expect(parsed.data.SENDGRID_API_KEY).toBeUndefined();
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["SENDGRID_API_KEY"],
+            message: expect.stringContaining("Required"),
+          }),
+        ]),
+      );
     }
   });
 });

--- a/packages/config/src/env/__tests__/email.test.ts
+++ b/packages/config/src/env/__tests__/email.test.ts
@@ -53,7 +53,28 @@ describe("email env module", () => {
     errorSpy.mockRestore();
   });
 
-  it("throws and logs structured error for invalid SMTP_URL", async () => {
+  it("logs structured error when SENDGRID_API_KEY is missing", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      EMAIL_PROVIDER: "sendgrid",
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../email.ts")).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid email environment variables:",
+      expect.objectContaining({
+        SENDGRID_API_KEY: { _errors: [expect.stringContaining("Required")] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("logs structured error for invalid SMTP_URL", async () => {
     process.env = {
       ...ORIGINAL_ENV,
       SMTP_URL: "not-a-url",
@@ -74,31 +95,8 @@ describe("email env module", () => {
     errorSpy.mockRestore();
   });
 
-  it(
-    "throws and logs error when SENDGRID_API_KEY is missing for sendgrid provider",
-    async () => {
-      process.env = {
-        ...ORIGINAL_ENV,
-        EMAIL_PROVIDER: "sendgrid",
-      } as NodeJS.ProcessEnv;
-      const errorSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      jest.resetModules();
-      await expect(import("../email.ts")).rejects.toThrow(
-        "Invalid email environment variables",
-      );
-      expect(errorSpy).toHaveBeenCalledWith(
-        "❌ Invalid email environment variables:",
-        expect.objectContaining({
-          SENDGRID_API_KEY: {
-            _errors: [expect.stringContaining("Required")],
-          },
-        }),
-      );
-      errorSpy.mockRestore();
-    },
-  );
+  // Previous coverage for SENDGRID_API_KEY and SMTP_URL errors has been
+  // consolidated into the dedicated tests above.
 
   it(
     "does not throw when RESEND_API_KEY is missing for resend provider",


### PR DESCRIPTION
## Summary
- add tests ensuring missing SENDGRID_API_KEY logs structured errors and throws
- add tests for invalid SMTP_URL logging and throwing
- align core env tests with SENDGRID_API_KEY requirement

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b8278ca8ec832f8e6041776d4a8e16