### PR TITLE
fix reverse logistics event typings

### DIFF
--- a/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
+++ b/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
@@ -31,10 +31,15 @@ export async function recordEvent(
 export async function listEvents(
   shop: string
 ): Promise<ReverseLogisticsEvent[]> {
-  return await prisma.reverseLogisticsEvent.findMany({
+  const events = await prisma.reverseLogisticsEvent.findMany({
     where: { shop },
     orderBy: { createdAt: "asc" },
   });
+
+  return events.map((evt) => ({
+    ...evt,
+    event: evt.event as ReverseLogisticsEventName,
+  }));
 }
 
 /** Convenience helpers for common reverse logistics events. */


### PR DESCRIPTION
## Summary
- map database event strings to typed `ReverseLogisticsEventName` when listing events

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Types of property 'expectedReturnDate' are incompatible)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/platform-core` *(fails: Could not find task `packages-platform-core`)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8df9087c832f926316ccc2e616a4