### PR TITLE
fix: ensure DeviceSelector test uses data-testid

### DIFF
--- a/packages/ui/src/components/__tests__/DeviceSelector.test.tsx
+++ b/packages/ui/src/components/__tests__/DeviceSelector.test.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, configure } from "@testing-library/react";
 import DeviceSelector from "../DeviceSelector";
 import { getLegacyPreset, devicePresets } from "../../utils/devicePresets";
+
+configure({ testIdAttribute: "data-testid" });
 
 jest.mock("../atoms/shadcn", () => {
   const React = require("react");


### PR DESCRIPTION
## Summary
- configure Testing Library to use `data-testid` in `DeviceSelector` tests so the span is found

## Testing
- `pnpm install`
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/ui' or its corresponding type declarations)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/__tests__/DeviceSelector.test.tsx --runInBand --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c0563f8244832fbdb56d3a32eb6a32