### PR TITLE
test: handle matchMedia errors

### DIFF
--- a/packages/platform-core/src/contexts/ThemeContext.tsx
+++ b/packages/platform-core/src/contexts/ThemeContext.tsx
@@ -27,7 +27,7 @@ export function getSavedTheme(): Theme | null {
   }
 }
 
-function getSystemTheme(): Theme {
+export function getSystemTheme(): Theme {
   try {
     return window.matchMedia &&
       window.matchMedia("(prefers-color-scheme: dark)").matches

--- a/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from "@testing-library/react";
-import { ThemeProvider, getSavedTheme, useTheme } from "../ThemeContext";
+import { ThemeProvider, getSavedTheme, getSystemTheme, useTheme } from "../ThemeContext";
 
 // React 19 requires this flag for `act` to suppress environment warnings
 // when not using a test renderer.
@@ -65,6 +65,17 @@ describe("ThemeContext", () => {
       value: { getItem: jest.fn().mockReturnValue(null) },
     });
     expect(getSavedTheme()).toBeNull();
+  });
+
+  it("falls back to base when matchMedia throws", () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: () => {
+        throw new Error("no media");
+      },
+    });
+
+    expect(getSystemTheme()).toBe("base");
   });
 
   it("uses system matchMedia and reacts to changes", () => {


### PR DESCRIPTION
## Summary
- export getSystemTheme for tests
- ensure getSystemTheme returns base when matchMedia throws

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/platform-core test`
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b84ca4df54832fbff780229f85abe0