### PR TITLE
test: cover pages repo prisma and fallback

### DIFF
--- a/packages/platform-core/__tests__/pagesRepo.test.ts
+++ b/packages/platform-core/__tests__/pagesRepo.test.ts
@@ -1,35 +1,64 @@
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-import { jest } from '@jest/globals';
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { jest } from "@jest/globals";
 
-const mockPages: any[] = [];
+// Minimal prisma mock to observe calls
+const prisma = {
+  page: {
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    deleteMany: jest.fn(),
+    update: jest.fn(),
+  },
+};
 
-jest.mock('../src/db', () => ({
-  prisma: {
-    page: {
-      findMany: jest.fn(async ({ where }: any) => mockPages.filter(p => p.shopId === where.shopId)),
-      upsert: jest.fn(async ({ create }: any) => { mockPages.push(create); return create; }),
-      deleteMany: jest.fn(async ({ where }: any) => { const idx = mockPages.findIndex(p => p.id === where.id); if (idx === -1) return { count: 0 }; mockPages.splice(idx,1); return { count:1 }; }),
-      findUnique: jest.fn(async ({ where }: any) => mockPages.find(p => p.id === where.id) || null),
-      update: jest.fn(async ({ where, data }: any) => { const idx = mockPages.findIndex(p => p.id === where.id); mockPages[idx] = { ...mockPages[idx], ...data }; return mockPages[idx]; }),
-    }
-  }
-}));
+jest.mock("../src/db", () => ({ prisma }));
 
-process.env.DATABASE_URL = 'postgres://localhost/test';
+process.env.DATABASE_URL = "postgres://localhost/test";
 
-describe('pages repository with prisma', () => {
-  it('performs CRUD operations through prisma', async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pagesrepo-'));
-    process.env.DATA_ROOT = path.join(dir, 'shops');
-    const repo = await import('../src/repositories/pages/index.server');
-    expect(await repo.getPages('shop1')).toEqual([]);
-    const page = { id:'1', slug:'home', status:'draft', components:[], seo:{ title:'Home' }, createdAt:'now', updatedAt:'now', createdBy:'tester' } as any;
-    await repo.savePage('shop1', page, undefined);
-    expect(mockPages).toHaveLength(1);
-    await repo.updatePage('shop1', { id:'1', slug:'start', updatedAt:'now' } as any, page);
-    await repo.deletePage('shop1', '1');
-    expect(mockPages).toHaveLength(0);
+describe("pages repository with prisma", () => {
+  let repo: typeof import("../src/repositories/pages/index.server");
+
+  beforeAll(async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pagesrepo-"));
+    process.env.DATA_ROOT = path.join(dir, "shops");
+    repo = await import("../src/repositories/pages/index.server");
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("performs CRUD operations through prisma", async () => {
+    const page = {
+      id: "1",
+      slug: "home",
+      status: "draft",
+      components: [],
+      seo: { title: { en: "Home" } },
+      createdAt: "now",
+      updatedAt: "now",
+      createdBy: "tester",
+    } as any;
+
+    prisma.page.findMany.mockResolvedValue([{ data: page }]);
+
+    const pages = await repo.getPages("shop1");
+    expect(prisma.page.findMany).toHaveBeenCalledWith({ where: { shopId: "shop1" } });
+    expect(pages[0]).toEqual(page);
+
+    prisma.page.upsert.mockResolvedValue({});
+    await repo.savePage("shop1", page, undefined);
+    expect(prisma.page.upsert).toHaveBeenCalled();
+
+    prisma.page.update.mockResolvedValue({});
+    await repo.updatePage("shop1", { id: "1", slug: "start", updatedAt: "now" }, page);
+    expect(prisma.page.update).toHaveBeenCalled();
+
+    prisma.page.deleteMany.mockResolvedValue({ count: 1 });
+    await repo.deletePage("shop1", "1");
+    expect(prisma.page.deleteMany).toHaveBeenCalledWith({ where: { id: "1", shopId: "shop1" } });
   });
 });
+

--- a/packages/platform-core/__tests__/pagesRepoFallback.test.ts
+++ b/packages/platform-core/__tests__/pagesRepoFallback.test.ts
@@ -67,6 +67,13 @@ describe("pages repository filesystem fallbacks", () => {
 
     const buf = await fs.readFile(path.join(root, shop, "pages.json"), "utf8");
     expect(JSON.parse(buf)).toEqual([page]);
+
+    const history = await fs.readFile(
+      path.join(root, shop, "pages.history.jsonl"),
+      "utf8"
+    );
+    const entry = JSON.parse(history.trim());
+    expect(entry.diff).toEqual(page);
   });
 
   it("deletePage throws when page not found", async () => {
@@ -133,5 +140,13 @@ describe("pages repository filesystem fallbacks", () => {
     const stored = JSON.parse(buf)[0];
     expect(stored.slug).toBe("b");
     expect(result.slug).toBe("b");
+
+    const history = await fs.readFile(
+      path.join(shopDir, "pages.history.jsonl"),
+      "utf8"
+    );
+    const diff = JSON.parse(history.trim()).diff;
+    expect(diff.slug).toBe("b");
+    expect(diff.updatedAt).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- add prisma-backed test suite for pages repository
- cover filesystem fallback with history writes when Prisma fails

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.user' is of type 'unknown')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest --ci --runInBand --detectOpenHandles --coverage=false --config jest.config.cjs packages/platform-core/__tests__/pagesRepo.test.ts packages/platform-core/__tests__/pagesRepoFallback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc5cb9a3cc832fabb0a308f27ecc14