### PR TITLE
test: isolate core env in stripe edge tests

### DIFF
--- a/packages/stripe/src/__tests__/stripe-edge.test.ts
+++ b/packages/stripe/src/__tests__/stripe-edge.test.ts
@@ -8,21 +8,21 @@ type StripeInternal = Stripe & {
 };
 
 describe("stripe edge client", () => {
-  const OLD_ENV = process.env;
+  const OLD_ENV = { ...process.env };
 
   // No special setup required; fetch and other APIs are polyfilled in test setup.
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = {
-      ...OLD_ENV,
-      STRIPE_SECRET_KEY: "sk_test_123",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_123",
-    } as NodeJS.ProcessEnv;
+    process.env = { ...OLD_ENV } as NodeJS.ProcessEnv;
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_123";
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: { STRIPE_SECRET_KEY: "sk_test_123" },
+    }));
   });
 
   afterEach(() => {
-    process.env = OLD_ENV;
+    process.env = OLD_ENV as NodeJS.ProcessEnv;
     jest.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- isolate Stripe edge client test from global env validation

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `CI=true pnpm exec jest packages/stripe/src/__tests__/stripe-edge.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68b99c0ebf48832fa415277c53019e4d