### PR TITLE
test: handle missing coupons file

### DIFF
--- a/__tests__/coupons.test.ts
+++ b/__tests__/coupons.test.ts
@@ -1,0 +1,12 @@
+import { promises as fs } from "fs";
+import { listCoupons } from "../packages/platform-core/src/coupons";
+
+describe("listCoupons", () => {
+  it("returns empty array when coupons file missing", async () => {
+    jest
+      .spyOn(fs, "readFile")
+      .mockRejectedValueOnce(Object.assign(new Error("missing"), { code: "ENOENT" }));
+
+    await expect(listCoupons("shop1")).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- test coupon list when discounts file missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: ENOENT: no such file or directory, open '/workspace/base-shop/apps/shop-shop1/package.json')*
- `pnpm exec jest __tests__/coupons.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b84c9525e8832fa6306b495939e7ea