### PR TITLE
Persist pages to disk without database

### DIFF
--- a/packages/platform-core/__tests__/pagesRepo.test.ts
+++ b/packages/platform-core/__tests__/pagesRepo.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { jest } from '@jest/globals';
 
 const mockPages: any[] = [];
@@ -14,8 +17,12 @@ jest.mock('../src/db', () => ({
   }
 }));
 
+process.env.DATABASE_URL = 'postgres://localhost/test';
+
 describe('pages repository with prisma', () => {
   it('performs CRUD operations through prisma', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pagesrepo-'));
+    process.env.DATA_ROOT = path.join(dir, 'shops');
     const repo = await import('../src/repositories/pages/index.server');
     expect(await repo.getPages('shop1')).toEqual([]);
     const page = { id:'1', slug:'home', status:'draft', components:[], seo:{ title:'Home' }, createdAt:'now', updatedAt:'now', createdBy:'tester' } as any;

--- a/packages/platform-core/__tests__/pagesRepoFallback.test.ts
+++ b/packages/platform-core/__tests__/pagesRepoFallback.test.ts
@@ -25,6 +25,7 @@ describe("pages repository filesystem fallbacks", () => {
     root = path.join(dir, "shops");
     await fs.mkdir(root, { recursive: true });
     process.env.DATA_ROOT = root;
+    process.env.DATABASE_URL = "postgres://localhost/test";
     repo = await import("../src/repositories/pages/index.server");
   });
 

--- a/packages/platform-core/__tests__/pagesRepoMock.test.ts
+++ b/packages/platform-core/__tests__/pagesRepoMock.test.ts
@@ -42,6 +42,7 @@ const prisma = {
 jest.mock("../src/db", () => ({ prisma }));
 
 process.env.DATA_ROOT = "/data";
+process.env.DATABASE_URL = "postgres://localhost/test";
 
 let repo: typeof import("../src/repositories/pages/index.server");
 const shop = "mockshop";

--- a/packages/platform-core/src/repositories/pages/__tests__/no-db.test.ts
+++ b/packages/platform-core/src/repositories/pages/__tests__/no-db.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { jest } from "@jest/globals";
+import type { Page, HistoryState } from "@acme/types";
+
+const prisma = {
+  page: {
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    update: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+};
+
+jest.mock("../../../db", () => ({ prisma }));
+
+describe("pages repository without database", () => {
+  let repo: typeof import("../index.server");
+  let root: string;
+
+  beforeAll(async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pages-nodb-"));
+    root = path.join(dir, "shops");
+    process.env.DATA_ROOT = root;
+    delete process.env.DATABASE_URL;
+    repo = await import("../index.server");
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("performs CRUD operations using filesystem", async () => {
+    const shop = "s1";
+    const page: Page = {
+      id: "1",
+      slug: "home",
+      status: "draft",
+      components: [],
+      seo: { title: { en: "Home" }, description: { en: "" }, image: { en: "" } } as any,
+      createdAt: "t",
+      updatedAt: "t",
+      createdBy: "tester",
+    } as Page;
+
+    await repo.savePage(shop, page, undefined);
+    let pages = await repo.getPages(shop);
+    expect(pages).toHaveLength(1);
+    expect(pages[0].createdBy).toBe("tester");
+    expect(prisma.page.upsert).not.toHaveBeenCalled();
+
+    const history: HistoryState = {
+      past: [],
+      present: [],
+      future: [],
+      gridCols: 12,
+    } as HistoryState;
+
+    const updated = await repo.updatePage(
+      shop,
+      { id: page.id, slug: "start", updatedAt: page.updatedAt, history },
+      page,
+    );
+    pages = await repo.getPages(shop);
+    expect(updated.slug).toBe("start");
+    expect(pages[0].history).toEqual(history);
+    expect(prisma.page.update).not.toHaveBeenCalled();
+
+    await repo.deletePage(shop, page.id);
+    pages = await repo.getPages(shop);
+    expect(pages).toHaveLength(0);
+    expect(prisma.page.deleteMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- persist page repository to JSON when no database is present
- always mirror Prisma writes to the filesystem
- add filesystem CRUD tests for page repository

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: TS18046 'prisma.rentalOrder' is of type 'unknown')*
- `pnpm exec jest --config ./jest.config.cjs packages/platform-core/src/repositories/pages/__tests__/index.server.test.ts packages/platform-core/src/repositories/pages/__tests__/no-db.test.ts packages/platform-core/__tests__/pagesRepoFallback.test.ts packages/platform-core/__tests__/pagesRepo.test.ts packages-platform-core/__tests__/pagesRepoMock.test.ts apps/cms/__tests__/pages.test.ts --runInBand --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc17f1d280832f86264d19726b0152