### PR TITLE
test: verify wrapper class on input and textarea

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/input.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/input.test.tsx
@@ -2,6 +2,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { Input } from "../input";
 
 describe("Input primitive", () => {
+  it("applies wrapper class to outer div", () => {
+    const { container } = render(<Input wrapperClassName="custom-wrapper" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass("custom-wrapper");
+  });
+
   it("renders without floating label and applies error styles", () => {
     render(<Input label="Email" error="Required" />);
     const input = screen.getByLabelText("Email");

--- a/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
@@ -3,6 +3,14 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { Textarea } from "../textarea";
 
 describe("Textarea", () => {
+  it("applies wrapper class to outer div", () => {
+    const { container } = render(
+      <Textarea wrapperClassName="custom-wrapper" />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass("custom-wrapper");
+  });
+
   it("renders label above textarea in standard mode", () => {
     const { container } = render(<Textarea label="Notes" />);
     const wrapper = container.firstChild as HTMLElement;


### PR DESCRIPTION
## Summary
- test wrapperClassName forwarding in Input primitive
- test wrapperClassName forwarding in Textarea primitive

## Testing
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@jest/globals')*
- `pnpm exec jest packages/ui/src/components/atoms/primitives/__tests__/input.test.tsx packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68b96aed8dbc832fbf48e72401b172c2