### PR TITLE
test(i18n): verify translation key completeness

### DIFF
--- a/packages/i18n/src/__tests__/translations-completeness.test.ts
+++ b/packages/i18n/src/__tests__/translations-completeness.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('translations completeness', () => {
+  const dir = path.join(__dirname, '..');
+  const baseFile = 'en.json';
+  const base = JSON.parse(fs.readFileSync(path.join(dir, baseFile), 'utf8')) as Record<string, unknown>;
+  const baseKeys = Object.keys(base).sort();
+
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json') && f !== baseFile);
+
+  for (const file of files) {
+    test(`${file} matches ${baseFile}`, () => {
+      const locale = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8')) as Record<string, unknown>;
+      const localeKeys = Object.keys(locale).sort();
+      const missing = baseKeys.filter((key) => !localeKeys.includes(key));
+      const extra = localeKeys.filter((key) => !baseKeys.includes(key));
+      expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add test to ensure locale JSON files match `en.json` keys

## Testing
- `pnpm --filter @acme/i18n run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter @acme/i18n run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter @acme/i18n build`
- `pnpm --filter @acme/i18n test -- packages/i18n/src/__tests__/translations-completeness.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c5adc28832fad145b527900cec1