### PR TITLE
chore(platform-core): replace eval require

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,6 +1,6 @@
 import { loadCoreEnv } from "@acme/config/env/core";
+import { createRequire } from "module";
 import type { PrismaClient } from "./prisma-client";
-
 
 const coreEnv = loadCoreEnv();
 type RentalOrderStub = {
@@ -73,8 +73,14 @@ if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
   prisma = createStubPrisma();
 } else {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { PrismaClient } = (eval("require") as any)("@prisma/client");
+    const requirePrisma = createRequire(
+      typeof __dirname !== "undefined"
+        ? __dirname
+        : `${process.cwd()}/package.json`
+    );
+    const { PrismaClient } = requirePrisma(
+      "@prisma/client"
+    ) as typeof import("@prisma/client");
 
     const databaseUrl = coreEnv.DATABASE_URL;
     prisma = new PrismaClient({


### PR DESCRIPTION
## Summary
- replace `eval("require")` with `createRequire` for safe prisma loading
- keep in-memory Prisma stub for tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core build` *(fails: TS2307 Cannot find module '@jest/globals')*
- `pnpm --filter @acme/platform-core test db.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc159e88832fbe043126deaa0b34