### PR TITLE
docs: document inventory seeding flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Run `pnpm init-shop` to scaffold a new shop. The configurator lists available pl
 See [docs/testing.md](docs/testing.md) for comprehensive testing instructions. Cypress fixtures live under `test/data/shops`. Override this path by setting the `TEST_DATA_ROOT` environment variable.
 For CMS configurator-specific end-to-end tests, see [docs/testing-configurator.md](docs/testing-configurator.md).
 
-Seed data before running the Cypress suite. The seed script populates minimal base data and inventory by default. Use `--skip-inventory` to omit inventory seeding when inventory is already prepared:
+Seed data before running the Cypress suite. The seed script populates minimal base data and inventory by default, loading fixtures from `data/shops/*/inventory.json` and computing `variantKey` for each variant. Use `--skip-inventory` to omit inventory seeding when inventory is already prepared:
 
 ```bash
-pnpm prisma db seed
+pnpm --filter @acme/platform-core exec prisma db seed
 pnpm e2e
 ```
 
 To skip inventory seeding:
 
 ```bash
-pnpm prisma db seed -- --skip-inventory
+pnpm --filter @acme/platform-core exec prisma db seed -- --skip-inventory
 ```
 
 ## Key Features

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,12 +18,12 @@ pnpm --filter @acme/platform-core exec prisma db seed
 
 ### Seeding
 
-`pnpm prisma db seed` loads both inventory and orders, pulling inventory fixtures from `data/shops/*/inventory.json`.
+`pnpm --filter @acme/platform-core exec prisma db seed` loads both inventory and orders, pulling inventory fixtures from `data/shops/*/inventory.json` and computing `variantKey` for each variant.
 
 To skip loading inventory, run:
 
 ```bash
-pnpm prisma db seed -- --skip-inventory
+pnpm --filter @acme/platform-core exec prisma db seed -- --skip-inventory
 ```
 
 Use the `--skip-inventory` flag to bypass inventory seeding when needed.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,10 +19,10 @@ Run migrations and seed data:
 ```bash
 pnpm --filter @acme/platform-core exec prisma migrate dev
 pnpm --filter @acme/platform-core run prisma:generate
-pnpm prisma db seed
+pnpm --filter @acme/platform-core exec prisma db seed
 ```
 
-Inventory fixtures come from `data/shops/*/inventory.json`. Run `pnpm prisma db seed -- --skip-inventory` to skip seeding inventory.
+Inventory fixtures come from `data/shops/*/inventory.json` and compute `variantKey` automatically. Run `pnpm --filter @acme/platform-core exec prisma db seed -- --skip-inventory` to skip seeding inventory.
 
 `postinstall` runs `prisma generate` automatically.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,12 +36,11 @@ Mock Prisma calls in unit tests to keep them fast and focused. Use a Postgres da
 When running integration tests against a real database, ensure the schema is migrated and populated with baseline data:
 
 ```bash
-pnpm prisma migrate reset --force
-pnpm prisma db seed
+pnpm --filter @acme/platform-core exec prisma migrate reset --force
+pnpm --filter @acme/platform-core exec prisma db seed
 ```
 
-`pnpm prisma db seed` seeds inventory and orders by default. Run `pnpm prisma db seed -- --skip-inventory` to omit inventory data.
-Inventory fixtures come from `data/shops/*/inventory.json`.
+`pnpm --filter @acme/platform-core exec prisma db seed` seeds inventory and orders by default. Run `pnpm --filter @acme/platform-core exec prisma db seed -- --skip-inventory` to omit inventory data. Inventory fixtures come from `data/shops/*/inventory.json` and compute `variantKey` for each variant.
 
 Run these commands before `pnpm test` so each test suite starts from a clean, seeded state.
 


### PR DESCRIPTION
## Summary
- document new `--skip-inventory` seeding flag and fixture path
- update Getting Started docs with filtered seeding commands

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm exec eslint README.md docs/install.md docs/setup.md docs/testing.md`
- `pnpm test` *(fails: command exited 137)*

------
https://chatgpt.com/codex/tasks/task_e_68bfca30e2e0832f92ec30b9fc05861f