### PR TITLE
docs: replace wizard with configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A multilingual, hybrid-rendered e-commerce demo built with **Next.js 15** and **
 
 Requires **Node.js >=20** and **pnpm 10.12.1**. See [docs/install.md](docs/install.md) for installation instructions and [docs/setup.md](docs/setup.md) for full setup and CI guidance.
 
-Run `pnpm init-shop` to scaffold a new shop. The configurator lists available plugins and, when invoked with `--auto-env`, writes `TODO_*` placeholders for any required environment variables so teams can fill them in later. The previous wizard is deprecated.
+Run `pnpm init-shop` to scaffold a new shop. The configurator lists available plugins and, when invoked with `--auto-env`, writes `TODO_*` placeholders for any required environment variables so teams can fill them in later.
 
 ## Key Features
 
 - Stripe handles deposits via escrow sessions.
 - Returned deposits can be refunded automatically by the deposit release service. See [docs/machine.md](docs/machine.md).
-- Inventory lives in JSON files under data/shops/*/inventory.json.
+- Inventory lives in JSON files under data/shops/\*/inventory.json.
 - Low-stock alerts email the configured recipient (`STOCK_ALERT_RECIPIENT`) when inventory falls below its threshold.
 - Rental pricing matrix defined in data/rental/pricing.json with duration discounts and damage-fee rules.
 - Return logistics options stored in data/return-logistics.json.
@@ -30,7 +30,6 @@ The root middleware applies [next-secure-headers](https://www.npmjs.com/package/
 - **X-Frame-Options** – `DENY` to block iframe embedding.
 - **Referrer-Policy** – `no-referrer`.
 - **X-Content-Type-Options** and **X-Download-Options** – `nosniff` and `noopen`.
-
 
 ## Installation
 
@@ -192,10 +191,7 @@ Every app should map workspace packages to both their built `dist` output and th
         "../../packages/lib/dist/index.d.ts",
         "../../packages/lib/src/index.ts"
       ],
-      "@acme/lib/*": [
-        "../../packages/lib/dist/*",
-        "../../packages/lib/src/*"
-      ]
+      "@acme/lib/*": ["../../packages/lib/dist/*", "../../packages/lib/src/*"]
     }
   }
 }

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -17,7 +17,7 @@ The sidebar inside the CMS provides quick access to different sections:
 - **Live** – Opens a list of running shop instances.
 - **RBAC** – (Admin only) Manage user roles.
 - **Account Requests** – (Admin only) Approve new user accounts.
-- **Create Shop** – (Admin only) Launch the wizard for creating a new shop.
+- **Create Shop** – (Admin only) Launch the configurator for creating a new shop.
 
 Links such as **New Product**, **New Page** and **SEO** only appear after picking a shop, otherwise they are hidden.
 
@@ -31,30 +31,35 @@ Certain pages are restricted to users with the `admin` role:
 
 - `/cms/rbac` – user management and role assignment.
 - `/cms/account-requests` – approve pending sign‑ups.
-- `/cms/wizard` – step‑by‑step workflow for creating a new shop.
+- `/cms/configurator` – step‑by‑step workflow for creating a new shop.
 
 Attempting to access these pages without the proper role will redirect back to the CMS dashboard.
 
-## Shop Creation Wizard
+## Shop Configurator
 
-Admins can scaffold and launch a shop directly from the CMS at `/cms/wizard`. The workflow proceeds through these steps:
+Admins can scaffold and launch a shop directly from the CMS at `/cms/configurator`. The configurator guides you through:
 
