### PR TITLE
test: enhance parseMultilingualInput coverage

### DIFF
--- a/packages/i18n/src/__tests__/parseMultilingualInput.test.ts
+++ b/packages/i18n/src/__tests__/parseMultilingualInput.test.ts
@@ -4,14 +4,14 @@ describe("parseMultilingualInput", () => {
   const locales = ["en", "de", "it"] as const;
 
   it("detects field and locale from name", () => {
-    expect(parseMultilingualInput("title_en", locales)).toEqual({
-      field: "title",
-      locale: "en",
-    });
-    expect(parseMultilingualInput("desc_it", locales)).toEqual({
-      field: "desc",
-      locale: "it",
-    });
+    const tokens = [
+      { name: "title_en", expected: { field: "title", locale: "en" } },
+      { name: "title_it", expected: { field: "title", locale: "it" } },
+    ];
+
+    for (const { name, expected } of tokens) {
+      expect(parseMultilingualInput(name, locales)).toEqual(expected);
+    }
   });
 
   it("returns null for invalid input", () => {
@@ -20,5 +20,12 @@ describe("parseMultilingualInput", () => {
     expect(parseMultilingualInput("title_EN", locales)).toBeNull();
     expect(parseMultilingualInput(" title_en", locales)).toBeNull();
     expect(parseMultilingualInput("title_en ", locales)).toBeNull();
+    expect(parseMultilingualInput("title__en", locales)).toBeNull();
+    expect(parseMultilingualInput("title-en", locales)).toBeNull();
+  });
+
+  it("returns null when locale not in provided list", () => {
+    const partialLocales = ["de", "it"] as const;
+    expect(parseMultilingualInput("title_en", partialLocales)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- expand parseMultilingualInput tests to cover multiple locales from a list
- ensure unknown locales and malformed names return null

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/i18n` *(fails: Missing task)*
- `pnpm --filter @acme/i18n test -- packages/i18n/src/__tests__/parseMultilingualInput.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b97fbd25e0832fb96699c15ed38ca7