### PR TITLE
fix: handle optional token param

### DIFF
--- a/apps/shop-bcd/src/app/password-reset/[token]/page.tsx
+++ b/apps/shop-bcd/src/app/password-reset/[token]/page.tsx
@@ -4,8 +4,7 @@ import { useState } from "react";
 import { useParams } from "next/navigation";
 
 export default function PasswordResetPage() {
-  const params = useParams<{ token: string }>();
-  const token = params?.token;
+  const token = useParams<{ token: string }>()?.token;
   const [msg, setMsg] = useState("");
 
   if (!token) {


### PR DESCRIPTION
## Summary
- handle nullable route params in password reset page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bea8c1e078832f84175ae991607f9c