### PR TITLE
fix(template-app): annotate locale parameter in product page

### DIFF
--- a/packages/template-app/src/app/[lang]/product/[slug]/page.tsx
+++ b/packages/template-app/src/app/[lang]/product/[slug]/page.tsx
@@ -1,6 +1,6 @@
 // packages/template-app/src/app/[lang]/product/[slug]/page.tsx
 
-import { LOCALES } from "@acme/i18n";
+import { LOCALES, type Locale } from "@acme/i18n";
 import { getProductBySlug } from "@platform-core/products";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -10,7 +10,7 @@ import { CleaningInfo } from "../../../../components/CleaningInfo";
 import shop from "../../../../../shop.json";
 
 export async function generateStaticParams() {
-  return LOCALES.flatMap((lang) =>
+  return LOCALES.flatMap((lang: Locale) =>
     ["green-sneaker", "sand-sneaker", "black-sneaker"].map((slug) => ({
       lang,
       slug,


### PR DESCRIPTION
## Summary
- type lang param in product page static params generation to avoid implicit any

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/template-app build`


------
https://chatgpt.com/codex/tasks/task_e_68b872e8d314832f89423b0943b733ce