### PR TITLE
chore: map packages to dist and src

### DIFF
--- a/packages/configurator/tsconfig.json
+++ b/packages/configurator/tsconfig.json
@@ -12,8 +12,8 @@
     "lib": ["es2022"],
     "baseUrl": ".",
     "paths": {
-      "@acme/config": ["../config/src/index.ts"],
-      "@acme/config/*": ["../config/src/*"]
+      "@acme/config": ["../config/dist/index.d.ts", "../config/src/index.ts"],
+      "@acme/config/*": ["../config/dist/*", "../config/src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -9,19 +9,19 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@date-utils": ["types-compat/date-utils"],
+      "@date-utils": ["../date-utils/dist/index.d.ts", "../date-utils/src/index.ts", "types-compat/date-utils"],
       "@acme/email-templates": [
-        "../email-templates/dist",
+        "../email-templates/dist/index.d.ts",
         "../email-templates/src/index.ts"
       ],
       "@acme/email-templates/*": [
         "../email-templates/dist/*",
         "../email-templates/src/*"
       ],
-      "@platform-core": ["../platform-core/src"],
-      "@platform-core/*": ["../platform-core/src/*"],
-      "@acme/lib": ["../lib/src/index.ts"],
-      "@acme/lib/*": ["../lib/src/*"]
+      "@platform-core": ["../platform-core/dist/index.d.ts", "../platform-core/src/index.ts"],
+      "@platform-core/*": ["../platform-core/dist/*", "../platform-core/src/*"],
+      "@acme/lib": ["../lib/dist/index.d.ts", "../lib/src/index.ts"],
+      "@acme/lib/*": ["../lib/dist/*", "../lib/src/*"]
     }
   },
   "include": ["src", "types-compat/**/*.d.ts"],

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -18,24 +18,24 @@
     "verbatimModuleSyntax": true,
     "baseUrl": ".",
     "paths": {
-      "@acme/ui": ["types-compat/ui"],
-      "@acme/ui/*": ["types-compat/ui"],
-      "@acme/platform-core": ["src/index.ts"],
-      "@acme/platform-core/*": ["src/*"],
+      "@acme/ui": ["../ui/dist/index.d.ts", "../ui/src/index.ts", "types-compat/ui"],
+      "@acme/ui/*": ["../ui/dist/*", "../ui/src/*"],
+      "@acme/platform-core": ["dist/index.d.ts", "src/index.ts"],
+      "@acme/platform-core/*": ["dist/*", "src/*"],
 
-      "@acme/shared-utils": ["../shared-utils/src/index.ts"],
-      "@acme/shared-utils/*": ["../shared-utils/src/*"],
-      "@acme/date-utils": ["../date-utils/src/index.ts"],
-      "@acme/date-utils/*": ["../date-utils/src/*"],
-      "@acme/stripe": ["../stripe/src/index.ts"],
-      "@acme/stripe/*": ["../stripe/src/*"],
+      "@acme/shared-utils": ["../shared-utils/dist/index.d.ts", "../shared-utils/src/index.ts"],
+      "@acme/shared-utils/*": ["../shared-utils/dist/*", "../shared-utils/src/*"],
+      "@acme/date-utils": ["../date-utils/dist/index.d.ts", "../date-utils/src/index.ts"],
+      "@acme/date-utils/*": ["../date-utils/dist/*", "../date-utils/src/*"],
+      "@acme/stripe": ["../stripe/dist/index.d.ts", "../stripe/src/index.ts"],
+      "@acme/stripe/*": ["../stripe/dist/*", "../stripe/src/*"],
 
-      "better-sqlite3": ["src/types/better-sqlite3"],
+      "better-sqlite3": ["dist/types/better-sqlite3", "src/types/better-sqlite3"],
 
-      "@acme/config/env/*": ["../config/src/env/*"],
-      "@acme/i18n": ["../i18n/src/index.ts"],
-      "@acme/i18n/*": ["../i18n/src/*"],
-      "@acme/email-templates": ["../email-templates/src/index.ts"]
+      "@acme/config/env/*": ["../config/dist/env/*", "../config/src/env/*"],
+      "@acme/i18n": ["../i18n/dist/index.d.ts", "../i18n/src/index.ts"],
+      "@acme/i18n/*": ["../i18n/dist/*", "../i18n/src/*"],
+      "@acme/email-templates": ["../email-templates/dist/index.d.ts", "../email-templates/src/index.ts"]
     }
   },
   "include": ["src*", "src*.json", "src/**/*", "src/**/*.json"],

