### PR TITLE
test: align cms tests with data-cy attribute

### DIFF
--- a/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
+++ b/apps/cms/src/app/[lang]/__tests__/layout.test.tsx
@@ -5,13 +5,13 @@ import LocaleLayout from "../layout";
 
 jest.mock("@ui/components/layout/Footer", () => ({
   __esModule: true,
-  default: () => <div data-testid="footer" />,
+  default: () => <div data-cy="footer" />,
 }));
 
 jest.mock("@ui/components/layout/Header", () => ({
   __esModule: true,
   default: jest.fn(({ lang }: { lang: string }) => (
-    <div data-testid="header">{lang}</div>
+    <div data-cy="header">{lang}</div>
   )),
 }));
 

--- a/apps/cms/src/app/cms/wizard/__tests__/TokenInspector.test.tsx
+++ b/apps/cms/src/app/cms/wizard/__tests__/TokenInspector.test.tsx
@@ -7,7 +7,7 @@ jest.mock("@ui/components/atoms", () => {
   return {
     __esModule: true,
     Button: (props: any) => <button {...props} />,
-    Popover: ({ open, children }: any) => (open ? <div data-testid="popover">{children}</div> : null),
+    Popover: ({ open, children }: any) => (open ? <div data-cy="popover">{children}</div> : null),
     PopoverAnchor: ({ children }: any) => <>{children}</>,
     PopoverContent: ({ children }: any) => <div>{children}</div>,
   };
@@ -18,7 +18,7 @@ describe("TokenInspector", () => {
     const onTokenSelect = jest.fn();
     render(
       <TokenInspector inspectMode onTokenSelect={onTokenSelect}>
-        <div data-testid="preview">
+        <div data-cy="preview">
           <div data-token="token-a">A</div>
           <div data-token="token-b">B</div>
         </div>


### PR DESCRIPTION
## Summary
- switch cms layout and token inspector tests to `data-cy`

## Testing
- `pnpm install`
- `pnpm test:cms` *(fails: Invalid core environment variables; unrelated to changes)*
- `pnpm exec jest ./apps/cms/src/app/[lang]/__tests__/layout.test.tsx --no-coverage`
- `pnpm exec jest ./apps/cms/src/app/cms/wizard/__tests__/TokenInspector.test.tsx --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c172e59d1c832fa19012d4cd52785b