-1. **Shop details** – provide the shop ID, display name, logo URL, contact email and choose whether it's for sales or rentals.
-2. **Options** – select the starter template and theme.
-3. **Theme tokens** – tweak design tokens to match your brand. See [advanced theming](./theming-advanced.md) for details.
-4. **Navigation** – build the header navigation tree or start from prebuilt presets.
-5. **Page layouts** – configure home, shop, product and checkout pages and any optional additional pages.
-6. **Environment** – supply required environment variables.
-7. **Seed/Import data** – seed example products or import existing data.
-8. **Hosting** – optionally provision CI and deployment settings.
-9. **Summary** – review all selections and launch the shop.
+1. **Shop Details** – provide the shop ID, display name, logo URL, contact email and shop type.
+2. **Theme** – pick a base theme.
+3. **Tokens** – tweak design tokens to match your brand. See [advanced theming](./theming-advanced.md) for details.
+4. **Options** – select the starter template and plugins.
+5. **Navigation** – build the header navigation tree or start from presets.
+6. **Layout** – choose overall page layouts.
+7. **Home Page** – configure the home page layout.
+8. **Checkout Page** – configure the checkout experience.
+9. **Shop Page** – configure the product listing page.
+10. **Product Page** – configure the product detail page.
+11. **Additional Pages** – optionally set up extra pages.
+12. **Environment Variables** – supply required environment variables.
+13. **Summary** – review selections and launch the shop.
+14. _(Optional)_ **Import Data**, **Seed Data** and **Hosting** steps for existing content, sample data and deployment settings.
 
-Progress saves automatically, so returning to `/cms/wizard` resumes from the last completed step.
+Progress saves automatically via the `cms-configurator-progress` key and the `/cms/api/configurator-progress` endpoint. Returning to `/cms/configurator` resumes from the last completed step.
 
-## Wizard Resume & Page Drafts
+## Configurator Resume & Page Drafts
 
-The shop creation wizard now resumes where you left off. If you log in via
-`/login?callbackUrl=/cms/wizard` or return to `/cms/wizard` later, the flow jumps
+The shop configurator now resumes where you left off. If you log in via
+`/login?callbackUrl=/cms/configurator` or return to `/cms/configurator` later, the flow jumps
 to your last completed step so you can continue configuring the shop without
 starting over.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ To scaffold a shop and immediately start the dev server in one step:
 pnpm quickstart-shop --id demo --theme base --template template-app --auto-plugins --auto-env --presets
 ```
 
-This wraps the `init-shop` configurator, validates the generated `.env`, and runs `pnpm dev` for the new shop. `--auto-plugins` selects all detected payment and shipping providers, `--auto-env` writes placeholder environment variables, and `--presets` applies default navigation, pages, and a GitHub Actions workflow. The earlier wizard is deprecated. You can also provide a configuration file and skip most flags:
+This wraps the `init-shop` configurator, validates the generated `.env`, and runs `pnpm dev` for the new shop. `--auto-plugins` selects all detected payment and shipping providers, `--auto-env` writes placeholder environment variables, and `--presets` applies default navigation, pages, and a GitHub Actions workflow. You can also provide a configuration file and skip most flags:
 
 ```bash
 pnpm quickstart-shop --config ./shop.config.json

--- a/docs/theming-advanced.md
+++ b/docs/theming-advanced.md
@@ -1,6 +1,7 @@
 # Advanced Theming
 
 ## Base themes
+
 Selecting a base theme resets overrides and reloads its default tokens:
 
 ```tsx
@@ -15,26 +16,29 @@ const handleThemeChange = (e: ChangeEvent<HTMLSelectElement>) => {
 ```
 
 ## Element overrides
+
 Each override merges with the current theme and updates the preview:
 
 ```tsx
 // apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx
-const handleOverrideChange = (key: string, defaultValue: string) => (value: string) => {
-  setOverrides((prev) => {
-    const next = { ...prev };
-    if (!value || value === defaultValue) {
-      delete next[key];
-    } else {
-      next[key] = value;
-    }
-    const merged = { ...tokensByThemeState[theme], ...next };
-    schedulePreviewUpdate(merged);
-    return next;
-  });
-};
+const handleOverrideChange =
+  (key: string, defaultValue: string) => (value: string) => {
+    setOverrides((prev) => {
+      const next = { ...prev };
+      if (!value || value === defaultValue) {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+      const merged = { ...tokensByThemeState[theme], ...next };
+      schedulePreviewUpdate(merged);
+      return next;
+    });
+  };
 ```
 
 ## Persistence
