### PR TITLE
test(api): add coverage for components route

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -19,6 +19,11 @@ describe('component helpers', () => {
       const log = '# heading\n\n  # another comment\n';
       expect(extractSummary(log)).toBe('');
     });
+
+    it('returns first non-comment line', () => {
+      const log = '# heading\n\nFirst change\n# another heading';
+      expect(extractSummary(log)).toBe('First change');
+    });
   });
 
   describe('gatherChanges', () => {

--- a/apps/api/src/routes/components/__tests__/onRequest.test.ts
+++ b/apps/api/src/routes/components/__tests__/onRequest.test.ts
@@ -1,42 +1,150 @@
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('jsonwebtoken', () => ({ verify: jest.fn() }));
+jest.mock('@acme/lib', () => ({ validateShopName: jest.fn((s: string) => s) }));
 
 import path from 'path';
 import { vol } from 'memfs';
 import jwt from 'jsonwebtoken';
-import { onRequest } from '../[shopId]';
+import * as route from '../[shopId]';
+import { validateShopName } from '@acme/lib';
+
+const { onRequest } = route;
 
 describe('onRequest route', () => {
   const verify = jwt.verify as jest.Mock;
+  const validate = validateShopName as jest.Mock;
+  let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     vol.reset();
     verify.mockReset();
+    validate.mockReset().mockImplementation((s: string) => s);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    delete process.env.UPGRADE_PREVIEW_TOKEN_SECRET;
   });
 
-  it('returns 400 for invalid shop id', async () => {
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('calls validateShopName with provided shop id', async () => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
+    verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });
     const res = await onRequest({
-      params: { shopId: 'Invalid!' },
+      params: { shopId: 'abc' },
+      request: new Request('http://localhost', {
+        headers: { authorization: 'Bearer good' },
+      }),
+    });
+    expect(validate).toHaveBeenCalledWith('abc');
+    expect(res.status).toBe(200);
+  });
+
+  it.each(['bad id', 'bad!', 'a'.repeat(64)])(
+    'returns 400 for invalid shop id "%s"',
+    async (bad) => {
+      validate.mockImplementation(() => {
+        throw new Error('Invalid');
+      });
+      const res = await onRequest({
+        params: { shopId: bad },
+        request: new Request('http://localhost'),
+      });
+      expect(validate).toHaveBeenCalledWith(bad);
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: 'Invalid shop id' });
+      expect(warnSpy).toHaveBeenCalledWith('invalid shop id', { id: bad });
+    },
+  );
+
+  it('returns 403 when authorization header missing', async () => {
+    const res = await onRequest({
+      params: { shopId: 'abc' },
       request: new Request('http://localhost'),
     });
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({ error: 'Invalid shop id' });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Forbidden' });
+    expect(warnSpy).toHaveBeenCalledWith('missing bearer token', { shopId: 'abc' });
   });
 
