### PR TITLE
test(shared-utils): add coverage for buildResponse and formatPrice

### DIFF
--- a/packages/shared-utils/src/__tests__/buildResponse.test.ts
+++ b/packages/shared-utils/src/__tests__/buildResponse.test.ts
@@ -48,4 +48,25 @@ describe('buildResponse', () => {
     expect(res.headers.get('X-Test')).toBe('abc');
     expect(res.headers.get('X-Other')).toBe('def');
   });
+
+  it('decodes body and applies multiple headers', async () => {
+    const json = JSON.stringify({ hello: 'world' });
+    const proxy: ProxyResponse = {
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Extra': '42',
+        },
+        body: Buffer.from(json).toString('base64'),
+      },
+    };
+
+    const res = buildResponse(proxy);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(res.headers.get('X-Extra')).toBe('42');
+    await expect(res.text()).resolves.toBe(json);
+  });
 });

--- a/packages/shared-utils/src/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/src/__tests__/formatPrice.test.ts
@@ -64,11 +64,31 @@ describe("formatPrice", () => {
     }
   );
 
-  it("throws when Intl.supportedValuesOf excludes the currency", () => {
+  it("formats when Intl.supportedValuesOf includes the currency", () => {
     const original = (Intl as any).supportedValuesOf;
     (Intl as any).supportedValuesOf = () => ["USD", "EUR"];
+    const amount = 12.34;
     try {
-      expect(() => formatPrice(10, "BTC")).toThrow(RangeError);
+      const formatted = formatPrice(amount, "USD", "en-GB");
+      const expected = new Intl.NumberFormat("en-GB", {
+        style: "currency",
+        currency: "USD",
+      }).format(amount);
+      expect(formatted).toBe(expected);
+    } finally {
+      if (original) {
+        (Intl as any).supportedValuesOf = original;
+      } else {
+        delete (Intl as any).supportedValuesOf;
+      }
+    }
+  });
+
+  it("throws when Intl.supportedValuesOf excludes the currency", () => {
+    const original = (Intl as any).supportedValuesOf;
+    (Intl as any).supportedValuesOf = () => ["EUR"];
+    try {
+      expect(() => formatPrice(10, "USD")).toThrow(RangeError);
     } finally {
       if (original) {
         (Intl as any).supportedValuesOf = original;


### PR DESCRIPTION
## Summary
- verify buildResponse decodes base64 body and rehydrates headers
- test formatPrice with stubbed Intl.supportedValuesOf for supported and unsupported currencies

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils test -- packages/shared-utils/src/__tests__/buildResponse.test.ts packages/shared-utils/src/__tests__/formatPrice.test.ts` *(incomplete: ran but produced extensive logs and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2308e74c832f9c5b77bf5588d7c2