### PR TITLE
test: add analytics and repository tests

### DIFF
--- a/packages/template-app/__tests__/analytics-provider.test.ts
+++ b/packages/template-app/__tests__/analytics-provider.test.ts
@@ -1,0 +1,122 @@
+/** @jest-environment node */
+import path from "path";
+
+jest.mock("@acme/date-utils", () => ({ nowIso: () => "2024-01-01T00:00:00.000Z" }));
+
+const readShop = jest.fn();
+const getShopSettings = jest.fn();
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  readShop: (...args: any[]) => readShop(...args),
+  getShopSettings: (...args: any[]) => getShopSettings(...args),
+}));
+
+const files = new Map<string, string>();
+const readFile = jest.fn(async (p: string) => {
+  const data = files.get(p);
+  if (data === undefined) {
+    const err = new Error("not found") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  }
+  return data;
+});
+const writeFile = jest.fn(async (p: string, data: string) => {
+  files.set(p, data);
+});
+const appendFile = jest.fn(async (p: string, data: string) => {
+  const cur = files.get(p) || "";
+  files.set(p, cur + data);
+});
+const mkdir = jest.fn(async () => {});
+
+jest.mock("fs", () => ({ promises: { readFile, writeFile, appendFile, mkdir } }));
+
+describe("analytics provider resolution", () => {
+  const shop = "shop1";
+  beforeEach(() => {
+    jest.resetModules();
+    readShop.mockReset();
+    getShopSettings.mockReset();
+    files.clear();
+    (globalThis.fetch as any) = jest.fn().mockResolvedValue({ ok: true });
+    process.env.DATA_ROOT = "/data";
+    delete process.env.GA_API_SECRET;
+  });
+
+  test("analytics disabled returns Noop provider", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: false });
+    getShopSettings.mockResolvedValue({});
+    const { trackEvent } = await import("@platform-core/analytics");
+    await trackEvent(shop, { type: "page_view", page: "/" });
+    expect(appendFile).not.toHaveBeenCalled();
+  });
+
+  test("console provider logs event", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({ analytics: { provider: "console", enabled: true } });
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const { trackEvent } = await import("@platform-core/analytics");
+    await trackEvent(shop, { type: "page_view", page: "home" });
+    expect(logSpy).toHaveBeenCalledWith(
+      "analytics",
+      expect.objectContaining({ type: "page_view", page: "home" })
+    );
+    logSpy.mockRestore();
+  });
+
+  test("ga provider requires measurementId and secret", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({ analytics: { provider: "ga", id: "G-XYZ" } });
+    process.env.GA_API_SECRET = "secret";
+    const fetchMock = globalThis.fetch as jest.Mock;
+    const { trackEvent } = await import("@platform-core/analytics");
+    await trackEvent(shop, { type: "page_view", page: "home" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("ga provider without secret falls back to FileProvider", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({ analytics: { provider: "ga", id: "G-XYZ" } });
+    const fetchMock = globalThis.fetch as jest.Mock;
+    const { trackEvent } = await import("@platform-core/analytics");
+    await trackEvent(shop, { type: "page_view", page: "home" });
+    expect(fetchMock).not.toHaveBeenCalled();
+    const file = path.join("/data", shop, "analytics.jsonl");
+    expect(files.get(file)).toContain("\"type\":\"page_view\"");
+  });
+
+  test("default FileProvider writes analytics.jsonl", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({});
+    const { trackEvent } = await import("@platform-core/analytics");
+    await trackEvent(shop, { type: "page_view", page: "home" });
+    const file = path.join("/data", shop, "analytics.jsonl");
+    expect(files.get(file)).toContain("\"type\":\"page_view\"");
+  });
+
+  test("provider result is cached", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({});
+    const { trackEvent } = await import("@platform-core/analytics");
+    await trackEvent(shop, { type: "page_view", page: "home" });
+    await trackEvent(shop, { type: "page_view", page: "about" });
+    expect(readShop).toHaveBeenCalledTimes(1);
+    expect(getShopSettings).toHaveBeenCalledTimes(1);
+  });
+
+  test("updateAggregates increments metrics", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({});
+    const { trackPageView, trackOrder, trackEvent } = await import("@platform-core/analytics");
+    await trackPageView(shop, "home");
+    await trackOrder(shop, "o1", 5);
+    await trackEvent(shop, { type: "discount_redeemed", code: "SAVE" });
+    await trackEvent(shop, { type: "ai_crawl" });
+    const aggPath = path.join("/data", shop, "analytics-aggregates.json");
+    const agg = JSON.parse(files.get(aggPath)!);
+    expect(agg.page_view["2024-01-01"]).toBe(1);
+    expect(agg.order["2024-01-01"]).toEqual({ count: 1, amount: 5 });
+    expect(agg.discount_redeemed["2024-01-01"].SAVE).toBe(1);
+    expect(agg.ai_crawl["2024-01-01"]).toBe(1);
+  });
+});

