### PR TITLE
feat(shipping): add ShippingRate type

### DIFF
--- a/apps/shop-bcd/__tests__/shipping-rate.test.ts
+++ b/apps/shop-bcd/__tests__/shipping-rate.test.ts
@@ -24,7 +24,7 @@ function makeRequest(body: any) {
 afterEach(() => jest.clearAllMocks());
 
 test("returns shipping rate for valid request", async () => {
-  (getShippingRate as jest.Mock).mockResolvedValue(42);
+  (getShippingRate as jest.Mock).mockResolvedValue({ rate: 42 });
   const res = await POST(
     makeRequest({
       provider: "dhl",

--- a/apps/shop-bcd/src/app/api/shipping-rate/route.ts
+++ b/apps/shop-bcd/src/app/api/shipping-rate/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: NextRequest) {
       carrier: body.carrier,
       premierDelivery,
     });
-    return NextResponse.json({ rate });
+    return NextResponse.json(rate);
   } catch (err) {
     return NextResponse.json(
       { error: (err as Error).message },

--- a/packages/platform-core/src/shipping/index.d.ts
+++ b/packages/platform-core/src/shipping/index.d.ts
@@ -1,3 +1,9 @@
+export interface ShippingRate {
+    rate: number;
+    surcharge?: number;
+    serviceLabel?: string;
+}
+
 export interface ShippingRateRequest {
     provider: "ups" | "dhl" | "premier-shipping";
     fromPostalCode: string;
@@ -18,7 +24,7 @@ export interface ShippingRateRequest {
  * Fetch a shipping rate from the configured provider.
  * The underlying provider API is called using the respective API key.
  */
-export declare function getShippingRate({ provider, fromPostalCode, toPostalCode, weight, region, window, carrier, premierDelivery, }: ShippingRateRequest): Promise<unknown>;
+export declare function getShippingRate({ provider, fromPostalCode, toPostalCode, weight, region, window, carrier, premierDelivery, }: ShippingRateRequest): Promise<ShippingRate>;
 export interface TrackingStatusRequest {
     provider: "ups" | "dhl";
     trackingNumber: string;

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -1,6 +1,13 @@
 // packages/platform-core/src/shipping/index.ts
 
 import { shippingEnv } from "@acme/config/env/shipping";
+
+export interface ShippingRate {
+  rate: number;
+  surcharge?: number;
+  serviceLabel?: string;
+}
+
 export interface ShippingRateRequest {
   provider: "ups" | "dhl" | "premier-shipping";
   fromPostalCode: string;
@@ -31,7 +38,7 @@ export async function getShippingRate({
   window,
   carrier,
   premierDelivery,
-}: ShippingRateRequest): Promise<unknown> {
+}: ShippingRateRequest): Promise<ShippingRate> {
   if (provider === "premier-shipping") {
     if (!premierDelivery) {
       throw new Error("Premier delivery not configured");
@@ -91,7 +98,12 @@ export async function getShippingRate({
     throw new Error(`Failed to fetch rate from ${provider}`);
   }
 
-  return res.json();
+  const data = await res.json();
+  return {
+    rate: data.rate,
+    surcharge: data.surcharge,
+    serviceLabel: data.serviceLabel,
+  };
 }
 
 export interface TrackingStatusRequest {


### PR DESCRIPTION
## Summary
- type `getShippingRate` to return a structured `ShippingRate`
- expose `ShippingRate` in declaration file
- return shipping rates directly from API route

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/platform-core/__tests__/shipping-index.test.ts` *(fails: global coverage threshold not met)*
- `pnpm exec jest apps/shop-bcd/__tests__/shipping-rate.test.ts` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5e051918832f97502c4e602c7194