### PR TITLE
chore: re-export prisma client type

### DIFF
--- a/packages/platform-core/src/prisma-client.ts
+++ b/packages/platform-core/src/prisma-client.ts
@@ -1,3 +1,8 @@
 import type { PrismaClient as GeneratedPrismaClient } from '@prisma/client';
 
+/**
+ * Re-export Prisma's generated type. Importing with `import type`
+ * allows TypeScript to infer the model delegates (shop, page,
+ * rentalOrder, etc.) without bundling any runtime from '@prisma/client'.
+ */
 export type PrismaClient = GeneratedPrismaClient;


### PR DESCRIPTION
## Summary
- re-export Prisma's generated client type

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0fdceba8832f90f80e4e5708c2ff