### PR TITLE
Use CommonJS SQLite stub for tests

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/inventory.sqlite.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/inventory.sqlite.test.ts
@@ -25,18 +25,20 @@ describe("sqlite inventory repository", () => {
     }
   });
 
-  it("handles simultaneous writes without corruption", async () => {
-    process.env.SKIP_STOCK_ALERT = "1";
-    const { writeInventory, readInventory } = await import("../inventory.server");
-    const shop = "demo";
-    const sets = [
-      [
-        { sku: "a", productId: "p1", quantity: 1, variantAttributes: {} },
-      ],
-      [
-        { sku: "b", productId: "p2", quantity: 2, variantAttributes: {} },
-      ],
-    ];
+  it(
+    "handles simultaneous writes without corruption",
+    async () => {
+      process.env.SKIP_STOCK_ALERT = "1";
+      const { writeInventory, readInventory } = await import("../inventory.server");
+      const shop = "demo";
+      const sets = [
+        [
+          { sku: "a", productId: "p1", quantity: 1, variantAttributes: {} },
+        ],
+        [
+          { sku: "b", productId: "p2", quantity: 2, variantAttributes: {} },
+        ],
+      ];
 
     await Promise.all(sets.map((s) => writeInventory(shop, s)));
 
@@ -49,7 +51,9 @@ describe("sqlite inventory repository", () => {
       }));
     const json = JSON.stringify(normalize(result));
     expect(sets.map((s) => JSON.stringify(normalize(s)))).toContain(json);
-  });
+  },
+    20000,
+  );
 
   it("updates items concurrently without losing changes", async () => {
     process.env.SKIP_STOCK_ALERT = "1";

--- a/packages/platform-core/src/repositories/inventory.sqlite.server.ts
+++ b/packages/platform-core/src/repositories/inventory.sqlite.server.ts
@@ -36,7 +36,7 @@ async function getDb(shop: string): Promise<Database> {
       ));
     } catch {
       ({ default: DatabaseConstructor } = await import(
-        "../types/better-sqlite3",
+        "../types/better-sqlite3.js",
       ));
     }
   }

--- a/packages/platform-core/src/types/better-sqlite3.d.ts
+++ b/packages/platform-core/src/types/better-sqlite3.d.ts
@@ -1,0 +1,13 @@
+declare class Database {
+  constructor(file: string);
+  static stores: Map<string, Map<string, Record<string, unknown>>>;
+  rows: Map<string, Record<string, unknown>>;
+  exec(sql: string): this;
+  prepare(sql: string): {
+    run: (...args: unknown[]) => { changes: number };
+    all: () => Array<{ sku: unknown; variantAttributes: unknown; quantity: unknown }>;
+    get: (...args: unknown[]) => unknown;
+  };
+  transaction<T extends (...args: any[]) => any>(fn: T): T & { immediate: T };
+}
+export default Database;


### PR DESCRIPTION
## Summary
- replace TS better-sqlite3 stub with CommonJS implementation
- fall back to JS stub when native better-sqlite3 is unavailable
- extend inventory sqlite test timeout for slow concurrent writes

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/repositories/__tests__/inventory.sqlite.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b898803e98832fbfd3ab2cd8087cf3