### PR TITLE
test: add cms block interaction tests

### DIFF
--- a/packages/ui/__tests__/BlogListing.test.tsx
+++ b/packages/ui/__tests__/BlogListing.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import BlogListing from "../src/components/cms/blocks/BlogListing";
 
 describe("BlogListing", () => {
@@ -16,5 +17,20 @@ describe("BlogListing", () => {
     expect(excerpt).toBeInTheDocument();
     expect(excerpt).toHaveAttribute("data-token", "--color-muted");
     expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("navigates when shop link is clicked", async () => {
+    render(
+      <BlogListing posts={[{ title: "Shop post", shopUrl: "/shop/story" }]} />
+    );
+    const link = screen.getByRole("link", { name: "Shop the story" });
+    expect(link).toHaveAttribute("href", "/shop/story");
+    let clicked = false;
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      clicked = true;
+    });
+    await userEvent.click(link);
+    expect(clicked).toBe(true);
   });
 });

--- a/packages/ui/__tests__/ColorInput.test.tsx
+++ b/packages/ui/__tests__/ColorInput.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ColorInput, hexToRgb } from "../src/components/cms/ColorInput";
+
+describe("ColorInput", () => {
+  it("calls onChange with converted HSL value", () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <ColorInput value="0 0% 0%" onChange={handleChange} />
+    );
+    const input = container.querySelector(
+      'input[type="color"]'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "#ffffff" } });
+    expect(handleChange).toHaveBeenCalledWith("0 0% 100%");
+  });
+
+  it("expands 3-digit hex values", () => {
+    expect(hexToRgb("#abc")).toEqual([170, 187, 204]);
+  });
+});

--- a/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
+++ b/packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx
@@ -54,4 +54,23 @@ describe("ImageUploaderWithOrientationCheck", () => {
     ).toBeInTheDocument();
     expect(container.querySelector("p")?.className).toContain("text-danger");
   });
+
+  it("calls onChange and shows no message when orientation unknown", () => {
+    const file = new File(["a"], "a.png", { type: "image/png" });
+    mockHook.mockReturnValue({ actual: null, isValid: null });
+    const handleChange = jest.fn();
+    const { container } = render(
+      <ImageUploaderWithOrientationCheck
+        file={null}
+        onChange={handleChange}
+        requiredOrientation="landscape"
+      />
+    );
+    const input = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(handleChange).toHaveBeenCalledWith(file);
+    expect(container.querySelector("p")).toBeNull();
+  });
 });

--- a/packages/ui/__tests__/ProductCard.test.tsx
+++ b/packages/ui/__tests__/ProductCard.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProductCard } from "../src/components/organisms/ProductCard";
+import { useCart } from "@acme/platform-core/contexts/CartContext";
+
+jest.mock("@acme/platform-core/contexts/CartContext");
+
+const product: any = { id: "1", title: "Prod", price: 10 };
+
+describe("ProductCard", () => {
+  const mockUseCart = useCart as unknown as jest.Mock;
+
+  beforeEach(() => {
+    mockUseCart.mockReturnValue([{}, jest.fn()]);
+  });
+
+  it("calls onAddToCart when button is clicked", async () => {
+    const handleAdd = jest.fn();
+    render(
+      <ProductCard
+        product={product}
+        onAddToCart={handleAdd}
+        showImage={false}
+        showPrice={false}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add to cart" }));
+    expect(handleAdd).toHaveBeenCalledWith(product);
+  });
+
+  it("dispatches add action when no onAddToCart provided", async () => {
+    const dispatch = jest.fn();
+    mockUseCart.mockReturnValue([{}, dispatch]);
+    render(
+      <ProductCard product={product} showImage={false} showPrice={false} />
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add to cart" }));
+    expect(dispatch).toHaveBeenCalledWith({ type: "add", sku: product });
+  });
+});


### PR DESCRIPTION
## Summary
- extend BlogListing test to handle shop links
- add ColorInput interaction and conversion tests
- add ProductCard add-to-cart tests
- expand ImageUploaderWithOrientationCheck tests

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/BlogListing.test.tsx packages/ui/__tests__/ColorInput.test.tsx packages/ui/__tests__/ProductCard.test.tsx packages/ui/__tests__/ImageUploaderWithOrientationCheck.test.tsx -- --coverage=false --collectCoverage=false` *(fails: global coverage threshold for branches (80%) not met: 15.43%)*

------
https://chatgpt.com/codex/tasks/task_e_68bc03453fbc832f9c48c2f05e308002