### PR TITLE
chore(shop-bcd): ignore cjs config files in eslint

### DIFF
--- a/apps/shop-bcd/eslint.config.js
+++ b/apps/shop-bcd/eslint.config.js
@@ -1,0 +1,10 @@
+import rootConfig from "../../eslint.config.mjs";
+
+const config = [
+  {
+    ignores: ["jest.config.cjs", "postcss.config.cjs"],
+  },
+  ...rootConfig,
+];
+
+export default config;


### PR DESCRIPTION
## Summary
- ignore CJS config files in shop-bcd to avoid require-import lint errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm --filter @apps/shop-bcd lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b56397c832fadc804146fc8b787