### PR TITLE
test(config): warn on invalid stripe key

### DIFF
--- a/packages/config/src/env/__tests__/payments.test.ts
+++ b/packages/config/src/env/__tests__/payments.test.ts
@@ -23,6 +23,9 @@ describe("payments env schema", () => {
 
     const parsed = paymentsEnvSchema.safeParse(process.env);
     expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.format()).toHaveProperty("STRIPE_SECRET_KEY");
+    }
     expect(warnSpy).toHaveBeenCalledWith(
       "⚠️ Invalid payments environment variables:",
       expect.any(Object),


### PR DESCRIPTION
## Summary
- add regression test for payments env schema to warn on invalid STRIPE_SECRET_KEY and fallback to defaults

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68b97a740de8832f975085e5d6a880ac