### PR TITLE
test: align testing selectors

### DIFF
--- a/packages/ui/__tests__/Block.interactions.test.tsx
+++ b/packages/ui/__tests__/Block.interactions.test.tsx
@@ -1,6 +1,6 @@
 jest.mock("../src/components/cms/blocks", () => ({
   blockRegistry: {
-    Dummy: { component: () => <div data-testid="inner">content</div> },
+    Dummy: { component: () => <div data-cy="inner">content</div> },
   },
 }));
 

--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx
@@ -17,7 +17,7 @@ test("moves element", () => {
       gridCols: 12,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startDrag} data-cy="box" />;
   }
   const { getByTestId } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;
@@ -44,7 +44,7 @@ test("snaps to grid units", () => {
       gridCols: 4,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startDrag} data-cy="box" />;
   }
   const { getByTestId } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;
@@ -74,7 +74,7 @@ test("removes listeners on unmount", () => {
       gridCols: 12,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startDrag} data-cy="box" />;
   }
   const { getByTestId, unmount } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;


### PR DESCRIPTION
## Summary
- fix tests to use default `data-cy` attribute

## Testing
- `pnpm exec jest packages/ui/__tests__/Block.interactions.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx --coverage=false`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c1359986cc832f8ec29e2eab090278