### PR TITLE
Fix PageBuilder resize test to use data-cy attribute

### DIFF
--- a/packages/ui/__tests__/PageBuilder.resize.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.resize.test.tsx
@@ -22,7 +22,7 @@ describe("PageBuilder resize interactions", () => {
             }
           />
           <div
-            data-testid="target"
+            data-cy="target"
             style={{ width: comp.widthDesktop, height: comp.heightDesktop }}
           />
         </>


### PR DESCRIPTION
## Summary
- adjust PageBuilder resize test to query `data-cy` attribute

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/ui/__tests__/PageBuilder.resize.test.tsx --config jest.config.cjs --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c055b79434832f9dd00c6beb55fbf0