### PR TITLE
Support PAGES_BACKEND env override for pages repository

### DIFF
--- a/__tests__/pages.backendSelection.test.ts
+++ b/__tests__/pages.backendSelection.test.ts
@@ -1,0 +1,62 @@
+import { jest } from "@jest/globals";
+
+let prismaImportCount = 0;
+let jsonImportCount = 0;
+const mockPrisma = { getPages: jest.fn() };
+const mockJson = { getPages: jest.fn() };
+
+jest.mock("../packages/platform-core/src/repositories/pages/pages.prisma.server", () => {
+  prismaImportCount++;
+  return mockPrisma;
+});
+
+jest.mock("../packages/platform-core/src/repositories/pages/pages.json.server", () => {
+  jsonImportCount++;
+  return mockJson;
+});
+
+jest.mock("../packages/platform-core/src/db", () => ({ prisma: { page: {} } }));
+
+describe("PAGES_BACKEND environment variable", () => {
+  const origBackend = process.env.PAGES_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    jsonImportCount = 0;
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.PAGES_BACKEND;
+    } else {
+      process.env.PAGES_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it("uses Prisma backend by default", async () => {
+    delete process.env.PAGES_BACKEND;
+    const repo = await import("../packages/platform-core/src/repositories/pages/index.server");
+    await repo.getPages("shop1");
+    expect(prismaImportCount).toBe(1);
+    expect(jsonImportCount).toBe(0);
+    expect(mockPrisma.getPages).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses JSON backend when PAGES_BACKEND=json", async () => {
+    process.env.PAGES_BACKEND = "json";
+    const repo = await import("../packages/platform-core/src/repositories/pages/index.server");
+    await repo.getPages("shop1");
+    expect(jsonImportCount).toBe(1);
+    expect(prismaImportCount).toBe(0);
+    expect(mockJson.getPages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/platform-core/src/repositories/pages/__tests__/index.server.test.ts
+++ b/packages/platform-core/src/repositories/pages/__tests__/index.server.test.ts
@@ -62,8 +62,10 @@ const resolveRepoMock = jest.fn(
     _delegate: any,
     prismaModule: any,
     jsonModule: any,
+    options?: { backendEnvVar?: string },
   ) => {
-    if (process.env.INVENTORY_BACKEND === "json") {
+    const envVar = options?.backendEnvVar ?? "INVENTORY_BACKEND";
+    if (process.env[envVar] === "json") {
       return await jsonModule();
     }
     return await prismaModule();
@@ -106,7 +108,7 @@ describe("pages repository backend selection", () => {
   });
 
   it("uses Prisma backend by default", async () => {
-    delete process.env.INVENTORY_BACKEND;
+    delete process.env.PAGES_BACKEND;
     const repo = await import("../index.server");
 
     await repo.getPages("shop1");
@@ -118,8 +120,8 @@ describe("pages repository backend selection", () => {
     expect(resolveRepoMock).toHaveBeenCalledTimes(1);
   });
 
-  it("uses JSON backend when INVENTORY_BACKEND=json", async () => {
-    process.env.INVENTORY_BACKEND = "json";
+  it("uses JSON backend when PAGES_BACKEND=json", async () => {
+    process.env.PAGES_BACKEND = "json";
     const repo = await import("../index.server");
 
     await repo.getPages("shop1");

--- a/packages/platform-core/src/repositories/pages/index.server.ts
+++ b/packages/platform-core/src/repositories/pages/index.server.ts
@@ -15,6 +15,7 @@ async function getRepo(): Promise<typeof import("./pages.prisma.server")> {
       () => (prisma as any).page,
       () => import("./pages.prisma.server"),
       () => import("./pages.json.server"),
+      { backendEnvVar: "PAGES_BACKEND" },
     );
   }
   return repoPromise;


### PR DESCRIPTION
## Summary
- allow pages repo to pick backend via `PAGES_BACKEND`
- adjust existing tests for new env var and add coverage for env selection

## Testing
- `pnpm build` *(fails: Build failed because of webpack errors)*
- `pnpm test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68beca270008832fbd6365c05eb17fad