### PR TITLE
feat: type shop data

### DIFF
--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -16,6 +16,7 @@ import {
   defaultDeploymentAdapter,
   type ShopDeploymentAdapter,
 } from "./deploymentAdapter";
+import type { Shop } from "@acme/types";
 
 function repoRoot(): string {
   const tryResolve = (p: string): string | null => {
@@ -48,7 +49,7 @@ export async function createShop(
   const themeDefaults = loadTokens(prepared.theme);
   const themeTokens = { ...themeDefaults, ...themeOverrides };
 
-  const shopData = {
+  const shopData: Shop = {
     id,
     name: prepared.name,
     catalogFilters: [],
@@ -68,10 +69,22 @@ export async function createShop(
     enableEditorial: prepared.enableEditorial,
     subscriptionsEnabled: prepared.enableSubscriptions,
     rentalSubscriptions: [],
+    coverageIncluded: true,
+    luxuryFeatures: {
+      blog: false,
+      contentMerchandising: false,
+      raTicketing: false,
+      fraudReviewThreshold: 0,
+      requireStrongCustomerAuth: false,
+      strictReturnConditions: false,
+      trackingDashboard: false,
+      premierDelivery: false,
+    },
+    componentVersions: {},
   };
 
   await prisma.shop.create({
-    data: { id, data: shopData as unknown },
+    data: { id, data: shopData },
   });
 
   try {


### PR DESCRIPTION
## Summary
- type shop seed data as `Shop`
- drop unnecessary `unknown` cast when persisting JSON to Prisma

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm typecheck` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/platform-core exec tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bb56372524832fa79eaedfe19cef1e