### PR TITLE
test(config): isolate env between tests

### DIFF
--- a/packages/config/__tests__/authEnv.test.ts
+++ b/packages/config/__tests__/authEnv.test.ts
@@ -1,68 +1,69 @@
 import { expect } from "@jest/globals";
+import { withEnv } from "../test/utils/withEnv";
 
 describe("authEnv", () => {
-  const OLD_ENV = process.env;
-
   afterEach(() => {
-    jest.resetModules();
-    process.env = OLD_ENV;
     jest.restoreAllMocks();
   });
 
   it("uses development defaults for secrets", async () => {
-    process.env = {
-      NODE_ENV: "development",
-    } as NodeJS.ProcessEnv;
-
-    const { authEnv } = await import("../src/env/auth");
+    const { authEnv } = await withEnv(
+      {
+        NODE_ENV: "development",
+      },
+      () => import("../src/env/auth"),
+    );
 
     expect(authEnv.NEXTAUTH_SECRET).toBe("dev-nextauth-secret");
     expect(authEnv.SESSION_SECRET).toBe("dev-session-secret");
   });
 
   it("throws and logs when NEXTAUTH_SECRET is missing in production", async () => {
-    process.env = {
-      NODE_ENV: "production",
-    } as NodeJS.ProcessEnv;
-
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/auth")).rejects.toThrow(
-      "Invalid auth environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+        },
+        () => import("../src/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
     expect(spy).toHaveBeenCalled();
   });
 
   it("throws and logs when SESSION_SECRET is missing in production", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      NEXTAUTH_SECRET: "x",
-    } as NodeJS.ProcessEnv;
-
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/auth")).rejects.toThrow(
-      "Invalid auth environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: "x",
+        },
+        () => import("../src/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
     expect(spy).toHaveBeenCalled();
   });
 
   it(
     "throws and logs when SESSION_STORE is redis without UPSTASH_REDIS_REST_URL",
     async () => {
-      process.env = {
-        NODE_ENV: "production",
-        NEXTAUTH_SECRET: "nextauth",
-        SESSION_SECRET: "session",
-        SESSION_STORE: "redis",
-        UPSTASH_REDIS_REST_TOKEN: "token",
-      } as NodeJS.ProcessEnv;
-
       const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-      await expect(import("../src/env/auth")).rejects.toThrow(
-        "Invalid auth environment variables",
-      );
+      await expect(
+        withEnv(
+          {
+            NODE_ENV: "production",
+            NEXTAUTH_SECRET: "nextauth",
+            SESSION_SECRET: "session",
+            SESSION_STORE: "redis",
+            UPSTASH_REDIS_REST_TOKEN: "token",
+          },
+          () => import("../src/env/auth"),
+        ),
+      ).rejects.toThrow("Invalid auth environment variables");
       expect(spy).toHaveBeenCalledWith(
         "❌ Invalid auth environment variables:",
         expect.objectContaining({
@@ -75,19 +76,20 @@ describe("authEnv", () => {
   it(
     "throws and logs when SESSION_STORE is redis without UPSTASH_REDIS_REST_TOKEN",
     async () => {
-      process.env = {
-        NODE_ENV: "production",
-        NEXTAUTH_SECRET: "nextauth",
-        SESSION_SECRET: "session",
-        SESSION_STORE: "redis",
-        UPSTASH_REDIS_REST_URL: "https://example.com",
-      } as NodeJS.ProcessEnv;
-
       const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-      await expect(import("../src/env/auth")).rejects.toThrow(
-        "Invalid auth environment variables",
-      );
+      await expect(
+        withEnv(
+          {
+            NODE_ENV: "production",
+            NEXTAUTH_SECRET: "nextauth",
+            SESSION_SECRET: "session",
+            SESSION_STORE: "redis",
+            UPSTASH_REDIS_REST_URL: "https://example.com",
+          },
+          () => import("../src/env/auth"),
+        ),
+      ).rejects.toThrow("Invalid auth environment variables");
       expect(spy).toHaveBeenCalledWith(
         "❌ Invalid auth environment variables:",
         expect.objectContaining({
@@ -98,18 +100,19 @@ describe("authEnv", () => {
   );
 
   it("throws and logs when only LOGIN_RATE_LIMIT_REDIS_URL is set", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      NEXTAUTH_SECRET: "nextauth",
-      SESSION_SECRET: "session",
-      LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
-    } as NodeJS.ProcessEnv;
-
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/auth")).rejects.toThrow(
-      "Invalid auth environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: "nextauth",
+          SESSION_SECRET: "session",
+          LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
+        },
+        () => import("../src/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
     expect(spy).toHaveBeenCalledWith(
       "❌ Invalid auth environment variables:",
       expect.objectContaining({
@@ -119,18 +122,19 @@ describe("authEnv", () => {
   });
 
   it("throws and logs when only LOGIN_RATE_LIMIT_REDIS_TOKEN is set", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      NEXTAUTH_SECRET: "nextauth",
-      SESSION_SECRET: "session",
-      LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
-    } as NodeJS.ProcessEnv;
-
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/auth")).rejects.toThrow(
-      "Invalid auth environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: "nextauth",
+          SESSION_SECRET: "session",
+          LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
+        },
+        () => import("../src/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
     expect(spy).toHaveBeenCalledWith(
       "❌ Invalid auth environment variables:",
       expect.objectContaining({
@@ -142,20 +146,21 @@ describe("authEnv", () => {
   it(
     "parses redis configuration when session store and rate limit fields are provided",
     async () => {
-      process.env = {
-        NODE_ENV: "production",
-        NEXTAUTH_SECRET: "nextauth",
-        SESSION_SECRET: "session",
-        SESSION_STORE: "redis",
-        UPSTASH_REDIS_REST_URL: "https://example.com",
-        UPSTASH_REDIS_REST_TOKEN: "token",
-        LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
-        LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
-      } as NodeJS.ProcessEnv;
-
       const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-      const { authEnv } = await import("../src/env/auth");
+      const { authEnv } = await withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: "nextauth",
+          SESSION_SECRET: "session",
+          SESSION_STORE: "redis",
+          UPSTASH_REDIS_REST_URL: "https://example.com",
+          UPSTASH_REDIS_REST_TOKEN: "token",
+          LOGIN_RATE_LIMIT_REDIS_URL: "https://example.com",
+          LOGIN_RATE_LIMIT_REDIS_TOKEN: "token",
+        },
+        () => import("../src/env/auth"),
+      );
 
       expect(authEnv).toMatchObject({
         SESSION_STORE: "redis",
@@ -168,3 +173,4 @@ describe("authEnv", () => {
     },
   );
 });
+

--- a/packages/config/__tests__/cmsEnv.test.ts
+++ b/packages/config/__tests__/cmsEnv.test.ts
@@ -1,23 +1,21 @@
 import { expect } from "@jest/globals";
+import { withEnv } from "../test/utils/withEnv";
 
 describe("cmsEnv", () => {
-  const OLD_ENV = process.env;
-
   afterEach(() => {
-    jest.resetModules();
-    process.env = OLD_ENV;
     jest.restoreAllMocks();
   });
 
   it("parses when required variables are present", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      CMS_SPACE_URL: "https://example.com",
-      CMS_ACCESS_TOKEN: "token",
-      SANITY_API_VERSION: "2023-01-01",
-    } as NodeJS.ProcessEnv;
-
-    const { cmsEnv } = await import("../src/env/cms");
+    const { cmsEnv } = await withEnv(
+      {
+        NODE_ENV: "production",
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "2023-01-01",
+      },
+      () => import("../src/env/cms"),
+    );
     expect(cmsEnv).toMatchObject({
       CMS_SPACE_URL: "https://example.com",
       CMS_ACCESS_TOKEN: "token",
@@ -26,11 +24,10 @@ describe("cmsEnv", () => {
   });
 
   it("uses fallback values in development", async () => {
-    process.env = {
-      NODE_ENV: "development",
-    } as NodeJS.ProcessEnv;
-
-    const { cmsEnv } = await import("../src/env/cms");
+    const { cmsEnv } = await withEnv(
+      { NODE_ENV: "development" },
+      () => import("../src/env/cms"),
+    );
 
     expect(cmsEnv).toMatchObject({
       CMS_SPACE_URL: "https://cms.example.com",
@@ -40,29 +37,33 @@ describe("cmsEnv", () => {
   });
 
   it("throws and logs when CMS_SPACE_URL is invalid", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      CMS_SPACE_URL: "not-a-url",
-      CMS_ACCESS_TOKEN: "token",
-      SANITY_API_VERSION: "2023-01-01",
-    } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../src/env/cms")).rejects.toThrow(
-      "Invalid CMS environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          CMS_SPACE_URL: "not-a-url",
+          CMS_ACCESS_TOKEN: "token",
+          SANITY_API_VERSION: "2023-01-01",
+        },
+        () => import("../src/env/cms"),
+      ),
+    ).rejects.toThrow("Invalid CMS environment variables");
     expect(spy).toHaveBeenCalled();
   });
 
   it("throws and logs when required variables are missing", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      CMS_SPACE_URL: "https://example.com",
-      NODE_ENV: "production",
-    } as NodeJS.ProcessEnv;
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../src/env/cms")).rejects.toThrow(
-      "Invalid CMS environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          CMS_SPACE_URL: "https://example.com",
+        },
+        () => import("../src/env/cms"),
+      ),
+    ).rejects.toThrow("Invalid CMS environment variables");
     expect(spy).toHaveBeenCalled();
   });
 });
+

--- a/packages/config/__tests__/cmsEnvFailure.test.ts
+++ b/packages/config/__tests__/cmsEnvFailure.test.ts
@@ -1,27 +1,26 @@
 import { expect } from "@jest/globals";
+import { withEnv } from "../test/utils/withEnv";
 
 describe("cmsEnv failure", () => {
-  const OLD_ENV = process.env;
-
   afterEach(() => {
-    jest.resetModules();
-    process.env = OLD_ENV;
     jest.restoreAllMocks();
   });
 
   it("throws and logs when CMS env is invalid", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      CMS_SPACE_URL: "notaurl",
-      CMS_ACCESS_TOKEN: "",
-      SANITY_API_VERSION: "",
-    } as NodeJS.ProcessEnv;
-
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/cms")).rejects.toThrow(
-      "Invalid CMS environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          CMS_SPACE_URL: "notaurl",
+          CMS_ACCESS_TOKEN: "",
+          SANITY_API_VERSION: "",
+        },
+        () => import("../src/env/cms"),
+      ),
+    ).rejects.toThrow("Invalid CMS environment variables");
     expect(spy).toHaveBeenCalled();
   });
 });
+

--- a/packages/config/__tests__/coreEnvProxy.test.ts
+++ b/packages/config/__tests__/coreEnvProxy.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, afterEach, expect } from "@jest/globals";
-
-const OLD_ENV = process.env;
+import { withEnv } from "../test/utils/withEnv";
 
 afterEach(() => {
-  jest.resetModules();
-  process.env = OLD_ENV;
+  jest.restoreAllMocks();
 });
 
 describe("coreEnv proxy", () => {
   it("supports proxy traps", async () => {
-    process.env = { ...OLD_ENV, NODE_ENV: "test" } as NodeJS.ProcessEnv;
-    const core = await import("../src/env/core");
+    const core = await withEnv(
+      { NODE_ENV: "test" },
+      () => import("../src/env/core"),
+    );
 
     expect("NODE_ENV" in core.coreEnv).toBe(true);
     expect(Object.keys(core.coreEnv)).toContain("NODE_ENV");
@@ -20,18 +20,20 @@ describe("coreEnv proxy", () => {
   });
 
   it("parses during import in production", async () => {
-    process.env = {
-      ...OLD_ENV,
-      NODE_ENV: "production",
-      CART_COOKIE_SECRET: "secret",
-      NEXTAUTH_SECRET: "nextauth",
-      SESSION_SECRET: "session",
-      CMS_SPACE_URL: "https://example.com",
-      CMS_ACCESS_TOKEN: "token",
-      SANITY_API_VERSION: "2023-01-01",
-    } as NodeJS.ProcessEnv;
-    const core = await import("../src/env/core");
+    const core = await withEnv(
+      {
+        NODE_ENV: "production",
+        CART_COOKIE_SECRET: "secret",
+        NEXTAUTH_SECRET: "nextauth",
+        SESSION_SECRET: "session",
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "2023-01-01",
+      },
+      () => import("../src/env/core"),
+    );
     // Fail-fast in production should parse at import time.
     expect(core.coreEnv.NODE_ENV).toBe("production");
   });
 });
+

--- a/packages/config/__tests__/coreEnvRefinement.test.ts
+++ b/packages/config/__tests__/coreEnvRefinement.test.ts
@@ -1,26 +1,16 @@
-import { expect, describe, it, afterEach } from "@jest/globals";
-
-const OLD_ENV = process.env;
-
-afterEach(() => {
-  jest.resetModules();
-  process.env = OLD_ENV;
-});
+import { expect, describe, it } from "@jest/globals";
 
 describe("coreEnvSchema refinement", () => {
   it("coerces boolean and number strings", async () => {
     const { coreEnvSchema } = await import("../src/env/core");
-    process.env = {
-      ...OLD_ENV,
+    const parsed = coreEnvSchema.parse({
       DEPOSIT_RELEASE_ENABLED: "true",
       DEPOSIT_RELEASE_INTERVAL_MS: "1000",
       REVERSE_LOGISTICS_ENABLED: "false",
       REVERSE_LOGISTICS_INTERVAL_MS: "2000",
       LATE_FEE_ENABLED: "true",
       LATE_FEE_INTERVAL_MS: "3000",
-    } as NodeJS.ProcessEnv;
-
-    const parsed = coreEnvSchema.parse(process.env);
+    } as NodeJS.ProcessEnv);
     expect(parsed.DEPOSIT_RELEASE_ENABLED).toBe(true);
     expect(parsed.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
     expect(parsed.REVERSE_LOGISTICS_ENABLED).toBe(false);
@@ -31,15 +21,12 @@ describe("coreEnvSchema refinement", () => {
 
   it("reports invalid env variables", async () => {
     const { coreEnvSchema } = await import("../src/env/core");
-    process.env = {
-      ...OLD_ENV,
+    const parsed = coreEnvSchema.safeParse({
       DEPOSIT_RELEASE_ENABLED: "notbool",
       REVERSE_LOGISTICS_INTERVAL_MS: "abc",
       LATE_FEE_INTERVAL_MS: "abc",
       DEPOSIT_RELEASE_FOO: "bar",
-    } as NodeJS.ProcessEnv;
-
-    const parsed = coreEnvSchema.safeParse(process.env);
+    } as NodeJS.ProcessEnv);
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
       expect(parsed.error.issues).toEqual(
@@ -90,3 +77,4 @@ describe("coreEnvSchema refinement", () => {
     );
   });
 });
+

--- a/packages/config/__tests__/env.test.ts
+++ b/packages/config/__tests__/env.test.ts
@@ -1,31 +1,29 @@
 import { expect } from "@jest/globals";
+import { withEnv } from "../test/utils/withEnv";
 
 describe("env", () => {
-  const OLD_ENV = process.env;
-
   afterEach(() => {
-    jest.resetModules();
-    process.env = OLD_ENV;
     jest.restoreAllMocks();
   });
 
   it("loads valid configuration when all variables are set", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      NEXTAUTH_SECRET: "nextauth",
-      SESSION_SECRET: "session",
-      CART_COOKIE_SECRET: "cartsecret",
-      CMS_SPACE_URL: "https://cms.example.com",
-      CMS_ACCESS_TOKEN: "token",
-      SANITY_API_VERSION: "2023-01-01",
-      EMAIL_PROVIDER: "sendgrid",
-      SENDGRID_API_KEY: "sg-key",
-      STRIPE_SECRET_KEY: "sk_live",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live",
-      STRIPE_WEBHOOK_SECRET: "whsec_live",
-    } as NodeJS.ProcessEnv;
-
-    const { env } = await import("../src/env");
+    const { env } = await withEnv(
+      {
+        NODE_ENV: "production",
+        NEXTAUTH_SECRET: "nextauth",
+        SESSION_SECRET: "session",
+        CART_COOKIE_SECRET: "cartsecret",
+        CMS_SPACE_URL: "https://cms.example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "2023-01-01",
+        EMAIL_PROVIDER: "sendgrid",
+        SENDGRID_API_KEY: "sg-key",
+        STRIPE_SECRET_KEY: "sk_live",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live",
+        STRIPE_WEBHOOK_SECRET: "whsec_live",
+      },
+      () => import("../src/env"),
+    );
 
     expect(env).toEqual(
       expect.objectContaining({
@@ -40,16 +38,17 @@ describe("env", () => {
         STRIPE_SECRET_KEY: "sk_live",
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live",
         STRIPE_WEBHOOK_SECRET: "whsec_live",
-      })
+      }),
     );
   });
 
   it("uses development defaults when variables are missing", async () => {
-    process.env = {
-      NODE_ENV: "development",
-    } as NodeJS.ProcessEnv;
-
-    const { env } = await import("../src/env");
+    const { env } = await withEnv(
+      {
+        NODE_ENV: "development",
+      },
+      () => import("../src/env"),
+    );
 
     expect(env).toEqual(
       expect.objectContaining({
@@ -62,26 +61,28 @@ describe("env", () => {
         STRIPE_SECRET_KEY: "sk_test",
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
         STRIPE_WEBHOOK_SECRET: "whsec_test",
-      })
+      }),
     );
   });
 
   it("throws and logs when invalid variables are provided", async () => {
-    process.env = {
-      NODE_ENV: "production",
-      NEXTAUTH_SECRET: "x",
-      SESSION_SECRET: "y",
-      CART_COOKIE_SECRET: "z",
-      CMS_SPACE_URL: "notaurl",
-      CMS_ACCESS_TOKEN: "token",
-      SANITY_API_VERSION: "2023-01-01",
-    } as NodeJS.ProcessEnv;
-
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env")).rejects.toThrow(
-      "Invalid CMS environment variables"
-    );
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: "x",
+          SESSION_SECRET: "y",
+          CART_COOKIE_SECRET: "z",
+          CMS_SPACE_URL: "notaurl",
+          CMS_ACCESS_TOKEN: "token",
+          SANITY_API_VERSION: "2023-01-01",
+        },
+        () => import("../src/env"),
+      ),
+    ).rejects.toThrow("Invalid CMS environment variables");
     expect(spy).toHaveBeenCalled();
   });
 });
+

--- a/packages/config/__tests__/envIndexFailure.test.ts
+++ b/packages/config/__tests__/envIndexFailure.test.ts
@@ -1,25 +1,22 @@
 import { expect } from "@jest/globals";
+import { withEnv } from "../test/utils/withEnv";
 
 describe("env index validation", () => {
-  const OLD_ENV = process.env;
-
   afterEach(() => {
-    jest.resetModules();
-    process.env = OLD_ENV;
     jest.restoreAllMocks();
   });
 
   it("throws and logs on invalid environment variables", async () => {
-    process.env = {
-      ...OLD_ENV,
-      DEPOSIT_RELEASE_INTERVAL_MS: "abc",
-    } as NodeJS.ProcessEnv;
-
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(import("../src/env/index")).rejects.toThrow(
-      "Invalid environment variables",
-    );
+    await expect(
+      withEnv(
+        {
+          DEPOSIT_RELEASE_INTERVAL_MS: "abc",
+        },
+        () => import("../src/env/index"),
+      ),
+    ).rejects.toThrow("Invalid environment variables");
     expect(errorSpy).toHaveBeenCalledWith(
       "❌ Invalid environment variables:",
       expect.objectContaining({
@@ -29,14 +26,16 @@ describe("env index validation", () => {
   });
 
   it("succeeds with valid environment variables", async () => {
-    process.env = {
-      ...OLD_ENV,
-      DEPOSIT_RELEASE_INTERVAL_MS: "1000",
-    } as NodeJS.ProcessEnv;
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-
-    const mod = await import("../src/env/index");
+    const mod = await withEnv(
+      {
+        DEPOSIT_RELEASE_INTERVAL_MS: "1000",
+      },
+      () => import("../src/env/index"),
+    );
     expect(mod.env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
     expect(errorSpy).not.toHaveBeenCalled();
   });

--- a/packages/config/__tests__/index.test.ts
+++ b/packages/config/__tests__/index.test.ts
@@ -1,35 +1,28 @@
 import { expect } from "@jest/globals";
+import { withEnv } from "../test/utils/withEnv";
 
 // Ensure the package's root entry re-exports the compiled core env
 // without throwing "Module not found" for missing compiled files.
 describe("config package entry", () => {
-  const OLD_ENV = process.env;
-
-  afterEach(() => {
-    jest.resetModules();
-    process.env = OLD_ENV;
-  });
-
   it("re-exports core env from root index", async () => {
-    process.env = {
-      ...OLD_ENV,
-      STRIPE_SECRET_KEY: "sk",
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
-      CART_COOKIE_SECRET: "secret",
-      STRIPE_WEBHOOK_SECRET: "whsec",
-      NEXTAUTH_SECRET: "nextauth",
-      SESSION_SECRET: "session",
-      CMS_SPACE_URL: "https://example.com",
-      CMS_ACCESS_TOKEN: "token",
-      SANITY_API_VERSION: "2023-01-01",
-      NODE_ENV: "production",
-    } as NodeJS.ProcessEnv;
-
-    const { env } = await import("../src/index");
+    const { env } = await withEnv(
+      {
+        STRIPE_SECRET_KEY: "sk",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+        CART_COOKIE_SECRET: "secret",
+        STRIPE_WEBHOOK_SECRET: "whsec",
+        NEXTAUTH_SECRET: "nextauth",
+        SESSION_SECRET: "session",
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "2023-01-01",
+        NODE_ENV: "production",
+      },
+      () => import("../src/index"),
+    );
     expect({
       STRIPE_SECRET_KEY: env.STRIPE_SECRET_KEY,
-      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
-        env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
       CART_COOKIE_SECRET: env.CART_COOKIE_SECRET,
       STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET,
       NEXTAUTH_SECRET: env.NEXTAUTH_SECRET,
@@ -44,3 +37,4 @@ describe("config package entry", () => {
     });
   });
 });
+

--- a/packages/config/__tests__/loadCoreEnv.test.ts
+++ b/packages/config/__tests__/loadCoreEnv.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, afterEach, expect } from "@jest/globals";
 
-const OLD_ENV = process.env;
-
 afterEach(() => {
-  jest.resetModules();
-  process.env = OLD_ENV;
   jest.restoreAllMocks();
 });
 

--- a/packages/config/test/utils/withEnv.ts
+++ b/packages/config/test/utils/withEnv.ts
@@ -1,0 +1,13 @@
+export async function withEnv<T>(
+  vars: NodeJS.ProcessEnv,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const OLD = process.env;
+  jest.resetModules();
+  process.env = { ...OLD, ...vars };
+  try {
+    return await loader();
+  } finally {
+    process.env = OLD;
+  }
+}


### PR DESCRIPTION
## Summary
- add `withEnv` helper for isolated environment imports
- wrap config package tests with `withEnv`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in configurator build)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test` *(fails: @apps/api#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b99e39b208832fb17a9e0d4f552f0b