### PR TITLE
test(shared-utils): add formatCurrency coverage

### DIFF
--- a/packages/shared-utils/src/formatCurrency.test.ts
+++ b/packages/shared-utils/src/formatCurrency.test.ts
@@ -1,0 +1,16 @@
+import { formatCurrency } from './formatCurrency';
+
+describe('formatCurrency', () => {
+  it('uses USD and current locale by default', () => {
+    const amount = 1234;
+    const expected = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount / 100);
+    expect(formatCurrency(amount)).toBe(expected);
+  });
+
+  it('throws for invalid ISO currency codes', () => {
+    expect(() => formatCurrency(100, 'INVALID')).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## Summary
- test the default locale and USD currency in formatCurrency
- ensure invalid currency codes throw

## Testing
- `pnpm test packages/shared-utils` *(fails: Could not find task `packages/shared-utils` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b97fbb4f78832f88c3309affb529bc