### PR TITLE
test: add CountdownTimer tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, act } from "@testing-library/react";
+import CountdownTimer from "../CountdownTimer";
+import {
+  parseTargetDate,
+  getTimeRemaining,
+  formatDuration,
+} from "@acme/date-utils";
+
+jest.mock("@acme/date-utils", () => ({
+  parseTargetDate: jest.fn(),
+  getTimeRemaining: jest.fn(),
+  formatDuration: jest.fn(),
+}));
+
+const mockParseTargetDate = parseTargetDate as jest.MockedFunction<
+  typeof parseTargetDate
+>;
+const mockGetTimeRemaining = getTimeRemaining as jest.MockedFunction<
+  typeof getTimeRemaining
+>;
+const mockFormatDuration = formatDuration as jest.MockedFunction<
+  typeof formatDuration
+>;
+
+describe("CountdownTimer", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("returns null when no targetDate", () => {
+    mockParseTargetDate.mockReturnValue(undefined);
+
+    const { container } = render(<CountdownTimer />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders formatted duration when time remaining is positive", () => {
+    mockParseTargetDate.mockReturnValue(new Date("2025-01-01T00:00:00Z"));
+    mockGetTimeRemaining.mockReturnValue(5000);
+    mockFormatDuration.mockReturnValue("00:05");
+
+    render(<CountdownTimer targetDate="future" />);
+
+    expect(screen.getByText("00:05")).toBeInTheDocument();
+  });
+
+  it("shows completionText when time runs out", () => {
+    mockParseTargetDate.mockReturnValue(new Date("2025-01-01T00:00:00Z"));
+    mockGetTimeRemaining
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1000)
+      .mockReturnValue(0);
+    mockFormatDuration.mockReturnValue("00:01");
+
+    render(
+      <CountdownTimer targetDate="future" completionText="Done" />
+    );
+
+    expect(screen.getByText("00:01")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+
+  it("renders null when no completionText and time runs out", () => {
+    mockParseTargetDate.mockReturnValue(new Date("2025-01-01T00:00:00Z"));
+    mockGetTimeRemaining
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1000)
+      .mockReturnValue(0);
+    mockFormatDuration.mockReturnValue("00:01");
+
+    const { container } = render(
+      <CountdownTimer targetDate="future" />
+    );
+
+    expect(screen.getByText("00:01")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for CountdownTimer covering missing target date, active countdown, and completion

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc45bc5e60832f853c906572139035