### PR TITLE
test: expand inventory utilities

### DIFF
--- a/packages/platform-core/src/utils/index.ts
+++ b/packages/platform-core/src/utils/index.ts
@@ -6,5 +6,8 @@ export type { LogMeta } from "./logger";
 export {
   flattenInventoryItem,
   expandInventoryItem,
+  normalizeQuantity,
+  computeAvailability,
+  applyInventoryBatch,
 } from "./inventory";
 export type { RawInventoryItem, FlattenedInventoryItem } from "./inventory";

--- a/packages/platform-core/src/utils/inventory.d.ts
+++ b/packages/platform-core/src/utils/inventory.d.ts
@@ -10,8 +10,22 @@ export interface RawInventoryItem {
     productId?: unknown;
     quantity: unknown;
     lowStockThreshold?: unknown;
+    unit?: unknown;
     variantAttributes?: Record<string, unknown>;
     [key: string]: unknown;
 }
 export declare function flattenInventoryItem(item: InventoryItem): FlattenedInventoryItem;
 export declare function expandInventoryItem(data: RawInventoryItem | InventoryItem): InventoryItem;
+export declare function normalizeQuantity(qty: unknown, unit?: unknown): number;
+export declare function computeAvailability(quantity: number, reserved?: number, requested?: number, allowBackorder?: boolean): {
+    reserved: number;
+    available: number;
+    canFulfill: boolean;
+};
+export declare function applyInventoryBatch(items: InventoryItem[], updates: {
+    sku: string;
+    delta: number;
+}[]): {
+    updated: InventoryItem[];
+    lowStock: InventoryItem[];
+};


### PR DESCRIPTION
## Summary
- enforce SKU/product ID presence and positive quantities in inventory expansion
- add quantity normalization, stock computation, and batch update helpers
- cover backorders, rounding and low-stock scenarios in tests

## Testing
- `pnpm test packages/platform-core/src/utils/inventory.test.ts` *(fails: Missing task)*
- `pnpm exec jest packages/platform-core/src/utils/inventory.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b98796d628832f8e401fe8482066e2