### PR TITLE
fix(prisma): correct constructor typing

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -2,6 +2,9 @@ import { loadCoreEnv } from "@acme/config/env/core";
 import { createRequire } from "module";
 import type { PrismaClient } from "./prisma-client";
 
+// Avoid referencing conditional exports from "@prisma/client" directly.
+type PrismaClientCtor = new (...args: any[]) => PrismaClient;
+
 const coreEnv = loadCoreEnv();
 type RentalOrderStub = {
   shop?: string;
@@ -79,9 +82,7 @@ if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
         : `${process.cwd()}/package.json`
     );
     const mod = requirePrisma("@prisma/client");
-    const PrismaClientCtor:
-      | typeof import("@prisma/client").PrismaClient
-      | undefined =
+    const PrismaClientCtor: PrismaClientCtor | undefined =
       (mod as any).PrismaClient ?? (mod as any).default?.PrismaClient;
     if (!PrismaClientCtor) {
       prisma = createStubPrisma();


### PR DESCRIPTION
## Summary
- define Prisma constructor signature without referencing conditional exports
- use local constructor type when instantiating the Prisma client

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build` *(fails: Cannot find module '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68babbe01704832f82ba8a9e40b192bc