### PR TITLE
test: trim whitespace in requireEnv

### DIFF
--- a/packages/config/src/env/__tests__/core.test.ts
+++ b/packages/config/src/env/__tests__/core.test.ts
@@ -51,6 +51,12 @@ describe("requireEnv", () => {
     const requireEnv = await getRequire();
     expect(() => requireEnv("SPACE")).toThrow();
   });
+
+  it("trims surrounding whitespace", async () => {
+    process.env.TRIM = "  value  ";
+    const requireEnv = await getRequire();
+    expect(requireEnv("TRIM")).toBe("value");
+  });
 });
 
 describe("requireEnv boolean parsing", () => {


### PR DESCRIPTION
## Summary
- extend requireEnv tests to verify string values are trimmed

## Testing
- `cd packages/config && pnpm test src/env/__tests__/core.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bb2e617a68832f92f7d161b193b1df