### PR TITLE
test: add deposits editor tests

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/__tests__/DepositsEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/__tests__/DepositsEditor.test.tsx
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DepositsEditor from "../DepositsEditor";
+
+const parseDepositForm = jest.fn(() => ({ data: { enabled: true, intervalMinutes: 5 } }));
+const updateDeposit = jest.fn(async (_shop: string, formData: FormData) => {
+  parseDepositForm(formData);
+  return { errors: { intervalMinutes: ["Invalid"] } };
+});
+
+jest.mock("@cms/actions/shops.server", () => ({ updateDeposit }));
+jest.mock("../../../../../../../services/shops/validation", () => ({ parseDepositForm }));
+jest.mock(
+  "@ui/components/atoms/shadcn",
+  () => ({
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Checkbox: (props: any) => <input type="checkbox" {...props} />,
+    Input: (props: any) => <input {...props} />,
+  }),
+  { virtual: true },
+);
+
+describe("DepositsEditor", () => {
+  it("submits updated values and shows validation errors", async () => {
+    render(<DepositsEditor shop="s1" initial={{ enabled: false, intervalMinutes: 1 }} />);
+
+    await userEvent.click(screen.getByRole("checkbox"));
+    const interval = screen.getByRole("spinbutton");
+    await userEvent.clear(interval);
+    await userEvent.type(interval, "5");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(parseDepositForm).toHaveBeenCalledTimes(1);
+    const fd = parseDepositForm.mock.calls[0][0] as FormData;
+    expect(fd.get("enabled")).toBe("on");
+    expect(fd.get("intervalMinutes")).toBe("5");
+
+    expect(await screen.findByText("Invalid")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- test form submission for deposits editor and error handling

## Testing
- `pnpm install` *(fails: pnpm: No such file or directory)*
- `pnpm -r build` *(fails: pnpm: No such file or directory)*
- `pnpm --filter @apps/cms test` *(fails: pnpm: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bc1f531604832f95061edefaff3cf4