### PR TITLE
test: add plugin env discovery tests

### DIFF
--- a/packages/platform-core/__tests__/plugin-env.test.ts
+++ b/packages/platform-core/__tests__/plugin-env.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+import { findPluginsDir } from "../src/plugins/env";
+
+describe("findPluginsDir", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns discovered plugins directory", () => {
+    const start = "/root/a/b";
+    const found = "/root/a/packages/plugins";
+
+    jest
+      .spyOn(fs, "existsSync")
+      .mockImplementation((p: any) => p === found);
+
+    jest.spyOn(path, "dirname").mockImplementation((p: string) => {
+      const map: Record<string, string> = {
+        "/root/a/b": "/root/a",
+        "/root/a": "/root",
+        "/root": "/",
+        "/": "/",
+      };
+      return map[p];
+    });
+
+    expect(findPluginsDir(start)).toBe(found);
+  });
+
+  it("returns final candidate when directory not found", () => {
+    const start = "/root/a/b";
+
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+
+    jest.spyOn(path, "dirname").mockImplementation((p: string) => {
+      const map: Record<string, string> = {
+        "/root/a/b": "/root/a",
+        "/root/a": "/root",
+        "/root": "/",
+        "/": "/",
+      };
+      return map[p];
+    });
+
+    expect(findPluginsDir(start)).toBe("/packages/plugins");
+  });
+});
+


### PR DESCRIPTION
## Summary
- test findPluginsDir for workspace discovery and root fallback

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/shop-bcd build failed)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/plugin-env.test.ts` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd511e6e4832fa6f3f996ba7888c1