### PR TITLE
Refactor order typings and remove redundant casts

### DIFF
--- a/packages/platform-core/src/orders.d.ts
+++ b/packages/platform-core/src/orders.d.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { RentalOrder } from "@acme/types";
+
 export type Order = RentalOrder;
 export declare function listOrders(shop: string): Promise<Order[]>;
 export declare const readOrders: typeof listOrders;

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -9,14 +9,12 @@ import { incrementSubscriptionUsage } from "./subscriptionUsage";
 
 export type Order = RentalOrder;
 
-type DbRentalOrder = Record<string, unknown>;
-
-function normalize(order: DbRentalOrder): Order {
-  const o: Record<string, unknown> = { ...order };
+function normalize<T extends object>(order: T): T {
+  const o = { ...order } as any;
   Object.keys(o).forEach((k) => {
     if (o[k] === null) o[k] = undefined;
   });
-  return o as Order;
+  return o;
 }
 
 export async function listOrders(shop: string): Promise<Order[]> {
@@ -51,7 +49,7 @@ export async function addOrder(
     ...(typeof flaggedForReview === "boolean" ? { flaggedForReview } : {}),
   };
   await prisma.rentalOrder.create({
-    data: order as Record<string, unknown>,
+    data: order,
   });
   await trackOrder(shop, order.id, deposit);
   if (customerId) {
@@ -81,7 +79,7 @@ export async function markReturned(
         ...(typeof damageFee === "number" ? { damageFee } : {}),
       },
     });
-    return order as Order;
+    return order;
   } catch {
     return null;
   }
@@ -104,7 +102,7 @@ export async function markRefunded(
         ...(typeof flaggedForReview === "boolean" ? { flaggedForReview } : {}),
       },
     });
-    return order as Order;
+    return order;
   } catch {
     return null;
   }
@@ -126,7 +124,7 @@ export async function updateRisk(
         ...(typeof flaggedForReview === "boolean" ? { flaggedForReview } : {}),
       },
     });
-    return order as Order;
+    return order;
   } catch {
     return null;
   }
@@ -153,7 +151,7 @@ export async function setReturnTracking(
       where: { shop_sessionId: { shop, sessionId } },
       data: { trackingNumber, labelUrl },
     });
-    return order as Order;
+    return order;
   } catch {
     return null;
   }
@@ -169,7 +167,7 @@ export async function setReturnStatus(
       where: { shop_trackingNumber: { shop, trackingNumber } },
       data: { returnStatus },
     });
-    return order as Order;
+    return order;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- alias rental orders to `Order` and simplify normalization
- remove unnecessary casts in order mutations
- ensure declaration file uses unified `Order` type

## Testing
- `pnpm install`
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm run build:ts` (fails: Missing script: build:ts)


------
https://chatgpt.com/codex/tasks/task_e_68bc04057660832fb3a3cd1eb8bf3b62