### PR TITLE
test: map category string to campaign

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -45,6 +45,23 @@ describe("mapSendGridEvent", () => {
     expect(mapSendGridEvent({ event: "processed" })).toBeNull();
   });
 
+  it("maps category strings to campaigns", async () => {
+    setupMocks();
+    const { mapSendGridEvent } = await import("../src/analytics");
+    const ev = {
+      event: "open",
+      category: "camp1",
+      sg_message_id: "m1",
+      email: "user@example.com",
+    } as const;
+    expect(mapSendGridEvent(ev)).toEqual<EmailAnalyticsEvent>({
+      type: "email_open",
+      campaign: "camp1",
+      messageId: "m1",
+      recipient: "user@example.com",
+    });
+  });
+
   it("uses the first value from category arrays", async () => {
     setupMocks();
     const { mapSendGridEvent } = await import("../src/analytics");


### PR DESCRIPTION
## Summary
- add test ensuring mapSendGridEvent maps string category to campaign metadata

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test` *(fails: bin.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c135fbebf0832fb650efbb4efd7088