### PR TITLE
test: cover json file helpers

### DIFF
--- a/apps/cms/src/lib/server/__tests__/jsonIO.test.ts
+++ b/apps/cms/src/lib/server/__tests__/jsonIO.test.ts
@@ -1,0 +1,62 @@
+// apps/cms/src/lib/server/__tests__/jsonIO.test.ts
+/* eslint-env jest */
+
+import { promises as fs } from "fs";
+import { readJsonFile, writeJsonFile } from "../jsonIO";
+
+jest.mock("fs", () => ({
+  promises: {
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    mkdir: jest.fn(),
+  },
+}));
+
+const mockedFs = fs as unknown as {
+  readFile: jest.Mock;
+  writeFile: jest.Mock;
+  mkdir: jest.Mock;
+};
+
+afterEach(() => jest.resetAllMocks());
+
+describe("readJsonFile", () => {
+  it("returns fallback when file is missing", async () => {
+    const fallback = { value: 1 };
+    mockedFs.readFile.mockRejectedValueOnce(new Error("missing"));
+
+    const result = await readJsonFile("missing.json", fallback);
+
+    expect(result).toBe(fallback);
+  });
+
+  it("returns fallback when JSON cannot be parsed", async () => {
+    const fallback = { value: 2 };
+    mockedFs.readFile.mockResolvedValueOnce("not json");
+
+    const result = await readJsonFile("bad.json", fallback);
+
+    expect(result).toBe(fallback);
+  });
+});
+
+describe("writeJsonFile", () => {
+  it("throws TypeError for non-object values", async () => {
+    // @ts-expect-error passing string to trigger TypeError
+    await expect(writeJsonFile("file.json", "nope")).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("writes JSON with 2-space indent by default", async () => {
+    mockedFs.mkdir.mockResolvedValueOnce(undefined);
+    mockedFs.writeFile.mockResolvedValueOnce(undefined);
+
+    const data = { a: 1 };
+    await writeJsonFile("out.json", data);
+
+    expect(mockedFs.writeFile).toHaveBeenCalledWith(
+      "out.json",
+      JSON.stringify(data, null, 2),
+      "utf8",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add jest tests for readJsonFile and writeJsonFile using fs mocks

## Testing
- `pnpm -r build` *(fails: 'prisma.rentalOrder' is of type 'unknown')*
- `pnpm --filter @apps/cms test` *(fails: DepositsEditor.test.tsx type error)*
- `pnpm --filter @apps/cms exec jest apps/cms/src/lib/server/__tests__/jsonIO.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d4760c0832f88f9c19c755af41d