### PR TITLE
test(config): expand shipping env tests

### DIFF
--- a/packages/config/__tests__/shippingEnv.test.ts
+++ b/packages/config/__tests__/shippingEnv.test.ts
@@ -73,5 +73,127 @@ describe("shippingEnv", () => {
     ).rejects.toThrow("Invalid shipping environment variables");
     expect(spy).toHaveBeenCalled();
   });
+
+  it("transforms ALLOWED_COUNTRIES to uppercase array", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const env = loadShippingEnv({
+      ALLOWED_COUNTRIES: "us, ca , de",
+    } as NodeJS.ProcessEnv);
+    expect(env.ALLOWED_COUNTRIES).toEqual(["US", "CA", "DE"]);
+  });
+
+  it("treats empty ALLOWED_COUNTRIES as undefined", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const env = loadShippingEnv({
+      ALLOWED_COUNTRIES: "",
+    } as NodeJS.ProcessEnv);
+    expect(env.ALLOWED_COUNTRIES).toBeUndefined();
+  });
+
+  it("parses truthy and falsy LOCAL_PICKUP_ENABLED", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    expect(
+      loadShippingEnv({ LOCAL_PICKUP_ENABLED: "true" } as NodeJS.ProcessEnv)
+        .LOCAL_PICKUP_ENABLED,
+    ).toBe(true);
+    expect(
+      loadShippingEnv({ LOCAL_PICKUP_ENABLED: "1" } as NodeJS.ProcessEnv)
+        .LOCAL_PICKUP_ENABLED,
+    ).toBe(true);
+    expect(
+      loadShippingEnv({ LOCAL_PICKUP_ENABLED: "false" } as NodeJS.ProcessEnv)
+        .LOCAL_PICKUP_ENABLED,
+    ).toBe(false);
+    expect(
+      loadShippingEnv({ LOCAL_PICKUP_ENABLED: "0" } as NodeJS.ProcessEnv)
+        .LOCAL_PICKUP_ENABLED,
+    ).toBe(false);
+  });
+
+  it("throws on invalid LOCAL_PICKUP_ENABLED value", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ LOCAL_PICKUP_ENABLED: "yes" } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid shipping environment variables");
+    const [[, err]] = spy.mock.calls;
+    expect(err.LOCAL_PICKUP_ENABLED._errors).toContain("must be a boolean");
+  });
+
+  it("accepts 2-letter DEFAULT_COUNTRY codes", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const env = loadShippingEnv({
+      DEFAULT_COUNTRY: "us",
+    } as NodeJS.ProcessEnv);
+    expect(env.DEFAULT_COUNTRY).toBe("US");
+  });
+
+  it("rejects invalid DEFAULT_COUNTRY codes", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ DEFAULT_COUNTRY: "USA" } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid shipping environment variables");
+    const [[, err1]] = spy.mock.calls;
+    expect(err1.DEFAULT_COUNTRY._errors).toContain(
+      "must be a 2-letter country code",
+    );
+  });
+
+  it("rejects non-alpha DEFAULT_COUNTRY codes", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ DEFAULT_COUNTRY: "1A" } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid shipping environment variables");
+    const [[, err2]] = spy.mock.calls;
+    expect(err2.DEFAULT_COUNTRY._errors).toContain(
+      "must be a 2-letter country code",
+    );
+  });
+
+  it("requires UPS_KEY when SHIPPING_PROVIDER=ups", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ SHIPPING_PROVIDER: "ups" } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid shipping environment variables");
+    const [[, err]] = spy.mock.calls;
+    expect(err.UPS_KEY._errors).toContain(
+      "UPS_KEY is required when SHIPPING_PROVIDER=ups",
+    );
+  });
+
+  it("requires DHL_KEY when SHIPPING_PROVIDER=dhl", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadShippingEnv({ SHIPPING_PROVIDER: "dhl" } as NodeJS.ProcessEnv),
+    ).toThrow("Invalid shipping environment variables");
+    const [[, err]] = spy.mock.calls;
+    expect(err.DHL_KEY._errors).toContain(
+      "DHL_KEY is required when SHIPPING_PROVIDER=dhl",
+    );
+  });
+
+  it("loadShippingEnv returns parsed data for valid config", async () => {
+    const { loadShippingEnv } = await import("../src/env/shipping");
+    const env = loadShippingEnv({
+      TAXJAR_KEY: "tax",
+      SHIPPING_PROVIDER: "ups",
+      UPS_KEY: "upsk",
+      ALLOWED_COUNTRIES: "us,ca",
+      LOCAL_PICKUP_ENABLED: "true",
+      DEFAULT_COUNTRY: "us",
+    } as NodeJS.ProcessEnv);
+    expect(env).toEqual({
+      TAXJAR_KEY: "tax",
+      SHIPPING_PROVIDER: "ups",
+      UPS_KEY: "upsk",
+      ALLOWED_COUNTRIES: ["US", "CA"],
+      LOCAL_PICKUP_ENABLED: true,
+      DEFAULT_COUNTRY: "US",
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- cover ALLOWED_COUNTRIES transformation to uppercase array and handling empty value
- validate LOCAL_PICKUP_ENABLED, DEFAULT_COUNTRY, and provider-specific key requirements
- ensure loadShippingEnv yields parsed config for valid settings and throws on invalid

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables in apps/shop-bcd)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68bb261b0cbc832fb67031dd7f37c72a