### PR TITLE
test(config): cover env schemas in email package

### DIFF
--- a/packages/email/src/__tests__/env.auth.test.ts
+++ b/packages/email/src/__tests__/env.auth.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+const REDIS_URL = "https://example.com";
+const STRONG_TOKEN = "redis-token-32-chars-long-string!";
+
+describe("auth env validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("normalises AUTH_TOKEN_TTL values", async () => {
+    const result = await withEnv(
+      { NODE_ENV: "development", AUTH_TOKEN_TTL: " 5 m " },
+      async () => {
+        const mod = await import("@acme/config/src/env/auth.ts");
+        return { ...mod, ttl: process.env.AUTH_TOKEN_TTL };
+      },
+    );
+    expect(result.ttl).toBe("5m");
+    expect(result.authEnv.AUTH_TOKEN_TTL).toBe(300);
+  });
+
+  it("requires both redis credentials when SESSION_STORE=redis (missing token)", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          SESSION_STORE: "redis",
+          UPSTASH_REDIS_REST_URL: REDIS_URL,
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    const formatted = errorSpy.mock.calls[0][1];
+    expect(formatted.UPSTASH_REDIS_REST_TOKEN?._errors[0]).toContain(
+      "UPSTASH_REDIS_REST_TOKEN is required",
+    );
+  });
+
+  it("requires both redis credentials when SESSION_STORE=redis (missing url)", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          SESSION_STORE: "redis",
+          UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    const formatted = errorSpy.mock.calls[0][1];
+    expect(formatted.UPSTASH_REDIS_REST_URL?._errors[0]).toContain(
+      "UPSTASH_REDIS_REST_URL is required",
+    );
+  });
+
+  it("accepts redis store when credentials provided", async () => {
+    const { authEnv } = await withEnv(
+      {
+        NODE_ENV: "development",
+        SESSION_STORE: "redis",
+        UPSTASH_REDIS_REST_URL: REDIS_URL,
+        UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
+      },
+      () => import("@acme/config/src/env/auth.ts"),
+    );
+    expect(authEnv.SESSION_STORE).toBe("redis");
+  });
+
+  it("requires both login rate limit redis credentials (missing token)", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          LOGIN_RATE_LIMIT_REDIS_URL: REDIS_URL,
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    const formatted = errorSpy.mock.calls[0][1];
+    expect(formatted.LOGIN_RATE_LIMIT_REDIS_TOKEN?._errors[0]).toContain(
+      "LOGIN_RATE_LIMIT_REDIS_TOKEN is required",
+    );
+  });
+
+  it("requires both login rate limit redis credentials (missing url)", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          LOGIN_RATE_LIMIT_REDIS_TOKEN: STRONG_TOKEN,
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    const formatted = errorSpy.mock.calls[0][1];
+    expect(formatted.LOGIN_RATE_LIMIT_REDIS_URL?._errors[0]).toContain(
+      "LOGIN_RATE_LIMIT_REDIS_URL is required",
+    );
+  });
+
+  it("throws for jwt provider without secret", async () => {
+    await expect(
+      withEnv(
+        { NODE_ENV: "development", AUTH_PROVIDER: "jwt" },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+  });
+
+  it("loads for jwt provider with secret", async () => {
+    const { authEnv } = await withEnv(
+      {
+        NODE_ENV: "development",
+        AUTH_PROVIDER: "jwt",
+        JWT_SECRET: STRONG_TOKEN,
+      },
+      () => import("@acme/config/src/env/auth.ts"),
+    );
+    expect(authEnv.JWT_SECRET).toBe(STRONG_TOKEN);
+  });
+
+  it("throws for oauth provider missing client id", async () => {
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          AUTH_PROVIDER: "oauth",
+          OAUTH_CLIENT_SECRET: STRONG_TOKEN,
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+  });
+
+  it("throws for oauth provider missing client secret", async () => {
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          AUTH_PROVIDER: "oauth",
+          OAUTH_CLIENT_ID: "client-id",
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+  });
+
+  it("loads when oauth provider has credentials", async () => {
+    const { authEnv } = await withEnv(
+      {
+        NODE_ENV: "development",
+        AUTH_PROVIDER: "oauth",
+        OAUTH_CLIENT_ID: "client-id",
+        OAUTH_CLIENT_SECRET: STRONG_TOKEN,
+      },
+      () => import("@acme/config/src/env/auth.ts"),
+    );
+    expect(authEnv.AUTH_PROVIDER).toBe("oauth");
+    expect(authEnv.OAUTH_CLIENT_ID).toBe("client-id");
+  });
+});
+

