### PR TITLE
test(email): filter empty recipients

### DIFF
--- a/packages/email/src/__tests__/cli.test.ts
+++ b/packages/email/src/__tests__/cli.test.ts
@@ -53,7 +53,7 @@ test("campaign create writes campaign file", async () => {
     "--body",
     "<p>Hi</p>",
     "--recipients",
-    "a@example.com",
+    "a@example.com, , b@example.com ",
     "--send-at",
     "2020-01-01T00:00:00.000Z",
   ];
@@ -68,7 +68,7 @@ test("campaign create writes campaign file", async () => {
   expect(json[0]).toMatchObject({
     subject: "Hi",
     body: "<p>Hi</p>",
-    recipients: ["a@example.com"],
+    recipients: ["a@example.com", "b@example.com"],
   });
   expect(typeof json[0].sendAt).toBe("string");
   expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/^Created campaign/));


### PR DESCRIPTION
## Summary
- ensure CLI campaign creation ignores empty recipient entries

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test src/__tests__/cli.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c158c31a3c832fae50ece6d5986778