### PR TITLE
chore: ignore jest configs in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,7 @@ export default [
       "**/jest.setup*.{ts,tsx}",
       "**/*.test.{ts,tsx,js,jsx}",
       "**/*.spec.{ts,tsx,js,jsx}",
+      "**/jest.config.*",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- exclude `jest.config.*` files from ESLint

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec eslint packages/email/jest.config.cjs`
- `pnpm --filter @acme/email lint` *(fails: Unexpected any. Specify a different type @packages/email/src/templates.ts:65:87)*

------
https://chatgpt.com/codex/tasks/task_e_68bb34dbda30832f91fe436e598b4370