### PR TITLE
test: add rbac store tests

### DIFF
--- a/apps/cms/src/lib/server/__tests__/rbacStore.test.ts
+++ b/apps/cms/src/lib/server/__tests__/rbacStore.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ROLE_PERMISSIONS } from "@auth/permissions";
+import type { Permission } from "@auth";
+
+async function withTempDir(cb: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "rbac-"));
+  const spy = jest.spyOn(process, "cwd").mockReturnValue(dir);
+  jest.resetModules();
+  try {
+    await cb(dir);
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+afterEach(() => jest.resetAllMocks());
+
+describe("rbacStore", () => {
+  it("readRbac returns defaults when file missing", async () => {
+    await withTempDir(async () => {
+      const { readRbac } = await import("../rbacStore");
+      const db = await readRbac();
+      expect(db.users["1"].email).toBe("admin@example.com");
+      expect(db.roles["1"]).toBe("admin");
+      expect(db.permissions.admin).toEqual(ROLE_PERMISSIONS.admin);
+    });
+  });
+
+  it("readRbac returns defaults when JSON malformed", async () => {
+    await withTempDir(async (dir) => {
+      const file = path.join(dir, "data", "cms", "users.json");
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, "{not valid json", "utf8");
+      const { readRbac } = await import("../rbacStore");
+      const db = await readRbac();
+      expect(db.permissions.admin).toEqual(ROLE_PERMISSIONS.admin);
+    });
+  });
+
+  it("merges new permissions with defaults", async () => {
+    await withTempDir(async (dir) => {
+      const extraPerm = "extra_perm" as unknown as Permission;
+      const file = path.join(dir, "data", "cms", "users.json");
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(
+        file,
+        JSON.stringify({
+          users: {},
+          roles: {},
+          permissions: { admin: [extraPerm] },
+        }),
+        "utf8"
+      );
+      const { readRbac } = await import("../rbacStore");
+      const db = await readRbac();
+      expect(db.permissions.admin).toEqual([
+        ...ROLE_PERMISSIONS.admin,
+        extraPerm,
+      ]);
+    });
+  });
+
+  it("writeRbac throws TypeError for null or undefined", async () => {
+    const { writeRbac } = await import("../rbacStore");
+    await expect(writeRbac(null as any)).rejects.toThrow(TypeError);
+    await expect(writeRbac(undefined as any)).rejects.toThrow(TypeError);
+  });
+
+  it("writeRbac calls fs.rename", async () => {
+    await withTempDir(async () => {
+      jest.resetModules();
+      jest.mock("fs", () => {
+        const actual = jest.requireActual("fs") as typeof import("fs");
+        return {
+          ...actual,
+          promises: {
+            ...actual.promises,
+            rename: jest.fn().mockResolvedValue(undefined),
+          },
+        } as typeof import("fs");
+      });
+      const { readRbac, writeRbac } = await import("../rbacStore");
+      const fsMock = await import("fs");
+      const db = await readRbac();
+      await writeRbac(db);
+      const dest = path.join(process.cwd(), "data", "cms", "users.json");
+      const calls = (fsMock.promises.rename as jest.Mock).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const match = calls.find(([, to]: [string, string]) => to === dest);
+      expect(match).toBeDefined();
+      expect(match![0]).toMatch(/users\.json\.\d+\.tmp$/);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for rbacStore default reads and permission merge
- test writeRbac error handling and rename call

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm test apps/cms` *(fails: Could not find task `apps/cms` in project)*
- `pnpm exec jest --runTestsByPath apps/cms/src/lib/server/__tests__/rbacStore.test.ts --config apps/cms/jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c1847fb028832fa8951e06e4beb43b