### PR TITLE
chore: add Cypress global support file

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,6 +1,12 @@
 // cypress/support/index.ts
-// This file is automatically processed before test files.
-// Add global Cypress custom commands and behavior here.
-// See https://on.cypress.io/configuration for more information.
 
-export {};
+/// <reference types="cypress" />
+
+// Prevent tests from failing on uncaught exceptions originating from the app
+Cypress.on("uncaught:exception", (_err, _runnable) => {
+  // returning false here prevents Cypress from failing the test
+  return false;
+});
+
+// You can add custom Cypress commands here if needed.
+// e.g., Cypress.Commands.add("login", (email, password) => { ... });


### PR DESCRIPTION
## Summary
- add global Cypress support file to silence app exceptions and centralize custom commands

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.<model>' is of type 'unknown')*
- `pnpm lint` *(fails: /workspace/base-shop/packages/config/test/utils/withEnv.ts was not found by the project service)*
- `pnpm test` *(fails: run failed: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a4acdfc832f81312b679e406798