### PR TITLE
test: cover env parsing

### DIFF
--- a/packages/platform-machine/src/__tests__/env.auth.test.ts
+++ b/packages/platform-machine/src/__tests__/env.auth.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "@jest/globals";
+import { authEnvSchema } from "@acme/config/env/auth";
+
+const NEXT_SECRET = "nextauth-secret-32-chars-long-string!";
+const SESSION_SECRET = "session-secret-32-chars-long-string!";
+const REDIS_URL = "https://redis.example.com";
+const REDIS_TOKEN = "redis-token-32-chars-long-string!";
+
+const base = { NEXTAUTH_SECRET: NEXT_SECRET, SESSION_SECRET };
+
+const selectStore = (env: any) =>
+  env.SESSION_STORE ??
+  (env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
+    ? "redis"
+    : "memory");
+
+describe("store selection", () => {
+  it("errors when redis creds incomplete", () => {
+    expect(() =>
+      authEnvSchema.parse({
+        ...base,
+        SESSION_STORE: "redis",
+        UPSTASH_REDIS_REST_URL: REDIS_URL,
+      }),
+    ).toThrow("UPSTASH_REDIS_REST_TOKEN is required when SESSION_STORE=redis");
+
+    expect(() =>
+      authEnvSchema.parse({
+        ...base,
+        SESSION_STORE: "redis",
+        UPSTASH_REDIS_REST_TOKEN: REDIS_TOKEN,
+      }),
+    ).toThrow("UPSTASH_REDIS_REST_URL is required when SESSION_STORE=redis");
+  });
+
+  it("accepts redis when creds provided", () => {
+    const env = authEnvSchema.parse({
+      ...base,
+      SESSION_STORE: "redis",
+      UPSTASH_REDIS_REST_URL: REDIS_URL,
+      UPSTASH_REDIS_REST_TOKEN: REDIS_TOKEN,
+    });
+    expect(env.SESSION_STORE).toBe("redis");
+  });
+
+  it("prefers memory when explicitly set", () => {
+    const env = authEnvSchema.parse({
+      ...base,
+      SESSION_STORE: "memory",
+      UPSTASH_REDIS_REST_URL: REDIS_URL,
+      UPSTASH_REDIS_REST_TOKEN: REDIS_TOKEN,
+    });
+    expect(env.SESSION_STORE).toBe("memory");
+  });
+
+  it("infers redis when creds present without store", () => {
+    const env = authEnvSchema.parse({
+      ...base,
+      UPSTASH_REDIS_REST_URL: REDIS_URL,
+      UPSTASH_REDIS_REST_TOKEN: REDIS_TOKEN,
+    });
+    expect(selectStore(env)).toBe("redis");
+  });
+});
+
+describe("login rate-limit", () => {
+  it("requires both url and token", () => {
+    expect(() =>
+      authEnvSchema.parse({
+        ...base,
+        LOGIN_RATE_LIMIT_REDIS_URL: REDIS_URL,
+      }),
+    ).toThrow(
+      "LOGIN_RATE_LIMIT_REDIS_TOKEN is required when LOGIN_RATE_LIMIT_REDIS_URL is set",
+    );
+
+    expect(() =>
+      authEnvSchema.parse({
+        ...base,
+        LOGIN_RATE_LIMIT_REDIS_TOKEN: REDIS_TOKEN,
+      }),
+    ).toThrow(
+      "LOGIN_RATE_LIMIT_REDIS_URL is required when LOGIN_RATE_LIMIT_REDIS_TOKEN is set",
+    );
+  });
+
+  it("passes when both provided", () => {
+    const env = authEnvSchema.parse({
+      ...base,
+      LOGIN_RATE_LIMIT_REDIS_URL: REDIS_URL,
+      LOGIN_RATE_LIMIT_REDIS_TOKEN: REDIS_TOKEN,
+    });
+    expect(env.LOGIN_RATE_LIMIT_REDIS_URL).toBe(REDIS_URL);
+  });
+});
+
+describe("provider selection", () => {
+  it("requires JWT_SECRET for jwt provider", () => {
+    expect(() =>
+      authEnvSchema.parse({ ...base, AUTH_PROVIDER: "jwt" }),
+    ).toThrow("JWT_SECRET is required when AUTH_PROVIDER=jwt");
+
+    const env = authEnvSchema.parse({
+      ...base,
+      AUTH_PROVIDER: "jwt",
+      JWT_SECRET: NEXT_SECRET,
+    });
+    expect(env.AUTH_PROVIDER).toBe("jwt");
+  });
+
+  it("requires id and secret for oauth provider", () => {
+    expect(() =>
+      authEnvSchema.parse({ ...base, AUTH_PROVIDER: "oauth" }),
+    ).toThrow("OAUTH_CLIENT_ID is required when AUTH_PROVIDER=oauth");
+
+    expect(() =>
+      authEnvSchema.parse({
+        ...base,
+        AUTH_PROVIDER: "oauth",
+        OAUTH_CLIENT_ID: "id",
+      }),
+    ).toThrow("OAUTH_CLIENT_SECRET is required when AUTH_PROVIDER=oauth");
+
+    const env = authEnvSchema.parse({
+      ...base,
+      AUTH_PROVIDER: "oauth",
+      OAUTH_CLIENT_ID: "id",
+      OAUTH_CLIENT_SECRET: NEXT_SECRET,
+    });
+    expect(env.AUTH_PROVIDER).toBe("oauth");
+  });
+});

