### PR TITLE
test(config): cover shipping env error cases

### DIFF
--- a/packages/config/src/env/__tests__/shipping.test.ts
+++ b/packages/config/src/env/__tests__/shipping.test.ts
@@ -472,5 +472,39 @@ describe("shipping env module", () => {
     expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
+
+  it("loadShippingEnv logs and throws on numeric UPS_KEY", async () => {
+    const { loadShippingEnv } = await import("../shipping.ts");
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => loadShippingEnv({ UPS_KEY: 123 as any })).toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        UPS_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("eager parse fails when DHL_KEY is null", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      DHL_KEY: null as any,
+    } as NodeJS.ProcessEnv;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.resetModules();
+    await expect(import("../shipping.ts")).rejects.toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid shipping environment variables:",
+      expect.objectContaining({
+        DHL_KEY: { _errors: [expect.any(String)] },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add test for invalid UPS_KEY showing console error and thrown exception
- add test verifying eager import fails when DHL_KEY is null

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found in @acme/template-app)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/config test src/env/__tests__/shipping.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b88e97fe38832f8d1f496f644ee6e7