### PR TITLE
test: cover db fallback scenarios and subscription usage

### DIFF
--- a/packages/platform-machine/src/__tests__/subscriptionUsage.test.ts
+++ b/packages/platform-machine/src/__tests__/subscriptionUsage.test.ts
@@ -1,0 +1,53 @@
+import { jest } from "@jest/globals";
+
+describe("subscriptionUsage", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("calls findUnique with composite key", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const findUnique = jest.fn().mockResolvedValue(null);
+      jest.doMock("@acme/platform-core/db", () => ({
+        prisma: { subscriptionUsage: { findUnique } },
+      }));
+      const { getSubscriptionUsage } = await import(
+        "@acme/platform-core/subscriptionUsage"
+      );
+      await getSubscriptionUsage("shop", "cust", "2023-10");
+      expect(findUnique).toHaveBeenCalledWith({
+        where: {
+          shop_customerId_month: {
+            shop: "shop",
+            customerId: "cust",
+            month: "2023-10",
+          },
+        },
+      });
+    });
+  });
+
+  it("upserts and increments shipments", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const upsert = jest.fn().mockResolvedValue(undefined);
+      jest.doMock("@acme/platform-core/db", () => ({
+        prisma: { subscriptionUsage: { upsert } },
+      }));
+      const { incrementSubscriptionUsage } = await import(
+        "@acme/platform-core/subscriptionUsage"
+      );
+      await incrementSubscriptionUsage("shop", "cust", "2023-10", 2);
+      expect(upsert).toHaveBeenCalledWith({
+        where: {
+          shop_customerId_month: {
+            shop: "shop",
+            customerId: "cust",
+            month: "2023-10",
+          },
+        },
+        create: { shop: "shop", customerId: "cust", month: "2023-10", shipments: 2 },
+        update: { shipments: { increment: 2 } },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expand db fallback tests for test env, missing DATABASE_URL and createRequire failures
- verify subscriptionUsage delegates to prisma with proper keys and increments

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build errors)*
- `pnpm run check:references` *(script missing)*
- `pnpm run build:ts` *(script missing)*
- `pnpm --filter @acme/platform-machine test` *(fails: unrelated lateFeeService.test)*
- `pnpm exec jest packages/platform-machine/src/__tests__/db.test.ts packages/platform-machine/src/__tests__/subscriptionUsage.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68baf83b2700832fbe15207eb4c007bc