--- a/packages/platform-machine/src/__tests__/env.cms.test.ts
+++ b/packages/platform-machine/src/__tests__/env.cms.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "@jest/globals";
+import { cmsEnvSchema } from "@acme/config/env/cms";
+import { withEnv } from "./helpers/env";
+
+const base = {
+  CMS_SPACE_URL: "https://example.com",
+  CMS_ACCESS_TOKEN: "token",
+  SANITY_API_VERSION: "v1",
+};
+
+describe("base URL trimming", () => {
+  it("removes trailing slashes", () => {
+    const env = cmsEnvSchema.parse({
+      ...base,
+      SANITY_BASE_URL: "https://sanity.example.com/",
+      CMS_BASE_URL: "https://cms.example.com/",
+    } as any);
+    expect(env.SANITY_BASE_URL).toBe("https://sanity.example.com");
+    expect(env.CMS_BASE_URL).toBe("https://cms.example.com");
+  });
+});
+
+describe("lists and numbers", () => {
+  it("parses lists and numeric limits", () => {
+    const env = cmsEnvSchema.parse({
+      ...base,
+      CMS_DRAFTS_DISABLED_PATHS: "foo, bar , baz",
+      CMS_SEARCH_DISABLED_PATHS: "",
+      CMS_PAGINATION_LIMIT: "50",
+    } as any);
+    expect(env.CMS_DRAFTS_DISABLED_PATHS).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+    expect(env.CMS_SEARCH_DISABLED_PATHS).toEqual([]);
+    expect(env.CMS_PAGINATION_LIMIT).toBe(50);
+  });
+
+  it("rejects invalid numbers", () => {
+    expect(() =>
+      cmsEnvSchema.parse({
+        ...base,
+        CMS_PAGINATION_LIMIT: "oops",
+      } as any),
+    ).toThrow();
+  });
+});
+
+describe("required ids", () => {
+  it("throw in production when missing", async () => {
+    await withEnv({ NODE_ENV: "production" }, async () => {
+      const { cmsEnvSchema: prodSchema } = await import(
+        "@acme/config/env/cms"
+      );
+      const res = prodSchema.safeParse({});
+      expect(res.success).toBe(false);
+    });
+  });
+});
+
+describe("preview secret", () => {
+  it("defaults when absent and uses provided value", () => {
+    const env1 = cmsEnvSchema.parse({ ...base } as any);
+    expect(env1.SANITY_PREVIEW_SECRET).toBe("dummy-preview-secret");
+    const env2 = cmsEnvSchema.parse({
+      ...base,
+      SANITY_PREVIEW_SECRET: "custom",
+    } as any);
+    expect(env2.SANITY_PREVIEW_SECRET).toBe("custom");
+  });
+});

