### PR TITLE
refactor: avoid require import in deposit service

### DIFF
--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -136,8 +136,7 @@ export async function startDepositReleaseService(
   releaseFn?: typeof releaseDepositsOnce,
   logFn: typeof logger.error = (msg, meta) => logger.error(msg, meta),
 ): Promise<() => void> {
-  const release =
-    releaseFn ?? (await import("./releaseDepositsService")).releaseDepositsOnce;
+  const release = releaseFn ?? releaseDepositsOnce;
   const shops = await readdir(dataRoot);
   const timers: NodeJS.Timeout[] = [];
 


### PR DESCRIPTION
## Summary
- refactor deposit release service to reference local function rather than performing a dynamic import

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types unknown)*
- `pnpm --filter @acme/platform-machine lint`
- `pnpm --filter @acme/platform-machine test` *(fails: releaseDepositsService log assertion, OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68bb393c8ac8832fb6103a2c5307f251