### PR TITLE
test(api): lock all dependencies when body empty

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -166,6 +166,57 @@ describe("onRequestPost", () => {
     },
   );
 
+  it("locks all dependencies and runs build/deploy when body is empty", async () => {
+    readFileSync.mockImplementation((file: string) => {
+      if (file.endsWith("package.json")) {
+        return JSON.stringify({
+          dependencies: { compA: "1.0.0", compB: "2.0.0", compC: "3.0.0" },
+        });
+      }
+      if (file.endsWith("shop.json")) {
+        return JSON.stringify({ componentVersions: {} });
+      }
+      return "";
+    });
+    spawn.mockImplementation(() => ({
+      on: (_: string, cb: (code: number) => void) => cb(0),
+    }));
+
+    const token = jwt.sign({}, "secret");
+    const res = await onRequestPost({
+      params: { id },
+      request: new Request("http://example.com", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({}),
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [shopPath, data] = writeFileSync.mock.calls[0];
+    expect(shopPath).toContain(`data/shops/${id}/shop.json`);
+    const written = JSON.parse(data as string);
+    expect(written.componentVersions).toEqual({
+      compA: "1.0.0",
+      compB: "2.0.0",
+      compC: "3.0.0",
+    });
+    expect(typeof written.lastUpgrade).toBe("string");
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      "pnpm",
+      ["--filter", `apps/shop-${id}`, "build"],
+      { cwd: root, stdio: "inherit" },
+    );
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      "pnpm",
+      ["--filter", `apps/shop-${id}`, "deploy"],
+      { cwd: root, stdio: "inherit" },
+    );
+  });
+
   it("locks all dependencies when body is invalid JSON", async () => {
     readFileSync.mockImplementation((file: string) => {
       if (file.endsWith("package.json")) {


### PR DESCRIPTION
## Summary
- test publish-upgrade locks all dependency versions when request body is empty

## Testing
- `pnpm --filter @apps/api test`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68bd5e603844832facf317e8b5a966d0