### PR TITLE
Handle missing password reset token param

### DIFF
--- a/apps/shop-bcd/src/app/password-reset/[token]/page.tsx
+++ b/apps/shop-bcd/src/app/password-reset/[token]/page.tsx
@@ -4,8 +4,13 @@ import { useState } from "react";
 import { useParams } from "next/navigation";
 
 export default function PasswordResetPage() {
-  const { token } = useParams<{ token: string }>();
+  const params = useParams<{ token: string }>();
+  const token = params?.token;
   const [msg, setMsg] = useState("");
+
+  if (!token) {
+    return null;
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- guard against missing token when reading password reset params

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bdef88bcf4832f85e829afd80e1944