### PR TITLE
fix configurator type resolution

### DIFF
--- a/packages/configurator/tsconfig.json
+++ b/packages/configurator/tsconfig.json
@@ -12,8 +12,8 @@
     "lib": ["es2022"],
     "baseUrl": ".",
     "paths": {
-      "@acme/config": ["../config/dist/index.d.ts", "../config/src/index.ts"],
-      "@acme/config/*": ["../config/dist/*", "../config/src/*"]
+      "@acme/config": ["../config/src/index.ts", "../config/dist/index.d.ts"],
+      "@acme/config/*": ["../config/src/*", "../config/dist/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- prioritize source files for @acme/config in configurator TypeScript paths

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '../../contexts/CartContext')*
- `pnpm --filter @acme/config run check:references` *(fails: missing script)*
- `pnpm --filter @acme/config run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/config run build`
- `pnpm --filter @acme/configurator run check:references` *(fails: missing script)*
- `pnpm --filter @acme/configurator run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/configurator run build`
- `pnpm --filter @acme/configurator run test` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b885e7a310832fa3347d958077509a