### PR TITLE
test: add Tabs block interaction coverage

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/Tabs.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Tabs.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import TabsBlock from "../Tabs";
+
+describe("TabsBlock", () => {
+  it("respects default active index and handles extra labels", () => {
+    render(
+      <TabsBlock labels={["One", "Two", "Three"]} active={1}>
+        <div>Content One</div>
+        <div>Content Two</div>
+      </TabsBlock>
+    );
+
+    const buttons = screen.getAllByRole("button");
+
+    // second tab should be active on mount
+    expect(buttons[1]).toHaveClass("border-primary");
+    expect(screen.getByText("Content Two")).toBeInTheDocument();
+
+    // switching to first tab updates active class and content
+    fireEvent.click(buttons[0]);
+    expect(buttons[0]).toHaveClass("border-primary");
+    expect(screen.getByText("Content One")).toBeInTheDocument();
+
+    // clicking a tab without corresponding content clamps to last pane
+    fireEvent.click(buttons[2]);
+    expect(buttons[1]).toHaveClass("border-primary");
+    expect(screen.getByText("Content Two")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive test for Tabs block
- verify default active index and safeIndex behavior when extra labels are present

## Testing
- `pnpm --filter @acme/ui run check:references` *(fails: missing script)*
- `pnpm --filter @acme/ui run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/ui build` *(fails: TS errors)*
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/Tabs.test.tsx --runInBand --config jest.config.cjs` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bc45bf9e98832faba67dc128e2c654