### PR TITLE
refactor: improve order normalization typing

### DIFF
--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -9,12 +9,14 @@ import { incrementSubscriptionUsage } from "./subscriptionUsage";
 
 export type Order = RentalOrder;
 
-function normalize<T extends object>(order: T): T {
-  const o = { ...order } as any;
-  Object.keys(o).forEach((k) => {
-    if (o[k] === null) o[k] = undefined;
+function normalize<T extends Order>(order: T): T {
+  const o = { ...order } as Record<keyof T, T[keyof T]>;
+  (Object.keys(o) as Array<keyof T>).forEach((k) => {
+    if (o[k] === null) {
+      o[k] = undefined as T[keyof T];
+    }
   });
-  return o;
+  return o as T;
 }
 
 export async function listOrders(shop: string): Promise<Order[]> {


### PR DESCRIPTION
## Summary
- tighten normalize() generic to extend Order and replace loose `any` casts with proper key typing

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc1cbd9894832fba9092c07e3bee5b