### PR TITLE
refactor late fee service startup

### DIFF
--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -144,13 +144,7 @@ export async function startLateFeeService(
   dataRoot: string = DATA_ROOT,
 ): Promise<() => void> {
   const { readdir, readFile } = await import("fs/promises");
-  let shops: string[];
-  try {
-    shops = await readdir(dataRoot);
-  } catch (err) {
-    logger.error("failed to start late fee service", { err });
-    throw err;
-  }
+  const shops = await readdir(dataRoot);
   const timers: NodeJS.Timeout[] = [];
 
   await Promise.all(
@@ -184,7 +178,9 @@ export async function startLateFeeService(
 
 const nodeEnvKey = "NODE" + "_ENV";
 if (process.env[nodeEnvKey] !== "test") {
-  startLateFeeService().catch((err) => {
-    logger.error("failed to start late fee service", { err });
+  setImmediate(() => {
+    startLateFeeService().catch((err) => {
+      logger.error("failed to start late fee service", { err });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- refactor late fee service startup error handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to compile template-app)*
- `pnpm --filter @acme/platform-machine test __tests__/lateFeeService.test.ts` *(fails: auto-start logs errors when service fails to start)*


------
https://chatgpt.com/codex/tasks/task_e_68bb139d0d80832f91a63beed45aa1be