### PR TITLE
test: listCoupons handles missing file

### DIFF
--- a/packages/platform-core/src/__tests__/coupons.test.ts
+++ b/packages/platform-core/src/__tests__/coupons.test.ts
@@ -1,0 +1,16 @@
+import { promises as fs } from "node:fs";
+import { listCoupons } from "../coupons";
+
+describe("listCoupons", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns empty array when coupons file missing", async () => {
+    jest
+      .spyOn(fs, "readFile")
+      .mockRejectedValueOnce(Object.assign(new Error("missing"), { code: "ENOENT" }));
+
+    await expect(listCoupons("demo")).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add coupon test verifying listCoupons returns empty list if coupons file missing

## Testing
- `pnpm --filter @acme/platform-core run build`
- `pnpm --filter @acme/platform-core run check:references` (fails: None of the selected packages has a "check:references" script)
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/__tests__/coupons.test.ts --coverage=false --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8959f731c832fbf0c4798b43d6368