### PR TITLE
feat: add repository backend resolver for products

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/products.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/products.backendSelection.test.ts
@@ -1,0 +1,115 @@
+import { jest } from '@jest/globals';
+
+const mockJson = {
+  read: jest.fn(),
+  write: jest.fn(),
+  getById: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  duplicate: jest.fn(),
+};
+
+const mockPrisma = {
+  read: jest.fn(),
+  write: jest.fn(),
+  getById: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  duplicate: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock('../products.json.server', () => ({
+  jsonProductsRepository: mockJson,
+}));
+
+jest.mock('../products.prisma.server', () => {
+  prismaImportCount++;
+  return { prismaProductsRepository: mockPrisma };
+});
+
+jest.mock('../../db', () => ({ prisma: { product: {} } }));
+
+jest.mock('../repoResolver', () => ({
+  resolveRepo: async (
+    prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === 'json') {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe('products repository backend selection', () => {
+  const origBackend = process.env.PRODUCTS_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = 'postgres://test';
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.PRODUCTS_BACKEND;
+    } else {
+      process.env.PRODUCTS_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when PRODUCTS_BACKEND="json"', async () => {
+    process.env.PRODUCTS_BACKEND = 'json';
+    const {
+      readRepo,
+      writeRepo,
+      updateProductInRepo,
+    } = await import('../products.server');
+
+    await readRepo('shop');
+    await writeRepo('shop', []);
+    await updateProductInRepo('shop', { id: 'id', row_version: 1 });
+
+    expect(mockJson.read).toHaveBeenCalledWith('shop');
+    expect(mockJson.write).toHaveBeenCalledWith('shop', []);
+    expect(mockJson.update).toHaveBeenCalledWith('shop', {
+      id: 'id',
+      row_version: 1,
+    });
+    expect(mockPrisma.read).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the Prisma repository when PRODUCTS_BACKEND is not set', async () => {
+    delete process.env.PRODUCTS_BACKEND;
+    const {
+      readRepo,
+      writeRepo,
+      updateProductInRepo,
+    } = await import('../products.server');
+
+    await readRepo('shop');
+    await writeRepo('shop', []);
+    await updateProductInRepo('shop', { id: 'id', row_version: 1 });
+
+    expect(mockPrisma.read).toHaveBeenCalledWith('shop');
+    expect(mockPrisma.write).toHaveBeenCalledWith('shop', []);
+    expect(mockPrisma.update).toHaveBeenCalledWith('shop', {
+      id: 'id',
+      row_version: 1,
+    });
+    expect(mockJson.read).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});

--- a/packages/platform-core/src/repositories/products.json.server.ts
+++ b/packages/platform-core/src/repositories/products.json.server.ts
@@ -1,0 +1,102 @@
+import "server-only";
+
+import { promises as fs } from "fs";
+import * as path from "path";
+import { ulid } from "ulid";
+import type { ProductPublication } from "../products/index";
+import { validateShopName } from "../shops/index";
+import { DATA_ROOT } from "../dataRoot";
+import { nowIso } from "@acme/date-utils";
+import type { ProductsRepository } from "./products.types";
+
+function filePath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "products.json");
+}
+
+async function ensureDir(shop: string): Promise<void> {
+  shop = validateShopName(shop);
+  await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
+}
+
+async function read<T = ProductPublication>(shop: string): Promise<T[]> {
+  try {
+    const buf = await fs.readFile(filePath(shop), "utf8");
+    return JSON.parse(buf) as T[];
+  } catch {
+    return [] as T[];
+  }
+}
+
+async function write<T = ProductPublication>(
+  shop: string,
+  catalogue: T[],
+): Promise<void> {
+  await ensureDir(shop);
+  const tmp = `${filePath(shop)}.${Date.now()}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(catalogue, null, 2), "utf8");
+  await fs.rename(tmp, filePath(shop));
+}
+
+async function getById<
+  T extends { id: string } = ProductPublication,
+>(shop: string, id: string): Promise<T | null> {
+  const catalogue = await read<T>(shop);
+  return catalogue.find((p) => p.id === id) ?? null;
+}
+
+async function update<
+  T extends { id: string; row_version: number } = ProductPublication,
+>(shop: string, patch: Partial<T> & { id: string }): Promise<T> {
+  const catalogue = await read<T>(shop);
+  const idx = catalogue.findIndex((p) => p.id === patch.id);
+  if (idx === -1) throw new Error(`Product ${patch.id} not found in ${shop}`);
+  const updated: T = {
+    ...catalogue[idx],
+    ...patch,
+    row_version: catalogue[idx].row_version + 1,
+  };
+  catalogue[idx] = updated;
+  await write<T>(shop, catalogue);
+  return updated;
+}
+
+async function remove<
+  T extends { id: string } = ProductPublication,
+>(shop: string, id: string): Promise<void> {
+  const catalogue = await read<T>(shop);
+  const next = catalogue.filter((p) => p.id !== id);
+  if (next.length === catalogue.length) {
+    throw new Error(`Product ${id} not found in ${shop}`);
+  }
+  await write<T>(shop, next);
+}
+
+async function duplicate<
+  T extends ProductPublication = ProductPublication,
+>(shop: string, id: string): Promise<T> {
+  const catalogue = await read<T>(shop);
+  const original = catalogue.find((p) => p.id === id);
+  if (!original) throw new Error(`Product ${id} not found in ${shop}`);
+  const now = nowIso();
+  const copy: T = {
+    ...original,
+    id: ulid(),
+    sku: `${original.sku}-copy`,
+    status: "draft",
+    row_version: 1,
+    created_at: now,
+    updated_at: now,
+  };
+  await write<T>(shop, [copy, ...catalogue]);
+  return copy;
+}
+
+export const jsonProductsRepository: ProductsRepository = {
+  read,
+  write,
+  getById,
+  update,
+  delete: remove,
+  duplicate,
+};

--- a/packages/platform-core/src/repositories/products.prisma.server.ts
+++ b/packages/platform-core/src/repositories/products.prisma.server.ts
@@ -1,0 +1,7 @@
+import "server-only";
+
+import type { ProductsRepository } from "./products.types";
+import { jsonProductsRepository } from "./products.json.server";
+
+// Placeholder Prisma implementation delegating to JSON repository.
+export const prismaProductsRepository: ProductsRepository = jsonProductsRepository;

--- a/packages/platform-core/src/repositories/products.server.ts
+++ b/packages/platform-core/src/repositories/products.server.ts
@@ -1,94 +1,69 @@
 import "server-only";
 
-import { promises as fs } from "fs";
-import * as path from "path";
-import { ulid } from "ulid";
+import { prisma } from "../db";
+import { resolveRepo } from "./repoResolver";
 import type { ProductPublication } from "../products/index";
-import { validateShopName } from "../shops/index";
-import { DATA_ROOT } from "../dataRoot";
-import { nowIso } from "@acme/date-utils";
+import type { ProductsRepository } from "./products.types";
 
-function filePath(shop: string): string {
-  shop = validateShopName(shop);
-  return path.join(DATA_ROOT, shop, "products.json");
-}
+let repoPromise: Promise<ProductsRepository> | undefined;
 
-async function ensureDir(shop: string): Promise<void> {
-  shop = validateShopName(shop);
-  await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
+async function getRepo(): Promise<ProductsRepository> {
+  if (!repoPromise) {
+    repoPromise = resolveRepo(
+      () => (prisma as any).product,
+      () =>
+        import("./products.prisma.server").then(
+          (m) => m.prismaProductsRepository,
+        ),
+      () =>
+        import("./products.json.server").then(
+          (m) => m.jsonProductsRepository,
+        ),
+      { backendEnvVar: "PRODUCTS_BACKEND" },
+    );
+  }
+  return repoPromise;
 }
 
 export async function readRepo<T = ProductPublication>(
-  shop: string
+  shop: string,
 ): Promise<T[]> {
-  try {
-    const buf = await fs.readFile(filePath(shop), "utf8");
-    return JSON.parse(buf) as T[];
-  } catch {
-    return [] as T[];
-  }
+  const repo = await getRepo();
+  return repo.read(shop);
 }
 
 export async function writeRepo<T = ProductPublication>(
   shop: string,
-  catalogue: T[]
+  catalogue: T[],
 ): Promise<void> {
-  await ensureDir(shop);
-  const tmp = `${filePath(shop)}.${Date.now()}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(catalogue, null, 2), "utf8");
-  await fs.rename(tmp, filePath(shop));
+  const repo = await getRepo();
+  return repo.write(shop, catalogue);
 }
 
 export async function getProductById<
   T extends { id: string } = ProductPublication,
 >(shop: string, id: string): Promise<T | null> {
-  const catalogue = await readRepo<T>(shop);
-  return catalogue.find((p) => p.id === id) ?? null;
+  const repo = await getRepo();
+  return repo.getById(shop, id);
 }
 
 export async function updateProductInRepo<
   T extends { id: string; row_version: number } = ProductPublication,
 >(shop: string, patch: Partial<T> & { id: string }): Promise<T> {
-  const catalogue = await readRepo<T>(shop);
-  const idx = catalogue.findIndex((p) => p.id === patch.id);
-  if (idx === -1) throw new Error(`Product ${patch.id} not found in ${shop}`);
-  const updated: T = {
-    ...catalogue[idx],
-    ...patch,
-    row_version: catalogue[idx].row_version + 1,
-  };
-  catalogue[idx] = updated;
-  await writeRepo<T>(shop, catalogue);
-  return updated;
+  const repo = await getRepo();
+  return repo.update(shop, patch);
 }
 
 export async function deleteProductFromRepo<
   T extends { id: string } = ProductPublication,
 >(shop: string, id: string): Promise<void> {
-  const catalogue = await readRepo<T>(shop);
-  const next = catalogue.filter((p) => p.id !== id);
-  if (next.length === catalogue.length) {
-    throw new Error(`Product ${id} not found in ${shop}`);
-  }
-  await writeRepo<T>(shop, next);
+  const repo = await getRepo();
+  return repo.delete(shop, id);
 }
 
 export async function duplicateProductInRepo<
   T extends ProductPublication = ProductPublication,
 >(shop: string, id: string): Promise<T> {
-  const catalogue = await readRepo<T>(shop);
-  const original = catalogue.find((p) => p.id === id);
-  if (!original) throw new Error(`Product ${id} not found in ${shop}`);
-  const now = nowIso();
-  const copy: T = {
-    ...original,
-    id: ulid(),
-    sku: `${original.sku}-copy`,
-    status: "draft",
-    row_version: 1,
-    created_at: now,
-    updated_at: now,
-  };
-  await writeRepo<T>(shop, [copy, ...catalogue]);
-  return copy;
+  const repo = await getRepo();
+  return repo.duplicate(shop, id);
 }

--- a/packages/platform-core/src/repositories/products.types.ts
+++ b/packages/platform-core/src/repositories/products.types.ts
@@ -1,0 +1,22 @@
+import type { ProductPublication } from "../products/index";
+
+export interface ProductsRepository {
+  read<T = ProductPublication>(shop: string): Promise<T[]>;
+  write<T = ProductPublication>(shop: string, catalogue: T[]): Promise<void>;
+  getById<T extends { id: string } = ProductPublication>(
+    shop: string,
+    id: string,
+  ): Promise<T | null>;
+  update<T extends { id: string; row_version: number } = ProductPublication>(
+    shop: string,
+    patch: Partial<T> & { id: string },
+  ): Promise<T>;
+  delete<T extends { id: string } = ProductPublication>(
+    shop: string,
+    id: string,
+  ): Promise<void>;
+  duplicate<T extends ProductPublication = ProductPublication>(
+    shop: string,
+    id: string,
+  ): Promise<T>;
+}


### PR DESCRIPTION
## Summary
- move product JSON persistence into dedicated repository
- add placeholder Prisma repository and resolver wrapper
- test PRODUCTS_BACKEND env selects correct repository backend

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm run test packages/platform-core` *(fails: Missing task `packages/platform-core`)*
- `pnpm --filter @acme/platform-core test` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68beca1bc020832f82a04f8c829a89aa