### PR TITLE
fix: register email service synchronously

### DIFF
--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,20 +1,17 @@
 import "server-only";
 import { sendEmail } from "./sendEmail";
+import { createRequire } from "module";
 
 try {
-  if (typeof require !== "undefined") {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { setEmailService } = require(
-      "@acme/platform-core/services/emailService"
-    );
-    setEmailService({ sendEmail });
-  } else {
-    void import("@acme/platform-core/services/emailService").then(
-      ({ setEmailService }) => {
-        setEmailService({ sendEmail });
-      }
-    );
-  }
+  const req =
+    typeof require !== "undefined"
+      ? require
+      : createRequire(process.cwd() + "/");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { setEmailService } = req(
+    "@acme/platform-core/services/emailService"
+  );
+  setEmailService({ sendEmail });
 } catch {
   // The core email service isn't available in the current environment.
 }


### PR DESCRIPTION
## Summary
- ensure email package registers sendEmail with platform core service on import using createRequire for ESM environments

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b97d85d358832fa8fc958138c84491