### PR TITLE
test: add startLateFeeService override and sale shop tests

### DIFF
--- a/packages/platform-machine/__tests__/lateFeeService.test.ts
+++ b/packages/platform-machine/__tests__/lateFeeService.test.ts
@@ -458,6 +458,121 @@ describe("startLateFeeService", () => {
     clearSpy.mockRestore();
   });
 
+  it("applies start config overrides", async () => {
+    const { setupLateFeeTest, NOW } = await import("./helpers/lateFee");
+    const overdueOrder = {
+      sessionId: "sess_1",
+      returnDueDate: new Date(NOW - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any;
+    const mocks = await setupLateFeeTest({ orders: [overdueOrder] });
+    process.env.LATE_FEE_ENABLED_TEST = "false";
+    process.env.LATE_FEE_INTERVAL_MS_TEST = "600000";
+    mocks.readFile.mockImplementation((path: string) => {
+      if (path.endsWith("settings.json"))
+        return Promise.resolve(
+          JSON.stringify({
+            lateFeeService: { enabled: false, intervalMinutes: 10 },
+          }),
+        );
+      if (path.endsWith("shop.json"))
+        return Promise.resolve(
+          JSON.stringify({ lateFeePolicy: { feeAmount: 25 } }),
+        );
+      return Promise.reject(new Error("not found"));
+    });
+    jest.doMock("@platform-core/dataRoot", () => ({
+      __esModule: true,
+      resolveDataRoot: () => "/data",
+    }));
+    jest.doMock("@acme/config/env/core", () => ({
+      __esModule: true,
+      coreEnv: { LATE_FEE_ENABLED: false, LATE_FEE_INTERVAL_MS: 300000 },
+      loadCoreEnv: () => ({
+        LATE_FEE_ENABLED: false,
+        LATE_FEE_INTERVAL_MS: 300000,
+      }),
+    }));
+
+    const mod = await import("../src/lateFeeService");
+    const setSpy = jest
+      .spyOn(global, "setInterval")
+      .mockImplementation((fn: any, ms?: number) => {
+        expect(ms).toBe(120000);
+        return 111 as any;
+      });
+    const clearSpy = jest
+      .spyOn(global, "clearInterval")
+      .mockImplementation(() => undefined as any);
+
+    const stop = await mod.startLateFeeService({
+      test: { enabled: true, intervalMinutes: 2 },
+    });
+
+    expect(mocks.stripeCharge).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 25 * 100, currency: "usd" }),
+    );
+    expect(mocks.markLateFeeCharged).toHaveBeenCalledWith(
+      "test",
+      "sess_1",
+      25,
+    );
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    stop();
+    expect(clearSpy).toHaveBeenCalledWith(111 as any);
+
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+    mocks.restore();
+  });
+
+  it("returns early for sale shops without scheduling", async () => {
+    const { setupLateFeeTest } = await import("./helpers/lateFee");
+    const mocks = await setupLateFeeTest({
+      orders: [],
+      shop: { type: "sale" },
+    });
+    mocks.readFile.mockImplementation((path: string) => {
+      if (path.endsWith("settings.json"))
+        return Promise.resolve(
+          JSON.stringify({
+            lateFeeService: { enabled: true, intervalMinutes: 1 },
+          }),
+        );
+      if (path.endsWith("shop.json"))
+        return Promise.resolve(JSON.stringify({ type: "sale" }));
+      return Promise.reject(new Error("not found"));
+    });
+    jest.doMock("@platform-core/dataRoot", () => ({
+      __esModule: true,
+      resolveDataRoot: () => "/data",
+    }));
+    jest.doMock("@acme/config/env/core", () => ({
+      __esModule: true,
+      coreEnv: {},
+      loadCoreEnv: () => ({}),
+    }));
+
+    const mod = await import("../src/lateFeeService");
+    const setSpy = jest
+      .spyOn(global, "setInterval")
+      .mockImplementation(() => 111 as any);
+    const clearSpy = jest
+      .spyOn(global, "clearInterval")
+      .mockImplementation(() => undefined as any);
+
+    const stop = await mod.startLateFeeService();
+
+    expect(mocks.readOrders).not.toHaveBeenCalled();
+    expect(mocks.stripeCharge).not.toHaveBeenCalled();
+    expect(setSpy).not.toHaveBeenCalled();
+
+    stop();
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+    mocks.restore();
+  });
+
   it("propagates readdir errors without scheduling", async () => {
     const err = new Error("boom");
     const readdir = jest.fn().mockRejectedValue(err);


### PR DESCRIPTION
## Summary
- verify startLateFeeService respects explicit config overrides
- ensure sale-type shops exit without scheduling or charging

## Testing
- `pnpm --filter @acme/platform-machine test -- packages/platform-machine/__tests__/lateFeeService.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c135cbe978832fa9d7b98da48c6322