### PR TITLE
fix: use data-cy id for cart quantity test

### DIFF
--- a/packages/platform-core/__tests__/addToCartButton.test.tsx
+++ b/packages/platform-core/__tests__/addToCartButton.test.tsx
@@ -11,7 +11,7 @@ function Qty() {
   const [state] = useCart();
   const size = PRODUCTS[0].sizes[0];
   const id = `${PRODUCTS[0].id}:${size}`;
-  return <span data-cy="qty">{state[id]?.qty ?? 0}</span>;
+  return <span data-cy="qty" data-testid="qty">{state[id]?.qty ?? 0}</span>;
 }
 
 describe("AddToCartButton", () => {


### PR DESCRIPTION
## Summary
- add `data-cy` test id to quantity span so Testing Library can locate it

## Testing
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/addToCartButton.test.tsx` *(fails: coverage thresholds not met)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c030430090832f9c3df48a66b17b99