--- a/packages/email/src/__tests__/env.cms.test.ts
+++ b/packages/email/src/__tests__/env.cms.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+describe("cms env", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("requires SANITY_PROJECT_ID and SANITY_DATASET", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          CMS_SPACE_URL: "https://example.com",
+          CMS_ACCESS_TOKEN: "token",
+          SANITY_PROJECT_ID: "",
+          SANITY_DATASET: "",
+          SANITY_API_TOKEN: "token",
+        },
+        () => import("@acme/config/src/env/cms.ts"),
+      ),
+    ).rejects.toThrow("Invalid CMS environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("allows read-only mode without SANITY_API_TOKEN", async () => {
+    const { cmsEnv } = await withEnv(
+      {
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_PROJECT_ID: "proj",
+        SANITY_DATASET: "production",
+        SANITY_API_TOKEN: undefined,
+      },
+      () => import("@acme/config/src/env/cms.ts"),
+    );
+    expect(cmsEnv.SANITY_PROJECT_ID).toBe("proj");
+  });
+
+  it("loads with API token", async () => {
+    const { cmsEnv } = await withEnv(
+      {
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_PROJECT_ID: "proj",
+        SANITY_DATASET: "production",
+        SANITY_API_TOKEN: "token",
+      },
+      () => import("@acme/config/src/env/cms.ts"),
+    );
+    expect(cmsEnv.SANITY_API_TOKEN).toBe("token");
+  });
+
+  it("uses default preview secret when unset", async () => {
+    const { cmsEnv } = await withEnv(
+      {
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_PROJECT_ID: "proj",
+        SANITY_DATASET: "production",
+        SANITY_API_TOKEN: "token",
+        SANITY_PREVIEW_SECRET: undefined,
+      },
+      () => import("@acme/config/src/env/cms.ts"),
+    );
+    expect(cmsEnv.SANITY_PREVIEW_SECRET).toBe("dummy-preview-secret");
+  });
+
+  it("rejects invalid SANITY_BASE_URL", async () => {
+    await expect(
+      withEnv(
+        {
+          CMS_SPACE_URL: "https://example.com",
+          CMS_ACCESS_TOKEN: "token",
+          SANITY_PROJECT_ID: "proj",
+          SANITY_DATASET: "production",
+          SANITY_API_TOKEN: "token",
+          SANITY_BASE_URL: "not-a-url",
+        },
+        () => import("@acme/config/src/env/cms.ts"),
+      ),
+    ).rejects.toThrow("Invalid CMS environment variables");
+  });
+
+  it("accepts valid SANITY_BASE_URL", async () => {
+    const { cmsEnv } = await withEnv(
+      {
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_PROJECT_ID: "proj",
+        SANITY_DATASET: "production",
+        SANITY_API_TOKEN: "token",
+        SANITY_BASE_URL: "https://cms.example.com/",
+      },
+      () => import("@acme/config/src/env/cms.ts"),
+    );
+    expect(cmsEnv.SANITY_BASE_URL).toBe("https://cms.example.com");
+  });
+});
+

