### PR TITLE
test(ui): add component tests

### DIFF
--- a/packages/ui/__tests__/FilterSidebar.test.tsx
+++ b/packages/ui/__tests__/FilterSidebar.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FilterSidebar } from "../src/components/organisms/FilterSidebar";
+
+describe("FilterSidebar", () => {
+  it("opens sidebar, selects option, and applies numeric width", async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(<FilterSidebar onChange={onChange} width={320} />);
+
+    expect(onChange).toHaveBeenCalledWith({ size: undefined });
+
+    await user.click(screen.getByRole("button", { name: /filters/i }));
+    expect(screen.getByRole("dialog")).toHaveClass("w-[320px]");
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "42" }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith({ size: "42" })
+    );
+  });
+
+  it("supports custom width class and keyboard navigation", async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(<FilterSidebar onChange={onChange} width="w-80" />);
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveClass("w-80");
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+});

--- a/packages/ui/__tests__/SideNav.test.tsx
+++ b/packages/ui/__tests__/SideNav.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+import { SideNav } from "../src/components/organisms/SideNav";
+
+describe("SideNav", () => {
+  it("has default width and token", () => {
+    const { container } = render(<SideNav />);
+    const aside = container.firstChild as HTMLElement;
+    expect(aside).toHaveClass("w-48");
+    expect(aside).toHaveAttribute("data-token", "--color-bg");
+  });
+
+  it("accepts a custom width class", () => {
+    const { container } = render(<SideNav width="w-72" />);
+    expect(container.firstChild).toHaveClass("w-72");
+  });
+});

--- a/packages/ui/__tests__/StatsGrid.test.tsx
+++ b/packages/ui/__tests__/StatsGrid.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { StatsGrid } from "../src/components/organisms/StatsGrid";
+
+describe("StatsGrid", () => {
+  it("renders items and merges className", () => {
+    const items = [
+      { label: "Users", value: "123" },
+      { label: "Sessions", value: "456" },
+    ];
+
+    const { container } = render(
+      <StatsGrid items={items} className="custom" />
+    );
+
+    items.forEach(({ label, value }) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(value)).toBeInTheDocument();
+    });
+
+    expect(container.firstChild).toHaveClass(
+      "grid",
+      "gap-4",
+      "sm:grid-cols-2",
+      "lg:grid-cols-3",
+      "custom"
+    );
+  });
+});

--- a/packages/ui/__tests__/StickyAddToCartBar.test.tsx
+++ b/packages/ui/__tests__/StickyAddToCartBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StickyAddToCartBar } from "../src/components/organisms/StickyAddToCartBar";
+import type { SKU } from "@acme/types";
+
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["USD", jest.fn()],
+}));
+
+describe("StickyAddToCartBar", () => {
+  const product: SKU = {
+    id: "1",
+    slug: "test-product",
+    title: "Test Product",
+    price: 9.99,
+    deposit: 0,
+    stock: 0,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: [],
+    description: "",
+  } as any;
+
+  it("renders product info and fires add to cart", async () => {
+    const handleAdd = jest.fn();
+    const user = userEvent.setup();
+    render(<StickyAddToCartBar product={product} onAddToCart={handleAdd} />);
+
+    expect(screen.getByText("Test Product")).toBeInTheDocument();
+    expect(screen.getByText(/\$9\.99/)).toBeInTheDocument();
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+    expect(handleAdd).toHaveBeenCalledWith(product);
+  });
+});


### PR DESCRIPTION
## Summary
- add SideNav tests for default and custom widths
- cover FilterSidebar open/close, option changes, keyboard nav
- verify StickyAddToCartBar renders and triggers add-to-cart
- exercise StatsGrid item rendering and className merge

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/SideNav.test.tsx packages/ui/__tests__/FilterSidebar.test.tsx packages/ui/__tests__/StickyAddToCartBar.test.tsx packages/ui/__tests__/StatsGrid.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bfd5dcf8e4832f9928469d239e2513