### PR TITLE
test: wrap StepShopPage interactions in act

### DIFF
--- a/apps/cms/__tests__/StepShopPage.test.tsx
+++ b/apps/cms/__tests__/StepShopPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor, act } from "@testing-library/react";
 import StepShopPage from "../src/app/cms/configurator/steps/StepShopPage";
 
 // Router mock
@@ -115,9 +115,13 @@ describe("StepShopPage", () => {
       .mockResolvedValueOnce({ data: null, error: "save error" })
       .mockResolvedValueOnce({ data: null, error: "publish error" });
     renderStep();
-    fireEvent.click(screen.getByText("save"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("save"));
+    });
     await screen.findByText("save error");
-    fireEvent.click(screen.getByText("publish"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("publish"));
+    });
     await screen.findByText("publish error");
   });
 
@@ -131,7 +135,9 @@ describe("StepShopPage", () => {
   it("marks step complete after saving page", async () => {
     apiRequest.mockResolvedValueOnce({ data: { id: "p1" }, error: null });
     renderStep();
-    fireEvent.click(screen.getByText("save"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("save"));
+    });
     await waitFor(() => expect(state.shopPageId).toBe("p1"));
     fireEvent.click(screen.getByText("Next"));
     expect(markStepComplete).toHaveBeenCalledWith("shop-page", "complete");


### PR DESCRIPTION
## Summary
- wrap save and publish interactions with `act` in `StepShopPage` tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `npm test __tests__/StepShopPage.test.tsx` *(fails: coverage threshold for branches 60% not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b93dda7f6c832f8d0c0d5e057dac14