### PR TITLE
refactor(shared-utils): type Intl supportedValuesOf

### DIFF
--- a/packages/shared-utils/src/formatCurrency.ts
+++ b/packages/shared-utils/src/formatCurrency.ts
@@ -16,9 +16,11 @@ export function formatCurrency(
     throw new RangeError(`Invalid currency code: ${currency}`);
   }
 
-  const supported = (Intl as any).supportedValuesOf?.("currency") as
-    | string[]
-    | undefined;
+  const supported = (
+    Intl as typeof Intl & {
+      supportedValuesOf?(category: "currency"): string[];
+    }
+  ).supportedValuesOf?.("currency");
   if (supported && !supported.includes(currency)) {
     throw new RangeError(`Invalid currency code: ${currency}`);
   }


### PR DESCRIPTION
## Summary
- refine Intl type for `supportedValuesOf` in `formatCurrency`

## Testing
- `pnpm install`
- `pnpm --filter @acme/shared-utils lint`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils test` *(incomplete: produced extensive output)*

------
https://chatgpt.com/codex/tasks/task_e_68bb35db0e3c832f996cf6e79a8ab0fe