### PR TITLE
test: improve cms test infra

### DIFF
--- a/apps/cms/__tests__/mocks/external.ts
+++ b/apps/cms/__tests__/mocks/external.ts
@@ -1,0 +1,68 @@
+/**
+ * Reusable Jest mocks for external dependencies used across CMS tests.
+ * Mocking these modules avoids network and database calls during test runs.
+ */
+
+export const prismaMock = {
+  PrismaClient: jest.fn(() => ({
+    $connect: jest.fn(),
+    $disconnect: jest.fn(),
+    $transaction: jest.fn(),
+  })),
+};
+jest.mock("@prisma/client", () => prismaMock);
+
+export const redisMock = jest.fn(() => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+}));
+jest.mock("ioredis", () => redisMock, { virtual: true });
+
+export const nodemailerMock = {
+  createTransport: jest.fn(() => ({
+    sendMail: jest.fn().mockResolvedValue(undefined),
+  })),
+};
+jest.mock("nodemailer", () => nodemailerMock);
+
+export const sendGridMock = {
+  setApiKey: jest.fn(),
+  send: jest.fn().mockResolvedValue({}),
+};
+jest.mock("@sendgrid/mail", () => sendGridMock, { virtual: true });
+
+export const resendMock = {
+  Resend: jest.fn(() => ({
+    emails: { send: jest.fn().mockResolvedValue({}) },
+  })),
+};
+jest.mock("resend", () => resendMock, { virtual: true });
+
+export const sanitizeHtmlMock = jest.fn((input: string) => input);
+jest.mock("sanitize-html", () => sanitizeHtmlMock);
+
+export const nextHeadersMock = {
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => ({ get: jest.fn(), set: jest.fn() })),
+};
+jest.mock("next/headers", () => nextHeadersMock);
+
+export const nextCookiesMock = {
+  cookies: jest.fn(() => ({ get: jest.fn(), set: jest.fn() })),
+};
+jest.mock("next/cookies", () => nextCookiesMock, { virtual: true });
+
+// Re-export a helper to make it easy for tests to reset mocks when needed.
+export function resetExternalMocks() {
+  prismaMock.PrismaClient.mockClear();
+  redisMock.mockClear();
+  nodemailerMock.createTransport.mockClear();
+  sendGridMock.setApiKey.mockClear();
+  sendGridMock.send.mockClear();
+  resendMock.Resend.mockClear();
+  sanitizeHtmlMock.mockClear();
+  nextHeadersMock.headers.mockClear();
+  nextHeadersMock.cookies.mockClear();
+  nextCookiesMock.cookies.mockClear();
+}

--- a/apps/cms/__tests__/tokenUtils.test.ts
+++ b/apps/cms/__tests__/tokenUtils.test.ts
@@ -8,11 +8,10 @@ describe("tokenUtils", () => {
     expect(baseTokens["--color-bg"]).toBeDefined();
   });
 
-  it("returns base tokens for base theme", async () => {
-    await expect(loadThemeTokens("base")).resolves.toEqual(baseTokens);
-  });
-
-  it("falls back to base tokens for unknown theme", async () => {
-    await expect(loadThemeTokens("nope")).resolves.toEqual(baseTokens);
+  it.each([
+    ["base", baseTokens],
+    ["nope", baseTokens],
+  ])("loads tokens for %s theme", async (theme, expected) => {
+    await expect(loadThemeTokens(theme)).resolves.toEqual(expected);
   });
 });

--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -50,4 +50,18 @@ module.exports = {
     ],
   },
   transformIgnorePatterns: ["/node_modules/(?!(?:@?jose)/)"],
+  collectCoverage: true,
+  coverageReporters: ["text", "lcov"],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "<rootDir>/apps/cms/src/components/cms/media/",
+  ],
+  coverageThreshold: {
+    global: {
+      statements: 40,
+      branches: 30,
+      functions: 10,
+      lines: 40,
+    },
+  },
 };

--- a/apps/cms/jest.setup.tsx
+++ b/apps/cms/jest.setup.tsx
@@ -8,6 +8,7 @@ import "cross-fetch/polyfill";
 import React from "react";
 import * as ReactDOMTestUtils from "react-dom/test-utils";
 import { TextDecoder, TextEncoder } from "node:util";
+import "./__tests__/mocks/external";
 
 /* -------------------------------------------------------------------------- */
 /* 1 ·  ENVIRONMENT VARIABLES                                                 */

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start -p 3006",
     "lint": "eslint .",
-    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --coverage --config ./jest.config.cjs",
     "dev:debug": "cross-env NODE_OPTIONS='--enable-source-maps --trace-uncaught --inspect' next dev -p 3006"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add reusable Jest mocks for Prisma, Redis, email, sanitize-html, and Next.js helpers
- parameterize token utility tests for multiple themes
- enforce coverage in CMS tests and exclude visual-only components

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/tokenUtils.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68badc5ee06c832fb07f6bc1bf9455df