### PR TITLE
test: cover CartTemplate size and removal

### DIFF
--- a/packages/ui/src/components/templates/__tests__/CartTemplate.test.tsx
+++ b/packages/ui/src/components/templates/__tests__/CartTemplate.test.tsx
@@ -25,6 +25,7 @@ const cart: CartState = {
       description: "",
     },
     qty: 2,
+    size: "M",
   },
   "2": {
     sku: {
@@ -81,5 +82,18 @@ describe("CartTemplate", () => {
     const removeButtons = screen.getAllByRole("button", { name: /remove/i });
     await userEvent.click(removeButtons[1]);
     expect(onRemove).toHaveBeenCalledWith("2");
+  });
+
+  it("renders size badge when size is provided", () => {
+    render(<CartTemplate cart={cart} />);
+    expect(screen.getByText("(M)")).toBeInTheDocument();
+  });
+
+  it("does not render remove column without onRemove", () => {
+    render(<CartTemplate cart={cart} />);
+    expect(
+      screen.queryByRole("button", { name: /remove/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Remove")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- test CartTemplate renders size badge when line has a size
- ensure CartTemplate omits remove column when onRemove is absent

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types are of type 'unknown')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/templates/__tests__/CartTemplate.test.tsx` *(coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c3d2bf0832f9d62fa16ad9996b6