### PR TITLE
Fix shop settings validation and late fee start logging

### DIFF
--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -54,6 +54,7 @@ function diffSettings(
 }
 
 export async function getShopSettings(shop: string): Promise<ShopSettings> {
+  shop = validateShopName(shop);
   try {
     const buf = await fs.readFile(settingsPath(shop), "utf8");
     const parsed = shopSettingsSchema

--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -184,5 +184,7 @@ export async function startLateFeeService(
 
 const nodeEnvKey = "NODE" + "_ENV";
 if (process.env[nodeEnvKey] !== "test") {
-  startLateFeeService().catch(() => undefined);
+  startLateFeeService().catch((err) => {
+    logger.error("failed to start late fee service", { err });
+  });
 }


### PR DESCRIPTION
## Summary
- validate shop identifiers before reading settings
- log failures when the late fee service auto-starts

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run build:stubs` *(fails: Missing script)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter platform-machine test __tests__/lateFeeService.test.ts src/__tests__/shops.utils.test.ts` *(fails: auto-start logs errors when service fails to start)*


------
https://chatgpt.com/codex/tasks/task_e_68bb0aa26548832f9d6163c2ea2058de