### PR TITLE
fix: guard ProductPreview against missing AbortController

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
+++ b/apps/cms/src/app/cms/blog/posts/ProductPreview.tsx
@@ -16,7 +16,8 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const controller = new AbortController();
+    const controller =
+      typeof AbortController !== "undefined" ? new AbortController() : null;
     setLoading(true);
     setProduct(null);
     onValidChange?.(false);
@@ -29,7 +30,7 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
         );
 
         const res = await fetch(url.toString(), {
-          signal: controller.signal,
+          signal: controller?.signal,
         });
         if (!res.ok) throw new Error("Failed to load product");
         const data = (await res.json()) as SKU;
@@ -37,19 +38,15 @@ export default function ProductPreview({ slug, onValidChange }: Props) {
         setError(null);
         onValidChange?.(true);
       } catch {
-        if (!controller.signal.aborted) {
-          setError("Failed to load product");
-          onValidChange?.(false);
-        }
+        setError("Failed to load product");
+        onValidChange?.(false);
       } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
+        setLoading(false);
       }
     })();
 
     return () => {
-      controller.abort();
+      controller?.abort();
       onValidChange?.(false);
     };
   }, [slug, onValidChange]);


### PR DESCRIPTION
## Summary
- handle absence of `AbortController` so product preview fetches complete

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/plugins/sanity, packages/plugins/premier-shipping, packages/plugins/paypal, packages/stripe prebuild)*
- `npx jest apps/cms/src/app/cms/blog/posts/__tests__/ProductPreview.spec.tsx --runInBand` *(fails: global coverage threshold for branches (80%) not met: 24.63%; global coverage threshold for lines (80%) not met: 44%)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acc4eddc832f926da0dabec70f2e