### PR TITLE
chore: ignore configurator bin in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default [
       "node_modules/",
       "**/dist/**",
       "packages/auth/dist/",
+      "packages/configurator/bin/**",
       "**/.next/**",
       "**/build/**",
       "**/coverage/**",


### PR DESCRIPTION
## Summary
- ignore `packages/configurator/bin/**` in ESLint to allow CommonJS bin script

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build: Failed)*
- `pnpm lint --filter @acme/configurator`
- `pnpm test --filter @acme/configurator` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bb34a304b8832f9f64122f02b1888a