### PR TITLE
test(core): add shop path utility tests

### DIFF
--- a/packages/platform-core/src/utils/__tests__/guessShopFromPath.test.ts
+++ b/packages/platform-core/src/utils/__tests__/guessShopFromPath.test.ts
@@ -1,0 +1,22 @@
+import { getShopFromPath as guessShopFromPath } from "../getShopFromPath";
+
+describe("guessShopFromPath", () => {
+  it("returns shop slug from valid path", () => {
+    expect(guessShopFromPath("/cms/shop/my-shop/products")).toBe("my-shop");
+  });
+
+  it("returns undefined for missing shop segment or slug", () => {
+    expect(guessShopFromPath("/cms/foo/bar")).toBeUndefined();
+    expect(guessShopFromPath("/cms/shop")).toBeUndefined();
+    expect(guessShopFromPath("/cms/shop/")).toBeUndefined();
+  });
+
+  it("handles paths with duplicate slashes", () => {
+    expect(guessShopFromPath("/cms//shop//my-shop//foo")).toBe("my-shop");
+  });
+
+  it("returns undefined for null or undefined inputs", () => {
+    expect(guessShopFromPath(null)).toBeUndefined();
+    expect(guessShopFromPath(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for guessing shop slug from path

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm test packages/core` *(fails: Could not find task `packages/core` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b982641f34832fb0163a2369bba68c