### PR TITLE
test: add checkout network outage scenario

### DIFF
--- a/test/e2e/checkout-flow.spec.ts
+++ b/test/e2e/checkout-flow.spec.ts
@@ -40,4 +40,20 @@ describe("Checkout success and cancel flows", () => {
     cy.wait("@confirmPayment");
     cy.location("pathname").should("eq", "/en/cancelled");
   });
+
+  it("shows an error when the Stripe network is unavailable", () => {
+    cy.intercept("POST", "https://api.stripe.com/**", {
+      forceNetworkError: true,
+    }).as("confirmPayment");
+
+    cy.visit("/en/checkout");
+    cy.wait("@createSession");
+    cy.contains("button", "Pay").click();
+    cy.wait("@confirmPayment");
+    cy.location("pathname").should("eq", "/en/cancelled");
+    cy.contains("Payment failed");
+
+    cy.visit("/en/checkout");
+    cy.contains("button", "Pay").should("not.be.disabled");
+  });
 });


### PR DESCRIPTION
## Summary
- add e2e test covering Stripe network outage and retry flow

## Testing
- `pnpm -r build` *(fails: prisma.* is of type 'unknown')*
- `pnpm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68bc9addbd6c832fb4e30f1ded878d6b