### PR TITLE
test: add campaign store index tests

### DIFF
--- a/packages/email/src/storage/__tests__/index.test.ts
+++ b/packages/email/src/storage/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import { fsCampaignStore, getCampaignStore, setCampaignStore } from "..";
+import type { CampaignStore, Campaign } from "..";
+
+describe("campaign store selection", () => {
+  afterEach(() => {
+    // reset to default store after each test
+    setCampaignStore(fsCampaignStore);
+  });
+
+  it("returns fsCampaignStore by default", () => {
+    expect(getCampaignStore()).toBe(fsCampaignStore);
+  });
+
+  it("returns the updated store after calling setCampaignStore", () => {
+    const mockStore: CampaignStore = {
+      readCampaigns: jest.fn(),
+      writeCampaigns: jest.fn(),
+      listShops: jest.fn(),
+    };
+
+    setCampaignStore(mockStore);
+    expect(getCampaignStore()).toBe(mockStore);
+  });
+});
+
+// Ensure type re-exports are accessible
+const _typeCheck: Campaign | undefined = undefined;


### PR DESCRIPTION
## Summary
- test campaign storage default and override

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: packages/configurator build: Cannot find module '@jest/globals')*
- `pnpm exec jest packages/email/src/storage/__tests__/index.test.ts --config jest.config.cjs --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b97a74eec4832f8f8c58a965ab4dce