### PR TITLE
fix: add telemetry path mapping

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -209,6 +209,14 @@
         "packages/tailwind-config/src/*",
         "packages/tailwind-config/dist/*"
       ],
+      "@acme/telemetry": [
+        "packages/telemetry/src/index.ts",
+        "packages/telemetry/dist/index.d.ts"
+      ],
+      "@acme/telemetry/*": [
+        "packages/telemetry/src/*",
+        "packages/telemetry/dist/*"
+      ],
       "@acme/zod-utils": [
         "packages/zod-utils/src/index.ts",
         "packages/zod-utils/dist/index.d.ts"


### PR DESCRIPTION
## Summary
- map `@acme/telemetry` in tsconfig paths

## Testing
- `pnpm -r build` *(fails: packages/auth build: Failed, packages/ui build: Failed)*
- `pnpm exec jest apps/cms/__tests__/configurator/useLaunchShop.test.ts --runInBand` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b89519e560832fb7e213e4afbaef85