### PR TITLE
feat(auth): add env test harness

### DIFF
--- a/packages/auth/src/__tests__/envTestUtils.ts
+++ b/packages/auth/src/__tests__/envTestUtils.ts
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+
+export async function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<void> | void,
+): Promise<void> {
+  const originalEnv = process.env;
+  process.env = { ...originalEnv };
+
+  try {
+    for (const [key, value] of Object.entries(vars)) {
+      if (typeof value === "undefined") {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    jest.resetModules();
+
+    await new Promise<void>((resolve, reject) => {
+      jest.isolateModules(async () => {
+        try {
+          await fn();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  } finally {
+    process.env = originalEnv;
+  }
+}
+
+export async function importFresh<T = unknown>(path: string): Promise<T> {
+  let mod: T;
+
+  await new Promise<void>((resolve, reject) => {
+    jest.isolateModules(async () => {
+      try {
+        mod = (await import(path)) as T;
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+
+  return mod!;
+}
+


### PR DESCRIPTION
## Summary
- add shared env test harness for isolating module imports and toggling process.env

## Testing
- `pnpm exec jest packages/auth/src/__tests__/memoryStore.test.ts`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/auth build` *(fails: TS2307 Cannot find module '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68baac628ba0832fa7f1eb77cd75565c