### PR TITLE
fix: correct metadata test import path

### DIFF
--- a/packages/platform-core/src/checkout/__tests__/metadata.test.ts
+++ b/packages/platform-core/src/checkout/__tests__/metadata.test.ts
@@ -1,4 +1,4 @@
-import { buildCheckoutMetadata } from './metadata';
+import { buildCheckoutMetadata } from '../metadata';
 
 describe('buildCheckoutMetadata', () => {
   const base = {


### PR DESCRIPTION
## Summary
- fix buildCheckoutMetadata test import path

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core lint` *(fails: Cannot find package '@acme/eslint-plugin-ds')*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/checkout/__tests__/metadata.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfebac5218832fb394855e939297be