### PR TITLE
Fix reset token lookup and inventory backend resolution

### DIFF
--- a/packages/platform-core/__tests__/users.resetToken.test.ts
+++ b/packages/platform-core/__tests__/users.resetToken.test.ts
@@ -89,11 +89,10 @@ describe("user operations", () => {
     expect(store["u2"].resetTokenExpiresAt).toBeNull();
   });
 
-  it("returns null for expired tokens", async () => {
+  it("throws for expired tokens", async () => {
     await createUser({ id: "u3", email: "u3@example.com", passwordHash: "hash" });
     await setResetToken("u3", "tok", new Date(Date.now() - 1000));
-    const user = await getUserByResetToken("tok");
-    expect(user).toBeNull();
+    await expect(getUserByResetToken("tok")).rejects.toThrow("User not found");
   });
 
   it("returns user when token valid", async () => {

--- a/packages/platform-core/src/repositories/inventory.server.ts
+++ b/packages/platform-core/src/repositories/inventory.server.ts
@@ -45,10 +45,6 @@ async function getRepo(): Promise<InventoryRepository> {
         ),
       {
         backendEnvVar: "INVENTORY_BACKEND",
-        sqliteModule: () =>
-          import("./inventory.sqlite.server").then(
-            (m) => m.sqliteInventoryRepository,
-          ),
       },
     );
   }

--- a/packages/platform-core/src/users.ts
+++ b/packages/platform-core/src/users.ts
@@ -50,14 +50,17 @@ export async function setResetToken(
 
 export async function getUserByResetToken(
   token: string,
-): Promise<User | null> {
+): Promise<User> {
   const user = await prisma.user.findFirst({
     where: {
       resetToken: token,
       resetTokenExpiresAt: { gt: new Date() },
     },
   });
-  return user ?? null;
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user;
 }
 
 export async function updatePassword(


### PR DESCRIPTION
## Summary
- ensure `getUserByResetToken` throws when token is invalid or expired
- default inventory repository to JSON even when `INVENTORY_BACKEND=sqlite`
- update reset-token tests for new behavior

## Testing
- `pnpm exec jest packages/platform-core/__tests__/users.test.ts packages/platform-core/__tests__/password-reset.flow.test.ts packages/platform-core/__tests__/users.resetToken.test.ts packages/platform-core/src/repositories/__tests__/inventory.server.branch.test.ts`
- `pnpm -F @acme/platform-core run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm -F @acme/platform-core run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm -F @acme/platform-core run build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c1304da2f8832f8833825072790b8f