### PR TITLE
fix(email): expose type declarations

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -7,9 +7,15 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "./analytics": "./dist/analytics.js"
+    "./analytics": {
+      "types": "./dist/analytics.d.ts",
+      "import": "./dist/analytics.js",
+      "default": "./dist/analytics.js"
+    }
   },
   "bin": {
     "email": "./src/bin.ts"


### PR DESCRIPTION
## Summary
- ensure `@acme/email` exports point to bundled type declarations

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Can't resolve '../../contexts/CartContext' in @acme/template-app)*
- `pnpm --filter @acme/email build`
- `pnpm --filter @acme/config build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec tsc -p functions/tsconfig.json` *(fails: Cannot find module '@platform-core/dataRoot', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8863c9314832fb1b09e3c6b48aa07