### PR TITLE
feat: validate shop id for republish

### DIFF
--- a/packages/template-app/src/app/api/publish/route.ts
+++ b/packages/template-app/src/app/api/publish/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from "next/server";
 import { requirePermission } from "@auth";
 import { spawnSync } from "child_process";
 
+const SHOP_ID_REGEX = /^[a-z0-9_-]+$/;
+
 export const runtime = "nodejs";
 
 export async function POST() {
@@ -16,6 +18,9 @@ export async function POST() {
   try {
     const raw = await fs.readFile(join(process.cwd(), "shop.json"), "utf8");
     const { id } = JSON.parse(raw) as { id: string };
+    if (!SHOP_ID_REGEX.test(id)) {
+      return NextResponse.json({ error: "Invalid shop ID" }, { status: 400 });
+    }
     const root = join(process.cwd(), "..", "..");
     const res = spawnSync(
       "pnpm",

--- a/scripts/__tests__/republish-shop.test.ts
+++ b/scripts/__tests__/republish-shop.test.ts
@@ -6,6 +6,7 @@ const fsMock = {
   readdirSync: jest.fn(),
   unlinkSync: jest.fn(),
   writeFileSync: jest.fn(),
+  appendFileSync: jest.fn(),
 };
 
 const cpMock = {
@@ -141,5 +142,10 @@ describe("republish-shop", () => {
         2
       )
     );
+  });
+
+  it("rejects invalid shop ids", async () => {
+    const { republishShop } = await import("../src/republish-shop");
+    expect(() => republishShop("../bad", root)).toThrow("Invalid shop ID");
   });
 });

--- a/test/integration/republish-shop.spec.ts
+++ b/test/integration/republish-shop.spec.ts
@@ -65,6 +65,7 @@ describe("republish-shop script", () => {
       expect(final.status).toBe("published");
       expect(final.componentVersions).toEqual({ comp: "1.0.0" });
       expect(existsSync(join(dataDir, "upgrade.json"))).toBe(false);
+      expect(existsSync(join(dataDir, "audit.log"))).toBe(true);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -120,6 +121,7 @@ describe("republish-shop script", () => {
       const final = JSON.parse(readFileSync(join(dataDir, "shop.json"), "utf8"));
       expect(final.status).toBe("published");
       expect(final.componentVersions).toEqual({ comp: "1.0.0" });
+      expect(existsSync(join(dataDir, "audit.log"))).toBe(true);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- validate shop ID format in republish script
- log republish audit entries
- ensure API publish route rejects invalid shop IDs

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@jest/globals')
- `pnpm run check:references` (fails: Missing script "check:references")
- `pnpm run build:ts` (fails: Missing script "build:ts")
- `pnpm test` (fails: command exited 1)


------
https://chatgpt.com/codex/tasks/task_e_68b9cc1dcee8832fa79cf34d73e40154