### PR TITLE
test(ui): add textarea primitive tests

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
@@ -1,0 +1,54 @@
+import "../../../../../../../test/resetNextMocks";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Textarea } from "../textarea";
+
+describe("Textarea", () => {
+  it("renders label above textarea in standard mode", () => {
+    const { container } = render(<Textarea label="Notes" />);
+    const wrapper = container.firstChild as HTMLElement;
+    const [label, textarea] = wrapper.children;
+
+    expect(label.tagName).toBe("LABEL");
+    expect(label).toHaveTextContent("Notes");
+    expect(label).toHaveClass("mb-1", "block", "text-sm", "font-medium");
+    expect(textarea.tagName).toBe("TEXTAREA");
+  });
+
+  it("renders floating label that moves on focus", () => {
+    const { container } = render(
+      <Textarea label="Message" floatingLabel />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    const [textarea, label] = wrapper.children;
+
+    expect(label).toHaveClass("absolute", "top-2", "left-3");
+    expect(label).not.toHaveClass("-translate-y-3", "text-xs");
+
+    fireEvent.focus(textarea);
+    expect(label).toHaveClass("-translate-y-3", "text-xs");
+  });
+
+  it("applies error class and message", () => {
+    render(<Textarea error="Required" />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveClass("border-red-500");
+    expect(textarea).toHaveAttribute("aria-invalid", "true");
+
+    const error = screen.getByText("Required");
+    expect(error).toHaveClass("text-danger");
+    expect(error).toHaveAttribute("data-token", "--color-danger");
+  });
+
+  it("floats label when controlled value is set", () => {
+    render(<Textarea label="Message" floatingLabel value="Hello" />);
+    const label = screen.getByText("Message");
+    expect(label).toHaveClass("-translate-y-3", "text-xs");
+  });
+
+  it("floats label when defaultValue is set", () => {
+    render(<Textarea label="Message" floatingLabel defaultValue="Hi" />);
+    const label = screen.getByText("Message");
+    expect(label).toHaveClass("-translate-y-3", "text-xs");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for Textarea primitive covering standard and floating labels, error state, and value detection

## Testing
- `pnpm exec jest packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b836b45c30832f87facfb5b56048a3