### PR TITLE
test: handle deploy failures

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -192,6 +192,41 @@ describe("onRequestPost", () => {
     });
   });
 
+  it("returns 500 when deploy command fails", async () => {
+    readFileSync.mockImplementation((file: string) => {
+      if (file.endsWith("package.json")) {
+        return JSON.stringify({ dependencies: { compA: "1.0.0" } });
+      }
+      if (file.endsWith("shop.json")) {
+        return JSON.stringify({ componentVersions: {} });
+      }
+      return "";
+    });
+    spawn
+      .mockImplementationOnce(() => ({
+        on: (_: string, cb: (code: number) => void) => cb(0),
+      }))
+      .mockImplementationOnce(() => ({
+        on: (_: string, cb: (code: number) => void) => cb(1),
+      }));
+
+    const token = jwt.sign({}, "secret");
+    const res = await onRequestPost({
+      params: { id },
+      request: new Request("http://example.com", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ components: ["compA"] }),
+      }),
+    });
+
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      error: `pnpm --filter apps/shop-${id} deploy failed with status 1`,
+    });
+  });
+
   it("returns 500 on unexpected errors", async () => {
     readFileSync.mockImplementation((file: string) => {
       if (file.endsWith("package.json")) {


### PR DESCRIPTION
## Summary
- test deploy failures when publish-upgrade deploy step exits non-zero

## Testing
- `pnpm install`
- `pnpm -r build` (fails: prisma.* is of type 'unknown')
- `pnpm exec jest "apps/api/src/routes/shop/\\[id\\]/__tests__/publish-upgrade.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d3a0190832fab4f20b8665e3cd9