### PR TITLE
test: add replaceShopInPath tests

### DIFF
--- a/packages/shared-utils/src/replaceShopInPath.test.ts
+++ b/packages/shared-utils/src/replaceShopInPath.test.ts
@@ -1,0 +1,18 @@
+import { replaceShopInPath } from "./replaceShopInPath";
+
+describe("replaceShopInPath", () => {
+  it("replaces existing shop slug", () => {
+    expect(replaceShopInPath("/cms/shop/old/pages", "new")).toBe(
+      "/cms/shop/new/pages"
+    );
+  });
+
+  it("returns default pattern when shop segment missing", () => {
+    expect(replaceShopInPath("/cms/blog", "new")).toBe("/cms/shop/new");
+  });
+
+  it("handles null or undefined pathname", () => {
+    expect(replaceShopInPath(null, "new")).toBe("/cms/shop/new");
+    expect(replaceShopInPath(undefined, "new")).toBe("/cms/shop/new");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for replaceShopInPath utility

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm test packages/shared-utils/src/replaceShopInPath.test.ts` (fails: Missing task)
- `CI=true pnpm exec jest packages/shared-utils/src/replaceShopInPath.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9466ef010832fbbbfd1902dc11e74