### PR TITLE
fix theme token override path

### DIFF
--- a/packages/platform-core/src/themeTokens/index.ts
+++ b/packages/platform-core/src/themeTokens/index.ts
@@ -37,7 +37,11 @@ function transpileTokens(filePath: string): TokenMap {
 
 export function loadThemeTokensNode(theme: string): TokenMap {
   if (!theme || theme === "base") return {};
-  const baseDir = join("packages", "themes", theme);
+  // Resolve the workspace root relative to this file so consumers can call
+  // the loader from any package without relying on their current working
+  // directory.
+  const rootDir = join(__dirname, "../../../../..");
+  const baseDir = join(rootDir, "packages", "themes", theme);
   const candidates = [
     join(baseDir, "tailwind-tokens.js"),
     join(baseDir, "tailwind-tokens.ts"),


### PR DESCRIPTION
## Summary
- ensure theme token loader resolves workspace root so overrides apply correctly

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `pnpm run build:stubs` *(fails: Missing script: build:stubs)*
- `pnpm exec jest packages/platform-machine/src/__tests__/themeTokens.api.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bb0aad9c7c832fbf9a3fa66ad4a6b4