### PR TITLE
fix: ensure config env types built for stripe

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -54,7 +54,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "prebuild": "pnpm --filter @acme/zod-utils run build",
+    "prebuild": "rimraf dist tsconfig.tsbuildinfo && pnpm --filter @acme/zod-utils run build",
     "build:stubs": "node ./scripts/generate-env-stubs.mjs",
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -14,6 +14,7 @@
   },
   "files": ["dist"],
   "scripts": {
+    "prebuild": "pnpm --filter @acme/config run build",
     "build": "tsc -b",
     "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "lint": "eslint ."


### PR DESCRIPTION
## Summary
- clean config builds before compiling to avoid stale env outputs
- build config during stripe's prebuild so TypeScript can resolve env types

## Testing
- `pnpm --filter @acme/stripe build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6c1e030832f9e5c03fccc2ba196