### PR TITLE
test: ensure data-testid attr

### DIFF
--- a/packages/ui/__tests__/CurrencyContext.test.tsx
+++ b/packages/ui/__tests__/CurrencyContext.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { configure, fireEvent, render, screen } from "@testing-library/react";
 import { CurrencyProvider, useCurrency } from "@platform-core/contexts/CurrencyContext";
 
 // React 19 requires this flag for `act` to suppress environment warnings
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+configure({ testIdAttribute: "data-testid" });
 
 function Display() {
   const [currency, setCurrency] = useCurrency();

--- a/packages/ui/src/components/cms/__tests__/MediaSelectionCheck.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/MediaSelectionCheck.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@testing-library/react";
+import { configure, render } from "@testing-library/react";
 import MediaSelectionCheck from "../MediaSelectionCheck";
+
+configure({ testIdAttribute: "data-testid" });
 
 describe("MediaSelectionCheck", () => {
   it("toggles visibility based on selection", () => {


### PR DESCRIPTION
## Summary
- configure CurrencyContext and MediaSelectionCheck tests to use `data-testid`

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/ui/src/components/cms/__tests__/MediaSelectionCheck.test.tsx packages/ui/__tests__/CurrencyContext.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c135a2be70832f99255c6816798cf7