### PR TITLE
test: add path dirname mock

### DIFF
--- a/apps/cms/src/__tests__/media.server.test.ts
+++ b/apps/cms/src/__tests__/media.server.test.ts
@@ -15,6 +15,7 @@ jest.mock('fs', () => ({ promises: fsMock }));
 
 const pathMock = {
   join: (...parts: string[]) => parts.join('/'),
+  dirname: (p: string) => p.split('/').slice(0, -1).join('/'),
   posix: {
     join: (...parts: string[]) => parts.join('/'),
     normalize: (p: string) => p,


### PR DESCRIPTION
## Summary
- fix cms media server tests by mocking path.dirname

## Testing
- `pnpm exec jest apps/cms/src/__tests__/media.server.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bad6c1bc7c832f8018afe638239aa0