### PR TITLE
test: cover createContact behavior

### DIFF
--- a/packages/email/src/providers/__tests__/resend.test.ts
+++ b/packages/email/src/providers/__tests__/resend.test.ts
@@ -111,5 +111,31 @@ describe("ResendProvider", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
   });
+
+  describe("createContact", () => {
+    it("returns the new contact id on success", async () => {
+      process.env.RESEND_API_KEY = "rs";
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ id: "abc" }),
+      }) as any;
+      const { ResendProvider } = await import("../resend");
+      const provider = new ResendProvider();
+      await expect(
+        provider.createContact("test@example.com")
+      ).resolves.toBe("abc");
+    });
+
+    it("returns empty string when id missing", async () => {
+      process.env.RESEND_API_KEY = "rs";
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({}),
+      }) as any;
+      const { ResendProvider } = await import("../resend");
+      const provider = new ResendProvider();
+      await expect(
+        provider.createContact("test@example.com")
+      ).resolves.toBe("");
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- add tests for ResendProvider#createContact to verify contact ID handling

## Testing
- `pnpm -r build` *(fails: Project references may not form a circular graph. Cycle detected)*
- `pnpm test packages/email` *(fails: Could not find task `packages/email` in project)*
- `pnpm exec jest packages/email/src/providers/__tests__/resend.test.ts --runInBand --detectOpenHandles --config jest.config.cjs` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b8279edf68832f897f1ef950ab6a48