### PR TITLE
test: cover layout and translations for all locales

### DIFF
--- a/cypress/e2e/shop-i18n.cy.ts
+++ b/cypress/e2e/shop-i18n.cy.ts
@@ -10,28 +10,64 @@ const messages: Record<string, Record<string, string>> = {
 };
 
 describe("Localized storefront", () => {
-  locales
-    .filter((locale) => locale !== "en")
-    .forEach((locale) => {
-      const t = messages[locale];
+  locales.forEach((locale) => {
+    const t = messages[locale];
 
-      describe(`${locale} translations`, () => {
-        it("renders home hero and value strings", () => {
-          cy.visit(`/${locale}`);
-          cy.contains(t["hero.cta"]);
-          cy.contains(t["value.eco.title"]);
-        });
+    describe(`${locale} translations`, () => {
+      it("renders home hero and verifies layout", () => {
+        cy.viewport(1280, 800);
+        cy.visit(`/${locale}`);
+        cy.contains(t["hero.cta"]);
+        cy.contains(t["value.eco.title"]);
+        cy.get('nav[aria-label="Main navigation"]').should(
+          "have.css",
+          "flex-direction",
+          "row",
+        );
+        cy.get('[style*="grid-template-columns"]')
+          .first()
+          .invoke("attr", "style")
+          .then((style) => {
+            const match = /repeat\((\d+)/.exec(style || "");
+            const count = match ? Number(match[1]) : 0;
+            expect(count).to.eq(4);
+          });
+      });
 
-        it("renders checkout strings", () => {
-          cy.visit(`/${locale}/checkout`);
-          cy.contains(t["checkout.pay"]);
-          cy.contains(t["checkout.return"]);
-        });
+      it("renders checkout strings and layout", () => {
+        cy.viewport(1280, 800);
+        cy.visit(`/${locale}/checkout`);
+        cy.contains(t["checkout.pay"]);
+        cy.contains(t["checkout.return"]);
+        cy.get('nav[aria-label="Main navigation"]').should(
+          "have.css",
+          "flex-direction",
+          "row",
+        );
+        cy.get("main > div")
+          .first()
+          .should("have.css", "flex-direction", "column");
+      });
 
-        it("renders product page strings", () => {
-          cy.visit(`/${locale}/product/green-sneaker`);
-          cy.contains(t["pdp.selectSize"]);
-        });
+      it("renders product page strings and layout", () => {
+        cy.viewport(1280, 800);
+        cy.visit(`/${locale}/product/green-sneaker`);
+        cy.contains(t["pdp.selectSize"]);
+        cy.get('nav[aria-label="Main navigation"]').should(
+          "have.css",
+          "flex-direction",
+          "row",
+        );
+        cy.get("main > div")
+          .first()
+          .should("have.css", "display", "grid")
+          .invoke("attr", "style")
+          .then((style) => {
+            const match = /repeat\((\d+)/.exec(style || "");
+            const count = match ? Number(match[1]) : 0;
+            expect(count).to.eq(2);
+          });
       });
     });
+  });
 });


### PR DESCRIPTION
## Summary
- expand localization E2E tests to cover all locales and verify layout

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'customerMfa' does not exist on type...)*
- `pnpm cypress run --spec cypress/e2e/shop-i18n.cy.ts` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bda05b691c832f8368765a40e21bfc