### PR TITLE
chore: type parsed schema

### DIFF
--- a/packages/platform-core/src/createShop/schema.ts
+++ b/packages/platform-core/src/createShop/schema.ts
@@ -95,7 +95,8 @@ export function prepareOptions(
   id: string,
   opts: CreateShopOptions
 ): PreparedCreateShopOptions {
-  const parsed = createShopOptionsSchema.parse(opts);
+  const parsed: z.infer<typeof createShopOptionsSchema> =
+    createShopOptionsSchema.parse(opts);
   return {
     name: parsed.name ?? id,
     logo: parsed.logo ?? "",


### PR DESCRIPTION
## Summary
- ensure createShop options parse returns typed object

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a2de7354832f919c4d5cac50c8e9