### PR TITLE
test: add declined card checkout e2e

### DIFF
--- a/test/e2e/checkout-flow.spec.ts
+++ b/test/e2e/checkout-flow.spec.ts
@@ -41,6 +41,27 @@ describe("Checkout success and cancel flows", () => {
     cy.location("pathname").should("eq", "/en/cancelled");
   });
 
+  it("redirects to cancelled with a declined card message", () => {
+    cy.intercept("POST", "https://api.stripe.com/**", {
+      statusCode: 402,
+      body: { error: { message: "Your card was declined" } },
+    }).as("confirmPayment");
+
+    cy.visit("/en/checkout");
+    cy.wait("@createSession");
+    cy.contains("button", "Pay").click();
+    cy.wait("@confirmPayment");
+    cy.location("pathname").should("eq", "/en/cancelled");
+    cy.location("search").should(
+      "eq",
+      "?error=Your%20card%20was%20declined",
+    );
+    cy.contains("Your card was declined");
+
+    cy.visit("/en/checkout");
+    cy.contains("button", "Pay").should("not.be.disabled");
+  });
+
   it("shows an error when the Stripe network is unavailable", () => {
     cy.intercept("POST", "https://api.stripe.com/**", {
       forceNetworkError: true,


### PR DESCRIPTION
## Summary
- add Cypress test for declined card checkout flow

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm exec cypress run --spec test/e2e/checkout-flow.spec.ts` (fails: error while loading shared libraries: libatk-1.0.so.0)


------
https://chatgpt.com/codex/tasks/task_e_68bc9cd889f8832fbc7884a3f3723686