--- a/packages/template-app/__tests__/repositories/products.server.test.ts
+++ b/packages/template-app/__tests__/repositories/products.server.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+import path from "path";
+
+const files = new Map<string, string>();
+const readFile = jest.fn(async (p: string) => {
+  const data = files.get(p);
+  if (data === undefined) {
+    const err = new Error("not found") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  }
+  return data;
+});
+const writeFile = jest.fn(async (p: string, data: string) => {
+  files.set(p, data);
+});
+const mkdir = jest.fn(async () => {});
+const rename = jest.fn(async (a: string, b: string) => {
+  const data = files.get(a) || "";
+  files.set(b, data);
+  files.delete(a);
+});
+
+jest.mock("fs", () => ({ promises: { readFile, writeFile, mkdir, rename } }));
+
+describe("products repository", () => {
+  const shop = "shop1";
+  const file = path.join("/data", shop, "products.json");
+
+  beforeEach(() => {
+    files.clear();
+    jest.resetModules();
+    process.env.DATA_ROOT = "/data";
+  });
+
+  test("readRepo returns array and empty array when missing", async () => {
+    const { readRepo } = await import("@platform-core/repositories/products.server");
+    files.set(file, JSON.stringify([{ id: "p1" }]));
+    const list = await readRepo(shop);
+    expect(list).toEqual([{ id: "p1" }]);
+    files.delete(file);
+    const empty = await readRepo(shop);
+    expect(empty).toEqual([]);
+  });
+
+  test("updateProductInRepo updates record and increments version", async () => {
+    const { updateProductInRepo } = await import("@platform-core/repositories/products.server");
+    files.set(file, JSON.stringify([{ id: "p1", row_version: 1 }]));
+    const updated = await updateProductInRepo(shop, { id: "p1", title: "New" });
+    expect(updated).toMatchObject({ id: "p1", title: "New", row_version: 2 });
+    const written = JSON.parse(files.get(file)!);
+    expect(written[0]).toMatchObject({ id: "p1", title: "New", row_version: 2 });
+  });
+
+  test("updateProductInRepo throws when product missing", async () => {
+    const { updateProductInRepo } = await import("@platform-core/repositories/products.server");
+    files.set(file, JSON.stringify([{ id: "p1", row_version: 1 }]));
+    await expect(updateProductInRepo(shop, { id: "p2" })).rejects.toThrow(
+      "Product p2 not found"
+    );
+  });
+
+  test("deleteProductFromRepo removes product and errors when missing", async () => {
+    const { deleteProductFromRepo } = await import("@platform-core/repositories/products.server");
+    files.set(file, JSON.stringify([{ id: "p1", row_version: 1 }]));
+    await deleteProductFromRepo(shop, "p1");
+    expect(JSON.parse(files.get(file)!)).toEqual([]);
+    await expect(deleteProductFromRepo(shop, "p2")).rejects.toThrow(
+      "Product p2 not found"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add analytics provider resolution tests
- test product repository fs CRUD helpers

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/template-app exec jest __tests__/analytics-provider.test.ts __tests__/repositories/products.server.test.ts --runInBand --detectOpenHandles --config jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68bb0ef46c1c832fa3361df27ba63c7a