### PR TITLE
test: add navigation preview snapshot

### DIFF
--- a/packages/ui/__tests__/NavigationPreview.test.tsx
+++ b/packages/ui/__tests__/NavigationPreview.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, within } from "@testing-library/react";
+import NavigationPreview from "../src/components/cms/NavigationPreview";
+
+describe("NavigationPreview", () => {
+  it("renders nested menu links", () => {
+    const items = [
+      { id: "home", label: "Home", url: "/home" },
+      {
+        id: "products",
+        label: "Products",
+        url: "/products",
+        children: [
+          { id: "hats", label: "Hats", url: "/products/hats" },
+          { id: "shirts", label: "Shirts", url: "/products/shirts" },
+        ],
+      },
+      {
+        id: "about",
+        label: "About",
+        url: "/about",
+        children: [{ id: "team", label: "Team", url: "/about/team" }],
+      },
+      {
+        id: "misc",
+        label: "",
+        url: "",
+        children: [{ id: "nameless", label: "", url: "" }],
+      },
+    ];
+
+    const { container } = render(<NavigationPreview items={items} />);
+
+    const productsLink = screen.getByRole("link", { name: "Products" });
+    expect(productsLink).toHaveAttribute("href", "/products");
+    const productsItem = productsLink.closest("li")!;
+    expect(
+      within(productsItem).getByRole("link", { name: "Hats" }),
+    ).toHaveAttribute("href", "/products/hats");
+    expect(
+      within(productsItem).getByRole("link", { name: "Shirts" }),
+    ).toHaveAttribute("href", "/products/shirts");
+
+    const aboutLink = screen.getByRole("link", { name: "About" });
+    const aboutItem = aboutLink.closest("li")!;
+    expect(
+      within(aboutItem).getByRole("link", { name: "Team" }),
+    ).toHaveAttribute("href", "/about/team");
+
+    const placeholderLink = screen.getAllByRole("link", { name: "Item" })[0];
+    expect(placeholderLink).toHaveAttribute("href", "#");
+  
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+

--- a/packages/ui/__tests__/__snapshots__/NavigationPreview.test.tsx.snap
+++ b/packages/ui/__tests__/__snapshots__/NavigationPreview.test.tsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavigationPreview renders nested menu links 1`] = `
+<nav
+  class="bg-background text-foreground p-4 rounded border"
+  data-token="--color-bg"
+>
+  <ul
+    class="flex gap-4"
+  >
+    <li
+      class="relative group"
+    >
+      <a
+        class="font-medium"
+        data-token="--color-fg"
+        href="/home"
+      >
+        Home
+      </a>
+    </li>
+    <li
+      class="relative group"
+    >
+      <a
+        class="font-medium"
+        data-token="--color-fg"
+        href="/products"
+      >
+        Products
+      </a>
+      <ul
+        class="absolute left-0 top-full hidden min-w-[8rem] flex-col rounded-md border bg-background p-2 shadow-md group-hover:flex"
+        data-token="--color-bg"
+      >
+        <li>
+          <a
+            class="block px-2 py-1 hover:underline"
+            data-token="--color-fg"
+            href="/products/hats"
+          >
+            Hats
+          </a>
+        </li>
+        <li>
+          <a
+            class="block px-2 py-1 hover:underline"
+            data-token="--color-fg"
+            href="/products/shirts"
+          >
+            Shirts
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="relative group"
+    >
+      <a
+        class="font-medium"
+        data-token="--color-fg"
+        href="/about"
+      >
+        About
+      </a>
+      <ul
+        class="absolute left-0 top-full hidden min-w-[8rem] flex-col rounded-md border bg-background p-2 shadow-md group-hover:flex"
+        data-token="--color-bg"
+      >
+        <li>
+          <a
+            class="block px-2 py-1 hover:underline"
+            data-token="--color-fg"
+            href="/about/team"
+          >
+            Team
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="relative group"
+    >
+      <a
+        class="font-medium"
+        data-token="--color-fg"
+        href="#"
+      >
+        Item
+      </a>
+      <ul
+        class="absolute left-0 top-full hidden min-w-[8rem] flex-col rounded-md border bg-background p-2 shadow-md group-hover:flex"
+        data-token="--color-bg"
+      >
+        <li>
+          <a
+            class="block px-2 py-1 hover:underline"
+            data-token="--color-fg"
+            href="#"
+          >
+            Item
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+`;


### PR DESCRIPTION
## Summary
- add NavigationPreview test with nested menu data and snapshot

## Testing
- `pnpm run test packages/ui` *(fails: Could not find task `packages/ui`)*
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/NavigationPreview.test.tsx --config ../../jest.config.cjs --runInBand --detectOpenHandles`

------
https://chatgpt.com/codex/tasks/task_e_68bdd4b80990832f8ca405a7a198b529