### PR TITLE
fix: use stripe subscriptions del in cancel route

### DIFF
--- a/packages/template-app/src/api/subscription/cancel/route.ts
+++ b/packages/template-app/src/api/subscription/cancel/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const sub = await stripe.subscriptions.cancel(user.stripeSubscriptionId);
+    const sub = await stripe.subscriptions.del(user.stripeSubscriptionId);
     await setStripeSubscriptionId(userId, null, shopId);
     return NextResponse.json({ id: sub.id, status: sub.status });
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- use `stripe.subscriptions.del` to cancel subscriptions

## Testing
- `pnpm --filter @acme/template-app test __tests__/subscription-cancel.route.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c05273e66c832fb7b3b207cdb6957b