### PR TITLE
chore: improve stackdump error reporting

### DIFF
--- a/apps/cms/dev-hooks/stackdump.js
+++ b/apps/cms/dev-hooks/stackdump.js
@@ -4,7 +4,15 @@ if (!global.__STACKDUMP_INSTALLED__) {
   global.__STACKDUMP_INSTALLED__ = true;
 
   // Don't monkey‑patch require at all; it creates noise from optional probes.
-  const fmt = (x) => (x && x.stack ? x.stack : String(x));
+  const fmt = (x) => {
+    if (x && x.stack) return x.stack;
+    try {
+      const str = JSON.stringify(x);
+      return typeof str === "string" ? str : String(x);
+    } catch {
+      return String(x);
+    }
+  };
 
   process.on("uncaughtException", (err) => {
     console.error("[dev-hooks] uncaughtException\n", fmt(err));


### PR DESCRIPTION
## Summary
- improve dev stackdump logging: fall back to JSON.stringify when no stack is available

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fd46c60c832f8796c791cbccd67a