### PR TITLE
fix ShopSelector test to match data-cy config

### DIFF
--- a/packages/ui/src/components/cms/__tests__/ShopSelector.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ShopSelector.test.tsx
@@ -15,7 +15,7 @@ jest.mock("../../atoms/shadcn", () => {
     __esModule: true,
     Select: ({ value, onValueChange, children }: any) => (
       <select
-        data-testid="shop-select"
+        data-cy="shop-select"
         value={value ?? ""}
         onChange={(e) => onValueChange(e.target.value)}
       >


### PR DESCRIPTION
## Summary
- align ShopSelector test mock with Testing Library's `data-cy` test ID configuration

## Testing
- `pnpm exec jest packages/ui/src/components/cms/__tests__/ShopSelector.test.tsx --config jest.config.cjs --runInBand`
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c05673bcfc832fa302e744488f3f33