### PR TITLE
test: expand parseLimit coverage

### DIFF
--- a/packages/shared-utils/src/__tests__/parseJsonBody.test.ts
+++ b/packages/shared-utils/src/__tests__/parseJsonBody.test.ts
@@ -8,6 +8,14 @@ describe('parseLimit', () => {
 
   it('parses valid size strings', () => {
     expect(parseLimit('10kb')).toBe(10 * 1024);
+    expect(parseLimit('2GB')).toBe(2 * 1024 * 1024 * 1024);
+    expect(parseLimit('512b')).toBe(512);
+  });
+
+  it('accepts uppercase and mixed-case inputs', () => {
+    expect(parseLimit('1MB')).toBe(1 * 1024 * 1024);
+    expect(parseLimit('1mb')).toBe(1 * 1024 * 1024);
+    expect(parseLimit('1Mb')).toBe(1 * 1024 * 1024);
   });
 
   it('throws on invalid strings', () => {


### PR DESCRIPTION
## Summary
- add tests for parseLimit to cover additional units and case-insensitivity

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Project references may not form a circular graph. Cycle detected)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/shared-utils exec jest packages/shared-utils/src/__tests__/parseJsonBody.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs --color=false`

------
https://chatgpt.com/codex/tasks/task_e_68b833500c84832f8d353d6e620744ff