### PR TITLE
chore(dashboard): map dist types in tsconfig

### DIFF
--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -5,8 +5,14 @@
     "rootDir": "../..",
     "paths": {
       "@/*": ["./src/*"],
-      "@acme/types": ["../../packages/types/src/index.ts"],
-      "@acme/types/*": ["../../packages/types/src/*"]
+      "@acme/types": [
+        "../../packages/types/dist/index.d.ts",
+        "../../packages/types/src/index.ts"
+      ],
+      "@acme/types/*": [
+        "../../packages/types/dist/*",
+        "../../packages/types/src/*"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- map `@acme/types` to its built dist files in dashboard tsconfig

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '../../contexts/CartContext')*
- `pnpm --filter @apps/dashboard lint` *(fails: A `require()` style import is forbidden)*
- `pnpm --filter @apps/dashboard test`


------
https://chatgpt.com/codex/tasks/task_e_68b873e90908832fba86e58937d51d9a