### PR TITLE
fix: robust repo root detection for theme utilities

### DIFF
--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -22,6 +22,10 @@ function repoRoot(): string {
   const match = cwd.match(/^(.*?)(?:\/(?:packages|apps))(?:\/|$)/);
   if (match) return match[1];
 
+  if (fs.existsSync(join(cwd, "packages")) || fs.existsSync(join(cwd, "apps"))) {
+    return cwd;
+  }
+
   let dir = typeof __dirname !== "undefined" ? __dirname : cwd;
   while (
     !fs.existsSync(join(dir, "packages")) &&
@@ -164,14 +168,9 @@ export function listThemes(): string[] {
   const themesDir = join(repoRoot(), "packages", "themes");
   try {
     return fs
-      .readdirSync(themesDir)
-      .filter((name) => {
-        try {
-          return fs.statSync(join(themesDir, name)).isDirectory();
-        } catch {
-          return false;
-        }
-      });
+      .readdirSync(themesDir, { withFileTypes: true })
+      .filter((ent) => ent.isDirectory())
+      .map((ent) => ent.name);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- handle cases where working directory is repository root when resolving repoRoot
- improve listThemes by filtering directories via Dirent objects

## Testing
- `pnpm exec jest packages/platform-core/__tests__/createShopIndex.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bae90be4bc832fa5cdca6d9761f22d