### PR TITLE
test(i18n): cover invalid parse inputs

### DIFF
--- a/packages/i18n/src/__tests__/parseMultilingualInput.test.ts
+++ b/packages/i18n/src/__tests__/parseMultilingualInput.test.ts
@@ -17,5 +17,8 @@ describe("parseMultilingualInput", () => {
   it("returns null for invalid input", () => {
     expect(parseMultilingualInput("title_fr", locales)).toBeNull();
     expect(parseMultilingualInput("foo_en", locales)).toBeNull();
+    expect(parseMultilingualInput("title_EN", locales)).toBeNull();
+    expect(parseMultilingualInput(" title_en", locales)).toBeNull();
+    expect(parseMultilingualInput("title_en ", locales)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- ensure parseMultilingualInput rejects uppercase locales and names with spaces

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/i18n/src` *(fails: Missing tasks in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b2cc9dc832faf32feb46b7f6493