### PR TITLE
fix: polyfill window crypto for tests

### DIFF
--- a/test/setupFetchPolyfill.ts
+++ b/test/setupFetchPolyfill.ts
@@ -14,6 +14,13 @@ if (!globalThis.crypto) {
     value: webcrypto,
   });
 }
+// JSDOM exposes a `window` object separate from `globalThis`.  Libraries like
+// `ulid` look for `window.crypto`, so mirror the polyfill there as well.
+if (typeof window !== "undefined" && !(window as any).crypto) {
+  Object.defineProperty(window, "crypto", {
+    value: webcrypto,
+  });
+}
 
 // Node's test environment may lack FormData, so provide a minimal polyfill
 if (!("FormData" in globalThis)) {


### PR DESCRIPTION
## Summary
- ensure `window.crypto` is defined in test setup so libraries like `ulid` can locate a secure PRNG

## Testing
- `pnpm --filter @apps/cms test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ab068d4832f9d393863355929f8