### PR TITLE
fix: address environment type checks in template app

### DIFF
--- a/packages/template-app/src/lib/seo.ts
+++ b/packages/template-app/src/lib/seo.ts
@@ -33,7 +33,10 @@ export async function getSeo(
   locale: Locale,
   pageSeo: Partial<ExtendedSeoProps> = {}
 ): Promise<NextSeoProps> {
-    const shop = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "default";
+  const shop =
+    ((coreEnv as { NEXT_PUBLIC_SHOP_ID?: string }).NEXT_PUBLIC_SHOP_ID as
+      | string
+      | undefined) || "default";
   const { getShopSettings } = await import(
     "@platform-core/repositories/shops.server"
   );
@@ -62,12 +65,8 @@ export async function getSeo(
       perLocaleCanonical[l] = `${cBase}/${l}${canonicalPath}`;
     }
   }
-  const alternates: LinkTag[] = Object.entries(perLocaleCanonical).map(
-    ([l, href]) => ({
-      rel: "alternate",
-      hrefLang: l,
-      href,
-    })
+  const alternates: LinkTag[] = Object.entries(perLocaleCanonical).flatMap(
+    ([l, href]) => (href ? [{ rel: "alternate", hrefLang: l, href }] : [])
   );
 
   const imagePath =

--- a/packages/template-app/src/routes/preview/[pageId].ts
+++ b/packages/template-app/src/routes/preview/[pageId].ts
@@ -5,8 +5,15 @@ import { getPages } from "@platform-core/repositories/pages/index.server";
 import { createHmac, timingSafeEqual } from "crypto";
 import { coreEnv } from "@acme/config/env/core";
 
-const secret = coreEnv.PREVIEW_TOKEN_SECRET as string | undefined;
-const upgradeSecret = coreEnv.UPGRADE_PREVIEW_TOKEN_SECRET as string | undefined;
+const {
+  PREVIEW_TOKEN_SECRET: secret,
+  UPGRADE_PREVIEW_TOKEN_SECRET: upgradeSecret,
+  NEXT_PUBLIC_SHOP_ID,
+} = coreEnv as {
+  PREVIEW_TOKEN_SECRET?: string;
+  UPGRADE_PREVIEW_TOKEN_SECRET?: string;
+  NEXT_PUBLIC_SHOP_ID?: string;
+};
 
 function verify(
   id: string,
@@ -37,7 +44,7 @@ export const onRequest = async ({
   } else if (!verify(pageId, token, secret)) {
     return new Response("Unauthorized", { status: 401 });
   }
-  const shop = (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "default";
+  const shop = NEXT_PUBLIC_SHOP_ID || "default";
   const pages = await getPages(shop);
   const page = pages.find((p) => p.id === pageId);
   if (!page) return new Response("Not Found", { status: 404 });


### PR DESCRIPTION
## Summary
- handle optional environment variables in preview route
- filter undefined alternate links in SEO helper

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/template-app test` *(fails: @acme/template-app@ test: jest exited with status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b87276eb3c832f9b22aee77e2201a7