### PR TITLE
refactor: promise-based shop repo helpers

### DIFF
--- a/packages/platform-core/src/repositories/json.server.ts
+++ b/packages/platform-core/src/repositories/json.server.ts
@@ -19,7 +19,7 @@ import type { Shop } from "@acme/types";
 
 export async function readShop(shop: string): Promise<Shop> {
   const mod = await import("./shops.server");
-  return mod.readShop(shop);
+  return await mod.readShop(shop);
 }
 
 // Alias getShopSettings → readSettings so existing callers keep working.

--- a/packages/platform-core/src/repositories/shops.server.d.ts
+++ b/packages/platform-core/src/repositories/shops.server.d.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { type Shop } from "@acme/types";
 export { diffHistory, getShopSettings, saveShopSettings, type SettingsDiffEntry, } from "./settings.server";
+export declare function applyThemeData(data: Shop): Promise<Shop>;
 export declare function readShop(shop: string): Promise<Shop>;
 export declare function writeShop(shop: string, patch: Partial<Shop> & {
     id: string;

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -22,7 +22,7 @@ function shopPath(shop: string): string {
   return path.join(DATA_ROOT, shop, "shop.json");
 }
 
-async function applyThemeData(data: Shop): Promise<Shop> {
+export async function applyThemeData(data: Shop): Promise<Shop> {
   const defaults =
     Object.keys(data.themeDefaults ?? {}).length > 0
       ? data.themeDefaults!


### PR DESCRIPTION
## Summary
- export `applyThemeData` for external reuse
- ensure shop JSON helpers consistently return `Promise<Shop>`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bc042be214832fa31c3e2d7de1d0f6