### PR TITLE
docs: add backend env var references

### DIFF
--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -10,6 +10,15 @@ This page describes the environment variables the platform expects. Each variabl
 | `INVENTORY_BACKEND` | `json` forces JSON/disk storage (default when `DATABASE_URL` is unset); `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
 | `PAGES_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
 | `SHOP_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
+| `PRODUCTS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `SETTINGS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `THEME_PRESETS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `ANALYTICS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `COUPONS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `SEO_AUDIT_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `PRICING_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `RETURN_LOGISTICS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `RETURN_AUTH_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
 | `STRIPE_SECRET_KEY` | Server-side Stripe API key. |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Client-side Stripe key exposed to the browser. |
 | `STRIPE_WEBHOOK_SECRET` | Secret used to verify Stripe webhook signatures. |
@@ -44,3 +53,15 @@ This page describes the environment variables the platform expects. Each variabl
 | `STOCK_ALERT_WEBHOOK` | URL for posting low stock alerts to an external service. |
 | `STOCK_ALERT_DEFAULT_THRESHOLD` | Default stock level that triggers alerts. |
 | `NEXT_PUBLIC_BASE_URL` | Base URL exposed to the browser for constructing absolute links. |
+
+```env
+# PRODUCTS_BACKEND=json
+# SETTINGS_BACKEND=json
+# THEME_PRESETS_BACKEND=json
+# ANALYTICS_BACKEND=json
+# COUPONS_BACKEND=json
+# SEO_AUDIT_BACKEND=json
+# PRICING_BACKEND=json
+# RETURN_LOGISTICS_BACKEND=json
+# RETURN_AUTH_BACKEND=json
+```


### PR DESCRIPTION
## Summary
- document additional backend env vars in `.env.reference.md`
- include sample `.env` entries for new backend variables

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @apps/shop-bcd build)*

------
https://chatgpt.com/codex/tasks/task_e_68bee60a5134832f92bc2b3bf3ad00e4