### PR TITLE
test: expand configurator hook coverage

### DIFF
--- a/apps/cms/src/app/cms/configurator/hooks/__tests__/useStepCompletion.test.ts
+++ b/apps/cms/src/app/cms/configurator/hooks/__tests__/useStepCompletion.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from "@testing-library/react";
+import useStepCompletion from "../useStepCompletion";
+import { useConfigurator } from "../../ConfiguratorContext";
+
+jest.mock("../../ConfiguratorContext", () => ({
+  useConfigurator: jest.fn(),
+}));
+
+describe("useStepCompletion", () => {
+  const markStepComplete = jest.fn();
+  const resetDirty = jest.fn();
+  const baseState: any = {
+    completed: {},
+    shopId: "id",
+    storeName: "Store",
+    theme: "dark",
+  };
+
+  beforeEach(() => {
+    (useConfigurator as jest.Mock).mockReturnValue({
+      state: { ...baseState },
+      markStepComplete,
+      resetDirty,
+    });
+    markStepComplete.mockClear();
+    resetDirty.mockClear();
+  });
+
+  it("reports completion when state is complete and valid", () => {
+    (useConfigurator as jest.Mock).mockReturnValue({
+      state: { ...baseState, completed: { "shop-details": "complete" } },
+      markStepComplete,
+      resetDirty,
+    });
+    const { result } = renderHook(() => useStepCompletion("shop-details"));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("does not mark complete if validator fails", () => {
+    (useConfigurator as jest.Mock).mockReturnValue({
+      state: { ...baseState, shopId: "", storeName: "" },
+      markStepComplete,
+      resetDirty,
+    });
+    const { result } = renderHook(() => useStepCompletion("shop-details"));
+    act(() => result.current[1](true));
+    expect(markStepComplete).not.toHaveBeenCalled();
+  });
+
+  it("marks step complete and resets dirty when valid", () => {
+    const { result } = renderHook(() => useStepCompletion("shop-details"));
+    act(() => result.current[1](true));
+    expect(markStepComplete).toHaveBeenCalledWith("shop-details", "complete");
+    expect(resetDirty).toHaveBeenCalled();
+  });
+
+  it("marks step pending when toggled off", () => {
+    (useConfigurator as jest.Mock).mockReturnValue({
+      state: { ...baseState, completed: { theme: "complete" } },
+      markStepComplete,
+      resetDirty,
+    });
+    const { result } = renderHook(() => useStepCompletion("theme"));
+    act(() => result.current[1](false));
+    expect(markStepComplete).toHaveBeenCalledWith("theme", "pending");
+    expect(resetDirty).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/platform-core/src/__tests__/profile.test.ts
+++ b/packages/platform-core/src/__tests__/profile.test.ts
@@ -1,0 +1,11 @@
+/** @jest-environment node */
+
+import { getCustomerProfile } from "../profile";
+
+describe("profile", () => {
+  it("returns null regardless of customer id", async () => {
+    expect(await getCustomerProfile()).toBeNull();
+    expect(await getCustomerProfile("abc")).toBeNull();
+  });
+});
+

--- a/packages/platform-core/src/cartCookie.test.ts
+++ b/packages/platform-core/src/cartCookie.test.ts
@@ -88,6 +88,12 @@ describe("cartCookie", () => {
     expect(header).toMatch(/Max-Age=\d+/);
   });
 
+  it("sets Max-Age=0 when clearing the cookie", () => {
+    const header = asSetCookieHeader("gone", 0);
+    expect(header).toContain("Max-Age=0");
+    expect(header.startsWith(`${CART_COOKIE}=gone`)).toBe(true);
+  });
+
   it("throws when getSecret is called without a secret", async () => {
     jest.resetModules();
     jest.doMock("@acme/config/env/core", () => ({ loadCoreEnv: () => ({}) }));


### PR DESCRIPTION
## Summary
- cover cookie clearing behavior in cartCookie
- add profile and configurator hook tests including step completion validation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/platform-core/src/cartCookie.test.ts packages/platform-core/src/__tests__/profile.test.ts apps/cms/src/app/cms/configurator/hooks/__tests__/useConfiguratorPersistence.test.tsx apps/cms/src/app/cms/configurator/hooks/__tests__/useStepCompletion.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68badc46a5d4832fb7a6e4225704979c