### PR TITLE
feat(tsconfig): prioritize source over built paths

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -7,44 +7,34 @@
     "rootDir": "./src",
     "paths": {
       "@acme/lib": [
-        "../../packages/lib/dist/index.d.ts",
-        "../../packages/lib/src/index.ts"
+        "../../packages/lib/src/index.ts", "../../packages/lib/dist/index.d.ts"
       ],
       "@acme/lib/*": [
-        "../../packages/lib/dist/*",
-        "../../packages/lib/src/*"
+        "../../packages/lib/src/*", "../../packages/lib/dist/*"
       ],
       "@acme/config": [
-        "../../packages/config/dist/index.d.ts",
-        "../../packages/config/src/index.ts"
+        "../../packages/config/src/index.ts", "../../packages/config/dist/index.d.ts"
       ],
       "@acme/config/*": [
-        "../../packages/config/dist/*",
-        "../../packages/config/src/*"
+        "../../packages/config/src/*", "../../packages/config/dist/*"
       ],
       "@acme/zod-utils": [
-        "../../packages/zod-utils/dist/index.d.ts",
-        "../../packages/zod-utils/src/index.ts"
+        "../../packages/zod-utils/src/index.ts", "../../packages/zod-utils/dist/index.d.ts"
       ],
       "@acme/zod-utils/*": [
-        "../../packages/zod-utils/dist/*",
-        "../../packages/zod-utils/src/*"
+        "../../packages/zod-utils/src/*", "../../packages/zod-utils/dist/*"
       ],
       "@platform-core": [
-        "../../packages/platform-core/dist/index.d.ts",
-        "../../packages/platform-core/src/index.ts"
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index.d.ts"
       ],
       "@platform-core/*": [
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ],
       "@acme/platform-core": [
-        "../../packages/platform-core/dist/index.d.ts",
-        "../../packages/platform-core/src/index.ts"
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index.d.ts"
       ],
       "@acme/platform-core/*": [
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ]
     }
   },

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -21,155 +21,119 @@
       "@/*": ["./src/*"],
       "@cms/*": ["./src/*"],
       "@/components/*": [
-        "../../packages/ui/dist/components/*",
-        "../../packages/ui/src/components/*"
+        "../../packages/ui/src/components/*", "../../packages/ui/dist/components/*"
       ],
       "@/lib/*": [
         "./src/lib/*",
-        "../../packages/ui/dist/lib/*",
         "../../packages/ui/src/lib/*",
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*",
+        "../../packages/ui/dist/lib/*",
+        "../../packages/platform-core/dist/*"
       ],
       "@/contexts/*": [
-        "../../packages/platform-core/dist/contexts/*",
-        "../../packages/platform-core/src/contexts/*"
+        "../../packages/platform-core/src/contexts/*", "../../packages/platform-core/dist/contexts/*"
       ],
       "@/i18n/*": [
-        "../../packages/i18n/dist/*",
-        "../../packages/i18n/src/*"
+        "../../packages/i18n/src/*", "../../packages/i18n/dist/*"
       ],
       "@i18n": [
-        "../../packages/i18n/dist/index",
-        "../../packages/i18n/src/index.ts"
+        "../../packages/i18n/src/index.ts", "../../packages/i18n/dist/index"
       ],
       "@i18n/*": [
-        "../../packages/i18n/dist/*",
-        "../../packages/i18n/src/*"
+        "../../packages/i18n/src/*", "../../packages/i18n/dist/*"
       ],
       "@ui/*": [
-        "../../packages/ui/dist/*",
-        "../../packages/ui/src/*"
+        "../../packages/ui/src/*", "../../packages/ui/dist/*"
       ],
       "@ui": [
-        "../../packages/ui/dist/index",
-        "../../packages/ui/src/index.ts"
+        "../../packages/ui/src/index.ts", "../../packages/ui/dist/index"
       ],
       "@acme/ui": [
-        "../../packages/ui/dist/index",
-        "../../packages/ui/src/index.ts"
+        "../../packages/ui/src/index.ts", "../../packages/ui/dist/index"
       ],
       "@acme/ui/*": [
-        "../../packages/ui/dist/*",
-        "../../packages/ui/src/*"
+        "../../packages/ui/src/*", "../../packages/ui/dist/*"
       ],
       "@auth": [
-        "../../packages/auth/dist/index",
-        "../../packages/auth/src/index.ts"
+        "../../packages/auth/src/index.ts", "../../packages/auth/dist/index"
       ],
       "@auth/*": [
-        "../../packages/auth/dist/*",
-        "../../packages/auth/src/*"
+        "../../packages/auth/src/*", "../../packages/auth/dist/*"
       ],
       "@acme/lib": [
-        "../../packages/lib/dist/index",
-        "../../packages/lib/src/index.ts"
+        "../../packages/lib/src/index.ts", "../../packages/lib/dist/index"
       ],
       "@acme/lib/*": [
-        "../../packages/lib/dist/*",
-        "../../packages/lib/src/*"
+        "../../packages/lib/src/*", "../../packages/lib/dist/*"
       ],
       "@acme/shared-utils": [
-        "../../packages/shared-utils/dist/index",
-        "../../packages/shared-utils/src/index.ts"
+        "../../packages/shared-utils/src/index.ts", "../../packages/shared-utils/dist/index"
       ],
       "@acme/shared-utils/*": [
-        "../../packages/shared-utils/dist/*",
-        "../../packages/shared-utils/src/*"
+        "../../packages/shared-utils/src/*", "../../packages/shared-utils/dist/*"
       ],
       "@acme/types": [
-        "../../packages/types/dist/index",
-        "../../packages/types/src/index.ts"
+        "../../packages/types/src/index.ts", "../../packages/types/dist/index"
       ],
       "@acme/types/*": [
-        "../../packages/types/dist/*",
-        "../../packages/types/src/*"
+        "../../packages/types/src/*", "../../packages/types/dist/*"
       ],
       "@shared-utils": [
-        "../../packages/shared-utils/dist/index",
-        "../../packages/shared-utils/src/index.ts"
+        "../../packages/shared-utils/src/index.ts", "../../packages/shared-utils/dist/index"
       ],
       "@shared-utils/*": [
-        "../../packages/shared-utils/dist/*",
-        "../../packages/shared-utils/src/*"
+        "../../packages/shared-utils/src/*", "../../packages/shared-utils/dist/*"
       ],
       "@date-utils": [
-        "../../packages/date-utils/dist/index",
-        "../../packages/date-utils/src/index.ts"
+        "../../packages/date-utils/src/index.ts", "../../packages/date-utils/dist/index"
       ],
       "@date-utils/*": [
-        "../../packages/date-utils/dist/*",
-        "../../packages/date-utils/src/*"
+        "../../packages/date-utils/src/*", "../../packages/date-utils/dist/*"
       ],
       "@themes/*": [
-        "../../packages/themes/*/dist",
-        "../../packages/themes/*/src"
+        "../../packages/themes/*/src", "../../packages/themes/*/dist"
       ],
       "@platform-core": [
-        "../../packages/platform-core/dist/index",
-        "../../packages/platform-core/src/index.ts"
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index"
       ],
       "@platform-core/*": [
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ],
       "@acme/platform-core": [
-        "../../packages/platform-core/dist/index",
-        "../../packages/platform-core/src/index.ts"
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index"
       ],
       "@acme/platform-core/*": [
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ],
       "@acme/email": [
-        "../../packages/email/dist/index",
-        "../../packages/email/src/index.ts"
+        "../../packages/email/src/index.ts", "../../packages/email/dist/index"
       ],
       "@acme/email/*": [
-        "../../packages/email/dist/*",
-        "../../packages/email/src/*"
+        "../../packages/email/src/*", "../../packages/email/dist/*"
       ],
       "@acme/email-templates": [
-        "../../packages/email-templates/dist/index",
-        "../../packages/email-templates/src/index.ts"
+        "../../packages/email-templates/src/index.ts", "../../packages/email-templates/dist/index"
       ],
       "@acme/email-templates/*": [
-        "../../packages/email-templates/dist/*",
-        "../../packages/email-templates/src/*"
+        "../../packages/email-templates/src/*", "../../packages/email-templates/dist/*"
       ],
       "@acme/config": [
-        "../../packages/config/dist/index",
-        "../../packages/config/src/index.ts"
+        "../../packages/config/src/index.ts", "../../packages/config/dist/index"
       ],
       "@acme/config/*": [
-        "../../packages/config/dist/*",
-        "../../packages/config/src/*"
+        "../../packages/config/src/*", "../../packages/config/dist/*"
       ],
       "@acme/i18n": [
-        "../../packages/i18n/dist/index",
-        "../../packages/i18n/src/index.ts"
+        "../../packages/i18n/src/index.ts", "../../packages/i18n/dist/index"
       ],
       "@acme/i18n/*": [
-        "../../packages/i18n/dist/*",
-        "../../packages/i18n/src/*"
+        "../../packages/i18n/src/*", "../../packages/i18n/dist/*"
       ],
       "@acme/zod-utils": [
-        "../../packages/zod-utils/dist/index",
-        "../../packages/zod-utils/src/index.ts"
+        "../../packages/zod-utils/src/index.ts", "../../packages/zod-utils/dist/index"
       ],
       "@acme/zod-utils/*": [
-        "../../packages/zod-utils/dist/*",
-        "../../packages/zod-utils/src/*"
+        "../../packages/zod-utils/src/*", "../../packages/zod-utils/dist/*"
       ]
     },
     "module": "ESNext",

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -6,12 +6,10 @@
     "paths": {
       "@/*": ["./src/*"],
       "@acme/types": [
-        "../../packages/types/dist/index.d.ts",
-        "../../packages/types/src/index.ts"
+        "../../packages/types/src/index.ts", "../../packages/types/dist/index.d.ts"
       ],
       "@acme/types/*": [
-        "../../packages/types/dist/*",
-        "../../packages/types/src/*"
+        "../../packages/types/src/*", "../../packages/types/dist/*"
       ]
     }
   },

