### PR TITLE
Drain request body on invalid content-type in parseJsonBody

### DIFF
--- a/packages/shared-utils/src/parseJsonBody.ts
+++ b/packages/shared-utils/src/parseJsonBody.ts
@@ -34,6 +34,14 @@ export async function parseJsonBody<T>(
     const isJson = type === "application/json";
     const invalidParams = params.some((p) => !p.startsWith("charset="));
     if (!isJson || invalidParams) {
+      const request = req as Request & { text?: () => Promise<string> };
+      if (typeof request.text === "function") {
+        try {
+          await request.text();
+        } catch {
+          // ignore errors while draining the body
+        }
+      }
       return {
         success: false,
         response: NextResponse.json(


### PR DESCRIPTION
## Summary
- drain request body when content-type is invalid so req.bodyUsed reflects consumption

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/shared-utils build`
- `pnpm exec jest src/__tests__/parseJsonBody.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b99bc6a4dc832f94c16f53f2aed449