### PR TITLE
fix: avoid history for initial page save

### DIFF
--- a/packages/platform-core/src/repositories/pages/__tests__/json.server.test.ts
+++ b/packages/platform-core/src/repositories/pages/__tests__/json.server.test.ts
@@ -31,8 +31,10 @@ describe("pages.json.server", () => {
     let pages = await repo.getPages(shop);
     expect(pages).toHaveLength(1);
     expect(pages[0].createdBy).toBe("tester");
+    let history = await repo.diffHistory(shop);
+    expect(history).toHaveLength(0);
 
-    const history: HistoryState = {
+    const historyState: HistoryState = {
       past: [],
       present: [],
       future: [],
@@ -41,12 +43,14 @@ describe("pages.json.server", () => {
 
     const updated = await repo.updatePage(
       shop,
-      { id: page.id, slug: "start", updatedAt: page.updatedAt, history },
+      { id: page.id, slug: "start", updatedAt: page.updatedAt, history: historyState },
       page,
     );
     pages = await repo.getPages(shop);
     expect(updated.slug).toBe("start");
-    expect(pages[0].history).toEqual(history);
+    expect(pages[0].history).toEqual(historyState);
+    history = await repo.diffHistory(shop);
+    expect(history).toHaveLength(1);
 
     await repo.deletePage(shop, page.id);
     pages = await repo.getPages(shop);

--- a/packages/platform-core/src/repositories/pages/pages.json.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.json.server.ts
@@ -90,13 +90,15 @@ export async function savePage(
   page: Page,
   previous?: Page,
 ): Promise<Page> {
-  const patch = diffPages(previous, page);
   const pages = await readPagesFromDisk(shop);
   const idx = pages.findIndex((p) => p.id === page.id);
   if (idx === -1) pages.push(page);
   else pages[idx] = page;
   await writePages(shop, pages);
-  await appendHistory(shop, patch);
+  if (previous) {
+    const patch = diffPages(previous, page);
+    await appendHistory(shop, patch);
+  }
   return page;
 }
 


### PR DESCRIPTION
## Summary
- don't record diff history on initial save
- add regression test for history-less initial save

## Testing
- `pnpm -r build` *(fails: TS7006 Parameter 'order' implicitly has an 'any' type)*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/repositories/pages/__tests__/prisma.server.test.ts packages-platform-core/src/repositories/pages/__tests__/json.server.test.ts --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c032c856d8832f92a0f73597fdc42a