### PR TITLE
test: cover UPS label fallback on fetch failures

### DIFF
--- a/packages/platform-core/__tests__/shipping-ups.test.ts
+++ b/packages/platform-core/__tests__/shipping-ups.test.ts
@@ -57,6 +57,26 @@ describe('createReturnLabel', () => {
       }),
     );
   });
+
+  it('falls back when fetch response is not ok', async () => {
+    mockEnv.UPS_KEY = 'ups-key';
+    fetchMock.mockResolvedValue({ ok: false });
+    const result = await createReturnLabel('session');
+    expect(result).toEqual({
+      trackingNumber: '1Z1234567891',
+      labelUrl: 'https://www.ups.com/track?loc=en_US&tracknum=1Z1234567891',
+    });
+  });
+
+  it('falls back when fetch throws', async () => {
+    mockEnv.UPS_KEY = 'ups-key';
+    fetchMock.mockRejectedValue(new Error('network'));
+    const result = await createReturnLabel('session');
+    expect(result).toEqual({
+      trackingNumber: '1Z1234567891',
+      labelUrl: 'https://www.ups.com/track?loc=en_US&tracknum=1Z1234567891',
+    });
+  });
 });
 
 describe('getStatus', () => {


### PR DESCRIPTION
## Summary
- add tests for UPS return label to ensure fallback on non-ok response or thrown fetch

## Testing
- `pnpm exec jest packages/platform-core/__tests__/shipping-ups.test.ts --config jest.config.cjs --runInBand --coverage=false`
- `pnpm -r build` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @apps/cms build)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ca97768832f800f9532ccbe8741