### PR TITLE
test: cover page builder hooks

### DIFF
--- a/packages/ui/__tests__/useAutoSave.test.tsx
+++ b/packages/ui/__tests__/useAutoSave.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook, act } from "@testing-library/react";
+import useAutoSave from "../src/components/cms/page-builder/hooks/useAutoSave";
+
+describe("useAutoSave", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("debounces saving and resets state", async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const formData = new FormData();
+    const { result, rerender } = renderHook(({ deps }) =>
+      useAutoSave({ onSave, formData, deps })
+    , { initialProps: { deps: [0] } });
+
+    rerender({ deps: [1] });
+    expect(onSave).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(result.current.autoSaveState).toBe("saved");
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.autoSaveState).toBe("idle");
+  });
+
+  it("cleans up pending timeout on unmount", () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const formData = new FormData();
+    const { rerender, unmount } = renderHook(({ deps }) =>
+      useAutoSave({ onSave, formData, deps })
+    , { initialProps: { deps: [0] } });
+
+    rerender({ deps: [1] });
+    unmount();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/__tests__/useFileDrop.test.tsx
+++ b/packages/ui/__tests__/useFileDrop.test.tsx
@@ -44,4 +44,22 @@ describe("useFileDrop", () => {
       expect.objectContaining({ type: "add" })
     );
   });
+
+  it("logs errors from onDrop and resets drag state", async () => {
+    const dispatch = jest.fn();
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    onDropMock.mockImplementationOnce(() => {
+      throw new Error("fail");
+    });
+    const { result } = renderHook(() =>
+      useFileDrop({ shop: "shop", dispatch })
+    );
+    await act(async () => {
+      result.current.setDragOver(true);
+      await result.current.handleFileDrop({} as any);
+    });
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(result.current.dragOver).toBe(false);
+    consoleSpy.mockRestore();
+  });
 });

--- a/packages/ui/__tests__/usePageBuilderDnD.test.tsx
+++ b/packages/ui/__tests__/usePageBuilderDnD.test.tsx
@@ -58,4 +58,40 @@ describe("usePageBuilderDnD", () => {
     );
     expect(result.current.insertIndex).toBe(0);
   });
+
+  it("moves existing block within canvas", () => {
+    const components = [
+      { id: "a", type: "Text" },
+      { id: "b", type: "Text" },
+    ] as any;
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      usePageBuilderDnD({
+        components,
+        dispatch,
+        defaults: {},
+        containerTypes: [],
+        selectId: jest.fn(),
+      })
+    );
+
+    act(() =>
+      result.current.handleDragEnd({
+        active: {
+          data: { current: { from: "canvas", index: 0, parentId: undefined } },
+        },
+        over: {
+          id: "canvas",
+          data: { current: {} },
+        },
+      } as any)
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "move",
+      from: { parentId: undefined, index: 0 },
+      to: { parentId: undefined, index: 1 },
+    });
+    expect(result.current.insertIndex).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add fake-timer tests for debounced autosave
- verify page builder block movement and file drop errors
- ensure canvas drag removes listeners on unmount

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/useAutoSave.test.tsx packages/ui/__tests__/usePageBuilderDnD.test.tsx packages/ui/__tests__/useFileDrop.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx`
- `pnpm --filter @acme/ui test -- --coverage=false packages/ui/__tests__/useAutoSave.test.tsx packages/ui/__tests__/usePageBuilderDnD.test.tsx packages/ui/__tests__/useFileDrop.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx` *(fails: Jest coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af52a7b0832fbc51cff5315f659f