### PR TITLE
Add tests for Price, StockStatus, and FileSelector components

### DIFF
--- a/packages/ui/__tests__/FileSelector.test.tsx
+++ b/packages/ui/__tests__/FileSelector.test.tsx
@@ -1,0 +1,24 @@
+import { configure, fireEvent, render, screen } from "@testing-library/react";
+import { FileSelector } from "../src/components/atoms/FileSelector";
+
+configure({ testIdAttribute: "data-testid" });
+
+describe("FileSelector", () => {
+  it("invokes callback and lists selected files", () => {
+    const handle = jest.fn();
+    render(<FileSelector onFilesSelected={handle} />);
+    const input = screen.getByTestId("file-input") as HTMLInputElement;
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenCalledWith([file]);
+    expect(screen.getByText("hello.txt")).toBeInTheDocument();
+    expect(input).toHaveAttribute("type", "file");
+  });
+
+  it("supports multiple file selection", () => {
+    render(<FileSelector multiple />);
+    const input = screen.getByTestId("file-input");
+    expect(input).toHaveAttribute("multiple");
+  });
+});

--- a/packages/ui/__tests__/Price.test.tsx
+++ b/packages/ui/__tests__/Price.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { Price } from "../src/components/atoms/Price";
+
+jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
+  useCurrency: () => ["EUR", jest.fn()],
+}));
+
+describe("Price", () => {
+  it("formats amount with provided currency and applies class names", () => {
+    render(<Price amount={1234.56} currency="USD" className="highlight" />);
+    const span = screen.getByText("$1,234.56");
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveClass("highlight");
+  });
+
+  it("falls back to context currency when none provided and forwards aria-label", () => {
+    render(<Price amount={1234.56} aria-label="price" />);
+    const span = screen.getByLabelText("price");
+    expect(span).toHaveTextContent("€1,234.56");
+  });
+});

--- a/packages/ui/__tests__/StockStatus.test.tsx
+++ b/packages/ui/__tests__/StockStatus.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { StockStatus } from "../src/components/atoms/StockStatus";
+
+describe("StockStatus", () => {
+  it("renders in-stock state with default classes", () => {
+    render(<StockStatus inStock aria-label="availability" />);
+    const span = screen.getByText("In stock");
+    expect(span).toHaveClass("text-sm", "font-medium", "text-success");
+    expect(span).toHaveAttribute("data-token", "--color-success");
+    expect(screen.getByLabelText("availability")).toBe(span);
+  });
+
+  it("renders out-of-stock state", () => {
+    render(<StockStatus inStock={false} />);
+    const span = screen.getByText("Out of stock");
+    expect(span).toHaveClass("text-sm", "font-medium", "text-danger");
+    expect(span).toHaveAttribute("data-token", "--color-danger");
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for Price default formatting and class names
- verify StockStatus variants and accessibility
- test FileSelector selection callbacks and multiple option

## Testing
- `pnpm --filter @acme/ui test` *(fails: CartContext.test.tsx cannot find [data-cy="count"])*


------
https://chatgpt.com/codex/tasks/task_e_68bfd5daa580832f93876a9f98df182b