### PR TITLE
feat(platform-core): add pluggable analytics repository backend

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/analytics.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/analytics.backendSelection.test.ts
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+
+const mockJson = {
+  listEvents: jest.fn(),
+  readAggregates: jest.fn(),
+};
+
+const mockPrisma = {
+  listEvents: jest.fn(),
+  readAggregates: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock('../analytics.json.server', () => ({
+  jsonAnalyticsRepository: mockJson,
+}));
+
+jest.mock('../analytics.prisma.server', () => {
+  prismaImportCount++;
+  return { prismaAnalyticsRepository: mockPrisma };
+});
+
+jest.mock('../../db', () => ({ prisma: { analyticsEvent: {} } }));
+
+jest.mock('../repoResolver', () => ({
+  resolveRepo: async (
+    _prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === 'json') {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe('analytics repository backend selection', () => {
+  const origBackend = process.env.ANALYTICS_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = 'postgres://test';
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.ANALYTICS_BACKEND;
+    } else {
+      process.env.ANALYTICS_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when ANALYTICS_BACKEND="json"', async () => {
+    process.env.ANALYTICS_BACKEND = 'json';
+    const { listEvents, readAggregates } = await import('../analytics.server');
+
+    await listEvents('shop');
+    await readAggregates('shop');
+
+    expect(mockJson.listEvents).toHaveBeenCalledWith('shop');
+    expect(mockJson.readAggregates).toHaveBeenCalledWith('shop');
+    expect(mockPrisma.listEvents).not.toHaveBeenCalled();
+  });
+
+  it('defaults to Prisma repository when ANALYTICS_BACKEND is not set', async () => {
+    delete process.env.ANALYTICS_BACKEND;
+    const { listEvents, readAggregates } = await import('../analytics.server');
+
+    await listEvents('shop');
+    await readAggregates('shop');
+
+    expect(mockPrisma.listEvents).toHaveBeenCalledWith('shop');
+    expect(mockPrisma.readAggregates).toHaveBeenCalledWith('shop');
+    expect(mockJson.listEvents).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});

--- a/packages/platform-core/src/repositories/analytics.json.server.d.ts
+++ b/packages/platform-core/src/repositories/analytics.json.server.d.ts
@@ -1,0 +1,8 @@
+import "server-only";
+import type { AnalyticsAggregates, AnalyticsEvent } from "../analytics";
+export declare function listEvents(_shop?: string): Promise<AnalyticsEvent[]>;
+export declare function readAggregates(shop: string): Promise<AnalyticsAggregates>;
+export declare const jsonAnalyticsRepository: {
+  listEvents: typeof listEvents;
+  readAggregates: typeof readAggregates;
+};

--- a/packages/platform-core/src/repositories/analytics.json.server.ts
+++ b/packages/platform-core/src/repositories/analytics.json.server.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { promises as fs } from "fs";
+import * as path from "path";
+import { DATA_ROOT } from "../dataRoot";
+import { validateShopName } from "../shops";
+import type { AnalyticsAggregates, AnalyticsEvent } from "../analytics";
+
+/**
+ * Read analytics events from newline-delimited JSON files. When a shop is
+ * provided only that shop's log is read, otherwise the logs for all shops are
+ * concatenated. Missing files or invalid JSON lines are ignored so callers do
+ * not need to handle errors.
+ */
+export async function listEvents(_shop?: string): Promise<AnalyticsEvent[]> {
+  const shops = _shop
+    ? [validateShopName(_shop)]
+    : await fs
+        .readdir(DATA_ROOT, { withFileTypes: true })
+        .then((entries) =>
+          entries.filter((e) => e.isDirectory()).map((e) => e.name),
+        )
+        .catch(() => []);
+
+  const events: AnalyticsEvent[] = [];
+  for (const shop of shops) {
+    const file = path.join(DATA_ROOT, shop, "analytics.jsonl");
+    let data = "";
+    try {
+      data = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of data.split(/\n+/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        events.push(JSON.parse(trimmed) as AnalyticsEvent);
+      } catch {
+        // ignore malformed lines
+      }
+    }
+  }
+  return events;
+}
+
+export async function readAggregates(
+  shop: string,
+): Promise<AnalyticsAggregates> {
+  const file = path.join(
+    DATA_ROOT,
+    validateShopName(shop),
+    "analytics-aggregates.json",
+  );
+  try {
+    const buf = await fs.readFile(file, "utf8");
+    return JSON.parse(buf) as AnalyticsAggregates;
+  } catch {
+    return {
+      page_view: {},
+      order: {},
+      discount_redeemed: {},
+      ai_crawl: {},
+    };
+  }
+}
+
+export const jsonAnalyticsRepository = {
+  listEvents,
+  readAggregates,
+};
+

--- a/packages/platform-core/src/repositories/analytics.prisma.server.d.ts
+++ b/packages/platform-core/src/repositories/analytics.prisma.server.d.ts
@@ -1,0 +1,8 @@
+import "server-only";
+import type { AnalyticsAggregates, AnalyticsEvent } from "../analytics";
+export declare function listEvents(_shop?: string): Promise<AnalyticsEvent[]>;
+export declare function readAggregates(shop: string): Promise<AnalyticsAggregates>;
+export declare const prismaAnalyticsRepository: {
+  listEvents: typeof listEvents;
+  readAggregates: typeof readAggregates;
+};

--- a/packages/platform-core/src/repositories/analytics.prisma.server.ts
+++ b/packages/platform-core/src/repositories/analytics.prisma.server.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import type { AnalyticsAggregates, AnalyticsEvent } from "../analytics";
+import { jsonAnalyticsRepository } from "./analytics.json.server";
+
+export async function listEvents(
+  shop?: string,
+): Promise<AnalyticsEvent[]> {
+  return jsonAnalyticsRepository.listEvents(shop);
+}
+
+export async function readAggregates(
+  shop: string,
+): Promise<AnalyticsAggregates> {
+  return jsonAnalyticsRepository.readAggregates(shop);
+}
+
+export const prismaAnalyticsRepository = {
+  listEvents,
+  readAggregates,
+};
+


### PR DESCRIPTION
## Summary
- add wrapper choosing analytics repository via resolveRepo and ANALYTICS_BACKEND env var
- factor existing JSON logic into analytics.json.server and stub Prisma implementation
- test backend selection logic

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test --filter @acme/platform-core` *(fails: Command was killed with SIGABRT)*

------
https://chatgpt.com/codex/tasks/task_e_68beca20156c832f95dd27447f6d7922