### PR TITLE
test(platform-machine): verify index exports

### DIFF
--- a/packages/platform-machine/src/__tests__/index.test.ts
+++ b/packages/platform-machine/src/__tests__/index.test.ts
@@ -1,0 +1,28 @@
+import { renderHook } from "@testing-library/react";
+import * as pkg from "../index";
+
+describe("index exports", () => {
+  it("exposes startReverseLogisticsService", () => {
+    expect(pkg.startReverseLogisticsService).toBe(
+      require("../reverseLogisticsService").startReverseLogisticsService,
+    );
+  });
+
+  it("exposes startLateFeeService", () => {
+    expect(pkg.startLateFeeService).toBe(
+      require("../lateFeeService").startLateFeeService,
+    );
+  });
+
+  it("exposes useFSM", () => {
+    expect(pkg.useFSM).toBe(require("../useFSM").useFSM);
+    const { result } = renderHook(() => pkg.useFSM("idle", []));
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("exposes maintenance scheduler", () => {
+    const mod = require("../maintenanceScheduler");
+    expect(pkg.runMaintenanceScan).toBe(mod.runMaintenanceScan);
+    expect(pkg.startMaintenanceScheduler).toBe(mod.startMaintenanceScheduler);
+  });
+});


### PR DESCRIPTION
## Summary
- test platform-machine index re-exports startReverseLogisticsService, startLateFeeService, useFSM, and maintenance scheduler

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/platform-machine/src/__tests__/index.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b94d5c0e9c832f8e53ecbcea18d1ae