### PR TITLE
test: cover cart cookie utils

### DIFF
--- a/packages/platform-core/src/__tests__/cartCookie.test.ts
+++ b/packages/platform-core/src/__tests__/cartCookie.test.ts
@@ -1,27 +1,78 @@
 /** @jest-environment node */
 
-import { decodeCartCookie, encodeCartCookie } from "../cartCookie";
+const SECRET = "test_secret";
 
-describe("decodeCartCookie", () => {
-  it("logs and returns null for invalid signature", () => {
+describe("cartCookie", () => {
+  beforeEach(() => {
+    process.env.CART_COOKIE_SECRET = SECRET;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.CART_COOKIE_SECRET;
+    jest.resetModules();
+    jest.unmock("@acme/config/env/core");
+  });
+
+  it("caches secret and throws when missing", async () => {
+    const mod = await import("../cartCookie");
+    expect(mod.__test.getSecret()).toBe(SECRET);
+    expect(mod.__test.getSecret()).toBe(SECRET);
+
+    delete process.env.CART_COOKIE_SECRET;
+    jest.resetModules();
+    jest.doMock("@acme/config/env/core", () => ({ loadCoreEnv: () => ({}) }));
+    await expect(
+      import("../cartCookie").then((m) => m.__test.getSecret())
+    ).rejects.toThrow("env.CART_COOKIE_SECRET is required");
+  });
+
+  it("encodes JSON and decodes original object", async () => {
+    const { encodeCartCookie, decodeCartCookie } = await import("../cartCookie");
+    const value = { foo: "bar" };
+    const token = encodeCartCookie(JSON.stringify(value));
+    expect(token.split(".")).toHaveLength(2);
+    expect(decodeCartCookie(token)).toEqual(value);
+  });
+
+  it("encodes plain string and decodes raw value", async () => {
+    const { encodeCartCookie, decodeCartCookie } = await import("../cartCookie");
+    const value = "hello";
+    const token = encodeCartCookie(value);
+    expect(decodeCartCookie(token)).toBe(value);
+  });
+
+  it("returns null and warns on tampered signature", async () => {
+    const { encodeCartCookie, decodeCartCookie } = await import("../cartCookie");
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const valid = encodeCartCookie(JSON.stringify({ id: "123" }));
-    const [encoded] = valid.split(".");
-    const tampered = `${encoded}.invalid`; // wrong signature
-
+    const token = encodeCartCookie(JSON.stringify({ id: 1 }));
+    const [payload] = token.split(".");
+    const tampered = `${payload}.deadbeef`;
     expect(decodeCartCookie(tampered)).toBeNull();
     expect(warnSpy).toHaveBeenCalledWith("Invalid cart cookie");
-
     warnSpy.mockRestore();
   });
 
-  it("returns original string when payload is plain text", () => {
-    const original = "plain";
-    const parseSpy = jest.spyOn(JSON, "parse");
-    const encoded = encodeCartCookie(original);
-    expect(decodeCartCookie(encoded)).toBe(original);
-    expect(parseSpy).toHaveBeenCalledWith(original);
-    expect(parseSpy.mock.results[0].type).toBe("throw");
-    parseSpy.mockRestore();
+  it("returns null for missing, empty, or invalid raw values", async () => {
+    const { encodeCartCookie, decodeCartCookie } = await import("../cartCookie");
+    const valid = encodeCartCookie("payload");
+    const [, sig] = valid.split(".");
+    const cases = [undefined, null, "", "abc", `.${sig}`, "payload."];
+    for (const raw of cases) {
+      expect(decodeCartCookie(raw as any)).toBeNull();
+    }
+  });
+
+  it("builds Set-Cookie header", async () => {
+    const { asSetCookieHeader, CART_COOKIE } = await import("../cartCookie");
+    const header = asSetCookieHeader("value");
+    expect(header).toMatch(
+      new RegExp(`^${CART_COOKIE}=value; Path=/; Max-Age=\\d+; SameSite=Strict; Secure; HttpOnly$`)
+    );
+    const noAge = asSetCookieHeader("value", null);
+    expect(noAge).toBe(
+      `${CART_COOKIE}=value; Path=/; SameSite=Strict; Secure; HttpOnly`
+    );
   });
 });
+


### PR DESCRIPTION
## Summary
- add comprehensive tests for cart cookie utilities covering secret caching, encoding/decoding, tamper detection and cookie header options

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test src/__tests__/cartCookie.test.ts -- --coverage=false` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d94c5d08832f93e43b6239594f55