### PR TITLE
refactor: rely on default prisma client output

### DIFF
--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../../../node_modules/@prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- remove custom Prisma client output path to use default location

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm prisma:generate`


------
https://chatgpt.com/codex/tasks/task_e_68bd89b7161c832fafb14cabdc22ab04