### PR TITLE
test(ui): add sustainability badge cluster tests

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/SustainabilityBadgeCluster.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/SustainabilityBadgeCluster.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { SustainabilityBadgeCluster } from "../SustainabilityBadgeCluster";
+
+describe("SustainabilityBadgeCluster", () => {
+  it("renders badges with provided variant values", () => {
+    render(
+      <SustainabilityBadgeCluster
+        badges={[
+          { label: "Eco", variant: "default" },
+          { label: "Discount", variant: "sale" },
+        ]}
+      />
+    );
+
+    const eco = screen.getByText("Eco");
+    expect(eco).toHaveClass("text-fg");
+    expect(eco.parentElement).toHaveClass("bg-muted");
+
+    const discount = screen.getByText("Discount");
+    expect(discount).toHaveClass("text-danger-foreground");
+    expect(discount.parentElement).toHaveClass("bg-danger");
+  });
+
+  it("uses 'new' variant when none is provided", () => {
+    render(
+      <SustainabilityBadgeCluster badges={[{ label: "Recycled" }]} />
+    );
+
+    const badge = screen.getByText("Recycled");
+    expect(badge).toHaveClass("text-success-fg");
+    expect(badge.parentElement).toHaveClass("bg-success");
+  });
+});


### PR DESCRIPTION
## Summary
- test SustainabilityBadgeCluster renders explicit variant badges
- verify missing variant defaults to `new`

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/molecules/__tests__/SustainabilityBadgeCluster.test.tsx --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b836b06b00832fa1fcd884c8ff3f9e