### PR TITLE
test: cover enabled mfa verify path

### DIFF
--- a/packages/auth/src/mfa.test.ts
+++ b/packages/auth/src/mfa.test.ts
@@ -59,6 +59,18 @@ describe("mfa", () => {
     expect(result).toBe(true);
   });
 
+  it("verifyMfa returns true when already enabled", async () => {
+    const { verifyMfa } = await import("./mfa");
+    findUnique.mockResolvedValue({ enabled: true });
+    verify.mockReturnValue(true);
+
+    const result = await verifyMfa("cust", "123456");
+
+    expect(verify).toHaveBeenCalledWith({ token: "123456", secret: undefined });
+    expect(update).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
   it("verifyMfa returns false when record missing or token invalid", async () => {
     const { verifyMfa } = await import("./mfa");
 


### PR DESCRIPTION
## Summary
- add test verifying verifyMfa returns true without update when MFA already enabled

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm test packages/auth/src` *(fails: Missing tasks in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b32568c832fa1d9d8d72f9357af