### PR TITLE
Use local JSON helper in configurator progress API

### DIFF
--- a/apps/cms/src/app/api/configurator-progress/route.ts
+++ b/apps/cms/src/app/api/configurator-progress/route.ts
@@ -5,7 +5,7 @@ import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import * as fsSync from "fs";
-import { writeJsonFile } from "@acme/shared-utils";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 import path from "path";
 import {
   configuratorStateSchema,
@@ -87,7 +87,6 @@ async function writeDb(db: unknown): Promise<void> {
   }
   const payload = parsed.data;
   const json = JSON.stringify(payload, null, 2);
-  await fs.mkdir(path.dirname(FILE), { recursive: true });
   const tmp = `${FILE}.${Date.now()}.tmp`;
   try {
     console.log("[configurator-progress] write", {


### PR DESCRIPTION
## Summary
- use internal `writeJsonFile` helper in configurator progress API
- remove redundant manual directory creation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @apps/cms build` *(fails: Can't resolve '@acme/telemetry')*
- `pnpm --filter @apps/cms test` *(fails: write-json-file cannot be parsed)*


------
https://chatgpt.com/codex/tasks/task_e_68ba0b00d444832fa8a050d8437818ff