### PR TITLE
test: cover diffDirectories edge cases

### DIFF
--- a/apps/api/__tests__/routes/components/helpers.test.ts
+++ b/apps/api/__tests__/routes/components/helpers.test.ts
@@ -53,6 +53,29 @@ describe('helpers', () => {
   });
 
   describe('diffDirectories', () => {
+    it('returns empty diff for identical directories', () => {
+      vol.fromJSON({
+        '/a/same.txt': 'content',
+        '/b/same.txt': 'content',
+        '/a/nested/file.txt': 'hello',
+        '/b/nested/file.txt': 'hello',
+      });
+
+      expect(diffDirectories('/a', '/b')).toEqual([]);
+    });
+
+    it('lists files when one directory is missing', () => {
+      vol.fromJSON({
+        '/a/only.txt': 'one',
+        '/a/nested/file.txt': 'two',
+      });
+
+      const diff = diffDirectories('/a', '/b');
+      expect(diff.sort()).toEqual(
+        ['only.txt', path.join('nested', 'file.txt')].sort(),
+      );
+    });
+
     it('detects added, removed, and modified files', () => {
       vol.fromJSON({
         '/a/only-a.txt': 'A',


### PR DESCRIPTION
## Summary
- test diffDirectories handling of identical directories
- test diffDirectories when one directory is missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm exec jest apps/api/__tests__/routes/components/helpers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d3566f4832f9df99b8304b8c5ad