### PR TITLE
test(ui): add UploadPanel interaction tests

### DIFF
--- a/packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx
+++ b/packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import UploadPanel from "../UploadPanel";
+import { useMediaUpload } from "@ui/hooks/useMediaUpload";
+
+jest.mock("@ui/hooks/useMediaUpload", () => ({ useMediaUpload: jest.fn() }));
+jest.mock("@ui/components/atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    Input: React.forwardRef((props: any, ref: any) => <input ref={ref} {...props} />),
+  };
+});
+
+const mockHook = useMediaUpload as jest.MockedFunction<typeof useMediaUpload>;
+
+function setupMock(overrides: Partial<ReturnType<typeof useMediaUpload>> = {}) {
+  const defaults = {
+    pendingFile: { type: "image/png" } as any,
+    thumbnail: null as string | null,
+    altText: "",
+    setAltText: jest.fn(),
+    tags: "",
+    setTags: jest.fn(),
+    actual: "landscape" as const,
+    isValid: true as boolean | null,
+    progress: null as any,
+    error: undefined as string | undefined,
+    inputRef: { current: null },
+    openFileDialog: jest.fn(),
+    onDrop: jest.fn(),
+    onFileChange: jest.fn(),
+    handleUpload: jest.fn(),
+  };
+  mockHook.mockReturnValue({ ...defaults, ...overrides });
+  return { ...defaults, ...overrides };
+}
+
+describe("UploadPanel", () => {
+  it("handles drag enter/leave and drop", () => {
+    const { onDrop } = setupMock();
+    render(<UploadPanel shop="shop" onUploaded={jest.fn()} />);
+    const dropzone = screen.getByRole("button", {
+      name: /drop image or video here or press enter to browse/i,
+    });
+    fireEvent.dragEnter(dropzone);
+    expect(dropzone.className).toMatch(/highlighted/);
+    fireEvent.dragLeave(dropzone);
+    expect(dropzone.className).not.toMatch(/highlighted/);
+    fireEvent.dragEnter(dropzone);
+    const file = new File(["x"], "x.png", { type: "image/png" });
+    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+    expect(onDrop).toHaveBeenCalled();
+    expect(dropzone.className).not.toMatch(/highlighted/);
+  });
+
+  it("opens file dialog with keyboard", () => {
+    const { openFileDialog } = setupMock();
+    render(<UploadPanel shop="shop" onUploaded={jest.fn()} />);
+    const dropzone = screen.getByRole("button", {
+      name: /drop image or video here or press enter to browse/i,
+    });
+    fireEvent.keyDown(dropzone, { key: "Enter" });
+    expect(openFileDialog).toHaveBeenCalled();
+  });
+
+  it("shows invalid orientation message and feedback", () => {
+    setupMock({
+      actual: "portrait",
+      isValid: false,
+      progress: { done: 1, total: 2 },
+      error: "oops",
+    });
+    render(<UploadPanel shop="shop" onUploaded={jest.fn()} />);
+    expect(
+      screen.getByText(
+        "Selected image is portrait; please upload a landscape image."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Uploaded 1/2")).toBeInTheDocument();
+    expect(screen.getByText("oops")).toBeInTheDocument();
+  });
+
+  it("accepts alt and tag input and uploads when valid", () => {
+    const { setAltText, setTags, handleUpload } = setupMock({
+      actual: "landscape",
+      isValid: true,
+    });
+    render(<UploadPanel shop="shop" onUploaded={jest.fn()} />);
+    expect(
+      screen.getByText("Image orientation is landscape; requirement satisfied.")
+    ).toBeInTheDocument();
+    const alt = screen.getByPlaceholderText("Alt text");
+    fireEvent.change(alt, { target: { value: "desc" } });
+    expect(setAltText).toHaveBeenCalledWith("desc");
+    const tags = screen.getByPlaceholderText("Tags (comma separated)");
+    fireEvent.change(tags, { target: { value: "t1,t2" } });
+    expect(setTags).toHaveBeenCalledWith("t1,t2");
+    fireEvent.click(screen.getByText("Upload"));
+    expect(handleUpload).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for drag, drop, keyboard, and orientation flows in UploadPanel

## Testing
- `pnpm run check:references --filter @acme/ui` *(fails: Missing script)*
- `pnpm run build:ts --filter @acme/ui` *(fails: Missing script)*
- `pnpm --filter @acme/ui test src/components/cms/media/__tests__/UploadPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c3c14a0832f91743d66b31e19ca