### PR TITLE
test: verify subscription repository

### DIFF
--- a/packages/platform-core/__tests__/subscriptions.server.test.ts
+++ b/packages/platform-core/__tests__/subscriptions.server.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { prisma } from "../src/db";
+import {
+  updateSubscriptionPaymentStatus,
+  syncSubscriptionData,
+} from "../src/repositories/subscriptions.server";
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    user: {
+      update: jest.fn(),
+    },
+  },
+}));
+
+const updateMock = (prisma as any).user.update as jest.Mock;
+
+beforeEach(() => {
+  updateMock.mockReset();
+});
+
+describe("updateSubscriptionPaymentStatus", () => {
+  it("sends correct parameters", async () => {
+    updateMock.mockResolvedValue({});
+    await updateSubscriptionPaymentStatus("cus_1", "sub_1", "succeeded");
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "cus_1" },
+      data: { stripeSubscriptionId: "sub_1" },
+    });
+  });
+
+  it("propagates prisma errors", async () => {
+    const err = new Error("db error");
+    updateMock.mockRejectedValue(err);
+    await expect(
+      updateSubscriptionPaymentStatus("cus_1", "sub_1", "failed"),
+    ).rejects.toThrow("db error");
+  });
+});
+
+describe("syncSubscriptionData", () => {
+  it("sends correct parameters", async () => {
+    updateMock.mockResolvedValue({});
+    await syncSubscriptionData("cus_1", "sub_1");
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "cus_1" },
+      data: { stripeSubscriptionId: "sub_1" },
+    });
+  });
+
+  it("handles null subscription id", async () => {
+    updateMock.mockResolvedValue({});
+    await syncSubscriptionData("cus_1", null);
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "cus_1" },
+      data: { stripeSubscriptionId: null },
+    });
+  });
+
+  it("propagates prisma errors", async () => {
+    const err = new Error("db error");
+    updateMock.mockRejectedValue(err);
+    await expect(syncSubscriptionData("cus_1", "sub_1")).rejects.toThrow(
+      "db error",
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for `updateSubscriptionPaymentStatus` and `syncSubscriptionData`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references --filter @acme/platform-core` *(fails: Missing script: check:references)*
- `pnpm run build:ts --filter @acme/platform-core` *(fails: Missing script: build:ts)*
- `pnpm test --filter @acme/platform-core` *(fails: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68bfd6e0cea8832fbb6e0437166b9a82