### PR TITLE
test: add ComponentEditor test

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ComponentEditor from "../ComponentEditor";
+
+describe("ComponentEditor", () => {
+  it("propagates field changes and resizes", async () => {
+    const component: any = {
+      type: "Button",
+      label: "",
+      widthDesktop: "",
+    };
+    const onChange = jest.fn();
+    const onResize = jest.fn();
+
+    render(
+      <ComponentEditor
+        component={component}
+        onChange={onChange}
+        onResize={onResize}
+      />
+    );
+
+    // Update content via the specific editor
+    fireEvent.click(screen.getByRole("button", { name: /Content/ }));
+    const input = await screen.findByLabelText("Label");
+    fireEvent.change(input, { target: { value: "Click" } });
+    expect(onChange).toHaveBeenCalledWith({ label: "Click" });
+
+    // Update a layout field
+    fireEvent.click(screen.getByRole("button", { name: /Layout/ }));
+    fireEvent.change(screen.getByLabelText(/Width \(Desktop\)/), {
+      target: { value: "100px" },
+    });
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: "100px" });
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover ComponentEditor interactions with content and layout

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx --config ../../jest.config.cjs --runInBand --coverage=false`
- `pnpm --filter @acme/ui test` *(fails: CartProvider and releaseDepositsService tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd485a02bc832fa6daf3c9f73ba99c