### PR TITLE
test(i18n): cover fillLocales defaults and existing values

### DIFF
--- a/packages/i18n/src/__tests__/fillLocales.test.ts
+++ b/packages/i18n/src/__tests__/fillLocales.test.ts
@@ -2,16 +2,25 @@ import { fillLocales } from "../fillLocales";
 import { LOCALES } from "../locales";
 
 describe("fillLocales", () => {
-  it("fills missing locales with the fallback and keeps provided values", () => {
-    const result = fillLocales({ en: "Hello" }, "Hi");
+  it("fills all locales with the fallback when no values are provided", () => {
+    const result = fillLocales(undefined, "Hi");
 
-    expect(Object.keys(result)).toEqual([...LOCALES]);
     for (const locale of LOCALES) {
-      if (locale === "en") {
-        expect(result[locale]).toBe("Hello");
-      } else {
-        expect(result[locale]).toBe("Hi");
-      }
+      expect(result[locale]).toBe("Hi");
     }
   });
+
+  it("populates missing locales with the fallback", () => {
+    const result = fillLocales({ en: "Hello" }, "Hi");
+
+    expect(result).toEqual({ en: "Hello", de: "Hi", it: "Hi" });
+  });
+
+  it("leaves existing locales unchanged", () => {
+    const values = { en: "Hello", de: "Hallo", it: "Ciao" };
+    const result = fillLocales(values, "Hi");
+
+    expect(result).toEqual(values);
+  });
 });
+


### PR DESCRIPTION
## Summary
- test: add coverage for default and existing locales in `fillLocales`

## Testing
- `pnpm --filter @acme/i18n test -- packages/i18n/src/__tests__/fillLocales.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8a65a3a14832fb70c73428e0efd4b