### PR TITLE
test: cover sticky add to cart bar

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/StickyAddToCartBar.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/StickyAddToCartBar.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StickyAddToCartBar } from "../StickyAddToCartBar";
+import type { SKU } from "@acme/types";
+import "@testing-library/jest-dom";
+import "../../../../../../test/resetNextMocks";
+
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+describe("StickyAddToCartBar", () => {
+  const product: SKU = {
+    id: "1",
+    slug: "test-product",
+    title: "Test Product",
+    price: 9.99,
+    deposit: 0,
+    stock: 0,
+    forSale: true,
+    forRental: false,
+    media: [{ url: "/img.jpg", type: "image" }],
+    sizes: [],
+    description: "",
+  };
+
+  it("renders product info and handles add to cart", () => {
+    const handleAdd = jest.fn();
+    render(<StickyAddToCartBar product={product} onAddToCart={handleAdd} />);
+
+    expect(screen.getByText("Test Product")).toBeInTheDocument();
+    expect(screen.getByText(/\$9\.99/)).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /add to cart/i });
+    fireEvent.click(button);
+    expect(handleAdd).toHaveBeenCalledWith(product);
+  });
+
+  it("does not render add button without handler", () => {
+    render(<StickyAddToCartBar product={product} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText(/\$9\.99/)).toBeInTheDocument();
+  });
+
+  it("hides price when not provided", () => {
+    const noPrice = { ...product, price: undefined as unknown as number };
+    render(<StickyAddToCartBar product={noPrice} />);
+    expect(screen.queryByText(/\$9\.99/)).not.toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add behavior-focused tests for StickyAddToCartBar

## Testing
- `pnpm install`
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/StickyAddToCartBar.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68badc53081c832f80420fa5033617a1