### PR TITLE
test: mock filesystem in analytics repository tests

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/analytics.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/analytics.server.test.ts
@@ -1,99 +1,115 @@
+jest.mock("../../dataRoot", () => ({
+  DATA_ROOT: "/data/root",
+}));
+
+const files = new Map<string, string>();
+const readdir = jest.fn(async () => []);
+const readFile = jest.fn(async (p: string) => {
+  const data = files.get(p);
+  if (data === undefined) {
+    const err = new Error("not found") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  }
+  return data;
+});
+
+jest.mock("fs", () => ({
+  promises: {
+    readdir,
+    readFile,
+    __files: files,
+  },
+}));
+
+const validateShopName = jest.fn((s: string) => s.trim());
+jest.mock("../../shops", () => ({ validateShopName }));
+
 import { promises as fs } from "fs";
-import * as os from "os";
 import * as path from "path";
-import type { AnalyticsEvent, AnalyticsAggregates } from "../../analytics";
+import type { AnalyticsAggregates } from "../../analytics";
+import { listEvents, readAggregates } from "../analytics.server";
 
-let listEvents: (shop?: string) => Promise<AnalyticsEvent[]>;
-let readAggregates: (shop: string) => Promise<AnalyticsAggregates>;
-let root: string;
+const DATA_ROOT = "/data/root";
+const readdirMock = fs.readdir as jest.Mock;
+const readFileMock = fs.readFile as jest.Mock;
+const memfs = (fs as any).__files as Map<string, string>;
 
-beforeEach(async () => {
-  root = await fs.mkdtemp(path.join(os.tmpdir(), "analytics-"));
-  process.env.DATA_ROOT = root;
-  jest.resetModules();
-  ({ listEvents, readAggregates } = await import("../analytics.server"));
+beforeEach(() => {
+  jest.clearAllMocks();
+  memfs.clear();
+  validateShopName.mockImplementation((s: string) => s.trim());
 });
 
 describe("listEvents", () => {
-  it("reads events from multiple shops", async () => {
-    const shop1 = path.join(root, "shop1");
-    const shop2 = path.join(root, "shop2");
-    await fs.mkdir(shop1, { recursive: true });
-    await fs.writeFile(
-      path.join(shop1, "analytics.jsonl"),
-      JSON.stringify({ type: "a", value: 1 }) + "\n" +
-        JSON.stringify({ type: "b", value: 2 }) + "\n"
-    );
-    await fs.mkdir(shop2, { recursive: true });
-    await fs.writeFile(
-      path.join(shop2, "analytics.jsonl"),
-      JSON.stringify({ type: "c", value: 3 }) + "\n"
-    );
-
-    const events = await listEvents();
-    expect(events).toEqual([
-      { type: "a", value: 1 },
-      { type: "b", value: 2 },
-      { type: "c", value: 3 },
-    ]);
-  });
-
-  it("skips missing log files", async () => {
-    const shop1 = path.join(root, "shop1");
-    const shop2 = path.join(root, "shop2");
-    await fs.mkdir(shop1, { recursive: true });
-    await fs.writeFile(
-      path.join(shop1, "analytics.jsonl"),
-      JSON.stringify({ type: "a" }) + "\n"
-    );
-    await fs.mkdir(shop2, { recursive: true });
-
-    const events = await listEvents();
-    expect(events).toEqual([{ type: "a" }]);
-  });
-
-  it("ignores malformed JSON lines", async () => {
-    const shop1 = path.join(root, "shop1");
-    await fs.mkdir(shop1, { recursive: true });
-    await fs.writeFile(
-      path.join(shop1, "analytics.jsonl"),
+  it("reads events for a specific shop and normalizes the name", async () => {
+    validateShopName.mockImplementation((s) => s.trim().toLowerCase());
+    const file = path.join(DATA_ROOT, "shop1", "analytics.jsonl");
+    memfs.set(
+      file,
       JSON.stringify({ type: "a" }) +
         "\nnot json\n" +
-        "{bad}" +
-        "\n" +
         JSON.stringify({ type: "b" }) +
         "\n"
     );
 
-    const events = await listEvents();
+    const events = await listEvents(" SHOP1 ");
+
+    expect(validateShopName).toHaveBeenCalledWith(" SHOP1 ");
+    expect(readFileMock).toHaveBeenCalledWith(file, "utf8");
     expect(events).toEqual([{ type: "a" }, { type: "b" }]);
+  });
+
+  it("returns empty array when log file is missing", async () => {
+    const file = path.join(DATA_ROOT, "shop1", "analytics.jsonl");
+    const events = await listEvents("shop1");
+
+    expect(readFileMock).toHaveBeenCalledWith(file, "utf8");
+    expect(events).toEqual([]);
+  });
+
+  it("aggregates events from all shops and skips missing files", async () => {
+    readdirMock.mockResolvedValue([
+      { name: "shop1", isDirectory: () => true },
+      { name: "shop2", isDirectory: () => true },
+    ]);
+    const file1 = path.join(DATA_ROOT, "shop1", "analytics.jsonl");
+    memfs.set(file1, JSON.stringify({ type: "a" }) + "\ninvalid\n");
+
+    const events = await listEvents();
+
+    expect(readdirMock).toHaveBeenCalledWith(DATA_ROOT, {
+      withFileTypes: true,
+    });
+    expect(readFileMock).toHaveBeenCalledTimes(2);
+    expect(events).toEqual([{ type: "a" }]);
   });
 });
 
 describe("readAggregates", () => {
   it("returns parsed aggregates when file exists", async () => {
-    const shop = path.join(root, "shop1");
-    await fs.mkdir(shop, { recursive: true });
+    validateShopName.mockImplementation((s) => s.trim().toLowerCase());
+    const file = path.join(DATA_ROOT, "shop1", "analytics-aggregates.json");
     const agg: AnalyticsAggregates = {
       page_view: { d: 1 },
       order: { d: { count: 2, amount: 3 } },
       discount_redeemed: { d: { CODE: 4 } },
       ai_crawl: { d: 5 },
     };
-    await fs.writeFile(
-      path.join(shop, "analytics-aggregates.json"),
-      JSON.stringify(agg)
-    );
+    memfs.set(file, JSON.stringify(agg));
 
-    const result = await readAggregates("shop1");
+    const result = await readAggregates(" SHOP1 ");
+
+    expect(validateShopName).toHaveBeenCalledWith(" SHOP1 ");
+    expect(readFileMock).toHaveBeenCalledWith(file, "utf8");
     expect(result).toEqual(agg);
   });
 
-  it("returns defaults when file is missing", async () => {
-    const shop = path.join(root, "shop1");
-    await fs.mkdir(shop, { recursive: true });
-
+  it("returns zeroed aggregates when file missing", async () => {
+    const file = path.join(DATA_ROOT, "shop1", "analytics-aggregates.json");
     const result = await readAggregates("shop1");
+
+    expect(readFileMock).toHaveBeenCalledWith(file, "utf8");
     expect(result).toEqual({
       page_view: {},
       order: {},
@@ -102,3 +118,4 @@ describe("readAggregates", () => {
     });
   });
 });
+


### PR DESCRIPTION
## Summary
- mock filesystem to unit test analytics repository
- cover listEvents and readAggregates edge cases

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/repositories/__tests__/analytics.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b97a0dfaf4832f8e5d71a1f059ea0e