### PR TITLE
test: add git export route tests

### DIFF
--- a/apps/cms/src/app/api/git/export/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/git/export/__tests__/route.test.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+
+const track = jest.fn();
+jest.mock("@acme/telemetry", () => ({ track }));
+
+let POST: typeof import("../route").POST;
+
+beforeAll(async () => {
+  ({ POST } = await import("../route"));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.GITHUB_TOKEN;
+});
+
+function req() {
+  return new NextRequest("http://test.local", { method: "POST" } as any);
+}
+
+describe("POST", () => {
+  it("returns 501 when token missing", async () => {
+    const res = await POST(req());
+    expect(res.status).toBe(501);
+    expect(await res.json()).toEqual({ error: "GITHUB_TOKEN missing" });
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("triggers archive creation when authorized", async () => {
+    process.env.GITHUB_TOKEN = "test";
+    const res = await POST(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://example.com/pr/1" });
+    expect(track).toHaveBeenCalledWith("git:export", {});
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for git export API to check telemetry track and missing token handling

## Testing
- `pnpm --filter @apps/cms exec jest src/app/api/git/export/__tests__/route.test.ts --runInBand --coverage=false`
- `pnpm -r build` *(fails: Property 'token' does not exist on type)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4dad864832fbb68cd8e6e1cc8c9