### PR TITLE
docs: add configurator testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Run `pnpm init-shop` to scaffold a new shop. The configurator lists available pl
 ### Testing
 
 See [docs/testing.md](docs/testing.md) for comprehensive testing instructions. Cypress fixtures live under `test/data/shops`. Override this path by setting the `TEST_DATA_ROOT` environment variable.
+For CMS configurator-specific end-to-end tests, see [docs/testing-configurator.md](docs/testing-configurator.md).
 
 Seed data before running the Cypress suite:
 

--- a/docs/testing-configurator.md
+++ b/docs/testing-configurator.md
@@ -1,0 +1,28 @@
+# Configurator Testing
+
+This guide explains how to run the end-to-end configurator test.
+
+## Required commands
+
+1. `pnpm install`
+2. `pnpm -r build`
+3. `pnpm cypress run --spec test/e2e/configurator.spec.ts`
+
+## Environment variables
+
+- `NEXTAUTH_SECRET` – secret used by NextAuth for session signing.
+- `TEST_DATA_ROOT` – root directory for test fixtures. Defaults to `test/data/shops`.
+
+## Cleanup
+
+If the test fails, remove any partially created shop data to reset the environment:
+
+```bash
+rm -rf "${TEST_DATA_ROOT:-test/data}/shops/*"
+```
+
+Then re-seed fixtures as needed:
+
+```bash
+pnpm tsx scripts/src/seed-test-data.ts
+```


### PR DESCRIPTION
## Summary
- document required commands, env vars, and cleanup steps for the configurator end-to-end test
- link configurator test guide from the main README for easy discovery

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.user' is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_68bc932d60a8832f96878d9954d05966