### PR TITLE
feat: add refundTotal and status to RentalOrder

### DIFF
--- a/packages/platform-core/prisma/schema.prisma
+++ b/packages/platform-core/prisma/schema.prisma
@@ -46,6 +46,8 @@ model RentalOrder {
   shippedAt          String?
   deliveredAt        String?
   cancelledAt        String?
+  refundTotal        Int?
+  status             String?
 
   @@unique([shop, sessionId])
   @@unique([shop, trackingNumber])


### PR DESCRIPTION
## Summary
- add `refundTotal` and optional `status` fields to `RentalOrder` Prisma model

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @acme/template-app build: `next build` Exit status 1)*
- `pnpm --filter @acme/platform-core build`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9c1f4804832f8e0b2866945c73f3