### PR TITLE
test: add BlockResizer events test

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockResizer.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockResizer.test.tsx
@@ -1,0 +1,35 @@
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import BlockResizer from "../BlockResizer";
+
+// jsdom may not define PointerEvent
+if (typeof window !== "undefined" && !(window as any).PointerEvent) {
+  (window as any).PointerEvent = MouseEvent as any;
+}
+
+describe("BlockResizer", () => {
+  it("returns null when not selected", () => {
+    const { container } = render(
+      <BlockResizer selected={false} startResize={jest.fn()} startSpacing={jest.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("fires resize and spacing callbacks", () => {
+    const startResize = jest.fn();
+    const startSpacing = jest.fn();
+    const { container } = render(
+      <BlockResizer selected startResize={startResize} startSpacing={startSpacing} />
+    );
+    const resizeHandle = container.firstChild as HTMLElement;
+    const spacingHandle = container.children[4] as HTMLElement;
+    fireEvent.pointerDown(resizeHandle);
+    fireEvent.pointerDown(spacingHandle);
+    expect(startResize).toHaveBeenCalled();
+    expect(startResize.mock.calls[0][0].type).toBe("pointerdown");
+    const spacingArgs = startSpacing.mock.calls[0];
+    expect(spacingArgs[0].type).toBe("pointerdown");
+    expect(spacingArgs[1]).toBe("margin");
+    expect(spacingArgs[2]).toBe("top");
+  });
+});


### PR DESCRIPTION
## Summary
- test BlockResizer is null when not selected
- ensure resize and spacing callbacks fire on pointer down

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types unknown)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/page-builder/__tests__/BlockResizer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c3e7948832f90e2268863d0b707