### PR TITLE
test: add settings a11y checks

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor.tsx
@@ -46,9 +46,10 @@ export default function CurrencyTaxEditor({ shop, initial }: Props) {
           name="currency"
           value={state.currency}
           onChange={handleChange}
+          aria-invalid={errors.currency ? true : undefined}
         />
         {errors.currency && (
-          <span className="text-sm text-red-600">
+          <span role="alert" className="text-sm text-red-600">
             {errors.currency.join("; ")}
           </span>
         )}
@@ -59,9 +60,10 @@ export default function CurrencyTaxEditor({ shop, initial }: Props) {
           name="taxRegion"
           value={state.taxRegion}
           onChange={handleChange}
+          aria-invalid={errors.taxRegion ? true : undefined}
         />
         {errors.taxRegion && (
-          <span className="text-sm text-red-600">
+          <span role="alert" className="text-sm text-red-600">
             {errors.taxRegion.join("; ")}
           </span>
         )}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings.tsx
@@ -26,9 +26,12 @@ export default function GeneralSettings({
           name="name"
           value={info.name}
           onChange={handleChange}
+          aria-invalid={errors.name ? true : undefined}
         />
         {errors.name && (
-          <span className="text-sm text-red-600">{errors.name.join("; ")}</span>
+          <span role="alert" className="text-sm text-red-600">
+            {errors.name.join("; ")}
+          </span>
         )}
       </label>
       <label className="flex flex-col gap-1">
@@ -38,9 +41,12 @@ export default function GeneralSettings({
           name="themeId"
           value={info.themeId}
           onChange={handleChange}
+          aria-invalid={errors.themeId ? true : undefined}
         />
         {errors.themeId && (
-          <span className="text-sm text-red-600">{errors.themeId.join("; ")}</span>
+          <span role="alert" className="text-sm text-red-600">
+            {errors.themeId.join("; ")}
+          </span>
         )}
       </label>
       <fieldset className="col-span-2 flex flex-col gap-1">

--- a/cypress/e2e/cms-settings-a11y.cy.ts
+++ b/cypress/e2e/cms-settings-a11y.cy.ts
@@ -1,0 +1,66 @@
+import '@testing-library/cypress/add-commands';
+import 'cypress-axe';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+describe('CMS settings forms accessibility', () => {
+  it('GeneralSettings inputs are labelled and errors announced', () => {
+    cy.visit('about:blank').then(async (win) => {
+      const { default: GeneralSettings } = await import('../../apps/cms/src/app/cms/shop/[shop]/settings/GeneralSettings');
+      const Wrapper = () => {
+        const [info, setInfo] = React.useState({ name: '', themeId: '', luxuryFeatures: {} as any });
+        const [errors, setErrors] = React.useState<Record<string, string[]>>({});
+        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+          const { name, value, type, checked } = e.target;
+          setInfo((prev: any) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+        };
+        return (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              setErrors({ name: ['Required'], themeId: ['Required'] });
+            }}
+          >
+            <GeneralSettings info={info} setInfo={setInfo} errors={errors} handleChange={handleChange} />
+            <button type="submit">Save</button>
+          </form>
+        );
+      };
+      ReactDOM.createRoot(win.document.body).render(React.createElement(Wrapper));
+    });
+
+    cy.injectAxe();
+    cy.findByRole('button', { name: /save/i }).click();
+    cy.findByLabelText('Name').should('have.attr', 'aria-invalid', 'true');
+    cy.findByLabelText('Theme').should('have.attr', 'aria-invalid', 'true');
+    cy.findAllByText('Required').each(($el) => {
+      cy.wrap($el).should('have.attr', 'role', 'alert');
+    });
+    cy.checkA11y(undefined, undefined, undefined, true);
+  });
+
+  it('CurrencyTaxEditor inputs are labelled and errors announced', () => {
+    cy.visit('about:blank').then(async (win) => {
+      const actions = await import('../../apps/cms/src/actions/shops.server');
+      cy.stub(actions, 'updateCurrencyAndTax').resolves({
+        errors: { currency: ['Required'], taxRegion: ['Required'] },
+      });
+      const { default: CurrencyTaxEditor } = await import('../../apps/cms/src/app/cms/shop/[shop]/settings/CurrencyTaxEditor');
+      ReactDOM.createRoot(win.document.body).render(
+        React.createElement(CurrencyTaxEditor, {
+          shop: 'test-shop',
+          initial: { currency: '', taxRegion: '' },
+        }),
+      );
+    });
+
+    cy.injectAxe();
+    cy.findByRole('button', { name: /save/i }).click();
+    cy.findByLabelText('Currency').should('have.attr', 'aria-invalid', 'true');
+    cy.findByLabelText('Tax Region').should('have.attr', 'aria-invalid', 'true');
+    cy.findAllByText('Required').each(($el) => {
+      cy.wrap($el).should('have.attr', 'role', 'alert');
+    });
+    cy.checkA11y(undefined, undefined, undefined, true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:coverage": "CI=true pnpm -r --filter=!@acme/next-config run test -- --coverage && pnpm --filter @acme/next-config run test:coverage",
     "e2e": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run\"",
     "e2e:open": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress open\"",
-    "e2e:dashboard": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run --spec cypress/e2e/dashboard-signin.cy.ts\"",
+    "e2e:dashboard": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/cms build && pnpm --filter @apps/cms start -- --port 3006'\" http://localhost:3006 \"pnpm exec cypress run --spec cypress/e2e/dashboard-signin.cy.ts,cypress/e2e/cms-settings-a11y.cy.ts\"",
     "e2e:shop": "TEST_DATA_ROOT=test/data node scripts/src/seed-test-data.ts && start-server-and-test \"sh -c 'pnpm --filter @apps/shop-bcd build && pnpm --filter @apps/shop-bcd start -- --port 3004'\" http://localhost:3004 \"CYPRESS_BASE_URL=http://localhost:3004 pnpm exec cypress run --spec cypress/e2e/shop-*.cy.ts,cypress/e2e/session-expiration.cy.ts\"",
     "test:e2e": "pnpm run e2e:dashboard && pnpm run e2e:shop",
     "i18n:extract": "next-intl extract",


### PR DESCRIPTION
## Summary
- ensure settings forms mark invalid fields and announce errors
- add Cypress a11y tests for settings forms and hook into CI e2e run

## Testing
- `pnpm -r build` *(fails: Property 'customerMfa' does not exist on type)*
- `pnpm e2e:dashboard` *(fails: Unknown file extension ".ts" for seed-test-data.ts)*
- `pnpm exec cypress run --spec cypress/e2e/cms-settings-a11y.cy.ts` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bda065e11c832fbacf3464d77dfce3