### PR TITLE
fix jest path mapping for platform-core ESM modules

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -177,6 +177,7 @@ const config = {
     '^@acme/config$': ' /packages/config/src/env/index.ts',
     '^@acme/config/(.*)$': ' /packages/config/src/$1',
     '^@acme/platform-core$': ' /packages/platform-core/src/index.ts',
+    '^@acme/platform-core/(.*)\\.js$': ' /packages/platform-core/src/$1',
     '^@acme/platform-core/(.*)$': ' /packages/platform-core/src/$1',
     '^@acme/platform-machine/src/(.*)$': ' /packages/platform-machine/src/$1',
     '^@acme/plugin-sanity$': ' /test/__mocks__/pluginSanityStub.ts',


### PR DESCRIPTION
## Summary
- map `@acme/platform-core/*` imports with `.js` extensions back to source files in Jest

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm exec jest packages/ui/__tests__/ComponentEditor.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b898296564832f819f99aa65d52961