### PR TITLE
feat(ui): enable coverage collection

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -236,6 +236,7 @@ const config = {
     global: {
       lines: 80,
       branches: 80,
+      functions: 80,
     },
   },
   rootDir: '.', // each workspace already passes --config ../../jest.config.cjs

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage",
     "lint": "eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- collect coverage in UI package tests
- enforce function coverage threshold in Jest config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @acme/platform-core build TS errors)*
- `pnpm --filter @acme/ui run check:references` *(fails: missing script)*
- `pnpm --filter @acme/ui run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/ui test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d21b4b0832f9e7a77e827d77c6a