### PR TITLE
test(sanity): add getConfig error handling tests

### DIFF
--- a/packages/sanity/__tests__/getConfig.test.ts
+++ b/packages/sanity/__tests__/getConfig.test.ts
@@ -1,0 +1,37 @@
+jest.mock('@platform-core/repositories/shop.server', () => ({
+  getShopById: jest.fn(),
+}));
+
+jest.mock('@platform-core/shops', () => ({
+  getSanityConfig: jest.fn(),
+}));
+
+import { getConfig } from '../src';
+import { getShopById } from '@platform-core/repositories/shop.server';
+import { getSanityConfig } from '@platform-core/shops';
+
+describe('getConfig', () => {
+  const getShopByIdMock = getShopById as jest.Mock;
+  const getSanityConfigMock = getSanityConfig as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rethrows when getShopById rejects', async () => {
+    const err = new Error('fail');
+    getShopByIdMock.mockRejectedValue(err);
+
+    await expect(getConfig('shop1')).rejects.toBe(err);
+  });
+
+  it('throws when Sanity credentials are missing', async () => {
+    getShopByIdMock.mockResolvedValue(undefined);
+    getSanityConfigMock.mockReturnValue(undefined);
+
+    await expect(getConfig('shop1')).rejects.toThrow(
+      'Missing Sanity credentials for shop shop1',
+    );
+    expect(getSanityConfigMock).toHaveBeenCalledWith(undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `getConfig` to ensure shop lookup errors are rethrown
- check for missing Sanity credentials and throw with shop id

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/sanity test packages/sanity/__tests__/getConfig.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bd486d7068832faa2b1060ac27762b