### PR TITLE
test: verify provider route permissions

### DIFF
--- a/apps/cms/src/app/api/providers/shop/[shop]/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/providers/shop/[shop]/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import path from "path";
+import { NextRequest } from "next/server";
+
+const getServerSession = jest.fn();
+jest.mock("next-auth", () => ({ getServerSession }));
+
+const writeJsonFile = jest.fn();
+jest.mock("@/lib/server/jsonIO", () => ({ writeJsonFile }));
+
+jest.mock("@platform-core/dataRoot", () => ({ resolveDataRoot: () => "/tmp/data" }));
+
+const parseJsonBody = jest.fn();
+jest.mock("@shared-utils", () => ({ parseJsonBody }));
+
+let POST: typeof import("../route").POST;
+
+beforeAll(async () => {
+  ({ POST } = await import("../route"));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function req() {
+  return new NextRequest("http://test.local", { method: "POST" } as any);
+}
+
+describe("POST", () => {
+  it("updates providers for authorized user", async () => {
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+    parseJsonBody.mockResolvedValue({
+      success: true,
+      data: { payment: ["stripe"], shipping: ["ups"] },
+    });
+
+    const res = await POST(req(), { params: Promise.resolve({ shop: "shop1" }) });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(writeJsonFile).toHaveBeenCalledWith(
+      path.join("/tmp/data", "shop1", "providers.json"),
+      { payment: ["stripe"], shipping: ["ups"] },
+    );
+  });
+
+  it("returns 403 for unauthorized user", async () => {
+    getServerSession.mockResolvedValue(null);
+
+    const res = await POST(req(), { params: Promise.resolve({ shop: "shop1" }) });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+    expect(parseJsonBody).not.toHaveBeenCalled();
+    expect(writeJsonFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test provider route updates provider configuration
- test provider route permission checks

## Testing
- `pnpm -r build` *(fails: Property 'token' does not exist on type `{ token: string; } | null`)*
- `pnpm exec jest apps/cms/src/app/api/providers/shop/\[shop\]/__tests__/route.test.ts --config jest.config.cjs --runTestsByPath` *(fails: global coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4e10210832f997227ab51822645