### PR TITLE
test: cover friendlyErrorMap number cases

### DIFF
--- a/packages/zod-utils/src/__tests__/friendlyErrorMap.unit.test.ts
+++ b/packages/zod-utils/src/__tests__/friendlyErrorMap.unit.test.ts
@@ -66,6 +66,17 @@ describe("friendlyErrorMap", () => {
     expect(friendlyErrorMap(issue, ctx).message).toBe("Must have at least 2 items");
   });
 
+  test("too_small number", () => {
+    const issue = {
+      code: ZodIssueCode.too_small,
+      minimum: 3,
+      inclusive: true,
+      type: "number",
+      path: [],
+    } as const;
+    expect(friendlyErrorMap(issue, ctx)).toEqual({ message: ctx.defaultError });
+  });
+
   test("too_big string", () => {
     const issue = {
       code: ZodIssueCode.too_big,
@@ -86,6 +97,17 @@ describe("friendlyErrorMap", () => {
       path: [],
     } as const;
     expect(friendlyErrorMap(issue, ctx).message).toBe("Must have at most 2 items");
+  });
+
+  test("too_big number", () => {
+    const issue = {
+      code: ZodIssueCode.too_big,
+      maximum: 2,
+      inclusive: true,
+      type: "number",
+      path: [],
+    } as const;
+    expect(friendlyErrorMap(issue, ctx)).toEqual({ message: ctx.defaultError });
   });
 
   test("default case with custom message", () => {


### PR DESCRIPTION
## Summary
- add tests for too_small and too_big number issues

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS6202 cycle in packages/i18n)*
- `pnpm --filter @acme/zod-utils run check:references` *(fails: missing script)*
- `pnpm --filter @acme/zod-utils run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/zod-utils run test`


------
https://chatgpt.com/codex/tasks/task_e_68b837facb70832fb9be7f699aeb4a30