### PR TITLE
test: add organism component tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/CategoryCard.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/CategoryCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { CategoryCard } from "../CategoryCard";
+import "../../../../../../test/resetNextMocks";
+
+describe("CategoryCard", () => {
+  const category = {
+    id: "1",
+    title: "Shoes",
+    image: "/shoe.jpg",
+    description: "Great footwear",
+  };
+
+  it("renders category details and padding", () => {
+    const { container } = render(
+      <CategoryCard category={category} padding="p-8" className="extra" />
+    );
+
+    expect(screen.getByAltText("Shoes")).toBeInTheDocument();
+    expect(screen.getByText("Shoes")).toBeInTheDocument();
+    expect(screen.getByText("Great footwear")).toBeInTheDocument();
+
+    const card = container.firstChild as HTMLElement;
+    expect(card).toHaveClass("p-8", "extra");
+  });
+
+  it("omits description when absent", () => {
+    render(
+      <CategoryCard
+        category={{ id: "1", title: "Shoes", image: "/shoe.jpg" }}
+      />
+    );
+    expect(screen.queryByText("Great footwear")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/CheckoutStepper.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/CheckoutStepper.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { CheckoutStepper } from "../CheckoutStepper";
+
+describe("CheckoutStepper", () => {
+  const steps = ["Cart", "Shipping", "Payment"];
+
+  it("updates step visuals when currentStep changes", () => {
+    const { rerender } = render(
+      <CheckoutStepper steps={steps} currentStep={0} />
+    );
+
+    expect(screen.getByText("Cart").previousSibling).toHaveTextContent("1");
+
+    rerender(<CheckoutStepper steps={steps} currentStep={1} />);
+
+    const firstBullet = screen.getByText("Cart").previousSibling as HTMLElement;
+    expect(firstBullet.querySelector("svg")).toBeInTheDocument();
+
+    const secondLabel = screen.getByText("Shipping");
+    const secondBullet = secondLabel.previousSibling as HTMLElement;
+    expect(secondBullet).toHaveTextContent("2");
+    expect(secondBullet).toHaveClass("border-primary");
+    expect(secondLabel).toHaveClass("font-medium");
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/FilterSidebar.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/FilterSidebar.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FilterSidebar } from "../FilterSidebar";
+
+describe("FilterSidebar", () => {
+  it("opens sidebar and updates filters on selection", async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(<FilterSidebar onChange={onChange} width={320} />);
+
+    expect(onChange).toHaveBeenCalledWith({ size: undefined });
+
+    await user.click(screen.getByRole("button", { name: /filters/i }));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "42" }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith({ size: "42" })
+    );
+
+    expect(screen.getByRole("dialog")).toHaveClass("w-[320px]");
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/ProductFeatures.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductFeatures.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { ProductFeatures } from "../ProductFeatures";
+
+describe("ProductFeatures", () => {
+  it("renders features with icons and applies className", () => {
+    const features = ["Waterproof", "Eco-friendly"];
+    const { container } = render(
+      <ProductFeatures features={features} className="custom" />
+    );
+
+    features.forEach((f) => {
+      expect(screen.getByText(f)).toBeInTheDocument();
+    });
+
+    const list = container.firstChild as HTMLElement;
+    expect(list).toHaveClass("space-y-2", "custom");
+    expect(list.querySelectorAll("svg")).toHaveLength(features.length);
+  });
+});


### PR DESCRIPTION
## Summary
- test FilterSidebar opens and updates filters
- test ProductFeatures renders icons and custom class
- test CategoryCard renders details and optional description
- test CheckoutStepper reflects step transitions

## Testing
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/FilterSidebar.test.tsx packages/ui/src/components/organisms/__tests__/ProductFeatures.test.tsx packages/ui/src/components/organisms/__tests__/CategoryCard.test.tsx packages/ui/src/components/organisms/__tests__/CheckoutStepper.test.tsx --config jest.config.cjs --runInBand --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68bd48579c0c832fab9e7905ce90cfe0