### PR TITLE
fix useProductFilters test id

### DIFF
--- a/packages/ui/src/hooks/__tests__/useProductFilters.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useProductFilters.test.tsx
@@ -72,7 +72,7 @@ function Wrapper({
   }, [search, status, setSearch, setStatus]); // <- added missing deps
 
   return (
-    <span data-testid="ids">{filteredRows.map((p) => p.id).join(",")}</span>
+    <span data-cy="ids">{filteredRows.map((p) => p.id).join(",")}</span>
   );
 }
 


### PR DESCRIPTION
## Summary
- fix test ID in `useProductFilters` tests to match project configuration

## Testing
- `pnpm --filter @acme/ui exec jest packages/ui/src/hooks/__tests__/useProductFilters.test.tsx --config ../../jest.config.cjs --coverage=false`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c056e8c6bc832fa50cbbba95bf7257