### PR TITLE
fix: augment PrismaClient type

### DIFF
--- a/packages/platform-core/src/prisma.d.ts
+++ b/packages/platform-core/src/prisma.d.ts
@@ -1,9 +1,5 @@
-declare module "@prisma/client" {
-  /**
-   * Augment the generated PrismaClient without overwriting the
-   * existing class definition so model delegate types remain intact.
-   */
-  interface PrismaClient<T = any, U = any, V = any> {
+declare module '@prisma/client' {
+  interface PrismaClient {
     [key: string]: any;
   }
 }


### PR DESCRIPTION
## Summary
- augment PrismaClient to allow unknown keys without redefining type

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68bc0fe8e134832faecf3ac006b1a297