### PR TITLE
fix: align canvas spacing tests with data-cy queries

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasSpacing.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasSpacing.test.tsx
@@ -25,7 +25,7 @@ describe("useCanvasSpacing", () => {
       return (
         <div
           ref={ref}
-          data-testid="box"
+          data-cy="box"
           onPointerDown={(e) => hook!.startSpacing(e, "padding", "top")}
         />
       );
@@ -66,7 +66,7 @@ describe("useCanvasSpacing", () => {
       return (
         <div
           ref={ref}
-          data-testid="box"
+          data-cy="box"
           onPointerDown={(e) => hook!.startSpacing(e, "padding", "left")}
         />
       );
@@ -104,7 +104,7 @@ describe("useCanvasSpacing", () => {
       return (
         <div
           ref={ref}
-          data-testid="box"
+          data-cy="box"
           onPointerDown={(e) => hook!.startSpacing(e, "margin", "top")}
         />
       );
@@ -128,4 +128,3 @@ describe("useCanvasSpacing", () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary
- use `data-cy` instead of `data-testid` in `useCanvasSpacing` tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/ui/src/components/cms/page-builder/__tests__/useCanvasSpacing.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c056982a48832f926f1f26d5a85fdc