### PR TITLE
test: cover non-numeric input for requireEnv

### DIFF
--- a/packages/config/__tests__/requireEnv.test.ts
+++ b/packages/config/__tests__/requireEnv.test.ts
@@ -40,7 +40,7 @@ describe("requireEnv", () => {
     await withEnv(
       {
         BAD_BOOL: "yes",
-        BAD_NUM: "abc",
+        BAD_NUM: "forty",
       },
       async () => {
         const { requireEnv } = await import("../src/env/core");


### PR DESCRIPTION
## Summary
- test requireEnv number parsing with non-numeric "forty"

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: ERR_PNPM_NO_SCRIPT)*
- `pnpm run build:ts` *(fails: ERR_PNPM_NO_SCRIPT)*
- `CI=true pnpm --filter @acme/config test`

------
https://chatgpt.com/codex/tasks/task_e_68bc3cab75bc832f9fab67d7c702db82