### PR TITLE
test: cover components route edge cases

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -29,8 +29,14 @@ describe('component helpers', () => {
   describe('gatherChanges', () => {
     const root = '/tmp';
 
-    it('handles malformed shop.json gracefully', () => {
-      vol.fromJSON({ [`${root}/data/shops/abc/shop.json`]: '{"componentVersions"' });
+    it('returns empty array when shop.json contains invalid JSON', () => {
+      vol.fromJSON({
+        [`${root}/data/shops/abc/shop.json`]: '{ bad json',
+        [`${root}/packages/foo/package.json`]: JSON.stringify({
+          name: '@acme/foo',
+          version: '1.2.0',
+        }),
+      });
       expect(gatherChanges('abc', root)).toEqual([]);
     });
 


### PR DESCRIPTION
## Summary
- handle invalid shop.json when gathering component changes
- exercise missing shop id and token payload validation paths in components route

## Testing
- `pnpm -r build` *(fails: prisma.user is of type 'unknown')*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68bc183f8bcc832fae18cc7ba7cf46f7