### PR TITLE
feat(platform-machine): add env test utils

### DIFF
--- a/packages/platform-machine/src/__tests__/envTestUtils.ts
+++ b/packages/platform-machine/src/__tests__/envTestUtils.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+
+export async function withEnv<T>(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<T> | T,
+  options: { useFakeTimers?: boolean } = {},
+): Promise<T> {
+  const originalEnv = process.env;
+  process.env = { ...originalEnv };
+  const { useFakeTimers = false } = options;
+
+  try {
+    for (const [key, value] of Object.entries(vars)) {
+      if (typeof value === "undefined") {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    if (useFakeTimers) {
+      jest.useFakeTimers();
+    }
+
+    jest.resetModules();
+
+    return await new Promise<T>((resolve, reject) => {
+      jest.isolateModules(async () => {
+        try {
+          const result = await fn();
+          resolve(result);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  } finally {
+    if (useFakeTimers) {
+      jest.useRealTimers();
+    }
+    process.env = originalEnv;
+  }
+}
+
+export async function importFresh<T = unknown>(path: string): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    jest.isolateModules(async () => {
+      try {
+        const mod = (await import(path)) as T;
+        resolve(mod);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add test harness helpers to isolate env vars and fresh imports

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in @acme/configurator build)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-machine test` *(fails: ENOENT in apps/cms/__tests__/media.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68bacd3c1210832fa09bc44e87c5c81d