### PR TITLE
fix configurator step test ids

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
@@ -75,6 +75,7 @@ export default function StepShopDetails({
         <span>Shop ID</span>
         <Input
           data-cy="shop-id"
+          data-testid="shop-id"
           value={shopId}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setShopId(e.target.value)}
           placeholder="my-shop"
@@ -87,6 +88,7 @@ export default function StepShopDetails({
         <span>Store Name</span>
         <Input
           data-cy="store-name"
+          data-testid="store-name"
           value={storeName}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setStoreName(e.target.value)}
           placeholder="My Store"
@@ -99,6 +101,7 @@ export default function StepShopDetails({
         <span>Logo URL</span>
         <Input
           data-cy="logo-url"
+          data-testid="logo-url"
           value={logo}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLogo(e.target.value)}
           placeholder="https://example.com/logo.png"
@@ -111,6 +114,7 @@ export default function StepShopDetails({
         <span>Contact Info</span>
         <Input
           data-cy="contact-info"
+          data-testid="contact-info"
           value={contactInfo}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setContactInfo(e.target.value)}
           placeholder="Email or phone"
@@ -121,7 +125,7 @@ export default function StepShopDetails({
       </label>
       <label className="flex flex-col gap-1">
         <span>Shop Type</span>
-        <Select data-cy="shop-type" value={type} onValueChange={setType}>
+        <Select data-cy="shop-type" data-testid="shop-type" value={type} onValueChange={setType}>
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Select type" />
           </SelectTrigger>
@@ -136,7 +140,7 @@ export default function StepShopDetails({
       </label>
       <label className="flex flex-col gap-1">
         <span>Template</span>
-        <Select data-cy="template" value={template} onValueChange={setTemplate}>
+        <Select data-cy="template" data-testid="template" value={template} onValueChange={setTemplate}>
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Select template" />
           </SelectTrigger>
@@ -155,6 +159,7 @@ export default function StepShopDetails({
       <div className="flex justify-end">
         <Button
           data-cy="save-return"
+          data-testid="save-return"
           disabled={!isValid}
           onClick={() => {
             markComplete(true);

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -82,6 +82,7 @@ export default function StepTheme({
         {prevStepId && (
           <Button
             data-cy="back"
+            data-testid="back"
             variant="outline"
             onClick={() => router.push(`/cms/configurator/${prevStepId}`)}
           >
@@ -91,6 +92,7 @@ export default function StepTheme({
         {nextStepId && (
           <Button
             data-cy="next"
+            data-testid="next"
             onClick={() => {
               markComplete(true);
               router.push(`/cms/configurator/${nextStepId}`);


### PR DESCRIPTION
## Summary
- add `data-testid` attributes for navigation buttons in `StepTheme`
- expose test ids on shop details form inputs and save button

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm exec jest apps/cms/src/app/cms/configurator/steps/__tests__/StepTheme.test.tsx apps/cms/src/app/cms/configurator/steps/__tests__/StepShopDetails.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfe1d32a8c832fa247494f55a61b4d