### PR TITLE
test: add currency validation tests

### DIFF
--- a/packages/shared-utils/src/__tests__/formatCurrency.test.ts
+++ b/packages/shared-utils/src/__tests__/formatCurrency.test.ts
@@ -28,7 +28,7 @@ describe("formatCurrency", () => {
     }
   );
 
-  it.each([12345, 12345.6])(
+  it.each([12345, 12345.6]) (
     "converts and rounds minor units %p correctly",
     (minor) => {
       const expected = new Intl.NumberFormat(undefined, {
@@ -39,7 +39,7 @@ describe("formatCurrency", () => {
     }
   );
 
-  it.each([-12345, -12345.6])(
+  it.each([-12345, -12345.6]) (
     "formats negative minor-unit amount %p",
     (minor) => {
       const expected = new Intl.NumberFormat(undefined, {
@@ -50,7 +50,7 @@ describe("formatCurrency", () => {
     }
   );
 
-  it.each(["de-DE", "fr-FR"])(
+  it.each(["de-DE", "fr-FR"]) (
     "uses explicit locale %s over default locale",
     (locale) => {
       const minor = 123456; // $1234.56
@@ -64,4 +64,40 @@ describe("formatCurrency", () => {
       );
     }
   );
+
+  it("formats lowercase currency codes", () => {
+    const amount = 100; // $1.00
+    const expected = new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+    }).format(1);
+    expect(formatCurrency(amount, "usd")).toBe(expected);
+  });
+
+  it("throws RangeError for invalid currency pattern", () => {
+    expect(() => formatCurrency(100, "EU" as any)).toThrow(RangeError);
+  });
+
+  it("throws RangeError when Intl.supportedValuesOf excludes the code", () => {
+    const original = (Intl as any).supportedValuesOf;
+    (Intl as any).supportedValuesOf = () => ["USD", "EUR"];
+    try {
+      expect(() => formatCurrency(100, "ABC")).toThrow(RangeError);
+    } finally {
+      if (original) {
+        (Intl as any).supportedValuesOf = original;
+      } else {
+        delete (Intl as any).supportedValuesOf;
+      }
+    }
+  });
+
+  it("formats EUR in German locale", () => {
+    const minor = 12345; // 123.45
+    const expected = new Intl.NumberFormat("de-DE", {
+      style: "currency",
+      currency: "EUR",
+    }).format(123.45);
+    expect(formatCurrency(minor, "EUR", "de-DE")).toBe(expected);
+  });
 });

--- a/packages/shared-utils/src/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/src/__tests__/formatPrice.test.ts
@@ -21,14 +21,14 @@ describe("formatPrice", () => {
     );
   });
 
-  it.each(["BAD", "US", ""])(
+  it.each(["BAD", "US", ""]) (
     "throws RangeError for invalid currency %s",
     (currency) => {
       expect(() => formatPrice(1, currency as any)).toThrow(RangeError);
     }
   );
 
-  it.each([123.456, 1.005])(
+  it.each([123.456, 1.005]) (
     "rounds fractional amount %p correctly",
     (amount) => {
       const expected = new Intl.NumberFormat(undefined, {
@@ -39,7 +39,7 @@ describe("formatPrice", () => {
     }
   );
 
-  it.each([-1, -123.45])("formats negative amount %p", (amount) => {
+  it.each([-1, -123.45]) ("formats negative amount %p", (amount) => {
     const expected = new Intl.NumberFormat(undefined, {
       style: "currency",
       currency: "USD",
@@ -47,7 +47,7 @@ describe("formatPrice", () => {
     expect(formatPrice(amount)).toBe(expected);
   });
 
-  it.each(["de-DE", "ja-JP"])(
+  it.each(["de-DE", "ja-JP"]) (
     "uses explicit locale %s over default locale",
     (locale) => {
       const amount = 1234.56;
@@ -63,4 +63,34 @@ describe("formatPrice", () => {
       }
     }
   );
+
+  it("throws when Intl.supportedValuesOf excludes the currency", () => {
+    const original = (Intl as any).supportedValuesOf;
+    (Intl as any).supportedValuesOf = () => ["USD", "EUR"];
+    try {
+      expect(() => formatPrice(10, "BTC")).toThrow(RangeError);
+    } finally {
+      if (original) {
+        (Intl as any).supportedValuesOf = original;
+      } else {
+        delete (Intl as any).supportedValuesOf;
+      }
+    }
+  });
+
+  it("formats when Intl.supportedValuesOf is not available", () => {
+    const original = (Intl as any).supportedValuesOf;
+    delete (Intl as any).supportedValuesOf;
+    const amount = 12.34;
+    const expected = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(amount);
+    expect(formatPrice(amount, "USD", "en-US")).toBe(expected);
+    if (original) {
+      (Intl as any).supportedValuesOf = original;
+    } else {
+      delete (Intl as any).supportedValuesOf;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add Intl.supportedValuesOf coverage for formatPrice
- test formatCurrency with lowercase input and unsupported currencies

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils run build`
- `pnpm --filter @acme/shared-utils exec jest src/__tests__/formatPrice.test.ts src/__tests__/formatCurrency.test.ts --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9d94d89e8832fa91283dcb1e0ed28