### PR TITLE
test: add session store selection tests

### DIFF
--- a/packages/auth/__tests__/store.test.ts
+++ b/packages/auth/__tests__/store.test.ts
@@ -1,0 +1,80 @@
+import { jest } from "@jest/globals";
+
+describe("createSessionStore", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("uses Redis when credentials exist", async () => {
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: {
+        UPSTASH_REDIS_REST_URL: "https://example",
+        UPSTASH_REDIS_REST_TOKEN: "token",
+      },
+    }));
+    const redisCtor = jest.fn();
+    jest.doMock("@upstash/redis", () => ({
+      Redis: class {
+        constructor(opts: unknown) {
+          redisCtor(opts);
+        }
+      },
+    }));
+    const { createSessionStore } = await import("../src/store");
+    const { RedisSessionStore } = await import("../src/redisStore");
+    const store = await createSessionStore();
+    expect(store).toBeInstanceOf(RedisSessionStore);
+    expect(redisCtor).toHaveBeenCalledWith({
+      url: "https://example",
+      token: "token",
+    });
+  });
+
+  it("falls back to MemorySessionStore when credentials missing", async () => {
+    jest.doMock("@acme/config/env/core", () => ({ coreEnv: {} }));
+    const { createSessionStore } = await import("../src/store");
+    const { MemorySessionStore } = await import("../src/memoryStore");
+    const store = await createSessionStore();
+    expect(store).toBeInstanceOf(MemorySessionStore);
+  });
+
+  it("allows overriding via setSessionStoreFactory", async () => {
+    jest.doMock("@acme/config/env/core", () => ({ coreEnv: {} }));
+    const { createSessionStore, setSessionStoreFactory } = await import(
+      "../src/store"
+    );
+    const custom = { custom: true };
+    setSessionStoreFactory(async () => custom);
+    const store = await createSessionStore();
+    expect(store).toBe(custom);
+  });
+
+  it("logs error and falls back when Redis initialization fails", async () => {
+    const err = new Error("boom");
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: {
+        UPSTASH_REDIS_REST_URL: "https://example",
+        UPSTASH_REDIS_REST_TOKEN: "token",
+      },
+    }));
+    jest.doMock("@upstash/redis", () => ({
+      Redis: class {
+        constructor() {
+          throw err;
+        }
+      },
+    }));
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { createSessionStore } = await import("../src/store");
+    const { MemorySessionStore } = await import("../src/memoryStore");
+    const store = await createSessionStore();
+    expect(store).toBeInstanceOf(MemorySessionStore);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Failed to initialize Redis session store",
+      err,
+    );
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for session store factory to verify Redis selection and memory fallback

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/auth/__tests__/store.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c12a6d69d4832fb6f59375110b07d3