### PR TITLE
test: cover friendly zod error mapping

### DIFF
--- a/packages/zod-utils/src/__tests__/friendlyErrorMap.unit.test.ts
+++ b/packages/zod-utils/src/__tests__/friendlyErrorMap.unit.test.ts
@@ -11,6 +11,7 @@ import { applyFriendlyZodMessages, friendlyErrorMap } from "../zodErrorMap";
 describe("applyFriendlyZodMessages", () => {
   test("sets the global error map", () => {
     const spy = (z as any).setErrorMap as jest.Mock;
+    const original = z.getErrorMap();
     applyFriendlyZodMessages();
     expect(spy).toHaveBeenCalledWith(friendlyErrorMap);
     expect(z.getErrorMap()).toBe(friendlyErrorMap);
@@ -18,6 +19,24 @@ describe("applyFriendlyZodMessages", () => {
     const friendlyMsg =
       z.string().safeParse(undefined).error?.issues[0].message;
     expect(friendlyMsg).toBe("Required");
+
+    z.setErrorMap(original);
+    spy.mockClear();
+  });
+
+  test("updates error messages globally", () => {
+    const schema = z.object({ name: z.string().min(5) });
+    const original = z.getErrorMap();
+
+    const before = schema.safeParse({ name: "abc" }).error?.issues[0].message;
+    expect(before).toBe("String must contain at least 5 character(s)");
+
+    applyFriendlyZodMessages();
+
+    const after = schema.safeParse({ name: "abc" }).error?.issues[0].message;
+    expect(after).toBe("Must be at least 5 characters");
+
+    z.setErrorMap(original);
   });
 });
 


### PR DESCRIPTION
## Summary
- extend friendlyErrorMap unit tests to restore original error map
- verify applyFriendlyZodMessages updates global schema errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/zod-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1889e830832f8398c11598250605