### PR TITLE
fix: load base url from env

### DIFF
--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from "next";
-import { coreEnv } from "@acme/config/env/core";
+import { loadCoreEnv } from "@acme/config/env/core";
 
 export default function robots(): MetadataRoute.Robots {
+    const { NEXT_PUBLIC_BASE_URL } = loadCoreEnv();
     const base =
-      (coreEnv.NEXT_PUBLIC_BASE_URL as string | undefined) ||
+      (NEXT_PUBLIC_BASE_URL as string | undefined) ||
       "http://localhost:3000";
   return {
     rules: [


### PR DESCRIPTION
## Summary
- load base URL via `loadCoreEnv` in robots generator

## Testing
- `pnpm install`
- `pnpm --filter @acme/template-app run check:references` *(fails: missing script)*
- `pnpm --filter @acme/template-app run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/template-app run build` *(fails: Can't resolve modules)*
- `pnpm -r build` *(fails: apps/template builds fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b8729ac548832fb09d31450f58f4ef