### PR TITLE
test: iterate reverse logistics helpers

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/reverseLogisticsEvents.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/reverseLogisticsEvents.server.test.ts
@@ -109,22 +109,17 @@ describe("listEvents", () => {
 });
 
 describe("reverse logistics event helpers", () => {
-
-  it.each([
-    ["received", reverseLogisticsEvents.received],
-    ["cleaning", reverseLogisticsEvents.cleaning],
-    ["repair", reverseLogisticsEvents.repair],
-    ["qa", reverseLogisticsEvents.qa],
-    ["available", reverseLogisticsEvents.available],
-  ])("records %s events", async (name, fn) => {
-    await fn("shop1", "session1", "time");
-    expect(create).toHaveBeenCalledWith({
-      data: {
-        shop: "shop1",
-        sessionId: "session1",
-        event: name,
-        createdAt: "time",
-      },
-    });
+  it("records each event", async () => {
+    for (const [name, fn] of Object.entries(reverseLogisticsEvents)) {
+      await fn("shop1", "session1", "time");
+      expect(create).toHaveBeenLastCalledWith({
+        data: {
+          shop: "shop1",
+          sessionId: "session1",
+          event: name,
+          createdAt: "time",
+        },
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- refactor reverse logistics helper tests to iterate over all helpers and assert event names

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test src/repositories/__tests__/reverseLogisticsEvents.server.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc5cb7a0c0832f86149e6c66a8316c