### PR TITLE
test(i18n): cover locale helpers

### DIFF
--- a/packages/i18n/__tests__/fillLocales.test.ts
+++ b/packages/i18n/__tests__/fillLocales.test.ts
@@ -2,10 +2,10 @@ import { fillLocales, LOCALES } from "@acme/i18n";
 
 describe("fillLocales", () => {
   it("fills missing locales using the fallback and keeps provided values", () => {
-    const result = fillLocales({ en: "Hello", de: "Hallo" }, "Ciao");
+    const result = fillLocales({ en: "Hello" }, "Hi");
 
     expect(Object.keys(result)).toEqual([...LOCALES]);
-    expect(result).toEqual({ en: "Hello", de: "Hallo", it: "Ciao" });
+    expect(result).toEqual({ en: "Hello", de: "Hi", it: "Hi" });
   });
 
   it("uses the fallback when no values are provided", () => {

--- a/packages/i18n/__tests__/locales.test.ts
+++ b/packages/i18n/__tests__/locales.test.ts
@@ -11,12 +11,9 @@ describe("assertLocales", () => {
   });
 
   it("throws on empty arrays", () => {
-    expect.assertions(1);
-    try {
-      assertLocales([] as any);
-    } catch (err) {
-      expect(err).toBeInstanceOf(Error);
-    }
+    expect(() => assertLocales([] as any)).toThrow(
+      "LOCALES must be a non-empty array"
+    );
   });
 
   it("does not throw on non-empty arrays", () => {
@@ -29,7 +26,7 @@ describe("resolveLocale", () => {
     expect(resolveLocale("de")).toBe("de");
   });
 
-  it("falls back to 'en' for unsupported or undefined values", () => {
+  it("falls back to 'en' for unsupported locales", () => {
     expect(resolveLocale("fr" as any)).toBe("en");
     expect(resolveLocale(undefined)).toBe("en");
   });


### PR DESCRIPTION
## Summary
- test fillLocales with partial locale values and fallback
- check assertLocales error message and resolveLocale fallback

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: @acme/platform-core build: `tsc -b`)*
- `pnpm --filter @acme/i18n test -- packages/i18n/__tests__/fillLocales.test.ts packages/i18n/__tests__/locales.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc22d43fac832fb7835cd3320656c6