### PR TITLE
fix: use data-cy for DynamicRenderer coverage test

### DIFF
--- a/packages/ui/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/__tests__/DynamicRenderer.test.tsx
@@ -168,7 +168,7 @@ describe("DynamicRenderer block registry coverage", () => {
       key,
       {
         component: jest.fn(({ children }: any) => (
-          <div data-testid={key}>{children}</div>
+          <div data-cy={key}>{children}</div>
         )),
       },
     ])


### PR DESCRIPTION
## Summary
- ensure block registry test renders with `data-cy` attributes

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui build` *(fails: TS2307 Cannot find module '@acme/ui')*
- `pnpm exec jest packages/ui/__tests__/DynamicRenderer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c0558d8618832f9b7b009438b08b2a