### PR TITLE
fix(email): use explicit .js imports for analytics

### DIFF
--- a/packages/email/src/analytics.ts
+++ b/packages/email/src/analytics.ts
@@ -1,21 +1,21 @@
 import "server-only";
 import { trackEvent } from "@platform-core/analytics";
-import { getCampaignStore } from "./storage";
-import { SendgridProvider } from "./providers/sendgrid";
-import { ResendProvider } from "./providers/resend";
-import type { CampaignProvider } from "./providers/types";
-import { emptyStats, type CampaignStats } from "./stats";
+import { getCampaignStore } from "./storage/index.js";
+import { SendgridProvider } from "./providers/sendgrid.js";
+import { ResendProvider } from "./providers/resend.js";
+import type { CampaignProvider } from "./providers/types.js";
+import { emptyStats, type CampaignStats } from "./stats.js";
 export {
   mapSendGridStats,
   mapResendStats,
   normalizeProviderStats,
   emptyStats,
-} from "./stats";
+} from "./stats.js";
 export type {
   CampaignStats,
   SendGridStatsResponse,
   ResendStatsResponse,
-} from "./stats";
+} from "./stats.js";
 
 export type EmailEventType =
   | "email_delivered"

--- a/packages/email/src/providers/resend.js
+++ b/packages/email/src/providers/resend.js
@@ -1,0 +1,1 @@
+export * from './resend.ts';

--- a/packages/email/src/providers/sendgrid.js
+++ b/packages/email/src/providers/sendgrid.js
@@ -1,0 +1,1 @@
+export * from './sendgrid.ts';

--- a/packages/email/src/providers/types.js
+++ b/packages/email/src/providers/types.js
@@ -1,0 +1,1 @@
+export * from './types.ts';

--- a/packages/email/src/stats.js
+++ b/packages/email/src/stats.js
@@ -1,0 +1,1 @@
+export * from './stats.ts';

--- a/packages/email/src/storage/fsStore.js
+++ b/packages/email/src/storage/fsStore.js
@@ -1,0 +1,1 @@
+export * from './fsStore.ts';

--- a/packages/email/src/storage/fsStore.ts
+++ b/packages/email/src/storage/fsStore.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
-import type { Campaign } from "../types";
-import type { CampaignStore } from "./types";
+import type { Campaign } from "../types.js";
+import type { CampaignStore } from "./types.js";
 import { DATA_ROOT } from "@platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 

--- a/packages/email/src/storage/index.js
+++ b/packages/email/src/storage/index.js
@@ -1,0 +1,1 @@
+export * from './index.ts';

--- a/packages/email/src/storage/index.ts
+++ b/packages/email/src/storage/index.ts
@@ -1,6 +1,6 @@
-import { fsCampaignStore } from "./fsStore";
-import type { CampaignStore } from "./types";
-import type { Campaign } from "../types";
+import { fsCampaignStore } from "./fsStore.js";
+import type { CampaignStore } from "./types.js";
+import type { Campaign } from "../types.js";
 
 let store: CampaignStore = fsCampaignStore;
 

--- a/packages/email/src/storage/types.ts
+++ b/packages/email/src/storage/types.ts
@@ -1,4 +1,4 @@
-import type { Campaign } from "../types";
+import type { Campaign } from "../types.js";
 
 export interface CampaignStore {
   /**


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions in email analytics imports
- provide JS re-export shims so Jest can resolve TypeScript sources

## Testing
- `pnpm install`
- `pnpm --filter @acme/email build`
- `pnpm --filter @apps/cms test __tests__/emailProviderWebhooks.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b8952828a8832f97a2989be66a7558