### PR TITLE
test: cover shared utils helpers

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -184,6 +184,7 @@ const config = {
     '^@acme/platform-core/(.*)$': ' /packages/platform-core/src/$1',
     '^@acme/platform-core/contexts/CurrencyContext$': ' /test/__mocks__/currencyContextMock.tsx',
     '^@acme/platform-machine/src/(.*)$': ' /packages/platform-machine/src/$1',
+    '^@acme/shared-utils/src/(.*)$': ' /packages/shared-utils/src/$1',
     '^@acme/plugin-sanity$': ' /test/__mocks__/pluginSanityStub.ts',
     '^@acme/plugin-sanity/(.*)$': ' /test/__mocks__/pluginSanityStub.ts',
     '^@acme/telemetry$': ' /test/__mocks__/telemetryMock.ts',

--- a/packages/platform-machine/src/__tests__/buildResponse.test.ts
+++ b/packages/platform-machine/src/__tests__/buildResponse.test.ts
@@ -1,0 +1,40 @@
+import { buildResponse, type ProxyResponse } from '@acme/shared-utils/src/buildResponse';
+
+describe('buildResponse', () => {
+  it('builds OK response with JSON body and headers', async () => {
+    const proxy: ProxyResponse = {
+      response: {
+        status: 200,
+        headers: { 'content-type': 'application/json', 'x-test': '1' },
+        body: Buffer.from(JSON.stringify({ ok: true })).toString('base64'),
+      },
+    };
+    const res = buildResponse(proxy);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-test')).toBe('1');
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('builds error response merging headers and string body', async () => {
+    const proxy: ProxyResponse = {
+      response: {
+        status: 400,
+        headers: { 'X-Test': '1', 'x-test': '2' },
+        body: Buffer.from('bad').toString('base64'),
+      },
+    };
+    const res = buildResponse(proxy);
+    expect(res.status).toBe(400);
+    expect(res.headers.get('x-test')).toBe('2');
+    await expect(res.text()).resolves.toBe('bad');
+  });
+
+  it('handles missing body and headers', async () => {
+    const proxy: ProxyResponse = { response: { status: 204, headers: {} } };
+    const res = buildResponse(proxy);
+    expect(res.status).toBe(204);
+    expect([...res.headers.entries()]).toEqual([]);
+    await expect(res.text()).resolves.toBe('');
+  });
+});
+

--- a/packages/platform-machine/src/__tests__/fetchJson.test.ts
+++ b/packages/platform-machine/src/__tests__/fetchJson.test.ts
@@ -1,0 +1,49 @@
+import { fetchJson } from '@acme/shared-utils/src/fetchJson';
+import { z } from 'zod';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    // @ts-expect-error mock
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns parsed and validated data on 200', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(JSON.stringify({ ok: true })),
+    });
+    const schema = z.object({ ok: z.boolean() });
+    await expect(fetchJson('http://test', undefined, schema)).resolves.toEqual({ ok: true });
+  });
+
+  it('returns undefined on 200 with empty body and no schema', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(''),
+    });
+    await expect(fetchJson('http://test')).resolves.toBeUndefined();
+  });
+
+  it('throws error message from body when response not ok with JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Bad',
+      text: jest.fn().mockResolvedValue(JSON.stringify({ error: 'Boom' })),
+    });
+    await expect(fetchJson('http://test')).rejects.toThrow('Boom');
+  });
+
+  it('throws statusText when body is invalid JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      statusText: 'Teapot',
+      text: jest.fn().mockResolvedValue('nope'),
+    });
+    await expect(fetchJson('http://test')).rejects.toThrow('Teapot');
+  });
+});
+

--- a/packages/platform-machine/src/__tests__/formatCurrency.test.ts
+++ b/packages/platform-machine/src/__tests__/formatCurrency.test.ts
@@ -1,0 +1,30 @@
+import { formatCurrency } from '@acme/shared-utils/src/formatCurrency';
+
+describe('formatCurrency', () => {
+  const original = (Intl as any).supportedValuesOf;
+
+  afterEach(() => {
+    if (original) {
+      (Intl as any).supportedValuesOf = original;
+    } else {
+      delete (Intl as any).supportedValuesOf;
+    }
+  });
+
+  it('formats valid currency when supportedValuesOf absent', () => {
+    delete (Intl as any).supportedValuesOf;
+    const expected = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(1);
+    expect(formatCurrency(100, 'USD', 'en-US')).toBe(expected);
+  });
+
+  it('throws RangeError for invalid codes', () => {
+    expect(() => formatCurrency(100, 'EU' as any)).toThrow(RangeError);
+    expect(() => formatCurrency(100, 'usd' as any)).toThrow(RangeError);
+  });
+
+  it('throws when supportedValuesOf excludes currency', () => {
+    (Intl as any).supportedValuesOf = () => ['EUR'];
+    expect(() => formatCurrency(100, 'USD')).toThrow(RangeError);
+  });
+});
+

