### PR TITLE
test(sanity): verify client options

### DIFF
--- a/packages/sanity/__tests__/client.test.ts
+++ b/packages/sanity/__tests__/client.test.ts
@@ -1,0 +1,46 @@
+jest.mock('@sanity/client', () => ({
+  createClient: jest.fn(),
+}));
+jest.mock('@platform-core/repositories/shop.server', () => ({
+  getShopById: jest.fn(),
+}));
+jest.mock('@platform-core/shops', () => ({
+  getSanityConfig: jest.fn(),
+}));
+
+import { fetchPublishedPosts } from '../src';
+import { createClient } from '@sanity/client';
+import { getShopById } from '@platform-core/repositories/shop.server';
+import { getSanityConfig } from '@platform-core/shops';
+
+describe('client', () => {
+  const createClientMock = createClient as jest.Mock;
+  const getShopByIdMock = getShopById as jest.Mock;
+  const getSanityConfigMock = getSanityConfig as jest.Mock;
+
+  beforeEach(() => {
+    createClientMock.mockReturnValue({ fetch: jest.fn().mockResolvedValue([]) });
+    getShopByIdMock.mockResolvedValue({ id: 'shop1' });
+    getSanityConfigMock.mockReturnValue({
+      projectId: 'pid',
+      dataset: 'ds',
+      token: 'tkn',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls createClient with expected options', async () => {
+    await fetchPublishedPosts('shop1');
+
+    expect(createClientMock).toHaveBeenCalledWith({
+      projectId: 'pid',
+      dataset: 'ds',
+      token: 'tkn',
+      apiVersion: '2023-01-01',
+      useCdn: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying that fetchPublishedPosts passes correct options to createClient

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/sanity/__tests__/client.test.ts --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68bd486fcdf8832f87e7616995dfed51