### PR TITLE
refactor: enforce subscription usage return type

### DIFF
--- a/packages/platform-core/src/subscriptionUsage.d.ts
+++ b/packages/platform-core/src/subscriptionUsage.d.ts
@@ -5,7 +5,7 @@ export declare function getSubscriptionUsage(
   shop: string,
   customerId: string,
   month: string,
-): Promise<SubscriptionUsage | null>;
+): Promise<SubscriptionUsage>;
 
 export declare function incrementSubscriptionUsage(
   shop: string,

--- a/packages/platform-core/src/subscriptionUsage.ts
+++ b/packages/platform-core/src/subscriptionUsage.ts
@@ -7,8 +7,8 @@ export async function getSubscriptionUsage(
   shop: string,
   customerId: string,
   month: string,
-): Promise<SubscriptionUsage | null> {
-  return prisma.subscriptionUsage.findUnique({
+): Promise<SubscriptionUsage> {
+  return prisma.subscriptionUsage.findUniqueOrThrow({
     where: { shop_customerId_month: { shop, customerId, month } },
   });
 }

--- a/packages/platform-machine/src/__tests__/subscriptionUsage.test.ts
+++ b/packages/platform-machine/src/__tests__/subscriptionUsage.test.ts
@@ -5,17 +5,17 @@ describe("subscriptionUsage", () => {
     jest.resetModules();
   });
 
-  it("calls findUnique with composite key", async () => {
+  it("calls findUniqueOrThrow with composite key", async () => {
     await jest.isolateModulesAsync(async () => {
-      const findUnique = jest.fn().mockResolvedValue(null);
+      const findUniqueOrThrow = jest.fn().mockResolvedValue({});
       jest.doMock("@acme/platform-core/db", () => ({
-        prisma: { subscriptionUsage: { findUnique } },
+        prisma: { subscriptionUsage: { findUniqueOrThrow } },
       }));
       const { getSubscriptionUsage } = await import(
         "@acme/platform-core/subscriptionUsage"
       );
       await getSubscriptionUsage("shop", "cust", "2023-10");
-      expect(findUnique).toHaveBeenCalledWith({
+      expect(findUniqueOrThrow).toHaveBeenCalledWith({
         where: {
           shop_customerId_month: {
             shop: "shop",

--- a/packages/template-app/__tests__/subscription-usage.test.ts
+++ b/packages/template-app/__tests__/subscription-usage.test.ts
@@ -5,15 +5,15 @@ describe("subscriptionUsage", () => {
     jest.resetModules();
   });
 
-  it("calls findUnique with composite key", async () => {
+  it("calls findUniqueOrThrow with composite key", async () => {
     await jest.isolateModulesAsync(async () => {
-      const findUnique = jest.fn().mockResolvedValue(null);
+      const findUniqueOrThrow = jest.fn().mockResolvedValue({});
       jest.doMock("@platform-core/db", () => ({
-        prisma: { subscriptionUsage: { findUnique } },
+        prisma: { subscriptionUsage: { findUniqueOrThrow } },
       }));
       const { getSubscriptionUsage } = await import("@platform-core/subscriptionUsage");
       await getSubscriptionUsage("shop", "cust", "2023-10");
-      expect(findUnique).toHaveBeenCalledWith({
+      expect(findUniqueOrThrow).toHaveBeenCalledWith({
         where: {
           shop_customerId_month: {
             shop: "shop",


### PR DESCRIPTION
## Summary
- ensure getSubscriptionUsage never returns null by using `findUniqueOrThrow`
- align type declarations and tests with new non-null return type

## Testing
- `pnpm --filter @acme/platform-core test -- src/__tests__/subscriptionUsage.test.ts`
- `pnpm --filter @acme/platform-machine test -- src/__tests__/subscriptionUsage.test.ts`
- `pnpm --filter @acme/template-app test -- __tests__/subscription-usage.test.ts` *(fails: coverage threshold for branches 60% not met)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68bc101ed440832fa705ff7505cdb578