### PR TITLE
test: add plugin and analytics coverage

### DIFF
--- a/packages/platform-core/__tests__/analytics.unit.test.ts
+++ b/packages/platform-core/__tests__/analytics.unit.test.ts
@@ -1,0 +1,71 @@
+
+describe("analytics core functions", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("caches resolved provider", async () => {
+    const readShop = jest.fn().mockResolvedValue({ analyticsEnabled: true });
+    const getShopSettings = jest
+      .fn()
+      .mockResolvedValue({ analytics: { provider: "console" } });
+    jest.doMock("../src/repositories/shops.server", () => ({
+      readShop,
+      getShopSettings,
+    }));
+    const consoleLog = jest.spyOn(console, "log").mockImplementation(() => {});
+    const analytics = await import("../src/analytics");
+    await analytics.trackEvent("shop", { type: "page_view" });
+    await analytics.trackEvent("shop", { type: "page_view" });
+    expect(readShop).toHaveBeenCalledTimes(1);
+    expect(getShopSettings).toHaveBeenCalledTimes(1);
+    consoleLog.mockRestore();
+  });
+
+  it("tracks events and updates aggregates", async () => {
+    let stored: string | undefined;
+    const readFile = jest.fn(async () => {
+      if (stored) return stored;
+      throw new Error("no file");
+    });
+    const writeFile = jest.fn(async (_fp: string, data: string) => {
+      stored = data;
+    });
+    const mkdir = jest.fn().mockResolvedValue(undefined);
+    const appendFile = jest.fn();
+    jest.doMock("fs", () => ({ promises: { readFile, writeFile, mkdir, appendFile } }));
+    const readShop = jest.fn().mockResolvedValue({ analyticsEnabled: true });
+    const getShopSettings = jest
+      .fn()
+      .mockResolvedValue({ analytics: { provider: "console" } });
+    jest.doMock("../src/repositories/shops.server", () => ({
+      readShop,
+      getShopSettings,
+    }));
+    const nowIso = jest
+      .fn()
+      .mockReturnValue("2023-01-01T00:00:00.000Z");
+    jest.doMock("@acme/date-utils", () => ({ nowIso }));
+    const consoleLog = jest.spyOn(console, "log").mockImplementation(() => {});
+    const analytics = await import("../src/analytics");
+    await analytics.trackEvent("shop", { type: "page_view" });
+    await analytics.trackPageView("shop", "/home");
+    await analytics.trackEvent("shop", { type: "order", orderId: "o1", amount: 2 });
+    await analytics.trackOrder("shop", "o2", 5);
+    await analytics.trackEvent("shop", { type: "order", orderId: "o3" });
+    await analytics.trackEvent("shop", { type: "discount_redeemed", code: "SAVE" });
+    await analytics.trackEvent("shop", { type: "ai_crawl" });
+    expect(nowIso).toHaveBeenCalledTimes(7);
+    expect(consoleLog).toHaveBeenCalledTimes(7);
+    expect(writeFile).toHaveBeenCalled();
+    const agg = JSON.parse(stored!);
+    const day = "2023-01-01";
+    expect(agg.page_view[day]).toBe(2);
+    expect(agg.order[day]).toEqual({ count: 3, amount: 7 });
+    expect(agg.discount_redeemed[day].SAVE).toBe(1);
+    expect(agg.ai_crawl[day]).toBe(1);
+    consoleLog.mockRestore();
+  });
+});
+

