### PR TITLE
test(email): add unsubscribe URL test

### DIFF
--- a/packages/email/src/__tests__/unsubscribeUrl.test.ts
+++ b/packages/email/src/__tests__/unsubscribeUrl.test.ts
@@ -1,0 +1,18 @@
+import { unsubscribeUrl } from "../scheduler";
+
+describe("unsubscribeUrl", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+  });
+
+  test("encodes parameters and applies base URL", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://base.example.com";
+    const shop = "shop/ü? ";
+    const campaign = "camp &aign/?";
+    const email = "user+tag@example.com";
+    const url = unsubscribeUrl(shop, campaign, email);
+    expect(url).toBe(
+      `https://base.example.com/api/marketing/email/unsubscribe?shop=${encodeURIComponent(shop)}&campaign=${encodeURIComponent(campaign)}&email=${encodeURIComponent(email)}`,
+    );
+  });
+});

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -33,7 +33,11 @@ function trackedBody(shop: string, id: string, body: string): string {
   );
 }
 
-function unsubscribeUrl(shop: string, campaign: string, recipient: string): string {
+export function unsubscribeUrl(
+  shop: string,
+  campaign: string,
+  recipient: string,
+): string {
   const base = process.env.NEXT_PUBLIC_BASE_URL || "";
   return `${base}/api/marketing/email/unsubscribe?shop=${encodeURIComponent(
     shop,


### PR DESCRIPTION
## Summary
- export `unsubscribeUrl` utility
- add tests for unsubscribe URL encoding and base URL env

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email build`
- `pnpm exec jest --runTestsByPath packages/email/src/__tests__/unsubscribeUrl.test.ts --config packages/email/jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c049ab3848832fa29d85953b038950