### PR TITLE
test: cover email provider fallbacks

### DIFF
--- a/packages/email/src/send.test.ts
+++ b/packages/email/src/send.test.ts
@@ -1,0 +1,137 @@
+import { ProviderError } from "./providers/types";
+
+let mockSendgridSend: jest.Mock;
+let mockResendSend: jest.Mock;
+let mockSendMail: jest.Mock;
+
+jest.mock("nodemailer", () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn(() => ({
+      sendMail: (...args: any[]) => mockSendMail(...args),
+    })),
+  },
+}));
+
+jest.mock("./providers/sendgrid", () => ({
+  SendgridProvider: jest.fn().mockImplementation(() => ({
+    send: (...args: any[]) => mockSendgridSend(...args),
+  })),
+}));
+
+jest.mock("./providers/resend", () => ({
+  ResendProvider: jest.fn().mockImplementation(() => ({
+    send: (...args: any[]) => mockResendSend(...args),
+  })),
+}));
+
+describe("sendCampaignEmail", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    jest.clearAllTimers();
+    delete process.env.EMAIL_PROVIDER;
+    delete process.env.SENDGRID_API_KEY;
+    delete process.env.RESEND_API_KEY;
+    delete process.env.CAMPAIGN_FROM;
+  });
+
+  it("ensureText throws when html absent", async () => {
+    mockSendgridSend = jest.fn();
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
+
+    const { sendCampaignEmail } = await import("./send");
+
+    await expect(
+      sendCampaignEmail({
+        to: "to@example.com",
+        subject: "Subject",
+      })
+    ).rejects.toThrow("Missing html content for campaign email");
+
+    expect(mockSendgridSend).not.toHaveBeenCalled();
+    expect(mockResendSend).not.toHaveBeenCalled();
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it("throws on unsupported EMAIL_PROVIDER", async () => {
+    mockSendgridSend = jest.fn();
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
+
+    const { sendCampaignEmail } = await import("./send");
+
+    process.env.EMAIL_PROVIDER = "unknown";
+
+    await expect(
+      sendCampaignEmail({
+        to: "to@example.com",
+        subject: "Subject",
+        html: "<p>HTML</p>",
+        sanitize: false,
+      })
+    ).rejects.toThrow(
+      'Unsupported EMAIL_PROVIDER "unknown". Available providers: sendgrid, resend, smtp'
+    );
+
+    expect(mockSendgridSend).not.toHaveBeenCalled();
+    expect(mockResendSend).not.toHaveBeenCalled();
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it("retries failing provider then falls back in order", async () => {
+    const timeoutSpy = jest.spyOn(global, "setTimeout");
+    mockSendgridSend = jest.fn().mockRejectedValue(new ProviderError("fail", true));
+    mockResendSend = jest.fn().mockResolvedValue(undefined);
+    mockSendMail = jest.fn();
+
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    process.env.SENDGRID_API_KEY = "sg";
+    process.env.RESEND_API_KEY = "rs";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+
+    const { sendCampaignEmail } = await import("./send");
+
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      sanitize: false,
+    });
+
+    expect(mockSendgridSend).toHaveBeenCalledTimes(3);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 100);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 200);
+    expect(mockResendSend).toHaveBeenCalledTimes(1);
+    expect(mockSendMail).not.toHaveBeenCalled();
+    timeoutSpy.mockRestore();
+  });
+
+  it("falls back to Nodemailer when no provider available", async () => {
+    mockSendgridSend = jest.fn();
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn().mockResolvedValue(undefined);
+
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    process.env.CAMPAIGN_FROM = "campaign@example.com";
+
+    const { sendCampaignEmail } = await import("./send");
+
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      sanitize: false,
+    });
+
+    expect(mockSendgridSend).not.toHaveBeenCalled();
+    expect(mockResendSend).not.toHaveBeenCalled();
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for ensureText and provider fallback logic in sendCampaignEmail

## Testing
- `pnpm run --if-present check:references`
- `pnpm run --if-present build:ts`
- `pnpm --filter @acme/email test packages/email/src/send.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9466d0f04832f997d800c0f8d33dc