--- a/packages/email/src/__tests__/env.core.test.ts
+++ b/packages/email/src/__tests__/env.core.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+describe("deposit-release validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reports invalid boolean and number", async () => {
+    await withEnv(
+      {
+        DEPOSIT_RELEASE_ENABLED: "maybe",
+        DEPOSIT_RELEASE_INTERVAL_MS: "abc",
+      },
+      async () => {
+        const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+        expect(() => loadCoreEnv()).toThrow("Invalid core environment variables");
+        const calls = spy.mock.calls.map((c) => c[0]);
+        expect(calls).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("DEPOSIT_RELEASE_ENABLED: must be true or false"),
+            expect.stringContaining("DEPOSIT_RELEASE_INTERVAL_MS: must be a number"),
+          ]),
+        );
+        spy.mockRestore();
+      },
+    );
+  });
+
+  it("parses valid values", async () => {
+    await withEnv(
+      {
+        DEPOSIT_RELEASE_ENABLED: "true",
+        DEPOSIT_RELEASE_INTERVAL_MS: "5000",
+      },
+      async () => {
+        const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+        const env = loadCoreEnv();
+        expect(env.DEPOSIT_RELEASE_ENABLED).toBe(true);
+        expect(env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(5000);
+      },
+    );
+  });
+});
+
+describe("requireEnv helper", () => {
+  const getRequire = async () => (await import("@acme/config/src/env/core.ts")).requireEnv;
+
+  it("parses booleans", async () => {
+    await withEnv({ TEST_BOOL: "TrUe" }, async () => {
+      const requireEnv = await getRequire();
+      expect(requireEnv("TEST_BOOL", "boolean")).toBe(true);
+    });
+    await withEnv({ TEST_BOOL: "0" }, async () => {
+      const requireEnv = await getRequire();
+      expect(requireEnv("TEST_BOOL", "boolean")).toBe(false);
+    });
+  });
+
+  it("parses numbers", async () => {
+    await withEnv({ TEST_NUM: "42" }, async () => {
+      const requireEnv = await getRequire();
+      expect(requireEnv("TEST_NUM", "number")).toBe(42);
+    });
+  });
+
+  it("throws for invalid boolean", async () => {
+    await withEnv({ TEST_BOOL: "maybe" }, async () => {
+      const requireEnv = await getRequire();
+      expect(() => requireEnv("TEST_BOOL", "boolean")).toThrow(
+        "TEST_BOOL must be a boolean",
+      );
+    });
+  });
+
+  it("throws for invalid number", async () => {
+    await withEnv({ TEST_NUM: "abc" }, async () => {
+      const requireEnv = await getRequire();
+      expect(() => requireEnv("TEST_NUM", "number")).toThrow(
+        "TEST_NUM must be a number",
+      );
+    });
+  });
+
+  it("throws for missing key", async () => {
+    await withEnv({}, async () => {
+      const requireEnv = await getRequire();
+      expect(() => requireEnv("MISSING", "boolean")).toThrow("MISSING is required");
+    });
+  });
+});
+
+describe("AUTH_TOKEN_TTL normalisation", () => {
+  it("trims whitespace and normalises units", async () => {
+    await withEnv({ NODE_ENV: "development", AUTH_TOKEN_TTL: " 5 m " }, async () => {
+      const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+      const env = loadCoreEnv();
+      expect(env.AUTH_TOKEN_TTL).toBe(300);
+    });
+  });
+});
+
+describe("NEXT_PUBLIC_BASE_URL validation", () => {
+  it("rejects invalid url", async () => {
+    await withEnv({ NEXT_PUBLIC_BASE_URL: "not a url" }, async () => {
+      const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+      expect(() => loadCoreEnv()).toThrow("Invalid core environment variables");
+    });
+  });
+
+  it("accepts valid url", async () => {
+    await withEnv({ NEXT_PUBLIC_BASE_URL: "https://example.com" }, async () => {
+      const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+      const env = loadCoreEnv();
+      expect(env.NEXT_PUBLIC_BASE_URL).toBe("https://example.com");
+    });
+  });
+});
+

--- a/packages/email/src/__tests__/env.email.test.ts
+++ b/packages/email/src/__tests__/env.email.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+describe("email env", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("requires sendgrid api key when provider is sendgrid", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { EMAIL_PROVIDER: "sendgrid" },
+        () => import("@acme/config/src/env/email.ts"),
+      ),
+    ).rejects.toThrow("Invalid email environment variables");
+    const formatted = errorSpy.mock.calls[0][1];
+    expect(formatted.SENDGRID_API_KEY?._errors[0]).toBe("Required");
+  });
+
+  it("loads when sendgrid api key provided", async () => {
+    const { emailEnv } = await withEnv(
+      { EMAIL_PROVIDER: "sendgrid", SENDGRID_API_KEY: "key" },
+      () => import("@acme/config/src/env/email.ts"),
+    );
+    expect(emailEnv.EMAIL_PROVIDER).toBe("sendgrid");
+  });
+
+  it("requires resend api key when provider is resend", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { EMAIL_PROVIDER: "resend" },
+        () => import("@acme/config/src/env/email.ts"),
+      ),
+    ).rejects.toThrow("Invalid email environment variables");
+    const formatted = errorSpy.mock.calls[0][1];
+    expect(formatted.RESEND_API_KEY?._errors[0]).toBe("Required");
+  });
+
+  it("loads when resend api key provided", async () => {
+    const { emailEnv } = await withEnv(
+      { EMAIL_PROVIDER: "resend", RESEND_API_KEY: "key" },
+      () => import("@acme/config/src/env/email.ts"),
+    );
+    expect(emailEnv.EMAIL_PROVIDER).toBe("resend");
+  });
+
+  it("loads noop provider without keys", async () => {
+    const { emailEnv } = await withEnv(
+      { EMAIL_PROVIDER: "noop" },
+      () => import("@acme/config/src/env/email.ts"),
+    );
+    expect(emailEnv.EMAIL_PROVIDER).toBe("noop");
+  });
+});
+

