### PR TITLE
chore: disallow direct inventory backend imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,35 @@ module.exports = {
     "**/*.spec.*",
     "**/jest.config.*",
   ],
+  rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: [
+              "**/inventory.json.server",
+              "**/inventory.prisma.server",
+              "**/inventory.stub.server",
+            ],
+            message: "Import inventory repositories via inventory.server.ts façade instead.",
+          },
+        ],
+      },
+    ],
+  },
   overrides: [
+    {
+      files: [
+        "packages/platform-core/src/repositories/inventory.server.ts",
+        "**/__tests__/**",
+        "**/*.test.*",
+        "**/*.spec.*",
+      ],
+      rules: {
+        "no-restricted-imports": "off",
+      },
+    },
     {
       files: [
         "packages/page-builder/**/*.{ts,tsx}",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -208,6 +208,39 @@ export default [
     },
   },
 
+  /* ▸ Prevent direct inventory backend imports */
+  {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/inventory.json.server",
+                "**/inventory.prisma.server",
+                "**/inventory.stub.server",
+              ],
+              message:
+                "Import inventory repositories via inventory.server.ts façade instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      "packages/platform-core/src/repositories/inventory.server.ts",
+      "**/__tests__/**",
+      "**/*.test.*",
+      "**/*.spec.*",
+    ],
+    rules: {
+      "no-restricted-imports": "off",
+    },
+  },
+
   /* ▸ Test files relaxations */
 
   /* ▸ Enforce UI component layering */


### PR DESCRIPTION
## Summary
- disallow importing inventory storage backend implementations directly
- exempt facade and test files from restricted import rule

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm --filter @acme/platform-core lint` *(fails: Unexpected any...)*
- `pnpm exec eslint packages/platform-core/src/repositories/inventory.server.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc96d3ad44832f8e1a9698625cdc05