### PR TITLE
test(date-utils): cover formatTimestamp edge cases

### DIFF
--- a/packages/date-utils/__tests__/date.test.ts
+++ b/packages/date-utils/__tests__/date.test.ts
@@ -92,6 +92,14 @@ describe("formatTimestamp", () => {
   test("returns input for invalid timestamp", () => {
     expect(formatTimestamp("nope")).toBe("nope");
   });
+  test("returns input for invalid timestamp with locale", () => {
+    expect(formatTimestamp("nope", "en-US")).toBe("nope");
+  });
+  test("localizes ISO timestamp for given locale", () => {
+    const ts = "2025-01-01T05:06:07Z";
+    const expected = new Date(ts).toLocaleString("de-DE");
+    expect(formatTimestamp(ts, "de-DE")).toBe(expected);
+  });
 });
 
 describe("parseTargetDate", () => {

--- a/packages/date-utils/src/__tests__/index.test.ts
+++ b/packages/date-utils/src/__tests__/index.test.ts
@@ -61,6 +61,14 @@ describe("formatTimestamp", () => {
   it("returns input for invalid timestamp", () => {
     expect(formatTimestamp("bad")).toBe("bad");
   });
+  it("returns input for invalid timestamp with locale", () => {
+    expect(formatTimestamp("bad", "en-US")).toBe("bad");
+  });
+  it("localizes ISO timestamp for given locale", () => {
+    const ts = "2025-01-01T05:06:07Z";
+    const expected = new Date(ts).toLocaleString("de-DE");
+    expect(formatTimestamp(ts, "de-DE")).toBe(expected);
+  });
 });
 
 describe("parseTargetDate", () => {


### PR DESCRIPTION
## Summary
- add tests for invalid timestamp handling in `formatTimestamp`
- verify locale-specific formatting of ISO strings

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build failed)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/date-utils exec jest packages/date-utils/src/__tests__/index.test.ts packages/date-utils/__tests__/date.test.ts --runInBand --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68b85695cc1c832fa31a5cf97d8018bf