### PR TITLE
test: add RBAC integration tests for edit-changes and publish routes

### DIFF
--- a/apps/cms/src/app/api/edit-changes/__tests__/route.integration.test.ts
+++ b/apps/cms/src/app/api/edit-changes/__tests__/route.integration.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+import type { Role } from "@auth/types/roles";
+import { nextHeadersMock } from "../../../../../__tests__/mocks/external";
+
+const SHOP_URL = "http://localhost/api/edit-changes?shop=test";
+
+async function createSessionCookie(role: Role): Promise<string> {
+  const { createCustomerSession, CUSTOMER_SESSION_COOKIE } = await import("@auth");
+  const store = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
+  nextHeadersMock.cookies.mockReturnValue(store);
+  await createCustomerSession({ customerId: "c1", role });
+  const token = store.set.mock.calls.find(([name]) => name === CUSTOMER_SESSION_COOKIE)?.[1];
+  store.get.mockReturnValue({ value: token });
+  return `${CUSTOMER_SESSION_COOKIE}=${token}`;
+}
+
+afterEach(() => {
+  jest.resetModules();
+  nextHeadersMock.cookies.mockReset();
+});
+
+describe("GET /api/edit-changes RBAC", () => {
+  it("returns 401 for roles without manage_pages", async () => {
+    jest.doMock("@platform-core/repositories/settings.server", () => ({
+      __esModule: true,
+      diffHistory: jest.fn(),
+    }));
+    const { GET } = await import("../route");
+    for (const role of ["customer", "viewer"] as Role[]) {
+      const cookie = await createSessionCookie(role);
+      const req = new NextRequest(SHOP_URL, { headers: { cookie } });
+      const res = await GET(req);
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it("returns 200 with components for authorized roles", async () => {
+    const { ROLE_PERMISSIONS } = await import("@auth/permissions");
+    const original = [...(ROLE_PERMISSIONS.ShopAdmin || [])];
+    ROLE_PERMISSIONS.ShopAdmin = [...original, "manage_pages"];
+    jest.doMock("@platform-core/repositories/settings.server", () => ({
+      __esModule: true,
+      diffHistory: jest.fn().mockResolvedValue([
+        { diff: { pages: { p1: { components: [{ name: "Hero" }, "Banner"] } } } },
+      ]),
+    }));
+    const { GET } = await import("../route");
+    const cookie = await createSessionCookie("ShopAdmin");
+    const req = new NextRequest(SHOP_URL, { headers: { cookie } });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      components: [
+        { pageId: "p1", name: "Banner" },
+        { pageId: "p1", name: "Hero" },
+      ],
+    });
+    ROLE_PERMISSIONS.ShopAdmin = original;
+  });
+});
+

--- a/apps/shop-bcd/src/app/api/publish/__tests__/route.integration.test.ts
+++ b/apps/shop-bcd/src/app/api/publish/__tests__/route.integration.test.ts
@@ -1,0 +1,80 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import type { Role } from "@auth/types/roles";
+
+const mockCookies = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => mockCookies),
+}));
+
+jest.mock("@acme/config/env/core", () => ({
+  coreEnv: {
+    SESSION_SECRET: "test-session-secret-32-chars-long-string!",
+    COOKIE_DOMAIN: "example.com",
+  },
+}));
+
+jest.mock("fs", () => {
+  const actual = jest.requireActual("fs");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: jest.fn().mockResolvedValue(JSON.stringify({ id: "shop-1" })),
+      rm: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+jest.mock("../../../../../../scripts/src/republish-shop", () => ({
+  republishShop: jest.fn(),
+}), { virtual: true });
+
+async function setSession(role: Role): Promise<void> {
+  const { createCustomerSession, CUSTOMER_SESSION_COOKIE } = await import("@auth");
+  mockCookies.get.mockReset();
+  mockCookies.set.mockReset();
+  await createCustomerSession({ customerId: "c1", role });
+  const token = mockCookies.set.mock.calls.find(([name]) => name === CUSTOMER_SESSION_COOKIE)?.[1];
+  mockCookies.get.mockReturnValue({ value: token });
+}
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+function loadRoute() {
+  const src = fs.readFileSync(path.join(__dirname, "..", "route.ts"), "utf8");
+  let js = ts.transpileModule(src, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2019 },
+  }).outputText;
+  js = js.replace(/const require = .*createRequire.*\n/, "");
+  const mod: any = { exports: {} };
+  const func = new Function("exports", "require", "module", "__filename", "__dirname", js);
+  func(mod.exports, require, mod, __filename, path.join(__dirname, ".."));
+  return mod.exports as { POST: () => Promise<Response> };
+}
+
+describe("POST /api/publish RBAC", () => {
+  it("returns 401 for roles without manage_orders", async () => {
+    const { POST } = loadRoute();
+    for (const role of ["customer", "viewer"] as Role[]) {
+      await setSession(role);
+      const res = await POST();
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it("returns 200 for authorized roles", async () => {
+    const { POST } = loadRoute();
+    await setSession("ShopAdmin");
+    const res = await POST();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ status: "ok" });
+  });
+});
+

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -15,6 +15,7 @@ This guide lists built-in permissions and their default role mappings.
 | `manage_cart` | customer, admin, ShopAdmin, CatalogManager, ThemeEditor |
 | `view_orders` | customer, admin, ShopAdmin |
 | `manage_orders` | admin, ShopAdmin |
+| `manage_pages` | admin, ShopAdmin |
 | `manage_sessions` | admin, ShopAdmin |
 | `process_returns` | admin, ShopAdmin |
 | `manage_rentals` | admin, ShopAdmin |

--- a/packages/auth/src/permissions.json
+++ b/packages/auth/src/permissions.json
@@ -20,6 +20,7 @@
     "manage_cart",
     "view_orders",
     "manage_orders",
+    "manage_pages",
     "manage_sessions",
     "process_returns",
     "manage_rentals"
@@ -34,6 +35,7 @@
     "manage_cart",
     "view_orders",
     "manage_orders",
+    "manage_pages",
     "manage_sessions",
     "process_returns",
     "manage_rentals"


### PR DESCRIPTION
## Summary
- grant `manage_pages` to admin and ShopAdmin roles
- add integration tests for `/api/edit-changes` and `/api/publish` enforcing RBAC via session cookies

## Testing
- `pnpm --filter cms exec jest apps/cms/src/app/api/edit-changes/__tests__/route.integration.test.ts`
- `pnpm --filter shop-bcd exec jest apps/shop-bcd/src/app/api/publish/__tests__/route.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c08c798832f86dcad4b9f816d5a