### PR TITLE
test(ui): add cssVars unit tests

### DIFF
--- a/packages/ui/src/utils/style/__tests__/cssVars.test.ts
+++ b/packages/ui/src/utils/style/__tests__/cssVars.test.ts
@@ -1,6 +1,10 @@
-import { cssVars } from "../style";
+import { cssVars } from "../cssVars";
 
 describe("cssVars", () => {
+  it("returns empty object for no overrides", () => {
+    expect(cssVars()).toEqual({});
+  });
+
   it("maps color overrides to CSS variables", () => {
     const vars = cssVars({
       color: { bg: "--bg", fg: "--fg", border: "--border" },


### PR DESCRIPTION
## Summary
- add cssVars unit tests under style helpers

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/ui/src/utils/style/__tests__/cssVars.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c178455a74832f9b8b8e4141e668b5