### PR TITLE
Expand core env validation tests

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -93,17 +93,13 @@ export function depositReleaseEnvRefinement(
     const isReverse = key.startsWith("REVERSE_LOGISTICS_");
     const isLateFee = key.startsWith("LATE_FEE_");
     if (!isDeposit && !isReverse && !isLateFee) continue;
-    if (
-      key === "DEPOSIT_RELEASE_ENABLED" ||
-      key === "DEPOSIT_RELEASE_INTERVAL_MS" ||
-      key === "REVERSE_LOGISTICS_ENABLED" ||
-      key === "REVERSE_LOGISTICS_INTERVAL_MS" ||
-      key === "LATE_FEE_ENABLED" ||
-      key === "LATE_FEE_INTERVAL_MS"
-    )
-      continue;
     if (key.includes("ENABLED")) {
-      if (value !== "true" && value !== "false") {
+      if (
+        value !== "true" &&
+        value !== "false" &&
+        value !== true &&
+        value !== false
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: [key],
@@ -111,7 +107,8 @@ export function depositReleaseEnvRefinement(
         });
       }
     } else if (key.includes("INTERVAL_MS")) {
-      if (Number.isNaN(Number(value))) {
+      const num = typeof value === "number" ? value : Number(value);
+      if (Number.isNaN(num)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: [key],


### PR DESCRIPTION
## Summary
- test deposit release refinements on built-in keys
- ensure loadCoreEnv reports missing secrets
- check coreEnv proxy parses once and exposes keys

## Testing
- ⚠️ `pnpm -r build` (apps/cms build failed)
- ✅ `pnpm --filter @acme/config run build`
- ✅ `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b84a05b610832f9bc58aa0847ce59c