### PR TITLE
test(ui): add atom component tests

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/LineChart.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/LineChart.test.tsx
@@ -1,0 +1,34 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import { LineChart } from "../LineChart";
+
+type LineProps = React.ComponentProps<typeof LineChart>;
+
+const lineMock = jest.fn((props: any) => <div {...props} />);
+
+jest.mock("react-chartjs-2", () => ({
+  Line: (props: any) => lineMock(props),
+}));
+
+describe("LineChart", () => {
+  const data: LineProps["data"] = {
+    labels: ["Jan"],
+    datasets: [{ label: "Sales", data: [1] }],
+  };
+  const options = { responsive: true };
+
+  it("renders line chart with provided props", () => {
+    render(<LineChart data={data} options={options} className="custom" />);
+    const chart = screen.getByTestId("line-chart");
+    expect(chart).toBeInTheDocument();
+    expect(chart).toHaveClass("custom");
+    expect(lineMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data,
+        options,
+        className: "custom",
+        "data-testid": "line-chart",
+      }),
+    );
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/Popover.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Popover.test.tsx
@@ -1,0 +1,23 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Popover, PopoverContent, PopoverTrigger } from "../Popover";
+
+describe("Popover", () => {
+  it("opens content when trigger is clicked", async () => {
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent data-testid="content" className="p-2">
+          Hello
+        </PopoverContent>
+      </Popover>,
+    );
+
+    expect(screen.queryByTestId("content")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByText("Open"));
+    const content = screen.getByTestId("content");
+    expect(content).toBeInTheDocument();
+    expect(content).toHaveClass("p-2");
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/Skeleton.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Skeleton.test.tsx
@@ -1,0 +1,16 @@
+import "../../../../../../test/resetNextMocks";
+import { render } from "@testing-library/react";
+import { Skeleton } from "../Skeleton";
+
+describe("Skeleton", () => {
+  it("renders with default styling", () => {
+    const { container } = render(<Skeleton />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveClass("bg-muted", "animate-pulse", "rounded-md");
+  });
+
+  it("accepts custom className", () => {
+    const { container } = render(<Skeleton className="h-4" />);
+    expect(container.firstChild).toHaveClass("h-4");
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/StatCard.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/StatCard.test.tsx
@@ -1,0 +1,18 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import { StatCard } from "../StatCard";
+
+describe("StatCard", () => {
+  it("displays label and value", () => {
+    render(<StatCard label="Orders" value="10" />);
+    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <StatCard label="Revenue" value="$100" className="custom" />,
+    );
+    expect(container.firstChild).toHaveClass("custom");
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/Switch.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Switch.test.tsx
@@ -1,0 +1,21 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Switch } from "../Switch";
+
+describe("Switch", () => {
+  it("toggles and calls onChange", async () => {
+    const handleChange = jest.fn();
+    render(<Switch onChange={handleChange} />);
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    expect(handleChange).toHaveBeenCalled();
+    expect(checkbox).toBeChecked();
+  });
+
+  it("supports controlled checked prop", () => {
+    render(<Switch checked />);
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/Tag.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Tag.test.tsx
@@ -1,0 +1,21 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import { Tag } from "../Tag";
+
+describe("Tag", () => {
+  it("renders with default variant", () => {
+    render(<Tag>Default</Tag>);
+    const tag = screen.getByText("Default");
+    expect(tag).toHaveAttribute("data-token", "--color-muted");
+    expect(tag).toHaveAttribute("data-token-fg", "--color-fg");
+    expect(tag).toHaveClass("bg-muted", "text-fg");
+  });
+
+  it("applies success variant classes", () => {
+    render(<Tag variant="success">Success</Tag>);
+    const tag = screen.getByText("Success");
+    expect(tag).toHaveClass("bg-success", "text-success-fg");
+    expect(tag).toHaveAttribute("data-token", "--color-success");
+    expect(tag).toHaveAttribute("data-token-fg", "--color-success-fg");
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/Toast.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Toast.test.tsx
@@ -1,0 +1,23 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Toast } from "../Toast";
+
+describe("Toast", () => {
+  it("renders message when open", () => {
+    render(<Toast open message="Saved" />);
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    const { container } = render(<Toast open={false} message="Hidden" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls onClose when dismiss button clicked", async () => {
+    const handleClose = jest.fn();
+    render(<Toast open message="Saved" onClose={handleClose} />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/atoms/__tests__/Tooltip.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Tooltip.test.tsx
@@ -1,0 +1,20 @@
+import "../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Tooltip } from "../Tooltip";
+
+describe("Tooltip", () => {
+  it("reveals text on hover", async () => {
+    render(
+      <Tooltip text="Info">
+        <button>Hover me</button>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByText("Hover me");
+    expect(screen.queryByText("Info")).toBeNull();
+    await userEvent.hover(trigger);
+    expect(screen.getByText("Info")).toBeInTheDocument();
+    await userEvent.unhover(trigger);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for atom components: LineChart, Popover, Skeleton, StatCard, Switch, Tag, Toast, Tooltip

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS18046 'prisma.*' is of type 'unknown')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test` *(partial due to output volume)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d18008c832fa4a41135ede070da