### PR TITLE
fix tests for image upload and footer

### DIFF
--- a/packages/ui/__tests__/FooterBlock.test.tsx
+++ b/packages/ui/__tests__/FooterBlock.test.tsx
@@ -1,12 +1,28 @@
 import { render, screen } from "@testing-library/react";
 import FooterBlock from "../src/components/cms/blocks/FooterBlock";
 
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
 describe("FooterBlock", () => {
   it("renders links and logo when provided", () => {
     render(
       <FooterBlock
         locale={"en" as any}
-        logo="Brand"
+        shopName="Brand"
         links={[{ label: "About", href: "/about" }]}
       />,
     );

--- a/packages/ui/src/hooks/__tests__/useImageUpload.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useImageUpload.test.tsx
@@ -11,7 +11,7 @@ jest.mock("../../components/cms/ImageUploaderWithOrientationCheck", () => {
   return {
     __esModule: true,
     default: jest.fn(({ file }: { file: File | null }) => (
-      <div data-testid="uploader">{file ? file.name : "none"}</div>
+      <div data-cy="uploader">{file ? file.name : "none"}</div>
     )),
   };
 });


### PR DESCRIPTION
## Summary
- ensure image upload tests use configured data-cy attribute
- stub matchMedia and fix FooterBlock tests to use shopName

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' during platform-core build)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/ui/src/hooks/__tests__/useImageUpload.test.tsx packages/ui/__tests__/FooterBlock.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c056cb12cc832f840397f5858281a9