### PR TITLE
test(ui): add StyleEditor props forwarding test

### DIFF
--- a/packages/ui/src/components/cms/__tests__/StyleEditor.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/StyleEditor.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import type { TokenMap } from "../../../hooks/useTokenEditor";
+import StyleEditor from "../StyleEditor";
+
+jest.mock("../style/Presets", () => jest.fn(() => null));
+jest.mock("../style/Tokens", () => jest.fn(() => null));
+
+import Presets from "../style/Presets";
+import Tokens from "../style/Tokens";
+
+const MockPresets = Presets as unknown as jest.Mock;
+const MockTokens = Tokens as unknown as jest.Mock;
+
+describe("StyleEditor", () => {
+  it("forwards props to Presets and Tokens", () => {
+    const tokens: TokenMap = { "--color-primary": "#fff" };
+    const baseTokens: TokenMap = { "--color-primary": "#000" };
+    const onChange = jest.fn();
+    const props = {
+      tokens,
+      baseTokens,
+      onChange,
+      focusToken: "--color-primary",
+    };
+
+    render(<StyleEditor {...props} />);
+
+    expect(MockPresets).toHaveBeenCalledWith(props, undefined);
+    expect(MockTokens).toHaveBeenCalledWith(props, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `StyleEditor` verifying it forwards props to Presets and Tokens mocks

## Testing
- `pnpm test packages/ui/src/components/cms/__tests__/StyleEditor.test.tsx` *(fails: Could not find task)*
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in configurator package)*
- `pnpm -F @acme/ui build` *(fails: Cannot find module '@jest/globals')*
- `pnpm -F @acme/ui lint` *(fails: Cannot find package '@acme/eslint-plugin-ds')*
- `pnpm -F @acme/ui test packages/ui/src/components/cms/__tests__/StyleEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95b588738832faa7a4afa4f88780d