### PR TITLE
test(ui): add SocialLinks component tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/SocialLinks.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/SocialLinks.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import SocialLinks from "../SocialLinks";
+
+describe("SocialLinks", () => {
+  it("returns null when no links are provided", () => {
+    const { container } = render(<SocialLinks />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  const cases = [
+    ["facebook", "https://facebook.com/example"],
+    ["instagram", "https://instagram.com/example"],
+    ["x", "https://x.com/example"],
+    ["youtube", "https://youtube.com/example"],
+    ["linkedin", "https://linkedin.com/in/example"],
+  ] as const;
+
+  it.each(cases)("renders %s link", (name, url) => {
+    render(<SocialLinks {...{ [name]: url }} />);
+    const link = screen.getByRole("link", { name });
+    expect(link).toHaveAttribute("href", url);
+  });
+
+  it("renders multiple links", () => {
+    const links = {
+      facebook: "https://facebook.com/example",
+      instagram: "https://instagram.com/example",
+      x: "https://x.com/example",
+    } as const;
+
+    render(<SocialLinks {...links} />);
+
+    expect(screen.getAllByRole("link")).toHaveLength(3);
+    Object.entries(links).forEach(([name, url]) => {
+      expect(screen.getByRole("link", { name })).toHaveAttribute("href", url);
+    });
+  });
+
+  it("merges provided className", () => {
+    const { container } = render(
+      <SocialLinks facebook="https://facebook.com/example" className="custom" />
+    );
+
+    expect(container.firstChild).toHaveClass("flex");
+    expect(container.firstChild).toHaveClass("gap-4");
+    expect(container.firstChild).toHaveClass("custom");
+  });
+});


### PR DESCRIPTION
## Summary
- test SocialLinks returns null without links
- verify expected links and class merge

## Testing
- `pnpm -r build` *(fails: TS18046 in @acme/platform-core)*
- `pnpm -F @acme/ui test src/components/cms/blocks/__tests__/SocialLinks.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc45bef9b8832f9be392f128168db5