### PR TITLE
test(ui): add coverage for loader and cms blocks

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/Loader.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Loader.test.tsx
@@ -1,0 +1,33 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { Loader } from "../Loader";
+import React from "react";
+
+describe("Loader", () => {
+  it("applies default size classes", () => {
+    const { container } = render(<Loader />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveClass("h-[20px]");
+    expect(div).toHaveClass("w-[20px]");
+  });
+
+  it("accepts custom size", () => {
+    const { container } = render(<Loader size={40} />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveClass("h-[40px]");
+    expect(div).toHaveClass("w-[40px]");
+  });
+
+  it("merges class names", () => {
+    const { container } = render(<Loader className="text-blue" />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveClass("animate-spin");
+    expect(div).toHaveClass("text-blue");
+  });
+
+  it("forwards refs", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Loader ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/ui/src/components/cms/blocks/__tests__/FAQBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/FAQBlock.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FAQBlock from "../FAQBlock";
+
+describe("FAQBlock", () => {
+  const items = [
+    { question: "Q1", answer: "A1" },
+    { question: "Q2", answer: "A2" },
+  ];
+
+  it("renders accordion items and toggles answers", () => {
+    render(<FAQBlock items={items} />);
+    const btn = screen.getByRole("button", { name: /Q1/ });
+    fireEvent.click(btn);
+    expect(screen.getByText("A1")).toBeInTheDocument();
+  });
+
+  it("respects maxItems", () => {
+    render(<FAQBlock items={items} maxItems={1} />);
+    expect(screen.queryByText("Q2")).not.toBeInTheDocument();
+  });
+
+  it("returns null when below minItems", () => {
+    const { container } = render(<FAQBlock items={[items[0]]} minItems={2} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null with no items", () => {
+    const { container } = render(<FAQBlock items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx
@@ -1,0 +1,25 @@
+import "../../../../../../../test/resetNextMocks";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import Gallery from "../Gallery";
+
+describe("Gallery", () => {
+  const images = [
+    { src: "/a.jpg", alt: "a" },
+    { src: "/b.jpg", alt: "b" },
+  ];
+
+  it("renders images", () => {
+    const { container } = render(<Gallery images={images} />);
+    expect(screen.getByAltText("a")).toBeInTheDocument();
+    expect(screen.getAllByRole("img")).toHaveLength(2);
+    expect(container.firstChild).toHaveClass("grid");
+    expect(container.firstChild).toHaveClass("sm:grid-cols-2");
+    expect(container.firstChild).toHaveClass("md:grid-cols-3");
+  });
+
+  it("returns null without images", () => {
+    const { container } = render(<Gallery images={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Loader sizing, class merge, and ref forwarding
- cover FAQBlock render conditions and max/min item logic
- exercise Gallery image rendering and responsive classes

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui build`
- `pnpm exec jest packages/ui/src/components/atoms/__tests__/Loader.test.tsx packages/ui/src/components/cms/blocks/__tests__/FAQBlock.test.tsx packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb26b0f14c832fafae0da19dde2976