### PR TITLE
Fix legacy auth test imports

### DIFF
--- a/packages/auth/src/__tests__/legacy/mfa.test.ts
+++ b/packages/auth/src/__tests__/legacy/mfa.test.ts
@@ -24,7 +24,7 @@ describe("mfa", () => {
   });
 
   it("enrollMfa upserts secret and returns otpauth URI", async () => {
-    const { enrollMfa } = await import("./mfa");
+    const { enrollMfa } = await import("../../mfa");
     generateSecret.mockReturnValue("secret");
     keyuri.mockReturnValue("otpauth");
 
@@ -41,7 +41,7 @@ describe("mfa", () => {
   });
 
   it("verifyMfa enables record on first valid token", async () => {
-    const { verifyMfa } = await import("./mfa");
+    const { verifyMfa } = await import("../../mfa");
     findUnique.mockResolvedValue({
       customerId: "cust",
       secret: "secret",
@@ -60,7 +60,7 @@ describe("mfa", () => {
   });
 
   it("verifyMfa returns true when already enabled", async () => {
-    const { verifyMfa } = await import("./mfa");
+    const { verifyMfa } = await import("../../mfa");
     findUnique.mockResolvedValue({ enabled: true });
     verify.mockReturnValue(true);
 
@@ -72,7 +72,7 @@ describe("mfa", () => {
   });
 
   it("verifyMfa returns false when record missing or token invalid", async () => {
-    const { verifyMfa } = await import("./mfa");
+    const { verifyMfa } = await import("../../mfa");
 
     // Missing record
     findUnique.mockResolvedValueOnce(null);
@@ -92,7 +92,7 @@ describe("mfa", () => {
   });
 
   it("isMfaEnabled returns correct boolean", async () => {
-    const { isMfaEnabled } = await import("./mfa");
+    const { isMfaEnabled } = await import("../../mfa");
     findUnique.mockResolvedValueOnce({ customerId: "cust", enabled: true });
     await expect(isMfaEnabled("cust")).resolves.toBe(true);
 

--- a/packages/auth/src/__tests__/legacy/session.test.ts
+++ b/packages/auth/src/__tests__/legacy/session.test.ts
@@ -43,7 +43,7 @@ jest.mock("crypto", () => ({
 let mockSessionStore: any;
 const createSessionStore = jest.fn(async () => mockSessionStore);
 
-jest.mock("./store", () => ({
+jest.mock("../../store", () => ({
   createSessionStore,
   SESSION_TTL_S: 3600,
 }));
@@ -80,7 +80,7 @@ afterAll(() => {
 
 describe("session", () => {
   it("throws when SESSION_SECRET is missing", async () => {
-    const { createCustomerSession } = await import("./session");
+    const { createCustomerSession } = await import("../../session");
     delete process.env.SESSION_SECRET;
 
     await expect(
@@ -92,7 +92,7 @@ describe("session", () => {
 
   it("returns null for invalid or expired tokens", async () => {
     const { getCustomerSession, CUSTOMER_SESSION_COOKIE } = await import(
-      "./session"
+      "../../session"
     );
 
     // invalid token
@@ -118,7 +118,7 @@ describe("session", () => {
       getCustomerSession,
       CUSTOMER_SESSION_COOKIE,
       CSRF_TOKEN_COOKIE,
-    } = await import("./session");
+    } = await import("../../session");
 
     mockCookies.get.mockImplementation((name: string) =>
       name === CUSTOMER_SESSION_COOKIE ? { value: "tok" } : undefined
@@ -157,7 +157,7 @@ describe("session", () => {
   });
 
   it("validateCsrfToken returns true or false", async () => {
-    const { validateCsrfToken, CSRF_TOKEN_COOKIE } = await import("./session");
+    const { validateCsrfToken, CSRF_TOKEN_COOKIE } = await import("../../session");
 
     mockCookies.get.mockImplementation((name: string) =>
       name === CSRF_TOKEN_COOKIE ? { value: "csrf" } : undefined
@@ -173,7 +173,7 @@ describe("session", () => {
       destroyCustomerSession,
       CUSTOMER_SESSION_COOKIE,
       CSRF_TOKEN_COOKIE,
-    } = await import("./session");
+    } = await import("../../session");
 
     mockCookies.get.mockImplementation((name: string) =>
       name === CUSTOMER_SESSION_COOKIE ? { value: "tok" } : undefined
@@ -196,7 +196,7 @@ describe("session", () => {
   });
 
   it("listSessions delegates to the session store", async () => {
-    const { listSessions } = await import("./session");
+    const { listSessions } = await import("../../session");
 
     const sessions = [{ sessionId: "1" }];
     mockSessionStore.list.mockResolvedValue(sessions);
@@ -206,7 +206,7 @@ describe("session", () => {
   });
 
   it("revokeSession delegates to the session store", async () => {
-    const { revokeSession } = await import("./session");
+    const { revokeSession } = await import("../../session");
 
     await revokeSession("sid");
 


### PR DESCRIPTION
## Summary
- fix relative imports in legacy auth tests to target source modules

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/auth exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --no-coverage packages/auth/src/__tests__/legacy/session.test.ts packages/auth/src/__tests__/legacy/mfa.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfe3b6b8e8832fb4b2a8fee81074e7