### PR TITLE
chore: update prisma generate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test:cms": "pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs",
     "ops:backup-data": "tsx scripts/src/ops/backup-data-root.ts",
     "stripe:send-test-event": "tsx scripts/stripe-send-test-event.ts",
-    "prisma:generate": "prisma generate --schema=packages/platform-core/prisma/schema.prisma"
+    "prisma:generate": "pnpm --filter @acme/platform-core exec prisma generate"
   },
   "dependencies": {
     "@acme/config": "workspace:^",


### PR DESCRIPTION
## Summary
- use pnpm filter when generating Prisma client

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5fda3d70832f973ebbd682990095