### PR TITLE
Fix CartContext API mocks for reliable testing

### DIFF
--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -58,12 +58,19 @@ export const handlers = [
       ctx.body(stream)
     );
   }),
-  // Allow cart API requests to reach fetch mocks or real network
-  rest.get("*/api/cart", (req) => req.passthrough()),
-  rest.post("*/api/cart", (req) => req.passthrough()),
-  rest.put("*/api/cart", (req) => req.passthrough()),
-  rest.patch("*/api/cart", (req) => req.passthrough()),
-  rest.delete("*/api/cart", (req) => req.passthrough()),
+  // Allow cart API requests to reach fetch mocks or the real network.
+  //
+  // Using relative paths here ensures requests like `/api/cart` – which the
+  // tests issue – are matched correctly.  The previous patterns prefixed with
+  // `*/` failed to match and resulted in MSW treating the calls as unhandled,
+  // causing the CartContext tests to blow up.  By explicitly registering the
+  // relative `/api/cart` routes we let the requests passthrough to any fetch
+  // mocks without triggering MSW's `onUnhandledRequest` errors.
+  rest.get("/api/cart", (req) => req.passthrough()),
+  rest.post("/api/cart", (req) => req.passthrough()),
+  rest.put("/api/cart", (req) => req.passthrough()),
+  rest.patch("/api/cart", (req) => req.passthrough()),
+  rest.delete("/api/cart", (req) => req.passthrough()),
   // Allow API route tests to hit local handlers without mocking
   rest.post("*/shop/:id/publish-upgrade", (req) => req.passthrough()),
 ];


### PR DESCRIPTION
## Summary
- use relative MSW handlers for `/api/cart` requests
- wait for async updates and Request objects in CartContext tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm exec jest packages/platform-core/__tests__/CartContext.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c02fdafe84832f83b7a1db5cbb7e73