### PR TITLE
test: add Breadcrumbs client tests

### DIFF
--- a/packages/ui/__tests__/Breadcrumbs.client.test.tsx
+++ b/packages/ui/__tests__/Breadcrumbs.client.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import BreadcrumbsClient from "../src/components/cms/Breadcrumbs.client";
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+import { usePathname } from "next/navigation";
+const mockPathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+describe("CMS Breadcrumbs client", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders product breadcrumbs with fetched title", async () => {
+    mockPathname.mockReturnValue("/cms/shop/acme/products/123");
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ title: { en: "Product 123" } }),
+    }) as any;
+
+    render(<BreadcrumbsClient />);
+
+    await screen.findByText("Product 123");
+
+    expect(screen.getByRole("link", { name: "Shop" })).toHaveAttribute(
+      "href",
+      "/cms/shop"
+    );
+    expect(screen.getByRole("link", { name: "acme" })).toHaveAttribute(
+      "href",
+      "/cms/shop/acme"
+    );
+    expect(screen.getByRole("link", { name: "Products" })).toHaveAttribute(
+      "href",
+      "/cms/shop/acme/products"
+    );
+    expect(screen.queryByRole("link", { name: "Product 123" })).toBeNull();
+    expect(screen.getByText("Product 123")).toBeInTheDocument();
+  });
+
+  it("renders page breadcrumbs with fetched title", async () => {
+    mockPathname.mockReturnValue("/cms/shop/acme/pages/about");
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ slug: "about", seo: { title: "About Us" } }],
+    }) as any;
+
+    render(<BreadcrumbsClient />);
+
+    await screen.findByText("About Us");
+
+    expect(screen.getByRole("link", { name: "Shop" })).toHaveAttribute(
+      "href",
+      "/cms/shop"
+    );
+    expect(screen.getByRole("link", { name: "acme" })).toHaveAttribute(
+      "href",
+      "/cms/shop/acme"
+    );
+    expect(screen.getByRole("link", { name: "Pages" })).toHaveAttribute(
+      "href",
+      "/cms/shop/acme/pages"
+    );
+    expect(screen.queryByRole("link", { name: "About Us" })).toBeNull();
+    expect(screen.getByText("About Us")).toBeInTheDocument();
+  });
+
+  it("falls back to path segment when fetch fails", async () => {
+    mockPathname.mockReturnValue("/cms/shop/acme/products/999");
+    global.fetch = jest.fn().mockRejectedValue(new Error("fail")) as any;
+
+    render(<BreadcrumbsClient />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    expect(screen.getByText("999")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for CMS Breadcrumbs client
- verify product and page titles via mocked fetch and pathname
- ensure component gracefully handles fetch failures

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/Breadcrumbs.client.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bd48545e30832f862065dd0d0ae64a