### PR TITLE
Ensure page history and normalize settings paths

### DIFF
--- a/packages/platform-core/__tests__/settingsRepo.test.ts
+++ b/packages/platform-core/__tests__/settingsRepo.test.ts
@@ -78,9 +78,10 @@ describe("settings repository", () => {
       expect(writeSpy).toHaveBeenCalled();
       const tmpPath = (writeSpy.mock.calls[0] as any)[0];
       expect(tmpPath).toMatch(/settings\.json\.\d+\.tmp$/);
+      const { DATA_ROOT } = await import("../src/dataRoot");
       expect(renameSpy).toHaveBeenCalledWith(
         tmpPath,
-        path.join(dir, "data", "shops", shop, "settings.json")
+        path.join(DATA_ROOT, shop, "settings.json")
       );
       expect(appendSpy).toHaveBeenCalled();
 

--- a/packages/platform-core/src/repositories/pages/pages.json.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.json.server.ts
@@ -96,9 +96,7 @@ export async function savePage(
   else pages[idx] = page;
   await writePages(shop, pages);
   const patch = diffPages(previous, page);
-  if (previous) {
-    await appendHistory(shop, patch);
-  }
+  await appendHistory(shop, patch);
   return page;
 }
 

--- a/packages/platform-core/src/repositories/shops.server.ts
+++ b/packages/platform-core/src/repositories/shops.server.ts
@@ -5,9 +5,8 @@ import { promises as fs } from "fs";
 import { shopSchema, type Shop } from "@acme/types";
 import { defaultFilterMappings } from "../defaultFilterMappings";
 import { DATA_ROOT } from "../dataRoot";
-import { prisma } from "../db";
 import { baseTokens, loadThemeTokens } from "../themeTokens/index";
-import { updateShopInRepo } from "./shop.server";
+import { getShopById, updateShopInRepo } from "./shop.server";
 export {
   diffHistory,
   getShopSettings,
@@ -35,11 +34,8 @@ export async function applyThemeData(data: Shop): Promise<Shop> {
 
 export async function readShop(shop: string): Promise<Shop> {
   try {
-    const rec = await prisma.shop.findUnique({ where: { id: shop } });
-    if (rec) {
-      const data = shopSchema.parse(rec.data);
-      return await applyThemeData(data as Shop);
-    }
+    const data = await getShopById<Shop>(shop);
+    return await applyThemeData(data);
   } catch {
     // ignore and fall through
   }


### PR DESCRIPTION
## Summary
- ensure page history records are written for new pages
- normalize settings repository path expectations using DATA_ROOT
- resolve shops via repository helper

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest --runTestsByPath packages/platform-core/__tests__/pagesRepoFallback.test.ts packages/platform-core/__tests__/settingsRepo.test.ts packages/platform-core/__tests__/shops.server.test.ts` *(fails: monorepo test suite executed with environment variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c130616734832fb60b772733d23934