### PR TITLE
feat: type analytics events

### DIFF
--- a/packages/platform-core/src/repositories/analytics.server.d.ts
+++ b/packages/platform-core/src/repositories/analytics.server.d.ts
@@ -1,3 +1,3 @@
-import type { AnalyticsAggregates } from "../analytics";
-export declare function listEvents(_shop?: string): Promise<any[]>;
+import type { AnalyticsAggregates, AnalyticsEvent } from "../analytics";
+export declare function listEvents(_shop?: string): Promise<AnalyticsEvent[]>;
 export declare function readAggregates(shop: string): Promise<AnalyticsAggregates>;


### PR DESCRIPTION
## Summary
- type `listEvents` to return `Promise<AnalyticsEvent[]>`
- add `AnalyticsEvent` import to analytics repository declaration

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*


------
https://chatgpt.com/codex/tasks/task_e_68bb5e0a694c832f9cb584dbf9ebf84d