### PR TITLE
test: add ProductGallery scenarios

### DIFF
--- a/packages/ui/src/components/organisms/ProductGallery.tsx
+++ b/packages/ui/src/components/organisms/ProductGallery.tsx
@@ -26,6 +26,9 @@ export function ProductGallery({
   className,
   ...props
 }: ProductGalleryProps) {
+  if (media.length === 0) {
+    return null;
+  }
   const [index, setIndex] = React.useState(0);
   const item = media[index];
 

--- a/packages/ui/src/components/organisms/__tests__/ProductGallery.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGallery.test.tsx
@@ -1,0 +1,57 @@
+import { render } from "@testing-library/react";
+import { ProductGallery } from "../ProductGallery";
+import type { MediaItem } from "../molecules/MediaSelector";
+import "../../../../../../test/resetNextMocks";
+
+describe("ProductGallery media types", () => {
+  it("renders image media", () => {
+    const media: MediaItem[] = [
+      { type: "image", src: "/a.jpg", alt: "A" },
+    ];
+    const { container } = render(<ProductGallery media={media} />);
+    expect(container.querySelector("img")).toBeInTheDocument();
+  });
+
+  it("renders video media", () => {
+    const media: MediaItem[] = [{ type: "video", src: "/a.mp4" }];
+    const { container } = render(<ProductGallery media={media} />);
+    expect(container.querySelector("video")).toBeInTheDocument();
+  });
+
+  it("renders 360 media", () => {
+    const media: MediaItem[] = [
+      { type: "360", src: "/360.jpg", frames: ["/1.jpg", "/2.jpg"] },
+    ];
+    const { container } = render(<ProductGallery media={media} />);
+    expect(container.querySelector(".touch-none img")).toBeInTheDocument();
+  });
+
+  it("renders model media", () => {
+    const media: MediaItem[] = [{ type: "model", src: "/model.glb" }];
+    const { container } = render(<ProductGallery media={media} />);
+    expect(container.querySelector("model-viewer")).toBeInTheDocument();
+  });
+});
+
+describe("ProductGallery selector", () => {
+  it("hides selector when only one item", () => {
+    const media: MediaItem[] = [{ type: "image", src: "/a.jpg" }];
+    const { container } = render(<ProductGallery media={media} />);
+    expect(container.querySelector(".flex.gap-2")).toBeNull();
+  });
+
+  it("shows selector when multiple items", () => {
+    const media: MediaItem[] = [
+      { type: "image", src: "/a.jpg" },
+      { type: "video", src: "/b.mp4" },
+    ];
+    const { container } = render(<ProductGallery media={media} />);
+    expect(container.querySelector(".flex.gap-2")).toBeInTheDocument();
+  });
+});
+
+it("returns null when media array is empty", () => {
+  const { container } = render(<ProductGallery media={[]} />);
+  expect(container.firstChild).toBeNull();
+});
+


### PR DESCRIPTION
## Summary
- handle empty media arrays in ProductGallery
- add tests for ProductGallery media types and selector behavior

## Testing
- `pnpm install && pnpm -r build` *(fails: Cannot find module '@acme/ui' or its corresponding type declarations)*
- `pnpm --filter @acme/ui test` *(fails: Invalid core environment variables)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/ProductGallery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c185f47614832fb71b917cb1e3dff1