### PR TITLE
test(date-utils): cover same-day rental edge case

### DIFF
--- a/packages/date-utils/__tests__/date.test.ts
+++ b/packages/date-utils/__tests__/date.test.ts
@@ -54,6 +54,10 @@ describe("calculateRentalDays", () => {
     expect(calculateRentalDays("2025-01-03")).toBe(2);
   });
 
+  test("returns one day for same-day rentals", () => {
+    expect(calculateRentalDays("2025-01-01")).toBe(1);
+  });
+
   test("throws when return date is before today", () => {
     expect(() => calculateRentalDays("2024-12-31")).toThrow(
       "returnDate must be in the future",


### PR DESCRIPTION
## Summary
- add coverage for same-day rental in calculateRentalDays

## Testing
- `pnpm exec jest packages/date-utils/__tests__/date.test.ts packages/date-utils/__tests__/parseTargetDate.boundary.test.ts --runInBand --config jest.config.cjs --coverage=false`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68bb0454b484832f89e726cf84b7924e