### PR TITLE
test(auth): add unknown role permission test

### DIFF
--- a/packages/auth/src/__tests__/permissions.test.ts
+++ b/packages/auth/src/__tests__/permissions.test.ts
@@ -8,4 +8,8 @@ describe("hasPermission", () => {
   it("returns false when role lacks permission", () => {
     expect(hasPermission("viewer", "checkout")).toBe(false);
   });
+
+  it("returns false for unknown role", () => {
+    expect(hasPermission("ghost" as any, "view_products")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add test asserting `hasPermission` returns false for unknown roles

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'string | undefined' is not assignable to type 'string | StaticImport')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/auth exec jest src/__tests__/permissions.test.ts --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c03d04b4a4832f9425bf277691395c