### PR TITLE
fix: enforce NEXTAUTH_SECRET presence

### DIFF
--- a/apps/cms/src/auth/secret.ts
+++ b/apps/cms/src/auth/secret.ts
@@ -1,10 +1,10 @@
 // apps/cms/src/auth/secret.ts
 
-import { authEnv as env } from "@acme/config/env/auth";
+const secret = process.env.NEXTAUTH_SECRET;
 
-if (!env.NEXTAUTH_SECRET) {
+if (!secret) {
   throw new Error("NEXTAUTH_SECRET is not set");
 }
 
 // Explicitly cast to string so consumers receive a correctly typed secret
-export const authSecret = env.NEXTAUTH_SECRET as string;
+export const authSecret = secret as string;


### PR DESCRIPTION
## Summary
- ensure `NEXTAUTH_SECRET` must be set by reading from `process.env`
- remove dependency on `@acme/config/env/auth` in `auth/secret`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type error: Cannot find module '@acme/types/src/index')*
- `pnpm --filter @apps/cms exec jest apps/cms/src/auth/__tests__/secret.test.ts --collectCoverage=false --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8ad45a3b4832f8d862df38d56963a