### PR TITLE
test(auth): handle unknown session store with memory fallback

### DIFF
--- a/packages/auth/__tests__/store.test.ts
+++ b/packages/auth/__tests__/store.test.ts
@@ -38,6 +38,16 @@ describe("createSessionStore", () => {
     expect(store).toBeInstanceOf(MemorySessionStore);
   });
 
+  it("falls back to MemorySessionStore when SESSION_STORE is unrecognized", async () => {
+    jest.doMock("@acme/config/env/core", () => ({
+      coreEnv: { SESSION_STORE: "foobar" },
+    }));
+    const { createSessionStore } = await import("../src/store");
+    const { MemorySessionStore } = await import("../src/memoryStore");
+    const store = await createSessionStore();
+    expect(store).toBeInstanceOf(MemorySessionStore);
+  });
+
   it("allows overriding via setSessionStoreFactory", async () => {
     jest.doMock("@acme/config/env/core", () => ({ coreEnv: {} }));
     const { createSessionStore, setSessionStoreFactory } = await import(


### PR DESCRIPTION
## Summary
- test that createSessionStore falls back to MemorySessionStore when SESSION_STORE is unrecognized

## Testing
- `pnpm install`
- `pnpm --filter @acme/auth build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest --config jest.config.cjs --runTestsByPath packages/auth/__tests__/store.test.ts` *(fails: other tests across repo fail)*

------
https://chatgpt.com/codex/tasks/task_e_68c15caeab50832fa89c9ca4c352b8ce