### PR TITLE
test: cover date utils and filter bar

### DIFF
--- a/packages/date-utils/src/__tests__/index.test.ts
+++ b/packages/date-utils/src/__tests__/index.test.ts
@@ -9,6 +9,9 @@ import {
   parseISO,
   format,
   fromZonedTime,
+  startOfDay,
+  parseDate,
+  formatDate,
 } from "../index";
 
 describe("parseISO and format", () => {
@@ -31,6 +34,50 @@ describe("fromZonedTime", () => {
   it("handles invalid timezones", () => {
     const d = fromZonedTime("2025-01-01 00:00:00", "Invalid/Zone");
     expect(Number.isNaN(d.getTime())).toBe(true);
+  });
+});
+
+describe("startOfDay", () => {
+  it("returns midnight UTC when no timezone", () => {
+    const d = startOfDay("2025-03-03T15:30:00Z");
+    expect(d.toISOString()).toBe("2025-03-03T00:00:00.000Z");
+  });
+
+  it("adjusts for timezone offsets and DST", () => {
+    const d = startOfDay("2025-03-10T12:00:00Z", "America/New_York");
+    // After DST, midnight local is 04:00 UTC
+    expect(d.toISOString()).toBe("2025-03-10T04:00:00.000Z");
+  });
+});
+
+describe("parseDate", () => {
+  it("parses ISO strings", () => {
+    expect(parseDate("2025-03-03T00:00:00Z")?.toISOString()).toBe(
+      "2025-03-03T00:00:00.000Z"
+    );
+  });
+
+  it("parses with timezone", () => {
+    expect(
+      parseDate("2025-03-03T00:00:00", "America/New_York")?.toISOString()
+    ).toBe("2025-03-03T05:00:00.000Z");
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseDate("not-a-date")).toBeNull();
+  });
+});
+
+describe("formatDate", () => {
+  it("formats dates without timezone", () => {
+    expect(formatDate("2025-03-03T05:06:07Z", "yyyy-MM-dd")).toBe(
+      "2025-03-03"
+    );
+  });
+
+  it("formats dates for a timezone", () => {
+    const d = new Date("2025-03-03T05:06:07Z");
+    expect(formatDate(d, "HH:mm", "America/New_York")).toBe("00:06");
   });
 });
 

--- a/packages/date-utils/src/index.ts
+++ b/packages/date-utils/src/index.ts
@@ -1,5 +1,10 @@
-import { addDays, format, parseISO } from "date-fns";
-import { fromZonedTime } from "date-fns-tz";
+import {
+  addDays,
+  format,
+  parseISO,
+  startOfDay as dfStartOfDay,
+} from "date-fns";
+import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
 
 export { addDays, format, parseISO, fromZonedTime };
 
@@ -40,6 +45,36 @@ export function formatTimestamp(
 ): string {
   const date = new Date(ts);
   return Number.isNaN(date.getTime()) ? ts : date.toLocaleString(locale);
+}
+
+/** Return the start of day for the given date, optionally in a timezone. */
+export function startOfDay(date: Date | string, timezone?: string): Date {
+  const d = typeof date === "string" ? parseISO(date) : date;
+  if (!timezone) return dfStartOfDay(d);
+  const startStr = formatInTimeZone(d, timezone, "yyyy-MM-dd'T'00:00:00XXX");
+  return parseISO(startStr);
+}
+
+/** Parse an ISO string into a Date, returning null on failure. */
+export function parseDate(value: string, timezone?: string): Date | null {
+  try {
+    const date = timezone ? fromZonedTime(value, timezone) : parseISO(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a date with an optional timezone using a date-fns style format string.
+ */
+export function formatDate(
+  date: Date | string,
+  fmt = "yyyy-MM-dd",
+  timezone?: string
+): string {
+  const d = typeof date === "string" ? parseISO(date) : date;
+  return timezone ? formatInTimeZone(d, timezone, fmt) : format(d, fmt);
 }
 
 /**

--- a/packages/platform-core/__tests__/filterBar.test.tsx
+++ b/packages/platform-core/__tests__/filterBar.test.tsx
@@ -57,5 +57,24 @@ describe("FilterBar", () => {
     expect((select as HTMLSelectElement).value).toBe("");
     expect((price as HTMLInputElement).value).toBe("");
   });
+
+  it("syncs with external value updates", async () => {
+    const defs: FilterDefinition[] = [
+      { name: "size", label: "Size", type: "select", options: ["39", "40"] },
+    ];
+    const { rerender } = render(
+      <FilterBar definitions={defs} values={{ size: "39" }} onChange={() => {}} />
+    );
+    const select = screen.getByLabelText(/Size/);
+    expect((select as HTMLSelectElement).value).toBe("39");
+
+    rerender(
+      <FilterBar definitions={defs} values={{ size: "40" }} onChange={() => {}} />
+    );
+
+    await waitFor(() => {
+      expect((select as HTMLSelectElement).value).toBe("40");
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- add timezone-aware `startOfDay`, `parseDate`, and `formatDate` helpers
- expand date util tests for DST and invalid input
- test FilterBar syncing with external values

## Testing
- `pnpm exec jest packages/date-utils/src/__tests__/index.test.ts --ci --runInBand --detectOpenHandles`
- `pnpm exec jest packages/platform-core/__tests__/filterBar.test.tsx --ci --runInBand --detectOpenHandles`

------
https://chatgpt.com/codex/tasks/task_e_68baef1852e8832fbf85e5f40d1a3610