### PR TITLE
test(shared-utils): add toggleItem duplicate removal and immutability tests

### DIFF
--- a/packages/shared-utils/src/toggleItem.test.ts
+++ b/packages/shared-utils/src/toggleItem.test.ts
@@ -8,5 +8,18 @@ describe('toggleItem', () => {
   it('removes item when present', () => {
     expect(toggleItem([1, 2, 3], 2)).toEqual([1, 3]);
   });
+
+  it('removes all instances when duplicates are present', () => {
+    expect(toggleItem([1, 2, 2, 3], 2)).toEqual([1, 3]);
+  });
+
+  it('returns a new array without mutating the input', () => {
+    const input = [1, 2, 3];
+    const result = toggleItem(input, 4);
+
+    expect(result).toEqual([1, 2, 3, 4]);
+    expect(result).not.toBe(input);
+    expect(input).toEqual([1, 2, 3]);
+  });
 });
 


### PR DESCRIPTION
## Summary
- cover duplicate entries removal in toggleItem
- ensure toggleItem does not mutate the original array

## Testing
- `pnpm test packages/shared-utils` *(fails: Could not find task `packages/shared-utils`)*
- `pnpm --filter @acme/shared-utils exec jest packages/shared-utils/src/toggleItem.test.ts --config ../../jest.config.cjs`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script `check:references`)*
- `pnpm run build:ts` *(fails: Missing script `build:ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68b97fba73b8832fbcbbced714d2a9c3