### PR TITLE
test(ui): verify device presets dimensions

### DIFF
--- a/packages/ui/__tests__/devicePresets.test.ts
+++ b/packages/ui/__tests__/devicePresets.test.ts
@@ -1,0 +1,39 @@
+import { devicePresets } from "../src/utils/devicePresets";
+
+describe("devicePresets", () => {
+  it("contains expected viewport dimensions and labels", () => {
+    const expected = {
+      "desktop-1280": { label: "Desktop 1280", width: 1280, height: 800 },
+      "desktop-1440": { label: "Desktop 1440", width: 1440, height: 900 },
+      "ipad": { label: "iPad", width: 768, height: 1024 },
+      "ipad-pro": { label: "iPad Pro", width: 1024, height: 1366 },
+      "ipad-mini": { label: "iPad Mini", width: 744, height: 1133 },
+      "iphone-se": { label: "iPhone SE", width: 375, height: 667 },
+      "iphone-12": { label: "iPhone 12", width: 390, height: 844 },
+      "iphone-14": { label: "iPhone 14", width: 390, height: 844 },
+      "pixel-7": { label: "Pixel 7", width: 412, height: 915 },
+      "galaxy-note": { label: "Galaxy Note", width: 412, height: 869 },
+      "galaxy-s8": { label: "Galaxy S8", width: 360, height: 740 },
+    } as const;
+
+    expect(devicePresets).toHaveLength(Object.keys(expected).length);
+
+    for (const preset of devicePresets) {
+      const match = expected[preset.id as keyof typeof expected];
+      expect(match).toBeDefined();
+      expect(preset).toMatchObject(match);
+    }
+  });
+
+  it("handles custom width and height overrides", () => {
+    const custom = { ...devicePresets[0], width: 500, height: 400 };
+
+    expect(custom.width).toBe(500);
+    expect(custom.height).toBe(400);
+
+    // original preset remains unchanged
+    expect(devicePresets[0].width).toBe(1280);
+    expect(devicePresets[0].height).toBe(800);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for device presets to ensure expected viewport data
- verify custom width and height overrides don't mutate original presets

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/ui run check:references` *(fails: missing script)*
- `pnpm --filter @acme/ui run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/devicePresets.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfd5d92eb8832f845caf3250de1fce