### PR TITLE
test: expand email segment coverage

### DIFF
--- a/packages/email/__tests__/segments.test.ts
+++ b/packages/email/__tests__/segments.test.ts
@@ -1,4 +1,23 @@
-import { resolveSegment } from "../src/segments";
+
+const sendgrid = {
+  createContact: jest.fn().mockResolvedValue("sg"),
+  addToList: jest.fn(),
+  listSegments: jest.fn().mockResolvedValue([{ id: "sg" }]),
+};
+
+const resend = {
+  createContact: jest.fn().mockResolvedValue("rs"),
+  addToList: jest.fn(),
+  listSegments: jest.fn().mockResolvedValue([{ id: "rs" }]),
+};
+
+jest.mock("../src/providers/sendgrid", () => ({
+  SendgridProvider: jest.fn().mockImplementation(() => sendgrid),
+}));
+
+jest.mock("../src/providers/resend", () => ({
+  ResendProvider: jest.fn().mockImplementation(() => resend),
+}));
 
 jest.mock("@platform-core/repositories/analytics.server", () => ({
   listEvents: jest.fn(),
@@ -20,6 +39,15 @@ jest.mock("fs", () => ({
   },
 }));
 
+const {
+  resolveSegment,
+  readSegments,
+  analyticsMTime,
+  createContact,
+  addToList,
+  listSegments,
+} = require("../src/segments");
+
 const { listEvents } = require("@platform-core/repositories/analytics.server") as {
   listEvents: jest.Mock;
 };
@@ -28,9 +56,91 @@ const fs = require("fs").promises as {
   stat: jest.Mock;
 };
 
+const ORIG_PROVIDER = process.env.EMAIL_PROVIDER;
+const ORIG_TTL = process.env.SEGMENT_CACHE_TTL;
+
 beforeEach(() => {
   jest.clearAllMocks();
   fs.stat.mockResolvedValue({ mtimeMs: 0 });
+});
+
+afterEach(() => {
+  process.env.EMAIL_PROVIDER = ORIG_PROVIDER;
+  process.env.SEGMENT_CACHE_TTL = ORIG_TTL;
+  jest.useRealTimers();
+});
+
+describe("readSegments", () => {
+  it("returns empty array when file is missing", async () => {
+    fs.readFile.mockRejectedValueOnce(new Error("nope"));
+    await expect(readSegments("shop")).resolves.toEqual([]);
+  });
+
+  it("parses valid JSON arrays", async () => {
+    fs.readFile.mockResolvedValueOnce(
+      JSON.stringify([{ id: "s1", filters: [] }])
+    );
+    await expect(readSegments("shop")).resolves.toEqual([
+      { id: "s1", filters: [] },
+    ]);
+  });
+
+  it("ignores non-array JSON", async () => {
+    fs.readFile.mockResolvedValueOnce(JSON.stringify({ foo: 1 }));
+    await expect(readSegments("shop")).resolves.toEqual([]);
+  });
+});
+
+describe("analyticsMTime", () => {
+  it("returns file modification time", async () => {
+    fs.stat.mockResolvedValueOnce({ mtimeMs: 123 });
+    await expect(analyticsMTime("shop")).resolves.toBe(123);
+  });
+
+  it("falls back to 0 when file missing", async () => {
+    fs.stat.mockRejectedValueOnce(new Error("missing"));
+    await expect(analyticsMTime("shop")).resolves.toBe(0);
+  });
+});
+
+describe("segment cache", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(0);
+    fs.readFile.mockResolvedValue(
+      JSON.stringify([{ id: "seg", filters: [] }])
+    );
+  });
+
+  it("expires cached results after SEGMENT_CACHE_TTL", async () => {
+    process.env.SEGMENT_CACHE_TTL = "1000";
+    fs.stat.mockResolvedValue({ mtimeMs: 1 });
+    listEvents.mockResolvedValueOnce([{ email: "a@example.com" }]);
+
+    expect(await resolveSegment("shop", "seg")).toEqual(["a@example.com"]);
+
+    listEvents.mockClear();
+    listEvents.mockResolvedValueOnce([{ email: "b@example.com" }]);
+    expect(await resolveSegment("shop", "seg")).toEqual(["a@example.com"]);
+    expect(listEvents).not.toHaveBeenCalled();
+
+    jest.setSystemTime(1001);
+    expect(await resolveSegment("shop", "seg")).toEqual(["b@example.com"]);
+    expect(listEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates cache when analytics mtime changes", async () => {
+    process.env.SEGMENT_CACHE_TTL = "10000";
+    fs.stat
+      .mockResolvedValueOnce({ mtimeMs: 1 })
+      .mockResolvedValueOnce({ mtimeMs: 2 });
+    listEvents.mockResolvedValueOnce([{ email: "a@example.com" }]);
+    expect(await resolveSegment("shop2", "seg")).toEqual(["a@example.com"]);
+
+    listEvents.mockClear();
+    listEvents.mockResolvedValueOnce([{ email: "b@example.com" }]);
+    expect(await resolveSegment("shop2", "seg")).toEqual(["b@example.com"]);
+    expect(listEvents).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("resolveSegment", () => {
@@ -85,6 +195,37 @@ describe("resolveSegment", () => {
     const emails = await resolveSegment("shop", "seg3");
 
     expect(emails.sort()).toEqual(["a@example.com", "b@example.com"]);
+  });
+});
+
+describe("provider-dependent operations", () => {
+  it("forwards calls to the configured provider", async () => {
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    await createContact("a@example.com");
+    await addToList("cid", "lid");
+    await listSegments();
+    expect(sendgrid.createContact).toHaveBeenCalledWith("a@example.com");
+    expect(sendgrid.addToList).toHaveBeenCalledWith("cid", "lid");
+    expect(sendgrid.listSegments).toHaveBeenCalled();
+
+    process.env.EMAIL_PROVIDER = "resend";
+    await createContact("b@example.com");
+    await addToList("cid2", "lid2");
+    await listSegments();
+    expect(resend.createContact).toHaveBeenCalledWith("b@example.com");
+    expect(resend.addToList).toHaveBeenCalledWith("cid2", "lid2");
+    expect(resend.listSegments).toHaveBeenCalled();
+  });
+
+  it("no-ops when no provider configured", async () => {
+    process.env.EMAIL_PROVIDER = "";
+    const id = await createContact("none@example.com");
+    await addToList("c", "l");
+    const segs = await listSegments();
+    expect(id).toBe("");
+    expect(sendgrid.createContact).not.toHaveBeenCalled();
+    expect(sendgrid.addToList).not.toHaveBeenCalled();
+    expect(segs).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add tests for segment file parsing and analytics mtime helper
- verify segment cache ttl and provider delegation behavior

## Testing
- `pnpm --filter @acme/email test __tests__/segments.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bb022874c0832f82a80d419c4b599e