### PR TITLE
test: restore mocks between platform-core tests

### DIFF
--- a/packages/platform-core/__tests__/createShop.unit.test.ts
+++ b/packages/platform-core/__tests__/createShop.unit.test.ts
@@ -28,6 +28,9 @@ describe('createShop', () => {
     vol.reset();
     jest.clearAllMocks();
   });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   it('validates name, merges overrides, and writes shop.json', async () => {
     const { createShop } = await import('../src/createShop');
@@ -93,6 +96,7 @@ describe('createShop', () => {
     expect(deploySpy).toHaveBeenCalledWith('mocked', undefined, adapter);
     expect(deploySpy.getMockImplementation()).not.toBe(originalImpl);
     expect(result).toEqual({ status: 'success' });
+    deploySpy.mockRestore();
   });
 });
 

--- a/packages/platform-core/__tests__/deployShopImpl.test.ts
+++ b/packages/platform-core/__tests__/deployShopImpl.test.ts
@@ -51,3 +51,7 @@ describe('deployShopImpl', () => {
   });
 });
 
+afterAll(() => {
+  jest.resetModules();
+});
+


### PR DESCRIPTION
## Summary
- restore Jest mocks after each `createShop` unit test
- reset module registry after `deployShopImpl` tests

## Testing
- `pnpm --filter @acme/platform-core test -- __tests__/createShop.unit.test.ts __tests__/deployShop.test.ts`
- `pnpm --filter @acme/platform-core test -- __tests__/deployShopImpl.test.ts __tests__/deployShop.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c04919e134832f89c26468528099a4