### PR TITLE
feat: add data root backup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "tailwind:check": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" pnpm exec jest test/unit/tailwind-build.spec.ts test/unit/postcss-config.spec.ts test/unit/tailwind-postcss.spec.ts",
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "clean": "pnpm -r exec rimraf dist build lib *.tsbuildinfo",
-    "test:cms": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs"
+    "test:cms": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
+    "ops:backup-data": "tsx scripts/src/ops/backup-data-root.ts"
   },
   "dependencies": {
     "@acme/config": "workspace:^",

--- a/scripts/src/ops/backup-data-root.ts
+++ b/scripts/src/ops/backup-data-root.ts
@@ -1,0 +1,48 @@
+import { cpSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+interface Stats {
+  files: number;
+  bytes: number;
+}
+
+function collectStats(dir: string): Stats {
+  let files = 0;
+  let bytes = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const s = collectStats(full);
+      files += s.files;
+      bytes += s.bytes;
+    } else if (entry.isFile()) {
+      files++;
+      bytes += statSync(full).size;
+    }
+  }
+  return { files, bytes };
+}
+
+export function backupDataRoot(
+  root = process.env.DATA_ROOT || join(process.cwd(), "data", "shops"),
+): string {
+  const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const dest = `${root}.backup-${stamp}`;
+  cpSync(root, dest, { recursive: true });
+  const orig = collectStats(root);
+  const copy = collectStats(dest);
+  if (orig.files !== copy.files || orig.bytes !== copy.bytes) {
+    throw new Error("Backup verification failed");
+  }
+  return dest;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const dest = backupDataRoot();
+    console.log(`Backup created at ${dest}`);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add script to snapshot DATA_ROOT with size verification
- expose backup script via `pnpm ops:backup-data`

## Testing
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm ops:backup-data`
- `find data/shops -type f | wc -l`
- `find data/shops.backup-20250906 -type f | wc -l`
- `du -sb data/shops | cut -f1`
- `du -sb data/shops.backup-20250906 | cut -f1`
- `pnpm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68bc96e74a90832f817a4ba4dc210033