### PR TITLE
test: add currency switcher

### DIFF
--- a/packages/ui/src/components/molecules/__tests__/CurrencySwitcher.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/CurrencySwitcher.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import CurrencySwitcher from "../CurrencySwitcher.client";
+
+const setCurrencySpy = jest.fn();
+
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => {
+  const React = require("react");
+  return {
+    useCurrency: () => {
+      const [currency, setCurrency] = React.useState("EUR");
+      return [
+        currency,
+        (newCurrency: string) => {
+          setCurrency(newCurrency);
+          setCurrencySpy(newCurrency);
+        },
+      ] as const;
+    },
+  };
+});
+
+beforeAll(() => {
+  // Radix Select calls scrollIntoView which JSDOM doesn't implement
+  (window.HTMLElement.prototype as any).scrollIntoView = jest.fn();
+});
+
+describe("CurrencySwitcher", () => {
+  it("lists currencies and updates selection", async () => {
+    render(<CurrencySwitcher />);
+
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    for (const c of ["EUR", "USD", "GBP"]) {
+      expect(await screen.findByRole("option", { name: c })).toBeInTheDocument();
+    }
+
+    fireEvent.click(screen.getByRole("option", { name: "USD" }));
+
+    expect(setCurrencySpy).toHaveBeenCalledWith("USD");
+    expect(screen.getByRole("combobox")).toHaveTextContent("USD");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add CurrencySwitcher dropdown test covering option mapping and value updates

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/types/src/index')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/ui` *(fails: Missing tasks in project)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/molecules/__tests__/CurrencySwitcher.test.tsx --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8af61db64832fa0305a43906393b2