### PR TITLE
test: use project test id attribute

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
@@ -10,7 +10,7 @@ describe("Slot", () => {
     const ref = React.createRef<HTMLDivElement>();
     render(
       <Slot ref={ref} className="forwarded" data-test="passed">
-        <div data-cy="child" />
+        <div data-testid="child" />
       </Slot>
     );
     const child = screen.getByTestId("child");

--- a/packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx
@@ -5,7 +5,7 @@ jest.mock("../../../organisms/StoreLocatorMap", () => {
   const React = require("react");
   return {
     __esModule: true,
-    StoreLocatorMap: jest.fn(() => <div data-testid="map" />),
+    StoreLocatorMap: jest.fn(() => <div data-cy="map" />),
   };
 });
 


### PR DESCRIPTION
## Summary
- fix MapBlock test to use data-cy selector
- adjust Slot test to query child via data-testid

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/MapBlock.test.tsx packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c135ad9bfc832f9cd4890dd6f56859