### PR TITLE
test: update cms env defaults

### DIFF
--- a/packages/config/src/env/__tests__/cms.env.test.ts
+++ b/packages/config/src/env/__tests__/cms.env.test.ts
@@ -17,15 +17,12 @@ afterEach(() => {
 });
 
 describe("cms sanity env", () => {
-  it("throws when SANITY_PROJECT_ID is missing", async () => {
+  it("defaults SANITY_PROJECT_ID when missing", async () => {
     process.env = { ...baseEnv };
     delete process.env.SANITY_PROJECT_ID;
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    await expect(import("../cms.ts")).rejects.toThrow(
-      "Invalid CMS environment variables",
-    );
-    expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
+    jest.resetModules();
+    const { cmsEnv } = await import("../cms.ts");
+    expect(cmsEnv.SANITY_PROJECT_ID).toBe("dummy-project-id");
   });
 
   it("defaults SANITY_DATASET when missing", async () => {
@@ -36,11 +33,11 @@ describe("cms sanity env", () => {
     expect(cmsEnv.SANITY_DATASET).toBe("production");
   });
 
-  it("is read-only when SANITY_API_TOKEN absent", async () => {
+  it("defaults SANITY_API_TOKEN when missing", async () => {
     process.env = { ...baseEnv };
     jest.resetModules();
     const { cmsEnv } = await import("../cms.ts");
-    expect(cmsEnv.SANITY_API_TOKEN).toBeUndefined();
+    expect(cmsEnv.SANITY_API_TOKEN).toBe("dummy-api-token");
   });
 
   it("enables write when SANITY_API_TOKEN provided", async () => {
@@ -57,11 +54,11 @@ describe("cms sanity env", () => {
     expect(cmsEnv.SANITY_PREVIEW_SECRET).toBe("secret");
   });
 
-  it("disables preview when SANITY_PREVIEW_SECRET missing", async () => {
+  it("defaults SANITY_PREVIEW_SECRET when missing", async () => {
     process.env = { ...baseEnv };
     jest.resetModules();
     const { cmsEnv } = await import("../cms.ts");
-    expect(cmsEnv.SANITY_PREVIEW_SECRET).toBeUndefined();
+    expect(cmsEnv.SANITY_PREVIEW_SECRET).toBe("dummy-preview-secret");
   });
 
   it("parses SANITY_BASE_URL when valid", async () => {


### PR DESCRIPTION
## Summary
- adjust cms env tests for default SANITY values

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/config exec jest src/env/__tests__/cms.env.test.ts --runInBand --config jest.preset.cjs`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bab6ca285c832f88ecebcd6d6b3fc3