### PR TITLE
chore: map email templates source

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -10,7 +10,14 @@
     "baseUrl": ".",
     "paths": {
       "@date-utils": ["types-compat/date-utils"],
-      "@acme/email-templates": ["../email-templates/dist"],
+      "@acme/email-templates": [
+        "../email-templates/dist",
+        "../email-templates/src/index.ts"
+      ],
+      "@acme/email-templates/*": [
+        "../email-templates/dist/*",
+        "../email-templates/src/*"
+      ],
       "@platform-core": ["../platform-core/src"],
       "@platform-core/*": ["../platform-core/src/*"],
       "@acme/lib": ["../lib/src/index.ts"],


### PR DESCRIPTION
## Summary
- include `email-templates` source paths in `@acme/email` tsconfig

## Testing
- `pnpm install`
- `pnpm --filter @acme/email-templates build`
- `pnpm --filter @acme/email build`
- `rm -rf packages/email-templates/dist && rm -f packages/email-templates/tsconfig.tsbuildinfo && pnpm --filter @acme/email build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b875e8d0fc832f98aa2561de1aa7e1