### PR TITLE
test: cover updateProduct action edge cases

### DIFF
--- a/apps/cms/src/actions/__tests__/updateProduct.server.test.ts
+++ b/apps/cms/src/actions/__tests__/updateProduct.server.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+
+jest.mock('@platform-core/repositories/json.server', () => ({
+  getProductById: jest.fn(),
+  updateProductInRepo: jest.fn(),
+}));
+
+import { updateProduct } from '../updateProduct.server';
+import { getProductById, updateProductInRepo } from '@platform-core/repositories/json.server';
+
+describe('updateProduct', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates product with localized titles and price', async () => {
+    const current = {
+      id: 'p1',
+      title: { en: 'Old EN', de: 'Old DE', it: 'Old IT' },
+      price: 100,
+      row_version: 1,
+    };
+
+    (getProductById as jest.Mock).mockResolvedValue(current);
+    (updateProductInRepo as jest.Mock).mockImplementation((_shop: string, p: any) => Promise.resolve(p));
+
+    const fd = new FormData();
+    fd.append('id', 'p1');
+    fd.append('price', '200');
+    fd.append('title_en', 'New EN');
+    fd.append('title_de', 'New DE');
+    fd.append('title_it', 'New IT');
+
+    const updated = await updateProduct(fd);
+
+    expect(getProductById).toHaveBeenCalledWith('abc', 'p1');
+    expect(updateProductInRepo).toHaveBeenCalledWith('abc', expect.any(Object));
+    expect(updated.price).toBe(200);
+    expect(updated.title.en).toBe('New EN');
+    expect(updated.title.de).toBe('New DE');
+    expect(updated.title.it).toBe('New IT');
+    expect(updated.row_version).toBe(2);
+  });
+
+  it('throws when product is missing', async () => {
+    (getProductById as jest.Mock).mockResolvedValue(null);
+
+    const fd = new FormData();
+    fd.append('id', 'missing');
+
+    await expect(updateProduct(fd)).rejects.toThrow('Product missing not found in shop abc');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for updateProduct action covering successful update and missing product error

## Testing
- `pnpm --filter @apps/cms test src/actions/__tests__/updateProduct.server.test.ts`
- `pnpm -r build` *(fails: Invalid auth environment variables for @apps/shop-bcd)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd5c75400832fbf073f36956b6885