### PR TITLE
feat(stripe): use core env for Stripe key

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,7 +1,7 @@
 // packages/stripe/src/index.ts
 import "server-only";
 
-import { paymentsEnv } from "@acme/config/env/payments";
+import { coreEnv } from "@acme/config/env/core";
 import Stripe from "stripe";
 
 /**
@@ -10,12 +10,8 @@ import Stripe from "stripe";
  * • Uses `createFetchHttpClient` so it works on Cloudflare Workers / Pages.
  * • Pins `apiVersion` to Stripe’s latest GA (“2025-06-30.basil”) so typings
  *   and requests stay in sync.
- *
- * If you prefer to auto-upgrade on each Stripe release, simply delete the
- * `apiVersion` line and Stripe will default to the newest version whenever
- * you bump the SDK.
  */
-export const stripe = new Stripe(paymentsEnv.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(coreEnv.STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
   httpClient: Stripe.createFetchHttpClient(),
 });


### PR DESCRIPTION
## Summary
- swap to coreEnv for Stripe client configuration

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/types/src/index')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/stripe build`
- `pnpm --filter @acme/stripe test` *(fails: Cannot read properties of undefined (reading '_def'))*

------
https://chatgpt.com/codex/tasks/task_e_68b8ae9f28d8832fa7e03287b21deb6d