### PR TITLE
test(ui): handle empty image arrays in ImageCarousel

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ImageCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ImageCarousel.test.tsx
@@ -11,4 +11,9 @@ describe("ImageCarousel", () => {
     expect(getByAltText("A")).toBeInTheDocument();
     expect(getByAltText("B")).toBeInTheDocument();
   });
+
+  it("renders null when images array is empty", () => {
+    const { container } = render(<ImageCarousel images={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add test ensuring ImageCarousel renders null when provided an empty image list

## Testing
- `pnpm install && pnpm -r build` *(fails: @acme/platform-core build: `tsc -b`)*
- `pnpm --filter @acme/ui run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter @acme/ui run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter @acme/ui test` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c185f5ffec832fb6fbacbec43be2dc