### PR TITLE
test: cover currency and theme contexts

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/CurrencyContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/CurrencyContext.test.tsx
@@ -90,20 +90,25 @@ describe("CurrencyProvider", () => {
     unmount();
   });
 
-  it("updates localStorage when currency changes", async () => {
+  it("provides default and persists currency changes", async () => {
     const setSpy = jest.spyOn(Storage.prototype, "setItem");
 
-    const { getByText, unmount } = render(
+    const { getByTestId, getByText, unmount } = render(
       <CurrencyProvider>
         <Display />
       </CurrencyProvider>
     );
 
+    expect(getByTestId("currency").textContent).toBe("EUR");
+
     fireEvent.click(getByText("change"));
 
-    await waitFor(() =>
-      expect(setSpy).toHaveBeenLastCalledWith(LS_KEY, "USD")
-    );
+    await waitFor(() => {
+      expect(getByTestId("currency").textContent).toBe("USD");
+      expect(setSpy).toHaveBeenLastCalledWith(LS_KEY, "USD");
+    });
+
+    expect(window.localStorage.getItem(LS_KEY)).toBe("USD");
 
     unmount();
   });

--- a/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/ThemeContext.test.tsx
@@ -181,6 +181,10 @@ describe("ThemeContext", () => {
         <CaptureSetter />
       </ThemeProvider>
     );
+    expect(getByTestId("theme").textContent).toBe("system");
+    expect(document.documentElement.className).toBe("");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(setItem).toHaveBeenLastCalledWith("theme", "system");
 
     act(() => changeTheme("brandx"));
     expect(getByTestId("theme").textContent).toBe("brandx");
@@ -188,6 +192,7 @@ describe("ThemeContext", () => {
       true
     );
     expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(setItem).toHaveBeenLastCalledWith("theme", "brandx");
 
     act(() => changeTheme("dark"));
     expect(getByTestId("theme").textContent).toBe("dark");
@@ -198,6 +203,7 @@ describe("ThemeContext", () => {
       false
     );
     expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(setItem).toHaveBeenLastCalledWith("theme", "dark");
   });
 
   it("still renders when localStorage.setItem throws", () => {
@@ -224,5 +230,12 @@ describe("ThemeContext", () => {
     expect(() => render(<ThemeDisplay />)).toThrow(
       "useTheme must be inside ThemeProvider"
     );
+  });
+
+  it("throws when hook invoked directly", () => {
+    const orig = console.error;
+    console.error = () => {};
+    expect(() => useTheme()).toThrow();
+    console.error = orig;
   });
 });


### PR DESCRIPTION
## Summary
- add default currency and persistence assertions for `CurrencyContext`
- verify theme toggling updates DOM and localStorage
- ensure `useTheme` throws when invoked outside its provider

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test src/contexts/__tests__/CurrencyContext.test.tsx src/contexts/__tests__/ThemeContext.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc0b52ce24832f85adb840925cceca