### PR TITLE
test(email): add relative unsubscribe URL test

### DIFF
--- a/packages/email/src/__tests__/unsubscribeUrl.test.ts
+++ b/packages/email/src/__tests__/unsubscribeUrl.test.ts
@@ -15,4 +15,12 @@ describe("unsubscribeUrl", () => {
       `https://base.example.com/api/marketing/email/unsubscribe?shop=${encodeURIComponent(shop)}&campaign=${encodeURIComponent(campaign)}&email=${encodeURIComponent(email)}`,
     );
   });
+
+  test("falls back to relative path when base URL is unset", () => {
+    const shop = "shop";
+    const campaign = "campaign";
+    const email = "user@example.com";
+    const url = unsubscribeUrl(shop, campaign, email);
+    expect(url.startsWith("/api/marketing/email/unsubscribe")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- cover unsubscribeUrl when base URL env is missing

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/unsubscribeUrl.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script; file also includes test output)*

------
https://chatgpt.com/codex/tasks/task_e_68c130b97d10832fb3aa0dbce1606fd1