### PR TITLE
chore: add global Cypress support file

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     baseUrl: process.env.CYPRESS_BASE_URL || "http://localhost:3006",
-    supportFile: false,
+    supportFile: "cypress/support/index.ts",
     specPattern: "cypress/e2e/**/*.cy.ts",
   },
 });

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,0 +1,10 @@
+/// <reference types="cypress" />
+
+// Prevent tests from failing on uncaught exceptions originating from the app
+Cypress.on("uncaught:exception", (_err, _runnable) => {
+  // returning false here prevents Cypress from failing the test
+  return false;
+});
+
+// You can add custom Cypress commands here if needed.
+// e.g., Cypress.Commands.add("login", (email, password) => { ... });


### PR DESCRIPTION
## Summary
- ensure Cypress loads support file before tests
- suppress uncaught exceptions and leave space for custom commands

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL from @acme/platform-core build)*
- `pnpm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68bc53ceda94832fbbe0c69672cf00ea