### PR TITLE
test(ui): add primitive component tests

### DIFF
--- a/packages/ui/__tests__/Checkbox.test.tsx
+++ b/packages/ui/__tests__/Checkbox.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Checkbox } from "../src/components/atoms/shadcn";
+
+describe("Checkbox", () => {
+  it("toggles state, manages focus, and applies class overrides", () => {
+    render(<Checkbox className="custom-checkbox" />);
+    const checkbox = screen.getByRole("checkbox");
+
+    checkbox.focus();
+    expect(checkbox).toHaveFocus();
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+    expect(checkbox).toHaveFocus();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
+    expect(checkbox).toHaveClass("custom-checkbox");
+  });
+});

--- a/packages/ui/__tests__/Dialog.test.tsx
+++ b/packages/ui/__tests__/Dialog.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "../src/components/atoms/shadcn";
+
+describe("Dialog", () => {
+  it("opens and closes with focus restoration and class overrides", async () => {
+    render(
+      <Dialog>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogContent className="custom-dialog">
+          <DialogTitle>Title</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open" });
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    fireEvent.click(trigger);
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveClass("custom-dialog");
+
+    const close = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(close);
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/packages/ui/__tests__/SelectPrimitive.test.tsx
+++ b/packages/ui/__tests__/SelectPrimitive.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../src/components/atoms/shadcn";
+
+describe("SelectPrimitive", () => {
+  it("selects items with proper focus and class overrides", async () => {
+    render(
+      <Select defaultValue="apple">
+        <SelectTrigger className="custom-trigger">
+          <SelectValue placeholder="Select a fruit" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    const trigger = screen.getByRole("combobox");
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    fireEvent.click(trigger);
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+
+    const option = screen.getByRole("option", { name: "Banana" });
+    fireEvent.click(option);
+
+    await waitFor(() => expect(screen.queryByRole("listbox")).not.toBeInTheDocument());
+    expect(trigger).toHaveTextContent("Banana");
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveClass("custom-trigger");
+  });
+});


### PR DESCRIPTION
## Summary
- add checkbox primitive interactions test
- add select primitive focus and role test
- add dialog primitive open/close test

## Testing
- `pnpm -r build` (fails: Invalid auth environment variables)
- `pnpm --filter @acme/ui test` (fails: CartProvider tests)
- `pnpm exec jest packages/ui/__tests__/Checkbox.test.tsx packages/ui/__tests__/SelectPrimitive.test.tsx packages/ui/__tests__/Dialog.test.tsx --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68bfd5dba9e8832f9e75f61feb565cf8