### PR TITLE
test(platform-core): compute checkout totals

### DIFF
--- a/packages/platform-core/__tests__/checkout-totals.test.ts
+++ b/packages/platform-core/__tests__/checkout-totals.test.ts
@@ -1,0 +1,56 @@
+import { jest } from "@jest/globals";
+import type { CartState } from "../src/cart";
+
+const cart: CartState = {
+  a: { sku: { id: "a", deposit: 10 } as any, qty: 2 },
+  b: { sku: { id: "b", deposit: 5 } as any, qty: 1 },
+};
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+async function setupMocks() {
+  const priceForDays = jest.fn(async (sku: any, _days: number) =>
+    sku.id === "a" ? 100 : 200
+  );
+  const convertCurrency = jest.fn(async (amount: number) => amount);
+
+  jest.doMock("../src/pricing", () => ({
+    __esModule: true,
+    priceForDays,
+    convertCurrency,
+  }));
+
+  const { computeTotals } = await import("../src/checkout/totals");
+
+  return { computeTotals, priceForDays, convertCurrency };
+}
+
+describe("computeTotals", () => {
+  it("returns totals without discount", async () => {
+    const { computeTotals, convertCurrency } = await setupMocks();
+
+    const totals = await computeTotals(cart, 3, 0, "USD");
+
+    expect(totals).toEqual({ subtotal: 400, depositTotal: 25, discount: 0 });
+    expect(convertCurrency).toHaveBeenCalledTimes(3);
+    expect(convertCurrency).toHaveBeenNthCalledWith(1, 400, "USD");
+    expect(convertCurrency).toHaveBeenNthCalledWith(2, 25, "USD");
+    expect(convertCurrency).toHaveBeenNthCalledWith(3, 0, "USD");
+  });
+
+  it("applies discount rates", async () => {
+    const { computeTotals, convertCurrency } = await setupMocks();
+
+    const totals = await computeTotals(cart, 3, 0.25, "USD");
+
+    expect(totals).toEqual({ subtotal: 300, depositTotal: 25, discount: 100 });
+    expect(convertCurrency).toHaveBeenCalledTimes(3);
+    expect(convertCurrency).toHaveBeenNthCalledWith(1, 300, "USD");
+    expect(convertCurrency).toHaveBeenNthCalledWith(2, 25, "USD");
+    expect(convertCurrency).toHaveBeenNthCalledWith(3, 100, "USD");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add checkout totals tests with deterministic pricing mocks

## Testing
- `pnpm -F @acme/platform-core test packages/platform-core/__tests__/checkout-totals.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bdd50d4238832f9d1e38fbba1ff14a