### PR TITLE
test: add cms component tests

### DIFF
--- a/packages/ui/src/components/cms/__tests__/FontSelect.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/FontSelect.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FontSelect } from "../FontSelect";
+
+describe("FontSelect", () => {
+  const options = ["Arial", "Helvetica"];
+
+  it("renders provided options", () => {
+    render(
+      <FontSelect
+        value={"Arial"}
+        options={options}
+        onChange={jest.fn()}
+        onUpload={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole("option", { name: "Arial" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Helvetica" })).toBeInTheDocument();
+  });
+
+  it("calls onChange when selecting a font", async () => {
+    const handleChange = jest.fn();
+    render(
+      <FontSelect
+        value={"Arial"}
+        options={options}
+        onChange={handleChange}
+        onUpload={jest.fn()}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByRole("combobox"), "Helvetica");
+    expect(handleChange).toHaveBeenCalledWith("Helvetica");
+  });
+
+  it("calls onUpload when a file is chosen", async () => {
+    const handleUpload = jest.fn();
+    const { container } = render(
+      <FontSelect
+        value={"Arial"}
+        options={options}
+        onChange={jest.fn()}
+        onUpload={handleUpload}
+      />
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["data"], "font.woff", { type: "font/woff" });
+    await userEvent.upload(fileInput, file);
+
+    expect(handleUpload).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/cms/__tests__/ShopSelector.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ShopSelector.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ShopSelector from "../ShopSelector";
+
+const pushMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/cms/shop/demo/products",
+  useRouter: () => ({ push: pushMock }),
+}));
+
+jest.mock("../../atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Select: ({ value, onValueChange, children }: any) => (
+      <select
+        data-testid="shop-select"
+        value={value ?? ""}
+        onChange={(e) => onValueChange(e.target.value)}
+      >
+        <option value="" disabled>
+          Select shop
+        </option>
+        {children}
+      </select>
+    ),
+    SelectTrigger: ({ children }: any) => <>{children}</>,
+    SelectValue: ({ placeholder }: any) => (
+      <option disabled value="">
+        {placeholder}
+      </option>
+    ),
+    SelectContent: ({ children }: any) => <>{children}</>,
+    SelectItem: ({ value, children }: any) => (
+      <option value={value}>{children}</option>
+    ),
+  };
+});
+
+describe("ShopSelector", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+  });
+
+  it("renders shops from API and navigates on selection", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(["demo", "other"]), { status: 200 })
+      );
+
+    window.history.pushState(
+      {},
+      "",
+      "/cms/shop/demo/products?lang=en"
+    );
+
+    render(<ShopSelector />);
+
+    expect(screen.getByText("Loading shops…")).toBeInTheDocument();
+    const select = await screen.findByTestId("shop-select");
+    await userEvent.selectOptions(select, "other");
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/cms/shop/other/products?lang=en"
+    );
+    fetchMock.mockRestore();
+  });
+
+  it("shows error message when API fails", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    render(<ShopSelector />);
+
+    expect(await screen.findByText("Error 500")).toBeInTheDocument();
+    fetchMock.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add FontSelect tests for option rendering and interactions
- add ShopSelector tests for shop loading, navigation, and error handling

## Testing
- `pnpm -r build` *(fails: TS18046 unknown prisma type errors)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test` *(fails: cart API handlers test error)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/__tests__/FontSelect.test.tsx packages/ui/src/components/cms/__tests__/ShopSelector.test.tsx` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d1beac4832fab437df2ad6f9d48