### PR TITLE
Ensure Stripe publishable key in payments env test

### DIFF
--- a/packages/auth/src/__tests__/env.payments.test.ts
+++ b/packages/auth/src/__tests__/env.payments.test.ts
@@ -18,6 +18,7 @@ describe("payments env provider", () => {
         PAYMENTS_PROVIDER: "stripe",
         STRIPE_SECRET_KEY: "sk_live_123",
         STRIPE_WEBHOOK_SECRET: "whsec_live_123",
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_live_123",
       },
       () => import("@acme/config/env/payments"),
     );


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to Stripe payments env test

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest packages/auth/src/__tests__/env.payments.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c1597710bc832fa84568b13ad3054b