### PR TITLE
test: cover friendly zod error map

### DIFF
--- a/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
+++ b/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
@@ -1,114 +1,147 @@
-import { z } from "zod";
+import { z, ZodIssueCode, type ZodIssue } from "zod";
 import { applyFriendlyZodMessages, friendlyErrorMap } from "../zodErrorMap";
 
-test("applyFriendlyZodMessages sets global error map", () => {
-  const original = z.getErrorMap();
-  expect(original).not.toBe(friendlyErrorMap);
-  applyFriendlyZodMessages();
-  expect(z.getErrorMap()).toBe(friendlyErrorMap);
-  z.setErrorMap(original);
-});
+describe("friendlyErrorMap", () => {
+  const ctx = { defaultError: "fallback", data: undefined, path: [] };
 
-describe("friendly zod error messages", () => {
-  const defaultMap = z.getErrorMap();
+  test("invalid_type", () => {
+    const issues: ZodIssue[] = [
+      {
+        code: ZodIssueCode.invalid_type,
+        expected: "string",
+        received: "undefined",
+        path: [],
+      } as unknown as ZodIssue,
+      {
+        code: ZodIssueCode.invalid_type,
+        expected: "string",
+        received: "number",
+        path: [],
+      } as unknown as ZodIssue,
+    ];
 
-  beforeAll(() => {
-    applyFriendlyZodMessages();
-  });
-
-  afterAll(() => {
-    z.setErrorMap(defaultMap);
-  });
-
-  test("invalid_type undefined", () => {
-    const schema = z.string();
-    const result = schema.safeParse(undefined);
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Required");
-  });
-
-  test("invalid_type wrong type", () => {
-    const schema = z.string();
-    const result = schema.safeParse(123);
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Expected string");
-  });
-
-  test("invalid_type number", () => {
-    const schema = z.number();
-    const result = schema.safeParse("123");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Expected number");
-  });
-
-  test("invalid_type array", () => {
-    const schema = z.array(z.string());
-    const result = schema.safeParse("not-an-array");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Expected array");
+    const messages = issues.map((issue) => friendlyErrorMap(issue, ctx).message);
+    expect(messages).toEqual(["Required", "Expected string"]);
   });
 
   test("invalid_enum_value", () => {
-    const schema = z.enum(["a", "b"]);
-    const result = schema.safeParse("c");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Invalid value");
+    const issue = {
+      code: ZodIssueCode.invalid_enum_value,
+      options: ["a", "b"],
+      received: "c",
+      path: [],
+    } as unknown as ZodIssue;
+
+    expect(friendlyErrorMap(issue, ctx).message).toBe("Invalid value");
   });
 
-  test("too_small string", () => {
-    const schema = z.string().min(3);
-    const result = schema.safeParse("hi");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Must be at least 3 characters");
+  test("too_small", () => {
+    const issues: ZodIssue[] = [
+      {
+        code: ZodIssueCode.too_small,
+        type: "string",
+        minimum: 3,
+        inclusive: true,
+        exact: false,
+        message: "",
+        path: [],
+      } as unknown as ZodIssue,
+      {
+        code: ZodIssueCode.too_small,
+        type: "array",
+        minimum: 2,
+        inclusive: true,
+        exact: false,
+        message: "",
+        path: [],
+      } as unknown as ZodIssue,
+      {
+        code: ZodIssueCode.too_small,
+        type: "number",
+        minimum: 1,
+        inclusive: true,
+        exact: false,
+        message: "",
+        path: [],
+      } as unknown as ZodIssue,
+    ];
+
+    const messages = issues.map((issue) => friendlyErrorMap(issue, ctx).message);
+    expect(messages).toEqual([
+      "Must be at least 3 characters",
+      "Must have at least 2 items",
+      ctx.defaultError,
+    ]);
   });
 
-  test("too_big string", () => {
-    const schema = z.string().max(2);
-    const result = schema.safeParse("toolong");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Must be at most 2 characters");
+  test("too_big", () => {
+    const issues: ZodIssue[] = [
+      {
+        code: ZodIssueCode.too_big,
+        type: "string",
+        maximum: 5,
+        inclusive: true,
+        exact: false,
+        message: "",
+        path: [],
+      } as unknown as ZodIssue,
+      {
+        code: ZodIssueCode.too_big,
+        type: "array",
+        maximum: 4,
+        inclusive: true,
+        exact: false,
+        message: "",
+        path: [],
+      } as unknown as ZodIssue,
+      {
+        code: ZodIssueCode.too_big,
+        type: "number",
+        maximum: 1,
+        inclusive: true,
+        exact: false,
+        message: "",
+        path: [],
+      } as unknown as ZodIssue,
+    ];
+
+    const messages = issues.map((issue) => friendlyErrorMap(issue, ctx).message);
+    expect(messages).toEqual([
+      "Must be at most 5 characters",
+      "Must have at most 4 items",
+      ctx.defaultError,
+    ]);
   });
 
-  test("too_small number", () => {
-    const schema = z.number().min(1);
-    const result = schema.safeParse(0);
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Number must be greater than or equal to 1");
-  });
+  test("unknown issue", () => {
+    const issues: ZodIssue[] = [
+      {
+        code: ZodIssueCode.custom,
+        message: "Custom message",
+        path: [],
+      } as unknown as ZodIssue,
+      {
+        code: ZodIssueCode.custom,
+        path: [],
+      } as unknown as ZodIssue,
+    ];
 
-  test("too_big number", () => {
-    const schema = z.number().max(1);
-    const result = schema.safeParse(2);
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Number must be less than or equal to 1");
+    const messages = issues.map((issue) => friendlyErrorMap(issue, ctx).message);
+    expect(messages).toEqual(["Custom message", ctx.defaultError]);
   });
+});
 
-  test("too_small array", () => {
-    const schema = z.array(z.string()).min(2);
-    const result = schema.safeParse(["a"]);
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Must have at least 2 items");
-  });
+test("applyFriendlyZodMessages sets global error map", () => {
+  const original = z.getErrorMap();
+  const schema = z.string().min(3);
 
-  test("too_big array", () => {
-    const schema = z.array(z.string()).max(2);
-    const result = schema.safeParse(["a", "b", "c"]);
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Must have at most 2 items");
-  });
+  const before = schema.safeParse("hi");
+  expect(before.error.issues[0].message).not.toBe("Must be at least 3 characters");
 
-  test("default branch", () => {
-    const schema = z.string().refine(() => false, { message: "Custom error" });
-    const result = schema.safeParse("hello");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Custom error");
-  });
+  applyFriendlyZodMessages();
+  const after = schema.safeParse("hi");
+  expect(after.error.issues[0].message).toBe("Must be at least 3 characters");
 
-  test("default branch uses ctx.defaultError when no message", () => {
-    const schema = z.string().refine(() => false);
-    const result = schema.safeParse("hello");
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe("Invalid input");
-  });
+  z.setErrorMap(original);
 });
 


### PR DESCRIPTION
## Summary
- add synthetic issue coverage for friendly error map branches
- verify applyFriendlyZodMessages installs global error map

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in @acme/configurator build)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/zod-utils build`
- `pnpm --filter @acme/zod-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68b97a0facfc832f8cd971577d46bccc