### PR TITLE
test: verify inventory export fixtures

### DIFF
--- a/apps/cms/__tests__/data/shops/demo/inventory.json
+++ b/apps/cms/__tests__/data/shops/demo/inventory.json
@@ -1,0 +1,16 @@
+[
+  {
+    "sku": "demo-a",
+    "productId": "demo-a",
+    "variantAttributes": { "size": "M", "color": "red" },
+    "quantity": 1,
+    "lowStockThreshold": 1
+  },
+  {
+    "sku": "demo-b",
+    "productId": "demo-b",
+    "variantAttributes": { "size": "L", "color": "blue" },
+    "quantity": 2,
+    "lowStockThreshold": 1
+  }
+]

--- a/apps/cms/__tests__/data/shops/test/inventory.json
+++ b/apps/cms/__tests__/data/shops/test/inventory.json
@@ -1,0 +1,9 @@
+[
+  {
+    "sku": "test-a",
+    "productId": "test-a",
+    "variantAttributes": { "size": "S", "color": "green" },
+    "quantity": 3,
+    "lowStockThreshold": 2
+  }
+]


### PR DESCRIPTION
## Summary
- add fixture-based tests for inventory export route
- cover demo and test shops using JSON backend

## Testing
- `pnpm -r build` *(fails: 'prisma.shop' is of type 'unknown')*
- `pnpm test:cms apps/cms/__tests__/inventoryExportRoute.test.ts` *(fails: Jest global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bc98da6e3c832fa81b545dc23f2da1