### PR TITLE
test: add comprehensive products action tests

### DIFF
--- a/apps/cms/src/actions/__tests__/products.server.test.ts
+++ b/apps/cms/src/actions/__tests__/products.server.test.ts
@@ -4,112 +4,226 @@ jest.mock('../common/auth', () => ({
   ensureAuthorized: jest.fn(),
 }));
 
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}));
+
 jest.mock('@platform-core/repositories/json.server', () => ({
   readSettings: jest.fn(),
   readRepo: jest.fn(),
   writeRepo: jest.fn(),
   getProductById: jest.fn(),
   updateProductInRepo: jest.fn(),
-  deleteProductFromRepo: jest.fn(),
   duplicateProductInRepo: jest.fn(),
+  deleteProductFromRepo: jest.fn(),
 }));
 
 jest.mock('@/utils/sentry.server', () => ({
   captureException: jest.fn(),
 }));
 
-import { updateProduct, promoteProduct } from '../products.server';
+import {
+  createDraftRecord,
+  createDraft,
+  updateProduct,
+  duplicateProduct,
+  deleteProduct,
+  promoteProduct,
+} from '../products.server';
 import { ensureAuthorized } from '../common/auth';
 import {
   readSettings,
+  readRepo,
+  writeRepo,
   getProductById,
   updateProductInRepo,
+  duplicateProductInRepo,
+  deleteProductFromRepo,
 } from '@platform-core/repositories/json.server';
+import { redirect } from 'next/navigation';
 import { captureException } from '@/utils/sentry.server';
 
