### PR TITLE
Require MFA token for login

### DIFF
--- a/apps/shop-bcd/__tests__/login-api.test.ts
+++ b/apps/shop-bcd/__tests__/login-api.test.ts
@@ -3,9 +3,16 @@ jest.mock("@auth", () => ({
   __esModule: true,
   createCustomerSession: jest.fn(),
   validateCsrfToken: jest.fn(),
+  isMfaEnabled: jest.fn().mockResolvedValue(false),
+  verifyMfa: jest.fn(),
 }));
 
-import { createCustomerSession, validateCsrfToken } from "@auth";
+import {
+  createCustomerSession,
+  validateCsrfToken,
+  isMfaEnabled,
+  verifyMfa,
+} from "@auth";
 import { POST } from "../src/app/api/login/route";
 
 function makeRequest(body: any, headers: Record<string, string> = {}) {
@@ -22,7 +29,7 @@ test("logs in valid customer", async () => {
   (validateCsrfToken as jest.Mock).mockResolvedValue(true);
   const res = await POST(
     makeRequest(
-      { customerId: "cust1", password: "pass1" },
+      { customerId: "cust1", password: "pass1pass" },
       { "x-csrf-token": "token" },
     ),
   );
@@ -39,7 +46,7 @@ test("rejects invalid CSRF token", async () => {
   (validateCsrfToken as jest.Mock).mockResolvedValue(false);
   const res = await POST(
     makeRequest(
-      { customerId: "cust1", password: "pass1" },
+      { customerId: "cust1", password: "pass1pass" },
       { "x-csrf-token": "bad" },
     ),
   );
@@ -64,7 +71,7 @@ test("rejects unauthorized role", async () => {
   (validateCsrfToken as jest.Mock).mockResolvedValue(true);
   const res = await POST(
     makeRequest(
-      { customerId: "admin1", password: "admin" },
+      { customerId: "admin1", password: "adminadmin" },
       { "x-csrf-token": "token" },
     ),
   );

--- a/apps/shop-bcd/__tests__/login-mfa.test.ts
+++ b/apps/shop-bcd/__tests__/login-mfa.test.ts
@@ -1,0 +1,60 @@
+// apps/shop-bcd/__tests__/login-mfa.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  createCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn(),
+  isMfaEnabled: jest.fn(),
+  verifyMfa: jest.fn(),
+}));
+
+import {
+  createCustomerSession,
+  validateCsrfToken,
+  isMfaEnabled,
+  verifyMfa,
+} from "@auth";
+import { POST } from "../src/app/api/login/route";
+
+function makeRequest(body: any, headers: Record<string, string> = {}) {
+  return new Request("http://example.com/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(() => jest.clearAllMocks());
+
+test("rejects missing MFA token when enabled", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  (isMfaEnabled as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "pass1pass" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(res.status).toBe(401);
+  await expect(res.json()).resolves.toEqual({ error: "Invalid MFA token" });
+  expect(verifyMfa).not.toHaveBeenCalled();
+  expect(createCustomerSession).not.toHaveBeenCalled();
+});
+
+test("logs in when MFA token is valid", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  (isMfaEnabled as jest.Mock).mockResolvedValue(true);
+  (verifyMfa as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "pass1pass", mfaToken: "123456" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(verifyMfa).toHaveBeenCalledWith("cust1", "123456");
+  expect(createCustomerSession).toHaveBeenCalledWith({
+    customerId: "cust1",
+    role: "customer",
+  });
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ ok: true });
+});

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,7 @@
 // cypress.config.ts
 import { defineConfig } from "cypress";
+import { enrollMfa, verifyMfa } from "@auth";
+import { authenticator } from "otplib";
 
 export default defineConfig({
   e2e: {
@@ -18,6 +20,16 @@ export default defineConfig({
         "test-nextauth-secret-32-chars-long-string!",
       TEST_DATA_ROOT: process.env.TEST_DATA_ROOT || "test/data/shops"
     },
-    defaultCommandTimeout: 10000
+    defaultCommandTimeout: 10000,
+    async setupNodeEvents(on) {
+      on("task", {
+        async generateMfaToken(customerId: string) {
+          const { secret } = await enrollMfa(customerId);
+          const first = authenticator.generate(secret);
+          await verifyMfa(customerId, first);
+          return authenticator.generate(secret);
+        }
+      });
+    }
   }
 });

--- a/cypress/e2e/mfa-login.cy.ts
+++ b/cypress/e2e/mfa-login.cy.ts
@@ -1,0 +1,21 @@
+// cypress/e2e/mfa-login.cy.ts
+describe("MFA login", () => {
+  it("allows login with valid TOTP", () => {
+    cy.task("generateMfaToken", "cust1").then((token: string) => {
+      cy.setCookie("csrf_token", "csrf");
+      cy.request({
+        method: "POST",
+        url: "/api/login",
+        headers: { "x-csrf-token": "csrf" },
+        body: {
+          customerId: "cust1",
+          password: "pass1pass",
+          mfaToken: token,
+        },
+      }).then((res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body).to.deep.eq({ ok: true });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- require MFA token when MFA is enabled
- add unit tests covering MFA login
- add Cypress test for MFA login with TOTP

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/login-api.test.ts apps/shop-bcd/__tests__/login-mfa.test.ts`
- `pnpm exec cypress run --spec cypress/e2e/mfa-login.cy.ts` *(fails: Cypress executable not installed)*
- `pnpm -r build` *(fails: prisma types unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c083450832f8e7a96b8aae747f6