### PR TITLE
fix: load core env in sitemap

### DIFF
--- a/packages/template-app/__tests__/sitemap.test.ts
+++ b/packages/template-app/__tests__/sitemap.test.ts
@@ -12,14 +12,12 @@ jest.mock("@platform-core/repositories/products.server", () => ({
 }));
 
 jest.mock("@acme/config/env/core", () => ({
-  coreEnv: {
-    get NEXT_PUBLIC_BASE_URL() {
-      return process.env.NEXT_PUBLIC_BASE_URL as string | undefined;
-    },
-    get NEXT_PUBLIC_SHOP_ID() {
-      return process.env.NEXT_PUBLIC_SHOP_ID as string | undefined;
-    },
-  },
+  loadCoreEnv: jest.fn(() => ({
+    NEXT_PUBLIC_BASE_URL: process.env
+      .NEXT_PUBLIC_BASE_URL as string | undefined,
+    NEXT_PUBLIC_SHOP_ID: process.env
+      .NEXT_PUBLIC_SHOP_ID as string | undefined,
+  })),
 }));
 
 const ORIGINAL_ENV = process.env;

--- a/packages/template-app/src/app/sitemap.ts
+++ b/packages/template-app/src/app/sitemap.ts
@@ -1,16 +1,14 @@
 import type { MetadataRoute } from "next";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
 import { readRepo } from "@platform-core/repositories/products.server";
-import { coreEnv } from "@acme/config/env/core";
+import { loadCoreEnv } from "@acme/config/env/core";
 import type { ProductPublication } from "@acme/types";
 import { nowIso } from "@date-utils";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    const base =
-      (coreEnv.NEXT_PUBLIC_BASE_URL as string | undefined) ||
-      "http://localhost:3000";
-    const shop =
-      (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) || "shop";
+  const { NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_SHOP_ID } = loadCoreEnv();
+  const base = NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const shop = NEXT_PUBLIC_SHOP_ID || "shop";
   const now = nowIso();
 
   const [settings, products] = await Promise.all([


### PR DESCRIPTION
## Summary
- read NEXT_PUBLIC env vars via loadCoreEnv
- adjust sitemap tests for new env loader

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/template-app test` *(passes with coverage threshold warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b874e70150832f95d38bca1378a21c