### PR TITLE
fix(platform-core): preserve prisma delegate types

### DIFF
--- a/packages/platform-core/src/prisma.d.ts
+++ b/packages/platform-core/src/prisma.d.ts
@@ -1,14 +1,9 @@
 declare module "@prisma/client" {
-  export class PrismaClient {
-    constructor(...args: any[]);
+  /**
+   * Augment the generated PrismaClient without overwriting the
+   * existing class definition so model delegate types remain intact.
+   */
+  interface PrismaClient<T = any, U = any, V = any> {
     [key: string]: any;
-  }
-  export interface RentalOrder {}
-  export const Prisma: any;
-  export namespace Prisma {
-    export type InputJsonValue = unknown;
-    export type PageCreateManyInput = unknown;
-    export type RentalOrderCreateInput = unknown;
-    export type RentalOrderUpdateInput = unknown;
   }
 }


### PR DESCRIPTION
## Summary
- avoid overwriting PrismaClient types and instead augment with an index signature

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68bb421bf8d8832fb639e9f990478be2