### PR TITLE
fix prisma output path

### DIFF
--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../../node_modules/@prisma/client"
+  output   = "../../../node_modules/@prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- fix prisma client output path

## Testing
- `pnpm --filter @acme/platform-core run prisma:generate` *(fails: Generating client into node_modules/@prisma/client is not allowed)*
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm --filter @acme/platform-core run check:references` *(fails: missing script)*
- `pnpm --filter @acme/platform-core run build:ts` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bd620379c4832fbbfc5b1b1f916ee8