### PR TITLE
Add reference equality tests for history actions

### DIFF
--- a/packages/ui/src/components/cms/page-builder/state/__tests__/history.test.ts
+++ b/packages/ui/src/components/cms/page-builder/state/__tests__/history.test.ts
@@ -30,4 +30,21 @@ describe("history actions", () => {
     expect(branched.present).toEqual([b]);
     expect(branched.future).toEqual([]);
   });
+
+  it("returns same state when committing current present", () => {
+    const first = commit(init, [a]);
+    const result = commit(first, first.present);
+    expect(Object.is(result, first)).toBe(true);
+  });
+
+  it("returns original state on undo with empty past", () => {
+    const result = undo(init);
+    expect(Object.is(result, init)).toBe(true);
+  });
+
+  it("returns original state on redo with empty future", () => {
+    const state = commit(init, [a]);
+    const result = redo(state);
+    expect(Object.is(result, state)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests verifying `commit` returns the same state when passed the current `present`
- ensure `undo`/`redo` keep state unchanged when past/future are empty

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/ui/src/components/cms/page-builder/state/__tests__/history.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9583c0450832f95dc3c8f58d55871