### PR TITLE
chore: ignore Jest config from lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default [
       "**/*.test.{ts,tsx,js,jsx}",
       "**/*.spec.{ts,tsx,js,jsx}",
       "packages/config/jest.preset.cjs",
+      "**/jest.config.cjs",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- exclude `jest.config.cjs` files from linting

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @apps/cms lint` *(fails: parsing errors; jest config ignored)*
- `pnpm exec eslint apps/cms/jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68bb36a8ed44832f9e30f66397560f86