### PR TITLE
fix: log deposit start errors

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -169,7 +169,8 @@ if (process.env.RUN_DEPOSIT_RELEASE_SERVICE === "true") {
   void startDepositReleaseService().catch((err) => {
     // Log via both logger and console so that failures surface in
     // environments without structured logging.
-    logger.error("failed to start deposit release service", { err });
+    const { logger: log } = require("@platform-core/utils");
+    log.error("failed to start deposit release service", { err });
     console.error("failed to start deposit release service", err);
   });
 }


### PR DESCRIPTION
## Summary
- ensure deposit release auto-start logs to platform logger when boot fails

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test releaseDepositsService.test.ts` *(fails: expect(jest.fn()).toHaveBeenCalledWith(...))*

------
https://chatgpt.com/codex/tasks/task_e_68bb27dd74b8832f90551bd47c984d45