### PR TITLE
chore: add sanity defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ After running `pnpm create-shop <id>`, the CLI generates `.env` and `.env.templa
 - `SENDGRID_WEBHOOK_PUBLIC_KEY` – public key to verify SendGrid event webhook signatures
 - `RESEND_WEBHOOK_SECRET` – secret used to verify Resend webhook signatures
 
+### Sanity blog plugin variables
+
+The `cmsEnvSchema` and each app's `.env.production` file include **DO NOT REMOVE** comments with placeholder Sanity credentials:
+
+- `SANITY_PROJECT_ID`
+- `SANITY_API_VERSION`
+- `SANITY_DATASET`
+- `SANITY_API_TOKEN`
+- `SANITY_PREVIEW_SECRET`
+
+These dummy values keep the build working until a real Sanity project is configured. Replace them with production credentials, but do not remove the variables until a feature flag or conditional logic can skip the Sanity setup.
+
 SendGrid and Resend can be configured to POST event webhooks to:
 
 - `/api/marketing/email/provider-webhooks/sendgrid?shop=<SHOP_ID>`

--- a/apps/cms/.env.production
+++ b/apps/cms/.env.production
@@ -1,3 +1,9 @@
+# DO NOT REMOVE: required for Sanity blog plugin until real credentials are provided
+SANITY_PROJECT_ID=dummy-project-id
+SANITY_API_VERSION=2021-10-21
+SANITY_DATASET=production
+SANITY_API_TOKEN=dummy-api-token
+SANITY_PREVIEW_SECRET=dummy-preview-secret
 # TODO: Replace Stripe dummy values with real credentials before deployment
 STRIPE_SECRET_KEY=dummy-stripe-secret
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy-publishable-key

--- a/apps/template-app/.env.production
+++ b/apps/template-app/.env.production
@@ -1,3 +1,9 @@
+# DO NOT REMOVE: required for Sanity blog plugin until real credentials are provided
+SANITY_PROJECT_ID=dummy-project-id
+SANITY_API_VERSION=2021-10-21
+SANITY_DATASET=production
+SANITY_API_TOKEN=dummy-api-token
+SANITY_PREVIEW_SECRET=dummy-preview-secret
 # TODO: Replace Stripe dummy values with real credentials before deployment
 STRIPE_SECRET_KEY=dummy-stripe-secret
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy-publishable-key

--- a/packages/config/src/env/cms.ts
+++ b/packages/config/src/env/cms.ts
@@ -10,16 +10,14 @@ export const cmsEnvSchema = z.object({
   CMS_ACCESS_TOKEN: isProd
     ? z.string().min(1)
     : z.string().min(1).default("placeholder-token"),
-  // TODO: Replace dummy Sanity defaults with real project values or make optional for non‑Sanity shops
-  SANITY_API_VERSION: isProd
-    ? z.string().min(1)
-    : z.string().min(1).default("2021-10-21"),
-  SANITY_PROJECT_ID: isProd
-    ? z.string().min(1)
-    : z.string().min(1).default("dummy-project-id"),
+  // DO NOT REMOVE: required dummy values for the Sanity blog plugin.
+  // Replace these with real credentials and remove defaults once set up.
+  // TODO/DO NOT REMOVE: these dummy defaults are required until a real Sanity project is configured.
+  SANITY_API_VERSION: z.string().min(1).default("2021-10-21"),
+  SANITY_PROJECT_ID: z.string().min(1).default("dummy-project-id"),
   SANITY_DATASET: z.string().min(1).default("production"),
-  SANITY_API_TOKEN: z.string().min(1).optional(),
-  SANITY_PREVIEW_SECRET: z.string().min(1).optional(),
+  SANITY_API_TOKEN: z.string().min(1).default("dummy-api-token"),
+  SANITY_PREVIEW_SECRET: z.string().min(1).default("dummy-preview-secret"),
   SANITY_BASE_URL: z
     .string()
     .url()


### PR DESCRIPTION
## Summary
- provide Sanity dummy defaults in cmsEnvSchema
- add placeholder Sanity variables to production env files
- document Sanity env variable requirements

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bab31bcec8832f9b324e72afe67b6a