### PR TITLE
fix: flush progress state

### DIFF
--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -9,6 +9,7 @@
 
 import type { ChangeEvent, DragEvent, ReactElement, RefObject } from "react";
 import { useCallback, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useImageOrientationValidation } from "./useImageOrientationValidation";
@@ -90,7 +91,7 @@ export function useFileUpload(
   const handleUpload = useCallback(async () => {
     if (!pendingFile) return;
 
-    setProgress({ done: 0, total: 1 });
+    flushSync(() => setProgress({ done: 0, total: 1 }));
 
     const fd = new FormData();
     fd.append("file", pendingFile);


### PR DESCRIPTION
## Summary
- flush upload progress to sync state before asynchronous work

## Testing
- `pnpm -r build` *(fails: TS2307 cannot find module '@acme/ui' and other TS errors)*
- `pnpm --filter @acme/ui run check:references` *(fails: script not found)*
- `pnpm --filter @acme/ui run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/ui run build` *(fails: TS2322 property 'srcSet' does not exist, etc.)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/useFileUpload.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c0547ae35c832fb229f7ee1118ff2b