### PR TITLE
test: add i18n coverage

### DIFF
--- a/cypress/e2e/shop-i18n.cy.ts
+++ b/cypress/e2e/shop-i18n.cy.ts
@@ -1,0 +1,32 @@
+import { locales } from "@acme/i18n/locales";
+import en from "@acme/i18n/en.json";
+import de from "@acme/i18n/de.json";
+import it from "@acme/i18n/it.json";
+
+const messages: Record<string, Record<string, string>> = {
+  en,
+  de,
+  it,
+};
+
+describe("Localized storefront", () => {
+  locales.forEach((locale) => {
+    const t = messages[locale];
+
+    describe(`${locale} translations`, () => {
+      it("renders home hero and value strings", () => {
+        cy.visit(`/${locale}`);
+        cy.contains(t["hero.cta"]);
+        cy.contains(t["value.eco.title"]);
+      });
+
+      it("renders checkout strings", () => {
+        cy.visit(`/${locale}/checkout`);
+        cy.contains(t["checkout.pay"]);
+        cy.contains(t["checkout.return"]);
+      });
+    });
+  });
+});
+
+// TODO: Expand to product pages once translations are available


### PR DESCRIPTION
## Summary
- add Cypress test that verifies localized hero, value-prop, and checkout text for each supported locale

## Testing
- `pnpm install` *(warn: unsupported engine)*
- `pnpm -r build` *(fail: @acme/platform-core build TS18046 errors)*
- `pnpm test:e2e` *(fail: ERR_UNKNOWN_FILE_EXTENSION for seed-test-data.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93355a80832faeeadaccd9d7f483