### PR TITLE
fix: simplify internal package imports

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -1,11 +1,11 @@
 // apps/cms/src/actions/pages.server.ts
 
-import { LOCALES } from "@acme/i18n/src/index";
+import { LOCALES } from "@acme/i18n";
 import { captureException } from "@/utils/sentry.server";
-import type { Locale, Page, HistoryState } from "@acme/types/src/index";
-import { historyStateSchema } from "@acme/types/src/index";
+import type { Locale, Page, HistoryState } from "@acme/types";
+import { historyStateSchema } from "@acme/types";
 import { ulid } from "ulid";
-import { nowIso } from "@acme/date-utils/src/index";
+import { nowIso } from "@acme/date-utils";
 import { formDataToObject } from "../utils/formData";
 
 import { coreEnv as env } from "@acme/config/env/core";

--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -6,7 +6,7 @@ import path from "path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 import { coreEnv as env } from "@acme/config/env/core";
-import type { Coupon } from "@acme/types/src/index";
+import type { Coupon } from "@acme/types";
 
 interface Discount extends Coupon {
   active?: boolean;

--- a/apps/shop-bcd/src/app/[lang]/shop/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/shop/page.tsx
@@ -1,6 +1,6 @@
 // apps/shop-bcd/src/app/[lang]/shop/page.tsx
 import { PRODUCTS } from "@platform-core/products";
-import type { SKU } from "@acme/types/src/index";
+import type { SKU } from "@acme/types";
 import type { Metadata } from "next";
 import BlogListing, { type BlogPost } from "@ui/components/cms/blocks/BlogListing";
 import { fetchPublishedPosts } from "@acme/sanity";

--- a/apps/shop-bcd/src/lib/seo.ts
+++ b/apps/shop-bcd/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Locale } from "@i18n/locales";
 import { getShopSettings } from "@platform-core/repositories/settings.server";
-import type { ShopSettings } from "@acme/types/src/index";
+import type { ShopSettings } from "@acme/types";
 import type { NextSeoProps } from "next-seo";
 import { coreEnv as env } from "@acme/config/env/core";
 


### PR DESCRIPTION
## Summary
- simplify internal workspace imports in CMS page actions and routes
- replace redundant src/index paths in shop app

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @apps/cms test` *(fails: StepHomePage.test.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acf1b458832f866eb096fae95c55