### PR TITLE
Fix ReviewsList empty state and add tests

### DIFF
--- a/packages/ui/src/components/organisms/ReviewsList.tsx
+++ b/packages/ui/src/components/organisms/ReviewsList.tsx
@@ -104,18 +104,19 @@ export function ReviewsList({
           </Select>
         </div>
       )}
-      {filtered.map((r, i) => (
-        <div key={i} className="rounded-md border p-4">
-          <div className="flex items-center justify-between gap-2">
-            <span className="font-semibold">{r.author}</span>
-            <RatingStars rating={r.rating} />
+      {filtered.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No reviews found.</p>
+      ) : (
+        filtered.map((r, i) => (
+          <div key={i} className="rounded-md border p-4">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-semibold">{r.author}</span>
+              <RatingStars rating={r.rating} />
+            </div>
+            <p className="mt-2 text-sm">{r.content}</p>
           </div>
-          <p className="mt-2 text-sm">{r.content}</p>
-          {filtered.length === 0 && (
-            <p className="text-muted-foreground text-sm">No reviews found.</p>
-          )}
-        </div>
-      ))}
+        ))
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/organisms/__tests__/ReviewsList.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ReviewsList.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReviewsList, type Review } from "../ReviewsList";
+import "../../../../../../test/resetNextMocks";
+
+const reviews: Review[] = [
+  { author: "Alice", rating: 5, content: "Great product" },
+  { author: "Bob", rating: 4, content: "Okay item" },
+  { author: "Cara", rating: 3, content: "Great service" },
+];
+
+describe("ReviewsList", () => {
+  it("filters by rating and query", () => {
+    render(<ReviewsList reviews={reviews} minRating={4} query="great" />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cara")).not.toBeInTheDocument();
+  });
+
+  it("supports controlled and uncontrolled query", async () => {
+    // uncontrolled
+    const user = userEvent.setup();
+    render(<ReviewsList reviews={reviews} filterable />);
+    await user.type(screen.getByPlaceholderText("Search reviews…"), "Ali");
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+
+    // controlled
+    cleanup();
+    const handleQuery = jest.fn();
+    const { rerender } = render(
+      <ReviewsList
+        reviews={reviews}
+        filterable
+        query=""
+        onQueryChange={handleQuery}
+      />
+    );
+    await user.type(screen.getByPlaceholderText("Search reviews…"), "Bo");
+    expect(handleQuery).toHaveBeenCalledTimes(2);
+    // still shows all reviews because value is controlled externally
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+
+    rerender(
+      <ReviewsList
+        reviews={reviews}
+        filterable
+        query="Bob"
+        onQueryChange={handleQuery}
+      />
+    );
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+  });
+
+  it("shows message when no reviews match", () => {
+    render(<ReviewsList reviews={reviews} minRating={5} query="zzz" />);
+    expect(
+      screen.getByText("No reviews found.")
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- move empty-state check outside review map
- add unit tests for review filtering, controlled behavior and empty message

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/ReviewsList.test.tsx` (fails: global coverage threshold for branches (80%) not met: 43.66%)
- `pnpm -r build` (fails: Cannot find module '@jest/globals')
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm run build:ts` (fails: Missing script: build:ts)


------
https://chatgpt.com/codex/tasks/task_e_68b95b5bf37c832f93ed1e5b40e224d1