### PR TITLE
test: handle missing shop id on upgrade

### DIFF
--- a/apps/dashboard/__tests__/Upgrade.test.tsx
+++ b/apps/dashboard/__tests__/Upgrade.test.tsx
@@ -96,6 +96,17 @@ describe("Upgrade page", () => {
 
     errorSpy.mockRestore();
   });
+
+  it("does not fetch when shop id is missing", () => {
+    (useRouter as jest.Mock).mockReturnValue({ query: {} });
+
+    render(<Upgrade />);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /publish upgrade/i })
+    ).not.toBeInTheDocument();
+  });
 });
 
 it("restores global.fetch after tests", () => {


### PR DESCRIPTION
## Summary
- add regression test for Upgrade page when router query lacks shop id

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: missing module /workspace/base-shop/apps/shop-shop1/package.json)*
- `pnpm test apps/dashboard` *(fails: Could not find task `apps/dashboard`)*
- `pnpm --filter @apps/dashboard test`


------
https://chatgpt.com/codex/tasks/task_e_68b87118d074832fbf49e5e502a7d8b7