### PR TITLE
test(auth): add coverage for session store and mfa

### DIFF
--- a/packages/auth/src/__tests__/memoryStore.test.ts
+++ b/packages/auth/src/__tests__/memoryStore.test.ts
@@ -49,6 +49,17 @@ describe("MemorySessionStore", () => {
     await expect(store.get(record.sessionId)).resolves.toBeNull();
   });
 
+  it("purges expired sessions on access", async () => {
+    const store = new MemorySessionStore(1);
+    const record = createRecord("s1");
+    await store.set(record);
+
+    jest.advanceTimersByTime(1001);
+    await store.get(record.sessionId);
+
+    expect((store as any).sessions.has(record.sessionId)).toBe(false);
+  });
+
   it("list returns only unexpired sessions for the specified customerId", async () => {
     const store = new MemorySessionStore(1);
     const first = createRecord("s1");
@@ -77,6 +88,7 @@ describe("MemorySessionStore", () => {
 
     await expect(store.get(record.sessionId)).resolves.toBeNull();
     await expect(store.list(record.customerId)).resolves.toEqual([]);
+    expect((store as any).sessions.has(record.sessionId)).toBe(false);
   });
 });
 

--- a/packages/auth/src/__tests__/mfa.test.ts
+++ b/packages/auth/src/__tests__/mfa.test.ts
@@ -101,6 +101,32 @@ describe("mfa", () => {
       expect(update).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });
+
+    it("returns true when verification succeeds", async () => {
+      const { verifyMfa } = await import("../mfa");
+      findUnique.mockResolvedValue({
+        customerId: "cust",
+        secret: "secret",
+        enabled: false,
+      });
+      verify.mockReturnValue(true);
+
+      await expect(verifyMfa("cust", "123456")).resolves.toBe(true);
+      expect(update).toHaveBeenCalled();
+    });
+
+    it("returns false when verification fails", async () => {
+      const { verifyMfa } = await import("../mfa");
+      findUnique.mockResolvedValue({
+        customerId: "cust",
+        secret: "secret",
+        enabled: false,
+      });
+      verify.mockReturnValue(false);
+
+      await expect(verifyMfa("cust", "000000")).resolves.toBe(false);
+      expect(update).not.toHaveBeenCalled();
+    });
   });
 
   describe("isMfaEnabled", () => {

--- a/packages/auth/src/__tests__/session.test.ts
+++ b/packages/auth/src/__tests__/session.test.ts
@@ -146,6 +146,16 @@ it("getCustomerSession returns null for invalid token", async () => {
   await expect(getCustomerSession()).resolves.toBeNull();
 });
 
+it("getCustomerSession skips session store when token invalid", async () => {
+  const { getCustomerSession } = await import("../session");
+
+  mockCookies.get.mockReturnValue({ value: "bad" });
+  unsealData.mockRejectedValue(new Error("bad"));
+
+  await expect(getCustomerSession()).resolves.toBeNull();
+  expect(mockSessionStore.get).not.toHaveBeenCalled();
+});
+
 it("getCustomerSession returns null when SESSION_SECRET is undefined", async () => {
   delete process.env.SESSION_SECRET;
   const { getCustomerSession } = await import("../session");


### PR DESCRIPTION
## Summary
- ensure memory store purges expired sessions and removes deleted keys
- test MFA verification for success and failure outcomes
- verify invalid session tokens skip store lookup

## Testing
- `pnpm -r build` *(fails: TS18046 'prisma.*' is of type 'unknown')*
- `pnpm --filter @acme/auth test` *(fails: Cannot find module './parseJsonBody' from 'packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bc464073e0832fbb5bd7eb1c48e9c3