### PR TITLE
test: adjust cms env setup for auth secrets

### DIFF
--- a/apps/cms/__tests__/helpers.ts
+++ b/apps/cms/__tests__/helpers.ts
@@ -24,18 +24,18 @@ export async function withTempRepo(cb: (dir: string) => Promise<void>): Promise<
   await fs.mkdir(shopDir, { recursive: true });
   const cwd = process.cwd();
   process.chdir(dir);
-  Object.assign(process.env, {
-    NEXTAUTH_SECRET: "test",
-    SESSION_SECRET: "test",
-    CART_COOKIE_SECRET: "test-cart-secret",
-    STRIPE_SECRET_KEY: "sk",
-    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
-    STRIPE_WEBHOOK_SECRET: "whsec_test",
-    SKIP_STOCK_ALERT: "1",
-    CMS_SPACE_URL: "http://example.com",
-    CMS_ACCESS_TOKEN: "token",
-    SANITY_API_VERSION: "2024-01-01",
-  });
+    Object.assign(process.env, {
+      NEXTAUTH_SECRET: "test-nextauth-secret-32-chars-long-string!",
+      SESSION_SECRET: "test-session-secret-32-chars-long-string!",
+      CART_COOKIE_SECRET: "test-cart-secret",
+      STRIPE_SECRET_KEY: "sk",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+      SKIP_STOCK_ALERT: "1",
+      CMS_SPACE_URL: "http://example.com",
+      CMS_ACCESS_TOKEN: "token",
+      SANITY_API_VERSION: "2024-01-01",
+    });
   jest.resetModules();
   try {
     await cb(dir);

--- a/apps/cms/__tests__/helpers/shops.ts
+++ b/apps/cms/__tests__/helpers/shops.ts
@@ -53,7 +53,9 @@ export function mockShop(tokens: Record<string, string> = {}): void {
     },
   }));
 
-  jest.doMock("@acme/config", () => ({ env: { NEXTAUTH_SECRET: "secret" } }));
+  jest.doMock("@acme/config", () => ({
+    env: { NEXTAUTH_SECRET: "test-nextauth-secret-32-chars-long-string!" },
+  }));
   jest.doMock("@platform-core/createShop", () => ({
     syncTheme: jest.fn().mockResolvedValue(tokens),
   }));

