### PR TITLE
fix: ensure theme discovery and syncing

### DIFF
--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -18,7 +18,11 @@ import {
 } from "./deploymentAdapter";
 
 function repoRoot(): string {
-  let dir = typeof __dirname !== "undefined" ? __dirname : process.cwd();
+  const cwd = process.cwd().replace(/\\/g, "/");
+  const match = cwd.match(/^(.*?)(?:\/(?:packages|apps))(?:\/|$)/);
+  if (match) return match[1];
+
+  let dir = typeof __dirname !== "undefined" ? __dirname : cwd;
   while (
     !fs.existsSync(join(dir, "packages")) &&
     !fs.existsSync(join(dir, "apps"))
@@ -160,9 +164,14 @@ export function listThemes(): string[] {
   const themesDir = join(repoRoot(), "packages", "themes");
   try {
     return fs
-      .readdirSync(themesDir, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => d.name);
+      .readdirSync(themesDir)
+      .filter((name) => {
+        try {
+          return fs.statSync(join(themesDir, name)).isDirectory();
+        } catch {
+          return false;
+        }
+      });
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- make repo root detection resilient in mocked FS environments
- detect theme directories without relying on Dirent support

## Testing
- `pnpm exec jest packages/platform-core/__tests__/createShopIndex.test.ts --runInBand --detectOpenHandles --config jest.config.cjs --coverage=false`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bac649e3e8832f850298da9912b75b