### PR TITLE
test(lib): cover validateShopName edge cases

### DIFF
--- a/packages/lib/__tests__/validateShopName.test.ts
+++ b/packages/lib/__tests__/validateShopName.test.ts
@@ -1,7 +1,7 @@
 import { validateShopName } from '../src/validateShopName';
 
 describe('validateShopName', () => {
-  it('accepts valid shop names', () => {
+  it('returns valid shop names unchanged', () => {
     expect(validateShopName('shop-name_123')).toBe('shop-name_123');
   });
 
@@ -9,8 +9,19 @@ describe('validateShopName', () => {
     expect(validateShopName('  shop  ')).toBe('shop');
   });
 
-  it('throws for invalid names', () => {
+  it('rejects names with uppercase, spaces, or symbols', () => {
+    expect(() => validateShopName('BadName')).toThrow('Invalid shop name');
     expect(() => validateShopName('bad name')).toThrow('Invalid shop name');
     expect(() => validateShopName('bad/name')).toThrow('Invalid shop name');
+  });
+
+  it('rejects empty names', () => {
+    expect(() => validateShopName('')).toThrow('Invalid shop name');
+    expect(() => validateShopName('   ')).toThrow('Invalid shop name');
+  });
+
+  it('rejects names longer than 63 characters', () => {
+    const longName = 'a'.repeat(64);
+    expect(() => validateShopName(longName)).toThrow('Invalid shop name');
   });
 });

--- a/packages/lib/src/validateShopName.ts
+++ b/packages/lib/src/validateShopName.ts
@@ -1,4 +1,4 @@
-export const SHOP_NAME_RE = /^[a-z0-9_-]+$/i;
+export const SHOP_NAME_RE = /^[a-z0-9_-]+$/;
 const MAX_SHOP_NAME_LENGTH = 63;
 
 /** Ensure `shop` contains only safe characters and is within length limits. Returns the trimmed name. */


### PR DESCRIPTION
## Summary
- enforce lowercase shop names by making the regex case-sensitive
- expand validateShopName tests for whitespace, length, and invalid characters

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/lib/__tests__/validateShopName.test.ts --config jest.config.cjs --runInBand --detectOpenHandles --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68bbfdd1c484832fa43e2c38c11dd0cd