### PR TITLE
chore: rely on tsconfig for cypress types

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,7 +1,5 @@
 // cypress/support/index.ts
 
-/// <reference types="cypress" />
-
 // Prevent tests from failing on uncaught exceptions originating from the app
 Cypress.on("uncaught:exception", (_err, _runnable) => {
   // returning false here prevents Cypress from failing the test


### PR DESCRIPTION
## Summary
- remove outdated triple-slash Cypress types reference
- rely on `cypress/tsconfig.json` for type resolution

## Testing
- `pnpm exec tsc -p cypress/tsconfig.json --noEmit`
- `pnpm -r build` *(fails: prisma type is unknown in @acme/platform-core)*
- `pnpm test` *(aborted after ~48s)*

------
https://chatgpt.com/codex/tasks/task_e_68bc625e5660832fac5d1a2cd3d576e8