### PR TITLE
fix(ui): use data-cy for search results loading test id

### DIFF
--- a/packages/ui/src/components/templates/SearchResultsTemplate.tsx
+++ b/packages/ui/src/components/templates/SearchResultsTemplate.tsx
@@ -57,7 +57,7 @@ export function SearchResultsTemplate({
       {filters}
       {isLoading ? (
         <div
-          data-testid="search-results-loading"
+          data-cy="search-results-loading"
           className="grid gap-6"
           style={{
             gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,


### PR DESCRIPTION
## Summary
- use `data-cy` for search results loading skeleton so tests can locate element

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/ui' / TypeScript errors)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/templates/__tests__/SearchResultsTemplate.test.tsx --config ../../jest.config.cjs --runInBand --detectOpenHandles --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68c055e5d190832faa4a220a5e5cdf93