### PR TITLE
fix: align test selectors with global data-cy attribute

### DIFF
--- a/packages/ui/src/components/atoms/LineChart.tsx
+++ b/packages/ui/src/components/atoms/LineChart.tsx
@@ -33,7 +33,7 @@ export function LineChart({ data, options, className }: LineChartProps) {
       data={data}
       options={options}
       className={className}
-      data-testid="line-chart"
+      data-cy="line-chart"
     />
   );
 }

--- a/packages/ui/src/components/atoms/__tests__/LineChart.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/LineChart.test.tsx
@@ -27,7 +27,7 @@ describe("LineChart", () => {
         data,
         options,
         className: "custom",
-        "data-testid": "line-chart",
+        "data-cy": "line-chart",
       }),
     );
   });

--- a/packages/ui/src/hooks/__tests__/useTokenEditor.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useTokenEditor.test.tsx
@@ -73,7 +73,7 @@ describe("useTokenEditor", () => {
         setTokens((prev) => ({ ...prev, ...t }));
       const hook = useTokenEditor(tokens, {}, handleChange);
       upload = hook.handleUpload; // assigned synchronously
-      return <span data-testid="mono">{hook.monoFonts.join(",")}</span>;
+      return <span data-cy="mono">{hook.monoFonts.join(",")}</span>;
     }
 
     render(<Wrapper />);


### PR DESCRIPTION
## Summary
- use `data-cy` for LineChart test hook
- update tests to query `data-cy` elements

## Testing
- `pnpm exec jest packages/ui/src/components/atoms/__tests__/LineChart.test.tsx packages/ui/src/hooks/__tests__/useTokenEditor.test.tsx --runInBand`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui run build` *(fails: Cannot find module '@acme/ui' or its corresponding type declarations...)*

------
https://chatgpt.com/codex/tasks/task_e_68c05706ce08832f87584b3e0e9bff4f