### PR TITLE
test(ui): add color utility coverage

### DIFF
--- a/packages/ui/__tests__/colorUtils.test.ts
+++ b/packages/ui/__tests__/colorUtils.test.ts
@@ -1,4 +1,4 @@
-import { hexToRgb, getContrastColor } from "../src/utils/colorUtils";
+import { hexToRgb, getContrastColor, hexToHsl } from "../src/utils/colorUtils";
 
 describe("hexToRgb", () => {
   it("converts 6-digit hex to RGB", () => {
@@ -23,8 +23,26 @@ describe("getContrastColor", () => {
     expect(getContrastColor("#000000")).toBe("#ffffff");
   });
 
+  it("handles high-contrast colors", () => {
+    expect(getContrastColor("#ff0000")).toBe("#ffffff");
+  });
+
   it("throws on invalid hex", () => {
     expect(() => getContrastColor("oops" as any)).toThrow("Invalid hex color");
+  });
+});
+
+describe("hexToHsl", () => {
+  it("converts 6-digit hex to HSL", () => {
+    expect(hexToHsl("#123456")).toBe("210 65% 20%");
+  });
+
+  it("converts 3-digit hex to HSL", () => {
+    expect(hexToHsl("#0f0")).toBe("120 100% 50%");
+  });
+
+  it("handles high-contrast colors", () => {
+    expect(hexToHsl("#ff0000")).toBe("0 100% 50%");
   });
 });
 


### PR DESCRIPTION
## Summary
- add contrast case for color utilities
- cover hex to HSL conversion for 3- and 6-digit inputs

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/ui run check:references` *(fails: script not found)*
- `pnpm --filter @acme/ui run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/ui test` *(fails: core.env.test.ts, releaseDepositsService.test.ts, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68c178431808832f9ece63550d8696d1