### PR TITLE
fix: guard matchMedia availability in viewport hook

### DIFF
--- a/packages/ui/src/hooks/useViewport.ts
+++ b/packages/ui/src/hooks/useViewport.ts
@@ -3,6 +3,7 @@ import type { Viewport } from "../components/organisms/types";
 
 const getViewport = (): Viewport => {
   if (typeof window === "undefined") return "desktop";
+  if (typeof window.matchMedia !== "function") return "desktop";
   if (window.matchMedia("(min-width: 1024px)").matches) return "desktop";
   if (window.matchMedia("(min-width: 768px)").matches) return "tablet";
   return "mobile";


### PR DESCRIPTION
## Summary
- avoid calling `window.matchMedia` when it is not defined to prevent test environment failures

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/ui/src/components/organisms/__tests__/Header.test.tsx --config jest.config.cjs --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68c055f5ef20832fb55e72866095d299