### PR TITLE
refactor: replace any types in platform-core

### DIFF
--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -98,12 +98,13 @@ export const getDefaultCartStore = (): CartStore => {
   if (_defaultStore) return _defaultStore;
   // In tests, `createCartStore` is spied via the module export.
   // Access through `module.exports` when available so the spy is hit.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type ModuleWithCreateCartStore = NodeJS.Module & {
+    exports?: { createCartStore?: typeof createCartStore };
+  };
   const factory =
     typeof module !== "undefined" &&
-    (module as any).exports?.createCartStore
-      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ((module as any).exports.createCartStore as typeof createCartStore)
+    (module as ModuleWithCreateCartStore).exports?.createCartStore
+      ? (module as ModuleWithCreateCartStore).exports.createCartStore
       : createCartStore;
   _defaultStore = factory();
   return _defaultStore;

--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -3,7 +3,7 @@ import { createRequire } from "module";
 import type { PrismaClient } from "./prisma-client";
 
 // Avoid referencing conditional exports from "@prisma/client" directly.
-type PrismaClientCtor = new (...args: any[]) => PrismaClient;
+type PrismaClientCtor = new (...args: unknown[]) => PrismaClient;
 
 const coreEnv = loadCoreEnv();
 type RentalOrderStub = {
@@ -81,9 +81,12 @@ if (process.env.NODE_ENV === "test" || !coreEnv.DATABASE_URL) {
         ? __dirname
         : `${process.cwd()}/package.json`
     );
-    const mod = requirePrisma("@prisma/client");
+    const mod = requirePrisma("@prisma/client") as {
+      PrismaClient?: PrismaClientCtor;
+      default?: { PrismaClient?: PrismaClientCtor };
+    };
     const PrismaClientCtor: PrismaClientCtor | undefined =
-      (mod as any).PrismaClient ?? (mod as any).default?.PrismaClient;
+      mod.PrismaClient ?? mod.default?.PrismaClient;
     if (!PrismaClientCtor) {
       prisma = createStubPrisma();
     } else {

--- a/packages/platform-core/src/prisma-client.ts
+++ b/packages/platform-core/src/prisma-client.ts
@@ -1,3 +1,3 @@
 export interface PrismaClient {
-  [key: string]: any;
+  [key: string]: unknown;
 }

--- a/packages/platform-core/src/types/better-sqlite3.js
+++ b/packages/platform-core/src/types/better-sqlite3.js
@@ -70,7 +70,7 @@ class Database {
     this.rows = Database.stores.get(file);
   }
 
-  exec(_sql) {
+  exec() {
     return this;
   }
 


### PR DESCRIPTION
## Summary
- drop leftover eslint-disable directive and use typed module access in cart store factory
- replace `any` types in platform-core DB helper and Prisma stub
- remove unused arg in better-sqlite3 test stub

## Testing
- `pnpm install` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(partially ran, but could not complete within environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68bb357133cc832f9281ba431b8cf3ae