### PR TITLE
docs: clarify Prisma migrate command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ DATABASE_URL="postgres://user:password@localhost:5432/shop"
 ```
 
 ```bash
-pnpm prisma migrate dev
+pnpm exec prisma migrate dev
 pnpm tsx packages/platform-core/prisma/seed.ts
 ```
 


### PR DESCRIPTION
## Summary
- instruct users to run `pnpm exec prisma migrate dev` when applying migrations

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68bd472d2958832f8d330d26661eaa64