### PR TITLE
Add accessibility tests for navigation, modal, and form components

### DIFF
--- a/packages/ui/__tests__/HeaderClient.a11y.test.tsx
+++ b/packages/ui/__tests__/HeaderClient.a11y.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import HeaderClient from "../src/components/layout/HeaderClient.client";
+
+jest.mock("@acme/platform-core/contexts/CartContext", () => ({
+  useCart: () => [{}],
+}));
+
+jest.mock("../src/components/ThemeToggle", () => () => (
+  <div data-testid="theme-toggle" />
+));
+
+jest.mock("../src/components/molecules", () => ({
+  CurrencySwitcher: () => <div data-testid="currency-switcher" />,
+}));
+
+describe("HeaderClient accessibility", () => {
+  it("renders navigation with accessible label", () => {
+    render(
+      <HeaderClient
+        lang="en"
+        initialQty={0}
+        nav={[{ label: "Home", url: "/home" }]}
+      />,
+    );
+    const nav = screen.getByRole("navigation", { name: /main navigation/i });
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveAttribute("aria-label", "Main navigation");
+  });
+
+  it("does not render unnamed navigation", () => {
+    render(<HeaderClient lang="en" initialQty={0} nav={[]} />);
+    expect(screen.queryByRole("navigation", { name: "" })).toBeNull();
+  });
+});

--- a/packages/ui/__tests__/PopupModal.a11y.test.tsx
+++ b/packages/ui/__tests__/PopupModal.a11y.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import PopupModal from "../src/components/cms/blocks/PopupModal";
+
+describe("PopupModal accessibility", () => {
+  it("renders dialog role with accessible label", () => {
+    render(<PopupModal content="<p>Hello</p>" />);
+    const dialog = screen.getByRole("dialog", { name: /popup modal/i });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("does not render dialog without label", () => {
+    render(<PopupModal content="<p>Hello</p>" />);
+    expect(screen.queryByRole("dialog", { name: "" })).toBeNull();
+  });
+});

--- a/packages/ui/__tests__/ProfileForm.a11y.test.tsx
+++ b/packages/ui/__tests__/ProfileForm.a11y.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import ProfileForm from "../src/components/account/ProfileForm";
+
+describe("ProfileForm accessibility", () => {
+  it("associates inputs with labels", () => {
+    render(<ProfileForm />);
+    expect(screen.getByLabelText(/name/i)).toBeRequired();
+    expect(screen.getByLabelText(/email/i)).toBeRequired();
+  });
+
+  it("does not render unlabeled fields", () => {
+    render(<ProfileForm />);
+    expect(screen.queryByLabelText(/password/i)).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/PopupModal.tsx
+++ b/packages/ui/src/components/cms/blocks/PopupModal.tsx
@@ -64,6 +64,9 @@ export default function PopupModal({
       onClick={() => setOpen(false)}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Popup modal"
         className="relative bg-white p-4 shadow-lg"
         style={{ width, height }}
         onClick={(e) => e.stopPropagation()}

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -41,7 +41,7 @@ export default function HeaderClient({
         Base-Shop
       </Link>
 
-      <nav className="flex items-center gap-6">
+      <nav className="flex items-center gap-6" aria-label="Main navigation">
         {nav.map((item) => (
           <Link
             key={item.url}


### PR DESCRIPTION
## Summary
- label header navigation for screen readers
- mark popup modal with dialog semantics
- add a11y tests for navigation, modal, and profile form

## Testing
- `pnpm --filter ui run check:references` (no script)
- `pnpm --filter ui run build` (fails: TS18046 'prisma.shop' is of type 'unknown')
- `pnpm --filter ui test HeaderClient.a11y.test.tsx PopupModal.a11y.test.tsx ProfileForm.a11y.test.tsx` (coverage thresholds not met)


------
https://chatgpt.com/codex/tasks/task_e_68bc7c5c2920832fbce50831f69fc4b2