### PR TITLE
test: align test ids with Testing Library config

### DIFF
--- a/packages/ui/__tests__/HeroBannerBlock.test.tsx
+++ b/packages/ui/__tests__/HeroBannerBlock.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import CmsHeroBanner from "../src/components/cms/blocks/HeroBanner";
 
-const heroMock = jest.fn(() => <div data-testid="hero" />);
+const heroMock = jest.fn(() => <div data-cy="hero" data-testid="hero" />);
 jest.mock("../src/components/home/HeroBanner.client", () => ({
   __esModule: true,
   default: (props: any) => {
     heroMock(props);
-    return <div data-testid="hero" />;
+    return <div data-cy="hero" data-testid="hero" />;
   },
 }));
 

--- a/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
@@ -17,7 +17,7 @@ describe("Select", () => {
     const onValueChange = jest.fn();
     render(
       <Select onValueChange={onValueChange}>
-        <SelectTrigger data-cy="trigger">
+        <SelectTrigger data-cy="trigger" data-testid="trigger">
           <SelectValue placeholder="Pick" />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
## Summary
- add `data-testid` to `SelectTrigger`
- mock HeroBanner with both `data-cy` and `data-testid`

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- src/components/atoms/primitives/__tests__/select.test.tsx __tests__/HeroBannerBlock.test.tsx` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c1357a4398832fb0f276f1c39f6a6e