### PR TITLE
test: add context coverage

### DIFF
--- a/apps/storefront/src/contexts/__tests__/CurrencyContext.test.tsx
+++ b/apps/storefront/src/contexts/__tests__/CurrencyContext.test.tsx
@@ -12,7 +12,8 @@ function Display() {
   return (
     <>
       <span data-testid="currency">{currency}</span>
-      <button onClick={() => setCurrency("GBP")}>change</button>
+      <button onClick={() => setCurrency("USD")}>usd</button>
+      <button onClick={() => setCurrency("GBP")}>gbp</button>
     </>
   );
 }
@@ -23,6 +24,16 @@ describe("CurrencyContext", () => {
   beforeEach(() => {
     window.localStorage.clear();
     jest.restoreAllMocks();
+  });
+
+  it("defaults to EUR when nothing stored", () => {
+    const { getByTestId, unmount } = render(
+      <CurrencyProvider>
+        <Display />
+      </CurrencyProvider>
+    );
+    expect(getByTestId("currency").textContent).toBe("EUR");
+    unmount();
   });
 
   it("initializes from localStorage when a valid currency is stored", () => {
@@ -45,8 +56,13 @@ describe("CurrencyContext", () => {
       </CurrencyProvider>
     );
 
-    fireEvent.click(getByText("change"));
+    fireEvent.click(getByText("usd"));
+    await waitFor(() => {
+      expect(getByTestId("currency").textContent).toBe("USD");
+      expect(window.localStorage.getItem(LS_KEY)).toBe("USD");
+    });
 
+    fireEvent.click(getByText("gbp"));
     await waitFor(() => {
       expect(getByTestId("currency").textContent).toBe("GBP");
       expect(window.localStorage.getItem(LS_KEY)).toBe("GBP");
@@ -66,5 +82,15 @@ describe("CurrencyContext", () => {
 
     expect(getByTestId("currency").textContent).toBe("EUR");
     unmount();
+  });
+
+  it("throws when useCurrency is called outside provider", () => {
+    function Bare() {
+      useCurrency();
+      return null;
+    }
+    expect(() => render(<Bare />)).toThrow(
+      "useCurrency must be inside CurrencyProvider"
+    );
   });
 });

--- a/apps/storefront/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/storefront/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "../../../../../packages/platform-core/src/contexts/ThemeContext";
+
+function Toggle() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <button onClick={() => setTheme(theme === "dark" ? "base" : "dark")} data-testid="toggle">
+      {theme}
+    </button>
+  );
+}
+
+beforeEach(() => {
+  document.documentElement.className = "";
+  document.documentElement.style.colorScheme = "";
+  window.localStorage.clear();
+});
+
+describe("ThemeContext", () => {
+  it("restores theme from localStorage on mount", () => {
+    window.localStorage.setItem("theme", "dark");
+    render(
+      <ThemeProvider>
+        <Toggle />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(true);
+  });
+
+  it("toggles theme, applies class and persists to localStorage", () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <Toggle />
+      </ThemeProvider>
+    );
+    fireEvent.click(getByTestId("toggle"));
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(true);
+    expect(window.localStorage.getItem("theme")).toBe("dark");
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand CurrencyContext tests for defaults, switching and error cases
- verify ThemeContext toggling and persistence

## Testing
- `pnpm exec jest apps/storefront/src/contexts/__tests__/CurrencyContext.test.tsx apps/storefront/src/contexts/__tests__/ThemeContext.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ef432c4832fa96609d9b4ff55a8