### PR TITLE
test(ui): add ThemeToggle interactions

### DIFF
--- a/packages/ui/src/components/__tests__/ThemeToggle.test.tsx
+++ b/packages/ui/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,56 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ThemeToggle from "../ThemeToggle";
+
+var setThemeMock: jest.Mock;
+
+jest.mock("@platform-core/contexts/ThemeContext", () => {
+  const React = require("react");
+  setThemeMock = jest.fn();
+  return {
+    useTheme: () => {
+      const [theme, setThemeState] = React.useState("base");
+      const setTheme = (t: string) => {
+        setThemeMock(t);
+        setThemeState(t);
+      };
+      return { theme, setTheme };
+    },
+    setThemeMock,
+  };
+});
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    setThemeMock.mockClear();
+  });
+
+  it("toggles theme on click", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const button = screen.getByRole("button", { name: /switch to dark theme/i });
+    expect(screen.getByText(/light theme selected/i)).toBeInTheDocument();
+
+    await user.click(button);
+
+    expect(setThemeMock).toHaveBeenCalledWith("dark");
+    expect(screen.getByText(/dark theme selected/i)).toBeInTheDocument();
+  });
+
+  it.each([
+    { key: "Enter", label: /switch to dark theme/i },
+    { key: " ", label: /switch to dark theme/i },
+  ])("toggles theme on %s key", async ({ key, label }) => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+    const button = screen.getByRole("button", { name: label });
+
+    button.focus();
+    await user.keyboard(key === " " ? " " : `{${key}}`);
+
+    expect(setThemeMock).toHaveBeenCalledWith("dark");
+    expect(screen.getByText(/dark theme selected/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add ThemeToggle tests covering click and keyboard toggles

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/src/components/__tests__/ThemeToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96556b1d0832f9cd55b554bd620d2