### PR TITLE
test: align auth secret in cms middleware test

### DIFF
--- a/cypress/e2e/cms-middleware.cy.ts
+++ b/cypress/e2e/cms-middleware.cy.ts
@@ -1,6 +1,6 @@
 import type { CookieValue } from "cypress";
 
-const SECRET = "test-nextauth-secret";
+const SECRET = "test-nextauth-secret-32-chars-long-string!";
 const SHOP = "demo";
 
 function sign(role: string) {


### PR DESCRIPTION
## Summary
- use 32 character auth secret in cms middleware cypress test to match jest and env defaults

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma models typed as unknown)*
- `pnpm exec start-server-and-test "sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'" http://localhost:3006 "pnpm exec cypress run --spec cypress/e2e/cms-middleware.cy.ts"` *(fails: Server Actions must be async functions)*

------
https://chatgpt.com/codex/tasks/task_e_68bc53d86084832f8ba5d13f988a38be