### PR TITLE
test: add data root resolution tests

### DIFF
--- a/packages/platform-core/__tests__/dataRoot.test.ts
+++ b/packages/platform-core/__tests__/dataRoot.test.ts
@@ -1,0 +1,51 @@
+import * as path from "node:path";
+
+const fs = jest.requireActual("node:fs") as typeof import("node:fs");
+
+describe("dataRoot", () => {
+  const originalCwd = process.cwd();
+  const originalEnv = process.env.DATA_ROOT;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = originalEnv;
+    }
+    process.chdir(originalCwd);
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("returns resolved env path when DATA_ROOT is set", async () => {
+    process.env.DATA_ROOT = "/tmp/env-root";
+    const { resolveDataRoot } = await import("../src/dataRoot");
+    expect(resolveDataRoot()).toBe(path.resolve("/tmp/env-root"));
+  });
+
+  it("stops search at first parent containing data/shops", async () => {
+    jest.spyOn(process, "cwd").mockReturnValue("/repo/app/nested");
+    const spy = jest
+      .spyOn(fs, "existsSync")
+      .mockImplementation((p: fs.PathLike) => p === "/repo/data/shops");
+    const { resolveDataRoot } = await import("../src/dataRoot");
+    spy.mockClear();
+    expect(resolveDataRoot()).toBe("/repo/data/shops");
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenNthCalledWith(1, "/repo/app/nested/data/shops");
+    expect(spy).toHaveBeenNthCalledWith(2, "/repo/app/data/shops");
+    expect(spy).toHaveBeenNthCalledWith(3, "/repo/data/shops");
+  });
+
+  it("falls back to <cwd>/data/shops when nothing found", async () => {
+    jest.spyOn(process, "cwd").mockReturnValue("/repo/app");
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    const { resolveDataRoot } = await import("../src/dataRoot");
+    expect(resolveDataRoot()).toBe(path.resolve("/repo/app", "data", "shops"));
+  });
+
+  it("exports DATA_ROOT equal to resolveDataRoot()", async () => {
+    const mod = await import("../src/dataRoot");
+    expect(mod.DATA_ROOT).toBe(mod.resolveDataRoot());
+  });
+});


### PR DESCRIPTION
## Summary
- add data root tests for env override and directory search
- verify DATA_ROOT constant uses resolveDataRoot

## Testing
- `pnpm --filter @acme/platform-core run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter @acme/platform-core run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter @acme/platform-core build` *(fails: tsc -b: 'prisma.shop' is of type 'unknown')*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/dataRoot.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc3caaeaec832f8af5fc1486fa7b43