### PR TITLE
Add StatsGrid tests

### DIFF
--- a/packages/ui/src/components/organisms/StatsGrid.tsx
+++ b/packages/ui/src/components/organisms/StatsGrid.tsx
@@ -17,8 +17,8 @@ export function StatsGrid({ items, className, ...props }: StatsGridProps) {
       className={cn("grid gap-4 sm:grid-cols-2 lg:grid-cols-3", className)}
       {...props}
     >
-      {items.map((item) => (
-        <StatCard key={item.label} label={item.label} value={item.value} />
+      {items.map(({ label, value }) => (
+        <StatCard key={label} label={label} value={value} />
       ))}
     </div>
   );

--- a/packages/ui/src/components/organisms/__tests__/StatsGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/StatsGrid.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { StatsGrid } from "../StatsGrid";
+
+describe("StatsGrid", () => {
+  it("renders StatCards and merges className", () => {
+    const items = [
+      { label: "Users", value: "123" },
+      { label: "Sessions", value: "456" },
+    ];
+
+    const { container } = render(
+      <StatsGrid items={items} className="custom-class" />
+    );
+
+    items.forEach(({ label, value }) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(value)).toBeInTheDocument();
+    });
+
+    const grid = container.firstChild as HTMLElement;
+    expect(grid).toHaveClass(
+      "grid",
+      "gap-4",
+      "sm:grid-cols-2",
+      "lg:grid-cols-3",
+      "custom-class"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refactor StatsGrid item mapping for readability
- add StatsGrid test verifying StatCard rendering and class merging

## Testing
- `pnpm run -r check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm run -r build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui` in project)*
- `pnpm exec jest --config jest.config.cjs --runTestsByPath --coverage=false packages/ui/src/components/organisms/__tests__/StatsGrid.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b8af631e94832f889b510a58901b92