### PR TITLE
feat(ui): export color helpers and add tests

### DIFF
--- a/packages/ui/src/components/cms/ColorInput.tsx
+++ b/packages/ui/src/components/cms/ColorInput.tsx
@@ -7,15 +7,23 @@ interface ColorInputProps {
   onChange: (value: string) => void;
 }
 
-function hexToRgb(hex: string): [number, number, number] {
+export function hexToRgb(hex: string): [number, number, number] {
+  let value = hex.replace("#", "");
+  if (value.length === 3) {
+    value = value
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+
   return [
-    parseInt(hex.slice(1, 3), 16),
-    parseInt(hex.slice(3, 5), 16),
-    parseInt(hex.slice(5, 7), 16),
+    parseInt(value.slice(0, 2), 16),
+    parseInt(value.slice(2, 4), 16),
+    parseInt(value.slice(4, 6), 16),
   ];
 }
 
-function hslToRgb(hsl: string): [number, number, number] {
+export function hslToRgb(hsl: string): [number, number, number] {
   const [h, s, l] = hsl
     .split(" ")
     .map((p: string, i: number) =>
@@ -55,11 +63,11 @@ function hslToRgb(hsl: string): [number, number, number] {
   ];
 }
 
-function colorToRgb(color: string): [number, number, number] {
+export function colorToRgb(color: string): [number, number, number] {
   return color.startsWith("#") ? hexToRgb(color) : hslToRgb(color);
 }
 
-function luminance(rgb: [number, number, number]): number {
+export function luminance(rgb: [number, number, number]): number {
   const [r, g, b] = rgb.map((v) => {
     const c = v / 255;
     return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);

--- a/packages/ui/src/components/cms/__tests__/color-input.spec.ts
+++ b/packages/ui/src/components/cms/__tests__/color-input.spec.ts
@@ -1,0 +1,67 @@
+import {
+  colorToRgb,
+  hslToRgb,
+  luminance,
+  suggestContrastColor,
+  getContrast,
+} from "../ColorInput";
+
+describe("colorToRgb", () => {
+  it("handles hex input", () => {
+    expect(colorToRgb("#fff")).toEqual([255, 255, 255]);
+  });
+
+  it("handles HSL input", () => {
+    expect(colorToRgb("0 0% 100%"))
+      .toEqual([255, 255, 255]);
+  });
+});
+
+describe("luminance", () => {
+  it("uses the low-channel formula for small values", () => {
+    expect(luminance([10, 10, 10])).toBeCloseTo(0.003, 3);
+  });
+
+  it("uses the high-channel formula for larger values", () => {
+    expect(luminance([100, 100, 100])).toBeCloseTo(0.127, 3);
+  });
+});
+
+describe("hslToRgb", () => {
+  const cases: Array<[number, [number, number, number]]> = [
+    [0, [255, 0, 0]],
+    [60, [255, 255, 0]],
+    [120, [0, 255, 0]],
+    [180, [0, 255, 255]],
+    [240, [0, 0, 255]],
+    [300, [255, 0, 255]],
+  ];
+
+  it.each(cases)("converts %s° correctly", (hue, expected) => {
+    expect(hslToRgb(`${hue} 100% 50%`)).toEqual(expected);
+  });
+});
+
+describe("suggestContrastColor", () => {
+  it("returns a new color meeting the requested ratio", () => {
+    const base = "#000000";
+    const suggestion = suggestContrastColor(base, base, 4.5);
+    expect(suggestion).not.toBeNull();
+    if (suggestion) {
+      expect(suggestion).not.toBe(base);
+      expect(getContrast(suggestion, base)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("returns null when no adjustment can satisfy the ratio", () => {
+    expect(suggestContrastColor("#ffffff", "#ffffff", 4.5)).toBeNull();
+  });
+});
+
+describe("getContrast", () => {
+  it("matches expected ratio for known color pairs", () => {
+    expect(getContrast("#000000", "#ffffff")).toBeCloseTo(21, 5);
+    expect(getContrast("0 0% 0%", "0 0% 100%"))
+      .toBeCloseTo(21, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- export and enhance color helpers for ColorInput
- add unit tests covering color conversion and contrast utilities

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test` *(fails: Cannot find module '../utils/args' from 'test/unit/init-shop/env.spec.ts')*
- `pnpm exec jest packages/ui/src/components/cms/__tests__/color-input.spec.ts --config jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b89773671c832f982759e3e070fc6d