### PR TITLE
Add failing readdir test for deposit release service

### DIFF
--- a/packages/platform-machine/__tests__/releaseDepositsService.test.ts
+++ b/packages/platform-machine/__tests__/releaseDepositsService.test.ts
@@ -447,6 +447,18 @@ describe("startDepositReleaseService", () => {
     errorSpy.mockRestore();
 });
 
+  it("rejects when readdir fails without scheduling timers", async () => {
+    service = await import("@acme/platform-machine");
+    const err = new Error("boom");
+    readdir.mockRejectedValueOnce(err);
+    const setSpy = jest.spyOn(global, "setInterval");
+    await expect(service.startDepositReleaseService()).rejects.toBe(err);
+    expect(setSpy).not.toHaveBeenCalled();
+    setSpy.mockRestore();
+  });
+
+});
+
 describe("auto-start", () => {
   afterEach(() => {
     delete process.env.RUN_DEPOSIT_RELEASE_SERVICE;


### PR DESCRIPTION
## Summary
- add coverage for when `readdir` rejects to ensure timers aren't scheduled

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-machine test releaseDepositsService.test.ts` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeff01b10832fafb8c79d90556f55