### PR TITLE
test: ensure analytics sync early exit

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -118,6 +118,26 @@ describe("syncCampaignAnalytics", () => {
     delete process.env.EMAIL_PROVIDER;
   });
 
+  it("returns early when EMAIL_PROVIDER is unset", async () => {
+    jest.resetModules();
+    const trackEvent = jest.fn();
+    jest.doMock("@platform-core/analytics", () => ({
+      __esModule: true,
+      trackEvent,
+    }));
+    jest.doMock("../src/providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
+    jest.doMock("../src/providers/resend", () => ({ ResendProvider: jest.fn() }));
+    const getCampaignStore = jest.fn();
+    jest.doMock("../src/storage", () => ({ __esModule: true, getCampaignStore }));
+
+    delete process.env.EMAIL_PROVIDER;
+    const { syncCampaignAnalytics } = await import("../src/analytics");
+    await syncCampaignAnalytics();
+
+    expect(getCampaignStore).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
   it("sends stats for sent campaigns and falls back to empty stats on failure", async () => {
     jest.resetModules();
     const trackEvent = jest.fn();


### PR DESCRIPTION
## Summary
- add test verifying syncCampaignAnalytics exits early when EMAIL_PROVIDER unset

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/email/__tests__/analytics.test.ts --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1551485e4832f8bcd7241d949cdc8