### PR TITLE
fix(date-utils): treat timezone-less strings as UTC

### DIFF
--- a/packages/date-utils/src/index.ts
+++ b/packages/date-utils/src/index.ts
@@ -55,9 +55,15 @@ export function parseTargetDate(
 ): Date | null {
   if (!targetDate) return null;
   try {
-    const date = timezone
-      ? fromZonedTime(targetDate, timezone)
-      : parseISO(targetDate);
+    let date: Date;
+    if (timezone) {
+      date = fromZonedTime(targetDate, timezone);
+    } else {
+      const hasZone = /([zZ]|[+-]\d{2}:\d{2})$/.test(targetDate);
+      date = !hasZone && targetDate.includes("T")
+        ? parseISO(`${targetDate}Z`)
+        : parseISO(targetDate);
+    }
     return Number.isNaN(date.getTime()) ? null : date;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- ensure parseTargetDate treats strings without timezone as UTC

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve '../../contexts/CartContext')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec tsc -b --verbose`
- `pnpm exec jest packages/date-utils/__tests__/date.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b889f78654832f995536c9a54d8c8b