### PR TITLE
Add k6 load test for CMS media uploads

### DIFF
--- a/apps/cms/load-tests/media-upload.k6.js
+++ b/apps/cms/load-tests/media-upload.k6.js
@@ -1,0 +1,32 @@
+/**
+ * Load test for CMS media upload.
+ * Usage:
+ *   CMS_BASE_URL=http://localhost:8789 k6 run media-upload.k6.js
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import encoding from 'k6/encoding';
+
+export const options = {
+  scenarios: {
+    upload: {
+      executor: 'constant-vus',
+      vus: 5,
+      duration: '30s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+const imgBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==';
+
+export default function () {
+  const bin = encoding.b64decode(imgBase64, 'binary');
+  const data = { file: http.file(bin, 'pixel.png', 'image/png') };
+  const res = http.post(`${__ENV.CMS_BASE_URL}/cms/api/media?shop=test`, data);
+  check(res, { 'status 200': (r) => r.status === 200 });
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add media upload load test using k6 and inline image

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @apps/cms test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68bd458ff0b4832f9e49b2d18817fc4a