### PR TITLE
test: verify diffDirectories identical

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -160,6 +160,16 @@ describe('component helpers', () => {
   });
 
   describe('diffDirectories', () => {
+    it('returns empty array when directories are identical', () => {
+      vol.fromJSON({
+        '/a/same.txt': 'hello',
+        '/a/sub/deep.txt': 'world',
+        '/b/same.txt': 'hello',
+        '/b/sub/deep.txt': 'world',
+      });
+      expect(diffDirectories('/a', '/b')).toEqual([]);
+    });
+
     it('detects files present in only one directory', () => {
       vol.fromJSON({ '/a/only.txt': 'hello' });
       expect(diffDirectories('/a', '/b')).toEqual(['only.txt']);


### PR DESCRIPTION
## Summary
- ensure diffDirectories returns no changes when directories are identical

## Testing
- `pnpm -r build` *(fails: TS2322 and TS2741 in packages/ui)*
- `pnpm exec jest apps/api/src/routes/components/__tests__/helpers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c03c3f5680832fb7cdddf908c78e37