### PR TITLE
test: ensure sqlite backend uses json repository

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/settings.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/settings.backendSelection.test.ts
@@ -63,6 +63,15 @@ describe("settings repository backend selection", () => {
     expect(mockPrisma.getShopSettings).not.toHaveBeenCalled();
   });
 
+  it('uses JSON repository when SETTINGS_BACKEND="sqlite"', async () => {
+    process.env.SETTINGS_BACKEND = 'sqlite';
+    delete process.env.DATABASE_URL;
+    const { getShopSettings } = await import('../settings.server');
+    await getShopSettings('shop');
+    expect(mockJson.getShopSettings).toHaveBeenCalled();
+    expect(mockPrisma.getShopSettings).not.toHaveBeenCalled();
+  });
+
   it("defaults to the Prisma repository when SETTINGS_BACKEND is not set", async () => {
     delete process.env.SETTINGS_BACKEND;
     const {


### PR DESCRIPTION
## Summary
- test that sqlite backend routes settings to JSON repository

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test -- src/repositories/__tests__/settings.backendSelection.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfd43ba76c832f957809b87f9d97f8