### PR TITLE
test: add responsive checkout flow

### DIFF
--- a/cypress/e2e/responsive-checkout-flow.cy.ts
+++ b/cypress/e2e/responsive-checkout-flow.cy.ts
@@ -1,0 +1,41 @@
+import { viewports } from "../support/viewports";
+
+describe("Responsive checkout flow", () => {
+  viewports.forEach(({ label, width, height }) => {
+    it(`completes checkout at ${label} (${width}x${height})`, () => {
+      cy.viewport(width, height);
+      cy.intercept("POST", "**/api/checkout-session", {
+        statusCode: 200,
+        body: { clientSecret: "cs_test", sessionId: "sess_test" },
+      }).as("createSession");
+      cy.intercept("POST", "https://api.stripe.com/**", {
+        statusCode: 200,
+        body: {},
+      }).as("confirmPayment");
+
+      cy.request("POST", "/api/cart", {
+        sku: { id: "green-sneaker" },
+        qty: 1,
+        size: "42",
+      });
+
+      cy.visit("/cart");
+      cy.injectAxe();
+      cy.checkA11y();
+      cy.contains("Your Bag").should("be.visible");
+      cy.contains(/Checkout/i).click();
+      cy.wait("@createSession");
+
+      cy.location("pathname").should("include", "/checkout");
+      cy.injectAxe();
+      cy.checkA11y();
+      cy.contains("button", "Pay").click();
+      cy.wait("@confirmPayment");
+
+      cy.location("pathname").should("include", "/success");
+      cy.injectAxe();
+      cy.contains("Thanks for your order!").should("be.visible");
+      cy.checkA11y();
+    });
+  });
+});

--- a/cypress/support/viewports.ts
+++ b/cypress/support/viewports.ts
@@ -1,0 +1,5 @@
+export const viewports = [
+  { label: "mobile", width: 320, height: 640 },
+  { label: "tablet", width: 768, height: 1024 },
+  { label: "desktop", width: 1280, height: 800 },
+];


### PR DESCRIPTION
## Summary
- add viewport config for e2e tests
- check responsive checkout flow through cart, checkout, and success pages

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Property 'customerMfa' does not exist)
- `pnpm exec cypress run --spec cypress/e2e/responsive-checkout-flow.cy.ts` (fails: Cypress executable not found)


------
https://chatgpt.com/codex/tasks/task_e_68bda0643eb8832fb68ea6394b2d2a0e