### PR TITLE
test(api): handle duplicate components

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -128,6 +128,52 @@ describe("onRequestPost", () => {
       );
     });
 
+  it("deduplicates components and spawns build/deploy", async () => {
+    readFileSync.mockImplementation((file: string) => {
+      if (file.endsWith("package.json")) {
+        return JSON.stringify({ dependencies: { compA: "1.0.0" } });
+      }
+      if (file.endsWith("shop.json")) {
+        return JSON.stringify({ componentVersions: {} });
+      }
+      return "";
+    });
+    spawn.mockImplementation(() => ({
+      on: (_: string, cb: (code: number) => void) => cb(0),
+    }));
+
+    const token = jwt.sign({}, "secret");
+    const res = await onRequestPost({
+      params: { id },
+      request: new Request("http://example.com", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ components: ["compA", "compA"] }),
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [shopPath, data] = writeFileSync.mock.calls[0];
+    expect(shopPath).toContain(`data/shops/${id}/shop.json`);
+    const written = JSON.parse(data as string);
+    expect(written.componentVersions).toEqual({ compA: "1.0.0" });
+    expect(Object.keys(written.componentVersions)).toHaveLength(1);
+    expect(typeof written.lastUpgrade).toBe("string");
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      "pnpm",
+      ["--filter", `apps/shop-${id}`, "build"],
+      { cwd: root, stdio: "inherit" },
+    );
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      "pnpm",
+      ["--filter", `apps/shop-${id}`, "deploy"],
+      { cwd: root, stdio: "inherit" },
+    );
+  });
+
   it("creates componentVersions when missing and spawns build/deploy", async () => {
     readFileSync.mockImplementation((file: string) => {
       if (file.endsWith("package.json")) {


### PR DESCRIPTION
## Summary
- test duplicate components array when publishing upgrades

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/api test -- --runTestsByPath src/routes/shop/\\[id\\]/__tests__/publish-upgrade.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c17aafb2a0832f9a840bc5da2ad310