### PR TITLE
test: add seoAudit repo caching tests

### DIFF
--- a/packages/platform-core/__tests__/seoAuditRepo.test.ts
+++ b/packages/platform-core/__tests__/seoAuditRepo.test.ts
@@ -1,0 +1,66 @@
+import type { SeoAuditEntry } from "../src/repositories/seoAudit.server";
+
+describe("seoAudit repo", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("delegates read and append to the resolved repository", async () => {
+    const readSpy = jest.fn<Promise<SeoAuditEntry[]>, [string]>().mockResolvedValue([
+      { timestamp: "1", score: 50 },
+    ]);
+    const appendSpy = jest.fn<Promise<void>, [string, SeoAuditEntry]>().mockResolvedValue();
+
+    const resolveRepoMock = jest.fn().mockResolvedValue({
+      readSeoAudits: readSpy,
+      appendSeoAudit: appendSpy,
+    });
+
+    jest.doMock("../src/repositories/repoResolver", () => ({
+      resolveRepo: resolveRepoMock,
+    }));
+
+    const { readSeoAudits, appendSeoAudit } = await import(
+      "../src/repositories/seoAudit.server"
+    );
+
+    const shop = "acme";
+    const entry: SeoAuditEntry = { timestamp: "now", score: 90 };
+
+    await readSeoAudits(shop);
+    await appendSeoAudit(shop, entry);
+
+    expect(readSpy).toHaveBeenCalledWith(shop);
+    expect(appendSpy).toHaveBeenCalledWith(shop, entry);
+    expect(resolveRepoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches the repo between calls", async () => {
+    const readSpy = jest.fn<Promise<SeoAuditEntry[]>, [string]>().mockResolvedValue([]);
+    const appendSpy = jest.fn<Promise<void>, [string, SeoAuditEntry]>().mockResolvedValue();
+
+    const resolveRepoMock = jest.fn().mockResolvedValue({
+      readSeoAudits: readSpy,
+      appendSeoAudit: appendSpy,
+    });
+
+    jest.doMock("../src/repositories/repoResolver", () => ({
+      resolveRepo: resolveRepoMock,
+    }));
+
+    const { readSeoAudits, appendSeoAudit } = await import(
+      "../src/repositories/seoAudit.server"
+    );
+
+    const shop = "acme";
+    const entry: SeoAuditEntry = { timestamp: "now", score: 1 };
+
+    await readSeoAudits(shop);
+    await appendSeoAudit(shop, entry);
+    await readSeoAudits(shop);
+
+    expect(resolveRepoMock).toHaveBeenCalledTimes(1);
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for seoAudit repository calls and caching

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: build terminated)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test --filter @acme/platform-core` *(fails: missing env variables, partial run)*
- `pnpm --filter @acme/platform-core exec jest __tests__/seoAuditRepo.test.ts --runInBand --config ../../jest.config.cjs` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd6da89d0832f9516c05a7b55d858