### PR TITLE
test: cover StepImportData upload and save

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/__tests__/StepImportData.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/__tests__/StepImportData.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import StepImportData from "../StepImportData";
+
+const markComplete = jest.fn();
+const push = jest.fn();
+
+jest.mock("../../hooks/useStepCompletion", () => ({
+  __esModule: true,
+  default: () => [false, markComplete],
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe("StepImportData", () => {
+  it("handles file upload, text input, and save", async () => {
+    const setCsvFile = jest.fn();
+    const setCategoriesText = jest.fn();
+    const saveData = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <StepImportData
+        setCsvFile={setCsvFile}
+        categoriesText=""
+        setCategoriesText={setCategoriesText}
+        importResult={null}
+        importing={false}
+        saveData={saveData}
+      />
+    );
+
+    const file = new File(["name"], "products.csv", { type: "text/csv" });
+    const fileInput = screen.getByLabelText("Products CSV");
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(setCsvFile).toHaveBeenCalledWith(file);
+
+    const textarea = screen.getByPlaceholderText('["Shoes","Accessories"]');
+    fireEvent.change(textarea, { target: { value: "{\"a\":1}" } });
+    expect(setCategoriesText).toHaveBeenCalledWith("{\"a\":1}");
+
+    await userEvent.click(screen.getByText("Save & return"));
+
+    expect(saveData).toHaveBeenCalled();
+    await waitFor(() => expect(markComplete).toHaveBeenCalledWith(true));
+    expect(push).toHaveBeenCalledWith("/cms/configurator");
+  });
+});
+

--- a/test/__mocks__/shadcnDialogStub.tsx
+++ b/test/__mocks__/shadcnDialogStub.tsx
@@ -44,3 +44,13 @@ export function DialogTitle({ children, ...props }: React.HTMLAttributes<HTMLHea
 export function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return <button {...props} />;
 }
+
+export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input {...props} />;
+}
+
+export function Textarea(
+  props: React.TextareaHTMLAttributes<HTMLTextAreaElement>
+) {
+  return <textarea {...props} />;
+}


### PR DESCRIPTION
## Summary
- add tests for StepImportData to verify file upload, JSON typing, and save flow
- stub shadcn components for Input and Textarea in tests

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm test --filter @apps/cms -- apps/cms/src/app/cms/configurator/steps/__tests__/StepImportData.test.tsx` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b0f7660832f9bf335dba05cde5d