### PR TITLE
feat(platform-core): add refundOrder logic

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -44,6 +44,17 @@ function createTestPrismaStub(): Pick<
           if (where.customerId && o.customerId !== where.customerId) return false;
           return true;
         }),
+      findUnique: async ({ where }: any) => {
+        if (where?.shop_sessionId) {
+          const { shop, sessionId } = where.shop_sessionId;
+          return (
+            rentalOrders.find(
+              (o) => o.shop === shop && o.sessionId === sessionId,
+            ) || null
+          );
+        }
+        return null;
+      },
       create: async ({ data }: { data: RentalOrder }) => {
         rentalOrders.push({ ...data });
         return data;

--- a/packages/platform-core/src/orders.d.ts
+++ b/packages/platform-core/src/orders.d.ts
@@ -11,6 +11,7 @@ export declare function markDelivered(shop: string, sessionId: string): Promise<
 export declare function markCancelled(shop: string, sessionId: string): Promise<Order>;
 export declare function markReturned(shop: string, sessionId: string, damageFee?: number): Promise<Order | null>;
 export declare function markRefunded(shop: string, sessionId: string, riskLevel?: string, riskScore?: number, flaggedForReview?: boolean): Promise<Order | null>;
+export declare function refundOrder(shop: string, sessionId: string, amount: number): Promise<Order | null>;
 export declare function updateRisk(shop: string, sessionId: string, riskLevel?: string, riskScore?: number, flaggedForReview?: boolean): Promise<Order | null>;
 export declare function getOrdersForCustomer(shop: string, customerId: string): Promise<Order[]>;
 export declare function setReturnTracking(shop: string, sessionId: string, trackingNumber: string, labelUrl: string): Promise<Order | null>;


### PR DESCRIPTION
## Summary
- support partial deposit refunds by computing remaining refundable amount
- integrate Stripe refunds before marking orders and tracking totals
- extend test Prisma stub with `findUnique`

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5d2c6784832fb71fa3f6e5236597