### PR TITLE
test: ensure campaign email requires html

### DIFF
--- a/packages/email/src/__tests__/send.core.test.ts
+++ b/packages/email/src/__tests__/send.core.test.ts
@@ -433,5 +433,18 @@ describe("send core helpers", () => {
       });
     });
   });
+
+  describe("sendCampaignEmail", () => {
+    it("throws when html is missing", async () => {
+      const { sendCampaignEmail } = await import("../send");
+      await expect(
+        sendCampaignEmail({
+          to: "a@b.com",
+          subject: "Hi",
+          sanitize: false,
+        })
+      ).rejects.toThrow("Missing html content for campaign email");
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- add coverage for sendCampaignEmail missing html

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Invalid auth environment variables)
- `pnpm run check:references`
- `pnpm run build:ts`
- `pnpm --filter @acme/email exec jest src/__tests__/send.core.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c02f351da8832fb801615a086de61e