### PR TITLE
test: add cart cookie tests

### DIFF
--- a/packages/platform-core/src/cartCookie.test.ts
+++ b/packages/platform-core/src/cartCookie.test.ts
@@ -1,0 +1,88 @@
+/** @jest-environment node */
+
+jest.mock("@acme/config/env/core", () => ({
+  loadCoreEnv: () => ({ CART_COOKIE_SECRET: "test-secret" }),
+}));
+
+import {
+  CART_COOKIE,
+  encodeCartCookie,
+  decodeCartCookie,
+  asSetCookieHeader,
+} from "./cartCookie";
+
+describe("cartCookie", () => {
+  it("encodes then decodes JSON values", () => {
+    const value = { foo: "bar" };
+    const encoded = encodeCartCookie(JSON.stringify(value));
+    const decoded = decodeCartCookie(encoded);
+    expect(decoded).toEqual(value);
+  });
+
+  it("logs warning and returns null for invalid signature", () => {
+    const encoded = encodeCartCookie(JSON.stringify({ foo: "bar" }));
+    const tampered = encoded.replace(/.$/, "x");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const result = decodeCartCookie(tampered);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("Invalid cart cookie");
+    warnSpy.mockRestore();
+  });
+
+  it("warns and returns null for malformed cookie", () => {
+    const encoded = encodeCartCookie(JSON.stringify({ foo: "bar" }));
+    const truncated = encoded.slice(0, -1);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    expect(decodeCartCookie(truncated)).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("Invalid cart cookie");
+    warnSpy.mockRestore();
+  });
+
+  it("returns null when cookie missing", () => {
+    expect(decodeCartCookie(undefined)).toBeNull();
+  });
+
+  it("returns null when signature missing", () => {
+    expect(decodeCartCookie("abc")).toBeNull();
+  });
+
+  it("returns null when encoded value missing", () => {
+    const encoded = encodeCartCookie("payload");
+    const [, sig] = encoded.split(".");
+    expect(decodeCartCookie(`.${sig}`)).toBeNull();
+  });
+
+  it("returns raw string for non-JSON payload", () => {
+    const payload = "hello";
+    const encoded = encodeCartCookie(payload);
+    const decoded = decodeCartCookie(encoded);
+    expect(decoded).toBe(payload);
+  });
+
+  it("omits Max-Age when maxAge is null", () => {
+    const header = asSetCookieHeader("value", null);
+    expect(header.includes("Max-Age")).toBe(false);
+    expect(header).toBe(
+      `${CART_COOKIE}=value; Path=/; SameSite=Strict; Secure; HttpOnly`
+    );
+  });
+
+  it("includes Max-Age when provided", () => {
+    const header = asSetCookieHeader("value", 10);
+    expect(header).toContain("Max-Age=10");
+  });
+
+  it("uses default Max-Age when omitted", () => {
+    const header = asSetCookieHeader("value");
+    expect(header).toMatch(/Max-Age=\d+/);
+  });
+
+  it("throws when secret is missing", async () => {
+    jest.resetModules();
+    jest.doMock("@acme/config/env/core", () => ({ loadCoreEnv: () => ({}) }));
+    await expect(
+      import("./cartCookie").then((m) => m.encodeCartCookie("x"))
+    ).rejects.toThrow("env.CART_COOKIE_SECRET is required");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for cart cookie encode/decode and header generation

## Testing
- `pnpm --filter @acme/platform-core test src/cartCookie.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b94a5180d0832f899579661ebdf636