### PR TITLE
test: add ProductPreview component tests

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -60,17 +60,16 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
       <div className="border p-2 text-red-500">{error ?? "Not found"}</div>
     );
   const available = (product.stock ?? 0) > 0;
+  const imageUrl = product.media?.[0]?.url ?? "/file.svg";
   return (
     <div className="flex gap-2 border p-2">
-      {product.media?.[0] && (
-        <Image
-          src={product.media[0].url}
-          alt={product.title}
-          width={64}
-          height={64}
-          className="h-16 w-16 object-cover"
-        />
-      )}
+      <Image
+        src={imageUrl}
+        alt={product.title}
+        width={64}
+        height={64}
+        className="h-16 w-16 object-cover"
+      />
       <div className="space-y-1">
         <div className="font-semibold">{product.title}</div>
         <div>{formatCurrency(product.price)}</div>

--- a/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx
@@ -1,22 +1,59 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import ProductPreview from "@cms/app/cms/blog/posts/ProductPreview";
-import { rest, server } from "../../../../../../__tests__/msw/server";
+
+afterEach(() => {
+  (global.fetch as jest.Mock | undefined)?.mockReset?.();
+});
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} />;
+  },
+}));
 
 describe("ProductPreview", () => {
-  it("renders product info", async () => {
-    const onValid = jest.fn();
-    render(<ProductPreview slug="t" onValidChange={onValid} />);
-    await waitFor(() => expect(onValid).toHaveBeenCalledWith(true));
+  it("renders image and title when product resolves successfully", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        title: "Test",
+        price: 100,
+        stock: 1,
+        media: [{ url: "/image.png" }],
+      }),
+    });
+    render(<ProductPreview slug="t" />);
+    expect(await screen.findByText("Test")).toBeInTheDocument();
+    const img = screen.getByAltText("Test") as HTMLImageElement;
+    expect(img.src).toContain("/image.png");
   });
 
-  it("handles error", async () => {
-    server.use(
-      rest.get("*/api/products", (_req, res, ctx) =>
-        res(ctx.status(500))
-      )
-    );
-    const onValid = jest.fn();
-    render(<ProductPreview slug="t" onValidChange={onValid} />);
-    await waitFor(() => expect(onValid).toHaveBeenCalledWith(false));
+  it("displays fallback text when product document is missing", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => null,
+    });
+    render(<ProductPreview slug="t" />);
+    expect(await screen.findByText("Not found")).toBeInTheDocument();
+  });
+
+  it("falls back to default image when coverImage is missing", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ title: "Test", price: 100, stock: 1 }),
+    });
+    render(<ProductPreview slug="t" />);
+    const img = await screen.findByAltText("Test");
+    expect((img as HTMLImageElement).src).toContain("/file.svg");
+  });
+
+  it("renders error state when fetchProduct throws", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: false,
+    });
+    render(<ProductPreview slug="t" />);
+    expect(await screen.findByText("Failed to load product")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ensure ProductPreview uses a placeholder image when a product lacks media
- add unit tests covering success, missing product, missing image, and error cases

## Testing
- `pnpm exec jest apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b89a3a2cf0832fb8386ed197266536