--- a/packages/email/src/__tests__/env.index.test.ts
+++ b/packages/email/src/__tests__/env.index.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+describe("env index", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("throws for invalid deposit release config", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { DEPOSIT_RELEASE_ENABLED: "maybe" },
+        () => import("@acme/config/src/env/index.ts"),
+      ),
+    ).rejects.toThrow("Invalid environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("loads env when deposit release config is valid", async () => {
+    const mod = await withEnv(
+      {
+        DEPOSIT_RELEASE_ENABLED: "true",
+        DEPOSIT_RELEASE_INTERVAL_MS: "1000",
+      },
+      () => import("@acme/config/src/env/index.ts"),
+    );
+    expect(mod.env.DEPOSIT_RELEASE_ENABLED).toBe(true);
+    expect(mod.env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
+  });
+});
+

--- a/packages/email/src/__tests__/env.payments.test.ts
+++ b/packages/email/src/__tests__/env.payments.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+describe("payments env", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns defaults when gateway disabled", async () => {
+    const env = await withEnv(
+      { PAYMENTS_GATEWAY: "disabled" },
+      async () => {
+        const mod = await import("@acme/config/src/env/payments.ts");
+        return mod.loadPaymentsEnv();
+      },
+    );
+    expect(env.PAYMENTS_CURRENCY).toBe("USD");
+  });
+
+  it("loads stripe with valid keys", async () => {
+    const env = await withEnv(
+      {
+        PAYMENTS_PROVIDER: "stripe",
+        STRIPE_SECRET_KEY: "sk",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+        STRIPE_WEBHOOK_SECRET: "wh",
+      },
+      async () => {
+        const mod = await import("@acme/config/src/env/payments.ts");
+        return mod.loadPaymentsEnv();
+      },
+    );
+    expect(env.STRIPE_SECRET_KEY).toBe("sk");
+  });
+
+  it("throws when stripe keys are missing", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          PAYMENTS_PROVIDER: "stripe",
+          STRIPE_SECRET_KEY: "sk",
+          STRIPE_WEBHOOK_SECRET: undefined,
+        },
+        async () => {
+          const mod = await import("@acme/config/src/env/payments.ts");
+          return mod.loadPaymentsEnv();
+        },
+      ),
+    ).rejects.toThrow("Invalid payments environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+

--- a/packages/email/src/__tests__/env.shipping.test.ts
+++ b/packages/email/src/__tests__/env.shipping.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { withEnv } from "../../../config/test/utils/withEnv";
+
+describe("shipping env", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("parses allowed countries and threshold", async () => {
+    const env = await withEnv(
+      {
+        ALLOWED_COUNTRIES: "us, ca",
+        FREE_SHIPPING_THRESHOLD: "75",
+        DEFAULT_SHIPPING_ZONE: "domestic",
+      },
+      async () => {
+        const mod = await import("@acme/config/src/env/shipping.ts");
+        return mod.loadShippingEnv();
+      },
+    );
+    expect(env.ALLOWED_COUNTRIES).toEqual(["US", "CA"]);
+    expect(env.FREE_SHIPPING_THRESHOLD).toBe(75);
+    expect(env.DEFAULT_SHIPPING_ZONE).toBe("domestic");
+  });
+
+  it("rejects invalid zone", async () => {
+    await expect(
+      withEnv(
+        { DEFAULT_SHIPPING_ZONE: "moon" },
+        async () => {
+          const mod = await import("@acme/config/src/env/shipping.ts");
+          return mod.loadShippingEnv();
+        },
+      ),
+    ).rejects.toThrow("Invalid shipping environment variables");
+  });
+
+  it("rejects invalid threshold", async () => {
+    await expect(
+      withEnv(
+        { FREE_SHIPPING_THRESHOLD: "abc" },
+        async () => {
+          const mod = await import("@acme/config/src/env/shipping.ts");
+          return mod.loadShippingEnv();
+        },
+      ),
+    ).rejects.toThrow("Invalid shipping environment variables");
+  });
+
+  it("throws during eager parse when env invalid", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { UPS_KEY: 123 as any },
+        () => import("@acme/config/src/env/shipping.ts"),
+      ),
+    ).rejects.toThrow("Invalid shipping environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add env validation tests for auth, core, cms, email, payments, and shipping config
- ensure merged env schema catches invalid deposit release settings

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: packages/configurator build: error TS2307: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/email exec jest "src/__tests__/env.*.test.ts" --runInBand --detectOpenHandles --config ./jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bac10bc434832f9927c11b96d0cbf5