### PR TITLE
test(platform-core): cover resolveDataRoot branches

### DIFF
--- a/packages/platform-core/src/__tests__/dataRoot.test.ts
+++ b/packages/platform-core/src/__tests__/dataRoot.test.ts
@@ -1,0 +1,35 @@
+/** @jest-environment node */
+
+import * as path from "node:path";
+import type { PathLike } from "node:fs";
+
+describe("resolveDataRoot", () => {
+  afterEach(() => {
+    delete process.env.DATA_ROOT;
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("returns resolved DATA_ROOT when env var set", async () => {
+    process.env.DATA_ROOT = "/custom/path";
+    const { resolveDataRoot } = await import("../dataRoot");
+    expect(resolveDataRoot()).toBe(path.resolve("/custom/path"));
+  });
+
+  it("finds ancestor data/shops directory", async () => {
+    jest.spyOn(process, "cwd").mockReturnValue("/a/b/c");
+    jest.doMock("node:fs", () => ({
+      existsSync: (p: PathLike) => p === path.join("/a/b", "data", "shops"),
+    }));
+    const { resolveDataRoot } = await import("../dataRoot");
+    expect(resolveDataRoot()).toBe(path.join("/a/b", "data", "shops"));
+  });
+
+  it("falls back to cwd/data/shops when none found", async () => {
+    jest.spyOn(process, "cwd").mockReturnValue("/a/b/c");
+    jest.doMock("node:fs", () => ({ existsSync: () => false }));
+    const { resolveDataRoot } = await import("../dataRoot");
+    expect(resolveDataRoot()).toBe(path.resolve("/a/b/c", "data", "shops"));
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for resolveDataRoot covering env override, ancestor lookup, and default fallback

## Testing
- `pnpm --filter ./packages/platform-core run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter ./packages/platform-core run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter ./packages/platform-core test -- packages/platform-core/src/__tests__/dataRoot.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bad774166c832fb6e5f4cb5aa882de