### PR TITLE
Fix test ids for DynamicRenderer and PageCanvas tests

### DIFF
--- a/packages/ui/__tests__/PageCanvas.test.tsx
+++ b/packages/ui/__tests__/PageCanvas.test.tsx
@@ -5,25 +5,25 @@ import PageCanvas from "../src/components/cms/page-builder/PageCanvas";
 jest.mock("../src/components/cms/page-builder/CanvasItem", () => ({
   __esModule: true,
   default: jest.fn((props) => (
-    <div role="listitem" data-testid={`item-${props.component.id}`} />
+    <div role="listitem" data-cy={`item-${props.component.id}`} />
   )),
 }));
 
 jest.mock("../src/components/cms/page-builder/Block", () => ({
   __esModule: true,
   default: jest.fn((props) => (
-    <div data-testid={`block-${props.component.id}`} />
+    <div data-cy={`block-${props.component.id}`} />
   )),
 }));
 
 jest.mock("../src/components/cms/page-builder/GridOverlay", () => ({
   __esModule: true,
-  default: jest.fn(() => <div data-testid="grid" />),
+  default: jest.fn(() => <div data-cy="grid" />),
 }));
 
 jest.mock("../src/components/cms/page-builder/SnapLine", () => ({
   __esModule: true,
-  default: jest.fn(() => <div data-testid="snapline" />),
+  default: jest.fn(() => <div data-cy="snapline" />),
 }));
 
 const CanvasItemMock = jest.requireMock(

--- a/packages/ui/src/components/__tests__/DynamicRenderer.test.tsx
+++ b/packages/ui/src/components/__tests__/DynamicRenderer.test.tsx
@@ -2,11 +2,11 @@ import { render, screen } from "@testing-library/react";
 import type { PageComponent } from "@acme/types";
 
 const ParentComp = jest.fn(({ children }: any) => (
-  <div data-testid="parent">{children}</div>
+  <div data-cy="parent">{children}</div>
 ));
 
 const ChildComp = jest.fn(({ text }: any) => (
-  <div data-testid="child">{text}</div>
+  <div data-cy="child">{text}</div>
 ));
 
 const mockBlockRegistry = {


### PR DESCRIPTION
## Summary
- use `data-cy` in DynamicRenderer mocked components to match testing-library config
- switch PageCanvas mocks to `data-cy` attributes

## Testing
- `pnpm exec jest packages/ui/src/components/__tests__/DynamicRenderer.test.tsx packages/ui/__tests__/PageCanvas.test.tsx --runInBand --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c135903cb8832f91384cfd2a1e3ea6