### PR TITLE
feat(stripe): enforce secret key presence

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -11,8 +11,13 @@ import Stripe from "stripe";
  * • Pins `apiVersion` to Stripe’s latest GA (“2025-06-30.basil”) so typings
  *   and requests stay in sync.
  */
-// Use a dummy fallback for now. TODO: remove fallback once STRIPE_SECRET_KEY is guaranteed.
-const stripeSecret = coreEnv.STRIPE_SECRET_KEY ?? "dummy-stripe-secret";
+
+const stripeSecret = coreEnv.STRIPE_SECRET_KEY;
+
+if (!stripeSecret) {
+  throw new Error("Neither apiKey nor config.authenticator provided");
+}
+
 export const stripe = new Stripe(stripeSecret, {
   apiVersion: "2025-06-30.basil",
   httpClient: Stripe.createFetchHttpClient(),


### PR DESCRIPTION
## Summary
- throw if `STRIPE_SECRET_KEY` is missing instead of using a dummy fallback

## Testing
- `pnpm exec jest packages/stripe/src/__tests__/stripe.test.ts --runInBand --detectOpenHandles --config jest.config.cjs`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/stripe run build` *(fails: Cannot find module '@jest/globals')*
- `pnpm --filter @acme/stripe lint` *(fails: Cannot find package '@acme/eslint-plugin-ds')*


------
https://chatgpt.com/codex/tasks/task_e_68baec7fffbc832fa90ccc9152ae05e0