### PR TITLE
test(config): add cms env failure test

### DIFF
--- a/packages/config/__tests__/cmsEnvFailure.test.ts
+++ b/packages/config/__tests__/cmsEnvFailure.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "@jest/globals";
+
+describe("cmsEnv failure", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("throws and logs when CMS env is invalid", async () => {
+    process.env = {
+      NODE_ENV: "production",
+      CMS_SPACE_URL: "notaurl",
+      CMS_ACCESS_TOKEN: "",
+      SANITY_API_VERSION: "",
+    } as NodeJS.ProcessEnv;
+
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(import("../src/env/cms")).rejects.toThrow(
+      "Invalid CMS environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add test for CMS environment parsing failure when URL is invalid and tokens are blank

## Testing
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b84ab0a0e4832fa29d2c7024c8aed0