### PR TITLE
Add load test for shop cart API

### DIFF
--- a/apps/shop-bcd/load-tests/cart.k6.js
+++ b/apps/shop-bcd/load-tests/cart.k6.js
@@ -1,0 +1,60 @@
+/**
+ * Load test for cart API.
+ * Usage:
+ *   SHOP_BASE_URL=http://localhost:3004 k6 run cart.k6.js
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    cart: {
+      executor: 'constant-vus',
+      vus: 5,
+      duration: '30s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<300'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const baseUrl = __ENV.SHOP_BASE_URL;
+  const params = { headers: { 'Content-Type': 'application/json' } };
+
+  const getRes = http.get(`${baseUrl}/api/cart`);
+  check(getRes, {
+    'GET status 200': (r) => r.status === 200,
+  });
+
+  const postPayload = JSON.stringify({
+    sku: { id: 'green-sneaker' },
+    qty: 1,
+    size: '42',
+  });
+  const postRes = http.post(`${baseUrl}/api/cart`, postPayload, params);
+  check(postRes, {
+    'POST status 200': (r) => r.status === 200,
+  });
+
+  const cart = postRes.json('cart') || {};
+  const itemId = Object.keys(cart)[0];
+
+  if (itemId) {
+    const patchPayload = JSON.stringify({ id: itemId, qty: 2 });
+    const patchRes = http.patch(`${baseUrl}/api/cart`, patchPayload, params);
+    check(patchRes, {
+      'PATCH status 200': (r) => r.status === 200,
+    });
+
+    const deletePayload = JSON.stringify({ id: itemId });
+    const deleteRes = http.del(`${baseUrl}/api/cart`, deletePayload, params);
+    check(deleteRes, {
+      'DELETE status 200': (r) => r.status === 200,
+    });
+  }
+
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add k6 load test for /api/cart with GET→POST→PATCH→DELETE workflow

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @apps/shop-bcd lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `pnpm --filter @apps/shop-bcd test` *(warn: Unsupported engine, no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4c772cbc832fbee67dd8f78666ee