### PR TITLE
test: add rollback route tests

### DIFF
--- a/apps/cms/src/app/api/shop/[shop]/rollback/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/shop/[shop]/rollback/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+const requirePermission = jest.fn();
+jest.mock("@auth", () => ({ requirePermission }));
+
+const execFile = jest.fn();
+jest.mock("child_process", () => ({ execFile }));
+
+let POST: typeof import("../route").POST;
+
+beforeAll(async () => {
+  ({ POST } = await import("../route"));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("POST", () => {
+  function req() {
+    return new Request("http://test");
+  }
+
+  it("returns ok when rollback succeeds", async () => {
+    requirePermission.mockResolvedValue(undefined);
+    execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: "", stderr: "" });
+    });
+
+    const res = await POST(req(), { params: { shop: "shop1" } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+    expect(execFile).toHaveBeenCalled();
+  });
+
+  it("returns 500 when rollback fails for invalid diff ID", async () => {
+    requirePermission.mockResolvedValue(undefined);
+    execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(new Error("Invalid diff ID"), { stdout: "", stderr: "" });
+    });
+
+    const res = await POST(req(), { params: { shop: "bad" } });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Rollback failed" });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for rollback route covering success and invalid diff IDs

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm exec jest --runTestsByPath apps/cms/src/app/api/shop/[shop]/rollback/__tests__/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4e51414832fa78611222838c9d4