### PR TITLE
test: verify ProductGrid quick view add to cart

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
@@ -98,15 +98,34 @@ describe("ProductGrid responsive columns", () => {
 });
 
 jest.mock("../../overlays/ProductQuickView", () => ({
-  ProductQuickView: ({ product }: { product: Product }) => (
-    <div data-testid={`quickview-${product.id}`} />
+  ProductQuickView: ({
+    product,
+    onAddToCart,
+  }: {
+    product: Product;
+    onAddToCart: (p: Product) => void;
+  }) => (
+    <div data-testid={`quickview-${product.id}`}>
+      <button
+        data-testid="add-to-cart"
+        onClick={() => onAddToCart(product)}
+      />
+    </div>
   ),
 }));
 
 describe("ProductGrid quick view", () => {
-  it("renders button and opens ProductQuickView", async () => {
+  it("renders ProductQuickView and handles add to cart", async () => {
     mockResize(1200);
-    render(<ProductGrid products={products} enableQuickView showPrice={false} />);
+    const handleAdd = jest.fn();
+    render(
+      <ProductGrid
+        products={products}
+        enableQuickView
+        showPrice={false}
+        onAddToCart={handleAdd}
+      />
+    );
 
     const btn = screen.getByLabelText("Quick view A");
     expect(btn).toBeInTheDocument();
@@ -114,6 +133,9 @@ describe("ProductGrid quick view", () => {
     fireEvent.click(btn);
     const modal = await screen.findByTestId("quickview-1");
     expect(modal).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("add-to-cart"));
+    expect(handleAdd).toHaveBeenCalledWith(products[0]);
   });
 });
 


### PR DESCRIPTION
## Summary
- expand ProductGrid tests to mock ResizeObserver for responsive columns
- ensure Quick View opens ProductQuickView and calls onAddToCart

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types unknown)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `npx jest packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc284caca0832f81643863a1868352