### PR TITLE
Fix section index tests env handling

### DIFF
--- a/apps/cms/__tests__/sectionIndexPages.test.ts
+++ b/apps/cms/__tests__/sectionIndexPages.test.ts
@@ -23,7 +23,9 @@ async function withRepo(cb: (dir: string) => Promise<void>): Promise<void> {
   await fs.mkdir(path.join(shopsDir, "bar"), { recursive: true });
   const cwd = process.cwd();
   process.chdir(dir);
+  const env = process.env;
   jest.resetModules();
+  process.env = env;
   try {
     await cb(dir);
   } finally {


### PR DESCRIPTION
## Summary
- preserve `process.env` across module resets in `sectionIndexPages` tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Referenced project '/workspace/base-shop/packages/plugins/sanity' may not disable emit)*
- `pnpm --filter @apps/cms test -- __tests__/sectionIndexPages.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8394f7874832f94db4e32bdb7a49b