### PR TITLE
test: verify LayoutClient sidebar and progress behavior

### DIFF
--- a/apps/cms/__tests__/LayoutClient.client.test.tsx
+++ b/apps/cms/__tests__/LayoutClient.client.test.tsx
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+
+import { render, screen } from "@testing-library/react";
+import LayoutClient from "../src/app/cms/LayoutClient.client";
+
+// Mock the layout context
+const useLayoutMock = jest.fn();
+jest.mock("@platform-core/contexts/LayoutContext", () => ({
+  useLayout: () => useLayoutMock(),
+}));
+
+// Stub internal components
+jest.mock("@ui/components/cms/Sidebar.client", () => () => (
+  <div data-testid="sidebar">Sidebar</div>
+));
+jest.mock("@ui/components/cms/TopBar.client", () => () => <div>TopBar</div>);
+jest.mock("@/components/atoms", () => ({
+  Progress: ({ value, label }: any) => (
+    <div data-testid="progress">{label} - {value}</div>
+  ),
+}));
+
+describe("LayoutClient", () => {
+  it("shows sidebar when mobile nav is open and renders progress", () => {
+    useLayoutMock.mockReturnValue({
+      isMobileNavOpen: true,
+      configuratorProgress: {
+        completedRequired: 2,
+        totalRequired: 4,
+        completedOptional: 1,
+        totalOptional: 3,
+      },
+    });
+
+    render(<LayoutClient>child</LayoutClient>);
+
+    const sidebar = screen.getByTestId("sidebar");
+    expect(sidebar.parentElement).toHaveClass("block");
+
+    const progress = screen.getByTestId("progress");
+    expect(progress).toHaveTextContent("2/4 required, 1/3 optional");
+    expect(progress).toHaveTextContent("50");
+  });
+
+  it("hides sidebar when mobile nav is closed and omits progress", () => {
+    useLayoutMock.mockReturnValue({
+      isMobileNavOpen: false,
+      configuratorProgress: undefined,
+    });
+
+    render(<LayoutClient>child</LayoutClient>);
+
+    const sidebar = screen.getByTestId("sidebar");
+    expect(sidebar.parentElement).toHaveClass("hidden");
+    expect(screen.queryByTestId("progress")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for LayoutClient mobile navigation and progress bar

## Testing
- `pnpm --filter @apps/cms test apps/cms/__tests__/LayoutClient.client.test.tsx`
- `pnpm -r build` *(fails: Failed to collect page data for /api/account/profile)*
- `pnpm --filter @apps/cms test` *(fails: StepCheckoutPage.test.tsx, jsonIO.test.ts, StepImportData.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd5cbc9ec832f8f84582faae2ed1e