### PR TITLE
fix telemetry/theme path mapping and tax schema

### DIFF
--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -134,6 +134,18 @@
       ],
       "@acme/zod-utils/*": [
         "../../packages/zod-utils/src/*", "../../packages/zod-utils/dist/*"
+      ],
+      "@acme/telemetry": [
+        "../../packages/telemetry/src/index.ts", "../../packages/telemetry/dist/index"
+      ],
+      "@acme/telemetry/*": [
+        "../../packages/telemetry/src/*", "../../packages/telemetry/dist/*"
+      ],
+      "@acme/theme": [
+        "../../packages/theme/src/index.ts", "../../packages/theme/dist/index"
+      ],
+      "@acme/theme/*": [
+        "../../packages/theme/src/*", "../../packages/theme/dist/*"
       ]
     },
     "module": "ESNext",

--- a/apps/shop-bcd/src/app/api/tax/route.ts
+++ b/apps/shop-bcd/src/app/api/tax/route.ts
@@ -13,7 +13,7 @@ export const runtime = "nodejs";
 
 const schema = z
   .object({
-    provider: z.enum(["taxjar"]).default("taxjar"),
+    provider: z.literal("taxjar"),
     amount: z.number(),
     toCountry: z.string(),
     toPostalCode: z.string().optional(),

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -28,7 +28,9 @@
       "@ui/*": ["./src/*", "./dist/*"],
       "@auth": ["types-compat/auth"],
       "@acme/i18n": ["../i18n/src/index", "../i18n/dist/index.d.ts"],
-      "@acme/i18n/*": ["../i18n/src/*", "../i18n/dist/*"]
+      "@acme/i18n/*": ["../i18n/src/*", "../i18n/dist/*"],
+      "@acme/telemetry": ["../telemetry/src/index", "../telemetry/dist/index.d.ts"],
+      "@acme/telemetry/*": ["../telemetry/src/*", "../telemetry/dist/*"]
     }
   },
   "references": [


### PR DESCRIPTION
## Summary
- map telemetry and theme workspace packages in CMS and UI TypeScript configs
- require literal provider in shop tax API schema

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: 'prisma.user' is of type 'unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68bc95d66894832f89905114d5227b1b