### PR TITLE
test(platform-machine): propagate readdir errors

### DIFF
--- a/packages/platform-machine/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/__tests__/lateFeeService.test.ts
@@ -419,6 +419,26 @@ describe("startLateFeeService", () => {
     setSpy.mockRestore();
     clearSpy.mockRestore();
   });
+
+  it("propagates readdir errors without scheduling", async () => {
+    const err = new Error("boom");
+    const readdir = jest.fn().mockRejectedValue(err);
+    jest.doMock("fs/promises", () => ({
+      __esModule: true,
+      readdir,
+      readFile: jest.fn(),
+    }));
+
+    const mod = await import("../src/lateFeeService");
+    const setSpy = jest
+      .spyOn(global, "setInterval")
+      .mockImplementation(() => 111 as any);
+
+    await expect(mod.startLateFeeService()).rejects.toBe(err);
+    expect(setSpy).not.toHaveBeenCalled();
+
+    setSpy.mockRestore();
+  });
 });
 
 describe("auto-start", () => {


### PR DESCRIPTION
## Summary
- verify startLateFeeService bubbles readdir errors without scheduling any timers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type error: Property 'token' does not exist on type '{ token: string; } | null'.)*
- `pnpm run check:references` *(missing script: check:references)*
- `pnpm run build:ts` *(missing script: build:ts)*
- `pnpm --filter @acme/platform-machine test lateFeeService.test.ts` *(coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4fe8e60832f9545fc0efa531d3e