### PR TITLE
test: handle null post fetch

### DIFF
--- a/packages/sanity/__tests__/fetch.test.ts
+++ b/packages/sanity/__tests__/fetch.test.ts
@@ -54,6 +54,11 @@ describe('fetch helpers', () => {
     expect(fetchMock).toHaveBeenCalledWith(expect.any(String), { slug: 'post' });
   });
 
+  it('fetchPostBySlug returns null when not found', async () => {
+    fetchMock.mockResolvedValue(null);
+    await expect(fetchPostBySlug('shop1', 'post')).resolves.toBeNull();
+  });
+
   it('fetchPostBySlug returns null on failure', async () => {
     fetchMock.mockRejectedValue(new Error('fail'));
     await expect(fetchPostBySlug('shop1', 'post')).resolves.toBeNull();


### PR DESCRIPTION
## Summary
- extend Sanity fetch tests to ensure `fetchPostBySlug` gracefully handles null results

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/sanity test packages/sanity/__tests__/fetch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bd48724928832f87756247a546ca77