### PR TITLE
test(ui): add DataTable selection tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/DataTable.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/DataTable.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { DataTable, type Column } from "../DataTable";
+import "@testing-library/jest-dom";
+import "../../../../../../test/resetNextMocks";
+
+describe("DataTable", () => {
+  const rows = [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Bob" },
+  ];
+  const columns: Column<(typeof rows)[number]>[] = [
+    { header: "Name", render: (row) => row.name },
+  ];
+
+  it("renders without checkbox column when not selectable", () => {
+    render(<DataTable rows={rows} columns={columns} />);
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("handles row and checkbox selection", () => {
+    const handleChange = jest.fn();
+    render(
+      <DataTable
+        rows={rows}
+        columns={columns}
+        selectable
+        onSelectionChange={handleChange}
+      />
+    );
+
+    const rowElements = screen.getAllByRole("row");
+    fireEvent.click(rowElements[1]);
+    expect(handleChange).toHaveBeenNthCalledWith(1, [rows[0]]);
+
+    const secondCheckbox = screen.getAllByRole("checkbox")[1];
+    fireEvent.click(secondCheckbox);
+    expect(handleChange).toHaveBeenNthCalledWith(2, [rows[0], rows[1]]);
+
+    const firstCheckbox = screen.getAllByRole("checkbox")[0];
+    fireEvent.click(firstCheckbox);
+    expect(handleChange).toHaveBeenNthCalledWith(3, [rows[1]]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for DataTable selection behavior

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/DataTable.test.tsx --config jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b836bcbc38832f89bb1185f7a2c6ea