### PR TITLE
fix(lib): use direct module imports

### DIFF
--- a/packages/lib/src/__tests__/generateMeta.test.ts
+++ b/packages/lib/src/__tests__/generateMeta.test.ts
@@ -10,7 +10,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: undefined } as { OPENAI_API_KEY: string | undefined };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => { throw new Error("should not import"); }, { virtual: true });
       const originalEnv = process.env.NODE_ENV;
@@ -35,7 +35,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: undefined } as { OPENAI_API_KEY: string | undefined };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => { throw new Error("should not import"); }, { virtual: true });
       const originalEnv = process.env.NODE_ENV;
@@ -60,7 +60,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       (globalThis as any).__OPENAI_IMPORT_ERROR__ = true;
       const { generateMeta } = await import("../generateMeta");
@@ -83,7 +83,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => { throw new Error("boom"); }, { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -105,7 +105,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, default: {} }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -137,7 +137,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, OpenAI }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -167,7 +167,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock(
         "openai",
@@ -201,7 +201,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => OpenAI, { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -233,7 +233,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -270,7 +270,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -305,7 +305,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -338,7 +338,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");
@@ -369,7 +369,7 @@ describe("generateMeta", () => {
     let result;
     await jest.isolateModulesAsync(async () => {
       const envMock = { OPENAI_API_KEY: "key" };
-      jest.doMock("@acme/config", () => ({ env: envMock }));
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
       jest.doMock("fs", () => ({ promises: { writeFile: writeMock, mkdir: mkdirMock } }));
       jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), { virtual: true });
       const { generateMeta } = await import("../generateMeta");

--- a/packages/lib/src/checkShopExists.server.ts
+++ b/packages/lib/src/checkShopExists.server.ts
@@ -1,18 +1,23 @@
-// packages/lib/checkShopExists.server.ts
 import "server-only";
 
 import { promises as fs } from "node:fs";
 import * as path from "path";
-import { resolveDataRoot } from "@platform-core/dataRoot";
+import { resolveDataRoot } from "@acme/platform-core/dataRoot";
 import { validateShopName } from "./validateShopName";
 
+/** The root directory containing shop data */
 const DATA_ROOT = resolveDataRoot();
 
-/** Check if `data/shops/<shop>` exists and is a directory. */
+/**
+ * Determine whether a shop folder exists under the monorepo’s data root.
+ *
+ * @param shop the shop code to look up
+ * @returns true if a matching directory exists; false otherwise
+ */
 export async function checkShopExists(shop: string): Promise<boolean> {
-  shop = validateShopName(shop);
+  const sanitized = validateShopName(shop);
   try {
-    const stat = await fs.stat(path.join(DATA_ROOT, shop));
+    const stat = await fs.stat(path.join(DATA_ROOT, sanitized));
     return stat.isDirectory();
   } catch {
     return false;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,5 +1,13 @@
 export { SHOP_NAME_RE, validateShopName } from "./validateShopName";
 export { checkShopExists } from "./checkShopExists.server";
-export { applyFriendlyZodMessages, friendlyErrorMap } from "@acme/zod-utils";
+/**
+ * Re-export Zod helpers from their module files rather than the package
+ * root.  The root of @acme/zod-utils lacks a compiled index.d.ts, which
+ * causes TS6305 errors.  Importing from the specific module files avoids this.
+ */
+export {
+  applyFriendlyZodMessages,
+  friendlyErrorMap,
+} from "@acme/zod-utils/zodErrorMap";
 export { generateMeta } from "./generateMeta";
 export type { ProductData, GeneratedMeta } from "./generateMeta";

--- a/packages/lib/src/initZod.ts
+++ b/packages/lib/src/initZod.ts
@@ -1,2 +1,10 @@
-// packages/lib/src/initZod.ts
-export * from "@acme/zod-utils";
+/**
+ * Re-export the Zod initialiser and helper functions from their specific
+ * modules.  Importing from the package root would require a compiled
+ * index.d.ts that doesn’t exist.
+ */
+export { initZod } from "@acme/zod-utils/initZod";
+export {
+  applyFriendlyZodMessages,
+  friendlyErrorMap,
+} from "@acme/zod-utils/zodErrorMap";


### PR DESCRIPTION
## Summary
- resolve shop data root via platform-core and sanitize shop name
- import core env for OpenAI metadata generator and handle SDK variants
- re-export zod-utils helpers from module paths to avoid missing declarations
- update tests to mock new config env module

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core build`
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/zod-utils build`
- `pnpm --filter @acme/lib build`
- `pnpm --filter @acme/lib test` *(fails: Jest encountered an unexpected token)*
- `pnpm --filter @acme/lib exec jest packages/lib/src/__tests__/generateMeta.test.ts --config ../../jest.config.cjs`
- `pnpm --filter @acme/eslint-plugin-ds build`
- `pnpm --filter @acme/lib lint` *(fails: 25 errors in seoAudit.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b89a047008832fbea041afb74084b7