### PR TITLE
test(config): expand env schema coverage

### DIFF
--- a/packages/config/src/env/__tests__/auth.env.test.ts
+++ b/packages/config/src/env/__tests__/auth.env.test.ts
@@ -274,6 +274,38 @@ describe("authEnvSchema validation", () => {
   });
 });
 
+describe("boolean coercions and defaults", () => {
+  const baseVars = { NEXTAUTH_SECRET: NEXT_SECRET, SESSION_SECRET };
+
+  it.each([
+    [1, true],
+    [0, false],
+  ])("coerces ALLOW_GUEST=%s", async (input, expected) => {
+    const { authEnv } = await withEnv(
+      { ...baseVars, ALLOW_GUEST: input as any },
+      () => import("../auth"),
+    );
+    expect(authEnv.ALLOW_GUEST).toBe(expected);
+  });
+
+  it.each([
+    [1, true],
+    [0, false],
+  ])("coerces ENFORCE_2FA=%s", async (input, expected) => {
+    const { authEnv } = await withEnv(
+      { ...baseVars, ENFORCE_2FA: input as any },
+      () => import("../auth"),
+    );
+    expect(authEnv.ENFORCE_2FA).toBe(expected);
+  });
+
+  it("defaults ALLOW_GUEST and ENFORCE_2FA to false", async () => {
+    const { authEnv } = await withEnv(baseVars, () => import("../auth"));
+    expect(authEnv.ALLOW_GUEST).toBe(false);
+    expect(authEnv.ENFORCE_2FA).toBe(false);
+  });
+});
+
 describe("AUTH_TOKEN_TTL normalization", () => {
   const baseVars = {
     NODE_ENV: "production",

--- a/packages/config/src/env/__tests__/email.env.test.ts
+++ b/packages/config/src/env/__tests__/email.env.test.ts
@@ -10,6 +10,12 @@ afterEach(() => {
 });
 
 describe("email env provider selection", () => {
+  it("defaults EMAIL_PROVIDER to smtp", async () => {
+    delete process.env.EMAIL_PROVIDER;
+    const env = await loadEnv();
+    expect(env.EMAIL_PROVIDER).toBe("smtp");
+  });
+
   it("uses sendgrid when SENDGRID_API_KEY present", async () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.SENDGRID_API_KEY = "sg-key";

--- a/packages/config/src/env/__tests__/payments.env.test.ts
+++ b/packages/config/src/env/__tests__/payments.env.test.ts
@@ -6,6 +6,20 @@ afterEach(() => {
 });
 
 describe("payments env provider", () => {
+  it("returns defaults when PAYMENTS_GATEWAY disabled", async () => {
+    const { paymentsEnv } = await withEnv(
+      { PAYMENTS_GATEWAY: "disabled" },
+      () => import("../payments"),
+    );
+    expect(paymentsEnv).toMatchObject({
+      PAYMENTS_SANDBOX: true,
+      PAYMENTS_CURRENCY: "USD",
+      STRIPE_SECRET_KEY: "sk_test",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test",
+    });
+  });
+
   it("loads stripe config when provider set and keys present", async () => {
     const { paymentsEnv } = await withEnv(
       {

--- a/packages/config/src/env/core.test.ts
+++ b/packages/config/src/env/core.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, jest, afterEach } from "@jest/globals";
 import { z } from "zod";
-import { depositReleaseEnvRefinement, loadCoreEnv } from "./core.js";
+import {
+  depositReleaseEnvRefinement,
+  loadCoreEnv,
+  requireEnv,
+  coreEnvSchema,
+  coreEnv,
+} from "./core.js";
 
 const baseEnv = {
   CMS_SPACE_URL: "https://example.com",
@@ -9,12 +15,14 @@ const baseEnv = {
 };
 
 describe("depositReleaseEnvRefinement", () => {
-  it("adds issues for invalid DEPOSIT_RELEASE variables", () => {
+  it("adds issues for invalid deposit and reverse logistics vars", () => {
     const ctx = { addIssue: jest.fn() } as unknown as z.RefinementCtx;
     depositReleaseEnvRefinement(
       {
         DEPOSIT_RELEASE_ENABLED: "yes",
         DEPOSIT_RELEASE_INTERVAL_MS: "soon",
+        REVERSE_LOGISTICS_ENABLED: "maybe",
+        REVERSE_LOGISTICS_INTERVAL_MS: "later",
       },
       ctx,
     );
@@ -28,11 +36,21 @@ describe("depositReleaseEnvRefinement", () => {
       path: ["DEPOSIT_RELEASE_INTERVAL_MS"],
       message: "must be a number",
     });
+    expect(ctx.addIssue).toHaveBeenCalledWith({
+      code: z.ZodIssueCode.custom,
+      path: ["REVERSE_LOGISTICS_ENABLED"],
+      message: "must be true or false",
+    });
+    expect(ctx.addIssue).toHaveBeenCalledWith({
+      code: z.ZodIssueCode.custom,
+      path: ["REVERSE_LOGISTICS_INTERVAL_MS"],
+      message: "must be a number",
+    });
   });
 });
 
 describe("loadCoreEnv", () => {
-  it("throws on invalid env and succeeds when corrected", () => {
+  it("throws and logs issues on invalid env", () => {
     const errorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -43,8 +61,15 @@ describe("loadCoreEnv", () => {
         DEPOSIT_RELEASE_INTERVAL_MS: "later",
       } as unknown as NodeJS.ProcessEnv),
     ).toThrow("Invalid core environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+    const joined = errorSpy.mock.calls.flat().join("\n");
+    expect(joined).toContain(
+      "DEPOSIT_RELEASE_ENABLED: must be true or false",
+    );
     errorSpy.mockRestore();
+  });
 
+  it("succeeds when env is valid", () => {
     const parsed = loadCoreEnv({
       ...baseEnv,
       DEPOSIT_RELEASE_ENABLED: "true",
@@ -52,6 +77,75 @@ describe("loadCoreEnv", () => {
     } as unknown as NodeJS.ProcessEnv);
     expect(parsed.DEPOSIT_RELEASE_ENABLED).toBe(true);
     expect(parsed.DEPOSIT_RELEASE_INTERVAL_MS).toBe(1000);
+  });
+});
+
+describe("requireEnv", () => {
+  const ORIGINAL = process.env;
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it("throws when missing or empty", () => {
+    delete process.env.MISSING;
+    expect(() => requireEnv("MISSING")).toThrow("MISSING is required");
+    process.env.EMPTY = "   ";
+    expect(() => requireEnv("EMPTY")).toThrow("EMPTY is required");
+  });
+
+  it("returns trimmed strings", () => {
+    process.env.NAME = " value ";
+    expect(requireEnv("NAME")).toBe("value");
+  });
+
+  it.each([
+    ["true", true],
+    ["1", true],
+    ["false", false],
+    ["0", false],
+  ])("coerces boolean %s", (input, expected) => {
+    process.env.FLAG = input as string;
+    expect(requireEnv("FLAG", "boolean")).toBe(expected);
+  });
+
+  it("throws on invalid boolean", () => {
+    process.env.FLAG = "maybe";
+    expect(() => requireEnv("FLAG", "boolean")).toThrow(
+      "FLAG must be a boolean",
+    );
+  });
+
+  it("parses numbers and rejects invalid", () => {
+    process.env.NUM = "42";
+    expect(requireEnv("NUM", "number")).toBe(42);
+    process.env.NUM = "not";
+    expect(() => requireEnv("NUM", "number")).toThrow(
+      "NUM must be a number",
+    );
+  });
+});
+
+describe("AUTH_TOKEN_TTL normalization", () => {
+  const load = (ttl: string) =>
+    loadCoreEnv({ ...baseEnv, AUTH_TOKEN_TTL: ttl } as any);
+
+  it.each([
+    ["10", 10],
+    ["10s", 10],
+    ["10 m", 600],
+  ])("parses %s", (input, expected) => {
+    expect(load(input).AUTH_TOKEN_TTL).toBe(expected);
+  });
+
+  it("defaults when blank", () => {
+    expect(load(" ").AUTH_TOKEN_TTL).toBe(900); // 15m default
+  });
+
+  it("records issue for invalid format", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => load("oops")).toThrow("Invalid core environment variables");
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 
@@ -78,5 +172,28 @@ describe("coreEnv proxy caching", () => {
     expect(parseSpy).toHaveBeenCalledTimes(1);
     parseSpy.mockRestore();
   });
+
+  it("invokes loadCoreEnv only once", () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      ...baseEnv,
+    } as NodeJS.ProcessEnv;
+    jest.resetModules();
+    const mod = require("./core.js");
+    const loadSpy = jest
+      .spyOn(mod, "loadCoreEnv")
+      .mockReturnValue({
+        CMS_SPACE_URL: "https://example.com",
+        CMS_ACCESS_TOKEN: "token",
+        SANITY_API_VERSION: "v1",
+      } as any);
+    expect(mod.coreEnv.CMS_SPACE_URL).toBe("https://example.com");
+    expect(mod.coreEnv.CMS_ACCESS_TOKEN).toBe("token");
+    // Access again to ensure caching
+    expect(mod.coreEnv.CMS_SPACE_URL).toBe("https://example.com");
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    loadSpy.mockRestore();
+  });
 });
+
 


### PR DESCRIPTION
## Summary
- add requireEnv, TTL normalization, and proxy caching tests for core env
- cover default email provider, disabled payments gateway, and auth boolean coercions

## Testing
- `pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68bae83a0940832fa080e8ac720fdc2f