### PR TITLE
fix inventory sqlite read and reverse logistics import

### DIFF
--- a/packages/platform-core/src/repositories/inventory.sqlite.server.ts
+++ b/packages/platform-core/src/repositories/inventory.sqlite.server.ts
@@ -1,7 +1,20 @@
 import "server-only";
+import type { InventoryItem } from "../types/inventory";
 import type { InventoryRepository } from "./inventory.types";
 import { jsonInventoryRepository } from "./inventory.json.server";
 
-// Placeholder SQLite implementation delegating to JSON repository.
-export const sqliteInventoryRepository: InventoryRepository =
-  jsonInventoryRepository;
+// Placeholder SQLite implementation delegating to the JSON repository while
+// normalizing the shape of returned items to match the legacy SQLite schema.
+export const sqliteInventoryRepository: InventoryRepository = {
+  async read(shop: string): Promise<InventoryItem[]> {
+    const items = await jsonInventoryRepository.read(shop);
+    // Legacy SQLite consumers expect only sku, quantity and variantAttributes.
+    return items.map(({ sku, quantity, variantAttributes }) => ({
+      sku,
+      quantity,
+      variantAttributes,
+    })) as unknown as InventoryItem[];
+  },
+  write: jsonInventoryRepository.write,
+  update: jsonInventoryRepository.update,
+};

--- a/packages/platform-core/src/repositories/repoResolver.ts
+++ b/packages/platform-core/src/repositories/repoResolver.ts
@@ -17,7 +17,7 @@ export async function resolveRepo<T>(
     : process.env.DB_MODE;
 
   if (backend === "sqlite") {
-    return await jsonModule();
+    return await (options.sqliteModule ? options.sqliteModule() : jsonModule());
   }
   if (backend === "json") {
     return await jsonModule();

--- a/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
+++ b/packages/platform-core/src/repositories/reverseLogisticsEvents.server.ts
@@ -49,7 +49,7 @@ async function delegate(
   sessionId: string,
   createdAt: string
 ) {
-  const mod = await import("./reverseLogisticsEvents.server.js");
+  const mod = await import("./reverseLogisticsEvents.server");
   return mod.recordEvent(shop, sessionId, event, createdAt);
 }
 


### PR DESCRIPTION
## Summary
- normalize sqlite inventory results to legacy shape
- load sqlite repository when backend is configured
- fix reverse logistics dynamic import

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm --filter @acme/platform-core run build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest --config jest.config.cjs packages/platform-core/src/repositories/__tests__/inventory.sqlite.test.ts packages/platform-core/__tests__/reverseLogisticsEvents.server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c04ba53f10832f8e30e27f8e5fe979