### PR TITLE
fix: adjust subscription cancellation and barcode detector types

### DIFF
--- a/packages/template-app/src/api/subscription/cancel/route.ts
+++ b/packages/template-app/src/api/subscription/cancel/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const sub = await stripe.subscriptions.del(user.stripeSubscriptionId);
+    const sub = await stripe.subscriptions.cancel(user.stripeSubscriptionId);
     await setStripeSubscriptionId(userId, null, shopId);
     return NextResponse.json({ id: sub.id, status: sub.status });
   } catch (err: unknown) {

--- a/packages/template-app/src/app/account/returns/ReturnForm.tsx
+++ b/packages/template-app/src/app/account/returns/ReturnForm.tsx
@@ -7,12 +7,6 @@ interface ReturnFormProps {
   tracking?: boolean;
 }
 
-interface BarcodeDetectorGlobal extends Window {
-  BarcodeDetector: new (options: { formats: string[] }) => {
-    detect(video: HTMLVideoElement): Promise<Array<{ rawValue: string }>>;
-  };
-}
-
 export default function ReturnForm({
   bagType,
   tracking: trackingEnabled,
@@ -36,7 +30,7 @@ export default function ReturnForm({
           videoRef.current.srcObject = stream;
           await videoRef.current.play();
         }
-        const detector = new (window as BarcodeDetectorGlobal).BarcodeDetector({
+        const detector = new window.BarcodeDetector({
           formats: ["qr_code"],
         });
         const scan = async () => {


### PR DESCRIPTION
## Summary
- use Stripe's `subscriptions.cancel` instead of `del`
- rely on built-in `BarcodeDetector` types when scanning return labels

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'token' does not exist on type '{ token: string; } | null')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bdae014e30832f826d58e2e0050544