### PR TITLE
chore: default TEST_DATA_ROOT fallback

### DIFF
--- a/scripts/src/seed-test-data.ts
+++ b/scripts/src/seed-test-data.ts
@@ -6,11 +6,8 @@ import { join } from "node:path";
  * Existing shop data will be removed before copying to ensure fresh files.
  */
 export function seedTestData(): void {
-  const root = process.env.TEST_DATA_ROOT;
-  if (!root) {
-    throw new Error("TEST_DATA_ROOT environment variable is required");
-  }
-
+  // Default to "test/data" if TEST_DATA_ROOT is not provided
+  const root = process.env.TEST_DATA_ROOT || "test/data";
   const srcRoot = join("test", "data", "shops");
   const destRoot = join(root, "shops");
 


### PR DESCRIPTION
## Summary
- allow seeding test data without TEST_DATA_ROOT by defaulting to `test/data`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm test` *(fails: command exited 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6afd887c832fb555ca3379b7edb8