### PR TITLE
fix(SearchResultsTemplate): mock correct currency context

### DIFF
--- a/packages/ui/src/components/templates/__tests__/SearchResultsTemplate.test.tsx
+++ b/packages/ui/src/components/templates/__tests__/SearchResultsTemplate.test.tsx
@@ -5,7 +5,7 @@ import { SearchResultsTemplate } from "../SearchResultsTemplate";
 import type { SKU } from "@acme/types";
 import "../../../../../../test/resetNextMocks";
 
-jest.mock("@platform-core/contexts/CurrencyContext", () => ({
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
   useCurrency: () => ["USD", jest.fn()],
 }));
 


### PR DESCRIPTION
## Summary
- fix SearchResultsTemplate test to mock the currency context using the @acme namespace

## Testing
- `pnpm exec jest packages/ui/src/components/templates/__tests__/SearchResultsTemplate.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b893c4d6c0832f8a3f8fe60a65dc51