### PR TITLE
test: cover auth env boolean parsing

### DIFF
--- a/packages/configurator/src/__tests__/env.auth.test.ts
+++ b/packages/configurator/src/__tests__/env.auth.test.ts
@@ -156,5 +156,59 @@ describe('auth env validation', () => {
     expect(authEnv.AUTH_PROVIDER).toBe('oauth');
     expect(authEnv.OAUTH_CLIENT_ID).toBe('client-id');
   });
+
+  it.each([
+    ['true', true],
+    ['false', false],
+  ])('parses ALLOW_GUEST=%s', async (value, expected) => {
+    const { authEnv } = await withEnv(
+      { NODE_ENV: 'development', ALLOW_GUEST: value },
+      () => import('@acme/config/src/env/auth.ts'),
+    );
+    expect(authEnv.ALLOW_GUEST).toBe(expected);
+  });
+
+  it.each([
+    ['true', true],
+    ['false', false],
+  ])('parses ENFORCE_2FA=%s', async (value, expected) => {
+    const { authEnv } = await withEnv(
+      { NODE_ENV: 'development', ENFORCE_2FA: value },
+      () => import('@acme/config/src/env/auth.ts'),
+    );
+    expect(authEnv.ENFORCE_2FA).toBe(expected);
+  });
+
+  it('throws for invalid ALLOW_GUEST string', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { loadAuthEnv } = await import(
+      '@acme/config/src/env/auth.ts'
+    );
+    expect(() =>
+      loadAuthEnv({
+        NODE_ENV: 'development',
+        ALLOW_GUEST: 'maybe',
+      } as any),
+    ).toThrow('Invalid auth environment variables');
+    errorSpy.mockRestore();
+  });
+
+  it('throws for invalid ENFORCE_2FA string', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { loadAuthEnv } = await import(
+      '@acme/config/src/env/auth.ts'
+    );
+    expect(() =>
+      loadAuthEnv({
+        NODE_ENV: 'development',
+        ENFORCE_2FA: 'maybe',
+      } as any),
+    ).toThrow('Invalid auth environment variables');
+    errorSpy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add loadAuthEnv helper and stricter boolean coercion for auth env
- test ALLOW_GUEST and ENFORCE_2FA string parsing and invalid values

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables in apps/shop-bcd)*
- `pnpm --filter @acme/configurator run test` *(fails: loadShippingEnv negative case and coverage threshold)*
- `pnpm --filter @acme/configurator exec jest packages/configurator/src/__tests__/env.auth.test.ts --ci --runInBand --config ../../jest.config.cjs`
- `pnpm --filter @acme/config exec jest src/env/__tests__/auth.env.test.ts --runInBand --config jest.preset.cjs`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe56f9e8c832f8cf29d0cb505650f