### PR TITLE
test: add configure-shop route tests

### DIFF
--- a/apps/cms/src/app/api/configure-shop/[shop]/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/configure-shop/[shop]/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+// Polyfill Response.json if missing
+if (typeof (Response as any).json !== "function") {
+  ;(Response as any).json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    })
+}
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock("@platform-core/repositories/shop.server", () => ({
+  updateShopInRepo: jest.fn(),
+}))
+
+describe("configure-shop route", () => {
+  let getServerSession: jest.Mock
+  let updateShopInRepo: jest.Mock
+
+  beforeEach(() => {
+    jest.resetModules()
+    getServerSession = require("next-auth").getServerSession as jest.Mock
+    updateShopInRepo = require("@platform-core/repositories/shop.server").updateShopInRepo as jest.Mock
+    getServerSession.mockReset()
+    updateShopInRepo.mockReset()
+  })
+
+  it("updates shop when request is valid", async () => {
+    getServerSession.mockResolvedValueOnce({ user: { role: "admin" } })
+    updateShopInRepo.mockResolvedValueOnce(undefined)
+    const { POST } = await import("../route")
+    const req = new Request("http://localhost/api/configure-shop", {
+      method: "POST",
+      body: JSON.stringify({ payment: ["stripe"], shipping: ["shippo"] }),
+    }) as unknown as import("next/server").NextRequest
+    const res = await POST(req, { params: Promise.resolve({ shop: "shop1" }) })
+    expect(updateShopInRepo).toHaveBeenCalledWith("shop1", {
+      id: "shop1",
+      paymentProviders: ["stripe"],
+      shippingProviders: ["shippo"],
+    })
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ success: true })
+  })
+
+  it("returns error when update fails", async () => {
+    getServerSession.mockResolvedValueOnce({ user: { role: "admin" } })
+    updateShopInRepo.mockRejectedValueOnce(new Error("bad input"))
+    const { POST } = await import("../route")
+    const req = new Request("http://localhost/api/configure-shop", {
+      method: "POST",
+      body: JSON.stringify({ payment: "x" }),
+    }) as unknown as import("next/server").NextRequest
+    const res = await POST(req, { params: Promise.resolve({ shop: "shop2" }) })
+    expect(updateShopInRepo).toHaveBeenCalledWith("shop2", { id: "shop2" })
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "bad input" })
+  })
+})
+


### PR DESCRIPTION
## Summary
- add tests for configure-shop API route covering success and error cases

## Testing
- `pnpm --filter @apps/cms exec jest src/app/api/configure-shop/\\[shop\\]/__tests__/route.test.ts --runInBand --no-coverage`
- `pnpm -r build` *(fails: Property 'token' does not exist on type '{ token: string; } | null.)*


------
https://chatgpt.com/codex/tasks/task_e_68bdd4d6d628832fb33222c34bb0e43b