### PR TITLE
test(i18n): verify translation memoisation and warnings

### DIFF
--- a/packages/i18n/__tests__/translations-provider.test.tsx
+++ b/packages/i18n/__tests__/translations-provider.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react";
+import { TranslationsProvider, useTranslations } from "../src/Translations";
+import type { ReactNode } from "react";
+
+describe("useTranslations behaviour", () => {
+  it("returns translations, warns on missing keys, and memoises function", () => {
+    let translate: (key: string) => string = () => "";
+    function Consumer({ children }: { children?: ReactNode }) {
+      translate = useTranslations();
+      return <>{children}</>;
+    }
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = { hello: "Hallo" };
+    const { rerender } = render(
+      <TranslationsProvider messages={messages}>
+        <Consumer />
+      </TranslationsProvider>
+    );
+
+    expect(translate("hello")).toBe("Hallo");
+    expect(translate("missing")).toBe("missing");
+    expect(warnSpy).toHaveBeenCalledWith("Missing translation for key: missing");
+
+    const firstFn = translate;
+    rerender(
+      <TranslationsProvider messages={messages}>
+        <Consumer />
+      </TranslationsProvider>
+    );
+    expect(translate).toBe(firstFn);
+
+    rerender(
+      <TranslationsProvider messages={{ hello: "Bonjour" }}>
+        <Consumer />
+      </TranslationsProvider>
+    );
+    expect(translate).not.toBe(firstFn);
+    expect(translate("hello")).toBe("Bonjour");
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- test useTranslations memoisation and missing key warning

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/i18n test` (fails: JavaScript heap out of memory)


------
https://chatgpt.com/codex/tasks/task_e_68bbfb14069c832fb274ffe690c60235