### PR TITLE
test: add DeliveryScheduler tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/DeliveryScheduler.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/DeliveryScheduler.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeliveryScheduler } from "../DeliveryScheduler";
+
+describe("DeliveryScheduler", () => {
+  it("fires onChange when switching modes", async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(<DeliveryScheduler onChange={onChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /pickup/i }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith({
+        mode: "pickup",
+        date: "",
+        region: "",
+        window: "",
+      })
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /delivery/i }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith({
+        mode: "delivery",
+        date: "",
+        region: "",
+        window: "",
+      })
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders region dropdown only when regions are provided", () => {
+    const { queryByText, rerender } = render(<DeliveryScheduler />);
+    expect(queryByText("Region")).not.toBeInTheDocument();
+
+    rerender(<DeliveryScheduler regions={["East", "West"]} />);
+    expect(screen.getByText("Region")).toBeInTheDocument();
+  });
+
+  it("uses window select when windows are provided, otherwise time input", () => {
+    const { rerender } = render(<DeliveryScheduler />);
+    expect(screen.getByLabelText("Time")).toHaveAttribute("type", "time");
+
+    rerender(<DeliveryScheduler windows={["10-11", "11-12"]} />);
+    expect(screen.getByText("Window")).toBeInTheDocument();
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for DeliveryScheduler component

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/ui run check:references` *(no script)*
- `pnpm --filter @acme/ui run build:ts` *(no script)*
- `pnpm --filter @acme/ui test` *(fails: multiple test suites failed)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/DeliveryScheduler.test.tsx` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c185f3d1e0832f9652918c6f547d94