### PR TITLE
refactor: remove write-json-file from RBAC store

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -28,8 +28,7 @@
     "color-contrast-checker": "^2.1.0",
     "dompurify": "^3.2.6",
     "file-type": "^21.0.0",
-    "validator": "^13.15.15",
-    "write-json-file": "^6.0.0"
+    "validator": "^13.15.15"
   },
   "devDependencies": {
     "@types/busboy": "^1.5.4",

--- a/apps/cms/src/lib/server/rbacStore.ts
+++ b/apps/cms/src/lib/server/rbacStore.ts
@@ -8,7 +8,7 @@ import { ROLE_PERMISSIONS } from "@auth/permissions";
 import * as fsSync from "fs";
 import { promises as fs } from "fs";
 import * as path from "path";
-import writeJsonFile from "write-json-file";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 import type { Role } from "../../auth/roles";
 
 export interface RbacDB {
@@ -105,6 +105,6 @@ export async function writeRbac(
   }
   await fs.mkdir(path.dirname(FILE), { recursive: true });
   const tmp = `${FILE}.${Date.now()}.tmp`;
-  await writeJsonFile(tmp, db, { indent: 2 });
+  await writeJsonFile(tmp, db);
   await fs.rename(tmp, FILE);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,9 +473,6 @@ importers:
       validator:
         specifier: ^13.15.15
         version: 13.15.15
-      write-json-file:
-        specifier: ^6.0.0
-        version: 6.0.0
     devDependencies:
       '@types/busboy':
         specifier: ^1.5.4
@@ -6003,10 +6000,6 @@ packages:
     resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
     engines: {node: '>=0.10.0'}
 
-  detect-indent@7.0.1:
-    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
-    engines: {node: '>=12.20'}
-
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
@@ -7636,10 +7629,6 @@ packages:
 
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
-
-  is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
   is-plain-object@5.0.0:
@@ -10119,10 +10108,6 @@ packages:
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
-  sort-keys@5.1.0:
-    resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
-    engines: {node: '>=12'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -11240,14 +11225,6 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
-  write-file-atomic@5.0.1:
-    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  write-json-file@6.0.0:
-    resolution: {integrity: sha512-MNHcU3f9WxnNyR6MxsYSj64Jz0+dwIpisWKWq9gqLj/GwmA9INg3BZ3vt70/HB3GEwrnDQWr4RPrywnhNzmUFA==}
-    engines: {node: '>=18'}
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -16922,8 +16899,6 @@ snapshots:
 
   detect-file@1.0.0: {}
 
-  detect-indent@7.0.1: {}
-
   detect-libc@2.0.4: {}
 
   detect-newline@3.1.0: {}
@@ -18761,8 +18736,6 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-path-inside@4.0.0: {}
-
-  is-plain-obj@4.1.0: {}
 
   is-plain-object@5.0.0: {}
 
@@ -21730,10 +21703,6 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
-  sort-keys@5.1.0:
-    dependencies:
-      is-plain-obj: 4.1.0
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
@@ -23035,18 +23004,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-
-  write-file-atomic@5.0.1:
-    dependencies:
-      imurmurhash: 0.1.4
-      signal-exit: 4.1.0
-
-  write-json-file@6.0.0:
-    dependencies:
-      detect-indent: 7.0.1
-      is-plain-obj: 4.1.0
-      sort-keys: 5.1.0
-      write-file-atomic: 5.0.1
 
   ws@7.5.10: {}
 


### PR DESCRIPTION
## Summary
- use local jsonIO.writeJsonFile in RBAC store
- drop write-json-file dependency from cms app

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm --filter @apps/cms test` *(fails: InventoryForm export test and marketingEmailApi segment test)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0af20b60832fbaa99d196c5ccc92