### PR TITLE
test: cover core env fallback

### DIFF
--- a/packages/platform-machine/src/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/src/__tests__/lateFeeService.test.ts
@@ -228,6 +228,15 @@ describe("resolveConfig", () => {
     const cfg = await service.resolveConfig("s1", "/data", { intervalMinutes: 5 });
     expect(cfg).toEqual({ enabled: true, intervalMinutes: 5 });
   });
+
+  it("falls back to core env values when settings file and env vars missing", async () => {
+    readFileMock.mockRejectedValueOnce(new Error("boom"));
+    (coreEnv as any).LATE_FEE_ENABLED = true;
+    (coreEnv as any).LATE_FEE_INTERVAL_MS = 15 * 60 * 1000;
+
+    const cfg = await service.resolveConfig("s1", "/data");
+    expect(cfg).toEqual({ enabled: true, intervalMinutes: 15 });
+  });
 });
 
 describe("startLateFeeService", () => {


### PR DESCRIPTION
## Summary
- test late fee service core env fallbacks

## Testing
- `pnpm --filter @acme/platform-machine run test -- --coverage`
- `pnpm exec jest packages/platform-machine/src/__tests__/lateFeeService.test.ts --config jest.config.cjs --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b895905808832f9db5355ca3226669