### PR TITLE
fix email cli test path resolution

### DIFF
--- a/packages/email/__tests__/resolveDataRoot-parent.test.ts
+++ b/packages/email/__tests__/resolveDataRoot-parent.test.ts
@@ -17,7 +17,7 @@ describe("resolveDataRoot", () => {
     try {
       process.chdir(nested);
       const resolved = resolveDataRoot();
-      expect(resolved).toBe(shops);
+      expect(await fs.realpath(resolved)).toBe(await fs.realpath(shops));
     } finally {
       process.chdir(original);
       await fs.rm(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- fix resolveDataRoot test to compare real paths
- evaluate bin.ts in test via manual transpile to bypass shebang

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test -- packages/email/__tests__/resolveDataRoot-parent.test.ts packages/email/src/__tests__/bin.test.ts` *(coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c15d0fdd74832fbd2d24044c584c6f