### PR TITLE
test: cover resend campaign analytics

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -157,5 +157,60 @@ describe("syncCampaignAnalytics", () => {
       ...emptyStats,
     });
   });
+
+  it("sends stats for sent campaigns when using the Resend provider", async () => {
+    jest.resetModules();
+    const trackEvent = jest.fn();
+    jest.doMock("@platform-core/analytics", () => ({
+      __esModule: true,
+      trackEvent,
+    }));
+
+    const stats = {
+      delivered: 1,
+      opened: 2,
+      clicked: 3,
+      unsubscribed: 4,
+      bounced: 5,
+    };
+    const getCampaignStats = jest.fn().mockResolvedValue(stats);
+    jest.doMock("../src/providers/resend", () => ({
+      ResendProvider: jest.fn().mockImplementation(() => ({ getCampaignStats })),
+    }));
+    jest.doMock("../src/providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
+
+    const campaigns = [
+      { id: "c1", recipients: [], subject: "s1", body: "b1", sendAt: "t1", sentAt: "t1" },
+      { id: "c2", recipients: [], subject: "s2", body: "b2", sendAt: "t2", sentAt: "t2" },
+      { id: "c3", recipients: [], subject: "s3", body: "b3", sendAt: "t3", sentAt: undefined },
+    ];
+    const store = {
+      async listShops() {
+        return ["shop1"];
+      },
+      async readCampaigns() {
+        return campaigns;
+      },
+    };
+    const getCampaignStore = jest.fn().mockReturnValue(store);
+    jest.doMock("../src/storage", () => ({ __esModule: true, getCampaignStore }));
+
+    process.env.EMAIL_PROVIDER = "resend";
+    const { syncCampaignAnalytics } = await import("../src/analytics");
+    await syncCampaignAnalytics();
+
+    expect(getCampaignStats).toHaveBeenCalledTimes(2);
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+    expect(trackEvent).toHaveBeenNthCalledWith(1, "shop1", {
+      type: "email_campaign_stats",
+      campaign: "c1",
+      ...stats,
+    });
+    expect(trackEvent).toHaveBeenNthCalledWith(2, "shop1", {
+      type: "email_campaign_stats",
+      campaign: "c2",
+      ...stats,
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- extend analytics tests to validate Resend campaign stats forwarding

## Testing
- `pnpm --filter @acme/email test -- __tests__/analytics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c130bb8694832fac0336ddb2687045