### PR TITLE
chore: ignore postcss config for lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default [
       "**/*.test.{ts,tsx,js,jsx}",
       "**/*.spec.{ts,tsx,js,jsx}",
       "packages/config/jest.preset.cjs",
+      "**/postcss.config.cjs",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- ignore PostCSS config files from ESLint

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build, apps/shop-bcd build)*
- `pnpm exec eslint apps/cms/postcss.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68bb3684f934832fb47f22a768e5b5e8