-describe('products.server', () => {
+describe('products.server actions', () => {
+  const shop = 'shop1';
   const baseProduct = {
     id: 'p1',
     sku: 'sku1',
-    title: { en: 'Old' },
-    description: { en: 'Old desc' },
+    title: { en: 't' },
+    description: { en: 'd' },
     price: 5,
     currency: 'EUR',
-    media: [{ url: 'img.jpg', type: 'image' }],
+    media: [{ url: 'm', type: 'image' }],
     status: 'draft',
-    shop: 'shop',
+    shop,
     row_version: 1,
-    created_at: '2023-01-01',
-    updated_at: '2023-01-01',
+    created_at: '2020-01-01',
+    updated_at: '2020-01-01',
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     (ensureAuthorized as jest.Mock).mockResolvedValue(undefined);
     (readSettings as jest.Mock).mockResolvedValue({ languages: ['en'] });
-    (updateProductInRepo as jest.Mock).mockImplementation((_shop, product) =>
-      Promise.resolve(product)
-    );
-  });
-
-  test('invalid media JSON falls back to []', async () => {
+    (readRepo as jest.Mock).mockResolvedValue([]);
+    (writeRepo as jest.Mock).mockResolvedValue(undefined);
     (getProductById as jest.Mock).mockResolvedValue(baseProduct);
-    const formData = new FormData();
-    formData.append('id', 'p1');
-    formData.append('price', '10');
-    formData.append('title_en', 'New Title');
-    formData.append('desc_en', 'New Desc');
-    formData.append('media', 'not-json');
-
-    const result = await updateProduct('shop', formData);
-
-    expect(updateProductInRepo).toHaveBeenCalledWith(
-      'shop',
-      expect.objectContaining({ media: [] })
-    );
-    expect(result.product?.media).toEqual([]);
+    (updateProductInRepo as jest.Mock).mockImplementation((_s, p) => Promise.resolve(p));
+    (duplicateProductInRepo as jest.Mock).mockResolvedValue({ ...baseProduct, id: 'copy' });
+    (deleteProductFromRepo as jest.Mock).mockResolvedValue(undefined);
   });
 
-  test('validation failure returns errors', async () => {
-    const formData = new FormData();
-    formData.append('id', 'p1');
-    formData.append('price', '10');
-    formData.append('title_en', '');
-    formData.append('desc_en', 'Desc');
-    formData.append('media', '[]');
+  describe('createDraftRecord', () => {
+    it('creates draft and writes to repo', async () => {
+      const draft = await createDraftRecord(shop);
+      expect(ensureAuthorized).toHaveBeenCalled();
+      expect(writeRepo).toHaveBeenCalledWith(shop, expect.arrayContaining([draft]));
+      expect(draft.status).toBe('draft');
+    });
 
-    const result = await updateProduct('shop', formData);
+    it('throws on repo write failure', async () => {
+      (writeRepo as jest.Mock).mockRejectedValue(new Error('fail'));
+      await expect(createDraftRecord(shop)).rejects.toThrow('fail');
+    });
 
-    expect(result.errors).toBeDefined();
-    expect(Object.keys(result.errors || {})).not.toHaveLength(0);
-    expect(captureException).toHaveBeenCalled();
-    expect(updateProductInRepo).not.toHaveBeenCalled();
-    expect(getProductById).not.toHaveBeenCalled();
+    it('throws when unauthorized', async () => {
+      (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
+      await expect(createDraftRecord(shop)).rejects.toThrow('unauthorized');
+    });
   });
 
-  test('throws when product not found', async () => {
-    (getProductById as jest.Mock).mockResolvedValue(undefined);
-    const formData = new FormData();
-    formData.append('id', 'p1');
-    formData.append('price', '10');
-    formData.append('title_en', 'Title');
-    formData.append('desc_en', 'Desc');
-    formData.append('media', '[]');
+  describe('createDraft', () => {
+    it('redirects to edit page', async () => {
+      await createDraft(shop);
+      const draft = (writeRepo as jest.Mock).mock.calls[0][1][0];
+      expect(redirect).toHaveBeenCalledWith(
+        `/cms/shop/${shop}/products/${draft.id}/edit`
+      );
+    });
 
-    await expect(updateProduct('shop', formData)).rejects.toThrow(
-      'Product p1 not found in shop'
-    );
-    expect(updateProductInRepo).not.toHaveBeenCalled();
+    it('throws when unauthorized', async () => {
+      (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
+      await expect(createDraft(shop)).rejects.toThrow('unauthorized');
+      expect(redirect).not.toHaveBeenCalled();
+    });
   });
 
-  test('promoteProduct returns unchanged product when status final', async () => {
-    const activeProduct = { ...baseProduct, status: 'active' };
-    (getProductById as jest.Mock).mockResolvedValue(activeProduct);
+  describe('updateProduct', () => {
+    it('returns validation errors', async () => {
+      const fd = new FormData();
+      fd.append('id', 'p1');
+      fd.append('price', '10');
+      fd.append('title_en', '');
+      fd.append('desc_en', 'desc');
+      fd.append('media', '[]');
+      const result = await updateProduct(shop, fd);
+      expect(result.errors).toBeDefined();
+      expect(getProductById).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalled();
+    });
 
-    const result = await promoteProduct('shop', 'p1');
+    it('throws when product missing', async () => {
+      (getProductById as jest.Mock).mockResolvedValue(undefined);
+      const fd = new FormData();
+      fd.append('id', 'p1');
+      fd.append('price', '10');
+      fd.append('title_en', 't');
+      fd.append('desc_en', 'd');
+      fd.append('media', '[]');
+      await expect(updateProduct(shop, fd)).rejects.toThrow(
+        'Product p1 not found in shop1'
+      );
+    });
 
-    expect(result).toBe(activeProduct);
-    expect(updateProductInRepo).not.toHaveBeenCalled();
+    it('updates product successfully', async () => {
+      const fd = new FormData();
+      fd.append('id', 'p1');
+      fd.append('price', '10');
+      fd.append('title_en', 'new');
+      fd.append('desc_en', 'new');
+      fd.append('media', '[]');
+      const result = await updateProduct(shop, fd);
+      expect(updateProductInRepo).toHaveBeenCalled();
+      expect(result.product?.title.en).toBe('new');
+    });
+
+    it('throws when unauthorized', async () => {
+      (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
+      await expect(updateProduct(shop, new FormData())).rejects.toThrow('unauthorized');
+      expect(getProductById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('duplicateProduct', () => {
+    it('duplicates and redirects', async () => {
+      await duplicateProduct(shop, 'p1');
+      expect(duplicateProductInRepo).toHaveBeenCalledWith(shop, 'p1');
+      expect(redirect).toHaveBeenCalledWith(
+        `/cms/shop/${shop}/products/copy/edit`
+      );
+    });
+
+    it('throws when unauthorized', async () => {
+      (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
+      await expect(duplicateProduct(shop, 'p1')).rejects.toThrow('unauthorized');
+      expect(redirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteProduct', () => {
+    it('deletes and redirects', async () => {
+      await deleteProduct(shop, 'p1');
+      expect(deleteProductFromRepo).toHaveBeenCalledWith(shop, 'p1');
+      expect(redirect).toHaveBeenCalledWith(`/cms/shop/${shop}/products`);
+    });
+
+    it('throws when unauthorized', async () => {
+      (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
+      await expect(deleteProduct(shop, 'p1')).rejects.toThrow('unauthorized');
+      expect(redirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('promoteProduct', () => {
+    const statusMap: Record<string, string> = {
+      draft: 'review',
+      review: 'active',
+      scheduled: 'active',
+      active: 'active',
+      archived: 'archived',
+    };
+
+    (['draft', 'review', 'scheduled'] as const).forEach((status) => {
+      it(`promotes ${status} product`, async () => {
+        const product = { ...baseProduct, status };
+        (getProductById as jest.Mock).mockResolvedValue(product);
+        (updateProductInRepo as jest.Mock).mockImplementation((_s, p) => Promise.resolve(p));
+        const result = await promoteProduct(shop, 'p1');
+        expect(updateProductInRepo).toHaveBeenCalled();
+        expect(result.status).toBe(statusMap[status]);
+      });
+    });
+
+    (['active', 'archived'] as const).forEach((status) => {
+      it(`returns unchanged for ${status} product`, async () => {
+        const product = { ...baseProduct, status };
+        (getProductById as jest.Mock).mockResolvedValue(product);
+        const result = await promoteProduct(shop, 'p1');
+        expect(updateProductInRepo).not.toHaveBeenCalled();
+        expect(result).toBe(product);
+      });
+    });
+
+    it('throws when product missing', async () => {
+      (getProductById as jest.Mock).mockResolvedValue(undefined);
+      await expect(promoteProduct(shop, 'p2')).rejects.toThrow(
+        'Product p2 not found in shop1'
+      );
+    });
+
+    it('throws when unauthorized', async () => {
+      (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
+      await expect(promoteProduct(shop, 'p1')).rejects.toThrow('unauthorized');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add thorough tests for product actions covering drafts, updates, duplication, deletion, and promotion flows

## Testing
- `pnpm --filter @apps/cms test src/actions/__tests__/products.server.test.ts`
- `pnpm -r build` *(fails: apps/cms build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0a018304832fa783c2134568e543