### PR TITLE
test: handle missing componentVersions in gatherChanges

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -50,6 +50,18 @@ describe('component helpers', () => {
       expect(gatherChanges('abc', root)).toEqual([]);
     });
 
+    it('returns empty array when shop.json lacks componentVersions', () => {
+      vol.fromJSON({
+        [`${root}/data/shops/abc/shop.json`]: JSON.stringify({}),
+        [`${root}/packages/foo/package.json`]: JSON.stringify({
+          name: '@acme/foo',
+          version: '1.2.0',
+        }),
+      });
+      expect(() => gatherChanges('abc', root)).not.toThrow();
+      expect(gatherChanges('abc', root)).toEqual([]);
+    });
+
     it('skips stored components without a package.json', () => {
       vol.fromJSON({
         [`${root}/data/shops/abc/shop.json`]: JSON.stringify({


### PR DESCRIPTION
## Summary
- add test fixture for shop.json without componentVersions
- ensure gatherChanges returns an empty array and does not throw

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @apps/api test src/routes/components/__tests__/helpers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bd5e65d368832f8d5f329b56ddf1fc