### PR TITLE
Handle invalid late fee env values

### DIFF
--- a/packages/platform-machine/src/lateFeeService.ts
+++ b/packages/platform-machine/src/lateFeeService.ts
@@ -110,20 +110,20 @@ export async function resolveConfig(
   } catch {}
 
   const envEnabled = process.env[envKey(shop, "ENABLED")];
-  if (envEnabled !== undefined) {
-    config.enabled = envEnabled !== "false";
-    } else if (
-      coreEnv.LATE_FEE_ENABLED !== undefined &&
-      coreEnv.LATE_FEE_ENABLED !== null
-    ) {
-      config.enabled = coreEnv.LATE_FEE_ENABLED as boolean;
-    }
+  if (envEnabled === "true" || envEnabled === "false") {
+    config.enabled = envEnabled === "true";
+  } else if (
+    coreEnv.LATE_FEE_ENABLED !== undefined &&
+    coreEnv.LATE_FEE_ENABLED !== null
+  ) {
+    config.enabled = coreEnv.LATE_FEE_ENABLED as boolean;
+  }
 
-    const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
-    if (envInterval !== undefined) {
-      const num = Number(envInterval);
-      if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
-    } else if (
+  const envInterval = process.env[envKey(shop, "INTERVAL_MS")];
+  if (envInterval !== undefined) {
+    const num = Number(envInterval);
+    if (!Number.isNaN(num)) config.intervalMinutes = Math.round(num / 60000);
+    else if (
       coreEnv.LATE_FEE_INTERVAL_MS !== undefined &&
       coreEnv.LATE_FEE_INTERVAL_MS !== null
     ) {
@@ -131,6 +131,14 @@ export async function resolveConfig(
         (coreEnv.LATE_FEE_INTERVAL_MS as number) / 60000,
       );
     }
+  } else if (
+    coreEnv.LATE_FEE_INTERVAL_MS !== undefined &&
+    coreEnv.LATE_FEE_INTERVAL_MS !== null
+  ) {
+    config.intervalMinutes = Math.round(
+      (coreEnv.LATE_FEE_INTERVAL_MS as number) / 60000,
+    );
+  }
 
   if (override.enabled !== undefined) config.enabled = override.enabled;
   if (override.intervalMinutes !== undefined)


### PR DESCRIPTION
## Summary
- ensure late fee config ignores malformed shop env vars and falls back to core defaults

## Testing
- `pnpm exec tsc -b packages/platform-machine/tsconfig.json --pretty --dry`
- `pnpm --filter @acme/platform-machine run build`
- `pnpm --filter @acme/platform-machine run lint`
- `pnpm exec jest packages/platform-machine/src/__tests__/lateFeeService.test.ts --config jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c04c280404832f8ccbe331ab14f345