### PR TITLE
feat: add Stripe webhook test event sender

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "clean": "pnpm -r exec rimraf dist build lib *.tsbuildinfo",
     "test:cms": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
-    "ops:backup-data": "tsx scripts/src/ops/backup-data-root.ts"
+    "ops:backup-data": "tsx scripts/src/ops/backup-data-root.ts",
+    "stripe:send-test-event": "tsx scripts/stripe-send-test-event.ts"
   },
   "dependencies": {
     "@acme/config": "workspace:^",

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -9,3 +9,17 @@ Replace these placeholders with real secrets before deploying and remove
  the fallback defaults in `packages/config/src/env/payments.ts` once
  proper environment injection is in place.
 
+## Webhook testing
+
+Example Stripe event fixtures live in `test/fixtures` and cover common
+scenarios such as `checkout.session.completed` and
+`payment_intent.payment_failed`.
+
+Use the helper script to POST these fixtures to a local webhook endpoint:
+
+```
+pnpm stripe:send-test-event checkout.session.completed http://localhost:3000/api/stripe-webhook
+```
+
+If no URL is provided, the command defaults to
+`http://localhost:3000/api/stripe-webhook`.

--- a/packages/stripe/test/fixtures/checkout.session.completed.json
+++ b/packages/stripe/test/fixtures/checkout.session.completed.json
@@ -1,0 +1,15 @@
+{
+  "id": "evt_test_checkout_completed",
+  "object": "event",
+  "type": "checkout.session.completed",
+  "api_version": "2023-10-16",
+  "data": {
+    "object": {
+      "id": "cs_test_a1b2c3",
+      "object": "checkout.session",
+      "payment_status": "paid",
+      "amount_total": 2000,
+      "currency": "usd"
+    }
+  }
+}

--- a/packages/stripe/test/fixtures/payment_intent.payment_failed.json
+++ b/packages/stripe/test/fixtures/payment_intent.payment_failed.json
@@ -1,0 +1,18 @@
+{
+  "id": "evt_test_payment_failed",
+  "object": "event",
+  "type": "payment_intent.payment_failed",
+  "api_version": "2023-10-16",
+  "data": {
+    "object": {
+      "id": "pi_test_a1b2c3",
+      "object": "payment_intent",
+      "status": "requires_payment_method",
+      "amount": 2000,
+      "currency": "usd",
+      "last_payment_error": {
+        "message": "Your card was declined."
+      }
+    }
+  }
+}

--- a/packages/stripe/test/fixtures/payment_intent.succeeded.json
+++ b/packages/stripe/test/fixtures/payment_intent.succeeded.json
@@ -1,0 +1,15 @@
+{
+  "id": "evt_test_payment_succeeded",
+  "object": "event",
+  "type": "payment_intent.succeeded",
+  "api_version": "2023-10-16",
+  "data": {
+    "object": {
+      "id": "pi_test_succeeded",
+      "object": "payment_intent",
+      "status": "succeeded",
+      "amount": 5000,
+      "currency": "usd"
+    }
+  }
+}

--- a/scripts/__tests__/stripe-send-test-event.test.ts
+++ b/scripts/__tests__/stripe-send-test-event.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+import "ts-node/register";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { rest } from "msw";
+import { server as mswServer } from "../../test/msw/server";
+import { sendStripeTestEvent } from "../stripe-send-test-event.ts";
+
+describe("stripe-send-test-event script", () => {
+  it("POSTs fixture to provided webhook URL", async () => {
+    const received: any[] = [];
+    const webhookServer = createServer((req, res) => {
+      let data = "";
+      req.on("data", (chunk) => {
+        data += chunk;
+      });
+      req.on("end", () => {
+        received.push(JSON.parse(data));
+        res.statusCode = 200;
+        res.end("ok");
+      });
+    });
+
+    await new Promise<void>((resolve) => webhookServer.listen(0, resolve));
+    const port = (webhookServer.address() as AddressInfo).port;
+    const url = `http://localhost:${port}`;
+
+    // allow MSW to passthrough to local server
+    mswServer.use(rest.post(url, (req) => req.passthrough()));
+
+    const res = await sendStripeTestEvent("checkout.session.completed", url);
+    expect(res.status).toBe(200);
+    expect(received[0].type).toBe("checkout.session.completed");
+
+    webhookServer.close();
+  });
+});

--- a/scripts/stripe-send-test-event.ts
+++ b/scripts/stripe-send-test-event.ts
@@ -1,0 +1,58 @@
+// scripts/stripe-send-test-event.ts
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+/**
+ * POST a Stripe event fixture to a local webhook.
+ *
+ * @param eventName Name of the fixture file without extension.
+ * @param webhookUrl URL to POST the event to.
+ */
+export async function sendStripeTestEvent(
+  eventName: string,
+  webhookUrl: string,
+) {
+  const fixturePath = resolve(
+    process.cwd(),
+    "packages/stripe/test/fixtures",
+    `${eventName}.json`,
+  );
+  const body = await readFile(fixturePath, "utf8");
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status} ${res.statusText}`);
+  }
+  return res;
+}
+
+async function main() {
+  const [eventName, url] = process.argv.slice(2);
+  if (!eventName) {
+    console.error(
+      "Usage: pnpm stripe:send-test-event <event> [url]",
+    );
+    process.exit(1);
+  }
+  const webhookUrl = url ?? "http://localhost:3000/api/stripe-webhook";
+  try {
+    const res = await sendStripeTestEvent(eventName, webhookUrl);
+    console.log(
+      `Sent ${eventName} to ${webhookUrl}: ${res.status} ${res.statusText}`,
+    );
+    const text = await res.text();
+    if (text) console.log(text);
+  } catch (err) {
+    console.error(`Failed to send ${eventName} to ${webhookUrl}`, err);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith("stripe-send-test-event.ts")) {
+  // executed via tsx
+  main();
+}


### PR DESCRIPTION
## Summary
- add script to post Stripe event fixtures to local webhook endpoint
- provide sample Stripe webhook fixtures and docs
- document script usage in @acme/stripe package

## Testing
- `pnpm exec jest scripts/__tests__/stripe-send-test-event.test.ts --coverage=false`
- `pnpm exec jest packages/stripe/src/__tests__/stripe.test.ts --config jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd44cf7b40832f8fe2ee0e0f4ebb32