### PR TITLE
test: expand email provider coverage

### DIFF
--- a/packages/email/src/providers/__tests__/resend.test.ts
+++ b/packages/email/src/providers/__tests__/resend.test.ts
@@ -55,6 +55,16 @@ describe("ResendProvider", () => {
         "Resend credentials rejected with status 401"
       );
     });
+
+    it("resolves immediately when sanity check disabled", async () => {
+      process.env.RESEND_API_KEY = "rs";
+      const fetchSpy = jest.spyOn(global, "fetch");
+      const { ResendProvider } = await import("../resend");
+      const provider = new ResendProvider();
+      await expect(provider.ready).resolves.toBeUndefined();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
   });
 
   it("resolves on success", async () => {

--- a/packages/email/src/providers/__tests__/sendgrid.test.ts
+++ b/packages/email/src/providers/__tests__/sendgrid.test.ts
@@ -50,6 +50,16 @@ describe("SendgridProvider", () => {
         "Sendgrid credentials rejected with status 401"
       );
     });
+
+    it("resolves immediately when sanity check disabled", async () => {
+      process.env.SENDGRID_API_KEY = "key";
+      const fetchSpy = jest.spyOn(global, "fetch");
+      const { SendgridProvider } = await import("../sendgrid");
+      const provider = new SendgridProvider();
+      await expect(provider.ready).resolves.toBeUndefined();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
   });
 
   it("resolves on success", async () => {

--- a/packages/email/src/providers/__tests__/sendgridProvider.test.ts
+++ b/packages/email/src/providers/__tests__/sendgridProvider.test.ts
@@ -43,6 +43,14 @@ describe("SendgridProvider additional cases", () => {
     await expect(provider.createContact("user@example.com")).resolves.toBe("");
   });
 
+  it("createContact returns empty string without marketing key", async () => {
+    global.fetch = jest.fn();
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.createContact("user@example.com")).resolves.toBe("");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("createContact returns id on success", async () => {
     process.env.SENDGRID_API_KEY = "key";
     global.fetch = jest.fn().mockResolvedValueOnce({
@@ -59,6 +67,26 @@ describe("SendgridProvider additional cases", () => {
     process.env.SENDGRID_API_KEY = "key";
     global.fetch = jest.fn().mockResolvedValueOnce({
       json: () => Promise.reject(new Error("bad")),
+    }) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.createContact("user@example.com")).resolves.toBe("");
+  });
+
+  it("createContact returns empty string when persisted recipients empty", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      json: () => Promise.resolve({ persisted_recipients: [] }),
+    }) as any;
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.createContact("user@example.com")).resolves.toBe("");
+  });
+
+  it("createContact returns empty string when persisted recipients missing", async () => {
+    process.env.SENDGRID_API_KEY = "key";
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      json: () => Promise.resolve({}),
     }) as any;
     const { SendgridProvider } = await import("../sendgrid");
     const provider = new SendgridProvider();
@@ -87,6 +115,14 @@ describe("SendgridProvider additional cases", () => {
     const { SendgridProvider } = await import("../sendgrid");
     const provider = new SendgridProvider();
     await expect(provider.addToList("cid", "lid")).resolves.toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("listSegments returns [] when marketing key missing", async () => {
+    global.fetch = jest.fn();
+    const { SendgridProvider } = await import("../sendgrid");
+    const provider = new SendgridProvider();
+    await expect(provider.listSegments()).resolves.toEqual([]);
     expect(global.fetch).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- add Resend sanity-check ready test
- test Sendgrid ready without sanity check
- verify Sendgrid contact and segment fallbacks

## Testing
- `pnpm --filter @acme/email test packages/email/src/providers/__tests__/sendgrid.test.ts packages/email/src/providers/__tests__/sendgridProvider.test.ts packages/email/src/providers/__tests__/resend.test.ts`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0cb4c6a0832f90b917b00d7421da