### PR TITLE
test: add edge cases for useTranslations

### DIFF
--- a/packages/i18n/src/__tests__/Translations.edge.test.tsx
+++ b/packages/i18n/src/__tests__/Translations.edge.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { TranslationsProvider, useTranslations } from "../Translations";
+
+describe("useTranslations edge cases", () => {
+  it("returns key when used without provider", () => {
+    const { result } = renderHook(() => useTranslations());
+    expect(result.current("missing"))
+      .toBe("missing");
+  });
+
+  it("falls back to key when messages are for an unsupported locale", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TranslationsProvider messages={{ es: { greet: "Hola" } } as any}>
+        {children}
+      </TranslationsProvider>
+    );
+
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current("greet"))
+      .toBe("greet");
+  });
+
+  it("does not interpolate placeholders in messages", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TranslationsProvider messages={{ greet: "Hi {name}" }}>
+        {children}
+      </TranslationsProvider>
+    );
+
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current("greet"))
+      .toBe("Hi {name}");
+  });
+
+  it("returns key string for missing keys", () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TranslationsProvider messages={{}}>{children}</TranslationsProvider>
+    );
+
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current("unknown"))
+      .toBe("unknown");
+    expect(result.current("unknown"))
+      .not.toBe("");
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover TranslationsProvider edge cases
- verify that placeholder values are not interpolated

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm exec jest packages/i18n/src/__tests__/Translations.edge.test.tsx --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b987af636c832fb3debf708763d89c