### PR TITLE
fix(date-utils): adjust legacy test import path

### DIFF
--- a/packages/date-utils/src/__tests__/legacy/index.test.ts
+++ b/packages/date-utils/src/__tests__/legacy/index.test.ts
@@ -6,7 +6,7 @@ import {
   isoDateInNDays,
   nowIso,
   formatTimestamp,
-} from "./index";
+} from "../../index";
 
 process.env.TZ = "Europe/Rome";
 


### PR DESCRIPTION
## Summary
- fix legacy date-utils test to import from package root

## Testing
- `pnpm test src/__tests__/legacy/index.test.ts` *(fails: parseTargetDate interpreted as UTC and coverage thresholds unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe564642c832fb25aa4f60c02952d