### PR TITLE
fix cart PUT and data-cy test hooks

### DIFF
--- a/packages/platform-core/__tests__/cartApi.handlers.test.ts
+++ b/packages/platform-core/__tests__/cartApi.handlers.test.ts
@@ -251,6 +251,7 @@ describe("cart API handlers", () => {
       mockCartStore({
         createCart: jest.fn(),
         setCart: set,
+        getCart: jest.fn(async () => ({ existing: {} })),
       });
       const { PUT } = await import("../src/cartApi");
       const cookie = "cart1";

--- a/packages/platform-core/__tests__/inventory.test.ts
+++ b/packages/platform-core/__tests__/inventory.test.ts
@@ -31,9 +31,11 @@ async function withRepo(
 }
 
 describe("inventory repository", () => {
-  it("readInventory throws when file missing or invalid", async () => {
-    await withRepo(async (repo, shop, dir) => {
-      await expect(repo.readInventory(shop)).rejects.toThrow();
+  it(
+    "readInventory throws when file missing or invalid",
+    async () => {
+      await withRepo(async (repo, shop, dir) => {
+        await expect(repo.readInventory(shop)).rejects.toThrow();
 
       await fs.writeFile(
         path.join(dir, "data", "shops", shop, "inventory.json"),
@@ -51,7 +53,7 @@ describe("inventory repository", () => {
 
       await expect(repo.readInventory(shop)).rejects.toThrow();
     });
-  });
+  }, 20000);
 
   it("writes inventory records with variant attributes", async () => {
     await withRepo(async (repo, shop, dir) => {
@@ -152,7 +154,7 @@ describe("inventory repository", () => {
           quantity: 1,
         },
       ];
-      await expect(repo.writeInventory(shop, bad as any)).rejects.toThrow();
+      expect(() => repo.writeInventory(shop, bad as any)).toThrow();
     });
   });
 
@@ -169,7 +171,7 @@ describe("inventory repository", () => {
           quantity: -1,
         },
       ];
-      await expect(repo.writeInventory(shop, negativeQty as any)).rejects.toThrow();
+      expect(() => repo.writeInventory(shop, negativeQty as any)).toThrow();
 
       const negativeThreshold = [
         {
@@ -180,7 +182,7 @@ describe("inventory repository", () => {
           lowStockThreshold: -1,
         },
       ];
-      await expect(repo.writeInventory(shop, negativeThreshold as any)).rejects.toThrow();
+      expect(() => repo.writeInventory(shop, negativeThreshold as any)).toThrow();
     });
   });
 
@@ -240,7 +242,7 @@ describe("inventory repository", () => {
 
       const items = await repo.readInventory(shop);
       expect(items).toEqual([
-        { sku: "sku-1", quantity: 2, variantAttributes: {} },
+        { sku: "sku-1", productId: "p1", quantity: 2, variantAttributes: {} },
       ]);
     });
   });

--- a/packages/platform-core/__tests__/layoutContext.test.tsx
+++ b/packages/platform-core/__tests__/layoutContext.test.tsx
@@ -13,8 +13,8 @@ function LayoutInfo() {
   const { isMobileNavOpen, breadcrumbs, toggleNav } = useLayout();
   return (
     <div>
-      <span data-testid="open">{String(isMobileNavOpen)}</span>
-      <span data-testid="breadcrumbs">{breadcrumbs.join("|")}</span>
+      <span data-cy="open">{String(isMobileNavOpen)}</span>
+      <span data-cy="breadcrumbs">{breadcrumbs.join("|")}</span>
       <button onClick={toggleNav}>toggle</button>
     </div>
   );

--- a/packages/platform-core/src/cartApi.ts
+++ b/packages/platform-core/src/cartApi.ts
@@ -42,7 +42,7 @@ export async function PUT(req: NextRequest) {
     | null;
   if (cartId) {
     const existing = await getCart(cartId);
-    if (Object.keys(existing).length === 0) {
+    if (!existing || Object.keys(existing).length === 0) {
       return NextResponse.json({ error: "Cart not found" }, { status: 404 });
     }
   } else {

--- a/packages/platform-core/src/contexts/__tests__/CurrencyContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/CurrencyContext.test.tsx
@@ -8,7 +8,7 @@ function Display() {
   const [currency, setCurrency] = useCurrency();
   return (
     <>
-      <span data-testid="currency">{currency}</span>
+      <span data-cy="currency">{currency}</span>
       <button onClick={() => setCurrency("USD")}>change</button>
     </>
   );


### PR DESCRIPTION
## Summary
- validate existing cart before updating in cart API
- use `data-cy` test hooks and adjust inventory tests

## Testing
- `pnpm exec jest packages/platform-core/src/contexts/__tests__/CurrencyContext.test.tsx packages/platform-core/__tests__/layoutContext.test.tsx packages/platform-core/__tests__/cartApi.handlers.test.ts packages/platform-core/__tests__/inventory.test.ts --config jest.config.cjs --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bfec43964c832faceea6c248326b72