### PR TITLE
test: add payment gateway scenarios

### DIFF
--- a/packages/config/src/env/__tests__/payments-env.test.ts
+++ b/packages/config/src/env/__tests__/payments-env.test.ts
@@ -328,3 +328,80 @@ describe("payments env defaults", () => {
   );
 });
 
+describe("payment gateway flag", () => {
+  it("uses defaults without warnings when gateway disabled", () => {
+    process.env = {
+      PAYMENTS_GATEWAY: "disabled",
+      STRIPE_SECRET_KEY: "sk_live_123",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_123",
+      STRIPE_WEBHOOK_SECRET: "whsec_live_123",
+    } as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns provided test keys when stripe gateway active", () => {
+    process.env = {
+      PAYMENTS_GATEWAY: "stripe",
+      STRIPE_SECRET_KEY: "sk_test_abc",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_abc",
+      STRIPE_WEBHOOK_SECRET: "whsec_test_abc",
+    } as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test_abc",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_abc",
+      STRIPE_WEBHOOK_SECRET: "whsec_test_abc",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns provided live keys when stripe gateway active", () => {
+    process.env = {
+      PAYMENTS_GATEWAY: "stripe",
+      STRIPE_SECRET_KEY: "sk_live_abc",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_abc",
+      STRIPE_WEBHOOK_SECRET: "whsec_live_abc",
+    } as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_live_abc",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_abc",
+      STRIPE_WEBHOOK_SECRET: "whsec_live_abc",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns and falls back to defaults when stripe gateway active but keys missing", () => {
+    process.env = {
+      PAYMENTS_GATEWAY: "stripe",
+      STRIPE_SECRET_KEY: "",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "",
+      STRIPE_WEBHOOK_SECRET: "",
+    } as NodeJS.ProcessEnv;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.resetModules();
+    const { paymentsEnv } = require("../payments.js");
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "⚠️ Invalid payments environment variables:",
+      expect.any(Object),
+    );
+  });
+});
+

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -9,8 +9,21 @@ export const paymentsEnvSchema = z.object({
     .default("pk_test"),
   STRIPE_WEBHOOK_SECRET: z.string().min(1).default("whsec_test"),
 });
+// Allow disabling the payments gateway via an environment flag. When disabled
+// we ignore any provided Stripe keys and fall back to schema defaults without
+// emitting warnings.
+const gateway = process.env.PAYMENTS_GATEWAY;
+const rawEnv =
+  gateway === "disabled"
+    ? {}
+    : {
+        STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+          process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+        STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+      };
 
-const parsed = paymentsEnvSchema.safeParse(process.env);
+const parsed = paymentsEnvSchema.safeParse(rawEnv);
 if (!parsed.success) {
   console.warn(
     "⚠️ Invalid payments environment variables:",


### PR DESCRIPTION
## Summary
- add payment gateway flag handling in payments env
- expand payments env tests for disabled and active gateway modes

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/config test` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b987be3144832f89ed305606d6c25e