### PR TITLE
fix ContentPanel test for custom test id

### DIFF
--- a/packages/ui/src/components/cms/page-builder/panels/__tests__/ContentPanel.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/__tests__/ContentPanel.test.tsx
@@ -5,7 +5,7 @@ import ContentPanel from "../ContentPanel";
 jest.mock("../../editorRegistry", () => ({
   __esModule: true,
   default: {
-    Fancy: (props: any) => <div data-testid="fancy">fancy-{props.component.id}</div>,
+    Fancy: (props: any) => <div data-cy="fancy">fancy-{props.component.id}</div>,
   },
 }));
 


### PR DESCRIPTION
## Summary
- use `data-cy` attribute in mocked editor to match Testing Library config

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/page-builder/panels/__tests__/ContentPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c056675e7c832f9cc49a3662fbe9d5