### PR TITLE
fix: stabilize StepCheckoutPage test

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/__tests__/StepCheckoutPage.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/__tests__/StepCheckoutPage.test.tsx
@@ -32,6 +32,7 @@ jest.mock(
         <button onClick={() => onChange([{ id: "changed" }])}>change</button>
       </div>
     ),
+    Toast: ({ open, message }: any) => (open ? <div>{message}</div> : null),
   }),
   { virtual: true },
 );
@@ -66,15 +67,6 @@ jest.mock(
       ),
     };
   },
-  { virtual: true },
-);
-
-jest.mock(
-  "@/components/atoms",
-  () => ({
-    __esModule: true,
-    Toast: ({ open, message }: any) => (open ? <div>{message}</div> : null),
-  }),
   { virtual: true },
 );
 


### PR DESCRIPTION
## Summary
- ensure PageBuilder mock also exports Toast, avoiding undefined component during render

## Testing
- `pnpm exec jest StepCheckoutPage.test.tsx --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb24b727ec832f9f411018963bf234