### PR TITLE
test: cover replaceShopInPath for cms root

### DIFF
--- a/packages/platform-core/src/utils/__tests__/path-helpers.test.ts
+++ b/packages/platform-core/src/utils/__tests__/path-helpers.test.ts
@@ -1,6 +1,6 @@
 // packages/platform-core/src/utils/path-helpers.test.ts
-import { getShopFromPath } from "./getShopFromPath";
-import { replaceShopInPath } from "./replaceShopInPath";
+import { getShopFromPath } from "../getShopFromPath";
+import { replaceShopInPath } from "../replaceShopInPath";
 
 describe("getShopFromPath", () => {
   it("extracts shop codes from valid paths", () => {
@@ -29,6 +29,7 @@ describe("replaceShopInPath", () => {
 
   it("inserts shop codes when missing", () => {
     expect(replaceShopInPath("/cms/shop", "bravo")).toBe("/cms/shop/bravo");
+    expect(replaceShopInPath("/cms", "bravo")).toBe("/cms/shop/bravo");
     expect(replaceShopInPath(undefined, "bravo")).toBe("/cms/shop/bravo");
   });
 


### PR DESCRIPTION
## Summary
- ensure `replaceShopInPath('/cms', 'bravo')` returns `/cms/shop/bravo`
- correct test imports and expand coverage for `replaceShopInPath`

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: TS18046 in packages/platform-core build)*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/src/utils/__tests__/path-helpers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d437a0c832fb8173b3fe5bebee5