### PR TITLE
test: add ComponentPreview unit tests

### DIFF
--- a/packages/ui/src/components/__tests__/ComponentPreview.test.tsx
+++ b/packages/ui/src/components/__tests__/ComponentPreview.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ComponentPreview from "../ComponentPreview";
+import type { UpgradeComponent } from "@acme/types";
+
+describe("ComponentPreview", () => {
+  afterEach(() => {
+    delete (globalThis as any).__UPGRADE_MOCKS__;
+  });
+
+  const component: UpgradeComponent = {
+    componentName: "MyComp",
+    file: "MyComp.tsx",
+  } as UpgradeComponent;
+
+  it("renders the new component by default", async () => {
+    const NewComp = () => <div>New Component</div>;
+    const OldComp = () => <div>Old Component</div>;
+    (globalThis as any).__UPGRADE_MOCKS__ = {
+      "@ui/components/MyComp": NewComp,
+      "@ui/components/MyComp.bak": OldComp,
+    };
+
+    render(<ComponentPreview component={component} />);
+
+    expect(await screen.findByText("New Component")).toBeInTheDocument();
+    expect(screen.queryByText("Old Component")).not.toBeInTheDocument();
+  });
+
+  it("shows components side by side when comparison is enabled", async () => {
+    const NewComp = () => <div>New Component</div>;
+    const OldComp = () => <div>Old Component</div>;
+    (globalThis as any).__UPGRADE_MOCKS__ = {
+      "@ui/components/MyComp": NewComp,
+      "@ui/components/MyComp.bak": OldComp,
+    };
+
+    render(<ComponentPreview component={component} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+
+    expect(await screen.findByText("New Component")).toBeInTheDocument();
+    expect(await screen.findByText("Old Component")).toBeInTheDocument();
+  });
+
+  it("toggles between versions in toggle mode", async () => {
+    const NewComp = () => <div>New Component</div>;
+    const OldComp = () => <div>Old Component</div>;
+    (globalThis as any).__UPGRADE_MOCKS__ = {
+      "@ui/components/MyComp": NewComp,
+      "@ui/components/MyComp.bak": OldComp,
+    };
+
+    render(<ComponentPreview component={component} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+
+    const switchButton = screen.getByRole("button", { name: "Show old" });
+    fireEvent.click(switchButton);
+    expect(await screen.findByText("Old Component")).toBeInTheDocument();
+    expect(screen.queryByText("New Component")).not.toBeInTheDocument();
+  });
+
+  it("shows fallback when component throws", async () => {
+    const ErrorComp = () => {
+      throw new Error("boom");
+    };
+    (globalThis as any).__UPGRADE_MOCKS__ = {
+      "@ui/components/MyComp": ErrorComp,
+    };
+
+    render(<ComponentPreview component={component} />);
+
+    expect(
+      await screen.findByText("Failed to render preview")
+    ).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for ComponentPreview covering default render, comparison modes, and error fallback

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/__tests__/ComponentPreview.test.tsx`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b9655403a4832f80b6566b211fc7e4