### PR TITLE
test: add configurator tour and context tests

### DIFF
--- a/apps/cms/src/app/cms/configurator/__tests__/ConfiguratorContext.test.tsx
+++ b/apps/cms/src/app/cms/configurator/__tests__/ConfiguratorContext.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfiguratorProvider, useConfigurator } from "../ConfiguratorContext";
+import { STORAGE_KEY } from "../hooks/useConfiguratorPersistence";
+
+jest.mock("@platform-core/contexts/LayoutContext", () => ({
+  useLayout: () => ({ setConfiguratorProgress: jest.fn() }),
+}));
+
+function TestComponent(): JSX.Element {
+  const { update, markStepComplete, state } = useConfigurator();
+  return (
+    <>
+      <button onClick={() => update("storeName", "My Store")} data-testid="update" />
+      <button onClick={() => markStepComplete("intro", "complete")} data-testid="complete" />
+      <div data-testid="status">{state.completed.intro}</div>
+    </>
+  );
+}
+
+describe("ConfiguratorContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: {}, completed: {} }),
+      })
+    ) as any;
+  });
+
+  it("persists updates and step completion", async () => {
+    render(
+      <ConfiguratorProvider>
+        <TestComponent />
+      </ConfiguratorProvider>
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByTestId("update"));
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)! ).storeName).toBe("My Store")
+    );
+
+    await userEvent.click(screen.getByTestId("complete"));
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("complete")
+    );
+    await waitFor(() =>
+      expect(
+        JSON.parse(localStorage.getItem(STORAGE_KEY)!).completed.intro
+      ).toBe("complete")
+    );
+  });
+});

--- a/apps/cms/src/app/cms/configurator/__tests__/GuidedTour.test.tsx
+++ b/apps/cms/src/app/cms/configurator/__tests__/GuidedTour.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GuidedTour, { useGuidedTour } from "../GuidedTour";
+
+function ReplayButton(): JSX.Element {
+  const { replay } = useGuidedTour();
+  return <button onClick={replay}>Replay</button>;
+}
+
+describe("GuidedTour", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("updates localStorage through the tour lifecycle", async () => {
+    render(
+      <GuidedTour>
+        <div data-tour="select-template">template</div>
+        <div data-tour="drag-component">drag</div>
+        <div data-tour="edit-properties">edit</div>
+        <div data-tour="preview">preview</div>
+        <div data-tour="publish">publish</div>
+        <ReplayButton />
+      </GuidedTour>
+    );
+
+    await waitFor(() =>
+      expect(localStorage.getItem("configurator-guided-tour")).toBe("0")
+    );
+
+    await userEvent.click(screen.getByText("Next"));
+    expect(localStorage.getItem("configurator-guided-tour")).toBe("1");
+
+    await userEvent.click(screen.getByText("Back"));
+    expect(localStorage.getItem("configurator-guided-tour")).toBe("0");
+
+    await userEvent.click(screen.getByText("Skip"));
+    expect(localStorage.getItem("configurator-guided-tour")).toBe("done");
+
+    await userEvent.click(screen.getByText("Replay"));
+    expect(localStorage.getItem("configurator-guided-tour")).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary
- test GuidedTour lifecycle events update localStorage
- verify ConfiguratorContext persists state and step completion

## Testing
- `pnpm exec jest apps/cms/src/app/cms/configurator/__tests__/GuidedTour.test.tsx --runInBand --no-coverage`
- `pnpm exec jest apps/cms/src/app/cms/configurator/__tests__/ConfiguratorContext.test.tsx --runInBand --no-coverage`
- `pnpm --filter @apps/cms test` *(fails: configuration issues and failing existing tests)*
- `pnpm -r build` *(fails: apps/cms build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ae45c9a8832f83405bd19c06850f