### PR TITLE
test: add PublishLocationSelector tests

### DIFF
--- a/packages/ui/__tests__/PublishLocationSelector.test.tsx
+++ b/packages/ui/__tests__/PublishLocationSelector.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import PublishLocationSelector from "../src/components/cms/PublishLocationSelector";
+
+const locations = [
+  { id: "a", name: "A", description: "Alpha", requiredOrientation: "landscape" },
+  { id: "b", name: "B", description: "Beta", requiredOrientation: "portrait" },
+];
+
+const reload = jest.fn();
+
+jest.mock("@acme/platform-core/hooks/usePublishLocations", () => ({
+  usePublishLocations: () => ({ locations, reload }),
+}));
+
+describe("PublishLocationSelector", () => {
+  beforeEach(() => {
+    reload.mockClear();
+  });
+
+  it("calls onChange with updated ids when toggling", () => {
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <PublishLocationSelector selectedIds={["a"]} onChange={onChange} />
+    );
+
+    fireEvent.click(screen.getAllByRole("checkbox")[1]);
+    expect(onChange).toHaveBeenCalledWith(["a", "b"]);
+
+    rerender(
+      <PublishLocationSelector selectedIds={["a", "b"]} onChange={onChange} />
+    );
+
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    expect(onChange).toHaveBeenLastCalledWith(["b"]);
+  });
+
+  it("invokes reload when refresh clicked", () => {
+    const onChange = jest.fn();
+    render(
+      <PublishLocationSelector
+        selectedIds={[]}
+        onChange={onChange}
+        showReload
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /refresh list/i }));
+    expect(reload).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add PublishLocationSelector tests for checkbox toggling and refresh handling

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/PublishLocationSelector.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bd4851c7c8832fbf55b60dd2746d98