### PR TITLE
test(date-utils): add nowIso and formatTimestamp coverage

### DIFF
--- a/packages/date-utils/src/index.test.ts
+++ b/packages/date-utils/src/index.test.ts
@@ -4,6 +4,8 @@ import {
   getTimeRemaining,
   formatDuration,
   isoDateInNDays,
+  nowIso,
+  formatTimestamp,
 } from "./index";
 
 describe("calculateRentalDays", () => {
@@ -86,6 +88,29 @@ describe("isoDateInNDays", () => {
     base.setUTCDate(base.getUTCDate() - 1000);
     const expected = base.toISOString().slice(0, 10);
     expect(isoDateInNDays(-1000)).toBe(expected);
+  });
+});
+
+describe("nowIso", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  it("returns current time in ISO format", () => {
+    expect(nowIso()).toBe("2025-01-01T00:00:00.000Z");
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("formats valid ISO timestamp", () => {
+    const ts = "2025-01-01T05:06:07Z";
+    const expected = new Date(ts).toLocaleString("en-US");
+    expect(formatTimestamp(ts, "en-US")).toBe(expected);
+  });
+  it("returns input on invalid timestamp", () => {
+    expect(formatTimestamp("not-a-date", "en-US")).toBe("not-a-date");
   });
 });
 


### PR DESCRIPTION
## Summary
- expand date-utils tests for nowIso using mocked Date
- cover formatTimestamp with valid and invalid strings

## Testing
- `pnpm install`
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm run build:ts` (fails: Missing script: build:ts)
- `pnpm test packages/date-utils/src` (fails: Could not find task `packages/date-utils/src` in project)
- `pnpm --filter @acme/date-utils test packages/date-utils/src/index.test.ts` (fails: Jest "global" coverage threshold for branches (80%) not met: 79.16%)

------
https://chatgpt.com/codex/tasks/task_e_68b95b2e3870832fbc41e752ba797f6f