### PR TITLE
fix: guard home page data type

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepHomePage.tsx
@@ -64,7 +64,7 @@ export default function StepHomePage({
       const { data, error } = await apiRequest<Page[]>(
         `/cms/api/pages/${shopId}`,
       );
-      if (data) {
+      if (Array.isArray(data)) {
         const existing: Page | undefined = homePageId
           ? data.find((p) => p.id === homePageId)
           : data.find((p) => p.slug === "");


### PR DESCRIPTION
## Summary
- safeguard StepHomePage page fetch logic by verifying API response is an array before searching for existing page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: Done, packages/template-app build: Failed, ...)*
- `pnpm run test:cms -- apps/cms/__tests__/StepHomePage.test.tsx --runInBand --detectOpenHandles` *(hangs: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3574dac832f973b31c46d864e72