### PR TITLE
Add style token component tests

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/ColorToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/ColorToken.test.tsx
@@ -1,0 +1,68 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { ColorToken } from "../ColorToken";
+import { hexToHsl } from "../../../../utils/colorUtils";
+import type { TokenMap } from "../../../../hooks/useTokenEditor";
+
+describe("ColorToken", () => {
+  const baseTokens: TokenMap = {
+    "--color-bg": "0 0% 100%",
+    "--color-fg": "0 0% 0%",
+  };
+
+  it("renders with default value", () => {
+    const setToken = jest.fn();
+    render(
+      <ColorToken
+        tokenKey="--color-bg"
+        value="0 0% 100%"
+        defaultValue="0 0% 100%"
+        isOverridden={false}
+        tokens={{}}
+        baseTokens={baseTokens}
+        setToken={setToken}
+      />
+    );
+
+    expect(screen.getByText("--color-bg")).toBeInTheDocument();
+    expect(screen.getByText(/Default:/)).toHaveTextContent("Default: 0 0% 100%");
+    expect(screen.queryByText("Reset")).toBeNull();
+  });
+
+  it("emits updated value on change", () => {
+    const setToken = jest.fn();
+    const { container } = render(
+      <ColorToken
+        tokenKey="--color-bg"
+        value="0 0% 100%"
+        defaultValue="0 0% 100%"
+        isOverridden={false}
+        tokens={{}}
+        baseTokens={baseTokens}
+        setToken={setToken}
+      />
+    );
+
+    const input = container.querySelector('input[type="color"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "#000000" } });
+
+    expect(setToken).toHaveBeenCalledWith("--color-bg", hexToHsl("#000000"));
+  });
+
+  it("resets to default value", () => {
+    const setToken = jest.fn();
+    render(
+      <ColorToken
+        tokenKey="--color-bg"
+        value="0 0% 0%"
+        defaultValue="0 0% 100%"
+        isOverridden={true}
+        tokens={{ "--color-bg": "0 0% 0%" }}
+        baseTokens={baseTokens}
+        setToken={setToken}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Reset"));
+    expect(setToken).toHaveBeenCalledWith("--color-bg", "0 0% 100%");
+  });
+});

--- a/packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx
@@ -1,0 +1,67 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { FontToken } from "../FontToken";
+
+describe("FontToken", () => {
+  const tokenKey = "--font-sans";
+  const options = ["Arial", "Helvetica"];
+  const googleFonts = ["Roboto", "Inter"];
+
+  const renderToken = (props: Partial<React.ComponentProps<typeof FontToken>> = {}) =>
+    render(
+      FontToken({
+        key: tokenKey,
+        value: "Arial",
+        defaultValue: "Arial",
+        isOverridden: false,
+        options,
+        type: "sans",
+        googleFonts,
+        setToken: jest.fn(),
+        handleUpload: jest.fn(),
+        setGoogleFont: jest.fn(),
+        ...props,
+      })
+    );
+
+  it("renders with default value", () => {
+    renderToken();
+    expect(screen.getByDisplayValue("Arial")).toBeInTheDocument();
+    expect(screen.getByText(/Default:/)).toHaveTextContent("Default: Arial");
+    expect(screen.queryByText("Reset")).toBeNull();
+  });
+
+  it("emits updated value on selection", () => {
+    const setToken = jest.fn();
+    const { container } = renderToken({ setToken });
+    const select = container.querySelector("select") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "Helvetica" } });
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "Helvetica");
+  });
+
+  it("handles reset, upload, and google fonts", () => {
+    const setToken = jest.fn();
+    const handleUpload = jest.fn();
+    const setGoogleFont = jest.fn();
+    const { container } = renderToken({
+      value: "Helvetica",
+      isOverridden: true,
+      setToken,
+      handleUpload,
+      setGoogleFont,
+    });
+
+    fireEvent.click(screen.getByText("Reset"));
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "Arial");
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["foo"], "font.woff", { type: "font/woff" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(handleUpload).toHaveBeenCalled();
+
+    const selects = container.querySelectorAll("select");
+    const googleSelect = selects[1] as HTMLSelectElement;
+    fireEvent.change(googleSelect, { target: { value: "Roboto" } });
+    expect(setGoogleFont).toHaveBeenCalledWith("sans", "Roboto");
+    expect(googleSelect.value).toBe("");
+  });
+});

