### PR TITLE
test: add product repository scenarios

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/products.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/products.server.test.ts
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
 
-describe("products repository error cases", () => {
+describe("products repository", () => {
   const shop = "demo";
 
   beforeEach(() => {
@@ -8,25 +8,46 @@ describe("products repository error cases", () => {
     process.env.DATA_ROOT = "/tmp/data";
   });
 
-  it("readRepo returns empty array when file read fails", async () => {
-    const readFile = jest.fn().mockRejectedValue(new Error("fail"));
+  it("readRepo returns empty array when products file is missing", async () => {
+    const readFile = jest
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
     jest.doMock("fs", () => ({ promises: { readFile } }));
     const { readRepo } = await import("../products.server");
     await expect(readRepo(shop)).resolves.toEqual([]);
     expect(readFile).toHaveBeenCalled();
   });
 
-  it("updateProductInRepo throws when id not found", async () => {
-    const readFile = jest.fn().mockResolvedValue("[]");
-    const writeFile = jest.fn();
-    const mkdir = jest.fn();
-    const rename = jest.fn();
-    jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
-    const { updateProductInRepo } = await import("../products.server");
-    await expect(updateProductInRepo(shop, { id: "2" })).rejects.toThrow(
-      "Product 2 not found in demo",
-    );
-    expect(writeFile).not.toHaveBeenCalled();
+  describe("updateProductInRepo", () => {
+    it("updates product and increments row_version", async () => {
+      const readFile = jest
+        .fn()
+        .mockResolvedValue('[{"id":"1","row_version":1,"name":"old"}]');
+      const writeFile = jest.fn();
+      const mkdir = jest.fn();
+      const rename = jest.fn();
+      jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+      const { updateProductInRepo } = await import("../products.server");
+      const result = await updateProductInRepo(shop, { id: "1", name: "new" });
+      expect(result).toEqual({ id: "1", row_version: 2, name: "new" });
+      const written = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(written[0]).toEqual(result);
+      expect(readFile).toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalled();
+    });
+
+    it("throws when id not found", async () => {
+      const readFile = jest.fn().mockResolvedValue("[]");
+      const writeFile = jest.fn();
+      const mkdir = jest.fn();
+      const rename = jest.fn();
+      jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+      const { updateProductInRepo } = await import("../products.server");
+      await expect(updateProductInRepo(shop, { id: "2" })).rejects.toThrow(
+        "Product 2 not found in demo",
+      );
+      expect(writeFile).not.toHaveBeenCalled();
+    });
   });
 
   it("deleteProductFromRepo throws when product absent", async () => {
@@ -42,16 +63,50 @@ describe("products repository error cases", () => {
     expect(writeFile).not.toHaveBeenCalled();
   });
 
-  it("duplicateProductInRepo throws when original missing", async () => {
-    const readFile = jest.fn().mockResolvedValue("[]");
-    const writeFile = jest.fn();
-    const mkdir = jest.fn();
-    const rename = jest.fn();
-    jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
-    const { duplicateProductInRepo } = await import("../products.server");
-    await expect(duplicateProductInRepo(shop, "1")).rejects.toThrow(
-      "Product 1 not found in demo",
-    );
-    expect(writeFile).not.toHaveBeenCalled();
+  describe("duplicateProductInRepo", () => {
+    it("duplicates product with new id and sku", async () => {
+      const product = {
+        id: "1",
+        sku: "abc",
+        row_version: 3,
+        status: "published",
+        created_at: "old",
+        updated_at: "old",
+      };
+      const readFile = jest.fn().mockResolvedValue(JSON.stringify([product]));
+      const writeFile = jest.fn();
+      const mkdir = jest.fn();
+      const rename = jest.fn();
+      jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+      jest.doMock("ulid", () => ({ ulid: () => "new-id" }));
+      jest.doMock("@acme/date-utils", () => ({ nowIso: () => "2020-01-01T00:00:00Z" }));
+      const { duplicateProductInRepo } = await import("../products.server");
+      const copy = await duplicateProductInRepo(shop, "1");
+      expect(copy).toMatchObject({
+        id: "new-id",
+        sku: "abc-copy",
+        status: "draft",
+        row_version: 1,
+        created_at: "2020-01-01T00:00:00Z",
+        updated_at: "2020-01-01T00:00:00Z",
+      });
+      const written = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(written[0]).toEqual(copy);
+      expect(written[1]).toEqual(product);
+    });
+
+    it("throws when original missing", async () => {
+      const readFile = jest.fn().mockResolvedValue("[]");
+      const writeFile = jest.fn();
+      const mkdir = jest.fn();
+      const rename = jest.fn();
+      jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+      const { duplicateProductInRepo } = await import("../products.server");
+      await expect(duplicateProductInRepo(shop, "1")).rejects.toThrow(
+        "Product 1 not found in demo",
+      );
+      expect(writeFile).not.toHaveBeenCalled();
+    });
   });
 });
+


### PR DESCRIPTION
## Summary
- add tests for missing products file in `readRepo`
- cover update and duplicate product success cases
- ensure repository functions handle missing ids

## Testing
- ⚠️ `pnpm --filter @acme/platform-core run build` (fails: Cannot find module '@jest/globals')
- ✅ `pnpm exec jest packages/platform-core/src/repositories/__tests__/products.server.test.ts --ci --runInBand --detectOpenHandles --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b94d43bd2c832f9b7f3008aa97bd53