### PR TITLE
refactor: remove unsafe any casts

### DIFF
--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -7,6 +7,7 @@ import { trackOrder } from "./analytics";
 import { prisma } from "./db";
 import { incrementSubscriptionUsage } from "./subscriptionUsage";
 import { stripe } from "@acme/stripe";
+import type { Prisma } from "@prisma/client";
 
 export type Order = RentalOrder;
 
@@ -165,7 +166,8 @@ export async function refundOrder(
   });
   if (!order) return null;
 
-  const alreadyRefunded = (order as any).refundTotal ?? 0;
+  const alreadyRefunded =
+    (order as { refundTotal?: number }).refundTotal ?? 0;
   const refundable = Math.max(amount - alreadyRefunded, 0);
 
   if (refundable > 0) {
@@ -191,7 +193,7 @@ export async function refundOrder(
       data: {
         refundedAt: nowIso(),
         refundTotal: alreadyRefunded + refundable,
-      } as any,
+      } as Prisma.RentalOrderUpdateInput,
     });
     return updated as Order;
   } catch {

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -9,7 +9,7 @@ import { prisma } from "../../db";
 import { validateShopName } from "../../shops/index";
 import { DATA_ROOT } from "../../dataRoot";
 import { nowIso } from "@acme/date-utils";
-import { z } from "zod";
+import { z, type ZodRawShape } from "zod";
 
 /**
  * Prisma-backed pages repository. The database is the source of truth,
@@ -212,7 +212,7 @@ export interface PageDiffEntry {
 const entrySchema = z
   .object({
     timestamp: z.string().datetime(),
-    diff: z.object((pageSchema as any).shape).partial(),
+    diff: z.object(pageSchema.shape as ZodRawShape).partial(),
   })
   .strict();
 

--- a/packages/platform-core/src/repositories/subscriptions.server.ts
+++ b/packages/platform-core/src/repositories/subscriptions.server.ts
@@ -7,12 +7,12 @@ export async function updateSubscriptionPaymentStatus(
   subscriptionId: string,
   status: "succeeded" | "failed",
 ): Promise<void> {
-  await (prisma.user as any).update({
+  await prisma.user.update({
     where: { id: customerId },
     data: {
       stripeSubscriptionId: subscriptionId,
       subscriptionPaymentStatus: status,
-    } as any,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- remove `as any` cast from subscription repository and rely on typed `prisma.user.update`
- construct page history schema using a typed `z.object` instead of `(pageSchema as any).shape`
- eliminate remaining `as any` usage in orders repository

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `rg "as any" packages/platform-core/src --glob '!**/__tests__/**' --glob '!**/*.test.*'`


------
https://chatgpt.com/codex/tasks/task_e_68bd5fddd710832fa923f0fed5fedd6b