### PR TITLE
test(email): add bin script test

### DIFF
--- a/packages/email/src/__tests__/bin.test.ts
+++ b/packages/email/src/__tests__/bin.test.ts
@@ -1,0 +1,25 @@
+/** @jest-environment node */
+
+const run = jest.fn((argv = process.argv) => undefined);
+jest.mock("../cli", () => ({ run }));
+
+describe("bin", () => {
+  const originalArgv = process.argv;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("calls run with process.argv", () => {
+    const argv = ["node", "email", "test"];
+    process.argv = argv;
+
+    jest.isolateModules(() => {
+      require("../bin");
+    });
+
+    expect(run).toHaveBeenCalledWith(argv);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for email bin to ensure CLI run is invoked with process arguments

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm install`
- `pnpm --filter @acme/email test` *(fails: Error sending email at packages/email/src/sendEmail.ts:40)*

------
https://chatgpt.com/codex/tasks/task_e_68c049af3cbc832f8d0cc4747f5b7cab