### PR TITLE
test: add zod error map coverage

### DIFF
--- a/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
+++ b/packages/zod-utils/src/__tests__/zodErrorMap.test.ts
@@ -134,13 +134,18 @@ describe("friendlyErrorMap", () => {
 test("applyFriendlyZodMessages sets global error map", () => {
   const original = z.getErrorMap();
   const schema = z.string().min(3);
-
   const before = schema.safeParse("hi");
-  expect(before.error.issues[0].message).not.toBe("Must be at least 3 characters");
+  expect(before.error.issues[0].message).not.toBe(
+    "Must be at least 3 characters",
+  );
 
   applyFriendlyZodMessages();
+  expect(z.getErrorMap()).toBe(friendlyErrorMap);
+
   const after = schema.safeParse("hi");
-  expect(after.error.issues[0].message).toBe("Must be at least 3 characters");
+  expect(after.error.issues[0].message).toBe(
+    "Must be at least 3 characters",
+  );
 
   z.setErrorMap(original);
 });


### PR DESCRIPTION
## Summary
- expand zod error map tests for each issue code branch
- ensure applying friendly messages sets global zod error map

## Testing
- `pnpm install`
- `pnpm --filter @acme/zod-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68bc52e2bd2c832f9e295135eb39f3e9