### PR TITLE
test: add ctx default error case

### DIFF
--- a/packages/zod-utils/src/__tests__/friendlyErrorMap.unit.test.ts
+++ b/packages/zod-utils/src/__tests__/friendlyErrorMap.unit.test.ts
@@ -96,5 +96,19 @@ describe("friendlyErrorMap", () => {
     } as const;
     expect(friendlyErrorMap(issue, ctx).message).toBe("Boom");
   });
+
+  test("default case with ctx default error", () => {
+    const issue = {
+      code: ZodIssueCode.custom,
+      path: [],
+    } as const;
+    const customCtx = {
+      defaultError: "Ctx default message",
+      data: undefined,
+    } as const;
+    expect(friendlyErrorMap(issue, customCtx).message).toBe(
+      "Ctx default message",
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- add a test ensuring friendlyErrorMap falls back to ctx.defaultError when no message is provided

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS6202 circular project reference in @acme/i18n)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/zod-utils build`
- `pnpm --filter @acme/zod-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68b837fc35d4832fb86d48ba7a7bf800