### PR TITLE
feat(shared-utils): broaden shop slug detection

### DIFF
--- a/packages/shared-utils/src/getShopFromPath.test.ts
+++ b/packages/shared-utils/src/getShopFromPath.test.ts
@@ -5,8 +5,21 @@ describe("getShopFromPath", () => {
     expect(getShopFromPath("/cms//shop/demo///pages")).toBe("demo");
   });
 
+  it("returns the shop slug for /shops/:slug paths", () => {
+    expect(getShopFromPath("/cms/shops/demo/pages")).toBe("demo");
+  });
+
+  it("returns the shop slug from ?shop=:slug query parameter", () => {
+    expect(getShopFromPath("/cms/pages?shop=demo")).toBe("demo");
+  });
+
   it("returns undefined when the shop segment is missing", () => {
     expect(getShopFromPath("/cms/foo/bar")).toBeUndefined();
+  });
+
+  it("returns undefined when no slug is present", () => {
+    expect(getShopFromPath("/cms/shops/")).toBeUndefined();
+    expect(getShopFromPath("/cms/pages?shop=")).toBeUndefined();
   });
 
   it("returns undefined for null or undefined inputs", () => {

--- a/packages/shared-utils/src/getShopFromPath.ts
+++ b/packages/shared-utils/src/getShopFromPath.ts
@@ -1,14 +1,35 @@
 // packages/shared-utils/src/getShopFromPath.ts
 
 /**
- * Return the shop slug from a CMS pathname.
+ * Return the shop slug from a CMS pathname or query string.
  *
- * Empty path segments are removed before searching for `shop`,
- * ensuring paths with duplicate slashes are handled correctly.
+ * Empty path segments are removed before searching for either `shop` or
+ * `shops`, ensuring paths with duplicate slashes are handled correctly. The
+ * `?shop=` query parameter takes precedence if present.
  */
 export function getShopFromPath(pathname?: string | null): string | undefined {
   if (!pathname) return undefined;
+
+  // Support paths that include a `?shop=` query parameter. We attempt to parse
+  // the string as a URL relative to a dummy base so that both absolute and
+  // relative paths are handled. If the parameter exists and has a value, return
+  // it immediately.
+  try {
+    const url = new URL(pathname, "http://dummy");
+    const slug = url.searchParams.get("shop");
+    if (slug) return slug;
+    pathname = url.pathname;
+  } catch {
+    // Ignore URL parsing errors and fall back to the raw pathname.
+  }
+
   const segments = pathname.split("/").filter(Boolean);
-  const idx = segments.indexOf("shop");
+
+  // Check for singular "shop" segment first.
+  let idx = segments.indexOf("shop");
+  if (idx >= 0) return segments[idx + 1];
+
+  // Also handle paths that use the plural "shops" segment.
+  idx = segments.indexOf("shops");
   return idx >= 0 ? segments[idx + 1] : undefined;
 }


### PR DESCRIPTION
## Summary
- support `?shop=` query parameter and `/shops/:slug` path segment
- test `getShopFromPath` for plural paths, query param, and missing slug

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: TS2307: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/shared-utils build`
- `pnpm test packages/shared-utils/src/getShopFromPath.test.ts` *(fails: Missing task in project)*
- `pnpm --filter @acme/shared-utils test packages/shared-utils/src/getShopFromPath.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b97fb27970832fb3b2473980e190a4