### PR TITLE
docs: add env variable reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ yarn-error.log*
 .env*
 !**/.env.example
 !apps/cms/.env.production
+!docs/.env.reference.md
 
 # Build outputs (monorepo)
 **/dist/

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Configuration and usage examples for both are documented in [docs/machine.md](do
 
 # Environment Variables
 
+See [environment variable reference](./docs/.env.reference.md) for a comprehensive list and descriptions.
+
 After running `pnpm create-shop <id>`, the CLI generates `.env` and `.env.template` under `apps/shop-<id>/`, validates the variables, and can pull secrets from an external vault by passing `--vault-cmd <cmd>` (the command receives each variable name). Configure the resulting `.env` with:
 
 - `STRIPE_SECRET_KEY` – secret key used by the Stripe server SDK

--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -1,0 +1,33 @@
+# Environment variable reference
+
+This page describes the environment variables the platform expects. Each variable is read from `.env` files generated for shops and may be required at build or run time.
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | PostgreSQL connection string. If unset, an in-memory stub is used. |
+| `STRIPE_SECRET_KEY` | Server-side Stripe API key. |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Client-side Stripe key exposed to the browser. |
+| `STRIPE_WEBHOOK_SECRET` | Secret used to verify Stripe webhook signatures. |
+| `CMS_SPACE_URL` | Base URL of the headless CMS API. |
+| `CMS_ACCESS_TOKEN` | Token used to push schemas to the CMS. |
+| `SANITY_API_VERSION` | API version for the optional Sanity blog plugin. |
+| `CART_COOKIE_SECRET` | Secret for signing cart cookies. Required in production. |
+| `CART_TTL` | Cart expiration in seconds (defaults to 30 days). |
+| `DEPOSIT_RELEASE_ENABLED` | `true` or `false` to toggle automated deposit refunds. |
+| `DEPOSIT_RELEASE_INTERVAL_MS` | Interval in milliseconds between deposit refund runs. |
+| `REVERSE_LOGISTICS_ENABLED` | `true` or `false` to enable the reverse logistics service. |
+| `REVERSE_LOGISTICS_INTERVAL_MS` | Interval in milliseconds for the reverse logistics worker. |
+| `LATE_FEE_ENABLED` | `true` or `false` to toggle late fee processing. |
+| `LATE_FEE_INTERVAL_MS` | Interval in milliseconds for the late fee job. |
+| `LOG_LEVEL` | Logging verbosity (`error`, `warn`, `info`, or `debug`). |
+| `EMAIL_PROVIDER` | Campaign email provider (`smtp`, `sendgrid`, or `resend`). |
+| `SENDGRID_API_KEY` | API key for SendGrid when using the SendGrid provider. |
+| `SENDGRID_MARKETING_KEY` | SendGrid marketing API key for contact and segment endpoints. |
+| `RESEND_API_KEY` | API key for Resend when using the Resend provider. |
+| `SENDGRID_WEBHOOK_PUBLIC_KEY` | Public key to verify SendGrid webhook signatures. |
+| `RESEND_WEBHOOK_SECRET` | Secret used to verify Resend webhook signatures. |
+| `CHROMATIC_PROJECT_TOKEN` | Token for publishing Storybook builds to Chromatic. |
+| `STOCK_ALERT_RECIPIENT` | Email address that receives low stock alerts. Leave unset to disable notifications. |
+| `STOCK_ALERT_WEBHOOK` | URL for posting low stock alerts to an external service. |
+| `STOCK_ALERT_DEFAULT_THRESHOLD` | Default stock level that triggers alerts. |
+| `NEXT_PUBLIC_BASE_URL` | Base URL exposed to the browser for constructing absolute links. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@
 
 - **Node.js** v20 or newer
 - **pnpm** v10 (repo uses pnpm@10.12.1)
-- `DATABASE_URL` in your `.env` pointing to a PostgreSQL database
+- `DATABASE_URL` in your `.env` pointing to a PostgreSQL database. See [environment variable reference](./.env.reference.md) for the full list of required keys.
 
 See [Next.js configuration](./nextjs-config.md) for Cloudflare-specific framework options.
 


### PR DESCRIPTION
## Summary
- document required environment variables
- link reference from README and setup guide
- allow committing env reference via .gitignore

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: prisma.* is of type 'unknown')*
- `pnpm lint` *(fails: packages/config/test/utils/withEnv.ts was not found by the project service)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c5d6e8c832f8eb862333190b556