### PR TITLE
Add CustomHtml block tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/custom-html.spec.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/custom-html.spec.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import DOMPurify from "dompurify";
+import CustomHtml from "../CustomHtml";
+
+describe("CustomHtml", () => {
+  it("renders nothing when html is undefined", () => {
+    const { container } = render(<CustomHtml />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when html is empty", () => {
+    const { container } = render(<CustomHtml html="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("sanitizes html and does not execute scripts", () => {
+    (window as any).__custom_html_test__ = "safe";
+    const html = `<div>Safe<script>window.__custom_html_test__='hacked'<\/script></div>`;
+    const { container } = render(<CustomHtml html={html} />);
+    const sanitized = DOMPurify.sanitize(html);
+
+    expect(container.firstChild?.innerHTML).toBe(sanitized);
+    expect(container.querySelector("script")).toBeNull();
+    expect((window as any).__custom_html_test__).toBe("safe");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CustomHtml block to ensure empty content renders nothing and scripts are sanitized

## Testing
- `pnpm -r build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/src/components/cms/blocks/__tests__/custom-html.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b89777a1dc832f8199b46ac3b06c58