### PR TITLE
test(platform-core): cover product lookups

### DIFF
--- a/packages/platform-core/src/__tests__/products.test.ts
+++ b/packages/platform-core/src/__tests__/products.test.ts
@@ -1,0 +1,17 @@
+/** @jest-environment node */
+
+import { getProductBySlug, getProductById } from "../products";
+import { PRODUCTS } from "../products/index";
+
+describe("getProductBySlug", () => {
+  it("returns null for an unknown slug", () => {
+    expect(getProductBySlug("non-existent")).toBeNull();
+  });
+});
+
+describe("getProductById", () => {
+  it("resolves with the matching product via async path", async () => {
+    const product = PRODUCTS[0];
+    await expect(getProductById("shop", product.id)).resolves.toEqual(product);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for product lookup helpers
- ensure async path in getProductById resolves mock product

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: Cannot find module '../utils/args')*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/__tests__/products.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage --coverageThreshold='{}'`


------
https://chatgpt.com/codex/tasks/task_e_68b895a2b3b4832f915bb6970d388db6