### PR TITLE
test(configurator): handle undefined provider type

### DIFF
--- a/packages/configurator/__tests__/providers.test.ts
+++ b/packages/configurator/__tests__/providers.test.ts
@@ -31,6 +31,13 @@ describe("providersByType", () => {
     expect(providersByType("unknown" as any)).toEqual([]);
   });
 
+  it("returns empty array for undefined type without mutating providers", () => {
+    const original = [...providers];
+    const result = providersByType(undefined as any);
+    expect(result).toEqual([]);
+    expect(providers).toEqual(original);
+  });
+
   it("returns new arrays without mutating original providers list", () => {
     const original = [...providers];
     const result = providersByType("payment");


### PR DESCRIPTION
## Summary
- add coverage for invoking `providersByType` with undefined
- ensure original providers list is unchanged

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test --filter @acme/configurator` *(fails: Test failed; 1 failed, 11 passed)*
- `pnpm --filter @acme/configurator test --runTestsByPath __tests__/providers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c03d133f20832fb47d290333e433ed