### PR TITLE
fix: mock correct config env module in generateMeta tests

### DIFF
--- a/packages/lib/__tests__/generateMeta.test.ts
+++ b/packages/lib/__tests__/generateMeta.test.ts
@@ -14,7 +14,7 @@ describe('generateMeta', () => {
     });
     let result;
     await jest.isolateModulesAsync(async () => {
-      jest.doMock('@acme/config', () => ({ env: { OPENAI_API_KEY: 'key' } }));
+      jest.doMock('@acme/config/env/core', () => ({ coreEnv: { OPENAI_API_KEY: 'key' } }));
       jest.doMock('fs', () => ({ promises: { writeFile: jest.fn(), mkdir: jest.fn() } }));
       jest.doMock('openai', () => ({
         __esModule: true,
@@ -43,7 +43,7 @@ describe('generateMeta', () => {
     });
     let result;
     await jest.isolateModulesAsync(async () => {
-      jest.doMock('@acme/config', () => ({ env: { OPENAI_API_KEY: 'key' } }));
+      jest.doMock('@acme/config/env/core', () => ({ coreEnv: { OPENAI_API_KEY: 'key' } }));
       jest.doMock('fs', () => ({ promises: { writeFile: jest.fn(), mkdir: jest.fn() } }));
       jest.doMock('openai', () => ({
         __esModule: true,
@@ -72,7 +72,7 @@ describe('generateMeta', () => {
     });
     let result;
     await jest.isolateModulesAsync(async () => {
-      jest.doMock('@acme/config', () => ({ env: { OPENAI_API_KEY: 'key' } }));
+      jest.doMock('@acme/config/env/core', () => ({ coreEnv: { OPENAI_API_KEY: 'key' } }));
       jest.doMock('fs', () => ({ promises: { writeFile: jest.fn(), mkdir: jest.fn() } }));
       jest.doMock('openai', () => ({
         __esModule: true,
@@ -101,7 +101,7 @@ describe('generateMeta', () => {
     });
     let result;
     await jest.isolateModulesAsync(async () => {
-      jest.doMock('@acme/config', () => ({ env: { OPENAI_API_KEY: 'key' } }));
+      jest.doMock('@acme/config/env/core', () => ({ coreEnv: { OPENAI_API_KEY: 'key' } }));
       jest.doMock('fs', () => ({ promises: { writeFile: jest.fn(), mkdir: jest.fn() } }));
       jest.doMock('openai', () => ({
         __esModule: true,


### PR DESCRIPTION
## Summary
- mock `@acme/config/env/core` in generateMeta tests so OPENAI_API_KEY is defined

## Testing
- `pnpm exec jest packages/lib/__tests__/generateMeta.test.ts --config jest.config.cjs --runInBand`
- `pnpm -r build` *(fails: TS2307 cannot find module '@jest/globals')*
- `pnpm --filter @acme/lib build` *(fails: TS6305 Output file ... platform-core not built)*

------
https://chatgpt.com/codex/tasks/task_e_68b97adbc3ac832f973d6c43cc5d1a66