### PR TITLE
test: map sizes in checkout metadata

### DIFF
--- a/apps/shop-bcd/__tests__/checkout-session.test.ts
+++ b/apps/shop-bcd/__tests__/checkout-session.test.ts
@@ -62,9 +62,13 @@ test("builds Stripe session with correct items and metadata", async () => {
     payment_intent: { client_secret: "cs_test" },
   });
 
-  const sku = PRODUCTS[0];
-  const size = "40";
-  const cart = { [`${sku.id}:${size}`]: { sku, qty: 2, size } };
+  const [sku1, sku2] = PRODUCTS;
+  const size1 = "40";
+  const size2 = "41";
+  const cart = {
+    [`${sku1.id}:${size1}`]: { sku: sku1, qty: 2, size: size1 },
+    [`${sku2.id}:${size2}`]: { sku: sku2, qty: 1, size: size2 },
+  };
   const cookie = encodeCartCookie(cart as any);
   const returnDate = "2025-01-02";
   const expectedDays = calculateRentalDays(returnDate);
@@ -95,7 +99,7 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(stripeCreate).toHaveBeenCalled();
   const args = stripeCreate.mock.calls[0][0];
 
-  expect(args.line_items).toHaveLength(3);
+  expect(args.line_items).toHaveLength(5);
   expect(args.payment_intent_data.shipping.name).toBe("Jane Doe");
   expect(args.payment_intent_data.billing_details.email).toBe(
     "jane@example.com"
@@ -106,8 +110,10 @@ test("builds Stripe session with correct items and metadata", async () => {
   expect(args.payment_intent_data.metadata.client_ip).toBe("203.0.113.1");
   expect(args.metadata.client_ip).toBe("203.0.113.1");
   expect(args.metadata.rentalDays).toBe(expectedDays.toString());
-  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: size }));
-  expect(args.metadata.subtotal).toBe("20");
+  expect(args.metadata.sizes).toBe(
+    JSON.stringify({ [sku1.id]: size1, [sku2.id]: size2 })
+  );
+  expect(args.metadata.subtotal).toBe("30");
   expect(body.clientSecret).toBe("cs_test");
 });
 

--- a/packages/template-app/__tests__/checkout-session.test.ts
+++ b/packages/template-app/__tests__/checkout-session.test.ts
@@ -93,9 +93,13 @@ test(
     payment_intent: { client_secret: "cs_test" },
   });
 
-  const sku = PRODUCTS[0];
-  const size = "40";
-  const cart = { [`${sku.id}:${size}`]: { sku, qty: 2, size } };
+  const [sku1, sku2] = PRODUCTS;
+  const size1 = "40";
+  const size2 = "41";
+  const cart = {
+    [`${sku1.id}:${size1}`]: { sku: sku1, qty: 2, size: size1 },
+    [`${sku2.id}:${size2}`]: { sku: sku2, qty: 1, size: size2 },
+  };
   mockCart = cart;
   const cookie = encodeCartCookie("test");
   const returnDate = "2025-01-02";
@@ -127,8 +131,7 @@ test(
   expect(stripeCreate).toHaveBeenCalled();
   const [args, options] = stripeCreate.mock.calls[0];
 
-  expect(args.line_items).toHaveLength(2);
-  expect(args.line_items).toHaveLength(2);
+  expect(args.line_items).toHaveLength(4);
   expect(args.customer).toBe("cus_123");
   expect(args.payment_intent_data.shipping.name).toBe("Jane Doe");
   expect(args.payment_intent_data.billing_details.email).toBe(
@@ -139,8 +142,10 @@ test(
   ).toBe("automatic");
   expect(options.headers["Stripe-Client-IP"]).toBe("203.0.113.1");
   expect(args.metadata.rentalDays).toBe(expectedDays.toString());
-  expect(args.metadata.sizes).toBe(JSON.stringify({ [sku.id]: size }));
-  expect(args.metadata.subtotal).toBe("20");
+  expect(args.metadata.sizes).toBe(
+    JSON.stringify({ [sku1.id]: size1, [sku2.id]: size2 })
+  );
+  expect(args.metadata.subtotal).toBe("30");
   expect(body.clientSecret).toBe("cs_test");
 });
 


### PR DESCRIPTION
## Summary
- ensure carts with size selections map sku ids to sizes in checkout-session tests
- verify clientSecret is returned when Stripe provides payment_intent client_secret

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/checkout-session.test.ts packages/template-app/__tests__/checkout-session.test.ts packages/platform-core/__tests__/checkout-session.test.ts`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ca222b8832f87a1cd72a526ec51