### PR TITLE
Fix MapBlock test for React 18 context behavior

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx
@@ -23,13 +23,13 @@ describe("MapBlock", () => {
   it("renders StoreLocatorMap with correct props when coordinates are numeric", () => {
     const { getByTestId } = render(<MapBlock lat={1} lng={2} zoom={5} />);
     expect(getByTestId("map")).toBeInTheDocument();
-    expect(mockStoreLocatorMap).toHaveBeenCalledWith(
+    expect(mockStoreLocatorMap).toHaveBeenCalledTimes(1);
+    expect(mockStoreLocatorMap.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         locations: [{ lat: 1, lng: 2 }],
         zoom: 5,
         heightClass: "h-full",
-      }),
-      {}
+      })
     );
   });
 


### PR DESCRIPTION
## Summary
- adjust MapBlock test to check props from first call instead of expecting context argument

## Testing
- `pnpm --filter @acme/ui test -- src/components/cms/blocks/__tests__/MapBlock.test.tsx`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run build` *(fails: TS18046: prisma.* is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_68bc5b67a3f4832fbc0010dc6549c2f7