### PR TITLE
feat: type customer profile lookup

### DIFF
--- a/packages/platform-core/src/profile.d.ts
+++ b/packages/platform-core/src/profile.d.ts
@@ -1,1 +1,5 @@
-export declare function getCustomerProfile(): Promise<null>;
+import type { CustomerProfile } from "@acme/types";
+
+export declare function getCustomerProfile(
+  customerId?: string
+): Promise<CustomerProfile | null>;

--- a/packages/platform-core/src/profile.ts
+++ b/packages/platform-core/src/profile.ts
@@ -1,3 +1,8 @@
-export async function getCustomerProfile(/* customerId?: string */) {
+import type { CustomerProfile } from "@acme/types";
+
+export async function getCustomerProfile(
+  customerId?: string
+): Promise<CustomerProfile | null> {
+  void customerId;
   return null;
 }


### PR DESCRIPTION
## Summary
- declare CustomerProfile return type for getCustomerProfile
- export matching type definition

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm run check:references` (fails: Missing script 'check:references')
- `pnpm run build:ts` (fails: Missing script 'build:ts')
- `pnpm --filter @acme/platform-core test` (fails: Cannot find module './db' from 'packages/platform-core/src/__tests__/legacy/db.test.ts')

------
https://chatgpt.com/codex/tasks/task_e_68bb563278e0832fabdf0d3140c80bad