### PR TITLE
fix theme token reset behavior

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
@@ -23,13 +23,12 @@ export default function ThemeTokens({ shop, tokenRows, info, errors }: Props) {
     <div className="col-span-2 flex flex-col gap-1">
       <div className="flex items-center justify-between">
         <span>Theme Tokens</span>
-        <Button
-          asChild
-          variant="ghost"
+        <Link
+          href={`/cms/shop/${shop}/themes`}
           className="h-auto p-0 text-primary hover:bg-transparent"
         >
-          <Link href={`/cms/shop/${shop}/themes`}>Edit Theme</Link>
-        </Button>
+          Edit Theme
+        </Link>
       </div>
       <table className="mt-2 w-full text-sm">
         <thead>
@@ -62,7 +61,18 @@ export default function ThemeTokens({ shop, tokenRows, info, errors }: Props) {
                 </td>
                 <td className="border-t px-2 py-1">
                   {hasOverride && (
-                    <form action={resetThemeOverride.bind(null, shop, token)}>
+                    <form
+                      onSubmit={(e) => {
+                        e.preventDefault();
+                        (
+                          resetThemeOverride as unknown as (
+                            shop: string,
+                            token: string,
+                            formData: FormData,
+                          ) => void
+                        )(shop, token, new FormData());
+                      }}
+                    >
                       <Button
                         type="submit"
                         variant="ghost"


### PR DESCRIPTION
## Summary
- replace button-as-child link with plain link in ThemeTokens
- handle reset action via custom form submit using FormData

## Testing
- `pnpm -r build` (fails: Cannot find module '@jest/globals')
- `pnpm exec jest apps/cms/src/app/cms/shop/\[shop\]/settings/__tests__/ThemeTokens.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9cd1c8400832f912229faa4eb3161