### PR TITLE
test(email): ensure analytics sync skips without provider

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -157,5 +157,27 @@ describe("syncCampaignAnalytics", () => {
       ...emptyStats,
     });
   });
+
+  it("does nothing when no email provider is configured", async () => {
+    jest.resetModules();
+    delete process.env.EMAIL_PROVIDER;
+
+    const trackEvent = jest.fn();
+    jest.doMock("@platform-core/analytics", () => ({
+      __esModule: true,
+      trackEvent,
+    }));
+
+    const getCampaignStore = jest.fn();
+    jest.doMock("../src/storage", () => ({ __esModule: true, getCampaignStore }));
+    jest.doMock("../src/providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
+    jest.doMock("../src/providers/resend", () => ({ ResendProvider: jest.fn() }));
+
+    const { syncCampaignAnalytics } = await import("../src/analytics");
+    await syncCampaignAnalytics();
+
+    expect(getCampaignStore).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression test ensuring syncCampaignAnalytics returns early when EMAIL_PROVIDER is unset

## Testing
- `pnpm --filter @acme/email... build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test packages/email/__tests__/analytics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c13604da0c832fa135454df97547b3