### PR TITLE
fix: update payments env tests for new defaults

### DIFF
--- a/packages/config/__tests__/paymentsEnv.test.ts
+++ b/packages/config/__tests__/paymentsEnv.test.ts
@@ -14,7 +14,7 @@ describe("paymentsEnv", () => {
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_456",
         STRIPE_WEBHOOK_SECRET: "whsec_789",
       },
-      () => import("../src/env/payments"),
+      () => import("../src/env/payments")
     );
 
     expect(spy).not.toHaveBeenCalled();
@@ -27,21 +27,28 @@ describe("paymentsEnv", () => {
     });
   });
 
-  it("throws on invalid env", async () => {
-    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+  it("warns and uses defaults on invalid env", async () => {
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
-    await expect(
-      withEnv(
-        {
-          STRIPE_SECRET_KEY: "",
-          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_456",
-          STRIPE_WEBHOOK_SECRET: "whsec_789",
-        },
-        () => import("../src/env/payments"),
-      ),
-    ).rejects.toThrow("Invalid payments environment variables");
+    const { paymentsEnv } = await withEnv(
+      {
+        STRIPE_SECRET_KEY: "",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_456",
+        STRIPE_WEBHOOK_SECRET: "whsec_789",
+      },
+      () => import("../src/env/payments")
+    );
 
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      "⚠️ Invalid payments environment variables:",
+      expect.any(Object)
+    );
+    expect(paymentsEnv).toEqual({
+      STRIPE_SECRET_KEY: "sk_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+      PAYMENTS_SANDBOX: true,
+      PAYMENTS_CURRENCY: "USD",
+    });
   });
 });
-

--- a/packages/config/src/env/__tests__/payments.test.ts
+++ b/packages/config/src/env/__tests__/payments.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 
 async function withEnv<T>(
   env: Record<string, string | undefined>,
-  fn: () => Promise<T> | T,
+  fn: () => Promise<T> | T
 ): Promise<T> {
   const previous = process.env;
   process.env = { ...previous, ...env } as NodeJS.ProcessEnv;
@@ -38,10 +38,12 @@ describe("payments env schema", () => {
         STRIPE_WEBHOOK_SECRET: undefined,
       },
       async () => {
-        const { paymentsEnv, paymentsEnvSchema } = await import("../payments.js");
+        const { paymentsEnv, paymentsEnvSchema } = await import(
+          "../payments.js"
+        );
         expect(paymentsEnv).toEqual(paymentsEnvSchema.parse({}));
         expect(warnSpy).not.toHaveBeenCalled();
-      },
+      }
     );
   });
 
@@ -60,9 +62,9 @@ describe("payments env schema", () => {
           const { paymentsEnv } = await import("../payments.js");
           expect(paymentsEnv.STRIPE_SECRET_KEY).toBe(key);
           expect(warnSpy).not.toHaveBeenCalled();
-        },
+        }
       );
-    },
+    }
   );
 
   it("throws when STRIPE_WEBHOOK_SECRET is missing", async () => {
@@ -76,15 +78,13 @@ describe("payments env schema", () => {
       },
       async () => {
         await expect(import("../payments.js")).rejects.toThrow(
-          "Invalid payments environment variables",
+          "Invalid payments environment variables"
         );
         expect(errorSpy).toHaveBeenCalledWith(
-          "❌ Invalid payments environment variables:",
-          expect.any(Object),
+          "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe"
         );
-      },
+      }
     );
     errorSpy.mockRestore();
   });
 });
-


### PR DESCRIPTION
## Summary
- update payments env schema test to expect missing webhook secret message
- adjust paymentsEnv test to warn and fall back to defaults on invalid input

## Testing
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: packages/configurator build error: Cannot find module '@jest/globals')*
- `pnpm run --filter @acme/config check:references` *(fails: script missing)*
- `pnpm run --filter @acme/config build:ts` *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68badef4fde0832f81d718d45d8091fb