### PR TITLE
test(ui): verify useBlockDnD setNodeRef

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useBlockDnD.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useBlockDnD.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from "@testing-library/react";
+import useBlockDnD from "../useBlockDnD";
+
+const innerSetNodeRef = jest.fn();
+
+jest.mock("../useSortableBlock", () => ({
+  __esModule: true,
+  default: () => ({
+    setNodeRef: innerSetNodeRef,
+  }),
+}));
+
+describe("useBlockDnD", () => {
+  it("forwards setNodeRef and updates containerRef", () => {
+    const { result } = renderHook(() => useBlockDnD("a", 0, undefined));
+
+    const node = document.createElement("div");
+    result.current.setNodeRef(node);
+
+    expect(result.current.containerRef.current).toBe(node);
+    expect(innerSetNodeRef).toHaveBeenCalledWith(node);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test for useBlockDnD ensuring `setNodeRef` updates `containerRef` and delegates to `useSortableBlock`

## Testing
- `pnpm exec jest packages/ui/src/components/cms/page-builder/__tests__/useBlockDnD.test.tsx --runTestsByPath --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9583ff834832fb9d20ed3269d1dbb