### PR TITLE
test: expand platform-core coverage

### DIFF
--- a/packages/platform-core/src/db.test.ts
+++ b/packages/platform-core/src/db.test.ts
@@ -6,6 +6,8 @@ describe("db", () => {
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    jest.unmock("module");
+    jest.unmock("@prisma/client");
     delete process.env.NODE_ENV;
     delete process.env.DATABASE_URL;
   });
@@ -26,8 +28,19 @@ describe("db", () => {
     const shop = "stub-shop";
     expect(await prisma.rentalOrder.findMany({ where: { shop } })).toEqual([]);
 
-    await prisma.rentalOrder.create({
-      data: { shop, sessionId: "s1", trackingNumber: "t1" },
+    const created = await prisma.rentalOrder.create({
+      data: {
+        shop,
+        customerId: "c1",
+        sessionId: "s1",
+        trackingNumber: "t1",
+      },
+    });
+    expect(created).toMatchObject({
+      shop,
+      customerId: "c1",
+      sessionId: "s1",
+      trackingNumber: "t1",
     });
 
     const updated = await prisma.rentalOrder.update({
@@ -36,13 +49,68 @@ describe("db", () => {
     });
     expect(updated.trackingNumber).toBe("t2");
 
-    const orders = await prisma.rentalOrder.findMany({ where: { shop } });
+    const orders = await prisma.rentalOrder.findMany({
+      where: { shop, customerId: "c1" },
+    });
     expect(orders).toHaveLength(1);
     expect(orders[0]).toMatchObject({
       shop,
+      customerId: "c1",
       sessionId: "s1",
       trackingNumber: "t2",
     });
+  });
+
+  it("findMany filters by shop and customerId", async () => {
+    process.env.NODE_ENV = "test";
+    jest.doMock("@acme/config/env/core", () => ({ loadCoreEnv: () => ({}) }));
+    jest.doMock(
+      "@prisma/client",
+      () => {
+        throw new Error("should not load");
+      },
+      { virtual: true }
+    );
+
+    const { prisma } = (await import("./db")) as { prisma: PrismaClient };
+
+    await prisma.rentalOrder.create({
+      data: {
+        shop: "shop1",
+        customerId: "c1",
+        sessionId: "s1",
+        trackingNumber: "t1",
+      },
+    });
+    await prisma.rentalOrder.create({
+      data: {
+        shop: "shop1",
+        customerId: "c2",
+        sessionId: "s2",
+        trackingNumber: "t2",
+      },
+    });
+    await prisma.rentalOrder.create({
+      data: {
+        shop: "shop2",
+        customerId: "c1",
+        sessionId: "s3",
+        trackingNumber: "t3",
+      },
+    });
+
+    const results = await prisma.rentalOrder.findMany({
+      where: { shop: "shop1", customerId: "c1" },
+    });
+
+    expect(results).toEqual([
+      {
+        shop: "shop1",
+        customerId: "c1",
+        sessionId: "s1",
+        trackingNumber: "t1",
+      },
+    ]);
   });
 
   it("throws when updating a nonexistent order", async () => {
@@ -60,10 +128,46 @@ describe("db", () => {
 
     await expect(
       prisma.rentalOrder.update({
-        where: { shop_sessionId: { shop: "s", sessionId: "missing" } },
+        where: {
+          shop_trackingNumber: { shop: "s", trackingNumber: "missing" },
+        },
         data: { trackingNumber: "t1" },
       })
     ).rejects.toThrow("Order not found");
+  });
+
+  it("updates orders by trackingNumber", async () => {
+    process.env.NODE_ENV = "test";
+    jest.doMock("@acme/config/env/core", () => ({ loadCoreEnv: () => ({}) }));
+    jest.doMock(
+      "@prisma/client",
+      () => {
+        throw new Error("should not load");
+      },
+      { virtual: true }
+    );
+
+    const { prisma } = (await import("./db")) as { prisma: PrismaClient };
+
+    await prisma.rentalOrder.create({
+      data: {
+        shop: "shop",
+        trackingNumber: "t1",
+        sessionId: "s1",
+      },
+    });
+
+    const updated = await prisma.rentalOrder.update({
+      where: { shop_trackingNumber: { shop: "shop", trackingNumber: "t1" } },
+      data: { customerId: "c99" },
+    });
+
+    expect(updated).toMatchObject({
+      shop: "shop",
+      trackingNumber: "t1",
+      sessionId: "s1",
+      customerId: "c99",
+    });
   });
 
   it("uses stub when NODE_ENV=test even with DATABASE_URL", async () => {
@@ -135,6 +239,27 @@ describe("db", () => {
     expect(orders).toHaveLength(1);
   });
 
+  it("falls back to stub when createRequire throws", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.DATABASE_URL = "postgres://example";
+    jest.doMock("@acme/config/env/core", () => ({
+      loadCoreEnv: () => ({ DATABASE_URL: "postgres://example" }),
+    }));
+    const createRequireMock = jest.fn(() => {
+      throw new Error("fail");
+    });
+    jest.doMock("module", () => ({ createRequire: createRequireMock }));
+
+    const { prisma } = (await import("./db")) as { prisma: PrismaClient };
+
+    await prisma.rentalOrder.create({
+      data: { shop: "s", sessionId: "1", trackingNumber: "t1" },
+    });
+    const orders = await prisma.rentalOrder.findMany({ where: { shop: "s" } });
+    expect(orders).toHaveLength(1);
+    expect(createRequireMock).toHaveBeenCalled();
+  });
+
   it("passes DATABASE_URL to PrismaClient", async () => {
     process.env.NODE_ENV = "production";
     const databaseUrl = "postgres://from-core-env";
@@ -142,11 +267,9 @@ describe("db", () => {
       loadCoreEnv: () => ({ DATABASE_URL: databaseUrl }),
     }));
     const PrismaClientMock = jest.fn().mockImplementation(() => ({}));
-    jest.doMock(
-      "@prisma/client",
-      () => ({ PrismaClient: PrismaClientMock }),
-      { virtual: true }
-    );
+    jest.doMock("@prisma/client", () => ({ PrismaClient: PrismaClientMock }), {
+      virtual: true,
+    });
 
     await import("./db");
 


### PR DESCRIPTION
## Summary
- expand Prisma stub tests to cover create, filtering, updates, and fallback logic
- extend analytics provider tests with caching and aggregate updates for page views and orders

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `CI=true pnpm exec jest packages/platform-core/src/db.test.ts --runInBand --config jest.config.cjs --testTimeout 30000`
- `CI=true pnpm exec jest packages-platform-core/src/analytics/__tests__/index.test.ts --runInBand --config jest.config.cjs --testTimeout 30000 --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bae87965a8832f8c595ba5d4900176