### PR TITLE
test: cover CloudflareDeploymentAdapter deployment flow

### DIFF
--- a/packages/platform-core/__tests__/deploymentAdapter.test.ts
+++ b/packages/platform-core/__tests__/deploymentAdapter.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const spawnSyncMock = jest.fn();
+jest.mock('child_process', () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+describe('CloudflareDeploymentAdapter', () => {
+  it('throws when scaffold fails', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 1 });
+    const { CloudflareDeploymentAdapter } = await import('../src/createShop/deploymentAdapter');
+    const adapter = new CloudflareDeploymentAdapter();
+    expect(() => adapter.scaffold('app')).toThrow();
+  });
+
+  it('returns instructions only when domain provided', async () => {
+    const { CloudflareDeploymentAdapter } = await import('../src/createShop/deploymentAdapter');
+    const adapter = new CloudflareDeploymentAdapter();
+    const withDomain = adapter.deploy('shop', 'example.com');
+    expect(withDomain.instructions).toContain('example.com');
+    const withoutDomain = adapter.deploy('shop');
+    expect(withoutDomain.instructions).toBeUndefined();
+  });
+
+  it('swallows errors when writing deploy info', async () => {
+    const cwd = process.cwd();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-'));
+    process.chdir(dir);
+    const { CloudflareDeploymentAdapter } = await import('../src/createShop/deploymentAdapter');
+    const adapter = new CloudflareDeploymentAdapter();
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw new Error('fail');
+    });
+    expect(() =>
+      adapter.writeDeployInfo('shop', {
+        status: 'success',
+        previewUrl: '',
+        instructions: undefined,
+      }),
+    ).not.toThrow();
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    process.chdir(cwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for CloudflareDeploymentAdapter scaffold failures
- verify deploy returns instructions only when domain is provided
- ensure writeDeployInfo ignores write failures

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/deploymentAdapter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b828e924e8832fb43a82a45c593c2a