### PR TITLE
test: add tailwind config suite

### DIFF
--- a/packages/tailwind-config/__tests__/tailwind-config.test.ts
+++ b/packages/tailwind-config/__tests__/tailwind-config.test.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+
+import { execSync } from "node:child_process";
+
+describe("tailwind.config", () => {
+  const inspectConfig = () =>
+    JSON.parse(
+      execSync(
+        "node -e \"import('../tailwind.config.mjs').then(async m => {const forms=(await import('@tailwindcss/forms')).default; const cq=(await import('@tailwindcss/container-queries')).default; const cfg=m.default; const hasForms=cfg.plugins.includes(forms); const hasCq=cfg.plugins.includes(cq); console.log(JSON.stringify({hasForms,hasCq,content:cfg.content}));})\"",
+        { cwd: __dirname, encoding: "utf8" }
+      )
+    );
+
+  it("includes expected plugins", () => {
+    const { hasForms, hasCq } = inspectConfig();
+    expect(hasForms).toBe(true);
+    expect(hasCq).toBe(true);
+  });
+
+  it("resolves content paths to workspace", () => {
+    const { content } = inspectConfig();
+    const rootDir = path.resolve(__dirname, "..", "..", "..");
+    const expected = [
+      path.join(rootDir, "apps/**/*.{ts,tsx,mdx}"),
+      path.join(
+        rootDir,
+        "packages/{ui,platform-core,platform-machine,i18n,themes}/**/*.{ts,tsx,mdx}"
+      ),
+      path.join(rootDir, ".storybook/**/*.{ts,tsx,mdx}")
+    ];
+    expect(content).toEqual(expect.arrayContaining(expected));
+  });
+});

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist *.tsbuildinfo",
+    "test": "pnpm exec jest packages/tailwind-config/__tests__ --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverageDirectory ../../coverage/tailwind-config",
     "lint": "eslint ."
   }
 }


### PR DESCRIPTION
## Summary
- add jest test for tailwind config ensuring plugin and content setup
- wire up tailwind-config package test script

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/tailwind-config test`


------
https://chatgpt.com/codex/tasks/task_e_68c1718a576c832f883469fc934bdd8e