--- a/packages/platform-machine/src/__tests__/env.core.test.ts
+++ b/packages/platform-machine/src/__tests__/env.core.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { withEnv } from "./helpers/env";
+import { loadCoreEnv } from "@acme/config/env/core";
+
+const requireEnvImport = async () => (await import("@acme/config/env/core")).requireEnv;
+
+describe("requireEnv", () => {
+  it("parses boolean, number, and string", async () => {
+    await withEnv(
+      { BOOL: "TRUE", NUM: "0", STR: "-12.5" },
+      async () => {
+        const requireEnv = await requireEnvImport();
+        expect(requireEnv("BOOL", "boolean")).toBe(true);
+        expect(requireEnv("NUM", "number")).toBe(0);
+        expect(requireEnv("STR", "string")).toBe("-12.5");
+      },
+    );
+  });
+
+  it("throws on invalid values", async () => {
+    await withEnv(
+      { BOOL: "maybe", NUM1: "NaN", NUM2: "abc", STR: "" },
+      async () => {
+        const requireEnv = await requireEnvImport();
+        expect(() => requireEnv("BOOL", "boolean")).toThrow(
+          "BOOL must be a boolean",
+        );
+        expect(() => requireEnv("NUM1", "number")).toThrow(
+          "NUM1 must be a number",
+        );
+        expect(() => requireEnv("NUM2", "number")).toThrow(
+          "NUM2 must be a number",
+        );
+        expect(() => requireEnv("STR")).toThrow("STR is required");
+      },
+    );
+  });
+});
+
+describe("deposit/reverse/late-fee refinement", () => {
+  it("coerces valid values", () => {
+    const env = loadCoreEnv({
+      DEPOSIT_RELEASE_ENABLED: "true",
+      DEPOSIT_RELEASE_INTERVAL_MS: "1000",
+      REVERSE_LOGISTICS_ENABLED: "true",
+      REVERSE_LOGISTICS_INTERVAL_MS: "1000",
+      LATE_FEE_ENABLED: "true",
+      LATE_FEE_INTERVAL_MS: "250",
+    } as any);
+    expect(env.DEPOSIT_RELEASE_ENABLED).toBe(true);
+    expect(env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
+    expect(env.REVERSE_LOGISTICS_ENABLED).toBe(true);
+    expect(env.REVERSE_LOGISTICS_INTERVAL_MS).toBe(1000);
+    expect(env.LATE_FEE_ENABLED).toBe(true);
+    expect(env.LATE_FEE_INTERVAL_MS).toBe(250);
+  });
+
+  it("reports invalid booleans and numbers", () => {
+    const err = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadCoreEnv({
+        DEPOSIT_RELEASE_ENABLED: "maybe",
+        DEPOSIT_RELEASE_INTERVAL_MS: "soon",
+      } as any),
+    ).toThrow("Invalid core environment variables");
+    const output = err.mock.calls.flat().join("\n");
+    expect(output).toContain("DEPOSIT_RELEASE_ENABLED: must be true or false");
+    expect(output).toContain(
+      "DEPOSIT_RELEASE_INTERVAL_MS: must be a number",
+    );
+    err.mockRestore();
+  });
+});
+
+describe("invalid URL", () => {
+  it("fails when NEXT_PUBLIC_BASE_URL is invalid", () => {
+    const err = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadCoreEnv({ NEXT_PUBLIC_BASE_URL: "not a url" } as any),
+    ).toThrow("Invalid core environment variables");
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+});
+
+describe("coreEnv proxy traps", () => {
+  it("proxies property access and reflection", async () => {
+    await withEnv(
+      { CMS_SPACE_URL: "https://example.com", CMS_ACCESS_TOKEN: "tok" },
+      async () => {
+        const { coreEnv } = await import("@acme/config/env/core");
+        expect(coreEnv.CMS_SPACE_URL).toBe("https://example.com");
+        expect("CMS_SPACE_URL" in coreEnv).toBe(true);
+        expect(Object.keys(coreEnv)).toEqual(
+          expect.arrayContaining(["CMS_SPACE_URL", "CMS_ACCESS_TOKEN"]),
+        );
+        const desc = Object.getOwnPropertyDescriptor(
+          coreEnv,
+          "CMS_SPACE_URL",
+        );
+        expect(desc?.value).toBe("https://example.com");
+      },
+    );
+  });
+});

--- a/packages/platform-machine/src/__tests__/env.email.test.ts
+++ b/packages/platform-machine/src/__tests__/env.email.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "@jest/globals";
+import { emailEnvSchema } from "@acme/config/env/email";
+
+describe("email provider", () => {
+  it("validates sendgrid provider", () => {
+    expect(() =>
+      emailEnvSchema.parse({ EMAIL_PROVIDER: "sendgrid" } as any),
+    ).toThrow();
+    const env = emailEnvSchema.parse({
+      EMAIL_PROVIDER: "sendgrid",
+      SENDGRID_API_KEY: "key",
+    } as any);
+    expect(env.EMAIL_PROVIDER).toBe("sendgrid");
+  });
+
+  it("validates resend provider", () => {
+    expect(() =>
+      emailEnvSchema.parse({ EMAIL_PROVIDER: "resend" } as any),
+    ).toThrow();
+    const env = emailEnvSchema.parse({
+      EMAIL_PROVIDER: "resend",
+      RESEND_API_KEY: "key",
+    } as any);
+    expect(env.EMAIL_PROVIDER).toBe("resend");
+  });
+
+  it("supports noop provider", () => {
+    const env = emailEnvSchema.parse({ EMAIL_PROVIDER: "noop" } as any);
+    expect(env.EMAIL_PROVIDER).toBe("noop");
+  });
+});
+
+describe("from address", () => {
+  it("normalizes and lowercases", () => {
+    const env = emailEnvSchema.parse({
+      CAMPAIGN_FROM: " Admin@Example.COM ",
+    } as any);
+    expect(env.CAMPAIGN_FROM).toBe("admin@example.com");
+  });
+
+  it("omits when not provided", () => {
+    const env = emailEnvSchema.parse({} as any);
+    expect(env.CAMPAIGN_FROM).toBeUndefined();
+  });
+});

--- a/packages/platform-machine/src/__tests__/env.payments.test.ts
+++ b/packages/platform-machine/src/__tests__/env.payments.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { loadPaymentsEnv } from "@acme/config/env/payments";
+
+describe("payments env", () => {
+  it("returns defaults when gateway disabled", () => {
+    const env = loadPaymentsEnv({ PAYMENTS_GATEWAY: "disabled" } as any);
+    expect(env.STRIPE_SECRET_KEY).toBe("sk_test");
+    expect(env.PAYMENTS_SANDBOX).toBe(true);
+  });
+
+  it("parses stripe provider with keys", () => {
+    const env = loadPaymentsEnv({
+      PAYMENTS_PROVIDER: "stripe",
+      STRIPE_SECRET_KEY: "sk_live",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live",
+      STRIPE_WEBHOOK_SECRET: "whsec_live",
+    } as any);
+    expect(env.PAYMENTS_PROVIDER).toBe("stripe");
+  });
+
+  it("errors when stripe keys missing", () => {
+    const err = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadPaymentsEnv({
+        PAYMENTS_PROVIDER: "stripe",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+        STRIPE_WEBHOOK_SECRET: "whsec",
+      } as any),
+    ).toThrow("Invalid payments environment variables");
+    err.mockRestore();
+  });
+
+  it("toggles sandbox flag", () => {
+    const off = loadPaymentsEnv({ PAYMENTS_SANDBOX: "false" } as any);
+    expect(off.PAYMENTS_SANDBOX).toBe(false);
+    const on = loadPaymentsEnv({ PAYMENTS_SANDBOX: "true" } as any);
+    expect(on.PAYMENTS_SANDBOX).toBe(true);
+  });
+});

