### PR TITLE
test: verify srem not called when session missing

### DIFF
--- a/packages/auth/src/__tests__/redisStore.test.ts
+++ b/packages/auth/src/__tests__/redisStore.test.ts
@@ -133,12 +133,14 @@ describe("RedisSessionStore", () => {
     await expect(store.list("c1")).resolves.toEqual([]);
   });
 
-  it("deletes session without customer set when record is missing", async () => {
-    client.get.mockResolvedValueOnce(null);
-    await store.delete("s1");
+  it("does not call srem when session record is missing", async () => {
+    jest.spyOn(store, "get").mockResolvedValue(null);
+    const sremSpy = jest.spyOn(client, "srem");
 
-    expect(client.del).toHaveBeenCalledWith("session:s1");
-    expect(client.srem).not.toHaveBeenCalled();
+    await store.delete("id");
+
+    expect(client.del).toHaveBeenCalledWith("session:id");
+    expect(sremSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- test that RedisSessionStore.delete does not call `srem` when `get` returns null

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/auth test` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c15cb07148832f95c0c5a0fe6f08d5