### PR TITLE
fix: parse date-only strings in UTC

### DIFF
--- a/packages/date-utils/src/index.ts
+++ b/packages/date-utils/src/index.ts
@@ -96,10 +96,13 @@ export function parseTargetDate(
     if (timezone) {
       date = fromZonedTime(targetDate, timezone);
     } else {
+      const hasTime = targetDate.includes("T");
       const hasZone = /([zZ]|[+-]\d{2}:\d{2})$/.test(targetDate);
-      date = !hasZone && targetDate.includes("T")
-        ? parseISO(`${targetDate}Z`)
-        : parseISO(targetDate);
+      date = hasTime
+        ? hasZone
+          ? parseISO(targetDate)
+          : parseISO(`${targetDate}Z`)
+        : parseISO(`${targetDate}T00:00:00Z`);
     }
     return Number.isNaN(date.getTime()) ? null : date;
   } catch {


### PR DESCRIPTION
## Summary
- ensure `parseTargetDate` treats date-only strings as UTC midnight

## Testing
- `pnpm --filter @acme/date-utils lint`
- `pnpm --filter @acme/date-utils build`
- `pnpm --filter @acme/date-utils test` *(fails: out of memory)*
- `pnpm --filter @acme/date-utils exec jest packages/date-utils/__tests__/date.test.ts packages/date-utils/__tests__/parseTargetDate.boundary.test.ts` *(fails: configuration error)*


------
https://chatgpt.com/codex/tasks/task_e_68bfe48b958c832fb0d5ce447e6bfb93