### PR TITLE
Improve form accessibility and add Cypress tests

### DIFF
--- a/cypress/e2e/checkout-form-a11y.cy.ts
+++ b/cypress/e2e/checkout-form-a11y.cy.ts
@@ -1,0 +1,37 @@
+import '@testing-library/cypress/add-commands';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+describe('CheckoutForm accessibility', () => {
+  it('focuses first invalid field and announces errors', () => {
+    cy.visit('about:blank').then(async (win) => {
+      const shared = await import('../../packages/shared-utils/src');
+      cy.stub(shared, 'fetchJson').resolves({ clientSecret: 'cs' });
+
+      const stripeJs = await import('@stripe/stripe-js');
+      cy.stub(stripeJs, 'loadStripe').resolves({});
+
+      const stripeReact = await import('@stripe/react-stripe-js');
+      cy.stub(stripeReact, 'Elements').callsFake(({ children }) => <div>{children}</div>);
+      cy.stub(stripeReact, 'PaymentElement').callsFake(() => <div id="payment-element">payment-element</div>);
+      cy.stub(stripeReact, 'useStripe').returns(() => ({} as any));
+      cy.stub(stripeReact, 'useElements').returns(() => ({} as any));
+
+      const { default: CheckoutForm } = await import('../../packages/ui/src/components/checkout/CheckoutForm');
+      ReactDOM.createRoot(win.document.body).render(
+        React.createElement(CheckoutForm, { locale: 'en', taxRegion: 'eu' })
+      );
+    });
+
+    cy.findByRole('button', { name: 'checkout.pay' });
+    cy.injectAxe();
+
+    cy.findByLabelText('checkout.return').clear();
+    cy.findByRole('button', { name: 'checkout.pay' }).click();
+    cy.focused().should('have.attr', 'name', 'returnDate');
+    cy.findByText('checkout.returnDateRequired').should('have.attr', 'role', 'alert');
+    cy.findByLabelText('checkout.return').should('have.attr', 'aria-invalid', 'true');
+
+    cy.checkA11y(undefined, undefined, undefined, true);
+  });
+});

--- a/cypress/e2e/profile-form-a11y.cy.ts
+++ b/cypress/e2e/profile-form-a11y.cy.ts
@@ -1,0 +1,26 @@
+import '@testing-library/cypress/add-commands';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ProfileForm from '../../packages/ui/src/components/account/ProfileForm';
+
+describe('ProfileForm accessibility', () => {
+  it('focuses first invalid field and announces errors', () => {
+    cy.visit('about:blank').then((win) => {
+      ReactDOM.createRoot(win.document.body).render(
+        React.createElement(ProfileForm)
+      );
+    });
+
+    cy.injectAxe();
+
+    cy.findByRole('button', { name: /save/i }).click();
+
+    cy.focused().should('have.attr', 'id', 'name');
+    cy.findByText('Name is required.').should('have.attr', 'role', 'alert');
+    cy.findByText('Email is required.').should('have.attr', 'role', 'alert');
+    cy.findByLabelText('Name').should('have.attr', 'aria-invalid', 'true');
+    cy.findByLabelText('Email').should('have.attr', 'aria-invalid', 'true');
+
+    cy.checkA11y(undefined, undefined, undefined, true);
+  });
+});


### PR DESCRIPTION
## Summary
- add aria attributes and error focusing to ProfileForm and CheckoutForm
- render form errors with alert roles
- add Cypress a11y tests for ProfileForm and CheckoutForm

## Testing
- `pnpm install`
- `pnpm -r build` (failed: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm run check:references` (missing script)
- `pnpm run build:ts` (missing script)
- `pnpm --filter @acme/ui build` (failed: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm test`
- `pnpm exec cypress run --spec cypress/e2e/profile-form-a11y.cy.ts,cypress/e2e/checkout-form-a11y.cy.ts` (failed: Cypress executable not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd5d395c88832f944dbc285814be61