### PR TITLE
test: handle undefined smembers

### DIFF
--- a/packages/auth/src/__tests__/redisStore.test.ts
+++ b/packages/auth/src/__tests__/redisStore.test.ts
@@ -101,6 +101,14 @@ describe("RedisSessionStore", () => {
     expect(client.mget).not.toHaveBeenCalled();
   });
 
+  it("returns empty array when smembers returns undefined", async () => {
+    (client.smembers as jest.Mock).mockResolvedValue(undefined as any);
+
+    const list = await store.list("cust");
+    expect(list).toEqual([]);
+    expect(client.mget).not.toHaveBeenCalled();
+  });
+
   it("deletes sessions", async () => {
     const record = createRecord("s1");
     await store.set(record);


### PR DESCRIPTION
## Summary
- add RedisSessionStore test for smembers returning undefined

## Testing
- `pnpm --filter @acme/auth test src/__tests__/redisStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c03d0949cc832fbbede4ac75c860cc