### PR TITLE
fix: remove unknown subscription status update

### DIFF
--- a/packages/platform-core/src/repositories/subscriptions.server.ts
+++ b/packages/platform-core/src/repositories/subscriptions.server.ts
@@ -11,7 +11,6 @@ export async function updateSubscriptionPaymentStatus(
     where: { id: customerId },
     data: {
       stripeSubscriptionId: subscriptionId,
-      subscriptionPaymentStatus: status,
     },
   });
 }


### PR DESCRIPTION
## Summary
- remove nonexistent `subscriptionPaymentStatus` field when updating a user

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8de41398832fbc11a4b25486c2b0