### PR TITLE
fix: default DATA_ROOT to repo path

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -20,9 +20,9 @@ These fallbacks keep parts of the project functional during development or when 
 
 ## `DATA_ROOT`
 
-`DATA_ROOT` resolves to the root directory that holds per‑shop data files. If the variable is unset, `resolveDataRoot` walks up from the current working directory looking for `data/shops` and falls back to `<cwd>/data/shops`.
+`DATA_ROOT` resolves to the root directory that holds per‑shop data files. If the variable is unset, `resolveDataRoot` walks up from the current working directory and selects the outermost `data/shops` directory (typically the one at the repository root). If none is found, it falls back to `<cwd>/data/shops`.
 
-Override it to store data elsewhere, isolate test fixtures or run the system offline:
+Set `DATA_ROOT` to store data elsewhere, isolate test fixtures, or run the system offline:
 
 ```bash
 DATA_ROOT=/tmp/my-data pnpm dev

--- a/packages/platform-core/__tests__/dataRoot.test.ts
+++ b/packages/platform-core/__tests__/dataRoot.test.ts
@@ -23,18 +23,21 @@ describe("dataRoot", () => {
     expect(resolveDataRoot()).toBe(path.resolve("/tmp/env-root"));
   });
 
-  it("stops search at first parent containing data/shops", async () => {
+  it("returns outermost data/shops when multiple ancestors contain it", async () => {
     jest.spyOn(process, "cwd").mockReturnValue("/repo/app/nested");
     const spy = jest
       .spyOn(fs, "existsSync")
-      .mockImplementation((p: fs.PathLike) => p === "/repo/data/shops");
+      .mockImplementation(
+        (p: fs.PathLike) => p === "/repo/app/data/shops" || p === "/repo/data/shops"
+      );
     const { resolveDataRoot } = await import("../src/dataRoot");
     spy.mockClear();
     expect(resolveDataRoot()).toBe("/repo/data/shops");
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(4);
     expect(spy).toHaveBeenNthCalledWith(1, "/repo/app/nested/data/shops");
     expect(spy).toHaveBeenNthCalledWith(2, "/repo/app/data/shops");
     expect(spy).toHaveBeenNthCalledWith(3, "/repo/data/shops");
+    expect(spy).toHaveBeenNthCalledWith(4, "/data/shops");
   });
 
   it("falls back to <cwd>/data/shops when nothing found", async () => {

--- a/packages/platform-core/src/__tests__/dataRoot.test.ts
+++ b/packages/platform-core/src/__tests__/dataRoot.test.ts
@@ -24,13 +24,15 @@ describe("resolveDataRoot", () => {
     expect(resolveDataRoot()).toBe(path.resolve("/custom/path"));
   });
 
-  it("finds ancestor data/shops directory", async () => {
+  it("prefers outermost data/shops directory", async () => {
     jest.spyOn(process, "cwd").mockReturnValue("/a/b/c");
     jest.doMock("node:fs", () => ({
-      existsSync: (p: PathLike) => p === path.join("/a/b", "data", "shops"),
+      existsSync: (p: PathLike) =>
+        p === path.join("/a", "data", "shops") ||
+        p === path.join("/a/b", "data", "shops"),
     }));
     const { resolveDataRoot } = await import("../dataRoot");
-    expect(resolveDataRoot()).toBe(path.join("/a/b", "data", "shops"));
+    expect(resolveDataRoot()).toBe(path.join("/a", "data", "shops"));
   });
 
   it("falls back to cwd/data/shops when none found", async () => {

--- a/packages/platform-core/src/dataRoot.ts
+++ b/packages/platform-core/src/dataRoot.ts
@@ -12,15 +12,17 @@ export function resolveDataRoot() {
         return path.resolve(env);
     }
     let dir = process.cwd();
+    let found;
     while (true) {
         const candidate = path.join(dir, "data", "shops");
-        if (fsSync.existsSync(candidate))
-            return candidate;
+        if (fsSync.existsSync(candidate)) {
+            found = candidate;
+        }
         const parent = path.dirname(dir);
         if (parent === dir)
             break;
         dir = parent;
     }
-    return path.resolve(process.cwd(), "data", "shops");
+    return found ?? path.resolve(process.cwd(), "data", "shops");
 }
 export const DATA_ROOT = resolveDataRoot();


### PR DESCRIPTION
## Summary
- prefer outermost `data/shops` directory when resolving DATA_ROOT
- document how to override DATA_ROOT

## Testing
- `pnpm exec tsx -e "import('./packages/platform-core/src/dataRoot.ts').then(m=>console.log(m.resolveDataRoot()))"`
- `cd apps/cms && pnpm exec tsx -e "import('../../packages/platform-core/src/dataRoot.ts').then(m=>console.log(m.resolveDataRoot()))" && cd ../..`
- `pnpm --filter @acme/platform-core run check:references` *(fails: script not found)*
- `pnpm --filter @acme/platform-core run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/platform-core build` *(fails: TS18046 'prisma.*' is of type 'unknown')*
- `pnpm exec jest packages/platform-core/src/__tests__/dataRoot.test.ts packages/platform-core/__tests__/dataRoot.test.ts --config jest.config.cjs --runInBand --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_68bc98e2c7bc832fb090bab2f1e8a1d3