### PR TITLE
Add coupon repository backend resolver and tests

### DIFF
--- a/__tests__/coupons.backendSelection.test.ts
+++ b/__tests__/coupons.backendSelection.test.ts
@@ -1,0 +1,106 @@
+import { jest } from "@jest/globals";
+
+const mockJson = {
+  read: jest.fn(),
+  write: jest.fn(),
+  getByCode: jest.fn(),
+};
+
+const mockPrisma = {
+  read: jest.fn(),
+  write: jest.fn(),
+  getByCode: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock(
+  "../packages/platform-core/src/repositories/coupons.json.server",
+  () => ({ jsonCouponsRepository: mockJson }),
+);
+
+jest.mock(
+  "../packages/platform-core/src/repositories/coupons.prisma.server",
+  () => {
+    prismaImportCount++;
+    return { prismaCouponsRepository: mockPrisma };
+  },
+);
+
+jest.mock("../packages/platform-core/src/db", () => ({
+  prisma: { coupon: {} },
+}));
+
+jest.mock("../packages/platform-core/src/repositories/repoResolver", () => ({
+  resolveRepo: async (
+    prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === "json") {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe("coupons repository backend selection", () => {
+  const origBackend = process.env.COUPONS_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.COUPONS_BACKEND;
+    } else {
+      process.env.COUPONS_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when COUPONS_BACKEND="json"', async () => {
+    process.env.COUPONS_BACKEND = "json";
+    const repo = await import(
+      "../packages/platform-core/src/repositories/coupons.server"
+    );
+
+    await repo.readCouponRepo("shop");
+    await repo.writeCouponRepo("shop", []);
+    await repo.getCouponByCode("shop", "code");
+
+    expect(mockJson.read).toHaveBeenCalledWith("shop");
+    expect(mockJson.write).toHaveBeenCalledWith("shop", []);
+    expect(mockJson.getByCode).toHaveBeenCalledWith("shop", "code");
+    expect(mockPrisma.read).not.toHaveBeenCalled();
+  });
+
+  it("defaults to the Prisma repository when COUPONS_BACKEND is not set", async () => {
+    delete process.env.COUPONS_BACKEND;
+    const repo = await import(
+      "../packages/platform-core/src/repositories/coupons.server"
+    );
+
+    await repo.readCouponRepo("shop");
+    await repo.writeCouponRepo("shop", []);
+    await repo.getCouponByCode("shop", "code");
+
+    expect(mockPrisma.read).toHaveBeenCalledWith("shop");
+    expect(mockPrisma.write).toHaveBeenCalledWith("shop", []);
+    expect(mockPrisma.getByCode).toHaveBeenCalledWith("shop", "code");
+    expect(mockJson.read).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});
+

--- a/packages/platform-core/src/repositories/coupons.json.server.ts
+++ b/packages/platform-core/src/repositories/coupons.json.server.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { couponSchema, type Coupon } from "@acme/types";
+import { promises as fs } from "fs";
+import * as path from "path";
+import { validateShopName } from "../shops/index";
+import { DATA_ROOT } from "../dataRoot";
+
+function filePath(shop: string): string {
+  shop = validateShopName(shop);
+  return path.join(DATA_ROOT, shop, "coupons.json");
+}
+
+async function ensureDir(shop: string): Promise<void> {
+  shop = validateShopName(shop);
+  await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
+}
+
+async function read(shop: string): Promise<Coupon[]> {
+  try {
+    const buf = await fs.readFile(filePath(shop), "utf8");
+    try {
+      return couponSchema.array().parse(JSON.parse(buf));
+    } catch {
+      return [];
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+}
+
+async function write(shop: string, coupons: Coupon[]): Promise<void> {
+  await ensureDir(shop);
+  const tmp = `${filePath(shop)}.${Date.now()}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(coupons, null, 2), "utf8");
+  await fs.rename(tmp, filePath(shop));
+}
+
+async function getByCode(shop: string, code: string): Promise<Coupon | null> {
+  const coupons = await read(shop);
+  return coupons.find((c) => c.code.toLowerCase() === code.toLowerCase()) ?? null;
+}
+
+export interface CouponsRepository {
+  read(shop: string): Promise<Coupon[]>;
+  write(shop: string, coupons: Coupon[]): Promise<void>;
+  getByCode(shop: string, code: string): Promise<Coupon | null>;
+}
+
+export const jsonCouponsRepository: CouponsRepository = {
+  read,
+  write,
+  getByCode,
+};
+

--- a/packages/platform-core/src/repositories/coupons.prisma.server.ts
+++ b/packages/platform-core/src/repositories/coupons.prisma.server.ts
@@ -1,0 +1,8 @@
+import "server-only";
+
+import type { CouponsRepository } from "./coupons.json.server";
+import { jsonCouponsRepository } from "./coupons.json.server";
+
+// Placeholder Prisma implementation delegating to JSON repository.
+export const prismaCouponsRepository: CouponsRepository = jsonCouponsRepository;
+

--- a/packages/platform-core/src/repositories/coupons.server.ts
+++ b/packages/platform-core/src/repositories/coupons.server.ts
@@ -1,45 +1,50 @@
 import "server-only";
 
-import { couponSchema, type Coupon } from "@acme/types";
-import { promises as fs } from "fs";
-import * as path from "path";
-import { validateShopName } from "../shops/index";
-import { DATA_ROOT } from "../dataRoot";
+import type { Coupon } from "@acme/types";
+import { prisma } from "../db";
+import { resolveRepo } from "./repoResolver";
+import type { CouponsRepository } from "./coupons.json.server";
 
-function filePath(shop: string): string {
-  shop = validateShopName(shop);
-  return path.join(DATA_ROOT, shop, "coupons.json");
-}
+let repoPromise: Promise<CouponsRepository> | undefined;
 
-async function ensureDir(shop: string): Promise<void> {
-  shop = validateShopName(shop);
-  await fs.mkdir(path.join(DATA_ROOT, shop), { recursive: true });
+async function getRepo(): Promise<CouponsRepository> {
+  if (!repoPromise) {
+    repoPromise = resolveRepo<CouponsRepository>(
+      () => (prisma as any).coupon,
+      () =>
+        import("./coupons.prisma.server").then(
+          (m) => m.prismaCouponsRepository,
+        ),
+      () =>
+        import("./coupons.json.server").then(
+          (m) => m.jsonCouponsRepository,
+        ),
+      { backendEnvVar: "COUPONS_BACKEND" },
+    );
+  }
+  return repoPromise;
 }
 
 export async function readCouponRepo(shop: string): Promise<Coupon[]> {
-  try {
-    const buf = await fs.readFile(filePath(shop), "utf8");
-    try {
-      return couponSchema.array().parse(JSON.parse(buf));
-    } catch {
-      return [];
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
-    }
-    throw err;
-  }
+  const repo = await getRepo();
+  return repo.read(shop);
 }
 
-export async function writeCouponRepo(shop: string, coupons: Coupon[]): Promise<void> {
-  await ensureDir(shop);
-  const tmp = `${filePath(shop)}.${Date.now()}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(coupons, null, 2), "utf8");
-  await fs.rename(tmp, filePath(shop));
+export async function writeCouponRepo(
+  shop: string,
+  coupons: Coupon[],
+): Promise<void> {
+  const repo = await getRepo();
+  return repo.write(shop, coupons);
 }
 
-export async function getCouponByCode(shop: string, code: string): Promise<Coupon | null> {
-  const coupons = await readCouponRepo(shop);
-  return coupons.find((c) => c.code.toLowerCase() === code.toLowerCase()) ?? null;
+export async function getCouponByCode(
+  shop: string,
+  code: string,
+): Promise<Coupon | null> {
+  const repo = await getRepo();
+  return repo.getByCode(shop, code);
 }
+
+export type { CouponsRepository };
+


### PR DESCRIPTION
## Summary
- extract filesystem-based coupon repository into `coupons.json.server.ts`
- add stub `coupons.prisma.server.ts`
- resolve coupon repository backend via `COUPONS_BACKEND`
- test backend selection behavior

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: apps/cms build failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest __tests__/coupons.backendSelection.test.ts packages/platform-core/src/repositories/__tests__/coupons.server.test.ts` *(Jest global coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68beda4791a0832fb93fe1a438b7853a