### PR TITLE
docs: clarify database and inventory storage

### DIFF
--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -4,9 +4,10 @@ This page describes the environment variables the platform expects. Each variabl
 
 | Variable | Purpose |
 | --- | --- |
-| `DATABASE_URL` | PostgreSQL connection string. If unset, an in-memory stub is used. |
+| `DATABASE_URL` | PostgreSQL connection string. When set, Prisma (Postgres) is used; when unset, data is stored in JSON files. |
 | `DATA_ROOT` | Root directory for per-shop data files. If unset, falls back to `<cwd>/data/shops`. |
 | `TEST_DATA_ROOT` | Root directory for test fixtures. Defaults to `test/data/shops`. |
+| `INVENTORY_BACKEND` | `json` forces JSON/disk storage (default when `DATABASE_URL` is unset); `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
 | `STRIPE_SECRET_KEY` | Server-side Stripe API key. |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Client-side Stripe key exposed to the browser. |
 | `STRIPE_WEBHOOK_SECRET` | Secret used to verify Stripe webhook signatures. |


### PR DESCRIPTION
## Summary
- document Prisma vs JSON persistence for `DATABASE_URL`
- describe new `INVENTORY_BACKEND` options

## Testing
- `pnpm install`
- `pnpm test` *(fails: run failed command exited)*

------
https://chatgpt.com/codex/tasks/task_e_68beabc7979c832fa88836cc5d42b690