### PR TITLE
chore(email): add env test harness

### DIFF
--- a/packages/email/src/__tests__/envTestUtils.ts
+++ b/packages/email/src/__tests__/envTestUtils.ts
@@ -1,0 +1,48 @@
+/** @jest-environment node */
+
+export async function withEnv<T>(
+  vars: Record<string, string | undefined>,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const originalEnv = process.env;
+  process.env = { ...originalEnv };
+
+  try {
+    for (const [key, value] of Object.entries(vars)) {
+      if (typeof value === "undefined") {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    jest.resetModules();
+
+    return await new Promise<T>((resolve, reject) => {
+      jest.isolateModules(async () => {
+        try {
+          const result = await loader();
+          resolve(result);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  } finally {
+    process.env = originalEnv;
+  }
+}
+
+export async function importFresh<T = unknown>(path: string): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    jest.isolateModules(async () => {
+      try {
+        const mod = (await import(path)) as T;
+        resolve(mod);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add test utilities to isolate modules and override env vars for email package

## Testing
- `pnpm --filter @acme/email build` (fails: Cannot find module '@jest/globals')
- `pnpm --filter @acme/email test` (fails: coverage thresholds not met)
- `pnpm --filter @acme/email lint` (fails: Cannot find package '@acme/eslint-plugin-ds')

------
https://chatgpt.com/codex/tasks/task_e_68bac0fc2fbc832f888bd1cc321044b6