--- a/packages/platform-machine/src/__tests__/formatPrice.test.ts
+++ b/packages/platform-machine/src/__tests__/formatPrice.test.ts
@@ -1,0 +1,31 @@
+import { formatPrice } from '@acme/shared-utils/src/formatPrice';
+
+describe('formatPrice', () => {
+  const original = (Intl as any).supportedValuesOf;
+
+  afterEach(() => {
+    if (original) {
+      (Intl as any).supportedValuesOf = original;
+    } else {
+      delete (Intl as any).supportedValuesOf;
+    }
+  });
+
+  it('formats lowercase codes when supportedValuesOf absent', () => {
+    delete (Intl as any).supportedValuesOf;
+    const expected = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(12);
+    expect(formatPrice(12, 'usd', 'en-US')).toBe(expected);
+  });
+
+  it('throws RangeError for unsupported currency when supportedValuesOf present', () => {
+    (Intl as any).supportedValuesOf = () => ['USD'];
+    expect(() => formatPrice(1, 'ABC')).toThrow(RangeError);
+  });
+
+  it('formats valid currency in provided locale', () => {
+    (Intl as any).supportedValuesOf = () => ['USD', 'EUR'];
+    const expected = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(1);
+    expect(formatPrice(1, 'EUR', 'de-DE')).toBe(expected);
+  });
+});
+

--- a/packages/platform-machine/src/__tests__/getShopFromPath.shared.test.ts
+++ b/packages/platform-machine/src/__tests__/getShopFromPath.shared.test.ts
@@ -1,0 +1,25 @@
+import { getShopFromPath } from '@acme/shared-utils/src/getShopFromPath';
+
+describe('getShopFromPath', () => {
+  it('returns undefined for undefined input', () => {
+    expect(getShopFromPath(undefined)).toBeUndefined();
+  });
+
+  it('prefers ?shop query parameter', () => {
+    expect(getShopFromPath('/cms?shop=my-shop')).toBe('my-shop');
+  });
+
+  it('extracts slug from shop or shops segment', () => {
+    expect(getShopFromPath('/cms/shop/example')).toBe('example');
+    expect(getShopFromPath('/cms/shops/example')).toBe('example');
+  });
+
+  it('normalizes extra slashes', () => {
+    expect(getShopFromPath('/cms//shop//example')).toBe('example');
+  });
+
+  it('returns undefined when no shop segment present', () => {
+    expect(getShopFromPath('/cms/foo/bar')).toBeUndefined();
+  });
+});
+

--- a/packages/platform-machine/src/__tests__/parseJsonBody.test.ts
+++ b/packages/platform-machine/src/__tests__/parseJsonBody.test.ts
@@ -1,0 +1,74 @@
+import { parseJsonBody } from '@acme/shared-utils/src/parseJsonBody';
+import { z } from 'zod';
+
+type HeadersInit = Record<string, string> | undefined;
+
+function makeRequest(body: any, headers: HeadersInit = {}, mode: 'text' | 'json' = 'text') {
+  const h = new Headers(headers);
+  if (mode === 'json') {
+    return { headers: h, json: jest.fn().mockResolvedValue(body) } as unknown as Request;
+  }
+  return { headers: h, text: jest.fn().mockResolvedValue(body) } as unknown as Request;
+}
+
+describe('parseJsonBody', () => {
+  const schema = z.object({ foo: z.string() });
+
+  it('returns 400 for wrong content-type and drains body', async () => {
+    const req = makeRequest('text', { 'Content-Type': 'text/plain' });
+    const result = await parseJsonBody(req, schema, '1kb');
+    expect((req as any).text).toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+    await expect(result.response.json()).resolves.toEqual({ error: 'Invalid JSON' });
+  });
+
+  it('returns 400 when schema validation fails via json()', async () => {
+    const req = makeRequest({}, { 'Content-Type': 'application/json' }, 'json');
+    const result = await parseJsonBody(req, schema, '1kb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+    await expect(result.response.json()).resolves.toEqual({ foo: ['Required'] });
+  });
+
+  it('returns 400 for invalid JSON via text()', async () => {
+    const req = makeRequest('{oops', { 'Content-Type': 'application/json' });
+    const result = await parseJsonBody(req, schema, '1kb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+    await expect(result.response.json()).resolves.toEqual({ error: 'Invalid JSON' });
+  });
+
+  it('returns 413 when payload exceeds limit', async () => {
+    const req = makeRequest({ foo: 'bar' }, { 'Content-Type': 'application/json' }, 'json');
+    const Original = TextEncoder;
+    class MockEncoder extends TextEncoder {
+      encode(_: string): Uint8Array {
+        return new Uint8Array(11); // always 11 bytes
+      }
+    }
+    // @ts-expect-error overriding global
+    global.TextEncoder = MockEncoder;
+    try {
+      const result = await parseJsonBody(req, schema, 10);
+      expect(result.success).toBe(false);
+      expect(result.response.status).toBe(413);
+      await expect(result.response.json()).resolves.toEqual({ error: 'Payload Too Large' });
+    } finally {
+      global.TextEncoder = Original;
+    }
+  });
+
+  it('parses valid JSON within limit', async () => {
+    const req = makeRequest('{"foo":"bar"}', { 'Content-Type': 'application/json' });
+    await expect(parseJsonBody(req, schema, '1kb')).resolves.toEqual({ success: true, data: { foo: 'bar' } });
+  });
+
+  it.each([{}, { 'Content-Type': 'application/json' }])('handles missing body with headers %p', async (headers) => {
+    const req = makeRequest(undefined, headers);
+    const result = await parseJsonBody(req, schema, '1kb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add jest mapping for shared-utils src
- test shared-utils helpers from platform-machine

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/platform-machine/src/__tests__/parseJsonBody.test.ts packages/platform-machine/src/__tests__/fetchJson.test.ts packages/platform-machine/src/__tests__/formatPrice.test.ts packages/platform-machine/src/__tests__/formatCurrency.test.ts packages/platform-machine/src/__tests__/buildResponse.test.ts packages/platform-machine/src/__tests__/getShopFromPath.shared.test.ts --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68bacd5e7b44832f91cc66df940c63be