### PR TITLE
test: ensure fsStore handles invalid json

### DIFF
--- a/packages/email/src/storage/__tests__/fsStore.test.ts
+++ b/packages/email/src/storage/__tests__/fsStore.test.ts
@@ -24,6 +24,16 @@ describe("fsCampaignStore error handling", () => {
     await expect(fsCampaignStore.listShops())
       .resolves.toEqual([]);
   });
+
+  it("returns [] when campaigns.json has invalid JSON", async () => {
+    const shop = "invalid-json";
+    const file = path.join(DATA_ROOT, shop, "campaigns.json");
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, "{", "utf8");
+    await expect(fsCampaignStore.readCampaigns(shop))
+      .resolves.toEqual([]);
+    await fs.rm(path.join(DATA_ROOT, shop), { recursive: true, force: true });
+  });
 });
 
 describe("fsCampaignStore persistence", () => {


### PR DESCRIPTION
## Summary
- add regression test verifying fsCampaignStore returns an empty array when campaigns.json has invalid JSON

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/email/src/storage` *(fails: Could not find task packages/email/src/storage)*
- `pnpm --filter @acme/email test src/storage` *(fails: global coverage threshold for branches (80%) not met: 50%)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b2ae300832f8db0fe4a15d67b19