### PR TITLE
refactor(platform-core): tighten shop repo generic return types

### DIFF
--- a/packages/platform-core/src/repositories/shop.server.d.ts
+++ b/packages/platform-core/src/repositories/shop.server.d.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { type Shop } from "@acme/types";
-export declare function getShopById<T extends Shop = Shop>(shop: string): Promise<T>;
-export declare function updateShopInRepo<T extends Shop = Shop>(shop: string, patch: Partial<T> & {
+export declare function getShopById<T extends Shop>(shop: string): Promise<T>;
+export declare function updateShopInRepo<T extends Shop>(shop: string, patch: Partial<T> & {
     id: string;
 }): Promise<T>;

--- a/packages/platform-core/src/repositories/shop.server.ts
+++ b/packages/platform-core/src/repositories/shop.server.ts
@@ -22,7 +22,7 @@ async function ensureDir(shop: string): Promise<void> {
   await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
 }
 
-export async function getShopById<T extends Shop = Shop>(
+export async function getShopById<T extends Shop>(
   shop: string
 ): Promise<T> {
   try {
@@ -46,7 +46,7 @@ export async function getShopById<T extends Shop = Shop>(
   }
 }
 
-export async function updateShopInRepo<T extends Shop = Shop>(
+export async function updateShopInRepo<T extends Shop>(
   shop: string,
   patch: Partial<T> & { id: string }
 ): Promise<T> {


### PR DESCRIPTION
## Summary
- remove default Shop generic from shop repository helpers
- ensure internal ensureDir is explicitly typed

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bbff4b131c832fb1d4f6f6a45d6bbd