### PR TITLE
chore: pin prisma client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@portabletext/editor": "^2.3.1",
     "@portabletext/react": "^3.2.1",
-    "@prisma/client": "^6.14.0",
+    "@prisma/client": "6.14.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-icons": "^1.3.2",

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -144,7 +144,7 @@
     "ulid": "^3.0.1"
   },
   "devDependencies": {
-    "@prisma/client": "^6.14.0",
+    "@prisma/client": "6.14.0",
     "prisma": "6.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1(react@19.2.0-canary-3fbfb9ba-20250409)
       '@prisma/client':
-        specifier: ^6.14.0
+        specifier: 6.14.0
         version: 6.14.0(prisma@6.14.0(typescript@5.8.3))(typescript@5.8.3)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.2
@@ -769,8 +769,11 @@ importers:
         version: 3.0.1
     devDependencies:
       '@prisma/client':
-        specifier: ^6.14.0
+        specifier: 6.14.0
         version: 6.14.0(prisma@6.14.0(typescript@5.8.3))(typescript@5.8.3)
+      prisma:
+        specifier: 6.14.0
+        version: 6.14.0(typescript@5.8.3)
 
   packages/platform-machine:
     dependencies:


### PR DESCRIPTION
## Summary
- pin @prisma/client version to 6.14.0 in root and platform-core

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm run check:references` *(fails: Missing script 'check:references')*
- `pnpm run build:ts` *(fails: Missing script 'build:ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bd890e1850832faac49e79722953d6