### PR TITLE
test: ensure unsubscribe link uses relative path

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -46,6 +46,7 @@ describe("scheduler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    delete process.env.NEXT_PUBLIC_BASE_URL;
     memory = {};
     readCampaigns = jest.fn(async (s: string) => memory[s] || []);
     writeCampaigns = jest.fn(async (s: string, items: Campaign[]) => {
@@ -180,6 +181,8 @@ describe("scheduler", () => {
     expect(html).toMatch(/open\?shop=test-shop&campaign=.*&t=\d+/);
     expect(html).toContain("Unsubscribe");
     expect(html).toContain(encodeURIComponent("a@example.com"));
+    const match = html.match(/href="([^"]+)">Unsubscribe<\/a>/);
+    expect(match?.[1]).toMatch(/^\/api\/marketing\/email\/unsubscribe/);
     expect(emitSend).toHaveBeenCalledWith(shop, { campaign: expect.any(String) });
   });
 


### PR DESCRIPTION
## Summary
- clear NEXT_PUBLIC_BASE_URL before each scheduler test
- verify unsubscribe link is relative when no base URL is set

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid auth environment variables)*
- `pnpm --filter @acme/email test src/__tests__/scheduler.test.ts` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f3a0364832fbb2f722e27967726