### PR TITLE
test: add core env validation tests

### DIFF
--- a/packages/configurator/src/__tests__/env.core.test.ts
+++ b/packages/configurator/src/__tests__/env.core.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+const ORIGINAL_ENV = process.env;
+
+const withEnv = async <T>(env: NodeJS.ProcessEnv, fn: () => Promise<T>): Promise<T> => {
+  process.env = { ...ORIGINAL_ENV, ...env } as NodeJS.ProcessEnv;
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete (process.env as any)[key];
+  }
+  jest.resetModules();
+  try {
+    return await fn();
+  } finally {
+    process.env = ORIGINAL_ENV;
+  }
+};
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  jest.resetModules();
+});
+
+describe("deposit-release validation", () => {
+  it("reports invalid boolean and number", async () => {
+    await withEnv(
+      {
+        DEPOSIT_RELEASE_ENABLED: "maybe",
+        DEPOSIT_RELEASE_INTERVAL_MS: "abc",
+      },
+      async () => {
+        const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const { loadCoreEnv } = await import("@acme/config/env/core");
+        expect(() => loadCoreEnv()).toThrow("Invalid core environment variables");
+        const calls = spy.mock.calls.map((c) => c[0]);
+        expect(calls).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("DEPOSIT_RELEASE_ENABLED: must be true or false"),
+            expect.stringContaining("DEPOSIT_RELEASE_INTERVAL_MS: must be a number"),
+          ]),
+        );
+        spy.mockRestore();
+      },
+    );
+  });
+
+  it("parses valid values", async () => {
+    await withEnv(
+      {
+        DEPOSIT_RELEASE_ENABLED: "true",
+        DEPOSIT_RELEASE_INTERVAL_MS: "5000",
+      },
+      async () => {
+        const { loadCoreEnv } = await import("@acme/config/env/core");
+        const env = loadCoreEnv();
+        expect(env.DEPOSIT_RELEASE_ENABLED).toBe(true);
+        expect(env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(5000);
+      },
+    );
+  });
+});
+
+describe("requireEnv helper", () => {
+  const getRequire = async () => (await import("@acme/config/env/core")).requireEnv;
+
+  it("parses booleans", async () => {
+    await withEnv({ TEST_BOOL: "TrUe" }, async () => {
+      const requireEnv = await getRequire();
+      expect(requireEnv("TEST_BOOL", "boolean")).toBe(true);
+    });
+    await withEnv({ TEST_BOOL: "0" }, async () => {
+      const requireEnv = await getRequire();
+      expect(requireEnv("TEST_BOOL", "boolean")).toBe(false);
+    });
+  });
+
+  it("throws for invalid boolean", async () => {
+    await withEnv({ TEST_BOOL: "maybe" }, async () => {
+      const requireEnv = await getRequire();
+      expect(() => requireEnv("TEST_BOOL", "boolean")).toThrow(
+        "TEST_BOOL must be a boolean",
+      );
+    });
+  });
+
+  it("throws for missing key", async () => {
+    await withEnv({}, async () => {
+      const requireEnv = await getRequire();
+      expect(() => requireEnv("MISSING", "boolean")).toThrow("MISSING is required");
+    });
+  });
+});
+
+
+describe("NEXT_PUBLIC_BASE_URL validation", () => {
+  it("rejects invalid url", async () => {
+    await withEnv({ NEXT_PUBLIC_BASE_URL: "not a url" }, async () => {
+      const { loadCoreEnv } = await import("@acme/config/env/core");
+      expect(() => loadCoreEnv()).toThrow("Invalid core environment variables");
+    });
+  });
+
+  it("accepts valid url", async () => {
+    await withEnv({ NEXT_PUBLIC_BASE_URL: "https://example.com" }, async () => {
+      const { loadCoreEnv } = await import("@acme/config/env/core");
+      const env = loadCoreEnv();
+      expect(env.NEXT_PUBLIC_BASE_URL).toBe("https://example.com");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for deposit release env parsing and error logging
- verify requireEnv boolean parsing and missing key errors
- ensure NEXT_PUBLIC_BASE_URL validity is enforced

## Testing
- `pnpm --filter @acme/configurator test`

------
https://chatgpt.com/codex/tasks/task_e_68baba1521a0832f82ce671a97ed31dc