### PR TITLE
test: add resolveDataRoot parent directory test

### DIFF
--- a/packages/email/__tests__/resolveDataRoot-parent.test.ts
+++ b/packages/email/__tests__/resolveDataRoot-parent.test.ts
@@ -1,0 +1,27 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { resolveDataRoot } from "../src/cli";
+
+// Ensure temporary directories are removed after test
+
+describe("resolveDataRoot", () => {
+  it("walks up to parent data/shops", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "email-cli-test-"));
+    const shops = path.join(tmp, "data", "shops");
+    const nested = path.join(tmp, "nested", "workdir");
+    await fs.mkdir(shops, { recursive: true });
+    await fs.mkdir(nested, { recursive: true });
+
+    const original = process.cwd();
+    try {
+      process.chdir(nested);
+      const resolved = resolveDataRoot();
+      expect(resolved).toBe(shops);
+    } finally {
+      process.chdir(original);
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- test resolveDataRoot against parent data/shops directories

## Testing
- `pnpm -r build` *(fails: Property 'srcSet' does not exist on type 'LogoProps')*
- `pnpm --filter @acme/email exec jest __tests__/resolveDataRoot-parent.test.ts --runTestsByPath --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68c049a7d464832fbd4f368e34926c0e