### PR TITLE
test: add DST boundary coverage

### DIFF
--- a/packages/date-utils/__tests__/date.test.ts
+++ b/packages/date-utils/__tests__/date.test.ts
@@ -179,19 +179,71 @@ describe("formatDuration", () => {
     expect(formatDuration(-5000)).toBe("0s");
   });
 });
-describe("DST transitions", () => {
-  test("accounts for spring forward in New York", () => {
-    const before = parseTargetDate("2025-03-09T00:30:00", "America/New_York")!;
-    const after = parseTargetDate("2025-03-10T00:30:00", "America/New_York")!;
-    const diffHours = (after.getTime() - before.getTime()) / 3600000;
-    expect(diffHours).toBe(23);
+describe("DST boundaries", () => {
+  describe("spring forward in New York", () => {
+    beforeEach(() => {
+      const systemTime = parseTargetDate(
+        "2025-03-08T00:30:00",
+        "America/New_York"
+      )!;
+      jest.useFakeTimers().setSystemTime(systemTime);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test("parseTargetDate yields 23-hour span", () => {
+      const before = parseTargetDate(
+        "2025-03-09T00:30:00",
+        "America/New_York"
+      )!;
+      const after = parseTargetDate(
+        "2025-03-10T00:30:00",
+        "America/New_York"
+      )!;
+      const diffHours = (after.getTime() - before.getTime()) / 3600000;
+      expect(diffHours).toBe(23);
+    });
+
+    test("date helpers cross the missing hour", () => {
+      expect(isoDateInNDays(1)).toBe("2025-03-09");
+      expect(isoDateInNDays(2)).toBe("2025-03-10");
+      expect(calculateRentalDays("2025-03-10")).toBe(2);
+    });
   });
 
-  test("accounts for fall back in New York", () => {
-    const before = parseTargetDate("2025-11-02T00:30:00", "America/New_York")!;
-    const after = parseTargetDate("2025-11-03T00:30:00", "America/New_York")!;
-    const diffHours = (after.getTime() - before.getTime()) / 3600000;
-    expect(diffHours).toBe(25);
+  describe("fall back in New York", () => {
+    beforeEach(() => {
+      const systemTime = parseTargetDate(
+        "2025-11-01T00:30:00",
+        "America/New_York"
+      )!;
+      jest.useFakeTimers().setSystemTime(systemTime);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test("parseTargetDate yields 25-hour span", () => {
+      const before = parseTargetDate(
+        "2025-11-02T00:30:00",
+        "America/New_York"
+      )!;
+      const after = parseTargetDate(
+        "2025-11-03T00:30:00",
+        "America/New_York"
+      )!;
+      const diffHours = (after.getTime() - before.getTime()) / 3600000;
+      expect(diffHours).toBe(25);
+    });
+
+    test("date helpers cross the repeated hour", () => {
+      expect(isoDateInNDays(1)).toBe("2025-11-02");
+      expect(isoDateInNDays(2)).toBe("2025-11-03");
+      expect(calculateRentalDays("2025-11-03")).toBe(2);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- cover DST boundaries for America/New_York in date utils tests
- ensure helpers behave across spring forward and fall back

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in configurator build)*
- `pnpm --filter @acme/date-utils test packages/date-utils/__tests__/date.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b987a9292c832f8d73afde4076b929