### PR TITLE
test: add markFulfilled and markShipped tests

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -3,6 +3,8 @@
 import {
   listOrders,
   addOrder,
+  markFulfilled,
+  markShipped,
   markDelivered,
   markCancelled,
   markReturned,
@@ -144,6 +146,54 @@ describe("orders", () => {
       prismaMock.rentalOrder.create.mockRejectedValue(new Error("fail"));
       await expect(addOrder("shop", "sess", 10)).rejects.toThrow("fail");
       expect(trackOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("markFulfilled", () => {
+    it("updates order with fulfillment timestamp", async () => {
+      nowIsoMock.mockReturnValue("now");
+      const mockOrder = { id: "1" };
+      prismaMock.rentalOrder.update.mockResolvedValue(mockOrder);
+      const result = await markFulfilled("shop", "sess");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { fulfilledAt: "now" },
+      });
+      expect(result).toEqual(mockOrder);
+    });
+
+    it("propagates errors", async () => {
+      nowIsoMock.mockReturnValue("now");
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      await expect(markFulfilled("shop", "sess")).rejects.toThrow("fail");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { fulfilledAt: "now" },
+      });
+    });
+  });
+
+  describe("markShipped", () => {
+    it("updates order with shipment timestamp", async () => {
+      nowIsoMock.mockReturnValue("now");
+      const mockOrder = { id: "1" };
+      prismaMock.rentalOrder.update.mockResolvedValue(mockOrder);
+      const result = await markShipped("shop", "sess");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { shippedAt: "now" },
+      });
+      expect(result).toEqual(mockOrder);
+    });
+
+    it("propagates errors", async () => {
+      nowIsoMock.mockReturnValue("now");
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      await expect(markShipped("shop", "sess")).rejects.toThrow("fail");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { shippedAt: "now" },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- add tests for markFulfilled and markShipped helpers
- ensure timestamps and shop/session IDs passed to prisma update
- verify errors from prisma update are propagated

## Testing
- `pnpm --filter @acme/platform-core run test -- packages/platform-core/__tests__/orders.test.ts`
- `pnpm -r build` *(fails: TS18046 'prisma.user' is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e83aa64832fb2b8244e53d22f64