### PR TITLE
fix env validation and msw teardown

### DIFF
--- a/packages/platform-core/src/__tests__/tax.test.ts
+++ b/packages/platform-core/src/__tests__/tax.test.ts
@@ -2,11 +2,19 @@
 
 import { promises as fs } from "fs";
 
+// Preserve the real global fetch so it can be restored after each test.
+// The previous implementation deleted `globalThis.fetch`, which caused
+// MSW's `server.close()` cleanup in `jest.setup.ts` to crash when it
+// attempted to restore the original fetch implementation.
+const realFetch = globalThis.fetch;
+
 // Helper to reset modules and mocks between tests
 function reset() {
   jest.resetModules();
   jest.restoreAllMocks();
-  delete (globalThis as any).fetch;
+  // Rather than deleting `fetch`, reset it to the original implementation
+  // so MSW can safely unpatch it during teardown.
+  (globalThis as any).fetch = realFetch;
 }
 
 describe("tax", () => {


### PR DESCRIPTION
## Summary
- ensure configurator validation calls exported `readEnvFile` and doesn't swallow missing plugin vars
- keep original fetch in tax tests so MSW can clean up

## Testing
- `pnpm --filter @acme/platform-core test`

------
https://chatgpt.com/codex/tasks/task_e_68bfeb655f84832fbf7b55185dedf5c8