### PR TITLE
test: ignore invalid env for abandoned cart delay

### DIFF
--- a/packages/email/src/__tests__/abandonedCart.test.ts
+++ b/packages/email/src/__tests__/abandonedCart.test.ts
@@ -245,6 +245,18 @@ describe("resolveAbandonedCartDelay", () => {
     expect(delay).toBe(44444);
   });
 
+  it("uses file delay when env overrides are non-numeric", async () => {
+    jest
+      .spyOn(fs, "readFile")
+      .mockResolvedValue(
+        JSON.stringify({ abandonedCart: { delayMs: 12345 } }, null, 2),
+      );
+    process.env[key] = "not-a-number";
+    process.env.ABANDONED_CART_DELAY_MS = "also-not-a-number";
+    const delay = await resolveAbandonedCartDelay(shop, "/tmp");
+    expect(delay).toBe(12345);
+  });
+
   it("ignores non-numeric env values and returns default", async () => {
     jest
       .spyOn(fs, "readFile")


### PR DESCRIPTION
## Summary
- add test asserting resolveAbandonedCartDelay ignores non-numeric env overrides in favor of settings file

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm --filter @acme/email test packages/email/src/__tests__/abandonedCart.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c158bdc7fc832faae31a79e54604ec