### PR TITLE
test(sanity): snapshot fetch queries

### DIFF
--- a/packages/sanity/__tests__/__snapshots__/fetch.test.ts.snap
+++ b/packages/sanity/__tests__/__snapshots__/fetch.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fetch helpers fetchPublishedPosts returns posts on success 1`] = `"*[_type == \"post\" && defined(slug.current) && published == true && !(_id in path('drafts.**'))]{title, \"slug\": slug.current, excerpt, mainImage, author, categories, products}"`;
+
+exports[`fetch helpers fetchPostBySlug returns post on success 1`] = `"*[_type == \"post\" && slug.current == $slug && published == true][0]{title, \"slug\": slug.current, excerpt, mainImage, author, categories, products, body[]{..., _type == \"productReference\" => { _type, slug }}}"`;

--- a/packages/sanity/__tests__/fetch.test.ts
+++ b/packages/sanity/__tests__/fetch.test.ts
@@ -40,6 +40,7 @@ describe('fetch helpers', () => {
     const posts = [{ title: 'Post', slug: 'post' }];
     fetchMock.mockResolvedValue(posts);
     await expect(fetchPublishedPosts('shop1')).resolves.toEqual(posts);
+    expect(fetchMock.mock.calls[0][0]).toMatchSnapshot();
   });
 
   it('fetchPublishedPosts returns empty array on failure', async () => {
@@ -51,7 +52,8 @@ describe('fetch helpers', () => {
     const post = { title: 'Post', slug: 'post' };
     fetchMock.mockResolvedValue(post);
     await expect(fetchPostBySlug('shop1', 'post')).resolves.toEqual(post);
-    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), { slug: 'post' });
+    expect(fetchMock.mock.calls[0][0]).toMatchSnapshot();
+    expect(fetchMock.mock.calls[0][1]).toEqual({ slug: 'post' });
   });
 
   it('fetchPostBySlug returns null on failure', async () => {


### PR DESCRIPTION
## Summary
- use snapshots to verify GROQ queries in Sanity fetch helpers
- add stored snapshot strings for fetchPublishedPosts and fetchPostBySlug

## Testing
- `pnpm --filter @acme/sanity test packages/sanity/__tests__/fetch.test.ts` *(fails: "global" coverage threshold not met)*
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4870d348832fbb91dc4938483e1c