### PR TITLE
test: cover missing cart cookie cases

### DIFF
--- a/packages/platform-core/src/cartCookie.ts
+++ b/packages/platform-core/src/cartCookie.ts
@@ -91,3 +91,6 @@ export function asSetCookieHeader(
   parts.push("SameSite=Strict", "Secure", "HttpOnly");
   return parts.join("; ");
 }
+
+/** @internal - exposed for testing */
+export const __test = { getSecret };


### PR DESCRIPTION
## Summary
- expose `getSecret` for testing
- test missing `CART_COOKIE_SECRET`
- test invalid cart cookie signatures

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(missing script: check:references)*
- `pnpm run build:ts` *(missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: Jest encountered an unexpected token and other module resolution errors)*
- `pnpm exec jest packages/platform-core/src/cartCookie.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b94d4942e4832f8528044d6852b032