### PR TITLE
feat: add rental return load test

### DIFF
--- a/apps/shop-bcd/load-tests/rental-return.k6.js
+++ b/apps/shop-bcd/load-tests/rental-return.k6.js
@@ -1,0 +1,46 @@
+/**
+ * Load test for rental and return routes.
+ * Usage:
+ *   SHOP_BASE_URL=http://localhost:3004 k6 run rental-return.k6.js
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    rentalReturn: {
+      executor: 'constant-vus',
+      vus: 5,
+      duration: '30s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const base = __ENV.SHOP_BASE_URL;
+  const sessionId = `vu-${__VU}-iter-${__ITER}`;
+  const params = { headers: { 'Content-Type': 'application/json' } };
+
+  const rentalRes = http.post(`${base}/api/rental`, JSON.stringify({ sessionId }), params);
+  check(rentalRes, {
+    'rental status 200': (r) => r.status === 200,
+  });
+
+  if (Math.random() < 0.5) {
+    const patchRes = http.patch(`${base}/api/rental`, JSON.stringify({ sessionId }), params);
+    check(patchRes, {
+      'patch status 200': (r) => r.status === 200,
+    });
+  } else {
+    const returnRes = http.post(`${base}/api/return`, JSON.stringify({ sessionId }), params);
+    check(returnRes, {
+      'return status 200': (r) => r.status === 200,
+    });
+  }
+
+  sleep(1);
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,3 +41,14 @@ pnpm tsx packages/platform-core/prisma/seed.ts
 ```
 
 Run these commands before `pnpm test` so each test suite starts from a clean, seeded state.
+
+## Load testing
+
+Load tests use [k6](https://k6.io) and are run manually. They are not executed in continuous integration.
+
+To exercise the rental and return flows:
+
+```bash
+cd apps/shop-bcd/load-tests
+SHOP_BASE_URL=http://localhost:3004 k6 run rental-return.k6.js
+```


### PR DESCRIPTION
## Summary
- add k6 load test for rental and return endpoints
- document manual load test execution

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm exec eslint apps/shop-bcd/load-tests/rental-return.k6.js`
- `pnpm test --filter @apps/shop-bcd`


------
https://chatgpt.com/codex/tasks/task_e_68bd4590b0ec832f989e58e46764bb2f