### PR TITLE
test(auth): add requirePermission tests

### DIFF
--- a/packages/auth/src/__tests__/requirePermission.test.ts
+++ b/packages/auth/src/__tests__/requirePermission.test.ts
@@ -1,0 +1,53 @@
+import { jest } from "@jest/globals";
+
+const getCustomerSession = jest.fn();
+const hasPermission = jest.fn();
+
+jest.mock("../session", () => ({ getCustomerSession }));
+jest.mock("../permissions", () => ({ hasPermission }));
+
+describe("requirePermission", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("rejects with Unauthorized when no session", async () => {
+    getCustomerSession.mockResolvedValue(null);
+
+    const { requirePermission } = await import("../requirePermission");
+
+    await expect(
+      requirePermission("manage_orders")
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects with Unauthorized when permission is missing", async () => {
+    getCustomerSession.mockResolvedValue({
+      customerId: "cust",
+      role: "viewer",
+    });
+    hasPermission.mockReturnValue(false);
+
+    const { requirePermission } = await import("../requirePermission");
+
+    await expect(
+      requirePermission("manage_orders")
+    ).rejects.toThrow("Unauthorized");
+    expect(hasPermission).toHaveBeenCalledWith("viewer", "manage_orders");
+  });
+
+  it("returns session when permission is granted", async () => {
+    const session = { customerId: "cust", role: "admin" } as const;
+    getCustomerSession.mockResolvedValue(session);
+    hasPermission.mockReturnValue(true);
+
+    const { requirePermission } = await import("../requirePermission");
+
+    await expect(
+      requirePermission("manage_orders")
+    ).resolves.toEqual(session);
+    expect(hasPermission).toHaveBeenCalledWith("admin", "manage_orders");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add coverage for `requirePermission` covering unauthenticated, unauthorized, and valid session scenarios

## Testing
- `pnpm --filter @acme/auth test src/__tests__/requirePermission.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c03d03d67c832f98239b871b9093aa