### PR TITLE
feat: add prisma scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "clean": "pnpm -r exec rimraf dist build lib *.tsbuildinfo",
     "test:cms": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
     "ops:backup-data": "tsx scripts/src/ops/backup-data-root.ts",
-    "stripe:send-test-event": "tsx scripts/stripe-send-test-event.ts"
+    "stripe:send-test-event": "tsx scripts/stripe-send-test-event.ts",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {
     "@acme/config": "workspace:^",


### PR DESCRIPTION
## Summary
- add `prisma:generate` and `prisma:migrate` scripts for Prisma CLI

## Testing
- `pnpm install`
- `pnpm run prisma:generate` *(fails: prisma: not found)*
- `pnpm --filter @acme/platform-core test` *(fails: CartProvider offline fallback)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4894ad68832fb43c1b3e63e280b2