--- a/packages/platform-machine/src/__tests__/env.shipping.test.ts
+++ b/packages/platform-machine/src/__tests__/env.shipping.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { loadShippingEnv } from "@acme/config/env/shipping";
+import { withEnv } from "./helpers/env";
+
+describe("shipping env", () => {
+  it("accepts valid zone", () => {
+    const env = loadShippingEnv({ DEFAULT_SHIPPING_ZONE: "eu" } as any);
+    expect(env.DEFAULT_SHIPPING_ZONE).toBe("eu");
+  });
+
+  it("rejects invalid zone", () => {
+    const err = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ DEFAULT_SHIPPING_ZONE: "moon" } as any),
+    ).toThrow("Invalid shipping environment variables");
+    err.mockRestore();
+  });
+
+  it("coerces free shipping threshold", () => {
+    const env = loadShippingEnv({ FREE_SHIPPING_THRESHOLD: "25" } as any);
+    expect(env.FREE_SHIPPING_THRESHOLD).toBe(25);
+  });
+
+  it("rejects invalid thresholds", () => {
+    expect(() =>
+      loadShippingEnv({ FREE_SHIPPING_THRESHOLD: "soon" } as any),
+    ).toThrow("Invalid shipping environment variables");
+    expect(() =>
+      loadShippingEnv({ FREE_SHIPPING_THRESHOLD: "-1" } as any),
+    ).toThrow("Invalid shipping environment variables");
+  });
+
+  it("omits optional keys when absent", () => {
+    const env = loadShippingEnv({} as any);
+    expect(env.TAXJAR_KEY).toBeUndefined();
+    expect(env.UPS_KEY).toBeUndefined();
+    expect(env.DHL_KEY).toBeUndefined();
+  });
+
+  it("eager import validates env", async () => {
+    const mod = await withEnv(
+      { DEFAULT_SHIPPING_ZONE: "domestic" },
+      () => import("@acme/config/env/shipping"),
+    );
+    expect(mod.shippingEnv.DEFAULT_SHIPPING_ZONE).toBe("domestic");
+    await expect(
+      withEnv(
+        { DEFAULT_SHIPPING_ZONE: "galaxy" },
+        () => import("@acme/config/env/shipping"),
+      ),
+    ).rejects.toThrow("Invalid shipping environment variables");
+  });
+});

--- a/packages/platform-machine/src/__tests__/helpers/env.ts
+++ b/packages/platform-machine/src/__tests__/helpers/env.ts
@@ -1,0 +1,13 @@
+export async function withEnv<T>(env: NodeJS.ProcessEnv, fn: () => Promise<T>): Promise<T> {
+  const oldEnv = process.env;
+  process.env = { ...oldEnv, ...env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete (process.env as any)[key];
+  }
+  jest.resetModules();
+  try {
+    return await fn();
+  } finally {
+    process.env = oldEnv;
+  }
+}


### PR DESCRIPTION
## Summary
- add env validation tests for core, auth, cms, email, payments and shipping modules
- verify requireEnv helpers and feature refinements

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/platform-machine/src/__tests__/env.core.test.ts packages-platform-machine/src/__tests__/env.auth.test.ts packages-platform-machine/src/__tests__/env.cms.test.ts packages-platform-machine/src/__tests__/env.email.test.ts packages-platform-machine/src/__tests__/env.payments.test.ts packages-platform-machine/src/__tests__/env.shipping.test.ts --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68bad3981c30832fa3f6b9683e026321