### PR TITLE
fix(auth): correct types path

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,7 +46,7 @@
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "peerDependencies": {
     "next": "^15.3.5"
   }


### PR DESCRIPTION
## Summary
- fix types field to omit ./ prefix in @acme/auth package.json

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/auth test` (fails: Cannot find module '../utils/args')

------
https://chatgpt.com/codex/tasks/task_e_68b848752110832f81649357d2658780