### PR TITLE
docs: explain SQLite inventory persistence and plan Prisma migration

### DIFF
--- a/docs/issues/inventory-prisma-migration.md
+++ b/docs/issues/inventory-prisma-migration.md
@@ -1,0 +1,39 @@
+# Migrate inventory repositories to Prisma
+
+## Summary
+Inventory persistence currently supports a SQLite backend implemented in `inventory.sqlite.server.ts`, storing each shop's data in `data/shops/<shop>/inventory.sqlite`. For consistency with the rest of the platform, which already uses Prisma and PostgreSQL, the inventory repositories should migrate to Prisma.
+
+## Goals
+- Replace custom SQLite and JSON backends with a Prisma-based repository.
+- Centralize inventory data in PostgreSQL alongside other models.
+
+## Prisma schema changes
+```prisma
+model InventoryItem {
+  id String @id @default(cuid())
+  shopId String
+  sku String
+  productId String?
+  variantAttributes Json @default("{}")
+  quantity Int
+  lowStockThreshold Int?
+  wearCount Int?
+  wearAndTearLimit Int?
+  maintenanceCycle Int?
+  Shop Shop @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  @@unique([shopId, sku, variantAttributes])
+}
+```
+
+## Data migration
+- Script to iterate through `data/shops/*/inventory.sqlite` databases and upsert records via Prisma.
+- Script to convert existing `inventory.json` files to the Prisma model.
+- Provide backup strategy for legacy files during migration.
+
+## Tasks
+- Extend `packages/platform-core/prisma/schema.prisma` with the `InventoryItem` model and generate a Prisma migration.
+- Implement a Prisma-backed `InventoryRepository`.
+- Update `inventory.server.ts` to default to the Prisma backend.
+- Add migration scripts for SQLite and JSON inventories.
+- Remove or deprecate old backends after successful migration.
+

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,22 @@
+# Persistence
+
+## Inventory persistence
+
+Inventory data can be stored using either a JSON file or a SQLite database. The active backend is selected by the `INVENTORY_BACKEND` environment variable, defaulting to the JSON implementation when unset.
+
+When `INVENTORY_BACKEND` is set to `sqlite`, the repository uses [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) and creates an `inventory.sqlite` file for each shop under the `data/shops/<shop>` directory determined by `DATA_ROOT`. The repository ensures the database exists and bootstraps a single `inventory` table containing SKU, optional product reference and variant attributes, quantity tracking and optional wear & tear fields.
+
+`DATA_ROOT` is resolved at runtime by walking up from the current working directory to find a `data/shops` folder or by honoring an explicit `DATA_ROOT` environment variable.
+
+SQLite operations are performed in transactions to provide atomic updates and avoid partial writes. This approach offers stronger consistency and concurrency guarantees compared to the JSON backend while keeping the deployment lightweight.
+
+*Per-shop SQLite location and schema:*
+```ts
+const dir = path.join(DATA_ROOT, shop);
+await fs.mkdir(dir, { recursive: true });
+const db = new ctor(path.join(dir, "inventory.sqlite"));
+db.exec(
+  "CREATE TABLE IF NOT EXISTS inventory (sku TEXT, productId TEXT, variantAttributes TEXT, quantity INTEGER, lowStockThreshold INTEGER, wearCount INTEGER, wearAndTearLimit INTEGER, maintenanceCycle INTEGER, PRIMARY KEY (sku, variantAttributes))",
+);
+```
+


### PR DESCRIPTION
## Summary
- document current SQLite inventory backend and rationale
- propose migrating inventory repositories to Prisma with schema and migration tasks

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.rentalOrder' is of type 'unknown')*
- `pnpm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68bc5cc471e4832f8c765964ccdf33e9