### PR TITLE
test: log info when email creds missing

### DIFF
--- a/packages/email/src/__tests__/sendEmail.test.ts
+++ b/packages/email/src/__tests__/sendEmail.test.ts
@@ -46,6 +46,12 @@ describe("sendEmail", () => {
       .spyOn(console, "log")
       .mockImplementation(() => {});
 
+    const infoSpy = jest.fn();
+    jest.doMock("pino", () => ({
+      __esModule: true,
+      default: () => ({ info: infoSpy }),
+    }));
+
     jest.doMock("nodemailer", () => ({
       __esModule: true,
       default: { createTransport: jest.fn() },
@@ -56,6 +62,7 @@ describe("sendEmail", () => {
     await sendEmail("a@b.com", "Hi", "There");
 
     expect(consoleSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith({ to: "a@b.com" }, "Email simulated");
 
     consoleSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- test sendEmail logs via pino when Gmail credentials are absent

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/email/src` *(fails: Missing task `packages/email/src`)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b95b274c08832f83ce41c0ad631360