### PR TITLE
test: ensure config diff omitted when diff param missing

### DIFF
--- a/apps/api/src/routes/components/__tests__/onRequest.test.ts
+++ b/apps/api/src/routes/components/__tests__/onRequest.test.ts
@@ -236,6 +236,48 @@ describe('onRequest route', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('omits config diff when diff query param absent', async () => {
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
+    verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });
+    const root = path.resolve(__dirname, '../../../../../../..');
+    vol.fromJSON({
+      [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
+        componentVersions: { '@acme/button': '1.0.0' },
+      }),
+      [`${root}/packages/button/package.json`]: JSON.stringify({
+        name: '@acme/button',
+        version: '1.1.0',
+      }),
+      [`${root}/packages/button/CHANGELOG.md`]: '# Changelog\n\nFixed bug\n',
+      [`${root}/apps/shop-abc/src/templates/main.html`]: 'app',
+      [`${root}/packages/template-app/src/templates/main.html`]: 'template',
+      [`${root}/apps/shop-abc/src/translations/en.json`]: '{}',
+      [`${root}/packages/template-app/src/translations/en.json`]: '{"foo":"bar"}',
+    });
+
+    const res = await onRequest({
+      params: { shopId: 'abc' },
+      request: new Request('http://localhost', {
+        headers: { authorization: 'Bearer good' },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      components: [
+        {
+          name: '@acme/button',
+          from: '1.0.0',
+          to: '1.1.0',
+          summary: 'Fixed bug',
+          changelog: 'packages/button/CHANGELOG.md',
+        },
+      ],
+    });
+    expect(json).not.toHaveProperty('configDiff');
+  });
+
   it('returns components and config diff when diff requested', async () => {
     process.env.UPGRADE_PREVIEW_TOKEN_SECRET = 'secret';
     verify.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 60 });


### PR DESCRIPTION
## Summary
- ensure `onRequest` omits `configDiff` when diff param is missing

## Testing
- `pnpm exec jest apps/api/src/routes/components/__tests__/onRequest.test.ts --coverage=false`
- `pnpm -r build` *(fails: packages/ui build: src/components/organisms/Footer.tsx(30,11): Type 'string | undefined' is not assignable to type 'string | StaticImport')*


------
https://chatgpt.com/codex/tasks/task_e_68c03c3ebccc832f987c339d30567372