### PR TITLE
Verify Stripe webhook signature

### DIFF
--- a/apps/shop-bcd/__tests__/stripe-webhook.test.ts
+++ b/apps/shop-bcd/__tests__/stripe-webhook.test.ts
@@ -1,0 +1,94 @@
+import { jest } from "@jest/globals";
+process.env.STRIPE_SECRET_KEY = "sk_test";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+if (typeof (Response as any).json !== "function") {
+  (Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+afterEach(() => jest.resetModules());
+
+describe("/api/stripe-webhook", () => {
+  test("verifies signature and forwards events", async () => {
+    const handleStripeWebhook = jest.fn();
+    jest.doMock(
+      "@platform-core/stripe-webhook",
+      () => ({ __esModule: true, handleStripeWebhook }),
+      { virtual: true }
+    );
+    const payload = {
+      type: "checkout.session.completed",
+      data: { object: {} },
+    } as any;
+    const constructEvent = jest.fn().mockReturnValue(payload);
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { webhooks: { constructEvent } },
+    }));
+
+    const { POST } = await import("../src/api/stripe-webhook/route");
+    const body = JSON.stringify(payload);
+    const res = await POST({
+      text: async () => body,
+      headers: new Headers({ "stripe-signature": "sig" }),
+    } as any);
+    expect(constructEvent).toHaveBeenCalledWith(
+      body,
+      "sig",
+      "whsec_test"
+    );
+    expect(handleStripeWebhook).toHaveBeenCalledWith("bcd", payload);
+    expect(res.status).toBe(200);
+  });
+
+  test("returns 400 for invalid signature", async () => {
+    const handleStripeWebhook = jest.fn();
+    jest.doMock(
+      "@platform-core/stripe-webhook",
+      () => ({ __esModule: true, handleStripeWebhook }),
+      { virtual: true }
+    );
+    const constructEvent = jest.fn(() => {
+      throw new Error("bad");
+    });
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { webhooks: { constructEvent } },
+    }));
+
+    const { POST } = await import("../src/api/stripe-webhook/route");
+    const res = await POST({
+      text: async () => "{}",
+      headers: new Headers({ "stripe-signature": "sig" }),
+    } as any);
+    expect(res.status).toBe(400);
+    expect(handleStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when signature header is missing", async () => {
+    const handleStripeWebhook = jest.fn();
+    jest.doMock(
+      "@platform-core/stripe-webhook",
+      () => ({ __esModule: true, handleStripeWebhook }),
+      { virtual: true }
+    );
+    const constructEvent = jest.fn((_: string, sig: string) => {
+      if (!sig) {
+        throw new Error("missing signature");
+      }
+    });
+    jest.doMock("@acme/stripe", () => ({
+      __esModule: true,
+      stripe: { webhooks: { constructEvent } },
+    }));
+
+    const { POST } = await import("../src/api/stripe-webhook/route");
+    const res = await POST({
+      text: async () => "{}",
+      headers: new Headers(),
+    } as any);
+    expect(res.status).toBe(400);
+    expect(handleStripeWebhook).not.toHaveBeenCalled();
+  });
+});

--- a/apps/shop-bcd/src/api/stripe-webhook/route.ts
+++ b/apps/shop-bcd/src/api/stripe-webhook/route.ts
@@ -1,24 +1,24 @@
-import "@acme/zod-utils/initZod";
-import { z } from "zod";
 import { handleStripeWebhook } from "@platform-core/stripe-webhook";
-import type Stripe from "stripe";
+import { stripe } from "@acme/stripe";
+import { paymentsEnv } from "@acme/config/env/payments";
 import { NextRequest, NextResponse } from "next/server";
+import type Stripe from "stripe";
 
 export const runtime = "edge";
 
-const stripeEventSchema = z
-  .object({
-    type: z.string(),
-    data: z.object({ object: z.any() }),
-  })
-  .strict();
-
 export async function POST(req: NextRequest) {
-  const parsed = stripeEventSchema.safeParse(await req.json());
-  if (!parsed.success) {
-    return NextResponse.json({ errors: parsed.error.format() }, { status: 400 });
+  const body = await req.text();
+  const signature = req.headers.get("stripe-signature") ?? "";
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      paymentsEnv.STRIPE_WEBHOOK_SECRET,
+    );
+  } catch {
+    return new NextResponse("Invalid signature", { status: 400 });
   }
-  const event = parsed.data as unknown as Stripe.Event;
   await handleStripeWebhook("bcd", event);
   return NextResponse.json({ received: true });
 }


### PR DESCRIPTION
## Summary
- Verify and construct Stripe events using request body and signature
- Reject unsigned or malformed webhook requests

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/stripe-webhook.test.ts`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68bd44b341c0832fbc26156bc15d9986