### PR TITLE
test: cover missing redis store delete scenario

### DIFF
--- a/packages/auth/src/__tests__/redisStore.test.ts
+++ b/packages/auth/src/__tests__/redisStore.test.ts
@@ -89,5 +89,13 @@ describe("RedisSessionStore", () => {
     await expect(store.get("s1")).resolves.toBeNull();
     await expect(store.list("c1")).resolves.toEqual([]);
   });
+
+  it("deletes session without customer set when record is missing", async () => {
+    client.get.mockResolvedValueOnce(null);
+    await store.delete("s1");
+
+    expect(client.del).toHaveBeenCalledWith("session:s1");
+    expect(client.srem).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression test for deleting redis session when lookup fails

## Testing
- `pnpm test packages/auth` *(fails: Could not find task packages/auth)*
- `pnpm --filter @acme/auth exec jest src/__tests__/redisStore.test.ts --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68bfe4b1de44832fa7b1575ccd6bd71b