### PR TITLE
test(platform-core): clarify data-cy usage in LayoutContext test

### DIFF
--- a/packages/platform-core/__tests__/layoutContext.test.tsx
+++ b/packages/platform-core/__tests__/layoutContext.test.tsx
@@ -13,6 +13,7 @@ function LayoutInfo() {
   const { isMobileNavOpen, breadcrumbs, toggleNav } = useLayout();
   return (
     <div>
+      {/* Use `data-cy` because Testing Library is configured with `testIdAttribute: "data-cy"` */}
       <span data-cy="open">{String(isMobileNavOpen)}</span>
       <span data-cy="breadcrumbs">{breadcrumbs.join("|")}</span>
       <button onClick={toggleNav}>toggle</button>


### PR DESCRIPTION
## Summary
- document that LayoutContext tests should use data-cy attributes, matching Testing Library config

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/layoutContext.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c02ffc82f8832f832024ce8ae00077