### PR TITLE
refactor: use env constant in sitemap and robots

### DIFF
--- a/packages/template-app/src/app/robots.ts
+++ b/packages/template-app/src/app/robots.ts
@@ -1,10 +1,8 @@
 import type { MetadataRoute } from "next";
-import { coreEnv } from "@acme/config/env/core";
+import { env } from "@acme/config";
 
 export default function robots(): MetadataRoute.Robots {
-    const base =
-      (coreEnv.NEXT_PUBLIC_BASE_URL as string | undefined) ||
-      "http://localhost:3000";
+    const base = env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
   return {
     rules: [
       { userAgent: "*", allow: "/" },

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -1,16 +1,13 @@
 import type { MetadataRoute } from "next";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import { readRepo } from "@platform-core/repositories/products.server";
-import { coreEnv } from "@acme/config/env/core";
+import { env } from "@acme/config";
 import type { ProductPublication } from "@acme/types";
 import { nowIso } from "@date-utils";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    const base =
-      (coreEnv.NEXT_PUBLIC_BASE_URL as string | undefined) ||
-      "http://localhost:3000";
-    const shop =
-      (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "shop";
+    const base = env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+    const shop = env.NEXT_PUBLIC_SHOP_ID ?? "shop";
   const now = nowIso();
 
   const [settings, products] = await Promise.all([


### PR DESCRIPTION
## Summary
- import env from `@acme/config` for sitemap and robots
- simplify base url and shop id reads using env properties

## Testing
- `pnpm --filter template-app run check:references` *(fails: Missing script)*
- `pnpm --filter template-app run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: process interrupted after package builds)*

------
https://chatgpt.com/codex/tasks/task_e_68b8728f7570832f92480718fe15e242