### PR TITLE
fix tests for orders and ProductGrid

### DIFF
--- a/packages/platform-core/src/__tests__/legacy/orders.test.ts
+++ b/packages/platform-core/src/__tests__/legacy/orders.test.ts
@@ -15,10 +15,10 @@ import {
   setReturnStatus,
 } from "../../orders";
 
-const { trackOrder } = jest.requireMock("../../analytics") as { trackOrder: jest.Mock };
-const { incrementSubscriptionUsage } = jest.requireMock("../../subscriptionUsage") as {
-  incrementSubscriptionUsage: jest.Mock;
-};
+const trackOrder: jest.Mock =
+  jest.requireMock("../../analytics").trackOrder;
+const incrementSubscriptionUsage: jest.Mock =
+  jest.requireMock("../../subscriptionUsage").incrementSubscriptionUsage;
 
 describe("orders", () => {
   beforeEach(() => {

--- a/packages/platform-core/src/components/shop/ProductGrid.tsx
+++ b/packages/platform-core/src/components/shop/ProductGrid.tsx
@@ -94,7 +94,7 @@ function ProductGridInner({
         : Array.from({ length: columns ?? cols }).map((_, i) => (
             <div
               key={i}
-              data-testid="placeholder"
+              data-cy="placeholder"
               className="h-64 rounded-lg bg-gray-200 animate-pulse"
             />
           ))}

--- a/packages/platform-core/src/components/shop/__tests__/ProductGrid.test.tsx
+++ b/packages/platform-core/src/components/shop/__tests__/ProductGrid.test.tsx
@@ -4,7 +4,7 @@ import { ProductGrid } from "../ProductGrid";
 // Mock ProductCard to simplify rendering
 jest.mock("../ProductCard", () => ({
   ProductCard: ({ sku }: { sku: any }) => (
-    <div data-testid="sku">{sku.title}</div>
+    <div data-cy="sku">{sku.title}</div>
   ),
 }));
 


### PR DESCRIPTION
## Summary
- fix orders test mock typing
- use data-cy test IDs in ProductGrid and tests

## Testing
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/__tests__/legacy/orders.test.ts --runInBand --config ../../jest.config.cjs --coverage=false`
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/components/shop/__tests__/ProductGrid.test.tsx --runInBand --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c02c2507e0832fa3c3db81b26f0415