### PR TITLE
feat(cms): add basic templates with tests

### DIFF
--- a/apps/cms/src/app/cms/templates/HelloTemplate.tsx
+++ b/apps/cms/src/app/cms/templates/HelloTemplate.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export interface HelloTemplateProps {
+  /** Main heading text */
+  title: string;
+  /** Body content for the template */
+  body: string;
+}
+
+/**
+ * Simple template rendering a heading and body copy.
+ */
+export function HelloTemplate({ title, body }: HelloTemplateProps) {
+  return (
+    <section>
+      <h1>{title}</h1>
+      <p>{body}</p>
+    </section>
+  );
+}

--- a/apps/cms/src/app/cms/templates/ProductListTemplate.tsx
+++ b/apps/cms/src/app/cms/templates/ProductListTemplate.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export interface ProductListTemplateProps {
+  /** Section heading */
+  heading: string;
+  /** Products to render in an unordered list */
+  products: Array<{ id: string; name: string }>;
+}
+
+/**
+ * Renders a basic list of products with a heading.
+ */
+export function ProductListTemplate({ heading, products }: ProductListTemplateProps) {
+  return (
+    <section>
+      <h2>{heading}</h2>
+      <ul>
+        {products.map((p) => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/cms/src/app/cms/templates/__tests__/HelloTemplate.test.tsx
+++ b/apps/cms/src/app/cms/templates/__tests__/HelloTemplate.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { HelloTemplate } from "../HelloTemplate";
+
+describe("HelloTemplate", () => {
+  it("renders title and body", () => {
+    const { container } = render(
+      <HelloTemplate title="Welcome" body="Hello world" />
+    );
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Welcome"
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/cms/src/app/cms/templates/__tests__/ProductListTemplate.test.tsx
+++ b/apps/cms/src/app/cms/templates/__tests__/ProductListTemplate.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { ProductListTemplate } from "../ProductListTemplate";
+
+describe("ProductListTemplate", () => {
+  it("renders list of products", () => {
+    const products = [
+      { id: "1", name: "One" },
+      { id: "2", name: "Two" },
+    ];
+    const { container } = render(
+      <ProductListTemplate heading="Featured" products={products} />
+    );
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Featured"
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(products.length);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/cms/src/app/cms/templates/__tests__/__snapshots__/HelloTemplate.test.tsx.snap
+++ b/apps/cms/src/app/cms/templates/__tests__/__snapshots__/HelloTemplate.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelloTemplate renders title and body 1`] = `
+<div>
+  <section>
+    <h1>
+      Welcome
+    </h1>
+    <p>
+      Hello world
+    </p>
+  </section>
+</div>
+`;

--- a/apps/cms/src/app/cms/templates/__tests__/__snapshots__/ProductListTemplate.test.tsx.snap
+++ b/apps/cms/src/app/cms/templates/__tests__/__snapshots__/ProductListTemplate.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProductListTemplate renders list of products 1`] = `
+<div>
+  <section>
+    <h2>
+      Featured
+    </h2>
+    <ul>
+      <li>
+        One
+      </li>
+      <li>
+        Two
+      </li>
+    </ul>
+  </section>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add basic HelloTemplate and ProductListTemplate components under cms templates directory
- cover templates with snapshot tests for rendering sample props

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @apps/cms test apps/cms/src/app/cms/templates/__tests__/HelloTemplate.test.tsx apps/cms/src/app/cms/templates/__tests__/ProductListTemplate.test.tsx`
- `pnpm --filter @apps/cms test` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b96aee268c832f8dacaf66152894d4