### PR TITLE
docs: expand env var reference

### DIFF
--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -5,12 +5,18 @@ This page describes the environment variables the platform expects. Each variabl
 | Variable | Purpose |
 | --- | --- |
 | `DATABASE_URL` | PostgreSQL connection string. If unset, an in-memory stub is used. |
+| `DATA_ROOT` | Root directory for per-shop data files. If unset, falls back to `<cwd>/data/shops`. |
+| `TEST_DATA_ROOT` | Root directory for test fixtures. Defaults to `test/data/shops`. |
 | `STRIPE_SECRET_KEY` | Server-side Stripe API key. |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Client-side Stripe key exposed to the browser. |
 | `STRIPE_WEBHOOK_SECRET` | Secret used to verify Stripe webhook signatures. |
 | `CMS_SPACE_URL` | Base URL of the headless CMS API. |
 | `CMS_ACCESS_TOKEN` | Token used to push schemas to the CMS. |
+| `SANITY_PROJECT_ID` | Sanity project ID for the optional blog plugin (defaults to `dummy-project-id`). |
+| `SANITY_DATASET` | Sanity dataset name (defaults to `production`). |
+| `SANITY_API_TOKEN` | Token for Sanity write access (defaults to `dummy-api-token`; unset enables read-only mode). |
 | `SANITY_API_VERSION` | API version for the optional Sanity blog plugin. |
+| `SANITY_PREVIEW_SECRET` | Secret used to verify Sanity preview requests (defaults to `dummy-preview-secret`). |
 | `CART_COOKIE_SECRET` | Secret for signing cart cookies. Required in production. |
 | `CART_TTL` | Cart expiration in seconds (defaults to 30 days). |
 | `DEPOSIT_RELEASE_ENABLED` | `true` or `false` to toggle automated deposit refunds. |
@@ -26,7 +32,11 @@ This page describes the environment variables the platform expects. Each variabl
 | `RESEND_API_KEY` | API key for Resend when using the Resend provider. |
 | `SENDGRID_WEBHOOK_PUBLIC_KEY` | Public key to verify SendGrid webhook signatures. |
 | `RESEND_WEBHOOK_SECRET` | Secret used to verify Resend webhook signatures. |
+| `NEXTAUTH_SECRET` | Secret for NextAuth session signing (defaults to a dev secret in development; required in production). |
+| `PREVIEW_TOKEN_SECRET` | Secret for HMAC preview tokens (unset disables preview token routes). |
 | `CHROMATIC_PROJECT_TOKEN` | Token for publishing Storybook builds to Chromatic. |
+| `GA_MEASUREMENT_ID` | Google Analytics measurement ID (without this and `GA_API_SECRET`, events are stored locally). |
+| `GA_API_SECRET` | API secret for Google Analytics measurement protocol (without this and `GA_MEASUREMENT_ID`, events are stored locally). |
 | `STOCK_ALERT_RECIPIENT` | Email address that receives low stock alerts. Leave unset to disable notifications. |
 | `STOCK_ALERT_WEBHOOK` | URL for posting low stock alerts to an external service. |
 | `STOCK_ALERT_DEFAULT_THRESHOLD` | Default stock level that triggers alerts. |


### PR DESCRIPTION
## Summary
- document DATA_ROOT, TEST_DATA_ROOT, Sanity credentials, auth secrets, preview tokens, and Google Analytics settings in `.env` reference
- ensure README and setup variables are reflected in the reference

## Testing
- `pnpm install`
- `pnpm lint docs` *(fails: Missing tasks in project)*
- `pnpm lint` *(fails: command exited with code 2)*


------
https://chatgpt.com/codex/tasks/task_e_68bc7785b5bc832fb0742b5297db9b70