### PR TITLE
test: add hook tests

### DIFF
--- a/packages/ui/src/hooks/__tests__/useCart.test.ts
+++ b/packages/ui/src/hooks/__tests__/useCart.test.ts
@@ -1,0 +1,24 @@
+import { renderHook } from "@testing-library/react";
+import { useCart } from "../useCart";
+
+jest.mock("@acme/platform-core/contexts/CartContext", () => ({
+  useCart: jest.fn(),
+}));
+
+const { useCart: mockUseCart } = require("@acme/platform-core/contexts/CartContext");
+
+describe("useCart", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns cart context value", () => {
+    const value = { items: [{ id: "1" }], total: 10 };
+    (mockUseCart as jest.Mock).mockReturnValue(value);
+
+    const { result } = renderHook(() => useCart());
+
+    expect(result.current).toEqual(value);
+    expect(mockUseCart).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/__tests__/useContrastWarnings.test.ts
+++ b/packages/ui/src/hooks/__tests__/useContrastWarnings.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from "@testing-library/react";
+import useContrastWarnings from "../useContrastWarnings";
+
+jest.mock("../../components/cms/ColorInput", () => ({
+  getContrast: jest.fn(),
+  suggestContrastColor: jest.fn(),
+}));
+
+import {
+  getContrast,
+  suggestContrastColor,
+} from "../../components/cms/ColorInput";
+
+const mockGetContrast = getContrast as jest.MockedFunction<typeof getContrast>;
+const mockSuggestContrastColor =
+  suggestContrastColor as jest.MockedFunction<typeof suggestContrastColor>;
+
+describe("useContrastWarnings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null when contrast is sufficient", () => {
+    mockGetContrast.mockReturnValue(5);
+    const { result } = renderHook(() => useContrastWarnings("#000", "#fff"));
+    expect(result.current).toBeNull();
+    expect(mockGetContrast).toHaveBeenCalledWith("#000", "#fff");
+    expect(mockSuggestContrastColor).not.toHaveBeenCalled();
+  });
+
+  it("provides suggestion when contrast is low", () => {
+    mockGetContrast.mockReturnValue(3);
+    mockSuggestContrastColor.mockReturnValue("#123456");
+    const { result } = renderHook(() => useContrastWarnings("#000", "#111"));
+    expect(mockGetContrast).toHaveBeenCalledWith("#000", "#111");
+    expect(mockSuggestContrastColor).toHaveBeenCalledWith("#000", "#111");
+    expect(result.current).toEqual({ contrast: 3, suggestion: "#123456" });
+  });
+
+  it("returns null when colors are missing", () => {
+    const { result } = renderHook(() => useContrastWarnings("", "#fff"));
+    expect(result.current).toBeNull();
+    expect(mockGetContrast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/__tests__/usePublishLocations.test.ts
+++ b/packages/ui/src/hooks/__tests__/usePublishLocations.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  usePublishLocations,
+  loadPublishLocations,
+} from "@platform-core/hooks/usePublishLocations";
+
+jest.mock("@acme/shared-utils", () => ({
+  fetchJson: jest.fn(),
+}));
+
+import { fetchJson } from "@acme/shared-utils";
+
+const mockFetchJson = fetchJson as jest.MockedFunction<typeof fetchJson>;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("loadPublishLocations", () => {
+  it("returns fetched data", async () => {
+    const locations = [
+      { id: "a", name: "A", path: "a", requiredOrientation: "landscape" },
+    ];
+    mockFetchJson.mockResolvedValueOnce(locations);
+    await expect(loadPublishLocations()).resolves.toEqual(locations);
+  });
+
+  it("returns empty array on error", async () => {
+    mockFetchJson.mockRejectedValueOnce(new Error("fail"));
+    await expect(loadPublishLocations()).resolves.toEqual([]);
+  });
+});
+
+describe("usePublishLocations", () => {
+  it("loads and reloads locations", async () => {
+    const first = [
+      { id: "a", name: "A", path: "a", requiredOrientation: "landscape" },
+    ];
+    const second = [
+      { id: "b", name: "B", path: "b", requiredOrientation: "portrait" },
+    ];
+    mockFetchJson.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    const { result } = renderHook(() => usePublishLocations());
+    await waitFor(() => expect(result.current.locations).toEqual(first));
+
+    act(() => {
+      result.current.reload();
+    });
+    await waitFor(() => expect(result.current.locations).toEqual(second));
+
+    expect(mockFetchJson).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for useCart re-export
- cover contrast suggestions and null cases in useContrastWarnings
- verify usePublishLocations loads and reloads locations

## Testing
- `pnpm --filter @acme/ui exec jest packages/ui/src/hooks/__tests__/useCart.test.ts packages/ui/src/hooks/__tests__/useContrastWarnings.test.ts packages/ui/src/hooks/__tests__/usePublishLocations.test.ts --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68bc2d1de4e0832fa158b6609ee4c550