### PR TITLE
test: add page route tests

### DIFF
--- a/apps/cms/src/app/api/page/[shop]/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/page/[shop]/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+const mockGetPages = jest.fn();
+const mockUpdatePage = jest.fn();
+
+jest.mock("@platform-core/repositories/pages/index.server", () => ({
+  getPages: mockGetPages,
+  updatePage: mockUpdatePage,
+}));
+
+let route: typeof import("../route");
+
+beforeAll(async () => {
+  route = await import("../route");
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function req(id: string, components = "[]") {
+  const fd = new FormData();
+  fd.append("id", id);
+  fd.append("components", components);
+  return { formData: () => Promise.resolve(fd) } as any;
+}
+
+describe("POST", () => {
+  it("updates existing page and returns its id", async () => {
+    mockGetPages.mockResolvedValue([
+      { id: "p1", updatedAt: "0", components: [], status: "draft" },
+    ]);
+
+    const res = await route.POST(req("p1"), {
+      params: Promise.resolve({ shop: "s1" }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ id: "p1" });
+    expect(mockGetPages).toHaveBeenCalledWith("s1");
+    expect(mockUpdatePage).toHaveBeenCalledWith(
+      "s1",
+      { id: "p1", updatedAt: "0", status: "published", components: [] },
+      { id: "p1", updatedAt: "0", components: [], status: "draft" },
+    );
+  });
+
+  it("returns 404 when page is missing", async () => {
+    mockGetPages.mockResolvedValue([]);
+
+    const res = await route.POST(req("missing"), {
+      params: Promise.resolve({ shop: "s1" }),
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Page not found" });
+    expect(mockUpdatePage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for page update route covering successful update and 404 case

## Testing
- `pnpm -r build` *(fails: Property 'token' does not exist on type '{ token: string; } | null'.)*
- `pnpm -F cms test "src/app/api/page/\\[shop\\]/__tests__/route.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4ddb594832fb40f0541b3dd8289