### PR TITLE
test(email): emit rejects on listener errors

### DIFF
--- a/packages/email/__tests__/hooks.test.ts
+++ b/packages/email/__tests__/hooks.test.ts
@@ -48,6 +48,21 @@ describe.each([
     expect(second).toHaveBeenCalledWith(shop, payload);
   });
 
+  it("rejects when any listener throws", async () => {
+    const error = new Error("fail");
+    const failing = jest.fn(() => {
+      throw error;
+    });
+    const succeeding = jest.fn();
+
+    on(succeeding);
+    on(failing);
+
+    await expect(emit(shop, payload)).rejects.toThrow(error);
+    expect(failing).toHaveBeenCalledWith(shop, payload);
+    expect(succeeding).toHaveBeenCalledWith(shop, payload);
+  });
+
   it("captures listeners registered after emits", async () => {
     const early = jest.fn();
     const late = jest.fn();


### PR DESCRIPTION
## Summary
- add regression tests ensuring email emitters reject when any listener throws

## Testing
- `pnpm --filter @acme/email test -- hooks.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c130b77574832fac086e2adeb26bd6