### PR TITLE
test: handle malformed body and invalid components

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -171,9 +171,9 @@ describe("onRequestPost", () => {
     );
   });
 
-  it.each([[{ components: "foo" }], [{}]])(
-    "locks all dependencies when body is %j",
-    async (body: Record<string, unknown>) => {
+  it(
+    "locks all dependencies and runs build/deploy when components is not an array",
+    async () => {
       readFileSync.mockImplementation((file: string) => {
         if (file.endsWith("package.json")) {
           return JSON.stringify({
@@ -195,17 +195,32 @@ describe("onRequestPost", () => {
         request: new Request("http://example.com", {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },
-          body: JSON.stringify(body),
+          body: JSON.stringify({ components: "foo" }),
         }),
       });
 
       expect(res.status).toBe(200);
-      const written = JSON.parse(writeFileSync.mock.calls[0][1] as string);
+      expect(writeFileSync).toHaveBeenCalledTimes(1);
+      const [shopPath, data] = writeFileSync.mock.calls[0];
+      expect(shopPath).toContain(`data/shops/${id}/shop.json`);
+      const written = JSON.parse(data as string);
       expect(written.componentVersions).toEqual({
         compA: "1.0.0",
         compB: "2.0.0",
       });
       expect(typeof written.lastUpgrade).toBe("string");
+      expect(spawn).toHaveBeenNthCalledWith(
+        1,
+        "pnpm",
+        ["--filter", `apps/shop-${id}`, "build"],
+        { cwd: root, stdio: "inherit" },
+      );
+      expect(spawn).toHaveBeenNthCalledWith(
+        2,
+        "pnpm",
+        ["--filter", `apps/shop-${id}`, "deploy"],
+        { cwd: root, stdio: "inherit" },
+      );
     },
   );
 
@@ -260,53 +275,58 @@ describe("onRequestPost", () => {
     );
   });
 
-  it("locks all dependencies when body is invalid JSON", async () => {
-    readFileSync.mockImplementation((file: string) => {
-      if (file.endsWith("package.json")) {
-        return JSON.stringify({ dependencies: { compA: "1.0.0", compB: "2.0.0" } });
-      }
-      if (file.endsWith("shop.json")) {
-        return JSON.stringify({ componentVersions: {} });
-      }
-      return "";
-    });
-    spawn.mockImplementation(() => ({
-      on: (_: string, cb: (code: number) => void) => cb(0),
-    }));
+  it.each(["not-json", "\"{bad"])(
+    "locks all dependencies and runs build/deploy when body is invalid JSON",
+    async (badBody) => {
+      readFileSync.mockImplementation((file: string) => {
+        if (file.endsWith("package.json")) {
+          return JSON.stringify({
+            dependencies: { compA: "1.0.0", compB: "2.0.0" },
+          });
+        }
+        if (file.endsWith("shop.json")) {
+          return JSON.stringify({ componentVersions: {} });
+        }
+        return "";
+      });
+      spawn.mockImplementation(() => ({
+        on: (_: string, cb: (code: number) => void) => cb(0),
+      }));
 
-    const token = jwt.sign({}, "secret");
-    const res = await onRequestPost({
-      params: { id },
-      request: new Request("http://example.com", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-        body: "not-json",
-      }),
-    });
+      const token = jwt.sign({}, "secret");
+      const res = await onRequestPost({
+        params: { id },
+        request: new Request("http://example.com", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: badBody,
+        }),
+      });
 
-    expect(res.status).toBe(200);
-    expect(writeFileSync).toHaveBeenCalledTimes(1);
-    const [shopPath, data] = writeFileSync.mock.calls[0];
-    expect(shopPath).toContain(`data/shops/${id}/shop.json`);
-    const written = JSON.parse(data as string);
-    expect(written.componentVersions).toEqual({
-      compA: "1.0.0",
-      compB: "2.0.0",
-    });
-    expect(typeof written.lastUpgrade).toBe("string");
-    expect(spawn).toHaveBeenNthCalledWith(
-      1,
-      "pnpm",
-      ["--filter", `apps/shop-${id}`, "build"],
-      { cwd: root, stdio: "inherit" },
-    );
-    expect(spawn).toHaveBeenNthCalledWith(
-      2,
-      "pnpm",
-      ["--filter", `apps/shop-${id}`, "deploy"],
-      { cwd: root, stdio: "inherit" },
-    );
-  });
+      expect(res.status).toBe(200);
+      expect(writeFileSync).toHaveBeenCalledTimes(1);
+      const [shopPath, data] = writeFileSync.mock.calls[0];
+      expect(shopPath).toContain(`data/shops/${id}/shop.json`);
+      const written = JSON.parse(data as string);
+      expect(written.componentVersions).toEqual({
+        compA: "1.0.0",
+        compB: "2.0.0",
+      });
+      expect(typeof written.lastUpgrade).toBe("string");
+      expect(spawn).toHaveBeenNthCalledWith(
+        1,
+        "pnpm",
+        ["--filter", `apps/shop-${id}`, "build"],
+        { cwd: root, stdio: "inherit" },
+      );
+      expect(spawn).toHaveBeenNthCalledWith(
+        2,
+        "pnpm",
+        ["--filter", `apps/shop-${id}`, "deploy"],
+        { cwd: root, stdio: "inherit" },
+      );
+    },
+  );
 
   it("returns 500 when build command fails", async () => {
     readFileSync.mockImplementation((file: string) => {


### PR DESCRIPTION
## Summary
- add test for non-array components to ensure all dependencies are locked and build/deploy runs
- add test for malformed JSON body to verify upgrade proceeds and triggers build/deploy

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @apps/api test` *(fails: Jest coverage threshold for branches not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe2b984c0832f8563c9f34b4d5384