### PR TITLE
test: decodeCartCookie handles plain string payloads

### DIFF
--- a/packages/platform-core/src/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/src/__tests__/cartCookie.test.ts
@@ -14,4 +14,14 @@ describe("decodeCartCookie", () => {
 
     warnSpy.mockRestore();
   });
+
+  it("returns original string when payload is plain text", () => {
+    const original = "plain";
+    const parseSpy = jest.spyOn(JSON, "parse");
+    const encoded = encodeCartCookie(original);
+    expect(decodeCartCookie(encoded)).toBe(original);
+    expect(parseSpy).toHaveBeenCalledWith(original);
+    expect(parseSpy.mock.results[0].type).toBe("throw");
+    parseSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- cover cart cookie decoding when payload is a plain string
- verify JSON.parse failure path returns raw string

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core build`
- `pnpm exec jest --config jest.config.cjs packages/platform-core/src/__tests__/cartCookie.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b8959d10ec832f9208575c3f803bae