### PR TITLE
test: cover auth env schema branches

### DIFF
--- a/packages/auth/src/__tests__/authEnvSchema.test.ts
+++ b/packages/auth/src/__tests__/authEnvSchema.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+const REDIS_URL = "https://redis.example.com";
+const STRONG_TOKEN = "strongtokenstrongtokenstrongtoken!!";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("AUTH_TOKEN_TTL normalisation", () => {
+  it("trims and converts minutes to seconds", async () => {
+    const { authEnv, normalized } = await withEnv(
+      { AUTH_TOKEN_TTL: " 5 m ", NODE_ENV: "development" },
+      async () => {
+        const mod = await import("@acme/config/env/auth");
+        return { authEnv: mod.authEnv, normalized: process.env.AUTH_TOKEN_TTL };
+      },
+    );
+
+    expect(authEnv.AUTH_TOKEN_TTL).toBe(300);
+    expect(normalized).toBe("5m");
+  });
+});
+
+describe("redis session store requirements", () => {
+  it("requires redis token", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { SESSION_STORE: "redis", UPSTASH_REDIS_REST_URL: REDIS_URL },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        UPSTASH_REDIS_REST_TOKEN: {
+          _errors: expect.arrayContaining([
+            "UPSTASH_REDIS_REST_TOKEN is required when SESSION_STORE=redis",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+
+  it("requires redis url", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { SESSION_STORE: "redis", UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        UPSTASH_REDIS_REST_URL: {
+          _errors: expect.arrayContaining([
+            "UPSTASH_REDIS_REST_URL is required when SESSION_STORE=redis",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+
+  it("parses redis config when url and token present", async () => {
+    const { authEnv } = await withEnv(
+      {
+        SESSION_STORE: "redis",
+        UPSTASH_REDIS_REST_URL: REDIS_URL,
+        UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
+      },
+      () => import("@acme/config/env/auth"),
+    );
+    expect(authEnv.SESSION_STORE).toBe("redis");
+  });
+});
+
+describe("rate limit redis credentials", () => {
+  it("requires token when url provided", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { LOGIN_RATE_LIMIT_REDIS_URL: REDIS_URL },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        LOGIN_RATE_LIMIT_REDIS_TOKEN: {
+          _errors: expect.arrayContaining([
+            "LOGIN_RATE_LIMIT_REDIS_TOKEN is required when LOGIN_RATE_LIMIT_REDIS_URL is set",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+
+  it("requires url when token provided", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { LOGIN_RATE_LIMIT_REDIS_TOKEN: STRONG_TOKEN },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        LOGIN_RATE_LIMIT_REDIS_URL: {
+          _errors: expect.arrayContaining([
+            "LOGIN_RATE_LIMIT_REDIS_URL is required when LOGIN_RATE_LIMIT_REDIS_TOKEN is set",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("auth provider specific checks", () => {
+  it("requires JWT_SECRET for jwt provider", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { AUTH_PROVIDER: "jwt" },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        JWT_SECRET: {
+          _errors: expect.arrayContaining([
+            "JWT_SECRET is required when AUTH_PROVIDER=jwt",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+
+  it("parses jwt provider when secret present", async () => {
+    const { authEnv } = await withEnv(
+      { AUTH_PROVIDER: "jwt", JWT_SECRET: STRONG_TOKEN },
+      () => import("@acme/config/env/auth"),
+    );
+    expect(authEnv.AUTH_PROVIDER).toBe("jwt");
+  });
+
+  it("requires OAUTH_CLIENT_ID for oauth provider", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { AUTH_PROVIDER: "oauth", OAUTH_CLIENT_SECRET: STRONG_TOKEN },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        OAUTH_CLIENT_ID: {
+          _errors: expect.arrayContaining([
+            "OAUTH_CLIENT_ID is required when AUTH_PROVIDER=oauth",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+
+  it("requires OAUTH_CLIENT_SECRET for oauth provider", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { AUTH_PROVIDER: "oauth", OAUTH_CLIENT_ID: "client-id" },
+        () => import("@acme/config/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Invalid auth environment variables:",
+      expect.objectContaining({
+        OAUTH_CLIENT_SECRET: {
+          _errors: expect.arrayContaining([
+            "OAUTH_CLIENT_SECRET is required when AUTH_PROVIDER=oauth",
+          ]),
+        },
+      }),
+    );
+    spy.mockRestore();
+  });
+
+  it("parses oauth provider when credentials present", async () => {
+    const { authEnv } = await withEnv(
+      {
+        AUTH_PROVIDER: "oauth",
+        OAUTH_CLIENT_ID: "client-id",
+        OAUTH_CLIENT_SECRET: STRONG_TOKEN,
+      },
+      () => import("@acme/config/env/auth"),
+    );
+    expect(authEnv.AUTH_PROVIDER).toBe("oauth");
+  });
+});
+


### PR DESCRIPTION
## Summary
- test AUTH_TOKEN_TTL normalization
- validate redis store and rate-limit credential requirements
- enforce jwt and oauth provider env vars

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm --filter @acme/auth exec jest packages/auth/src/__tests__/authEnvSchema.test.ts --config ../../jest.config.cjs --runInBand --detectOpenHandles --ci`

------
https://chatgpt.com/codex/tasks/task_e_68bab7864098832fa0ceb3a6919f5f7d