### PR TITLE
test: verify payments ts import warns on invalid env

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -94,6 +94,38 @@ describe("payments env defaults", () => {
     );
   });
 
+  it(
+    "warns with formatted errors when variables have invalid types (ts import)",
+    async () => {
+      process.env = {
+        STRIPE_SECRET_KEY: 123 as unknown as string,
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 456 as unknown as string,
+        STRIPE_WEBHOOK_SECRET: 789 as unknown as string,
+      } as unknown as NodeJS.ProcessEnv;
+      warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      jest.resetModules();
+      const { paymentsEnv } = await import("../payments.ts");
+      expect(paymentsEnv).toEqual({
+        STRIPE_SECRET_KEY: "sk_test",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+        STRIPE_WEBHOOK_SECRET: "whsec_test",
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "⚠️ Invalid payments environment variables:",
+        {
+          _errors: [],
+          STRIPE_SECRET_KEY: { _errors: ["Expected string, received number"] },
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: {
+            _errors: ["Expected string, received number"],
+          },
+          STRIPE_WEBHOOK_SECRET: {
+            _errors: ["Expected string, received number"],
+          },
+        },
+      );
+    },
+  );
+
   it("warns and falls back to defaults when STRIPE_SECRET_KEY is empty", () => {
     process.env = {
       STRIPE_SECRET_KEY: "",


### PR DESCRIPTION
## Summary
- add test for payments env TypeScript module to verify formatted warnings and default fallbacks

## Testing
- `pnpm -r build` (fails: Project references may not form a circular graph. Cycle detected: /workspace/base-shop/packages/i18n/tsconfig.json)
- `pnpm --filter @acme/config exec jest src/env/__tests__/payments-env.test.ts --config jest.preset.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b8278ef900832f85ac61dc01823dbb