### PR TITLE
docs: document repo backends

### DIFF
--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -7,9 +7,9 @@ This page describes the environment variables the platform expects. Each variabl
 | `DATABASE_URL` | PostgreSQL connection string. When set, Prisma (Postgres) is used; when unset, data is stored in JSON files. |
 | `DATA_ROOT` | Root directory for per-shop data files. If unset, falls back to `<cwd>/data/shops`. |
 | `TEST_DATA_ROOT` | Root directory for test fixtures. Defaults to `test/data/shops`. |
-| `INVENTORY_BACKEND` | `json` forces JSON/disk storage (default when `DATABASE_URL` is unset); `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
-| `PAGES_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
-| `SHOP_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON. |
+| `INVENTORY_BACKEND` | `json` forces JSON/disk storage (default when `DATABASE_URL` is unset); `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `PAGES_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
+| `SHOP_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
 | `PRODUCTS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
 | `SETTINGS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |
 | `THEME_PRESETS_BACKEND` | `json` forces JSON/disk storage; `sqlite` is a legacy flag kept only for tests and proxies to JSON; when unset and `DATABASE_URL` is set, Prisma is used. |

--- a/docs/inventory-migration.md
+++ b/docs/inventory-migration.md
@@ -39,7 +39,7 @@ Current inventory data is sourced from `data/shops/<shop>/inventory.json` files 
 3. Verify counts using the inventory check script to ensure parity with the original dataset.
 
    ```bash
-   pnpm tsx scripts/src/inventory/check-inventory.ts --shop demo
+   pnpm tsx scripts/src/inventory/check-inventory.ts --shop my-shop
    ```
 
    You can also run the packaged command `pnpm inventory:check` which invokes the same script.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -26,8 +26,7 @@ Each variable accepts:
 
 - `json` – read and write JSON files under `<DATA_ROOT>/<shop>`.
 - `sqlite` – legacy option that delegates to the JSON repository.
-
-When the variable is unset and `DATABASE_URL` is configured, the repository uses the primary database via Prisma.
+- _unset_ – uses Prisma when `DATABASE_URL` is present; otherwise falls back to JSON.
 
 ## Repositories with disk fallbacks
 


### PR DESCRIPTION
## Summary
- document all repository `*_BACKEND` variables and their semantics
- correct inventory migration guide to use the current inventory check script

## Testing
- `pnpm install`
- `pnpm lint` *(fails: command exited (2) in @acme/eslint-plugin-ds)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd3a19384832fb25a752c95ab5aa8