### PR TITLE
feat(template-app): add subscription cancel route

### DIFF
--- a/packages/template-app/__tests__/subscription-cancel.route.test.ts
+++ b/packages/template-app/__tests__/subscription-cancel.route.test.ts
@@ -1,0 +1,100 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock("@acme/stripe", () => ({
+  stripe: {
+    subscriptions: {
+      del: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  readShop: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/users", () => ({
+  getUserById: jest.fn(),
+  setStripeSubscriptionId: jest.fn(),
+}));
+
+import { stripe } from "@acme/stripe";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { getUserById, setStripeSubscriptionId } from "@platform-core/repositories/users";
+
+const SHOP = {
+  subscriptionsEnabled: true,
+  billingProvider: "stripe",
+};
+
+const makeReq = (body: unknown) =>
+  ({
+    json: async () => body,
+    nextUrl: { searchParams: new URLSearchParams([["shop", "bcd"]]) },
+  }) as unknown as NextRequest;
+
+describe("/api/subscription/cancel POST", () => {
+  test("deletes subscription and clears id", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue({ id: "u1", stripeSubscriptionId: "sub1" });
+    (stripe.subscriptions.del as jest.Mock).mockResolvedValue({ id: "sub1", status: "canceled" });
+
+    const { POST } = await import("../src/api/subscription/cancel/route");
+    const res = await POST(makeReq({ userId: "u1" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "sub1", status: "canceled" });
+    expect(stripe.subscriptions.del).toHaveBeenCalledWith("sub1");
+    expect(setStripeSubscriptionId).toHaveBeenCalledWith("u1", null, "bcd");
+    const delOrder = (stripe.subscriptions.del as jest.Mock).mock.invocationCallOrder[0];
+    const setOrder = (setStripeSubscriptionId as jest.Mock).mock.invocationCallOrder[0];
+    expect(delOrder).toBeLessThan(setOrder);
+  });
+
+  test("returns 400 on missing params", async () => {
+    const { POST } = await import("../src/api/subscription/cancel/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing parameters" });
+  });
+
+  test("returns 403 when subscriptions disabled", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ subscriptionsEnabled: false });
+    const { POST } = await import("../src/api/subscription/cancel/route");
+    const res = await POST(makeReq({ userId: "u1" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Subscriptions disabled" });
+  });
+
+  test("returns 400 when billing provider missing", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ subscriptionsEnabled: true, billingProvider: "other" });
+    const { POST } = await import("../src/api/subscription/cancel/route");
+    const res = await POST(makeReq({ userId: "u1" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Billing not enabled" });
+  });
+
+  test("returns 404 when subscription not found", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue({ id: "u1" });
+    const { POST } = await import("../src/api/subscription/cancel/route");
+    const res = await POST(makeReq({ userId: "u1" }));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Subscription not found" });
+  });
+
+  test("returns 500 on stripe error", async () => {
+    (readShop as jest.Mock).mockResolvedValue(SHOP);
+    (getUserById as jest.Mock).mockResolvedValue({ id: "u1", stripeSubscriptionId: "sub1" });
+    (stripe.subscriptions.del as jest.Mock).mockRejectedValue(new Error("boom"));
+    const { POST } = await import("../src/api/subscription/cancel/route");
+    const res = await POST(makeReq({ userId: "u1" }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "boom" });
+    expect(setStripeSubscriptionId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/template-app/src/api/subscription/cancel/route.ts
+++ b/packages/template-app/src/api/subscription/cancel/route.ts
@@ -1,0 +1,51 @@
+// packages/template-app/src/api/subscription/cancel/route.ts
+import { stripe } from "@acme/stripe";
+import { coreEnv } from "@acme/config/env/core";
+import { NextRequest, NextResponse } from "next/server";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { getUserById, setStripeSubscriptionId } from "@platform-core/repositories/users";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const { userId } = (await req.json()) as { userId?: string };
+  if (!userId) {
+    return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
+  }
+
+  const shopId =
+    req.nextUrl.searchParams.get("shop") ||
+    (coreEnv.NEXT_PUBLIC_SHOP_ID as string | undefined) ||
+    "shop";
+
+  const shop = await readShop(shopId);
+  if (!shop.subscriptionsEnabled) {
+    return NextResponse.json(
+      { error: "Subscriptions disabled" },
+      { status: 403 },
+    );
+  }
+  if (shop.billingProvider !== "stripe") {
+    return NextResponse.json({ error: "Billing not enabled" }, { status: 400 });
+  }
+
+  const user = await getUserById(userId);
+  if (!user || !user.stripeSubscriptionId) {
+    return NextResponse.json(
+      { error: "Subscription not found" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const sub = await stripe.subscriptions.del(user.stripeSubscriptionId);
+    await setStripeSubscriptionId(userId, null, shopId);
+    return NextResponse.json({ id: sub.id, status: sub.status });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+    }
+    console.error("An unknown error occurred");
+    return NextResponse.json({ error: "Unknown error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add subscription cancel route for removing Stripe subscriptions
- test cancelling subscriptions and error handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script `check:references`)*
- `pnpm run build:ts` *(fails: Missing script `build:ts`)*
- `pnpm --filter @acme/template-app test --coverage=false __tests__/subscription-cancel.route.test.ts __tests__/subscription-change.route.test.ts __tests__/subscribe.route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bd44c096c8832f98d06c33aa56618f