### PR TITLE
test(platform-core): avoid notifying unchanged tracking status

### DIFF
--- a/packages/platform-core/__tests__/tracking-dashboard.test.ts
+++ b/packages/platform-core/__tests__/tracking-dashboard.test.ts
@@ -64,4 +64,24 @@ describe("tracking dashboard", () => {
     expect(sendEmail).toHaveBeenCalled();
     expect(fetch).toHaveBeenCalled();
   });
+
+  test("does not notify when status is unchanged", async () => {
+    const sendEmail = jest.fn();
+    global.fetch = jest
+      .fn<Promise<any>, any>()
+      .mockResolvedValue({ ok: true, json: async () => ({}) } as any) as any;
+    process.env.TWILIO_SID = "sid";
+    process.env.TWILIO_TOKEN = "tok";
+    process.env.TWILIO_FROM = "+111";
+    const { notifyStatusChange } = await import("../src/tracking");
+    await notifyStatusChange(
+      { email: "a@b.com", phone: "+1222" },
+      { id: "1", type: "shipment", provider: "ups", trackingNumber: "1" },
+      "same",
+      "same",
+      { sendEmail },
+    );
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure notifyStatusChange exits early on unchanged statuses

## Testing
- `pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false __tests__/tracking-dashboard.test.ts`
- `pnpm -r build` *(fails: Type error in apps/shop-bcd build)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd510cbf8832fb3136711651cdecc