### PR TITLE
Handle missing telemetry in StylePanel tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -4,9 +4,19 @@
 import type { PageComponent } from "@acme/types";
 import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
-import { track } from "@acme/telemetry";
 import { useTranslations } from "@acme/i18n";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";
+
+type TrackFn = (name: string, payload?: Record<string, unknown>) => void;
+let track: TrackFn = () => {};
+
+import("@acme/telemetry")
+  .then((m) => {
+    track = m.track;
+  })
+  .catch(() => {
+    // telemetry is optional in tests
+  });
 
 interface Props {
   component: PageComponent;


### PR DESCRIPTION
## Summary
- load telemetry lazily in StylePanel and fall back to no-op when module unavailable

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @apps/cms test __tests__/shopPages404.test.ts` *(fails: coverage thresholds and test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68b89991b534832fafc8b1675a9a7822