### PR TITLE
test: add getShopFromPath edge cases

### DIFF
--- a/packages/shared-utils/src/getShopFromPath.test.ts
+++ b/packages/shared-utils/src/getShopFromPath.test.ts
@@ -1,0 +1,16 @@
+import { getShopFromPath } from "./getShopFromPath";
+
+describe("getShopFromPath", () => {
+  it("returns the shop slug even with extra slashes", () => {
+    expect(getShopFromPath("/cms//shop/demo///pages")).toBe("demo");
+  });
+
+  it("returns undefined when the shop segment is missing", () => {
+    expect(getShopFromPath("/cms/foo/bar")).toBeUndefined();
+  });
+
+  it("returns undefined for null or undefined inputs", () => {
+    expect(getShopFromPath(null)).toBeUndefined();
+    expect(getShopFromPath(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for getShopFromPath handling extra slashes, missing segments, and null/undefined inputs

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/shared-utils/src/getShopFromPath.test.ts` *(fails: Missing tasks in project)*
- `pnpm --filter @acme/shared-utils test packages/shared-utils/src/getShopFromPath.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b94a4f8e78832f818792666fd3e03c