### PR TITLE
feat(platform-core): return typed tax calculation result

### DIFF
--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -25,8 +25,7 @@ export async function POST(req: NextRequest) {
   if ("response" in parsed) {
     return parsed.response;
   }
-
-  const body = parsed.data as TaxCalculationRequest;
+  const body: TaxCalculationRequest = parsed.data;
 
   try {
     const tax = await calculateTax(body);

--- a/packages/platform-core/src/tax/index.d.ts
+++ b/packages/platform-core/src/tax/index.d.ts
@@ -1,0 +1,13 @@
+export interface TaxCalculationRequest {
+  provider: "taxjar";
+  amount: number;
+  toCountry: string;
+  toPostalCode?: string;
+}
+
+export interface TaxCalculationResult {
+  tax: number;
+}
+
+export declare function getTaxRate(region: string): Promise<number>;
+export declare function calculateTax({ provider, ...payload }: TaxCalculationRequest): Promise<TaxCalculationResult>;

--- a/packages/platform-core/src/tax/index.ts
+++ b/packages/platform-core/src/tax/index.ts
@@ -15,6 +15,10 @@ export interface TaxCalculationRequest {
   toPostalCode?: string;
 }
 
+export interface TaxCalculationResult {
+  tax: number;
+}
+
 let rulesCache: Record<string, number> | null = null;
 
 async function loadRules() {
@@ -45,7 +49,10 @@ export async function getTaxRate(region: string): Promise<number> {
 /**
  * Calculate taxes using the configured provider API.
  */
-export async function calculateTax({ provider, ...payload }: TaxCalculationRequest): Promise<unknown> {
+export async function calculateTax({
+  provider,
+  ...payload
+}: TaxCalculationRequest): Promise<TaxCalculationResult> {
   const apiKey = (shippingEnv as Record<string, string | undefined>)[
     `${provider.toUpperCase()}_KEY`
   ];
@@ -68,7 +75,8 @@ export async function calculateTax({ provider, ...payload }: TaxCalculationReque
       throw new Error(`Failed to calculate tax with ${provider}`);
     }
 
-    return res.json();
+    const data: TaxCalculationResult = await res.json();
+    return data;
   } catch {
     throw new Error(`Failed to calculate tax with ${provider}`);
   }


### PR DESCRIPTION
## Summary
- define TaxCalculationResult interface for provider responses
- return typed data from calculateTax and expose declarations
- remove cast in tax API route

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(missing script)*
- `pnpm run build:ts` *(missing script)*
- `pnpm --filter @acme/platform-core run build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @acme/platform-core test` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5e03375c832f95fa66f4e3f45042