### PR TITLE
feat: add inventory parity checker script

### DIFF
--- a/scripts/src/inventory/check-inventory.ts
+++ b/scripts/src/inventory/check-inventory.ts
@@ -1,35 +1,81 @@
-// scripts/src/inventory/check-inventory.ts
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 import { prisma } from "@acme/platform-core/db";
+import { variantKey } from "@acme/platform-core/types/inventory";
+
+async function checkShop(shopId: string): Promise<boolean> {
+  const filePath = join("data", "shops", shopId, "inventory.json");
+  let json: any[];
+  try {
+    const raw = await readFile(filePath, "utf8");
+    json = JSON.parse(raw) as any[];
+  } catch (err) {
+    console.error(`[${shopId}] failed to read inventory.json`);
+    return false;
+  }
+
+  const jsonKeys = new Set<string>();
+  for (const item of json) {
+    const attrs = (item.variant || item.variantAttributes || {}) as Record<string, string>;
+    const key = variantKey(item.sku, attrs);
+    jsonKeys.add(`${item.sku}|${key}`);
+  }
+
+  const dbItems = await prisma.inventoryItem.findMany({
+    where: { shopId },
+    select: { sku: true, variantKey: true },
+  });
+
+  const dbKeys = new Set(dbItems.map((i) => `${i.sku}|${i.variantKey}`));
+
+  const missing = [...jsonKeys].filter((k) => !dbKeys.has(k));
+  const extra = [...dbKeys].filter((k) => !jsonKeys.has(k));
+
+  const jsonCount = json.length;
+  const dbCount = dbItems.length;
+
+  if (missing.length || extra.length || jsonCount !== dbCount) {
+    console.log(
+      `[${shopId}] mismatch: file=${jsonCount} db=${dbCount}`,
+    );
+    if (missing.length) console.log(`  missing in db: ${missing.join(", ")}`);
+    if (extra.length) console.log(`  extra in db: ${extra.join(", ")}`);
+    return false;
+  }
+
+  console.log(`[${shopId}] inventory matches (${jsonCount})`);
+  return true;
+}
 
 async function main(): Promise<void> {
   const { values } = parseArgs({
     options: {
       shop: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
     },
   });
-  const shopId = values.shop;
-  if (!shopId) {
-    console.error("Missing required --shop argument");
-    process.exit(1);
+
+  const dryRun = values["dry-run"] ?? false;
+
+  let shops: string[];
+  if (values.shop) {
+    shops = [values.shop as string];
+  } else {
+    const entries = await readdir(join("data", "shops"), { withFileTypes: true });
+    shops = entries.filter((e) => e.isDirectory()).map((e) => e.name);
   }
 
-  const filePath = join("data", "shops", shopId, "inventory.json");
-  const raw = await readFile(filePath, "utf8");
-  const jsonItems = JSON.parse(raw) as unknown[];
-  const jsonCount = jsonItems.length;
-
-  const dbCount = await prisma.inventoryItem.count({ where: { shopId } });
-
-  if (jsonCount !== dbCount) {
-    console.log(`[${shopId}] count mismatch: file=${jsonCount} db=${dbCount}`);
-    process.exit(1);
+  let ok = true;
+  for (const shop of shops) {
+    const result = await checkShop(shop);
+    if (!result) ok = false;
   }
 
-  console.log(`[${shopId}] inventory counts match (${jsonCount})`);
+  if (!ok && !dryRun) {
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- expand inventory parity checker to compare SKU/variant keys and counts across shops

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm inventory:check --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68bfc9d418d4832fb7e2504848985df7