### PR TITLE
Replace wizard references with configurator terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A multilingual, hybrid-rendered e-commerce demo built with **Next.js 15** and **
 
 Requires **Node.js >=20** and **pnpm 10.12.1**. See [docs/install.md](docs/install.md) for installation instructions and [docs/setup.md](docs/setup.md) for full setup and CI guidance.
 
-Run `pnpm init-shop` to scaffold a new shop. The wizard lists available plugins and, when invoked with `--auto-env`, writes `TODO_*` placeholders for any required environment variables so teams can fill them in later.
+Run `pnpm init-shop` to scaffold a new shop. The configurator lists available plugins and, when invoked with `--auto-env`, writes `TODO_*` placeholders for any required environment variables so teams can fill them in later. The previous wizard is deprecated.
 
 ## Key Features
 
@@ -114,7 +114,7 @@ Configuration and usage examples for both are documented in [docs/machine.md](do
 
 # Environment Variables
 
-After running `pnpm create-shop <id>`, the wizard generates `.env` and `.env.template` under `apps/shop-<id>/`, validates the variables, and can pull secrets from an external vault by passing `--vault-cmd <cmd>` (the command receives each variable name). Configure the resulting `.env` with:
+After running `pnpm create-shop <id>`, the CLI generates `.env` and `.env.template` under `apps/shop-<id>/`, validates the variables, and can pull secrets from an external vault by passing `--vault-cmd <cmd>` (the command receives each variable name). Configure the resulting `.env` with:
 
 - `STRIPE_SECRET_KEY` – secret key used by the Stripe server SDK
 - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` – public key for the Stripe client SDK

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ To scaffold a shop and immediately start the dev server in one step:
 pnpm quickstart-shop --id demo --theme base --template template-app --auto-plugins --auto-env --presets
 ```
 
-This wraps the `init-shop` wizard, validates the generated `.env`, and runs `pnpm dev` for the new shop. `--auto-plugins` selects all detected payment and shipping providers, `--auto-env` writes placeholder environment variables, and `--presets` applies default navigation, pages, and a GitHub Actions workflow. You can also provide a configuration file and skip most flags:
+This wraps the `init-shop` configurator, validates the generated `.env`, and runs `pnpm dev` for the new shop. `--auto-plugins` selects all detected payment and shipping providers, `--auto-env` writes placeholder environment variables, and `--presets` applies default navigation, pages, and a GitHub Actions workflow. The earlier wizard is deprecated. You can also provide a configuration file and skip most flags:
 
 ```bash
 pnpm quickstart-shop --config ./shop.config.json
@@ -39,12 +39,12 @@ Example `shop.config.json`:
    pnpm setup-ci <id>
    ```
 
-   `init-shop` launches an interactive wizard that asks for the shop ID, display name, logo URL,
+   `init-shop` launches an interactive configurator that asks for the shop ID, display name, logo URL,
    contact email, shop type (`sale` or `rental`), and which theme and template to use. Payment and
    shipping providers are chosen from guided lists of available providers. It then
    scaffolds `apps/shop-<id>` and prompts for environment variables like Stripe keys and CMS
    credentials, writing them directly to `apps/shop-<id>/.env` and generating a matching
-   `.env.template` with the required keys. The wizard validates the environment immediately and
+   `.env.template` with the required keys. The configurator validates the environment immediately and
    can fetch secrets from an external vault by providing `--vault-cmd <cmd>` (the command is invoked
    with each variable name). For scripted setups you can still
    call `pnpm create-shop <id>` and pass flags like `--name`, `--logo` and `--contact` to skip those
@@ -66,7 +66,7 @@ Example `shop.config.json`:
    pnpm dev
    ```
 
-   The wizard already validated your environment variables. Rerun `pnpm validate-env <id>` after
+   The configurator already validated your environment variables. Rerun `pnpm validate-env <id>` after
    editing `.env` if you need to re-check. Open http://localhost:3000 to view the site. Pages
    hot-reload on save.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -41,7 +41,7 @@ Example `shop.config.json`:
 pnpm init-shop
 ```
 
-`init-shop` launches an interactive wizard that collects:
+`init-shop` launches an interactive configurator that collects:
 
 - shop ID
 - display name
@@ -55,11 +55,11 @@ pnpm init-shop
 - theme token overrides (`token=value` pairs)
 - environment variables like Stripe keys and CMS credentials
 
-Passing `--defaults` tells the wizard to prefill navigation links and pages
+Passing `--defaults` tells the configurator to prefill navigation links and pages
 from the selected template's `shop.json` when those fields exist. Any missing
 entries fall back to interactive prompts.
 
-After answering the prompts the wizard scaffolds `apps/shop-<id>` and writes your answers to `apps/shop-<id>/.env`.
+After answering the prompts the configurator scaffolds `apps/shop-<id>` and writes your answers to `apps/shop-<id>/.env`.
 
 To skip the theme prompts, provide overrides via flags:
 
@@ -73,15 +73,15 @@ For more extensive customization you could import design tokens from common sour
 
 To populate the new shop with sample data, run `pnpm init-shop --seed`. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings. Provide `--pages-template <name>` to copy predefined page layouts (`hero`, `product-grid`, `contact`). Use `pnpm init-shop --defaults` to apply preset nav links and pages from the
 selected template without prompting for them.
-Add `--auto-env` to skip prompts for provider environment variables. The wizard writes
+Add `--auto-env` to skip prompts for provider environment variables. The configurator writes
 `TODO_*` placeholders to the new shop's `.env` file; replace them with real
 secrets before deploying.
 To prefill answers from an existing file, supply `--env-file <path>`.
 Keys in the file are merged before prompting—any variables already present are
 written directly to the generated `.env` and prompts for them are skipped. After
-validation the wizard warns about unused entries or missing required variables.
+validation the configurator warns about unused entries or missing required variables.
 To reuse answers across runs, create `profiles/<name>.json` and run
-`pnpm init-shop --profile <name>`. Profile values prefill the wizard. Combine
+`pnpm init-shop --profile <name>`. Profile values prefill the configurator. Combine
 with `--skip-prompts` to accept defaults for remaining questions and run
 non-interactively.
 
@@ -103,7 +103,7 @@ pnpm create-shop <id> [--type=sale|rental] [--theme=name] [--template=name] [--p
 - `--seed` – copy sample `products.json` and `inventory.json` into the new shop.
 - `--seed-full` – additionally copy `shop.json`, navigation defaults, page templates, and `settings.json`.
 - `--contact` – contact email for the shop.
-- `--config` – path to a JSON or TS file exporting options. Values from the file prefill the wizard and skip prompts.
+- `--config` – path to a JSON or TS file exporting options. Values from the file prefill the configurator and skip prompts.
 
 Example configuration file:
 
@@ -126,7 +126,7 @@ Run with:
 pnpm create-shop demo --config ./shop.config.json
 ```
 
-### Example wizard run
+### Example configurator run
 
 ```bash
 pnpm init-shop
@@ -160,16 +160,16 @@ Scaffolded apps/shop-demo
 
 ## 2. Review environment variables
 
-The wizard captures common environment variables and writes them to `apps/shop-<id>/.env`.
+The configurator captures common environment variables and writes them to `apps/shop-<id>/.env`.
 
-After scaffolding, the wizard writes both `.env` and `.env.template` to `apps/shop-<id>/`.
+After scaffolding, the configurator writes both `.env` and `.env.template` to `apps/shop-<id>/`.
 The template lists all variables required by your chosen providers. If you used `--auto-env`,
 `.env` contains placeholder values like `TODO_API_KEY`. Supplying `--env-file` copies matching keys
 from that file, and `--vault-cmd <cmd>` invokes the given command with each variable name to retrieve
 secrets from an external vault. Placeholders and missing variables must be replaced with real
 credentials before deployment.
 
-The wizard validates the environment immediately. Rerun the check manually any time after editing:
+The configurator validates the environment immediately. Rerun the check manually any time after editing:
 
 ```bash
 pnpm validate-env <id>
@@ -200,7 +200,7 @@ This creates `.github/workflows/shop-<id>.yml` which installs dependencies, runs
 
 Plugins extend the platform with extra payment providers, shipping integrations or storefront widgets. The platform automatically loads any plugin found under `packages/plugins/*`.
 
-During `init-shop` you will be presented with a list of detected plugins. Selected plugins are added to the new shop's `package.json` and the wizard prompts for any required environment variables.
+During `init-shop` you will be presented with a list of detected plugins. Selected plugins are added to the new shop's `package.json` and the configurator prompts for any required environment variables.
 
 To add a plugin manually, place it in the `packages/plugins` directory (e.g. `packages/plugins/paypal`) and export a default plugin object. After restarting the CMS you can enable and configure the plugin under **CMS → Plugins**.
 

--- a/test/unit/init-shop/env.spec.ts
+++ b/test/unit/init-shop/env.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import ts from 'typescript';
 import { runInNewContext } from 'vm';
 
-describe('init-shop wizard - env', () => {
+describe('init-shop configurator - env', () => {
   it('collects user input and validates environment', async () => {
     const questions: string[] = [];
     const answers = [

--- a/test/unit/init-shop/provider.spec.ts
+++ b/test/unit/init-shop/provider.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import ts from 'typescript';
 import { runInNewContext } from 'vm';
 
-describe('init-shop wizard - providers', () => {
+describe('init-shop configurator - providers', () => {
   it('allows selecting payment and shipping providers', async () => {
     const questions: string[] = [];
     const answers = [

--- a/test/unit/init-shop/runtime.spec.ts
+++ b/test/unit/init-shop/runtime.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import ts from 'typescript';
 import { runInNewContext } from 'vm';
 
-describe('init-shop wizard - runtime checks', () => {
+describe('init-shop configurator - runtime checks', () => {
   it('exits when Node.js version is below 20', () => {
     const sandbox: any = {
       exports: {},

--- a/test/unit/init-shop/theme.spec.ts
+++ b/test/unit/init-shop/theme.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import ts from 'typescript';
 import { runInNewContext } from 'vm';
 
-describe('init-shop wizard - theme', () => {
+describe('init-shop configurator - theme', () => {
   it('supports theme overrides via CLI flags', async () => {
     const questions: string[] = [];
     const answers = [

--- a/test/unit/init-shop/vault.spec.ts
+++ b/test/unit/init-shop/vault.spec.ts
@@ -10,7 +10,7 @@ jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => ({})),
 }));
 
-describe('init-shop wizard - vault', () => {
+describe('init-shop configurator - vault', () => {
   it('fetches secrets using --vault-cmd', async () => {
     const questions: string[] = [];
     const answers = [


### PR DESCRIPTION
## Summary
- Update docs to describe the `init-shop` CLI as a configurator and note the old wizard is deprecated
- Rename unit tests from "init-shop wizard" to "init-shop configurator"

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve '@babel/runtime/helpers/asyncToGenerator')*
- `pnpm test` *(fails: @acme/config#test exited with code 137)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c221011c832fa79e2acea1877c32