### PR TITLE
test: add DeviceSelector interactions

### DIFF
--- a/packages/ui/src/components/__tests__/DeviceSelector.test.tsx
+++ b/packages/ui/src/components/__tests__/DeviceSelector.test.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DeviceSelector from "../DeviceSelector";
+import { getLegacyPreset, devicePresets } from "../../utils/devicePresets";
+
+jest.mock("../atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    Button: ({ children, ...props }: any) => (
+      <button {...props}>{children}</button>
+    ),
+    Select: ({ value, onValueChange, children }: any) => (
+      <select
+        aria-label="Device"
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+      >
+        {children}
+      </select>
+    ),
+    SelectTrigger: ({ children }: any) => <>{children}</>,
+    SelectValue: () => null,
+    SelectContent: ({ children }: any) => <>{children}</>,
+    SelectItem: ({ children, value }: any) => (
+      <option value={value}>{children}</option>
+    ),
+  };
+});
+
+function Wrapper() {
+  const [deviceId, setDeviceId] = useState(getLegacyPreset("desktop").id);
+  return (
+    <>
+      <span data-testid="device-id">{deviceId}</span>
+      <DeviceSelector deviceId={deviceId} setDeviceId={setDeviceId} />
+    </>
+  );
+}
+
+describe("DeviceSelector", () => {
+  it("updates deviceId via buttons and dropdown", () => {
+    render(<Wrapper />);
+    const display = screen.getByTestId("device-id");
+
+    fireEvent.click(screen.getByRole("button", { name: "tablet" }));
+    expect(display).toHaveTextContent(getLegacyPreset("tablet").id);
+
+    fireEvent.click(screen.getByRole("button", { name: "mobile" }));
+    expect(display).toHaveTextContent(getLegacyPreset("mobile").id);
+
+    fireEvent.click(screen.getByRole("button", { name: "desktop" }));
+    expect(display).toHaveTextContent(getLegacyPreset("desktop").id);
+
+    const select = screen.getByLabelText("Device");
+    const newPreset = devicePresets.find((p) => p.id === "ipad-pro")!;
+    fireEvent.change(select, { target: { value: newPreset.id } });
+    expect(display).toHaveTextContent(newPreset.id);
+  });
+});


### PR DESCRIPTION
## Summary
- add stateful DeviceSelector test covering button and dropdown updates

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/__tests__/DeviceSelector.test.tsx`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b965551134832f8c03f900dcd0b64f