### PR TITLE
feat(i18n): type server translations helper

### DIFF
--- a/packages/i18n/src/useTranslations.server.d.ts
+++ b/packages/i18n/src/useTranslations.server.d.ts
@@ -1,0 +1,6 @@
+import { type Locale } from "./locales";
+/**
+ * Load translation messages for a given locale on the server and return a lookup function.
+ */
+export declare function useTranslations(locale: Locale): Promise<(key: string) => string>;
+

--- a/packages/i18n/src/useTranslations.server.ts
+++ b/packages/i18n/src/useTranslations.server.ts
@@ -4,7 +4,9 @@ import type { Locale } from "./locales";
  * Load translation messages for a given locale on the server and return a
  * lookup function.
  */
-export async function useTranslations(locale: Locale) {
+export async function useTranslations(
+  locale: Locale
+): Promise<(key: string) => string> {
   const messages = (
     await import(
       /* webpackInclude: /(en|de|it)\.json$/ */


### PR DESCRIPTION
## Summary
- type `useTranslations` server helper to resolve to `(key: string) => string`
- expose matching `useTranslations.server.d.ts` for consumers

## Testing
- `pnpm install`
- `pnpm exec tsc -b`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/i18n test packages/i18n/src/__tests__/fillLocales.test.ts` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5e0647b0832fbcf41db9f0cdec17