### PR TITLE
test: verify sequential publish order

### DIFF
--- a/packages/sanity/__tests__/publish.integration.test.ts
+++ b/packages/sanity/__tests__/publish.integration.test.ts
@@ -1,0 +1,70 @@
+jest.mock('@sanity/client', () => ({
+  createClient: jest.fn(),
+}));
+jest.mock('@platform-core/repositories/shop.server', () => ({
+  getShopById: jest.fn(),
+}));
+jest.mock('@platform-core/shops', () => ({
+  getSanityConfig: jest.fn(),
+}));
+
+import { publishQueuedPost } from '../src';
+import { createClient } from '@sanity/client';
+import { getShopById } from '@platform-core/repositories/shop.server';
+import { getSanityConfig } from '@platform-core/shops';
+
+describe('publishQueuedPost integration', () => {
+  const createClientMock = createClient as jest.Mock;
+  const getShopByIdMock = getShopById as jest.Mock;
+  const getSanityConfigMock = getSanityConfig as jest.Mock;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    createClientMock.mockReturnValue({ fetch: fetchMock });
+    getShopByIdMock.mockResolvedValue({ id: 'shop1' });
+    getSanityConfigMock.mockReturnValue({
+      projectId: 'pid',
+      dataset: 'ds',
+      token: 'tkn',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('publishes posts sequentially', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ _id: 'p1' })
+      .mockResolvedValueOnce({ _id: 'p2' });
+
+    const commitMock1 = jest.fn();
+    const commitMock2 = jest.fn();
+    const setMock1 = jest.fn().mockReturnValue({ commit: commitMock1 });
+    const setMock2 = jest.fn().mockReturnValue({ commit: commitMock2 });
+    const patchMock = jest
+      .fn()
+      .mockImplementationOnce(() => ({ set: setMock1 }))
+      .mockImplementationOnce(() => ({ set: setMock2 }));
+
+    createClientMock.mockReturnValue({ fetch: fetchMock, patch: patchMock });
+
+    await publishQueuedPost('shop1');
+    await publishQueuedPost('shop1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(patchMock).toHaveBeenNthCalledWith(1, 'p1');
+    expect(setMock1).toHaveBeenCalledWith(
+      expect.objectContaining({ published: true, publishedAt: expect.any(String) }),
+    );
+    expect(commitMock1).toHaveBeenCalledTimes(1);
+
+    expect(patchMock).toHaveBeenNthCalledWith(2, 'p2');
+    expect(setMock2).toHaveBeenCalledWith(
+      expect.objectContaining({ published: true, publishedAt: expect.any(String) }),
+    );
+    expect(commitMock2).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration test verifying `publishQueuedPost` publishes two queued posts in sequence and commits each

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/sanity run build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/sanity exec jest packages/sanity/__tests__/publish.integration.test.ts packages/sanity/__tests__/index.test.ts packages/sanity/__tests__/fetch.test.ts --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd48783bd0832faf82c8ef897ac5bb