### PR TITLE
refactor: centralize CMS JSON writes

### DIFF
--- a/apps/cms/src/actions/deployShop.server.ts
+++ b/apps/cms/src/actions/deployShop.server.ts
@@ -5,6 +5,7 @@ import { deployShop, type DeployShopResult } from "@platform-core/createShop";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import fs from "fs/promises";
 import path from "path";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 import { ensureAuthorized } from "./common/auth";
 
 export async function deployShopHosting(
@@ -43,8 +44,7 @@ export async function updateDeployStatus(
     const existing = await fs.readFile(file, "utf8").catch(() => "{}");
     const parsed = JSON.parse(existing) as Record<string, unknown>;
     const updated = { ...parsed, ...data };
-    await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, JSON.stringify(updated, null, 2), "utf8");
+    await writeJsonFile(file, updated);
   } catch (err) {
     console.error("Failed to write deploy status", err);
   }

--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -5,6 +5,7 @@ import { validateShopName } from "@platform-core/shops";
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { promises as fs } from "fs";
 import * as path from "path";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 import sharp from "sharp";
 import { ulid } from "ulid";
 import { ensureAuthorized } from "./common/auth";
@@ -41,7 +42,7 @@ async function writeMetadata(
   shop: string,
   data: Record<string, { title?: string; altText?: string; type?: "image" | "video" }>
 ): Promise<void> {
-  await fs.writeFile(metadataPath(shop), JSON.stringify(data, null, 2));
+  await writeJsonFile(metadataPath(shop), data);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/src/app/api/categories/[shop]/route.ts
+++ b/apps/cms/src/app/api/categories/[shop]/route.ts
@@ -1,9 +1,9 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { promises as fs } from "fs";
 import path from "path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 export async function POST(
   req: NextRequest,
@@ -17,12 +17,7 @@ export async function POST(
     const categories = await req.json();
     const { shop } = await context.params;
     const dir = path.join(resolveDataRoot(), shop);
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(
-      path.join(dir, "categories.json"),
-      JSON.stringify(categories, null, 2),
-      "utf8"
-    );
+    await writeJsonFile(path.join(dir, "categories.json"), categories);
     return NextResponse.json({ success: true });
   } catch (err) {
     return NextResponse.json(

--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -8,6 +8,7 @@ import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "@platform-core/shops";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 /**
  * POST /cms/api/configurator/init-shop
@@ -65,11 +66,7 @@ export async function POST(req: Request) {
       await fs.writeFile(path.join(dir, "products.csv"), buf);
     }
     if (categories) {
-      await fs.writeFile(
-        path.join(dir, "categories.json"),
-        JSON.stringify(categories, null, 2),
-        "utf8"
-      );
+      await writeJsonFile(path.join(dir, "categories.json"), categories);
     }
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/apps/cms/src/app/api/marketing/discounts/route.ts
+++ b/apps/cms/src/app/api/marketing/discounts/route.ts
@@ -7,6 +7,7 @@ import { resolveDataRoot } from "@platform-core/dataRoot";
 import { listEvents } from "@platform-core/repositories/analytics.server";
 import { coreEnv as env } from "@acme/config/env/core";
 import type { Coupon } from "@acme/types";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 interface Discount extends Coupon {
   active?: boolean;
@@ -37,8 +38,7 @@ async function readDiscounts(shop: string): Promise<Discount[]> {
 
 async function writeDiscounts(shop: string, discounts: Discount[]): Promise<void> {
   const fp = filePath(shop);
-  await fs.mkdir(path.dirname(fp), { recursive: true });
-  await fs.writeFile(fp, JSON.stringify(discounts, null, 2), "utf8");
+  await writeJsonFile(fp, discounts);
 }
 
 async function requireAdmin() {

--- a/apps/cms/src/app/api/providers/[provider]/route.ts
+++ b/apps/cms/src/app/api/providers/[provider]/route.ts
@@ -1,9 +1,9 @@
 import "@acme/zod-utils/initZod";
 import { NextRequest, NextResponse } from "next/server";
-import { promises as fs } from "fs";
 import path from "path";
 import { z } from "zod";
 import { resolveDataRoot } from "@platform-core/dataRoot";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 const ParamsSchema = z
   .object({ shop: z.string(), code: z.string().optional() })
@@ -30,12 +30,7 @@ export async function GET(
   }
 
   const dir = path.join(resolveDataRoot(), shop);
-  await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(
-    path.join(dir, `${provider}.json`),
-    JSON.stringify({ token: code }, null, 2),
-    "utf8"
-  );
+  await writeJsonFile(path.join(dir, `${provider}.json`), { token: code });
 
   return NextResponse.redirect(`/cms/configurator?connected=${provider}`);
 }

--- a/apps/cms/src/app/api/providers/shop/[shop]/route.ts
+++ b/apps/cms/src/app/api/providers/shop/[shop]/route.ts
@@ -2,11 +2,11 @@ import "@acme/zod-utils/initZod";
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { promises as fs } from "fs";
 import path from "path";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { z } from "zod";
 import { parseJsonBody } from "@shared-utils";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 const schema = z
   .object({
@@ -28,12 +28,7 @@ export async function POST(
     if (parsed.success === false) return parsed.response;
     const { shop } = await context.params;
     const dir = path.join(resolveDataRoot(), shop);
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(
-      path.join(dir, "providers.json"),
-      JSON.stringify(parsed.data, null, 2),
-      "utf8"
-    );
+    await writeJsonFile(path.join(dir, "providers.json"), parsed.data);
     return NextResponse.json({ success: true });
   } catch (err) {
     return NextResponse.json(

--- a/apps/cms/src/app/api/segments/route.ts
+++ b/apps/cms/src/app/api/segments/route.ts
@@ -2,6 +2,7 @@ import "@acme/zod-utils/initZod";
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 import { DATA_ROOT } from "@platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 import { z } from "zod";
@@ -24,8 +25,7 @@ async function readSegments(shop: string): Promise<Segment[]> {
 }
 
 async function writeSegments(shop: string, items: Segment[]): Promise<void> {
-  await fs.mkdir(path.dirname(segmentsPath(shop)), { recursive: true });
-  await fs.writeFile(segmentsPath(shop), JSON.stringify(items, null, 2), "utf8");
+  await writeJsonFile(segmentsPath(shop), items);
 }
 
 export async function GET(req: NextRequest): Promise<NextResponse> {

--- a/apps/cms/src/app/api/seo/generate/route.ts
+++ b/apps/cms/src/app/api/seo/generate/route.ts
@@ -3,6 +3,7 @@ import { DATA_ROOT } from "@platform-core/dataRoot";
 import { validateShopName } from "@acme/lib";
 import fs from "fs/promises";
 import path from "path";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 interface Body {
   shop: string;
@@ -28,7 +29,6 @@ export async function POST(req: NextRequest) {
   });
 
   const file = path.join(DATA_ROOT, shop, "seo.json");
-  await fs.mkdir(path.dirname(file), { recursive: true });
   let current: Record<string, unknown> = {};
   try {
     const buf = await fs.readFile(file, "utf8");
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
     /* ignore */
   }
   current[body.id] = result;
-  await fs.writeFile(file, JSON.stringify(current, null, 2), "utf8");
+  await writeJsonFile(file, current);
 
   return NextResponse.json(result);
 }

--- a/apps/cms/src/app/api/themes/[themeId]/route.ts
+++ b/apps/cms/src/app/api/themes/[themeId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import { themeLibrarySchema, type ThemeLibraryEntry } from "@acme/theme";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 const LIB_PATH = path.join(process.cwd(), "data", "themes", "library.json");
 
@@ -15,8 +16,7 @@ async function readLibrary(): Promise<ThemeLibraryEntry[]> {
 }
 
 async function writeLibrary(themes: ThemeLibraryEntry[]) {
-  await fs.mkdir(path.dirname(LIB_PATH), { recursive: true });
-  await fs.writeFile(LIB_PATH, JSON.stringify(themes, null, 2), "utf8");
+  await writeJsonFile(LIB_PATH, themes);
 }
 
 export async function GET(

--- a/apps/cms/src/app/api/themes/route.ts
+++ b/apps/cms/src/app/api/themes/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import { themeLibrarySchema, type ThemeLibraryEntry } from "@acme/theme";
+import { writeJsonFile } from "@/lib/server/jsonIO";
 
 const LIB_PATH = path.join(process.cwd(), "data", "themes", "library.json");
 
@@ -15,8 +16,7 @@ async function readLibrary(): Promise<ThemeLibraryEntry[]> {
 }
 
 async function writeLibrary(themes: ThemeLibraryEntry[]) {
-  await fs.mkdir(path.dirname(LIB_PATH), { recursive: true });
-  await fs.writeFile(LIB_PATH, JSON.stringify(themes, null, 2), "utf8");
+  await writeJsonFile(LIB_PATH, themes);
 }
 
 export async function GET() {


### PR DESCRIPTION
## Summary
- replace direct fs.writeFile JSON outputs with writeJsonFile helper across CMS actions and API routes
- ensure categories, segments, providers, themes and other endpoints serialize data consistently

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm test:cms` *(terminated after extended run)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0d266b88832f8fd9ff436f334956