### PR TITLE
test: expand email env cases

### DIFF
--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -15,13 +15,15 @@ export const emailEnvSchema = z
       .optional(),
     SMTP_SECURE: z
       .string()
-      .refine((v) => v === "true" || v === "false", {
-        message: "must be true or false",
+      .transform((v) => v.trim().toLowerCase())
+      .refine((v) => ["true", "false", "1", "0", "yes", "no"].includes(v), {
+        message: "must be a boolean",
       })
-      .transform((v) => v === "true")
+      .transform((v) => ["true", "1", "yes"].includes(v))
       .optional(),
     CAMPAIGN_FROM: z
       .string()
+      .trim()
       .email()
       .transform((v) => v.toLowerCase())
       .optional(),


### PR DESCRIPTION
## Summary
- expand email environment schema to handle flexible boolean and sender parsing
- add withEnv helper tests covering providers, port coercion, boolean toggles, sender normalization, API key validation and template path

## Testing
- `pnpm test packages/config/src/env/__tests__/email.test.ts` (fails: Missing tasks in project)
- `pnpm exec jest packages/config/src/env/__tests__/email.test.ts --config packages/config/jest.preset.cjs --runInBand --runTestsByPath`
- `pnpm -r build` (fails: @jest/globals missing in @acme/configurator build)


------
https://chatgpt.com/codex/tasks/task_e_68b99e340a44832fab11d8065ff0f303