### PR TITLE
test: add order and pricing tests

### DIFF
--- a/packages/platform-core/src/orders.test.ts
+++ b/packages/platform-core/src/orders.test.ts
@@ -143,5 +143,102 @@ describe("orders", () => {
     expect(orders).toHaveLength(1);
     expect((orders[0] as any).foo).toBeUndefined();
   });
+
+  it("does not increment subscription usage when disabled", async () => {
+    const shop = "shop-no-sub";
+    const sessionId = "sess2";
+    const customerId = "cust2";
+    const findUniqueSpy = jest
+      .spyOn(prisma.shop, "findUnique")
+      .mockResolvedValue({ data: { subscriptionsEnabled: false } });
+
+    const order = await addOrder(shop, sessionId, 5, undefined, undefined, customerId);
+
+    expect(order).toMatchObject({ shop, sessionId, deposit: 5 });
+    expect(trackOrder).toHaveBeenCalledWith(shop, order.id, 5);
+    expect(incrementSubscriptionUsage).not.toHaveBeenCalled();
+    findUniqueSpy.mockRestore();
+  });
+
+  it("markReturned updates with damage fee and returns null when missing", async () => {
+    const shop = "shop-update-return";
+    const sessionId = "sess-return";
+    const updateSpy = jest
+      .spyOn(prisma.rentalOrder, "update")
+      .mockResolvedValueOnce({} as any);
+
+    await markReturned(shop, sessionId, 3);
+    expect(updateSpy).toHaveBeenCalledWith({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { returnedAt: expect.any(String), damageFee: 3 },
+    });
+
+    updateSpy.mockRejectedValueOnce(new Error("missing"));
+    const missing = await markReturned(shop, sessionId, 3);
+    expect(missing).toBeNull();
+    updateSpy.mockRestore();
+  });
+
+  it("markRefunded updates risk data and returns null when missing", async () => {
+    const shop = "shop-update-refund";
+    const sessionId = "sess-refund";
+    const updateSpy = jest
+      .spyOn(prisma.rentalOrder, "update")
+      .mockResolvedValueOnce({} as any);
+
+    await markRefunded(shop, sessionId, "high", 7, true);
+    expect(updateSpy).toHaveBeenCalledWith({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: {
+        refundedAt: expect.any(String),
+        riskLevel: "high",
+        riskScore: 7,
+        flaggedForReview: true,
+      },
+    });
+
+    updateSpy.mockRejectedValueOnce(new Error("missing"));
+    const missing = await markRefunded(shop, sessionId);
+    expect(missing).toBeNull();
+    updateSpy.mockRestore();
+  });
+
+  it("setReturnTracking updates fields and returns null when missing", async () => {
+    const shop = "shop-update-track";
+    const sessionId = "sess-track";
+    const updateSpy = jest
+      .spyOn(prisma.rentalOrder, "update")
+      .mockResolvedValueOnce({} as any);
+
+    await setReturnTracking(shop, sessionId, "tn2", "url2");
+    expect(updateSpy).toHaveBeenCalledWith({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { trackingNumber: "tn2", labelUrl: "url2" },
+    });
+
+    updateSpy.mockRejectedValueOnce(new Error("missing"));
+    const missing = await setReturnTracking(shop, sessionId, "tn2", "url2");
+    expect(missing).toBeNull();
+    updateSpy.mockRestore();
+  });
+
+  it("updateRisk sends correct payload and returns null when missing", async () => {
+    const shop = "shop-update-risk";
+    const sessionId = "sess-risk";
+    const updateSpy = jest
+      .spyOn(prisma.rentalOrder, "update")
+      .mockResolvedValueOnce({} as any);
+
+    await updateRisk(shop, sessionId, "low", 1, false);
+    expect(updateSpy).toHaveBeenCalledWith({
+      where: { shop_sessionId: { shop, sessionId } },
+      data: { riskLevel: "low", riskScore: 1, flaggedForReview: false },
+    });
+
+    updateSpy.mockRejectedValueOnce(new Error("missing"));
+    const missing = await updateRisk(shop, sessionId, "low", 1, false);
+    expect(missing).toBeNull();
+    updateSpy.mockRestore();
+  });
 });
 

--- a/packages/platform-core/src/pricing/index.test.ts
+++ b/packages/platform-core/src/pricing/index.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment node */
+
+jest.mock('node:fs', () => ({ promises: { readFile: jest.fn() } }));
+jest.mock('../dataRoot', () => ({ resolveDataRoot: () => '/data' }));
+
+const readFileMock = () =>
+  (jest.requireMock('node:fs') as { promises: { readFile: jest.Mock } }).promises
+    .readFile;
+
+const pricingData = {
+  baseDailyRate: 10,
+  durationDiscounts: [
+    { minDays: 3, rate: 0.9 },
+    { minDays: 5, rate: 0.8 },
+    { minDays: 10, rate: 0.5 },
+  ],
+  damageFees: { lost: 'deposit', scuff: 20 },
+  coverage: {
+    lost: { fee: 0, waiver: 30 },
+    scuff: { fee: 0, waiver: 25 },
+  },
+};
+
+const rateData = { base: 'USD', rates: { EUR: 1.27, GBP: 1.23 } };
+
+async function loadModule() {
+  const mod = await import('./index');
+  return mod;
+}
+
+describe('pricing', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    readFileMock().mockReset();
+  });
+
+  it('getPricing caches result', async () => {
+    readFileMock().mockResolvedValueOnce(JSON.stringify(pricingData));
+    const { getPricing } = await loadModule();
+    await getPricing();
+    await getPricing();
+    expect(readFileMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('convertCurrency rounds and errors on missing rate', async () => {
+    readFileMock().mockImplementation(async (file: string) => {
+      if (file.includes('exchangeRates.json')) return JSON.stringify(rateData);
+      return JSON.stringify(pricingData);
+    });
+    const { convertCurrency } = await loadModule();
+    await expect(convertCurrency(10, 'EUR')).resolves.toBe(13);
+    await expect(convertCurrency(10, 'GBP')).resolves.toBe(12);
+    await expect(convertCurrency(10, 'JPY')).rejects.toThrow('Missing exchange rate for JPY');
+  });
+
+  it('applyDurationDiscount chooses largest applicable discount', async () => {
+    const { applyDurationDiscount } = await loadModule();
+    const rate = applyDurationDiscount(100, 6, pricingData.durationDiscounts);
+    expect(rate).toBe(80);
+  });
+
+  it('computeDamageFee respects coverage and rules', async () => {
+    readFileMock().mockImplementation(async (file: string) => {
+      if (file.includes('pricing.json')) return JSON.stringify(pricingData);
+      return JSON.stringify({ base: 'USD', rates: {} });
+    });
+    const { computeDamageFee } = await loadModule();
+    await expect(computeDamageFee(undefined, 50)).resolves.toBe(0);
+    await expect(computeDamageFee('lost', 50)).resolves.toBe(50);
+    await expect(computeDamageFee('scuff', 0)).resolves.toBe(20);
+    await expect(computeDamageFee('scuff', 0, ['scuff'])).resolves.toBe(0);
+    await expect(computeDamageFee('lost', 50, [], true)).resolves.toBe(20);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add coverage for order update flows and subscription usage
- test pricing helpers for caching, currency conversion, discounts and damage fees

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js optimized build failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test src/orders.test.ts src/pricing/index.test.ts -- --coverage --coverageThreshold='{\"global\":{\"branches\":0,\"lines\":0}}'`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ee9f0d8832f9d81877e398b38f6