### PR TITLE
docs: add orders and subscription usage modules

### DIFF
--- a/docs/orders.md
+++ b/docs/orders.md
@@ -1,0 +1,40 @@
+# Orders
+
+## Purpose
+The orders module manages rental orders for a shop. It stores each order's status lifecycle and deposit information.
+
+## Key Prisma model
+`RentalOrder` contains fields such as:
+- `id` – primary key.
+- `shop` and `sessionId` – unique per order.
+- `deposit` – amount held for the rental.
+- Timestamps: `startedAt`, `returnedAt`, `refundedAt`, `fulfilledAt`, `shippedAt`, `deliveredAt`, `cancelledAt`.
+- Optional fields like `expectedReturnDate`, `returnDueDate`, `customerId`, `damageFee`, `riskLevel`, `riskScore`, `flaggedForReview`, `trackingNumber`, `labelUrl`, and `returnStatus`.
+
+Unique constraints:
+- `@@unique([shop, sessionId])`
+- `@@unique([shop, trackingNumber])`
+- `@@index([customerId])`
+
+## Public API
+```ts
+import { addOrder, listOrders, markShipped } from "@platform-core/orders";
+
+// create a new order
+await addOrder("shop1", "sess_123", 500, "2025-01-01", undefined, "cust_1");
+
+// list orders for a shop
+const orders = await listOrders("shop1");
+
+// update lifecycle status
+await markShipped("shop1", "sess_123");
+```
+Other lifecycle helpers include `markFulfilled`, `markDelivered`, `markCancelled`, `markReturned`, `markRefunded`, `updateRisk`, `getOrdersForCustomer`, `setReturnTracking`, and `setReturnStatus`.
+
+## Interactions
+When `addOrder` is called with a `customerId` and the shop has subscriptions enabled, it calls `incrementSubscriptionUsage` to record a shipment for that customer. Orders are also tracked via the analytics module through `trackOrder`.
+
+## Notes
+- Lifecycle fields (e.g., `startedAt`, `returnedAt`, `refundedAt`) track the order's progress.
+- The module ensures tracking number and session ID uniqueness per shop.
+- Failed `markReturned` or `markRefunded` calls return `null` if the order does not exist.

--- a/docs/subscription-usage.md
+++ b/docs/subscription-usage.md
@@ -1,0 +1,35 @@
+# Subscription Usage
+
+## Purpose
+Tracks how many shipments each subscribed customer uses per month.
+
+## Key Prisma model
+`SubscriptionUsage` fields:
+- `id` – primary key.
+- `shop` – shop identifier.
+- `customerId` – customer using the subscription.
+- `month` – ISO `YYYY-MM` string.
+- `shipments` – number of shipments in that month.
+
+Unique constraint:
+- `@@unique([shop, customerId, month])`
+
+## Public API
+```ts
+import { getSubscriptionUsage, incrementSubscriptionUsage } from "@platform-core/subscriptionUsage";
+
+// read current usage
+await getSubscriptionUsage("shop1", "cust_1", "2025-01");
+
+// increment shipments for the month
+await incrementSubscriptionUsage("shop1", "cust_1", "2025-01", 2);
+```
+`incrementSubscriptionUsage` uses an upsert so the first call creates the record and subsequent calls increment `shipments`.
+
+## Interactions
+The `addOrder` function from the orders module invokes `incrementSubscriptionUsage` whenever a qualifying order ships for a subscribed customer.
+
+## Notes
+- Shipment counts are scoped by `shop`, `customerId`, and `month`.
+- The module assumes month strings are normalized (`YYYY-MM`).
+- No automatic reset occurs; a new record is created for each month.


### PR DESCRIPTION
## Summary
- document orders module purpose, API, interactions, and constraints
- document subscription usage module and how it's incremented by orders

## Testing
- `pnpm -r build` (fails: 'prisma.rentalOrder' is of type 'unknown')
- `pnpm test` (fails: act warning in `StepHomePage.tsx`)


------
https://chatgpt.com/codex/tasks/task_e_68bc5cbed498832fb951c26ea0e06cdf