### PR TITLE
test(email): handle segment without recipients

### DIFF
--- a/packages/email/src/__tests__/cli.test.ts
+++ b/packages/email/src/__tests__/cli.test.ts
@@ -74,6 +74,40 @@ test("campaign create writes campaign file", async () => {
   expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/^Created campaign/));
 });
 
+test("campaign create with segment and no recipients", async () => {
+  process.argv = [
+    "node",
+    "email",
+    "campaign",
+    "create",
+    "shop1",
+    "--subject",
+    "Hi",
+    "--body",
+    "<p>Hi</p>",
+    "--segment",
+    "vip",
+    "--send-at",
+    "2020-01-01T00:00:00.000Z",
+  ];
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  const { run } = await import("../cli");
+  await run();
+
+  const campaignsPath = path.join(dataRoot, "shop1", "campaigns.json");
+  expect(files[campaignsPath]).toBeDefined();
+  const json = JSON.parse(files[campaignsPath]);
+  expect(json).toHaveLength(1);
+  expect(json[0]).toMatchObject({
+    subject: "Hi",
+    body: "<p>Hi</p>",
+    recipients: [],
+    segment: "vip",
+  });
+  expect(typeof json[0].sendAt).toBe("string");
+  expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/^Created campaign/));
+});
+
 test("campaign list outputs campaigns", async () => {
   const campaignsPath = path.join(dataRoot, "shop1", "campaigns.json");
   files[campaignsPath] = JSON.stringify([


### PR DESCRIPTION
## Summary
- add test for campaign creation without recipients but with segment

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/cli.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c13604088c832f91c8d4e6dd8be0bb