### PR TITLE
feat: validate refund amount

### DIFF
--- a/apps/shop-bcd/src/app/api/orders/[id]/route.ts
+++ b/apps/shop-bcd/src/app/api/orders/[id]/route.ts
@@ -53,7 +53,7 @@ export async function PATCH(
   if (
     status === "refunded" &&
     amount !== undefined &&
-    typeof amount !== "number"
+    (typeof amount !== "number" || Number.isNaN(amount))
   ) {
     return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- check that refund amount is a number before invoking refundOrder

## Testing
- `pnpm exec jest apps/shop-bcd/__tests__/orders-api.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bd8da5a340832f8a74b5a5f647a0ec