### PR TITLE
test: use data-cy for DataTable

### DIFF
--- a/apps/cms/__tests__/DataTable.test.tsx
+++ b/apps/cms/__tests__/DataTable.test.tsx
@@ -16,7 +16,7 @@ const rows: Row[] = [
 
 const columns: Column<Row>[] = [
   { header: "Name", render: (r) => <span>{r.name}</span> },
-  { header: "Age", render: (r) => <span data-testid={`age-${r.id}`}>{r.age}</span> },
+  { header: "Age", render: (r) => <span data-cy={`age-${r.id}`}>{r.age}</span> },
 ];
 
 describe("DataTable", () => {

--- a/packages/ui/__tests__/DataTable.test.tsx
+++ b/packages/ui/__tests__/DataTable.test.tsx
@@ -15,7 +15,7 @@ const columns: Column<Row>[] = [
   {
     header: "Name",
     width: "150px",
-    render: (row) => <span data-testid={`name-${row.name}`}>{row.name}</span>,
+    render: (row) => <span data-cy={`name-${row.name}`}>{row.name}</span>,
   },
   { header: "Age", render: (row) => <span>{row.age}</span> },
 ];


### PR DESCRIPTION
## Summary
- align DataTable tests with global data-cy test id config

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/DataTable.test.tsx`
- `pnpm --filter @apps/cms test apps/cms/__tests__/DataTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c056ba7a18832f9e4e2801085670a4