### PR TITLE
test: cover preview device storage

### DIFF
--- a/packages/ui/src/hooks/__tests__/usePreviewDevice.responsive.test.tsx
+++ b/packages/ui/src/hooks/__tests__/usePreviewDevice.responsive.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, act } from "@testing-library/react";
+import { usePreviewDevice, PREVIEW_DEVICE_STORAGE_KEY } from "../usePreviewDevice";
+import { useEffect } from "react";
+
+describe("usePreviewDevice", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1200,
+    });
+  });
+
+  function useResponsivePreview() {
+    const [device, setDevice] = usePreviewDevice("desktop");
+    useEffect(() => {
+      const handler = () => {
+        const w = window.innerWidth;
+        if (w < 768) setDevice("mobile");
+        else if (w < 1024) setDevice("tablet");
+        else setDevice("desktop");
+      };
+      window.addEventListener("resize", handler);
+      handler();
+      return () => window.removeEventListener("resize", handler);
+    }, [setDevice]);
+    return device;
+  }
+
+  it("returns device string for breakpoints", () => {
+    const { result } = renderHook(() => useResponsivePreview());
+
+    expect(result.current).toBe("desktop");
+
+    act(() => {
+      (window as any).innerWidth = 500;
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current).toBe("mobile");
+
+    act(() => {
+      (window as any).innerWidth = 800;
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current).toBe("tablet");
+
+    act(() => {
+      (window as any).innerWidth = 1300;
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current).toBe("desktop");
+    expect(localStorage.getItem(PREVIEW_DEVICE_STORAGE_KEY)).toBe("desktop");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `usePreviewDevice` to verify default, stored, and failure cases
- retain prior responsive breakpoint coverage in a dedicated test file

## Testing
- `pnpm install`
- `pnpm -r build` (fails: @acme/platform-core build TS18046 errors)
- `pnpm --filter @acme/ui exec jest packages/ui/src/hooks/__tests__/usePreviewDevice.test.tsx packages/ui/src/hooks/__tests__/usePreviewDevice.responsive.test.tsx --runInBand --config ../../jest.config.cjs`
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68bc45c228c0832f8b844888d4c7e232