### PR TITLE
test(ui): add env module tests

### DIFF
--- a/packages/ui/__tests__/env.auth.test.ts
+++ b/packages/ui/__tests__/env.auth.test.ts
@@ -1,0 +1,57 @@
+/** @jest-environment node */
+import { describe, it, expect, jest } from "@jest/globals";
+import { withEnv } from "../../config/test/utils/withEnv";
+
+const REDIS_URL = "https://example.com";
+const STRONG_SECRET = "redis-token-32-chars-long-string!";
+
+describe("auth env validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("requires strong JWT secrets", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        { NODE_ENV: "development", AUTH_PROVIDER: "jwt", JWT_SECRET: "weak" },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    const formatted = spy.mock.calls[0][1];
+    expect(formatted.JWT_SECRET?._errors[0]).toContain(
+      "must be at least 32 characters",
+    );
+  });
+
+  it("requires upstash credentials for redis session store", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          SESSION_STORE: "redis",
+          UPSTASH_REDIS_REST_URL: REDIS_URL,
+        },
+        () => import("@acme/config/src/env/auth.ts"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+    const formatted = spy.mock.calls[0][1];
+    expect(formatted.UPSTASH_REDIS_REST_TOKEN?._errors[0]).toContain(
+      "UPSTASH_REDIS_REST_TOKEN is required",
+    );
+  });
+
+  it("loads when redis credentials provided", async () => {
+    const { authEnv } = await withEnv(
+      {
+        NODE_ENV: "development",
+        SESSION_STORE: "redis",
+        UPSTASH_REDIS_REST_URL: REDIS_URL,
+        UPSTASH_REDIS_REST_TOKEN: STRONG_SECRET,
+      },
+      () => import("@acme/config/src/env/auth.ts"),
+    );
+    expect(authEnv.SESSION_STORE).toBe("redis");
+  });
+});

--- a/packages/ui/__tests__/env.core.test.ts
+++ b/packages/ui/__tests__/env.core.test.ts
@@ -1,0 +1,81 @@
+/** @jest-environment node */
+import { describe, it, expect, jest } from "@jest/globals";
+import { withEnv } from "../../config/test/utils/withEnv";
+
+describe("core env", () => {
+  it("coerces boolean and number values", async () => {
+    await withEnv(
+      {
+        NODE_ENV: "development",
+        DEPOSIT_RELEASE_ENABLED: "true",
+        DEPOSIT_RELEASE_INTERVAL_MS: "5000",
+      },
+      async () => {
+        const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+        const env = loadCoreEnv();
+        expect(env.DEPOSIT_RELEASE_ENABLED).toBe(true);
+        expect(env.DEPOSIT_RELEASE_INTERVAL_MS).toBe(5000);
+      },
+    );
+  });
+
+  it("applies defaults outside production", async () => {
+    const original = process.env;
+    process.env = { ...original, NODE_ENV: "development" };
+    delete process.env.CART_COOKIE_SECRET;
+    jest.resetModules();
+    try {
+      const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+      const env = loadCoreEnv();
+      expect(env.CART_COOKIE_SECRET).toBe("dev-cart-secret");
+    } finally {
+      process.env = original;
+    }
+  });
+
+  it("reports validation errors for malformed values", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "development",
+          DEPOSIT_RELEASE_ENABLED: "maybe",
+          DEPOSIT_RELEASE_INTERVAL_MS: "oops",
+        },
+        async () => {
+          const { loadCoreEnv } = await import("@acme/config/src/env/core.ts");
+          loadCoreEnv();
+        },
+      ),
+    ).rejects.toThrow("Invalid core environment variables");
+    const messages = spy.mock.calls.map((c) => c[0]);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("DEPOSIT_RELEASE_ENABLED: must be true or false"),
+        expect.stringContaining("DEPOSIT_RELEASE_INTERVAL_MS: must be a number"),
+      ]),
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("requireEnv", () => {
+  const loadRequire = async () => (await import("@acme/config/src/env/core.ts")).requireEnv;
+
+  it("parses booleans and numbers", async () => {
+    await withEnv({ BOOL_VAL: "true", NUM_VAL: "42" }, async () => {
+      const requireEnv = await loadRequire();
+      expect(requireEnv("BOOL_VAL", "boolean")).toBe(true);
+      expect(requireEnv("NUM_VAL", "number")).toBe(42);
+    });
+  });
+
+  it("throws for invalid boolean", async () => {
+    await withEnv({ BOOL_VAL: "nope" }, async () => {
+      const requireEnv = await loadRequire();
+      expect(() => requireEnv("BOOL_VAL", "boolean")).toThrow(
+        "BOOL_VAL must be a boolean",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add core env tests for coercion, defaults, and validation
- cover auth env for strong secrets and redis session requirements

## Testing
- `pnpm exec jest packages/ui/__tests__/env.core.test.ts packages/ui/__tests__/env.auth.test.ts --runTestsByPath --runInBand --detectOpenHandles --coverage=false --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68bb043f95d0832f859875491dd7f033