--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -25,30 +25,31 @@
      * ---------------------------------------------------------------- */
     "paths": {
       /* this package itself */
-      "@acme/platform-machine": ["packages/platform-machine/src/index.ts"],
-      "@acme/platform-machine/*": ["packages/platform-machine/src/*"],
+      "@acme/platform-machine": ["packages/platform-machine/dist/index.d.ts", "packages/platform-machine/src/index.ts"],
+      "@acme/platform-machine/*": ["packages/platform-machine/dist/*", "packages/platform-machine/src/*"],
 
       /* platform core utilities */
-      "@platform-core": ["packages/platform-core/src/index.ts"],
-      "@platform-core/*": ["packages/platform-core/src/*"],
+      "@platform-core": ["packages/platform-core/dist/index.d.ts", "packages/platform-core/src/index.ts"],
+      "@platform-core/*": ["packages/platform-core/dist/*", "packages/platform-core/src/*"],
 
       /* shared lib utilities */
-      "@acme/lib": ["packages/lib/src/index.ts"],
-      "@acme/lib/*": ["packages/lib/src/*"],
+      "@acme/lib": ["packages/lib/dist/index.d.ts", "packages/lib/src/index.ts"],
+      "@acme/lib/*": ["packages/lib/dist/*", "packages/lib/src/*"],
 
       /* runtime config helper */
-      "@config": ["packages/config/src/env/index.ts"],
-      "@config/*": ["packages/config/src/env/*"],
+      "@config": ["packages/config/dist/env/index.d.ts", "packages/config/src/env/index.ts"],
+      "@config/*": ["packages/config/dist/env/*", "packages/config/src/env/*"],
 
-      "@acme/config": ["packages/config/src/index.ts"],
-      "@acme/config/*": ["packages/config/src/*"],
+      "@acme/config": ["packages/config/dist/index.d.ts", "packages/config/src/index.ts"],
+      "@acme/config/*": ["packages/config/dist/*", "packages/config/src/*"],
 
       /* date utilities */
-      "@date-utils": ["packages/date-utils/src/index.ts"],
+      "@date-utils": ["packages/date-utils/dist/index.d.ts", "packages/date-utils/src/index.ts"],
+      "@date-utils/*": ["packages/date-utils/dist/*", "packages/date-utils/src/*"],
 
       /* shared runtime types */
-      "@acme/types": ["packages/types/src/index.ts"],
-      "@acme/types/*": ["packages/types/src/*"]
+      "@acme/types": ["packages/types/dist/index.d.ts", "packages/types/src/index.ts"],
+      "@acme/types/*": ["packages/types/dist/*", "packages/types/src/*"]
     }
   },
 

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -8,10 +8,10 @@
     "rootDir": "src",
     "outDir": "dist",
     "paths": {
-      "@platform-core": ["packages/platform-core/src/index.ts"],
-      "@platform-core/*": ["packages/platform-core/src/*"],
-      "@date-utils": ["packages/date-utils/src/index.ts"],
-      "@date-utils/*": ["packages/date-utils/src/*"]
+      "@platform-core": ["packages/platform-core/dist/index.d.ts", "packages/platform-core/src/index.ts"],
+      "@platform-core/*": ["packages/platform-core/dist/*", "packages/platform-core/src/*"],
+      "@date-utils": ["packages/date-utils/dist/index.d.ts", "packages/date-utils/src/index.ts"],
+      "@date-utils/*": ["packages/date-utils/dist/*", "packages/date-utils/src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -27,7 +27,7 @@
         "../i18n/src/*"
       ],
       "@platform-core": [
-        "../platform-core/dist/index",
+        "../platform-core/dist/index.d.ts",
         "../platform-core/src/index.ts"
       ],
       "@platform-core/*": [
@@ -35,7 +35,7 @@
         "../platform-core/src/*"
       ],
       "@acme/platform-core": [
-        "../platform-core/dist/index",
+        "../platform-core/dist/index.d.ts",
         "../platform-core/src/index.ts"
       ],
       "@acme/platform-core/*": [
@@ -47,12 +47,12 @@
         "../config/src/index.ts"
       ],
       "@acme/config/*": [
-        "./src/env/*.ts",
         "../config/dist/*",
+        "./src/env/*.ts",
         "../config/src/*"
       ],
       "@auth": [
-        "../auth/dist/index",
+        "../auth/dist/index.d.ts",
         "../auth/dist",
         "../auth/src/index.ts",
         "../auth/src"
@@ -62,7 +62,7 @@
         "../auth/src/*"
       ],
       "@date-utils": [
-        "../date-utils/dist/index",
+        "../date-utils/dist/index.d.ts",
         "../date-utils/dist",
         "../date-utils/src/index.ts",
         "../date-utils/src"

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -18,16 +18,16 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@acme/platform-core": ["../platform-core/dist/index", "../platform-core/src/index"],
+      "@acme/platform-core": ["../platform-core/dist/index.d.ts", "../platform-core/src/index"],
       "@acme/platform-core/*": ["../platform-core/dist/*", "../platform-core/src/*"],
-      "@platform-core": ["../platform-core/dist/index", "../platform-core/src/index"],
+      "@platform-core": ["../platform-core/dist/index.d.ts", "../platform-core/src/index"],
       "@platform-core/*": ["../platform-core/dist/*", "../platform-core/src/*"],
-      "@acme/types": ["../types/dist/index", "../types/src/index"],
+      "@acme/types": ["../types/dist/index.d.ts", "../types/src/index"],
       "@acme/types/*": ["../types/dist/*", "../types/src/*"],
-      "@ui": ["./src/index"],
-      "@ui/*": ["./src/*"],
+      "@ui": ["./dist/index.d.ts", "./src/index"],
+      "@ui/*": ["./dist/*", "./src/*"],
       "@auth": ["types-compat/auth"],
-      "@acme/i18n": ["../i18n/dist/index", "../i18n/src/index"],
+      "@acme/i18n": ["../i18n/dist/index.d.ts", "../i18n/src/index"],
       "@acme/i18n/*": ["../i18n/dist/*", "../i18n/src/*"]
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,147 +30,195 @@
     ],
     "paths": {
       "@acme/platform-machine": [
+        "packages/platform-machine/dist/index.d.ts",
         "packages/platform-machine/src/index.ts"
       ],
       "@acme/platform-machine/*": [
+        "packages/platform-machine/dist/*",
         "packages/platform-machine/src/*"
       ],
       "@acme/ui": [
+        "packages/ui/dist/index.d.ts",
         "packages/ui/src/index.ts"
       ],
       "@acme/ui/*": [
+        "packages/ui/dist/*",
         "packages/ui/src/*"
       ],
       "@ui": [
+        "packages/ui/dist/index.d.ts",
         "packages/ui/src/index.ts"
       ],
       "@ui/*": [
+        "packages/ui/dist/*",
         "packages/ui/src/*"
       ],
       "@cms": [
+        "apps/cms/dist/index.d.ts",
         "apps/cms/src"
       ],
       "@cms/*": [
+        "apps/cms/dist/*",
         "apps/cms/src/*"
       ],
       "@themes/*": [
+        "packages/themes/*/dist/index.d.ts",
         "packages/themes/*/src"
       ],
       "@acme/lib": [
+        "packages/lib/dist/index.d.ts",
         "packages/lib/src/index.ts"
       ],
       "@acme/lib/*": [
+        "packages/lib/dist/*",
         "packages/lib/src/*"
       ],
       "@i18n": [
+        "packages/i18n/dist/index.d.ts",
         "packages/i18n/src/index.ts"
       ],
       "@i18n/*": [
+        "packages/i18n/dist/*",
         "packages/i18n/src/*"
       ],
       "@acme/i18n": [
+        "packages/i18n/dist/index.d.ts",
         "packages/i18n/src/index.ts"
       ],
       "@acme/i18n/*": [
+        "packages/i18n/dist/*",
         "packages/i18n/src/*"
       ],
       "@auth": [
+        "packages/auth/dist/index.d.ts",
         "packages/auth/src/index.ts"
       ],
       "@auth/*": [
+        "packages/auth/dist/*",
         "packages/auth/src/*"
       ],
       "@platform-core": [
+        "packages/platform-core/dist/index.d.ts",
         "packages/platform-core/src/index.ts"
       ],
       "@platform-core/*": [
+        "packages/platform-core/dist/*",
         "packages/platform-core/src/*"
       ],
       "@acme/platform-core": [
+        "packages/platform-core/dist/index.d.ts",
         "packages/platform-core/src/index.ts"
       ],
       "@acme/platform-core/*": [
+        "packages/platform-core/dist/*",
         "packages/platform-core/src/*"
       ],
       "@acme/shared-utils": [
+        "packages/shared-utils/dist/index.d.ts",
         "packages/shared-utils/src/index.ts"
       ],
       "@acme/shared-utils/*": [
+        "packages/shared-utils/dist/*",
         "packages/shared-utils/src/*"
       ],
       "@shared-utils": [
+        "packages/shared-utils/dist/index.d.ts",
         "packages/shared-utils/src/index.ts"
       ],
       "@shared-utils/*": [
+        "packages/shared-utils/dist/*",
         "packages/shared-utils/src/*"
       ],
       "@acme/email": [
+        "packages/email/dist/index.d.ts",
         "packages/email/src/index.ts"
       ],
       "@acme/email/*": [
+        "packages/email/dist/*",
         "packages/email/src/*"
       ],
       "@acme/email-templates": [
+        "packages/email-templates/dist/index.d.ts",
         "packages/email-templates/src/index.ts"
       ],
       "@acme/email-templates/*": [
+        "packages/email-templates/dist/*",
         "packages/email-templates/src/*"
       ],
       "@acme/stripe": [
+        "packages/stripe/dist/index.d.ts",
         "packages/stripe/src/index.ts"
       ],
       "@acme/stripe/*": [
+        "packages/stripe/dist/*",
         "packages/stripe/src/*"
       ],
       "@acme/sanity": [
+        "packages/sanity/dist/index.d.ts",
         "packages/sanity/src/index.ts"
       ],
       "@acme/sanity/*": [
+        "packages/sanity/dist/*",
         "packages/sanity/src/*"
       ],
       "@acme/date-utils": [
+        "packages/date-utils/dist/index.d.ts",
         "packages/date-utils/src/index.ts"
       ],
       "@acme/date-utils/*": [
+        "packages/date-utils/dist/*",
         "packages/date-utils/src/*"
       ],
       "@date-utils": [
+        "packages/date-utils/dist/index.d.ts",
         "packages/date-utils/src/index.ts"
       ],
       "@date-utils/*": [
+        "packages/date-utils/dist/*",
         "packages/date-utils/src/*"
       ],
       "@acme/config": [
+        "packages/config/dist/index.d.ts",
         "packages/config/src/index.ts"
       ],
       "@acme/config/*": [
+        "packages/config/dist/*",
         "packages/config/src/*"
       ],
       "@acme/configurator": [
+        "packages/configurator/dist/index.d.ts",
         "packages/configurator/src/index.ts"
       ],
       "@acme/configurator/*": [
+        "packages/configurator/dist/*",
         "packages/configurator/src/*"
       ],
       "@acme/next-config": [
+        "packages/next-config/dist/index.d.ts",
         "packages/next-config/src/index.ts"
       ],
       "@acme/next-config/*": [
+        "packages/next-config/dist/*",
         "packages/next-config/src/*"
       ],
       "@acme/tailwind-config": [
+        "packages/tailwind-config/dist/index.d.ts",
         "packages/tailwind-config/src/index.ts"
       ],
       "@acme/tailwind-config/*": [
+        "packages/tailwind-config/dist/*",
         "packages/tailwind-config/src/*"
       ],
       "@acme/zod-utils": [
+        "packages/zod-utils/dist/index.d.ts",
         "packages/zod-utils/src/index.ts"
       ],
       "@acme/zod-utils/*": [
+        "packages/zod-utils/dist/*",
         "packages/zod-utils/src/*"
       ],
       "better-sqlite3": [
+        "packages/platform-core/dist/types/better-sqlite3",
         "packages/platform-core/src/types/better-sqlite3"
       ]
     }


### PR DESCRIPTION
## Summary
- map workspace package aliases to built dist files before source
- propagate dist+src path mappings in package tsconfigs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '../../contexts/CartContext')*
- `node -e "const ts=require('typescript');const config=ts.readConfigFile('packages/configurator/tsconfig.json', ts.sys.readFile).config;const parsed=ts.parseJsonConfigFileContent(config, ts.sys, 'packages/configurator');const host=ts.createCompilerHost(parsed.options);const res=ts.resolveModuleName('@acme/config', '/workspace/base-shop/packages/configurator/src/index.ts', parsed.options, host);console.log(res.resolvedModule);"`

------
https://chatgpt.com/codex/tasks/task_e_68b87bd6fd5c832fb99901908dc87503