### PR TITLE
test: cover cms actions and subscription route

### DIFF
--- a/apps/cms/src/actions/__tests__/blog.server.test.ts
+++ b/apps/cms/src/actions/__tests__/blog.server.test.ts
@@ -1,0 +1,110 @@
+import { jest } from "@jest/globals";
+
+jest.mock("../../services/blog", () => ({
+  getPosts: jest.fn(),
+  getPost: jest.fn(),
+  createPost: jest.fn(),
+  updatePost: jest.fn(),
+  publishPost: jest.fn(),
+  unpublishPost: jest.fn(),
+  deletePost: jest.fn(),
+}));
+
+import {
+  getPosts,
+  getPost,
+  createPost,
+  updatePost,
+  publishPost,
+  unpublishPost,
+  deletePost,
+} from "../blog.server";
+import * as service from "../../services/blog";
+
+describe("blog.server actions", () => {
+  const fd = new FormData();
+  const post = { id: "1" };
+
+  const cases: Array<{
+    name: string;
+    action: (...args: any[]) => Promise<any>;
+    serviceFn: jest.Mock;
+    args: any[];
+    result: any;
+    serviceArgs?: any[];
+  }> = [
+    {
+      name: "getPosts",
+      action: getPosts,
+      serviceFn: service.getPosts as jest.Mock,
+      args: ["shop"],
+      serviceArgs: ["shop"],
+      result: [post],
+    },
+    {
+      name: "getPost",
+      action: getPost,
+      serviceFn: service.getPost as jest.Mock,
+      args: ["shop", "1"],
+      serviceArgs: ["shop", "1"],
+      result: post,
+    },
+    {
+      name: "createPost",
+      action: createPost,
+      serviceFn: service.createPost as jest.Mock,
+      args: ["shop", undefined, fd],
+      serviceArgs: ["shop", fd],
+      result: { message: "ok", id: "1" },
+    },
+    {
+      name: "updatePost",
+      action: updatePost,
+      serviceFn: service.updatePost as jest.Mock,
+      args: ["shop", undefined, fd],
+      serviceArgs: ["shop", fd],
+      result: { message: "ok" },
+    },
+    {
+      name: "publishPost",
+      action: publishPost,
+      serviceFn: service.publishPost as jest.Mock,
+      args: ["shop", "1", undefined, fd],
+      serviceArgs: ["shop", "1", fd],
+      result: { message: "ok" },
+    },
+    {
+      name: "unpublishPost",
+      action: unpublishPost,
+      serviceFn: service.unpublishPost as jest.Mock,
+      args: ["shop", "1"],
+      serviceArgs: ["shop", "1"],
+      result: { message: "ok" },
+    },
+    {
+      name: "deletePost",
+      action: deletePost,
+      serviceFn: service.deletePost as jest.Mock,
+      args: ["shop", "1"],
+      serviceArgs: ["shop", "1"],
+      result: { message: "ok" },
+    },
+  ];
+
+  describe.each(cases)('%s', ({ name, action, serviceFn, args, result, serviceArgs }) => {
+    afterEach(() => jest.clearAllMocks());
+
+    test("forwards to service", async () => {
+      serviceFn.mockResolvedValue(result);
+      const res = await action(...args);
+      expect(serviceFn).toHaveBeenCalledWith(...(serviceArgs ?? args));
+      expect(res).toBe(result);
+    });
+
+    test("propagates errors", async () => {
+      serviceFn.mockRejectedValue(new Error("fail"));
+      await expect(action(...args)).rejects.toThrow("fail");
+    });
+  });
+});
+

