### PR TITLE
fix(ui): mark FileSelector as client component

### DIFF
--- a/packages/ui/src/components/atoms/FileSelector.tsx
+++ b/packages/ui/src/components/atoms/FileSelector.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, type ChangeEvent } from "react";
 
 export interface FileSelectorProps {


### PR DESCRIPTION
## Summary
- declare FileSelector as a client component so it can use React hooks

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui run build` *(fails: Cannot find module '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68b977a50344832f8d0f0b829c1e038c