### PR TITLE
test: use data-cy for ThemeContext

### DIFF
--- a/packages/ui/__tests__/ThemeContext.test.tsx
+++ b/packages/ui/__tests__/ThemeContext.test.tsx
@@ -7,7 +7,7 @@ function Display() {
   const { theme, setTheme } = useTheme();
   return (
     <>
-      <span data-testid="theme">{theme}</span>
+      <span data-cy="theme">{theme}</span>
       <button onClick={() => setTheme("dark")}>dark</button>
     </>
   );


### PR DESCRIPTION
## Summary
- fix ThemeContext tests in @acme/ui to use `data-cy`

## Testing
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/ThemeContext.test.tsx` *(fails: global coverage threshold for branches (80%) not met: 68.42%)*

------
https://chatgpt.com/codex/tasks/task_e_68c03009fbc8832f9198389945d63eea