### PR TITLE
test: add ProviderSelect tests

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ProviderSelect.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ProviderSelect.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProviderSelect from "@/app/cms/shop/[shop]/settings/ProviderSelect";
+import type { Provider } from "@acme/configurator/providers";
+
+describe("ProviderSelect", () => {
+  const shippingProviders: Provider[] = [
+    { id: "ups", name: "UPS", type: "shipping" },
+    { id: "dhl", name: "DHL", type: "shipping" },
+    { id: "fedex", name: "FedEx", type: "shipping" },
+  ];
+
+  it("calls setTrackingProviders with selected options", async () => {
+    const setTrackingProviders = jest.fn();
+    render(
+      <ProviderSelect
+        trackingProviders={[]}
+        setTrackingProviders={setTrackingProviders}
+        errors={{}}
+        shippingProviders={shippingProviders}
+      />
+    );
+
+    const select = screen.getByLabelText("Tracking Providers") as HTMLSelectElement;
+    const upsOption = screen.getByRole("option", { name: "UPS" }) as HTMLOptionElement;
+    const dhlOption = screen.getByRole("option", { name: "DHL" }) as HTMLOptionElement;
+    upsOption.selected = true;
+    dhlOption.selected = true;
+    fireEvent.change(select);
+    expect(setTrackingProviders).toHaveBeenCalledWith(["ups", "dhl"]);
+  });
+
+  it("renders error message when errors provided", () => {
+    render(
+      <ProviderSelect
+        trackingProviders={[]}
+        setTrackingProviders={jest.fn()}
+        errors={{ trackingProviders: ["Required"] }}
+        shippingProviders={shippingProviders}
+      />
+    );
+
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for ProviderSelect selecting multiple shipping providers
- verify error message rendering for trackingProviders field

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm test:cms` *(fails: multiple test suites with errors)*
- `pnpm exec jest --runTestsByPath apps/cms/src/app/cms/shop/\[shop\]/settings/__tests__/ProviderSelect.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9654e9994832f8814d66ad3e428ee