### PR TITLE
test: verify email log level handling

### DIFF
--- a/packages/email/src/__tests__/sendEmail.test.ts
+++ b/packages/email/src/__tests__/sendEmail.test.ts
@@ -44,12 +44,14 @@ describe("sendEmail", () => {
       ...OLD_ENV,
       STRIPE_SECRET_KEY: "sk",
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      EMAIL_LOG_LEVEL: "info",
     } as NodeJS.ProcessEnv;
 
     const infoSpy = jest.fn();
+    const pinoMock = jest.fn(() => ({ info: infoSpy }));
     jest.doMock("pino", () => ({
       __esModule: true,
-      default: () => ({ info: infoSpy }),
+      default: pinoMock,
     }));
     jest.doMock("nodemailer", () => ({
       __esModule: true,
@@ -63,6 +65,7 @@ describe("sendEmail", () => {
     await sendEmail("a@b.com", "Hi", "There");
 
     expect(infoSpy).toHaveBeenCalledWith({ to: "a@b.com" }, "Email simulated");
+    expect(pinoMock).toHaveBeenCalledWith({ level: "info" });
     expect(getDefaultSender).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- test email logging uses EMAIL_LOG_LEVEL and passes correct level to pino

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test -- src/__tests__/sendEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c13600884c832f8c853cb23e5e2279