### PR TITLE
test: shipping env invalid cases

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -386,5 +386,52 @@ describe("shipping env module", () => {
     );
     errorSpy.mockRestore();
   });
+
+  it("loadShippingEnv throws and logs when DHL_KEY is null", async () => {
+    const { loadShippingEnv } = await import("../shipping.ts");
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => loadShippingEnv({ DHL_KEY: null as any })).toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        DHL_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("throws during eager parse when DHL_KEY is null", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      DHL_KEY: null as any,
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../shipping.ts")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        DHL_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("loadShippingEnv returns object when variables are valid", async () => {
+    const { loadShippingEnv } = await import("../shipping.ts");
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const env = loadShippingEnv({
+      TAXJAR_KEY: "tax",
+      UPS_KEY: "ups",
+      DHL_KEY: "dhl",
+    });
+    expect(env).toEqual({ TAXJAR_KEY: "tax", UPS_KEY: "ups", DHL_KEY: "dhl" });
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- extend shipping env tests for null DHL_KEY
- cover eager parse failure when DHL_KEY is null
- verify valid shipping env returns parsed values

## Testing
- `pnpm -r build` *(fails: Project references may not form a circular graph. Cycle detected: packages/i18n/tsconfig.json)*
- `pnpm -F @acme/config test` *(fails: allows missing SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid)*

------
https://chatgpt.com/codex/tasks/task_e_68b827904fd4832f8bf54af660b83230