### PR TITLE
feat: expose UPS return label and mock Prisma

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -1,4 +1,12 @@
-import { PrismaClient } from '@prisma/client';
+import type { PrismaClient as PrismaClientType } from '@prisma/client';
+
+let PrismaClient: { new (): PrismaClientType };
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  PrismaClient = require('@prisma/client').PrismaClient;
+} catch {
+  PrismaClient = class {} as any;
+}
 
 /**
  * Avoid augmenting `PrismaClient` with a permissive index signature.
@@ -33,7 +41,7 @@ type InventoryItemDelegate = {
 };
 
 function createTestPrismaStub(): Pick<
-  PrismaClient,
+  PrismaClientType,
   | 'rentalOrder'
   | 'shop'
   | 'page'
@@ -92,11 +100,11 @@ function createTestPrismaStub(): Pick<
         Object.assign(order, data);
         return order;
       },
-    } as unknown as PrismaClient['rentalOrder'],
+    } as unknown as PrismaClientType['rentalOrder'],
 
     shop: {
       findUnique: async () => ({ data: {} }),
-    } as unknown as PrismaClient['shop'],
+    } as unknown as PrismaClientType['shop'],
 
     page: {
       createMany: async () => {},
@@ -104,7 +112,7 @@ function createTestPrismaStub(): Pick<
       update: async () => ({}),
       deleteMany: async () => ({ count: 0 }),
       upsert: async () => ({}),
-    } as unknown as PrismaClient['page'],
+    } as unknown as PrismaClientType['page'],
 
     customerProfile: {
       findUnique: async ({ where }: any) =>
@@ -128,7 +136,7 @@ function createTestPrismaStub(): Pick<
         customerProfiles.push(profile);
         return profile;
       },
-    } as unknown as PrismaClient['customerProfile'],
+    } as unknown as PrismaClientType['customerProfile'],
 
     customerMfa: {
       upsert: async ({ where, update, create }: any) => {
@@ -153,24 +161,24 @@ function createTestPrismaStub(): Pick<
         customerMfas[idx] = { ...customerMfas[idx], ...data };
         return customerMfas[idx];
       },
-    } as unknown as PrismaClient['customerMfa'],
+    } as unknown as PrismaClientType['customerMfa'],
 
     subscriptionUsage: {
       findUnique: async () => null,
       upsert: async () => ({}),
-    } as unknown as PrismaClient['subscriptionUsage'],
+    } as unknown as PrismaClientType['subscriptionUsage'],
 
     user: {
       findUnique: async () => null,
       findFirst: async () => null,
       create: async () => ({}),
       update: async () => ({}),
-    } as unknown as PrismaClient['user'],
+    } as unknown as PrismaClientType['user'],
 
     reverseLogisticsEvent: {
       create: async () => ({}),
       findMany: async () => [],
-    } as unknown as PrismaClient['reverseLogisticsEvent'],
+    } as unknown as PrismaClientType['reverseLogisticsEvent'],
 
     inventoryItem: {
       findMany: async ({ where: { shopId } }: any) =>

--- a/packages/platform-core/src/shipping/index.d.ts
+++ b/packages/platform-core/src/shipping/index.d.ts
@@ -43,4 +43,8 @@ export interface TrackingStatus {
  * Implementations call the provider APIs but gracefully fall back on failure.
  */
 export declare function getTrackingStatus({ provider, trackingNumber, }: TrackingStatusRequest): Promise<TrackingStatus>;
-export { createReturnLabel as createUpsReturnLabel, getStatus as getUpsStatus } from "./ups";
+export {
+    createReturnLabel,
+    createReturnLabel as createUpsReturnLabel,
+    getStatus as getUpsStatus
+} from "./ups";

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -153,4 +153,8 @@ export async function getTrackingStatus({
   }
 }
 
-export { createReturnLabel as createUpsReturnLabel, getStatus as getUpsStatus } from "./ups";
+export {
+  createReturnLabel,
+  createReturnLabel as createUpsReturnLabel,
+  getStatus as getUpsStatus,
+} from "./ups";

--- a/packages/platform-core/src/shipping/ups.ts
+++ b/packages/platform-core/src/shipping/ups.ts
@@ -2,7 +2,8 @@ import { shippingEnv } from "@acme/config/env/shipping";
 export async function createReturnLabel(
   _sessionId: string,
 ): Promise<{ trackingNumber: string; labelUrl: string }> {
-  const fallback = `1Z${Math.random().toString().slice(2, 12)}`;
+  const random = Math.random().toString().slice(2);
+  const fallback = `1Z${random.padEnd(10, "0").slice(0, 10)}`;
   const fallbackUrl = `https://www.ups.com/track?loc=en_US&tracknum=${fallback}`;
   const apiKey = shippingEnv.UPS_KEY;
   if (!apiKey) {


### PR DESCRIPTION
## Summary
- export `createReturnLabel` from shipping module
- generate consistent 10-digit UPS return labels
- dynamically mock Prisma client when not available

## Testing
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/shipping/__tests__/index.test.ts`
- `pnpm --filter @acme/platform-core test packages-platform-core/__tests__/rentalOrders.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bfec07cf48832f98df80135a3f761b