### PR TITLE
test: ensure DataTable non-selectable

### DIFF
--- a/packages/ui/__tests__/DataTable.test.tsx
+++ b/packages/ui/__tests__/DataTable.test.tsx
@@ -61,6 +61,24 @@ describe("DataTable", () => {
     expect(handleChange).toHaveBeenLastCalledWith([]);
   });
 
+  it("renders without selection when selectable is false", () => {
+    const handleChange = jest.fn();
+    render(
+      <DataTable
+        rows={rows}
+        columns={columns}
+        selectable={false}
+        onSelectionChange={handleChange}
+      />
+    );
+
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+
+    const aliceRow = screen.getByText("Alice").closest("tr") as HTMLElement;
+    fireEvent.click(aliceRow);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
   it("applies column widths", () => {
     render(<DataTable rows={rows} columns={columns} />);
     const nameHeader = screen.getByText("Name").closest("th") as HTMLElement;


### PR DESCRIPTION
## Summary
- verify DataTable omits selection when `selectable` is false

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/ui/__tests__/DataTable.test.tsx` *(fails: Could not find task)*
- `pnpm --filter @acme/ui exec jest __tests__/DataTable.test.tsx --runInBand --config ../../jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68b95b534480832fbaaaca22b4c18b20