### PR TITLE
feat(ui): add FileSelector component with tests

### DIFF
--- a/packages/ui/src/components/atoms/FileSelector.tsx
+++ b/packages/ui/src/components/atoms/FileSelector.tsx
@@ -1,0 +1,31 @@
+import { useState, type ChangeEvent } from "react";
+
+export interface FileSelectorProps {
+  onFilesSelected?: (files: File[]) => void;
+  multiple?: boolean;
+}
+
+export function FileSelector({ onFilesSelected, multiple = false }: FileSelectorProps) {
+  const [files, setFiles] = useState<File[]>([]);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    setFiles(selected);
+    onFilesSelected?.(selected);
+  };
+
+  return (
+    <div>
+      <input type="file" multiple={multiple} onChange={handleChange} data-testid="file-input" />
+      {files.length > 0 && (
+        <ul>
+          {files.map((file) => (
+            <li key={file.name}>{file.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default FileSelector;

--- a/packages/ui/src/components/atoms/__tests__/FileSelector.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/FileSelector.test.tsx
@@ -1,0 +1,19 @@
+import "../../../../../../test/resetNextMocks";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FileSelector } from "../FileSelector";
+
+describe("FileSelector", () => {
+  it("invokes callback and displays selected file names", () => {
+    const handleSelect = jest.fn();
+    render(<FileSelector onFilesSelected={handleSelect} />);
+
+    const input = screen.getByTestId("file-input") as HTMLInputElement;
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith([file]);
+    expect(screen.getByText("hello.txt")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/atoms/index.ts
+++ b/packages/ui/src/components/atoms/index.ts
@@ -36,6 +36,7 @@ export { ARViewer } from "./ARViewer";
 export { Avatar } from "./Avatar";
 export { Chip } from "./Chip";
 export { ColorSwatch } from "./ColorSwatch";
+export { FileSelector } from "./FileSelector";
 export { Icon } from "./Icon";
 export { LineChart } from "./LineChart";
 export { Loader, Loader as Spinner } from "./Loader";


### PR DESCRIPTION
## Summary
- add `FileSelector` atom for selecting and previewing files
- test file selection callback and UI updates

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@jest/globals')*
- `pnpm test` *(fails: run failed: command exited (1))*
- `pnpm exec jest packages/ui/src/components/atoms/__tests__/FileSelector.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b95b186ec0832fa6134c029aba4c8c