### PR TITLE
Fix wizard page test render import

### DIFF
--- a/apps/cms/__tests__/wizardPage.test.tsx
+++ b/apps/cms/__tests__/wizardPage.test.tsx
@@ -63,11 +63,9 @@ describe("WizardPage", () => {
       // environments Jest’s module cache can be cleared which leaves React
       // undefined when `react-dom/server` evaluates.
       await import("react");
-      // Use the CommonJS build of `react-dom/server`. Loading it via `require`
-      // avoids crashes in environments where the ESM loader is missing the
-      // legacy `exports` object the module expects.
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { renderToStaticMarkup } = require("react-dom/server");
+      // Load the server renderer via dynamic import so it works in both CJS
+      // and ESM environments.
+      const { renderToStaticMarkup } = await import("react-dom/server");
       const { default: WizardPage } = await import(
         "../src/app/cms/wizard/page"
       );


### PR DESCRIPTION
## Summary
- ensure wizard page test dynamically imports `react-dom/server` to support CJS and ESM environments

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: Referenced project '/workspace/base-shop/packages/plugins/sanity' may not disable emit)*
- `pnpm --filter @apps/cms test` *(fails: product and SEO timeline tests exceed timeout)*
- `pnpm --filter @apps/cms test -- apps/cms/__tests__/wizardPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b83946f8a4832f86a84031a5221ff6