### PR TITLE
feat(ui): make telemetry optional in style panel

### DIFF
--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -4,7 +4,6 @@
 import type { PageComponent } from "@acme/types";
 import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
-import { track } from "@acme/telemetry";
 import { useTranslations } from "@acme/i18n";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";
 
@@ -36,7 +35,9 @@ export default function StylePanel({ component, handleInput }: Props) {
       next.typography = { ...typography, [key]: value };
     }
     handleInput("styles", JSON.stringify(next));
-    track("stylepanel:update", { group, key });
+    void import("@acme/telemetry")
+      .then(({ track }) => track("stylepanel:update", { group, key }))
+      .catch(() => {});
   };
 
   return (


### PR DESCRIPTION
## Summary
- prevent build errors when telemetry package is missing by lazily importing it in StylePanel

## Testing
- `node ./node_modules/jest/bin/jest.js apps/cms/__tests__/stepValidators.test.ts --ci --runInBand --detectOpenHandles --passWithNoTests` *(fails: process terminated due to resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_68b8953aad3c832fa46fbfec030df8a4