### PR TITLE
Add login API rate limit test

### DIFF
--- a/apps/shop-bcd/src/app/api/login/route.ts
+++ b/apps/shop-bcd/src/app/api/login/route.ts
@@ -13,9 +13,9 @@ const limiter = new RateLimiterMemory({ points: 5, duration: 60 });
 
 // Mock customer store. In a real application this would be a database or external identity provider.
 const CUSTOMER_STORE: Record<string, { password: string; role: Role }> = {
-  cust1: { password: "pass1", role: "customer" },
-  viewer1: { password: "view", role: "viewer" },
-  admin1: { password: "admin", role: "admin" },
+  cust1: { password: "pass1234", role: "customer" },
+  viewer1: { password: "viewpass", role: "viewer" },
+  admin1: { password: "admin123", role: "admin" },
 };
 
 const ALLOWED_ROLES: Role[] = ["customer", "viewer"];


### PR DESCRIPTION
## Summary
- expand login API tests to cover rate limiting using valid credentials
- ensure mock customer store passwords satisfy schema

## Testing
- `pnpm -r build` *(fails: prisma.* unknown types)*
- `pnpm test apps/shop-bcd/__tests__/login-api.test.ts` *(fails: Could not find task)*
- `pnpm exec jest apps/shop-bcd/__tests__/login-api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc7bc60270832f908131f13b264ad6