### PR TITLE
chore: compile sanity package

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -3,15 +3,20 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
+  "files": ["dist"],
   "scripts": {
-    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
     "lint": "eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add build script and dist main entry for @acme/sanity
- export compiled files and include dist folder only

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -F @acme/sanity clean && pnpm -F @acme/sanity build` *(fails: Cannot find module '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68b95dd227e0832f939995f3878d661d