### PR TITLE
refactor: add pricing repo resolver

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/pricing.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/pricing.backendSelection.test.ts
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+
+const mockJson = {
+  read: jest.fn(),
+  write: jest.fn(),
+};
+
+const mockPrisma = {
+  read: jest.fn(),
+  write: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock('../pricing.json.server', () => ({
+  jsonPricingRepository: mockJson,
+}));
+
+jest.mock('../pricing.prisma.server', () => {
+  prismaImportCount++;
+  return { prismaPricingRepository: mockPrisma };
+});
+
+jest.mock('../../db', () => ({ prisma: { pricing: {} } }));
+
+jest.mock('../repoResolver', () => ({
+  resolveRepo: async (
+    prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === 'json') {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe('pricing repository backend selection', () => {
+  const origBackend = process.env.PRICING_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = 'postgres://test';
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.PRICING_BACKEND;
+    } else {
+      process.env.PRICING_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when PRICING_BACKEND="json"', async () => {
+    process.env.PRICING_BACKEND = 'json';
+    const { readPricing, writePricing } = await import('../pricing.server');
+
+    await readPricing();
+    await writePricing({} as any);
+
+    expect(mockJson.read).toHaveBeenCalled();
+    expect(mockJson.write).toHaveBeenCalled();
+    expect(mockPrisma.read).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the Prisma repository when PRICING_BACKEND is not set', async () => {
+    delete process.env.PRICING_BACKEND;
+    const { readPricing, writePricing } = await import('../pricing.server');
+
+    await readPricing();
+    await writePricing({} as any);
+
+    expect(mockPrisma.read).toHaveBeenCalled();
+    expect(mockPrisma.write).toHaveBeenCalled();
+    expect(mockJson.read).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});

--- a/packages/platform-core/src/repositories/pricing.json.server.d.ts
+++ b/packages/platform-core/src/repositories/pricing.json.server.d.ts
@@ -1,0 +1,7 @@
+import "server-only";
+import { type PricingMatrix } from "@acme/types";
+export interface PricingRepository {
+  read(): Promise<PricingMatrix>;
+  write(data: PricingMatrix): Promise<void>;
+}
+export declare const jsonPricingRepository: PricingRepository;

--- a/packages/platform-core/src/repositories/pricing.prisma.server.d.ts
+++ b/packages/platform-core/src/repositories/pricing.prisma.server.d.ts
@@ -1,0 +1,7 @@
+import "server-only";
+import { type PricingMatrix } from "@acme/types";
+export interface PricingRepository {
+  read(): Promise<PricingMatrix>;
+  write(data: PricingMatrix): Promise<void>;
+}
+export declare const prismaPricingRepository: PricingRepository;

--- a/packages/platform-core/src/repositories/pricing.prisma.server.ts
+++ b/packages/platform-core/src/repositories/pricing.prisma.server.ts
@@ -1,0 +1,5 @@
+import "server-only";
+import { jsonPricingRepository } from "./pricing.json.server";
+
+// Placeholder Prisma implementation delegating to JSON repository.
+export const prismaPricingRepository = jsonPricingRepository;


### PR DESCRIPTION
## Summary
- move pricing JSON storage into dedicated `pricing.json.server.ts`
- stub Prisma-backed pricing repository
- resolve pricing repository backend via `PRICING_BACKEND`
- add backend selection tests for pricing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/platform-core build`
- `pnpm run build:stubs` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/repositories/__tests__/pricing.backendSelection.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68beca1dd89c832fa366ebede3f0f0f1