### PR TITLE
test(ui): add ProfileForm tests

### DIFF
--- a/packages/ui/src/components/account/__tests__/ProfileForm.test.tsx
+++ b/packages/ui/src/components/account/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProfileForm from "../ProfileForm";
+
+jest.mock("@acme/shared-utils", () => ({
+  __esModule: true,
+  getCsrfToken: jest.fn(() => "csrf-token"),
+}));
+
+describe("ProfileForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows validation errors when fields are empty", async () => {
+    render(<ProfileForm />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText("Please fix the errors below.")).toBeInTheDocument();
+    expect(screen.getByText("Name is required.")).toBeInTheDocument();
+    expect(screen.getByText("Email is required.")).toBeInTheDocument();
+  });
+
+  it("displays conflict error on 409 response", async () => {
+    // @ts-expect-error
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "Email already in use" }),
+    });
+
+    render(<ProfileForm name="Jane" email="jane@example.com" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findAllByText("Email already in use")).toHaveLength(2);
+  });
+
+  it("displays field errors on 400 response", async () => {
+    // @ts-expect-error
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ email: ["Invalid email"] }),
+    });
+
+    render(<ProfileForm name="Jane" email="jane@example.com" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText("Please fix the errors below.")).toBeInTheDocument();
+    expect(await screen.findByText("Invalid email")).toBeInTheDocument();
+  });
+
+  it("displays generic error on 500 response", async () => {
+    // @ts-expect-error
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Server error" }),
+    });
+
+    render(<ProfileForm name="Jane" email="jane@example.com" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText("Server error")).toBeInTheDocument();
+  });
+
+  it("shows success message on 200 response", async () => {
+    // @ts-expect-error
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    render(<ProfileForm name="Jane" email="jane@example.com" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(
+      await screen.findByText("Profile updated successfully.")
+    ).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add coverage for ProfileForm validation and API error/success cases

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TS6202 circular project references)
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm run build:ts` (fails: Missing script: build:ts)
- `pnpm exec jest packages/ui/src/components/account/__tests__/ProfileForm.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b836ba355c832fab9bb31da1948405