### PR TITLE
test: add seoAudit import variants

### DIFF
--- a/packages/lib/__tests__/seoAudit.test.ts
+++ b/packages/lib/__tests__/seoAudit.test.ts
@@ -3,11 +3,8 @@ import { jest } from "@jest/globals";
 const lighthouseMock = jest.fn();
 const launchMock = jest.fn();
 
-const lighthouseModule: any = { __esModule: true, default: lighthouseMock };
-const chromeModule: any = {
-  __esModule: true,
-  default: { launch: launchMock },
-};
+let lighthouseModule: any;
+let chromeModule: any;
 
 jest.mock("lighthouse", () => lighthouseModule, { virtual: true });
 
@@ -19,30 +16,37 @@ jest.mock(
   { virtual: true },
 );
 
-import { runSeoAudit } from "../src/seoAudit";
+async function loadRunSeoAudit() {
+  const mod = await import("../src/seoAudit");
+  return mod.runSeoAudit;
+}
 
 describe("runSeoAudit", () => {
-  afterEach(() => {
+  beforeEach(() => {
+    jest.resetModules();
     lighthouseMock.mockReset();
     launchMock.mockReset();
-    chromeModule.default.launch = launchMock;
-    lighthouseModule.default = lighthouseMock;
+    lighthouseModule = { __esModule: true, default: lighthouseMock };
+    chromeModule = { __esModule: true, default: { launch: launchMock } };
   });
+
+  const successResponse = {
+    lhr: {
+      categories: { seo: { score: 0.9 } },
+      audits: {
+        good: { score: 1, scoreDisplayMode: "numeric", title: "Good" },
+        bad: { score: 0, scoreDisplayMode: "numeric", title: "Bad" },
+        na: { score: 0, scoreDisplayMode: "notApplicable", title: "N/A" },
+      },
+    },
+  };
 
   it("returns score and recommendations and closes chrome", async () => {
     const killSpy = jest.fn();
     launchMock.mockResolvedValue({ port: 1234, kill: killSpy });
-    lighthouseMock.mockResolvedValue({
-      lhr: {
-        categories: { seo: { score: 0.9 } },
-        audits: {
-          good: { score: 1, scoreDisplayMode: "numeric", title: "Good" },
-          bad: { score: 0, scoreDisplayMode: "numeric", title: "Bad" },
-          na: { score: 0, scoreDisplayMode: "notApplicable", title: "N/A" },
-        },
-      },
-    });
+    lighthouseMock.mockResolvedValue(successResponse);
 
+    const runSeoAudit = await loadRunSeoAudit();
     const result = await runSeoAudit("https://example.com");
 
     expect(result).toEqual({ score: 90, recommendations: ["Bad"] });
@@ -54,6 +58,7 @@ describe("runSeoAudit", () => {
     launchMock.mockResolvedValue({ port: 1234, kill: killSpy });
     lighthouseMock.mockResolvedValue(undefined);
 
+    const runSeoAudit = await loadRunSeoAudit();
     await expect(runSeoAudit("https://example.com")).rejects.toThrow(
       "Lighthouse did not return a result",
     );
@@ -63,6 +68,7 @@ describe("runSeoAudit", () => {
   it("throws when chrome-launcher launch function is not available", async () => {
     chromeModule.default = {};
 
+    const runSeoAudit = await loadRunSeoAudit();
     await expect(runSeoAudit("https://example.com")).rejects.toThrow(
       "chrome-launcher launch function not available",
     );
@@ -72,9 +78,61 @@ describe("runSeoAudit", () => {
     lighthouseModule.default = {};
     chromeModule.default.launch = launchMock;
 
+    const runSeoAudit = await loadRunSeoAudit();
     await expect(runSeoAudit("https://example.com")).rejects.toThrow(
       "lighthouse is not a function",
     );
   });
-});
 
+  it("supports lighthouse exported as default.default", async () => {
+    lighthouseModule.default = { default: lighthouseMock };
+    const killSpy = jest.fn();
+    launchMock.mockResolvedValue({ port: 1234, kill: killSpy });
+    lighthouseMock.mockResolvedValue(successResponse);
+
+    const runSeoAudit = await loadRunSeoAudit();
+    const result = await runSeoAudit("https://example.com");
+
+    expect(result).toEqual({ score: 90, recommendations: ["Bad"] });
+    expect(killSpy).toHaveBeenCalled();
+  });
+
+  it("supports lighthouse module being a function", async () => {
+    lighthouseModule = lighthouseMock;
+    const killSpy = jest.fn();
+    launchMock.mockResolvedValue({ port: 1234, kill: killSpy });
+    lighthouseMock.mockResolvedValue(successResponse);
+
+    const runSeoAudit = await loadRunSeoAudit();
+    const result = await runSeoAudit("https://example.com");
+
+    expect(result).toEqual({ score: 90, recommendations: ["Bad"] });
+    expect(killSpy).toHaveBeenCalled();
+  });
+
+  it("supports chrome-launcher exporting launch directly", async () => {
+    chromeModule = { __esModule: true, launch: launchMock };
+    const killSpy = jest.fn();
+    launchMock.mockResolvedValue({ port: 1234, kill: killSpy });
+    lighthouseMock.mockResolvedValue(successResponse);
+
+    const runSeoAudit = await loadRunSeoAudit();
+    const result = await runSeoAudit("https://example.com");
+
+    expect(result).toEqual({ score: 90, recommendations: ["Bad"] });
+    expect(killSpy).toHaveBeenCalled();
+  });
+
+  it("supports chrome-launcher exporting launch via default.default", async () => {
+    chromeModule.default = { default: { launch: launchMock } };
+    const killSpy = jest.fn();
+    launchMock.mockResolvedValue({ port: 1234, kill: killSpy });
+    lighthouseMock.mockResolvedValue(successResponse);
+
+    const runSeoAudit = await loadRunSeoAudit();
+    const result = await runSeoAudit("https://example.com");
+
+    expect(result).toEqual({ score: 90, recommendations: ["Bad"] });
+    expect(killSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- expand seoAudit test coverage for dynamic import fallbacks
- handle lighthouse exports via nested defaults or direct module functions
- ensure chrome-launcher launch resolution from multiple shapes

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm test packages/lib/__tests__/seoAudit.test.ts` (fails: Missing tasks)
- `pnpm exec jest packages/lib/__tests__/seoAudit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b84be1f31c832f9c39f246869e1ece