--- a/apps/shop-bcd/tsconfig.json
+++ b/apps/shop-bcd/tsconfig.json
@@ -6,101 +6,86 @@
     "rootDir": "../..",
     "paths": {
       "@/*": [
-        "./dist/*",
+        "../../packages/ui/src/*",
+        "../../packages/i18n/src/*",
         "../../packages/ui/dist/src/*",
         "../../packages/i18n/dist/*",
-        "../../packages/ui/src/*",
-        "../../packages/i18n/src/*"
+        "./dist/*"
       ],
       "@ui/*": [
-        "../../packages/ui/dist/src/*",
-        "../../packages/ui/src/*"
+        "../../packages/ui/src/*", "../../packages/ui/dist/src/*"
       ],
       "@ui/src/*": [
-        "../../packages/ui/dist/src/*",
-        "../../packages/ui/src/*"
+        "../../packages/ui/src/*", "../../packages/ui/dist/src/*"
       ],
       "@i18n": [
-        "../../packages/i18n/dist/index",
-        "../../packages/i18n/src/index.ts"
+        "../../packages/i18n/src/index.ts", "../../packages/i18n/dist/index"
       ],
       "@i18n/*": [
-        "../../packages/i18n/dist/*",
-        "../../packages/i18n/src/*"
+        "../../packages/i18n/src/*", "../../packages/i18n/dist/*"
       ],
       "@acme/i18n": [
-        "../../packages/i18n/dist/index",
-        "../../packages/i18n/src/index.ts"
+        "../../packages/i18n/src/index.ts", "../../packages/i18n/dist/index"
       ],
       "@acme/i18n/*": [
-        "../../packages/i18n/dist/*",
-        "../../packages/i18n/src/*"
+        "../../packages/i18n/src/*", "../../packages/i18n/dist/*"
       ],
       "@platform-core": [
-        "../../packages/platform-core/dist/index",
-        "../../packages/platform-core/src/index.ts"
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index"
       ],
       "@platform-core/*": [
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ],
       "@acme/platform-core": [
-        "../../packages/platform-core/dist/index",
-        "../../packages/platform-core/src/index.ts"
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index"
       ],
       "@acme/platform-core/*": [
-        "../../packages/platform-core/dist/*",
-        "../../packages/platform-core/src/*"
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ],
       "@auth": [
-        "../../packages/auth/dist/index",
-        "../../packages/auth/dist",
         "../../packages/auth/src/index.ts",
-        "../../packages/auth/src"
+        "../../packages/auth/src",
+        "../../packages/auth/dist/index",
+        "../../packages/auth/dist"
       ],
       "@auth/*": [
-        "../../packages/auth/dist/*",
-        "../../packages/auth/src/*"
+        "../../packages/auth/src/*", "../../packages/auth/dist/*"
       ],
       "@date-utils": [
-        "../../packages/date-utils/dist/index",
-        "../../packages/date-utils/dist",
         "../../packages/date-utils/src/index.ts",
-        "../../packages/date-utils/src"
+        "../../packages/date-utils/src",
+        "../../packages/date-utils/dist/index",
+        "../../packages/date-utils/dist"
       ],
       "@date-utils/*": [
-        "../../packages/date-utils/dist/*",
-        "../../packages/date-utils/src/*"
+        "../../packages/date-utils/src/*", "../../packages/date-utils/dist/*"
       ],
       "@shared-utils": [
-        "../../packages/shared-utils/dist/index",
-        "../../packages/shared-utils/dist",
         "../../packages/shared-utils/src/index.ts",
-        "../../packages/shared-utils/src"
+        "../../packages/shared-utils/src",
+        "../../packages/shared-utils/dist/index",
+        "../../packages/shared-utils/dist"
       ],
       "@shared-utils/*": [
-        "../../packages/shared-utils/dist/*",
-        "../../packages/shared-utils/src/*"
+        "../../packages/shared-utils/src/*", "../../packages/shared-utils/dist/*"
       ],
       "@scripts": [
-        "../../scripts/dist/index",
-        "../../scripts/dist",
         "../../scripts/src/index.ts",
-        "../../scripts/src"
+        "../../scripts/src",
+        "../../scripts/dist/index",
+        "../../scripts/dist"
       ],
       "@scripts/*": [
-        "../../scripts/dist/*",
-        "../../scripts/src/*"
+        "../../scripts/src/*", "../../scripts/dist/*"
       ],
       "@acme/types": [
-        "../../packages/types/dist/index",
-        "../../packages/types/dist",
         "../../packages/types/src/index.ts",
-        "../../packages/types/src"
+        "../../packages/types/src",
+        "../../packages/types/dist/index",
+        "../../packages/types/dist"
       ],
       "@acme/types/*": [
-        "../../packages/types/dist/*",
-        "../../packages/types/src/*"
+        "../../packages/types/src/*", "../../packages/types/dist/*"
       ]
     },
     "module": "ESNext",

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -31,7 +31,7 @@
      */
     "baseUrl": ".",
     "paths": {
-      "@acme/email": ["../packages/email"]
+      "@acme/email": ["../packages/email/src/index.ts", "../packages/email"]
     }
   },
 

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -9,19 +9,17 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@date-utils": ["../date-utils/dist/index.d.ts", "../date-utils/src/index.ts", "types-compat/date-utils"],
+      "@date-utils": ["../date-utils/src/index.ts", "../date-utils/dist/index.d.ts", "types-compat/date-utils"],
       "@acme/email-templates": [
-        "../email-templates/dist/index.d.ts",
-        "../email-templates/src/index.ts"
+        "../email-templates/src/index.ts", "../email-templates/dist/index.d.ts"
       ],
       "@acme/email-templates/*": [
-        "../email-templates/dist/*",
-        "../email-templates/src/*"
+        "../email-templates/src/*", "../email-templates/dist/*"
       ],
