### PR TITLE
test: add primitives tests

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
@@ -1,0 +1,38 @@
+import "../../../../../../../test/resetNextMocks";
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select";
+
+describe("Select", () => {
+  it("fires onValueChange and shows indicator on selected item", async () => {
+    const onValueChange = jest.fn();
+    render(
+      <Select onValueChange={onValueChange}>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="one">One</SelectItem>
+          <SelectItem value="two">Two</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("trigger"));
+    const optionTwo = await screen.findByRole("option", { name: "Two" });
+    await user.click(optionTwo);
+
+    expect(onValueChange).toHaveBeenCalledWith("two");
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(optionTwo.getAttribute("data-state")).toBe("checked");
+    expect(optionTwo.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
@@ -1,0 +1,24 @@
+import "../../../../../../../test/resetNextMocks";
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { Slot } from "../slot";
+
+describe("Slot", () => {
+  it("forwards props and ref to child element", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <Slot ref={ref} className="forwarded" data-test="passed">
+        <div data-testid="child" />
+      </Slot>
+    );
+    const child = screen.getByTestId("child");
+    expect(child).toHaveClass("forwarded");
+    expect(child).toHaveAttribute("data-test", "passed");
+    expect(ref.current).toBe(child);
+  });
+
+  it("returns null when children is not a valid element", () => {
+    const { container } = render(<Slot>{"text"}</Slot>);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/atoms/primitives/__tests__/table.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/table.test.tsx
@@ -1,0 +1,36 @@
+import "../../../../../../../test/resetNextMocks";
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../table";
+
+describe("Table", () => {
+  it("renders with header and body and wraps table in overflow container", () => {
+    const { container } = render(
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Header</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(screen.getByText("Header")).toBeInTheDocument();
+    expect(screen.getByText("Cell")).toBeInTheDocument();
+    const wrapper = container.firstChild as HTMLElement | null;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveClass("w-full", "overflow-x-auto");
+  });
+});


### PR DESCRIPTION
## Summary
- add Select primitive tests verifying value change and indicator
- add Table primitive tests ensuring wrapper overflow styling
- add Slot primitive tests for prop/ref forwarding and null renders

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test` *(fails: multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b96aecc190832f833aa14183435328