### PR TITLE
test: add tokens editor interactions

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/Tokens.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/Tokens.test.tsx
@@ -1,0 +1,78 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import Tokens from "../Tokens";
+import Presets from "../Presets";
+import type { TokenMap } from "../../../../hooks/useTokenEditor";
+
+describe("Tokens", () => {
+  it("propagates token edits via onChange", () => {
+    const baseTokens: TokenMap = {
+      "--color-bg": "0 0% 100%",
+      "--color-fg": "0 0% 0%",
+    };
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Tokens tokens={{}} baseTokens={baseTokens} onChange={handleChange} />
+    );
+
+    const input = container.querySelector(
+      'label[data-token-key="--color-bg"] input'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "#000000" } });
+
+    expect(handleChange).toHaveBeenCalledWith({ "--color-bg": "0 0% 0%" });
+  });
+
+  it("resets token to default value", () => {
+    const baseTokens: TokenMap = {
+      "--color-bg": "0 0% 100%",
+      "--color-fg": "0 0% 0%",
+    };
+    const handleChange = jest.fn();
+    render(
+      <Tokens
+        tokens={{ "--color-bg": "0 0% 0%" }}
+        baseTokens={baseTokens}
+        onChange={handleChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Reset"));
+    expect(handleChange).toHaveBeenCalledWith({ "--color-bg": "0 0% 100%" });
+  });
+
+  it("shows validation warning for low contrast colors", () => {
+    const baseTokens: TokenMap = {
+      "--color-bg": "0 0% 100%",
+      "--color-fg": "0 0% 0%",
+    };
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Tokens tokens={{}} baseTokens={baseTokens} onChange={handleChange} />
+    );
+
+    const input = container.querySelector(
+      'label[data-token-key="--color-bg"] input'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "#000000" } });
+
+    expect(screen.getByText(/Low contrast/)).toBeInTheDocument();
+  });
+});
+
+describe("Presets", () => {
+  it("applies selected preset and resets tokens", () => {
+    const handleChange = jest.fn();
+    render(<Presets tokens={{}} baseTokens={{}} onChange={handleChange} />);
+
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: "brand" },
+    });
+    expect(handleChange).toHaveBeenCalledWith(
+      expect.objectContaining({ "--color-primary": "340 82% 52%" })
+    );
+
+    fireEvent.click(screen.getByTestId("preset-reset"));
+    expect(handleChange).toHaveBeenLastCalledWith({});
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests covering token editing, reset, and preset selection
- validate low contrast colors show warnings

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/types/src/index' while building apps/shop-bcd)*
- `pnpm --filter @acme/ui build`
- `pnpm --filter @acme/ui test` *(fails: Jest encountered unexpected token in packages/email)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af53adac832f835634c1972559a6