### PR TITLE
fix: update progress state synchronously

### DIFF
--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -9,6 +9,7 @@
 
 import type { ChangeEvent, DragEvent, ReactElement, RefObject } from "react";
 import { useCallback, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useImageOrientationValidation } from "./useImageOrientationValidation";
@@ -90,7 +91,7 @@ export function useFileUpload(
   const handleUpload = useCallback(async () => {
     if (!pendingFile) return;
 
-    setProgress({ done: 0, total: 1 });
+    flushSync(() => setProgress({ done: 0, total: 1 }));
 
     const fd = new FormData();
     fd.append("file", pendingFile);
@@ -117,7 +118,7 @@ export function useFileUpload(
       if (err instanceof Error) setError(err.message);
     }
 
-    setProgress(null);
+    flushSync(() => setProgress(null));
     setPendingFile(null);
     setAltText("");
     setTags("");


### PR DESCRIPTION
## Summary
- ensure file upload progress is set synchronously

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/useImageUpload.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c05466c64c832fba7b65c5426c46a6