### PR TITLE
test: verify cartStore fallback after delete/expire failures

### DIFF
--- a/packages/platform-core/__tests__/cartStore/redis.test.ts
+++ b/packages/platform-core/__tests__/cartStore/redis.test.ts
@@ -159,6 +159,20 @@ describe("RedisCartStore", () => {
     expect(fallback.removeItem).toHaveBeenCalled();
   });
 
+  it("delegates to fallback and returns its result when delete/expire fail", async () => {
+    const fallback = makeFallback();
+    const expected = { cart: true } as any;
+    fallback.removeItem.mockResolvedValue(expected);
+    const store = new RedisCartStore({} as any, 1, fallback);
+    jest
+      .spyOn(store as any, "exec")
+      .mockResolvedValueOnce(1)
+      .mockResolvedValue(undefined);
+    const result = await store.removeItem("id", "sku");
+    expect(fallback.removeItem).toHaveBeenCalledWith("id", "sku");
+    expect(result).toBe(expected);
+  });
+
   it("returns null when setting qty=0 for missing item and falls back on failure", async () => {
     const fallback = makeFallback();
     const hexists = jest.fn().mockResolvedValueOnce(0);


### PR DESCRIPTION
## Summary
- test that RedisCartStore.removeItem delegates to fallback when delete/expire operations fail
- ensure fallback result is returned when exec yields `undefined`

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` *(fails: ERR_PNPM_NO_SCRIPT)*
- `pnpm run build:ts` *(fails: ERR_PNPM_NO_SCRIPT)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/cartStore/redis.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b84ca01920832f9c0f5ebd0a31b49a