### PR TITLE
test: expand coverage for theme, seo and cart

### DIFF
--- a/packages/platform-core/src/cartStore/__tests__/memoryStore.test.ts
+++ b/packages/platform-core/src/cartStore/__tests__/memoryStore.test.ts
@@ -108,5 +108,12 @@ describe("MemoryCartStore", () => {
       expect(await store.getCart("cart")).toEqual({});
     });
   });
+
+  it("supports concurrent increments without race conditions", async () => {
+    const store = new MemoryCartStore(60);
+    await Promise.all(Array.from({ length: 5 }, () => store.incrementQty("c", sku, 1)));
+    const cart = await store.getCart("c");
+    expect(cart[sku.id!].qty).toBe(5);
+  });
 });
 

--- a/packages/platform-core/src/themeTokens/__tests__/index.test.ts
+++ b/packages/platform-core/src/themeTokens/__tests__/index.test.ts
@@ -78,6 +78,26 @@ describe('loadThemeTokensBrowser', () => {
       themeTokens.baseTokens
     );
   });
+
+  it('merges partial overrides with base tokens and tolerates invalid values', async () => {
+    jest.mock(
+      '@themes/partial',
+      () => ({
+        __esModule: true,
+        tokens: {
+          '--color-bg': { light: '123 50% 50%' },
+          '--bogus': { light: 42 as any },
+        },
+      }),
+      { virtual: true }
+    );
+
+    const tokens = await themeTokens.loadThemeTokensBrowser('partial');
+    const merged = { ...themeTokens.baseTokens, ...tokens } as Record<string, any>;
+    expect(merged['--color-bg']).toBe('123 50% 50%');
+    expect(merged['--color-fg']).toBe(themeTokens.baseTokens['--color-fg']);
+    expect(merged['--bogus']).toBe(42);
+  });
 });
 
 describe('loadThemeTokens', () => {

--- a/packages/template-app/__tests__/cart/helpers.ts
+++ b/packages/template-app/__tests__/cart/helpers.ts
@@ -43,6 +43,18 @@ export async function createCartWithItem(qty = 1) {
   return { cart, cartId, idKey, sku, size };
 }
 
+export function withOutOfStockSku() {
+  const original = TEST_SKU.stock;
+  TEST_SKU.stock = 0;
+  return () => {
+    TEST_SKU.stock = original;
+  };
+}
+
+export function invalidSize() {
+  return "ZZ";
+}
+
 export {
   decodeCartCookie,
   encodeCartCookie,

--- a/packages/template-app/__tests__/cart/post.test.ts
+++ b/packages/template-app/__tests__/cart/post.test.ts
@@ -4,6 +4,8 @@ import {
   createRequest,
   decodeCartCookie,
   getCart,
+  withOutOfStockSku,
+  invalidSize,
 } from "./helpers";
 
 afterEach(() => {
@@ -48,4 +50,29 @@ test("rejects negative or non-integer quantity", async () => {
   expect(res.status).toBe(400);
   res = await POST(createRequest({ sku: { id: sku.id }, qty: 1.5, size }));
   expect(res.status).toBe(400);
+});
+
+test("returns 409 when SKU out of stock", async () => {
+  const reset = withOutOfStockSku();
+  const size = TEST_SKU.sizes[0];
+  const res = await POST(
+    createRequest({ sku: { id: TEST_SKU.id }, qty: 1, size })
+  );
+  expect(res.status).toBe(409);
+  reset();
+});
+
+test("returns 400 when size missing", async () => {
+  const sku = TEST_SKU;
+  const res = await POST(createRequest({ sku: { id: sku.id }, qty: 1 }));
+  expect(res.status).toBe(400);
+});
+
+test("accepts unknown size values", async () => {
+  const sku = TEST_SKU;
+  const size = invalidSize();
+  const res = await POST(
+    createRequest({ sku: { id: sku.id }, qty: 1, size })
+  );
+  expect(res.status).toBe(200);
 });

--- a/packages/template-app/__tests__/return-partial-refund.test.ts
+++ b/packages/template-app/__tests__/return-partial-refund.test.ts
@@ -1,0 +1,29 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+import { setupReturnMocks, type SessionSubset } from "./helpers/return";
+
+afterEach(() => jest.resetModules());
+
+describe("/api/return partial refund", () => {
+  test("deducts damage and refunds remainder", async () => {
+    const session: SessionSubset = {
+      metadata: { depositTotal: "80" },
+      payment_intent: "pi_1",
+    } as SessionSubset;
+    const { computeDamageFee, refundCreate, markReturned } = setupReturnMocks({ session });
+    computeDamageFee.mockResolvedValue(30);
+
+    const { POST } = await import("../src/api/return/route");
+    const res = await POST({
+      json: async () => ({ sessionId: "sess", damage: "scuff" }),
+    } as unknown as NextRequest);
+
+    expect(computeDamageFee).toHaveBeenCalledWith("scuff", 80, [], true);
+    expect(refundCreate).toHaveBeenCalledWith({
+      payment_intent: "pi_1",
+      amount: 50 * 100,
+    });
+    expect(markReturned.mock.calls[1][2]).toBe(30);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/packages/template-app/__tests__/seo-get.test.ts
+++ b/packages/template-app/__tests__/seo-get.test.ts
@@ -119,6 +119,43 @@ describe("getSeo", () => {
     ]);
   });
 
+  it.each([
+    [
+      {
+        title: "Custom",
+        description: "Desc",
+        canonical: "https://shop.com/en/page",
+        openGraph: { image: "/og.jpg" },
+      },
+      {
+        title: "Custom",
+        description: "Desc",
+        canonical: "https://shop.com/en/page",
+        image: "https://shop.com/og.jpg",
+      },
+    ],
+    [
+      {
+        title: "Another",
+        description: "More",
+        openGraph: { images: [{ url: "/img.png" }] },
+      },
+      {
+        title: "Another",
+        description: "More",
+        canonical: "https://shop.com/en",
+        image: "https://shop.com/img.png",
+      },
+    ],
+  ])("generates meta tags for %o", async (input, expected) => {
+    const { getSeo } = await import("../src/lib/seo");
+    const seo = await getSeo("en", input);
+    expect(seo.title).toBe(expected.title);
+    expect(seo.description).toBe(expected.description);
+    expect(seo.canonical).toBe(expected.canonical);
+    expect(seo.openGraph?.images?.[0]?.url).toBe(expected.image);
+  });
+
   it("resolves openGraph images array", async () => {
     const { getSeo } = await import("../src/lib/seo");
     const seo = await getSeo("en", {


### PR DESCRIPTION
## Summary
- test merging theme tokens with defaults and handle invalid overrides
- add SEO combinations of title, description, canonical and OG image
- cover cart API edge cases and memory store concurrency
- verify partial deposit refunds on returns

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter platform-core test src/themeTokens/__tests__/index.test.ts src/cartStore/__tests__/memoryStore.test.ts` *(fails: Could not locate module @themes/withTokens, etc.)*
- `pnpm --filter template-app test __tests__/cart/post.test.ts __tests__/seo-get.test.ts __tests__/return-partial-refund.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bb0f0b2504832fbf6e1342acdf0bfb