### PR TITLE
docs: clarify primary datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pnpm e2e
 
 - Stripe handles deposits via escrow sessions.
 - Returned deposits can be refunded automatically by the deposit release service. See [docs/machine.md](docs/machine.md).
-- Inventory persists through Prisma by default, with legacy fallbacks to JSON files (`data/shops/\*/inventory.json`) or a local SQLite store.
+- Inventory currently persists to JSON files (`data/shops/\*/inventory.json`) or a local SQLite store. A migration to Prisma/PostgreSQL is planned; see [docs/inventory-migration.md](docs/inventory-migration.md).
 - Low-stock alerts email the configured recipient (`STOCK_ALERT_RECIPIENT`) when inventory falls below its threshold.
 - Rental pricing matrix defined in data/rental/pricing.json with duration discounts and damage-fee rules.
 - Return logistics options stored in data/return-logistics.json.
@@ -74,7 +74,7 @@ primary datastore. The schema includes:
 
 ## Persistence
 
-Some repositories retain JSON or SQLite fallbacks under a common `DATA_ROOT`, but Prisma with PostgreSQL is the default datastore. See [docs/persistence.md](docs/persistence.md) for details on these fallbacks and the `DATA_ROOT` environment variable.
+Some repositories retain JSON or SQLite fallbacks under a common `DATA_ROOT`, but Prisma with PostgreSQL is the default datastore. Inventory currently uses these fallbacks; the migration plan lives in [docs/inventory-migration.md](docs/inventory-migration.md). See [docs/persistence.md](docs/persistence.md) for details on these fallbacks and the `DATA_ROOT` environment variable.
 
 ## Contributing
 

--- a/docs/marketing-automation.md
+++ b/docs/marketing-automation.md
@@ -28,9 +28,10 @@ The scheduler will deliver any campaigns whose `sendAt` timestamp has passed.
 
 ## Custom campaign stores
 
-Campaigns are persisted using a filesystem store by default. You can replace
-this storage layer by providing your own implementation of the `CampaignStore`
-interface and registering it with `setCampaignStore`.
+Campaigns use Prisma with PostgreSQL as the default backend. The filesystem
+store remains available only as a fallback. You can replace either storage
+layer by providing your own implementation of the `CampaignStore` interface and
+registering it with `setCampaignStore`.
 
 ```ts
 import { setCampaignStore, type CampaignStore } from "@acme/email";

--- a/packages/platform-core/src/repositories/__tests__/inventory.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/inventory.backendSelection.test.ts
@@ -51,7 +51,7 @@ describe('inventory repository backend selection', () => {
     expect(mockJson.read).not.toHaveBeenCalled();
   });
 
-  it('defaults to JSON repository when INVENTORY_BACKEND is not "sqlite"', async () => {
+  it('falls back to the JSON repository when INVENTORY_BACKEND is not "sqlite"', async () => {
     delete process.env.INVENTORY_BACKEND;
     const { inventoryRepository } = await import('../inventory.server');
     const mutate = jest.fn();

--- a/packages/platform-machine/src/__tests__/inventoryRepository.test.ts
+++ b/packages/platform-machine/src/__tests__/inventoryRepository.test.ts
@@ -42,7 +42,7 @@ describe('inventory repository', () => {
     }
   });
 
-  it('getRepo uses json backend by default and caches the promise', async () => {
+  it('getRepo falls back to the json backend and caches the promise', async () => {
     const mod1 = await import('@acme/platform-core/repositories/inventory.server');
     await mod1.inventoryRepository.read('s1');
     const mod2 = await import('@acme/platform-core/repositories/inventory.server');


### PR DESCRIPTION
## Summary
- note Prisma/PostgreSQL as the default marketing campaign store with filesystem fallback
- clarify inventory relies on JSON/SQLite persistence with planned Prisma migration
- adjust tests to describe JSON inventory backend as a fallback

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma types unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bc778852c4832fb53ac9a39cef1eeb