### PR TITLE
test(ui): verify icon dynamic selection

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/Icon.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Icon.test.tsx
@@ -1,0 +1,18 @@
+import "../../../../../../test/resetNextMocks";
+import { render } from "@testing-library/react";
+import { HeartIcon, PersonIcon, StarIcon } from "@radix-ui/react-icons";
+import { Icon, IconName } from "../Icon";
+
+describe("Icon", () => {
+  const icons: Record<IconName, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
+    star: StarIcon,
+    heart: HeartIcon,
+    user: PersonIcon,
+  };
+
+  it.each(Object.entries(icons))("renders %s icon", (name, RadixIcon) => {
+    const { container } = render(<Icon name={name as IconName} />);
+    const { container: expected } = render(<RadixIcon />);
+    expect(container.firstChild?.isEqualNode(expected.firstChild)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering dynamic icon selection for Icon atom

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af64d990832fb4593c8e55317be8