### PR TITLE
feat: support responsive logo variants

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepSummary.tsx
@@ -4,7 +4,7 @@
 
 import { Button, Input } from "@ui/components/atoms/shadcn";
 import { LOCALES } from "@acme/i18n";
-import type { Locale } from "@acme/types";
+import type { Locale, ShopLogo } from "@acme/types";
 import React, { useState } from "react";
 import WizardPreview from "../../wizard/WizardPreview";
 import PreviewDeviceSelector from "../../wizard/PreviewDeviceSelector";
@@ -15,7 +15,7 @@ import { useRouter } from "next/navigation";
 interface Props {
   shopId: string;
   name: string;
-  logo: string;
+  logo: ShopLogo;
   contactInfo: string;
   type: "sale" | "rental";
   template: string;
@@ -76,7 +76,18 @@ export default function StepSummary({
           <b>Store Name:</b> {name}
         </li>
         <li>
-          <b>Logo:</b> {logo || "none"}
+          <b>Logo:</b>{" "}
+          {(() => {
+            const entries: string[] = [];
+            for (const [viewport, orient] of Object.entries(logo)) {
+              for (const [orientation, url] of Object.entries(
+                orient as Record<string, string>,
+              )) {
+                if (url) entries.push(`${viewport}-${orientation}: ${url}`);
+              }
+            }
+            return entries.length ? entries.join(", ") : "none";
+          })()}
         </li>
         <li>
           <b>Contact:</b> {contactInfo || "none"}

--- a/apps/cms/src/app/cms/configurator/steps/components/ShopPreview.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/components/ShopPreview.tsx
@@ -1,14 +1,21 @@
+import type { ShopLogo } from "@acme/types";
+
 interface ShopPreviewProps {
-  logo: string;
+  logo: ShopLogo;
   storeName: string;
 }
 
 export default function ShopPreview({ logo, storeName }: ShopPreviewProps) {
+  const src =
+    logo.desktop?.landscape ||
+    logo.desktop?.portrait ||
+    logo.mobile?.landscape ||
+    logo.mobile?.portrait;
   return (
     <div className="flex items-center gap-2 rounded border p-2">
-      {logo ? (
+      {src ? (
         // eslint-disable-next-line @next/next/no-img-element
-        <img src={logo} alt="Logo preview" className="h-8 w-8 object-contain" />
+        <img src={src} alt="Logo preview" className="h-8 w-8 object-contain" />
       ) : (
         <div className="h-8 w-8 bg-gray-200" />
       )}

--- a/apps/cms/src/app/cms/wizard/schema.ts
+++ b/apps/cms/src/app/cms/wizard/schema.ts
@@ -1,11 +1,7 @@
 // apps/cms/src/app/cms/wizard/schema.ts
 import { LOCALES } from "@acme/i18n";
 import { fillLocales } from "@i18n/fillLocales";
-import {
-  pageComponentSchema,
-  localeSchema,
-  type Locale,
-} from "@acme/types";
+import { pageComponentSchema, localeSchema, type Locale } from "@acme/types";
 import {
   environmentSettingsSchema,
   providerSettingsSchema,
@@ -31,6 +27,35 @@ function defaultLocaleRecord(
 }
 
 const localeRecordSchema = z.record(localeSchema, z.string());
+
+const logoSchema = z.preprocess(
+  (val) =>
+    typeof val === "string"
+      ? {
+          desktop: { landscape: val, portrait: val },
+          mobile: { landscape: val, portrait: val },
+        }
+      : val,
+  z
+    .object({
+      desktop: z
+        .object({
+          landscape: z.string().default(""),
+          portrait: z.string().default(""),
+        })
+        .default({ landscape: "", portrait: "" }),
+      mobile: z
+        .object({
+          landscape: z.string().default(""),
+          portrait: z.string().default(""),
+        })
+        .default({ landscape: "", portrait: "" }),
+    })
+    .default({
+      desktop: { landscape: "", portrait: "" },
+      mobile: { landscape: "", portrait: "" },
+    }),
+);
 
 /* -------------------------------------------------------------------------- */
 /*  Nav‑item schema (recursive)                                               */
@@ -90,7 +115,10 @@ const configuratorStateSchemaBase: z.AnyZodObject = z
     /* ------------ Wizard progress & identity ------------ */
     shopId: z.string().optional().default(""),
     storeName: z.string().optional().default(""),
-    logo: z.string().optional().default(""),
+    logo: logoSchema.optional().default({
+      desktop: { landscape: "", portrait: "" },
+      mobile: { landscape: "", portrait: "" },
+    }),
     contactInfo: z.string().optional().default(""),
     type: z.enum(["sale", "rental"]).optional().default("sale"),
     completed: z.record(stepStatusSchema).optional().default({}),

--- a/apps/cms/src/app/cms/wizard/services/__tests__/submitShop.test.ts
+++ b/apps/cms/src/app/cms/wizard/services/__tests__/submitShop.test.ts
@@ -19,7 +19,10 @@ describe("submitShop", () => {
 
   const baseState: any = {
     storeName: "Store",
-    logo: "",
+    logo: {
+      desktop: { landscape: "", portrait: "" },
+      mobile: { landscape: "", portrait: "" },
+    },
     contactInfo: "",
     type: "sale",
     template: "temp",

--- a/apps/cms/src/app/cms/wizard/services/createShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/createShop.ts
@@ -66,7 +66,11 @@ export async function createShop(
 
   const options = {
     name: storeName || undefined,
-    logo: logo || undefined,
+    logo:
+      Object.values(logo.desktop).some(Boolean) ||
+      Object.values(logo.mobile).some(Boolean)
+        ? logo
+        : undefined,
     contactInfo: contactInfo || undefined,
     type,
     template,

--- a/apps/cms/src/app/cms/wizard/services/submitShop.ts
+++ b/apps/cms/src/app/cms/wizard/services/submitShop.ts
@@ -71,7 +71,11 @@ export async function submitShop(
 
   const options = {
     name: storeName || undefined,
-    logo: logo || undefined,
+    logo:
+      Object.values(logo.desktop).some(Boolean) ||
+      Object.values(logo.mobile).some(Boolean)
+        ? logo
+        : undefined,
     contactInfo: contactInfo || undefined,
     type,
     template,

--- a/apps/cms/src/types/configurator.ts
+++ b/apps/cms/src/types/configurator.ts
@@ -1,12 +1,13 @@
 import type { ReactNode } from "react";
+import type { ShopLogo } from "@acme/types";
 
 export interface ConfiguratorStepProps {
   shopId: string;
   setShopId: (v: string) => void;
   storeName: string;
   setStoreName: (v: string) => void;
-  logo: string;
-  setLogo: (v: string) => void;
+  logo: ShopLogo;
+  setLogo: (v: ShopLogo) => void;
   contactInfo: string;
   setContactInfo: (v: string) => void;
   type: "sale" | "rental";

--- a/packages/platform-core/src/createShop/schema.d.ts
+++ b/packages/platform-core/src/createShop/schema.d.ts
@@ -1,4 +1,5 @@
 import type { PageComponent } from "@acme/types";
+import { shopLogoSchema, type ShopLogo } from "@acme/types";
 import { z } from "zod";
 export interface NavItem {
     label: string;
@@ -7,7 +8,7 @@ export interface NavItem {
 }
 export declare const createShopOptionsSchema: z.ZodObject<{
     name: z.ZodOptional<z.ZodString>;
-    logo: z.ZodOptional<z.ZodString>;
+    logo: z.ZodOptional<z.ZodUnion<[z.ZodString, typeof shopLogoSchema]>>;
     contactInfo: z.ZodOptional<z.ZodString>;
     type: z.ZodOptional<z.ZodEnum<["sale", "rental"]>>;
     theme: z.ZodOptional<z.ZodString>;
@@ -206,6 +207,7 @@ export type PreparedCreateShopOptions = Required<Omit<CreateShopOptions, "analyt
     enableEditorial: boolean;
     enableSubscriptions: boolean;
     checkoutPage: PageComponent[];
+    logo: ShopLogo;
 };
 /** Parse and populate option defaults. */
 export declare function prepareOptions(id: string, opts: CreateShopOptions): PreparedCreateShopOptions;

--- a/packages/types/src/Shop.d.ts
+++ b/packages/types/src/Shop.d.ts
@@ -42,10 +42,60 @@ export declare const lateFeeServiceSchema: z.ZodObject<{
     intervalMinutes: number;
 }>;
 export type LateFeeService = z.infer<typeof lateFeeServiceSchema>;
+export declare const shopLogoSchema: z.ZodEffects<z.ZodUnion<[z.ZodString, z.ZodObject<{
+    desktop: z.ZodObject<{
+        landscape: z.ZodOptional<z.ZodString>;
+        portrait: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    }, {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    }>;
+    mobile: z.ZodObject<{
+        landscape: z.ZodOptional<z.ZodString>;
+        portrait: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    }, {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    }>;
+}, "strip", z.ZodTypeAny, {
+    desktop?: {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    } | undefined;
+    mobile?: {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    } | undefined;
+}, {
+    desktop?: {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    } | undefined;
+    mobile?: {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    } | undefined;
+}>]>, {
+    desktop?: {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    } | undefined;
+    mobile?: {
+        landscape?: string | undefined;
+        portrait?: string | undefined;
+    } | undefined;
+}, unknown>;
+export type ShopLogo = z.infer<typeof shopLogoSchema>;
 export declare const shopSchema: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
-    logo: z.ZodOptional<z.ZodString>;
+    logo: z.ZodOptional<typeof shopLogoSchema>;
     contactInfo: z.ZodOptional<z.ZodString>;
     catalogFilters: z.ZodArray<z.ZodString, "many">;
     themeId: z.ZodString;
@@ -228,7 +278,7 @@ export declare const shopSchema: z.ZodObject<{
     }[];
     subscriptionsEnabled: boolean;
     type?: string | undefined;
-    logo?: string | undefined;
+    logo?: ShopLogo | undefined;
     contactInfo?: string | undefined;
     domain?: {
         name: string;
@@ -273,7 +323,7 @@ export declare const shopSchema: z.ZodObject<{
     themeId: string;
     filterMappings: Record<string, string>;
     type?: string | undefined;
-    logo?: string | undefined;
+    logo?: ShopLogo | undefined;
     contactInfo?: string | undefined;
     themeDefaults?: Record<string, string> | undefined;
     themeOverrides?: Record<string, string> | undefined;

--- a/packages/types/src/Shop.ts
+++ b/packages/types/src/Shop.ts
@@ -36,11 +36,39 @@ export const lateFeeServiceSchema = z
 
 export type LateFeeService = z.infer<typeof lateFeeServiceSchema>;
 
+export const shopLogoSchema = z.preprocess(
+  (val) =>
+    typeof val === "string"
+      ? {
+          desktop: { landscape: val, portrait: val },
+          mobile: { landscape: val, portrait: val },
+        }
+      : val,
+  z
+    .object({
+      desktop: z
+        .object({
+          landscape: z.string().url().optional(),
+          portrait: z.string().url().optional(),
+        })
+        .default({}),
+      mobile: z
+        .object({
+          landscape: z.string().url().optional(),
+          portrait: z.string().url().optional(),
+        })
+        .default({}),
+    })
+    .partial(),
+);
+
+export type ShopLogo = z.infer<typeof shopLogoSchema>;
+
 export const shopSchema = z
   .object({
     id: z.string(),
     name: z.string(),
-    logo: z.string().optional(),
+    logo: shopLogoSchema.optional(),
     contactInfo: z.string().optional(),
     catalogFilters: z.array(z.string()),
     themeId: z.string(),


### PR DESCRIPTION
## Summary
- add `shopLogoSchema` to describe desktop and mobile logo orientations
- collect and preview all logo variants in the CMS configurator
- normalize logo options for shop creation APIs and state persistence

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Parameter 'order' implicitly has an 'any' type)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest apps/cms/src/app/cms/configurator/steps/__tests__/StepShopDetails.test.tsx apps/cms/src/app/cms/wizard/services/__tests__/submitShop.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0329ff940832f94378811d96e8567