### PR TITLE
fix jest esm stubs

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -178,7 +178,8 @@ describe("scheduler", () => {
       subject: "Hello",
       body: "<p>Hi %%UNSUBSCRIBE%%</p>",
     });
-    jest.runAllTimers();
+    // Run all scheduled timers, including those added during execution.
+    await jest.runAllTimersAsync();
     await promise;
     jest.useRealTimers();
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10);

--- a/packages/email/src/providers/resend.js
+++ b/packages/email/src/providers/resend.js
@@ -1,1 +1,1 @@
-export * from './resend.ts';
+module.exports = require('./resend.ts');

--- a/packages/email/src/providers/sendgrid.js
+++ b/packages/email/src/providers/sendgrid.js
@@ -1,1 +1,1 @@
-export * from './sendgrid.ts';
+module.exports = require('./sendgrid.ts');

--- a/packages/email/src/providers/types.js
+++ b/packages/email/src/providers/types.js
@@ -1,1 +1,1 @@
-export * from './types.ts';
+module.exports = require('./types.ts');

--- a/packages/email/src/stats.js
+++ b/packages/email/src/stats.js
@@ -1,1 +1,1 @@
-export * from './stats.ts';
+module.exports = require('./stats.ts');

--- a/packages/email/src/storage/fsStore.js
+++ b/packages/email/src/storage/fsStore.js
@@ -1,1 +1,1 @@
-export * from './fsStore.ts';
+module.exports = require('./fsStore.ts');

--- a/packages/email/src/storage/index.js
+++ b/packages/email/src/storage/index.js
@@ -1,1 +1,1 @@
-export * from './index.ts';
+module.exports = require('./index.ts');


### PR DESCRIPTION
## Summary
- switch email package js stubs to CommonJS so Jest can parse them
- flush pending timers in scheduler test to prevent timeout

## Testing
- `pnpm --filter @acme/email test -- packages/email/src/__tests__/scheduler.test.ts` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b977f8bf1c832f81286b61f7bfa297