### PR TITLE
test: enhance page builder state hook

### DIFF
--- a/packages/ui/__tests__/usePageBuilderState.test.tsx
+++ b/packages/ui/__tests__/usePageBuilderState.test.tsx
@@ -1,17 +1,98 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, fireEvent } from "@testing-library/react";
 import usePageBuilderState from "../src/components/cms/page-builder/hooks/usePageBuilderState";
 
 describe("usePageBuilderState", () => {
-  it("supports undo and redo", () => {
-    const page: any = {
-      id: "p1",
-      updatedAt: "now",
-      slug: "home",
-      status: "draft",
-      seo: { title: { en: "Home" } },
-      components: [],
+  const basePage: any = {
+    id: "p1",
+    updatedAt: "now",
+    slug: "home",
+    status: "draft",
+    seo: { title: { en: "Home" } },
+    components: [],
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("persists history to localStorage and clears it", () => {
+    const history = {
+      past: [],
+      present: [{ id: "c1", type: "Text" }],
+      future: [],
+      gridCols: 12,
     };
-    const { result } = renderHook(() => usePageBuilderState({ page }));
+    const getItem = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockReturnValueOnce(JSON.stringify(history));
+    const setItem = jest.spyOn(Storage.prototype, "setItem");
+    const removeItem = jest.spyOn(Storage.prototype, "removeItem");
+
+    const { result } = renderHook(() => usePageBuilderState({ page: basePage }));
+    expect(getItem).toHaveBeenCalledWith("page-builder-history-p1");
+    expect(result.current.components).toEqual(history.present);
+    expect(setItem).toHaveBeenCalledWith(
+      "page-builder-history-p1",
+      JSON.stringify(result.current.state)
+    );
+    act(() => result.current.clearHistory());
+    expect(removeItem).toHaveBeenCalledWith("page-builder-history-p1");
+  });
+
+  it("updates liveMessage on actions", () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => usePageBuilderState({ page: basePage }));
+
+    act(() =>
+      result.current.dispatch({
+        type: "add",
+        component: { id: "c1", type: "Text" } as any,
+      })
+    );
+    expect(result.current.liveMessage).toBe("Block added");
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current.liveMessage).toBe("");
+
+    act(() =>
+      result.current.dispatch({
+        type: "move",
+        from: { index: 0 },
+        to: { index: 0 },
+      })
+    );
+    expect(result.current.liveMessage).toBe("Block moved");
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current.liveMessage).toBe("");
+
+    act(() =>
+      result.current.dispatch({
+        type: "resize",
+        id: "c1",
+        width: "100",
+      })
+    );
+    expect(result.current.liveMessage).toBe("Block resized");
+  });
+
+  it("handles keyboard shortcuts", () => {
+    const onSave = jest.fn();
+    const onPreview = jest.fn();
+    const onRotate = jest.fn();
+    const { result } = renderHook(() =>
+      usePageBuilderState({
+        page: basePage,
+        onSaveShortcut: onSave,
+        onTogglePreview: onPreview,
+        onRotateDevice: onRotate,
+      })
+    );
+
     act(() =>
       result.current.dispatch({
         type: "add",
@@ -19,10 +100,43 @@ describe("usePageBuilderState", () => {
       })
     );
     expect(result.current.components).toHaveLength(1);
-    act(() => result.current.dispatch({ type: "undo" }));
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    });
     expect(result.current.components).toHaveLength(0);
-    act(() => result.current.dispatch({ type: "redo" }));
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "y", ctrlKey: true });
+    });
     expect(result.current.components).toHaveLength(1);
-    act(() => result.current.clearHistory());
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    });
+    expect(onSave).toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "p", ctrlKey: true });
+    });
+    expect(onPreview).toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.keyDown(window, {
+        key: "[",
+        ctrlKey: true,
+        shiftKey: true,
+      });
+    });
+    expect(onRotate).toHaveBeenCalledWith("left");
+
+    act(() => {
+      fireEvent.keyDown(window, {
+        key: "]",
+        ctrlKey: true,
+        shiftKey: true,
+      });
+    });
+    expect(onRotate).toHaveBeenCalledWith("right");
   });
 });


### PR DESCRIPTION
## Summary
- test history persistence and clearHistory via mocked localStorage
- assert liveMessage updates on add/move/resize actions
- verify keyboard shortcuts for undo/redo/save/preview/rotate

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/usePageBuilderState.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9584446f8832fb97daee3641416b0