### PR TITLE
feat: provide default auth secret for tests

### DIFF
--- a/apps/cms/src/auth/secret.ts
+++ b/apps/cms/src/auth/secret.ts
@@ -1,6 +1,11 @@
 // apps/cms/src/auth/secret.ts
 
-const secret = process.env.NEXTAUTH_SECRET;
+// Allow tests and local development to run without configuring a secret.
+// `NEXTAUTH_SECRET` is still required in production to ensure sessions are
+// cryptographically signed.
+const secret =
+  process.env.NEXTAUTH_SECRET ??
+  (process.env.NODE_ENV === "production" ? undefined : "test-secret");
 
 if (!secret) {
   throw new Error("NEXTAUTH_SECRET is not set");


### PR DESCRIPTION
## Summary
- allow cms auth secret to default to test-secret outside production

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm exec jest apps/cms/__tests__/shops.update.test.ts apps/cms/__tests__/inventoryUpdateRoute.test.ts --testTimeout=30000`
- `pnpm exec jest apps/cms/__tests__/errorPages.test.tsx --testTimeout=30000`


------
https://chatgpt.com/codex/tasks/task_e_68b93e701868832f9e3ee121c821e339