### PR TITLE
fix: ensure default cart store is non-null

### DIFF
--- a/packages/platform-core/src/cartStore.ts
+++ b/packages/platform-core/src/cartStore.ts
@@ -107,7 +107,7 @@ export const getDefaultCartStore = (): CartStore => {
       ? (module as ModuleWithCreateCartStore).exports.createCartStore
       : createCartStore;
   _defaultStore = factory();
-  return _defaultStore;
+  return _defaultStore!;
 };
 
 // Test-only helper to override the lazily created store


### PR DESCRIPTION
## Summary
- assert default cart store is always returned as non-null

## Testing
- `pnpm install`
- `pnpm -r build` (fails: prisma.* is of type unknown)
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68bb3b339590832fb4b12d75f9c5ebdf