### PR TITLE
test: mock prisma client

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -198,6 +198,7 @@ const config = {
     '^\\./providers/sendgrid\\.js$': ' /packages/email/src/providers/sendgrid.ts',
     '^\\./providers/types\\.js$': ' /packages/email/src/providers/types.ts',
     '^\\./stats\\.js$': ' /packages/email/src/stats.ts',
+    '^@prisma/client$': ' /__mocks__/@prisma/client.ts',
     '^@/components/atoms/shadcn$': ' /test/__mocks__/shadcnDialogStub.tsx',
     '^@/i18n/(.*)$': ' /packages/i18n/src/$1',
     '^@/components/(.*)$': ' /test/__mocks__/componentStub.js',


### PR DESCRIPTION
## Summary
- map `@prisma/client` to a manual mock in Jest config so tests run without installing Prisma

## Testing
- `pnpm exec jest --config jest.config.cjs --runTestsByPath packages/platform-core/src/__tests__/stripe-webhook.test.ts packages/platform-core/src/__tests__/db.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c02e4501c8832fa80bba333ccc03c2