### PR TITLE
test: cover ProductCard branches

### DIFF
--- a/packages/platform-core/__tests__/priceComponent.test.tsx
+++ b/packages/platform-core/__tests__/priceComponent.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+describe("Price", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("uses explicit currency prop over context", async () => {
+    jest.doMock("../src/contexts/CurrencyContext", () => ({
+      __esModule: true,
+      useCurrency: () => ["EUR", () => {}],
+      CurrencyProvider: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+      ),
+    }));
+    const { Price } = await import("../src/components/shop/ProductCard");
+    const { CurrencyProvider } = await import(
+      "../src/contexts/CurrencyContext"
+    );
+    render(
+      <CurrencyProvider>
+        <Price amount={1000} currency="USD" />
+      </CurrencyProvider>,
+    );
+    expect(screen.getByText("$1,000.00")).toBeInTheDocument();
+  });
+
+  it("falls back to context when currency prop missing", async () => {
+    jest.doMock("../src/contexts/CurrencyContext", () => ({
+      __esModule: true,
+      useCurrency: () => ["EUR", () => {}],
+      CurrencyProvider: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+      ),
+    }));
+    const { Price } = await import("../src/components/shop/ProductCard");
+    const { CurrencyProvider } = await import(
+      "../src/contexts/CurrencyContext"
+    );
+    render(
+      <CurrencyProvider>
+        <Price amount={1000} />
+      </CurrencyProvider>,
+    );
+    expect(screen.getByText("€1,000.00")).toBeInTheDocument();
+  });
+
+  it("defaults to EUR when no context is provided", async () => {
+    jest.doMock("../src/contexts/CurrencyContext", () => ({
+      __esModule: true,
+      useCurrency: () => [undefined, () => {}],
+      CurrencyProvider: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+      ),
+    }));
+    const { Price } = await import("../src/components/shop/ProductCard");
+    render(<Price amount={500} />);
+    expect(screen.getByText("€500.00")).toBeInTheDocument();
+  });
+});
+

--- a/packages/platform-core/__tests__/productCardInner.test.tsx
+++ b/packages/platform-core/__tests__/productCardInner.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import type { SKU } from "@acme/types";
+
+const addToCartMock = jest.fn(() => <div data-testid="add" />);
+
+jest.mock("../src/components/shop/AddToCartButton.client", () => ({
+  __esModule: true,
+  default: addToCartMock,
+}));
+
+jest.mock("../src/contexts/CurrencyContext", () =>
+  require("../../../test/__mocks__/currencyContextMock.tsx"),
+);
+
+import { ProductCard } from "../src/components/shop/ProductCard";
+
+describe("ProductCard media and rendering", () => {
+  function baseSku(): SKU {
+    return {
+      id: "base",
+      slug: "base",
+      title: "Base title",
+      price: 10,
+      media: [],
+      sizes: [],
+    } as unknown as SKU;
+  }
+
+  it("renders image media", () => {
+    const url = "https://example.com/test.jpg";
+    const sku = { ...baseSku(), media: [{ type: "image", url }] } as SKU;
+    const { container } = render(<ProductCard sku={sku} />);
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img?.getAttribute("src")).toContain(encodeURIComponent(url));
+  });
+
+  it("renders video for non-image media", () => {
+    const url = "https://example.com/test.mp4";
+    const sku = { ...baseSku(), media: [{ type: "video", url }] } as SKU;
+    const { container } = render(<ProductCard sku={sku} />);
+    const video = container.querySelector("video");
+    expect(video).toBeInTheDocument();
+    expect(video).toHaveAttribute("src", url);
+  });
+
+  it("renders no media when absent", () => {
+    const sku = baseSku();
+    const { container } = render(<ProductCard sku={sku} />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("video")).toBeNull();
+  });
+
+  it("renders the product title", () => {
+    const sku = { ...baseSku(), title: "Fancy Shoe" } as SKU;
+    render(<ProductCard sku={sku} />);
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Fancy Shoe" }),
+    ).toBeInTheDocument();
+  });
+
+  it("memoizes inner component", () => {
+    const sku = baseSku();
+    const { rerender } = render(<ProductCard sku={sku} />);
+    const initialCalls = addToCartMock.mock.calls.length;
+    rerender(<ProductCard sku={sku} />);
+    expect(addToCartMock).toHaveBeenCalledTimes(initialCalls);
+    const sku2 = { ...sku, id: "other" } as SKU;
+    rerender(<ProductCard sku={sku2} />);
+    expect(addToCartMock).toHaveBeenCalledTimes(initialCalls + 1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for Price component currency handling
- exercise ProductCard image/video branches, title rendering and memoization

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @acme/platform-core exec jest __tests__/priceComponent.test.tsx __tests__/productCardInner.test.tsx --runInBand --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc0b39f29c832fa3194398d682fad9