### PR TITLE
test(email): check ResendProvider ready behavior

### DIFF
--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -39,6 +39,25 @@ describe("ResendProvider", () => {
     });
   });
 
+  it("resolves when sanity check succeeds", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    await expect(
+      new ResendProvider({ sanityCheck: true }).ready
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when sanity check fetch fails", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    const err = new Error("fail");
+    global.fetch = jest.fn().mockRejectedValue(err) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    await expect(
+      new ResendProvider({ sanityCheck: true }).ready
+    ).rejects.toBe(err);
+  });
+
   it("throws when sanity check fails", async () => {
     process.env.RESEND_API_KEY = "rs";
     const originalFetch = global.fetch;


### PR DESCRIPTION
## Summary
- add tests for `ResendProvider.ready` resolving or rejecting based on fetch behavior

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/resend.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c158c4e1b4832fbfd49e6b158a504d