### PR TITLE
fix deposit release auto-start logging

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -166,11 +166,14 @@ export async function startDepositReleaseService(
 // imported. Production environments can opt-in by explicitly setting an
 // environment variable.
 if (process.env.RUN_DEPOSIT_RELEASE_SERVICE === "true") {
-  void startDepositReleaseService().catch((err) => {
-    // Log via both logger and console so that failures surface in
-    // environments without structured logging.
-    const { logger: log } = require("@platform-core/utils");
-    log.error("failed to start deposit release service", { err });
-    console.error("failed to start deposit release service", err);
-  });
+  (async () => {
+    try {
+      await startDepositReleaseService();
+    } catch (err) {
+      // Log via both logger and console so that failures surface in
+      // environments without structured logging.
+      logger.error("failed to start deposit release service", { err });
+      console.error("failed to start deposit release service", err);
+    }
+  })();
 }


### PR DESCRIPTION
## Summary
- ensure deposit release service logs startup failures via logger and console

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/edit-changes)*
- `pnpm exec jest packages/platform-machine/__tests__/releaseDepositsService.test.ts --runInBand --config jest.config.cjs` *(fails: expect(jest.fn()).toHaveBeenCalledWith)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ef6f7a8832f91bf8b60fbb18aee