### PR TITLE
test: add i18n helper coverage

### DIFF
--- a/packages/template-app/__tests__/MultilingualInput.test.tsx
+++ b/packages/template-app/__tests__/MultilingualInput.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import { render, screen, fireEvent } from "@testing-library/react";
+import MultilingualFields from "@acme/ui/components/cms/MultilingualFields";
+import type { Locale } from "@acme/i18n";
+
+describe("MultilingualInput", () => {
+  it("calls onChange with correct locale key/value", () => {
+    const locales: readonly Locale[] = ["en", "de"];
+    const product = {
+      title: { en: "", de: "" },
+      description: { en: "", de: "" },
+    };
+    const calls: { name: string; value: string }[] = [];
+    const onChange = (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    ) => {
+      const { name, value } = e.target;
+      calls.push({ name, value });
+    };
+
+    render(
+      <MultilingualFields locales={locales} product={product} onChange={onChange} />
+    );
+
+    const titleInputs = screen.getAllByLabelText("Title");
+    fireEvent.change(titleInputs[0], { target: { value: "Hello" } });
+    fireEvent.change(titleInputs[1], { target: { value: "Hallo" } });
+
+    expect(calls).toEqual([
+      { name: "title_en", value: "Hello" },
+      { name: "title_de", value: "Hallo" },
+    ]);
+
+    calls.length = 0;
+    const descInputs = screen.getAllByLabelText("Description");
+    fireEvent.change(descInputs[0], { target: { value: "EN desc" } });
+    fireEvent.change(descInputs[1], { target: { value: "DE besch" } });
+
+    expect(calls).toEqual([
+      { name: "desc_en", value: "EN desc" },
+      { name: "desc_de", value: "DE besch" },
+    ]);
+  });
+});
+

--- a/packages/template-app/__tests__/fillLocales.filesystem.test.ts
+++ b/packages/template-app/__tests__/fillLocales.filesystem.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import { fillLocales, LOCALES, type Locale } from "@acme/i18n";
+
+jest.mock("node:fs/promises", () => ({
+  readFile: jest.fn(),
+}));
+
+const readFileMock = readFile as jest.MockedFunction<typeof readFile>;
+
+describe("fillLocales with filesystem", () => {
+  it("merges keys and skips missing locale files", async () => {
+    readFileMock.mockImplementation(async (file: string) => {
+      if (file.endsWith("en.json")) {
+        return JSON.stringify({ greet: "Hello", bye: "Bye" });
+      }
+      if (file.endsWith("de.json")) {
+        return JSON.stringify({ greet: "Hallo" });
+      }
+      const err: NodeJS.ErrnoException = new Error("not found");
+      err.code = "ENOENT";
+      throw err;
+    });
+
+    const translations: Record<string, Partial<Record<Locale, string>>> = {};
+
+    for (const locale of LOCALES) {
+      try {
+        const json = await readFile(`/locales/${locale}.json`, "utf8");
+        const data = JSON.parse(json) as Record<string, string>;
+        for (const [key, value] of Object.entries(data)) {
+          translations[key] ??= {};
+          translations[key][locale] = value;
+        }
+      } catch {
+        // ignore missing files
+      }
+    }
+
+    const result = Object.fromEntries(
+      Object.entries(translations).map(([key, map]) => [
+        key,
+        fillLocales(map, map.en!),
+      ])
+    );
+
+    expect(result).toEqual({
+      greet: { en: "Hello", de: "Hallo", it: "Hello" },
+      bye: { en: "Bye", de: "Bye", it: "Bye" },
+    });
+  });
+});
+

--- a/packages/template-app/__tests__/locales.test.ts
+++ b/packages/template-app/__tests__/locales.test.ts
@@ -1,0 +1,19 @@
+import { assertLocales, resolveLocale } from "@i18n/locales";
+
+describe("locales", () => {
+  it("resolves supported locales and falls back to 'en'", () => {
+    expect(resolveLocale("en")).toBe("en");
+    expect(resolveLocale("de")).toBe("de");
+    expect(resolveLocale("fr")).toBe("en");
+    expect(resolveLocale(undefined)).toBe("en");
+  });
+
+  it("assertLocales rejects empty arrays", () => {
+    expect(() => assertLocales([] as any)).toThrow("LOCALES must be a non-empty array");
+    expect(() => assertLocales(undefined as any)).toThrow(
+      "LOCALES must be a non-empty array"
+    );
+    expect(() => assertLocales(["en"])).not.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add filesystem-based test for fillLocales
- verify MultilingualFields change events by locale
- assert locale resolution and validation helpers

## Testing
- `pnpm --filter @acme/template-app test` *(fails: global coverage threshold for branches (60%) not met: 51.15%)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0ea10504832fb3e21423484e5294