### PR TITLE
test(configurator): handle missing env vars

### DIFF
--- a/packages/configurator/__tests__/cli.integration.test.ts
+++ b/packages/configurator/__tests__/cli.integration.test.ts
@@ -4,6 +4,22 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 describe('configurator CLI integration', () => {
+  it('exits with code 1 when required env vars are missing', () => {
+    const env = {
+      ...process.env,
+      STRIPE_SECRET_KEY: 'sk',
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk',
+    };
+    delete env.CART_COOKIE_SECRET;
+    const result = spawnSync('node', ['bin/configurator.cjs', 'dev'], {
+      cwd: resolve(__dirname, '..'),
+      env,
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Missing required environment variables');
+  });
+
   it('delegates to vite dev and exits with code 0', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'configurator-cli-'));
     const logFile = join(tempDir, 'spawn.json');


### PR DESCRIPTION
## Summary
- ensure configurator CLI exits with error and message when required env vars are missing

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/configurator run test` *(fails: env.shipping.test.ts - rejects invalid values)*
- `pnpm --filter @acme/configurator exec jest --config ../../jest.config.cjs packages/configurator/__tests__/cli.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfe571bb90832fab40c398b11da28a