### PR TITLE
test(ui): verify custom size in RatingStars

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx
@@ -8,10 +8,15 @@ describe("RatingStars", () => {
     { rating: 4.8, filled: 5 },
     { rating: 0, filled: 0 },
   ])("renders correct stars for rating %p", ({ rating, filled }) => {
-    const { container } = render(<RatingStars rating={rating} />);
+    const size = 24;
+    const { container } = render(
+      <RatingStars rating={rating} size={size} />,
+    );
     const stars = container.querySelectorAll("svg");
     expect(stars).toHaveLength(5);
     stars.forEach((star, index) => {
+      expect(star).toHaveAttribute("width", size.toString());
+      expect(star).toHaveAttribute("height", size.toString());
       if (index < filled) {
         expect(star).toHaveClass("fill-yellow-500");
       } else {


### PR DESCRIPTION
## Summary
- ensure RatingStars test supports custom size 24 and validates SVG dimensions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96aea3bdc832f9e8c730a605b4396