### PR TITLE
test(configurator): cover env helpers

### DIFF
--- a/packages/configurator/src/__tests__/envTestUtils.test.ts
+++ b/packages/configurator/src/__tests__/envTestUtils.test.ts
@@ -1,0 +1,43 @@
+/** @jest-environment node */
+import { withEnv, importFresh } from './envTestUtils';
+
+describe('withEnv', () => {
+  const KEY = 'TEST_ENV_VAR';
+
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it('temporarily removes environment variables when set to undefined', async () => {
+    process.env[KEY] = 'original';
+
+    await withEnv({ [KEY]: undefined }, async () => {
+      expect(process.env[KEY]).toBeUndefined();
+    });
+
+    expect(process.env[KEY]).toBe('original');
+  });
+
+  it('sets and restores environment variables', async () => {
+    process.env[KEY] = 'original';
+
+    await withEnv({ [KEY]: 'temp' }, async () => {
+      expect(process.env[KEY]).toBe('temp');
+    });
+
+    expect(process.env[KEY]).toBe('original');
+  });
+});
+
+describe('importFresh', () => {
+  it('imports a module freshly', async () => {
+    const mod = await importFresh<typeof import('./envTestUtils')>(
+      './envTestUtils',
+    );
+    expect(mod).toHaveProperty('withEnv');
+  });
+
+  it('rejects when module cannot be imported', async () => {
+    await expect(importFresh('./does-not-exist')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for withEnv to verify env vars are removed or restored
- exercise importFresh helper including rejection path

## Testing
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `pnpm --filter @acme/configurator test` *(fails: global branch coverage < 80%)*
- `pnpm exec jest packages/configurator/src/__tests__/envTestUtils.test.ts --config jest.config.cjs`
- `pnpm --filter @acme/configurator lint` *(fails: Cannot find package '@acme/eslint-plugin-ds')*

------
https://chatgpt.com/codex/tasks/task_e_68bae805ed94832fb81e730d8a344569