### PR TITLE
test: ensure gatherChanges filters unchanged components

### DIFF
--- a/apps/api/src/routes/components/__tests__/helpers.test.ts
+++ b/apps/api/src/routes/components/__tests__/helpers.test.ts
@@ -100,6 +100,34 @@ describe('component helpers', () => {
       expect(gatherChanges('abc', root)).toEqual([]);
     });
 
+    it('returns only components whose versions have changed', () => {
+      vol.fromJSON({
+        [`${root}/data/shops/abc/shop.json`]: JSON.stringify({
+          componentVersions: {
+            '@acme/foo': '1.0.0',
+            '@acme/bar': '1.0.0',
+          },
+        }),
+        [`${root}/packages/foo/package.json`]: JSON.stringify({
+          name: '@acme/foo',
+          version: '1.0.0',
+        }),
+        [`${root}/packages/bar/package.json`]: JSON.stringify({
+          name: '@acme/bar',
+          version: '2.0.0',
+        }),
+      });
+      expect(gatherChanges('abc', root)).toEqual([
+        {
+          name: '@acme/bar',
+          from: '1.0.0',
+          to: '2.0.0',
+          summary: '',
+          changelog: '',
+        },
+      ]);
+    });
+
     it('handles missing changelog files', () => {
       vol.fromJSON({
         [`${root}/data/shops/abc/shop.json`]: JSON.stringify({


### PR DESCRIPTION
## Summary
- add test covering mixed component versions in gatherChanges

## Testing
- `pnpm install`
- `pnpm -r build` (failed: Cannot find module '@acme/ui')
- `pnpm exec jest apps/api/src/routes/components/__tests__/helpers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c15a634738832fb946f41d2c02e659