### PR TITLE
test: extend StockStatus overrides

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/StockStatus.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/StockStatus.test.tsx
@@ -16,4 +16,37 @@ describe("StockStatus", () => {
     expect(span).toHaveAttribute("data-token", "--color-danger");
     expect(span).toHaveClass("text-danger");
   });
+
+  it("renders custom labels and classes", () => {
+    render(
+      <>
+        <StockStatus
+          inStock
+          labelInStock="Available"
+          className="custom"
+        />
+        <StockStatus
+          inStock={false}
+          labelOutOfStock="Unavailable"
+          className="custom"
+        />
+      </>
+    );
+
+    const inStock = screen.getByText("Available");
+    expect(inStock).toHaveClass(
+      "text-sm",
+      "font-medium",
+      "text-success",
+      "custom",
+    );
+
+    const outOfStock = screen.getByText("Unavailable");
+    expect(outOfStock).toHaveClass(
+      "text-sm",
+      "font-medium",
+      "text-danger",
+      "custom",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- test StockStatus with custom labels and className

## Testing
- `pnpm --filter @acme/ui test` *(fails: Jest encountered an unexpected token in packages/email)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b96aeb1e04832f936a2e7f1f159375