### PR TITLE
test(platform-machine): handle readdir failure in deposit release

### DIFF
--- a/packages/platform-machine/__tests__/releaseDepositsService.test.ts
+++ b/packages/platform-machine/__tests__/releaseDepositsService.test.ts
@@ -238,6 +238,20 @@ describe("startDepositReleaseService", () => {
     jest.resetModules();
   });
 
+  it("rejects when readdir fails without calling setInterval", async () => {
+    service = await import("@acme/platform-machine");
+    const err = new Error("boom");
+    readdir.mockRejectedValueOnce(err);
+    const setSpy = jest
+      .spyOn(global, "setInterval")
+      .mockImplementation(() => 0 as any);
+
+    await expect(service.startDepositReleaseService()).rejects.toThrow(err);
+    expect(setSpy).not.toHaveBeenCalled();
+
+    setSpy.mockRestore();
+  });
+
   it("runs each shop in parallel and schedules timers after initial run", async () => {
     service = await import("@acme/platform-machine");
     readdir.mockResolvedValue(["shop1", "shop2"]);

--- a/packages/platform-machine/src/__tests__/releaseDepositsService.test.ts
+++ b/packages/platform-machine/src/__tests__/releaseDepositsService.test.ts
@@ -235,7 +235,9 @@ describe("startDepositReleaseService", () => {
 
   it("uses provided log function when release fails", async () => {
     const err = new Error("boom");
-    (service.releaseDepositsOnce as jest.Mock).mockRejectedValueOnce(err);
+    const releaseFn = jest.fn(async () => {
+      throw err;
+    });
     const logSpy = jest.fn();
     const setSpy = jest
       .spyOn(global, "setInterval")
@@ -247,7 +249,7 @@ describe("startDepositReleaseService", () => {
     const stop = await service.startDepositReleaseService(
       {},
       "/data",
-      undefined,
+      releaseFn,
       logSpy,
     );
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- test startDepositReleaseService rejects when `readdir` fails without scheduling intervals
- use a custom release function to verify logging on release failure

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'token' does not exist on type '{ token: string; } | null')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-machine test releaseDepositsService.test.ts` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4fa78f0832fb2ce6b46d001ad93