### PR TITLE
docs: clarify prisma as primary datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ pnpm e2e
 
 - Stripe handles deposits via escrow sessions.
 - Returned deposits can be refunded automatically by the deposit release service. See [docs/machine.md](docs/machine.md).
-- Inventory lives in JSON files under data/shops/\*/inventory.json.
+- Inventory persists in the Prisma database; a JSON file at
+  `data/shops/\*/inventory.json` remains as a development and test
+  fallback.
 - Low-stock alerts email the configured recipient (`STOCK_ALERT_RECIPIENT`) when inventory falls below its threshold.
 - Rental pricing matrix defined in data/rental/pricing.json with duration discounts and damage-fee rules.
 - Return logistics options stored in data/return-logistics.json.
@@ -70,7 +72,11 @@ primary datastore. The schema includes:
 
 ## Persistence
 
-Several repositories store data as JSON files under a common root so the demo works without a database. See [docs/persistence.md](docs/persistence.md) for details on disk fallbacks and the `DATA_ROOT` environment variable.
+The stack primarily relies on Prisma. A few modules, such as the
+inventory repository, can fall back to JSON files under a common root for
+development and tests. See [docs/persistence.md](docs/persistence.md)
+for details on these disk fallbacks and the `DATA_ROOT` environment
+variable.
 
 ## Contributing
 
@@ -84,7 +90,9 @@ See [docs/upgrade-preview-republish.md](docs/upgrade-preview-republish.md) for g
 
 ### Variant schema
 
-Inventory items live in `data/shops/<shop>/inventory.json` and follow this structure:
+Inventory records are stored in the database. During development the
+repository can fall back to `data/shops/<shop>/inventory.json`, which
+uses this structure:
 
 ```json
 {

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -37,8 +37,7 @@ Passwords should be hashed before inserting, and any related tables such as
 
 ## Inventory Migration
 
-Inventory currently relies on a local SQLite database. When inventory data
-is moved to another database or service, export the existing SQLite tables
-and import them into the new storage layer using the tooling provided by
-that system. Keep the export handy so the migration can be repeated if the
-target storage changes again.
+Inventory now persists in the Prisma database. If migrating from the
+legacy JSON or SQLite backends, export the existing records and import
+them with a seed script or Prisma's tooling. Keep the export handy so the
+migration can be repeated if the target storage changes again.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,22 +1,20 @@
 # Persistence and `DATA_ROOT`
 
-Many repositories use a simple filesystem backend when a database or remote service isn't configured. Data is stored under a shop-specific directory rooted at `DATA_ROOT` so the demo and tests work completely offline.
+Prisma with PostgreSQL provides the primary data store. For development or
+test scenarios where a database isn't available, certain repositories can
+fall back to a simple filesystem backend rooted at `DATA_ROOT`.
 
 ## Repositories with disk fallbacks
 
-The following repositories read and write JSON or JSONL files under `<DATA_ROOT>/<shop>`:
-
-- `@acme/platform-core` repositories for shops, products, pages, settings, theme presets, analytics and SEO audits.
-- `@acme/email` repositories for campaigns, segments and abandoned cart reminders.
-- Background services in `@acme/platform-machine` that log analytics or scheduling data.
-
-These fallbacks keep the project functional during development before wiring up a real database and make it easy to run the stack without any external dependencies.
+Currently only the `@acme/platform-core` inventory repository reads and
+writes JSON (or SQLite) files under `<DATA_ROOT>/<shop>`. These fallbacks
+are meant to support development before a database is configured.
 
 ## `DATA_ROOT`
 
 `DATA_ROOT` resolves to the root directory that holds per‑shop data files. If the variable is unset, `resolveDataRoot` walks up from the current working directory looking for `data/shops` and falls back to `<cwd>/data/shops`.
 
-Override it to store data elsewhere, isolate test fixtures or run the system offline:
+Override it to store data elsewhere or isolate test fixtures:
 
 ```bash
 DATA_ROOT=/tmp/my-data pnpm dev


### PR DESCRIPTION
## Summary
- clarify inventory uses Prisma with optional JSON fallback
- explain limited disk persistence and update migration guide

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm test` *(partially executed; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c59f04c832fa158a52547dd6014