### PR TITLE
Ensure DepositsEditor uses DOM FormData in tests

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
@@ -22,7 +22,9 @@ export default function DepositsEditor({ shop, initial }: Props) {
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSaving(true);
-    const fd = new FormData(e.currentTarget);
+
+    const form = e.currentTarget;
+    const fd = new (form.ownerDocument.defaultView!).FormData(form);
     const result = await updateDeposit(shop, fd);
     if (result.errors) {
       setErrors(result.errors);


### PR DESCRIPTION
## Summary
- construct FormData from the form's owning document to avoid Node's FormData incompatibility during tests

## Testing
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm exec jest --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/deposits/__tests__/DepositsEditor.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc3c366608832fb1f0057b73912f3a