### PR TITLE
docs: document performance budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ Repeat this pattern for any other packages an app consumes to avoid missing modu
 
 - If `pnpm run dev` fails with an `array.length` error, run the appropriate Codex command to retrieve detailed failure information.
 
+## Performance
+
+See [docs/performance-budgets.md](docs/performance-budgets.md) for p95 latency budgets and corresponding k6 thresholds.
+
 ## Notes
 
 See [docs/lighthouse.md](docs/lighthouse.md) for running Lighthouse audits.

--- a/docs/performance-budgets.md
+++ b/docs/performance-budgets.md
@@ -1,0 +1,13 @@
+# Performance Budgets
+
+This document outlines p95 latency goals for critical API routes. Each goal mirrors the `http_req_duration` threshold defined in its accompanying [k6](https://k6.io/) load test script.
+
+| Route | k6 script | p95 latency threshold |
+|-------|-----------|-----------------------|
+| Checkout | `apps/api/load-tests/checkout.k6.js` | < 750ms |
+| Cart | `apps/api/load-tests/cart.k6.js` | < 500ms |
+| Media | `apps/api/load-tests/media.k6.js` | < 1000ms |
+| Rental return | `apps/api/load-tests/rental-return.k6.js` | < 1500ms |
+| Publish upgrade | `apps/api/load-tests/publish-upgrade.k6.js` | < 5000ms |
+
+These budgets help ensure that high-traffic routes remain responsive under load. Adjust the thresholds in the corresponding k6 scripts if real-world conditions require different targets.


### PR DESCRIPTION
## Summary
- document p95 latency budgets for checkout, cart, media, rental-return, and publish-upgrade routes
- cross-reference relevant k6 load test scripts
- link performance budget doc from README

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68bd4591c73c832fb430f8d72b0fcc8d