### PR TITLE
chore(types): remove redundant root index file

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,4 +1,0 @@
-export * from "./src/index";
-export { ExampleProps } from "./src/ExampleProps";
-export { historyStateSchema } from "./src/page/page";
-export type { CartLine, CartState } from "./src/Cart";


### PR DESCRIPTION
## Summary
- remove redundant top-level index.ts in types package which caused TypeScript project errors

## Testing
- `pnpm install`
- `pnpm --filter @acme/types build`
- `pnpm --filter @acme/types lint`
- `pnpm test --filter @acme/types`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb364a4ccc832f9b830a6afa173490