### PR TITLE
chore(test): specify outDir for ts-jest

### DIFF
--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
     "noEmit": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "outDir": "dist"
   },
   "include": ["src/**/*"],
   "exclude": ["__tests__", "**/__tests__/**", "**/*.test.*", "**/*.spec.*"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -17,7 +17,8 @@
     /* test-specific flags ------------------------------------------- */
     "noEmit": true, // type-check only
     "importsNotUsedAsValues": "remove",
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "outDir": ".ts-jest"
   },
 
   /* ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- set explicit `outDir` in root test tsconfig
- set explicit `outDir` in UI package test tsconfig

## Testing
- `pnpm --filter @acme/ui exec jest __tests__/useAutoSave.test.tsx --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb5be11298832f8aeca23bdd9bdd56