+
 Preview tokens are saved to `localStorage` and shop configs persist theme data:
 
 ```tsx
@@ -68,10 +72,10 @@ useEffect(() => {
 ```
 
 ## Live preview
-`WizardPreview` listens for token updates and merges them into its styles:
+
+The configurator preview listens for token updates and merges them into its styles:
 
 ```tsx
-// apps/cms/src/app/cms/wizard/WizardPreview.tsx
 useEffect(() => {
   const handle = () => {
     setThemeStyle((prev) => ({ ...prev, ...loadPreviewTokens() }));

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -3,6 +3,7 @@
 Base themes provide the starting set of design tokens for a shop. The **Theme Editor** lets you pick a base theme and layer token overrides on top. Overrides merge with the base tokens and are persisted with the shop so they can be shared across sessions.
 
 ## Device presets
+
 Both the Page Builder and live preview provide a device menu with presets for common screens:
 
 - Desktop 1280
@@ -16,19 +17,23 @@ Both the Page Builder and live preview provide a device menu with presets for co
 Use the desktop/tablet/mobile buttons or the dropdown to switch widths and breakpoints. Selections are kept only for the current session and reset to **Desktop 1280** on reload. The original Desktop/Tablet/Mobile buttons map to the closest preset for backward compatibility.
 
 ## Selecting elements and overriding colors
+
 1. Open the Theme Editor in the CMS.
-2. The preview uses `WizardPreview` in inspect mode. Clicking any tokenised element highlights it and focuses its matching input.
+2. The preview offers an inspect mode. Clicking any tokenised element highlights it and focuses its matching input.
 3. Click a color swatch or field to open the picker and enter a new value. Only differences from the base theme are stored as overrides.
 
 ## Presets
-- Type a name in *Preset name* and press **Save Preset** to capture the current set of overrides.
+
+- Type a name in _Preset name_ and press **Save Preset** to capture the current set of overrides.
 - Presets appear in the theme list and can be removed with **Delete Preset**.
 
 ## Resetting to defaults
+
 - Use the reset icon beside a color input to remove its override.
 - To clear an override outside the editor, call `resetThemeOverride(shop, token)` from [`apps/cms/src/actions/shops.server.ts`](../apps/cms/src/actions/shops.server.ts).
 
 ## Implementation references
+
 - **Theme Editor** – [`apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx`](../apps/cms/src/app/cms/shop/[shop]/themes/ThemeEditor.tsx)
-- **Live preview** – [`apps/cms/src/app/cms/wizard/WizardPreview.tsx`](../apps/cms/src/app/cms/wizard/WizardPreview.tsx)
+- **Live preview** – [`apps/cms/src/app/cms/configurator/steps/ThemeEditorForm.tsx`](../apps/cms/src/app/cms/configurator/steps/ThemeEditorForm.tsx)
 - **Server actions** – [`apps/cms/src/actions/shops.server.ts`](../apps/cms/src/actions/shops.server.ts)

--- a/docs/upgrade-preview-republish.md
+++ b/docs/upgrade-preview-republish.md
@@ -45,7 +45,7 @@ The script requires a corresponding `data/shops/<id>/upgrade.json`, runs `pnpm -
 
 ## Preview UI
 
-CMS components fetch the preview endpoint and render changes live. The wizard's preview reads state from `localStorage` so edits appear instantly, and deployments expose a preview URL (`<shop-id>.pages.dev`) written to `deploy.json`.
+CMS components fetch the preview endpoint and render changes live. The configurator preview reads state from `localStorage` so edits appear instantly, and deployments expose a preview URL (`<shop-id>.pages.dev`) written to `deploy.json`.
 
 ## Metadata
 


### PR DESCRIPTION
## Summary
- update CMS guide to document Shop Configurator and new `/cms/configurator` route
- scrub remaining wizard mentions from theming, install, and upgrade docs
- clarify configurator preview token handling and progress persistence

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm exec prettier --check docs/cms.md docs/theming.md docs/upgrade-preview-republish.md docs/theming-advanced.md docs/install.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_68b9cb5ada54832fb0b9f03508a11c66