### PR TITLE
test(ui): align product editor tests with data-cy attributes

### DIFF
--- a/packages/ui/src/hooks/__tests__/useProductEditorFormState.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useProductEditorFormState.test.tsx
@@ -58,19 +58,19 @@ function Wrapper({
   return (
     <form onSubmit={state.handleSubmit}>
       <input
-        data-testid="title-en"
+        data-cy="title-en"
         name="title_en"
         value={state.product.title.en}
         onChange={state.handleChange}
       />
       <input
-        data-testid="price"
+        data-cy="price"
         name="price"
         value={state.product.price}
         onChange={state.handleChange}
       />
       <input
-        data-testid="variant-size"
+        data-cy="variant-size"
         name="variant_size"
         value={state.product.variants.size.join(",")}
         onChange={state.handleChange}


### PR DESCRIPTION
## Summary
- use `data-cy` attributes in `useProductEditorFormState` tests to match Testing Library configuration

## Testing
- `pnpm exec jest packages/ui/src/hooks/__tests__/useProductEditorFormState.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c056d99ac0832fbc6a1431644ea716