### PR TITLE
test: add blog slug filtering edge cases

### DIFF
--- a/apps/cms/src/services/blog/__tests__/config.test.ts
+++ b/apps/cms/src/services/blog/__tests__/config.test.ts
@@ -45,6 +45,32 @@ describe("blog config service", () => {
   });
 
   describe("filterExistingProductSlugs", () => {
+    test("returns [] and skips fetch for empty slugs", async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock as any;
+      await expect(
+        filterExistingProductSlugs("shop", []),
+      ).resolves.toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("returns [] on non-ok response", async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false }) as any;
+      await expect(
+        filterExistingProductSlugs("shop", ["a"]),
+      ).resolves.toEqual([]);
+    });
+
+    test("returns original slugs when JSON is not an array", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ not: "array" }),
+      }) as any;
+      await expect(
+        filterExistingProductSlugs("shop", ["a", "b"]),
+      ).resolves.toEqual(["a", "b"]);
+    });
+
     test("returns filtered slugs", async () => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## Summary
- add tests for empty slug list and non-ok response in blog service
- ensure non-array JSON responses yield original slugs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm test apps/cms` *(fails: Missing tasks in project)*

------
https://chatgpt.com/codex/tasks/task_e_68c1848580a8832fa63fbd34b42a1424