### PR TITLE
feat: centralize customer mfa type

### DIFF
--- a/packages/auth/src/mfa.ts
+++ b/packages/auth/src/mfa.ts
@@ -1,6 +1,7 @@
 // packages/auth/src/mfa.ts
 import { authenticator } from "otplib";
 import { prisma } from "@acme/platform-core/db";
+import type { CustomerMfa } from "@acme/types";
 
 export interface MfaEnrollment {
   secret: string;
@@ -22,7 +23,9 @@ export async function verifyMfa(
   customerId: string,
   token: string
 ): Promise<boolean> {
-  const record = await prisma.customerMfa.findUnique({ where: { customerId } });
+  const record: CustomerMfa | null = await prisma.customerMfa.findUnique({
+    where: { customerId },
+  });
   if (!record) return false;
   const valid = authenticator.verify({ token, secret: record.secret });
   if (valid && !record.enabled) {
@@ -35,6 +38,8 @@ export async function verifyMfa(
 }
 
 export async function isMfaEnabled(customerId: string): Promise<boolean> {
-  const record = await prisma.customerMfa.findUnique({ where: { customerId } });
+  const record: CustomerMfa | null = await prisma.customerMfa.findUnique({
+    where: { customerId },
+  });
   return record?.enabled ?? false;
 }

--- a/packages/platform-machine/src/reverseLogisticsService.ts
+++ b/packages/platform-machine/src/reverseLogisticsService.ts
@@ -1,5 +1,5 @@
 import { coreEnv } from "@acme/config/env/core";
-import type { RentalOrder } from "@acme/types";
+import type { ReverseLogisticsEventName } from "@acme/types";
 import {
   markAvailable,
   markCleaning,
@@ -18,7 +18,7 @@ const DATA_ROOT = resolveDataRoot();
 
 interface ReverseLogisticsEvent {
   sessionId: string;
-  status: NonNullable<RentalOrder["status"]>;
+  status: ReverseLogisticsEventName;
 }
 
 export async function writeReverseLogisticsEvent(

--- a/packages/types/src/CustomerMfa.d.ts
+++ b/packages/types/src/CustomerMfa.d.ts
@@ -1,0 +1,5 @@
+export interface CustomerMfa {
+  customerId: string;
+  secret: string;
+  enabled: boolean;
+}

--- a/packages/types/src/CustomerMfa.ts
+++ b/packages/types/src/CustomerMfa.ts
@@ -1,0 +1,5 @@
+export interface CustomerMfa {
+  customerId: string;
+  secret: string;
+  enabled: boolean;
+}

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -23,6 +23,7 @@ export * from "./SubscriptionUsage";
 export * from "./CustomerProfile";
 export * from "./User";
 export * from "./ReverseLogisticsEvent";
+export * from "./CustomerMfa";
 export * from "./Coverage";
 export * from "./upgrade";
 export * from "./ExampleProps";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,6 +23,7 @@ export * from "./SubscriptionUsage";
 export * from "./CustomerProfile";
 export * from "./User";
 export * from "./ReverseLogisticsEvent";
+export * from "./CustomerMfa";
 export * from "./Coverage";
 export * from "./upgrade";
 export * from "./ExampleProps";


### PR DESCRIPTION
## Summary
- add CustomerMfa interface to shared types and export it
- use shared ReverseLogisticsEventName and CustomerMfa types in modules

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_68bc5cc29b70832f9f003772e8fee0ba