### PR TITLE
Add loadPlugins benchmarking script and baseline

### DIFF
--- a/docs/loadPlugins-baseline.md
+++ b/docs/loadPlugins-baseline.md
@@ -1,0 +1,10 @@
+# loadPlugins Benchmark Baseline
+
+This benchmark populates a large number of dummy plugin directories and measures the runtime and I/O behavior of `loadPlugins`.
+
+- Command: `pnpm benchmark:loadPlugins`
+- Plugin directories created: 1000 (plus existing workspace plugins)
+- Result: `Loaded 1003 plugins in 2677.73 ms`
+- I/O operations (`async_hooks` FS events): `{ "FSREQPROMISE": 4015 }`
+
+Runtime exceeded the 500 ms threshold, suggesting that parallelized directory reads may be necessary for larger plugin sets.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "seo:audit": "tsx scripts/seo-audit.ts",
     "validate-env": "ts-node scripts/src/validate-env.ts",
     "inventory": "ts-node scripts/src/inventory.ts",
+    "benchmark:loadPlugins": "tsx scripts/benchmark-loadPlugins.ts",
     "quickstart-shop": "ts-node scripts/src/quickstart-shop.ts",
     "check:locales": "ts-node scripts/src/check-locales.ts",
     "add-locale": "tsx scripts/src/add-locale.ts",

--- a/scripts/benchmark-loadPlugins.ts
+++ b/scripts/benchmark-loadPlugins.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile, rm } from "fs/promises";
+import path from "path";
+import { performance } from "perf_hooks";
+import { createHook } from "async_hooks";
+
+const COUNT = parseInt(process.argv[2] ?? "1000", 10);
+const BASE_DIR = path.join("packages", ".bench-plugins");
+
+async function createDummyPlugins(count: number) {
+  await rm(BASE_DIR, { recursive: true, force: true });
+  for (let i = 0; i < count; i++) {
+    const dir = path.join(BASE_DIR, `plugin-${i}`);
+    await mkdir(path.join(dir, "dist"), { recursive: true });
+    const pkg = {
+      name: `dummy-plugin-${i}`,
+      version: "0.0.1",
+      type: "module",
+      main: "dist/index.js",
+    };
+    await writeFile(path.join(dir, "package.json"), JSON.stringify(pkg));
+    const code = `export default { id: \"dummy-plugin-${i}\", name: \"Dummy Plugin ${i}\" };`;
+    await writeFile(path.join(dir, "dist/index.js"), code);
+  }
+}
+
+async function run() {
+  await createDummyPlugins(COUNT);
+  const ioCounts = new Map<string, number>();
+  const hook = createHook({
+    init(_id, type) {
+      if (type.startsWith("FS")) {
+        ioCounts.set(type, (ioCounts.get(type) ?? 0) + 1);
+      }
+    },
+  });
+  const originalEval = global.eval;
+  global.eval = (code) => {
+    if (code === "import.meta.url") return import.meta.url;
+    return originalEval(code);
+  };
+  const { loadPlugins } = await import(
+    "../packages/platform-core/dist/plugins.js"
+  );
+  hook.enable();
+  const start = performance.now();
+  const plugins = await loadPlugins({ directories: [BASE_DIR] });
+  const duration = performance.now() - start;
+  hook.disable();
+  global.eval = originalEval;
+  console.log(
+    `Loaded ${plugins.length} plugins in ${duration.toFixed(2)} ms`
+  );
+  console.log(
+    `IO counts: ${JSON.stringify(Object.fromEntries(ioCounts))}`
+  );
+  const threshold = 500;
+  if (duration > threshold) {
+    console.log(
+      `Runtime exceeded ${threshold} ms; consider parallelizing directory reads.`
+    );
+  }
+  await rm(BASE_DIR, { recursive: true, force: true });
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add benchmark script to stress `loadPlugins` with many dummy plugin directories and capture async FS operations
- document baseline results from running the benchmark
- expose convenience script via package.json

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS18046 unknown type errors in packages/platform-core)*
- `pnpm benchmark:loadPlugins`
- `pnpm --filter @acme/platform-core test` *(terminated due to extensive output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c6b41b4832f85c60233d4d622af