### PR TITLE
docs: add TS2307 guidance to package agent notes

### DIFF
--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -27,6 +27,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/configurator/AGENTS.md
+++ b/packages/configurator/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/date-utils/AGENTS.md
+++ b/packages/date-utils/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/email-templates/AGENTS.md
+++ b/packages/email-templates/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/email/AGENTS.md
+++ b/packages/email/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/eslint-plugin-ds/AGENTS.md
+++ b/packages/eslint-plugin-ds/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/i18n/AGENTS.md
+++ b/packages/i18n/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/lib/AGENTS.md
+++ b/packages/lib/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/platform-core/AGENTS.md
+++ b/packages/platform-core/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/platform-machine/AGENTS.md
+++ b/packages/platform-machine/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/sanity/AGENTS.md
+++ b/packages/sanity/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/shared-utils/AGENTS.md
+++ b/packages/shared-utils/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/stripe/AGENTS.md
+++ b/packages/stripe/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/tailwind-config/AGENTS.md
+++ b/packages/tailwind-config/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/telemetry/AGENTS.md
+++ b/packages/telemetry/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/template-app/AGENTS.md
+++ b/packages/template-app/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/theme/AGENTS.md
+++ b/packages/theme/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.

--- a/packages/zod-utils/AGENTS.md
+++ b/packages/zod-utils/AGENTS.md
@@ -19,6 +19,7 @@ tsc -b
 ## Common Errors
 - **TS6305**: Build outputs are missing or stale. Clean the project (rimraf dist tsconfig.tsbuildinfo) and rebuild.
 - **TS6202**: Circular project references. Update references to remove cycles.
+- **TS2307**: Cannot find module or its corresponding type declarations. This happens when TypeScript can’t find a module or its types due to missing type definitions, incorrect import paths, or a misconfigured `baseUrl`/`paths` setup:contentReference[oaicite:9]{index=9}. Check that the module exists (in `src/` or `node_modules`), install `@types` packages if the library has no built-in types:contentReference[oaicite:10]{index=10}, correct any relative paths in imports:contentReference[oaicite:11]{index=11}, and ensure `tsconfig.json` has the correct `baseUrl` and `paths` mappings:contentReference[oaicite:12]{index=12}.
 
 ## CI Expectations
 `pnpm run check:references` and `pnpm run build:ts` must pass on a clean checkout.


### PR DESCRIPTION
## Summary
- document TS2307 solutions in each package's AGENTS.md to help debug missing module errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Referenced project may not disable emit)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a31dc98832fabd0cdd9e9c658f0