### PR TITLE
test: validate segment cache ttl

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -220,6 +220,34 @@ describe("resolveSegment filters", () => {
   });
 });
 
+describe("cacheTtl", () => {
+  const originalTtl = process.env.SEGMENT_CACHE_TTL;
+
+  afterEach(() => {
+    if (originalTtl === undefined) delete process.env.SEGMENT_CACHE_TTL;
+    else process.env.SEGMENT_CACHE_TTL = originalTtl;
+    jest.resetModules();
+  });
+
+  it("returns default when ttl is negative", async () => {
+    process.env.SEGMENT_CACHE_TTL = "-1";
+    const { cacheTtl } = await import("../segments");
+    expect(cacheTtl()).toBe(60_000);
+  });
+
+  it("returns default when ttl is zero", async () => {
+    process.env.SEGMENT_CACHE_TTL = "0";
+    const { cacheTtl } = await import("../segments");
+    expect(cacheTtl()).toBe(60_000);
+  });
+
+  it("returns default when ttl is non-numeric", async () => {
+    process.env.SEGMENT_CACHE_TTL = "abc";
+    const { cacheTtl } = await import("../segments");
+    expect(cacheTtl()).toBe(60_000);
+  });
+});
+
 describe("resolveSegment caching", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -342,6 +370,9 @@ describe("resolveSegment events", () => {
     jest.resetModules();
     jest.clearAllMocks();
   });
+  afterEach(() => {
+    delete process.env.SEGMENT_CACHE_TTL;
+  });
 
   it("resolves emails from segment events when no definition exists", async () => {
     mockReadFile.mockResolvedValue("[]");
@@ -373,7 +404,6 @@ describe("resolveSegment events", () => {
     expect(r1).toEqual(["a@example.com"]);
     expect(r2).toEqual(["a@example.com"]);
     expect(mockListEvents).toHaveBeenCalledTimes(1);
-    delete process.env.SEGMENT_CACHE_TTL;
   });
 });
 

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -42,7 +42,7 @@ export async function readSegments(shop: string): Promise<SegmentDef[]> {
   }
 }
 
-function cacheTtl(): number {
+export function cacheTtl(): number {
   const ttl = Number(process.env.SEGMENT_CACHE_TTL);
   return Number.isFinite(ttl) && ttl > 0 ? ttl : 60_000;
 }


### PR DESCRIPTION
## Summary
- export `cacheTtl` and test negative, zero, and non-numeric `SEGMENT_CACHE_TTL`
- restore environment variables after each segment test

## Testing
- `pnpm -r build` *(fails: packages/ui build error)*
- `pnpm --filter @acme/email run check:references` *(fails: script not found)*
- `pnpm --filter @acme/email run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/email test -- src/__tests__/segments.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c049abd378832f8584579753cf3f8f