### PR TITLE
test: ensure analytics sync handles rejections

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -475,6 +475,12 @@ describe("scheduler", () => {
     expect(fetchCampaignAnalytics).toHaveBeenCalled();
   });
 
+  test('syncCampaignAnalytics handles analytics failures gracefully', async () => {
+    (fetchCampaignAnalytics as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    await expect(syncCampaignAnalytics()).resolves.toBeUndefined();
+    expect(fetchCampaignAnalytics).toHaveBeenCalled();
+  });
+
   test('createCampaign propagates send errors', async () => {
     (sendCampaignEmail as jest.Mock).mockRejectedValueOnce(new Error('boom'));
     await expect(

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -174,5 +174,9 @@ export async function sendDueCampaigns(): Promise<void> {
  * Periodically sync campaign analytics for all shops.
  */
 export async function syncCampaignAnalytics(): Promise<void> {
-  await fetchCampaignAnalytics();
+  try {
+    await fetchCampaignAnalytics();
+  } catch {
+    // ignore analytics sync errors to avoid crashing scheduled jobs
+  }
 }


### PR DESCRIPTION
## Summary
- avoid crashing when campaign analytics syncing fails
- test syncCampaignAnalytics gracefully handles analytics rejection

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types of unknown)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `npx jest packages/email/src/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc284d90d8832f8280943b458ddc6f