--- a/packages/ui/src/components/cms/style/__tests__/Presets.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/Presets.test.tsx
@@ -1,0 +1,36 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import Presets from "../Presets";
+import type { TokenMap } from "../../../../hooks/useTokenEditor";
+
+describe("Presets", () => {
+  const tokens: TokenMap = {};
+
+  it("renders preset selector", () => {
+    render(<Presets tokens={tokens} baseTokens={{}} onChange={jest.fn()} />);
+    expect(screen.getByTestId("preset-select")).toBeInTheDocument();
+    expect(screen.getByTestId("preset-reset")).toBeInTheDocument();
+  });
+
+  it("applies selected preset and resets tokens", () => {
+    const handleChange = jest.fn();
+    render(<Presets tokens={tokens} baseTokens={{}} onChange={handleChange} />);
+
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: "brand" },
+    });
+    expect(handleChange).toHaveBeenCalledWith(
+      expect.objectContaining({ "--color-primary": "340 82% 52%" })
+    );
+
+    fireEvent.click(screen.getByTestId("preset-reset"));
+    expect(handleChange).toHaveBeenLastCalledWith({});
+  });
+
+  it("shows placeholder when no presets are available", async () => {
+    jest.resetModules();
+    jest.doMock("../presets.json", () => [], { virtual: true });
+    const { default: EmptyPresets } = await import("../Presets");
+    render(<EmptyPresets tokens={{}} baseTokens={{}} onChange={jest.fn()} />);
+    expect(screen.getByTestId("presets-placeholder")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/style/__tests__/RangeToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/RangeToken.test.tsx
@@ -1,0 +1,39 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { RangeToken } from "../RangeToken";
+
+describe("RangeToken", () => {
+  const tokenKey = "--spacing";
+
+  const renderToken = (props: Partial<React.ComponentProps<typeof RangeToken>> = {}) =>
+    render(
+      RangeToken({
+        key: tokenKey,
+        value: "8px",
+        defaultValue: "8px",
+        isOverridden: false,
+        setToken: jest.fn(),
+        ...props,
+      })
+    );
+
+  it("renders with default value", () => {
+    renderToken();
+    expect(screen.getByText(/Default: 8px/)).toBeInTheDocument();
+    expect(screen.queryByText("Reset")).toBeNull();
+  });
+
+  it("emits updated value on change", () => {
+    const setToken = jest.fn();
+    const { container } = renderToken({ setToken });
+    const range = container.querySelector('input[type="range"]') as HTMLInputElement;
+    fireEvent.change(range, { target: { value: "12" } });
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "12px");
+  });
+
+  it("resets to default value", () => {
+    const setToken = jest.fn();
+    renderToken({ value: "12px", isOverridden: true, setToken });
+    fireEvent.click(screen.getByText("Reset"));
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "8px");
+  });
+});

--- a/packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx
@@ -1,0 +1,40 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { TextToken } from "../TextToken";
+
+describe("TextToken", () => {
+  const tokenKey = "--custom-token";
+
+  const renderToken = (props: Partial<React.ComponentProps<typeof TextToken>> = {}) =>
+    render(
+      TextToken({
+        key: tokenKey,
+        value: "hello",
+        defaultValue: "hello",
+        isOverridden: false,
+        setToken: jest.fn(),
+        ...props,
+      })
+    );
+
+  it("renders with default value", () => {
+    renderToken();
+    expect(screen.getByDisplayValue("hello")).toBeInTheDocument();
+    expect(screen.getByText(/Default: hello/)).toBeInTheDocument();
+    expect(screen.queryByText("Reset")).toBeNull();
+  });
+
+  it("emits updated value on change", () => {
+    const setToken = jest.fn();
+    const { container } = renderToken({ setToken });
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "world" } });
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "world");
+  });
+
+  it("resets to default value", () => {
+    const setToken = jest.fn();
+    renderToken({ value: "world", isOverridden: true, setToken });
+    fireEvent.click(screen.getByText("Reset"));
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "hello");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for ColorToken, FontToken, RangeToken, TextToken, and Presets components

## Testing
- `pnpm -r build` *(fails: prisma.* unknown errors)*
- `pnpm --filter @acme/ui run check:references` *(fails: missing script)*
- `pnpm --filter @acme/ui run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/ui test -- --no-coverage packages/ui/src/components/cms/style/__tests__` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d1c7adc832fa09cf4408fda6311