### PR TITLE
test: cover unhandled reverse logistics event

### DIFF
--- a/packages/platform-machine/__tests__/reverseLogisticsService.test.ts
+++ b/packages/platform-machine/__tests__/reverseLogisticsService.test.ts
@@ -91,6 +91,27 @@ describe("processReverseLogisticsEventsOnce", () => {
     });
   }
 
+  it("skips unknown status events", async () => {
+    readdir.mockResolvedValueOnce(["shop"]).mockResolvedValueOnce(["a.json"]);
+    readFile.mockResolvedValueOnce(
+      JSON.stringify({ sessionId: "s", status: "unhandled" })
+    );
+    await service.processReverseLogisticsEventsOnce(undefined, "/data");
+    expect(markReceived).not.toHaveBeenCalled();
+    expect(markCleaning).not.toHaveBeenCalled();
+    expect(markRepair).not.toHaveBeenCalled();
+    expect(markQa).not.toHaveBeenCalled();
+    expect(markAvailable).not.toHaveBeenCalled();
+    expect(evtReceived).not.toHaveBeenCalled();
+    expect(evtCleaning).not.toHaveBeenCalled();
+    expect(evtRepair).not.toHaveBeenCalled();
+    expect(evtQa).not.toHaveBeenCalled();
+    expect(evtAvailable).not.toHaveBeenCalled();
+    expect(unlink).toHaveBeenCalledWith(
+      "/data/shop/reverse-logistics/a.json"
+    );
+  });
+
   it("continues when events directory is missing", async () => {
     readdir.mockResolvedValueOnce(["shop"]).mockRejectedValueOnce(new Error("nope"));
     await service.processReverseLogisticsEventsOnce(undefined, "/data");


### PR DESCRIPTION
## Summary
- add test ensuring unhandled reverse logistics events are ignored and cleaned up

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-machine test` *(fails: tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd7006d3c832fbc45e96c80f35137