### PR TITLE
test(date-utils): add formatDuration edge cases

### DIFF
--- a/packages/date-utils/__tests__/date.test.ts
+++ b/packages/date-utils/__tests__/date.test.ts
@@ -148,16 +148,26 @@ describe("getTimeRemaining", () => {
 });
 
 describe("formatDuration", () => {
-  test("formats durations spanning days, hours, minutes, and seconds", () => {
+  test("formats durations with only seconds", () => {
+    expect(formatDuration(45 * 1000)).toBe("45s");
+  });
+
+  test("formats durations including minutes", () => {
+    const ms = (3 * 60 + 15) * 1000; // 3m 15s
+    expect(formatDuration(ms)).toBe("3m 15s");
+  });
+
+  test("formats durations including hours", () => {
+    const ms = (2 * 3600 + 5 * 60 + 30) * 1000; // 2h 5m 30s
+    expect(formatDuration(ms)).toBe("2h 5m 30s");
+  });
+
+  test("formats durations including days", () => {
     const ms = (1 * 86400 + 2 * 3600 + 3 * 60 + 4) * 1000;
     expect(formatDuration(ms)).toBe("1d 2h 3m 4s");
   });
 
-  test("formats seconds-only durations", () => {
-    expect(formatDuration(45 * 1000)).toBe("45s");
-  });
-
-  test("treats negative durations as 0s", () => {
+  test("clamps negative milliseconds to 0s", () => {
     expect(formatDuration(-5000)).toBe("0s");
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for seconds-only, minute, hour, day, and negative durations in `formatDuration`

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/date-utils/__tests__/date.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b856993c40832fb197513a52c2c541