### PR TITLE
test: cover shipping module

### DIFF
--- a/packages/platform-core/__tests__/shipping-index.test.ts
+++ b/packages/platform-core/__tests__/shipping-index.test.ts
@@ -159,6 +159,18 @@ describe('getShippingRate', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('throws when DHL API key is missing', async () => {
+    await expect(
+      getShippingRate({
+        provider: 'dhl',
+        fromPostalCode: '11111',
+        toPostalCode: '22222',
+        weight: 5,
+      }),
+    ).rejects.toThrow('Missing DHL_KEY');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('throws when fetch response is not ok', async () => {
     mockEnv.UPS_KEY = 'ups-key';
     fetchMock.mockResolvedValue({ ok: false });
@@ -182,6 +194,53 @@ describe('getShippingRate', () => {
       toPostalCode: '22222',
       weight: 5,
     });
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('supports premierDelivery fields for non-premier provider', async () => {
+    mockEnv.UPS_KEY = 'ups-key';
+    const apiResponse = {
+      rate: 15,
+      surcharge: 2,
+      serviceLabel: 'Standard',
+    };
+    fetchMock.mockResolvedValue({ ok: true, json: async () => apiResponse });
+    const result = await getShippingRate({
+      provider: 'ups',
+      fromPostalCode: '11111',
+      toPostalCode: '22222',
+      weight: 5,
+      region: 'eligible',
+      window: 'morning',
+      carrier: 'ups',
+      premierDelivery: {
+        regions: ['eligible'],
+        windows: ['morning'],
+        carriers: ['ups'],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('returns JSON for valid DHL request', async () => {
+    mockEnv.DHL_KEY = 'dhl-key';
+    const apiResponse = {
+      rate: 20,
+      surcharge: 3,
+      serviceLabel: 'DHL Express',
+    };
+    fetchMock.mockResolvedValue({ ok: true, json: async () => apiResponse });
+    const result = await getShippingRate({
+      provider: 'dhl',
+      fromPostalCode: '11111',
+      toPostalCode: '22222',
+      weight: 5,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.dhl.com/rates',
+      expect.any(Object),
+    );
     expect(result).toEqual(apiResponse);
   });
 });
@@ -232,6 +291,12 @@ describe('getTrackingStatus', () => {
   it('falls back on non-ok response', async () => {
     fetchMock.mockResolvedValue({ ok: false });
     const result = await getTrackingStatus({ provider: 'ups', trackingNumber: 'abc' });
+    expect(result).toEqual({ status: null, steps: [] });
+  });
+
+  it('returns null when response lacks status', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const result = await getTrackingStatus({ provider: 'dhl', trackingNumber: '123' });
     expect(result).toEqual({ status: null, steps: [] });
   });
 });

--- a/packages/platform-core/__tests__/shipping-ups.test.ts
+++ b/packages/platform-core/__tests__/shipping-ups.test.ts
@@ -77,6 +77,16 @@ describe('createReturnLabel', () => {
       labelUrl: 'https://www.ups.com/track?loc=en_US&tracknum=1Z1234567891',
     });
   });
+
+  it('falls back when response lacks data fields', async () => {
+    mockEnv.UPS_KEY = 'ups-key';
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const result = await createReturnLabel('session');
+    expect(result).toEqual({
+      trackingNumber: '1Z1234567891',
+      labelUrl: 'https://www.ups.com/track?loc=en_US&tracknum=1Z1234567891',
+    });
+  });
 });
 
 describe('getStatus', () => {
@@ -103,6 +113,11 @@ describe('getStatus', () => {
 
   it('returns null on fetch error', async () => {
     fetchMock.mockRejectedValue(new Error('network'));
+    await expect(getStatus('1Z123')).resolves.toBeNull();
+  });
+
+  it('returns null when track details missing', async () => {
+    fetchMock.mockResolvedValue({ json: async () => ({}) });
     await expect(getStatus('1Z123')).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add DHL and premier-delivery scenarios to shipping rate tests
- exercise UPS helpers for missing data and track-details gaps

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test -- shipping-index.test.ts shipping-ups.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc0b6066bc832fa5a83573544c0566