### PR TITLE
test(email): ensure real timers in send tests

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -56,6 +56,10 @@ describe("sendCampaignEmail", () => {
     process.env.CAMPAIGN_FROM = "campaign@example.com";
   };
 
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
   afterEach(() => {
     jest.resetModules();
     jest.resetAllMocks();


### PR DESCRIPTION
## Summary
- ensure email send tests restore real timers before each test

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/send.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b867a55970832f891278c7518548f7