### PR TITLE
test: cover theme switching and storage errors

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
@@ -138,6 +138,65 @@ describe("ThemeContext", () => {
     expect(setItem).toHaveBeenCalledWith("theme", "dark");
   });
 
+  it("updates DOM when theme changes", () => {
+    const setItem = jest.fn();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: { getItem: () => null, setItem },
+    });
+
+    let changeTheme: (t: any) => void = () => {};
+    function CaptureSetter() {
+      const { setTheme } = useTheme();
+      changeTheme = setTheme;
+      return null;
+    }
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeDisplay />
+        <CaptureSetter />
+      </ThemeProvider>
+    );
+
+    act(() => changeTheme("brandx"));
+    expect(getByTestId("theme").textContent).toBe("brandx");
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(
+      true
+    );
+    expect(document.documentElement.style.colorScheme).toBe("light");
+
+    act(() => changeTheme("dark"));
+    expect(getByTestId("theme").textContent).toBe("dark");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(
+      true
+    );
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(
+      false
+    );
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("still renders when localStorage.setItem throws", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error("fail");
+        },
+      },
+    });
+
+    expect(() =>
+      render(
+        <ThemeProvider>
+          <ThemeDisplay />
+        </ThemeProvider>
+      )
+    ).not.toThrow();
+  });
+
   it("throws when useTheme is called outside provider", () => {
     expect(() => render(<ThemeDisplay />)).toThrow(
       "useTheme must be inside ThemeProvider"


### PR DESCRIPTION
## Summary
- add tests verifying setTheme updates DOM classes and color scheme
- ensure ThemeProvider tolerates localStorage.setItem failures

## Testing
- `pnpm test packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx` *(fails: Missing task `packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx`)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b9587ef85c832fb541deb780eae08a