### PR TITLE
fix ui tests

### DIFF
--- a/packages/ui/__tests__/PageCanvas.test.tsx
+++ b/packages/ui/__tests__/PageCanvas.test.tsx
@@ -2,34 +2,42 @@ import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import PageCanvas from "../src/components/cms/page-builder/PageCanvas";
 
-// mock CanvasItem and Block for controlled rendering
-const CanvasItemMock = jest.fn((props) => (
-  <div role="listitem" data-testid={`item-${props.component.id}`} />
-));
 jest.mock("../src/components/cms/page-builder/CanvasItem", () => ({
   __esModule: true,
-  default: CanvasItemMock,
+  default: jest.fn((props) => (
+    <div role="listitem" data-testid={`item-${props.component.id}`} />
+  )),
 }));
 
-const BlockMock = jest.fn((props) => (
-  <div data-testid={`block-${props.component.id}`} />
-));
 jest.mock("../src/components/cms/page-builder/Block", () => ({
   __esModule: true,
-  default: BlockMock,
+  default: jest.fn((props) => (
+    <div data-testid={`block-${props.component.id}`} />
+  )),
 }));
 
-const GridMock = jest.fn(() => <div data-testid="grid" />);
 jest.mock("../src/components/cms/page-builder/GridOverlay", () => ({
   __esModule: true,
-  default: GridMock,
+  default: jest.fn(() => <div data-testid="grid" />),
 }));
 
-const SnapLineMock = jest.fn(() => <div data-testid="snapline" />);
 jest.mock("../src/components/cms/page-builder/SnapLine", () => ({
   __esModule: true,
-  default: SnapLineMock,
+  default: jest.fn(() => <div data-testid="snapline" />),
 }));
+
+const CanvasItemMock = jest.requireMock(
+  "../src/components/cms/page-builder/CanvasItem"
+).default as jest.Mock;
+const BlockMock = jest.requireMock(
+  "../src/components/cms/page-builder/Block"
+).default as jest.Mock;
+const GridMock = jest.requireMock(
+  "../src/components/cms/page-builder/GridOverlay"
+).default as jest.Mock;
+const SnapLineMock = jest.requireMock(
+  "../src/components/cms/page-builder/SnapLine"
+).default as jest.Mock;
 
 describe("PageCanvas", () => {
   const components: any[] = [{ id: "a", type: "Text" }];
@@ -72,7 +80,7 @@ describe("PageCanvas", () => {
   });
 
   it("renders blocks only when preview is true", () => {
-    render(
+    const { queryByTestId } = render(
       <PageCanvas
         components={components}
         preview
@@ -82,7 +90,7 @@ describe("PageCanvas", () => {
       />
     );
     expect(BlockMock).toHaveBeenCalledTimes(1);
-    expect(CanvasItemMock).not.toHaveBeenCalled();
+    expect(queryByTestId("item-a")).toBeNull();
   });
 
   it("shows grid and snapline when enabled", () => {
@@ -101,4 +109,3 @@ describe("PageCanvas", () => {
     expect(SnapLineMock).toHaveBeenCalled();
   });
 });
-

--- a/packages/ui/src/components/cms/page-builder/__tests__/PageToolbar.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/PageToolbar.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { Locale } from "@acme/i18n/locales";
 import PageToolbar from "../PageToolbar";
-import { getLegacyPreset } from "../../../utils/devicePresets";
+import { getLegacyPreset } from "../../../../utils/devicePresets";
 
 describe("PageToolbar", () => {
   it("responds to keyboard shortcuts", () => {

--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["src/**/*"],
   "exclude": ["__tests__", "**/__tests__/**", "**/*.test.*", "**/*.spec.*"]


### PR DESCRIPTION
## Summary
- fix PageToolbar test import path
- allow tests outside src by setting rootDir in ui tsconfig.test
- stabilize PageCanvas tests with explicit mocks

## Testing
- `pnpm exec jest packages/ui/src/components/cms/page-builder/__tests__/PageToolbar.test.tsx packages/ui/__tests__/useAutoSave.test.tsx packages/ui/__tests__/PageCanvas.test.tsx --config jest.config.cjs`
- `pnpm -r build` *(fails: Invalid auth environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68baf55396a0832fac86eff763b0cebf