### PR TITLE
test: expand email analytics and error mapping coverage

### DIFF
--- a/packages/email/__tests__/stats.test.ts
+++ b/packages/email/__tests__/stats.test.ts
@@ -1,0 +1,49 @@
+import { mapSendGridStats, mapResendStats, normalizeProviderStats, emptyStats } from "../src/analytics";
+
+describe("provider stats mapping", () => {
+  it("normalizes SendGrid stats including string numbers", () => {
+    const raw = {
+      delivered: "1",
+      opens: "2",
+      clicks: "3",
+      unsubscribes: "4",
+      bounces: "5",
+    };
+    expect(mapSendGridStats(raw)).toEqual({
+      delivered: 1,
+      opened: 2,
+      clicked: 3,
+      unsubscribed: 4,
+      bounced: 5,
+    });
+  });
+
+  it("normalizes Resend stats with alternate keys", () => {
+    const raw = {
+      delivered_count: "6",
+      opened_count: "7",
+      clicked_count: "8",
+      unsubscribed_count: "9",
+      bounced_count: "10",
+    };
+    expect(mapResendStats(raw)).toEqual({
+      delivered: 6,
+      opened: 7,
+      clicked: 8,
+      unsubscribed: 9,
+      bounced: 10,
+    });
+  });
+
+  it("uses normalizeProviderStats and falls back to empty stats", () => {
+    expect(normalizeProviderStats("sendgrid", { delivered: 2 })).toEqual({
+      ...emptyStats,
+      delivered: 2,
+    });
+    expect(normalizeProviderStats("resend", { opened: "3" })).toEqual({
+      ...emptyStats,
+      opened: 3,
+    });
+    expect(normalizeProviderStats("other", { delivered: 99 })).toEqual(emptyStats);
+  });
+});

--- a/packages/platform-core/src/services/__tests__/emailService.test.ts
+++ b/packages/platform-core/src/services/__tests__/emailService.test.ts
@@ -11,14 +11,20 @@ describe("emailService", () => {
     expect(() => getEmailService()).toThrow("EmailService not registered");
   });
 
-  it("resolves when the stub sendEmail succeeds", async () => {
+  it("returns the registered service and sends emails", async () => {
     const { setEmailService, getEmailService } = await import("../emailService");
     const stub: EmailService = { sendEmail: jest.fn().mockResolvedValue(undefined) };
     setEmailService(stub);
+    const svc = getEmailService();
+    expect(svc).toBe(stub);
     await expect(
-      getEmailService().sendEmail("to@example.com", "subject", "body"),
+      svc.sendEmail("to@example.com", "subject", "body"),
     ).resolves.toBeUndefined();
-    expect(stub.sendEmail).toHaveBeenCalledWith("to@example.com", "subject", "body");
+    expect(stub.sendEmail).toHaveBeenCalledWith(
+      "to@example.com",
+      "subject",
+      "body",
+    );
   });
 
   it("propagates rejection when the stub sendEmail rejects", async () => {

--- a/packages/zod-utils/src/__tests__/zodErrorMap.form.test.ts
+++ b/packages/zod-utils/src/__tests__/zodErrorMap.form.test.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { applyFriendlyZodMessages } from "../zodErrorMap";
+
+describe("friendly error map for user form", () => {
+  const original = z.getErrorMap();
+  beforeAll(() => applyFriendlyZodMessages());
+  afterAll(() => {
+    z.setErrorMap(original);
+  });
+
+  const schema = z.object({
+    email: z.string().email(),
+    password: z.string().min(8),
+  });
+
+  it("returns human friendly messages and format for multiple issues", () => {
+    const result = schema.safeParse({ email: "not-an-email", password: "123" });
+    expect(result.success).toBe(false);
+    const messages = result.error.issues.map((i) => i.message);
+    expect(messages).toEqual([
+      "Invalid email",
+      "Must be at least 8 characters",
+    ]);
+    expect(result.error.format()).toEqual({
+      email: { _errors: ["Invalid email"] },
+      password: { _errors: ["Must be at least 8 characters"] },
+      _errors: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add provider stats normalization tests for email analytics
- verify email service registration and sending
- ensure friendly zod error map handles multiple field issues

## Testing
- `pnpm --filter @acme/email test`
- `pnpm exec jest packages/platform-core/src/services/__tests__/emailService.test.ts --ci --runInBand --detectOpenHandles --config jest.config.cjs`
- `pnpm --filter @acme/zod-utils test`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: Build error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68bb02506224832f8f7dd032321a6020