### PR TITLE
test: log missing auth secret

### DIFF
--- a/packages/config/src/env/__tests__/auth.test.ts
+++ b/packages/config/src/env/__tests__/auth.test.ts
@@ -84,6 +84,27 @@ describe("auth env module", () => {
     errorSpy.mockRestore();
   });
 
+  it("throws when NEXTAUTH_SECRET is missing in production", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      SESSION_SECRET: "session-secret",
+    } as NodeJS.ProcessEnv;
+    delete process.env.NEXTAUTH_SECRET;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../auth.ts")).rejects.toThrow(
+      "Invalid auth environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        NEXTAUTH_SECRET: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("throws when required secrets are empty", async () => {
     process.env = {
       ...ORIGINAL_ENV,


### PR DESCRIPTION
## Summary
- add regression test for missing NEXTAUTH_SECRET

## Testing
- `pnpm test packages/config` *(fails: core env sub-schema integration requires SENDGRID_API_KEY when EMAIL_PROVIDER=sendgrid)*
- `pnpm --filter @acme/config exec jest src/env/__tests__/auth.test.ts --runInBand --config jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b829984c4c832fa5a737f60cc62107