### PR TITLE
test(email): cover unknown provider stats normalization

### DIFF
--- a/packages/email/src/__tests__/stats.test.ts
+++ b/packages/email/src/__tests__/stats.test.ts
@@ -14,7 +14,12 @@ jest.mock("../stats", () => {
 
 import * as stats from "../stats";
 
-const { mapSendGridStats, mapResendStats, emptyStats } = stats;
+const {
+  mapSendGridStats,
+  mapResendStats,
+  emptyStats,
+  normalizeProviderStats,
+} = stats;
 
 describe("mapSendGridStats", () => {
   it("converts mixed string/number fields", () => {
@@ -62,7 +67,7 @@ describe("normalizeProviderStats", () => {
   });
 
   it("returns empty stats for unknown provider", () => {
-    expect(stats.normalizeProviderStats("unknown", undefined)).toEqual(emptyStats);
+    expect(normalizeProviderStats("unknown", undefined)).toEqual(emptyStats);
   });
 
   it("invokes mapSendGridStats for sendgrid provider", () => {
@@ -142,6 +147,6 @@ describe("normalizeProviderStats", () => {
 describe("normalizeProviderStats real module", () => {
   it("uses actual implementation for unknown providers", () => {
     const { normalizeProviderStats, emptyStats } = jest.requireActual("../stats");
-    expect(normalizeProviderStats("unknown", undefined)).toEqual({ ...emptyStats });
+    expect(normalizeProviderStats("unknown", undefined)).toEqual(emptyStats);
   });
 });


### PR DESCRIPTION
## Summary
- ensure normalizeProviderStats returns empty stats for unknown providers
- test the real implementation against emptyStats

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS6202 project references cycle in packages/i18n)*
- `pnpm test packages/email` *(fails: Could not find task `packages/email`)*
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__/stats.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b8279b19bc832fb2fab2469a356730