### PR TITLE
refactor: narrow createShop return type

### DIFF
--- a/packages/platform-core/src/createShop/deployTypes.d.ts
+++ b/packages/platform-core/src/createShop/deployTypes.d.ts
@@ -4,7 +4,4 @@ export interface DeployStatusBase {
     instructions?: string;
     error?: string;
 }
-export interface DeployShopResult extends DeployStatusBase {
-    status: "success" | "error";
-    previewUrl: string;
-}
+export interface DeployShopResult extends DeployStatusBase {}

--- a/packages/platform-core/src/createShop/deployTypes.ts
+++ b/packages/platform-core/src/createShop/deployTypes.ts
@@ -7,8 +7,5 @@ export interface DeployStatusBase {
   error?: string;
 }
 
-export interface DeployShopResult extends DeployStatusBase {
-  status: "success" | "error";
-  previewUrl: string;
-}
+export interface DeployShopResult extends DeployStatusBase {}
 

--- a/packages/platform-core/src/createShop/index.d.ts
+++ b/packages/platform-core/src/createShop/index.d.ts
@@ -7,9 +7,7 @@ import { type ShopDeploymentAdapter } from "./deploymentAdapter";
  */
 export declare function createShop(id: string, opts?: CreateShopOptions, options?: {
     deploy?: boolean;
-}, adapter?: ShopDeploymentAdapter): Promise<DeployShopResult | {
-    status: "pending";
-}>;
+}, adapter?: ShopDeploymentAdapter): Promise<DeployShopResult>;
 export declare function deployShop(id: string, domain?: string, adapter?: ShopDeploymentAdapter): DeployShopResult;
 export declare function listThemes(): string[];
 /**

--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -40,7 +40,7 @@ export async function createShop(
   opts: CreateShopOptions = {} as CreateShopOptions,
   options?: { deploy?: boolean },
   adapter: ShopDeploymentAdapter = defaultDeploymentAdapter
-): Promise<DeployShopResult | { status: "pending" }> {
+): Promise<DeployShopResult> {
   id = validateShopName(id);
 
   const prepared = prepareOptions(id, opts);


### PR DESCRIPTION
## Summary
- simplify deploy result typing to allow pending deployments
- expose createShop as always returning DeployShopResult

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1031901c832f94a583d36395f204