### PR TITLE
test: cover genSecret default and custom bytes

### DIFF
--- a/packages/platform-machine/src/__tests__/genSecret.test.ts
+++ b/packages/platform-machine/src/__tests__/genSecret.test.ts
@@ -1,18 +1,38 @@
 import { genSecret } from '@acme/shared-utils/src/genSecret';
 
 describe('genSecret', () => {
-  it('returns expected hex string for mocked random values', () => {
-    const spy = jest
-      .spyOn(globalThis.crypto, 'getRandomValues')
-      .mockImplementation((array: Uint8Array) => {
-        array.set([0xde, 0xad, 0xbe, 0xef]);
-        return array;
-      });
+  const original = globalThis.crypto;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'crypto', { value: original });
+  });
+
+  it('returns a default-length hex string when crypto is stubbed', () => {
+    const mock = {
+      getRandomValues: (arr: Uint8Array) => {
+        arr.fill(0);
+        return arr;
+      },
+    } as Crypto;
+    Object.defineProperty(globalThis, 'crypto', { value: mock });
+
+    const secret = genSecret();
+    expect(secret).toBe('00'.repeat(16));
+    expect(secret).toHaveLength(32);
+  });
+
+  it('returns expected hex string for custom byte length', () => {
+    const mock = {
+      getRandomValues: (arr: Uint8Array) => {
+        arr.set([0xde, 0xad, 0xbe, 0xef]);
+        return arr;
+      },
+    } as Crypto;
+    Object.defineProperty(globalThis, 'crypto', { value: mock });
 
     const secret = genSecret(4);
     expect(secret).toBe('deadbeef');
     expect(secret).toHaveLength(8);
-
-    spy.mockRestore();
   });
 });
+


### PR DESCRIPTION
## Summary
- add deterministic tests for genSecret default and custom byte lengths

## Testing
- `pnpm --filter @acme/platform-machine test` *(fails: Cannot find module './db' from packages/platform-core/src/__tests__/legacy/db.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2d79e354832f945508228badec02