### PR TITLE
test(auth): handle empty redis list

### DIFF
--- a/packages/auth/src/__tests__/redisStore.test.ts
+++ b/packages/auth/src/__tests__/redisStore.test.ts
@@ -93,6 +93,14 @@ describe("RedisSessionStore", () => {
     expect(list[0].createdAt).toBeInstanceOf(Date);
   });
 
+  it("returns empty array when no sessions exist", async () => {
+    (client.smembers as jest.Mock).mockResolvedValue([]);
+
+    const list = await store.list("cust");
+    expect(list).toEqual([]);
+    expect(client.mget).not.toHaveBeenCalled();
+  });
+
   it("deletes sessions", async () => {
     const record = createRecord("s1");
     await store.set(record);


### PR DESCRIPTION
## Summary
- add test to ensure RedisSessionStore.list returns empty array and skips mget when smembers returns no session ids

## Testing
- `pnpm test packages/auth` *(fails: Missing tasks in project)*


------
https://chatgpt.com/codex/tasks/task_e_68bfe6705844832f96ba0d45b6e595cf