### PR TITLE
test: expand shared-utils coverage

### DIFF
--- a/packages/shared-utils/__tests__/fetchJson.test.ts
+++ b/packages/shared-utils/__tests__/fetchJson.test.ts
@@ -59,6 +59,19 @@ describe("fetchJson", () => {
     await expect(fetchJson("https://example.com")).resolves.toBeUndefined();
   });
 
+  it("throws statusText when error body isn't valid JSON", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      text: jest.fn().mockResolvedValue("<html></html>"),
+    });
+
+    await expect(fetchJson("https://example.com")).rejects.toThrow(
+      "Bad Gateway",
+    );
+  });
+
   it("validates data with an optional Zod schema", async () => {
     const data = { message: "ok" };
     (global.fetch as jest.Mock).mockResolvedValue({

--- a/packages/shared-utils/__tests__/slugify.test.ts
+++ b/packages/shared-utils/__tests__/slugify.test.ts
@@ -22,4 +22,14 @@ describe('slugify', () => {
   it('handles diacritics and UTF-8 characters', () => {
     expect(slugify('Crème Brûlée')).toBe('creme-brulee');
   });
+
+  it('returns empty string for blank input', () => {
+    expect(slugify('')).toBe('');
+    expect(slugify('   ')).toBe('');
+  });
+
+  it('handles null and undefined inputs gracefully', () => {
+    expect(slugify(null)).toBe('');
+    expect(slugify(undefined)).toBe('');
+  });
 });

--- a/packages/shared-utils/src/slugify.ts
+++ b/packages/shared-utils/src/slugify.ts
@@ -5,7 +5,8 @@
  * symbols, collapses whitespace/underscores to hyphens and trims extraneous
  * hyphens from the start and end of the resulting string.
  */
-export default function slugify(str: string): string {
+export default function slugify(str?: string | null): string {
+  if (!str) return "";
   return str
     .normalize("NFKD")
     // Remove diacritical marks


### PR DESCRIPTION
## Summary
- handle null input in slugify
- cover non-JSON error bodies in fetchJson
- test slugify with blank and nullable inputs

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'Prisma'.)
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm run build:ts` (fails: Missing script: build:ts)
- `pnpm exec jest packages/shared-utils/__tests__ --config jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb4837ac832fb56904a6d5f3f055