### PR TITLE
test: add provider stats mapping tests

### DIFF
--- a/packages/email/src/__tests__/stats.test.ts
+++ b/packages/email/src/__tests__/stats.test.ts
@@ -1,25 +1,7 @@
-jest.mock("../stats", () => {
-  const actual = jest.requireActual("../stats");
-  return {
-    ...actual,
-    mapSendGridStats: jest.fn(actual.mapSendGridStats),
-    mapResendStats: jest.fn(actual.mapResendStats),
-    normalizeProviderStats(provider: string, data: any) {
-      if (provider === "sendgrid") return (this as any).mapSendGridStats(data || {});
-      if (provider === "resend") return (this as any).mapResendStats(data || {});
-      return { ...actual.emptyStats };
-    },
-  };
-});
-
 import * as stats from "../stats";
 
-const {
-  mapSendGridStats,
-  mapResendStats,
-  emptyStats,
-  normalizeProviderStats,
-} = stats;
+const { mapSendGridStats, mapResendStats, emptyStats, normalizeProviderStats } =
+  stats;
 
 describe("mapSendGridStats", () => {
   it("converts mixed string/number fields", () => {
@@ -62,91 +44,23 @@ describe("mapResendStats", () => {
 });
 
 describe("normalizeProviderStats", () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("returns empty stats for unknown provider", () => {
-    expect(normalizeProviderStats("unknown", undefined)).toEqual(emptyStats);
-  });
-
-  it("invokes mapSendGridStats for sendgrid provider", () => {
+  it("uses sendgrid mapper for sendgrid provider", () => {
     const raw = { delivered: "1" } as const;
-    stats.normalizeProviderStats("sendgrid", raw);
-    expect(mapSendGridStats).toHaveBeenCalledWith(raw);
-  });
-
-  it("invokes mapResendStats for resend provider", () => {
-    const raw = { delivered_count: "1" } as const;
-    stats.normalizeProviderStats("resend", raw);
-    expect(mapResendStats).toHaveBeenCalledWith(raw);
-  });
-
-  it("normalizes sendgrid stats", () => {
-    const raw = {
-      delivered: "1",
-      opens: "2",
-      clicks: "3",
-      unsubscribes: "4",
-      bounces: "5",
-    };
-
-    expect(stats.normalizeProviderStats("sendgrid", raw)).toEqual({
-      delivered: 1,
-      opened: 2,
-      clicked: 3,
-      unsubscribed: 4,
-      bounced: 5,
-    });
-  });
-
-  it("normalizes resend stats", () => {
-    const raw = {
-      delivered_count: "1",
-      opened: 2,
-      clicked_count: "3",
-      unsubscribed: "4",
-      bounced_count: 5,
-    };
-
-    expect(stats.normalizeProviderStats("resend", raw)).toEqual({
-      delivered: 1,
-      opened: 2,
-      clicked: 3,
-      unsubscribed: 4,
-      bounced: 5,
-    });
-  });
-
-  it("returns mapped stats for sendgrid provider", () => {
-    const raw = {
-      delivered: "1",
-      opens: "2",
-    };
-
-    expect(stats.normalizeProviderStats("sendgrid", raw)).toEqual(
+    expect(normalizeProviderStats("sendgrid", raw)).toEqual(
       mapSendGridStats(raw)
     );
   });
 
-  it("returns mapped stats for resend provider", () => {
-    const raw = {
-      delivered_count: "1",
-      opened_count: "2",
-    };
-
-    expect(stats.normalizeProviderStats("resend", raw)).toEqual(
+  it("uses resend mapper for resend provider", () => {
+    const raw = { delivered_count: "1" } as const;
+    expect(normalizeProviderStats("resend", raw)).toEqual(
       mapResendStats(raw)
     );
   });
 
-  it("returns empty stats for other provider", () => {
-    expect(stats.normalizeProviderStats("other", undefined)).toEqual(emptyStats);
-  });
-});
-describe("normalizeProviderStats real module", () => {
-  it("uses actual implementation for unknown providers", () => {
-    const { normalizeProviderStats, emptyStats } = jest.requireActual("../stats");
-    expect(normalizeProviderStats("unknown", undefined)).toEqual(emptyStats);
+  it("returns empty stats for unknown provider", () => {
+    expect(normalizeProviderStats("unknown", undefined)).toEqual({
+      ...emptyStats,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- use real normalizeProviderStats and verify mappings for sendgrid and resend providers
- ensure unknown providers return empty stats

## Testing
- `pnpm --filter @acme/email test src/__tests__/stats.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b84ac28538832f9fece88132b2d7f4