### PR TITLE
Allow zero inventory quantity

### DIFF
--- a/apps/cms/__tests__/inventoryImportCsvRoute.test.ts
+++ b/apps/cms/__tests__/inventoryImportCsvRoute.test.ts
@@ -69,7 +69,7 @@ describe("inventory import route - csv", () => {
       });
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toMatch(/greater than 0/);
+      expect(body.error).toMatch(/greater than or equal to 0/);
     });
   });
 });

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/__tests__/route.test.ts
@@ -97,7 +97,9 @@ describe("POST", () => {
     const file = new File([csv], "inv.csv", { type: "text/csv" });
     const res = await POST(req(file), { params: Promise.resolve({ shop: "s1" }) });
     expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({ error: expect.stringContaining("quantity must be greater than 0") });
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("quantity must be greater than or equal to 0"),
+    });
     expect(write).not.toHaveBeenCalled();
   });
 

--- a/packages/platform-core/src/utils/inventory.ts
+++ b/packages/platform-core/src/utils/inventory.ts
@@ -55,8 +55,8 @@ export function expandInventoryItem(
   data: RawInventoryItem | InventoryItem
 ): InventoryItem {
   if (isInventoryItem(data)) {
-    if (data.quantity <= 0) {
-      throw new Error("quantity must be greater than 0");
+    if (data.quantity < 0) {
+      throw new Error("quantity must be greater than or equal to 0");
     }
     if (data.productId.trim() === "") {
       throw new Error("productId is required");
@@ -85,8 +85,8 @@ export function expandInventoryItem(
   }
 
   const normalizedQuantity = normalizeQuantity(quantity, unit);
-  if (!Number.isFinite(normalizedQuantity) || normalizedQuantity <= 0) {
-    throw new Error("quantity must be greater than 0");
+  if (!Number.isFinite(normalizedQuantity) || normalizedQuantity < 0) {
+    throw new Error("quantity must be greater than or equal to 0");
   }
 
   const normalizedLowStock =

--- a/packages/platform-machine/src/__tests__/inventoryUtils.test.ts
+++ b/packages/platform-machine/src/__tests__/inventoryUtils.test.ts
@@ -47,14 +47,16 @@ describe("expandInventoryItem", () => {
     expect(expandInventoryItem(item)).toEqual(item);
   });
 
-  it("throws on InventoryItem with non-positive quantity", () => {
+  it("throws on InventoryItem with negative quantity", () => {
     const item: InventoryItem = {
       sku: "s1",
       productId: "p1",
-      quantity: 0,
+      quantity: -1,
       variantAttributes: {},
     };
-    expect(() => expandInventoryItem(item)).toThrow("quantity must be greater than 0");
+    expect(() => expandInventoryItem(item)).toThrow(
+      "quantity must be greater than or equal to 0",
+    );
   });
 
   it("throws on InventoryItem with empty productId", () => {
@@ -95,15 +97,23 @@ describe("expandInventoryItem", () => {
     expect(() => expandInventoryItem(blank)).toThrow("productId is required");
   });
 
-  it("throws when quantity is zero or non-finite", () => {
-    const zero: RawInventoryItem = { sku: "s1", productId: "p1", quantity: 0 } as any;
+  it("throws when quantity is negative or non-finite", () => {
+    const negative: RawInventoryItem = {
+      sku: "s1",
+      productId: "p1",
+      quantity: -1,
+    } as any;
     const nonFinite: RawInventoryItem = {
       sku: "s1",
       productId: "p1",
       quantity: "abc",
     } as any;
-    expect(() => expandInventoryItem(zero)).toThrow("quantity must be greater than 0");
-    expect(() => expandInventoryItem(nonFinite)).toThrow("quantity must be greater than 0");
+    expect(() => expandInventoryItem(negative)).toThrow(
+      "quantity must be greater than or equal to 0",
+    );
+    expect(() => expandInventoryItem(nonFinite)).toThrow(
+      "quantity must be greater than or equal to 0",
+    );
   });
 
   it("normalizes unit and variant fields", () => {


### PR DESCRIPTION
## Summary
- allow zero quantity in inventory items and update validation
- fix inventory import tests for non-negative quantities

## Testing
- `pnpm exec jest --runTestsByPath packages/platform-machine/src/__tests__/inventoryUtils.test.ts`
- `pnpm --filter @apps/cms test` *(fails: shopPages404 timeout and MediaManager deletion test)*

------
https://chatgpt.com/codex/tasks/task_e_68bb24ace810832fa937ef317da62272