### PR TITLE
test: cover shipping modules

### DIFF
--- a/packages/platform-core/__tests__/shipping-index.test.ts
+++ b/packages/platform-core/__tests__/shipping-index.test.ts
@@ -40,6 +40,24 @@ describe('getShippingRate', () => {
     });
   });
 
+  it('allows carrier when premierDelivery has no carriers list', async () => {
+    const result = await getShippingRate({
+      provider: 'premier-shipping',
+      fromPostalCode: '00000',
+      toPostalCode: '99999',
+      weight: 1,
+      region: 'eligible',
+      window: 'morning',
+      carrier: 'ups',
+      premierDelivery: {
+        regions: ['eligible'],
+        windows: ['morning'],
+        // no carriers array
+      },
+    });
+    expect(result).toEqual({ rate: 0, surcharge: 0, serviceLabel: 'Premier Delivery' });
+  });
+
   it('throws when premierDelivery is missing', async () => {
     await expect(
       getShippingRate({

--- a/packages/platform-core/__tests__/ups.test.ts
+++ b/packages/platform-core/__tests__/ups.test.ts
@@ -1,0 +1,96 @@
+import { jest } from '@jest/globals';
+
+const mockEnv: Record<string, string | undefined> = {};
+jest.mock('@acme/config/env/shipping', () => ({ shippingEnv: mockEnv }));
+
+import { createReturnLabel, getStatus } from '../src/shipping/ups';
+
+describe('createReturnLabel', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    // @ts-expect-error replace global fetch
+    global.fetch = fetchMock;
+    for (const key of Object.keys(mockEnv)) {
+      delete mockEnv[key];
+    }
+  });
+
+  it('returns fallback when UPS_KEY missing', async () => {
+    const result = await createReturnLabel('session');
+    expect(result.trackingNumber).toMatch(/^1Z\d{10}$/);
+    expect(result.labelUrl).toContain(result.trackingNumber);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns API data when request succeeds', async () => {
+    mockEnv.UPS_KEY = 'key';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ShipmentResults: {
+          PackageResults: {
+            TrackingNumber: '1Z999',
+            LabelURL: 'https://label',
+          },
+        },
+      }),
+    });
+    const result = await createReturnLabel('session');
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      trackingNumber: '1Z999',
+      labelUrl: 'https://label',
+    });
+  });
+
+  it('falls back when response is not ok', async () => {
+    mockEnv.UPS_KEY = 'key';
+    fetchMock.mockResolvedValue({ ok: false });
+    const result = await createReturnLabel('session');
+    expect(result.trackingNumber).toMatch(/^1Z\d{10}$/);
+    expect(result.labelUrl).toContain(result.trackingNumber);
+  });
+
+  it('falls back on fetch error', async () => {
+    mockEnv.UPS_KEY = 'key';
+    fetchMock.mockRejectedValue(new Error('network'));
+    const result = await createReturnLabel('session');
+    expect(result.trackingNumber).toMatch(/^1Z\d{10}$/);
+    expect(result.labelUrl).toContain(result.trackingNumber);
+  });
+
+  it('falls back when API omits label details', async () => {
+    mockEnv.UPS_KEY = 'key';
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const result = await createReturnLabel('session');
+    expect(result.trackingNumber).toMatch(/^1Z\d{10}$/);
+    expect(result.labelUrl).toContain(result.trackingNumber);
+  });
+});
+
+describe('getStatus', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    // @ts-expect-error replace global fetch
+    global.fetch = fetchMock;
+  });
+
+  it('returns status when API succeeds', async () => {
+    fetchMock.mockResolvedValue({
+      json: async () => ({
+        trackDetails: [{ packageStatus: { statusType: 'IN_TRANSIT' } }],
+      }),
+    });
+    await expect(getStatus('1Z999')).resolves.toBe('IN_TRANSIT');
+  });
+
+  it('returns null on error', async () => {
+    fetchMock.mockRejectedValue(new Error('oops'));
+    await expect(getStatus('1Z999')).resolves.toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add premier shipping test for unrestricted carrier list
- add UPS return label and status tests covering success and error paths

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'Prisma')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/platform-core/__tests__/ups.test.ts packages/platform-core/__tests__/shipping-index.test.ts --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68bc11244e90832f9cb8e0af450b2b30