### PR TITLE
chore(test): allow cart API requests in msw

### DIFF
--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -58,6 +58,12 @@ export const handlers = [
       ctx.body(stream)
     );
   }),
+  // Allow cart API requests to reach fetch mocks or real network
+  rest.get("*/api/cart", (req) => req.passthrough()),
+  rest.post("*/api/cart", (req) => req.passthrough()),
+  rest.put("*/api/cart", (req) => req.passthrough()),
+  rest.patch("*/api/cart", (req) => req.passthrough()),
+  rest.delete("*/api/cart", (req) => req.passthrough()),
   // Allow API route tests to hit local handlers without mocking
   rest.post("*/shop/:id/publish-upgrade", (req) => req.passthrough()),
 ];


### PR DESCRIPTION
## Summary
- allow cart API requests to pass through Mock Service Worker

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/platform-core run test packages/platform-core/__tests__/CartContext.test.tsx` *(fails: CartContext tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bfec78dcac832f98c594464cf9e48e