### PR TITLE
docs: centralize testing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run `pnpm init-shop` to scaffold a new shop. The configurator lists available pl
 
 ### Testing
 
-Cypress fixtures live under `test/data/shops`. Override this path by setting the `TEST_DATA_ROOT` environment variable.
+See [docs/testing.md](docs/testing.md) for comprehensive testing instructions. Cypress fixtures live under `test/data/shops`. Override this path by setting the `TEST_DATA_ROOT` environment variable.
 
 Seed data before running the Cypress suite:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+For testing guidance, see [testing](./testing.md).
+
 This project organizes UI code according to a simple five‑layer model loosely based on Atomic Design. Each layer may depend only on layers below it. Higher layers should never be imported by lower layers.
 
 ## Layers

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,22 +18,9 @@ Create branches from `main` and name them descriptively (e.g., `feat/login-form`
 
 Before submitting changes, run [`pnpm lint`](../package.json#L24) and [`pnpm test`](../package.json#L28) to ensure the codebase is formatted correctly and the test suite passes.
 
-## Testing with Prisma
+## Testing
 
-Tests run with a stubbed Prisma client by default, so `pnpm test` completes
-without requiring a database.
-
-To execute tests against a real Postgres instance, set `DATABASE_URL` and run
-pending migrations before running the tests:
-
-```bash
-export DATABASE_URL=postgres://...
-pnpm prisma migrate deploy
-pnpm test
-```
-
-Mock Prisma calls in unit tests to keep them fast and focused. Use a Postgres
-database for integration tests to verify end-to-end behavior.
+See [testing](./testing.md) for guidance on running tests with Prisma.
 
 ## API documentation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-This guide explains how to run unit and integration tests and how to choose between mocking Prisma calls or using a real database.
+This guide explains how to run unit and integration tests and how to choose between mocking Prisma calls or using a real database. Tests run with a stubbed Prisma client by default, so `pnpm test` completes without requiring a database.
 
 ## Running tests
 
@@ -16,10 +16,11 @@ pnpm test
 
 ### Real Prisma client (`DATABASE_URL` set)
 
-Set `DATABASE_URL` to point at a test database to exercise the real Prisma client. This enables end-to-end and integration tests that need actual queries.
+Set `DATABASE_URL` to point at a test database to exercise the real Prisma client. Run pending migrations before executing the tests. This enables end-to-end and integration tests that need actual queries.
 
 ```bash
 export DATABASE_URL="postgres://user:password@localhost:5432/base_shop_test"
+pnpm prisma migrate deploy
 pnpm test
 ```
 
@@ -27,6 +28,8 @@ pnpm test
 
 - **Mock Prisma calls** for isolated unit tests where database access would slow down execution or introduce external dependencies. Mocks let you assert that code calls Prisma with the expected arguments.
 - **Use a test database** for integration tests that rely on real SQL behavior, migrations, or interactions across multiple layers of the application.
+
+Mock Prisma calls in unit tests to keep them fast and focused. Use a Postgres database for integration tests to verify end-to-end behavior.
 
 ## Seeding the database for integration tests
 


### PR DESCRIPTION
## Summary
- move Prisma testing instructions to dedicated guide
- link testing guide from contributing, README, and architecture docs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm lint` *(fails: command exited (1))*
- `pnpm test` *(incomplete: command exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7786ce78832f8dd2a90dd80f84e6