### PR TITLE
test: add StepTheme tests

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/__tests__/StepTheme.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/__tests__/StepTheme.test.tsx
@@ -1,0 +1,121 @@
+/* eslint-env jest */
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import StepTheme from "../StepTheme";
+import { STORAGE_KEY } from "../../hooks/useConfiguratorPersistence";
+import { useConfigurator } from "../../ConfiguratorContext";
+import { useThemeLoader } from "../../hooks/useThemeLoader";
+import { useThemePalette } from "../hooks/useThemePalette";
+import { useThemePreviewDevice } from "../hooks/useThemePreviewDevice";
+import useStepCompletion from "../../hooks/useStepCompletion";
+import { useRouter } from "next/navigation";
+
+// ---------------------------------------------------------------------------
+// mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("../../ConfiguratorContext", () => ({
+  useConfigurator: jest.fn(),
+}));
+
+jest.mock("../../hooks/useThemeLoader", () => ({
+  useThemeLoader: jest.fn(),
+}));
+
+jest.mock("../hooks/useThemePalette", () => ({
+  useThemePalette: jest.fn(),
+}));
+
+jest.mock("../hooks/useThemePreviewDevice", () => ({
+  useThemePreviewDevice: jest.fn(),
+}));
+
+jest.mock("../../hooks/useStepCompletion", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("../ThemeEditorForm", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ onThemeChange }: any) => (
+      <button onClick={() => onThemeChange("dark")}>select theme</button>
+    ),
+  };
+});
+
+jest.mock("@ui/components/atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+const update = jest.fn();
+const handleReset = jest.fn();
+const markComplete = jest.fn();
+const push = jest.fn();
+
+describe("StepTheme", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useConfigurator as jest.Mock).mockReturnValue({
+      state: { theme: "base" },
+      update,
+    });
+    (useThemeLoader as jest.Mock).mockReturnValue({});
+    (useThemePalette as jest.Mock).mockReturnValue({
+      colorPalettes: [],
+      palette: "",
+      setPalette: jest.fn(),
+      themeOverrides: {},
+      themeDefaults: {},
+      handleTokenChange: jest.fn(),
+      handleReset,
+    });
+    (useThemePreviewDevice as jest.Mock).mockReturnValue({
+      device: {},
+      deviceId: "phone",
+      orientation: "portrait",
+      setDeviceId: jest.fn(),
+      toggleOrientation: jest.fn(),
+    });
+    (useStepCompletion as jest.Mock).mockReturnValue([false, markComplete]);
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ theme: "base", themeOverrides: { foo: "bar" } })
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("changes theme and updates persistence", () => {
+    render(<StepTheme themes={[]} nextStepId="next" /> as any);
+    fireEvent.click(screen.getByText("select theme"));
+    expect(update).toHaveBeenCalledWith("theme", "dark");
+    expect(handleReset).toHaveBeenCalled();
+    const data = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(data.theme).toBe("dark");
+    expect(data.themeOverrides).toEqual({});
+  });
+
+  it("marks complete and navigates to next step", () => {
+    render(<StepTheme themes={[]} nextStepId="next" /> as any);
+    fireEvent.click(screen.getByText("Next"));
+    expect(markComplete).toHaveBeenCalledWith(true);
+    expect(push).toHaveBeenCalledWith("/cms/configurator/next");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for StepTheme to verify theme change persistence and navigation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `CI=1 pnpm test` *(fails: run failed: command  exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68b95b159b34832fb579e1e7d00aaa8c