### PR TITLE
chore(ui): add jest-axe dev dependency

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@storybook/react": "^9.1.3",
     "@types/qrcode": "^1.5.5",
+    "jest-axe": "^10.0.0",
     "next": "15.3.5",
     "typescript": "^5.8.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1039,6 +1039,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.5
+      jest-axe:
+        specifier: ^10.0.0
+        version: 10.0.0
       next:
         specifier: 15.3.5
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409)


### PR DESCRIPTION
## Summary
- add `jest-axe` to UI package devDependencies for accessibility tests

## Testing
- `pnpm exec jest packages/ui/__tests__/MfaChallenge.test.tsx --config jest.config.cjs`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in packages/platform-core build)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c05454d830832fa0a0ab3ac1e4af12