### PR TITLE
test: add color utils validations

### DIFF
--- a/packages/ui/__tests__/colorUtils.test.ts
+++ b/packages/ui/__tests__/colorUtils.test.ts
@@ -1,4 +1,31 @@
-import { hexToRgb, getContrastColor, hexToHsl } from "../src/utils/colorUtils";
+import {
+  hexToRgb,
+  getContrastColor,
+  hexToHsl,
+  isHex,
+  isHsl,
+} from "../src/utils/colorUtils";
+
+describe("isHex", () => {
+  it("accepts short and long hex colors", () => {
+    expect(isHex("#fff")).toBe(true);
+    expect(isHex("#ffffff")).toBe(true);
+  });
+
+  it("rejects non-hex strings", () => {
+    expect(isHex("not-hex")).toBe(false);
+  });
+});
+
+describe("isHsl", () => {
+  it("accepts valid HSL string", () => {
+    expect(isHsl("0 0% 0%")).toBe(true);
+  });
+
+  it("rejects malformed inputs", () => {
+    expect(isHsl("0 0 0")).toBe(false);
+  });
+});
 
 describe("hexToRgb", () => {
   it("converts 6-digit hex to RGB", () => {


### PR DESCRIPTION
## Summary
- expand color util tests for hex and hsl validation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/ui/__tests__/colorUtils.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c17e121bdc832f8d22bd4d835a9e94