### PR TITLE
test: expand token color coverage

### DIFF
--- a/packages/ui/src/hooks/__tests__/useTokenColors.test.ts
+++ b/packages/ui/src/hooks/__tests__/useTokenColors.test.ts
@@ -48,6 +48,22 @@ describe("useTokenColors", () => {
     expect(result.current).toBeNull();
   });
 
+  it("returns contrast warning for low contrast when token starts with --color-fg", () => {
+    mockGetContrast.mockReturnValue(3);
+    mockSuggestContrastColor.mockReturnValue("#123456");
+    const tokens = {
+      "--color-bg-secondary": "#ffffff",
+    } as unknown as TokenMap;
+    const { result } = renderHook(() =>
+      useTokenColors("--color-fg-secondary", "#111111", tokens, {} as TokenMap)
+    );
+    expect(mockSuggestContrastColor).toHaveBeenCalledWith(
+      "#111111",
+      "#ffffff"
+    );
+    expect(result.current).toEqual({ contrast: 3, suggestion: "#123456" });
+  });
+
   it("pairs *-fg with base key", () => {
     mockGetContrast.mockReturnValue(5);
     const tokens = {
@@ -59,6 +75,22 @@ describe("useTokenColors", () => {
     expect(mockGetContrast).toHaveBeenCalledWith("#000000", "#ffffff");
     expect(mockSuggestContrastColor).not.toHaveBeenCalled();
     expect(result.current).toBeNull();
+  });
+
+  it("returns contrast warning for low contrast when token ends with -fg", () => {
+    mockGetContrast.mockReturnValue(3);
+    mockSuggestContrastColor.mockReturnValue("#123456");
+    const tokens = {
+      "--brand": "#ffffff",
+    } as unknown as TokenMap;
+    const { result } = renderHook(() =>
+      useTokenColors("--brand-fg", "#111111", tokens, {} as TokenMap)
+    );
+    expect(mockSuggestContrastColor).toHaveBeenCalledWith(
+      "#111111",
+      "#ffffff"
+    );
+    expect(result.current).toEqual({ contrast: 3, suggestion: "#123456" });
   });
 
   it("finds candidate -fg key in base tokens", () => {
@@ -74,7 +106,23 @@ describe("useTokenColors", () => {
     expect(result.current).toBeNull();
   });
 
-  it("returns contrast warning for low contrast", () => {
+  it("returns contrast warning for low contrast when base token has -fg variant", () => {
+    mockGetContrast.mockReturnValue(3);
+    mockSuggestContrastColor.mockReturnValue("#123456");
+    const baseTokens = {
+      "--accent-fg": "#000000",
+    } as unknown as TokenMap;
+    const { result } = renderHook(() =>
+      useTokenColors("--accent", "#111111", {} as TokenMap, baseTokens)
+    );
+    expect(mockSuggestContrastColor).toHaveBeenCalledWith(
+      "#111111",
+      "#000000"
+    );
+    expect(result.current).toEqual({ contrast: 3, suggestion: "#123456" });
+  });
+
+  it("returns contrast warning for low contrast when token starts with --color-bg", () => {
     mockGetContrast.mockReturnValue(3);
     mockSuggestContrastColor.mockReturnValue("#123456");
     const tokens = {


### PR DESCRIPTION
## Summary
- test all token color pairings for low-contrast suggestions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types unknown in @acme/platform-core)*
- `pnpm --filter @acme/ui test` *(fails: cart API handlers, parseJsonBody import)*

------
https://chatgpt.com/codex/tasks/task_e_68bc57067934832f962d9bfe5a2fde33