### PR TITLE
test: add translations provider tests

### DIFF
--- a/packages/i18n/src/__tests__/Translations.test.tsx
+++ b/packages/i18n/src/__tests__/Translations.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { TranslationsProvider, useTranslations } from "../Translations";
+
+describe("TranslationsProvider and useTranslations", () => {
+  it("returns translations from provided messages", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TranslationsProvider messages={{ hello: "Hallo" }}>
+        {children}
+      </TranslationsProvider>
+    );
+
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current("hello")).toBe("Hallo");
+  });
+
+  it("falls back to key when translation is missing", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TranslationsProvider messages={{}}>{children}</TranslationsProvider>
+    );
+
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current("missing")).toBe("missing");
+  });
+
+  it("memoises translator function when messages remain unchanged", () => {
+    const messages = { hello: "Hallo" };
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TranslationsProvider messages={messages}>{children}</TranslationsProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useTranslations(), { wrapper });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for TranslationsProvider and useTranslations
- cover translation fallback and memoisation behavior

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/i18n test` *(fails: Cannot find module '../utils/args')*


------
https://chatgpt.com/codex/tasks/task_e_68b88e7c701c832fb0b57c32557d182f