### PR TITLE
test: ensure deriveText decodes quotes

### DIFF
--- a/packages/email/src/__tests__/send.helpers.test.ts
+++ b/packages/email/src/__tests__/send.helpers.test.ts
@@ -43,8 +43,8 @@ describe("send helpers", () => {
   it("deriveText strips tags and entities", async () => {
     const { deriveText } = await import("../send");
     const html =
-      '<style>.x{}</style><script>alert(1)</script><p>Hello&nbsp;<strong>world</strong>&lt;3 &amp;</p>';
-    expect(deriveText(html)).toBe("Hello world <3 &");
+      '<style>.x{}</style><script>alert(1)</script><p>Hello&nbsp;<strong>world</strong>&lt;3 &amp; &quot;double&quot; and &#39;single&#39;</p>';
+    expect(deriveText(html)).toBe(`Hello world <3 & "double" and 'single'`);
   });
 
   it("ensureText throws when html missing", async () => {


### PR DESCRIPTION
## Summary
- extend deriveText tests to ensure HTML-encoded quotes decode to actual characters

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email exec jest packages/email/src/__tests__/send.helpers.test.ts --runInBand --forceExit` *(fails: global coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c13602713c832f835375e1738a4a0a