### PR TITLE
refactor: use generated prisma client type

### DIFF
--- a/packages/platform-core/src/prisma-client.ts
+++ b/packages/platform-core/src/prisma-client.ts
@@ -1,3 +1,6 @@
-export interface PrismaClient {
-  [key: string]: unknown;
-}
+import type { PrismaClient as GeneratedPrismaClient } from '@prisma/client';
+
+// Re-export the generated Prisma client type to avoid pulling in runtime code
+// while preserving full type information across the codebase.
+export type PrismaClient = GeneratedPrismaClient;
+


### PR DESCRIPTION
## Summary
- refactor `PrismaClient` type to re-export generated type from `@prisma/client`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4212d7c4832fb74257e70d650461