### PR TITLE
test: fallback to memory cart store when require fails

### DIFF
--- a/packages/platform-core/__tests__/cartStore/require-fallback.test.ts
+++ b/packages/platform-core/__tests__/cartStore/require-fallback.test.ts
@@ -1,0 +1,34 @@
+import { jest } from "@jest/globals";
+
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "test";
+process.env.CART_COOKIE_SECRET = "test";
+
+describe("createCartStore require fallback", () => {
+  const originalEval = global.eval;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    // restore global eval after each test
+    global.eval = originalEval;
+  });
+
+  it("falls back to createMemoryCartStore when require throws", async () => {
+    // stub eval('require') to throw
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    global.eval = () => {
+      throw new Error("require not available");
+    };
+
+    const { createCartStore } = await import("../../src/cartStore");
+    const { MemoryCartStore } = await import("../../src/cartStore/memoryStore");
+
+    const store = createCartStore({ backend: "redis" });
+
+    expect(store).toBeInstanceOf(MemoryCartStore);
+  });
+});


### PR DESCRIPTION
## Summary
- verify `createCartStore` falls back to `createMemoryCartStore` when `eval('require')` throws

## Testing
- `pnpm exec jest packages/platform-core/__tests__/cartStore/require-fallback.test.ts --config jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b84c93c268832fb2b6df7a897728c7