### PR TITLE
feat(platform-core): add typed Prisma stub client with reset

### DIFF
--- a/packages/platform-core/src/db.d.ts
+++ b/packages/platform-core/src/db.d.ts
@@ -1,2 +1,3 @@
 import { PrismaClient } from "@prisma/client";
 export declare const prisma: PrismaClient;
+export declare function resetStubPrisma(): void;


### PR DESCRIPTION
## Summary
- add `StubPrismaClient` interface with typed delegates
- replace untyped arrays with typed collections and add `resetStubPrisma`
- implement missing stub methods like `shop.findMany`, `page.findUnique`, and `user.deleteMany`

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/platform-core build`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_68bb507abe2c832fbed07afd52a9eabe