### PR TITLE
Fix timestamp parsing in date-utils

### DIFF
--- a/packages/date-utils/src/index.ts
+++ b/packages/date-utils/src/index.ts
@@ -44,7 +44,7 @@ export function formatTimestamp(
   ts: string,
   locale?: string
 ): string {
-  const date = new Date(ts);
+  const date = /^\d+$/.test(ts) ? new Date(Number(ts)) : new Date(ts);
   return Number.isNaN(date.getTime()) ? ts : date.toLocaleString(locale);
 }
 
@@ -93,7 +93,7 @@ export function parseTargetDate(
   try {
     if (targetDate === "today" || targetDate === "tomorrow") {
       const base = targetDate === "today" ? new Date() : addDays(new Date(), 1);
-      return startOfDay(base, timezone);
+      return startOfDay(base, timezone ?? "UTC");
     }
     let date: Date;
     if (timezone) {


### PR DESCRIPTION
## Summary
- support epoch millisecond strings in `formatTimestamp`
- default relative date parsing to UTC in `parseTargetDate`

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/date-utils run build`
- `pnpm exec jest packages/template-app/__tests__/date-utils.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b0e2b2c832f960df3fe5f602803