### PR TITLE
test: expand marketing email template coverage

### DIFF
--- a/packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx
+++ b/packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx
@@ -29,13 +29,19 @@ describe("MarketingEmailTemplate", () => {
     );
   });
 
-  it("omits CTA section when no CTA props provided", () => {
-    const { container, queryByRole } = render(
-      <MarketingEmailTemplate headline="Headline" content={<p>Body</p>} />,
+  it("renders logo and footer but omits CTA when CTA props are missing", () => {
+    const { getByAltText, getByText, queryByRole } = render(
+      <MarketingEmailTemplate
+        headline="Headline"
+        content={<p>Body</p>}
+        logoSrc="/logo.png"
+        footer={<span>Bye</span>}
+      />
     );
 
+    expect(getByAltText("logo")).toBeInTheDocument();
+    expect(getByText("Bye")).toBeInTheDocument();
     expect(queryByRole("link")).toBeNull();
-    expect(container.querySelector("a")).toBeNull();
   });
 
   it("renders i18n variations", () => {


### PR DESCRIPTION
## Summary
- cover MarketingEmailTemplate CTA behavior with logo and footer present

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email-templates test` *(fails: multiple tests across workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c69d9ac832fbf73f7bf3d6197bb