### PR TITLE
feat(platform-core): centralize inventory types and validation

### DIFF
--- a/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
+++ b/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
@@ -21,7 +21,7 @@ jest.mock(
   { virtual: true }
 );
 
-jest.mock("@acme/types", () => {
+jest.mock("@platform-core/types/inventory", () => {
   const { z } = require("zod");
   const inventoryItemSchema = z
     .object({

--- a/apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/[sku]/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { inventoryItemSchema } from "@acme/types";
+import { inventoryItemSchema } from "@platform-core/types/inventory";
 import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 
 export async function PATCH(

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { inventoryItemSchema } from "@acme/types";
+import { inventoryItemSchema } from "@platform-core/types/inventory";
 
 // Polyfill setImmediate used by fast-csv in the test environment
 (global as any).setImmediate =

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { inventoryItemSchema } from "@acme/types";
+import { inventoryItemSchema } from "@platform-core/types/inventory";
 import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 import {
   expandInventoryItem,

--- a/apps/cms/src/app/api/data/[shop]/inventory/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from "@cms/auth/options";
 import { getServerSession } from "next-auth";
 import { NextResponse, type NextRequest } from "next/server";
-import { inventoryItemSchema } from "@acme/types";
+import { inventoryItemSchema } from "@platform-core/types/inventory";
 import { inventoryRepository } from "@platform-core/repositories/inventory.server";
 
 export async function POST(

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/atoms/shadcn";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "@platform-core/types/inventory";
 import { FormEvent, useRef, useState } from "react";
 import InventoryRow from "./InventoryRow";
 import { useInventoryValidation } from "./useInventoryValidation";

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryRow.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryRow.tsx
@@ -6,7 +6,7 @@ import {
   TableCell,
   TableRow,
 } from "@/components/atoms/shadcn";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "@platform-core/types/inventory";
 import type { ChangeEvent } from "react";
 
 interface Props {

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx
@@ -22,7 +22,7 @@ jest.mock(
   { virtual: true }
 );
 
-jest.mock("@acme/types", () => {
+jest.mock("@platform-core/types/inventory", () => {
   const inventoryItemSchema = z
     .object({
       sku: z.string(),
@@ -41,7 +41,7 @@ jest.mock("@acme/types", () => {
 import InventoryForm from "../InventoryForm";
 let capturedUpdateItem: (
   index: number,
-  field: keyof import("@acme/types").InventoryItem | `variantAttributes.${string}`,
+  field: keyof import("@platform-core/types/inventory").InventoryItem | `variantAttributes.${string}`,
   value: string,
 ) => void;
 jest.mock("../InventoryRow", () => {

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/__tests__/inventoryValidation.test.ts
@@ -1,7 +1,7 @@
 import { validateInventoryItems } from "../useInventoryValidation";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "@platform-core/types/inventory";
 
-jest.mock("@acme/types", () => {
+jest.mock("@platform-core/types/inventory", () => {
   const { z } = require("zod");
   const inventoryItemSchema = z
     .object({

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/useInventoryValidation.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/useInventoryValidation.ts
@@ -1,4 +1,7 @@
-import { inventoryItemSchema, type InventoryItem } from "@acme/types";
+import {
+  inventoryItemSchema,
+  type InventoryItem,
+} from "@platform-core/types/inventory";
 import { expandInventoryItem } from "@platform-core/utils/inventory";
 
 /**

--- a/packages/platform-core/__tests__/inventory.test.ts
+++ b/packages/platform-core/__tests__/inventory.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../src/types/inventory";
 
 async function withRepo(
   backend: "json" | "sqlite",

--- a/packages/platform-core/__tests__/rentalAllocation.test.ts
+++ b/packages/platform-core/__tests__/rentalAllocation.test.ts
@@ -1,4 +1,5 @@
-import type { InventoryItem, SKU } from "@acme/types";
+import type { SKU } from "@acme/types";
+import type { InventoryItem } from "../src/types/inventory";
 
 jest.mock("../src/repositories/inventory.server", () => ({
   updateInventoryItem: jest.fn(),

--- a/packages/platform-core/src/orders/rentalAllocation.ts
+++ b/packages/platform-core/src/orders/rentalAllocation.ts
@@ -1,4 +1,5 @@
-import type { InventoryItem, SKU } from "@acme/types";
+import type { SKU } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 import { updateInventoryItem } from "../repositories/inventory.server";
 
 /**

--- a/packages/platform-core/src/repositories/__tests__/inventory.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/inventory.server.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import os from "node:os";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../../types/inventory";
 
 // Hold mutable repository implementations so we can swap them per test.
 let jsonRepo: any;

--- a/packages/platform-core/src/repositories/inventory.json.server.ts
+++ b/packages/platform-core/src/repositories/inventory.json.server.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import { inventoryItemSchema, type InventoryItem } from "@acme/types";
+import {
+  inventoryItemSchema,
+  type InventoryItem,
+  variantKey,
+} from "../types/inventory";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { validateShopName } from "../shops/index";
@@ -72,7 +76,7 @@ async function write(shop: string, items: InventoryItem[]): Promise<void> {
     items.map((i: InventoryItem) => ({
       ...i,
       variantAttributes: { ...i.variantAttributes },
-    }))
+    })),
   );
   const serialized: RawInventoryItem[] = normalized.map(
     ({ variantAttributes, ...rest }: InventoryItem): RawInventoryItem => ({
@@ -184,14 +188,6 @@ async function update(
   }
 
   return updated;
-}
-
-function variantKey(sku: string, attrs: Record<string, string>): string {
-  const variantPart = Object.entries(attrs)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}:${v}`)
-    .join("|");
-  return variantPart ? `${sku}#${variantPart}` : sku;
 }
 
 export const jsonInventoryRepository: InventoryRepository = {

--- a/packages/platform-core/src/repositories/inventory.server.d.ts
+++ b/packages/platform-core/src/repositories/inventory.server.d.ts
@@ -1,8 +1,8 @@
 import "server-only";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 import type { InventoryRepository, InventoryMutateFn } from "./inventory.types";
 export declare const inventoryRepository: InventoryRepository;
-export declare function variantKey(sku: string, attrs: Record<string, string>): string;
+export { variantKey } from "../types/inventory";
 export declare function readInventoryMap(shop: string): Promise<Record<string, InventoryItem>>;
 export declare function readInventory(shop: string): Promise<{
     sku: string;

--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import type { InventoryItem } from "@acme/types";
+import {
+  inventoryItemSchema,
+  type InventoryItem,
+  variantKey,
+} from "../types/inventory";
 import type {
   InventoryRepository,
   InventoryMutateFn,
@@ -34,7 +38,8 @@ export const inventoryRepository: InventoryRepository = {
   },
   async write(shop: string, items: InventoryItem[]) {
     const repo = await getRepo();
-    return repo.write(shop, items);
+    const parsed = inventoryItemSchema.array().parse(items);
+    return repo.write(shop, parsed);
   },
   async update(
     shop: string,
@@ -46,17 +51,6 @@ export const inventoryRepository: InventoryRepository = {
     return repo.update(shop, sku, variantAttributes, mutate);
   },
 };
-
-export function variantKey(
-  sku: string,
-  attrs: Record<string, string>,
-): string {
-  const variantPart = Object.entries(attrs)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}:${v}`)
-    .join("|");
-  return variantPart ? `${sku}#${variantPart}` : sku;
-}
 
 export async function readInventoryMap(
   shop: string,
@@ -72,7 +66,8 @@ export function readInventory(shop: string) {
 }
 
 export function writeInventory(shop: string, items: InventoryItem[]) {
-  return inventoryRepository.write(shop, items);
+  const parsed = inventoryItemSchema.array().parse(items);
+  return inventoryRepository.write(shop, parsed);
 }
 
 export function updateInventoryItem(
@@ -83,3 +78,6 @@ export function updateInventoryItem(
 ) {
   return inventoryRepository.update(shop, sku, variantAttributes, mutate);
 }
+
+export { variantKey };
+export type { InventoryItem };

--- a/packages/platform-core/src/repositories/inventory.sqlite.server.d.ts
+++ b/packages/platform-core/src/repositories/inventory.sqlite.server.d.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type InventoryItem } from "@acme/types";
+import { type InventoryItem } from "../types/inventory";
 import type { InventoryRepository, InventoryMutateFn } from "./inventory.types";
 export declare function updateInventoryItem(shop: string, sku: string, variantAttributes: Record<string, string>, mutate: InventoryMutateFn): Promise<InventoryItem | undefined>;
 export declare const sqliteInventoryRepository: InventoryRepository;

--- a/packages/platform-core/src/repositories/inventory.sqlite.server.ts
+++ b/packages/platform-core/src/repositories/inventory.sqlite.server.ts
@@ -1,10 +1,6 @@
 import "server-only";
 
-import {
-  inventoryItemSchema,
-  type InventoryItem,
-  type SerializedInventoryItem,
-} from "@acme/types";
+import { inventoryItemSchema, type InventoryItem } from "../types/inventory";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { validateShopName } from "../shops/index";
@@ -28,6 +24,17 @@ interface SqliteInventoryRow {
   wearCount: number | null;
   wearAndTearLimit: number | null;
   maintenanceCycle: number | null;
+}
+
+interface SerializedInventoryItem {
+  sku: string;
+  productId?: string;
+  quantity: number;
+  variantAttributes?: Record<string, string>;
+  lowStockThreshold?: number;
+  wearCount?: number;
+  wearAndTearLimit?: number;
+  maintenanceCycle?: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/platform-core/src/repositories/inventory.types.d.ts
+++ b/packages/platform-core/src/repositories/inventory.types.d.ts
@@ -1,4 +1,4 @@
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 export type InventoryMutateFn = (current: InventoryItem | undefined) => InventoryItem | undefined;
 export interface InventoryRepository {
     read(shop: string): Promise<InventoryItem[]>;

--- a/packages/platform-core/src/repositories/inventory.types.ts
+++ b/packages/platform-core/src/repositories/inventory.types.ts
@@ -1,4 +1,4 @@
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 
 export type InventoryMutateFn = (
   current: InventoryItem | undefined,

--- a/packages/platform-core/src/services/stockAlert.server.d.ts
+++ b/packages/platform-core/src/services/stockAlert.server.d.ts
@@ -1,3 +1,3 @@
 import "server-only";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 export declare function checkAndAlert(shop: string, items: InventoryItem[]): Promise<void>;

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -5,7 +5,7 @@ import { DATA_ROOT } from "../dataRoot";
 import { type EmailService, getEmailService } from "./emailService";
 import { promises as fs } from "fs";
 import * as path from "path";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 import { z } from "zod";
 import { variantKey } from "../repositories/inventory.server";
 import { getShopSettings } from "../repositories/settings.server";

--- a/packages/platform-core/src/services/stockScheduler.server.ts
+++ b/packages/platform-core/src/services/stockScheduler.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../types/inventory";
 import { checkAndAlert } from "./stockAlert.server";
 
 /**

--- a/packages/platform-core/src/types/__tests__/inventorySchema.test.ts
+++ b/packages/platform-core/src/types/__tests__/inventorySchema.test.ts
@@ -1,0 +1,45 @@
+import { inventoryItemSchema } from "../inventory";
+
+describe("inventoryItemSchema", () => {
+  it("rejects negative quantities", () => {
+    expect(() =>
+      inventoryItemSchema.parse({
+        sku: "s1",
+        productId: "p1",
+        quantity: -1,
+        variantAttributes: {},
+      }),
+    ).toThrow();
+  });
+
+  it("rejects empty sku or productId", () => {
+    expect(() =>
+      inventoryItemSchema.parse({
+        sku: "",
+        productId: "p1",
+        quantity: 1,
+        variantAttributes: {},
+      }),
+    ).toThrow();
+    expect(() =>
+      inventoryItemSchema.parse({
+        sku: "s1",
+        productId: "",
+        quantity: 1,
+        variantAttributes: {},
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-string variant attribute values", () => {
+    expect(() =>
+      inventoryItemSchema.parse({
+        sku: "s1",
+        productId: "p1",
+        quantity: 1,
+        // @ts-expect-error intentionally wrong type
+        variantAttributes: { size: 42 as any },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/platform-core/src/types/inventory.ts
+++ b/packages/platform-core/src/types/inventory.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const variantAttributesSchema = z.record(z.string());
+
+export const inventoryItemSchema = z
+  .object({
+    sku: z.string().min(1, "sku is required"),
+    productId: z.string().min(1, "productId is required"),
+    quantity: z.number().int().min(0),
+    variantAttributes: variantAttributesSchema,
+    lowStockThreshold: z.number().int().min(0).optional(),
+    wearCount: z.number().int().min(0).optional(),
+    wearAndTearLimit: z.number().int().min(0).optional(),
+    maintenanceCycle: z.number().int().min(0).optional(),
+  })
+  .strict();
+
+export type VariantAttributes = z.infer<typeof variantAttributesSchema>;
+export type InventoryItem = z.infer<typeof inventoryItemSchema>;
+
+export function variantKey(
+  sku: string,
+  attrs: Record<string, string>,
+): string {
+  const variantPart = Object.entries(attrs)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}:${v}`)
+    .join("|");
+  return variantPart ? `${sku}#${variantPart}` : sku;
+}
+
+export const inventoryItemDtoSchema = z
+  .object({
+    sku: z.string().min(1, "sku is required"),
+    productId: z.string().min(1, "productId is required"),
+    quantity: z.number().int().min(0),
+    variant: variantAttributesSchema.optional(),
+    variantAttributes: variantAttributesSchema.optional(),
+    lowStockThreshold: z.number().int().min(0).optional(),
+    wearCount: z.number().int().min(0).optional(),
+    wearAndTearLimit: z.number().int().min(0).optional(),
+    maintenanceCycle: z.number().int().min(0).optional(),
+  })
+  .strict();
+

--- a/packages/platform-core/src/utils/__tests__/inventory.test.ts
+++ b/packages/platform-core/src/utils/__tests__/inventory.test.ts
@@ -6,7 +6,7 @@ import {
   applyInventoryBatch,
   type RawInventoryItem,
 } from "../inventory";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../../types/inventory";
 
 describe("normalizeQuantity", () => {
   it("handles pair units", () => {

--- a/packages/platform-core/src/utils/__tests__/legacy/inventory.test.ts
+++ b/packages/platform-core/src/utils/__tests__/legacy/inventory.test.ts
@@ -5,7 +5,7 @@ import {
   computeAvailability,
   applyInventoryBatch,
 } from "./inventory";
-import type { InventoryItem } from "@acme/types";
+import type { InventoryItem } from "../../types/inventory";
 
 describe("flattenInventoryItem", () => {
   it("flattens items with full variant attributes", () => {

--- a/packages/platform-core/src/utils/inventory.d.ts
+++ b/packages/platform-core/src/utils/inventory.d.ts
@@ -1,4 +1,4 @@
-import { type InventoryItem } from "@acme/types";
+import { type InventoryItem } from "../types/inventory";
 export type FlattenedInventoryItem = {
     sku: string;
     productId: string;

--- a/packages/platform-core/src/utils/inventory.ts
+++ b/packages/platform-core/src/utils/inventory.ts
@@ -1,4 +1,7 @@
-import { inventoryItemSchema, type InventoryItem } from "@acme/types";
+import {
+  inventoryItemSchema,
+  type InventoryItem,
+} from "../types/inventory";
 
 export type FlattenedInventoryItem = {
   sku: string;

--- a/packages/platform-machine/src/__tests__/inventoryUtils.test.ts
+++ b/packages/platform-machine/src/__tests__/inventoryUtils.test.ts
@@ -5,7 +5,8 @@ import {
   computeAvailability,
   applyInventoryBatch,
 } from "@acme/platform-core/utils/inventory";
-import type { InventoryItem, RawInventoryItem } from "@acme/types";
+import type { InventoryItem } from "@platform-core/types/inventory";
+import type { RawInventoryItem } from "@acme/types";
 
 describe("normalizeQuantity", () => {
   it("handles various units and invalid input", () => {

--- a/packages/template-app/src/api/rental/route.ts
+++ b/packages/template-app/src/api/rental/route.ts
@@ -1,5 +1,6 @@
 import { stripe } from "@acme/stripe";
-import type { InventoryItem, SKU } from "@acme/types";
+import type { SKU } from "@acme/types";
+import type { InventoryItem } from "@platform-core/types/inventory";
 import { readShop } from "@platform-core/repositories/shops.server";
 import {
   addOrder,


### PR DESCRIPTION
## Summary
- add shared inventory types, schema, and variantKey
- refactor repositories and utilities to use shared inventory module
- update CMS inventory routes and tests for new validation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: prisma.* unknown)*
- `pnpm --filter @acme/platform-core test` *(fails: CartContext)*
- `pnpm --filter @apps/cms test` *(fails: StepProductPage.test.tsx)*


------
https://chatgpt.com/codex/tasks/task_e_68bc9811fed8832f9473782fc20ecbde