### PR TITLE
test: cover theme token fallbacks

### DIFF
--- a/packages/platform-core/src/themeTokens/__tests__/index.test.ts
+++ b/packages/platform-core/src/themeTokens/__tests__/index.test.ts
@@ -21,6 +21,15 @@ describe('loadThemeTokensNode', () => {
     expect(loadThemeTokensNode('base')).toEqual({});
   });
 
+  it('returns empty object when theme string is empty', () => {
+    expect(loadThemeTokensNode('')).toEqual({});
+  });
+
+  it('returns empty object when no candidate files exist', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    expect(loadThemeTokensNode('ghost')).toEqual({});
+  });
+
   it('loads tokens from existing theme file', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     (fs.readFileSync as jest.Mock).mockReturnValue(
@@ -28,6 +37,15 @@ describe('loadThemeTokensNode', () => {
     );
 
     expect(loadThemeTokensNode('custom')).toEqual({ '--foo': 'bar' });
+  });
+
+  it('surfaces read errors from readFileSync', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    expect(() => loadThemeTokensNode('broken')).toThrow('boom');
   });
 });
 
@@ -75,5 +93,16 @@ describe('loadThemeTokensBrowser', () => {
 
   it('returns base tokens for base theme', async () => {
     await expect(loadThemeTokensBrowser('base')).resolves.toEqual(baseTokens);
+  });
+
+  it('returns base tokens when theme is empty string', async () => {
+    await expect(loadThemeTokensBrowser('')).resolves.toEqual(baseTokens);
+  });
+
+  it('returns base tokens when theme is undefined', async () => {
+    await expect(
+      // Cast undefined to match function signature
+      loadThemeTokensBrowser(undefined as unknown as string)
+    ).resolves.toEqual(baseTokens);
   });
 });


### PR DESCRIPTION
## Summary
- expand theme token tests for empty themes and missing files
- ensure browser loader defaults to base tokens when theme is absent
- surface read errors from loadThemeTokensNode

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/platform-core` *(fails: Missing tasks in project)*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/themeTokens/__tests__/index.test.ts --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b982665b10832fb6dccab2f59071f4