### PR TITLE
docs: add Prisma testing guidance

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,6 +18,23 @@ Create branches from `main` and name them descriptively (e.g., `feat/login-form`
 
 Before submitting changes, run [`pnpm lint`](../package.json#L24) and [`pnpm test`](../package.json#L28) to ensure the codebase is formatted correctly and the test suite passes.
 
+## Testing with Prisma
+
+Tests run with a stubbed Prisma client by default, so `pnpm test` completes
+without requiring a database.
+
+To execute tests against a real Postgres instance, set `DATABASE_URL` and run
+pending migrations before running the tests:
+
+```bash
+export DATABASE_URL=postgres://...
+pnpm prisma migrate deploy
+pnpm test
+```
+
+Mock Prisma calls in unit tests to keep them fast and focused. Use a Postgres
+database for integration tests to verify end-to-end behavior.
+
 ## API documentation
 
 Generate API reference docs for all public packages by running:


### PR DESCRIPTION
## Summary
- document how to run tests with Prisma, including Postgres setup and mocking guidance

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm lint` *(fails: parsing error in packages/config/test/utils/withEnv.ts)*
- `pnpm test` *(fails: command exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5cbf9d00832f9eeea25136acca44