### PR TITLE
test: skip unsupported reverse logistics statuses

### DIFF
--- a/packages/platform-machine/src/__tests__/reverseLogisticsService.test.ts
+++ b/packages/platform-machine/src/__tests__/reverseLogisticsService.test.ts
@@ -172,6 +172,29 @@ describe("processReverseLogisticsEventsOnce", () => {
     );
   });
 
+  it("skips unsupported statuses", async () => {
+    readdirMock.mockResolvedValueOnce(["e.json"]);
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({ sessionId: "abc", status: "unknown" })
+    );
+
+    await service.processReverseLogisticsEventsOnce("shop", "/data");
+
+    expect(markReceived).not.toHaveBeenCalled();
+    expect(markCleaning).not.toHaveBeenCalled();
+    expect(markRepair).not.toHaveBeenCalled();
+    expect(markQa).not.toHaveBeenCalled();
+    expect(markAvailable).not.toHaveBeenCalled();
+    expect(reverseLogisticsEvents.received).not.toHaveBeenCalled();
+    expect(reverseLogisticsEvents.cleaning).not.toHaveBeenCalled();
+    expect(reverseLogisticsEvents.repair).not.toHaveBeenCalled();
+    expect(reverseLogisticsEvents.qa).not.toHaveBeenCalled();
+    expect(reverseLogisticsEvents.available).not.toHaveBeenCalled();
+    expect(unlinkMock).toHaveBeenCalledWith(
+      path.join("/data", "shop", "reverse-logistics", "e.json")
+    );
+  });
+
   it("logs and removes file on parse error", async () => {
     readdirMock.mockResolvedValueOnce(["bad.json"]);
     readFileMock.mockResolvedValueOnce("not json");


### PR DESCRIPTION
## Summary
- cover unsupported reverse logistics statuses in service tests

## Testing
- `pnpm --filter @acme/platform-machine test reverseLogisticsService.test.ts`
- `pnpm -r build` *(fails: Property 'token' does not exist on type)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf08b2464832fbbdfc3f653e9036f