### PR TITLE
chore: add inventory scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "validate-env": "ts-node scripts/src/validate-env.ts",
     "inventory": "ts-node scripts/src/inventory.ts",
     "inventory:check": "tsx scripts/src/inventory/check-inventory.ts",
+    "inventory:import": "tsx scripts/src/inventory/import-json-to-postgres.ts",
     "benchmark:loadPlugins": "tsx scripts/benchmark-loadPlugins.ts",
     "quickstart-shop": "ts-node scripts/src/quickstart-shop.ts",
     "check:locales": "ts-node scripts/src/check-locales.ts",


### PR DESCRIPTION
## Summary
- add inventory:import to streamline importing JSON inventory into Postgres
- ensure inventory scripts run via pnpm aliases

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm inventory:import --dry-run --shop placeholder`
- `pnpm inventory:check --shop placeholder` *(fails: ENOENT no such file or directory, open 'data/shops/placeholder/inventory.json')*
- `pnpm test` *(fails: Exceeded timeout of 5000 ms for a test)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc9e7deec832fb88ba4805cd748bc