### PR TITLE
refactor: add theme preset repository backends

### DIFF
--- a/__tests__/themePresets.backendSelection.test.ts
+++ b/__tests__/themePresets.backendSelection.test.ts
@@ -1,0 +1,113 @@
+import { jest } from "@jest/globals";
+
+const mockJson = {
+  getThemePresets: jest.fn(),
+  saveThemePreset: jest.fn(),
+  deleteThemePreset: jest.fn(),
+};
+
+const mockPrisma = {
+  getThemePresets: jest.fn(),
+  saveThemePreset: jest.fn(),
+  deleteThemePreset: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock(
+  "../packages/platform-core/src/repositories/themePresets.json.server",
+  () => ({ jsonThemePresetRepository: mockJson }),
+);
+
+jest.mock(
+  "../packages/platform-core/src/repositories/themePresets.prisma.server",
+  () => {
+    prismaImportCount++;
+    return { prismaThemePresetRepository: mockPrisma };
+  },
+);
+
+jest.mock("../packages/platform-core/src/db", () => ({
+  prisma: { themePreset: {} },
+}));
+
+jest.mock("../packages/platform-core/src/repositories/repoResolver", () => ({
+  resolveRepo: async (
+    prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === "json") {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe("themePresets repository backend selection", () => {
+  const origBackend = process.env.THEME_PRESETS_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.THEME_PRESETS_BACKEND;
+    } else {
+      process.env.THEME_PRESETS_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when THEME_PRESETS_BACKEND="json"', async () => {
+    process.env.THEME_PRESETS_BACKEND = "json";
+    const repo = await import(
+      "../packages/platform-core/src/repositories/themePresets.server"
+    );
+
+    await repo.getThemePresets("shop");
+    await repo.saveThemePreset("shop", "name", {});
+    await repo.deleteThemePreset("shop", "name");
+
+    expect(mockJson.getThemePresets).toHaveBeenCalledWith("shop");
+    expect(mockJson.saveThemePreset).toHaveBeenCalledWith(
+      "shop",
+      "name",
+      {},
+    );
+    expect(mockJson.deleteThemePreset).toHaveBeenCalledWith("shop", "name");
+    expect(mockPrisma.getThemePresets).not.toHaveBeenCalled();
+  });
+
+  it("defaults to the Prisma repository when THEME_PRESETS_BACKEND is not set", async () => {
+    delete process.env.THEME_PRESETS_BACKEND;
+    const repo = await import(
+      "../packages/platform-core/src/repositories/themePresets.server"
+    );
+
+    await repo.getThemePresets("shop");
+    await repo.saveThemePreset("shop", "name", {});
+    await repo.deleteThemePreset("shop", "name");
+
+    expect(mockPrisma.getThemePresets).toHaveBeenCalledWith("shop");
+    expect(mockPrisma.saveThemePreset).toHaveBeenCalledWith(
+      "shop",
+      "name",
+      {},
+    );
+    expect(mockPrisma.deleteThemePreset).toHaveBeenCalledWith("shop", "name");
+    expect(mockJson.getThemePresets).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});

--- a/packages/platform-core/src/repositories/themePresets.json.server.d.ts
+++ b/packages/platform-core/src/repositories/themePresets.json.server.d.ts
@@ -1,0 +1,10 @@
+import "server-only";
+export declare const jsonThemePresetRepository: {
+  getThemePresets(shop: string): Promise<Record<string, Record<string, string>>>;
+  saveThemePreset(
+    shop: string,
+    name: string,
+    tokens: Record<string, string>,
+  ): Promise<void>;
+  deleteThemePreset(shop: string, name: string): Promise<void>;
+};

--- a/packages/platform-core/src/repositories/themePresets.json.server.ts
+++ b/packages/platform-core/src/repositories/themePresets.json.server.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { promises as fs } from "fs";
+import * as path from "path";
+import { validateShopName } from "../shops/index";
+import { DATA_ROOT } from "../dataRoot";
+
+function presetsPath(shop: string) {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "theme-presets.json");
+}
+
+async function readPresets(shop: string) {
+  try {
+    const buf = await fs.readFile(presetsPath(shop), "utf8");
+    return JSON.parse(buf) as Record<string, Record<string, string>>;
+  } catch {
+    return {} as Record<string, Record<string, string>>;
+  }
+}
+
+export async function getThemePresets(
+  shop: string,
+): Promise<Record<string, Record<string, string>>> {
+  return readPresets(shop);
+}
+
+export async function saveThemePreset(
+  shop: string,
+  name: string,
+  tokens: Record<string, string>,
+): Promise<void> {
+  const presets = await readPresets(shop);
+  presets[name] = tokens;
+  await fs.mkdir(path.dirname(presetsPath(shop)), { recursive: true });
+  await fs.writeFile(
+    presetsPath(shop),
+    JSON.stringify(presets, null, 2),
+    "utf8",
+  );
+}
+
+export async function deleteThemePreset(
+  shop: string,
+  name: string,
+): Promise<void> {
+  const presets = await readPresets(shop);
+  delete presets[name];
+  await fs.mkdir(path.dirname(presetsPath(shop)), { recursive: true });
+  await fs.writeFile(
+    presetsPath(shop),
+    JSON.stringify(presets, null, 2),
+    "utf8",
+  );
+}
+
+export const jsonThemePresetRepository = {
+  getThemePresets,
+  saveThemePreset,
+  deleteThemePreset,
+};

--- a/packages/platform-core/src/repositories/themePresets.prisma.server.d.ts
+++ b/packages/platform-core/src/repositories/themePresets.prisma.server.d.ts
@@ -1,0 +1,10 @@
+import "server-only";
+export declare const prismaThemePresetRepository: {
+  getThemePresets(shop: string): Promise<Record<string, Record<string, string>>>;
+  saveThemePreset(
+    shop: string,
+    name: string,
+    tokens: Record<string, string>,
+  ): Promise<void>;
+  deleteThemePreset(shop: string, name: string): Promise<void>;
+};

--- a/packages/platform-core/src/repositories/themePresets.prisma.server.ts
+++ b/packages/platform-core/src/repositories/themePresets.prisma.server.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { prisma } from "../db";
+
+export async function getThemePresets(
+  shop: string,
+): Promise<Record<string, Record<string, string>>> {
+  const db = prisma as any;
+  if (!db.themePreset) return {};
+  const rows = await db.themePreset.findMany({ where: { shopId: shop } });
+  const result: Record<string, Record<string, string>> = {};
+  for (const row of rows) {
+    result[row.name] = row.tokens as Record<string, string>;
+  }
+  return result;
+}
+
+export async function saveThemePreset(
+  shop: string,
+  name: string,
+  tokens: Record<string, string>,
+): Promise<void> {
+  const db = prisma as any;
+  if (!db.themePreset) return;
+  await db.themePreset.upsert({
+    where: { shopId_name: { shopId: shop, name } },
+    create: { shopId: shop, name, tokens },
+    update: { tokens },
+  });
+}
+
+export async function deleteThemePreset(
+  shop: string,
+  name: string,
+): Promise<void> {
+  const db = prisma as any;
+  if (!db.themePreset) return;
+  try {
+    await db.themePreset.delete({
+      where: { shopId_name: { shopId: shop, name } },
+    });
+  } catch {
+    // ignore
+  }
+}
+
+export const prismaThemePresetRepository = {
+  getThemePresets,
+  saveThemePreset,
+  deleteThemePreset,
+};


### PR DESCRIPTION
## Summary
- split theme preset repository into json and prisma implementations
- wrap themePresets.server with resolveRepo and backend env var
- test backend selection for theme preset repo

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest __tests__/themePresets.backendSelection.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68beca23eef0832facf71df3af7bf617