### PR TITLE
test: use data-cy for DeviceSelector state

### DIFF
--- a/packages/ui/src/components/cms/__tests__/DeviceSelector.behavior.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/DeviceSelector.behavior.test.tsx
@@ -27,7 +27,7 @@ function Wrapper({ onToggle }: { onToggle?: () => void }) {
         setDeviceId={handleSetDeviceId}
         toggleOrientation={toggleOrientation}
       />
-      <div data-testid="state">{`${deviceId}-${orientation}`}</div>
+      <div data-cy="state">{`${deviceId}-${orientation}`}</div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- align DeviceSelector behavior test with custom testId attribute by switching to `data-cy`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' during platform-core build)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/__tests__/DeviceSelector.behavior.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c055a72b0c832f836a0dd5e5b6382e