### PR TITLE
test: add preview-token permission tests

### DIFF
--- a/apps/shop-bcd/__tests__/preview-token.test.ts
+++ b/apps/shop-bcd/__tests__/preview-token.test.ts
@@ -1,0 +1,51 @@
+// apps/shop-bcd/__tests__/preview-token.test.ts
+import path from "node:path";
+import { createHmac } from "node:crypto";
+
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+describe("/api/preview-token", () => {
+  const appDir = path.join(__dirname, "..");
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    process.chdir(appDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    jest.resetModules();
+  });
+
+  test("returns 401 for unauthorized", async () => {
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn().mockRejectedValue(new Error("no")),
+    }));
+    const { GET } = await import("../src/app/api/preview-token/route");
+    const res = await GET(new Request("https://example.com/api/preview-token"));
+    expect(res.status).toBe(401);
+  });
+
+  test("returns token when authorized", async () => {
+    jest.doMock("@auth", () => ({
+      __esModule: true,
+      requirePermission: jest.fn(),
+    }));
+    jest.doMock("@acme/config/env/auth", () => ({
+      authEnv: { UPGRADE_PREVIEW_TOKEN_SECRET: "shhh" },
+    }));
+    const { GET } = await import("../src/app/api/preview-token/route");
+    const res = await GET(
+      new Request("https://example.com/api/preview-token?pageId=abc"),
+    );
+    const token = createHmac("sha256", "shhh").update("abc").digest("hex");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ token });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for `/api/preview-token` verifying unauthorized requests return 401
- ensure successful requests return HMAC token when permission granted

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: src/repositories/rentalOrders.server.ts(79,25): error TS18046: 'prisma.rentalOrder' is of type 'unknown')*
- `pnpm --filter @apps/shop-bcd exec jest apps/shop-bcd/__tests__/preview-token.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc9ad6d470832fac1db419ee63f086