### PR TITLE
test: add product retrieval edge case tests

### DIFF
--- a/packages/platform-core/src/__tests__/products.test.ts
+++ b/packages/platform-core/src/__tests__/products.test.ts
@@ -1,11 +1,16 @@
 /** @jest-environment node */
 
-import { getProductBySlug, getProductById } from "../products";
+import { getProductBySlug, getProductById, getProducts } from "../products";
 import { PRODUCTS } from "../products/index";
 
 describe("getProductBySlug", () => {
   it("returns null for an unknown slug", () => {
     expect(getProductBySlug("non-existent")).toBeNull();
+  });
+
+  it("returns the product for a known slug", () => {
+    const product = PRODUCTS[0];
+    expect(getProductBySlug(product.slug)).toEqual(product);
   });
 });
 
@@ -13,5 +18,35 @@ describe("getProductById", () => {
   it("resolves with the matching product via async path", async () => {
     const product = PRODUCTS[0];
     await expect(getProductById("shop", product.id)).resolves.toEqual(product);
+  });
+
+  it("returns the product synchronously when available", () => {
+    const product = PRODUCTS[0];
+    expect(getProductById(product.id)).toEqual(product);
+  });
+
+  it("returns null for out-of-stock products", () => {
+    const outOfStock = PRODUCTS.find((p) => p.stock === 0)!;
+    expect(getProductById(outOfStock.id)).toBeNull();
+  });
+
+  it("returns null for unknown product ids", () => {
+    expect(getProductById("missing-id")).toBeNull();
+  });
+
+  it("resolves null for unknown ids via async path", async () => {
+    await expect(getProductById("shop", "missing-id")).resolves.toBeNull();
+  });
+
+  it("handles invalid input gracefully", () => {
+    expect(getProductById(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe("getProducts", () => {
+  it("returns a copy of all products", async () => {
+    const list = await getProducts();
+    expect(list).toEqual(PRODUCTS);
+    expect(list).not.toBe(PRODUCTS);
   });
 });


### PR DESCRIPTION
## Summary
- expand product lookup tests to cover slug and ID lookups
- ensure getProducts returns a copy of the catalog
- verify null handling for missing and invalid product IDs

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/src/__tests__/products.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b8a65f08b0832fb8314751b6ed0142