### PR TITLE
test: add env typed variable tests

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -1198,3 +1198,63 @@ describe("coreEnv proxy caching", () => {
   });
 });
 
+describe("typed variable helpers", () => {
+  it("retrieves string, number, and boolean variables", () => {
+    const parsed = coreEnvSchema.safeParse({
+      ...baseEnv,
+      OUTPUT_EXPORT: "true",
+      CART_TTL: "99",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.OUTPUT_EXPORT).toBe(true);
+      expect(parsed.data.CART_TTL).toBe(99);
+      expect(parsed.data.CMS_SPACE_URL).toBe("https://example.com");
+    }
+  });
+
+  it("falls back to defaults when variables are missing", () => {
+    const parsed = coreEnvSchema.safeParse({
+      ...baseEnv,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.CART_COOKIE_SECRET).toBe("dev-cart-secret");
+    }
+  });
+
+  it("reports errors for absent or malformed variables", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadCoreEnv({
+        CMS_SPACE_URL: "",
+        CMS_ACCESS_TOKEN: "",
+        SANITY_API_VERSION: "v1",
+        OUTPUT_EXPORT: "notbool",
+        CART_TTL: "abc",
+      } as unknown as NodeJS.ProcessEnv),
+    ).toThrow("Invalid core environment variables");
+    errorSpy.mockRestore();
+  });
+
+  it("coerces booleans and validates numbers", () => {
+    const boolParsed = coreEnvSchema.safeParse({
+      ...baseEnv,
+      OUTPUT_EXPORT: "",
+    });
+    expect(boolParsed.success).toBe(true);
+    if (boolParsed.success) {
+      expect(boolParsed.data.OUTPUT_EXPORT).toBe(false);
+    }
+
+    const numParsed = coreEnvSchema.safeParse({
+      ...baseEnv,
+      CART_TTL: "",
+    });
+    expect(numParsed.success).toBe(true);
+    if (numParsed.success) {
+      expect(numParsed.data.CART_TTL).toBe(0);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover typed env retrieval including string, number, and boolean cases
- verify default fallbacks and malformed var errors
- exercise boolean coercion and empty/invalid numeric inputs

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/types/src/index')*
- `pnpm test packages/config/src/env/core.test.ts` *(fails: Missing task)*
- `pnpm --filter @acme/config test packages/config/src/env/__tests__/core.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8a652ca60832fb408c1ea2e9ce068