### PR TITLE
test(ui): add organism tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/AccountPanel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/AccountPanel.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AccountPanel } from "../AccountPanel";
+
+jest.mock("next/image", () => (props: any) => <img {...props} />);
+
+describe("AccountPanel", () => {
+  it("renders user info and logout button", async () => {
+    const handleLogout = jest.fn();
+    render(
+      <AccountPanel
+        user={{ name: "Alice", email: "alice@example.com" }}
+        onLogout={handleLogout}
+      />
+    );
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /log out/i }));
+    expect(handleLogout).toHaveBeenCalled();
+  });
+
+  it("shows avatar when provided", () => {
+    render(
+      <AccountPanel
+        user={{
+          name: "Bob",
+          email: "bob@example.com",
+          avatar: "/bob.png",
+        }}
+      />
+    );
+
+    expect(screen.getByAltText("Bob")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/LiveChatWidget.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/LiveChatWidget.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LiveChatWidget } from "../LiveChatWidget";
+
+describe("LiveChatWidget", () => {
+  it("opens chat and sends messages", async () => {
+    render(<LiveChatWidget />);
+
+    expect(screen.queryByText(/how can we help/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /chat/i }));
+    expect(await screen.findByText(/how can we help/i)).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/type a message/i),
+      "Hello"
+    );
+    await userEvent.click(screen.getByText("Send"));
+
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText(/thanks for your message/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/QAModule.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/QAModule.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QAModule } from "../QAModule";
+
+describe("QAModule", () => {
+  it("renders questions and toggles answers", async () => {
+    render(
+      <QAModule items={[{ question: "What is X?", answer: "X is Y" }]} />
+    );
+
+    expect(screen.getByText("What is X?")).toBeInTheDocument();
+    expect(screen.queryByText("X is Y")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("What is X?"));
+    expect(screen.getByText("X is Y")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/WishlistDrawer.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/WishlistDrawer.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WishlistDrawer } from "../WishlistDrawer";
+import type { SKU } from "@acme/types";
+
+describe("WishlistDrawer", () => {
+  it("shows empty state", async () => {
+    render(<WishlistDrawer trigger={<button>Open</button>} items={[]} />);
+
+    expect(screen.queryByText(/wishlist/i)).not.toBeInTheDocument();
+    await userEvent.click(screen.getByText("Open"));
+    expect(await screen.findByText(/wishlist/i)).toBeInTheDocument();
+    expect(screen.getByText(/your wishlist is empty/i)).toBeInTheDocument();
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByText(/wishlist/i)).not.toBeInTheDocument()
+    );
+  });
+
+  it("lists items", async () => {
+    const items: SKU[] = [
+      { id: "1", title: "Item 1" },
+      { id: "2", title: "Item 2" },
+    ];
+    render(<WishlistDrawer trigger={<button>Open</button>} items={items} />);
+
+    await userEvent.click(screen.getByText("Open"));
+    expect(screen.getByText("Item 1")).toBeInTheDocument();
+    expect(screen.getByText("Item 2")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AccountPanel, LiveChatWidget, QAModule, and WishlistDrawer components

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* unknown in platform-core)*
- `pnpm --filter @acme/ui test` *(fails: cartApi.handlers, parseJsonBody)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d1b2814832fb7273ed494b4ed6b