### PR TITLE
test: expand core env coverage

### DIFF
--- a/packages/config/__tests__/coreEnvRefinement.test.ts
+++ b/packages/config/__tests__/coreEnvRefinement.test.ts
@@ -8,6 +8,27 @@ afterEach(() => {
 });
 
 describe("coreEnvSchema refinement", () => {
+  it("coerces boolean and number strings", async () => {
+    const { coreEnvSchema } = await import("../src/env/core");
+    process.env = {
+      ...OLD_ENV,
+      DEPOSIT_RELEASE_ENABLED: "true",
+      DEPOSIT_RELEASE_INTERVAL_MS: "1000",
+      REVERSE_LOGISTICS_ENABLED: "false",
+      REVERSE_LOGISTICS_INTERVAL_MS: "2000",
+      LATE_FEE_ENABLED: "true",
+      LATE_FEE_INTERVAL_MS: "3000",
+    } as NodeJS.ProcessEnv;
+
+    const parsed = coreEnvSchema.parse(process.env);
+    expect(parsed.DEPOSIT_RELEASE_ENABLED).toBe(true);
+    expect(parsed.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
+    expect(parsed.REVERSE_LOGISTICS_ENABLED).toBe(false);
+    expect(parsed.REVERSE_LOGISTICS_INTERVAL_MS).toBe(2000);
+    expect(parsed.LATE_FEE_ENABLED).toBe(true);
+    expect(parsed.LATE_FEE_INTERVAL_MS).toBe(3000);
+  });
+
   it("reports invalid env variables", async () => {
     const { coreEnvSchema } = await import("../src/env/core");
     process.env = {
@@ -34,5 +55,38 @@ describe("coreEnvSchema refinement", () => {
         ]),
       );
     }
+  });
+
+  it("adds issues for malformed prefixed variables", async () => {
+    const { depositReleaseEnvRefinement } = await import("../src/env/core");
+    const ctx = { addIssue: jest.fn() } as any;
+
+    depositReleaseEnvRefinement(
+      {
+        DEPOSIT_RELEASE_FOO_ENABLED: "yes",
+        REVERSE_LOGISTICS_BAR_INTERVAL_MS: "soon",
+        LATE_FEE_BAZ_ENABLED: "maybe",
+      },
+      ctx,
+    );
+
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["DEPOSIT_RELEASE_FOO_ENABLED"],
+        message: "must be true or false",
+      }),
+    );
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["REVERSE_LOGISTICS_BAR_INTERVAL_MS"],
+        message: "must be a number",
+      }),
+    );
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["LATE_FEE_BAZ_ENABLED"],
+        message: "must be true or false",
+      }),
+    );
   });
 });

--- a/packages/config/__tests__/loadCoreEnv.test.ts
+++ b/packages/config/__tests__/loadCoreEnv.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, afterEach, expect } from "@jest/globals";
+
+const OLD_ENV = process.env;
+
+afterEach(() => {
+  jest.resetModules();
+  process.env = OLD_ENV;
+  jest.restoreAllMocks();
+});
+
+describe("loadCoreEnv", () => {
+  it("throws and logs issues for invalid env", async () => {
+    const { loadCoreEnv } = await import("../src/env/core");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      loadCoreEnv({
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "v1",
+        DEPOSIT_RELEASE_ENABLED: "maybe",
+      } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid core environment variables");
+
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid core environment variables:",
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "  • DEPOSIT_RELEASE_ENABLED: must be true or false",
+    );
+  });
+
+  it("returns parsed env without logging for valid env", async () => {
+    const { loadCoreEnv } = await import("../src/env/core");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = loadCoreEnv({
+      CMS_SPACE_URL: "https://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "v1",
+      DEPOSIT_RELEASE_ENABLED: "true",
+      DEPOSIT_RELEASE_INTERVAL_MS: "1000",
+      REVERSE_LOGISTICS_ENABLED: "false",
+      REVERSE_LOGISTICS_INTERVAL_MS: "2000",
+      LATE_FEE_ENABLED: "true",
+      LATE_FEE_INTERVAL_MS: "3000",
+    } as NodeJS.ProcessEnv);
+
+    expect(env.DEPOSIT_RELEASE_ENABLED).toBe(true);
+    expect(env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
+    expect(env.REVERSE_LOGISTICS_ENABLED).toBe(false);
+    expect(env.REVERSE_LOGISTICS_INTERVAL_MS).toBe(2000);
+    expect(env.LATE_FEE_ENABLED).toBe(true);
+    expect(env.LATE_FEE_INTERVAL_MS).toBe(3000);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend coreEnvSchema tests for boolean/number coercion and malformed prefix handling
- add loadCoreEnv tests for invalid logging and valid parsing

## Testing
- `pnpm --filter @acme/config test`
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ab1e300832fb538f8863f8e5bf9