### PR TITLE
test: add page template route tests

### DIFF
--- a/apps/cms/src/app/api/page-templates/[name]/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/page-templates/[name]/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from "next/server";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+let route: typeof import("../route");
+
+beforeAll(async () => {
+  route = await import("../route");
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function req(name: string) {
+  return new NextRequest(`http://test.local/${name}`);
+}
+
+describe("GET", () => {
+  it("reads and returns existing template", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tpl-"));
+    fs.writeFileSync(path.join(dir, "home.json"), JSON.stringify({ ok: true }));
+    jest.spyOn(route, "resolveTemplatesRoot").mockReturnValue(dir);
+
+    const res = await route.GET(req("home"), {
+      params: Promise.resolve({ name: "home" }),
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("returns 404 for missing template", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tpl-"));
+    jest.spyOn(route, "resolveTemplatesRoot").mockReturnValue(dir);
+
+    const res = await route.GET(req("missing"), {
+      params: Promise.resolve({ name: "missing" }),
+    });
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Not found" });
+  });
+
+  it("returns 404 when templates root resolution fails", async () => {
+    jest
+      .spyOn(route, "resolveTemplatesRoot")
+      .mockImplementation(() => {
+        throw new Error("fail");
+      });
+
+    const res = await route.GET(req("any"), {
+      params: Promise.resolve({ name: "any" }),
+    });
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Not found" });
+  });
+});

--- a/apps/cms/src/app/api/page-templates/[name]/route.ts
+++ b/apps/cms/src/app/api/page-templates/[name]/route.ts
@@ -4,7 +4,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import fsSync, { promises as fs } from "fs";
 import path from "path";
 
-function resolveTemplatesRoot(): string {
+export function resolveTemplatesRoot(): string {
   let dir = process.cwd();
   while (true) {
     const candidate = path.join(


### PR DESCRIPTION
## Summary
- expose resolveTemplatesRoot for easier testing
- add tests for page template route covering success and failure cases

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm test` (fails: command exited with code 1)

------
https://chatgpt.com/codex/tasks/task_e_68b897890018832fb7bc02d70da229f8