### PR TITLE
test: add plugin manager registry tests

### DIFF
--- a/packages/platform-core/__tests__/pluginsManager.test.ts
+++ b/packages/platform-core/__tests__/pluginsManager.test.ts
@@ -1,0 +1,46 @@
+import { PluginManager, Registry } from "../src/plugins/PluginManager";
+
+describe("MapRegistry", () => {
+  it("adds and retrieves items", () => {
+    const registry = new Registry<number>();
+    registry.add("one", 1);
+    expect(registry.get("one")).toBe(1);
+    expect(registry.get("missing")).toBeUndefined();
+  });
+
+  it("lists all registered items", () => {
+    const registry = new Registry<string>();
+    registry.add("a", "alpha");
+    registry.add("b", "beta");
+    expect(registry.list()).toEqual([
+      { id: "a", value: "alpha" },
+      { id: "b", value: "beta" },
+    ]);
+  });
+});
+
+describe("PluginManager", () => {
+  it("registers a plugin via addPlugin and retrieves it with getPlugin", () => {
+    const manager = new PluginManager();
+    const plugin = { id: "test" } as any;
+    manager.addPlugin(plugin);
+    expect(manager.getPlugin("test")).toEqual({
+      id: "test",
+      name: undefined,
+      description: undefined,
+      plugin,
+    });
+  });
+
+  it("returns all plugins via listPlugins", () => {
+    const manager = new PluginManager();
+    const pluginA = { id: "a" } as any;
+    const pluginB = { id: "b" } as any;
+    manager.addPlugin(pluginA);
+    manager.addPlugin(pluginB);
+    expect(manager.listPlugins()).toEqual([
+      { id: "a", name: undefined, description: undefined, plugin: pluginA },
+      { id: "b", name: undefined, description: undefined, plugin: pluginB },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for MapRegistry add/get/list
- ensure PluginManager registers and lists plugins

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/pluginsManager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b828ec1b80832f8f50a7ec8b8170cf