### PR TITLE
fix cms tests failing to find theme select

### DIFF
--- a/apps/cms/jest.setup.tsx
+++ b/apps/cms/jest.setup.tsx
@@ -5,10 +5,13 @@
 
 import "@testing-library/jest-dom";
 import "cross-fetch/polyfill";
+import { configure } from "@testing-library/react";
 import React from "react";
 import * as ReactDOMTestUtils from "react-dom/test-utils";
 import { TextDecoder, TextEncoder } from "node:util";
 import "./__tests__/mocks/external";
+
+configure({ testIdAttribute: "data-cy" });
 
 /* -------------------------------------------------------------------------- */
 /* 1 ·  ENVIRONMENT VARIABLES                                                 */


### PR DESCRIPTION
## Summary
- configure Testing Library in CMS tests to use `data-cy` as the test id attribute

## Testing
- `pnpm install`
- `pnpm --filter @apps/cms test -- apps/cms/src/app/cms/configurator/steps/__tests__/ThemeEditorForm.test.tsx`
- `pnpm --filter @apps/cms exec jest apps/cms/src/app/cms/configurator/steps/__tests__/StepTheme.test.tsx --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bfe19fff10832fbbc5f39d0301a63e