### PR TITLE
test: cover generateMeta response variants

### DIFF
--- a/packages/lib/src/__tests__/generateMeta.test.ts
+++ b/packages/lib/src/__tests__/generateMeta.test.ts
@@ -190,5 +190,102 @@ describe("generateMeta", () => {
     expect(mkdirMock).toHaveBeenCalledWith(path.dirname(file), { recursive: true });
     expect(writeMock).toHaveBeenCalledWith(file, Buffer.from("img"));
   });
+
+  it("parses metadata when OpenAI returns string content", async () => {
+    const writeMock = jest.fn();
+    const mkdirMock = jest.fn();
+    const responsesCreate = jest.fn().mockResolvedValue({
+      output: [{ content: ['{"title":"T","description":"D","alt":"A"}'] }],
+    });
+    const imagesGenerate = jest.fn().mockResolvedValue({
+      data: [{ b64_json: Buffer.from("img").toString("base64") }],
+    });
+    const OpenAI = jest.fn().mockImplementation(() => ({
+      responses: { create: responsesCreate },
+      images: { generate: imagesGenerate },
+    }));
+    let result;
+    await jest.isolateModulesAsync(async () => {
+      const envMock = { OPENAI_API_KEY: "key" };
+      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
+      jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
+      const { generateMeta } = await import("../generateMeta");
+      result = await generateMeta(product);
+    });
+    const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
+    expect(responsesCreate).toHaveBeenCalled();
+    expect(imagesGenerate).toHaveBeenCalled();
+    expect(mkdirMock).toHaveBeenCalledWith(path.dirname(file), { recursive: true });
+    expect(writeMock).toHaveBeenCalledWith(file, Buffer.from("img"));
+    expect(result).toEqual({
+      title: "T",
+      description: "D",
+      alt: "A",
+      image: `/og/${product.id}.png`,
+    });
+  });
+
+  it("falls back when OpenAI returns no content", async () => {
+    const writeMock = jest.fn();
+    const mkdirMock = jest.fn();
+    const responsesCreate = jest.fn().mockResolvedValue({ output: [{}] });
+    const imagesGenerate = jest.fn().mockResolvedValue({
+      data: [{ b64_json: Buffer.from("img").toString("base64") }],
+    });
+    const OpenAI = jest.fn().mockImplementation(() => ({
+      responses: { create: responsesCreate },
+      images: { generate: imagesGenerate },
+    }));
+    let result;
+    await jest.isolateModulesAsync(async () => {
+      const envMock = { OPENAI_API_KEY: "key" };
+      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
+      jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
+      const { generateMeta } = await import("../generateMeta");
+      result = await generateMeta(product);
+    });
+    const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
+    expect(result).toEqual({
+      title: product.title,
+      description: product.description,
+      alt: product.title,
+      image: `/og/${product.id}.png`,
+    });
+    expect(mkdirMock).toHaveBeenCalledWith(path.dirname(file), { recursive: true });
+    expect(writeMock).toHaveBeenCalledWith(file, Buffer.from("img"));
+  });
+
+  it("falls back when OpenAI returns no output", async () => {
+    const writeMock = jest.fn();
+    const mkdirMock = jest.fn();
+    const responsesCreate = jest.fn().mockResolvedValue({});
+    const imagesGenerate = jest.fn().mockResolvedValue({
+      data: [{ b64_json: Buffer.from("img").toString("base64") }],
+    });
+    const OpenAI = jest.fn().mockImplementation(() => ({
+      responses: { create: responsesCreate },
+      images: { generate: imagesGenerate },
+    }));
+    let result;
+    await jest.isolateModulesAsync(async () => {
+      const envMock = { OPENAI_API_KEY: "key" };
+      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
+      jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
+      const { generateMeta } = await import("../generateMeta");
+      result = await generateMeta(product);
+    });
+    const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
+    expect(result).toEqual({
+      title: product.title,
+      description: product.description,
+      alt: product.title,
+      image: `/og/${product.id}.png`,
+    });
+    expect(mkdirMock).toHaveBeenCalledWith(path.dirname(file), { recursive: true });
+    expect(writeMock).toHaveBeenCalledWith(file, Buffer.from("img"));
+  });
 });
 


### PR DESCRIPTION
## Summary
- add generateMeta tests for string and missing-content responses

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build: Failed; apps/shop-bcd build: Failed)*
- `pnpm test packages/lib/__tests__/generateMeta.test.ts` *(fails: Could not find task)*
- `pnpm --filter @acme/lib test src/__tests__/generateMeta.test.ts` *(fails: global coverage threshold for branches (80%) not met: 75.86%)*


------
https://chatgpt.com/codex/tasks/task_e_68b84bdeaef4832fa3c64ffc0a757f0f