### PR TITLE
Add 404 test for GET publish-upgrade route

### DIFF
--- a/apps/api/__tests__/createRequestHandler.spec.ts
+++ b/apps/api/__tests__/createRequestHandler.spec.ts
@@ -164,6 +164,29 @@ describe("createRequestHandler", () => {
     expect(end).toHaveBeenCalledWith("");
   });
 
+  it("returns 404 for GET /shop/:id/publish-upgrade", async () => {
+    const handler = createRequestHandler();
+
+    const req = new Readable({
+      read() {
+        this.push(null);
+      },
+    }) as unknown as IncomingMessage;
+    req.url = "/shop/abc/publish-upgrade";
+    req.method = "GET";
+    req.headers = {};
+
+    const end = jest.fn();
+    const res = { statusCode: 0, setHeader: jest.fn(), end } as unknown as ServerResponse;
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(end).toHaveBeenCalledWith();
+    expect(componentsHandlerMock).not.toHaveBeenCalled();
+    expect(publishUpgradeMock).not.toHaveBeenCalled();
+  });
+
   it("returns 404 for unrecognized path", async () => {
     const handler = createRequestHandler();
 


### PR DESCRIPTION
## Summary
- add test verifying GET `/shop/:id/publish-upgrade` is not handled and returns 404

## Testing
- `pnpm --filter @apps/api exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs --no-coverage`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c15a5fb1fc832fac265b04212aecfe