### PR TITLE
test: fix publish selector test id

### DIFF
--- a/packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx
@@ -5,10 +5,7 @@ import { useProductEditorFormState } from "../../../hooks/useProductEditorFormSt
 jest.mock("../PublishLocationSelector", () => ({
   __esModule: true,
   default: ({ onChange }: { onChange: (ids: string[]) => void }) => (
-    <button
-      data-testid="publish-selector"
-      onClick={() => onChange(["loc1"])}
-    />
+    <button data-cy="publish-selector" onClick={() => onChange(["loc1"])} />
   ),
 }));
 


### PR DESCRIPTION
## Summary
- align publish selector mock with testId config

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c05613c838832fa09c2d7e3e9e9b31