-      "@platform-core": ["../platform-core/dist/index.d.ts", "../platform-core/src/index.ts"],
-      "@platform-core/*": ["../platform-core/dist/*", "../platform-core/src/*"],
-      "@acme/lib": ["../lib/dist/index.d.ts", "../lib/src/index.ts"],
-      "@acme/lib/*": ["../lib/dist/*", "../lib/src/*"]
+      "@platform-core": ["../platform-core/src/index.ts", "../platform-core/dist/index.d.ts"],
+      "@platform-core/*": ["../platform-core/src/*", "../platform-core/dist/*"],
+      "@acme/lib": ["../lib/src/index.ts", "../lib/dist/index.d.ts"],
+      "@acme/lib/*": ["../lib/src/*", "../lib/dist/*"]
     }
   },
   "include": ["src", "types-compat/**/*.d.ts"],

--- a/packages/platform-core/tsconfig.json
+++ b/packages/platform-core/tsconfig.json
@@ -18,24 +18,24 @@
     "verbatimModuleSyntax": true,
     "baseUrl": ".",
     "paths": {
-      "@acme/ui": ["../ui/dist/index.d.ts", "../ui/src/index.ts", "types-compat/ui"],
-      "@acme/ui/*": ["../ui/dist/*", "../ui/src/*"],
-      "@acme/platform-core": ["dist/index.d.ts", "src/index.ts"],
-      "@acme/platform-core/*": ["dist/*", "src/*"],
+      "@acme/ui": ["../ui/src/index.ts", "../ui/dist/index.d.ts", "types-compat/ui"],
+      "@acme/ui/*": ["../ui/src/*", "../ui/dist/*"],
+      "@acme/platform-core": ["src/index.ts", "dist/index.d.ts"],
+      "@acme/platform-core/*": ["src/*", "dist/*"],
 
-      "@acme/shared-utils": ["../shared-utils/dist/index.d.ts", "../shared-utils/src/index.ts"],
-      "@acme/shared-utils/*": ["../shared-utils/dist/*", "../shared-utils/src/*"],
-      "@acme/date-utils": ["../date-utils/dist/index.d.ts", "../date-utils/src/index.ts"],
-      "@acme/date-utils/*": ["../date-utils/dist/*", "../date-utils/src/*"],
-      "@acme/stripe": ["../stripe/dist/index.d.ts", "../stripe/src/index.ts"],
-      "@acme/stripe/*": ["../stripe/dist/*", "../stripe/src/*"],
+      "@acme/shared-utils": ["../shared-utils/src/index.ts", "../shared-utils/dist/index.d.ts"],
+      "@acme/shared-utils/*": ["../shared-utils/src/*", "../shared-utils/dist/*"],
+      "@acme/date-utils": ["../date-utils/src/index.ts", "../date-utils/dist/index.d.ts"],
+      "@acme/date-utils/*": ["../date-utils/src/*", "../date-utils/dist/*"],
+      "@acme/stripe": ["../stripe/src/index.ts", "../stripe/dist/index.d.ts"],
+      "@acme/stripe/*": ["../stripe/src/*", "../stripe/dist/*"],
 
-      "better-sqlite3": ["dist/types/better-sqlite3", "src/types/better-sqlite3"],
+      "better-sqlite3": ["src/types/better-sqlite3", "dist/types/better-sqlite3"],
 
-      "@acme/config/env/*": ["../config/dist/env/*", "../config/src/env/*"],
-      "@acme/i18n": ["../i18n/dist/index.d.ts", "../i18n/src/index.ts"],
-      "@acme/i18n/*": ["../i18n/dist/*", "../i18n/src/*"],
-      "@acme/email-templates": ["../email-templates/dist/index.d.ts", "../email-templates/src/index.ts"]
+      "@acme/config/env/*": ["../config/src/env/*", "../config/dist/env/*"],
+      "@acme/i18n": ["../i18n/src/index.ts", "../i18n/dist/index.d.ts"],
+      "@acme/i18n/*": ["../i18n/src/*", "../i18n/dist/*"],
+      "@acme/email-templates": ["../email-templates/src/index.ts", "../email-templates/dist/index.d.ts"]
     }
   },
   "include": ["src*", "src*.json", "src/**/*", "src/**/*.json"],

