### PR TITLE
docs: document backend overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ primary datastore. The schema includes:
 
 ## Persistence
 
-Some repositories retain JSON or SQLite fallbacks under a common `DATA_ROOT`, but Prisma with PostgreSQL is the default datastore. Inventory stays on these fallbacks to keep demos lightweight and support offline development until a relational schema is ready. The migration plan lives in [docs/inventory-migration.md](docs/inventory-migration.md). See [docs/persistence.md](docs/persistence.md) for details on these fallbacks and the `DATA_ROOT` environment variable.
+Some repositories retain JSON or SQLite fallbacks under a common `DATA_ROOT`, but Prisma with PostgreSQL is the default datastore. Inventory stays on these fallbacks to keep demos lightweight and support offline development until a relational schema is ready. The pages and shops repositories prefer the database but can be forced to JSON by setting `PAGES_BACKEND=json` or `SHOP_BACKEND=json`; the `sqlite` options are legacy no-ops that proxy to the JSON backend. The migration plan lives in [docs/inventory-migration.md](docs/inventory-migration.md). See [docs/persistence.md](docs/persistence.md) for details on these fallbacks and the `DATA_ROOT` environment variable.
 
 ## Contributing
 

--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -8,6 +8,8 @@ This page describes the environment variables the platform expects. Each variabl
 | `DATA_ROOT` | Root directory for per-shop data files. If unset, falls back to `<cwd>/data/shops`. |
 | `TEST_DATA_ROOT` | Root directory for test fixtures. Defaults to `test/data/shops`. |
 | `INVENTORY_BACKEND` | `json` forces JSON/disk storage (default when `DATABASE_URL` is unset); `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
+| `PAGES_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
+| `SHOP_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
 | `STRIPE_SECRET_KEY` | Server-side Stripe API key. |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Client-side Stripe key exposed to the browser. |
 | `STRIPE_WEBHOOK_SECRET` | Secret used to verify Stripe webhook signatures. |

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -21,6 +21,20 @@ Set `INVENTORY_BACKEND` to force a specific implementation:
 - `json` – read and write `data/shops/<shop>/inventory.json` files.
 - `sqlite` – legacy/no-op option. `inventory.sqlite.server.ts` delegates to the JSON repository.
 
+The pages repository falls back to `data/shops/<shop>/pages.json`.
+
+Set `PAGES_BACKEND` to force a specific implementation:
+
+- `json` – read and write `data/shops/<shop>/pages.json` files.
+- `sqlite` – legacy/no-op option that proxies to the JSON repository.
+
+The shops repository falls back to `data/shops/<shop>/shop.json`.
+
+Set `SHOP_BACKEND` to force a specific implementation:
+
+- `json` – read and write `data/shops/<shop>/shop.json` files.
+- `sqlite` – legacy/no-op option that proxies to the JSON repository.
+
 These fallbacks keep parts of the project functional during development or when the database is unreachable.
 
 ## `DATA_ROOT`


### PR DESCRIPTION
## Summary
- add pages and shops backend overrides to persistence docs and env reference
- clarify backend overrides in README

## Testing
- `pnpm install`
- `pnpm lint docs` *(fails: Could not find task `docs` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68bec301d708832f8730789d6dc8c4d5