### PR TITLE
feat(shop-bcd): add orders history API route

### DIFF
--- a/apps/shop-bcd/__tests__/orders-history-api.test.ts
+++ b/apps/shop-bcd/__tests__/orders-history-api.test.ts
@@ -1,0 +1,54 @@
+// apps/shop-bcd/__tests__/orders-history-api.test.ts
+jest.mock("@auth", () => ({
+  __esModule: true,
+  getCustomerSession: jest.fn(),
+}));
+
+jest.mock("@platform-core/orders", () => ({
+  __esModule: true,
+  getOrdersForCustomer: jest.fn(),
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), init),
+  },
+}));
+
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
+import { GET } from "../src/app/api/orders/route";
+
+describe("/api/orders GET", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns orders for authenticated user", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    const orders = [{ id: "o1" }];
+    (getOrdersForCustomer as jest.Mock).mockResolvedValue(orders);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, orders });
+    expect(getOrdersForCustomer).toHaveBeenCalledWith("bcd", "cust1");
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 on database errors", async () => {
+    (getCustomerSession as jest.Mock).mockResolvedValue({
+      customerId: "cust1",
+    });
+    (getOrdersForCustomer as jest.Mock).mockRejectedValue(new Error("db"));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/shop-bcd/src/app/api/orders/route.ts
+++ b/apps/shop-bcd/src/app/api/orders/route.ts
@@ -1,0 +1,20 @@
+// apps/shop-bcd/src/app/api/orders/route.ts
+import { getCustomerSession } from "@auth";
+import { getOrdersForCustomer } from "@platform-core/orders";
+import { NextResponse } from "next/server";
+import shop from "../../../../shop.json";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const session = await getCustomerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const orders = await getOrdersForCustomer(shop.id, session.customerId);
+    return NextResponse.json({ ok: true, orders });
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch orders" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add /api/orders route to return orders for authenticated customers
- cover orders API success, unauthorized, and error cases

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/orders-history-api.test.ts`
- `pnpm -r build` *(fails: 'prisma.rentalOrder is of type unknown')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e88451c832fabdfd074133b1021