### PR TITLE
test: cover resend analytics edge cases

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -106,6 +106,35 @@ describe("mapResendEvent", () => {
     });
   });
 
+  it("handles events with only campaign_id", async () => {
+    setupMocks();
+    const { mapResendEvent } = await import("../src/analytics");
+    const ev = {
+      type: "email.delivered",
+      data: {
+        campaign_id: "camp-1",
+      },
+    } as const;
+    expect(mapResendEvent(ev)).toEqual<EmailAnalyticsEvent>({
+      type: "email_delivered",
+      campaign: "camp-1",
+      messageId: undefined,
+      recipient: undefined,
+    });
+  });
+
+  it("handles events without data", async () => {
+    setupMocks();
+    const { mapResendEvent } = await import("../src/analytics");
+    const ev = { type: "email.delivered" } as const;
+    expect(mapResendEvent(ev)).toEqual<EmailAnalyticsEvent>({
+      type: "email_delivered",
+      campaign: undefined,
+      messageId: undefined,
+      recipient: undefined,
+    });
+  });
+
   it("returns null for unknown types", async () => {
     setupMocks();
     const { mapResendEvent } = await import("../src/analytics");


### PR DESCRIPTION
## Summary
- extend resend analytics tests for campaign_id and missing data cases

## Testing
- `pnpm --filter @acme/email test packages/email/__tests__/analytics.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*


------
https://chatgpt.com/codex/tasks/task_e_68c1562bd1a4832f86165d5d24bd563a