### PR TITLE
fix: use data-cy for ProductGrid tests

### DIFF
--- a/packages/ui/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/__tests__/ProductGrid.test.tsx
@@ -22,7 +22,7 @@ const products = [
 
 describe("ProductGrid", () => {
   it("renders products with given column count", () => {
-    render(<ProductGrid products={products} columns={2} data-testid="grid" />);
+    render(<ProductGrid products={products} columns={2} data-cy="grid" />);
     expect(screen.getAllByRole("article")).toHaveLength(2);
     expect(screen.getByTestId("grid")).toHaveStyle({
       gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
@@ -45,7 +45,7 @@ describe("ProductGrid", () => {
         products={products}
         minItems={2}
         maxItems={4}
-        data-testid="grid"
+        data-cy="grid"
       />
     );
     const grid = screen.getByTestId("grid") as HTMLElement;
@@ -88,7 +88,7 @@ describe("ProductGrid", () => {
         desktopItems={4}
         tabletItems={2}
         mobileItems={1}
-        data-testid="grid"
+        data-cy="grid"
       />
     );
     const grid = screen.getByTestId("grid") as HTMLElement;

--- a/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
@@ -105,9 +105,9 @@ jest.mock("../../overlays/ProductQuickView", () => ({
     product: Product;
     onAddToCart: (p: Product) => void;
   }) => (
-    <div data-testid={`quickview-${product.id}`}>
+    <div data-cy={`quickview-${product.id}`}>
       <button
-        data-testid="add-to-cart"
+        data-cy="add-to-cart"
         onClick={() => onAddToCart(product)}
       />
     </div>

--- a/packages/ui/src/components/shop/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/shop/__tests__/ProductGrid.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../../organisms/ProductCard", () => {
   return {
     __esModule: true,
     ProductCard: ({ product, showImage, showPrice, ctaLabel }: any) => (
-      <div data-testid="product-card">
+      <div data-cy="product-card">
         {product.title}-{String(showImage)}-{String(showPrice)}-{ctaLabel}
       </div>
     ),
@@ -19,7 +19,7 @@ jest.mock("../../overlays/ProductQuickView", () => {
   return {
     __esModule: true,
     ProductQuickView: ({ product, open }: any) =>
-      open ? <div data-testid="quick-view">{product.title}</div> : null,
+      open ? <div data-cy="quick-view">{product.title}</div> : null,
   };
 });
 


### PR DESCRIPTION
## Summary
- fix ProductGrid tests to use `data-cy` attribute
- align ProductGrid mocks with Testing Library `data-cy` configuration

## Testing
- `pnpm --filter @acme/ui test packages/ui/__tests__/ProductGrid.test.tsx packages/ui/src/components/shop/__tests__/ProductGrid.test.tsx packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c056ab8098832fbf482f4577d21767