### PR TITLE
test: align test ids with configuration

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/button.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/button.test.tsx
@@ -25,7 +25,7 @@ describe("Button", () => {
     const CustomLink = React.forwardRef<
       HTMLAnchorElement,
       React.AnchorHTMLAttributes<HTMLAnchorElement>
-    >((props, ref) => <a ref={ref} data-testid="custom-link" {...props} />);
+    >((props, ref) => <a ref={ref} data-cy="custom-link" {...props} />);
 
     render(
       <Button asChild>

--- a/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
@@ -15,7 +15,7 @@ describe("Select", () => {
     const onValueChange = jest.fn();
     render(
       <Select onValueChange={onValueChange}>
-        <SelectTrigger data-testid="trigger">
+        <SelectTrigger data-cy="trigger">
           <SelectValue placeholder="Pick" />
         </SelectTrigger>
         <SelectContent>

--- a/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
@@ -8,7 +8,7 @@ describe("Slot", () => {
     const ref = React.createRef<HTMLDivElement>();
     render(
       <Slot ref={ref} className="forwarded" data-test="passed">
-        <div data-testid="child" />
+        <div data-cy="child" />
       </Slot>
     );
     const child = screen.getByTestId("child");


### PR DESCRIPTION
## Summary
- use `data-cy` attributes in primitive component tests to match Testing Library configuration

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/primitives/__tests__`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c11f9a4c64832f870553cc26ff9e06