### PR TITLE
test(sanity): cover getConfig error cases

### DIFF
--- a/packages/sanity/__tests__/getConfig.test.ts
+++ b/packages/sanity/__tests__/getConfig.test.ts
@@ -22,6 +22,22 @@ describe('getConfig', () => {
     jest.clearAllMocks();
   });
 
+  it('rethrows errors from getShopById', async () => {
+    const err = new Error('boom');
+    getShopByIdMock.mockRejectedValue(err);
+
+    await expect(getConfig('shop1')).rejects.toBe(err);
+    expect(getSanityConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when shop is missing Sanity credentials', async () => {
+    getShopByIdMock.mockResolvedValue(undefined);
+    getSanityConfigMock.mockReturnValue(undefined);
+
+    await expect(getConfig('shop1'))
+      .rejects.toThrow('Missing Sanity credentials for shop shop1');
+  });
+
   it('throws a ZodError when token is missing', async () => {
     getSanityConfigMock.mockReturnValue({
       projectId: 'pid',


### PR DESCRIPTION
## Summary
- add tests for getShopById failures and missing Sanity credentials in getConfig

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/sanity test` *(fails: process output truncated)*


------
https://chatgpt.com/codex/tasks/task_e_68bd4c284f30832f84b5a2b97b2b2db8