### PR TITLE
test: extend initTheme coverage

### DIFF
--- a/packages/platform-core/src/utils/__tests__/initTheme.test.ts
+++ b/packages/platform-core/src/utils/__tests__/initTheme.test.ts
@@ -38,4 +38,100 @@ describe("initTheme", () => {
       false
     );
   });
+
+  it("applies dark theme from localStorage", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => "dark",
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn(),
+    });
+
+    // eslint-disable-next-line no-eval
+    eval(initTheme);
+
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(
+      true
+    );
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(
+      false
+    );
+  });
+
+  it("applies brandx theme from localStorage", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => "brandx",
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn(),
+    });
+
+    // eslint-disable-next-line no-eval
+    eval(initTheme);
+
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(
+      false
+    );
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(
+      true
+    );
+  });
+
+  it("uses system theme with prefers dark", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => "system",
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn().mockReturnValue({ matches: true }),
+    });
+
+    // eslint-disable-next-line no-eval
+    eval(initTheme);
+
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(
+      true
+    );
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(
+      false
+    );
+  });
+
+  it("uses system theme with prefers light", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => "system",
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn().mockReturnValue({ matches: false }),
+    });
+
+    // eslint-disable-next-line no-eval
+    eval(initTheme);
+
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(document.documentElement.classList.contains("theme-dark")).toBe(
+      false
+    );
+    expect(document.documentElement.classList.contains("theme-brandx")).toBe(
+      false
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend initTheme tests for dark and brandx themes
- cover system theme with both dark and light preferences

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test -- initTheme.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d42bb78832f8956d452d9153e40