### PR TITLE
feat(ui): add responsive logo sources

### DIFF
--- a/packages/ui/src/components/atoms/Logo.d.ts
+++ b/packages/ui/src/components/atoms/Logo.d.ts
@@ -1,8 +1,20 @@
 import { type ImageProps } from "next/image";
 import * as React from "react";
-export interface LogoProps extends ImageProps {
-    /** Name of the shop for alt text or fallback */
-    shopName: string;
+
+type Viewport = "desktop" | "tablet" | "mobile";
+interface LogoSource {
+    src: ImageProps["src"];
+    width?: number;
+    height?: number;
+}
+export interface LogoProps extends Omit<ImageProps, "alt" | "src" | "width" | "height"> {
+    /** Text to display when no image source is available */
+    fallbackText: string;
+    src?: ImageProps["src"];
+    sources?: Partial<Record<Viewport, LogoSource>>;
+    width?: number;
+    height?: number;
+    alt?: string;
 }
 export declare const Logo: React.ForwardRefExoticComponent<LogoProps & React.RefAttributes<HTMLImageElement>>;
 //# sourceMappingURL=Logo.d.ts.map

--- a/packages/ui/src/components/atoms/Logo.stories.tsx
+++ b/packages/ui/src/components/atoms/Logo.stories.tsx
@@ -4,7 +4,7 @@ import { Logo } from "./Logo";
 const meta: Meta<typeof Logo> = {
   component: Logo,
   args: {
-    shopName: "Logo",
+    fallbackText: "Logo",
   },
 };
 export default meta;

--- a/packages/ui/src/components/atoms/Logo.tsx
+++ b/packages/ui/src/components/atoms/Logo.tsx
@@ -1,10 +1,27 @@
 import Image, { type ImageProps } from "next/image";
 import * as React from "react";
+import useViewport from "../../hooks/useViewport";
 import { cn } from "../../utils/style";
 
-export interface LogoProps extends ImageProps {
-  /** Name of the shop for alt text or fallback */
-  shopName: string;
+type Viewport = "desktop" | "tablet" | "mobile";
+
+interface LogoSource {
+  src: ImageProps["src"];
+  width?: number;
+  height?: number;
+}
+
+export interface LogoProps
+  extends Omit<ImageProps, "alt" | "src" | "width" | "height"> {
+  /** Text to display when no image source is available */
+  fallbackText: string;
+  /** Default image source */
+  src?: ImageProps["src"];
+  /** Responsive sources keyed by viewport */
+  sources?: Partial<Record<Viewport, LogoSource>>;
+  width?: number;
+  height?: number;
+  alt?: string;
 }
 
 export const Logo = React.forwardRef<HTMLImageElement, LogoProps>(
@@ -12,31 +29,54 @@ export const Logo = React.forwardRef<HTMLImageElement, LogoProps>(
     {
       className,
       src,
+      sources,
       alt,
-      shopName,
+      fallbackText,
       width = 32,
       height = 32,
+      srcSet,
+      sizes,
       ...props
     },
-    ref
+    ref,
   ) => {
-    const altText = alt ?? shopName;
-    if (!src) {
-      return <span className={cn("font-bold", className)}>{shopName}</span>;
+    const viewport = useViewport();
+    const responsive = sources?.[viewport];
+    const imageSrc = responsive?.src ?? src;
+    const imageWidth = responsive?.width ?? width;
+    const imageHeight = responsive?.height ?? height;
+
+    const computedSrcSet =
+      srcSet ??
+      (sources
+        ? Object.values(sources)
+            .filter((s) => s.width)
+            .map((s) => `${s.src} ${s.width}w`)
+            .join(", ")
+        : undefined);
+
+    const altText = alt ?? fallbackText;
+
+    if (!imageSrc) {
+      return <span className={cn("font-bold", className)}>{fallbackText}</span>;
     }
-    const widthClass = `w-[${width}px]`;
-    const heightClass = `h-[${height}px]`;
+
+    const widthClass = `w-[${imageWidth}px]`;
+    const heightClass = `h-[${imageHeight}px]`;
+
     return (
       <Image
         ref={ref}
-        src={src}
+        src={imageSrc}
         alt={altText}
-        width={width}
-        height={height}
+        width={imageWidth}
+        height={imageHeight}
+        srcSet={computedSrcSet}
+        sizes={sizes}
         className={cn(widthClass, heightClass, className)}
         {...props}
       />
     );
-  }
+  },
 );
 Logo.displayName = "Logo";

--- a/packages/ui/src/components/atoms/__tests__/Logo.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Logo.test.tsx
@@ -2,17 +2,45 @@ import "../../../../../../test/resetNextMocks";
 import { render, screen } from "@testing-library/react";
 import { Logo } from "../Logo";
 
+import useViewport from "../../../hooks/useViewport";
+jest.mock("../../../hooks/useViewport");
+const mockedUseViewport = useViewport as jest.Mock;
+
 describe("Logo", () => {
+  beforeEach(() => {
+    mockedUseViewport.mockReset();
+  });
+
   it("renders an image when src is provided", () => {
-    render(<Logo src="/logo.png" shopName="Acme" />);
+    mockedUseViewport.mockReturnValue("desktop");
+    render(<Logo src="/logo.png" fallbackText="Acme" />);
     const img = screen.getByRole("img");
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute("src", "/logo.png");
     expect(img).toHaveAttribute("alt", "Acme");
   });
 
-  it("renders fallback text when src is undefined", () => {
-    render(<Logo src={undefined} shopName="Shop" />);
+  it("selects the correct source for the current viewport", () => {
+    mockedUseViewport.mockReturnValue("mobile");
+    render(
+      <Logo
+        fallbackText="Shop"
+        sources={{
+          mobile: { src: "/logo-mobile.png", width: 100, height: 50 },
+          desktop: { src: "/logo-desktop.png", width: 200, height: 100 },
+        }}
+      />,
+    );
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "/logo-mobile.png");
+    expect(img).toHaveAttribute(
+      "srcset",
+      "/logo-mobile.png 100w, /logo-desktop.png 200w",
+    );
+  });
+
+  it("renders fallback text when no source is available", () => {
+    render(<Logo fallbackText="Shop" />);
     expect(screen.getByText("Shop")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/organisms/Footer.tsx
+++ b/packages/ui/src/components/organisms/Footer.tsx
@@ -31,7 +31,7 @@ export const Footer = React.forwardRef<HTMLDivElement, FooterProps>(
           width={logo?.width}
           height={logo?.height}
           alt={shopName}
-          textFallback={shopName}
+          fallbackText={shopName}
           className="font-bold"
         />
         <nav className="ml-auto flex gap-4 text-sm">

--- a/packages/ui/src/components/organisms/Header.tsx
+++ b/packages/ui/src/components/organisms/Header.tsx
@@ -50,7 +50,7 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
                 width={logo?.width}
                 height={logo?.height}
                 alt={shopName}
-                textFallback={shopName}
+                fallbackText={shopName}
                 className="font-bold"
               />
             </a>


### PR DESCRIPTION
## Summary
- support viewport-based logo sources and `srcSet`/`sizes`
- require `fallbackText` and default `alt` to shop name
- test responsive image selection and text fallback

## Testing
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/atoms/__tests__/Logo.test.tsx --runInBand --config ../../jest.config.cjs`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c039d90dd8832faf239b064dde18c3