### PR TITLE
Validate page draft components before auth

### DIFF
--- a/apps/cms/src/actions/pages.server.ts
+++ b/apps/cms/src/actions/pages.server.ts
@@ -102,8 +102,6 @@ export async function savePageDraft(
   shop: string,
   formData: FormData
 ): Promise<{ page?: Page; errors?: Record<string, string[]> }> {
-  const session = await ensureAuthorized();
-
   const id = (formData.get("id") as string) || ulid();
   const compStr = formData.get("components");
   const parsedComponents = componentsField.safeParse(
@@ -113,6 +111,8 @@ export async function savePageDraft(
     return { errors: { components: ["Invalid components"] } };
   }
   const components = parsedComponents.data;
+
+  const session = await ensureAuthorized();
 
   let history = undefined;
   const historyStr = formData.get("history");


### PR DESCRIPTION
## Summary
- Validate page draft components before verifying auth to return structured errors for invalid component data

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/pages.server.test.ts -t "component structure is invalid"`

------
https://chatgpt.com/codex/tasks/task_e_68bbfea9e964832fa2737462f0f612b0