### PR TITLE
feat: make test fixtures path configurable

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
     env: {
       NEXTAUTH_SECRET:
         process.env.NEXTAUTH_SECRET ||
-        "test-nextauth-secret-32-chars-long-string!"
+        "test-nextauth-secret-32-chars-long-string!",
+      TEST_DATA_ROOT: process.env.TEST_DATA_ROOT || "test/data/shops"
     },
     defaultCommandTimeout: 10000
   }

--- a/cypress/e2e/cms-middleware.cy.ts
+++ b/cypress/e2e/cms-middleware.cy.ts
@@ -2,7 +2,7 @@ import type { CookieValue } from "cypress";
 
 const SECRET = "test-nextauth-secret-32-chars-long-string!";
 const SHOP = "demo";
-const dataDir = "test/data/shops";
+const dataDir = Cypress.env("TEST_DATA_ROOT");
 
 function sign(role: string) {
   return cy

--- a/test/e2e/page-builder.spec.ts
+++ b/test/e2e/page-builder.spec.ts
@@ -3,7 +3,7 @@
 describe("Page Builder happy path", () => {
   const shopId = "abc";
   const builderUrl = `/cms/shop/${shopId}/pages/home/builder`;
-  const dataDir = "test/data/shops";
+  const dataDir = Cypress.env("TEST_DATA_ROOT");
 
   it("drags a block, saves draft and publishes", () => {
     // programmatically sign in via NextAuth credentials provider

--- a/test/e2e/rental-return-flow.spec.ts
+++ b/test/e2e/rental-return-flow.spec.ts
@@ -4,7 +4,7 @@
 
 describe("Rental return flow", () => {
   const shopId = "abc";
-  const dataDir = "test/data/shops";
+  const dataDir = Cypress.env("TEST_DATA_ROOT");
   const sku = {
     id: "test-sku",
     slug: "test-sku",

--- a/test/e2e/seo-settings.spec.ts
+++ b/test/e2e/seo-settings.spec.ts
@@ -6,7 +6,7 @@
 
 describe("SEO settings", () => {
   const seoUrl = "/cms/shop/demo/settings/seo";
-  const dataDir = "test/data/shops";
+  const dataDir = Cypress.env("TEST_DATA_ROOT");
   const historyFile = `${dataDir}/demo/settings.history.jsonl`;
 
   it("switch language, edit meta and verify", () => {

--- a/test/e2e/theme-editor.spec.ts
+++ b/test/e2e/theme-editor.spec.ts
@@ -3,7 +3,7 @@
 describe("Theme editor", () => {
   const shop = "abc";
   const themeUrl = `/cms/shop/${shop}/themes`;
-  const dataDir = "test/data/shops";
+  const dataDir = Cypress.env("TEST_DATA_ROOT");
   const shopFile = `${dataDir}/${shop}/shop.json`;
 
   it("updates colors and typography and persists", () => {


### PR DESCRIPTION
## Summary
- add `TEST_DATA_ROOT` env var to Cypress config for test fixtures
- update E2E specs to resolve fixture paths via `Cypress.env("TEST_DATA_ROOT")`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm test` *(fails: run failed, command exited 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc625bbfe8832f812e4fa3c1a5d8b7