### PR TITLE
test: ensure extendRoles ignores existing roles

### DIFF
--- a/packages/auth/__tests__/roles.test.ts
+++ b/packages/auth/__tests__/roles.test.ts
@@ -61,4 +61,14 @@ describe("extendRoles", () => {
     expect(READ_ROLES).toContain("guest");
     expect(WRITE_ROLES).not.toContain("guest");
   });
+
+  it("ignores existing roles without duplication", () => {
+    extendRoles({ write: ["admin"], read: ["viewer"] });
+
+    expect(WRITE_ROLES).toEqual(originalWrite);
+    expect(READ_ROLES).toEqual(originalRead);
+
+    expect(roles.RoleSchema.safeParse("admin").success).toBe(true);
+    expect(roles.RoleSchema.safeParse("viewer").success).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- extend auth role extension tests to ensure existing roles aren't duplicated and schemas remain valid

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/auth exec jest packages/auth/__tests__/roles.test.ts --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverageDirectory ../../coverage/auth`


------
https://chatgpt.com/codex/tasks/task_e_68c12a6b1088832f8677b731c2bf2ce6