### PR TITLE
test: cover dashboard upgrade non-selection path

### DIFF
--- a/apps/dashboard/__tests__/Upgrade.test.tsx
+++ b/apps/dashboard/__tests__/Upgrade.test.tsx
@@ -22,6 +22,28 @@ describe("Upgrade page", () => {
     global.fetch = originalFetch;
   });
 
+  it("hides publish section when nothing selected", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        core: [
+          { file: "CompA.tsx", componentName: "CompA" },
+        ],
+      }),
+    });
+
+    render(<Upgrade />);
+
+    await screen.findByText("core");
+
+    expect(
+      screen.queryByText(/selected components/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /publish upgrade/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("shows error message when publish fails", async () => {
     (global.fetch as jest.Mock)
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- add test verifying publish section hidden when no components selected

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to determine port for shop shop1, etc.)*
- `pnpm test --filter @apps/dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b871199190832f9d18adeda6ad6f9c