### PR TITLE
test: expand ProductCarousel coverage

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx
@@ -1,4 +1,5 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ProductCarousel, type Product } from "../ProductCarousel";
 import { CurrencyProvider } from "@acme/platform-core/contexts/CurrencyContext";
 import "../../../../../../test/resetNextMocks";
@@ -8,6 +9,25 @@ jest.mock(
   () => require("../../../../../../test/__mocks__/currencyContextMock")
 );
 
+jest.mock("../../overlays/ProductQuickView", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    ProductQuickView: ({ product, open, onOpenChange }: any) =>
+      open ? (
+        <div data-testid="quick-view">
+          <span>{product.title}</span>
+          <button
+            data-testid="close-quick-view"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </button>
+        </div>
+      ) : null,
+  };
+});
+
 function mockResize(width: number) {
   (global as any).ResizeObserver = class {
     cb: ResizeObserverCallback;
@@ -15,7 +35,10 @@ function mockResize(width: number) {
       this.cb = cb;
     }
     observe(el: Element) {
-      Object.defineProperty(el, "clientWidth", { value: width, configurable: true });
+      Object.defineProperty(el, "clientWidth", {
+        value: width,
+        configurable: true,
+      });
       this.cb([{ target: el } as ResizeObserverEntry], this);
     }
     disconnect() {}
@@ -55,6 +78,22 @@ describe("ProductCarousel viewport counts", () => {
     expect(slide.style.flex).toBe("0 0 25%");
   });
 
+  it("uses tabletItems for medium containers", () => {
+    mockResize(800);
+    const { container } = render(
+      <CurrencyProvider>
+        <ProductCarousel
+          products={products}
+          desktopItems={4}
+          tabletItems={2}
+          mobileItems={1}
+        />
+      </CurrencyProvider>
+    );
+    const slide = container.querySelector(".snap-start") as HTMLElement;
+    expect(slide.style.flex).toBe("0 0 50%");
+  });
+
   it("uses mobileItems for narrow containers", () => {
     mockResize(400);
     const { container } = render(
@@ -71,3 +110,43 @@ describe("ProductCarousel viewport counts", () => {
     expect(slide.style.flex).toBe("0 0 100%");
   });
 });
+
+describe("ProductCarousel slide width", () => {
+  it("allows custom getSlideWidth", () => {
+    mockResize(1200);
+    const custom = jest.fn().mockReturnValue("80px");
+    const { container } = render(
+      <CurrencyProvider>
+        <ProductCarousel
+          products={products}
+          desktopItems={4}
+          tabletItems={2}
+          mobileItems={1}
+          getSlideWidth={custom}
+        />
+      </CurrencyProvider>
+    );
+    expect(custom).toHaveBeenCalledWith(4);
+    const slide = container.querySelector(".snap-start") as HTMLElement;
+    expect(slide.style.flex).toBe("0 0 80px");
+  });
+});
+
+describe("ProductCarousel quick view", () => {
+  it("opens and closes quick view", async () => {
+    mockResize(1200);
+    const user = userEvent.setup();
+    render(
+      <CurrencyProvider>
+        <ProductCarousel products={products} enableQuickView />
+      </CurrencyProvider>
+    );
+    expect(screen.queryByTestId("quick-view")).toBeNull();
+    const btn = screen.getByRole("button", { name: /quick view a/i });
+    await user.click(btn);
+    expect(screen.getByTestId("quick-view")).toHaveTextContent("A");
+    await user.click(screen.getByTestId("close-quick-view"));
+    expect(screen.queryByTestId("quick-view")).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test responsive item counts for desktop, tablet and mobile
- validate custom getSlideWidth logic
- verify quick view opens and closes properly

## Testing
- `pnpm test packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx` *(fails: Could not find task)*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b95b5d8328832f9d787e71b16ce9d8