### PR TITLE
test: add undefined provider stats case

### DIFF
--- a/packages/email/__tests__/stats.test.ts
+++ b/packages/email/__tests__/stats.test.ts
@@ -40,10 +40,12 @@ describe("provider stats mapping", () => {
       ...emptyStats,
       delivered: 2,
     });
+    expect(normalizeProviderStats("sendgrid", undefined)).toEqual(emptyStats);
     expect(normalizeProviderStats("resend", { opened: "3" })).toEqual({
       ...emptyStats,
       opened: 3,
     });
+    expect(normalizeProviderStats("resend", undefined)).toEqual(emptyStats);
     expect(normalizeProviderStats("other", { delivered: 99 })).toEqual(emptyStats);
   });
 });


### PR DESCRIPTION
## Summary
- test normalizeProviderStats with undefined stats

## Testing
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/email test`

------
https://chatgpt.com/codex/tasks/task_e_68c135fe756c832fa2a87fedc0d86808