### PR TITLE
test: cover repo resolver backend selection

### DIFF
--- a/packages/platform-core/__tests__/repoResolver.test.ts
+++ b/packages/platform-core/__tests__/repoResolver.test.ts
@@ -1,0 +1,64 @@
+// packages/platform-core/__tests__/repoResolver.test.ts
+import { resolveRepo } from "../src/repositories/repoResolver";
+
+describe("resolveRepo", () => {
+  const prismaDelegate = jest.fn();
+  const prismaModule = jest.fn<Promise<string>, []>(() => Promise.resolve("prisma"));
+  const jsonModule = jest.fn<Promise<string>, []>(() => Promise.resolve("json"));
+
+  afterEach(() => {
+    delete process.env.INVENTORY_BACKEND;
+    delete process.env.DATABASE_URL;
+    jest.clearAllMocks();
+  });
+
+  it("uses json module when INVENTORY_BACKEND=json", async () => {
+    process.env.INVENTORY_BACKEND = "json";
+
+    await expect(
+      resolveRepo(prismaDelegate, prismaModule, jsonModule)
+    ).resolves.toBe("json");
+
+    expect(jsonModule).toHaveBeenCalledTimes(1);
+    expect(prismaModule).not.toHaveBeenCalled();
+  });
+
+  it("uses prisma module when DATABASE_URL is set and delegate returns truthy", async () => {
+    process.env.DATABASE_URL = "postgres://example";
+    prismaDelegate.mockReturnValue({});
+
+    await expect(
+      resolveRepo(prismaDelegate, prismaModule, jsonModule)
+    ).resolves.toBe("prisma");
+
+    expect(prismaModule).toHaveBeenCalledTimes(1);
+    expect(jsonModule).not.toHaveBeenCalled();
+  });
+
+  it("falls back to json module when delegate throws", async () => {
+    process.env.DATABASE_URL = "postgres://example";
+    prismaDelegate.mockImplementation(() => {
+      throw new Error("fail");
+    });
+
+    await expect(
+      resolveRepo(prismaDelegate, prismaModule, jsonModule)
+    ).resolves.toBe("json");
+
+    expect(jsonModule).toHaveBeenCalledTimes(1);
+    expect(prismaModule).not.toHaveBeenCalled();
+  });
+
+  it("falls back to json module when delegate returns falsy", async () => {
+    process.env.DATABASE_URL = "postgres://example";
+    prismaDelegate.mockReturnValue(undefined);
+
+    await expect(
+      resolveRepo(prismaDelegate, prismaModule, jsonModule)
+    ).resolves.toBe("json");
+
+    expect(jsonModule).toHaveBeenCalledTimes(1);
+    expect(prismaModule).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for resolveRepo to ensure json backend, prisma backend, and fallback behaviors

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `pnpm --filter @acme/platform-core test __tests__/repoResolver.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdd50c94fc832faa4b96935fd6a4b4