### PR TITLE
fix: synchronous email service registration

### DIFF
--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,18 +1,23 @@
 import "server-only";
 import { sendEmail } from "./sendEmail";
 
-async function registerEmailService() {
-  try {
-    const { setEmailService } = await import(
+try {
+  if (typeof require !== "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { setEmailService } = require(
       "@acme/platform-core/services/emailService"
     );
     setEmailService({ sendEmail });
-  } catch {
-    // The core email service isn't available in the current environment.
+  } else {
+    void import("@acme/platform-core/services/emailService").then(
+      ({ setEmailService }) => {
+        setEmailService({ sendEmail });
+      }
+    );
   }
+} catch {
+  // The core email service isn't available in the current environment.
 }
-
-void registerEmailService();
 
 export type { CampaignOptions } from "./send";
 export { sendCampaignEmail } from "./send";


### PR DESCRIPTION
## Summary
- ensure `@acme/email` registers its email service during module import using synchronous `require` when available, falling back to dynamic import

## Testing
- `pnpm install`
- `pnpm exec jest packages/email/src/__tests__/index.test.ts --runInBand --config jest.config.cjs --runTestsByPath` *(fails coverage thresholds but passes tests)*
- `pnpm --filter @acme/email run build` *(fails: Cannot find module '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68b9781732cc832fb926ecd97bd19030