### PR TITLE
test: mock prisma client

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -203,6 +203,7 @@ const config = {
     '^@/components/(.*)$': ' /test/__mocks__/componentStub.js',
     '^@/(.*)$': ' /apps/cms/src/$1',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '^@prisma/client$': ' /__mocks__/@prisma/client.ts',
     '^server-only$': ' /test/server-only-stub.ts',
     // Use resolved React paths to ensure a single instance across tests
     '^react$': reactPath,


### PR DESCRIPTION
## Summary
- map `@prisma/client` to jest mock so tests run without Prisma

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm install`
- `pnpm -r build` *(fails: TS errors in @acme/platform-machine build)*
- `pnpm exec jest packages/platform-core/src/__tests__/stripe-webhook.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c03059d080832f83be56fde305183b