### PR TITLE
test(i18n): add fillLocales fallback test

### DIFF
--- a/packages/i18n/src/__tests__/fillLocales.test.ts
+++ b/packages/i18n/src/__tests__/fillLocales.test.ts
@@ -1,0 +1,17 @@
+import { fillLocales } from "../fillLocales";
+import { LOCALES } from "../locales";
+
+describe("fillLocales", () => {
+  it("fills missing locales with the fallback and keeps provided values", () => {
+    const result = fillLocales({ en: "Hello" }, "Hi");
+
+    expect(Object.keys(result)).toEqual([...LOCALES]);
+    for (const locale of LOCALES) {
+      if (locale === "en") {
+        expect(result[locale]).toBe("Hello");
+      } else {
+        expect(result[locale]).toBe("Hi");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- test fillLocales with partial locale map and fallback

## Testing
- `pnpm exec jest packages/i18n/src/__tests__/fillLocales.test.ts --config jest.config.cjs`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b88e7d6b98832fab67025c65e758c0