### PR TITLE
test(ui): cover currency and theme contexts

### DIFF
--- a/packages/ui/__tests__/CurrencyContext.test.tsx
+++ b/packages/ui/__tests__/CurrencyContext.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CurrencyProvider, useCurrency } from "@platform-core/contexts/CurrencyContext";
+
+// React 19 requires this flag for `act` to suppress environment warnings
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Display() {
+  const [currency, setCurrency] = useCurrency();
+  return (
+    <>
+      <span data-testid="currency">{currency}</span>
+      <button onClick={() => setCurrency("USD")}>change</button>
+    </>
+  );
+}
+
+describe("CurrencyContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("defaults to EUR and toggles/persists to USD", () => {
+    render(
+      <CurrencyProvider>
+        <Display />
+      </CurrencyProvider>
+    );
+
+    const cur = screen.getByTestId("currency");
+    expect(cur.textContent).toBe("EUR");
+    fireEvent.click(screen.getByText("change"));
+    expect(cur.textContent).toBe("USD");
+    expect(localStorage.getItem("PREFERRED_CURRENCY")).toBe("USD");
+  });
+
+  it("uses currency from localStorage when available", () => {
+    localStorage.setItem("PREFERRED_CURRENCY", "GBP");
+    render(
+      <CurrencyProvider>
+        <Display />
+      </CurrencyProvider>
+    );
+    expect(screen.getByTestId("currency").textContent).toBe("GBP");
+  });
+
+  it("throws when useCurrency called outside provider", () => {
+    const orig = console.error;
+    console.error = () => {};
+    expect(() => useCurrency()).toThrow("useCurrency must be inside CurrencyProvider");
+    console.error = orig;
+  });
+});

--- a/packages/ui/__tests__/ThemeContext.test.tsx
+++ b/packages/ui/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "@platform-core/contexts/ThemeContext";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Display() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={() => setTheme("dark")}>dark</button>
+    </>
+  );
+}
+
+describe("ThemeContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.documentElement.style.colorScheme = "";
+    window.matchMedia =
+      window.matchMedia ||
+      ((q: string) => ({
+        matches: false,
+        media: q,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      })) as any;
+    jest.restoreAllMocks();
+  });
+
+  it("defaults to system and toggles to dark with persistence", () => {
+    const spy = jest.spyOn(Storage.prototype, "setItem");
+    render(
+      <ThemeProvider>
+        <Display />
+      </ThemeProvider>
+    );
+
+    const span = screen.getByTestId("theme");
+    expect(span.textContent).toBe("system");
+    fireEvent.click(screen.getByText("dark"));
+    expect(span.textContent).toBe("dark");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(true);
+    expect(spy).toHaveBeenLastCalledWith("theme", "dark");
+  });
+
+  it("uses saved theme from localStorage", () => {
+    localStorage.setItem("theme", "brandx");
+    render(
+      <ThemeProvider>
+        <Display />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("brandx");
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(true);
+  });
+
+  it("throws when useTheme called outside provider", () => {
+    const orig = console.error;
+    console.error = () => {};
+    function Bare() {
+      useTheme();
+      return null;
+    }
+    expect(() => render(<Bare />)).toThrow(
+      "useTheme must be inside ThemeProvider"
+    );
+    console.error = orig;
+  });
+});


### PR DESCRIPTION
## Summary
- add CurrencyContext tests for default, storage and guard outside provider
- add ThemeContext tests verifying defaults, persistence, and hook guard

## Testing
- `pnpm --filter @acme/ui run check:references` (fails: None of the selected packages has a "check:references" script)
- `pnpm --filter @acme/ui run build:ts` (fails: None of the selected packages has a "build:ts" script)
- `pnpm --filter @acme/ui run build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm exec jest packages/ui/__tests__/CurrencyContext.test.tsx packages/ui/__tests__/ThemeContext.test.tsx --runTestsByPath --runInBand --config jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb3db5a0832f84fbac8cdff03b39