### PR TITLE
test(platform-machine): expand resolveConfig coverage

### DIFF
--- a/packages/platform-machine/src/__tests__/reverseLogisticsService.test.ts
+++ b/packages/platform-machine/src/__tests__/reverseLogisticsService.test.ts
@@ -268,6 +268,31 @@ describe("resolveConfig", () => {
     });
     expect(cfg).toEqual({ enabled: true, intervalMinutes: 10 });
   });
+
+  it("keeps default enabled when coreEnv flag is null", async () => {
+    readFileMock.mockRejectedValueOnce(new Error("missing"));
+    coreEnv.REVERSE_LOGISTICS_ENABLED = null as any;
+    const cfg = await service.resolveConfig("shop", "/data");
+    expect(cfg).toEqual({ enabled: false, intervalMinutes: 60 });
+  });
+
+  it("keeps default interval when coreEnv interval is null", async () => {
+    readFileMock.mockRejectedValueOnce(new Error("missing"));
+    coreEnv.REVERSE_LOGISTICS_INTERVAL_MS = null as any;
+    const cfg = await service.resolveConfig("shop", "/data");
+    expect(cfg).toEqual({ enabled: false, intervalMinutes: 60 });
+  });
+
+  it("disables service when env enabled is false", async () => {
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        reverseLogisticsService: { enabled: true, intervalMinutes: 5 },
+      })
+    );
+    process.env.REVERSE_LOGISTICS_ENABLED_SHOP = "false";
+    const cfg = await service.resolveConfig("shop", "/data");
+    expect(cfg).toEqual({ enabled: false, intervalMinutes: 5 });
+  });
 });
 
 describe("startReverseLogisticsService", () => {


### PR DESCRIPTION
## Summary
- add tests for null `coreEnv` values in `resolveConfig`
- verify disabling service when `REVERSE_LOGISTICS_ENABLED` env is false

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/platform-machine/src/__tests__/reverseLogisticsService.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b94d56f4cc832f85fa4e886e2e2a72