### PR TITLE
fix: add id type annotation

### DIFF
--- a/packages/template-app/src/app/upgrade-preview/page.tsx
+++ b/packages/template-app/src/app/upgrade-preview/page.tsx
@@ -29,7 +29,7 @@ export default function UpgradePreviewPage() {
         if (Array.isArray(data.pages)) {
           const pageLinks = (
             await Promise.all(
-              data.pages.map(async (id) => {
+              data.pages.map(async (id: string) => {
                 try {
                   const r = await fetch(
                     `/api/preview-token?pageId=${encodeURIComponent(id)}`,


### PR DESCRIPTION
## Summary
- add explicit `string` type for page ID in upgrade preview page to satisfy TypeScript

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Generating static pages... Failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/template-app build`


------
https://chatgpt.com/codex/tasks/task_e_68b87284a9b4832f8cfccf0d0040b6f3