### PR TITLE
test: validate missing shop id

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -26,6 +26,19 @@ beforeEach(() => {
 
 describe("onRequestPost", () => {
   describe("id validation", () => {
+    it("rejects missing id", async () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation();
+      const res = await onRequestPost({
+        params: {} as any,
+        request: new Request("http://example.com", { method: "POST" }),
+      });
+      const body = await res.json();
+      expect(res.status).toBe(400);
+      expect(body).toEqual({ error: "Invalid shop id" });
+      expect(warn).toHaveBeenCalledWith("invalid shop id", { id: undefined });
+      warn.mockRestore();
+    });
+
     it.each(["", "ABC", "abc!", "Shop"])(
       "rejects invalid id '%s'",
       async (bad) => {

--- a/apps/api/src/routes/shop/[id]/publish-upgrade.ts
+++ b/apps/api/src/routes/shop/[id]/publish-upgrade.ts
@@ -22,7 +22,7 @@ export const onRequestPost = async ({
 }) => {
   try {
     const id = params.id;
-    if (!/^[a-z0-9_-]+$/.test(id)) {
+    if (!id || !/^[a-z0-9_-]+$/.test(id)) {
       console.warn("invalid shop id", { id });
       return new Response(JSON.stringify({ error: "Invalid shop id" }), {
         status: 400,


### PR DESCRIPTION
## Summary
- test publish-upgrade with missing shop id
- ensure publish-upgrade rejects requests lacking shop id

## Testing
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm exec jest 'apps/api/src/routes/shop/\[id\]/__tests__/publish-upgrade.test.ts'`


------
https://chatgpt.com/codex/tasks/task_e_68c178001bc4832fb5e4ede1eaa840d8