### PR TITLE
Use data-cy attributes in UI tests

### DIFF
--- a/packages/ui/src/components/cms/__tests__/MediaFileList.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/MediaFileList.test.tsx
@@ -2,7 +2,7 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import MediaFileList from "../MediaFileList";
 
 jest.mock("../MediaFileItem", () => (props: any) => (
-  <div data-testid="media-item" onClick={() => props.onDelete(props.item.url)}>
+  <div data-cy="media-item" onClick={() => props.onDelete(props.item.url)}>
     item
   </div>
 ));

--- a/packages/ui/src/components/molecules/__tests__/PaymentMethodSelector.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/PaymentMethodSelector.test.tsx
@@ -5,8 +5,8 @@ import { PaymentMethodSelector, type PaymentMethod } from "../PaymentMethodSelec
 
 describe("PaymentMethodSelector", () => {
   const methods: PaymentMethod[] = [
-    { value: "card", label: "Credit Card", icon: <svg data-testid="card-icon" /> },
-    { value: "paypal", label: "PayPal", icon: <svg data-testid="paypal-icon" /> },
+    { value: "card", label: "Credit Card", icon: <svg data-cy="card-icon" /> },
+    { value: "paypal", label: "PayPal", icon: <svg data-cy="paypal-icon" /> },
   ];
 
   function Wrapper({ onChange }: { onChange: (value: string) => void }) {


### PR DESCRIPTION
## Summary
- use data-cy for icon IDs in PaymentMethodSelector tests
- use data-cy on MediaFileList mocked items

## Testing
- `pnpm exec jest packages/ui/src/components/molecules/__tests__/PaymentMethodSelector.test.tsx packages/ui/src/components/cms/__tests__/MediaFileList.test.tsx --config jest.config.cjs --runInBand --runTestsByPath`
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui run build` *(fails: TS2307: Cannot find module '@acme/ui')*


------
https://chatgpt.com/codex/tasks/task_e_68c1356bb060832f9853c4f48c468ec5