### PR TITLE
fix: ensure session secret added during deploy

### DIFF
--- a/packages/platform-core/src/createShop/index.ts
+++ b/packages/platform-core/src/createShop/index.ts
@@ -162,28 +162,26 @@ function deployShopImpl(
     adapter.scaffold(newApp);
       const envRel = join(newApp, ".env");
       const envAbs = join(repoRoot(), envRel);
-      const envPath = fs.existsSync(envAbs) ? envAbs : envRel;
-      const envFile = fs.existsSync(envRel)
-        ? envRel
-        : fs.existsSync(envAbs)
-        ? envAbs
-        : null;
 
-      if (envFile) {
-        let env = fs.readFileSync(envFile, "utf8");
-        const secret = `SESSION_SECRET=${genSecret(32)}`;
-        if (/^SESSION_SECRET=/m.test(env)) {
-          env = env.replace(/^SESSION_SECRET=.*$/m, secret);
-        } else {
-          env += (env.endsWith("\n") ? "" : "\n") + secret + "\n";
-        }
+      let env = "";
+      try {
+        env = fs.readFileSync(fs.existsSync(envAbs) ? envAbs : envRel, "utf8");
+      } catch {
+        /* no existing env file */
+      }
 
-        for (const p of new Set([envRel, envAbs])) {
-          try {
-            fs.writeFileSync(p, env);
-          } catch {
-            /* ignore write errors */
-          }
+      const secret = `SESSION_SECRET=${genSecret(32)}`;
+      if (/^SESSION_SECRET=/m.test(env)) {
+        env = env.replace(/^SESSION_SECRET=.*$/m, secret);
+      } else {
+        env += (env.endsWith("\n") ? "" : "\n") + secret + "\n";
+      }
+
+      for (const p of new Set([envRel, envAbs])) {
+        try {
+          fs.writeFileSync(p, env);
+        } catch {
+          /* ignore write errors */
         }
       }
   } catch (err) {


### PR DESCRIPTION
## Summary
- write SESSION_SECRET to shop .env during deploy

## Testing
- `pnpm --filter @acme/platform-core run check:references` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build` *(fails: Parameter 'order' implicitly has an 'any' type)*
- `pnpm exec jest packages/platform-core/__tests__/deployShopImpl.test.ts --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c03a886dc8832f943731e5d6d88144