### PR TITLE
feat: add backend selection for return logistics

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/returnLogistics.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/returnLogistics.backendSelection.test.ts
@@ -1,0 +1,90 @@
+import { jest } from '@jest/globals';
+
+const mockJson = {
+  readReturnLogistics: jest.fn(),
+  writeReturnLogistics: jest.fn(),
+};
+
+const mockPrisma = {
+  readReturnLogistics: jest.fn(),
+  writeReturnLogistics: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock('../returnLogistics.json.server', () => ({
+  jsonReturnLogisticsRepository: mockJson,
+}));
+
+jest.mock('../returnLogistics.prisma.server', () => {
+  prismaImportCount++;
+  return { prismaReturnLogisticsRepository: mockPrisma };
+});
+
+jest.mock('../../db', () => ({ prisma: { returnLogistics: {} } }));
+
+jest.mock('../repoResolver', () => ({
+  resolveRepo: async (
+    prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === 'json') {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe('return logistics repository backend selection', () => {
+  const origBackend = process.env.RETURN_LOGISTICS_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = 'postgres://test';
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.RETURN_LOGISTICS_BACKEND;
+    } else {
+      process.env.RETURN_LOGISTICS_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when RETURN_LOGISTICS_BACKEND="json"', async () => {
+    process.env.RETURN_LOGISTICS_BACKEND = 'json';
+    const { readReturnLogistics, writeReturnLogistics } = await import('../returnLogistics.server');
+
+    await readReturnLogistics();
+    await writeReturnLogistics({} as any);
+
+    expect(mockJson.readReturnLogistics).toHaveBeenCalled();
+    expect(mockJson.writeReturnLogistics).toHaveBeenCalled();
+    expect(mockPrisma.readReturnLogistics).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the Prisma repository when RETURN_LOGISTICS_BACKEND is not set', async () => {
+    delete process.env.RETURN_LOGISTICS_BACKEND;
+    const { readReturnLogistics, writeReturnLogistics } = await import('../returnLogistics.server');
+
+    await readReturnLogistics();
+    await writeReturnLogistics({} as any);
+
+    expect(mockPrisma.readReturnLogistics).toHaveBeenCalled();
+    expect(mockPrisma.writeReturnLogistics).toHaveBeenCalled();
+    expect(mockJson.readReturnLogistics).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});
+

--- a/packages/platform-core/src/repositories/returnLogistics.json.server.d.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.json.server.d.ts
@@ -1,0 +1,10 @@
+import "server-only";
+import { type ReturnLogistics } from "@acme/types";
+
+export interface ReturnLogisticsRepository {
+  readReturnLogistics(): Promise<ReturnLogistics>;
+  writeReturnLogistics(data: ReturnLogistics): Promise<void>;
+}
+
+export declare const jsonReturnLogisticsRepository: ReturnLogisticsRepository;
+

--- a/packages/platform-core/src/repositories/returnLogistics.json.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.json.server.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { returnLogisticsSchema, type ReturnLogistics } from "@acme/types";
+import { promises as fs } from "fs";
+import * as path from "path";
+import { resolveDataRoot } from "../dataRoot";
+
+function logisticsPath(): string {
+  return path.join(resolveDataRoot(), "..", "return-logistics.json");
+}
+
+async function readReturnLogistics(): Promise<ReturnLogistics> {
+  const buf = await fs.readFile(logisticsPath(), "utf8");
+  const parsed = returnLogisticsSchema.safeParse(JSON.parse(buf));
+  if (!parsed.success) {
+    throw new Error("Invalid return logistics data");
+  }
+  return parsed.data;
+}
+
+async function writeReturnLogistics(data: ReturnLogistics): Promise<void> {
+  const file = logisticsPath();
+  const tmp = `${file}.${Date.now()}.tmp`;
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  await fs.rename(tmp, file);
+}
+
+export const jsonReturnLogisticsRepository = {
+  readReturnLogistics,
+  writeReturnLogistics,
+};
+
+export type { ReturnLogistics };
+

--- a/packages/platform-core/src/repositories/returnLogistics.prisma.server.d.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.prisma.server.d.ts
@@ -1,0 +1,10 @@
+import "server-only";
+import { type ReturnLogistics } from "@acme/types";
+
+export interface ReturnLogisticsRepository {
+  readReturnLogistics(): Promise<ReturnLogistics>;
+  writeReturnLogistics(data: ReturnLogistics): Promise<void>;
+}
+
+export declare const prismaReturnLogisticsRepository: ReturnLogisticsRepository;
+

--- a/packages/platform-core/src/repositories/returnLogistics.prisma.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.prisma.server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import type { ReturnLogistics } from "@acme/types";
+import { jsonReturnLogisticsRepository } from "./returnLogistics.json.server";
+
+// TODO: replace with real Prisma implementation
+export async function readReturnLogistics(): Promise<ReturnLogistics> {
+  return jsonReturnLogisticsRepository.readReturnLogistics();
+}
+
+export async function writeReturnLogistics(
+  data: ReturnLogistics,
+): Promise<void> {
+  await jsonReturnLogisticsRepository.writeReturnLogistics(data);
+}
+
+export const prismaReturnLogisticsRepository = {
+  readReturnLogistics,
+  writeReturnLogistics,
+};
+
+export type { ReturnLogistics };
+


### PR DESCRIPTION
## Summary
- extract return logistics JSON repository
- stub Prisma return logistics repository
- wrap return logistics repo selection via `resolveRepo`
- add backend selection tests for return logistics

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Failed to collect page data for /api/account/profile)*
- `pnpm run build:stubs` *(fails: Missing script: build:stubs)*
- `pnpm test` *(fails: command exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68beca263668832f9e0d36a85de87b09