### PR TITLE
test(api): skip unmatched components in publish upgrade

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -171,6 +171,49 @@ describe("onRequestPost", () => {
     );
   });
 
+  it("leaves componentVersions empty when all components are missing and still runs build/deploy", async () => {
+    readFileSync.mockImplementation((file: string) => {
+      if (file.endsWith("package.json")) {
+        return JSON.stringify({ dependencies: { compA: "1.0.0" } });
+      }
+      if (file.endsWith("shop.json")) {
+        return JSON.stringify({ componentVersions: {} });
+      }
+      return "";
+    });
+    spawn.mockImplementation(() => ({
+      on: (_: string, cb: (code: number) => void) => cb(0),
+    }));
+
+    const token = jwt.sign({}, "secret");
+    const res = await onRequestPost({
+      params: { id },
+      request: new Request("http://example.com", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ components: ["compB"] }),
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(writeFileSync.mock.calls[0][1] as string);
+    expect(written.componentVersions).toEqual({});
+    expect(typeof written.lastUpgrade).toBe("string");
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      "pnpm",
+      ["--filter", `apps/shop-${id}`, "build"],
+      { cwd: root, stdio: "inherit" },
+    );
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      "pnpm",
+      ["--filter", `apps/shop-${id}`, "deploy"],
+      { cwd: root, stdio: "inherit" },
+    );
+  });
+
   it.each([
     ["object", {}],
     ["string", "foo"],


### PR DESCRIPTION
## Summary
- add test verifying publish-upgrade ignores components not in dependencies

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts --runTestsByPath --ci --runInBand --detectOpenHandles --coverage=false --config apps/api/jest.config.cjs --rootDir .`

------
https://chatgpt.com/codex/tasks/task_e_68c12a5f02e4832f94b0259b998bce86