### PR TITLE
test: add theme preset repo delegation tests

### DIFF
--- a/packages/platform-core/__tests__/themePresets.server.test.ts
+++ b/packages/platform-core/__tests__/themePresets.server.test.ts
@@ -1,0 +1,47 @@
+// packages/platform-core/__tests__/themePresets.server.test.ts
+import { jest } from "@jest/globals";
+
+const mockRepo = {
+  getThemePresets: jest.fn(async () => ({})),
+  saveThemePreset: jest.fn(async () => {}),
+  deleteThemePreset: jest.fn(async () => {}),
+};
+
+const mockResolveRepo = jest.fn(async () => mockRepo);
+
+jest.mock("../src/db", () => ({ prisma: { themePreset: {} } }));
+jest.mock("../src/repositories/repoResolver", () => ({ resolveRepo: mockResolveRepo }));
+
+describe("themePresets.server", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  async function importRepo() {
+    return await import("../src/repositories/themePresets.server");
+  }
+
+  it("delegates to the resolved repository", async () => {
+    const repo = await importRepo();
+
+    await repo.getThemePresets("shop");
+    await repo.saveThemePreset("shop", "name", { color: "red" });
+    await repo.deleteThemePreset("shop", "name");
+
+    expect(mockRepo.getThemePresets).toHaveBeenCalledWith("shop");
+    expect(mockRepo.saveThemePreset).toHaveBeenCalledWith("shop", "name", { color: "red" });
+    expect(mockRepo.deleteThemePreset).toHaveBeenCalledWith("shop", "name");
+  });
+
+  it("caches the repository", async () => {
+    const repo = await importRepo();
+
+    await repo.getThemePresets("shop");
+    await repo.saveThemePreset("shop", "name", {});
+    await repo.getThemePresets("shop");
+
+    expect(mockResolveRepo).toHaveBeenCalledTimes(1);
+    expect(mockRepo.getThemePresets).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for theme preset repository to ensure methods delegate to resolved repo and caching works

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test --filter @acme/platform-core` *(fails: Command was killed with SIGABRT)*
- `pnpm --filter @acme/platform-core exec jest --config ../../jest.config.cjs packages/platform-core/__tests__/themePresets.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfd6e21e30832f98c6e5e4e7c7963a