### PR TITLE
test: add persistence hook test

### DIFF
--- a/apps/cms/src/app/cms/configurator/hooks/__tests__/useConfiguratorPersistence.test.tsx
+++ b/apps/cms/src/app/cms/configurator/hooks/__tests__/useConfiguratorPersistence.test.tsx
@@ -1,0 +1,91 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import React, { useState } from "react";
+import { flushSync } from "react-dom";
+import {
+  STORAGE_KEY,
+  useConfiguratorPersistence,
+} from "../useConfiguratorPersistence";
+import {
+  wizardStateSchema,
+  type WizardState,
+} from "../../../wizard/schema";
+
+describe("useConfiguratorPersistence", () => {
+  let fetchMock: jest.Mock;
+  let complete: ((id: string, status: any) => void) | null = null;
+
+  function TestComponent(): JSX.Element {
+    const [state, setState] = useState<WizardState>(wizardStateSchema.parse({}));
+    const [markStepComplete] = useConfiguratorPersistence(state, setState);
+    complete = markStepComplete;
+    return (
+      <input
+        placeholder="store"
+        value={state.storeName}
+        onChange={(e) => setState({ ...state, storeName: e.target.value })}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+    fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: { storeName: "Server" }, completed: {} }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("loads, persists and marks steps", async () => {
+    const updateListener = jest.fn();
+    window.addEventListener("configurator:update", updateListener);
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect((screen.getByPlaceholderText("store") as HTMLInputElement).value).toBe("Server")
+    );
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).storeName).toBe("Server");
+
+    fireEvent.change(screen.getByPlaceholderText("store"), {
+      target: { value: "Updated" },
+    });
+    jest.runOnlyPendingTimers();
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        "/cms/api/wizard-progress",
+        expect.objectContaining({
+          method: "PUT",
+          body: expect.stringContaining("Updated"),
+        })
+      )
+    );
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).storeName).toBe("Updated");
+
+    fetchMock.mockClear();
+    updateListener.mockClear();
+
+    flushSync(() => complete!("intro", "complete"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/cms/api/wizard-progress",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ stepId: "intro", completed: "complete" }),
+        })
+      )
+    );
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).completed.intro).toBe("complete");
+    expect(updateListener).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for useConfiguratorPersistence hook

## Testing
- `pnpm --filter @apps/cms test apps/cms/src/app/cms/configurator/hooks/__tests__/useConfiguratorPersistence.test.tsx` *(fails: Expected PATCH request)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b1868f0832fb1d2e04934432476