### PR TITLE
test: verify readShop lazy import

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/json.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/json.server.test.ts
@@ -1,0 +1,21 @@
+import type { Shop } from "@acme/types";
+
+describe("json.readShop", () => {
+  it("lazy-loads shops.server and forwards the result", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const fake: Shop = { id: "s1" } as Shop;
+      const readMock = jest.fn(async () => fake);
+      let loaded = false;
+      jest.doMock("../shops.server", () => {
+        loaded = true;
+        return { readShop: readMock };
+      });
+      const { readShop } = await import("../json.server");
+      expect(loaded).toBe(false);
+      const result = await readShop("s1");
+      expect(loaded).toBe(true);
+      expect(readMock).toHaveBeenCalledWith("s1");
+      expect(result).toBe(fake);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test to ensure `json.readShop` only imports `shops.server` when invoked and returns the underlying data

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript project references not fully supported)*
- `pnpm --filter @acme/platform-core build`
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/repositories/__tests__/json.server.test.ts --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b84cab1a20832fbdbf1acf217bc57e