### PR TITLE
docs: add database setup instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,21 @@
 # Installation
 
-Requires **Node.js >=20** and **pnpm 10.12.1**.
-See [setup](./setup.md) for full setup and CI guidance.
+Requires **Node.js >=20**, **pnpm 10.12.1**, and a `DATABASE_URL` pointing to your
+PostgreSQL instance. See [setup](./setup.md) for full setup and CI guidance.
+
+Create a `.env` file with your database connection string and apply migrations
+before starting:
+
+```env
+DATABASE_URL="postgres://user:password@localhost:5432/shop"
+```
+
+```bash
+pnpm prisma migrate dev
+pnpm tsx packages/platform-core/prisma/seed.ts
+```
+
+If `DATABASE_URL` is unset, the platform falls back to an in-memory test stub.
 
 ## Getting Started
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,8 +4,24 @@
 
 - **Node.js** v20 or newer
 - **pnpm** v10 (repo uses pnpm@10.12.1)
+- `DATABASE_URL` in your `.env` pointing to a PostgreSQL database
 
 See [Next.js configuration](./nextjs-config.md) for Cloudflare-specific framework options.
+
+Example `.env` entry:
+
+```env
+DATABASE_URL="postgres://user:password@localhost:5432/shop"
+```
+
+Run migrations and seed data:
+
+```bash
+pnpm prisma migrate dev
+pnpm tsx packages/platform-core/prisma/seed.ts
+```
+
+If `DATABASE_URL` is unset, the platform falls back to an in-memory test stub.
 
 For a one-liner that scaffolds a shop, validates the environment, and starts the dev server:
 


### PR DESCRIPTION
## Summary
- document DATABASE_URL requirement and fallback stub
- include migration and seed commands in install and setup guides

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is type unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5cbcaed8832f97f6c4e04777bbe1