### PR TITLE
test: cover api edge cases

### DIFF
--- a/apps/api/__tests__/routes/components/[shopId].test.ts
+++ b/apps/api/__tests__/routes/components/[shopId].test.ts
@@ -91,4 +91,23 @@ describe("components route", () => {
     expect(res.status).toBe(403);
     expect(res.body).toEqual({ error: "Forbidden" });
   });
+
+  it("rejects token without expiration", async () => {
+    const token = jwt.sign(
+      {},
+      process.env.UPGRADE_PREVIEW_TOKEN_SECRET!,
+      {
+        algorithm: "HS256",
+        audience: "upgrade-preview",
+        issuer: "acme",
+        subject: "shop:abc:upgrade-preview",
+        noTimestamp: true,
+      },
+    );
+    const res = await request(createRequestHandler())
+      .get("/components/abc")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Forbidden" });
+  });
 });


### PR DESCRIPTION
## Summary
- add missing-expiration token test for components route
- harden publish-upgrade route tests for bad secrets and string errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e797f28832f89d46912f2796c2b