### PR TITLE
fix: remove .js imports in email for Jest compatibility

### DIFF
--- a/packages/email/src/analytics.ts
+++ b/packages/email/src/analytics.ts
@@ -1,21 +1,21 @@
 import "server-only";
 import { trackEvent } from "@platform-core/analytics";
-import { getCampaignStore } from "./storage/index.js";
-import { SendgridProvider } from "./providers/sendgrid.js";
-import { ResendProvider } from "./providers/resend.js";
-import type { CampaignProvider } from "./providers/types.js";
-import { emptyStats, type CampaignStats } from "./stats.js";
+import { getCampaignStore } from "./storage";
+import { SendgridProvider } from "./providers/sendgrid";
+import { ResendProvider } from "./providers/resend";
+import type { CampaignProvider } from "./providers/types";
+import { emptyStats, type CampaignStats } from "./stats";
 export {
   mapSendGridStats,
   mapResendStats,
   normalizeProviderStats,
   emptyStats,
-} from "./stats.js";
+} from "./stats";
 export type {
   CampaignStats,
   SendGridStatsResponse,
   ResendStatsResponse,
-} from "./stats.js";
+} from "./stats";
 
 export type EmailEventType =
   | "email_delivered"

--- a/packages/email/src/storage/fsStore.ts
+++ b/packages/email/src/storage/fsStore.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
-import type { Campaign } from "../types.js";
-import type { CampaignStore } from "./types.js";
+import type { Campaign } from "../types";
+import type { CampaignStore } from "./types";
 import { DATA_ROOT } from "@platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 

--- a/packages/email/src/storage/index.ts
+++ b/packages/email/src/storage/index.ts
@@ -1,6 +1,6 @@
-import { fsCampaignStore } from "./fsStore.js";
-import type { CampaignStore } from "./types.js";
-import type { Campaign } from "../types.js";
+import { fsCampaignStore } from "./fsStore";
+import type { CampaignStore } from "./types";
+import type { Campaign } from "../types";
 
 let store: CampaignStore = fsCampaignStore;
 

--- a/packages/email/src/storage/types.ts
+++ b/packages/email/src/storage/types.ts
@@ -1,4 +1,4 @@
-import type { Campaign } from "../types.js";
+import type { Campaign } from "../types";
 
 export interface CampaignStore {
   /**


### PR DESCRIPTION
## Summary
- replace internal `.js` import paths with extensionless imports in email package so Jest can transform TypeScript
- update analytics and storage modules accordingly

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email build` *(fails: Cannot find module '@jest/globals')*
- `pnpm exec jest packages/email/__tests__/scheduler.test.ts --runInBand --config jest.config.cjs` *(fails: coverage thresholds not met)*


------
https://chatgpt.com/codex/tasks/task_e_68b9788e9dd8832f8d9e4d67013c91a1