### PR TITLE
test: cover rental and return endpoints in load test

### DIFF
--- a/apps/shop-bcd/load-tests/README.md
+++ b/apps/shop-bcd/load-tests/README.md
@@ -1,0 +1,22 @@
+# Load Tests
+
+This directory contains k6 scripts for exercising the shop service.
+
+## Environment variables
+
+- `SHOP_BASE_URL` – base URL of the shop service (e.g., `http://localhost:3004`).
+
+## Session IDs
+
+Session IDs used in the tests follow the pattern `vu-<VU>-iter-<ITER>`. Examples:
+
+- `vu-1-iter-0`
+- `vu-5-iter-3`
+
+## Usage
+
+Run a script with:
+
+```sh
+SHOP_BASE_URL=http://localhost:3004 k6 run rental-return.k6.js
+```

--- a/apps/shop-bcd/load-tests/rental-return.k6.js
+++ b/apps/shop-bcd/load-tests/rental-return.k6.js
@@ -1,5 +1,11 @@
 /**
  * Load test for rental and return routes.
+ *
+ * Environment variables:
+ *   SHOP_BASE_URL - base URL of the shop service (e.g., http://localhost:3004)
+ *
+ * Session IDs follow the pattern `vu-<VU>-iter-<ITER>`, for example `vu-1-iter-0`.
+ *
  * Usage:
  *   SHOP_BASE_URL=http://localhost:3004 k6 run rental-return.k6.js
  */
@@ -30,17 +36,15 @@ export default function () {
     'rental status 200': (r) => r.status === 200,
   });
 
-  if (Math.random() < 0.5) {
-    const patchRes = http.patch(`${base}/api/rental`, JSON.stringify({ sessionId }), params);
-    check(patchRes, {
-      'patch status 200': (r) => r.status === 200,
-    });
-  } else {
-    const returnRes = http.post(`${base}/api/return`, JSON.stringify({ sessionId }), params);
-    check(returnRes, {
-      'return status 200': (r) => r.status === 200,
-    });
-  }
+  const patchRes = http.patch(`${base}/api/rental`, JSON.stringify({ sessionId }), params);
+  check(patchRes, {
+    'patch status 200': (r) => r.status === 200,
+  });
+
+  const returnRes = http.post(`${base}/api/return`, JSON.stringify({ sessionId }), params);
+  check(returnRes, {
+    'return status 200': (r) => r.status === 200,
+  });
 
   sleep(1);
 }


### PR DESCRIPTION
## Summary
- expand rental-return k6 script to exercise rental POST/PATCH and return POST
- document SHOP_BASE_URL and session ID format for load tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68bd4c7aa55c832f9cbc6f3d94b98790