### PR TITLE
test: add session expiration e2e test

### DIFF
--- a/cypress/e2e/session-expiration.cy.ts
+++ b/cypress/e2e/session-expiration.cy.ts
@@ -1,0 +1,24 @@
+import { SESSION_TTL_S } from "@acme/auth/store";
+
+describe("Shop session expiration", () => {
+  it("redirects to login after session expires", () => {
+    cy.visit("/login", {
+      onBeforeLoad(win) {
+        cy.clock(win.Date.now());
+      },
+    });
+
+    cy.get('input[name="customerId"]').type("cust1");
+    cy.get('input[name="password"]').type("pass1");
+    cy.contains("button", "Login").click();
+
+    cy.getCookie("customer_session").should("exist");
+
+    cy.tick((SESSION_TTL_S + 1) * 1000);
+
+    cy.getCookie("customer_session").should("not.exist");
+
+    cy.visit("/account/profile");
+    cy.location("pathname").should("eq", "/login");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "e2e": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run\"",
     "e2e:open": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress open\"",
     "e2e:dashboard": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run --spec cypress/e2e/dashboard-signin.cy.ts\"",
-    "e2e:shop": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/shop-bcd build && pnpm --filter @apps/shop-bcd start -- --port 3004'\" http://localhost:3004 \"CYPRESS_BASE_URL=http://localhost:3004 pnpm exec cypress run --spec cypress/e2e/shop-*.cy.ts\"",
+    "e2e:shop": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/shop-bcd build && pnpm --filter @apps/shop-bcd start -- --port 3004'\" http://localhost:3004 \"CYPRESS_BASE_URL=http://localhost:3004 pnpm exec cypress run --spec cypress/e2e/shop-*.cy.ts,cypress/e2e/session-expiration.cy.ts\"",
     "test:e2e": "pnpm run e2e:dashboard && pnpm run e2e:shop",
     "i18n:extract": "next-intl extract",
     "i18n:check": "ts-node scripts/check-i18n-schemas.ts",


### PR DESCRIPTION
## Summary
- add Cypress test for customer session expiration and redirect to login
- run new test with other shop e2e specs

## Testing
- `pnpm -r build` *(fails: TS18046 unknown type 'prisma.*')*
- `pnpm run e2e:shop` *(fails: ERR_UNKNOWN_FILE_EXTENSION for seed-test-data.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7ebb6fc4832fa34fba41264b988b