### PR TITLE
fix(prisma): relax PrismaClient index signature

### DIFF
--- a/packages/platform-core/src/prisma.d.ts
+++ b/packages/platform-core/src/prisma.d.ts
@@ -1,12 +1,13 @@
 declare module "@prisma/client" {
   /**
-   * Augment the generated PrismaClient with a permissive index signature so
+   * Augment the generated PrismaClient with an `any` index signature so
    * dynamic string access is allowed at compile time while preserving all
-   * existing delegate method types. Avoids `any` by returning `unknown`,
-   * which callers can safely narrow via user code or helpers.
+   * existing delegate method types. This is intentionally permissive and may
+   * bypass type safety, so callers should narrow results in user code or via
+   * helpers.
    */
   // Do NOT redeclare the class — merge onto the existing interface only.
   interface PrismaClient {
-    [key: string]: unknown;
+    [key: string]: any;
   }
 }


### PR DESCRIPTION
## Summary
- allow dynamic delegate access via `any`-typed index signature on PrismaClient

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*


------
https://chatgpt.com/codex/tasks/task_e_68bc1cbcc12c832fa6c8a9e3fa52ba1c