### PR TITLE
test(ui): add RangeInput component tests

### DIFF
--- a/packages/ui/src/components/cms/__tests__/RangeInput.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/RangeInput.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from "@testing-library/react";
+import { RangeInput } from "../RangeInput";
+
+describe("RangeInput", () => {
+  it("uses default min and max", () => {
+    const { container } = render(<RangeInput value="16px" onChange={() => {}} />);
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input).toHaveAttribute("min", "0");
+    expect(input).toHaveAttribute("max", "64");
+  });
+
+  it("calls onChange with px suffix", () => {
+    const handleChange = jest.fn();
+    const { container } = render(<RangeInput value="16px" onChange={handleChange} />);
+    const input = container.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "20" } });
+    expect(handleChange).toHaveBeenCalledWith("20px");
+  });
+});


### PR DESCRIPTION
## Summary
- verify RangeInput uses default min/max values
- ensure change handler appends `px`

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/__tests__/RangeInput.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95b555704832fac1a09e6f0befe36