### PR TITLE
fix type inference in edit preview page

### DIFF
--- a/packages/template-app/src/app/edit-preview/page.tsx
+++ b/packages/template-app/src/app/edit-preview/page.tsx
@@ -29,7 +29,7 @@ export default function EditPreviewPage() {
         if (Array.isArray(data.pages)) {
           const pageLinks = (
             await Promise.all(
-              data.pages.map(async (id) => {
+              (data.pages as string[]).map(async (id) => {
                 try {
                   const r = await fetch(
                     `/api/preview-token?pageId=${encodeURIComponent(id)}`,


### PR DESCRIPTION
## Summary
- ensure edit-preview pages array is typed

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/template-app build: Failed, packages/email build: Failed, packages/platform-machine build: Failed, packages/auth build: Failed, packages/lib build: Failed)*
- `pnpm run check:references` *(missing script: check:references)*
- `pnpm run build:ts` *(missing script: build:ts)*
- `pnpm --filter @acme/template-app test` *(hung, manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b872aaddb0832f98b5ea4e671eafc2