### PR TITLE
refactor: enforce user fetch return types

### DIFF
--- a/packages/platform-core/src/users.d.ts
+++ b/packages/platform-core/src/users.d.ts
@@ -1,7 +1,7 @@
 import type { User } from "@acme/types";
 
-export declare function getUserById(id: string): Promise<User | null>;
-export declare function getUserByEmail(email: string): Promise<User | null>;
+export declare function getUserById(id: string): Promise<User>;
+export declare function getUserByEmail(email: string): Promise<User>;
 export declare function createUser({
   id,
   email,
@@ -22,7 +22,7 @@ export declare function setResetToken(
 ): Promise<void>;
 export declare function getUserByResetToken(
   token: string,
-): Promise<User | null>;
+): Promise<User>;
 export declare function updatePassword(
   id: string,
   passwordHash: string,

--- a/packages/platform-core/src/users.ts
+++ b/packages/platform-core/src/users.ts
@@ -3,12 +3,20 @@ import "server-only";
 import { prisma } from "./db";
 import type { User } from "@acme/types";
 
-export async function getUserById(id: string): Promise<User | null> {
-  return prisma.user.findUnique({ where: { id } });
+export async function getUserById(id: string): Promise<User> {
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user;
 }
 
-export async function getUserByEmail(email: string): Promise<User | null> {
-  return prisma.user.findUnique({ where: { email } });
+export async function getUserByEmail(email: string): Promise<User> {
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user;
 }
 
 export async function createUser({
@@ -42,13 +50,17 @@ export async function setResetToken(
 
 export async function getUserByResetToken(
   token: string,
-): Promise<User | null> {
-  return prisma.user.findFirst({
+): Promise<User> {
+  const user = await prisma.user.findFirst({
     where: {
       resetToken: token,
       resetTokenExpiresAt: { gt: new Date() },
     },
   });
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user;
 }
 
 export async function updatePassword(


### PR DESCRIPTION
## Summary
- enforce strict user fetch return types
- ensure declaration files match new user contract

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'Prisma')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68bc1028593c832f92d475aa48406f8c