### PR TITLE
fix: enforce positive inventory quantity

### DIFF
--- a/packages/platform-core/src/utils/inventory.ts
+++ b/packages/platform-core/src/utils/inventory.ts
@@ -55,8 +55,8 @@ export function expandInventoryItem(
   data: RawInventoryItem | InventoryItem
 ): InventoryItem {
   if (isInventoryItem(data)) {
-    if (data.quantity < 0) {
-      throw new Error("quantity must be greater than or equal to 0");
+    if (data.quantity <= 0) {
+      throw new Error("quantity must be greater than 0");
     }
     if (data.productId.trim() === "") {
       throw new Error("productId is required");
@@ -85,8 +85,8 @@ export function expandInventoryItem(
   }
 
   const normalizedQuantity = normalizeQuantity(quantity, unit);
-  if (!Number.isFinite(normalizedQuantity) || normalizedQuantity < 0) {
-    throw new Error("quantity must be greater than or equal to 0");
+  if (!Number.isFinite(normalizedQuantity) || normalizedQuantity <= 0) {
+    throw new Error("quantity must be greater than 0");
   }
 
   const normalizedLowStock =


### PR DESCRIPTION
## Summary
- ensure expandInventoryItem rejects zero or negative quantity

## Testing
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/utils/inventory.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bac66e8be0832f8fc0160a2c31f4da