### PR TITLE
test: expand ColorInput utilities coverage

### DIFF
--- a/packages/ui/src/components/cms/__tests__/ColorInput.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ColorInput.test.tsx
@@ -1,5 +1,15 @@
 import { render, fireEvent } from "@testing-library/react";
-import { ColorInput, getContrast, suggestContrastColor } from "../ColorInput";
+import * as CI from "../ColorInput";
+
+const {
+  ColorInput,
+  getContrast,
+  suggestContrastColor,
+  hexToRgb,
+  hslToRgb,
+  colorToRgb,
+  luminance,
+} = CI;
 
 describe("getContrast", () => {
   it("computes contrast for hex and HSL colors", () => {
@@ -39,6 +49,45 @@ describe("ColorInput component", () => {
     const input = container.querySelector("input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "#00ff00" } });
     expect(handleChange).toHaveBeenCalledWith("120 100% 50%");
+  });
+});
+
+describe("hexToRgb", () => {
+  it("handles 3-character hex codes", () => {
+    expect(hexToRgb("#abc")).toEqual([170, 187, 204]);
+  });
+});
+
+describe("hslToRgb", () => {
+  it.each([
+    ["30 100% 50%", [255, 128, 0]],
+    ["90 100% 50%", [128, 255, 0]],
+    ["150 100% 50%", [0, 255, 128]],
+    ["210 100% 50%", [0, 128, 255]],
+    ["270 100% 50%", [128, 0, 255]],
+    ["330 100% 50%", [255, 0, 128]],
+  ])("converts %s to %p", (hsl, expected) => {
+    expect(hslToRgb(hsl)).toEqual(expected);
+  });
+});
+
+describe("colorToRgb", () => {
+  it("delegates to hexToRgb for hex colors", () => {
+    expect(colorToRgb("#fff")).toEqual(hexToRgb("#fff"));
+  });
+
+  it("delegates to hslToRgb for hsl colors", () => {
+    expect(colorToRgb("0 0% 0%")).toEqual(hslToRgb("0 0% 0%"));
+  });
+});
+
+describe("luminance", () => {
+  it.each([
+    [[0, 0, 0], 0],
+    [[255, 255, 255], 1],
+    [[255, 0, 0], 0.2126],
+  ])("computes luminance for %p", (rgb, expected) => {
+    expect(luminance(rgb as [number, number, number])).toBeCloseTo(expected, 5);
   });
 });
 


### PR DESCRIPTION
## Summary
- add tests for hexToRgb 3-digit shorthand
- exercise hslToRgb across hue branches
- ensure colorToRgb delegates appropriately and verify luminance calculations

## Testing
- `pnpm -r build` (fails: Cannot find module '@jest/globals')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm test packages/ui/src/components/cms/__tests__/ColorInput.test.tsx` (fails: Missing task in project)
- `pnpm exec jest packages/ui/src/components/cms/__tests__/ColorInput.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95b523758832f8777927a41cdf98c