--- a/apps/cms/__tests__/inventoryUpdateRoute.test.ts
+++ b/apps/cms/__tests__/inventoryUpdateRoute.test.ts
@@ -34,13 +34,13 @@ describe("inventory update route", () => {
       jest.doMock("next-auth", () => ({
         getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),
       }));
-      jest.doMock("@acme/config", () => ({
-        env: {
-          NEXTAUTH_SECRET: "s",
-          CART_COOKIE_SECRET: "c",
-          SESSION_SECRET: "s",
-        },
-      }));
+        jest.doMock("@acme/config", () => ({
+          env: {
+            NEXTAUTH_SECRET: "test-nextauth-secret-32-chars-long-string!",
+            CART_COOKIE_SECRET: "c",
+            SESSION_SECRET: "test-session-secret-32-chars-long-string!",
+          },
+        }));
       const { writeInventory, readInventory } = await import(
         "@platform-core/repositories/inventory.server",
       );
@@ -80,13 +80,13 @@ describe("inventory update route", () => {
       jest.doMock("next-auth", () => ({
         getServerSession: jest.fn().mockResolvedValue({ user: { role: "admin" } }),
       }));
-      jest.doMock("@acme/config", () => ({
-        env: {
-          NEXTAUTH_SECRET: "s",
-          CART_COOKIE_SECRET: "c",
-          SESSION_SECRET: "s",
-        },
-      }));
+        jest.doMock("@acme/config", () => ({
+          env: {
+            NEXTAUTH_SECRET: "test-nextauth-secret-32-chars-long-string!",
+            CART_COOKIE_SECRET: "c",
+            SESSION_SECRET: "test-session-secret-32-chars-long-string!",
+          },
+        }));
       const { writeInventory, readInventory } = await import(
         "@platform-core/repositories/inventory.server",
       );

--- a/apps/cms/__tests__/middleware.integration.test.ts
+++ b/apps/cms/__tests__/middleware.integration.test.ts
@@ -19,7 +19,7 @@ jest.mock("@auth/rbac", () => ({
 /* -------------------------------------------------------------------------- */
 jest.mock("@acme/config", () => ({
   __esModule: true,
-  env: { NEXTAUTH_SECRET: "test" },
+  env: { NEXTAUTH_SECRET: "test-nextauth-secret-32-chars-long-string!" },
 }));
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/__tests__/page-draft.route.test.ts
+++ b/apps/cms/__tests__/page-draft.route.test.ts
@@ -9,7 +9,7 @@ if (typeof (Response as any).json !== "function") {
     });
 }
 
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "test-nextauth-secret-32-chars-long-string!";
 
 const mockGetPages = jest.fn();
 

--- a/apps/cms/__tests__/products.test.ts
+++ b/apps/cms/__tests__/products.test.ts
@@ -3,7 +3,7 @@
 import type { ProductPublication } from "@acme/platform-core/products";
 
 // Ensure auth options do not throw on import
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "test-nextauth-secret-32-chars-long-string!";
 
 import fs from "node:fs/promises";
 import os from "node:os";

--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -12,10 +12,14 @@ module.exports = {
   ...base,
   testEnvironment: "jsdom",
   roots: ["<rootDir>/apps/cms/src", "<rootDir>/apps/cms/__tests__"],
+  setupFiles: ["<rootDir>/apps/cms/jest.env.ts"],
+  // Ensure environment variables and polyfills are applied before other setup
+  // files that may import modules requiring them.  `jest.setup.tsx` establishes
+  // auth secrets needed by configuration code, so it must run first.
   setupFilesAfterEnv: [
+    "<rootDir>/apps/cms/jest.setup.tsx",
     "<rootDir>/apps/cms/jest.setup.polyfills.ts",
     "<rootDir>/apps/cms/__tests__/msw/server.ts",
-    "<rootDir>/apps/cms/jest.setup.tsx",
   ],
   moduleNameMapper: {
     ...baseModuleNameMapper,

--- a/apps/cms/jest.env.ts
+++ b/apps/cms/jest.env.ts
@@ -1,0 +1,9 @@
+const mutableEnv = process.env as Record<string, string>;
+const ensureSecret = (key: string, fallback: string) => {
+  const current = mutableEnv[key];
+  if (!current || current.length < 32) {
+    mutableEnv[key] = fallback;
+  }
+};
+ensureSecret('NEXTAUTH_SECRET', 'test-nextauth-secret-32-chars-long-string!');
+ensureSecret('SESSION_SECRET', 'test-session-secret-32-chars-long-string!');

--- a/apps/cms/jest.setup.tsx
+++ b/apps/cms/jest.setup.tsx
@@ -20,6 +20,7 @@ Object.assign(process.env, {
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "pk_test",
 });
 
+
 /* -------------------------------------------------------------------------- */
 /* 2 ·  GLOBAL POLYFILLS & SHIMS                                              */
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/src/__tests__/cmsAccess.integration.test.tsx
+++ b/apps/cms/src/__tests__/cmsAccess.integration.test.tsx
@@ -13,7 +13,7 @@ jest.mock("@auth/rbac", () => ({
 // Minimal env config for auth secret
 jest.mock("@acme/config", () => ({
   __esModule: true,
-  env: { NEXTAUTH_SECRET: "test" },
+  env: { NEXTAUTH_SECRET: "test-nextauth-secret-32-chars-long-string!" },
 }));
 
 // Mock next-auth token retrieval

--- a/apps/cms/src/__tests__/products.server.test.ts
+++ b/apps/cms/src/__tests__/products.server.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Minimal auth config
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "test-nextauth-secret-32-chars-long-string!";
 
 jest.mock("../actions/common/auth", () => ({
   ensureAuthorized: jest.fn(),

--- a/apps/cms/src/app/api/configurator/init-shop/route.test.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.test.ts
@@ -13,7 +13,7 @@ jest.mock("fs", () => {
   };
 });
 
-process.env.NEXTAUTH_SECRET = "test-secret";
+process.env.NEXTAUTH_SECRET = "test-nextauth-secret-32-chars-long-string!";
 
 const getServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession }));

--- a/apps/cms/src/auth/__tests__/secret.test.ts
+++ b/apps/cms/src/auth/__tests__/secret.test.ts
@@ -25,10 +25,13 @@ describe("auth secret", () => {
   });
 
   it("exports the NEXTAUTH_SECRET value", async () => {
-    (process.env as Record<string, string>).NEXTAUTH_SECRET = "test-secret";
+    (process.env as Record<string, string>).NEXTAUTH_SECRET =
+      "test-nextauth-secret-32-chars-long-string!";
     jest.doMock("@acme/config", () => ({ env: process.env }));
     const { authSecret } = await import("../secret");
-    expect(authSecret).toBe("test-secret");
+    expect(authSecret).toBe(
+      "test-nextauth-secret-32-chars-long-string!",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure global Jest setup replaces too-short auth secrets
- add dedicated env initializer for CMS tests
- update CMS test helpers and mocks to use 32+ char secrets

## Testing
- `pnpm test` *(fails: @apps/api#test)*
- `pnpm --filter @apps/cms exec jest __tests__/inventoryExportRoute.test.ts`
- `pnpm --filter @apps/cms exec jest __tests__/inventoryImportCsvRoute.test.ts`
- `pnpm --filter @apps/cms exec jest __tests__/page-draft.route.test.ts`
- `pnpm --filter @apps/cms exec jest __tests__/products.test.ts` *(fails: rejects invalid product payloads)*

------
https://chatgpt.com/codex/tasks/task_e_68bad64bdbcc832fb08eff880f60d2f9