### PR TITLE
fix(email): adjust stub exports for Jest compatibility

### DIFF
--- a/packages/email/src/providers/resend.js
+++ b/packages/email/src/providers/resend.js
@@ -1,1 +1,2 @@
-export * from './resend.ts';
+// CommonJS re-export for Jest compatibility
+module.exports = require('./resend.ts');

--- a/packages/email/src/providers/sendgrid.js
+++ b/packages/email/src/providers/sendgrid.js
@@ -1,1 +1,2 @@
-export * from './sendgrid.ts';
+// CommonJS re-export for Jest compatibility
+module.exports = require('./sendgrid.ts');

--- a/packages/email/src/providers/types.js
+++ b/packages/email/src/providers/types.js
@@ -1,1 +1,2 @@
-export * from './types.ts';
+// CommonJS re-export for Jest compatibility
+module.exports = require('./types.ts');

--- a/packages/email/src/stats.js
+++ b/packages/email/src/stats.js
@@ -1,1 +1,2 @@
-export * from './stats.ts';
+// CommonJS re-export for Jest compatibility
+module.exports = require('./stats.ts');

--- a/packages/email/src/storage/fsStore.js
+++ b/packages/email/src/storage/fsStore.js
@@ -1,1 +1,2 @@
-export * from './fsStore.ts';
+// CommonJS re-export for Jest compatibility
+module.exports = require('./fsStore.ts');

--- a/packages/email/src/storage/index.js
+++ b/packages/email/src/storage/index.js
@@ -1,1 +1,4 @@
-export * from './index.ts';
+// Provide a CommonJS re-export of the TypeScript source for Jest
+// which does not transform this `.js` file. Using `require` avoids
+// syntax errors when the tests import `./storage/index.js`.
+module.exports = require('./index.ts');


### PR DESCRIPTION
## Summary
- fix stub `.js` files in email package to use CommonJS re-exports so Jest can parse them

## Testing
- `pnpm exec jest src/__tests__/analytics.test.ts --ci --config ../../jest.config.cjs`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b978ae8388832fb681e192931ddfb0