### PR TITLE
chore(lib): exclude tests from build

### DIFF
--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -21,7 +21,8 @@
   "exclude": [
     "dist", // freshly emitted output
     ".turbo", // turbo cache
-    "node_modules" // package deps (if any local)
+    "node_modules", // package deps (if any local)
+    "src/__tests__" // test files
   ],
 
   "references": [


### PR DESCRIPTION
## Summary
- avoid typechecking test files in lib

## Testing
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `pnpm --filter @acme/lib build` *(fails: Output file '/workspace/base-shop/packages/platform-core/dist/dataRoot.d.ts' has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68ba92becca0832f9e6aa39bf26c6089