### PR TITLE
test: strengthen config env tests

### DIFF
--- a/packages/config/src/env/__tests__/email.env.test.ts
+++ b/packages/config/src/env/__tests__/email.env.test.ts
@@ -61,6 +61,16 @@ describe("email env provider selection", () => {
     const env = await loadEnv();
     expect(env.EMAIL_PROVIDER).toBe("noop");
   });
+
+  it("rejects unknown EMAIL_PROVIDER", async () => {
+    process.env.EMAIL_PROVIDER = "unknown" as any;
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(loadEnv()).rejects.toThrow(
+      "Invalid email environment variables",
+    );
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });
 
 describe("webhook verification toggle", () => {

--- a/packages/config/src/env/__tests__/payments.env.test.ts
+++ b/packages/config/src/env/__tests__/payments.env.test.ts
@@ -65,6 +65,12 @@ describe("payments env provider", () => {
     ).rejects.toThrow("Invalid payments environment variables");
     expect(errSpy).toHaveBeenCalled();
   });
+
+  it("rejects unknown PAYMENTS_PROVIDER", async () => {
+    await expect(
+      withEnv({ PAYMENTS_PROVIDER: "paypal" as any }, () => import("../payments")),
+    ).rejects.toThrow("Invalid payments environment variables");
+  });
 });
 
 describe("payments env sandbox flag", () => {

--- a/packages/config/src/env/__tests__/shipping.env.test.ts
+++ b/packages/config/src/env/__tests__/shipping.env.test.ts
@@ -23,6 +23,35 @@ describe("shipping environment parser", () => {
     expect(load({ SHIPPING_PROVIDER: "shippo" }).SHIPPING_PROVIDER).toBe(
       "shippo",
     );
+    expect(load({ SHIPPING_PROVIDER: "ups", UPS_KEY: "key" }).SHIPPING_PROVIDER).toBe(
+      "ups",
+    );
+    expect(load({ SHIPPING_PROVIDER: "dhl", DHL_KEY: "key" }).SHIPPING_PROVIDER).toBe(
+      "dhl",
+    );
+  });
+
+  it("requires carrier keys for ups and dhl", async () => {
+    const load = await getLoader();
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => load({ SHIPPING_PROVIDER: "ups" })).toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(() => load({ SHIPPING_PROVIDER: "dhl" })).toThrow(
+      "Invalid shipping environment variables",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("rejects unknown providers", async () => {
+    const load = await getLoader();
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      load({ SHIPPING_PROVIDER: "invalid" as any }),
+    ).toThrow("Invalid shipping environment variables");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   it("returns parsed data on valid input", async () => {

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -102,7 +102,7 @@ export const coreEnvBaseSchema = authEnvSchema
   .merge(cmsEnvSchema)
   .merge(emailEnvSchema.innerType())
   .merge(paymentsEnvSchema)
-  .merge(shippingEnvSchema)
+  .merge(shippingEnvSchema.innerType())
   .merge(baseEnvSchema);
 
 export function depositReleaseEnvRefinement(

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -30,7 +30,7 @@ export const mergeEnvSchemas = <T extends readonly AnyZodObject[]>(
 const mergedEnvSchema = mergeEnvSchemas(
   coreEnvBaseSchema,
   paymentsEnvSchema,
-  shippingEnvSchema
+  shippingEnvSchema.innerType()
 );
 
 export const envSchema = mergedEnvSchema.superRefine(

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -36,6 +36,17 @@ export function loadPaymentsEnv(
     return paymentsEnvSchema.parse({});
   }
 
+  if (
+    raw.PAYMENTS_PROVIDER &&
+    raw.PAYMENTS_PROVIDER !== "stripe"
+  ) {
+    console.error(
+      "❌ Unsupported PAYMENTS_PROVIDER:",
+      raw.PAYMENTS_PROVIDER,
+    );
+    throw new Error("Invalid payments environment variables");
+  }
+
   if (raw.PAYMENTS_PROVIDER === "stripe") {
     if (!raw.STRIPE_SECRET_KEY) {
       console.error("❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe");


### PR DESCRIPTION
## Summary
- require carrier secrets for `UPS`/`DHL` and restrict shipping providers
- reject unsupported payment providers
- cover late-fee env validation and nested auth/payment error propagation
- test unknown email and payment providers

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config test`
- `pnpm -r build` *(fails: Invalid auth environment variables for apps)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bb01c5bd0c832fbbea786745a15c44