### PR TITLE
test(platform-core): add redis cart TTL expiry test

### DIFF
--- a/packages/platform-core/src/cartStore/redisStore.test.ts
+++ b/packages/platform-core/src/cartStore/redisStore.test.ts
@@ -11,6 +11,7 @@ class MockRedis {
   constructor(private failUntil = 0) {}
 
   data = new Map<string, Record<string, any>>();
+  expires = new Map<string, number>();
 
   private maybeFail() {
     if (this.failCount < this.failUntil) {
@@ -19,8 +20,19 @@ class MockRedis {
     }
   }
 
+  private isExpired(key: string) {
+    const exp = this.expires.get(key);
+    if (exp && Date.now() > exp) {
+      this.data.delete(key);
+      this.expires.delete(key);
+      return true;
+    }
+    return false;
+  }
+
   hset = jest.fn(async (key: string, value: Record<string, any>) => {
     this.maybeFail();
+     this.isExpired(key);
     const obj = this.data.get(key) ?? {};
     Object.assign(obj, value);
     this.data.set(key, obj);
@@ -29,22 +41,26 @@ class MockRedis {
 
   hgetall = jest.fn(async (key: string) => {
     this.maybeFail();
+    if (this.isExpired(key)) return undefined;
     return this.data.get(key) ?? {};
   });
 
-  expire = jest.fn(async (_key: string, _ttl: number) => {
+  expire = jest.fn(async (key: string, ttl: number) => {
     this.maybeFail();
+    this.expires.set(key, Date.now() + ttl * 1000);
     return 1;
   });
 
   del = jest.fn(async (key: string) => {
     this.maybeFail();
     this.data.delete(key);
+     this.expires.delete(key);
     return 1;
   });
 
   hdel = jest.fn(async (key: string, field: string) => {
     this.maybeFail();
+    this.isExpired(key);
     const obj = this.data.get(key) ?? {};
     const existed = obj[field] !== undefined ? 1 : 0;
     delete obj[field];
@@ -54,6 +70,7 @@ class MockRedis {
 
   hincrby = jest.fn(async (key: string, field: string, qty: number) => {
     this.maybeFail();
+    this.isExpired(key);
     const obj = this.data.get(key) ?? {};
     obj[field] = (obj[field] ?? 0) + qty;
     this.data.set(key, obj);
@@ -62,6 +79,7 @@ class MockRedis {
 
   hexists = jest.fn(async (key: string, field: string) => {
     this.maybeFail();
+    this.isExpired(key);
     const obj = this.data.get(key) ?? {};
     return obj[field] !== undefined ? 1 : 0;
   });
@@ -155,6 +173,24 @@ describe("RedisCartStore mocks", () => {
     expect(await store.getCart(id)).toEqual({
       [key]: { sku, size: "L", qty: 2 },
     });
+  });
+
+  it("uses fallback store when keys expire", async () => {
+    jest.useFakeTimers();
+    const ttl = 60;
+    const redis = new MockRedis();
+    const fallback = new MemoryCartStore(ttl);
+    const store = new RedisCartStore(redis as any, ttl, fallback);
+
+    const id = await store.createCart();
+    await store.incrementQty(id, sku, 1);
+
+    const getSpy = jest.spyOn(fallback, "getCart");
+
+    jest.advanceTimersByTime(ttl * 1000 + 1);
+    await expect(store.getCart(id)).resolves.toEqual({});
+    expect(getSpy).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });
 


### PR DESCRIPTION
## Summary
- extend mock Redis to track key expirations
- test RedisCartStore falls back to memory store after TTL expiry

## Testing
- `pnpm --filter @acme/platform-core test -- src/cartStore/redisStore.test.ts`
- `pnpm --filter @acme/platform-core run build`


------
https://chatgpt.com/codex/tasks/task_e_68baff638e18832fa19ff2030cd33e0e