### PR TITLE
test: cover diffDirectories missing in second dir

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -153,6 +153,11 @@ describe('component helpers', () => {
       expect(diffDirectories('/a', '/b')).toEqual(['only.txt']);
     });
 
+    it('detects files present only in second directory', () => {
+      vol.fromJSON({ '/b/only.txt': 'hello' });
+      expect(diffDirectories('/a', '/b')).toEqual(['only.txt']);
+    });
+
     it('detects when file contents differ', () => {
       vol.fromJSON({
         '/a/same.txt': 'one',


### PR DESCRIPTION
## Summary
- test diffDirectories when files exist only in second directory

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Module '@prisma/client' has no exported member 'PrismaClient')
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e68ad10832f9d5aa028a1405b30