### PR TITLE
test(api): omit undefined headers

### DIFF
--- a/apps/api/__tests__/createRequestHandler.spec.ts
+++ b/apps/api/__tests__/createRequestHandler.spec.ts
@@ -51,6 +51,28 @@ describe("createRequestHandler", () => {
     expect(headers.get("x-multi")).toBe("a,b");
   });
 
+  it("omits headers with undefined values", async () => {
+    const handler = createRequestHandler();
+
+    const req = new Readable({
+      read() {
+        this.push(null);
+      },
+    }) as unknown as IncomingMessage;
+    req.url = "/unknown";
+    req.method = "GET";
+    req.headers = { "x-empty": undefined } as unknown as IncomingMessage["headers"];
+
+    const end = jest.fn();
+    const res = { statusCode: 200, setHeader: jest.fn(), end } as unknown as ServerResponse;
+
+    await handler(req, res);
+
+    expect(RequestMock).toHaveBeenCalled();
+    const headers = (RequestMock.mock.calls[0][1]!.headers as Headers) || new Headers();
+    expect(headers.has("x-empty")).toBe(false);
+  });
+
   it("uses undefined body when request lacks body", async () => {
     const handler = createRequestHandler();
 


### PR DESCRIPTION
## Summary
- verify request handler drops headers with undefined values

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe2bd4320832f910183f691061be6