### PR TITLE
test: add buildResponse coverage

### DIFF
--- a/packages/shared-utils/src/__tests__/buildResponse.test.ts
+++ b/packages/shared-utils/src/__tests__/buildResponse.test.ts
@@ -1,7 +1,37 @@
 import { buildResponse, type ProxyResponse } from '../buildResponse';
 
 describe('buildResponse', () => {
-  it('decodes base64 body and preserves multiple headers', async () => {
+  it('returns a Response with correct status and decoded body on success', async () => {
+    const message = 'all good';
+    const body = Buffer.from(message).toString('base64');
+    const proxyResponse: ProxyResponse = {
+      response: {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+        body,
+      },
+    };
+
+    const resp = buildResponse(proxyResponse);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get('content-type')).toBe('text/plain');
+    await expect(resp.text()).resolves.toBe(message);
+  });
+
+  it('handles missing message or data by returning an empty body', async () => {
+    const proxyResponse: ProxyResponse = {
+      response: {
+        status: 500,
+        headers: { 'content-type': 'text/plain' },
+      },
+    };
+
+    const resp = buildResponse(proxyResponse);
+    expect(resp.status).toBe(500);
+    await expect(resp.text()).resolves.toBe('');
+  });
+
+  it('preserves custom headers and content types', async () => {
     const text = 'hello world';
     const body = Buffer.from(text).toString('base64');
     const proxyResponse: ProxyResponse = {


### PR DESCRIPTION
## Summary
- expand buildResponse tests to cover success, missing body, and custom headers

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils test packages/shared-utils/src/__tests__/buildResponse.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b8a7b9d644832fa2ff3fde74cfb22f