### PR TITLE
test(email): ensure resend not called with sendgrid

### DIFF
--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -122,6 +122,25 @@ describe("sendCampaignEmail", () => {
     });
   });
 
+  it("does not call Resend when using Sendgrid", async () => {
+    mockSendgridSend = jest.fn().mockResolvedValue(undefined);
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
+    mockSanitizeHtml = jest.fn((html: string) => html);
+
+    setupEnv();
+
+    const { sendCampaignEmail } = await import("../send");
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: "<p>HTML</p>",
+      sanitize: false,
+    });
+
+    expect(mockResendSend).not.toHaveBeenCalled();
+  });
+
     it("sanitizes HTML and derives text", async () => {
       mockSendgridSend = jest.fn().mockResolvedValue(undefined);
       mockResendSend = jest.fn();


### PR DESCRIPTION
## Summary
- add test verifying Resend isn't invoked when Sendgrid is selected as email provider

## Testing
- `pnpm --filter @acme/email test src/__tests__/send.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c1360180e8832f89775a04d58b5c2c