### PR TITLE
Add orders API route tests

### DIFF
--- a/apps/shop-bcd/__tests__/orders-api.test.ts
+++ b/apps/shop-bcd/__tests__/orders-api.test.ts
@@ -1,0 +1,60 @@
+// apps/shop-bcd/__tests__/orders-api.test.ts
+import { GET, PATCH } from "../src/app/api/orders/[id]/route";
+
+jest.mock("@platform-core/orders", () => ({
+  __esModule: true,
+  getOrdersForCustomer: jest.fn(),
+  markCancelled: jest.fn(),
+  markDelivered: jest.fn(),
+}));
+
+jest.mock("@auth", () => ({
+  getCustomerSession: jest.fn(),
+}));
+
+const {
+  getOrdersForCustomer,
+  markCancelled,
+  markDelivered,
+} = require("@platform-core/orders");
+const { getCustomerSession } = require("@auth");
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  getCustomerSession.mockResolvedValue({ customerId: "cust" });
+});
+
+describe("/api/orders/[id]", () => {
+  test("GET returns order", async () => {
+    getOrdersForCustomer.mockResolvedValue([{ id: "ord1" }]);
+    const res = await GET({} as any, { params: { id: "ord1" } });
+    expect(getOrdersForCustomer).toHaveBeenCalledWith("bcd", "cust");
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ order: { id: "ord1" } });
+  });
+
+  test("PATCH cancels order", async () => {
+    markCancelled.mockResolvedValue({ id: "ord1" });
+    const req = { json: async () => ({ status: "cancelled" }) } as any;
+    const res = await PATCH(req, { params: { id: "ord1" } });
+    expect(markCancelled).toHaveBeenCalledWith("bcd", "ord1");
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ order: { id: "ord1" } });
+  });
+
+  test("PATCH marks order delivered", async () => {
+    markDelivered.mockResolvedValue({ id: "ord1" });
+    const req = { json: async () => ({ status: "delivered" }) } as any;
+    const res = await PATCH(req, { params: { id: "ord1" } });
+    expect(markDelivered).toHaveBeenCalledWith("bcd", "ord1");
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ order: { id: "ord1" } });
+  });
+
+  test("GET returns 404 when order not found", async () => {
+    getOrdersForCustomer.mockResolvedValue([]);
+    const res = await GET({} as any, { params: { id: "missing" } });
+    expect(res.status).toBe(404);
+  });
+});
+

--- a/apps/shop-bcd/src/app/api/orders/[id]/route.ts
+++ b/apps/shop-bcd/src/app/api/orders/[id]/route.ts
@@ -1,0 +1,59 @@
+// apps/shop-bcd/src/app/api/orders/[id]/route.ts
+import { getCustomerSession } from "@auth";
+import {
+  getOrdersForCustomer,
+  markCancelled,
+  markDelivered,
+} from "@platform-core/orders";
+import { NextResponse } from "next/server";
+import shop from "../../../../../shop.json";
+
+// @auth relies on Node APIs, so use Node runtime
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const session = await getCustomerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const orders = await getOrdersForCustomer(shop.id, session.customerId);
+  const order = orders.find((o) => o.id === params.id);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+  return NextResponse.json({ order });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const session = await getCustomerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let status: unknown;
+  try {
+    ({ status } = (await req.json()) as { status?: string });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  const mutate =
+    status === "cancelled"
+      ? markCancelled
+      : status === "delivered"
+        ? markDelivered
+        : null;
+  if (!mutate) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+  const order = await mutate(shop.id, params.id);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+  return NextResponse.json({ order });
+}
+


### PR DESCRIPTION
## Summary
- implement `/api/orders/[id]` route to fetch and update orders
- add Jest tests covering order retrieval and status updates

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/orders-api.test.ts`
- `pnpm -r build` *(fails: prisma.* is of type unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e84caf4832fa340b92fddd0636b