### PR TITLE
test(platform-core): expand shop helper coverage

### DIFF
--- a/packages/platform-core/src/shops/__tests__/index.test.ts
+++ b/packages/platform-core/src/shops/__tests__/index.test.ts
@@ -12,12 +12,16 @@ import {
 } from "../index";
 
 describe("validateShopName", () => {
-  it("accepts valid names", () => {
-    expect(validateShopName(" store-name_123 ")).toBe("store-name_123");
+  it("accepts mixed case", () => {
+    expect(validateShopName(" Store_Name-123 ")).toBe("Store_Name-123");
   });
 
-  it("rejects invalid names", () => {
-    for (const invalid of ["bad name", "bad/name", "bad@name"]) {
+  it("rejects names with spaces", () => {
+    expect(() => validateShopName("bad name")).toThrow(/Invalid shop name/);
+  });
+
+  it("rejects names with special characters", () => {
+    for (const invalid of ["bad/name", "bad@name", "bad$name"]) {
       expect(() => validateShopName(invalid)).toThrow(/Invalid shop name/);
     }
   });
@@ -25,7 +29,7 @@ describe("validateShopName", () => {
 
 describe("sanityBlog accessors", () => {
   it("adds and removes config", () => {
-    const shop: Shop = {};
+    const shop: Shop = { other: true };
     const original = { ...shop };
     expect(getSanityConfig(shop)).toBeUndefined();
 
@@ -33,12 +37,14 @@ describe("sanityBlog accessors", () => {
     const withConfig = setSanityConfig(shop, config);
     expect(Object.is(shop, withConfig)).toBe(false);
     expect(shop).toEqual(original);
+    expect(withConfig.other).toBe(true);
     expect(getSanityConfig(withConfig)).toEqual(config);
 
     const beforeClear = { ...withConfig };
     const cleared = setSanityConfig(withConfig, undefined);
     expect(Object.is(withConfig, cleared)).toBe(false);
     expect(withConfig).toEqual(beforeClear);
+    expect(cleared.other).toBe(true);
     expect(getSanityConfig(cleared)).toBeUndefined();
     expect("sanityBlog" in cleared).toBe(false);
   });
@@ -46,7 +52,7 @@ describe("sanityBlog accessors", () => {
 
 describe("editorialBlog accessors", () => {
   it("adds and removes editorial blog", () => {
-    const shop: Shop = {};
+    const shop: Shop = { other: true };
     const original = { ...shop };
     expect(getEditorialBlog(shop)).toBeUndefined();
 
@@ -54,12 +60,14 @@ describe("editorialBlog accessors", () => {
     const withBlog = setEditorialBlog(shop, editorial);
     expect(Object.is(shop, withBlog)).toBe(false);
     expect(shop).toEqual(original);
+    expect(withBlog.other).toBe(true);
     expect(getEditorialBlog(withBlog)).toEqual(editorial);
 
     const beforeClear = { ...withBlog };
     const cleared = setEditorialBlog(withBlog, undefined);
     expect(Object.is(withBlog, cleared)).toBe(false);
     expect(withBlog).toEqual(beforeClear);
+    expect(cleared.other).toBe(true);
     expect(getEditorialBlog(cleared)).toBeUndefined();
     expect("editorialBlog" in cleared).toBe(false);
   });
@@ -67,7 +75,7 @@ describe("editorialBlog accessors", () => {
 
 describe("domain accessors", () => {
   it("adds and removes domain", () => {
-    const shop: Shop = {};
+    const shop: Shop = { other: true };
     const original = { ...shop };
     expect(getDomain(shop)).toBeUndefined();
 
@@ -75,12 +83,14 @@ describe("domain accessors", () => {
     const withDomain = setDomain(shop, domain);
     expect(Object.is(shop, withDomain)).toBe(false);
     expect(shop).toEqual(original);
+    expect(withDomain.other).toBe(true);
     expect(getDomain(withDomain)).toEqual(domain);
 
     const beforeClear = { ...withDomain };
     const cleared = setDomain(withDomain, undefined);
     expect(Object.is(withDomain, cleared)).toBe(false);
     expect(withDomain).toEqual(beforeClear);
+    expect(cleared.other).toBe(true);
     expect(getDomain(cleared)).toBeUndefined();
     expect("domain" in cleared).toBe(false);
   });


### PR DESCRIPTION
## Summary
- add mixed-case and invalid character tests for validateShopName
- verify shop configuration helpers preserve other fields and return new objects

## Testing
- `pnpm exec jest packages/platform-core/src/shops/__tests__/index.test.ts --runInBand --config jest.config.cjs`
- `pnpm -r build` *(fails: apps/shop-bcd build: Critical dependency, apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b97a0f06f8832f9e59c80bc235454f