### PR TITLE
feat(ui): reintroduce MediaSelectionCheck component

### DIFF
--- a/packages/ui/src/components/cms/MediaSelectionCheck.tsx
+++ b/packages/ui/src/components/cms/MediaSelectionCheck.tsx
@@ -1,0 +1,35 @@
+// packages/ui/src/components/cms/MediaSelectionCheck.tsx
+"use client";
+
+import { CheckIcon } from "@radix-ui/react-icons";
+import type { ReactElement } from "react";
+import { cn } from "../../utils/style";
+
+export interface MediaSelectionCheckProps {
+  /** Whether the media item is currently selected. */
+  selected: boolean;
+  /** Optional additional class names. */
+  className?: string;
+}
+
+/**
+ * Displays a checkmark overlay used to indicate selected media items
+ * in the media library.
+ */
+export default function MediaSelectionCheck({
+  selected,
+  className,
+}: MediaSelectionCheckProps): ReactElement {
+  return (
+    <span
+      data-testid="media-selection-check"
+      className={cn(
+        "pointer-events-none absolute top-1 right-1 flex h-5 w-5 items-center justify-center rounded-full border border-bg bg-primary text-primary-fg transition-opacity",
+        selected ? "opacity-100" : "opacity-0",
+        className,
+      )}
+    >
+      <CheckIcon className="h-4 w-4" />
+    </span>
+  );
+}

--- a/packages/ui/src/components/cms/__tests__/MediaSelectionCheck.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/MediaSelectionCheck.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+import MediaSelectionCheck from "../MediaSelectionCheck";
+
+describe("MediaSelectionCheck", () => {
+  it("toggles visibility based on selection", () => {
+    const { rerender, getByTestId } = render(
+      <MediaSelectionCheck selected={false} />,
+    );
+
+    expect(getByTestId("media-selection-check")).toHaveClass("opacity-0");
+
+    rerender(<MediaSelectionCheck selected />);
+
+    expect(getByTestId("media-selection-check")).toHaveClass("opacity-100");
+  });
+});

--- a/packages/ui/src/components/cms/index.ts
+++ b/packages/ui/src/components/cms/index.ts
@@ -10,3 +10,4 @@ export { default as StyleEditor } from "./StyleEditor";
 export { default as PageBuilder } from "./page-builder/PageBuilder";
 export * from "./page-builder";
 export { default as DeviceSelector } from "./DeviceSelector";
+export { default as MediaSelectionCheck } from "./MediaSelectionCheck";


### PR DESCRIPTION
## Summary
- add MediaSelectionCheck component for media library selection
- export component via cms index
- add tests for selection visibility

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/ui/src/components/cms/__tests__/MediaSelectionCheck.test.tsx` *(fails: Could not find task)*
- `pnpm --filter @acme/ui exec jest src/components/cms/__tests__/MediaSelectionCheck.test.tsx --runInBand --detectOpenHandles --config ../../jest.config.cjs --ci --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b95b5a2cbc832fafd7e46e05f4e5e2