### PR TITLE
test: add block tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/AnnouncementBarBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/AnnouncementBarBlock.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import AnnouncementBarBlock from "../AnnouncementBarBlock";
+
+describe("AnnouncementBarBlock", () => {
+  it("renders provided text", () => {
+    render(<AnnouncementBarBlock text="Sale" />);
+    expect(screen.getByText("Sale")).toBeInTheDocument();
+  });
+
+  it("returns null when no text", () => {
+    const { container } = render(<AnnouncementBarBlock />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/__tests__/BlogListing.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/BlogListing.test.tsx
@@ -1,0 +1,19 @@
+import "../../../../../../../test/resetNextMocks";
+import { render, screen } from "@testing-library/react";
+import BlogListing from "../BlogListing";
+
+describe("BlogListing", () => {
+  it("renders blog posts", () => {
+    render(<BlogListing posts={[{ title: "Post", url: "/post" }]} />);
+    expect(screen.getByRole("heading", { name: "Post" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Post" })).toHaveAttribute(
+      "href",
+      "/post",
+    );
+  });
+
+  it("returns null without posts", () => {
+    const { container } = render(<BlogListing posts={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/cms/blocks/__tests__/Button.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Button.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import Button from "../Button";
+
+describe("Button", () => {
+  it("renders label and href", () => {
+    render(<Button label="Click" href="/go" />);
+    const link = screen.getByRole("link", { name: "Click" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/go");
+  });
+});

--- a/packages/ui/src/components/cms/blocks/__tests__/VideoBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/VideoBlock.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import VideoBlock from "../VideoBlock";
+
+describe("VideoBlock", () => {
+  it("renders video with src", () => {
+    const { container } = render(<VideoBlock src="movie.mp4" />);
+    const video = container.querySelector("video");
+    expect(video).toBeInTheDocument();
+    expect(video).toHaveAttribute("src", "movie.mp4");
+  });
+
+  it("supports autoplay", () => {
+    const { container } = render(<VideoBlock src="movie.mp4" autoplay />);
+    const video = container.querySelector("video") as HTMLVideoElement;
+    expect(video.autoplay).toBe(true);
+    expect(video.muted).toBe(true);
+  });
+
+  it("plays when play is called", () => {
+    const playSpy = jest
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue();
+    const { container } = render(<VideoBlock src="movie.mp4" />);
+    const video = container.querySelector("video") as HTMLVideoElement;
+    video.play();
+    expect(playSpy).toHaveBeenCalled();
+    playSpy.mockRestore();
+  });
+
+  it("returns null without src", () => {
+    const { container } = render(<VideoBlock />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AnnouncementBarBlock, BlogListing, Button, and VideoBlock

## Testing
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm --filter @acme/ui test` (fails: Cannot find module '.prisma/client/index-browser')

------
https://chatgpt.com/codex/tasks/task_e_68bd4856047c832f82bb1d3812074bbb