### PR TITLE
test: align quick view tests with data-cy attribute

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx
@@ -19,10 +19,10 @@ jest.mock("../../overlays/ProductQuickView", () => {
     __esModule: true,
     ProductQuickView: ({ product, open, onOpenChange }: any) =>
       open ? (
-        <div data-testid="quick-view">
+        <div data-cy="quick-view">
           <span>{product.title}</span>
           <button
-            data-testid="close-quick-view"
+            data-cy="close-quick-view"
             onClick={() => onOpenChange(false)}
           >
             Close

--- a/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
@@ -105,9 +105,9 @@ jest.mock("../../overlays/ProductQuickView", () => ({
     product: Product;
     onAddToCart: (p: Product) => void;
   }) => (
-    <div data-testid={`quickview-${product.id}`}>
+    <div data-cy={`quickview-${product.id}`}>
       <button
-        data-testid="add-to-cart"
+        data-cy="add-to-cart"
         onClick={() => onAddToCart(product)}
       />
     </div>

--- a/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
@@ -4,7 +4,7 @@ import type { SKU } from "@acme/types";
 
 jest.mock("../ProductCard", () => ({
   ProductCard: ({ product }: { product: SKU }) => (
-    <div data-testid={`product-${product.id}`} />
+    <div data-cy={`product-${product.id}`} />
   ),
 }));
 


### PR DESCRIPTION
## Summary
- use `data-cy` attributes in ProductGrid quick view test
- use `data-cy` attributes in ProductCarousel and RecommendationCarousel mocks

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c0565a0ccc832fa7c6a0b1a4090032