### PR TITLE
fix: skip page history on first save

### DIFF
--- a/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
@@ -71,7 +71,6 @@ export async function savePage(
   page: Page,
   previous?: Page,
 ): Promise<Page> {
-  const patch = diffPages(previous, page);
   await prisma.page.upsert({
     where: { id: page.id },
     update: { data: page as unknown as JsonObject, slug: page.slug },
@@ -82,7 +81,10 @@ export async function savePage(
       data: page as unknown as JsonObject,
     },
   });
-  await appendHistory(shop, patch);
+  if (previous) {
+    const patch = diffPages(previous, page);
+    await appendHistory(shop, patch);
+  }
   return page;
 }
 


### PR DESCRIPTION
## Summary
- avoid writing history when creating a new page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test src/repositories/pages/__tests__/prisma.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfeb5b9708832fa1360386cca8df39