--- a/apps/cms/src/actions/__tests__/shops.server.test.ts
+++ b/apps/cms/src/actions/__tests__/shops.server.test.ts
@@ -1,0 +1,150 @@
+import { jest } from "@jest/globals";
+
+jest.mock("../../services/shops", () => ({
+  updateShop: jest.fn(),
+  getSettings: jest.fn(),
+  updateSeo: jest.fn(),
+  generateSeo: jest.fn(),
+  revertSeo: jest.fn(),
+  setFreezeTranslations: jest.fn(),
+  updateCurrencyAndTax: jest.fn(),
+  updateDeposit: jest.fn(),
+  updateReverseLogistics: jest.fn(),
+  updateUpsReturns: jest.fn(),
+  updatePremierDelivery: jest.fn(),
+  updateAiCatalog: jest.fn(),
+  updateStockAlert: jest.fn(),
+  resetThemeOverride: jest.fn(),
+}));
+
+import * as actions from "../shops.server";
+import * as service from "../../services/shops";
+
+describe("shops.server actions", () => {
+  const fd = new FormData();
+  const shop = { id: "s" };
+
+  const cases: Array<{
+    name: keyof typeof actions;
+    action: (...args: any[]) => Promise<any>;
+    serviceFn: jest.Mock;
+    args: any[];
+    result: any;
+  }> = [
+    {
+      name: "updateShop",
+      action: actions.updateShop,
+      serviceFn: service.updateShop as jest.Mock,
+      args: ["s", fd],
+      result: { shop },
+    },
+    {
+      name: "getSettings",
+      action: actions.getSettings,
+      serviceFn: service.getSettings as jest.Mock,
+      args: ["s"],
+      result: { ok: true },
+    },
+    {
+      name: "updateSeo",
+      action: actions.updateSeo,
+      serviceFn: service.updateSeo as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "generateSeo",
+      action: actions.generateSeo,
+      serviceFn: service.generateSeo as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "revertSeo",
+      action: actions.revertSeo,
+      serviceFn: service.revertSeo as jest.Mock,
+      args: ["s", "t"],
+      result: { ok: true },
+    },
+    {
+      name: "setFreezeTranslations",
+      action: actions.setFreezeTranslations,
+      serviceFn: service.setFreezeTranslations as jest.Mock,
+      args: ["s", true],
+      result: { ok: true },
+    },
+    {
+      name: "updateCurrencyAndTax",
+      action: actions.updateCurrencyAndTax,
+      serviceFn: service.updateCurrencyAndTax as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "updateDeposit",
+      action: actions.updateDeposit,
+      serviceFn: service.updateDeposit as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "updateReverseLogistics",
+      action: actions.updateReverseLogistics,
+      serviceFn: service.updateReverseLogistics as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "updateUpsReturns",
+      action: actions.updateUpsReturns,
+      serviceFn: service.updateUpsReturns as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "updatePremierDelivery",
+      action: actions.updatePremierDelivery,
+      serviceFn: service.updatePremierDelivery as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "updateAiCatalog",
+      action: actions.updateAiCatalog,
+      serviceFn: service.updateAiCatalog as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "updateStockAlert",
+      action: actions.updateStockAlert,
+      serviceFn: service.updateStockAlert as jest.Mock,
+      args: ["s", fd],
+      result: { ok: true },
+    },
+    {
+      name: "resetThemeOverride",
+      action: actions.resetThemeOverride,
+      serviceFn: service.resetThemeOverride as jest.Mock,
+      args: ["s", "token"],
+      result: { ok: true },
+    },
+  ];
+
+  describe.each(cases)('%s', ({ name, action, serviceFn, args, result }) => {
+    afterEach(() => jest.clearAllMocks());
+
+    test("forwards to service", async () => {
+      serviceFn.mockResolvedValue(result);
+      const res = await action(...args);
+      expect(serviceFn).toHaveBeenCalledWith(...args);
+      expect(res).toBe(result);
+    });
+
+    test("propagates errors", async () => {
+      serviceFn.mockRejectedValue(new Error("fail"));
+      await expect(action(...args)).rejects.toThrow("fail");
+    });
+  });
+});
+

