### PR TITLE
test: verify loadTokens merges theme tokens

### DIFF
--- a/packages/platform-core/__tests__/loadTokens.test.ts
+++ b/packages/platform-core/__tests__/loadTokens.test.ts
@@ -1,0 +1,43 @@
+import { jest } from "@jest/globals";
+import fs from "fs";
+
+jest.mock("../src/themeTokens", () => ({
+  loadThemeTokensNode: jest.fn(),
+}));
+
+let loadTokens: (theme: string) => Record<string, string>;
+let themeTokens: typeof import("../src/themeTokens");
+
+beforeAll(async () => {
+  themeTokens = await import("../src/themeTokens");
+  ({ loadTokens } = await import("../src/createShop/themeUtils"));
+});
+
+describe("loadTokens", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("combines base and theme token maps with theme overriding", () => {
+    jest.spyOn(fs, "readFileSync").mockImplementation((p: fs.PathLike) => {
+      const file = String(p);
+      if (file.endsWith("tokens.ts")) {
+        return "export const tokens = { baseOnly: { light: 'base' }, shared: { light: 'base' } };";
+      }
+      return "";
+    });
+
+    (themeTokens.loadThemeTokensNode as jest.Mock).mockReturnValue({
+      themeOnly: "theme",
+      shared: "theme",
+    });
+
+    const tokens = loadTokens("foo");
+    expect(tokens).toEqual({
+      baseOnly: "base",
+      themeOnly: "theme",
+      shared: "theme",
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test to combine base and theme token maps with theme override

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/template-app build failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest --runInBand packages/platform-core/__tests__/loadTokens.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b84ca75d64832faa905e9b008cf9a3