### PR TITLE
Add MapBlock component tests for valid and invalid coordinates

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import MapBlock from "../MapBlock";
+
+jest.mock("../../../organisms/StoreLocatorMap", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    StoreLocatorMap: jest.fn(() => <div data-testid="map" />),
+  };
+});
+
+const { StoreLocatorMap } = require("../../../organisms/StoreLocatorMap") as {
+  StoreLocatorMap: jest.Mock;
+};
+
+const mockStoreLocatorMap = StoreLocatorMap;
+
+describe("MapBlock", () => {
+  afterEach(() => {
+    mockStoreLocatorMap.mockClear();
+  });
+
+  it("renders StoreLocatorMap with correct props when coordinates are numeric", () => {
+    const { getByTestId } = render(<MapBlock lat={1} lng={2} zoom={5} />);
+    expect(getByTestId("map")).toBeInTheDocument();
+    expect(mockStoreLocatorMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        locations: [{ lat: 1, lng: 2 }],
+        zoom: 5,
+        heightClass: "h-full",
+      }),
+      {}
+    );
+  });
+
+  it.each([
+    { lat: undefined, lng: 1 },
+    { lat: 1, lng: undefined },
+    { lat: undefined, lng: undefined },
+    { lat: "1" as any, lng: 2 },
+    { lat: 1, lng: "2" as any },
+    { lat: "1" as any, lng: "2" as any },
+  ])("returns null when lat/lng invalid: %o", (props) => {
+    const { container } = render(<MapBlock {...(props as any)} />);
+    expect(container.firstChild).toBeNull();
+    expect(mockStoreLocatorMap).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests ensuring MapBlock renders StoreLocatorMap with numeric lat/lng
- ensure MapBlock returns null for missing or non-number coordinates

## Testing
- `pnpm -r build` *(fails: prisma types unknown)*
- `pnpm --filter @acme/ui test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc45bda1ac832f8b826fb62f840d20