### PR TITLE
test: add profile viewport accessibility checks

### DIFF
--- a/cypress/e2e/account-management-a11y.cy.ts
+++ b/cypress/e2e/account-management-a11y.cy.ts
@@ -21,6 +21,33 @@ describe('Account management accessibility', () => {
     });
   });
 
+  const viewports = [
+    { name: 'mobile', width: 375, height: 667 },
+    { name: 'tablet', width: 768, height: 1024 },
+    { name: 'desktop', width: 1280, height: 800 }
+  ];
+
+  viewports.forEach(({ name, width, height }) => {
+    it(`Profile form validation is accessible on ${name}`, () => {
+      cy.viewport(width, height);
+      login();
+      cy.visit('/account/profile');
+
+      cy.findByRole('button', { name: /save/i }).click();
+      cy.findByLabelText('Name')
+        .should('have.attr', 'id', 'name')
+        .and('have.attr', 'aria-invalid', 'true');
+      cy.findByLabelText('Email')
+        .should('have.attr', 'id', 'email')
+        .and('have.attr', 'aria-invalid', 'true');
+      cy.findByText('Name is required.').should('have.attr', 'role', 'alert');
+      cy.findByText('Email is required.').should('have.attr', 'role', 'alert');
+
+      cy.injectAxe();
+      cy.checkA11y(undefined, undefined, undefined, true);
+    });
+  });
+
   it('ProfileForm links labels, announces errors, and tabs correctly', () => {
     login();
     cy.visit('/account/profile');


### PR DESCRIPTION
## Summary
- iterate profile form accessibility tests across mobile, tablet, and desktop viewports
- ensure validation errors expose labels, aria-invalid, and alerts consistently

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'customerMfa' does not exist on type 'PrismaClient')*
- `pnpm exec start-server-and-test "sh -c 'pnpm --filter @apps/shop-bcd build && pnpm --filter @apps/shop-bcd start -- --port 3004'" http://localhost:3004 "CYPRESS_BASE_URL=http://localhost:3004 pnpm exec cypress run --spec cypress/e2e/account-management-a11y.cy.ts"` *(fails: Module not found: Can't resolve '@acme/sanity')*

------
https://chatgpt.com/codex/tasks/task_e_68bda0651a20832fb7f3f88bba8036f7