### PR TITLE
test(cms): add blog post service tests

### DIFF
--- a/apps/cms/__tests__/services/blog/get.test.ts
+++ b/apps/cms/__tests__/services/blog/get.test.ts
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+
+import { getPost } from '../../../src/services/blog/posts/get';
+import { ensureAuthorized } from '../../../src/actions/common/auth';
+
+jest.mock('../../../src/actions/common/auth', () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+jest.mock('../../../src/services/blog/config', () => ({
+  getConfig: jest.fn().mockResolvedValue({}),
+}));
+
+const repoGetPost = jest.fn();
+
+jest.mock('@platform-core/repositories/blog.server', () => ({
+  getPost: (...args: unknown[]) => repoGetPost(...args),
+}));
+
+describe('getPost', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ensures authorization and calls repository', async () => {
+    repoGetPost.mockResolvedValue({ id: '123' });
+    const result = await getPost('shop', '123');
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(repoGetPost).toHaveBeenCalledWith({}, '123');
+    expect(result).toEqual({ id: '123' });
+  });
+});
+

--- a/apps/cms/__tests__/services/blog/publish.test.ts
+++ b/apps/cms/__tests__/services/blog/publish.test.ts
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+
+import { publishPost } from '../../../src/services/blog/posts/publish';
+import { nowIso } from '@date-utils';
+
+jest.mock('../../../src/actions/common/auth', () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+jest.mock('../../../src/services/blog/config', () => ({
+  getConfig: jest.fn().mockResolvedValue({}),
+}));
+
+const repoPublishPost = jest.fn();
+
+jest.mock('@platform-core/repositories/blog.server', () => ({
+  publishPost: (...args: unknown[]) => repoPublishPost(...args),
+}));
+
+jest.mock('@date-utils', () => ({
+  nowIso: jest.fn(),
+}));
+
+describe('publishPost', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses current time when publishedAt not provided', async () => {
+    (nowIso as jest.Mock).mockReturnValue('2024-01-01T00:00:00.000Z');
+    repoPublishPost.mockResolvedValue(undefined);
+
+    const fd = new FormData();
+    const result = await publishPost('shop', '1', fd);
+
+    expect(repoPublishPost).toHaveBeenCalledWith({}, '1', '2024-01-01T00:00:00.000Z');
+    expect(result).toEqual({ message: 'Post published' });
+  });
+
+  it('uses provided publishedAt value', async () => {
+    (nowIso as jest.Mock).mockReturnValue('ignored');
+    repoPublishPost.mockResolvedValue(undefined);
+
+    const fd = new FormData();
+    fd.set('publishedAt', '2023-05-01');
+
+    await publishPost('shop', '1', fd);
+
+    expect(nowIso).not.toHaveBeenCalled();
+    expect(repoPublishPost).toHaveBeenCalledWith(
+      {},
+      '1',
+      new Date('2023-05-01').toISOString(),
+    );
+  });
+
+  it('logs error when repository fails', async () => {
+    const error = new Error('fail');
+    repoPublishPost.mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const result = await publishPost('shop', '1');
+
+    expect(consoleError).toHaveBeenCalledWith('Failed to publish post', error);
+    expect(result).toEqual({ error: 'Failed to publish post' });
+
+    consoleError.mockRestore();
+  });
+});
+

