### PR TITLE
test: handle shop read failure

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -708,6 +708,33 @@ describe("onRequestPost", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("returns 500 when reading shop file fails", async () => {
+    readFileSync.mockImplementation((file: string) => {
+      if (file.endsWith("package.json")) {
+        return JSON.stringify({ dependencies: { compA: "1.0.0" } });
+      }
+      if (file.endsWith("shop.json")) {
+        throw new Error("cannot read");
+      }
+      return "";
+    });
+
+    const token = jwt.sign({}, "secret");
+    const res = await onRequestPost({
+      params: { id },
+      request: new Request("http://example.com", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ components: ["compA"] }),
+      }),
+    });
+
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "cannot read" });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it("returns 500 when shop file cannot be parsed", async () => {
     const invalid = "not-json";
     readFileSync.mockImplementation((file: string) => {


### PR DESCRIPTION
## Summary
- add coverage for shop.json read errors in publish-upgrade route

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68c17804b274832f8e068980bff7ffdc