### PR TITLE
fix template route test

### DIFF
--- a/apps/cms/src/app/api/page-templates/[name]/route.ts
+++ b/apps/cms/src/app/api/page-templates/[name]/route.ts
@@ -11,6 +11,7 @@ export function resolveTemplatesRoot(): string {
       dir,
       "packages",
       "ui",
+      "src",
       "components",
       "templates"
     );
@@ -23,6 +24,7 @@ export function resolveTemplatesRoot(): string {
     process.cwd(),
     "packages",
     "ui",
+    "src",
     "components",
     "templates"
   );
@@ -33,6 +35,7 @@ export async function GET(
   context: { params: Promise<{ name: string }> }
 ) {
   try {
+    const { resolveTemplatesRoot } = await import("./route");
     const dir = resolveTemplatesRoot();
     const { name } = await context.params;
     const file = path.join(dir, `${name}.json`);


### PR DESCRIPTION
## Summary
- resolve templates from `packages/ui/src/components/templates`
- allow GET route to use mocked template root for testing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator build)*
- `pnpm --filter @apps/cms test 'src/app/api/page-templates/\[name\]/__tests__/route.test.ts'`

------
https://chatgpt.com/codex/tasks/task_e_68b954b1a5e8832f9e373be31856dccd