### PR TITLE
test: handle json rejection in parseJsonBody

### DIFF
--- a/packages/shared-utils/__tests__/parseJsonBody.test.ts
+++ b/packages/shared-utils/__tests__/parseJsonBody.test.ts
@@ -28,6 +28,20 @@ describe('parseJsonBody', () => {
     });
   });
 
+  it('returns an error response when json() throws a SyntaxError', async () => {
+    const req = {
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Request;
+    const result = await parseJsonBody(req, schema, '1mb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+    await expect(result.response.json()).resolves.toEqual({
+      error: 'Invalid JSON',
+    });
+  });
+
   it('falls back to json() for non-string bodies', async () => {
     const req = { json: async () => ({ foo: 'bar' }) } as unknown as Request;
     const result = await parseJsonBody(req, schema, '1mb');


### PR DESCRIPTION
## Summary
- add test to ensure parseJsonBody handles SyntaxError from Request.json

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/shared-utils test -- --runTestsByPath packages/shared-utils/__tests__/parseJsonBody.test.ts --coverage=false` *(fails: Jest: "global" coverage threshold for branches (80%) not met: 36.36%)*

------
https://chatgpt.com/codex/tasks/task_e_68b8334d2b84832fb5009d4b5491a4c7