### PR TITLE
test(template-app): extend rental return flow timeout

### DIFF
--- a/packages/template-app/__tests__/rental-return-flow.test.ts
+++ b/packages/template-app/__tests__/rental-return-flow.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
 
-jest.setTimeout(20000);
+jest.setTimeout(60000);
 
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: unknown, init?: ResponseInit) =>


### PR DESCRIPTION
## Summary
- extend rental return flow test timeout to handle longer setup

## Testing
- `pnpm -r build` *(fails: Project references may not form a circular graph)*
- `pnpm --filter @acme/template-app run check:references` *(fails: script not found)*
- `pnpm --filter @acme/template-app run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/template-app test` *(fails: global coverage threshold for branches (60%) not met: 51.16%)*
- `pnpm --filter @acme/template-app exec jest __tests__/rental-return-flow.test.ts --runInBand --detectOpenHandles --config jest.config.cjs --ci --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b832f7a82c832fa5ed2e75207208b9