### PR TITLE
Map @acme/platform-core to source in Jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -176,6 +176,8 @@ const config = {
     '^@acme/config/env/(.*)$': ' /packages/config/src/env/$1.ts',
     '^@acme/config$': ' /packages/config/src/env/index.ts',
     '^@acme/config/(.*)$': ' /packages/config/src/$1',
+    '^@acme/platform-core$': ' /packages/platform-core/src/index.ts',
+    '^@acme/platform-core/(.*)$': ' /packages/platform-core/src/$1',
     '^@acme/platform-machine/src/(.*)$': ' /packages/platform-machine/src/$1',
     '^@acme/plugin-sanity$': ' /test/__mocks__/pluginSanityStub.ts',
     '^@acme/plugin-sanity/(.*)$': ' /test/__mocks__/pluginSanityStub.ts',


### PR DESCRIPTION
## Summary
- map `@acme/platform-core` to source files in Jest config to fix ESM import errors during tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx packages/ui/src/components/organisms/__tests__/Header.test.tsx --runInBand --detectOpenHandles --config jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b894552130832f8b1f15ca3bbcfde2