### PR TITLE
test: add products API route tests

### DIFF
--- a/apps/cms/src/app/api/products/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/products/__tests__/route.test.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from "next/server";
+
+const readRepo = jest.fn();
+const readInventory = jest.fn();
+
+jest.mock("@platform-core/repositories/json.server", () => ({
+  readRepo: (shop: string) => readRepo(shop),
+  readInventory: (shop: string) => readInventory(shop),
+}));
+
+let GET: typeof import("../route").GET;
+
+beforeAll(async () => {
+  ({ GET } = await import("../route"));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function req(path: string) {
+  return new NextRequest(`http://test.local/api/products${path}`);
+}
+
+describe("GET", () => {
+  it("filters products by query", async () => {
+    readRepo.mockResolvedValue([
+      {
+        id: "p1",
+        sku: "p1",
+        title: { en: "Red Shirt" },
+        price: 10,
+        media: [],
+        availability: [],
+      },
+      {
+        id: "p2",
+        sku: "p2",
+        title: { en: "Blue Pants" },
+        price: 20,
+        media: [],
+        availability: [],
+      },
+    ]);
+    readInventory.mockResolvedValue([
+      { productId: "p1", quantity: 3 },
+      { productId: "p2", quantity: 1 },
+    ]);
+
+    const res = await GET(req("?q=red"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ slug: "p1", title: "Red Shirt", stock: 3 });
+  });
+
+  it("returns 400 for invalid search params", async () => {
+    const res = await GET(req("?foo=bar"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid search parameters" });
+    expect(readRepo).not.toHaveBeenCalled();
+    expect(readInventory).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when no products match", async () => {
+    readRepo.mockResolvedValue([
+      {
+        id: "p1",
+        sku: "p1",
+        title: { en: "Red Shirt" },
+        price: 10,
+        media: [],
+        availability: [],
+      },
+    ]);
+    readInventory.mockResolvedValue([{ productId: "p1", quantity: 3 }]);
+
+    const res = await GET(req("?q=green"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CMS product API route
- cover filtering, invalid param errors, and empty results

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'token' does not exist on type...)*
- `pnpm --filter @apps/cms test` *(fails: 12 failed, 196 passed, 208 of 209 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4dfd9e4832f8f196d156a7b3930