### PR TITLE
test(platform-core): add stock scheduler tests

### DIFF
--- a/packages/platform-core/__tests__/stockScheduler.test.ts
+++ b/packages/platform-core/__tests__/stockScheduler.test.ts
@@ -1,0 +1,47 @@
+import { jest } from "@jest/globals";
+
+const checkAndAlert = jest.fn();
+jest.mock("../src/services/stockAlert.server", () => ({
+  checkAndAlert,
+}));
+
+describe("scheduleStockChecks", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("passes fetched items to checkAndAlert", async () => {
+    const mockGetItems = jest.fn().mockResolvedValue([{ sku: "s" } as any]);
+    const { scheduleStockChecks } = await import("../src/services/stockScheduler.server");
+
+    scheduleStockChecks("shop", mockGetItems, 100);
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(mockGetItems).toHaveBeenCalledTimes(1);
+    expect(checkAndAlert).toHaveBeenCalledWith("shop", [{ sku: "s" }]);
+  });
+
+  it("logs when getItems rejects", async () => {
+    const mockGetItems = jest.fn().mockRejectedValueOnce(new Error("fail"));
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { scheduleStockChecks } = await import("../src/services/stockScheduler.server");
+
+    scheduleStockChecks("shop", mockGetItems, 100);
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Scheduled stock check failed",
+      expect.any(Error),
+    );
+
+    consoleError.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for scheduleStockChecks covering timer execution and error logging

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/stockScheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdd508f480832f88f9270e960d2e29