### PR TITLE
test(email): cover normalizeProviderStats edge cases

### DIFF
--- a/packages/email/src/__tests__/stats.test.ts
+++ b/packages/email/src/__tests__/stats.test.ts
@@ -51,16 +51,18 @@ describe("normalizeProviderStats", () => {
     );
   });
 
-  it("uses resend mapper for resend provider", () => {
-    const raw = { delivered_count: "1" } as const;
-    expect(normalizeProviderStats("resend", raw)).toEqual(
-      mapResendStats(raw)
-    );
+  it("normalizes resend stats with string counts", () => {
+    expect(
+      normalizeProviderStats("resend", { opened: "2" })
+    ).toEqual({
+      ...emptyStats,
+      opened: 2,
+    });
   });
 
-  it("returns empty stats for unknown provider", () => {
-    expect(normalizeProviderStats("unknown", undefined)).toEqual({
-      ...emptyStats,
-    });
+  it("returns empty stats clone for unsupported provider", () => {
+    const result = normalizeProviderStats("unsupported", { opened: "2" });
+    expect(result).toEqual(emptyStats);
+    expect(result).not.toBe(emptyStats);
   });
 });


### PR DESCRIPTION
## Summary
- verify Resend stats normalization handles string counts
- ensure unknown providers return a clone of `emptyStats`

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/stats.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b97a76a658832fbd117b7696f385bf