### PR TITLE
fix: handle missing rename in json write

### DIFF
--- a/apps/cms/src/lib/server/jsonIO.ts
+++ b/apps/cms/src/lib/server/jsonIO.ts
@@ -43,13 +43,15 @@ export async function writeJsonFile(
   }
 
   await fs.mkdir(path.dirname(file), { recursive: true });
-  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-  await fs.writeFile(
-    tmp,
-    JSON.stringify(value, null, indent ?? 2),
-    "utf8",
-  );
-  await fs.rename(tmp, file);
+  const data = JSON.stringify(value, null, indent ?? 2);
+
+  if (typeof fs.rename === "function") {
+    const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+    await fs.writeFile(tmp, data, "utf8");
+    await fs.rename(tmp, file);
+  } else {
+    await fs.writeFile(file, data, "utf8");
+  }
 }
 
 export { withFileLock };


### PR DESCRIPTION
## Summary
- avoid rename when fs.rename is unavailable

## Testing
- `pnpm --filter @apps/cms test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe1957804832fbca9be6a42f9bf53