### PR TITLE
test: expand CartContext coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,8 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-cli": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
+    "jest-localstorage-mock": "^2.4.21",
     "lighthouse": "^11.5.0",
     "msw": "^1.3.5",
     "nock": "^13.4.0",

--- a/packages/platform-core/__tests__/CartContext.test.tsx
+++ b/packages/platform-core/__tests__/CartContext.test.tsx
@@ -1,8 +1,12 @@
 // packages/platform-core/__tests__/CartContext.test.tsx
 import React from "react";
+import fetchMock from "jest-fetch-mock";
+import "jest-localstorage-mock";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CartProvider, useCart } from "../src/contexts/CartContext";
 import { PRODUCTS } from "../src/products/index";
+
+fetchMock.enableMocks();
 
 function TestComponent() {
   const [state, dispatch] = useCart();
@@ -13,7 +17,6 @@ function TestComponent() {
   return (
     <div>
       <span data-testid="qty">{line?.qty ?? 0}</span>
-
       <button onClick={() => dispatch({ type: "add", sku: PRODUCTS[0], size })}>
         add
       </button>
@@ -35,32 +38,116 @@ function CaptureDispatch({
   return null;
 }
 
-describe("CartContext actions", () => {
-  const originalFetch = global.fetch;
+beforeEach(() => {
+  fetchMock.resetMocks();
+  localStorage.clear();
+  jest.restoreAllMocks();
+});
 
-  afterEach(() => {
-    global.fetch = originalFetch;
+describe("CartContext", () => {
+  it("loads cart from API and caches it", async () => {
+    const size = PRODUCTS[0].sizes[0];
+    const id = `${PRODUCTS[0].id}:${size}`;
+    const cart = { [id]: { sku: PRODUCTS[0], qty: 2, size } };
+    fetchMock.mockResponseOnce(JSON.stringify({ cart }));
+
+    render(
+      <CartProvider>
+        <TestComponent />
+      </CartProvider>
+    );
+
+    const qty = await screen.findByTestId("qty");
+    expect(qty.textContent).toBe("2");
+    expect(fetchMock).toHaveBeenCalledWith("/api/cart");
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "cart",
+      JSON.stringify(cart)
+    );
+  });
+
+  it("falls back to cached cart and syncs on online", async () => {
+    const size = PRODUCTS[0].sizes[0];
+    const id = `${PRODUCTS[0].id}:${size}`;
+    const cached = { [id]: { sku: PRODUCTS[0], qty: 2, size } };
+    localStorage.setItem("cart", JSON.stringify(cached));
+    fetchMock.mockRejectOnce(new Error("fail"));
+    fetchMock.mockResponseOnce(JSON.stringify({ cart: {} }));
+
+    const addSpy = jest.spyOn(window, "addEventListener");
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+
+    render(
+      <CartProvider>
+        <TestComponent />
+      </CartProvider>
+    );
+
+    const qty = await screen.findByTestId("qty");
+    expect(qty.textContent).toBe("2");
+    expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function));
+    const handler = addSpy.mock.calls.find((c) => c[0] === "online")?.[1] as EventListener;
+
+    window.dispatchEvent(new Event("online"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        "/api/cart",
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+    await waitFor(() => expect(qty.textContent).toBe("0"));
+    expect(localStorage.setItem).toHaveBeenLastCalledWith("cart", "{}");
+    expect(removeSpy).toHaveBeenCalledWith("online", handler);
+  });
+
+  it("handles localStorage errors when reading cache", async () => {
+    fetchMock.mockRejectOnce(new Error("fail"));
+    const addSpy = jest.spyOn(window, "addEventListener");
+    (localStorage.getItem as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("ls fail");
+    });
+
+    render(
+      <CartProvider>
+        <TestComponent />
+      </CartProvider>
+    );
+
+    const qty = await screen.findByTestId("qty");
+    expect(qty.textContent).toBe("0");
+    expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function));
+  });
+
+  it("throws when adding SKU requiring size without one", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ cart: {} }));
+    let dispatch: ReturnType<typeof useCart>[1] | undefined;
+
+    render(
+      <CartProvider>
+        <CaptureDispatch onReady={(d) => (dispatch = d)} />
+      </CartProvider>
+    );
+
+    await waitFor(() => expect(dispatch).toBeDefined());
+    await expect(
+      dispatch!({ type: "add", sku: PRODUCTS[0] })
+    ).rejects.toThrow("Size is required");
   });
 
   it("handles add, setQty and remove actions", async () => {
     const size = PRODUCTS[0].sizes[0];
     const id = `${PRODUCTS[0].id}:${size}`;
-    global.fetch = jest
-      .fn()
-      // initial GET
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) })
-      // add
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } }),
-      })
-      // setQty
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ cart: { [id]: { sku: PRODUCTS[0], qty: 3, size } } }),
-      })
-      // remove
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });
+    fetchMock
+      .mockResponseOnce(JSON.stringify({ cart: {} }))
+      .mockResponseOnce(
+        JSON.stringify({ cart: { [id]: { sku: PRODUCTS[0], qty: 1, size } } })
+      )
+      .mockResponseOnce(
+        JSON.stringify({ cart: { [id]: { sku: PRODUCTS[0], qty: 3, size } } })
+      )
+      .mockResponseOnce(JSON.stringify({ cart: {} }));
 
     render(
       <CartProvider>
@@ -75,22 +162,18 @@ describe("CartContext actions", () => {
 
     fireEvent.click(add);
     await waitFor(() => expect(qty.textContent).toBe("1"));
-    expect(global.fetch).toHaveBeenNthCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       "/api/cart",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({
-          sku: { id: PRODUCTS[0].id },
-          qty: 1,
-          size,
-        }),
+        body: JSON.stringify({ sku: { id: PRODUCTS[0].id }, qty: 1, size }),
       })
     );
 
     fireEvent.click(set);
     await waitFor(() => expect(qty.textContent).toBe("3"));
