### PR TITLE
test: add page draft GET route tests

### DIFF
--- a/apps/cms/__tests__/page-draft.route.test.ts
+++ b/apps/cms/__tests__/page-draft.route.test.ts
@@ -1,0 +1,76 @@
+/** @jest-environment node */
+
+// Polyfill Response.json for environments missing it
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    });
+}
+
+process.env.NEXTAUTH_SECRET = "test-secret";
+
+const mockGetPages = jest.fn();
+
+function mockAuth() {
+  jest.doMock("next-auth", () => ({
+    getServerSession: jest.fn().mockResolvedValue({
+      user: { role: "admin", email: "admin@example.com" },
+    }),
+  }));
+}
+
+describe("page draft GET route", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  it("returns draft content for valid shop", async () => {
+    mockAuth();
+    jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+      getPages: mockGetPages,
+    }));
+    mockGetPages.mockResolvedValue([
+      { id: "p1", status: "draft" },
+    ]);
+    const route = await import("../src/app/api/page-draft/[shop]/route");
+    const res = await route.GET({} as any, {
+      params: Promise.resolve({ shop: "shop" }),
+    });
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.id).toBe("p1");
+  });
+
+  it("returns 404 when draft is missing", async () => {
+    mockAuth();
+    jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+      getPages: mockGetPages,
+    }));
+    mockGetPages.mockResolvedValue([{ id: "p1", status: "published" }]);
+    const route = await import("../src/app/api/page-draft/[shop]/route");
+    const res = await route.GET({} as any, {
+      params: Promise.resolve({ shop: "shop" }),
+    });
+    const json = await res.json();
+    expect(res.status).toBe(404);
+    expect(json).toEqual({});
+  });
+
+  it("handles service errors", async () => {
+    mockAuth();
+    jest.doMock("@platform-core/repositories/pages/index.server", () => ({
+      getPages: mockGetPages,
+    }));
+    mockGetPages.mockRejectedValue(new Error("boom"));
+    const route = await import("../src/app/api/page-draft/[shop]/route");
+    const res = await route.GET({} as any, {
+      params: Promise.resolve({ shop: "shop" }),
+    });
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("boom");
+  });
+});

--- a/apps/cms/src/app/api/page-draft/[shop]/route.ts
+++ b/apps/cms/src/app/api/page-draft/[shop]/route.ts
@@ -1,5 +1,32 @@
 import { savePageDraft } from "@cms/actions/pages.server";
+import { authOptions } from "@cms/auth/options";
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ shop: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["admin", "ShopAdmin"].includes(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const { shop } = await context.params;
+    const pages = await getPages(shop);
+    const draft = pages.find((p) => p.status === "draft");
+    if (!draft) {
+      return NextResponse.json({}, { status: 404 });
+    }
+    return NextResponse.json(draft);
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}
 
 export async function POST(
   req: NextRequest,


### PR DESCRIPTION
## Summary
- add GET handler to page draft API to return draft if present
- add tests for page-draft route covering success, missing draft, and service errors

## Testing
- `pnpm -r build` *(fails: packages/lib build: src/checkShopExists.server.ts(5,33): error TS6305: Output file '/workspace/base-shop/packages/platform-core/dist/dataRoot.d.ts' has not been built from source file '/workspace/base-shop/packages/platform-core/src/dataRoot.ts'.)*
- `pnpm --filter @apps/cms test` *(fails: NEXTAUTH_SECRET is not set)*


------
https://chatgpt.com/codex/tasks/task_e_68b8af4f48b0832faac20ea5737d5019