### PR TITLE
fix: avoid writing page history when no previous

### DIFF
--- a/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
@@ -81,10 +81,11 @@ export async function savePage(
       data: page as unknown as JsonObject,
     },
   });
-  if (previous) {
-    const patch = diffPages(previous, page);
-    await appendHistory(shop, patch);
+  if (previous === undefined) {
+    return page;
   }
+  const patch = diffPages(previous, page);
+  await appendHistory(shop, patch);
   return page;
 }
 


### PR DESCRIPTION
## Summary
- ensure savePage skips history when no prior page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test -- src/repositories/pages/__tests__/prisma.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c02feb8308832f899a6bcaafb31b9d