### PR TITLE
test(api): cover missing token secret

### DIFF
--- a/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
+++ b/apps/api/src/routes/shop/[id]/__tests__/publish-upgrade.test.ts
@@ -63,13 +63,13 @@ describe("onRequestPost", () => {
     );
   });
 
-  it("returns 403 when token provided but secret missing", async () => {
+  it("returns 403 for any bearer token when secret missing", async () => {
     const warn = jest.spyOn(console, "warn").mockImplementation();
     const res = await onRequestPost({
       params: { id },
       request: new Request("http://example.com", {
         method: "POST",
-        headers: { Authorization: "Bearer token" },
+        headers: { Authorization: "Bearer any-token" },
       }),
     });
     const body = await res.json();
@@ -159,7 +159,7 @@ describe("onRequestPost", () => {
     spawn.mockImplementation(() => ({
       on: (_: string, cb: (code: number) => void) => cb(0),
     }));
-
+    process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "secret";
     const token = jwt.sign({}, "secret");
     const res = await onRequestPost({
       params: { id },


### PR DESCRIPTION
## Summary
- test publish-upgrade without UPGRADE_PREVIEW_TOKEN_SECRET set using any bearer token
- set token secret in deduplication test to restore success path

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/api test --runTestsByPath src/routes/shop/\[id\]/__tests__/publish-upgrade.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c178020794832f8dff9079e40c6286