### PR TITLE
test: add layout helper edge cases

### DIFF
--- a/packages/ui/src/components/cms/page-builder/state/__tests__/layout.helpers.test.ts
+++ b/packages/ui/src/components/cms/page-builder/state/__tests__/layout.helpers.test.ts
@@ -87,6 +87,46 @@ describe("layout helper coordinate and size updates", () => {
     expect(updated.top).toBe("2px");
   });
 
+  it("resize ignores empty string values", () => {
+    const a = makeComp("a", { width: "10px", height: "5px", left: "7px", top: "8px" });
+    const state = resize(
+      { ...init, present: [a] },
+      { type: "resize", id: "a", width: "", height: "", left: "", top: "" },
+    );
+    const updated = state.present[0];
+    expect(updated.width).toBe("10px");
+    expect(updated.height).toBe("5px");
+    expect(updated.left).toBe("7px");
+    expect(updated.top).toBe("8px");
+  });
+
+  it("resize normalizes margin and padding breakpoints", () => {
+    const a = makeComp("a", {
+      marginDesktop: "1px",
+      paddingTablet: "5px",
+    });
+    const state = resize(
+      { ...init, present: [a] },
+      {
+        type: "resize",
+        id: "a",
+        marginDesktop: "",
+        marginTablet: "10",
+        marginMobile: "",
+        paddingDesktop: "12",
+        paddingTablet: "",
+        paddingMobile: "8",
+      },
+    );
+    const updated = state.present[0] as PageComponent & Record<string, string | undefined>;
+    expect(updated.marginDesktop).toBe("1px");
+    expect(updated.marginTablet).toBe("10px");
+    expect(updated.marginMobile).toBeUndefined();
+    expect(updated.paddingDesktop).toBe("12px");
+    expect(updated.paddingTablet).toBe("5px");
+    expect(updated.paddingMobile).toBe("8px");
+  });
+
   it("setGridCols updates grid column count", () => {
     const state = setGridCols(init, { type: "set-grid-cols", gridCols: 24 });
     expect(state.gridCols).toBe(24);


### PR DESCRIPTION
## Summary
- add tests for resize to ignore empty strings
- add tests for margin/padding breakpoint normalization

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- --testPathPattern=layout.helpers.test.ts` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9583cb714832fbda7fc1357bf3d90