### PR TITLE
test: verify locale translation files

### DIFF
--- a/packages/i18n/src/__tests__/translations-completeness.test.ts
+++ b/packages/i18n/src/__tests__/translations-completeness.test.ts
@@ -1,18 +1,30 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { LOCALES } from '../locales';
+
 describe('translations completeness', () => {
   const dir = path.join(__dirname, '..');
-  const baseFile = 'en.json';
-  const base = JSON.parse(fs.readFileSync(path.join(dir, baseFile), 'utf8')) as Record<string, unknown>;
+  const baseLocale = 'en';
+  const baseFile = `${baseLocale}.json`;
+  const base = JSON.parse(
+    fs.readFileSync(path.join(dir, baseFile), 'utf8'),
+  ) as Record<string, unknown>;
   const baseKeys = Object.keys(base).sort();
 
-  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json') && f !== baseFile);
+  for (const locale of LOCALES) {
+    const file = `${locale}.json`;
+    const filepath = path.join(dir, file);
 
-  for (const file of files) {
+    test(`${file} exists`, () => {
+      expect(fs.existsSync(filepath)).toBe(true);
+    });
+
     test(`${file} matches ${baseFile}`, () => {
-      const locale = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8')) as Record<string, unknown>;
-      const localeKeys = Object.keys(locale).sort();
+      const localeJson = JSON.parse(
+        fs.readFileSync(filepath, 'utf8'),
+      ) as Record<string, unknown>;
+      const localeKeys = Object.keys(localeJson).sort();
       const missing = baseKeys.filter((key) => !localeKeys.includes(key));
       const extra = localeKeys.filter((key) => !baseKeys.includes(key));
       expect({ missing, extra }).toEqual({ missing: [], extra: [] });


### PR DESCRIPTION
## Summary
- ensure translations completeness tests rely on declared locales
- confirm each locale file exists and matches keys in en.json

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/i18n test packages/i18n/src/__tests__/translations-completeness.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc93349124832f8b598095201b6377