### PR TITLE
chore: allow jest to transpile internal packages

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -139,8 +139,10 @@ const config = {
     ],
   },
   transformIgnorePatterns: [
-    // Transpile ESM‑only dependencies that would break under CommonJS
-    '/node_modules/(?!(jose|next-auth|ulid|@upstash/redis|uncrypto)/)',
+    // Transpile ESM‑only dependencies that would break under CommonJS.
+    // Also ensure internal "@acme" workspace packages are transformed so
+    // their ESM builds can run in Jest.
+    '/node_modules/(?!(jose|next-auth|ulid|@upstash/redis|uncrypto|@acme)/)',
   ],
   setupFiles: ['dotenv/config', ' /test/setupFetchPolyfill.ts'],
   setupFilesAfterEnv: [' /jest.setup.ts', ' /test/polyfills/messageChannel.js'],


### PR DESCRIPTION
## Summary
- run internal `@acme` packages through Jest's transform pipeline so their ESM builds execute during tests

## Testing
- `pnpm --filter @acme/ui test`

------
https://chatgpt.com/codex/tasks/task_e_68b893d7460c832f8dd545d0b694188e