### PR TITLE
test(email): assert provider helper rejects on errors

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -165,6 +165,108 @@ describe("provider functions", () => {
     expect(segments).toEqual([{ id: "s1", name: "All" }]);
   });
 
+  it("createContact rejects when Sendgrid provider throws", async () => {
+    const err = new Error("sendgrid createContact");
+    jest.doMock("../providers/sendgrid", () => ({
+      SendgridProvider: class {
+        createContact = jest.fn(() => {
+          throw err;
+        });
+        addToList = jest.fn();
+        listSegments = jest.fn();
+      },
+    }));
+
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    const { createContact } = await import("../segments");
+    await expect(createContact("user@example.com")).rejects.toBe(err);
+  });
+
+  it("addToList rejects when Sendgrid provider throws", async () => {
+    const err = new Error("sendgrid addToList");
+    jest.doMock("../providers/sendgrid", () => ({
+      SendgridProvider: class {
+        createContact = jest.fn().mockResolvedValue("contact-1");
+        addToList = jest.fn(() => {
+          throw err;
+        });
+        listSegments = jest.fn();
+      },
+    }));
+
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    const { addToList } = await import("../segments");
+    await expect(addToList("c1", "l1")).rejects.toBe(err);
+  });
+
+  it("listSegments rejects when Sendgrid provider throws", async () => {
+    const err = new Error("sendgrid listSegments");
+    jest.doMock("../providers/sendgrid", () => ({
+      SendgridProvider: class {
+        createContact = jest.fn();
+        addToList = jest.fn();
+        listSegments = jest.fn(() => {
+          throw err;
+        });
+      },
+    }));
+
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    const { listSegments } = await import("../segments");
+    await expect(listSegments()).rejects.toBe(err);
+  });
+
+  it("createContact rejects when Resend provider throws", async () => {
+    const err = new Error("resend createContact");
+    jest.doMock("../providers/resend", () => ({
+      ResendProvider: class {
+        createContact = jest.fn(() => {
+          throw err;
+        });
+        addToList = jest.fn();
+        listSegments = jest.fn();
+      },
+    }));
+
+    process.env.EMAIL_PROVIDER = "resend";
+    const { createContact } = await import("../segments");
+    await expect(createContact("user@example.com")).rejects.toBe(err);
+  });
+
+  it("addToList rejects when Resend provider throws", async () => {
+    const err = new Error("resend addToList");
+    jest.doMock("../providers/resend", () => ({
+      ResendProvider: class {
+        createContact = jest.fn().mockResolvedValue("contact-1");
+        addToList = jest.fn(() => {
+          throw err;
+        });
+        listSegments = jest.fn();
+      },
+    }));
+
+    process.env.EMAIL_PROVIDER = "resend";
+    const { addToList } = await import("../segments");
+    await expect(addToList("c1", "l1")).rejects.toBe(err);
+  });
+
+  it("listSegments rejects when Resend provider throws", async () => {
+    const err = new Error("resend listSegments");
+    jest.doMock("../providers/resend", () => ({
+      ResendProvider: class {
+        createContact = jest.fn();
+        addToList = jest.fn();
+        listSegments = jest.fn(() => {
+          throw err;
+        });
+      },
+    }));
+
+    process.env.EMAIL_PROVIDER = "resend";
+    const { listSegments } = await import("../segments");
+    await expect(listSegments()).rejects.toBe(err);
+  });
+
   it("returns empty list for unknown provider", async () => {
     process.env.EMAIL_PROVIDER = "unknown";
     const { listSegments } = await import("../segments");


### PR DESCRIPTION
## Summary
- ensure Sendgrid helper functions propagate provider errors
- cover Resend provider for consistent error handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Property 'srcSet' does not exist on type 'LogoProps')*
- `pnpm --filter @acme/email build`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c049ad4d1c832fb7a8225b398fa9e7