### PR TITLE
test: handle invalid late fee env vars

### DIFF
--- a/packages/platform-machine/src/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/src/__tests__/lateFeeService.test.ts
@@ -270,8 +270,19 @@ describe("resolveConfig", () => {
     expect(cfg).toEqual({ enabled: true, intervalMinutes: 5 });
   });
 
-  it("falls back to core env values when settings file and env vars missing", async () => {
+  it("ignores invalid env values", async () => {
     readFileMock.mockRejectedValueOnce(new Error("boom"));
+    process.env.LATE_FEE_ENABLED_S1 = "maybe";
+    process.env.LATE_FEE_INTERVAL_MS_S1 = "abc";
+
+    const cfg = await service.resolveConfig("s1", "/data");
+    expect(cfg).toEqual({ enabled: false, intervalMinutes: 60 });
+  });
+
+  it("falls back to core env values when settings file missing and env vars invalid", async () => {
+    readFileMock.mockRejectedValueOnce(new Error("boom"));
+    process.env.LATE_FEE_ENABLED_S1 = "maybe";
+    process.env.LATE_FEE_INTERVAL_MS_S1 = "abc";
     (coreEnv as any).LATE_FEE_ENABLED = true;
     (coreEnv as any).LATE_FEE_INTERVAL_MS = 15 * 60 * 1000;
 


### PR DESCRIPTION
## Summary
- test late fee config ignores bad env values
- ensure coreEnv fallback still works when env vars invalid

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'token' does not exist on type)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-machine test lateFeeService.test.ts` *(fails: expect(received).toEqual(expected))*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4fdc880832f807d8eb5722a9e60