### PR TITLE
chore(email): map acme lib for ts

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -12,7 +12,9 @@
       "@date-utils": ["types-compat/date-utils"],
       "@acme/email-templates": ["../email-templates/dist"],
       "@platform-core": ["../platform-core/src"],
-      "@platform-core/*": ["../platform-core/src/*"]
+      "@platform-core/*": ["../platform-core/src/*"],
+      "@acme/lib": ["../lib/src/index.ts"],
+      "@acme/lib/*": ["../lib/src/*"]
     }
   },
   "include": ["src", "types-compat/**/*.d.ts"],


### PR DESCRIPTION
## Summary
- add path mapping for `@acme/lib` to email package tsconfig

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@babel/runtime/helpers/asyncToGenerator')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email build`


------
https://chatgpt.com/codex/tasks/task_e_68b86831d144832f83100eba768ac397