### PR TITLE
feat: add quick view data selectors

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductCarousel.test.tsx
@@ -13,24 +13,11 @@ jest.mock("@platform-core/contexts/CartContext", () => ({
   useCart: () => [{}, jest.fn()],
 }));
 
-jest.mock("../../overlays/ProductQuickView", () => {
-  const React = require("react");
-  return {
-    __esModule: true,
-    ProductQuickView: ({ product, open, onOpenChange }: any) =>
-      open ? (
-        <div data-cy="quick-view">
-          <span>{product.title}</span>
-          <button
-            data-cy="close-quick-view"
-            onClick={() => onOpenChange(false)}
-          >
-            Close
-          </button>
-        </div>
-      ) : null,
-  };
-});
+jest.mock(
+  "../../atoms/shadcn",
+  () => require("../../../../../../test/__mocks__/shadcnDialogStub.tsx")
+);
+
 
 function mockResize(width: number) {
   (global as any).ResizeObserver = class {

--- a/packages/ui/src/components/overlays/ProductQuickView.tsx
+++ b/packages/ui/src/components/overlays/ProductQuickView.tsx
@@ -1,6 +1,6 @@
 "use client";
 import * as React from "react";
-import { Dialog, DialogContent } from "../atoms/shadcn";
+import { Dialog, DialogContent, Button } from "../atoms/shadcn";
 import type { SKU } from "@acme/types";
 import { ProductCard } from "../organisms/ProductCard";
 
@@ -48,7 +48,20 @@ export function ProductQuickView({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="p-0" style={style}>
+      <DialogContent
+        className="relative p-0"
+        style={style}
+        data-cy="quick-view"
+      >
+        <Button
+          variant="outline"
+          className="absolute right-2 top-2 px-2 py-1 text-xs"
+          aria-label="Close"
+          data-cy="close-quick-view"
+          onClick={() => onOpenChange(false)}
+        >
+          Close
+        </Button>
         <ProductCard
           product={product}
           onAddToCart={onAddToCart}


### PR DESCRIPTION
## Summary
- add `data-cy` hooks and close button to `ProductQuickView`
- exercise real quick view in `ProductCarousel` tests using shadcn dialog stubs

## Testing
- `pnpm --filter @acme/ui exec jest src/components/organisms/__tests__/ProductCarousel.test.tsx --runInBand --config ../../jest.config.cjs --coverage=false`
- `pnpm --filter @acme/ui build` *(fails: Cannot find module '@acme/ui' or its corresponding type declarations; Logo.tsx property errors; AppShell stories missing props)*

------
https://chatgpt.com/codex/tasks/task_e_68c122bb4e64832f913da3b7e3c9d87e