### PR TITLE
test: add configurator tests

### DIFF
--- a/packages/platform-core/__tests__/configurator.test.ts
+++ b/packages/platform-core/__tests__/configurator.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as configurator from "../src/configurator";
+
+const { readEnvFile, validateEnvFile, validateShopEnv } = configurator;
+
+describe("readEnvFile", () => {
+  it("ignores comments and empty values", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "env-"));
+    const envPath = path.join(tmpDir, ".env");
+    fs.writeFileSync(
+      envPath,
+      [
+        "FOO=bar",
+        "# this is a comment",
+        "EMPTY=",
+        "BAR=baz",
+        "",
+      ].join("\n"),
+    );
+
+    expect(readEnvFile(envPath)).toEqual({ FOO: "bar", BAR: "baz" });
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("validateEnvFile", () => {
+  it("throws for missing files", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "env-"));
+    const missing = path.join(tmpDir, "missing.env");
+    expect(() => validateEnvFile(missing)).toThrow(`Missing ${missing}`);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("throws for invalid entries", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "env-"));
+    const envPath = path.join(tmpDir, ".env");
+    fs.writeFileSync(envPath, "FOO=bar");
+
+    jest
+      .spyOn(configurator, "readEnvFile")
+      .mockReturnValue({ FOO: 1 } as any);
+
+    expect(() => validateEnvFile(envPath)).toThrow();
+
+    jest.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("validateShopEnv", () => {
+  const shop = "my-shop";
+
+  it("throws when required plugin variables are missing", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "shop-"));
+    const envDir = path.join(root, "apps", shop);
+    fs.mkdirSync(envDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(envDir, ".env"),
+      "STRIPE_SECRET_KEY=sk_test\n",
+    );
+
+    const cfgDir = path.join(root, "data", "shops", shop);
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cfgDir, "shop.json"),
+      JSON.stringify({ paymentProviders: ["stripe"] }),
+    );
+
+    const cwd = process.cwd();
+    process.chdir(root);
+    try {
+      expect(() => validateShopEnv(shop)).toThrow(
+        "Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+      );
+    } finally {
+      process.chdir(cwd);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when all required plugin variables are present", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "shop-"));
+    const envDir = path.join(root, "apps", shop);
+    fs.mkdirSync(envDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(envDir, ".env"),
+      [
+        "STRIPE_SECRET_KEY=sk_test",
+        "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test",
+        "STRIPE_WEBHOOK_SECRET=whsec",
+      ].join("\n"),
+    );
+
+    const cfgDir = path.join(root, "data", "shops", shop);
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cfgDir, "shop.json"),
+      JSON.stringify({ paymentProviders: ["stripe"] }),
+    );
+
+    const cwd = process.cwd();
+    process.chdir(root);
+    try {
+      expect(() => validateShopEnv(shop)).not.toThrow();
+    } finally {
+      process.chdir(cwd);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for configurator utilities
- ensure environment validation handles missing files and plugin vars

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test --filter @acme/platform-core` *(fails: Error in checkout-session.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd6d79ed4832f982358cc34a812df