### PR TITLE
test: cover cms mocks

### DIFF
--- a/apps/cms/__tests__/mocks/external.test.ts
+++ b/apps/cms/__tests__/mocks/external.test.ts
@@ -1,0 +1,37 @@
+import {
+  redisMock,
+  nodemailerMock,
+  sendGridMock,
+  resendMock,
+  sanitizeHtmlMock,
+  nextHeadersMock,
+  nextCookiesMock,
+  resetExternalMocks,
+} from "./external";
+
+describe("external mocks", () => {
+  it("resetExternalMocks clears all mock call counts", () => {
+    // trigger mocks
+    redisMock();
+    nodemailerMock.createTransport();
+    sendGridMock.setApiKey();
+    sendGridMock.send();
+    resendMock.Resend();
+    sanitizeHtmlMock("test");
+    nextHeadersMock.headers();
+    nextHeadersMock.cookies();
+    nextCookiesMock.cookies();
+
+    resetExternalMocks();
+
+    expect(redisMock).toHaveBeenCalledTimes(0);
+    expect(nodemailerMock.createTransport).toHaveBeenCalledTimes(0);
+    expect(sendGridMock.setApiKey).toHaveBeenCalledTimes(0);
+    expect(sendGridMock.send).toHaveBeenCalledTimes(0);
+    expect(resendMock.Resend).toHaveBeenCalledTimes(0);
+    expect(sanitizeHtmlMock).toHaveBeenCalledTimes(0);
+    expect(nextHeadersMock.headers).toHaveBeenCalledTimes(0);
+    expect(nextHeadersMock.cookies).toHaveBeenCalledTimes(0);
+    expect(nextCookiesMock.cookies).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/cms/__tests__/mswHandlers.test.ts
+++ b/apps/cms/__tests__/mswHandlers.test.ts
@@ -1,0 +1,32 @@
+import { handlers } from "./msw/handlers";
+
+describe("msw handlers", () => {
+  it("executes all mock handlers at least once", () => {
+    const ctx = {
+      status: () => null,
+      json: () => null,
+    } as any;
+    const res = () => null;
+
+    for (const handler of handlers) {
+      const url = (() => {
+        switch (handler.info.path) {
+          case "/cms/api/theme/tokens":
+            return new URL("http://localhost/cms/api/theme/tokens?name=base");
+          case "/cms/api/products/slug/:slug":
+            return new URL("http://localhost/cms/api/products/slug/test");
+          case "*/api/products":
+            return new URL("http://localhost/api/products");
+          default:
+            return new URL(`http://localhost${handler.info.path}`);
+        }
+      })();
+
+      handler.resolver(
+        { params: { slug: "test" }, url } as any,
+        res as any,
+        ctx
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ensure cms msw handlers run at least once
- validate resetExternalMocks clears all external mock calls

## Testing
- `pnpm exec jest apps/cms/__tests__/mswHandlers.test.ts apps/cms/__tests__/mocks/external.test.ts --config ./jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68bb29380524832fb4263e1e07033baa