### PR TITLE
test(api): improve helper coverage

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -131,5 +131,13 @@ describe('component helpers', () => {
       vol.fromJSON({ '/a/only.txt': 'hello' });
       expect(diffDirectories('/a', '/b')).toEqual(['only.txt']);
     });
+
+    it('detects when file contents differ', () => {
+      vol.fromJSON({
+        '/a/same.txt': 'one',
+        '/b/same.txt': 'two',
+      });
+      expect(diffDirectories('/a', '/b')).toEqual(['same.txt']);
+    });
   });
 });

--- a/apps/api/src/routes/shop/[id]/__tests__/run.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/run.test.ts
@@ -1,0 +1,34 @@
+import { run } from "../publish-upgrade";
+import { spawn } from "child_process";
+
+jest.mock("child_process", () => ({ spawn: jest.fn() }));
+
+const spawnMock = spawn as unknown as jest.Mock;
+
+describe("run", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("resolves when command exits with code 0", async () => {
+    spawnMock.mockReturnValueOnce({
+      on: (_event: string, cb: (code: number) => void) => cb(0),
+    });
+
+    await expect(run("cmd", ["a"], "/tmp")).resolves.toBeUndefined();
+    expect(spawnMock).toHaveBeenCalledWith("cmd", ["a"], {
+      cwd: "/tmp",
+      stdio: "inherit",
+    });
+  });
+
+  it("rejects when command exits with non-zero code", async () => {
+    spawnMock.mockReturnValueOnce({
+      on: (_event: string, cb: (code: number) => void) => cb(1),
+    });
+
+    await expect(run("cmd", ["a"], "/tmp")).rejects.toThrow(
+      "cmd a failed with status 1",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use shared beforeEach/afterEach hooks in API request handler tests
- cover diffDirectories file content changes
- add unit tests for run helper

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @apps/api test` *(fails: coverage threshold not met)*
- `pnpm --filter @apps/api exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68bb263599c4832f981bede3855ae26f