### PR TITLE
test(email): ensure table styles survive sanitization

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -148,6 +148,30 @@ describe("sendCampaignEmail", () => {
       });
     });
 
+  it("preserves table elements and styles during sanitization", async () => {
+    mockSendgridSend = jest.fn().mockResolvedValue(undefined);
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
+    mockSanitizeHtml = jest.fn((html: string) => html);
+
+    setupEnv();
+
+    const { sendCampaignEmail } = await import("../index");
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: '<table><tr><td style="color:red">x</td></tr></table>',
+    });
+
+    expect(mockSanitizeHtml).toHaveBeenCalled();
+    const sentHtml = (mockSendgridSend.mock.calls[0][0] as { html: string })
+      .html;
+    expect(sentHtml).toContain("<table>");
+    expect(sentHtml).toContain("<tr>");
+    expect(sentHtml).toContain("<td");
+    expect(sentHtml).toContain('style="color:red"');
+  });
+
     it("renders templates before sending", async () => {
       mockSendgridSend = jest.fn().mockResolvedValue(undefined);
       mockResendSend = jest.fn();


### PR DESCRIPTION
## Summary
- add regression test to ensure table and style attributes survive HTML sanitization

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email exec jest src/__tests__/send.test.ts -t "preserves table elements" --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1360369c0832f84236b0998f6b79c