### PR TITLE
Expand test coverage for telemetry, date utilities and profile page

### DIFF
--- a/packages/date-utils/src/__tests__/index.test.ts
+++ b/packages/date-utils/src/__tests__/index.test.ts
@@ -66,6 +66,20 @@ describe("parseDate", () => {
   it("returns null for invalid input", () => {
     expect(parseDate("not-a-date")).toBeNull();
   });
+
+  it("returns null when timezone parsing throws", async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock("date-fns-tz", () => ({
+        fromZonedTime: () => {
+          throw new Error("boom");
+        },
+      }));
+      const { parseDate: mocked } = await import("../index");
+      expect(
+        mocked("2025-01-01T00:00:00", "America/New_York")
+      ).toBeNull();
+    });
+  });
 });
 
 describe("formatDate", () => {

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -45,8 +45,9 @@ async function flush() {
         body: JSON.stringify(events),
       });
       break;
-    } catch {
+    } catch (err) {
       attempts++;
+      console.error("Failed to send telemetry", err);
       if (attempts >= MAX_RETRIES) {
         BUFFER.unshift(...events); // restore
       }

--- a/packages/ui/src/components/account/__tests__/Profile.test.tsx
+++ b/packages/ui/src/components/account/__tests__/Profile.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import ProfilePage from "../Profile";
+
+const getCustomerSession = jest.fn();
+const hasPermission = jest.fn();
+jest.mock("@auth", () => ({
+  getCustomerSession: () => getCustomerSession(),
+  hasPermission: (...args: any[]) => hasPermission(...args),
+}));
+
+const getCustomerProfile = jest.fn();
+jest.mock("@acme/platform-core/customerProfiles", () => ({
+  getCustomerProfile: (...args: any[]) => getCustomerProfile(...args),
+}));
+
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({ redirect }));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("redirects to login when session missing", async () => {
+    getCustomerSession.mockResolvedValue(null);
+    const result = await ProfilePage({ callbackUrl: "/dest" });
+    expect(redirect).toHaveBeenCalledWith("/login?callbackUrl=%2Fdest");
+    expect(result).toBeNull();
+  });
+
+  it("renders change password link when permitted", async () => {
+    getCustomerSession.mockResolvedValue({ customerId: "1", role: "admin" });
+    getCustomerProfile.mockResolvedValue({ name: "n", email: "e" });
+    hasPermission.mockReturnValue(true);
+    const element = await ProfilePage({});
+    render(element);
+    expect(screen.getByText("Change password")).toBeInTheDocument();
+  });
+
+  it("omits change password link without permission", async () => {
+    getCustomerSession.mockResolvedValue({ customerId: "1", role: "user" });
+    getCustomerProfile.mockResolvedValue({ name: "n", email: "e" });
+    hasPermission.mockReturnValue(false);
+    const element = await ProfilePage({});
+    render(element);
+    expect(screen.queryByText("Change password")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- log and recover from telemetry send failures
- cover parseDate error paths
- add ProfilePage tests for auth and permission flows

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @acme/telemetry test` *(fails: Cannot find module './parseJsonBody' from 'packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bc0f0844a4832f8b455a02b33f3404