### PR TITLE
test(ui): cover radio label and children

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/Radio.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Radio.test.tsx
@@ -1,0 +1,19 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import { Radio } from "../Radio";
+
+describe("Radio", () => {
+  it("renders provided label", () => {
+    render(<Radio label="A" />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("renders children when no label is provided", () => {
+    render(
+      <Radio>
+        <span>B</span>
+      </Radio>
+    );
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Radio component tests to ensure label and child text rendering

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS6202 cycle in packages/i18n)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/__tests__/Radio.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b836ae38bc832fa4850a0ee14f1589