### PR TITLE
test: ensure Noop analytics provider is cached

### DIFF
--- a/packages/platform-core/src/analytics/__tests__/index.test.ts
+++ b/packages/platform-core/src/analytics/__tests__/index.test.ts
@@ -34,6 +34,18 @@ describe("trackEvent providers", () => {
     await expect(fs.readFile(file, "utf8")).rejects.toBeDefined();
   });
 
+  test("analytics provider 'none' uses Noop provider and is cached", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({ analytics: { provider: "none" } });
+    const { trackEvent } = await import("../index");
+    await trackEvent(shop, { type: "page_view", page: "home" });
+    await trackEvent(shop, { type: "page_view", page: "about" });
+    expect(readShop).toHaveBeenCalledTimes(1);
+    expect(getShopSettings).toHaveBeenCalledTimes(1);
+    const file = path.join(tmp, shop, "analytics.jsonl");
+    await expect(fs.readFile(file, "utf8")).rejects.toBeDefined();
+  });
+
   test("console provider logs event", async () => {
     readShop.mockResolvedValue({ analyticsEnabled: true });
     getShopSettings.mockResolvedValue({ analytics: { provider: "console", enabled: true } });


### PR DESCRIPTION
## Summary
- add regression test verifying analytics provider 'none' uses Noop provider and is cached

## Testing
- `pnpm exec jest packages/platform-core/src/analytics/__tests__/index.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c9e1528832f9fdf91a72cdbef29