### PR TITLE
Fix maintenance scheduler and deposit release logging

### DIFF
--- a/packages/platform-machine/src/maintenanceScheduler.ts
+++ b/packages/platform-machine/src/maintenanceScheduler.ts
@@ -14,10 +14,17 @@ export async function runMaintenanceScan(
 ): Promise<void> {
   const shops = await readdir(dataRoot);
   for (const shop of shops) {
-    const [inventory, products] = await Promise.all([
-      readInventory(shop),
-      readProducts(shop),
-    ]);
+    let inventory;
+    let products;
+    try {
+      [inventory, products] = await Promise.all([
+        readInventory(shop),
+        readProducts(shop),
+      ]);
+    } catch (err) {
+      logger.error("maintenance scan failed", { shopId: shop, err });
+      continue;
+    }
     const productMap = new Map(products.map((p) => [p.sku, p]));
 
     for (const item of inventory) {

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -133,9 +133,11 @@ async function resolveConfig(
 export async function startDepositReleaseService(
   configs: Record<string, Partial<DepositReleaseConfig>> = {},
   dataRoot: string = DATA_ROOT,
-  releaseFn: typeof releaseDepositsOnce = releaseDepositsOnce,
+  releaseFn?: typeof releaseDepositsOnce,
   logFn: typeof logger.error = (msg, meta) => logger.error(msg, meta),
 ): Promise<() => void> {
+  const release =
+    releaseFn ?? (await import("./releaseDepositsService")).releaseDepositsOnce;
   const shops = await readdir(dataRoot);
   const timers: NodeJS.Timeout[] = [];
 
@@ -146,7 +148,7 @@ export async function startDepositReleaseService(
 
       async function run() {
         try {
-          await releaseFn(shop, dataRoot);
+          await release(shop, dataRoot);
         } catch (err) {
           logFn("deposit release failed", { shopId: shop, err });
         }


### PR DESCRIPTION
## Summary
- handle inventory/product read failures during maintenance scans
- allow custom deposit release implementations to be mocked in tests
- refactor late fee service to use runtime fs imports and improved startup handling

## Testing
- `pnpm -F @acme/platform-machine test packages/platform-machine/__tests__/lateFeeService.test.ts packages/platform-machine/__tests__/maintenanceScheduler.test.ts packages/platform-machine/src/__tests__/releaseDepositsService.test.ts` *(fails: auto-start › logs errors when service fails to start)*


------
https://chatgpt.com/codex/tasks/task_e_68baf67e8190832f8d4f36b959a658bc