### PR TITLE
test: update translations hook rerender

### DIFF
--- a/packages/i18n/src/__tests__/Translations.test.tsx
+++ b/packages/i18n/src/__tests__/Translations.test.tsx
@@ -34,5 +34,24 @@ describe("TranslationsProvider and useTranslations", () => {
     rerender();
     expect(result.current).toBe(first);
   });
+
+  it("updates translations and function identity when messages change", () => {
+    const wrapper = ({ children, messages }: PropsWithChildren<{ messages: Record<string, string> }>) => (
+      <TranslationsProvider messages={messages}>{children}</TranslationsProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useTranslations(), {
+      wrapper,
+      initialProps: { messages: { hello: "Hallo" } },
+    });
+
+    const first = result.current;
+    expect(first("hello")).toBe("Hallo");
+
+    rerender({ messages: { hello: "Salut" } });
+    const second = result.current;
+    expect(second("hello")).toBe("Salut");
+    expect(second).not.toBe(first);
+  });
 });
 


### PR DESCRIPTION
## Summary
- extend translation hook tests to verify updates when messages change

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/i18n/src` *(fails: Missing task)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b2c3058832f990fcead81abb9c5