### PR TITLE
test(email): support recipient fallback

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -88,6 +88,24 @@ describe("mapResendEvent", () => {
     });
   });
 
+  it("uses recipient if email is missing", async () => {
+    setupMocks();
+    const { mapResendEvent } = await import("../src/analytics");
+    const ev = {
+      type: "email.delivered",
+      data: {
+        message_id: "r2",
+        recipient: "alt@example.com",
+      },
+    } as const;
+    expect(mapResendEvent(ev)).toEqual<EmailAnalyticsEvent>({
+      type: "email_delivered",
+      campaign: undefined,
+      messageId: "r2",
+      recipient: "alt@example.com",
+    });
+  });
+
   it("returns null for unknown types", async () => {
     setupMocks();
     const { mapResendEvent } = await import("../src/analytics");


### PR DESCRIPTION
## Summary
- test mapResendEvent to use recipient when email is missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test` *(fails: Jest encountered an unexpected token in packages/email/src/__tests__/bin.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c130b9efb8832f98356197db543e57