### PR TITLE
test: cover shipping modules

### DIFF
--- a/packages/platform-core/src/shipping/index.d.ts
+++ b/packages/platform-core/src/shipping/index.d.ts
@@ -9,6 +9,12 @@ export interface ShippingRateRequest {
     fromPostalCode: string;
     toPostalCode: string;
     weight: number;
+    toCountry?: string;
+    dimensions?: {
+        length: number;
+        width: number;
+        height: number;
+    };
     region?: string;
     window?: string;
     carrier?: string;
@@ -24,7 +30,7 @@ export interface ShippingRateRequest {
  * Fetch a shipping rate from the configured provider.
  * The underlying provider API is called using the respective API key.
  */
-export declare function getShippingRate({ provider, fromPostalCode, toPostalCode, weight, region, window, carrier, premierDelivery, }: ShippingRateRequest): Promise<ShippingRate>;
+export declare function getShippingRate({ provider, fromPostalCode, toPostalCode, weight, toCountry, dimensions, region, window, carrier, premierDelivery, }: ShippingRateRequest): Promise<ShippingRate>;
 export interface TrackingStatusRequest {
     provider: "ups" | "dhl";
     trackingNumber: string;


### PR DESCRIPTION
## Summary
- extend shipping rate wrapper with free-shipping threshold, zone multipliers, and country restrictions
- add comprehensive tests for shipping rate calculations and UPS return label failures

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/__tests__/shipping-index.test.ts packages/platform-core/__tests__/shipping-ups.test.ts --config ../../jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc0efbc460832f9885724a95353660