### PR TITLE
Fix default history parsing for new page drafts

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -140,7 +140,7 @@ export async function savePageDraft(
         slug: "",
         status: "draft",
         components,
-        history: history ?? historyStateSchema.parse({}),
+        history: history ?? historyStateSchema.parse(undefined),
         seo: {
           title: emptyTranslated(),
           description: emptyTranslated(),


### PR DESCRIPTION
## Summary
- ensure new page drafts use `historyStateSchema.parse(undefined)` to load default history state

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @apps/cms test` *(fails: NEXTAUTH_SECRET is not set and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b93eeb7e98832fa47536f9a1375288