### PR TITLE
test: add UpgradeButton component tests

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeButton.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeButton.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UpgradeButton from "@/app/cms/shop/[shop]/UpgradeButton";
+
+describe("UpgradeButton", () => {
+  const shop = "test-shop";
+  let originalFetch: typeof fetch;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    const mock = jest.fn() as any;
+    global.fetch = mock;
+    Object.defineProperty(window, "fetch", { value: mock, writable: true });
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      value: { ...originalLocation, href: "" },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window, "fetch", { value: originalFetch, writable: true });
+    Object.defineProperty(window, "location", { value: originalLocation });
+    jest.clearAllMocks();
+  });
+
+  function setup() {
+    render(<UpgradeButton shop={shop} />);
+    return screen.getByRole("button");
+  }
+
+  it("redirects on successful upgrade", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ ok: true })
+    );
+    const button = setup();
+    await act(async () => {
+      await userEvent.click(button);
+    });
+    await waitFor(() => {
+      expect(window.location.href).toBe(`/cms/shop/${shop}/upgrade-preview`);
+    });
+  });
+
+  it("shows server error message", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: "msg" }),
+      })
+    );
+    const button = setup();
+    await act(async () => {
+      await userEvent.click(button);
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent("msg");
+  });
+
+  it("shows default error when server lacks message", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      })
+    );
+    const button = setup();
+    await act(async () => {
+      await userEvent.click(button);
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent("Upgrade failed");
+  });
+
+  it("handles network errors", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      Promise.reject(new Error("Network error"))
+    );
+    const button = setup();
+    await act(async () => {
+      await userEvent.click(button);
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent("Network error");
+  });
+
+  it("toggles loading and resets error between attempts", async () => {
+    let rejectFetch: (reason?: any) => void;
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectFetch = reject;
+          })
+      )
+      .mockImplementationOnce(() => Promise.resolve({ ok: true }));
+
+    const button = setup();
+
+    // First click fails
+    userEvent.click(button);
+    await waitFor(() => expect(button).toHaveTextContent(/Upgrading.../i));
+    rejectFetch(new Error("fail"));
+    await act(async () => {});
+    expect(await screen.findByRole("alert")).toHaveTextContent("fail");
+    await waitFor(() => expect(button).toHaveTextContent(/Upgrade & preview/i));
+
+    // Second click succeeds
+    userEvent.click(button);
+    await waitFor(() => expect(button).toHaveTextContent(/Upgrading.../i));
+    await act(async () => {});
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+    await waitFor(() => {
+      expect(window.location.href).toBe(`/cms/shop/${shop}/upgrade-preview`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for UpgradeButton covering success, server and network errors, and multiple retry behavior

## Testing
- `pnpm --filter @apps/cms test -- UpgradeButton --coverage=false`
- `pnpm --filter @apps/cms test` *(fails: marketingEmailApi, seoTimelineRevert, shopPages404, ProductPreview, products)*
- `pnpm -r build` *(fails: @apps/shop-bcd build: Module '@prisma/client' has no exported member 'Prisma')*


------
https://chatgpt.com/codex/tasks/task_e_68b899047f04832f9f2c177c03a13fa7