### PR TITLE
test: handle nodemailer sendMail rejection

### DIFF
--- a/packages/email/__tests__/send.core.test.ts
+++ b/packages/email/__tests__/send.core.test.ts
@@ -124,4 +124,29 @@ describe("sendWithNodemailer", () => {
       text: "text",
     });
   });
+
+  it("surfaces sendMail errors", async () => {
+    process.env.SMTP_URL = "smtp://example";
+    const sendMail = jest.fn().mockRejectedValue(new Error("smtp fail"));
+    const createTransport = jest.fn(() => ({ sendMail }));
+    jest.doMock("nodemailer", () => ({ __esModule: true, default: { createTransport } }));
+    jest.doMock("../src/config", () => ({ getDefaultSender: () => "from@example.com" }));
+    const { sendWithNodemailer } = await import("../src/send");
+    await expect(
+      sendWithNodemailer({
+        to: "to@example.com",
+        subject: "Subj",
+        html: "<p>HTML</p>",
+        text: "text",
+      })
+    ).rejects.toThrow("smtp fail");
+    expect(createTransport).toHaveBeenCalledWith({ url: "smtp://example" });
+    expect(sendMail).toHaveBeenCalledWith({
+      from: "from@example.com",
+      to: "to@example.com",
+      subject: "Subj",
+      html: "<p>HTML</p>",
+      text: "text",
+    });
+  });
 });

--- a/packages/email/src/__tests__/send.core.test.ts
+++ b/packages/email/src/__tests__/send.core.test.ts
@@ -432,6 +432,29 @@ describe("send core helpers", () => {
         text: "T",
       });
     });
+
+    it("surfaces sendMail rejections", async () => {
+      process.env.SMTP_URL = "smtp://test";
+      const err = new Error("smtp fail");
+      mockSendMail.mockRejectedValue(err);
+      const { sendWithNodemailer } = await import("../send");
+      await expect(
+        sendWithNodemailer({
+          to: "to@example.com",
+          subject: "Sub",
+          html: "<p>H</p>",
+          text: "T",
+        })
+      ).rejects.toThrow("smtp fail");
+      expect(mockCreateTransport).toHaveBeenCalledWith({ url: "smtp://test" });
+      expect(mockSendMail).toHaveBeenCalledWith({
+        from: "from@example.com",
+        to: "to@example.com",
+        subject: "Sub",
+        html: "<p>H</p>",
+        text: "T",
+      });
+    });
   });
 
   describe("sendCampaignEmail", () => {


### PR DESCRIPTION
## Summary
- add test for sendWithNodemailer to ensure sendMail rejections bubble up

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/send.core.test.ts packages/email/__tests__/send.core.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c130b4c02c832fb50682db22fa2ad2