### PR TITLE
fix: resolve templates without src prefix

### DIFF
--- a/apps/cms/src/app/api/page-templates/[name]/route.ts
+++ b/apps/cms/src/app/api/page-templates/[name]/route.ts
@@ -7,15 +7,13 @@ import path from "path";
 export function resolveTemplatesRoot(): string {
   let dir = process.cwd();
   while (true) {
-    const candidate = path.join(
-      dir,
-      "packages",
-      "ui",
-      "src",
-      "components",
-      "templates"
-    );
-    if (fsSync.existsSync(candidate)) return candidate;
+    const candidates = [
+      path.join(dir, "packages", "ui", "components", "templates"),
+      path.join(dir, "packages", "ui", "src", "components", "templates"),
+    ];
+    for (const candidate of candidates) {
+      if (fsSync.existsSync(candidate)) return candidate;
+    }
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -24,7 +22,6 @@ export function resolveTemplatesRoot(): string {
     process.cwd(),
     "packages",
     "ui",
-    "src",
     "components",
     "templates"
   );


### PR DESCRIPTION
## Summary
- allow page template API route to read templates from built or source directories

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @apps/cms test` *(fails: InventoryForm and product tests)*
- `pnpm --filter @apps/cms test -- __tests__/pageTemplateNameRoute.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9cd747600832f9625277664e0cfee