--- a/apps/cms/__tests__/services/blog/update.test.ts
+++ b/apps/cms/__tests__/services/blog/update.test.ts
@@ -1,0 +1,119 @@
+/* eslint-env jest */
+
+import { updatePost } from '../../../src/services/blog/posts/update';
+
+jest.mock('../../../src/actions/common/auth', () => ({
+  ensureAuthorized: jest.fn(),
+}));
+
+const mockCollectProductSlugs = jest.fn();
+const mockFilterExistingProductSlugs = jest.fn();
+
+jest.mock('../../../src/services/blog/config', () => ({
+  getConfig: jest.fn().mockResolvedValue({}),
+  collectProductSlugs: (...args: unknown[]) => mockCollectProductSlugs(...args),
+  filterExistingProductSlugs: (
+    ...args: unknown[]
+  ) => mockFilterExistingProductSlugs(...args),
+}));
+
+const repoUpdatePost = jest.fn();
+const repoSlugExists = jest.fn();
+
+jest.mock('@platform-core/repositories/blog.server', () => ({
+  updatePost: (...args: unknown[]) => repoUpdatePost(...args),
+  slugExists: (...args: unknown[]) => repoSlugExists(...args),
+}));
+
+describe('updatePost', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns error on slug collision', async () => {
+    repoSlugExists.mockResolvedValue(true);
+    mockCollectProductSlugs.mockReturnValue([]);
+    mockFilterExistingProductSlugs.mockResolvedValue([]);
+    const fd = new FormData();
+    fd.set('id', '1');
+    fd.set('slug', 'exists');
+
+    const result = await updatePost('shop', fd);
+
+    expect(result).toEqual({ error: 'Slug already exists' });
+    expect(repoUpdatePost).not.toHaveBeenCalled();
+  });
+
+  it('handles JSON parse failure', async () => {
+    repoSlugExists.mockResolvedValue(false);
+    mockCollectProductSlugs.mockReturnValue(['x']);
+    mockFilterExistingProductSlugs.mockResolvedValue([]);
+
+    const fd = new FormData();
+    fd.set('id', '1');
+    fd.set('title', 't');
+    fd.set('content', '{invalid');
+
+    const result = await updatePost('shop', fd);
+
+    expect(result).toEqual({ message: 'Post updated' });
+    expect(mockCollectProductSlugs).not.toHaveBeenCalled();
+    expect(repoUpdatePost).toHaveBeenCalledWith({}, '1', expect.objectContaining({
+      body: [],
+      products: [],
+    }));
+  });
+
+  it('filters product slugs', async () => {
+    repoSlugExists.mockResolvedValue(false);
+    mockCollectProductSlugs.mockReturnValue(['a', 'b']);
+    mockFilterExistingProductSlugs.mockResolvedValue(['b', 'd']);
+
+    const fd = new FormData();
+    fd.set('id', '1');
+    fd.set('content', '[]');
+    fd.set('products', 'c, d');
+
+    await updatePost('shop', fd);
+
+    expect(mockFilterExistingProductSlugs).toHaveBeenCalledWith('shop', ['a', 'b', 'c', 'd']);
+    expect(repoUpdatePost).toHaveBeenCalledWith(
+      {},
+      '1',
+      expect.objectContaining({ products: ['b', 'd'] }),
+    );
+  });
+
+  it('updates post successfully', async () => {
+    repoSlugExists.mockResolvedValue(false);
+    mockCollectProductSlugs.mockReturnValue([]);
+    mockFilterExistingProductSlugs.mockResolvedValue([]);
+
+    const fd = new FormData();
+    fd.set('id', '1');
+    fd.set('title', 'T');
+    fd.set('content', '[]');
+    fd.set('slug', 's');
+    fd.set('excerpt', 'e');
+    fd.set('mainImage', 'm');
+    fd.set('author', 'a');
+    fd.set('categories', 'c1, c2');
+    fd.set('publishedAt', '2024-01-01');
+
+    const result = await updatePost('shop', fd);
+
+    expect(result).toEqual({ message: 'Post updated' });
+    expect(repoUpdatePost).toHaveBeenCalledWith({}, '1', {
+      title: 'T',
+      body: [],
+      products: [],
+      slug: { current: 's' },
+      excerpt: 'e',
+      mainImage: 'm',
+      author: 'a',
+      categories: ['c1', 'c2'],
+      publishedAt: new Date('2024-01-01').toISOString(),
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for fetching blog posts with auth and repository integration
- cover publishedAt handling and error logging in publish
- exercise slug collisions, JSON parse failure, slug filtering and success in update

## Testing
- `pnpm test apps/cms/__tests__/services/blog/*.test.ts` *(fails: Missing tasks in project)*
- `pnpm exec jest apps/cms/__tests__/services/blog/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b95b62d47c832f9c3dff37e3a4b498