### PR TITLE
test: handle non-array components

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -173,7 +173,7 @@ describe("onRequestPost", () => {
 
   it.each([
     ["object", {}],
-    ["string", "foo"],
+    ["string", "not-an-array"],
   ])(
     "locks all dependencies and runs build/deploy when components is a %s",
     async (_type, components) => {
@@ -202,7 +202,9 @@ describe("onRequestPost", () => {
         }),
       });
 
+      const body = await res.json();
       expect(res.status).toBe(200);
+      expect(body).toEqual({ ok: true });
       expect(writeFileSync).toHaveBeenCalledTimes(1);
       const [shopPath, data] = writeFileSync.mock.calls[0];
       expect(shopPath).toContain(`data/shops/${id}/shop.json`);


### PR DESCRIPTION
## Summary
- test publish upgrade when `components` is not an array
- verify full dependency lock and successful response

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm --filter @apps/api test "src/routes/shop/\\[id\\]/__tests__/publish-upgrade.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68c12a5ec230832f8a31021c7d7b2dd3