### PR TITLE
chore(env): add database url to templates

### DIFF
--- a/apps/cms/.env.example
+++ b/apps/cms/.env.example
@@ -1,7 +1,7 @@
 # apps/cms/.env.example
 NEXTAUTH_URL=http://localhost:3006
+DATABASE_URL=postgresql://user:password@localhost:5432/db
 STRIPE_SECRET_KEY=sk_test_placeholder
-STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 # 32+ characters recommended for secrets
 NEXTAUTH_SECRET=dev-nextauth-secret-32-chars-long-string!

--- a/apps/cms/.env.production
+++ b/apps/cms/.env.production
@@ -4,6 +4,8 @@ SANITY_API_VERSION=2021-10-21
 SANITY_DATASET=production
 SANITY_API_TOKEN=dummy-api-token
 SANITY_PREVIEW_SECRET=dummy-preview-secret
+# Database connection for Prisma
+DATABASE_URL=postgresql://user:password@localhost:5432/db
 # TODO: Replace Stripe dummy values with real credentials before deployment
 STRIPE_SECRET_KEY=dummy-stripe-secret
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy-publishable-key

--- a/apps/template-app/.env.production
+++ b/apps/template-app/.env.production
@@ -4,6 +4,8 @@ SANITY_API_VERSION=2021-10-21
 SANITY_DATASET=production
 SANITY_API_TOKEN=dummy-api-token
 SANITY_PREVIEW_SECRET=dummy-preview-secret
+# Database connection for Prisma
+DATABASE_URL=postgresql://user:password@localhost:5432/db
 # TODO: Replace Stripe dummy values with real credentials before deployment
 STRIPE_SECRET_KEY=dummy-stripe-secret
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy-publishable-key


### PR DESCRIPTION
## Summary
- add `DATABASE_URL` to CMS env examples
- document database URL in template-app and CMS production env templates
- drop unused `STRIPE_PUBLISHABLE_KEY`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5cc359f4832f8336c8a070e76638