### PR TITLE
Add MFA enforcement to login flow

### DIFF
--- a/apps/shop-bcd/__tests__/login-mfa.test.ts
+++ b/apps/shop-bcd/__tests__/login-mfa.test.ts
@@ -1,0 +1,60 @@
+// apps/shop-bcd/__tests__/login-mfa.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  createCustomerSession: jest.fn(),
+  validateCsrfToken: jest.fn(),
+  isMfaEnabled: jest.fn(),
+  verifyMfa: jest.fn(),
+}));
+
+import {
+  createCustomerSession,
+  validateCsrfToken,
+  isMfaEnabled,
+  verifyMfa,
+} from "@auth";
+import { POST } from "../src/app/api/login/route";
+
+function makeRequest(body: any, headers: Record<string, string> = {}) {
+  return new Request("http://example.com/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(() => jest.clearAllMocks());
+
+test("rejects missing MFA token", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  (isMfaEnabled as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "pass1234" },
+      { "x-csrf-token": "token" },
+    ),
+  );
+  expect(res.status).toBe(401);
+  await expect(res.json()).resolves.toEqual({ error: "MFA token required" });
+  expect(verifyMfa).not.toHaveBeenCalled();
+  expect(createCustomerSession).not.toHaveBeenCalled();
+});
+
+test("logs in when MFA token valid", async () => {
+  (validateCsrfToken as jest.Mock).mockResolvedValue(true);
+  (isMfaEnabled as jest.Mock).mockResolvedValue(true);
+  (verifyMfa as jest.Mock).mockResolvedValue(true);
+  const res = await POST(
+    makeRequest(
+      { customerId: "cust1", password: "pass1234" },
+      { "x-csrf-token": "token", "x-mfa-token": "123456" },
+    ),
+  );
+  expect(verifyMfa).toHaveBeenCalledWith("cust1", "123456");
+  expect(createCustomerSession).toHaveBeenCalledWith({
+    customerId: "cust1",
+    role: "customer",
+  });
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ ok: true });
+});

--- a/test/e2e/login-mfa.spec.ts
+++ b/test/e2e/login-mfa.spec.ts
@@ -1,0 +1,26 @@
+import { authenticator } from "otplib";
+import { enrollMfa, verifyMfa } from "@auth";
+
+describe("MFA login", () => {
+  it("allows login with TOTP", () => {
+    cy.then(async () => {
+      const { secret } = await enrollMfa("cust1");
+      const initial = authenticator.generate(secret);
+      await verifyMfa("cust1", initial);
+      const csrf = "csrf-token";
+      return { secret, csrf };
+    }).then(({ secret, csrf }) => {
+      cy.setCookie("csrf_token", csrf);
+      const mfaToken = authenticator.generate(secret);
+      cy.request({
+        method: "POST",
+        url: "/api/login",
+        headers: { "x-csrf-token": csrf, "x-mfa-token": mfaToken },
+        body: { customerId: "cust1", password: "pass1234" },
+      }).then((res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body).to.deep.equal({ ok: true });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- require MFA verification before creating a customer session when enabled
- add unit tests for MFA login scenarios
- demonstrate end-to-end MFA login with a generated TOTP code via Cypress

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/login-mfa.test.ts`
- `pnpm exec cypress run --spec test/e2e/login-mfa.spec.ts` *(fails: Cypress failed to verify that your server is running)*
- `pnpm -r build` *(fails: packages/platform-core build: src/repositories/rentalOrders.server.ts(79,25): error TS18046: 'prisma.rentalOrder' is of type 'unknown'.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc899c5fe8832fa7e207af64b84560