### PR TITLE
test(platform-core): add return logistics test

### DIFF
--- a/packages/platform-core/src/__tests__/returnLogistics.test.ts
+++ b/packages/platform-core/src/__tests__/returnLogistics.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+
+import { promises as fs } from "fs";
+
+describe("getReturnBagAndLabel", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  it("returns only bag and label fields", async () => {
+    const cfg = {
+      labelService: "ups",
+      inStore: true,
+      dropOffProvider: "happy-returns",
+      tracking: true,
+      bagType: "reusable",
+      returnCarrier: ["ups"],
+      homePickupZipCodes: ["12345"],
+      mobileApp: true,
+      requireTags: true,
+      allowWear: false,
+    };
+
+    jest
+      .spyOn(fs, "readFile")
+      .mockResolvedValue(JSON.stringify(cfg) as any);
+
+    const { getReturnBagAndLabel } = await import("../returnLogistics");
+    const result = await getReturnBagAndLabel();
+
+    expect(result).toEqual({
+      bagType: cfg.bagType,
+      labelService: cfg.labelService,
+      tracking: cfg.tracking,
+      returnCarrier: cfg.returnCarrier,
+      homePickupZipCodes: cfg.homePickupZipCodes,
+    });
+
+    expect(result).not.toHaveProperty("inStore");
+    expect(result).not.toHaveProperty("dropOffProvider");
+    expect(result).not.toHaveProperty("mobileApp");
+    expect(result).not.toHaveProperty("requireTags");
+    expect(result).not.toHaveProperty("allowWear");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test for getReturnBagAndLabel ensuring only required fields are returned

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/__tests__/returnLogistics.test.ts` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b895a6af34832f909627f83b35527d