### PR TITLE
fix: mock history schema for built paths

### DIFF
--- a/apps/cms/src/actions/__tests__/pages.server.test.ts
+++ b/apps/cms/src/actions/__tests__/pages.server.test.ts
@@ -5,11 +5,10 @@ const captureException = jest.fn();
 jest.mock("@acme/i18n/src/index", () => ({ LOCALES: ["en", "de"] }), {
   virtual: true,
 });
-jest.mock(
-  "@acme/types/src/index",
-  () => ({ historyStateSchema }),
-  { virtual: true },
-);
+jest.mock("@acme/types", () => ({ historyStateSchema }), { virtual: true });
+jest.mock("@acme/types/src/index", () => ({ historyStateSchema }), {
+  virtual: true,
+});
 jest.mock("../common/auth", () => ({
   ensureAuthorized: jest
     .fn()


### PR DESCRIPTION
## Summary
- ensure history state schema is mocked for both source and built module paths

## Testing
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*
- `pnpm test:cms apps/cms/src/actions/__tests__/pages.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bad6967c8c832fa72f630e1f0140de