### PR TITLE
test: ensure pages and shops ignore inventory backend

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/shop.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/shop.server.test.ts
@@ -178,3 +178,97 @@ describe("inventory backend unaffected by SHOP_BACKEND", () => {
   });
 });
 
+describe("shop backend unaffected by INVENTORY_BACKEND", () => {
+  const origInventoryBackend = process.env.INVENTORY_BACKEND;
+  const origShopBackend = process.env.SHOP_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  afterEach(() => {
+    if (origInventoryBackend === undefined) {
+      delete process.env.INVENTORY_BACKEND;
+    } else {
+      process.env.INVENTORY_BACKEND = origInventoryBackend;
+    }
+    if (origShopBackend === undefined) {
+      delete process.env.SHOP_BACKEND;
+    } else {
+      process.env.SHOP_BACKEND = origShopBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it("uses Prisma shop backend when INVENTORY_BACKEND=sqlite", async () => {
+    process.env.INVENTORY_BACKEND = "sqlite";
+    delete process.env.SHOP_BACKEND;
+
+    const prismaRepo = {
+      getShopById: jest.fn(),
+      updateShopInRepo: jest.fn(),
+    };
+    const jsonRepo = {
+      getShopById: jest.fn(),
+      updateShopInRepo: jest.fn(),
+    };
+
+    (resolveRepo as jest.Mock).mockImplementation(
+      async (
+        _delegate: any,
+        _prismaModule: any,
+        _jsonModule: any,
+        options: any = {},
+      ) => {
+        const backend = process.env[options.backendEnvVar ?? "INVENTORY_BACKEND"];
+        return backend === "json" ? jsonRepo : prismaRepo;
+      },
+    );
+
+    const { getShopById: getShopByIdFresh } = await import("../shop.server");
+    await getShopByIdFresh("shop1");
+
+    expect(prismaRepo.getShopById).toHaveBeenCalledWith("shop1");
+    expect(jsonRepo.getShopById).not.toHaveBeenCalled();
+  });
+
+  it("uses JSON shop backend when SHOP_BACKEND=json even if INVENTORY_BACKEND=sqlite", async () => {
+    process.env.INVENTORY_BACKEND = "sqlite";
+    process.env.SHOP_BACKEND = "json";
+
+    const prismaRepo = {
+      getShopById: jest.fn(),
+      updateShopInRepo: jest.fn(),
+    };
+    const jsonRepo = {
+      getShopById: jest.fn(),
+      updateShopInRepo: jest.fn(),
+    };
+
+    (resolveRepo as jest.Mock).mockImplementation(
+      async (
+        _delegate: any,
+        _prismaModule: any,
+        _jsonModule: any,
+        options: any = {},
+      ) => {
+        const backend = process.env[options.backendEnvVar ?? "INVENTORY_BACKEND"];
+        return backend === "json" ? jsonRepo : prismaRepo;
+      },
+    );
+
+    const { getShopById: getShopByIdFresh } = await import("../shop.server");
+    await getShopByIdFresh("shop1");
+
+    expect(jsonRepo.getShopById).toHaveBeenCalledWith("shop1");
+    expect(prismaRepo.getShopById).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/platform-core/src/repositories/pages/__tests__/index.server.test.ts
+++ b/packages/platform-core/src/repositories/pages/__tests__/index.server.test.ts
@@ -148,4 +148,28 @@ describe("pages repository backend selection", () => {
     expect(inventoryPrismaImportCount).toBe(1);
     expect(inventoryJsonImportCount).toBe(0);
   });
+
+  it("ignores INVENTORY_BACKEND=sqlite and uses Prisma by default", async () => {
+    process.env.INVENTORY_BACKEND = "sqlite";
+    delete process.env.PAGES_BACKEND;
+
+    const repo = await import("../index.server");
+
+    await repo.getPages("shop1");
+
+    expect(prismaImportCount).toBe(1);
+    expect(jsonImportCount).toBe(0);
+  });
+
+  it("uses JSON backend when PAGES_BACKEND=json even if INVENTORY_BACKEND=sqlite", async () => {
+    process.env.INVENTORY_BACKEND = "sqlite";
+    process.env.PAGES_BACKEND = "json";
+
+    const repo = await import("../index.server");
+
+    await repo.getPages("shop1");
+
+    expect(jsonImportCount).toBe(1);
+    expect(prismaImportCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- verify pages repository uses Prisma when INVENTORY_BACKEND=sqlite
- confirm shop repository defaults to Prisma despite INVENTORY_BACKEND=sqlite
- cover overrides via PAGES_BACKEND and SHOP_BACKEND

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build: Failed, apps/shop-bcd build: Failed)*
- `pnpm test` *(fails: run failed: command  exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68beda553e5c832f956098b79cb62617