### PR TITLE
feat: allow injecting deposit release deps

### DIFF
--- a/packages/platform-machine/__tests__/releaseDepositsService.test.ts
+++ b/packages/platform-machine/__tests__/releaseDepositsService.test.ts
@@ -304,30 +304,33 @@ describe("startDepositReleaseService", () => {
     readdir.mockResolvedValue(["shop1"]);
     readOrders.mockResolvedValue([]);
     const err = new Error("boom");
-    const releaseSpy = jest
-      .spyOn(service, "releaseDepositsOnce")
-      .mockRejectedValue(err);
+    const releaseSpy = jest.fn(async () => {
+      throw err;
+    });
     const setSpy = jest
       .spyOn(global, "setInterval")
       .mockImplementation(() => 0 as any);
     const clearSpy = jest
       .spyOn(global, "clearInterval")
       .mockImplementation(() => undefined as any);
-    const logSpy = jest
-      .spyOn(logger, "error")
-      .mockImplementation(() => undefined);
+    const logSpy = jest.fn();
 
-    const stop = await service.startDepositReleaseService();
+    const stop = await service.startDepositReleaseService(
+      {},
+      undefined,
+      releaseSpy,
+      logSpy,
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(releaseSpy).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith("deposit release failed", {
       shopId: "shop1",
       err,
     });
 
     stop();
-    releaseSpy.mockRestore();
     setSpy.mockRestore();
     clearSpy.mockRestore();
-    logSpy.mockRestore();
   });
 });
 

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -133,6 +133,8 @@ async function resolveConfig(
 export async function startDepositReleaseService(
   configs: Record<string, Partial<DepositReleaseConfig>> = {},
   dataRoot: string = DATA_ROOT,
+  releaseFn: typeof releaseDepositsOnce = releaseDepositsOnce,
+  logFn: typeof logger.error = (msg, meta) => logger.error(msg, meta),
 ): Promise<() => void> {
   const shops = await readdir(dataRoot);
   const timers: NodeJS.Timeout[] = [];
@@ -144,9 +146,9 @@ export async function startDepositReleaseService(
 
       async function run() {
         try {
-          await releaseDepositsOnce(shop, dataRoot);
+          await releaseFn(shop, dataRoot);
         } catch (err) {
-          logger.error("deposit release failed", { shopId: shop, err });
+          logFn("deposit release failed", { shopId: shop, err });
         }
       }
 


### PR DESCRIPTION
## Summary
- allow injection of release function and logger in deposit release service
- adjust deposit release service tests to use injected dependencies

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm --filter @acme/platform-machine exec jest __tests__/releaseDepositsService.test.ts --config ../../jest.config.cjs --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b828ab8810832fabab9f482f6ceb7e