### PR TITLE
fix: narrow syncTheme return type

### DIFF
--- a/packages/platform-core/src/createShop/index.d.ts
+++ b/packages/platform-core/src/createShop/index.d.ts
@@ -17,7 +17,7 @@ export declare function listThemes(): string[];
  * It returns the default token map for the selected theme so callers can merge
  * in any overrides before persisting to the shop.json file.
  */
-export declare function syncTheme(shop: string, theme: string): Record<string, unknown>;
+export declare function syncTheme(shop: string, theme: string): Record<string, string>;
 export declare const createShopOptionsSchema: typeof baseCreateShopOptionsSchema;
 export { prepareOptions };
 export type { CreateShopOptions, PreparedCreateShopOptions, NavItem } from "./schema";

--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -195,7 +195,7 @@ export function listThemes(): string[] {
  * It returns the default token map for the selected theme so callers can merge
  * in any overrides before persisting to the shop.json file.
  */
-export function syncTheme(shop: string, theme: string): Record<string, unknown> {
+export function syncTheme(shop: string, theme: string): Record<string, string> {
   const root = repoRoot();
   const pkgRel = join("apps", shop, "package.json");
   const pkgAbs = join(root, pkgRel);


### PR DESCRIPTION
## Summary
- type syncTheme to return string token map

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: prisma types 'unknown')*
- `pnpm --filter @acme/platform-core test` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64cb5df8832fb1f14ed464c7e5a1