### PR TITLE
Mock cart context in ProductGrid tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
@@ -2,6 +2,10 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ProductGrid, type Product } from "../ProductGrid";
 import "../../../../../../test/resetNextMocks";
 
+jest.mock("@acme/platform-core/contexts/CartContext", () => ({
+  useCart: () => [{}, jest.fn()],
+}));
+
 function mockResize(initialWidth: number) {
   let cb: ResizeObserverCallback;
   let element: Element;


### PR DESCRIPTION
## Summary
- mock `useCart` to isolate `ProductGrid` unit tests from `CartProvider`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @acme/ui run check:references` *(fails: script missing)*
- `pnpm --filter @acme/ui run build:ts` *(fails: script missing)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bb5b7e624c832fae8ee323a364f799