### PR TITLE
test(i18n): add edge cases for fillLocales

### DIFF
--- a/packages/i18n/src/__tests__/fillLocales.edge.test.ts
+++ b/packages/i18n/src/__tests__/fillLocales.edge.test.ts
@@ -1,0 +1,31 @@
+import { fillLocales } from "../fillLocales";
+import { LOCALES } from "../locales";
+
+describe("fillLocales edge cases", () => {
+  it("fills all locales when provided an empty object", () => {
+    const result = fillLocales({}, "Hi");
+
+    for (const locale of LOCALES) {
+      expect(result[locale]).toBe("Hi");
+    }
+  });
+
+  it("fills missing locales when default locale is absent", () => {
+    const values = { it: "Ciao" };
+    const result = fillLocales(values, "Hi");
+
+    expect(result).toEqual({ en: "Hi", de: "Hi", it: "Ciao" });
+    expect(result.it).toBe(values.it);
+  });
+
+  it("preserves references for nested objects and arrays", () => {
+    const nested = { msg: "Hi" };
+    const arr = ["Hi"];
+
+    const resultObj = fillLocales({ en: nested } as any, "Hi" as any);
+    const resultArr = fillLocales({ en: arr } as any, "Hi" as any);
+
+    expect(resultObj.en).toBe(nested);
+    expect(resultArr.en).toBe(arr);
+  });
+});


### PR DESCRIPTION
## Summary
- add edge case tests for fillLocales covering empty object, missing default locale, and nested values

## Testing
- `pnpm exec jest packages/i18n/src/__tests__/fillLocales.test.ts packages/i18n/src/__tests__/fillLocales.edge.test.ts packages/i18n/src/__tests__/locales.test.ts packages/i18n/src/__tests__/parseMultilingualInput.test.ts packages/i18n/src/__tests__/Translations.test.tsx --runInBand --config jest.config.cjs`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b987adf094832f97bb09478a97eb94