### PR TITLE
test: add combined shipments refund scenario

### DIFF
--- a/packages/platform-core/__tests__/combined-shipments.test.ts
+++ b/packages/platform-core/__tests__/combined-shipments.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+
+interface OrderItem {
+  id: string;
+  type: 'rental' | 'sale';
+  status: 'pending' | 'shipped' | 'failed' | 'refunded';
+}
+
+interface Order {
+  id: string;
+  items: OrderItem[];
+  status: 'pending' | 'partial' | 'shipped';
+}
+
+function buildOrder(items: OrderItem[]): Order {
+  return { id: 'order1', items: [...items], status: 'pending' };
+}
+
+function applyShipmentUpdate(
+  order: Order,
+  updates: Array<{ id: string; status: OrderItem['status'] }>,
+): Order {
+  for (const update of updates) {
+    const item = order.items.find((i) => i.id === update.id);
+    if (item) item.status = update.status;
+  }
+  const shipped = order.items.filter((i) => i.status === 'shipped').length;
+  const handled = order.items.filter((i) => i.status === 'shipped' || i.status === 'refunded').length;
+  if (handled === order.items.length) {
+    order.status = 'shipped';
+  } else if (shipped > 0) {
+    order.status = 'partial';
+  } else {
+    order.status = 'pending';
+  }
+  return order;
+}
+
+describe('combined shipments with refunds', () => {
+  it('transitions from partial to shipped when remaining items are refunded', () => {
+    const order = buildOrder([
+      { id: 'rental1', type: 'rental', status: 'pending' },
+      { id: 'sale1', type: 'sale', status: 'pending' },
+      { id: 'sale2', type: 'sale', status: 'pending' },
+    ]);
+
+    applyShipmentUpdate(order, [
+      { id: 'rental1', status: 'shipped' },
+      { id: 'sale1', status: 'shipped' },
+    ]);
+    expect(order.status).toBe('partial');
+
+    applyShipmentUpdate(order, [{ id: 'sale2', status: 'failed' }]);
+    expect(order.status).toBe('partial');
+
+    applyShipmentUpdate(order, [{ id: 'sale2', status: 'refunded' }]);
+    expect(order.status).toBe('shipped');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add combined shipments test covering shipped and refunded items

## Testing
- `pnpm test packages/platform-core/__tests__/combined-shipments.test.ts` *(fails: Missing tasks in project)*
- `pnpm exec jest packages/platform-core/__tests__/combined-shipments.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d309834832f95ad09f8dae5be13