### PR TITLE
docs: note helper for dynamic prisma access

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,6 +22,24 @@ Before submitting changes, run [`pnpm lint`](../package.json#L24) and [`pnpm tes
 
 See [testing](./testing.md) for guidance on running tests with Prisma.
 
+## Prisma model access
+
+Avoid extending `PrismaClient` with a permissive string index signature. When a
+model name must be chosen dynamically, use a helper function to keep type
+safety:
+
+```ts
+function getModelDelegate<K extends keyof PrismaClient>(
+  client: PrismaClient,
+  model: K,
+): PrismaClient[K] {
+  return client[model];
+}
+```
+
+This approach prevents the accidental introduction of an `any`-typed index
+signature on the Prisma client.
+
 ## API documentation
 
 Generate API reference docs for all public packages by running:

--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,5 +1,19 @@
 import { PrismaClient } from '@prisma/client';
 
+/**
+ * Avoid augmenting `PrismaClient` with a permissive index signature.
+ * For dynamic model access, use a typed helper instead:
+ *
+ * ```ts
+ * function getModelDelegate<K extends keyof PrismaClient>(
+ *   client: PrismaClient,
+ *   model: K,
+ * ): PrismaClient[K] {
+ *   return client[model];
+ * }
+ * ```
+ */
+
 type RentalOrder = {
   shop: string;
   sessionId: string;


### PR DESCRIPTION
## Summary
- document type-safe helper for dynamic Prisma model access
- advise contributors against adding PrismaClient index signatures

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/platform-core lint` *(fails: Cannot find package '@acme/eslint-plugin-ds/dist/index.js')*
- `pnpm --filter @acme/platform-core test` *(fails: CartContext tests and env schema tests)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bd457b3de4832fbda1f41fcdad5609