### PR TITLE
test: cover useProductInputs variants and multilingual changes

### DIFF
--- a/packages/ui/src/hooks/__tests__/useProductInputs.test.ts
+++ b/packages/ui/src/hooks/__tests__/useProductInputs.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ProductPublication } from "@acme/types";
+import type { Locale } from "@acme/i18n";
+import { useProductInputs } from "../useProductInputs";
+
+function createProduct(): ProductPublication {
+  return {
+    id: "p1",
+    sku: "sku1",
+    title: { en: "Old EN", de: "Old DE" },
+    description: { en: "Desc EN", de: "Desc DE" },
+    price: 100,
+    currency: "EUR",
+    media: [],
+    created_at: "2023-01-01",
+    updated_at: "2023-01-01",
+    shop: "shop",
+    status: "draft",
+    row_version: 1,
+  };
+}
+
+const locales: readonly Locale[] = ["en", "de"];
+
+describe("useProductInputs", () => {
+  it("handleChange processes multilingual, price, indexed and comma-separated variant fields", () => {
+    const { result } = renderHook(() =>
+      useProductInputs({ ...createProduct(), variants: {} }, locales)
+    );
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: "title_en", value: "New EN" },
+      } as any);
+    });
+    expect(result.current.product.title.en).toBe("New EN");
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: "price", value: "200" },
+      } as any);
+    });
+    expect(result.current.product.price).toBe(200);
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: "variant_color_0", value: "red" },
+      } as any);
+    });
+    expect(result.current.product.variants.color).toEqual(["red"]);
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: "variant_size", value: "m, l" },
+      } as any);
+    });
+    expect(result.current.product.variants.size).toEqual(["m", "l"]);
+  });
+
+  it("addVariantValue and removeVariantValue update variants correctly", () => {
+    const { result } = renderHook(() =>
+      useProductInputs({ ...createProduct(), variants: {} }, locales)
+    );
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: "variant_color", value: "red" },
+      } as any);
+    });
+    expect(result.current.product.variants.color).toEqual(["red"]);
+
+    act(() => {
+      result.current.addVariantValue("color");
+    });
+    expect(result.current.product.variants.color).toEqual(["red", ""]);
+
+    act(() => {
+      result.current.removeVariantValue("color", 0);
+    });
+    expect(result.current.product.variants.color).toEqual([""]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test handleChange for multilingual, price, indexed, and comma-separated variant fields
- test add and remove of variant values in useProductInputs

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run build` *(fails: TS6202: circular project references)*
- `pnpm --filter @acme/ui run test -- packages/ui/src/hooks/__tests__/useProductInputs.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b836bae5e4832fb5e422e0f271356f