### PR TITLE
docs: link additional modules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,10 +100,14 @@ The schema (see `packages/platform-core/prisma/schema.prisma`) defines:
 - `SubscriptionUsage` – monthly shipment counts with a unique
   `(shop, customerId, month)` tuple. See
   [subscription-usage.md](subscription-usage.md).
-- `CustomerProfile` and `CustomerMfa` – customer metadata and MFA
-  secrets keyed by `customerId`.
-- `User` – accounts with a unique `email`.
-- `ReverseLogisticsEvent` – return tracking events indexed by `shop`.
+- [`CustomerProfile`](customer-profiles.md) – stores customer metadata
+  and preferences keyed by `customerId`.
+- [`CustomerMfa`](mfa.md) – holds multi-factor authentication secrets
+  for each customer.
+- [`User`](users.md) – application user accounts identified by unique
+  email addresses.
+- [`ReverseLogisticsEvent`](reverse-logistics-events.md) – logs
+  return-processing milestones for rental items per shop.
 
 The connection string is provided via the `DATABASE_URL` environment
 variable.


### PR DESCRIPTION
## Summary
- link `CustomerProfile`, `CustomerMfa`, `User` and `ReverseLogisticsEvent` tables to their docs
- briefly explain each table's role in the system

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.user' is of type 'unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68bc6c5573f4832f8fb782cbc83eef62