### PR TITLE
test: expand auth env coverage

### DIFF
--- a/packages/config/__tests__/authEnv.test.ts
+++ b/packages/config/__tests__/authEnv.test.ts
@@ -183,5 +183,138 @@ describe("authEnv", () => {
       expect(spy).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    ["60s", 60],
+    ["2m", 120],
+  ])("parses TTL %s into %d seconds", async (input, expected) => {
+    const { authEnv } = await withEnv(
+      { NODE_ENV: "test", AUTH_TOKEN_TTL: input },
+      () => import("../src/env/auth"),
+    );
+    expect(authEnv.AUTH_TOKEN_TTL).toBe(expected);
+  });
+
+  describe("AUTH_TOKEN_TTL normalization", () => {
+    const baseVars = {
+      NODE_ENV: "development",
+      NEXTAUTH_SECRET: NEXT_SECRET,
+      SESSION_SECRET,
+    };
+
+    it("removes blank AUTH_TOKEN_TTL", async () => {
+      const { snapshot } = await withEnv(
+        { ...baseVars, AUTH_TOKEN_TTL: "" },
+        async () => {
+          await import("../src/env/auth");
+          return { snapshot: { ...process.env } };
+        },
+      );
+      expect(snapshot.AUTH_TOKEN_TTL).toBeUndefined();
+    });
+
+    it("appends seconds to numeric AUTH_TOKEN_TTL", async () => {
+      const { snapshot } = await withEnv(
+        { ...baseVars, AUTH_TOKEN_TTL: "60" },
+        async () => {
+          await import("../src/env/auth");
+          return { snapshot: { ...process.env } };
+        },
+      );
+      expect(snapshot.AUTH_TOKEN_TTL).toBe("60s");
+    });
+  });
+
+  describe("strongSecret schema", () => {
+    it("rejects secrets shorter than 32 characters", async () => {
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+      await expect(
+        withEnv(
+          {
+            NODE_ENV: "production",
+            NEXTAUTH_SECRET: NEXT_SECRET,
+            SESSION_SECRET,
+            AUTH_PROVIDER: "jwt",
+            JWT_SECRET: "short",
+          },
+          () => import("../src/env/auth"),
+        ),
+      ).rejects.toThrow("Invalid auth environment variables");
+      expect(spy).toHaveBeenCalledWith(
+        "❌ Invalid auth environment variables:",
+        expect.objectContaining({
+          JWT_SECRET: { _errors: expect.arrayContaining([expect.any(String)]) },
+        }),
+      );
+    });
+
+    it("rejects secrets with non-printable ASCII characters", async () => {
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+      await expect(
+        withEnv(
+          {
+            NODE_ENV: "production",
+            NEXTAUTH_SECRET: NEXT_SECRET,
+            SESSION_SECRET,
+            AUTH_PROVIDER: "jwt",
+            JWT_SECRET: `${"a".repeat(31)}\n`,
+          },
+          () => import("../src/env/auth"),
+        ),
+      ).rejects.toThrow("Invalid auth environment variables");
+      expect(spy).toHaveBeenCalledWith(
+        "❌ Invalid auth environment variables:",
+        expect.objectContaining({
+          JWT_SECRET: { _errors: expect.arrayContaining([expect.any(String)]) },
+        }),
+      );
+    });
+  });
+
+  it("requires JWT_SECRET when AUTH_PROVIDER=jwt", async () => {
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: NEXT_SECRET,
+          SESSION_SECRET,
+          AUTH_PROVIDER: "jwt",
+        },
+        () => import("../src/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+  });
+
+  it("requires OAuth credentials when AUTH_PROVIDER=oauth", async () => {
+    await expect(
+      withEnv(
+        {
+          NODE_ENV: "production",
+          NEXTAUTH_SECRET: NEXT_SECRET,
+          SESSION_SECRET,
+          AUTH_PROVIDER: "oauth",
+        },
+        () => import("../src/env/auth"),
+      ),
+    ).rejects.toThrow("Invalid auth environment variables");
+  });
+
+  it("applies defaults and computes token expiry", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2020-01-01T00:00:00Z"));
+    const { authEnv } = await withEnv(
+      {
+        NODE_ENV: "production",
+        NEXTAUTH_SECRET: NEXT_SECRET,
+        SESSION_SECRET,
+      },
+      () => import("../src/env/auth"),
+    );
+    expect(authEnv.AUTH_TOKEN_TTL).toBe(900);
+    expect(authEnv.TOKEN_ALGORITHM).toBe("HS256");
+    expect(authEnv.AUTH_TOKEN_EXPIRES_AT.toISOString()).toBe(
+      "2020-01-01T00:15:00.000Z",
+    );
+    jest.useRealTimers();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add tests for TTL parsing and normalization in auth env schema
- cover strong secret validation and provider requirements
- ensure default TTL and expiry date behavior

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/config test`


------
https://chatgpt.com/codex/tasks/task_e_68bb25ead3e4832fb37e6fd22ce15d99