### PR TITLE
test(email): cover missing SendGrid fields

### DIFF
--- a/packages/email/src/__tests__/analytics.test.ts
+++ b/packages/email/src/__tests__/analytics.test.ts
@@ -120,6 +120,42 @@ describe("analytics mapping", () => {
     });
   });
 
+  it("handles SendGrid events without sg_message_id", async () => {
+    jest.resetModules();
+    process.env.CART_COOKIE_SECRET = "secret";
+    jest.doMock("@platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
+    jest.doMock("../providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
+    jest.doMock("../providers/resend", () => ({ ResendProvider: jest.fn() }));
+    const { mapSendGridEvent } = await import("../analytics");
+    const ev = {
+      event: "open",
+      email: "user@example.com",
+    };
+    expect(mapSendGridEvent(ev)).toEqual({
+      type: "email_open",
+      messageId: undefined,
+      recipient: "user@example.com",
+    });
+  });
+
+  it("handles SendGrid events without email", async () => {
+    jest.resetModules();
+    process.env.CART_COOKIE_SECRET = "secret";
+    jest.doMock("@platform-core/analytics", () => ({ __esModule: true, trackEvent: jest.fn() }));
+    jest.doMock("../providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
+    jest.doMock("../providers/resend", () => ({ ResendProvider: jest.fn() }));
+    const { mapSendGridEvent } = await import("../analytics");
+    const ev = {
+      event: "open",
+      sg_message_id: "msg-4",
+    };
+    expect(mapSendGridEvent(ev)).toEqual({
+      type: "email_open",
+      messageId: "msg-4",
+      recipient: undefined,
+    });
+  });
+
   it("normalizes Resend webhook events with campaign_id", async () => {
     jest.resetModules();
     process.env.CART_COOKIE_SECRET = "secret";


### PR DESCRIPTION
## Summary
- test SendGrid event mapping when sg_message_id is absent
- test SendGrid event mapping when email is missing

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: TS2307 Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test src/__tests__/analytics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c158c427f0832fbe96311bcc6fd552