### PR TITLE
test: add media file item selection test

### DIFF
--- a/packages/ui/__tests__/MediaFileItem.test.tsx
+++ b/packages/ui/__tests__/MediaFileItem.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import {
+  MediaSelector,
+  type MediaItem,
+} from "../src/components/molecules/MediaSelector";
+
+describe("MediaFileItem", () => {
+  const items: MediaItem[] = [
+    { type: "image", src: "/a.jpg", thumbnail: "/thumb.jpg" },
+    { type: "video", src: "/b.mp4" },
+  ];
+
+  function Wrapper({ onSelect }: { onSelect: (i: number) => void }) {
+    const [active, setActive] = useState(0);
+    return (
+      <MediaSelector
+        items={items}
+        active={active}
+        onChange={(i) => {
+          setActive(i);
+          onSelect(i);
+        }}
+      />
+    );
+  }
+
+  it("renders metadata and selection state, and calls onSelect on click", () => {
+    const handle = jest.fn();
+    render(<Wrapper onSelect={handle} />);
+
+    // image item renders provided thumbnail
+    const img = screen.getAllByRole("img")[0] as HTMLImageElement;
+    expect(img.src).toContain("thumb.jpg");
+
+    // video item shows a label
+    expect(screen.getByText("Video")).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0].className).toContain("ring-2");
+    expect(buttons[1].className).not.toContain("ring-2");
+
+    fireEvent.click(buttons[1]);
+    expect(handle).toHaveBeenCalledWith(1);
+    expect(buttons[1].className).toContain("ring-2");
+  });
+});


### PR DESCRIPTION
## Summary
- add MediaFileItem unit test to verify thumbnail rendering, title fallback, selection state, and onSelect callback

## Testing
- `pnpm run test packages/ui` (fails: Missing tasks in project)
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/MediaFileItem.test.tsx --config ../../jest.config.cjs --runInBand --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4c10880832fbf290b76565d160a