### PR TITLE
test: verify currency default in node env

### DIFF
--- a/packages/platform-core/__tests__/CurrencyContext.node.test.ts
+++ b/packages/platform-core/__tests__/CurrencyContext.node.test.ts
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment node
+ */
+
+// packages/platform-core/__tests__/CurrencyContext.node.test.ts
+import { readInitial } from "../src/contexts/CurrencyContext";
+
+describe("readInitial (node)", () => {
+  it("returns EUR when window is undefined", () => {
+    expect(typeof window).toBe("undefined");
+    expect(readInitial()).toBe("EUR");
+  });
+});

--- a/packages/platform-core/src/contexts/CurrencyContext.tsx
+++ b/packages/platform-core/src/contexts/CurrencyContext.tsx
@@ -17,7 +17,7 @@ const CurrencyContext = createContext<
   [Currency, (c: Currency) => void] | undefined
 >(undefined);
 
-function readInitial(): Currency {
+export function readInitial(): Currency {
   if (typeof window === "undefined") return DEFAULT_CURRENCY;
   try {
     const stored = localStorage.getItem(LS_KEY) as Currency | null;


### PR DESCRIPTION
## Summary
- export `readInitial` from CurrencyContext so it can be tested directly
- add node-environment test ensuring `readInitial` returns EUR when `window` is undefined

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: ENOENT during apps/cms build)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/CurrencyContext.node.test.ts -- --coverage=false` *(coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ca43198832f93f780265fbedb40