### PR TITLE
test(api): add listFiles tests

### DIFF
--- a/apps/api/__tests__/routes/components/listFiles.test.ts
+++ b/apps/api/__tests__/routes/components/listFiles.test.ts
@@ -1,0 +1,33 @@
+jest.mock('fs', () => require('memfs').fs);
+
+import { vol } from 'memfs';
+import path from 'path';
+import { listFiles } from '../../../src/routes/components/[shopId]';
+
+describe('listFiles', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('returns all nested files for a multi-level directory', () => {
+    vol.fromJSON({
+      '/root/a.txt': 'A',
+      '/root/dir1/b.txt': 'B',
+      '/root/dir1/dir2/c.txt': 'C',
+    });
+
+    const files = listFiles('/root');
+    expect(files.sort()).toEqual(
+      [
+        'a.txt',
+        path.join('dir1', 'b.txt'),
+        path.join('dir1', 'dir2', 'c.txt'),
+      ].sort(),
+    );
+  });
+
+  it('returns an empty array when the directory does not exist', () => {
+    const files = listFiles('/missing');
+    expect(files).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- test listFiles handles multi-level directories
- test listFiles handles missing directories

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TS18046 in @acme/platform-core)
- `pnpm --filter @apps/api test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2d32837c832fb8542474b5e55fbc