### PR TITLE
refactor: unify test id attributes

### DIFF
--- a/apps/cms/__tests__/LayoutClient.client.test.tsx
+++ b/apps/cms/__tests__/LayoutClient.client.test.tsx
@@ -11,12 +11,12 @@ jest.mock("@platform-core/contexts/LayoutContext", () => ({
 
 // Stub internal components
 jest.mock("@ui/components/cms/Sidebar.client", () => () => (
-  <div data-testid="sidebar">Sidebar</div>
+  <div data-cy="sidebar">Sidebar</div>
 ));
 jest.mock("@ui/components/cms/TopBar.client", () => () => <div>TopBar</div>);
 jest.mock("@/components/atoms", () => ({
   Progress: ({ value, label }: any) => (
-    <div data-testid="progress">{label} - {value}</div>
+    <div data-cy="progress">{label} - {value}</div>
   ),
 }));
 

--- a/apps/cms/__tests__/PageBuilder.integration.test.tsx
+++ b/apps/cms/__tests__/PageBuilder.integration.test.tsx
@@ -68,7 +68,7 @@ jest.mock("@ui/components/cms/page-builder/CanvasItem", () => ({
     const color = overrides.color?.fg;
     return (
       <div role="listitem">
-        <div data-testid={`block-${component.id}`} style={{ color }}>
+        <div data-cy={`block-${component.id}`} style={{ color }}>
           {component.type}
         </div>
         <button onClick={onRemove}>×</button>
@@ -83,7 +83,7 @@ jest.mock("@ui/components/cms/page-builder/Block", () => ({
     const overrides = component.styles ? JSON.parse(component.styles) : {};
     const color = overrides.color?.fg;
     return (
-      <div data-testid={`block-${component.id}`} style={{ color }}>
+      <div data-cy={`block-${component.id}`} style={{ color }}>
         {component.type}
       </div>
     );
@@ -175,7 +175,7 @@ describe("PageBuilder integration", () => {
     });
     await waitFor(() => expect(componentsState[0].id).toBe(secondId));
     expect(screen.getAllByTestId(/block-/)[0]).toHaveAttribute(
-      "data-testid",
+      "data-cy",
       `block-${secondId}`,
     );
 

--- a/apps/cms/__tests__/configuratorSteps.test.tsx
+++ b/apps/cms/__tests__/configuratorSteps.test.tsx
@@ -25,7 +25,7 @@ jest.mock("@/components/atoms/shadcn", () => ({
     <select
       value={value}
       onChange={(e) => onValueChange(e.target.value)}
-      data-testid="select"
+      data-cy="select"
     >
       {children}
     </select>
@@ -44,7 +44,7 @@ jest.mock("@ui/components/atoms/shadcn", () => ({
     <select
       value={value}
       onChange={(e) => onValueChange(e.target.value)}
-      data-testid="select"
+      data-cy="select"
     >
       {children}
     </select>
@@ -115,12 +115,12 @@ jest.mock("../src/app/cms/configurator/steps/ThemeEditorForm", () => ({
 
 jest.mock("@ui/components/cms/StyleEditor", () => ({
   __esModule: true,
-  default: () => <div data-testid="style-editor">editor</div>,
+  default: () => <div data-cy="style-editor">editor</div>,
 }));
 
 jest.mock("../src/app/cms/wizard/WizardPreview", () => ({
   __esModule: true,
-  default: (props: any) => <div data-testid="preview" {...props} />,
+  default: (props: any) => <div data-cy="preview" {...props} />,
 }));
 
 jest.mock("../src/app/cms/wizard/TokenInspector", () => ({

--- a/apps/cms/__tests__/wizard-inspector.test.tsx
+++ b/apps/cms/__tests__/wizard-inspector.test.tsx
@@ -29,7 +29,10 @@ jest.mock("@ui/components/common/DeviceSelector", () => {
 jest.mock("../src/app/cms/wizard/WizardPreview", () => ({
   __esModule: true,
   default: ({ style, device }: any) => (
-    <div data-testid="preview" style={{ ...style, width: `${device.width}px`, height: `${device.height}px` }} />
+    <div
+      data-cy="preview"
+      style={{ ...style, width: `${device.width}px`, height: `${device.height}px` }}
+    />
   ),
 }));
 

--- a/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
+++ b/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
@@ -5,13 +5,13 @@ import LocaleLayout from "../layout";
 
 jest.mock("@ui/components/layout/Footer", () => ({
   __esModule: true,
-  default: () => <div data-testid="footer" />,
+  default: () => <div data-cy="footer" />,
 }));
 
 jest.mock("@ui/components/layout/Header", () => ({
   __esModule: true,
   default: jest.fn(({ lang }: { lang: string }) => (
-    <div data-testid="header">{lang}</div>
+    <div data-cy="header">{lang}</div>
   )),
 }));
 

--- a/apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.tsx
@@ -17,7 +17,7 @@ jest.mock("@cms/app/cms/blog/posts/ProductPreview", () => ({
   __esModule: true,
   default: ({ onValidChange }: any) => {
     onValidChange?.(false);
-    return <div data-testid="product-preview" />;
+    return <div data-cy="product-preview" />;
   },
 }));
 

--- a/apps/cms/src/app/cms/configurator/__tests__/ConfiguratorContext.test.tsx
+++ b/apps/cms/src/app/cms/configurator/__tests__/ConfiguratorContext.test.tsx
@@ -11,9 +11,9 @@ function TestComponent(): JSX.Element {
   const { update, markStepComplete, state } = useConfigurator();
   return (
     <>
-      <button onClick={() => update("storeName", "My Store")} data-testid="update" />
-      <button onClick={() => markStepComplete("intro", "complete")} data-testid="complete" />
-      <div data-testid="status">{state.completed.intro}</div>
+      <button onClick={() => update("storeName", "My Store")} data-cy="update" />
+      <button onClick={() => markStepComplete("intro", "complete")} data-cy="complete" />
+      <div data-cy="status">{state.completed.intro}</div>
     </>
   );
 }

--- a/apps/cms/src/app/cms/configurator/steps/StepAdditionalPages/__tests__/StepAdditionalPages.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepAdditionalPages/__tests__/StepAdditionalPages.test.tsx
@@ -46,7 +46,7 @@ jest.mock("../PageMetaForm", () => ({
   default: ({ slug, setSlug, setTitle, setDesc, setImage }: any) => (
     <div>
       <span>meta form</span>
-      <span data-testid="slug-display">{slug}</span>
+      <span data-cy="slug-display">{slug}</span>
       <button
         onClick={() => {
           setSlug("slug");

--- a/apps/cms/src/app/cms/configurator/steps/StepCheckoutPage.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepCheckoutPage.tsx
@@ -55,7 +55,6 @@ export default function StepCheckoutPage({
       <h2 className="text-xl font-semibold">Checkout Page</h2>
       <Select
         data-cy="checkout-layout"
-        data-testid="checkout-layout"
         value={checkoutLayout}
         onValueChange={(val: string) => {
           const layout = val === "blank" ? "" : val;
@@ -126,7 +125,6 @@ export default function StepCheckoutPage({
       <div className="flex justify-end">
         <Button
           data-cy="save-return"
-          data-testid="save-return"
           onClick={() => {
             markComplete(true);
             router.push("/cms/configurator");

--- a/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepShopDetails.tsx
@@ -79,7 +79,6 @@ export default function StepShopDetails({
         <span>Shop ID</span>
         <Input
           data-cy="shop-id"
-          data-testid="shop-id"
           value={shopId}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setShopId(e.target.value)}
           placeholder="my-shop"
@@ -92,7 +91,6 @@ export default function StepShopDetails({
         <span>Store Name</span>
         <Input
           data-cy="store-name"
-          data-testid="store-name"
           value={storeName}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setStoreName(e.target.value)}
           placeholder="My Store"
@@ -114,7 +112,6 @@ export default function StepShopDetails({
           <div className="flex items-center gap-2">
             <Input
               data-cy={`logo-${key}`}
-              data-testid={`logo-${key}`}
               value={logo[key] ?? ""}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setLogo({ ...logo, [key]: e.target.value })
@@ -134,7 +131,6 @@ export default function StepShopDetails({
         <span>Contact Info</span>
         <Input
           data-cy="contact-info"
-          data-testid="contact-info"
           value={contactInfo}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setContactInfo(e.target.value)}
           placeholder="Email or phone"
@@ -145,7 +141,7 @@ export default function StepShopDetails({
       </label>
       <label className="flex flex-col gap-1">
         <span>Shop Type</span>
-        <Select data-cy="shop-type" data-testid="shop-type" value={type} onValueChange={setType}>
+        <Select data-cy="shop-type" value={type} onValueChange={setType}>
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Select type" />
           </SelectTrigger>
@@ -160,7 +156,7 @@ export default function StepShopDetails({
       </label>
       <label className="flex flex-col gap-1">
         <span>Template</span>
-        <Select data-cy="template" data-testid="template" value={template} onValueChange={setTemplate}>
+        <Select data-cy="template" value={template} onValueChange={setTemplate}>
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Select template" />
           </SelectTrigger>
@@ -179,7 +175,6 @@ export default function StepShopDetails({
       <div className="flex justify-end">
         <Button
           data-cy="save-return"
-          data-testid="save-return"
           disabled={!isValid}
           onClick={() => {
             markComplete(true);

--- a/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/StepTheme.tsx
@@ -82,7 +82,6 @@ export default function StepTheme({
         {prevStepId && (
           <Button
             data-cy="back"
-            data-testid="back"
             variant="outline"
             onClick={() => router.push(`/cms/configurator/${prevStepId}`)}
           >
@@ -92,7 +91,6 @@ export default function StepTheme({
         {nextStepId && (
           <Button
             data-cy="next"
-            data-testid="next"
             onClick={() => {
               markComplete(true);
               router.push(`/cms/configurator/${nextStepId}`);

--- a/apps/cms/src/app/cms/wizard/__tests__/TokenInspector.test.tsx
+++ b/apps/cms/src/app/cms/wizard/__tests__/TokenInspector.test.tsx
@@ -7,7 +7,7 @@ jest.mock("@ui/components/atoms", () => {
   return {
     __esModule: true,
     Button: (props: any) => <button {...props} />,
-    Popover: ({ open, children }: any) => (open ? <div data-testid="popover">{children}</div> : null),
+    Popover: ({ open, children }: any) => (open ? <div data-cy="popover">{children}</div> : null),
     PopoverAnchor: ({ children }: any) => <>{children}</>,
     PopoverContent: ({ children }: any) => <div>{children}</div>,
   };
@@ -18,7 +18,7 @@ describe("TokenInspector", () => {
     const onTokenSelect = jest.fn();
     render(
       <TokenInspector inspectMode onTokenSelect={onTokenSelect}>
-        <div data-testid="preview">
+        <div data-cy="preview">
           <div data-token="token-a">A</div>
           <div data-token="token-b">B</div>
         </div>

--- a/apps/cms/src/components/cms/__tests__/PageBuilder.test.tsx
+++ b/apps/cms/src/components/cms/__tests__/PageBuilder.test.tsx
@@ -4,7 +4,7 @@ import UiPageBuilder from "@ui/components/cms/PageBuilder";
 
 jest.mock("@ui/components/cms/PageBuilder", () => ({
   __esModule: true,
-  default: jest.fn(() => <div data-testid="ui-page-builder" />),
+  default: jest.fn(() => <div data-cy="ui-page-builder" />),
 }));
 
 describe("cms PageBuilder re-export", () => {


### PR DESCRIPTION
## Summary
- use `data-cy` instead of `data-testid` across cms tests and components

## Testing
- `pnpm exec jest apps/cms/__tests__/wizard-inspector.test.tsx --runInBand --passWithNoTests`
- `pnpm exec jest apps/cms/src/app/cms/blog/posts/__tests__/schema.spec.tsx --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c172f2b30c832fa00e2f4dab01d2e0