### PR TITLE
test: add backend selection tests for pricing and return auth

### DIFF
--- a/__tests__/pricing.backendSelection.test.ts
+++ b/__tests__/pricing.backendSelection.test.ts
@@ -1,0 +1,112 @@
+import { jest } from "@jest/globals";
+
+const mockJson = {
+  read: jest.fn(),
+  write: jest.fn(),
+};
+
+const mockPrisma = {
+  read: jest.fn(),
+  write: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock(
+  "../packages/platform-core/src/repositories/pricing.json.server",
+  () => ({ jsonPricingRepository: mockJson }),
+);
+
+jest.mock(
+  "../packages/platform-core/src/repositories/pricing.prisma.server",
+  () => {
+    prismaImportCount++;
+    return { prismaPricingRepository: mockPrisma };
+  },
+);
+
+jest.mock("../packages/platform-core/src/db", () => ({
+  prisma: { pricing: {} },
+}));
+
+jest.mock("../packages/platform-core/src/repositories/repoResolver", () => ({
+  resolveRepo: async (
+    _prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === "json" || backend === "sqlite") {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe("pricing repository backend selection", () => {
+  const origBackend = process.env.PRICING_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.PRICING_BACKEND;
+    } else {
+      process.env.PRICING_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when PRICING_BACKEND="json"', async () => {
+    process.env.PRICING_BACKEND = "json";
+    const repo = await import(
+      "../packages/platform-core/src/repositories/pricing.server",
+    );
+
+    await repo.readPricing();
+    await repo.writePricing({} as any);
+
+    expect(mockJson.read).toHaveBeenCalled();
+    expect(mockJson.write).toHaveBeenCalled();
+    expect(mockPrisma.read).not.toHaveBeenCalled();
+  });
+
+  it('uses json repository when PRICING_BACKEND="sqlite"', async () => {
+    process.env.PRICING_BACKEND = "sqlite";
+    const repo = await import(
+      "../packages/platform-core/src/repositories/pricing.server",
+    );
+
+    await repo.readPricing();
+
+    expect(mockJson.read).toHaveBeenCalled();
+    expect(mockPrisma.read).not.toHaveBeenCalled();
+  });
+
+  it("defaults to the Prisma repository when PRICING_BACKEND is not set", async () => {
+    delete process.env.PRICING_BACKEND;
+    const repo = await import(
+      "../packages/platform-core/src/repositories/pricing.server",
+    );
+
+    await repo.readPricing();
+    await repo.writePricing({} as any);
+
+    expect(mockPrisma.read).toHaveBeenCalled();
+    expect(mockPrisma.write).toHaveBeenCalled();
+    expect(mockJson.read).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});
+

--- a/__tests__/returnAuthorization.backendSelection.test.ts
+++ b/__tests__/returnAuthorization.backendSelection.test.ts
@@ -1,0 +1,124 @@
+import { jest } from "@jest/globals";
+
+const mockJson = {
+  readReturnAuthorizations: jest.fn(),
+  writeReturnAuthorizations: jest.fn(),
+  addReturnAuthorization: jest.fn(),
+  getReturnAuthorization: jest.fn(),
+};
+
+const mockPrisma = {
+  readReturnAuthorizations: jest.fn(),
+  writeReturnAuthorizations: jest.fn(),
+  addReturnAuthorization: jest.fn(),
+  getReturnAuthorization: jest.fn(),
+};
+
+let prismaImportCount = 0;
+
+jest.mock(
+  "../packages/platform-core/src/repositories/returnAuthorization.json.server",
+  () => ({ jsonReturnAuthorizationRepository: mockJson }),
+);
+
+jest.mock(
+  "../packages/platform-core/src/repositories/returnAuthorization.prisma.server",
+  () => {
+    prismaImportCount++;
+    return { prismaReturnAuthorizationRepository: mockPrisma };
+  },
+);
+
+jest.mock("../packages/platform-core/src/db", () => ({
+  prisma: { returnAuthorization: {} },
+}));
+
+jest.mock("../packages/platform-core/src/repositories/repoResolver", () => ({
+  resolveRepo: async (
+    _prismaDelegate: any,
+    prismaModule: any,
+    jsonModule: any,
+    options: any,
+  ) => {
+    const backend = process.env[options.backendEnvVar];
+    if (backend === "json" || backend === "sqlite") {
+      return await jsonModule();
+    }
+    return await prismaModule();
+  },
+}));
+
+describe("return authorization repository backend selection", () => {
+  const origBackend = process.env.RETURN_AUTH_BACKEND;
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    prismaImportCount = 0;
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  afterEach(() => {
+    if (origBackend === undefined) {
+      delete process.env.RETURN_AUTH_BACKEND;
+    } else {
+      process.env.RETURN_AUTH_BACKEND = origBackend;
+    }
+    if (origDbUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = origDbUrl;
+    }
+  });
+
+  it('uses json repository when RETURN_AUTH_BACKEND="json"', async () => {
+    process.env.RETURN_AUTH_BACKEND = "json";
+    const repo = await import(
+      "../packages/platform-core/src/repositories/returnAuthorization.server",
+    );
+
+    await repo.readReturnAuthorizations();
+    await repo.writeReturnAuthorizations([]);
+    await repo.addReturnAuthorization({} as any);
+    await repo.getReturnAuthorization("id");
+
+    expect(mockJson.readReturnAuthorizations).toHaveBeenCalled();
+    expect(mockJson.writeReturnAuthorizations).toHaveBeenCalled();
+    expect(mockJson.addReturnAuthorization).toHaveBeenCalled();
+    expect(mockJson.getReturnAuthorization).toHaveBeenCalled();
+    expect(mockPrisma.readReturnAuthorizations).not.toHaveBeenCalled();
+  });
+
+  it('uses json repository when RETURN_AUTH_BACKEND="sqlite"', async () => {
+    process.env.RETURN_AUTH_BACKEND = "sqlite";
+    const repo = await import(
+      "../packages/platform-core/src/repositories/returnAuthorization.server",
+    );
+
+    await repo.readReturnAuthorizations();
+
+    expect(mockJson.readReturnAuthorizations).toHaveBeenCalled();
+    expect(mockPrisma.readReturnAuthorizations).not.toHaveBeenCalled();
+  });
+
+  it("defaults to Prisma repository when RETURN_AUTH_BACKEND is not set", async () => {
+    delete process.env.RETURN_AUTH_BACKEND;
+    const repo = await import(
+      "../packages/platform-core/src/repositories/returnAuthorization.server",
+    );
+
+    await repo.readReturnAuthorizations();
+    await repo.writeReturnAuthorizations([]);
+    await repo.addReturnAuthorization({} as any);
+    await repo.getReturnAuthorization("id");
+
+    expect(mockPrisma.readReturnAuthorizations).toHaveBeenCalled();
+    expect(mockPrisma.writeReturnAuthorizations).toHaveBeenCalled();
+    expect(mockPrisma.addReturnAuthorization).toHaveBeenCalled();
+    expect(mockPrisma.getReturnAuthorization).toHaveBeenCalled();
+    expect(mockJson.readReturnAuthorizations).not.toHaveBeenCalled();
+    expect(prismaImportCount).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add backend selection tests for pricing repo
- add backend selection tests for return authorization repo

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm exec jest __tests__/pricing.backendSelection.test.ts __tests__/returnAuthorization.backendSelection.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bfe020bd4c832f83d1202309925e83