### PR TITLE
Ensure React is loaded in wizard route SSR test

### DIFF
--- a/apps/cms/__tests__/wizardRoute.test.ts
+++ b/apps/cms/__tests__/wizardRoute.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 /* eslint-env jest */
 
-import { ReactNode } from "react";
+import React, { ReactNode } from "react";
 
 /* ------------------------------------------------------------------ */
 /*  Environment setup                                                 */
@@ -42,7 +42,6 @@ describe("wizard route", () => {
   it("renders wizard page for admin", async () => {
     jest.resetModules(); // ensure mocks are applied fresh
     await import("../../../test/resetNextMocks");
-    await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const { default: WizardPage } = await import("../src/app/cms/wizard/page");
 


### PR DESCRIPTION
## Summary
- statically import React in the wizard route SSR test and remove dynamic import

## Testing
- `pnpm test:cms __tests__/wizardRoute.test.ts`
- `pnpm -r build` *(fails: Referenced project '/workspace/base-shop/packages/plugins/sanity' may not disable emit)*

------
https://chatgpt.com/codex/tasks/task_e_68b83956e3c8832f9b8579d1abad28ef