### PR TITLE
test: add Sanity CMS env coverage

### DIFF
--- a/packages/auth/src/__tests__/env.cms.test.ts
+++ b/packages/auth/src/__tests__/env.cms.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+const baseEnv = {
+  NODE_ENV: "production",
+  CMS_SPACE_URL: "https://cms.example.com",
+  CMS_ACCESS_TOKEN: "token",
+  SANITY_API_VERSION: "2024-01-01",
+  SANITY_PROJECT_ID: "proj",
+  SANITY_DATASET: "dataset",
+} as NodeJS.ProcessEnv;
+
+const ORIGINAL_ENV = process.env;
+
+afterEach(() => {
+  jest.resetModules();
+  process.env = ORIGINAL_ENV;
+});
+
+describe("cms sanity env", () => {
+  it("throws when SANITY_PROJECT_ID is missing", async () => {
+    process.env = { ...baseEnv };
+    delete process.env.SANITY_PROJECT_ID;
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("@acme/config/env/cms"))
+      .rejects.toThrow("Invalid CMS environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("defaults SANITY_DATASET when missing", async () => {
+    process.env = { ...baseEnv };
+    delete process.env.SANITY_DATASET;
+    const { cmsEnv } = await import("@acme/config/env/cms");
+    expect(cmsEnv.SANITY_DATASET).toBe("production");
+  });
+
+  it("is read-only when SANITY_API_TOKEN absent", async () => {
+    process.env = { ...baseEnv };
+    const { cmsEnv } = await import("@acme/config/env/cms");
+    expect(cmsEnv.SANITY_API_TOKEN).toBeUndefined();
+  });
+
+  it("enables write when SANITY_API_TOKEN provided", async () => {
+    process.env = { ...baseEnv, SANITY_API_TOKEN: "tok" };
+    const { cmsEnv } = await import("@acme/config/env/cms");
+    expect(cmsEnv.SANITY_API_TOKEN).toBe("tok");
+  });
+
+  it("enables preview when SANITY_PREVIEW_SECRET set", async () => {
+    process.env = { ...baseEnv, SANITY_PREVIEW_SECRET: "secret" };
+    const { cmsEnv } = await import("@acme/config/env/cms");
+    expect(cmsEnv.SANITY_PREVIEW_SECRET).toBe("secret");
+  });
+
+  it("disables preview when SANITY_PREVIEW_SECRET missing", async () => {
+    process.env = { ...baseEnv };
+    const { cmsEnv } = await import("@acme/config/env/cms");
+    expect(cmsEnv.SANITY_PREVIEW_SECRET).toBeUndefined();
+  });
+
+  it("parses SANITY_BASE_URL when valid", async () => {
+    process.env = { ...baseEnv, SANITY_BASE_URL: "https://sanity.example.com/" };
+    const { cmsEnv } = await import("@acme/config/env/cms");
+    expect(cmsEnv.SANITY_BASE_URL).toBe("https://sanity.example.com");
+  });
+
+  it("throws when SANITY_BASE_URL is invalid", async () => {
+    process.env = { ...baseEnv, SANITY_BASE_URL: "not-a-url" };
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(import("@acme/config/env/cms"))
+      .rejects.toThrow("Invalid CMS environment variables");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "❌ Invalid CMS environment variables:",
+      expect.objectContaining({
+        SANITY_BASE_URL: { _errors: expect.arrayContaining([expect.any(String)]) },
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/config/src/env/cms.ts
+++ b/packages/config/src/env/cms.ts
@@ -18,8 +18,8 @@ export const cmsEnvSchema = z.object({
     ? z.string().min(1)
     : z.string().min(1).default("dummy-project-id"),
   SANITY_DATASET: z.string().min(1).default("production"),
-  SANITY_API_TOKEN: z.string().min(1).default("dummy-api-token"),
-  SANITY_PREVIEW_SECRET: z.string().min(1).default("dummy-preview-secret"),
+  SANITY_API_TOKEN: z.string().min(1).optional(),
+  SANITY_PREVIEW_SECRET: z.string().min(1).optional(),
   SANITY_BASE_URL: z
     .string()
     .url()


### PR DESCRIPTION
## Summary
- allow optional Sanity API token and preview secret in CMS env schema
- add tests for CMS env handling covering read-only, preview, and URL validation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/config exec jest src/env/__tests__/cms.env.test.ts --runInBand --config jest.preset.cjs`
- `pnpm --filter @acme/auth exec jest src/__tests__/env.cms.test.ts src/__tests__/memoryStore.test.ts src/__tests__/mfa.test.ts src/__tests__/redisStore.test.ts src/__tests__/session.test.ts src/__tests__/store.test.ts --runTestsByPath --runInBand --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68baac8ea17c832fba202bf17e11d75a