### PR TITLE
test: cover parseJsonBody scenarios

### DIFF
--- a/packages/shared-utils/__tests__/parseJsonBody.scenarios.test.ts
+++ b/packages/shared-utils/__tests__/parseJsonBody.scenarios.test.ts
@@ -1,0 +1,66 @@
+import { parseJsonBody } from '../src/parseJsonBody';
+import { Readable } from 'node:stream';
+import { z } from 'zod';
+
+describe('parseJsonBody scenarios', () => {
+  const schema = z.object({ a: z.number() });
+
+  it('parses valid JSON', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"a":1}',
+    });
+    await expect(parseJsonBody(req, schema, '1mb')).resolves.toEqual({
+      success: true,
+      data: { a: 1 },
+    });
+  });
+
+  it('handles empty body', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '',
+    });
+    const result = await parseJsonBody(req, schema, '1mb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+  });
+
+  it('handles malformed JSON', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    });
+    const result = await parseJsonBody(req, schema, '1mb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+  });
+
+  it('rejects non-json content type', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: '{"a":1}',
+    });
+    const result = await parseJsonBody(req, schema, '1mb');
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(400);
+  });
+
+  it('parses JSON from stream bodies', async () => {
+    const stream = Readable.from([Buffer.from(JSON.stringify({ a: 1 }))]);
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: stream,
+    });
+    await expect(parseJsonBody(req, schema, '1mb')).resolves.toEqual({
+      success: true,
+      data: { a: 1 },
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand shared-utils test coverage for parseJsonBody
- verify valid JSON, empty/malformed input, bad content-type, and stream handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/shared-utils exec jest __tests__/parseJsonBody.scenarios.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs` *(fails: global coverage threshold for branches (80%) not met: 44.44%)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0ec32ee8832f96a95c94ad503427