### PR TITLE
test: add API route integration tests for parseJsonBody

### DIFF
--- a/packages/shared-utils/__tests__/parseJsonBody.api.test.ts
+++ b/packages/shared-utils/__tests__/parseJsonBody.api.test.ts
@@ -1,0 +1,46 @@
+import { parseJsonBody } from '../src/parseJsonBody';
+import { z } from 'zod';
+
+const schema = z.object({ foo: z.string() });
+
+async function handler(req: Request) {
+  const parsed = await parseJsonBody(req, schema, '1mb');
+  if (!parsed.success) {
+    return parsed.response;
+  }
+  return Response.json(parsed.data);
+}
+
+describe('parseJsonBody API route integration', () => {
+  it('parses valid JSON and returns data', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ foo: 'bar' }),
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ foo: 'bar' });
+  });
+
+  it('returns error for invalid JSON', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{invalid}',
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid JSON' });
+  });
+
+  it('parses JSON without content-type header', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar' }),
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ foo: 'bar' });
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests verifying parseJsonBody behavior in a mock API route

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script `check:references`)*
- `pnpm run build:ts` *(fails: Missing script `build:ts`)*
- `pnpm --filter @acme/shared-utils test` *(fails: process ran out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0b7a71b4832fba1440ad6217513e