### PR TITLE
chore(cms): update ts-jest config

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -36,20 +36,14 @@ module.exports = {
     "^packages/config/src/env/(.*)\\.js$": "<rootDir>/packages/config/src/env/$1.ts",
     // TODO: map test-friendly stubs once available
   },
-  globals: {
-    "ts-jest": {
-      tsconfig: path.resolve(__dirname, "tsconfig.test.json"),
-      useESM: false,
-      // Disable Babel transpilation to avoid ts-jest attempting to load
-      // `babel-jest`, which can cause "createTransformer is not a function"
-      // errors when the module is missing or incompatible.
-      babelConfig: false,
-    },
-  },
   transform: {
     "^.+\\.[tj]sx?$": [
       "ts-jest",
-      { useESM: false, babelConfig: false },
+      {
+        tsconfig: path.resolve(__dirname, "tsconfig.test.json"),
+        useESM: false,
+        babelConfig: false,
+      },
     ],
   },
   transformIgnorePatterns: ["/node_modules/(?!(?:@?jose)/)"],


### PR DESCRIPTION
## Summary
- remove ts-jest globals block
- configure ts-jest transform with explicit tsconfig and disable ESM/Babel

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @apps/cms test apps/cms` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5e73dde0832fa5800b9cafba1182