### PR TITLE
feat: enhance marketing email logo handling

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/components/ShopPreview.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/components/ShopPreview.tsx
@@ -1,3 +1,5 @@
+import { Logo } from "@acme/ui";
+
 interface ShopPreviewProps {
   logo: string;
   storeName: string;
@@ -6,12 +8,14 @@ interface ShopPreviewProps {
 export default function ShopPreview({ logo, storeName }: ShopPreviewProps) {
   return (
     <div className="flex items-center gap-2 rounded border p-2">
-      {logo ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={logo} alt="Logo preview" className="h-8 w-8 object-contain" />
-      ) : (
-        <div className="h-8 w-8 bg-gray-200" />
-      )}
+      <Logo
+        src={logo}
+        alt={storeName}
+        textFallback={storeName || "Store Name"}
+        width={32}
+        height={32}
+        className="h-8 w-8 object-contain"
+      />
       <span>{storeName || "Store Name"}</span>
     </div>
   );

--- a/packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx
+++ b/packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx
@@ -6,7 +6,8 @@ describe("MarketingEmailTemplate", () => {
   it("renders full template", () => {
     const { container, getByText, getByAltText } = render(
       <MarketingEmailTemplate
-        logoSrc="/logo.png"
+        shopName="Acme"
+        logo={{ light: "/logo.png" }}
         headline="Welcome"
         content={<p>Hi there</p>}
         ctaLabel="Click me"
@@ -17,7 +18,7 @@ describe("MarketingEmailTemplate", () => {
 
     expect(getByText("Welcome")).toBeInTheDocument();
     expect(getByText("Hi there")).toBeInTheDocument();
-    expect(getByAltText("logo")).toBeInTheDocument();
+    expect(getByAltText("Acme")).toBeInTheDocument();
     expect(getByText("Click me").closest("a")).toHaveAttribute(
       "href",
       "https://example.com"
@@ -32,14 +33,15 @@ describe("MarketingEmailTemplate", () => {
   it("renders logo and footer but omits CTA when CTA props are missing", () => {
     const { getByAltText, getByText, queryByRole } = render(
       <MarketingEmailTemplate
+        shopName="Acme"
         headline="Headline"
         content={<p>Body</p>}
-        logoSrc="/logo.png"
+        logo={{ light: "/logo.png" }}
         footer={<span>Bye</span>}
       />
     );
 
-    expect(getByAltText("logo")).toBeInTheDocument();
+    expect(getByAltText("Acme")).toBeInTheDocument();
     expect(getByText("Bye")).toBeInTheDocument();
     expect(queryByRole("link")).toBeNull();
   });
@@ -74,11 +76,11 @@ describe("MarketingEmailTemplate", () => {
   });
 
   it("omits logo and footer containers when data is missing", () => {
-    const { container, queryByAltText } = render(
+    const { container, queryByRole } = render(
       <MarketingEmailTemplate headline="No Extras" content={<p>content</p>} />
     );
 
-    expect(queryByAltText("logo")).toBeNull();
+    expect(queryByRole("img")).toBeNull();
     expect(container.querySelector(".border-t")).toBeNull();
   });
   it("throws when headline is missing or empty", () => {

--- a/packages/email-templates/package.json
+++ b/packages/email-templates/package.json
@@ -22,6 +22,9 @@
     "test": "jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverageDirectory ../../coverage/email-templates",
     "lint": "eslint ."
   },
+  "dependencies": {
+    "@acme/ui": "workspace:*"
+  },
   "peerDependencies": {
     "react": ">=19 <20",
     "react-dom": ">=19 <20"

--- a/packages/email-templates/src/MarketingEmailTemplate.tsx
+++ b/packages/email-templates/src/MarketingEmailTemplate.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
-
-/* eslint-disable @next/next/no-img-element */
+import { Logo } from "@acme/ui";
 
 export interface MarketingEmailTemplateProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "content"> {
-  logoSrc?: string;
+  shopName?: string;
+  logo?: {
+    light?: string;
+    dark?: string;
+  };
   headline: string;
   content: React.ReactNode;
   ctaLabel?: string;
@@ -13,7 +16,8 @@ export interface MarketingEmailTemplateProps
 }
 
 export function MarketingEmailTemplate({
-  logoSrc,
+  shopName,
+  logo,
   headline,
   content,
   ctaLabel,
@@ -30,21 +34,32 @@ export function MarketingEmailTemplate({
   }
 
   const showCta = Boolean(ctaLabel && ctaHref);
+  const hasLogo = Boolean(logo?.light || logo?.dark || shopName);
 
   return (
     <div
       className={`mx-auto w-full max-w-xl overflow-hidden rounded-md border text-sm${className ? ` ${className}` : ""}`}
       {...props}
     >
-      {logoSrc && (
+      {hasLogo && (
         <div className="bg-muted p-6 text-center" data-token="--color-muted">
-          <img
-            src={logoSrc}
-            alt="logo"
-            width={40}
-            height={40}
-            style={{ margin: "0 auto", height: "40px", width: "auto" }}
-          />
+          <picture>
+            {logo?.dark && (
+              <source
+                srcSet={logo.dark}
+                media="(prefers-color-scheme: dark)"
+              />
+            )}
+            <Logo
+              src={logo?.light ?? logo?.dark}
+              alt={shopName ?? ""}
+              textFallback={shopName}
+              width={40}
+              height={40}
+              className="mx-auto"
+              style={{ height: "40px", width: "auto" }}
+            />
+          </picture>
         </div>
       )}
       <div className="space-y-4 p-6">

--- a/packages/email-templates/tsconfig.json
+++ b/packages/email-templates/tsconfig.json
@@ -6,7 +6,12 @@
     "declarationMap": true,
     "noEmit": false,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@acme/ui": ["../ui/dist/index.d.ts"],
+      "@acme/ui/*": ["../ui/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/__tests__/**", ".turbo", "node_modules"]


### PR DESCRIPTION
## Summary
- support shop names and dark/light logo variants in MarketingEmailTemplate
- use Logo atom for CMS shop preview with alt and text fallback

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' or TypeScript errors in platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/email-templates/__tests__/MarketingEmailTemplate.test.tsx --config jest.config.cjs --runInBand --detectOpenHandles` *(fails: coverage threshold not met)*
- `pnpm --filter @apps/cms test` *(fails: marketingEmailApi.test.ts and configuratorSteps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c032a2c840832fa51c13199cfe3eb8