### PR TITLE
test: cover telemetry auto flush

### DIFF
--- a/packages/telemetry/src/__tests__/telemetry.spec.ts
+++ b/packages/telemetry/src/__tests__/telemetry.spec.ts
@@ -65,6 +65,16 @@ describe("telemetry", () => {
     expect(mod.__buffer.length).toBe(0);
   });
 
+  test("defaults sample rate to 1 when NaN", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "true";
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_TELEMETRY_SAMPLE_RATE = "not-a-number";
+    const mod = await import("../index");
+    jest.spyOn(Math, "random").mockReturnValue(0.99);
+    mod.track("event");
+    expect(mod.__buffer.length).toBe(1);
+  });
+
   test("flush no-ops when buffer empty", async () => {
     const mod = await import("../index");
     await mod.__flush();
@@ -83,6 +93,28 @@ describe("telemetry", () => {
       expect(spy).toHaveBeenCalledTimes(1);
     } finally {
       spy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  test("auto flushes buffered events after interval", async () => {
+    process.env.NEXT_PUBLIC_ENABLE_TELEMETRY = "true";
+    process.env.NODE_ENV = "production";
+    jest.useFakeTimers();
+    const mod = await import("../index");
+    const fetchMock = jest.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    try {
+      mod.track("e1");
+      mod.track("e2");
+      expect(mod.__buffer.length).toBe(2);
+      await jest.runOnlyPendingTimersAsync();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body.map((e: any) => e.name)).toEqual(["e1", "e2"]);
+      expect(mod.__buffer.length).toBe(0);
+    } finally {
       jest.useRealTimers();
     }
   });


### PR DESCRIPTION
## Summary
- expand telemetry tests to cover auto flushing and NaN sample rates

## Testing
- `pnpm exec jest packages/telemetry/src/__tests__/telemetry.spec.ts packages/telemetry/src/__tests__/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc0b59bdc4832fb0cd9f0084294a84