### PR TITLE
feat(stripe): add mock Stripe client option

### DIFF
--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -2,10 +2,26 @@
 
 Utilities for interacting with the Stripe API.
 
-## TODO
+## Mocking during development
 
-The current implementation uses dummy Stripe credentials for development.
-Replace these placeholders with real secrets before deploying and remove
- the fallback defaults in `packages/config/src/env/payments.ts` once
- proper environment injection is in place.
+Set the `STRIPE_USE_MOCK` environment variable to `true` to replace the
+real Stripe client with a lightweight mock. The mock logs all requests and
+returns predictable dummy data:
+
+```ts
+process.env.STRIPE_USE_MOCK = "true";
+import { stripe } from "@acme/stripe";
+
+await stripe.checkout.sessions.create({
+  mode: "payment",
+  success_url: "https://example.com/success",
+  cancel_url: "https://example.com/cancel",
+  line_items: [{ price: "price_123", quantity: 1 }],
+});
+// → logs "[stripe-mock] checkout.sessions.create" and returns
+//   { id: "cs_test_mock", url: "https://example.com/mock-session" }
+```
+
+`paymentIntents.update` is also implemented. Unset the flag or set it to any
+value other than `true` to use the real Stripe API.
 

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -4,21 +4,52 @@ import "server-only";
 import { coreEnv } from "@acme/config/env/core";
 import Stripe from "stripe";
 
+const useMock = process.env.STRIPE_USE_MOCK === "true";
 /**
  * Edge-friendly Stripe client.
  *
  * • Uses `createFetchHttpClient` so it works on Cloudflare Workers / Pages.
  * • Pins `apiVersion` to Stripe’s latest GA (“2025-06-30.basil”) so typings
  *   and requests stay in sync.
+ * • When `STRIPE_USE_MOCK` is true, exports a lightweight mock that logs
+ *   calls and returns predictable dummy data.
  */
 
-const stripeSecret = coreEnv.STRIPE_SECRET_KEY;
+let stripeClient: Stripe;
 
-if (!stripeSecret) {
-  throw new Error("Neither apiKey nor config.authenticator provided");
+if (useMock) {
+  const mockStripe = {
+    checkout: {
+      sessions: {
+        async create(params: unknown) {
+          console.info("[stripe-mock] checkout.sessions.create", params);
+          return {
+            id: "cs_test_mock",
+            url: "https://example.com/mock-session",
+            object: "checkout.session",
+          };
+        },
+      },
+    },
+    paymentIntents: {
+      async update(id: string, params: unknown) {
+        console.info("[stripe-mock] paymentIntents.update", id, params);
+        return { id, object: "payment_intent", ...(params as object) };
+      },
+    },
+  };
+  stripeClient = mockStripe as unknown as Stripe;
+} else {
+  const stripeSecret = coreEnv.STRIPE_SECRET_KEY;
+
+  if (!stripeSecret) {
+    throw new Error("Neither apiKey nor config.authenticator provided");
+  }
+
+  stripeClient = new Stripe(stripeSecret, {
+    apiVersion: "2025-06-30.basil",
+    httpClient: Stripe.createFetchHttpClient(),
+  });
 }
 
-export const stripe = new Stripe(stripeSecret, {
-  apiVersion: "2025-06-30.basil",
-  httpClient: Stripe.createFetchHttpClient(),
-});
+export const stripe = stripeClient;


### PR DESCRIPTION
## Summary
- allow using a lightweight Stripe mock via `STRIPE_USE_MOCK`
- document how to enable the mock for development/testing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/stripe build`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*


------
https://chatgpt.com/codex/tasks/task_e_68bd44c9d478832fb68f411bb5538842