### PR TITLE
test: cover env route cases

### DIFF
--- a/apps/cms/src/app/api/env/[shopId]/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/env/[shopId]/__tests__/route.test.ts
@@ -1,0 +1,81 @@
+import { type NextRequest } from "next/server";
+import path from "path";
+
+const getServerSession = jest.fn();
+const setupSanityBlog = jest.fn();
+const parseJsonBody = jest.fn();
+
+jest.mock("next-auth", () => ({ getServerSession }));
+jest.mock("@cms/auth/options", () => ({ authOptions: {} }));
+jest.mock("@cms/actions/setupSanityBlog", () => ({ setupSanityBlog }));
+jest.mock("@shared-utils", () => ({ parseJsonBody }));
+
+const mkdir = jest.fn();
+const writeFile = jest.fn();
+jest.mock("fs", () => ({ promises: { mkdir, writeFile } }));
+
+const resolveDataRoot = jest.fn();
+jest.mock("@platform-core/dataRoot", () => ({ resolveDataRoot }));
+
+let POST: typeof import("../route").POST;
+
+beforeAll(async () => {
+  ({ POST } = await import("../route"));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resolveDataRoot.mockReturnValue("/data");
+  mkdir.mockResolvedValue(undefined);
+  writeFile.mockResolvedValue(undefined);
+  setupSanityBlog.mockResolvedValue(undefined as any);
+});
+
+function req(body: Record<string, string>): NextRequest {
+  parseJsonBody.mockResolvedValue({ data: body });
+  return {} as NextRequest;
+}
+
+describe("POST", () => {
+  it("writes env vars and sets up blog", async () => {
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+    const res = await POST(
+      req({
+        SANITY_PROJECT_ID: "p",
+        SANITY_DATASET: "d",
+        SANITY_TOKEN: "t",
+        ENABLE_EDITORIAL: "true",
+        PROMOTE_SCHEDULE: "0 0 * * *",
+        FOO: "bar",
+      }),
+      { params: Promise.resolve({ shopId: "s1" }) },
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true });
+    expect(mkdir).toHaveBeenCalledWith(path.join("/data", "s1"), {
+      recursive: true,
+    });
+    expect(writeFile).toHaveBeenCalledWith(
+      path.join("/data", "s1", ".env"),
+      expect.stringContaining("FOO=bar"),
+      "utf8",
+    );
+    expect(setupSanityBlog).toHaveBeenCalledWith(
+      { projectId: "p", dataset: "d", token: "t" },
+      { enabled: true, promoteSchedule: "0 0 * * *" },
+    );
+  });
+
+  it("returns 400 when write fails", async () => {
+    getServerSession.mockResolvedValue({ user: { role: "admin" } });
+    writeFile.mockRejectedValueOnce(new Error("disk"));
+    const res = await POST(req({ FOO: "bar" }), {
+      params: Promise.resolve({ shopId: "s1" }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: "disk" });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for environment variable writing and blog setup
- verify error response when shop write fails

## Testing
- `pnpm --filter @apps/cms test -- "src/app/api/env/\\[shopId\\]/__tests__/route.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4d90bf4832fa6b4d53d068221e6