### PR TITLE
fix: use node fs for shop creation

### DIFF
--- a/packages/platform-core/__tests__/createShop.unit.test.ts
+++ b/packages/platform-core/__tests__/createShop.unit.test.ts
@@ -6,7 +6,7 @@ import path from 'path';
 const vol = new Volume();
 const fs = createFsFromVolume(vol);
 
-jest.mock('fs', () => fs);
+jest.mock('node:fs', () => fs);
 
 // mock prisma
 const prismaMock = {

--- a/packages/platform-core/__tests__/createShopHelpers.test.ts
+++ b/packages/platform-core/__tests__/createShopHelpers.test.ts
@@ -1,5 +1,5 @@
 // packages/platform-core/__tests__/createShopHelpers.test.ts
-import fs from "fs";
+import fs from "node:fs";
 import { createShopOptionsSchema, prepareOptions } from "../src/createShop/schema";
 import {
   ensureTemplateExists,
@@ -8,7 +8,7 @@ import {
   copyTemplate,
 } from "../src/createShop/fsUtils";
 
-jest.mock("fs");
+jest.mock("node:fs");
 
 const fsMock = fs as jest.Mocked<typeof fs>;
 

--- a/packages/platform-core/__tests__/createShopIndex.test.ts
+++ b/packages/platform-core/__tests__/createShopIndex.test.ts
@@ -5,7 +5,7 @@ import { Volume, createFsFromVolume } from 'memfs';
 const vol = new Volume();
 const fs = createFsFromVolume(vol);
 
-jest.mock('fs', () => fs);
+jest.mock('node:fs', () => fs);
 
 // mock database and theme utils
 const prismaMock = {

--- a/packages/platform-core/__tests__/deployShopImpl.test.ts
+++ b/packages/platform-core/__tests__/deployShopImpl.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 const vol = new Volume();
 const fs = createFsFromVolume(vol);
 
-jest.mock('fs', () => fs);
+jest.mock('node:fs', () => fs);
 
 const genSecret = jest.fn(() => 'secret-123');
 jest.mock('@acme/shared-utils', () => ({ genSecret }));

--- a/packages/platform-core/src/createShop/deploymentAdapter.ts
+++ b/packages/platform-core/src/createShop/deploymentAdapter.ts
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "child_process";
 import { join } from "path";
-import { writeFileSync, mkdirSync } from "fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 
 import type { DeployShopResult } from "./deployTypes";
 

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -4,7 +4,7 @@
  * The utilities here are intentionally small wrappers around Node's `fs`
  * functions so they can be mocked and tested in isolation.
  */
-import { cpSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { cpSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "path";
 
 /**

--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -1,5 +1,5 @@
 // packages/platform-core/src/createShop/index.ts
-import * as fs from "fs";
+import * as fs from "node:fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { genSecret } from "@acme/shared-utils";

--- a/packages/platform-core/src/createShop/themeUtils.ts
+++ b/packages/platform-core/src/createShop/themeUtils.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { join } from "path";
 import ts from "typescript";
 import { runInNewContext } from "vm";


### PR DESCRIPTION
## Summary
- use Node's builtin fs to avoid tests that mock `fs`
- update test mocks to target `node:fs`

## Testing
- `pnpm exec jest --config jest.config.cjs packages/platform-core/__tests__/deployShopImpl.test.ts packages/platform-core/__tests__/createShopHelpers.test.ts packages/platform-core/__tests__/createShopIndex.test.ts packages-platform-core/__tests__/createShop.unit.test.ts packages-platform-core/__tests__/deployShop.test.ts packages-platform-core/__tests__/createShop.test.ts`
- `pnpm install`
- `pnpm -r build` *(fails: Parameter 'order' implicitly has an 'any' type)*
- `pnpm --filter @acme/platform-core build` *(fails: Parameter 'order' implicitly has an 'any' type)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c038579294832fab39470cdf78d92c