### PR TITLE
test: ensure themes dir exists in theme token tests

### DIFF
--- a/packages/platform-core/src/themeTokens/__tests__/index.test.ts
+++ b/packages/platform-core/src/themeTokens/__tests__/index.test.ts
@@ -37,6 +37,9 @@ describe('loadThemeTokensBrowser', () => {
   const altDir = join(rootDir, 'packages/themes/alt/tailwind-tokens/src');
 
   beforeAll(() => {
+    const themesDir = join(rootDir, 'packages/themes');
+    // Ensure the base themes directory exists before creating fixtures.
+    fs.mkdirSync(themesDir, { recursive: true });
     fs.mkdirSync(fancyDir, { recursive: true });
     fs.writeFileSync(
       join(fancyDir, 'index.ts'),


### PR DESCRIPTION
## Summary
- ensure the theme token tests create the `packages/themes` directory before writing fixtures

## Testing
- `pnpm exec jest packages/platform-core/src/themeTokens/__tests__/index.test.ts`
- `pnpm --filter @acme/platform-core run build` *(fails: Cannot find module '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68b97ec2b5e0832fa8fbe262ca98334c