### PR TITLE
fix: stabilize plugin init test

### DIFF
--- a/packages/platform-core/__tests__/plugins.test.ts
+++ b/packages/platform-core/__tests__/plugins.test.ts
@@ -20,53 +20,55 @@ const configSchema = {
 };
 const callOrder = [];
 const init = jest.fn(async () => {
-  await new Promise(resolve => setTimeout(resolve, 10));
+  await Promise.resolve();
   callOrder.push('init');
 });
 const registerPayments = jest.fn(() => callOrder.push('registerPayments'));
 const registerShipping = jest.fn(() => callOrder.push('registerShipping'));
 const registerWidgets = jest.fn(() => callOrder.push('registerWidgets'));
-export default {
-  id: 'good',
-  defaultConfig: { enabled: true },
-  configSchema,
-  init,
-  registerPayments,
-  registerShipping,
-  registerWidgets,
-  callOrder,
+module.exports = {
+  default: {
+    id: 'good',
+    defaultConfig: { enabled: true },
+    configSchema,
+    init,
+    registerPayments,
+    registerShipping,
+    registerWidgets,
+    callOrder,
+  }
 };
 `;
-    await fs.writeFile(path.join(validDir, "index.ts"), pluginCode);
+    await fs.writeFile(path.join(validDir, "index.js"), pluginCode);
     await fs.writeFile(
       path.join(validDir, "package.json"),
-      JSON.stringify({ name: "good", main: "index.ts" })
+      JSON.stringify({ name: "good", main: "index.js" })
     );
     // missing plugin dir (no index.ts)
     const missingDir = path.join(base, "missing");
     await fs.mkdir(missingDir, { recursive: true });
     await fs.writeFile(
       path.join(missingDir, "package.json"),
-      JSON.stringify({ name: "missing", main: "index.ts" })
+      JSON.stringify({ name: "missing", main: "index.js" })
     );
     // plugin that throws
     const badDir = path.join(base, "bad");
     await fs.mkdir(badDir, { recursive: true });
-    await fs.writeFile(path.join(badDir, "index.ts"), "throw new Error('boom')");
+    await fs.writeFile(path.join(badDir, "index.js"), "throw new Error('boom')");
     await fs.writeFile(
       path.join(badDir, "package.json"),
-      JSON.stringify({ name: "bad", main: "index.ts" })
+      JSON.stringify({ name: "bad", main: "index.js" })
     );
     // plugin exporting wrong type
     const wrongDir = path.join(base, "wrong");
     await fs.mkdir(wrongDir, { recursive: true });
     await fs.writeFile(
-      path.join(wrongDir, "index.ts"),
-      "export const notPlugin = {};"
+      path.join(wrongDir, "index.js"),
+      "module.exports = { notPlugin: {} };"
     );
     await fs.writeFile(
       path.join(wrongDir, "package.json"),
-      JSON.stringify({ name: "wrong", main: "index.ts" })
+      JSON.stringify({ name: "wrong", main: "index.js" })
     );
     // link root node_modules so imports resolve
     await fs.symlink(


### PR DESCRIPTION
## Summary
- create mock plugin in tests as prebuilt CommonJS module
- replace timer delay with microtask to avoid long build/timeout

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS6305 output file not built, TS7006 parameters implicit any, etc.)*
- `pnpm --filter @acme/platform-core test __tests__/plugins.test.ts -t "initPlugins awaits init before registration hooks" --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8b012cdb0832f915b20a0a5b766e3