### PR TITLE
feat(auth): return session from requirePermission

### DIFF
--- a/packages/auth/src/requirePermission.ts
+++ b/packages/auth/src/requirePermission.ts
@@ -1,12 +1,13 @@
 // packages/auth/src/requirePermission.ts
-import { getCustomerSession } from "./session";
+import { getCustomerSession, type CustomerSession } from "./session";
 import { hasPermission } from "./permissions";
 import type { Permission } from "./types/index";
 
-export async function requirePermission(perm: Permission) {
+export async function requirePermission(
+  perm: Permission
+): Promise<CustomerSession> {
   const session = await getCustomerSession();
-  const role = session?.role;
-  if (!role || !hasPermission(role, perm)) {
+  if (!session || !hasPermission(session.role, perm)) {
     throw new Error("Unauthorized");
   }
   return session;

--- a/packages/template-app/types-compat/auth.d.ts
+++ b/packages/template-app/types-compat/auth.d.ts
@@ -1,4 +1,12 @@
 declare module "@auth" {
-  export async function getCustomerSession(...args: any[]): Promise<any>;
-  export async function requirePermission(...args: any[]): Promise<void>;
+  export interface CustomerSession {
+    customerId: string;
+    role: string;
+  }
+  export async function getCustomerSession(
+    ...args: any[]
+  ): Promise<CustomerSession | null>;
+  export async function requirePermission(
+    ...args: any[]
+  ): Promise<CustomerSession>;
 }


### PR DESCRIPTION
## Summary
- ensure `requirePermission` returns the active `CustomerSession`
- update auth types compat to surface `CustomerSession`

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5e084d88832fbb33ee70165d3585