### PR TITLE
refactor(template-app): declare auth helpers

### DIFF
--- a/packages/template-app/types-compat/auth.d.ts
+++ b/packages/template-app/types-compat/auth.d.ts
@@ -1,12 +1,13 @@
 declare module "@auth" {
-  export interface CustomerSession {
-    customerId: string;
-    role: string;
-  }
-  export async function getCustomerSession(
+  import type { CustomerSession } from "@acme/auth";
+
+  export type { CustomerSession };
+
+  export function getCustomerSession(
     ...args: any[]
   ): Promise<CustomerSession | null>;
-  export async function requirePermission(
+
+  export function requirePermission(
     ...args: any[]
   ): Promise<CustomerSession>;
 }


### PR DESCRIPTION
## Summary
- import CustomerSession from `@acme/auth` in auth type compat module
- declare `getCustomerSession` and `requirePermission` returning typed sessions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfc6a853c832f891a4cd18836304a