### PR TITLE
test: extend media list timeout

### DIFF
--- a/apps/cms/__tests__/media.test.ts
+++ b/apps/cms/__tests__/media.test.ts
@@ -97,7 +97,7 @@ describe("media actions", () => {
         );
       })
     );
-  });
+  }, 15_000);
 
   it("uploadMedia stores file, metadata and returns item", async () => {
     await withTmpDir((dir) =>


### PR DESCRIPTION
## Summary
- increase timeout for missing media directory test

## Testing
- `pnpm --filter @apps/cms exec jest __tests__/media.test.ts --runInBand --detectOpenHandles --collectCoverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b867fbde58832fb79e99b8f3e012a7