### PR TITLE
test: update redis token lengths

### DIFF
--- a/packages/auth/src/__tests__/store.test.ts
+++ b/packages/auth/src/__tests__/store.test.ts
@@ -1,5 +1,7 @@
 import { jest } from "@jest/globals";
 
+const STRONG_TOKEN = "strongtokenstrongtokenstrongtoken!!";
+
 const RedisClientMock = jest.fn();
 class RedisSessionStoreMock {}
 
@@ -35,7 +37,7 @@ afterAll(() => {
 describe("createSessionStore", () => {
   it("uses Redis when UPSTASH_REDIS_* env vars are present", async () => {
     process.env.UPSTASH_REDIS_REST_URL = "https://example";
-    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;
 
     const { createSessionStore } = await import("../store");
 
@@ -53,7 +55,7 @@ describe("createSessionStore", () => {
 
   it("setSessionStoreFactory overrides default store", async () => {
     process.env.UPSTASH_REDIS_REST_URL = "https://example";
-    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;
 
     const { createSessionStore, setSessionStoreFactory } = await import("../store");
     const customStore = {} as any;
@@ -65,7 +67,7 @@ describe("createSessionStore", () => {
 
   it("falls back to MemorySessionStore and logs when Redis instantiation fails", async () => {
     process.env.UPSTASH_REDIS_REST_URL = "https://example";
-    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;
 
     const err = new Error("boom");
     RedisClientMock.mockImplementation(() => {

--- a/packages/platform-core/__tests__/cartStore.test.ts
+++ b/packages/platform-core/__tests__/cartStore.test.ts
@@ -1,6 +1,8 @@
 // packages/platform-core/__tests__/cartStore.test.ts
 import { jest } from "@jest/globals";
 
+const STRONG_TOKEN = "strongtokenstrongtokenstrongtoken!!";
+
 const hsetMock = jest.fn();
 const hgetallMock = jest.fn();
 const expireMock = jest.fn();
@@ -77,7 +79,7 @@ describe("RedisCartStore", () => {
     hincrbyMock.mockClear();
     hexistsMock.mockClear();
     process.env.UPSTASH_REDIS_REST_URL = "http://localhost";
-    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;
     process.env.CART_TTL = "1";
   });
 
@@ -127,7 +129,7 @@ describe("createCart backend selection", () => {
   it("uses redis backend when Redis env vars are provided", async () => {
     process.env.CART_TTL = "1";
     process.env.UPSTASH_REDIS_REST_URL = "http://localhost";
-    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;
     const { createCart } = await import("../src/cartStore");
     await createCart();
     expect(RedisMock).toHaveBeenCalledTimes(1);

--- a/packages/platform-core/__tests__/cartStore/factory.test.ts
+++ b/packages/platform-core/__tests__/cartStore/factory.test.ts
@@ -1,5 +1,7 @@
 import { jest } from "@jest/globals";
 
+const STRONG_TOKEN = "strongtokenstrongtokenstrongtoken!!";
+
 const hsetMock = jest.fn();
 const hgetallMock = jest.fn();
 const expireMock = jest.fn();
@@ -49,7 +51,7 @@ describe("createCartStore backend selection", () => {
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "test";
     process.env.CART_COOKIE_SECRET = "test";
     process.env.UPSTASH_REDIS_REST_URL = "https://example.com";
-    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;
     const { createCartStore } = await import("../../src/cartStore");
     createCartStore();
     expect(RedisMock).toHaveBeenCalled();

--- a/packages/platform-core/src/__tests__/cartStore.factory.test.ts
+++ b/packages/platform-core/src/__tests__/cartStore.factory.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+const STRONG_TOKEN = "strongtokenstrongtokenstrongtoken!!";
+
 describe("cartStore factory", () => {
   afterEach(() => {
     jest.resetModules();
@@ -21,7 +23,7 @@ describe("cartStore factory", () => {
         loadCoreEnv: () => ({
           SESSION_STORE: "redis",
           UPSTASH_REDIS_REST_URL: "https://example",
-          UPSTASH_REDIS_REST_TOKEN: "token",
+          UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
         }),
       }));
       jest.doMock("@upstash/redis", () => ({ Redis: RedisClass }));
@@ -47,7 +49,7 @@ describe("cartStore factory", () => {
       jest.doMock("@acme/config/env/core", () => ({
         loadCoreEnv: () => ({
           UPSTASH_REDIS_REST_URL: "https://example",
-          UPSTASH_REDIS_REST_TOKEN: "token",
+          UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
         }),
       }));
       jest.doMock("@upstash/redis", () => ({ Redis: RedisClass }));
@@ -65,7 +67,7 @@ describe("cartStore factory", () => {
       {
         SESSION_STORE: "memory",
         UPSTASH_REDIS_REST_URL: "https://example",
-        UPSTASH_REDIS_REST_TOKEN: "token",
+        UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
       },
     ],
     ["redis credentials missing", {}],
@@ -99,7 +101,7 @@ describe("cartStore factory", () => {
       jest.doMock("@acme/config/env/core", () => ({
         loadCoreEnv: () => ({
           UPSTASH_REDIS_REST_URL: "https://example",
-          UPSTASH_REDIS_REST_TOKEN: "token",
+          UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
         }),
       }));
       jest.doMock("@upstash/redis", () => {
@@ -127,7 +129,7 @@ describe("cartStore factory", () => {
         loadCoreEnv: () => ({
           SESSION_STORE: "redis",
           UPSTASH_REDIS_REST_URL: "https://example",
-          UPSTASH_REDIS_REST_TOKEN: "token",
+          UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
         }),
       }));
       jest.doMock("@upstash/redis", () => ({ Redis: RedisClass }));

--- a/packages/platform-core/src/__tests__/cartStore.test.ts
+++ b/packages/platform-core/src/__tests__/cartStore.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+const STRONG_TOKEN = "strongtokenstrongtokenstrongtoken!!";
+
 describe("createCartStore", () => {
   afterEach(() => {
     jest.resetModules();
@@ -43,7 +45,7 @@ describe("createCartStore", () => {
     jest.doMock("@acme/config/env/core", () => ({
       loadCoreEnv: () => ({
         UPSTASH_REDIS_REST_URL: "https://example",
-        UPSTASH_REDIS_REST_TOKEN: "token",
+        UPSTASH_REDIS_REST_TOKEN: STRONG_TOKEN,
       }),
     }));
     jest.doMock("@upstash/redis", () => ({
@@ -55,7 +57,7 @@ describe("createCartStore", () => {
 
     expect(RedisClass).toHaveBeenCalledWith({
       url: "https://example",
-      token: "token",
+      token: STRONG_TOKEN,
     });
     expect(memoryCtor).toHaveBeenCalledWith(99);
     expect(redisCtor).toHaveBeenCalledWith(redisClient, 99, memoryStoreInstance);


### PR DESCRIPTION
## Summary
- use strong Upstash Redis tokens in cart store tests
- update auth session store tests accordingly

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/platform-core/__tests__/cartStore/factory.test.ts packages/platform-core/__tests__/cartStore.test.ts packages/auth/src/__tests__/store.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bac66610b4832f8c5eb565d71e0258