### PR TITLE
test: verify logout clears cookies

### DIFF
--- a/apps/shop-bcd/__tests__/logout.test.ts
+++ b/apps/shop-bcd/__tests__/logout.test.ts
@@ -3,8 +3,10 @@ jest.mock("@auth", () => ({
   __esModule: true,
   destroyCustomerSession: jest.fn(),
 }));
+jest.mock("next/headers", () => ({ cookies: jest.fn() }));
 
 import { destroyCustomerSession } from "@auth";
+import { cookies } from "next/headers";
 import { GET } from "../src/app/logout/route";
 
 afterEach(() => jest.clearAllMocks());
@@ -21,4 +23,31 @@ test("propagates errors from session destroy", async () => {
   (destroyCustomerSession as jest.Mock).mockRejectedValueOnce(new Error("boom"));
   const req = new Request("http://example.com/logout");
   await expect(GET(req as any)).rejects.toThrow("boom");
+});
+
+test("removes session cookies", async () => {
+  const data = new Map<
+    string,
+    { name: string; value: string }
+  >([
+    ["customer_session", { name: "customer_session", value: "a" }],
+    ["csrf_token", { name: "csrf_token", value: "b" }],
+  ]);
+  const store = {
+    get: jest.fn((name: string) => data.get(name)),
+    set: jest.fn(),
+    delete: jest.fn(({ name }: { name: string }) => {
+      data.delete(name);
+    }),
+  };
+  (cookies as unknown as jest.Mock).mockResolvedValue(store);
+  (destroyCustomerSession as jest.Mock).mockImplementationOnce(async () => {
+    const s = await cookies();
+    s.delete({ name: "customer_session" });
+    s.delete({ name: "csrf_token" });
+  });
+  const req = new Request("http://example.com/logout");
+  await GET(req as any);
+  expect(data.has("customer_session")).toBe(false);
+  expect(data.has("csrf_token")).toBe(false);
 });


### PR DESCRIPTION
## Summary
- add a test verifying logout clears customer_session and csrf_token cookies

## Testing
- `pnpm install`
- `pnpm -r build` (fails: prisma.* is of type 'unknown')
- `pnpm test apps/shop-bcd` (fails: Could not find task `apps/shop-bcd`)


------
https://chatgpt.com/codex/tasks/task_e_68bc9ad3e158832f88869439d7e28245