### PR TITLE
fix: point package entry to compiled output

### DIFF
--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -3,21 +3,21 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "configurator": "bin/configurator.cjs"
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./providers": {
-      "types": "./src/providers.d.ts",
-      "import": "./src/providers.ts",
-      "default": "./src/providers.ts"
+      "types": "./dist/providers.d.ts",
+      "import": "./dist/providers.js",
+      "default": "./dist/providers.js"
     }
   },
   "sideEffects": false,

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -2,11 +2,11 @@
   "name": "@acme/telemetry",
   "version": "0.0.1",
   "private": true,
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",
@@ -16,9 +16,9 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -2,11 +2,11 @@
   "name": "@acme/theme",
   "version": "0.0.1",
   "private": true,
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -b",
@@ -20,9 +20,9 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use built JS files as entry points for telemetry, theme, and configurator
- restrict published files to dist output

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b85f0cf214832f8429e7ee32539853