### PR TITLE
test(ui): cover StatsGrid mapping

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/StatsGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/StatsGrid.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { StatsGrid } from "../StatsGrid";
+
+describe("StatsGrid", () => {
+  it("renders each StatCard and merges class names", () => {
+    const items = [
+      { label: "Visits", value: "1200" },
+      { label: "Purchases", value: "300" },
+    ];
+
+    const { container } = render(
+      <StatsGrid items={items} className="custom-class" />
+    );
+
+    for (const item of items) {
+      expect(screen.getByText(item.label)).toBeInTheDocument();
+      expect(screen.getByText(String(item.value))).toBeInTheDocument();
+    }
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass(
+      "grid",
+      "gap-4",
+      "sm:grid-cols-2",
+      "lg:grid-cols-3",
+      "custom-class"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `StatsGrid` to assert item rendering and className merging

## Testing
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `pnpm test packages/ui` *(fails: Missing task `packages/ui`)*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/StatsGrid.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b8aefdc49c832fb6b5c69c1a9089ac