### PR TITLE
test: cover HTTP status fallback

### DIFF
--- a/packages/shared-utils/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/__tests__/fetchJson.test.ts
@@ -66,6 +66,17 @@ describe('fetchJson', () => {
     );
   });
 
+  it('throws HTTP status when status text is empty and response body is not JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 418,
+      statusText: '',
+      text: jest.fn().mockResolvedValue('not json'),
+    });
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('HTTP 418');
+  });
+
   it('propagates network errors', async () => {
     (global.fetch as jest.Mock).mockRejectedValue(new Error('Network failure'));
 


### PR DESCRIPTION
## Summary
- test fetchJson rejects with HTTP status when status text is missing and body isn't JSON

## Testing
- `pnpm --filter @acme/shared-utils test` *(fails: Cannot find module '../utils/args' from 'test/unit/init-shop/env.spec.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b8334e22fc832f9cc2e6cb9b088461