### PR TITLE
test: add telemetry index tests

### DIFF
--- a/packages/telemetry/src/__tests__/index.test.ts
+++ b/packages/telemetry/src/__tests__/index.test.ts
@@ -1,0 +1,56 @@
+import { jest } from "@jest/globals";
+
+describe("telemetry index", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_ENABLE_TELEMETRY;
+    delete process.env.NEXT_PUBLIC_TELEMETRY_SAMPLE_RATE;
+    delete process.env.NODE_ENV;
+    // restore fetch if mocked
+    // @ts-ignore
+    if (originalFetch) global.fetch = originalFetch;
+  });
+
+  let originalFetch: typeof fetch | undefined;
+
+  test("track respects ENABLED and SAMPLE_RATE", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "true";
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_TELEMETRY_SAMPLE_RATE = "0.5";
+    const mod = await import("../index");
+    const rand = jest.spyOn(Math, "random").mockReturnValue(0.6);
+    mod.track("event1");
+    expect(mod.__buffer.length).toBe(0);
+    rand.mockReturnValue(0.4);
+    mod.track("event2");
+    expect(mod.__buffer.length).toBe(1);
+  });
+
+  test("__flush sends buffered events and retries on failure", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "true";
+    process.env.NODE_ENV = "production";
+    const mod = await import("../index");
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce({ ok: true } as any);
+    originalFetch = global.fetch;
+    // @ts-ignore
+    global.fetch = fetchMock;
+    mod.track("evt", { foo: "bar" });
+    await mod.__flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body[0].name).toBe("evt");
+    expect(mod.__buffer.length).toBe(0);
+  });
+
+  test("__stripPII removes sensitive keys", async () => {
+    const mod = await import("../index");
+    expect(
+      mod.__stripPII({ email: "a@b.com", password: "secret", keep: 1 })
+    ).toEqual({ keep: 1 });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for telemetry track, flush retries, and PII stripping

## Testing
- `pnpm test packages/telemetry/src` *(fails: Could not find task `packages/telemetry/src` in project)*
- `pnpm exec jest packages/telemetry/src`


------
https://chatgpt.com/codex/tasks/task_e_68b95b347eb4832f82d6ada303a5d586