### PR TITLE
test(page-builder): verify sidebar dispatch

### DIFF
--- a/packages/ui/__tests__/PageSidebar.test.tsx
+++ b/packages/ui/__tests__/PageSidebar.test.tsx
@@ -1,0 +1,50 @@
+import { render, fireEvent } from "@testing-library/react";
+import type { PageComponent } from "@acme/types";
+import PageSidebar from "../src/components/cms/page-builder/PageSidebar";
+
+describe("PageSidebar", () => {
+  it("dispatches correct actions for edits and duplication", () => {
+    const component: PageComponent = {
+      id: "c1",
+      type: "ProductCarousel",
+      minItems: 1,
+      maxItems: 5,
+    } as PageComponent;
+    const dispatch = jest.fn();
+    const { getByText, getByLabelText } = render(
+      <PageSidebar
+        components={[component]}
+        selectedId={component.id}
+        dispatch={dispatch}
+      />
+    );
+
+    // onResize
+    fireEvent.click(getByText("Layout"));
+    fireEvent.change(getByLabelText("Width (Desktop)", { exact: false }), {
+      target: { value: "200" },
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "resize",
+      id: component.id,
+      widthDesktop: "200",
+    });
+    dispatch.mockClear();
+
+    // onChange
+    fireEvent.click(getByText("Content"));
+    fireEvent.change(getByLabelText("Min Items", { exact: false }), {
+      target: { value: "2" },
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "update",
+      id: component.id,
+      patch: { minItems: 2 },
+    });
+    dispatch.mockClear();
+
+    // duplicate
+    fireEvent.click(getByText("Duplicate"));
+    expect(dispatch).toHaveBeenCalledWith({ type: "duplicate", id: component.id });
+  });
+});


### PR DESCRIPTION
## Summary
- add PageSidebar test ensuring resize, update, and duplicate actions dispatch

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm install`
- `pnpm -r build` *(fails: TS2307: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/ui test __tests__/PageSidebar.test.tsx` *(Jest: "global" coverage threshold for branches (80%) not met: 18.49%)*

------
https://chatgpt.com/codex/tasks/task_e_68b9584767f0832f96d6bc49ae97c8f0