### PR TITLE
test(date-utils): add edge case coverage

### DIFF
--- a/packages/date-utils/src/__tests__/index.test.ts
+++ b/packages/date-utils/src/__tests__/index.test.ts
@@ -75,6 +75,9 @@ describe("calculateRentalDays", () => {
   it("throws on invalid date", () => {
     expect(() => calculateRentalDays("not-a-date")).toThrow("Invalid returnDate");
   });
+  it("throws on impossible calendar dates", () => {
+    expect(() => calculateRentalDays("2025-02-30")).toThrow("Invalid returnDate");
+  });
 });
 
 describe("formatTimestamp", () => {
@@ -84,8 +87,9 @@ describe("formatTimestamp", () => {
     expect(formatted).toContain("2025");
     expect(formatted).not.toBe(ts);
   });
-  it("returns input for invalid timestamp", () => {
-    expect(formatTimestamp("bad")).toBe("bad");
+  it("returns original string for invalid timestamp", () => {
+    const bad = "not-a-date";
+    expect(formatTimestamp(bad)).toBe(bad);
   });
   it("returns input for invalid timestamp with locale", () => {
     expect(formatTimestamp("bad", "en-US")).toBe("bad");
@@ -170,6 +174,18 @@ describe("getTimeRemaining and formatDuration", () => {
   });
   it("formats durations just under a day", () => {
     expect(formatDuration(24 * 60 * 60 * 1000 - 1000)).toBe("23h 59m 59s");
+  });
+  it("formats combined day, hour, minute and second durations", () => {
+    const ms =
+      1 * 24 * 60 * 60 * 1000 +
+      2 * 60 * 60 * 1000 +
+      3 * 60 * 1000 +
+      4 * 1000;
+    expect(formatDuration(ms)).toBe("1d 2h 3m 4s");
+  });
+  it("formats hour, minute and second durations without days", () => {
+    const ms = 1 * 60 * 60 * 1000 + 1 * 60 * 1000 + 1 * 1000;
+    expect(formatDuration(ms)).toBe("1h 1m 1s");
   });
 });
 


### PR DESCRIPTION
## Summary
- extend calculateRentalDays tests to handle impossible dates
- ensure formatTimestamp echoes invalid strings
- exercise formatDuration with mixed-day/hour/minute/second durations

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@jest/globals')
- `pnpm test packages/date-utils/src/index.test.ts` (fails: Could not find task `packages/date-utils/src/index.test.ts` in project)
- `pnpm exec jest packages/date-utils/src/__tests__/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bac94fc090832f897eb3b3e76e09b4