-  it('returns 403 for invalid token', async () => {
-    verify.mockImplementation(() => { throw new Error('bad'); });
+  it('returns 403 when authorization not bearer', async () => {
+    const res = await onRequest({
+      params: { shopId: 'abc' },
+      request: new Request('http://localhost', {
+        headers: { authorization: 'Token token' },
+      }),
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Forbidden' });
+    expect(warnSpy).toHaveBeenCalledWith('missing bearer token', { shopId: 'abc' });
+  });
+
+  it('returns 403 when jwt.verify throws', async () => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
+    verify.mockImplementation(() => {
+      throw new Error('bad');
+    });
     const res = await onRequest({
       params: { shopId: 'abc' },
       request: new Request('http://localhost', {
         headers: { authorization: 'Bearer token' },
       }),
     });
+    expect(verify).toHaveBeenCalledWith(
+      'token',
+      'secret',
+      expect.objectContaining({
+        algorithms: ['HS256'],
+        audience: 'upgrade-preview',
+        issuer: 'acme',
+        subject: 'shop:abc:upgrade-preview',
+      }),
+    );
     expect(res.status).toBe(403);
     await expect(res.json()).resolves.toEqual({ error: 'Forbidden' });
+    expect(warnSpy).toHaveBeenCalledWith('invalid token', { shopId: 'abc' });
   });
 
-  it('returns components and config diff for valid request', async () => {
-    verify.mockImplementation(() => ({ exp: Math.floor(Date.now() / 1000) + 60 }));
+  it('returns components without config diff when diff not requested', async () => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
+    verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });
+    const root = path.resolve(__dirname, '../../../../../../..');
+    vol.fromJSON({
+      [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
+        componentVersions: { '@acme/button': '1.0.0' },
+      }),
+      [`${root}/packages/button/package.json`]: JSON.stringify({
+        name: '@acme/button',
+        version: '1.1.0',
+      }),
+      [`${root}/packages/button/CHANGELOG.md`]: '# Changelog\n\nFixed bug\n',
+    });
+
+    const res = await onRequest({
+      params: { shopId: 'abc' },
+      request: new Request('http://localhost', {
+        headers: { authorization: 'Bearer good' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      components: [
+        {
+          name: '@acme/button',
+          from: '1.0.0',
+          to: '1.1.0',
+          summary: 'Fixed bug',
+          changelog: 'packages/button/CHANGELOG.md',
+        },
+      ],
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns components and config diff when diff requested', async () => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
+    verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });
     const root = path.resolve(__dirname, '../../../../../../..');
     vol.fromJSON({
       [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
@@ -55,70 +163,13 @@ describe('onRequest route', () => {
 
     const res = await onRequest({
       params: { shopId: 'abc' },
-      request: new Request('http://localhost?diff', {
+      request: new Request('http://localhost?diff=1', {
         headers: { authorization: 'Bearer good' },
       }),
     });
-    expect(verify).toHaveBeenCalledWith(
-      'good',
-      '',
-      expect.objectContaining({
-        algorithms: ['HS256'],
-        audience: 'upgrade-preview',
-        issuer: 'acme',
-        subject: 'shop:abc:upgrade-preview',
-      }),
-    );
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.components).toEqual([
-      {
-        name: '@acme/button',
-        from: '1.0.0',
-        to: '1.1.0',
-        summary: 'Fixed bug',
-        changelog: 'packages/button/CHANGELOG.md',
-      },
-    ]);
-    expect(body.configDiff).toEqual({
-      templates: ['main.html'],
-      translations: ['en.json'],
-    });
-  });
 
-  it('returns components only for valid request without diff', async () => {
-    verify.mockImplementation(() => ({ exp: Math.floor(Date.now() / 1000) + 60 }));
-    const root = path.resolve(__dirname, '../../../../../../..');
-    vol.fromJSON({
-      [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
-        componentVersions: { '@acme/button': '1.0.0' },
-      }),
-      [`${root}/packages/button/package.json`]: JSON.stringify({
-        name: '@acme/button',
-        version: '1.1.0',
-      }),
-      [`${root}/packages/button/CHANGELOG.md`]: '# Changelog\n\nFixed bug\n',
-    });
-
-    const res = await onRequest({
-      params: { shopId: 'abc' },
-      request: new Request('http://localhost', {
-        headers: { authorization: 'Bearer good' },
-      }),
-    });
-    expect(verify).toHaveBeenCalledWith(
-      'good',
-      '',
-      expect.objectContaining({
-        algorithms: ['HS256'],
-        audience: 'upgrade-preview',
-        issuer: 'acme',
-        subject: 'shop:abc:upgrade-preview',
-      }),
-    );
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual({
+    await expect(res.json()).resolves.toEqual({
       components: [
         {
           name: '@acme/button',
@@ -128,8 +179,7 @@ describe('onRequest route', () => {
           changelog: 'packages/button/CHANGELOG.md',
         },
       ],
+      configDiff: { templates: ['main.html'], translations: ['en.json'] },
     });
-    expect(body.configDiff).toBeUndefined();
   });
 });
-


### PR DESCRIPTION
## Summary
- cover components route shop-id validation, auth headers, and JWT verification
- assert diff and no-diff branches return expected payloads
- exercise component helper extractSummary with non-comment lines

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '"@prisma/client"' has no exported member 'Prisma')*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfda70444832f9029aff7c44bc01a