### PR TITLE
test: expand theme tokens coverage

### DIFF
--- a/packages/platform-core/__tests__/themeTokens.test.ts
+++ b/packages/platform-core/__tests__/themeTokens.test.ts
@@ -33,6 +33,11 @@ describe("loadThemeTokensNode", () => {
     const tokens = loadThemeTokensNode("dark");
     expect(tokens).toEqual({});
   });
+
+  it.each(["", "base"])('returns empty object for %s theme', (theme) => {
+    const tokens = loadThemeTokensNode(theme as string);
+    expect(tokens).toEqual({});
+  });
 });
 
 describe("loadThemeTokensBrowser", () => {
@@ -69,6 +74,11 @@ describe("loadThemeTokensBrowser", () => {
 
   it("short-circuits for base theme", async () => {
     const tokens = await loadThemeTokensBrowser("base");
+    expect(tokens).toBe(baseTokens);
+  });
+
+  it("returns base tokens when all imports fail", async () => {
+    const tokens = await loadThemeTokensBrowser("missing-theme");
     expect(tokens).toBe(baseTokens);
   });
 });


### PR DESCRIPTION
## Summary
- test that `loadThemeTokensNode` returns an empty object for base or empty themes
- verify `loadThemeTokensBrowser` falls back to `baseTokens` when all imports fail

## Testing
- `pnpm test packages/platform-core/__tests__/themeTokens.test.ts` *(fails: Could not find task `packages/platform-core/__tests__/themeTokens.test.ts` in project)*
- `pnpm exec jest packages/platform-core/__tests__/themeTokens.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b95b6434c0832f92adb1ea905fc1ad