### PR TITLE
test(ui): verify avatar string dimensions

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/Avatar.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Avatar.test.tsx
@@ -34,4 +34,27 @@ describe("Avatar", () => {
     expect(img).toHaveClass("rounded-full");
     expect(img).toHaveClass("rounded-none");
   });
+
+  it("parses string dimensions and applies spacing", () => {
+    const nextImage = require("next/image");
+    const spy = jest.spyOn(nextImage, "default");
+
+    render(
+      <Avatar
+        src="/avatar.jpg"
+        alt="User avatar"
+        width="48"
+        height="64"
+        padding="p-4"
+        margin="m-2"
+      />
+    );
+
+    expect(spy.mock.calls[0][0]).toMatchObject({ width: 48, height: 64 });
+
+    const img = screen.getByAltText("User avatar");
+    expect(img).toHaveStyle({ width: "48", height: "64" });
+    expect(img).toHaveClass("p-4");
+    expect(img).toHaveClass("m-2");
+  });
 });


### PR DESCRIPTION
## Summary
- extend Avatar unit tests for string width/height props
- assert parsed numeric dimensions and spacing classes

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/__tests__/Avatar.test.tsx` *(fails: coverage threshold not met)*
- `pnpm --filter @acme/ui exec jest --runInBand --config ../../jest.config.cjs --coverage=false packages/ui/src/components/atoms/__tests__/Avatar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b965597d10832f9774f2a39af8b6d7