### PR TITLE
refactor: stabilize product preview fetching

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -21,29 +21,32 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
     setProduct(null);
     onValidChange?.(false);
 
-    fetch(`/api/products?slug=${encodeURIComponent(slug)}`, {
-      signal: controller.signal,
-    })
-      .then((res) => {
+    (async () => {
+      try {
+        const url = new URL(
+          `/api/products?slug=${encodeURIComponent(slug)}`,
+          globalThis.location?.origin ?? "http://localhost"
+        );
+
+        const res = await fetch(url.toString(), {
+          signal: controller.signal,
+        });
         if (!res.ok) throw new Error("Failed to load product");
-        return res.json() as Promise<SKU>;
-      })
-      .then((data) => {
+        const data = (await res.json()) as SKU;
         setProduct(data);
         setError(null);
         onValidChange?.(true);
-      })
-      .catch(() => {
+      } catch {
         if (!controller.signal.aborted) {
           setError("Failed to load product");
           onValidChange?.(false);
         }
-      })
-      .finally(() => {
+      } finally {
         if (!controller.signal.aborted) {
           setLoading(false);
         }
-      });
+      }
+    })();
 
     return () => {
       controller.abort();


### PR DESCRIPTION
## Summary
- build ProductPreview fetch URL with an absolute origin and handle errors via async/await
- simplify ProductPreview tests to use MSW server and validate callbacks

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @apps/cms test apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx`
- `pnpm --filter @apps/cms test` *(fails: products.test.ts timeout, seoTimelineRevert.test.ts timeout)*


------
https://chatgpt.com/codex/tasks/task_e_68b894fb2580832fb0e5371f5c9c6bc3