### PR TITLE
Fix publish locations test IDs to align with config

### DIFF
--- a/packages/platform-core/src/hooks/__tests__/usePublishLocations.test.tsx
+++ b/packages/platform-core/src/hooks/__tests__/usePublishLocations.test.tsx
@@ -65,8 +65,8 @@ describe("usePublishLocations", () => {
       hook = usePublishLocations();
       return (
         <div>
-          <span data-testid="names">{hook.locations.map((l) => l.name).join(",")}</span>
-          <button data-testid="reload" onClick={() => hook.reload()} />
+          <span data-cy="names">{hook.locations.map((l) => l.name).join(",")}</span>
+          <button data-cy="reload" onClick={() => hook.reload()} />
         </div>
       );
     }
@@ -91,7 +91,7 @@ describe("usePublishLocations", () => {
 
     function ErrorComponent() {
       const { locations } = usePublishLocations();
-      return <span data-testid="length">{locations.length}</span>;
+      return <span data-cy="length">{locations.length}</span>;
     }
 
     render(<ErrorComponent />);


### PR DESCRIPTION
## Summary
- use `data-cy` attributes in publish locations tests

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/src/hooks/__tests__/usePublishLocations.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfebfed930832fb9330ded29a7861e