--- a/packages/platform-machine/tsconfig.json
+++ b/packages/platform-machine/tsconfig.json
@@ -25,31 +25,31 @@
      * ---------------------------------------------------------------- */
     "paths": {
       /* this package itself */
-      "@acme/platform-machine": ["packages/platform-machine/dist/index.d.ts", "packages/platform-machine/src/index.ts"],
-      "@acme/platform-machine/*": ["packages/platform-machine/dist/*", "packages/platform-machine/src/*"],
+      "@acme/platform-machine": ["packages/platform-machine/src/index.ts", "packages/platform-machine/dist/index.d.ts"],
+      "@acme/platform-machine/*": ["packages/platform-machine/src/*", "packages/platform-machine/dist/*"],
 
       /* platform core utilities */
-      "@platform-core": ["packages/platform-core/dist/index.d.ts", "packages/platform-core/src/index.ts"],
-      "@platform-core/*": ["packages/platform-core/dist/*", "packages/platform-core/src/*"],
+      "@platform-core": ["packages/platform-core/src/index.ts", "packages/platform-core/dist/index.d.ts"],
+      "@platform-core/*": ["packages/platform-core/src/*", "packages/platform-core/dist/*"],
 
       /* shared lib utilities */
-      "@acme/lib": ["packages/lib/dist/index.d.ts", "packages/lib/src/index.ts"],
-      "@acme/lib/*": ["packages/lib/dist/*", "packages/lib/src/*"],
+      "@acme/lib": ["packages/lib/src/index.ts", "packages/lib/dist/index.d.ts"],
+      "@acme/lib/*": ["packages/lib/src/*", "packages/lib/dist/*"],
 
       /* runtime config helper */
-      "@config": ["packages/config/dist/env/index.d.ts", "packages/config/src/env/index.ts"],
-      "@config/*": ["packages/config/dist/env/*", "packages/config/src/env/*"],
+      "@config": ["packages/config/src/env/index.ts", "packages/config/dist/env/index.d.ts"],
+      "@config/*": ["packages/config/src/env/*", "packages/config/dist/env/*"],
 
-      "@acme/config": ["packages/config/dist/index.d.ts", "packages/config/src/index.ts"],
-      "@acme/config/*": ["packages/config/dist/*", "packages/config/src/*"],
+      "@acme/config": ["packages/config/src/index.ts", "packages/config/dist/index.d.ts"],
+      "@acme/config/*": ["packages/config/src/*", "packages/config/dist/*"],
 
       /* date utilities */
-      "@date-utils": ["packages/date-utils/dist/index.d.ts", "packages/date-utils/src/index.ts"],
-      "@date-utils/*": ["packages/date-utils/dist/*", "packages/date-utils/src/*"],
+      "@date-utils": ["packages/date-utils/src/index.ts", "packages/date-utils/dist/index.d.ts"],
+      "@date-utils/*": ["packages/date-utils/src/*", "packages/date-utils/dist/*"],
 
       /* shared runtime types */
-      "@acme/types": ["packages/types/dist/index.d.ts", "packages/types/src/index.ts"],
-      "@acme/types/*": ["packages/types/dist/*", "packages/types/src/*"]
+      "@acme/types": ["packages/types/src/index.ts", "packages/types/dist/index.d.ts"],
+      "@acme/types/*": ["packages/types/src/*", "packages/types/dist/*"]
     }
   },
 

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -10,8 +10,8 @@
     "paths": {
       "@platform-core": ["packages/platform-core/src/index.ts", "packages/platform-core/dist/index.d.ts"],
       "@platform-core/*": ["packages/platform-core/src/*", "packages/platform-core/dist/*"],
-      "@date-utils": ["packages/date-utils/dist/index.d.ts", "packages/date-utils/src/index.ts"],
-      "@date-utils/*": ["packages/date-utils/dist/*", "packages/date-utils/src/*"]
+      "@date-utils": ["packages/date-utils/src/index.ts", "packages/date-utils/dist/index.d.ts"],
+      "@date-utils/*": ["packages/date-utils/src/*", "packages/date-utils/dist/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/template-app/tsconfig.json
+++ b/packages/template-app/tsconfig.json
@@ -7,73 +7,62 @@
     "resolveJsonModule": true,
     "paths": {
       "@/*": [
-        "./dist/*",
-        "../ui/dist/src/*",
-        "../i18n/dist/*",
         "./src/*",
         "../ui/src/*",
-        "../i18n/src/*"
+        "../i18n/src/*",
+        "../ui/dist/src/*",
+        "../i18n/dist/*",
+        "./dist/*"
       ],
       "@ui/*": [
-        "../ui/dist/src/*",
-        "../ui/src/*"
+        "../ui/src/*", "../ui/dist/src/*"
       ],
       "@ui/src/*": [
-        "../ui/dist/src/*",
-        "../ui/src/*"
+        "../ui/src/*", "../ui/dist/src/*"
       ],
       "@i18n/*": [
-        "../i18n/dist/*",
-        "../i18n/src/*"
+        "../i18n/src/*", "../i18n/dist/*"
       ],
       "@platform-core": [
-        "../platform-core/dist/index.d.ts",
-        "../platform-core/src/index.ts"
+        "../platform-core/src/index.ts", "../platform-core/dist/index.d.ts"
       ],
       "@platform-core/*": [
-        "../platform-core/dist/*",
-        "../platform-core/src/*"
+        "../platform-core/src/*", "../platform-core/dist/*"
       ],
       "@acme/platform-core": [
-        "../platform-core/dist/index.d.ts",
-        "../platform-core/src/index.ts"
+        "../platform-core/src/index.ts", "../platform-core/dist/index.d.ts"
       ],
       "@acme/platform-core/*": [
-        "../platform-core/dist/*",
-        "../platform-core/src/*"
+        "../platform-core/src/*", "../platform-core/dist/*"
       ],
       "@acme/config": [
-        "../config/dist/index.d.ts",
-        "../config/src/index.ts"
+        "../config/src/index.ts", "../config/dist/index.d.ts"
       ],
       "@acme/config/*": [
-        "../config/dist/*",
         "./src/env/*.ts",
-        "../config/src/*"
+        "../config/src/*",
+        "../config/dist/*"
       ],
       "@auth": [
-        "../auth/dist/index.d.ts",
-        "../auth/dist",
         "../auth/src/index.ts",
-        "../auth/src"
+        "../auth/src",
+        "../auth/dist/index.d.ts",
+        "../auth/dist"
       ],
       "@auth/*": [
-        "../auth/dist/*",
-        "../auth/src/*"
+        "../auth/src/*", "../auth/dist/*"
       ],
       "@date-utils": [
-        "../date-utils/dist/index.d.ts",
-        "../date-utils/dist",
         "../date-utils/src/index.ts",
-        "../date-utils/src"
+        "../date-utils/src",
+        "../date-utils/dist/index.d.ts",
+        "../date-utils/dist"
       ],
       "@date-utils/*": [
-        "../date-utils/dist/*",
-        "../date-utils/src/*"
+        "../date-utils/src/*", "../date-utils/dist/*"
       ],
       "better-sqlite3": [
-        "../platform-core/dist/types/better-sqlite3",
-        "../platform-core/src/types/better-sqlite3"
+        "../platform-core/src/types/better-sqlite3", "../platform-core/dist/types/better-sqlite3"
       ]
     },
     "allowJs": true,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -18,17 +18,17 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@acme/platform-core": ["../platform-core/dist/index.d.ts", "../platform-core/src/index"],
-      "@acme/platform-core/*": ["../platform-core/dist/*", "../platform-core/src/*"],
-      "@platform-core": ["../platform-core/dist/index.d.ts", "../platform-core/src/index"],
-      "@platform-core/*": ["../platform-core/dist/*", "../platform-core/src/*"],
-      "@acme/types": ["../types/dist/index.d.ts", "../types/src/index"],
-      "@acme/types/*": ["../types/dist/*", "../types/src/*"],
-      "@ui": ["./dist/index.d.ts", "./src/index"],
-      "@ui/*": ["./dist/*", "./src/*"],
+      "@acme/platform-core": ["../platform-core/src/index", "../platform-core/dist/index.d.ts"],
+      "@acme/platform-core/*": ["../platform-core/src/*", "../platform-core/dist/*"],
+      "@platform-core": ["../platform-core/src/index", "../platform-core/dist/index.d.ts"],
+      "@platform-core/*": ["../platform-core/src/*", "../platform-core/dist/*"],
+      "@acme/types": ["../types/src/index", "../types/dist/index.d.ts"],
+      "@acme/types/*": ["../types/src/*", "../types/dist/*"],
+      "@ui": ["./src/index", "./dist/index.d.ts"],
+      "@ui/*": ["./src/*", "./dist/*"],
       "@auth": ["types-compat/auth"],
-      "@acme/i18n": ["../i18n/dist/index.d.ts", "../i18n/src/index"],
-      "@acme/i18n/*": ["../i18n/dist/*", "../i18n/src/*"]
+      "@acme/i18n": ["../i18n/src/index", "../i18n/dist/index.d.ts"],
+      "@acme/i18n/*": ["../i18n/src/*", "../i18n/dist/*"]
     }
   },
   "references": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,72 +30,72 @@
     ],
     "paths": {
       "@acme/platform-machine": [
-        "packages/platform-machine/dist/index.d.ts",
-        "packages/platform-machine/src/index.ts"
+        "packages/platform-machine/src/index.ts",
+        "packages/platform-machine/dist/index.d.ts"
       ],
       "@acme/platform-machine/*": [
-        "packages/platform-machine/dist/*",
-        "packages/platform-machine/src/*"
+        "packages/platform-machine/src/*",
+        "packages/platform-machine/dist/*"
       ],
       "@acme/ui": [
-        "packages/ui/dist/index.d.ts",
-        "packages/ui/src/index.ts"
+        "packages/ui/src/index.ts",
+        "packages/ui/dist/index.d.ts"
       ],
       "@acme/ui/*": [
-        "packages/ui/dist/*",
-        "packages/ui/src/*"
+        "packages/ui/src/*",
+        "packages/ui/dist/*"
       ],
       "@ui": [
-        "packages/ui/dist/index.d.ts",
-        "packages/ui/src/index.ts"
+        "packages/ui/src/index.ts",
+        "packages/ui/dist/index.d.ts"
       ],
       "@ui/*": [
-        "packages/ui/dist/*",
-        "packages/ui/src/*"
+        "packages/ui/src/*",
+        "packages/ui/dist/*"
       ],
       "@cms": [
-        "apps/cms/dist/index.d.ts",
-        "apps/cms/src"
+        "apps/cms/src",
+        "apps/cms/dist/index.d.ts"
       ],
       "@cms/*": [
-        "apps/cms/dist/*",
-        "apps/cms/src/*"
+        "apps/cms/src/*",
+        "apps/cms/dist/*"
       ],
       "@themes/*": [
-        "packages/themes/*/dist/index.d.ts",
-        "packages/themes/*/src"
+        "packages/themes/*/src",
+        "packages/themes/*/dist/index.d.ts"
       ],
       "@acme/lib": [
-        "packages/lib/dist/index.d.ts",
-        "packages/lib/src/index.ts"
+        "packages/lib/src/index.ts",
+        "packages/lib/dist/index.d.ts"
       ],
       "@acme/lib/*": [
-        "packages/lib/dist/*",
-        "packages/lib/src/*"
+        "packages/lib/src/*",
+        "packages/lib/dist/*"
       ],
       "@i18n": [
-        "packages/i18n/dist/index.d.ts",
-        "packages/i18n/src/index.ts"
+        "packages/i18n/src/index.ts",
+        "packages/i18n/dist/index.d.ts"
       ],
       "@i18n/*": [
-        "packages/i18n/dist/*",
-        "packages/i18n/src/*"
+        "packages/i18n/src/*",
+        "packages/i18n/dist/*"
       ],
       "@acme/i18n": [
-        "packages/i18n/dist/index.d.ts",
-        "packages/i18n/src/index.ts"
+        "packages/i18n/src/index.ts",
+        "packages/i18n/dist/index.d.ts"
       ],
       "@acme/i18n/*": [
-        "packages/i18n/dist/*",
-        "packages/i18n/src/*"
+        "packages/i18n/src/*",
+        "packages/i18n/dist/*"
       ],
       "@auth": [
-        "packages/auth/dist/index.d.ts",
-        "packages/auth/src/index.ts"
+        "packages/auth/src/index.ts",
+        "packages/auth/dist/index.d.ts"
       ],
       "@auth/*": [
-        "packages/auth/dist/*",
-        "packages/auth/src/*"
+        "packages/auth/src/*",
+        "packages/auth/dist/*"
       ],
       "@platform-core": [
         "packages/platform-core/src/index.ts",
@@ -114,112 +114,112 @@
         "packages/platform-core/dist/*"
       ],
       "@acme/shared-utils": [
-        "packages/shared-utils/dist/index.d.ts",
-        "packages/shared-utils/src/index.ts"
+        "packages/shared-utils/src/index.ts",
+        "packages/shared-utils/dist/index.d.ts"
       ],
       "@acme/shared-utils/*": [
-        "packages/shared-utils/dist/*",
-        "packages/shared-utils/src/*"
+        "packages/shared-utils/src/*",
+        "packages/shared-utils/dist/*"
       ],
       "@shared-utils": [
-        "packages/shared-utils/dist/index.d.ts",
-        "packages/shared-utils/src/index.ts"
+        "packages/shared-utils/src/index.ts",
+        "packages/shared-utils/dist/index.d.ts"
       ],
       "@shared-utils/*": [
-        "packages/shared-utils/dist/*",
-        "packages/shared-utils/src/*"
+        "packages/shared-utils/src/*",
+        "packages/shared-utils/dist/*"
       ],
       "@acme/email": [
-        "packages/email/dist/index.d.ts",
-        "packages/email/src/index.ts"
+        "packages/email/src/index.ts",
+        "packages/email/dist/index.d.ts"
       ],
       "@acme/email/*": [
-        "packages/email/dist/*",
-        "packages/email/src/*"
+        "packages/email/src/*",
+        "packages/email/dist/*"
       ],
       "@acme/email-templates": [
-        "packages/email-templates/dist/index.d.ts",
-        "packages/email-templates/src/index.ts"
+        "packages/email-templates/src/index.ts",
+        "packages/email-templates/dist/index.d.ts"
       ],
       "@acme/email-templates/*": [
-        "packages/email-templates/dist/*",
-        "packages/email-templates/src/*"
+        "packages/email-templates/src/*",
+        "packages/email-templates/dist/*"
       ],
       "@acme/stripe": [
-        "packages/stripe/dist/index.d.ts",
-        "packages/stripe/src/index.ts"
+        "packages/stripe/src/index.ts",
+        "packages/stripe/dist/index.d.ts"
       ],
       "@acme/stripe/*": [
-        "packages/stripe/dist/*",
-        "packages/stripe/src/*"
+        "packages/stripe/src/*",
+        "packages/stripe/dist/*"
       ],
       "@acme/sanity": [
-        "packages/sanity/dist/index.d.ts",
-        "packages/sanity/src/index.ts"
+        "packages/sanity/src/index.ts",
+        "packages/sanity/dist/index.d.ts"
       ],
       "@acme/sanity/*": [
-        "packages/sanity/dist/*",
-        "packages/sanity/src/*"
+        "packages/sanity/src/*",
+        "packages/sanity/dist/*"
       ],
       "@acme/date-utils": [
-        "packages/date-utils/dist/index.d.ts",
-        "packages/date-utils/src/index.ts"
+        "packages/date-utils/src/index.ts",
+        "packages/date-utils/dist/index.d.ts"
       ],
       "@acme/date-utils/*": [
-        "packages/date-utils/dist/*",
-        "packages/date-utils/src/*"
+        "packages/date-utils/src/*",
+        "packages/date-utils/dist/*"
       ],
       "@date-utils": [
-        "packages/date-utils/dist/index.d.ts",
-        "packages/date-utils/src/index.ts"
+        "packages/date-utils/src/index.ts",
+        "packages/date-utils/dist/index.d.ts"
       ],
       "@date-utils/*": [
-        "packages/date-utils/dist/*",
-        "packages/date-utils/src/*"
+        "packages/date-utils/src/*",
+        "packages/date-utils/dist/*"
       ],
       "@acme/config": [
-        "packages/config/dist/index.d.ts",
-        "packages/config/src/index.ts"
+        "packages/config/src/index.ts",
+        "packages/config/dist/index.d.ts"
       ],
       "@acme/config/*": [
-        "packages/config/dist/*",
-        "packages/config/src/*"
+        "packages/config/src/*",
+        "packages/config/dist/*"
       ],
       "@acme/configurator": [
-        "packages/configurator/dist/index.d.ts",
-        "packages/configurator/src/index.ts"
+        "packages/configurator/src/index.ts",
+        "packages/configurator/dist/index.d.ts"
       ],
       "@acme/configurator/*": [
-        "packages/configurator/dist/*",
-        "packages/configurator/src/*"
+        "packages/configurator/src/*",
+        "packages/configurator/dist/*"
       ],
       "@acme/next-config": [
-        "packages/next-config/dist/index.d.ts",
-        "packages/next-config/src/index.ts"
+        "packages/next-config/src/index.ts",
+        "packages/next-config/dist/index.d.ts"
       ],
       "@acme/next-config/*": [
-        "packages/next-config/dist/*",
-        "packages/next-config/src/*"
+        "packages/next-config/src/*",
+        "packages/next-config/dist/*"
       ],
       "@acme/tailwind-config": [
-        "packages/tailwind-config/dist/index.d.ts",
-        "packages/tailwind-config/src/index.ts"
+        "packages/tailwind-config/src/index.ts",
+        "packages/tailwind-config/dist/index.d.ts"
       ],
       "@acme/tailwind-config/*": [
-        "packages/tailwind-config/dist/*",
-        "packages/tailwind-config/src/*"
+        "packages/tailwind-config/src/*",
+        "packages/tailwind-config/dist/*"
       ],
       "@acme/zod-utils": [
-        "packages/zod-utils/dist/index.d.ts",
-        "packages/zod-utils/src/index.ts"
+        "packages/zod-utils/src/index.ts",
+        "packages/zod-utils/dist/index.d.ts"
       ],
       "@acme/zod-utils/*": [
-        "packages/zod-utils/dist/*",
-        "packages/zod-utils/src/*"
+        "packages/zod-utils/src/*",
+        "packages/zod-utils/dist/*"
       ],
       "better-sqlite3": [
-        "packages/platform-core/dist/types/better-sqlite3",
-        "packages/platform-core/src/types/better-sqlite3"
+        "packages/platform-core/src/types/better-sqlite3",
+        "packages/platform-core/dist/types/better-sqlite3"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- prioritize package source files before built artifacts in global tsconfig paths
- align package and app tsconfig paths with source-first resolution
- ensure functions worker resolves email package from source when available

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*


------
https://chatgpt.com/codex/tasks/task_e_68b888d935a8832f8c7a1595c26b96c8