### PR TITLE
test: add tryJsonParse tests

### DIFF
--- a/apps/cms/src/utils/__tests__/formData.test.ts
+++ b/apps/cms/src/utils/__tests__/formData.test.ts
@@ -1,4 +1,4 @@
-import { formDataEntries, formDataToObject } from "../formData";
+import { formDataEntries, formDataToObject, tryJsonParse } from "../formData";
 
 describe("formData helpers", () => {
   it("uses iterator when available", () => {
@@ -35,5 +35,24 @@ describe("formData helpers", () => {
       alpha: "1",
       beta: "2",
     });
+  });
+});
+
+describe("tryJsonParse", () => {
+  it("parses valid JSON strings", () => {
+    expect(
+      tryJsonParse<{ foo: string }>("{\"foo\":\"bar\"}"),
+    ).toEqual({ foo: "bar" });
+  });
+
+  it("returns undefined for invalid JSON strings", () => {
+    expect(tryJsonParse("not json")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string values", () => {
+    expect(tryJsonParse<{ foo: string }>(null)).toBeUndefined();
+    expect(
+      tryJsonParse<{ foo: string }>(new File([], "file.txt")),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- expand formData tests with tryJsonParse coverage

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm test apps/cms` *(fails: Could not find task `apps/cms` in project)*
- `pnpm --filter @apps/cms test` *(fails: TypeError: loadCoreEnv is not a function in marketingEmailApi.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1847c7d38832f96573ee1349086ca