### PR TITLE
fix: avoid duplicate headers

### DIFF
--- a/packages/shared-utils/src/buildResponse.ts
+++ b/packages/shared-utils/src/buildResponse.ts
@@ -14,5 +14,9 @@ export interface ProxyResponse {
 export function buildResponse(proxyResponse: ProxyResponse): Response {
   const { status, headers, body } = proxyResponse.response;
   const decodedBody = body ? Buffer.from(body, "base64") : null;
-  return new Response(decodedBody, { status, headers: new Headers(headers) });
+  const finalHeaders = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    finalHeaders.set(key, value);
+  }
+  return new Response(decodedBody, { status, headers: finalHeaders });
 }


### PR DESCRIPTION
## Summary
- dedupe conflicting headers when building a Response

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec tsx -e "import { buildResponse } from './packages/shared-utils/src/buildResponse.ts'; const proxy={response:{status:200,headers:{'X-Test':'1','x-test':'2','content-type':'text/plain'},body:Buffer.from('ok').toString('base64')}}; const res=buildResponse(proxy as any); console.log(res.status); console.log(res.headers.get('x-test')); res.text().then(t=>console.log(t));"`

------
https://chatgpt.com/codex/tasks/task_e_68b99be87690832f93b51fdbb0849c6c