### PR TITLE
fix payments and shipping env validations

### DIFF
--- a/packages/config/__tests__/loadPaymentsEnv.test.ts
+++ b/packages/config/__tests__/loadPaymentsEnv.test.ts
@@ -48,6 +48,7 @@ describe("loadPaymentsEnv", () => {
       loadPaymentsEnv({
         PAYMENTS_PROVIDER: "stripe",
         STRIPE_SECRET_KEY: "sk",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
       } as NodeJS.ProcessEnv),
     ).toThrow("Invalid payments environment variables");
     expect(spy).toHaveBeenCalledWith(

--- a/packages/config/__tests__/payments-env.test.ts
+++ b/packages/config/__tests__/payments-env.test.ts
@@ -40,6 +40,7 @@ describe("payments env", () => {
         loadPaymentsEnv({
           PAYMENTS_PROVIDER: "stripe",
           STRIPE_SECRET_KEY: "sk",
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
         } as any),
       ).toThrow("Invalid payments environment variables");
       expect(err).toHaveBeenCalledWith(

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -52,6 +52,12 @@ export function loadPaymentsEnv(
       console.error("❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe");
       throw new Error("Invalid payments environment variables");
     }
+    if (!raw.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {
+      console.error(
+        "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
+      );
+      throw new Error("Invalid payments environment variables");
+    }
     if (!raw.STRIPE_WEBHOOK_SECRET) {
       console.error(
         "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -24,13 +24,17 @@ export const shippingEnvSchema = z
   LOCAL_PICKUP_ENABLED: z
     .string()
     .optional()
-    .refine((v) =>
-      v == null ? true : /^(true|false|1|0)$/i.test(v.trim()),
-    {
-      message: "must be a boolean",
-    })
+    .refine(
+      (v) =>
+        v == null
+          ? true
+          : /^(true|false|1|0|yes)$/i.test(v.trim()),
+      {
+        message: "must be a boolean",
+      },
+    )
     .transform((v) =>
-      v == null ? undefined : /^(true|1)$/i.test(v.trim()),
+      v == null ? undefined : /^(true|1|yes)$/i.test(v.trim()),
     ),
   DEFAULT_COUNTRY: z
     .string()


### PR DESCRIPTION
## Summary
- require Stripe publishable key when PAYMENTS_PROVIDER=stripe
- allow `LOCAL_PICKUP_ENABLED` to accept "yes" for enabling local pickup
- adjust payments tests to include publishable key

## Testing
- `pnpm install`
- `pnpm --filter @acme/config run build` (fails: cannot find module for build:stubs script)
- `pnpm --filter @acme/config run lint` (fails: cannot find @acme/eslint-plugin-ds)
- `pnpm exec jest packages/config/src/env/__tests__/payments.test.ts packages/config/src/env/__tests__/shipping-env.test.ts packages/config/__tests__/payments-env.test.ts packages/config/__tests__/loadPaymentsEnv.test.ts packages/config/__tests__/shippingEnv.test.ts --config packages/config/jest.preset.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c125c6c890832f9998679aaa130ef6