### PR TITLE
test: expand shipping env coverage

### DIFF
--- a/packages/configurator/src/__tests__/env.shipping.test.ts
+++ b/packages/configurator/src/__tests__/env.shipping.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import { withEnv } from "./envTestUtils";
 
 const MODULE_PATH = "@acme/config/src/env/shipping.ts";
@@ -19,24 +19,114 @@ describe("loadShippingEnv", () => {
     );
   });
 
+  it("parses and normalizes allowed countries", async () => {
+    await withEnv(
+      { ALLOWED_COUNTRIES: "us, ca , de" },
+      async () => {
+        const { loadShippingEnv } = await import(MODULE_PATH);
+        const env = loadShippingEnv();
+        expect(env.ALLOWED_COUNTRIES).toEqual(["US", "CA", "DE"]);
+      }
+    );
+  });
+
+  it.each(["", undefined])(
+    "returns undefined for ALLOWED_COUNTRIES=%p",
+    async (val) => {
+      await withEnv({ ALLOWED_COUNTRIES: val as any }, async () => {
+        const { loadShippingEnv } = await import(MODULE_PATH);
+        const env = loadShippingEnv();
+        expect(env.ALLOWED_COUNTRIES).toBeUndefined();
+      });
+    }
+  );
+
+  describe("local pickup toggle", () => {
+    const cases: Array<[string, boolean]> = [
+      ["true", true],
+      ["1", true],
+      ["0", false],
+      ["false", false],
+    ];
+
+    it.each(cases)("parses %s", async (input, expected) => {
+      await withEnv({ LOCAL_PICKUP_ENABLED: input }, async () => {
+        const { loadShippingEnv } = await import(MODULE_PATH);
+        const env = loadShippingEnv();
+        expect(env.LOCAL_PICKUP_ENABLED).toBe(expected);
+      });
+    });
+
+    it("rejects invalid values", async () => {
+      await withEnv({}, async () => {
+        const { loadShippingEnv } = await import(MODULE_PATH);
+        const errorSpy = jest
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        expect(() =>
+          loadShippingEnv({ LOCAL_PICKUP_ENABLED: "Yes" as any })
+        ).toThrow("Invalid shipping environment variables");
+        expect(() =>
+          loadShippingEnv({ LOCAL_PICKUP_ENABLED: "maybe" as any })
+        ).toThrow("Invalid shipping environment variables");
+        expect(errorSpy).toHaveBeenCalledTimes(2);
+        errorSpy.mockRestore();
+      });
+    });
+  });
+
+  describe("default country", () => {
+    it("normalizes lowercase codes", async () => {
+      await withEnv({ DEFAULT_COUNTRY: "us" }, async () => {
+        const { loadShippingEnv } = await import(MODULE_PATH);
+        const env = loadShippingEnv();
+        expect(env.DEFAULT_COUNTRY).toBe("US");
+      });
+    });
+
+    it("throws on invalid codes", async () => {
+      await withEnv({}, async () => {
+        const { loadShippingEnv } = await import(MODULE_PATH);
+        const errorSpy = jest
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        expect(() =>
+          loadShippingEnv({ DEFAULT_COUNTRY: "USA" as any })
+        ).toThrow("Invalid shipping environment variables");
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+      });
+    });
+  });
+
   it("rejects invalid zone", async () => {
     await withEnv({}, async () => {
       const { loadShippingEnv } = await import(MODULE_PATH);
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       expect(() =>
-        loadShippingEnv({ DEFAULT_SHIPPING_ZONE: "galaxy" })
+        loadShippingEnv({ DEFAULT_SHIPPING_ZONE: "asia" as any })
       ).toThrow("Invalid shipping environment variables");
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 
   it("rejects negative or NaN threshold", async () => {
     await withEnv({}, async () => {
       const { loadShippingEnv } = await import(MODULE_PATH);
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       expect(() =>
         loadShippingEnv({ FREE_SHIPPING_THRESHOLD: "-10" })
       ).toThrow("Invalid shipping environment variables");
       expect(() =>
         loadShippingEnv({ FREE_SHIPPING_THRESHOLD: "abc" })
       ).toThrow("Invalid shipping environment variables");
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      errorSpy.mockRestore();
     });
   });
 
@@ -60,13 +150,18 @@ describe("eager shippingEnv import", () => {
     );
   });
 
-  it("throws on invalid env during import", async () => {
+  it("logs and throws on invalid env during import", async () => {
     await withEnv(
       { DEFAULT_SHIPPING_ZONE: "galaxy" },
       async () => {
+        const errorSpy = jest
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
         await expect(import(MODULE_PATH)).rejects.toThrow(
           "Invalid shipping environment variables"
         );
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
       }
     );
   });


### PR DESCRIPTION
## Summary
- add shipping env tests for allowed country parsing, local pickup toggle, and default country normalization
- validate invalid shipping zones and negative free-shipping thresholds
- cover eager shippingEnv import logging

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/configurator run build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/configurator test` *(fails: coverage threshold for branches (80%) not met)*
- `pnpm --filter @acme/configurator exec jest packages/configurator/src/__tests__/env.shipping.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68bae7f49c18832f839006d1f340d5fb