### PR TITLE
feat: isolate cypress test data in temp directory

### DIFF
--- a/cypress/e2e/cms-middleware.cy.ts
+++ b/cypress/e2e/cms-middleware.cy.ts
@@ -2,7 +2,7 @@ import type { CookieValue } from "cypress";
 
 const SECRET = "test-nextauth-secret-32-chars-long-string!";
 const SHOP = "demo";
-const dataDir = Cypress.env("TEST_DATA_ROOT");
+let dataDir: string;
 
 function sign(role: string) {
   return cy
@@ -15,30 +15,41 @@ function sign(role: string) {
 
 describe("cms middleware", () => {
   before(() => {
-    const product = {
-      id: "1",
-      sku: "sku1",
-      title: { en: "Demo" },
-      description: { en: "" },
-      price: 0,
-      currency: "EUR",
-      media: [],
-      status: "draft",
-      shop: SHOP,
-      row_version: 1,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
-    const settings = {
-      languages: ["en"],
-      seo: {},
-      currency: "EUR",
-      taxRegion: "",
-      updatedAt: "",
-      updatedBy: "",
-    };
-    cy.writeFile(`${dataDir}/${SHOP}/products.json`, [product]);
-    cy.writeFile(`${dataDir}/${SHOP}/settings.json`, settings);
+    cy.task("testData:setup", SHOP)
+      .then((dir) => {
+        dataDir = dir as string;
+        Cypress.env("TEST_DATA_ROOT", dir);
+      })
+      .then(() => {
+        const product = {
+          id: "1",
+          sku: "sku1",
+          title: { en: "Demo" },
+          description: { en: "" },
+          price: 0,
+          currency: "EUR",
+          media: [],
+          status: "draft",
+          shop: SHOP,
+          row_version: 1,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        };
+        const settings = {
+          languages: ["en"],
+          seo: {},
+          currency: "EUR",
+          taxRegion: "",
+          updatedAt: "",
+          updatedBy: "",
+        };
+        cy.writeFile(`${dataDir}/${SHOP}/products.json`, [product]);
+        cy.writeFile(`${dataDir}/${SHOP}/settings.json`, settings);
+      });
+  });
+
+  after(() => {
+    cy.task("testData:cleanup");
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- create Cypress tasks to prepare and clean a temporary TEST_DATA_ROOT
- copy minimal pages and settings fixtures for tests
- update cms middleware spec to use the temporary data dir

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/config build: Failed, packages/types build: Failed)*
- `pnpm exec cypress run --spec cypress/e2e/cms-middleware.cy.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc932c7284832f8ceedb9a7e5009a4