### PR TITLE
test: cover shop name edge cases

### DIFF
--- a/packages/lib/src/__tests__/checkShopExists.server.test.ts
+++ b/packages/lib/src/__tests__/checkShopExists.server.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+const statMock = jest.fn((p: string) => {
+  if (p.toLowerCase() === "/data/shop") {
+    return Promise.resolve({ isDirectory: () => true });
+  }
+  const err = new Error("not found");
+  err.code = "ENOENT";
+  return Promise.reject(err);
+});
+
+jest.mock("@acme/platform-core/dataRoot", () => ({
+  resolveDataRoot: () => "/data",
+}));
+
+jest.mock("node:fs", () => ({
+  promises: { stat: (p: string) => statMock(p) },
+}));
+
+import { checkShopExists } from "../checkShopExists.server";
+
+describe("checkShopExists", () => {
+  it("detects existing shops regardless of case", async () => {
+    await expect(checkShopExists("shop")).resolves.toBe(true);
+    await expect(checkShopExists("Shop")).resolves.toBe(true);
+  });
+
+  it("returns false for missing shops", async () => {
+    await expect(checkShopExists("missing")).resolves.toBe(false);
+  });
+});

--- a/packages/lib/src/__tests__/validateShopName.test.ts
+++ b/packages/lib/src/__tests__/validateShopName.test.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import { validateShopName } from "../validateShopName";
+
+describe("validateShopName", () => {
+  it("trims leading and trailing spaces", () => {
+    expect(validateShopName(" myshop ")).toBe("myshop");
+  });
+
+  it("allows underscores and dashes", () => {
+    expect(validateShopName("my_shop")).toBe("my_shop");
+    expect(validateShopName("my-shop")).toBe("my-shop");
+  });
+
+  it("rejects spaces or non-ascii characters", () => {
+    expect(() => validateShopName("shop name")).toThrow();
+    expect(() => validateShopName("caf\u00E9")).toThrow();
+  });
+
+  it("rejects empty or overly long names", () => {
+    expect(() => validateShopName("")).toThrow();
+    expect(() => validateShopName("a".repeat(65))).toThrow();
+  });
+});

--- a/packages/lib/src/validateShopName.ts
+++ b/packages/lib/src/validateShopName.ts
@@ -1,9 +1,14 @@
 export const SHOP_NAME_RE = /^[a-z0-9_-]+$/i;
+const MAX_SHOP_NAME_LENGTH = 64;
 
-/** Ensure `shop` contains only safe characters. Returns the trimmed name. */
+/** Ensure `shop` contains only safe characters and is within length limits. Returns the trimmed name. */
 export function validateShopName(shop: string): string {
   const normalized = shop.trim();
-  if (!SHOP_NAME_RE.test(normalized)) {
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_SHOP_NAME_LENGTH ||
+    !SHOP_NAME_RE.test(normalized)
+  ) {
     throw new Error(`Invalid shop name: ${shop}`);
   }
   return normalized;


### PR DESCRIPTION
## Summary
- enforce max length in `validateShopName`
- add tests for shop name trimming and invalid names
- add checkShopExists test for case-insensitive collisions

## Testing
- `pnpm -F @acme/lib test` *(fails: Cannot read properties of undefined in packages/stripe tests)*
- `pnpm --filter @acme/lib test -- src/__tests__/validateShopName.test.ts src/__tests__/checkShopExists.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b97cea2154832fb9d836a6dc897ed9