### PR TITLE
test(ui): add usePreviewDevice storage tests

### DIFF
--- a/packages/ui/src/hooks/__tests__/usePreviewDevice.test.tsx
+++ b/packages/ui/src/hooks/__tests__/usePreviewDevice.test.tsx
@@ -6,42 +6,29 @@ import {
 
 describe("usePreviewDevice", () => {
   beforeEach(() => {
+    localStorage.clear();
     jest.restoreAllMocks();
   });
 
-  it("defaults to the initial id when no value is stored", () => {
-    jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
-    const { result } = renderHook(() => usePreviewDevice("desktop"));
-
-    expect(result.current[0]).toBe("desktop");
-    expect(window.localStorage.getItem).toHaveBeenCalledWith(
-      PREVIEW_DEVICE_STORAGE_KEY,
-    );
-  });
-
-  it("loads a stored device id", async () => {
-    jest.spyOn(Storage.prototype, "getItem").mockReturnValue("tablet");
-    const setItem = jest
-      .spyOn(Storage.prototype, "setItem")
-      .mockImplementation(() => undefined);
+  it("uses the device id stored in localStorage", async () => {
+    const getItem = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockReturnValue("tablet");
+    const setItem = jest.spyOn(Storage.prototype, "setItem");
 
     const { result } = renderHook(() => usePreviewDevice("desktop"));
 
     await waitFor(() => expect(result.current[0]).toBe("tablet"));
+    expect(getItem).toHaveBeenCalledWith(PREVIEW_DEVICE_STORAGE_KEY);
     expect(setItem).toHaveBeenCalledWith(
       PREVIEW_DEVICE_STORAGE_KEY,
       "tablet",
     );
   });
 
-  it("continues gracefully when storage access fails", () => {
+  it("falls back to the initial id when storage access throws", () => {
     jest
       .spyOn(Storage.prototype, "getItem")
-      .mockImplementation(() => {
-        throw new Error("denied");
-      });
-    jest
-      .spyOn(Storage.prototype, "setItem")
       .mockImplementation(() => {
         throw new Error("denied");
       });
@@ -49,10 +36,42 @@ describe("usePreviewDevice", () => {
     const { result } = renderHook(() => usePreviewDevice("desktop"));
 
     expect(result.current[0]).toBe("desktop");
+  });
+
+  it("updates device id even when persistence fails", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+    const setItem = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+
+    const { result } = renderHook(() => usePreviewDevice("desktop"));
+
+    expect(() =>
+      act(() => {
+        result.current[1]("mobile");
+      }),
+    ).not.toThrow();
+
+    expect(result.current[0]).toBe("mobile");
+    expect(setItem).toHaveBeenCalledWith(
+      PREVIEW_DEVICE_STORAGE_KEY,
+      "mobile",
+    );
+    expect(localStorage.getItem(PREVIEW_DEVICE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("persists device id changes", async () => {
+    const { result } = renderHook(() => usePreviewDevice("desktop"));
+
     act(() => {
       result.current[1]("mobile");
     });
-    expect(result.current[0]).toBe("mobile");
+
+    await waitFor(() =>
+      expect(localStorage.getItem(PREVIEW_DEVICE_STORAGE_KEY)).toBe("mobile"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- improve usePreviewDevice tests to verify stored device retrieval
- ensure hook swallows storage errors and avoids crashing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types unknown)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_68bc52e4701c832f89e3c5a53c87fb8f