### PR TITLE
test(shared-utils): expand getShopFromPath coverage

### DIFF
--- a/packages/shared-utils/src/getShopFromPath.test.ts
+++ b/packages/shared-utils/src/getShopFromPath.test.ts
@@ -13,8 +13,20 @@ describe("getShopFromPath", () => {
     expect(getShopFromPath("/cms/pages?shop=demo")).toBe("demo");
   });
 
+  it("handles trailing slashes for shop paths", () => {
+    expect(getShopFromPath("/cms/shop/demo/")).toBe("demo");
+    expect(getShopFromPath("/cms/shops/demo/")).toBe("demo");
+  });
+
+  it("handles additional nested segments after the slug", () => {
+    expect(getShopFromPath("/shop/demo/products/123")).toBe("demo");
+    expect(getShopFromPath("/shops/demo/settings/profile")).toBe("demo");
+  });
+
   it("returns undefined when the shop segment is missing", () => {
     expect(getShopFromPath("/cms/foo/bar")).toBeUndefined();
+    expect(getShopFromPath("/cms/foo/bar/")).toBeUndefined();
+    expect(getShopFromPath("/cms/pages?foo=bar")).toBeUndefined();
   });
 
   it("returns undefined when no slug is present", () => {


### PR DESCRIPTION
## Summary
- add tests for trailing slashes and nested paths in `getShopFromPath`
- ensure undefined is returned when no shop hint exists

## Testing
- `pnpm --filter shared-utils run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter shared-utils run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter shared-utils test` *(fails: Cannot find module '../utils/args' from 'test/unit/init-shop/env.spec.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68b987ca96f8832faabbed649e6b6830