### PR TITLE
test: cover core env helpers

### DIFF
--- a/packages/config/__tests__/coreEnvNormalization.test.ts
+++ b/packages/config/__tests__/coreEnvNormalization.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "@jest/globals";
+
+const baseEnv = {
+  CMS_SPACE_URL: "https://example.com",
+  CMS_ACCESS_TOKEN: "token",
+  SANITY_API_VERSION: "v1",
+};
+
+describe("coreEnvSchema AUTH_TOKEN_TTL normalization", () => {
+  it.each([
+    [60, undefined],
+    ["", undefined],
+    ["60", "60s"],
+    ["15 m", "15m"],
+  ])("normalizes %p to %p", async (input, normalized) => {
+    const { coreEnvSchema } = await import("../src/env/core");
+    const { authEnvSchema } = await import("../src/env/auth");
+    const refine = (coreEnvSchema as any)._def.effect.refinement as (
+      env: Record<string, unknown>,
+      ctx: { addIssue: () => void },
+    ) => void;
+    const spy = jest
+      .spyOn(authEnvSchema, "safeParse")
+      .mockReturnValue({ success: true, data: {} } as any);
+
+    refine({ ...baseEnv, AUTH_TOKEN_TTL: input as any }, { addIssue: () => {} });
+
+    const arg = spy.mock.calls[0][0] as Record<string, unknown>;
+    if (normalized === undefined) {
+      expect(arg).not.toHaveProperty("AUTH_TOKEN_TTL");
+    } else {
+      expect(arg).toHaveProperty("AUTH_TOKEN_TTL", normalized);
+    }
+    spy.mockRestore();
+  });
+});

--- a/packages/config/__tests__/coreEnvProxy.test.ts
+++ b/packages/config/__tests__/coreEnvProxy.test.ts
@@ -35,12 +35,13 @@ describe("coreEnv proxy", () => {
       () => import("../src/env/core"),
     );
     const parseSpy = jest.spyOn(core.coreEnvSchema, "safeParse");
+    expect(parseSpy).not.toHaveBeenCalled();
     const url = core.coreEnv.CMS_SPACE_URL;
+    expect(parseSpy).toHaveBeenCalledTimes(1);
     const token = core.coreEnv.CMS_ACCESS_TOKEN;
+    expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(core.coreEnv.CMS_SPACE_URL).toBe(url);
     expect(core.coreEnv.CMS_ACCESS_TOKEN).toBe(token);
-    expect(core.coreEnv.CMS_SPACE_URL).toBe(url);
-    expect(parseSpy).toHaveBeenCalledTimes(1);
   });
 
   it("parses during import in production", async () => {

--- a/packages/config/__tests__/coreEnvRefinement.test.ts
+++ b/packages/config/__tests__/coreEnvRefinement.test.ts
@@ -109,6 +109,21 @@ describe("coreEnvSchema refinement", () => {
       }),
     );
   });
+
+  it("ignores unrelated keys", async () => {
+    const { depositReleaseEnvRefinement } = await import("../src/env/core");
+    const ctx = { addIssue: jest.fn() } as any;
+
+    depositReleaseEnvRefinement(
+      {
+        SOME_OTHER_KEY: "value",
+        DEPOSIT_RELEASE_FOO: "bar",
+      },
+      ctx,
+    );
+
+    expect(ctx.addIssue).not.toHaveBeenCalled();
+  });
 });
 
 


### PR DESCRIPTION
## Summary
- add tests for auth token TTL normalization before auth schema validation
- ensure deposit release refinement ignores unrelated keys
- confirm core env proxy parses once and reuses cached values

## Testing
- `pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68bb25de4d3c832f93e2c4937ed89c7e