### PR TITLE
Handle provider errors in segment operations

### DIFF
--- a/packages/email/__tests__/segments.test.ts
+++ b/packages/email/__tests__/segments.test.ts
@@ -217,6 +217,29 @@ describe("provider-dependent operations", () => {
     expect(resend.listSegments).toHaveBeenCalled();
   });
 
+  it("handles provider errors gracefully", async () => {
+    process.env.EMAIL_PROVIDER = "sendgrid";
+    sendgrid.createContact.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+    sendgrid.addToList.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+    sendgrid.listSegments.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+
+    const id = await createContact("err@example.com");
+    await expect(addToList("c", "l")).resolves.toBeUndefined();
+    const segs = await listSegments();
+
+    expect(id).toBe("");
+    expect(segs).toEqual([]);
+    expect(sendgrid.createContact).toHaveBeenCalledWith("err@example.com");
+    expect(sendgrid.addToList).toHaveBeenCalledWith("c", "l");
+    expect(sendgrid.listSegments).toHaveBeenCalled();
+  });
+
   it("no-ops when no provider configured", async () => {
     process.env.EMAIL_PROVIDER = "";
     const id = await createContact("none@example.com");

--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -165,12 +165,11 @@ describe("provider functions", () => {
     expect(segments).toEqual([{ id: "s1", name: "All" }]);
   });
 
-  it("createContact rejects when Sendgrid provider throws", async () => {
-    const err = new Error("sendgrid createContact");
+  it("createContact returns empty string when Sendgrid provider throws", async () => {
     jest.doMock("../providers/sendgrid", () => ({
       SendgridProvider: class {
         createContact = jest.fn(() => {
-          throw err;
+          throw new Error("sendgrid createContact");
         });
         addToList = jest.fn();
         listSegments = jest.fn();
@@ -179,16 +178,15 @@ describe("provider functions", () => {
 
     process.env.EMAIL_PROVIDER = "sendgrid";
     const { createContact } = await import("../segments");
-    await expect(createContact("user@example.com")).rejects.toBe(err);
+    await expect(createContact("user@example.com")).resolves.toBe("");
   });
 
-  it("addToList rejects when Sendgrid provider throws", async () => {
-    const err = new Error("sendgrid addToList");
+  it("addToList resolves when Sendgrid provider throws", async () => {
     jest.doMock("../providers/sendgrid", () => ({
       SendgridProvider: class {
         createContact = jest.fn().mockResolvedValue("contact-1");
         addToList = jest.fn(() => {
-          throw err;
+          throw new Error("sendgrid addToList");
         });
         listSegments = jest.fn();
       },
@@ -196,32 +194,30 @@ describe("provider functions", () => {
 
     process.env.EMAIL_PROVIDER = "sendgrid";
     const { addToList } = await import("../segments");
-    await expect(addToList("c1", "l1")).rejects.toBe(err);
+    await expect(addToList("c1", "l1")).resolves.toBeUndefined();
   });
 
-  it("listSegments rejects when Sendgrid provider throws", async () => {
-    const err = new Error("sendgrid listSegments");
+  it("listSegments returns empty array when Sendgrid provider throws", async () => {
     jest.doMock("../providers/sendgrid", () => ({
       SendgridProvider: class {
         createContact = jest.fn();
         addToList = jest.fn();
         listSegments = jest.fn(() => {
-          throw err;
+          throw new Error("sendgrid listSegments");
         });
       },
     }));
 
     process.env.EMAIL_PROVIDER = "sendgrid";
     const { listSegments } = await import("../segments");
-    await expect(listSegments()).rejects.toBe(err);
+    await expect(listSegments()).resolves.toEqual([]);
   });
 
-  it("createContact rejects when Resend provider throws", async () => {
-    const err = new Error("resend createContact");
+  it("createContact returns empty string when Resend provider throws", async () => {
     jest.doMock("../providers/resend", () => ({
       ResendProvider: class {
         createContact = jest.fn(() => {
-          throw err;
+          throw new Error("resend createContact");
         });
         addToList = jest.fn();
         listSegments = jest.fn();
@@ -230,16 +226,15 @@ describe("provider functions", () => {
 
     process.env.EMAIL_PROVIDER = "resend";
     const { createContact } = await import("../segments");
-    await expect(createContact("user@example.com")).rejects.toBe(err);
+    await expect(createContact("user@example.com")).resolves.toBe("");
   });
 
-  it("addToList rejects when Resend provider throws", async () => {
-    const err = new Error("resend addToList");
+  it("addToList resolves when Resend provider throws", async () => {
     jest.doMock("../providers/resend", () => ({
       ResendProvider: class {
         createContact = jest.fn().mockResolvedValue("contact-1");
         addToList = jest.fn(() => {
-          throw err;
+          throw new Error("resend addToList");
         });
         listSegments = jest.fn();
       },
@@ -247,24 +242,23 @@ describe("provider functions", () => {
 
     process.env.EMAIL_PROVIDER = "resend";
     const { addToList } = await import("../segments");
-    await expect(addToList("c1", "l1")).rejects.toBe(err);
+    await expect(addToList("c1", "l1")).resolves.toBeUndefined();
   });
 
-  it("listSegments rejects when Resend provider throws", async () => {
-    const err = new Error("resend listSegments");
+  it("listSegments returns empty array when Resend provider throws", async () => {
     jest.doMock("../providers/resend", () => ({
       ResendProvider: class {
         createContact = jest.fn();
         addToList = jest.fn();
         listSegments = jest.fn(() => {
-          throw err;
+          throw new Error("resend listSegments");
         });
       },
     }));
 
     process.env.EMAIL_PROVIDER = "resend";
     const { listSegments } = await import("../segments");
-    await expect(listSegments()).rejects.toBe(err);
+    await expect(listSegments()).resolves.toEqual([]);
   });
 
   it("returns empty list for unknown provider", async () => {

--- a/packages/email/src/segments.ts
+++ b/packages/email/src/segments.ts
@@ -65,7 +65,14 @@ const segmentCache = new Map<string, CacheEntry>();
 
 export async function createContact(email: string): Promise<string> {
   const provider = getProvider();
-  return provider?.createContact ? provider.createContact(email) : "";
+  if (provider?.createContact) {
+    try {
+      return await provider.createContact(email);
+    } catch {
+      return "";
+    }
+  }
+  return "";
 }
 
 export async function addToList(
@@ -73,12 +80,22 @@ export async function addToList(
   listId: string
 ): Promise<void> {
   const provider = getProvider();
-  if (provider?.addToList) await provider.addToList(contactId, listId);
+  if (provider?.addToList)
+    try {
+      await provider.addToList(contactId, listId);
+    } catch {
+      /* noop */
+    }
 }
 
 export async function listSegments(): Promise<{ id: string; name?: string }[]> {
   const provider = getProvider();
-  if (provider?.listSegments) return provider.listSegments();
+  if (provider?.listSegments)
+    try {
+      return await provider.listSegments();
+    } catch {
+      return [];
+    }
   return [];
 }
 


### PR DESCRIPTION
## Summary
- gracefully handle provider failures in `createContact`, `addToList`, and `listSegments`
- cover provider error cases in segment tests and ensure default fallbacks

## Testing
- `pnpm --filter @acme/email run test`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*


------
https://chatgpt.com/codex/tasks/task_e_68c130bd9150832fa20642743739f7cc