### PR TITLE
fix: add explicit types

### DIFF
--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -26,8 +26,10 @@ function normalize<T extends Order>(order: T): T {
 }
 
 export async function listOrders(shop: string): Promise<Order[]> {
-  const orders = await prisma.rentalOrder.findMany({ where: { shop } });
-  return orders.map((order) => normalize(order as Order));
+  const orders = (await prisma.rentalOrder.findMany({
+    where: { shop },
+  })) as Order[];
+  return orders.map((order) => normalize(order));
 }
 
 export const readOrders = listOrders;
@@ -256,10 +258,10 @@ export async function getOrdersForCustomer(
   shop: string,
   customerId: string
 ): Promise<Order[]> {
-  const orders = await prisma.rentalOrder.findMany({
+  const orders = (await prisma.rentalOrder.findMany({
     where: { shop, customerId },
-  });
-  return orders.map((order) => normalize(order as Order));
+  })) as Order[];
+  return orders.map((order) => normalize(order));
 }
 
 export async function setReturnTracking(

--- a/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
+++ b/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
@@ -31,10 +31,10 @@ export async function recordEvent(
 export async function listEvents(
   shop: string
 ): Promise<ReverseLogisticsEvent[]> {
-  const events = await prisma.reverseLogisticsEvent.findMany({
+  const events = (await prisma.reverseLogisticsEvent.findMany({
     where: { shop },
     orderBy: { createdAt: "asc" },
-  });
+  })) as ReverseLogisticsEvent[];
 
   return events.map((evt) => ({
     ...evt,
@@ -49,7 +49,7 @@ async function delegate(
   sessionId: string,
   createdAt: string
 ) {
-  const mod = await import("./reverseLogisticsEvents.server.ts");
+  const mod = await import("./reverseLogisticsEvents.server.js");
   return mod.recordEvent(shop, sessionId, event, createdAt);
 }
 


### PR DESCRIPTION
## Summary
- add explicit Order typing to Prisma results
- ensure reverse logistics events are typed and dynamically imported via JavaScript extension

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c0392063e8832faa5acbd6c70017b5