### PR TITLE
Add Zod validation tests for getConfig

### DIFF
--- a/packages/sanity/__tests__/getConfig.test.ts
+++ b/packages/sanity/__tests__/getConfig.test.ts
@@ -1,0 +1,45 @@
+jest.mock('@platform-core/repositories/shop.server', () => ({
+  getShopById: jest.fn(),
+}));
+jest.mock('@platform-core/shops', () => ({
+  getSanityConfig: jest.fn(),
+}));
+
+import { getConfig } from '../src';
+import { getShopById } from '@platform-core/repositories/shop.server';
+import { getSanityConfig } from '@platform-core/shops';
+import { ZodError } from 'zod';
+
+describe('getConfig', () => {
+  const getShopByIdMock = getShopById as jest.Mock;
+  const getSanityConfigMock = getSanityConfig as jest.Mock;
+
+  beforeEach(() => {
+    getShopByIdMock.mockResolvedValue({ id: 'shop1' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws a ZodError when token is missing', async () => {
+    getSanityConfigMock.mockReturnValue({
+      projectId: 'pid',
+      dataset: 'ds',
+    });
+
+    await expect(getConfig('shop1')).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it('throws a ZodError when unexpected fields are present', async () => {
+    getSanityConfigMock.mockReturnValue({
+      projectId: 'pid',
+      dataset: 'ds',
+      token: 'tkn',
+      extra: 'nope',
+    });
+
+    await expect(getConfig('shop1')).rejects.toBeInstanceOf(ZodError);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for missing token and extra fields in getConfig

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/sanity test` *(fails: CartProvider tests in platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68bd486e8fc8832f985612dec6a35713