### PR TITLE
test(email): cover fsStore end-to-end

### DIFF
--- a/packages/email/src/storage/__tests__/fsStore.integration.test.ts
+++ b/packages/email/src/storage/__tests__/fsStore.integration.test.ts
@@ -1,0 +1,69 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { fsCampaignStore } from "../fsStore";
+import { recoverAbandonedCarts } from "../../abandonedCart";
+import { sendCampaignEmail } from "../../send";
+import type { AbandonedCart } from "../../abandonedCart";
+import type { Campaign } from "../types";
+
+jest.mock("../../send", () => ({
+  __esModule: true,
+  sendCampaignEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@acme/lib", () => ({
+  __esModule: true,
+  validateShopName: (s: string) => s,
+}));
+
+const sendCampaignEmailMock = sendCampaignEmail as jest.Mock;
+
+describe("fsCampaignStore integration", () => {
+  const shop = "integration-shop";
+  const shopDir = path.join(DATA_ROOT, shop);
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await fs.rm(shopDir, { recursive: true, force: true });
+  });
+
+  it("stores, retrieves, and sends abandoned cart emails", async () => {
+    const carts: AbandonedCart[] = [
+      { email: "user@example.com", cart: {}, updatedAt: 0 },
+    ];
+
+    await recoverAbandonedCarts(carts, 0, 0);
+    expect(sendCampaignEmailMock).toHaveBeenCalledTimes(1);
+
+    const opts = sendCampaignEmailMock.mock.calls[0][0];
+    const campaign: Campaign = {
+      id: "c1",
+      recipients: [opts.to],
+      subject: opts.subject,
+      body: opts.html!,
+      sendAt: new Date().toISOString(),
+    };
+
+    await fsCampaignStore.writeCampaigns(shop, [campaign]);
+    const file = path.join(shopDir, "campaigns.json");
+    const fileJson = JSON.parse(await fs.readFile(file, "utf8"));
+    expect(fileJson).toEqual([campaign]);
+
+    const saved = await fsCampaignStore.readCampaigns(shop);
+    expect(saved).toEqual([campaign]);
+
+    await sendCampaignEmail({
+      to: saved[0].recipients[0],
+      subject: saved[0].subject,
+      html: saved[0].body,
+    });
+
+    expect(sendCampaignEmailMock).toHaveBeenCalledTimes(2);
+    expect(sendCampaignEmailMock).toHaveBeenNthCalledWith(2, {
+      to: campaign.recipients[0],
+      subject: campaign.subject,
+      html: campaign.body,
+    });
+  });
+});

--- a/packages/email/src/storage/__tests__/fsStore.test.ts
+++ b/packages/email/src/storage/__tests__/fsStore.test.ts
@@ -25,6 +25,13 @@ describe("fsCampaignStore error handling", () => {
       .resolves.toEqual([]);
   });
 
+  it("propagates writeFile errors", async () => {
+    jest.spyOn(fs, "writeFile").mockRejectedValue(new Error("fail"));
+    await expect(
+      fsCampaignStore.writeCampaigns("shop", []),
+    ).rejects.toThrow("fail");
+  });
+
   it("returns [] when campaigns.json has invalid JSON", async () => {
     const shop = "invalid-json";
     const file = path.join(DATA_ROOT, shop, "campaigns.json");


### PR DESCRIPTION
## Summary
- test: add error propagation check for fsStore write failures
- test: verify fsStore saves and retrieves abandoned cart emails for sending

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm --filter @acme/email build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm exec jest packages/email/src/storage/__tests__/fsStore.test.ts packages/email/src/storage/__tests__/fsStore.integration.test.ts --config packages/email/jest.config.cjs --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc033a1b50832f825e8577019eb95e