### PR TITLE
fix deployShop env secret and stabilize cart context tests

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/CartContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/CartContext.test.tsx
@@ -1,12 +1,14 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, configure } from "@testing-library/react";
 import { CartProvider, useCart } from "../CartContext";
+
+configure({ testIdAttribute: "data-testid" });
 import type { SKU } from "@acme/types";
 
 type CartState = Record<string, { sku: SKU; qty: number; size?: string }>
 
 function CartDisplay() {
   const [cart] = useCart();
-  return <span data-cy="count">{Object.keys(cart).length}</span>;
+  return <span data-testid="count">{Object.keys(cart).length}</span>;
 }
 
 describe("useCart", () => {


### PR DESCRIPTION
## Summary
- ensure deployShop writes new SESSION_SECRET to env files
- update cart context tests to use data-testid and configure Testing Library

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/platform-core test` *(fails: resolveConfig ignores invalid env values)*

------
https://chatgpt.com/codex/tasks/task_e_68c02e9d9868832fb1a8a14cb36dc278