### PR TITLE
test: diff directories config

### DIFF
--- a/apps/api/src/routes/components/__tests__/onRequest.test.ts
+++ b/apps/api/src/routes/components/__tests__/onRequest.test.ts
@@ -277,6 +277,55 @@ describe('onRequest route', () => {
     });
   });
 
+  it('returns config diff for files present in only one directory', async () => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
+    verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });
+    const root = path.resolve(__dirname, '../../../../../../..');
+    vol.fromJSON({
+      [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
+        componentVersions: { '@acme/button': '1.0.0' },
+      }),
+      [`${root}/packages/button/package.json`]: JSON.stringify({
+        name: '@acme/button',
+        version: '1.1.0',
+      }),
+      [`${root}/packages/button/CHANGELOG.md`]: '# Changelog\\n\\nFixed bug\\n',
+      // app has an extra template and translation
+      [`${root}/apps/shop-abc/src/templates/app-only.html`]: 'app',
+      [`${root}/apps/shop-abc/src/templates/shared.html`]: 'same',
+      [`${root}/packages/template-app/src/templates/template-only.html`]: 'tpl',
+      [`${root}/packages/template-app/src/templates/shared.html`]: 'same',
+      [`${root}/apps/shop-abc/src/translations/app-only.json`]: '{}',
+      [`${root}/apps/shop-abc/src/translations/common.json`]: '{}',
+      [`${root}/packages/template-app/src/translations/template-only.json`]: '{}',
+      [`${root}/packages/template-app/src/translations/common.json`]: '{}',
+    });
+
+    const res = await onRequest({
+      params: { shopId: 'abc' },
+      request: new Request('http://localhost?diff=1', {
+        headers: { authorization: 'Bearer good' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      components: [
+        {
+          name: '@acme/button',
+          from: '1.0.0',
+          to: '1.1.0',
+          summary: '',
+          changelog: 'packages/button/CHANGELOG.md',
+        },
+      ],
+      configDiff: {
+        templates: ['app-only.html', 'template-only.html'],
+        translations: ['app-only.json', 'template-only.json'],
+      },
+    });
+  });
+
   it('returns empty config diff when diff requested but config directories missing', async () => {
     process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
     verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });


### PR DESCRIPTION
## Summary
- add test verifying config diff lists files present in only one directory

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-machine build: Failed)*
- `pnpm --filter @apps/api test apps/api/src/routes/components/__tests__/onRequest.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfe2bc98b0832f93d16896f4a72af6