### PR TITLE
fix: stabilize MediaManager deletion test

### DIFF
--- a/apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx
+++ b/apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx
@@ -2,7 +2,6 @@ import {
   render,
   fireEvent,
   waitFor,
-  waitForElementToBeRemoved,
   act,
 } from "@testing-library/react";
 import MediaManager from "../MediaManager";
@@ -71,8 +70,9 @@ describe("MediaManager", () => {
     await waitFor(() =>
       expect(onDelete).toHaveBeenCalledWith("shop", "old.mp4")
     );
-    // Use a live query so the assertion tracks DOM updates reliably.
-    await waitForElementToBeRemoved(() => queryByText("Delete"));
+    await waitFor(() =>
+      expect(queryByText("Delete")).not.toBeInTheDocument()
+    );
   });
 
   it("displays error message when upload fails", async () => {


### PR DESCRIPTION
## Summary
- avoid waiting for already-removed node by using `waitFor` in MediaManager deletion test

## Testing
- `pnpm exec jest apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx --config jest.config.cjs` *(fails: coverage threshold not met)*
- `pnpm -r build` *(fails: Invalid auth environment variables for @apps/shop-bcd)*


------
https://chatgpt.com/codex/tasks/task_e_68bb24c014e4832f8b5656626344b2e4