### PR TITLE
refactor: remove rentalOrder update casts

### DIFF
--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -72,7 +72,7 @@ export async function markFulfilled(
   shop: string,
   sessionId: string,
 ): Promise<Order> {
-  const order = await (prisma.rentalOrder.update as any)({
+  const order = await prisma.rentalOrder.update({
     where: { shop_sessionId: { shop, sessionId } },
     data: { fulfilledAt: nowIso() },
   });
@@ -83,7 +83,7 @@ export async function markShipped(
   shop: string,
   sessionId: string,
 ): Promise<Order> {
-  const order = await (prisma.rentalOrder.update as any)({
+  const order = await prisma.rentalOrder.update({
     where: { shop_sessionId: { shop, sessionId } },
     data: { shippedAt: nowIso() },
   });
@@ -94,7 +94,7 @@ export async function markDelivered(
   shop: string,
   sessionId: string,
 ): Promise<Order> {
-  const order = await (prisma.rentalOrder.update as any)({
+  const order = await prisma.rentalOrder.update({
     where: { shop_sessionId: { shop, sessionId } },
     data: { deliveredAt: nowIso() },
   });
@@ -105,7 +105,7 @@ export async function markCancelled(
   shop: string,
   sessionId: string,
 ): Promise<Order> {
-  const order = await (prisma.rentalOrder.update as any)({
+  const order = await prisma.rentalOrder.update({
     where: { shop_sessionId: { shop, sessionId } },
     data: { cancelledAt: nowIso() },
   });


### PR DESCRIPTION
## Summary
- remove `(as any)` casts on `prisma.rentalOrder.update`

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc986a205c832fa539fff2ae226880