### PR TITLE
chore: ignore config files from lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,8 @@ export default [
       "**/jest.setup*.{ts,tsx}",
       "**/*.test.{ts,tsx,js,jsx}",
       "**/*.spec.{ts,tsx,js,jsx}",
+      "**/jest.config.*",
+      "**/postcss.config.*",
       "packages/config/jest.preset.cjs",
     ],
   },
@@ -61,12 +63,12 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-          project: [
-            "./tsconfig.json",
-            "./apps/*/tsconfig.json",
-            "./packages/*/tsconfig.json",
-            "./packages/*/tsconfig.eslint.json",
-          ],
+        project: [
+          "./tsconfig.json",
+          "./apps/*/tsconfig.json",
+          "./packages/*/tsconfig.json",
+          "./packages/*/tsconfig.eslint.json",
+        ],
         projectService: true,
         allowDefaultProject: true,
         sourceType: "module",


### PR DESCRIPTION
## Summary
- exclude `jest.config.*` and `postcss.config.*` from ESLint

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @apps/dashboard lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb36e8f3b8832fb8ff54a8fd657bd0