--- a/packages/platform-core/__tests__/plugins.loadFromDir.test.ts
+++ b/packages/platform-core/__tests__/plugins.loadFromDir.test.ts
@@ -1,0 +1,155 @@
+import path from "node:path";
+import type { Dirent } from "fs";
+
+describe("loadPluginFromDir and loadPlugins", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns undefined and logs error when entryPath missing", async () => {
+    const resolvePluginEntry = jest.fn().mockResolvedValue({ entryPath: undefined, isModule: false });
+    const importByType = jest.fn();
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { logger } = await import("../src/utils");
+    const error = jest.spyOn(logger, "error").mockImplementation(() => {});
+    const { loadPlugin } = await import("../src/plugins");
+    const plugin = await loadPlugin("/plugin");
+    expect(plugin).toBeUndefined();
+    expect(resolvePluginEntry).toHaveBeenCalledWith("/plugin");
+    expect(error).toHaveBeenCalledWith(
+      "No compiled plugin entry found. Ensure plugin is built before runtime.",
+      expect.objectContaining({ plugin: "/plugin" })
+    );
+    error.mockRestore();
+  });
+
+  it("returns undefined and logs error when module lacks default export", async () => {
+    const resolvePluginEntry = jest
+      .fn()
+      .mockResolvedValue({ entryPath: "/plugin/index.js", isModule: false });
+    const importByType = jest.fn().mockResolvedValue({ notPlugin: {} });
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { logger } = await import("../src/utils");
+    const error = jest.spyOn(logger, "error").mockImplementation(() => {});
+    const { loadPlugin } = await import("../src/plugins");
+    const plugin = await loadPlugin("/plugin");
+    expect(plugin).toBeUndefined();
+    expect(error).toHaveBeenCalledWith(
+      "Plugin module did not export a default Plugin",
+      expect.objectContaining({ plugin: "/plugin", entry: "/plugin/index.js", exportedKeys: ["notPlugin"] })
+    );
+    error.mockRestore();
+  });
+
+  it("returns plugin when module exports default", async () => {
+    const resolvePluginEntry = jest
+      .fn()
+      .mockResolvedValue({ entryPath: "/plugin/index.js", isModule: false });
+    const pluginObj = { id: "good" } as any;
+    const importByType = jest.fn().mockResolvedValue({ default: pluginObj });
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { loadPlugin } = await import("../src/plugins");
+    const plugin = await loadPlugin("/plugin");
+    expect(plugin).toBe(pluginObj);
+  });
+
+  it("discovers plugin directories and loads plugins", async () => {
+    const resolvePluginEnvironment = jest
+      .fn()
+      .mockResolvedValue({ searchDirs: ["/search"], pluginDirs: ["/explicit"] });
+    jest.doMock("../src/plugins/env", () => ({ resolvePluginEnvironment }));
+    const dirent = (name: string, isDir: boolean): Dirent => ({
+      name,
+      isDirectory: () => isDir,
+    } as Dirent);
+    const readdir = jest
+      .fn()
+      .mockResolvedValue([dirent("p1", true), dirent("file.txt", false)]);
+    jest.doMock("fs/promises", () => ({ readdir }));
+    const resolvePluginEntry = jest
+      .fn()
+      .mockImplementation(async (dir: string) => ({ entryPath: path.join(dir, "index.js"), isModule: false }));
+    const importByType = jest
+      .fn()
+      .mockImplementation(async (entry: string) => ({ default: { id: path.basename(path.dirname(entry)) } }));
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { loadPlugins } = await import("../src/plugins");
+    const plugins = await loadPlugins();
+    expect(readdir).toHaveBeenCalledWith("/search", { withFileTypes: true });
+    expect(plugins.map((p) => p.id).sort()).toEqual(["explicit", "p1"]);
+  });
+
+  it("logs warning when readdir fails", async () => {
+    const resolvePluginEnvironment = jest
+      .fn()
+      .mockResolvedValue({ searchDirs: ["/search"], pluginDirs: [] });
+    jest.doMock("../src/plugins/env", () => ({ resolvePluginEnvironment }));
+    const readdir = jest.fn().mockRejectedValue(new Error("fail"));
+    jest.doMock("fs/promises", () => ({ readdir }));
+    const resolvePluginEntry = jest.fn();
+    const importByType = jest.fn();
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { logger } = await import("../src/utils");
+    const warn = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    const { loadPlugins } = await import("../src/plugins");
+    const plugins = await loadPlugins();
+    expect(plugins).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to read plugins directory",
+      expect.objectContaining({ directory: "/search", err: expect.any(Error) })
+    );
+    warn.mockRestore();
+  });
+
+  it("initializes plugins and skips invalid config", async () => {
+    const validPlugin = {
+      id: "valid",
+      defaultConfig: { enabled: true },
+      configSchema: { safeParse: (v: any) => ({ success: true, data: v }) },
+      init: jest.fn(),
+      registerPayments: jest.fn(),
+      registerShipping: jest.fn(),
+      registerWidgets: jest.fn(),
+    } as any;
+    const invalidPlugin = {
+      id: "invalid",
+      defaultConfig: { enabled: true },
+      configSchema: { safeParse: () => ({ success: false, error: new Error("bad") }) },
+      init: jest.fn(),
+      registerPayments: jest.fn(),
+      registerShipping: jest.fn(),
+      registerWidgets: jest.fn(),
+    } as any;
+    const resolvePluginEnvironment = jest
+      .fn()
+      .mockResolvedValue({ searchDirs: [], pluginDirs: ["/valid", "/invalid"] });
+    jest.doMock("../src/plugins/env", () => ({ resolvePluginEnvironment }));
+    const resolvePluginEntry = jest
+      .fn()
+      .mockImplementation(async (dir: string) => ({ entryPath: path.join(dir, "index.js"), isModule: false }));
+    const importByType = jest.fn(async (entry: string) => {
+      const dir = path.dirname(entry);
+      if (dir.includes("valid")) return { default: validPlugin };
+      if (dir.includes("invalid")) return { default: invalidPlugin };
+      return {};
+    });
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { logger } = await import("../src/utils");
+    const error = jest.spyOn(logger, "error").mockImplementation(() => {});
+    const { initPlugins } = await import("../src/plugins");
+    const manager = await initPlugins({ config: { valid: { enabled: false }, invalid: {} } });
+    expect(manager.listPlugins().map((p) => p.id)).toEqual(["valid"]);
+    expect(validPlugin.init).toHaveBeenCalledWith({ enabled: false });
+    expect(validPlugin.registerPayments).toHaveBeenCalled();
+    expect(validPlugin.registerShipping).toHaveBeenCalled();
+    expect(validPlugin.registerWidgets).toHaveBeenCalled();
+    expect(invalidPlugin.init).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      "Invalid config for plugin",
+      expect.objectContaining({ plugin: "invalid" })
+    );
+    error.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for platform-core plugin loading and initialization
- cover analytics provider caching and aggregate updates

## Testing
- `pnpm --filter @acme/platform-core test` *(fails: expected env variables? ran but coverage logs displayed)*

------
https://chatgpt.com/codex/tasks/task_e_68baf39d8624832f946e5d66380d8447