### PR TITLE
fix test ids in ui components

### DIFF
--- a/packages/ui/src/components/atoms/LineChart.tsx
+++ b/packages/ui/src/components/atoms/LineChart.tsx
@@ -34,6 +34,7 @@ export function LineChart({ data, options, className }: LineChartProps) {
       options={options}
       className={className}
       data-cy="line-chart"
+      data-testid="line-chart"
     />
   );
 }

--- a/packages/ui/src/components/atoms/__tests__/LineChart.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/LineChart.test.tsx
@@ -30,6 +30,7 @@ describe("LineChart", () => {
         options,
         className: "custom",
         "data-cy": "line-chart",
+        "data-testid": "line-chart",
       }),
     );
   });

--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx
@@ -17,7 +17,7 @@ test("moves element", () => {
       gridCols: 12,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startDrag} data-cy="box" />;
   }
   const { getByTestId } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;
@@ -44,7 +44,7 @@ test("snaps to grid units", () => {
       gridCols: 4,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startDrag} data-cy="box" />;
   }
   const { getByTestId } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;
@@ -74,7 +74,7 @@ test("removes listeners on unmount", () => {
       gridCols: 12,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startDrag} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startDrag} data-cy="box" />;
   }
   const { getByTestId, unmount } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;

--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasResize.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasResize.test.tsx
@@ -21,7 +21,7 @@ test("resizes element", () => {
       gridCols: 12,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startResize} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startResize} data-cy="box" />;
   }
   const { getByTestId } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;
@@ -52,7 +52,7 @@ test("snaps to grid units", () => {
       gridCols: 4,
       containerRef: ref,
     });
-    return <div ref={ref} onPointerDown={startResize} data-testid="box" />;
+    return <div ref={ref} onPointerDown={startResize} data-cy="box" />;
   }
   const { getByTestId } = render(<Wrapper />);
   const box = getByTestId("box") as HTMLElement;

--- a/packages/ui/src/components/cms/page-builder/__tests__/useGuides.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useGuides.test.tsx
@@ -13,9 +13,9 @@ test("computes sibling edge offsets", () => {
     siblingEdgesRef = hooks.siblingEdgesRef;
     return (
       <div>
-        <div data-testid="s1" />
-        <div ref={ref} data-testid="target" />
-        <div data-testid="s2" />
+        <div data-cy="s1" />
+        <div ref={ref} data-cy="target" />
+        <div data-cy="s2" />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- add `data-testid` to LineChart and update test
- use `data-cy` attributes in page builder hook tests

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run build` *(fails: TypeScript errors)*
- `pnpm exec jest --runTestsByPath packages/ui/src/components/atoms/__tests__/LineChart.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useCanvasResize.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useGuides.test.tsx packages/ui/src/components/cms/page-builder/__tests__/useCanvasDrag.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c13586a5f8832f9b4fb5ba09f6637f