### PR TITLE
test(shared-utils): cover currency code and locale handling

### DIFF
--- a/packages/shared-utils/__tests__/formatCurrency.test.ts
+++ b/packages/shared-utils/__tests__/formatCurrency.test.ts
@@ -44,5 +44,42 @@ describe('formatCurrency', () => {
     }).format(2);
     expect(formatCurrency(minor)).toBe(expected);
   });
+
+  it('formats using provided currency code and locale', () => {
+    const minor = 12345; // €123.45
+    const expected = new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(123.45);
+    expect(formatCurrency(minor, 'EUR', 'de-DE')).toBe(expected);
+  });
+
+  it.each(['BAD', 'US', '', 'usd'])('throws RangeError for invalid currency %s', (code) => {
+    expect(() => formatCurrency(100, code as any)).toThrow(RangeError);
+  });
+
+  it('uses explicit locale over default', () => {
+    const minor = 12345; // $123.45
+    const defaultFormatted = formatCurrency(minor, 'USD');
+    const deFormatted = formatCurrency(minor, 'USD', 'de-DE');
+    const expected = new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(123.45);
+    expect(deFormatted).toBe(expected);
+    if (deFormatted !== defaultFormatted) {
+      expect(deFormatted).not.toBe(defaultFormatted);
+    }
+  });
+
+  it('throws RangeError when Intl.supportedValuesOf excludes the currency', () => {
+    const original = (Intl as any).supportedValuesOf;
+    (Intl as any).supportedValuesOf = () => ['USD'];
+    try {
+      expect(() => formatCurrency(100, 'EUR')).toThrow(RangeError);
+    } finally {
+      (Intl as any).supportedValuesOf = original;
+    }
+  });
 });
 

--- a/packages/shared-utils/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/__tests__/formatPrice.test.ts
@@ -44,5 +44,42 @@ describe('formatPrice', () => {
     }).format(1.01);
     expect(formatPrice(amount)).toBe(expected);
   });
+
+  it('formats using provided currency code and locale', () => {
+    const amount = 123.45;
+    const expected = new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(amount);
+    expect(formatPrice(amount, 'EUR', 'de-DE')).toBe(expected);
+  });
+
+  it.each(['BAD', 'US', '', 'usd'])('throws RangeError for invalid currency %s', (code) => {
+    expect(() => formatPrice(1, code as any)).toThrow(RangeError);
+  });
+
+  it('throws unsupported currency code error when Intl.supportedValuesOf excludes the code', () => {
+    const original = (Intl as any).supportedValuesOf;
+    (Intl as any).supportedValuesOf = () => ['USD'];
+    try {
+      expect(() => formatPrice(1, 'EUR')).toThrow('Unsupported currency code: EUR');
+    } finally {
+      (Intl as any).supportedValuesOf = original;
+    }
+  });
+
+  it('uses explicit locale over default', () => {
+    const amount = 1234.56;
+    const defaultFormatted = formatPrice(amount, 'USD');
+    const deFormatted = formatPrice(amount, 'USD', 'de-DE');
+    const expected = new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount);
+    expect(deFormatted).toBe(expected);
+    if (defaultFormatted !== deFormatted) {
+      expect(deFormatted).not.toBe(defaultFormatted);
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- expand formatCurrency tests to cover currency code validation and locale overrides
- expand formatPrice tests to exercise currency code validation and locale handling

## Testing
- `pnpm install`
- `pnpm --filter @acme/shared-utils build`
- `pnpm --filter @acme/shared-utils test` *(fails: packages/platform-machine/__tests__/lateFeeService.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68bb26719190832fa69dfa4b3d131ced