### PR TITLE
refactor: replace explicit any in config core env

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -146,7 +146,9 @@ export const coreEnvSchema = coreEnvBaseSchema.superRefine((env, ctx) => {
   // Normalize AUTH_TOKEN_TTL before delegating to the auth schema so builds
   // don't fail if the value is provided as a plain number or contains
   // incidental whitespace.
-  const envForAuth: Record<string, unknown> = { ...(env as any) };
+  const envForAuth: Record<string, unknown> = {
+    ...(env as Record<string, unknown>),
+  };
   const rawTtl = envForAuth.AUTH_TOKEN_TTL;
   if (typeof rawTtl === "number") {
     // Let auth schema default to 15m when undefined
@@ -194,11 +196,11 @@ let __cachedCoreEnv: CoreEnv | null = null;
 export const coreEnv: CoreEnv = new Proxy({} as CoreEnv, {
   get: (_t, prop: string) => {
     if (!__cachedCoreEnv) __cachedCoreEnv = loadCoreEnv();
-    return (__cachedCoreEnv as any)[prop];
+    return __cachedCoreEnv![prop as keyof CoreEnv];
   },
   has: (_t, prop: string) => {
     if (!__cachedCoreEnv) __cachedCoreEnv = loadCoreEnv();
-    return prop in (__cachedCoreEnv as any);
+    return prop in __cachedCoreEnv!;
   },
   ownKeys: () => {
     if (!__cachedCoreEnv) __cachedCoreEnv = loadCoreEnv();


### PR DESCRIPTION
## Summary
- refactor envForAuth and proxy traps to avoid `any` usage

## Testing
- `pnpm exec eslint packages/config/src/env/core.ts`
- `pnpm --filter @acme/config lint` *(fails: Missing project file and disallowed require imports)*
- `pnpm --filter @acme/config test`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bb346083bc832fbc74ebeb910d7f0f