### PR TITLE
test: ensure immediate campaigns record sent timestamp

### DIFF
--- a/packages/email/__tests__/scheduler.test.ts
+++ b/packages/email/__tests__/scheduler.test.ts
@@ -68,6 +68,7 @@ describe("scheduler", () => {
       body: "<p>Hi</p>",
     });
     expect(mockedSend).toHaveBeenCalledTimes(1);
+    expect(memory[shop][0].sentAt).toEqual(expect.any(String));
 
     mockedSend.mockClear();
     const future = new Date(now.getTime() + 60_000).toISOString();


### PR DESCRIPTION
## Summary
- verify immediate campaign storage includes a `sentAt` timestamp

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/email/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c184ed443c832fbe4aaaf5df61dbc4