### PR TITLE
Allow zero quantity in inventory item validation

### DIFF
--- a/packages/platform-core/src/utils/inventory.ts
+++ b/packages/platform-core/src/utils/inventory.ts
@@ -55,8 +55,8 @@ export function expandInventoryItem(
   data: RawInventoryItem | InventoryItem
 ): InventoryItem {
   if (isInventoryItem(data)) {
-    if (data.quantity <= 0) {
-      throw new Error("quantity must be greater than 0");
+    if (data.quantity < 0) {
+      throw new Error("quantity must be greater than or equal to 0");
     }
     if (data.productId.trim() === "") {
       throw new Error("productId is required");
@@ -85,8 +85,8 @@ export function expandInventoryItem(
   }
 
   const normalizedQuantity = normalizeQuantity(quantity, unit);
-  if (!Number.isFinite(normalizedQuantity) || normalizedQuantity <= 0) {
-    throw new Error("quantity must be greater than 0");
+  if (!Number.isFinite(normalizedQuantity) || normalizedQuantity < 0) {
+    throw new Error("quantity must be greater than or equal to 0");
   }
 
   const normalizedLowStock =


### PR DESCRIPTION
## Summary
- permit zero values during inventory import and validation
- clarify error messages to state quantities must be greater than or equal to 0

## Testing
- `pnpm exec jest apps/cms/__tests__/inventoryImportJsonRoute.test.ts apps/cms/__tests__/inventoryImportCsvRoute.test.ts --runInBand`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in @acme/configurator build)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cd5735b0832f9e111b834455c2d4