### PR TITLE
feat(platform-core): type readShop return value

### DIFF
--- a/packages/platform-core/src/repositories/json.server.d.ts
+++ b/packages/platform-core/src/repositories/json.server.d.ts
@@ -8,7 +8,9 @@
  * • diffHistory      – return patch history for settings.json
  * • products.server  – catalogue helpers (read/write/update/delete/…)
  */
-export { readShop } from "./shops.server";
+import type { Shop } from "@acme/types";
+
+export declare function readShop(shop: string): Promise<Shop>;
 export { getShopSettings as readSettings } from "./settings.server";
 export * from "./products.server";
 export * from "./inventory.server";


### PR DESCRIPTION
## Summary
- declare readShop in json.server.d.ts to return `Promise<Shop>` and expose explicit Shop type

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `npx tsc -b` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest src/repositories/__tests__/json.server.test.ts` *(fails: Unexpected token, expected "from")*

------
https://chatgpt.com/codex/tasks/task_e_68bbff425ae8832fa2ab2059bd1c09f1