### PR TITLE
fix product grid test selectors

### DIFF
--- a/packages/ui/src/components/shop/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/shop/__tests__/ProductGrid.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../../organisms/ProductCard", () => {
   return {
     __esModule: true,
     ProductCard: ({ product, showImage, showPrice, ctaLabel }: any) => (
-      <div data-testid="product-card">
+      <div data-cy="product-card">
         {product.title}-{String(showImage)}-{String(showPrice)}-{ctaLabel}
       </div>
     ),
@@ -19,7 +19,7 @@ jest.mock("../../overlays/ProductQuickView", () => {
   return {
     __esModule: true,
     ProductQuickView: ({ product, open }: any) =>
-      open ? <div data-testid="quick-view">{product.title}</div> : null,
+      open ? <div data-cy="quick-view">{product.title}</div> : null,
   };
 });
 


### PR DESCRIPTION
## Summary
- align ProductGrid tests with repo-wide `data-cy` test id convention

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/shop/__tests__/ProductGrid.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c05687f31c832fa61481cf82f80b6d