### PR TITLE
chore(cms): ignore config files in eslint

### DIFF
--- a/apps/cms/eslint.config.mjs
+++ b/apps/cms/eslint.config.mjs
@@ -1,6 +1,9 @@
 import baseConfig from "../../eslint.config.mjs";
 
 const config = [
+  {
+    ignores: ["postcss.config.cjs", "jest.config.cjs"],
+  },
   ...baseConfig,
   {
     files: [


### PR DESCRIPTION
## Summary
- ignore `postcss.config.cjs` and `jest.config.cjs` in CMS ESLint config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.rentalOrder' is of type 'unknown')*
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test` *(fails: CMS shop pages returns 404 for shop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e71d3a4832f8f9e835945703f03