### PR TITLE
test: cover sentry server util

### DIFF
--- a/apps/cms/src/utils/__tests__/sentry.server.test.ts
+++ b/apps/cms/src/utils/__tests__/sentry.server.test.ts
@@ -1,0 +1,24 @@
+const captureExceptionSpy = jest.fn();
+const importMock = jest.fn(() => ({ captureException: captureExceptionSpy }));
+
+jest.mock("@sentry/node", () => importMock());
+
+describe("captureException", () => {
+  it("imports module only once and forwards errors", async () => {
+    const { captureException } = await import("../sentry.server");
+
+    const error1 = new Error("first");
+    const context = { foo: "bar" };
+    await captureException(error1, context);
+
+    expect(importMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(error1, context);
+
+    const error2 = new Error("second");
+    await captureException(error2);
+
+    expect(importMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(error2);
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for Sentry server captureException
- verify module is imported once and error/context are forwarded

## Testing
- `pnpm install`
- `pnpm -r build` (fails: prisma.* is of type unknown)
- `pnpm --filter @apps/cms test` (fails: FormData constructor undefined in DepositsEditor.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68bc2d493e1c832f8b5207a9c0999e0d