### PR TITLE
test(stripe): verify client initialization

### DIFF
--- a/packages/stripe/src/__tests__/stripe-init.test.ts
+++ b/packages/stripe/src/__tests__/stripe-init.test.ts
@@ -1,0 +1,43 @@
+/** @jest-environment node */
+// packages/stripe/src/__tests__/stripe-init.test.ts
+
+describe("stripe client initialization", () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+    process.env = OLD_ENV;
+  });
+
+  it("throws when STRIPE_SECRET_KEY is undefined", async () => {
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: { STRIPE_SECRET_KEY: undefined },
+    }));
+
+    await expect(import("../index.ts")).rejects.toThrow(
+      "Neither apiKey nor config.authenticator provided",
+    );
+  });
+
+  it("creates client with fetch http client and api version", async () => {
+    const httpClient = {};
+    const createHttpClient = jest.fn().mockReturnValue(httpClient);
+    const StripeMock = jest.fn().mockImplementation(() => ({}));
+    StripeMock.createFetchHttpClient = createHttpClient;
+
+    jest.doMock("stripe", () => ({ __esModule: true, default: StripeMock }));
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: { STRIPE_SECRET_KEY: "sk_test_123" },
+    }));
+
+    await import("../index.ts");
+
+    expect(createHttpClient).toHaveBeenCalled();
+    expect(StripeMock).toHaveBeenCalledWith("sk_test_123", {
+      apiVersion: "2025-06-30.basil",
+      httpClient,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for Stripe client initialization
- ensure missing STRIPE_SECRET_KEY throws
- assert correct API version and fetch HTTP client when secret present

## Testing
- `pnpm exec jest --config jest.config.cjs --runInBand --runTestsByPath packages/stripe/src/__tests__/stripe-init.test.ts packages/stripe/src/__tests__/client-instantiation.test.ts`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2d6bdca8832f85b318c8031a3f6d