### PR TITLE
test: add keyboard navigation tests for switchers

### DIFF
--- a/packages/ui/__tests__/CurrencySwitcher.a11y.test.tsx
+++ b/packages/ui/__tests__/CurrencySwitcher.a11y.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CurrencySwitcher from "../src/components/molecules/CurrencySwitcher.client";
+
+const setCurrencySpy = jest.fn();
+
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => {
+  const React = require("react");
+  return {
+    useCurrency: () => {
+      const [currency, setCurrency] = React.useState("USD");
+      return [currency, (v: string) => {
+        setCurrency(v);
+        setCurrencySpy(v);
+      }] as const;
+    },
+  };
+});
+
+describe("CurrencySwitcher keyboard navigation", () => {
+  it("changes currency using keyboard controls", async () => {
+    render(<CurrencySwitcher />);
+    const user = userEvent.setup();
+
+    await user.tab();
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    await screen.findByRole("option", { name: "USD" });
+
+    await user.keyboard("{ArrowUp}");
+    await user.keyboard("{Enter}");
+
+    expect(setCurrencySpy).toHaveBeenCalledWith("EUR");
+    expect(trigger).toHaveTextContent("EUR");
+  });
+});

--- a/packages/ui/__tests__/LanguageSwitcher.a11y.test.tsx
+++ b/packages/ui/__tests__/LanguageSwitcher.a11y.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LanguageSwitcher from "../src/components/molecules/LanguageSwitcher";
+
+describe("LanguageSwitcher keyboard navigation", () => {
+  it("moves focus with Tab and activates links with Enter", async () => {
+    render(<LanguageSwitcher current="en" />);
+    const user = userEvent.setup();
+
+    await user.tab();
+    const enLink = screen.getByRole("link", { name: "EN" });
+    expect(enLink).toHaveFocus();
+
+    await user.tab();
+    const deLink = screen.getByRole("link", { name: "DE" });
+    expect(deLink).toHaveFocus();
+
+    const handler = jest.fn((e: Event) => e.preventDefault());
+    deLink.addEventListener("click", handler);
+
+    await user.keyboard("{Enter}");
+
+    expect(handler).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add keyboard accessibility tests for LanguageSwitcher
- verify CurrencySwitcher responds to keyboard navigation

## Testing
- `pnpm install`
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm -r build` (fails: TS errors in @acme/platform-core)
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/CurrencySwitcher.a11y.test.tsx packages/ui/__tests__/LanguageSwitcher.a11y.test.tsx` (fails: global coverage thresholds not met)

------
https://chatgpt.com/codex/tasks/task_e_68bc7c5d658c832f86fc7358bdaaf031