### PR TITLE
test: add MenuBar editor interactions

### DIFF
--- a/packages/ui/__tests__/MenuBar.test.tsx
+++ b/packages/ui/__tests__/MenuBar.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import MenuBar from "../src/components/cms/page-builder/MenuBar";
+
+describe("MenuBar", () => {
+  const createEditor = () => {
+    const chain = {
+      focus: jest.fn().mockReturnThis(),
+      toggleBold: jest.fn().mockReturnThis(),
+      toggleItalic: jest.fn().mockReturnThis(),
+      extendMarkRange: jest.fn().mockReturnThis(),
+      setLink: jest.fn().mockReturnThis(),
+      run: jest.fn().mockReturnThis(),
+    };
+
+    const editor = {
+      isActive: jest.fn().mockReturnValue(false),
+      chain: jest.fn(() => chain),
+    } as any;
+
+    return { editor, chain };
+  };
+
+  it("invokes bold command chain", () => {
+    const { editor, chain } = createEditor();
+    render(<MenuBar editor={editor} />);
+    fireEvent.click(screen.getByRole("button", { name: "B" }));
+    expect(editor.chain).toHaveBeenCalled();
+    expect(chain.focus).toHaveBeenCalled();
+    expect(chain.toggleBold).toHaveBeenCalled();
+    expect(chain.run).toHaveBeenCalled();
+  });
+
+  it("invokes italic command chain", () => {
+    const { editor, chain } = createEditor();
+    render(<MenuBar editor={editor} />);
+    fireEvent.click(screen.getByRole("button", { name: "I" }));
+    expect(chain.focus).toHaveBeenCalled();
+    expect(chain.toggleItalic).toHaveBeenCalled();
+    expect(chain.run).toHaveBeenCalled();
+  });
+
+  it("invokes link command chain with prompt value", () => {
+    const { editor, chain } = createEditor();
+    const promptSpy = jest
+      .spyOn(window, "prompt")
+      .mockReturnValue("https://example.com");
+    render(<MenuBar editor={editor} />);
+    fireEvent.click(screen.getByRole("button", { name: "Link" }));
+    expect(promptSpy).toHaveBeenCalled();
+    expect(chain.focus).toHaveBeenCalled();
+    expect(chain.extendMarkRange).toHaveBeenCalledWith("link");
+    expect(chain.setLink).toHaveBeenCalledWith({ href: "https://example.com" });
+    expect(chain.run).toHaveBeenCalled();
+    promptSpy.mockRestore();
+  });
+
+  it("renders nothing when editor is null", () => {
+    const { container } = render(<MenuBar editor={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add MenuBar tests for bold, italic, and link commands
- verify MenuBar renders nothing when editor is null

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/MenuBar.test.tsx --config ../../jest.config.cjs`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b9584a3258832fafe0331bb8969ae6