### PR TITLE
test: handle missing OpenAI image data

### DIFF
--- a/packages/lib/src/__tests__/generateMeta.test.ts
+++ b/packages/lib/src/__tests__/generateMeta.test.ts
@@ -164,9 +164,11 @@ describe("generateMeta", () => {
     const responsesCreate = jest.fn().mockResolvedValue({
       output: [{ content: [{ text: "not json" }] }],
     });
-    const imagesGenerate = jest.fn().mockResolvedValue({
-      data: [{ b64_json: Buffer.from("img").toString("base64") }],
-    });
+    const imagesGenerate = jest
+      .fn()
+      .mockResolvedValue({
+        data: [{}],
+      });
     const OpenAI = jest.fn().mockImplementation(() => ({
       responses: { create: responsesCreate },
       images: { generate: imagesGenerate },
@@ -188,7 +190,7 @@ describe("generateMeta", () => {
       image: `/og/${product.id}.png`,
     });
     expect(mkdirMock).toHaveBeenCalledWith(path.dirname(file), { recursive: true });
-    expect(writeMock).toHaveBeenCalledWith(file, Buffer.from("img"));
+    expect(writeMock).toHaveBeenCalledWith(file, Buffer.from(""));
   });
 });
 


### PR DESCRIPTION
## Summary
- test generateMeta with missing OpenAI image data and expect fallback behavior

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/lib test -- packages/lib/__tests__/generateMeta.test.ts`
- `pnpm --filter @acme/lib test -- packages/lib/src/__tests__/generateMeta.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b84bdfe198832f9d8387957043b9ac