### PR TITLE
feat(platform-core): type rental order status helpers

### DIFF
--- a/packages/platform-core/src/repositories/rentalOrders.server.d.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.d.ts
@@ -1,0 +1,42 @@
+import "server-only";
+import type { RentalOrder } from "@acme/types";
+
+type Order = RentalOrder;
+
+export declare function updateStatus(
+  shop: string,
+  sessionId: string,
+  status: NonNullable<Order["status"]>,
+  extra?: Record<string, unknown>,
+): Promise<Order | null>;
+
+export declare function markReceived(
+  shop: string,
+  sessionId: string,
+): Promise<Order | null>;
+
+export declare function markCleaning(
+  shop: string,
+  sessionId: string,
+): Promise<Order | null>;
+
+export declare function markRepair(
+  shop: string,
+  sessionId: string,
+): Promise<Order | null>;
+
+export declare function markQa(
+  shop: string,
+  sessionId: string,
+): Promise<Order | null>;
+
+export declare function markAvailable(
+  shop: string,
+  sessionId: string,
+): Promise<Order | null>;
+
+export declare function markLateFeeCharged(
+  shop: string,
+  sessionId: string,
+  amount: number,
+): Promise<Order | null>;

--- a/packages/platform-core/src/repositories/rentalOrders.server.ts
+++ b/packages/platform-core/src/repositories/rentalOrders.server.ts
@@ -16,7 +16,7 @@ export {
 
 type Order = RentalOrder;
 
-async function updateStatus(
+export async function updateStatus(
   shop: string,
   sessionId: string,
   status: NonNullable<Order["status"]>,
@@ -34,31 +34,40 @@ async function updateStatus(
   }
 }
 
-export const markReceived = (
+export async function markReceived(
   shop: string,
   sessionId: string,
-): Promise<Order | null> =>
-  updateStatus(shop, sessionId, "received", { returnReceivedAt: nowIso() });
+): Promise<Order | null> {
+  return updateStatus(shop, sessionId, "received", { returnReceivedAt: nowIso() });
+}
 
-export const markCleaning = (
+export async function markCleaning(
   shop: string,
   sessionId: string,
-): Promise<Order | null> => updateStatus(shop, sessionId, "cleaning");
+): Promise<Order | null> {
+  return updateStatus(shop, sessionId, "cleaning");
+}
 
-export const markRepair = (
+export async function markRepair(
   shop: string,
   sessionId: string,
-): Promise<Order | null> => updateStatus(shop, sessionId, "repair");
+): Promise<Order | null> {
+  return updateStatus(shop, sessionId, "repair");
+}
 
-export const markQa = (
+export async function markQa(
   shop: string,
   sessionId: string,
-): Promise<Order | null> => updateStatus(shop, sessionId, "qa");
+): Promise<Order | null> {
+  return updateStatus(shop, sessionId, "qa");
+}
 
-export const markAvailable = (
+export async function markAvailable(
   shop: string,
   sessionId: string,
-): Promise<Order | null> => updateStatus(shop, sessionId, "available");
+): Promise<Order | null> {
+  return updateStatus(shop, sessionId, "available");
+}
 
 export async function markLateFeeCharged(
   shop: string,


### PR DESCRIPTION
## Summary
- add explicit return types for rental order status helpers
- declare rental order status helpers in rentalOrders.server.d.ts

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test`


------
https://chatgpt.com/codex/tasks/task_e_68bbff722618832fb8393cd97454f861