### PR TITLE
test(email): expand scheduler timing coverage

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -38,6 +38,7 @@ describe("scheduler", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     memory = {};
     const store: CampaignStore = {
       async readCampaigns(s) {
@@ -52,8 +53,13 @@ describe("scheduler", () => {
     };
     setCampaignStore(store);
     now = new Date("2020-01-01T00:00:00Z");
-    setClock({ now: () => now });
+    jest.setSystemTime(now);
+    setClock({ now: () => new Date() });
     (listEvents as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   test("listCampaigns forwards arguments to the campaign store", async () => {
@@ -75,7 +81,7 @@ describe("scheduler", () => {
         id: "c1",
         recipients: ["a@example.com", "b@example.com"],
         subject: "Hi",
-        body: "<p>Hi</p>",
+        body: "<p>Hi %%UNSUBSCRIBE%%</p>",
         segment: null,
         sendAt: past,
         templateId: null,
@@ -87,9 +93,10 @@ describe("scheduler", () => {
     await sendDueCampaigns();
     expect(listEvents).toHaveBeenCalledWith(shop);
     expect(sendCampaignEmail).toHaveBeenCalledTimes(1);
-    expect((sendCampaignEmail as jest.Mock).mock.calls[0][0].to).toBe(
-      "a@example.com",
-    );
+    const { to, html } = (sendCampaignEmail as jest.Mock).mock.calls[0][0];
+    expect(to).toBe("a@example.com");
+    expect(html).toContain("Unsubscribe");
+    expect(html).not.toContain("%%UNSUBSCRIBE%%");
   });
 
   test("filterUnsubscribed returns original list on error", async () => {
@@ -162,37 +169,35 @@ describe("scheduler", () => {
     expect(html).toContain("Rendered");
   });
 
-  test.skip(
+  test(
     "deliverCampaign batches recipients and adds unsubscribe links",
     async () => {
       process.env.EMAIL_BATCH_SIZE = "2";
       process.env.EMAIL_BATCH_DELAY_MS = "10";
-      jest.useFakeTimers();
-    const setTimeoutSpy = jest.spyOn(global, "setTimeout");
-    const recipients = [
-      "a@example.com",
-      "b@example.com",
-      "c@example.com",
-    ];
-    const promise = createCampaign({
-      shop,
-      recipients,
-      subject: "Hello",
-      body: "<p>Hi %%UNSUBSCRIBE%%</p>",
-    });
-    // Run all scheduled timers, including those added during execution.
-    await jest.runAllTimersAsync();
-    await promise;
-    jest.useRealTimers();
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10);
-    expect(sendCampaignEmail).toHaveBeenCalledTimes(recipients.length);
-    recipients.forEach((r, i) => {
-      const html = (sendCampaignEmail as jest.Mock).mock.calls[i][0]
-        .html as string;
-      expect(html).toContain("Unsubscribe");
-      expect(html).toContain(encodeURIComponent(r));
-    });
-    setTimeoutSpy.mockRestore();
+      const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+      const recipients = [
+        "a@example.com",
+        "b@example.com",
+        "c@example.com",
+      ];
+      const promise = createCampaign({
+        shop,
+        recipients,
+        subject: "Hello",
+        body: "<p>Hi %%UNSUBSCRIBE%%</p>",
+      });
+      // Run all scheduled timers, including those added during execution.
+      await jest.runAllTimersAsync();
+      await promise;
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10);
+      expect(sendCampaignEmail).toHaveBeenCalledTimes(recipients.length);
+      recipients.forEach((r, i) => {
+        const html = (sendCampaignEmail as jest.Mock).mock.calls[i][0]
+          .html as string;
+        expect(html).toContain("Unsubscribe");
+        expect(html).toContain(encodeURIComponent(r));
+      });
+      setTimeoutSpy.mockRestore();
       delete process.env.EMAIL_BATCH_SIZE;
       delete process.env.EMAIL_BATCH_DELAY_MS;
     },
@@ -216,69 +221,61 @@ describe("scheduler", () => {
     expect(typeof id).toBe("string");
   });
 
-  test("createCampaign rejects when neither recipients nor segment provided", async () => {
+  test("createCampaign throws when required fields are missing", async () => {
+    await expect(
+      createCampaign({
+        shop,
+        recipients: ["a@example.com"],
+        body: "<p>Hi</p>",
+      } as any),
+    ).rejects.toThrow("Missing fields");
+    await expect(
+      createCampaign({
+        shop,
+        recipients: ["a@example.com"],
+        subject: "Hi",
+      } as any),
+    ).rejects.toThrow("Missing fields");
     await expect(
       createCampaign({
         shop,
         subject: "Hi",
         body: "<p>Hi</p>",
+        recipients: [],
       }),
     ).rejects.toThrow("Missing fields");
   });
 
-  test("createCampaign sends immediately or schedules later", async () => {
-    const idImmediate = await createCampaign({
+  test("createCampaign handles past and future sendAt", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const idPast = await createCampaign({
       shop,
-      recipients: ["a@example.com"],
-      subject: "Hi",
-      body: "<p>Hi</p>",
+      recipients: ["past@example.com"],
+      subject: "Past",
+      body: "<p>Past</p>",
+      sendAt: past,
     });
     expect(sendCampaignEmail).toHaveBeenCalledTimes(1);
-    const immediate = memory[shop].find((c) => c.id === idImmediate)!;
-    expect(immediate.sentAt).toBe(now.toISOString());
+    const sentPast = memory[shop].find((c) => c.id === idPast)!;
+    expect(sentPast.sentAt).toBe(new Date().toISOString());
 
-    (sendCampaignEmail as jest.Mock).mockClear();
-    now = new Date(now.getTime() + 1);
-    const future = new Date(now.getTime() + 60000).toISOString();
-    const idScheduled = await createCampaign({
+    const futureDate = new Date(Date.now() + 60000);
+    const future = futureDate.toISOString();
+    await createCampaign({
       shop,
-      recipients: ["b@example.com"],
-      subject: "Later",
-      body: "<p>Later</p>",
+      recipients: ["future@example.com"],
+      subject: "Future",
+      body: "<p>Future</p>",
       sendAt: future,
     });
-    expect(sendCampaignEmail).not.toHaveBeenCalled();
-    const scheduled = memory[shop].find((c) => c.id === idScheduled)!;
-    expect(scheduled.sentAt).toBeUndefined();
-  });
-
-  test("sendDueCampaigns delivers pending campaigns", async () => {
-    const past = new Date(now.getTime() - 1000).toISOString();
-    const future = new Date(now.getTime() + 1000).toISOString();
-    memory[shop] = [
-      {
-        id: "c1",
-        recipients: ["past@example.com"],
-        subject: "Past",
-        body: "<p>Past</p>",
-        segment: null,
-        sendAt: past,
-        templateId: null,
-      },
-      {
-        id: "c2",
-        recipients: ["future@example.com"],
-        subject: "Future",
-        body: "<p>Future</p>",
-        segment: null,
-        sendAt: future,
-        templateId: null,
-      },
-    ];
+    expect(sendCampaignEmail).toHaveBeenCalledTimes(1);
     await sendDueCampaigns();
     expect(sendCampaignEmail).toHaveBeenCalledTimes(1);
-    expect(memory[shop][0].sentAt).toBe(now.toISOString());
-    expect(memory[shop][1].sentAt).toBeUndefined();
+    jest.setSystemTime(futureDate);
+    await sendDueCampaigns();
+    expect(sendCampaignEmail).toHaveBeenCalledTimes(2);
+    await sendDueCampaigns();
+    expect(sendCampaignEmail).toHaveBeenCalledTimes(2);
   });
 
   test("syncCampaignAnalytics delegates to analytics module", async () => {


### PR DESCRIPTION
## Summary
- use fake timers and setClock for scheduler tests
- cover unsubscribed filtering, batching, and missing field validation
- ensure future campaigns send once when due

## Testing
- `pnpm --filter @acme/email test`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: TS2307 in @acme/configurator)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e171210832faad38da73944203a