### PR TITLE
test: verify shop setters preserve input

### DIFF
--- a/packages/platform-core/src/shops/__tests__/index.test.ts
+++ b/packages/platform-core/src/shops/__tests__/index.test.ts
@@ -26,13 +26,19 @@ describe("validateShopName", () => {
 describe("sanityBlog accessors", () => {
   it("adds and removes config", () => {
     const shop: Shop = {};
+    const original = { ...shop };
     expect(getSanityConfig(shop)).toBeUndefined();
 
     const config: SanityBlogConfig = { projectId: "p", dataset: "d", token: "t" };
     const withConfig = setSanityConfig(shop, config);
+    expect(Object.is(shop, withConfig)).toBe(false);
+    expect(shop).toEqual(original);
     expect(getSanityConfig(withConfig)).toEqual(config);
 
+    const beforeClear = { ...withConfig };
     const cleared = setSanityConfig(withConfig, undefined);
+    expect(Object.is(withConfig, cleared)).toBe(false);
+    expect(withConfig).toEqual(beforeClear);
     expect(getSanityConfig(cleared)).toBeUndefined();
     expect("sanityBlog" in cleared).toBe(false);
   });
@@ -41,13 +47,19 @@ describe("sanityBlog accessors", () => {
 describe("editorialBlog accessors", () => {
   it("adds and removes editorial blog", () => {
     const shop: Shop = {};
+    const original = { ...shop };
     expect(getEditorialBlog(shop)).toBeUndefined();
 
     const editorial = { enabled: true };
     const withBlog = setEditorialBlog(shop, editorial);
+    expect(Object.is(shop, withBlog)).toBe(false);
+    expect(shop).toEqual(original);
     expect(getEditorialBlog(withBlog)).toEqual(editorial);
 
+    const beforeClear = { ...withBlog };
     const cleared = setEditorialBlog(withBlog, undefined);
+    expect(Object.is(withBlog, cleared)).toBe(false);
+    expect(withBlog).toEqual(beforeClear);
     expect(getEditorialBlog(cleared)).toBeUndefined();
     expect("editorialBlog" in cleared).toBe(false);
   });
@@ -56,13 +68,19 @@ describe("editorialBlog accessors", () => {
 describe("domain accessors", () => {
   it("adds and removes domain", () => {
     const shop: Shop = {};
+    const original = { ...shop };
     expect(getDomain(shop)).toBeUndefined();
 
     const domain: ShopDomain = { name: "shop.example.com" };
     const withDomain = setDomain(shop, domain);
+    expect(Object.is(shop, withDomain)).toBe(false);
+    expect(shop).toEqual(original);
     expect(getDomain(withDomain)).toEqual(domain);
 
+    const beforeClear = { ...withDomain };
     const cleared = setDomain(withDomain, undefined);
+    expect(Object.is(withDomain, cleared)).toBe(false);
+    expect(withDomain).toEqual(beforeClear);
     expect(getDomain(cleared)).toBeUndefined();
     expect("domain" in cleared).toBe(false);
   });


### PR DESCRIPTION
## Summary
- ensure `setSanityConfig`, `setEditorialBlog`, and `setDomain` don't mutate input shops

## Testing
- `pnpm test packages/platform-core/src/shops` *(fails: Could not find task `packages/platform-core/src/shops` in project)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/shops`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: packages/configurator build: error TS2307: Cannot find module '@jest/globals' or its corresponding type declarations.)*


------
https://chatgpt.com/codex/tasks/task_e_68b958c4b8f0832fbed472055b2e3dbe