### PR TITLE
test(platform-core): add coverage for shop creation and deployment

### DIFF
--- a/packages/platform-core/__tests__/createShop.unit.test.ts
+++ b/packages/platform-core/__tests__/createShop.unit.test.ts
@@ -1,0 +1,98 @@
+import { jest } from '@jest/globals';
+import { Volume, createFsFromVolume } from 'memfs';
+import path from 'path';
+
+// mock fs with memfs
+const vol = new Volume();
+const fs = createFsFromVolume(vol);
+
+jest.mock('fs', () => fs);
+
+// mock prisma
+const prismaMock = {
+  shop: { create: jest.fn(async () => ({})) },
+  page: { createMany: jest.fn(async () => ({})) },
+};
+jest.mock('../src/db', () => ({ prisma: prismaMock }));
+
+// mock shop name validation
+const validateShopName = jest.fn((id: string) => id.toLowerCase());
+jest.mock('../src/shops', () => ({ validateShopName }));
+
+// mock tokens loader
+const loadTokensMock = jest.fn(() => ({ primary: 'red', secondary: 'green' }));
+jest.mock('../src/createShop/themeUtils', () => ({ loadTokens: loadTokensMock }));
+
+describe('createShop', () => {
+  beforeEach(() => {
+    vol.reset();
+    jest.clearAllMocks();
+  });
+
+  it('validates name, merges overrides, and writes shop.json', async () => {
+    const { createShop } = await import('../src/createShop');
+    await createShop(
+      'MyShop',
+      { theme: 'base', themeOverrides: { secondary: 'blue' } },
+      { deploy: false }
+    );
+    expect(validateShopName).toHaveBeenCalledWith('MyShop');
+    const file = path.join(
+      process.cwd(),
+      'data',
+      'shops',
+      'myshop',
+      'shop.json'
+    );
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(data.themeDefaults).toEqual({ primary: 'red', secondary: 'green' });
+    expect(data.themeOverrides).toEqual({ secondary: 'blue' });
+    expect(data.themeTokens).toEqual({ primary: 'red', secondary: 'blue' });
+  });
+
+  it('seeds pages only when pages array has items', async () => {
+    const { createShop } = await import('../src/createShop');
+    await createShop('no-pages', { theme: 'base', pages: [] }, { deploy: false });
+    expect(prismaMock.page.createMany).not.toHaveBeenCalled();
+    await createShop(
+      'pages',
+      {
+        theme: 'base',
+        pages: [
+          { slug: 'about', title: { en: 'About' }, components: [] } as any,
+        ],
+      },
+      { deploy: false }
+    );
+    expect(prismaMock.page.createMany).toHaveBeenCalledTimes(1);
+    const call = prismaMock.page.createMany.mock.calls[0][0];
+    expect(call.data[0]).toMatchObject({ shopId: 'pages', slug: 'about' });
+  });
+
+  it('returns pending and skips deploy when deploy=false', async () => {
+    const mod = await import('../src/createShop');
+    const spy = jest.spyOn(mod, 'deployShop');
+    const result = await mod.createShop('pending', { theme: 'base' }, { deploy: false });
+    expect(result).toEqual({ status: 'pending' });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('uses mocked deployShop when provided', async () => {
+    const mod = await import('../src/createShop');
+    const adapter = {
+      scaffold: jest.fn(),
+      deploy: jest.fn(() => ({ status: 'success' as const })),
+      writeDeployInfo: jest.fn(),
+    };
+    const deploySpy = jest
+      .spyOn(mod, 'deployShop')
+      .mockReturnValue({ status: 'mocked' } as any);
+    const originalImpl = deploySpy.getMockImplementation();
+    const result = await mod.createShop('mocked', { theme: 'base' }, undefined, adapter as any);
+    expect(deploySpy).toHaveBeenCalledWith('mocked', undefined, adapter);
+    expect(deploySpy.getMockImplementation()).not.toBe(originalImpl);
+    expect(result).toEqual({ status: 'success' });
+  });
+});
+

--- a/packages/platform-core/__tests__/deployShopImpl.test.ts
+++ b/packages/platform-core/__tests__/deployShopImpl.test.ts
@@ -1,0 +1,53 @@
+import { jest } from '@jest/globals';
+import { Volume, createFsFromVolume } from 'memfs';
+import path from 'path';
+
+const vol = new Volume();
+const fs = createFsFromVolume(vol);
+
+jest.mock('fs', () => fs);
+
+const genSecret = jest.fn(() => 'secret-123');
+jest.mock('@acme/shared-utils', () => ({ genSecret }));
+
+describe('deployShopImpl', () => {
+  beforeEach(() => {
+    vol.reset();
+    jest.clearAllMocks();
+  });
+
+  it('scaffolds, injects SESSION_SECRET, deploys, and writes deploy info', async () => {
+    vol.fromJSON({
+      '/workspace/base-shop/apps/shop/.env': ''
+    }, '/');
+    const adapter = {
+      scaffold: jest.fn(),
+      deploy: jest.fn(() => ({ status: 'success' as const })),
+      writeDeployInfo: jest.fn(),
+    };
+    const { deployShop } = await import('../src/createShop');
+    const result = deployShop('shop', undefined, adapter as any);
+    expect(adapter.scaffold).toHaveBeenCalledWith(path.join('apps', 'shop'));
+    const envPath = '/workspace/base-shop/apps/shop/.env';
+    const env = fs.readFileSync(envPath, 'utf8');
+    expect(env).toMatch(/SESSION_SECRET=secret-123/);
+    expect(adapter.deploy).toHaveBeenCalledWith('shop', undefined);
+    expect(adapter.writeDeployInfo).toHaveBeenCalledWith('shop', result);
+    expect(result).toEqual({ status: 'success' });
+  });
+
+  it('handles errors and still writes deploy info', async () => {
+    const adapter = {
+      scaffold: jest.fn(() => { throw new Error('boom'); }),
+      deploy: jest.fn(() => ({ status: 'success' as const })),
+      writeDeployInfo: jest.fn(),
+    };
+    const { deployShop } = await import('../src/createShop');
+    const result = deployShop('boomshop', undefined, adapter as any);
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('boom');
+    expect(adapter.deploy).toHaveBeenCalledWith('boomshop', undefined);
+    expect(adapter.writeDeployInfo).toHaveBeenCalledWith('boomshop', result);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for createShop validating names, theme overrides, page seeding, optional deployment, and mocked deploy paths
- add tests for deployShopImpl to check scaffolding, env secret injection, adapter hooks, and error handling

## Testing
- `pnpm exec jest packages/platform-core/__tests__/createShopIndex.test.ts packages/platform-core/__tests__/createShop.unit.test.ts packages/platform-core/__tests__/deployShopImpl.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@jest/globals' in packages/configurator)*

------
https://chatgpt.com/codex/tasks/task_e_68baeea982f8832fb1d125a74fc51efb