### PR TITLE
feat: require NEXTAUTH_SECRET for auth

### DIFF
--- a/apps/cms/src/auth/secret.ts
+++ b/apps/cms/src/auth/secret.ts
@@ -1,11 +1,10 @@
 // apps/cms/src/auth/secret.ts
 
-// Allow tests and local development to run without configuring a secret.
-// `NEXTAUTH_SECRET` is still required in production to ensure sessions are
-// cryptographically signed.
-const secret =
-  process.env.NEXTAUTH_SECRET ??
-  (process.env.NODE_ENV === "production" ? undefined : "test-secret");
+import { env } from "@acme/config";
+
+// `NEXTAUTH_SECRET` is required to ensure sessions are cryptographically
+// signed.
+const secret = env.NEXTAUTH_SECRET;
 
 if (!secret) {
   throw new Error("NEXTAUTH_SECRET is not set");


### PR DESCRIPTION
## Summary
- require NEXTAUTH_SECRET to be set for auth secret

## Testing
- `pnpm test:cms apps/cms/src/auth/__tests__/secret.test.ts`
- `pnpm install`
- `pnpm -r build` *(fails: packages/configurator build: Cannot find module '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68b954e30510832fbe2add77df8a3afa