### PR TITLE
test: expand inventory coverage

### DIFF
--- a/packages/platform-core/src/utils/inventory.test.ts
+++ b/packages/platform-core/src/utils/inventory.test.ts
@@ -52,6 +52,22 @@ describe("flattenInventoryItem", () => {
       quantity: 1,
     });
   });
+
+  it("omits lowStockThreshold when undefined", () => {
+    const item: InventoryItem = {
+      sku: "sku4",
+      productId: "prod4",
+      quantity: 7,
+      variantAttributes: {},
+      lowStockThreshold: undefined,
+    };
+
+    expect(flattenInventoryItem(item)).toEqual({
+      sku: "sku4",
+      productId: "prod4",
+      quantity: 7,
+    });
+  });
 });
 
 describe("expandInventoryItem", () => {
@@ -97,6 +113,34 @@ describe("expandInventoryItem", () => {
       productId: "sku3",
       quantity: 1,
       variantAttributes: {},
+    });
+  });
+
+  it("is idempotent when given a valid InventoryItem", () => {
+    const item: InventoryItem = {
+      sku: "sku6",
+      productId: "prod6",
+      quantity: 4,
+      variantAttributes: { color: "red" },
+      lowStockThreshold: 1,
+    };
+
+    expect(expandInventoryItem(item)).toEqual(item);
+  });
+
+  it("omits lowStockThreshold when provided as an empty string", () => {
+    const raw = {
+      sku: "sku7",
+      quantity: 3,
+      "variant.size": "S",
+      lowStockThreshold: "",
+    };
+
+    expect(expandInventoryItem(raw)).toEqual({
+      sku: "sku7",
+      productId: "sku7",
+      quantity: 3,
+      variantAttributes: { size: "S" },
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure `expandInventoryItem` handles already parsed items idempotently
- test omission of `lowStockThreshold` on both flattening and expansion

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script `check:references`)*
- `pnpm run build:ts` *(fails: Missing script `build:ts`)*
- `pnpm test packages/platform-core/src/utils/inventory.test.ts` *(fails: Could not find task)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/utils/inventory.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b95b64f6c4832f82f824fe6d71079d