### PR TITLE
docs: document reverse logistics events

### DIFF
--- a/docs/machine.md
+++ b/docs/machine.md
@@ -60,6 +60,7 @@ const stop = await startReverseLogisticsService();
 ```
 
 Events are JSON files placed in `data/shops/<id>/reverse-logistics/` with a `sessionId` and `status` field (e.g. `received`, `cleaning`, `repair`, `qa`, or `available`). As the worker processes each file it emits a matching event to the `reverseLogisticsEvents` table, providing an auditable history of lifecycle changes.
+See [reverse logistics events](./reverse-logistics-events.md) for details on the persistence layer and event schema.
 
 Operational dashboards can read from this event log to provide real‑time visibility into how many items are in each stage of the reverse logistics pipeline and to spot bottlenecks.
 

--- a/docs/reverse-logistics-events.md
+++ b/docs/reverse-logistics-events.md
@@ -1,0 +1,25 @@
+# Reverse logistics events
+
+The `ReverseLogisticsEvent` model records each step an item passes through after it is returned. It provides an auditable history that other services and dashboards can consume.
+
+## Model
+
+| field      | type   | description |
+|------------|--------|-------------|
+| `id`       | string | Unique identifier for the event. |
+| `shop`     | string | Shop identifier associated with the event. |
+| `sessionId`| string | Rental session to which the event applies. |
+| `event`    | string | Name of the stage. One of the values listed below. |
+| `createdAt`| string | ISO timestamp when the event was recorded. |
+
+## Event names
+
+The `event` field is restricted to the following values:
+
+- `received` – item has been returned to the warehouse.
+- `cleaning` – item is being cleaned or laundered.
+- `repair` – item is under repair.
+- `qa` – item is undergoing quality assurance checks.
+- `available` – item is ready to be rented again.
+
+Each time the reverse logistics worker processes a status file it persists an entry using this model.

--- a/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
+++ b/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
@@ -4,6 +4,14 @@ import { nowIso } from "@acme/date-utils";
 import { prisma } from "../db";
 import type { ReverseLogisticsEvent, ReverseLogisticsEventName } from "@acme/types";
 
+/**
+ * Insert a reverse logistics event for a rental session.
+ *
+ * @param shop - Shop identifier.
+ * @param sessionId - Rental session ID.
+ * @param event - Stage name to record.
+ * @param createdAt - ISO timestamp; defaults to now.
+ */
 export async function recordEvent(
   shop: string,
   sessionId: string,
@@ -15,6 +23,11 @@ export async function recordEvent(
   });
 }
 
+/**
+ * Retrieve all events for a shop ordered chronologically.
+ *
+ * @param shop - Shop identifier.
+ */
 export async function listEvents(
   shop: string
 ): Promise<ReverseLogisticsEvent[]> {
@@ -24,15 +37,21 @@ export async function listEvents(
   });
 }
 
+/** Convenience helpers for common reverse logistics events. */
 export const reverseLogisticsEvents = {
+  /** Record that a returned item was received into inventory. */
   received: (shop: string, sessionId: string, createdAt: string = nowIso()) =>
     recordEvent(shop, sessionId, "received", createdAt),
+  /** Record that an item is being cleaned. */
   cleaning: (shop: string, sessionId: string, createdAt: string = nowIso()) =>
     recordEvent(shop, sessionId, "cleaning", createdAt),
+  /** Record that an item is undergoing repair. */
   repair: (shop: string, sessionId: string, createdAt: string = nowIso()) =>
     recordEvent(shop, sessionId, "repair", createdAt),
+  /** Record that an item is in quality assurance. */
   qa: (shop: string, sessionId: string, createdAt: string = nowIso()) =>
     recordEvent(shop, sessionId, "qa", createdAt),
+  /** Record that an item is available for rental again. */
   available: (shop: string, sessionId: string, createdAt: string = nowIso()) =>
     recordEvent(shop, sessionId, "available", createdAt),
 };


### PR DESCRIPTION
## Summary
- add reverse logistics events model doc
- link machine worker docs to persistence layer
- document repository helpers for reverse logistics events

## Testing
- `pnpm -r build` *(fails: prisma.<model> is of type 'unknown')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c52ecf8832fb1a70446098e7ab8