### PR TITLE
test: add product filter tests

### DIFF
--- a/apps/storefront/src/products/__tests__/index.test.ts
+++ b/apps/storefront/src/products/__tests__/index.test.ts
@@ -1,0 +1,55 @@
+import { filterProducts, type Product } from "../index";
+
+describe("filterProducts", () => {
+  const products: Product[] = [
+    {
+      id: "p1",
+      price: 100,
+      availability: [{ from: "2023-01-01", to: "2023-12-31" }],
+      tags: ["eco", "sale"],
+    },
+    {
+      id: "p2",
+      price: 50,
+      availability: [{ from: "2024-01-01", to: "2024-12-31" }],
+      tags: ["clearance"],
+    },
+    {
+      id: "p3",
+      price: 150,
+      tags: ["eco"],
+    },
+  ];
+
+  it("filters by availability", () => {
+    const date = new Date("2023-06-01");
+    const result = filterProducts(products, { availableOn: date });
+    expect(result.map((p) => p.id)).toEqual(["p1", "p3"]);
+    // product outside availability window should be excluded
+    expect(result.some((p) => p.id === "p2")).toBe(false);
+  });
+
+  it("filters by price range", () => {
+    const within = filterProducts(products, { minPrice: 60, maxPrice: 120 });
+    expect(within.map((p) => p.id)).toEqual(["p1"]);
+
+    const none = filterProducts(products, { minPrice: 160 });
+    expect(none).toEqual([]);
+  });
+
+  it("filters by tags", () => {
+    const eco = filterProducts(products, { tags: ["eco"] });
+    expect(eco.map((p) => p.id)).toEqual(["p1", "p3"]);
+
+    const ecoSale = filterProducts(products, { tags: ["eco", "sale"] });
+    expect(ecoSale.map((p) => p.id)).toEqual(["p1"]);
+  });
+
+  it("handles empty product arrays", () => {
+    expect(filterProducts([], { tags: ["eco"] })).toEqual([]);
+  });
+
+  it("returns all products when filters undefined", () => {
+    expect(filterProducts(products)).toEqual(products);
+  });
+});

--- a/apps/storefront/src/products/index.ts
+++ b/apps/storefront/src/products/index.ts
@@ -1,0 +1,57 @@
+export interface AvailabilityWindow {
+  from?: string;
+  to?: string;
+}
+
+export interface Product {
+  id: string;
+  price: number;
+  availability?: AvailabilityWindow[];
+  tags?: string[];
+}
+
+export interface ProductFilters {
+  /** Date that must fall within availability windows */
+  availableOn?: Date;
+  /** Minimum price (inclusive) */
+  minPrice?: number;
+  /** Maximum price (inclusive) */
+  maxPrice?: number;
+  /** Required tags */
+  tags?: string[];
+}
+
+/**
+ * Filter an array of products by optional availability, price and tag criteria.
+ */
+export function filterProducts(
+  products: Product[],
+  filters: ProductFilters = {}
+): Product[] {
+  const { availableOn, minPrice, maxPrice, tags } = filters;
+
+  return products.filter((p) => {
+    const availabilityMatch =
+      !availableOn ||
+      !p.availability ||
+      p.availability.length === 0 ||
+      p.availability.some((w) => {
+        const from = w.from ? new Date(w.from).getTime() : undefined;
+        const to = w.to ? new Date(w.to).getTime() : undefined;
+        const time = availableOn.getTime();
+        return (
+          (from === undefined || time >= from) &&
+          (to === undefined || time <= to)
+        );
+      });
+
+    const priceMatch =
+      (minPrice === undefined || p.price >= minPrice) &&
+      (maxPrice === undefined || p.price <= maxPrice);
+
+    const tagsMatch =
+      !tags || tags.every((t) => (p.tags ?? []).includes(t));
+
+    return availabilityMatch && priceMatch && tagsMatch;
+  });
+}


### PR DESCRIPTION
## Summary
- add product filtering helper to storefront
- add tests covering availability, price range, tag filters and edge cases

## Testing
- `pnpm exec jest apps/storefront/src/products/__tests__/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8a7bc10d4832fa7d5572388f371a3