### PR TITLE
test: add DeviceSelector interactions

### DIFF
--- a/packages/ui/src/components/cms/__tests__/DeviceSelector.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/DeviceSelector.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DeviceSelector from "../DeviceSelector";
+
+describe("DeviceSelector", () => {
+  beforeAll(() => {
+    // JSDOM doesn't implement these pointer APIs used by Radix Select
+    // @ts-ignore
+    HTMLElement.prototype.hasPointerCapture = () => false;
+    // @ts-ignore
+    HTMLElement.prototype.setPointerCapture = () => {};
+    // @ts-ignore
+    Element.prototype.scrollIntoView = () => {};
+  });
+  it("calls setDeviceId when a new device is selected", async () => {
+    const setDeviceId = jest.fn();
+    render(
+      <DeviceSelector
+        deviceId="desktop-1280"
+        orientation="portrait"
+        setDeviceId={setDeviceId}
+        toggleOrientation={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText("Device"));
+    await userEvent.click(await screen.findByRole("option", { name: "iPad" }));
+
+    expect(setDeviceId).toHaveBeenCalledWith("ipad");
+  });
+
+  it("invokes toggleOrientation and rotates icon when landscape", async () => {
+    const toggleOrientation = jest.fn();
+    const { rerender } = render(
+      <DeviceSelector
+        deviceId="desktop-1280"
+        orientation="portrait"
+        setDeviceId={jest.fn()}
+        toggleOrientation={toggleOrientation}
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Rotate" }));
+    expect(toggleOrientation).toHaveBeenCalled();
+
+    rerender(
+      <DeviceSelector
+        deviceId="desktop-1280"
+        orientation="landscape"
+        setDeviceId={jest.fn()}
+        toggleOrientation={toggleOrientation}
+      />
+    );
+
+    const icon = screen
+      .getByRole("button", { name: "Rotate" })
+      .querySelector("svg");
+    expect(icon).toHaveClass("rotate-90");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for CMS DeviceSelector component verifying device selection and orientation toggle

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm test packages/ui/src/components/cms/__tests__/DeviceSelector.test.tsx` *(fails: Could not find task `packages/ui/src/components/cms/__tests__/DeviceSelector.test.tsx`)*
- `pnpm exec jest packages/ui/src/components/cms/__tests__/DeviceSelector.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95b1644f4832f92e744e1d2747f2d