### PR TITLE
Fix legacy email test imports

### DIFF
--- a/packages/email/src/__tests__/legacy/cli.test.ts
+++ b/packages/email/src/__tests__/legacy/cli.test.ts
@@ -27,11 +27,11 @@ describe('email cli', () => {
     const fs = mockFs();
     fs.existsSync.mockImplementation((p: string) => p === path.join('/root', 'data', 'shops'));
     jest.doMock('fs', () => fs);
-    jest.doMock('./scheduler', () => ({ sendDueCampaigns: jest.fn() }));
+    jest.doMock('../../scheduler', () => ({ sendDueCampaigns: jest.fn() }));
     jest.doMock('@date-utils', () => ({ nowIso: () => '2020-01-01T00:00:00.000Z' }));
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue('/root/project');
 
-    const { resolveDataRoot } = await import('./cli');
+    const { resolveDataRoot } = await import('../../cli');
     expect(resolveDataRoot()).toBe(path.join('/root', 'data', 'shops'));
 
     cwdSpy.mockRestore();
@@ -42,11 +42,11 @@ describe('email cli', () => {
     fs.existsSync.mockReturnValue(true);
     fs.promises.readFile.mockRejectedValue(new Error('fail'));
     jest.doMock('fs', () => fs);
-    jest.doMock('./scheduler', () => ({ sendDueCampaigns: jest.fn() }));
+    jest.doMock('../../scheduler', () => ({ sendDueCampaigns: jest.fn() }));
     jest.doMock('@date-utils', () => ({ nowIso: () => '2020-01-01T00:00:00.000Z' }));
     const log = jest.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { run } = await import('./cli');
+    const { run } = await import('../../cli');
     await run(['node', 'cli', 'campaign', 'list', 'shop']);
     expect(log).toHaveBeenCalledWith('[]');
 
@@ -60,11 +60,11 @@ describe('email cli', () => {
     fs.promises.writeFile.mockResolvedValue(undefined as any);
     fs.promises.mkdir.mockResolvedValue(undefined as any);
     jest.doMock('fs', () => fs);
-    jest.doMock('./scheduler', () => ({ sendDueCampaigns: jest.fn() }));
+    jest.doMock('../../scheduler', () => ({ sendDueCampaigns: jest.fn() }));
     jest.doMock('@date-utils', () => ({ nowIso: () => '2020-01-01T00:00:00.000Z' }));
     const log = jest.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { run } = await import('./cli');
+    const { run } = await import('../../cli');
     await run([
       'node',
       'cli',
@@ -94,11 +94,11 @@ describe('email cli', () => {
     fs.promises.writeFile.mockResolvedValue(undefined as any);
     fs.promises.mkdir.mockResolvedValue(undefined as any);
     jest.doMock('fs', () => fs);
-    jest.doMock('./scheduler', () => ({ sendDueCampaigns: jest.fn() }));
+    jest.doMock('../../scheduler', () => ({ sendDueCampaigns: jest.fn() }));
     jest.doMock('@date-utils', () => ({ nowIso: () => '2020-01-01T00:00:00.000Z' }));
     const log = jest.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { run } = await import('./cli');
+    const { run } = await import('../../cli');
     await run([
       'node',
       'cli',

--- a/packages/email/src/__tests__/legacy/send.test.ts
+++ b/packages/email/src/__tests__/legacy/send.test.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "./providers/types";
+import { ProviderError } from "../../providers/types";
 
 let mockSendgridSend: jest.Mock;
 let mockResendSend: jest.Mock;
@@ -13,13 +13,13 @@ jest.mock("nodemailer", () => ({
   },
 }));
 
-jest.mock("./providers/sendgrid", () => ({
+jest.mock("../../providers/sendgrid", () => ({
   SendgridProvider: jest.fn().mockImplementation(() => ({
     send: (...args: any[]) => mockSendgridSend(...args),
   })),
 }));
 
-jest.mock("./providers/resend", () => ({
+jest.mock("../../providers/resend", () => ({
   ResendProvider: jest.fn().mockImplementation(() => ({
     send: (...args: any[]) => mockResendSend(...args),
   })),
@@ -45,7 +45,7 @@ describe("sendCampaignEmail", () => {
     mockResendSend = jest.fn();
     mockSendMail = jest.fn();
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     await expect(
       sendCampaignEmail({
@@ -64,7 +64,7 @@ describe("sendCampaignEmail", () => {
     mockResendSend = jest.fn();
     mockSendMail = jest.fn();
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     process.env.EMAIL_PROVIDER = "unknown";
 
@@ -92,7 +92,7 @@ describe("sendCampaignEmail", () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.SENDGRID_API_KEY = "sg";
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     await sendCampaignEmail({
       to: "to@example.com",
@@ -118,7 +118,7 @@ describe("sendCampaignEmail", () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.SENDGRID_API_KEY = "sg";
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     await sendCampaignEmail({
       to: "to@example.com",
@@ -140,7 +140,7 @@ describe("sendCampaignEmail", () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.SENDGRID_API_KEY = "sg";
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     await sendCampaignEmail({
       to: "to@example.com",
@@ -155,7 +155,7 @@ describe("sendCampaignEmail", () => {
       sanitize: false,
     });
 
-    const { SendgridProvider } = await import("./providers/sendgrid");
+    const { SendgridProvider } = await import("../../providers/sendgrid");
     expect(SendgridProvider).toHaveBeenCalledTimes(1);
     expect(mockSendgridSend).toHaveBeenCalledTimes(2);
   });
@@ -171,7 +171,7 @@ describe("sendCampaignEmail", () => {
     process.env.RESEND_API_KEY = "rs";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     await sendCampaignEmail({
       to: "to@example.com",
@@ -196,7 +196,7 @@ describe("sendCampaignEmail", () => {
     process.env.EMAIL_PROVIDER = "sendgrid";
     process.env.CAMPAIGN_FROM = "campaign@example.com";
 
-    const { sendCampaignEmail } = await import("./send");
+    const { sendCampaignEmail } = await import("../../send");
 
     await sendCampaignEmail({
       to: "to@example.com",

--- a/packages/email/src/providers/__tests__/legacy/resend.test.ts
+++ b/packages/email/src/providers/__tests__/legacy/resend.test.ts
@@ -37,7 +37,7 @@ describe("ResendProvider", () => {
   it("sanityCheck resolves when credentials valid", async () => {
     process.env.RESEND_API_KEY = "rs";
     global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
-    const { ResendProvider } = await import("./resend");
+    const { ResendProvider } = await import("../../resend");
     const provider = new ResendProvider({ sanityCheck: true });
     await expect(provider.ready).resolves.toBeUndefined();
     expect(global.fetch).toHaveBeenCalledWith("https://api.resend.com/domains", {
@@ -51,7 +51,7 @@ describe("ResendProvider", () => {
     global.fetch = jest
       .fn()
       .mockResolvedValue({ ok: false, status: 401 }) as any;
-    const { ResendProvider } = await import("./resend");
+    const { ResendProvider } = await import("../../resend");
     const provider = new ResendProvider({ sanityCheck: true });
     await expect(provider.ready).rejects.toThrow(
       "Resend credentials rejected with status 401"
@@ -59,7 +59,7 @@ describe("ResendProvider", () => {
   });
 
   it("send exits early when RESEND_API_KEY missing", async () => {
-    const { ResendProvider } = await import("./resend");
+    const { ResendProvider } = await import("../../resend");
     const provider = new ResendProvider();
     await expect(provider.send(options)).resolves.toBeUndefined();
     expect(mockSend).not.toHaveBeenCalled();
@@ -72,8 +72,8 @@ describe("ResendProvider", () => {
     err.statusCode = 400;
     mockSend.mockRejectedValueOnce(err);
     process.env.CAMPAIGN_FROM = "from@example.com";
-    const { ResendProvider } = await import("./resend");
-    const { ProviderError } = await import("./types");
+    const { ResendProvider } = await import("../../resend");
+    const { ProviderError } = await import("../../types");
     const provider = new ResendProvider();
     const promise = provider.send(options);
     await expect(promise).rejects.toBeInstanceOf(ProviderError);
@@ -87,8 +87,8 @@ describe("ResendProvider", () => {
     err.statusCode = 500;
     mockSend.mockRejectedValueOnce(err);
     process.env.CAMPAIGN_FROM = "from@example.com";
-    const { ResendProvider } = await import("./resend");
-    const { ProviderError } = await import("./types");
+    const { ResendProvider } = await import("../../resend");
+    const { ProviderError } = await import("../../types");
     const provider = new ResendProvider();
     const promise = provider.send(options);
     await expect(promise).rejects.toBeInstanceOf(ProviderError);
@@ -100,8 +100,8 @@ describe("ResendProvider", () => {
     process.env.RESEND_API_KEY = "rs";
     mockSend.mockRejectedValueOnce("boom");
     process.env.CAMPAIGN_FROM = "from@example.com";
-    const { ResendProvider } = await import("./resend");
-    const { ProviderError } = await import("./types");
+    const { ResendProvider } = await import("../../resend");
+    const { ProviderError } = await import("../../types");
     const provider = new ResendProvider();
     const promise = provider.send(options);
     await expect(promise).rejects.toBeInstanceOf(ProviderError);
@@ -116,9 +116,9 @@ describe("ResendProvider", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue({ json: () => Promise.resolve(stats) }) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
-      const { mapResendStats } = await import("../stats");
+      const { mapResendStats } = await import("../../../stats");
       await expect(provider.getCampaignStats("1")).resolves.toEqual(
         mapResendStats(stats)
       );
@@ -127,9 +127,9 @@ describe("ResendProvider", () => {
     it("returns empty stats on network error", async () => {
       process.env.RESEND_API_KEY = "rs";
       global.fetch = jest.fn().mockRejectedValue(new Error("fail")) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
-      const { mapResendStats } = await import("../stats");
+      const { mapResendStats } = await import("../../../stats");
       await expect(provider.getCampaignStats("1")).resolves.toEqual(
         mapResendStats({})
       );
@@ -142,7 +142,7 @@ describe("ResendProvider", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue({ json: () => Promise.resolve({ id: "abc" }) }) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
       await expect(provider.createContact("test@example.com")).resolves.toBe(
         "abc"
@@ -154,7 +154,7 @@ describe("ResendProvider", () => {
       global.fetch = jest
         .fn()
         .mockRejectedValue(new Error("fail")) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
       await expect(provider.createContact("test@example.com")).resolves.toBe(
         ""
@@ -166,7 +166,7 @@ describe("ResendProvider", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue({ json: () => Promise.resolve({}) }) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
       await expect(provider.createContact("test@example.com")).resolves.toBe(
         ""
@@ -181,7 +181,7 @@ describe("ResendProvider", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue({ json: () => Promise.resolve({ data: segments }) }) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
       await expect(provider.listSegments()).resolves.toEqual(segments);
     });
@@ -194,7 +194,7 @@ describe("ResendProvider", () => {
         .mockResolvedValue(
           { json: () => Promise.resolve({ segments }) }
         ) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
       await expect(provider.listSegments()).resolves.toEqual(segments);
     });
@@ -204,7 +204,7 @@ describe("ResendProvider", () => {
       global.fetch = jest
         .fn()
         .mockRejectedValue(new Error("fail")) as any;
-      const { ResendProvider } = await import("./resend");
+      const { ResendProvider } = await import("../../resend");
       const provider = new ResendProvider();
       await expect(provider.listSegments()).resolves.toEqual([]);
     });


### PR DESCRIPTION
## Summary
- fix legacy email CLI test module paths
- correct imports in legacy send and resend provider tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Next.js build failed)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb135242e4832fa2ecc637b8e3648e