### PR TITLE
Ensure CSRF token retrieval ignores whitespace and respects precedence

### DIFF
--- a/packages/shared-utils/src/getCsrfToken.test.ts
+++ b/packages/shared-utils/src/getCsrfToken.test.ts
@@ -38,6 +38,33 @@ describe('getCsrfToken', () => {
       const req = new Request('https://example.com?csrf_token=query-token');
       expect(getCsrfToken(req)).toBe('query-token');
     });
+
+    it('header token overrides query and cookie tokens', () => {
+      const req = new Request('https://example.com?csrf_token=query-token', {
+        headers: {
+          'x-csrf-token': 'header-token',
+          cookie: 'csrf_token=cookie-token',
+        },
+      });
+      expect(getCsrfToken(req)).toBe('header-token');
+    });
+
+    it('returns undefined when no token in header, query, or cookie', () => {
+      const req = new Request('https://example.com', {
+        headers: { cookie: 'foo=bar' },
+      });
+      expect(getCsrfToken(req)).toBeUndefined();
+    });
+
+    it('treats whitespace-only tokens as missing', () => {
+      const req = new Request('https://example.com?csrf_token=%20%20', {
+        headers: {
+          'x-csrf-token': '   ',
+          cookie: 'csrf_token=   ',
+        },
+      });
+      expect(getCsrfToken(req)).toBeUndefined();
+    });
   });
 
   describe('browser', () => {


### PR DESCRIPTION
## Summary
- Trim CSRF tokens from headers, query params, and cookies
- Fall back to query/cookie tokens only when header token missing
- Add comprehensive tests for precedence, missing tokens, and whitespace-only values

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in @acme/configurator)*
- `pnpm --filter @acme/shared-utils build`
- `pnpm test packages/shared-utils/src/getCsrfToken.test.ts` *(fails: Could not find task in project)*
- `pnpm --filter @acme/shared-utils test packages/shared-utils/src/getCsrfToken.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b97fb0bb08832f90700d583a0a07ca