-    expect(global.fetch).toHaveBeenNthCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
       3,
       "/api/cart",
       expect.objectContaining({
@@ -101,22 +184,19 @@ describe("CartContext actions", () => {
 
     fireEvent.click(remove);
     await waitFor(() => expect(qty.textContent).toBe("0"));
-    expect(global.fetch).toHaveBeenNthCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
       4,
       "/api/cart",
-      expect.objectContaining({
-        method: "DELETE",
-        body: JSON.stringify({ id }),
-      })
+      expect.objectContaining({ method: "DELETE", body: JSON.stringify({ id }) })
     );
   });
 
-  it("throws when adding SKU requiring size without one", async () => {
-    let dispatch: ReturnType<typeof useCart>[1] | undefined;
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });
+  it("throws API error message from dispatch", async () => {
+    fetchMock
+      .mockResponseOnce(JSON.stringify({ cart: {} }))
+      .mockResponseOnce(JSON.stringify({ error: "nope" }), { status: 400 });
 
+    let dispatch: ReturnType<typeof useCart>[1] | undefined;
     render(
       <CartProvider>
         <CaptureDispatch onReady={(d) => (dispatch = d)} />
@@ -125,65 +205,26 @@ describe("CartContext actions", () => {
 
     await waitFor(() => expect(dispatch).toBeDefined());
     await expect(
-      dispatch!({ type: "add", sku: PRODUCTS[0] })
-    ).rejects.toThrow("Size is required");
-  });
-
-  it("falls back to localStorage and syncs on online", async () => {
-    const size = PRODUCTS[0].sizes[0];
-    const id = `${PRODUCTS[0].id}:${size}`;
-    const cached = { [id]: { sku: PRODUCTS[0], qty: 2, size } };
-    localStorage.setItem("cart", JSON.stringify(cached));
-
-    global.fetch = jest
-      .fn()
-      // initial GET fails
-      .mockRejectedValueOnce(new Error("fail"))
-      // sync PUT succeeds
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) });
-
-    render(
-      <CartProvider>
-        <TestComponent />
-      </CartProvider>
-    );
-
-    const qty = await screen.findByTestId("qty");
-    expect(qty.textContent).toBe("2");
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-
-    window.dispatchEvent(new Event("online"));
-
-    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
-    expect(global.fetch).toHaveBeenLastCalledWith(
-      "/api/cart",
-      expect.objectContaining({ method: "PUT" })
-    );
-    await waitFor(() => expect(qty.textContent).toBe("0"));
-    expect(localStorage.getItem("cart")).toBe("{}");
-  });
-
-  it("throws when cart API response is non-ok", async () => {
-    let dispatch: ReturnType<typeof useCart>[1] | undefined;
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ cart: {} }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: "nope" }) });
-
-    render(
-      <CartProvider>
-        <CaptureDispatch onReady={(d) => (dispatch = d)} />
-      </CartProvider>
-    );
-
-    await waitFor(() => expect(dispatch).toBeDefined());
-    await expect(
-      dispatch!({
-        type: "add",
-        sku: PRODUCTS[0],
-        size: PRODUCTS[0].sizes[0],
-      })
+      dispatch!({ type: "add", sku: PRODUCTS[0], size: PRODUCTS[0].sizes[0] })
     ).rejects.toThrow("nope");
+  });
+
+  it("throws default error when dispatch API fails without message", async () => {
+    fetchMock
+      .mockResponseOnce(JSON.stringify({ cart: {} }))
+      .mockResponseOnce(JSON.stringify({}), { status: 500 });
+
+    let dispatch: ReturnType<typeof useCart>[1] | undefined;
+    render(
+      <CartProvider>
+        <CaptureDispatch onReady={(d) => (dispatch = d)} />
+      </CartProvider>
+    );
+
+    await waitFor(() => expect(dispatch).toBeDefined());
+    await expect(
+      dispatch!({ type: "add", sku: PRODUCTS[0], size: PRODUCTS[0].sizes[0] })
+    ).rejects.toThrow("Cart update failed");
   });
 
   it("throws when used outside provider", () => {


### PR DESCRIPTION
## Summary
- add jest-fetch-mock and jest-localstorage-mock
- expand CartContext tests for API success, offline cache, sync, dispatch errors, and provider usage

## Testing
- `pnpm install` *(fails: command not found)*
- `pnpm -r build` *(fails: command not found)*
- `pnpm --filter @acme/platform-core test` *(fails: command not found)*
- `npx jest packages/platform-core/__tests__/CartContext.test.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfb313628832f8120b9666c882e2b