### PR TITLE
fix: ensure page diff schema uses object

### DIFF
--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -9,7 +9,8 @@ import { prisma } from "../../db";
 import { validateShopName } from "../../shops/index";
 import { DATA_ROOT } from "../../dataRoot";
 import { nowIso } from "@acme/date-utils";
-import { z, type ZodRawShape } from "zod";
+import { z } from "zod";
+import type { Prisma } from "@prisma/client";
 
 /**
  * Prisma-backed pages repository. The database is the source of truth,
@@ -18,7 +19,7 @@ import { z, type ZodRawShape } from "zod";
 // Use Prisma when a database connection is configured
 const useDb = !!process.env.DATABASE_URL;
 
-type Json = Record<string, unknown>;
+type Json = Prisma.InputJsonValue;
 
 /* -------------------------------------------------------------------------- */
 /*  Helpers                                                                   */
@@ -212,7 +213,7 @@ export interface PageDiffEntry {
 const entrySchema = z
   .object({
     timestamp: z.string().datetime(),
-    diff: z.object(pageSchema.shape as ZodRawShape).partial(),
+    diff: (pageSchema as unknown as z.AnyZodObject).partial(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- use Prisma's InputJsonValue for page persistence
- generate diff schema using AnyZodObject instead of invalid shape access

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'Json' is not assignable etc.)*
- `pnpm run check:references` *(missing script)*
- `pnpm run build:ts` *(missing script)*
- `pnpm --filter @acme/platform-core build` *(fails: expectedReturnDate type mismatch)*
- `pnpm --filter @acme/platform-core test` *(fails: CartContext.test.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8e015488832fa6220a20be0458e8