### PR TITLE
fix: ensure startOfDay returns UTC midnight

### DIFF
--- a/packages/date-utils/src/index.ts
+++ b/packages/date-utils/src/index.ts
@@ -1,9 +1,4 @@
-import {
-  addDays,
-  format,
-  parseISO,
-  startOfDay as dfStartOfDay,
-} from "date-fns";
+import { addDays, format, parseISO } from "date-fns";
 import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
 
 export { addDays, format, parseISO, fromZonedTime };
@@ -51,7 +46,9 @@ export function formatTimestamp(
 /** Return the start of day for the given date, optionally in a timezone. */
 export function startOfDay(date: Date | string, timezone?: string): Date {
   const d = typeof date === "string" ? parseISO(date) : date;
-  if (!timezone) return dfStartOfDay(d);
+  if (!timezone) {
+    return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  }
   const startStr = formatInTimeZone(d, timezone, "yyyy-MM-dd'T'00:00:00XXX");
   return parseISO(startStr);
 }


### PR DESCRIPTION
## Summary
- ensure `startOfDay` returns UTC midnight when no timezone is provided

## Testing
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm run build:ts` (fails: Missing script: build:ts)
- `pnpm exec jest packages/ui/__tests__/date-utils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc037708e4832fa32a6161e97a83d6