### PR TITLE
chore(api): add source fallbacks to tsconfig paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,5 @@
 - Build all packages before starting any app: `pnpm -r build`.
 - Regenerate config stubs after editing `.impl.ts` files: `pnpm run build:stubs`.
 - If `pnpm run dev` fails with an `array.length` error, run the appropriate Codex command to retrieve detailed failure logs.
+- Apps must map workspace packages in their `tsconfig.json` to both built `dist` files and raw `src` sources so TypeScript can resolve imports even when packages haven't been built.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ The provider’s `package.json` must then point to the generated type declaratio
 { "types": "dist/index.d.ts" }
 ```
 
+## TSConfig path fallbacks for apps
+
+Every app should map workspace packages to both their built `dist` output and the raw `src` files. This mirrors `apps/shop-bcd` and lets TypeScript resolve imports even when packages haven't been built.
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@acme/lib": [
+        "../../packages/lib/dist/index.d.ts",
+        "../../packages/lib/src/index.ts"
+      ],
+      "@acme/lib/*": [
+        "../../packages/lib/dist/*",
+        "../../packages/lib/src/*"
+      ]
+    }
+  }
+}
+```
+
+Repeat this pattern for any other packages an app consumes to avoid missing module errors when the package hasn't been built yet.
+
 ## Troubleshooting
 
 - If `pnpm run dev` fails with an `array.length` error, run the appropriate Codex command to retrieve detailed failure information.

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -6,16 +6,46 @@
     "outDir": "dist",
     "rootDir": "./src",
     "paths": {
-      "@acme/lib": ["../../packages/lib/dist/index.d.ts"],
-      "@acme/lib/*": ["../../packages/lib/dist/*"],
-      "@acme/config": ["../../packages/config/dist/index.d.ts"],
-      "@acme/config/*": ["../../packages/config/dist/*"],
-      "@acme/zod-utils": ["../../packages/zod-utils/dist/index.d.ts"],
-      "@acme/zod-utils/*": ["../../packages/zod-utils/dist/*"],
-      "@platform-core": ["../../packages/platform-core/dist/index.d.ts"],
-      "@platform-core/*": ["../../packages/platform-core/dist/*"],
-      "@acme/platform-core": ["../../packages/platform-core/dist/index.d.ts"],
-      "@acme/platform-core/*": ["../../packages/platform-core/dist/*"]
+      "@acme/lib": [
+        "../../packages/lib/dist/index.d.ts",
+        "../../packages/lib/src/index.ts"
+      ],
+      "@acme/lib/*": [
+        "../../packages/lib/dist/*",
+        "../../packages/lib/src/*"
+      ],
+      "@acme/config": [
+        "../../packages/config/dist/index.d.ts",
+        "../../packages/config/src/index.ts"
+      ],
+      "@acme/config/*": [
+        "../../packages/config/dist/*",
+        "../../packages/config/src/*"
+      ],
+      "@acme/zod-utils": [
+        "../../packages/zod-utils/dist/index.d.ts",
+        "../../packages/zod-utils/src/index.ts"
+      ],
+      "@acme/zod-utils/*": [
+        "../../packages/zod-utils/dist/*",
+        "../../packages/zod-utils/src/*"
+      ],
+      "@platform-core": [
+        "../../packages/platform-core/dist/index.d.ts",
+        "../../packages/platform-core/src/index.ts"
+      ],
+      "@platform-core/*": [
+        "../../packages/platform-core/dist/*",
+        "../../packages/platform-core/src/*"
+      ],
+      "@acme/platform-core": [
+        "../../packages/platform-core/dist/index.d.ts",
+        "../../packages/platform-core/src/index.ts"
+      ],
+      "@acme/platform-core/*": [
+        "../../packages/platform-core/dist/*",
+        "../../packages/platform-core/src/*"
+      ]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- allow `apps/api` to resolve packages from both built `dist` and raw `src` files
- document tsconfig path fallback requirement for all apps

## Testing
- `pnpm install`
- `pnpm -r build`


------
https://chatgpt.com/codex/tasks/task_e_68b86e737fe4832fbc1d382fac9c5fa5