### PR TITLE
test: ensure csrf header takes precedence

### DIFF
--- a/packages/shared-utils/__tests__/getCsrfToken.test.ts
+++ b/packages/shared-utils/__tests__/getCsrfToken.test.ts
@@ -11,6 +11,13 @@ describe('getCsrfToken on server', () => {
     expect(getCsrfToken(req)).toBe('header-token');
   });
 
+  it('prioritizes header token when query parameter is also present', () => {
+    const req = new Request('https://example.com?csrf_token=query-token', {
+      headers: { 'x-csrf-token': 'header-token' },
+    });
+    expect(getCsrfToken(req)).toBe('header-token');
+  });
+
   it('returns token from query string parameter', () => {
     const req = new Request('https://example.com?csrf_token=query-token');
     expect(getCsrfToken(req)).toBe('query-token');


### PR DESCRIPTION
## Summary
- add test to verify CSRF header token takes precedence over query parameter

## Testing
- `pnpm --filter @acme/shared-utils test -- packages/shared-utils/__tests__/getCsrfToken.test.ts`
- `pnpm -r build` *(fails: TS6202 circular project references)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8335180c4832f822d5aa82c0be58d