--- a/packages/template-app/__tests__/subscribe.route.test.ts
+++ b/packages/template-app/__tests__/subscribe.route.test.ts
@@ -1,0 +1,117 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock("@acme/stripe", () => ({
+  stripe: {
+    subscriptions: {
+      update: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  readShop: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/users", () => ({
+  getUserById: jest.fn(),
+  setStripeSubscriptionId: jest.fn(),
+}));
+
+import { stripe } from "@acme/stripe";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { getUserById, setStripeSubscriptionId } from "@platform-core/repositories/users";
+
+const SHOP = { subscriptionsEnabled: true, billingProvider: "stripe" };
+
+describe("/api/subscribe POST", () => {
+  test("creates new subscription", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue({ id: "u1" });
+    (stripe.subscriptions.create as jest.Mock).mockResolvedValue({ id: "sub1", status: "active" });
+
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({ userId: "u1", priceId: "p1" }) } as unknown as NextRequest);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "sub1", status: "active" });
+    expect(stripe.subscriptions.create).toHaveBeenCalledWith({
+      customer: "u1",
+      items: [{ price: "p1" }],
+      proration_behavior: "create_prorations",
+      metadata: { userId: "u1", shop: "bcd" },
+    });
+    expect(setStripeSubscriptionId).toHaveBeenCalledWith("u1", "sub1", "bcd");
+    const createOrder = (stripe.subscriptions.create as jest.Mock).mock.invocationCallOrder[0];
+    const setOrder = (setStripeSubscriptionId as jest.Mock).mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(setOrder);
+  });
+
+  test("updates existing subscription", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue({ id: "u1", stripeSubscriptionId: "subOld" });
+    (stripe.subscriptions.update as jest.Mock).mockResolvedValue({ id: "subOld", status: "active" });
+
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({ userId: "u1", priceId: "p1" }) } as unknown as NextRequest);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "subOld", status: "active" });
+    expect(stripe.subscriptions.update).toHaveBeenCalledWith("subOld", {
+      items: [{ price: "p1" }],
+      proration_behavior: "create_prorations",
+    });
+    expect(setStripeSubscriptionId).toHaveBeenCalledWith("u1", "subOld", "bcd");
+    const updateOrder = (stripe.subscriptions.update as jest.Mock).mock.invocationCallOrder[0];
+    const setOrder = (setStripeSubscriptionId as jest.Mock).mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(setOrder);
+  });
+
+  test("returns 400 on missing params", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({}) } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing parameters" });
+  });
+
+  test("returns 403 when subscriptions disabled", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ subscriptionsEnabled: false });
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({ userId: "u1", priceId: "p1" }) } as unknown as NextRequest);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Subscriptions disabled" });
+  });
+
+  test("returns 400 when billing provider missing", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ subscriptionsEnabled: true, billingProvider: "other" });
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({ userId: "u1", priceId: "p1" }) } as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Billing not enabled" });
+  });
+
+  test("returns 404 when user not found", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue(undefined);
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({ userId: "u1", priceId: "p1" }) } as unknown as NextRequest);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "User not found" });
+  });
+
+  test("returns 500 on stripe error", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue({ id: "u1" });
+    (stripe.subscriptions.create as jest.Mock).mockRejectedValue(new Error("boom"));
+    const { POST } = await import("../src/api/subscribe/route");
+    const res = await POST({ json: async () => ({ userId: "u1", priceId: "p1" }) } as unknown as NextRequest);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "boom" });
+    expect(setStripeSubscriptionId).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add coverage for CMS blog actions with success and failure flows
- verify shop action wrappers invoke service layer and bubble errors
- test subscription API route for happy path and error handling

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @apps/cms test` *(fails: inventory import route rejects negative values)*
- `pnpm --filter @apps/cms test -- apps/cms/src/actions/__tests__/blog.server.test.ts apps/cms/src/actions/__tests__/shops.server.test.ts`
- `pnpm --filter @acme/template-app test`

------
https://chatgpt.com/codex/tasks/task_e_68bb292c4530832fb368ae9273fcf8db