### PR TITLE
Add account profile integration tests using Prisma stub

### DIFF
--- a/apps/shop-bcd/__tests__/account-profile-api.integration.test.ts
+++ b/apps/shop-bcd/__tests__/account-profile-api.integration.test.ts
@@ -1,0 +1,36 @@
+/** @jest-environment node */
+
+jest.mock("@acme/zod-utils/initZod", () => ({}));
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+
+import { getCustomerSession } from "@auth";
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../src/app/api/account/profile/route";
+import { updateCustomerProfile } from "@platform-core/customerProfiles";
+
+describe("/api/account/profile integration", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns 404 when profile is missing", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust-404" });
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when email is duplicate", async () => {
+    await updateCustomerProfile("cust-1", { name: "Jane", email: "jane@example.com" });
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cust-2" });
+    const req = new NextRequest("http://localhost/api/account/profile", {
+      method: "PUT",
+      body: JSON.stringify({ name: "John", email: "jane@example.com" }),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -47,11 +47,21 @@ export async function PUT(req: NextRequest) {
     return parsed.response;
   }
 
-  await updateCustomerProfile(
-    session.customerId,
-    parsed.data as { name: string; email: string },
-  );
+  try {
+    await updateCustomerProfile(
+      session.customerId,
+      parsed.data as { name: string; email: string },
+    );
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Conflict")) {
+      return NextResponse.json({ error: err.message }, { status: 409 });
+    }
+    throw err;
+  }
   const profile = await getCustomerProfile(session.customerId);
+  if (!profile) {
+    return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+  }
   return NextResponse.json({ ok: true, profile });
 }
 

--- a/packages/platform-core/src/customerProfiles.ts
+++ b/packages/platform-core/src/customerProfiles.ts
@@ -2,12 +2,10 @@
 import type { CustomerProfile } from "@acme/types";
 import { prisma } from "./db";
 
-export async function getCustomerProfile(customerId: string): Promise<CustomerProfile> {
-  const profile = await prisma.customerProfile.findUnique({ where: { customerId } });
-  if (!profile) {
-    throw new Error("Customer profile not found");
-  }
-  return profile;
+export async function getCustomerProfile(
+  customerId: string,
+): Promise<CustomerProfile | null> {
+  return prisma.customerProfile.findUnique({ where: { customerId } });
 }
 
 export async function updateCustomerProfile(


### PR DESCRIPTION
## Summary
- add in-memory customer profile storage to Prisma stub
- propagate duplicate email errors with 409 in account profile route
- exercise getCustomerProfile/updateCustomerProfile with new integration tests

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/account-profile-api.integration.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68bc5cbb0a30832fbd65afd730babb17