### PR TITLE
Record page creation in page history

### DIFF
--- a/packages/platform-core/src/repositories/pages/pages.json.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.json.server.ts
@@ -95,10 +95,8 @@ export async function savePage(
   if (idx === -1) pages.push(page);
   else pages[idx] = page;
   await writePages(shop, pages);
-  if (previous) {
-    const patch = diffPages(previous, page);
-    await appendHistory(shop, patch);
-  }
+  const patch = diffPages(previous, page);
+  await appendHistory(shop, patch);
   return page;
 }
 

--- a/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
@@ -88,10 +88,8 @@ export async function savePage(
         data: page as unknown as JsonObject,
       },
     });
-    if (previous) {
-      const patch = diffPages(previous, page);
-      await appendHistory(shop, patch);
-    }
+    const patch = diffPages(previous, page);
+    await appendHistory(shop, patch);
     return page;
   } catch (err) {
     console.error(`Failed to save page ${page.id} for ${shop}`, err);


### PR DESCRIPTION
## Summary
- always append a diff entry when saving pages so new pages are recorded in history
- mirror this behavior in the Prisma-backed repository

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build`
- `pnpm --filter @acme/platform-core test -- __tests__/pagesRepoFallback.test.ts` *(fails coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68c03b057b84832f8e40ebbbe8244944