### PR TITLE
feat: add user type declarations

### DIFF
--- a/packages/platform-core/src/users.d.ts
+++ b/packages/platform-core/src/users.d.ts
@@ -1,0 +1,30 @@
+import type { User } from "@acme/types";
+
+export declare function getUserById(id: string): Promise<User | null>;
+export declare function getUserByEmail(email: string): Promise<User | null>;
+export declare function createUser({
+  id,
+  email,
+  passwordHash,
+  role,
+  emailVerified,
+}: {
+  id: string;
+  email: string;
+  passwordHash: string;
+  role?: string;
+  emailVerified?: boolean;
+}): Promise<User>;
+export declare function setResetToken(
+  id: string,
+  token: string | null,
+  expiresAt: Date | null,
+): Promise<void>;
+export declare function getUserByResetToken(
+  token: string,
+): Promise<User | null>;
+export declare function updatePassword(
+  id: string,
+  passwordHash: string,
+): Promise<void>;
+export declare function verifyEmail(id: string): Promise<void>;


### PR DESCRIPTION
## Summary
- expose user service type signatures in a new declaration file

## Testing
- `pnpm install` *(fails: command not found)*
- `pnpm -r build` *(fails: command not found)*
- `pnpm run check:references` *(fails: command not found)*
- `pnpm run build:ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbff3b53a4832f81375c62c8357720