### PR TITLE
test: cover layout defaults

### DIFF
--- a/packages/types/__tests__/layouts.test.ts
+++ b/packages/types/__tests__/layouts.test.ts
@@ -24,6 +24,60 @@ describe("layouts schemas", () => {
     expect(schema.parse(data)).toEqual(data);
   });
 
+  describe("default values", () => {
+    it("defaults children for Section", () => {
+      expect(
+        sectionComponentSchema.parse({ id: "s2", type: "Section" })
+      ).toEqual({ id: "s2", type: "Section", children: [] });
+    });
+
+    it("defaults children for MultiColumn", () => {
+      expect(
+        multiColumnComponentSchema.parse({ id: "m2", type: "MultiColumn" })
+      ).toEqual({ id: "m2", type: "MultiColumn", children: [] });
+    });
+
+    it("defaults labels and children for Tabs", () => {
+      expect(tabsComponentSchema.parse({ id: "t2", type: "Tabs" })).toEqual({
+        id: "t2",
+        type: "Tabs",
+        labels: [],
+        children: [],
+      });
+    });
+  });
+
+  describe("optional properties", () => {
+    it("accepts columns and gap for MultiColumn", () => {
+      expect(
+        multiColumnComponentSchema.parse({
+          id: "m3",
+          type: "MultiColumn",
+          columns: 3,
+          gap: "1rem",
+        })
+      ).toEqual({
+        id: "m3",
+        type: "MultiColumn",
+        columns: 3,
+        gap: "1rem",
+        children: [],
+      });
+    });
+
+    it("accepts active index for Tabs", () => {
+      expect(
+        tabsComponentSchema.parse({ id: "t3", type: "Tabs", active: 1 })
+      ).toEqual({
+        id: "t3",
+        type: "Tabs",
+        active: 1,
+        labels: [],
+        children: [],
+      });
+    });
+  });
+
   it("rejects tabs with invalid active index", () => {
     expect(
       tabsComponentSchema.safeParse({ id: "t2", type: "Tabs", active: "a" } as any).success


### PR DESCRIPTION
## Summary
- add tests for default children and labels in layout schemas
- verify optional columns, gap, and active fields

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve '@babel/runtime/helpers/asyncToGenerator')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/types/__tests__/layouts.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b85699d054832f8ff8193540f260e6