### PR TITLE
Add accessibility checks for login and checkout forms

### DIFF
--- a/cypress/e2e/shop-login.cy.ts
+++ b/cypress/e2e/shop-login.cy.ts
@@ -11,4 +11,31 @@ describe("Shop login", () => {
     cy.location("pathname").should("eq", "/");
     cy.getCookie("customer_session").should("not.exist");
   });
+
+  it("has accessible form inputs and validation", () => {
+    cy.visit("/login");
+    cy.injectAxe();
+    cy.checkA11y();
+
+    ["customerId", "password"].forEach((name) => {
+      cy.get(`input[name="${name}"]`).should(($input) => {
+        const id = $input.attr("id");
+        const ariaLabel = $input.attr("aria-label");
+        const hasLabel = !!id && Cypress.$(`label[for="${id}"]`).length > 0;
+        expect(Boolean(ariaLabel) || hasLabel).to.be.true;
+      });
+    });
+
+    cy.contains("button", "Login").click();
+
+    ["customerId", "password"].forEach((name) => {
+      cy.get(`input[name="${name}"]`)
+        .should("have.attr", "aria-invalid", "true")
+        .invoke("attr", "aria-describedby")
+        .then((describedBy) => {
+          expect(describedBy).to.exist;
+          cy.get(`#${describedBy}`).should("be.visible");
+        });
+    });
+  });
 });

--- a/cypress/e2e/shop-order.cy.ts
+++ b/cypress/e2e/shop-order.cy.ts
@@ -58,5 +58,34 @@ describe("Shop order flow", () => {
     cy.visit("/account/orders");
     cy.contains("Order:").should("exist");
   });
+
+  it("has accessible checkout form inputs and validation", () => {
+    cy.visit("/login");
+    cy.get('input[name="customerId"]').type("cust1");
+    cy.get('input[name="password"]').type("pass1");
+    cy.contains("button", "Login").click();
+
+    cy.visit("/en/checkout");
+    cy.injectAxe();
+    cy.checkA11y();
+
+    cy.get('input[type="date"]').should(($input) => {
+      const id = $input.attr("id");
+      const ariaLabel = $input.attr("aria-label");
+      const hasForLabel = !!id && Cypress.$(`label[for="${id}"]`).length > 0;
+      const hasParentLabel = $input.closest("label").length > 0;
+      expect(Boolean(ariaLabel) || hasForLabel || hasParentLabel).to.be.true;
+    });
+
+    cy.get('input[type="date"]').clear();
+    cy.contains("button", "Pay").click();
+
+    cy.get('input[type="date"]').should("have.attr", "aria-invalid", "true")
+      .invoke("attr", "aria-describedby")
+      .then((describedBy) => {
+        expect(describedBy).to.exist;
+        cy.get(`#${describedBy}`).should("be.visible");
+      });
+  });
 });
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,5 +1,8 @@
 // cypress/support/index.ts
 
+// Enable accessibility testing commands
+import "cypress-axe";
+
 // Enable Mock Service Worker for API mocking in Cypress tests
 import { server } from "../../test/msw/server";
 

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "cross-env": "^7.0.3",
     "cross-fetch": "^4.1.0",
     "cypress": "^14.5.0",
+    "cypress-axe": "^1.7.0",
     "dotenv": "^17.2.1",
     "eslint": "^9.30.1",
     "eslint-config-next": "15.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       cypress:
         specifier: ^14.5.0
         version: 14.5.1
+      cypress-axe:
+        specifier: ^1.7.0
+        version: 1.7.0(axe-core@4.10.3)(cypress@14.5.1)
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -5838,6 +5841,13 @@ packages:
   cwd@0.10.0:
     resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
     engines: {node: '>=0.8'}
+
+  cypress-axe@1.7.0:
+    resolution: {integrity: sha512-zzJpvAAjauEB3GZl0KYXb8i3w6MztWAt2WM3czYTFyNVC30alDmqCm9E7GwZ4bgkldZJlmHakaVEyu73R5St4w==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      axe-core: ^3 || ^4
+      cypress: ^10 || ^11 || ^12 || ^13 || ^14 || ^15
 
   cypress@14.5.1:
     resolution: {integrity: sha512-vYBeZKW3UAtxwv5mFuSlOBCYhyO0H86TeDKRJ7TgARyHiREIaiDjeHtqjzrXRFrdz9KnNavqlm+z+hklC7v8XQ==}
@@ -16735,6 +16745,11 @@ snapshots:
     dependencies:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
+
+  cypress-axe@1.7.0(axe-core@4.10.3)(cypress@14.5.1):
+    dependencies:
+      axe-core: 4.10.3
+      cypress: 14.5.1
 
   cypress@14.5.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add cypress-axe support for accessibility testing
- check login form inputs for labels, validation, and a11y issues
- add similar accessibility assertions for checkout return date field

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm cypress run --spec cypress/e2e/shop-login.cy.ts` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4c3fe898832fbeab3c13a1f46015