### PR TITLE
refactor(platform-core): export Order type alias

### DIFF
--- a/packages/platform-core/src/orders.d.ts
+++ b/packages/platform-core/src/orders.d.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import type { RentalOrder } from "@acme/types";
-type Order = RentalOrder;
+export type Order = RentalOrder;
 export declare function listOrders(shop: string): Promise<Order[]>;
 export declare const readOrders: typeof listOrders;
 export declare function addOrder(shop: string, sessionId: string, deposit: number, expectedReturnDate?: string, returnDueDate?: string, customerId?: string, riskLevel?: string, riskScore?: number, flaggedForReview?: boolean): Promise<Order>;

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -7,7 +7,7 @@ import { trackOrder } from "./analytics";
 import { prisma } from "./db";
 import { incrementSubscriptionUsage } from "./subscriptionUsage";
 
-type Order = RentalOrder;
+export type Order = RentalOrder;
 
 type DbRentalOrder = Record<string, unknown>;
 


### PR DESCRIPTION
## Summary
- export the `Order` alias for rental orders
- keep order-related functions typed with `Promise<Order>` and `Promise<Order[]>`

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script `check:references`)*
- `pnpm run build:ts` *(fails: Missing script `build:ts`)*
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*


------
https://chatgpt.com/codex/tasks/task_e_68bbff2955c4832f928bb82a39ebaa1e