### PR TITLE
test: stabilize ProductPreview fetch mock

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
@@ -6,13 +6,15 @@ describe("ProductPreview", () => {
     (global as any).fetch = jest.fn();
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("renders product info", async () => {
-    (global as any).fetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ title: "Test", price: 100 }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
-    );
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ title: "Test", price: 100 }),
+    } as Response);
     const onValid = jest.fn();
     render(<ProductPreview slug="t" onValidChange={onValid} />);
     await screen.findByText("Test");


### PR DESCRIPTION
## Summary
- simplify ProductPreview tests by mocking fetch with plain object
- reset mocks after each test to avoid cross-test pollution

## Testing
- `pnpm -r build` *(fails: packages/platform-core build: tsconfig.json(52,5): error TS6310: Referenced project '/workspace/base-shop/packages/plugins/sanity' may not disable emit)*
- `pnpm exec jest apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b839382f08832f91403f2ada85c856