### PR TITLE
fix jest redirect mock in profile tests

### DIFF
--- a/packages/ui/src/components/account/__tests__/Profile.test.tsx
+++ b/packages/ui/src/components/account/__tests__/Profile.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import ProfilePage from "../Profile";
+import { redirect } from "next/navigation";
 
 const getCustomerSession = jest.fn();
 const hasPermission = jest.fn();
@@ -13,8 +14,7 @@ jest.mock("@acme/platform-core/customerProfiles", () => ({
   getCustomerProfile: (...args: any[]) => getCustomerProfile(...args),
 }));
 
-const redirect = jest.fn();
-jest.mock("next/navigation", () => ({ redirect }));
+jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
 
 jest.mock("next/link", () => ({
   __esModule: true,


### PR DESCRIPTION
## Summary
- fix redirect mocking in ProfilePage test to avoid hoisting ReferenceError

## Testing
- `pnpm -r build` *(fails: prisma types unknown in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/src/components/account/__tests__/Profile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc1d9a9a98832f9da411699e58caca