### PR TITLE
feat: refine createShop and syncTheme signatures

### DIFF
--- a/packages/platform-core/src/createShop/index.d.ts
+++ b/packages/platform-core/src/createShop/index.d.ts
@@ -1,5 +1,5 @@
 import { prepareOptions, createShopOptionsSchema as baseCreateShopOptionsSchema, type CreateShopOptions } from "./schema";
-import type { DeployStatusBase, DeployShopResult } from "./deployTypes";
+import type { DeployShopResult } from "./deployTypes";
 import { type ShopDeploymentAdapter } from "./deploymentAdapter";
 /**
  * Create a new shop app and seed data.
@@ -7,7 +7,9 @@ import { type ShopDeploymentAdapter } from "./deploymentAdapter";
  */
 export declare function createShop(id: string, opts?: CreateShopOptions, options?: {
     deploy?: boolean;
-}, adapter?: ShopDeploymentAdapter): Promise<DeployStatusBase>;
+}, adapter?: ShopDeploymentAdapter): Promise<DeployShopResult | {
+    status: "pending";
+}>;
 export declare function deployShop(id: string, domain?: string, adapter?: ShopDeploymentAdapter): DeployShopResult;
 export declare function listThemes(): string[];
 /**
@@ -17,7 +19,7 @@ export declare function listThemes(): string[];
  * It returns the default token map for the selected theme so callers can merge
  * in any overrides before persisting to the shop.json file.
  */
-export declare function syncTheme(shop: string, theme: string): Record<string, string>;
+export declare function syncTheme(shop: string, theme: string): Record<string, unknown>;
 export declare const createShopOptionsSchema: typeof baseCreateShopOptionsSchema;
 export { prepareOptions };
 export type { CreateShopOptions, PreparedCreateShopOptions, NavItem } from "./schema";

--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -11,7 +11,7 @@ import {
   type PreparedCreateShopOptions,
 } from "./schema";
 import { loadTokens } from "./themeUtils";
-import type { DeployStatusBase, DeployShopResult } from "./deployTypes";
+import type { DeployShopResult } from "./deployTypes";
 import {
   defaultDeploymentAdapter,
   type ShopDeploymentAdapter,
@@ -40,7 +40,7 @@ export async function createShop(
   opts: CreateShopOptions = {} as CreateShopOptions,
   options?: { deploy?: boolean },
   adapter: ShopDeploymentAdapter = defaultDeploymentAdapter
-): Promise<DeployStatusBase> {
+): Promise<DeployShopResult | { status: "pending" }> {
   id = validateShopName(id);
 
   const prepared = prepareOptions(id, opts);
@@ -195,7 +195,7 @@ export function listThemes(): string[] {
  * It returns the default token map for the selected theme so callers can merge
  * in any overrides before persisting to the shop.json file.
  */
-export function syncTheme(shop: string, theme: string): Record<string, string> {
+export function syncTheme(shop: string, theme: string): Record<string, unknown> {
   const root = repoRoot();
   const pkgRel = join("apps", shop, "package.json");
   const pkgAbs = join(root, pkgRel);


### PR DESCRIPTION
## Summary
- refine createShop to explicitly return a deploy result or pending status
- broaden syncTheme output typing to a generic record

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec tsc -b` *(fails: Module '@prisma/client' has no exported member 'Prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68bbff7a4600832fb567e6897991c33f