### PR TITLE
Fix theme token path resolution

### DIFF
--- a/packages/platform-core/__tests__/themeTokens.test.ts
+++ b/packages/platform-core/__tests__/themeTokens.test.ts
@@ -17,13 +17,14 @@ describe("loadThemeTokensNode", () => {
       .spyOn(fs, "readFileSync")
       .mockReturnValue("export const tokens = { '--color-bg': '#000' };");
     const tokens = loadThemeTokensNode("dark");
+    const rootDir = join(__dirname, "../../..");
     expect(existsSpy).toHaveBeenNthCalledWith(
       1,
-      join("packages", "themes", "dark", "tailwind-tokens.js"),
+      join(rootDir, "packages", "themes", "dark", "tailwind-tokens.js"),
     );
     expect(existsSpy).toHaveBeenNthCalledWith(
       2,
-      join("packages", "themes", "dark", "tailwind-tokens.ts"),
+      join(rootDir, "packages", "themes", "dark", "tailwind-tokens.ts"),
     );
     expect(tokens["--color-bg"]).toBe("#000");
   });

--- a/packages/platform-core/src/themeTokens/index.ts
+++ b/packages/platform-core/src/themeTokens/index.ts
@@ -40,7 +40,7 @@ export function loadThemeTokensNode(theme: string): TokenMap {
   // Resolve the workspace root relative to this file so consumers can call
   // the loader from any package without relying on their current working
   // directory.
-  const rootDir = join(__dirname, "../../../../..");
+  const rootDir = join(__dirname, "../../../..");
   const baseDir = join(rootDir, "packages", "themes", theme);
   const candidates = [
     join(baseDir, "tailwind-tokens.js"),


### PR DESCRIPTION
## Summary
- fix loadThemeTokensNode root directory resolution
- update theme token tests for absolute paths

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core run build`
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/themeTokens.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c02fb3d670832f8f2b24924e549475