### PR TITLE
fix: update translations test to mutate messages

### DIFF
--- a/packages/i18n/src/__tests__/Translations.test.tsx
+++ b/packages/i18n/src/__tests__/Translations.test.tsx
@@ -36,19 +36,22 @@ describe("TranslationsProvider and useTranslations", () => {
   });
 
   it("updates translations and function identity when messages change", () => {
-    const wrapper = ({ children, messages }: PropsWithChildren<{ messages: Record<string, string> }>) => (
+    // Use a closure variable for messages since the `renderHook` wrapper option
+    // does not support receiving custom props. Updating this variable and
+    // calling `rerender` will trigger the provider to receive the new
+    // messages.
+    let messages: Record<string, string> = { hello: "Hallo" };
+    const wrapper = ({ children }: PropsWithChildren) => (
       <TranslationsProvider messages={messages}>{children}</TranslationsProvider>
     );
 
-    const { result, rerender } = renderHook(() => useTranslations(), {
-      wrapper,
-      initialProps: { messages: { hello: "Hallo" } },
-    });
+    const { result, rerender } = renderHook(() => useTranslations(), { wrapper });
 
     const first = result.current;
     expect(first("hello")).toBe("Hallo");
 
-    rerender({ messages: { hello: "Salut" } });
+    messages = { hello: "Salut" };
+    rerender();
     const second = result.current;
     expect(second("hello")).toBe("Salut");
     expect(second).not.toBe(first);


### PR DESCRIPTION
## Summary
- fix Translations test by mutating closure messages and rerendering

## Testing
- `pnpm --filter @acme/i18n test packages/i18n/src/__tests__/Translations.test.tsx`
- `pnpm --filter @acme/i18n run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter @acme/i18n run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator build)*


------
https://chatgpt.com/codex/tasks/task_e_68b97acd7784832f8a6d146e3e470577