### PR TITLE
test: add ProductRowActions unit test

### DIFF
--- a/packages/ui/__tests__/ProductRowActions.test.tsx
+++ b/packages/ui/__tests__/ProductRowActions.test.tsx
@@ -1,0 +1,39 @@
+import "../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProductRowActions from "../src/components/cms/products/ProductRowActions";
+
+describe("ProductRowActions", () => {
+  const shop = "demo-shop";
+  const product = { id: "prod1" } as any;
+
+  it("links to edit and view pages and triggers callbacks", async () => {
+    const onDuplicate = jest.fn();
+    const onDelete = jest.fn();
+
+    render(
+      <ProductRowActions
+        shop={shop}
+        product={product}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Edit" })).toHaveAttribute(
+      "href",
+      `/cms/shop/${shop}/products/${product.id}/edit`,
+    );
+    expect(screen.getByRole("link", { name: "View" })).toHaveAttribute(
+      "href",
+      `/en/product/${product.id}`,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Duplicate" }));
+    expect(onDuplicate).toHaveBeenCalledWith(product.id);
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledWith(product.id);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test for ProductRowActions edit/view links and callbacks

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test` *(fails: CartContext tests failing)*
- `pnpm exec jest packages/ui/__tests__/ProductRowActions.test.tsx --runInBand --detectOpenHandles --config jest.config.cjs` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4850aad8832fb14c7bb29e9b0dd3