### PR TITLE
docs: add database overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ See [docs/install.md](docs/install.md) for setup and quickstart instructions.
 
 See [docs/architecture.md](docs/architecture.md) for a component layer overview.
 
+## Database
+
+The project uses [Prisma](https://www.prisma.io/) with PostgreSQL as the
+primary datastore. The schema includes:
+
+- `Shop` – JSON shop configuration.
+- `Page` – per-shop pages tied to a `Shop`.
+- `RentalOrder` – rental lifecycle data with unique constraints on
+  `(shop, sessionId)` and `(shop, trackingNumber)`; indexed by
+  `customerId`. See [docs/orders.md](docs/orders.md).
+- `SubscriptionUsage` – monthly shipment counts with a unique
+  `(shop, customerId, month)` tuple. See
+  [docs/subscription-usage.md](docs/subscription-usage.md).
+- `CustomerProfile` and `CustomerMfa` – customer metadata and MFA
+  secrets keyed by `customerId`.
+- `User` – application users with a unique `email`.
+- `ReverseLogisticsEvent` – return tracking events indexed by `shop`.
+
 ## Persistence
 
 Several repositories store data as JSON files under a common root so the demo works without a database. See [docs/persistence.md](docs/persistence.md) for details on disk fallbacks and the `DATA_ROOT` environment variable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,3 +86,24 @@ graph TD
 ```
 
 Atoms have no internal dependencies. Molecules may depend on atoms; organisms may depend on molecules and atoms; templates may depend on organisms, molecules and atoms; and pages may depend on any UI layer. Keeping this order prevents cyclical dependencies and helps maintain separation of concerns.
+
+## Database
+
+Data is stored in PostgreSQL through [Prisma](https://www.prisma.io/).
+The schema (see `packages/platform-core/prisma/schema.prisma`) defines:
+
+- `Shop` – JSON shop configuration and related `Page` records.
+- `Page` – per-shop pages tied to a `Shop`.
+- `RentalOrder` – rental transactions with unique `(shop, sessionId)`
+  and `(shop, trackingNumber)` plus an index on `customerId`. See
+  [orders.md](orders.md).
+- `SubscriptionUsage` – monthly shipment counts with a unique
+  `(shop, customerId, month)` tuple. See
+  [subscription-usage.md](subscription-usage.md).
+- `CustomerProfile` and `CustomerMfa` – customer metadata and MFA
+  secrets keyed by `customerId`.
+- `User` – accounts with a unique `email`.
+- `ReverseLogisticsEvent` – return tracking events indexed by `shop`.
+
+The connection string is provided via the `DATABASE_URL` environment
+variable.


### PR DESCRIPTION
## Summary
- document Prisma + PostgreSQL datastore
- outline key models and unique constraints
- link to order and subscription usage modules

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5cbbdde8832f8e191efede79b93a