### PR TITLE
test email default sender fallback

### DIFF
--- a/packages/auth/src/__tests__/emailConfig.test.ts
+++ b/packages/auth/src/__tests__/emailConfig.test.ts
@@ -1,0 +1,38 @@
+import { getDefaultSender } from "@acme/email/config";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("getDefaultSender", () => {
+  it("throws when no sender environment variables are set", () => {
+    delete process.env.CAMPAIGN_FROM;
+    delete process.env.GMAIL_USER;
+    expect(() => getDefaultSender()).toThrow("Default sender email is required");
+  });
+
+  it("throws for invalid sender email", () => {
+    process.env.CAMPAIGN_FROM = "not-an-email";
+    expect(() => getDefaultSender()).toThrow("Invalid sender email address");
+  });
+
+  it("returns normalized CAMPAIGN_FROM email", () => {
+    process.env.CAMPAIGN_FROM = " Test@Example.COM ";
+    expect(getDefaultSender()).toBe("test@example.com");
+  });
+
+  it("falls back to GMAIL_USER when CAMPAIGN_FROM is blank", () => {
+    process.env.CAMPAIGN_FROM = " ";
+    process.env.GMAIL_USER = "USER@EXAMPLE.COM";
+    expect(getDefaultSender()).toBe("user@example.com");
+  });
+
+  it("throws when CAMPAIGN_FROM is blank and GMAIL_USER is unset", () => {
+    process.env.CAMPAIGN_FROM = " ";
+    delete process.env.GMAIL_USER;
+    expect(() => getDefaultSender()).toThrow("Default sender email is required");
+  });
+});
+

--- a/packages/email/src/config.ts
+++ b/packages/email/src/config.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 const emailSchema = z.string().email().transform((v) => v.toLowerCase());
 
 export function getDefaultSender(): string {
-  const sender = (process.env.CAMPAIGN_FROM || process.env.GMAIL_USER || "").trim();
+  const sender =
+    process.env.CAMPAIGN_FROM?.trim() ||
+    process.env.GMAIL_USER?.trim() ||
+    "";
   if (!sender) {
     throw new Error(
       "Default sender email is required. Set CAMPAIGN_FROM or GMAIL_USER."


### PR DESCRIPTION
## Summary
- ensure getDefaultSender trims vars and falls back to GMAIL_USER
- add unit tests for default sender selection

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm --filter @acme/auth run check:references` *(fails: script not found)*
- `pnpm --filter @acme/auth run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/email run check:references` *(fails: script not found)*
- `pnpm --filter @acme/email run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/email build` *(fails: Cannot find module '@jest/globals' in ../config/src/env/core.test.ts)*
- `pnpm --filter @acme/auth build` *(fails: Cannot find module '@jest/globals' in ../config/src/env/core.test.ts)*
- `pnpm exec jest packages/auth/src/__tests__/emailConfig.test.ts --runInBand --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68bab7a0c064832fb030ff3fbbe6cd07