### PR TITLE
feat: type theme preset repository

### DIFF
--- a/packages/platform-core/src/repositories/themePresets.server.ts
+++ b/packages/platform-core/src/repositories/themePresets.server.ts
@@ -19,7 +19,9 @@ async function readPresets(shop: string) {
   }
 }
 
-export async function getThemePresets(shop: string) {
+export async function getThemePresets(
+  shop: string,
+): Promise<Record<string, Record<string, string>>> {
   return readPresets(shop);
 }
 
@@ -27,14 +29,17 @@ export async function saveThemePreset(
   shop: string,
   name: string,
   tokens: Record<string, string>,
-) {
+): Promise<void> {
   const presets = await readPresets(shop);
   presets[name] = tokens;
   await fs.mkdir(path.dirname(presetsPath(shop)), { recursive: true });
   await fs.writeFile(presetsPath(shop), JSON.stringify(presets, null, 2), "utf8");
 }
 
-export async function deleteThemePreset(shop: string, name: string) {
+export async function deleteThemePreset(
+  shop: string,
+  name: string,
+): Promise<void> {
   const presets = await readPresets(shop);
   delete presets[name];
   await fs.mkdir(path.dirname(presetsPath(shop)), { recursive: true });


### PR DESCRIPTION
## Summary
- add explicit return types for theme preset repository methods

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/platform-core test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e090608832f80e613a7d42fb7aa