### PR TITLE
Polyfill URL object URLs in tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -80,6 +80,14 @@ if (typeof window !== "undefined") {
   (globalThis as any).FormData ||= UndiciFormData;
 }
 
+/** JSDOM doesn't implement object URLs; stub the APIs used in tests */
+if (!(URL as any).createObjectURL) {
+  (URL as any).createObjectURL = () => "blob:mock";
+}
+if (!(URL as any).revokeObjectURL) {
+  (URL as any).revokeObjectURL = () => {};
+}
+
 /**
  * React 19+ uses `MessageChannel` internally for suspense & streaming.
  * Node’s impl can leave ports open, preventing Jest from exiting, so


### PR DESCRIPTION
## Summary
- stub `URL.createObjectURL` and `URL.revokeObjectURL` in Jest setup so jsdom-based tests can create video thumbnails

## Testing
- `pnpm test:cms apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx`
- `pnpm -r build` *(fails: Module '"@prisma/client"' has no exported member 'Prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68b93e08c248832f98b120a3795bb9cf