### PR TITLE
test: add blog post publish/unpublish/delete tests

### DIFF
--- a/apps/cms/src/services/blog/posts/__tests__/delete.test.ts
+++ b/apps/cms/src/services/blog/posts/__tests__/delete.test.ts
@@ -1,0 +1,67 @@
+import { deletePost } from "../delete";
+
+jest.mock("../../../../actions/common/auth", () => ({
+  ensureAuthorized: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../config", () => ({
+  getConfig: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/blog.server", () => ({
+  deletePost: jest.fn(),
+}));
+
+describe("deletePost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls authorization, deletes post, and returns message", async () => {
+    const { ensureAuthorized } = await import(
+      "../../../../actions/common/auth"
+    );
+    const { getConfig } = await import("../../config");
+    const { deletePost: repoDeletePost } = await import(
+      "@platform-core/repositories/blog.server"
+    );
+
+    const config = { id: "config" } as any;
+    getConfig.mockResolvedValue(config);
+    repoDeletePost.mockResolvedValue(undefined);
+
+    const result = await deletePost("shop123", "post1");
+
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(getConfig).toHaveBeenCalledWith("shop123");
+    expect(repoDeletePost).toHaveBeenCalledWith(config, "post1");
+    expect(result).toEqual({ message: "Post deleted" });
+  });
+
+  it("returns error when repository rejects", async () => {
+    const { ensureAuthorized } = await import(
+      "../../../../actions/common/auth"
+    );
+    const { getConfig } = await import("../../config");
+    const { deletePost: repoDeletePost } = await import(
+      "@platform-core/repositories/blog.server"
+    );
+
+    const config = { id: "config" } as any;
+    getConfig.mockResolvedValue(config);
+    const error = new Error("fail");
+    repoDeletePost.mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await deletePost("shop123", "post1");
+
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(repoDeletePost).toHaveBeenCalledWith(config, "post1");
+    expect(result).toEqual({ error: "Failed to delete post" });
+
+    consoleError.mockRestore();
+  });
+});
+

--- a/apps/cms/src/services/blog/posts/__tests__/publish.test.ts
+++ b/apps/cms/src/services/blog/posts/__tests__/publish.test.ts
@@ -1,0 +1,83 @@
+import { publishPost } from "../publish";
+
+jest.mock("../../../../actions/common/auth", () => ({
+  ensureAuthorized: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../config", () => ({
+  getConfig: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/blog.server", () => ({
+  publishPost: jest.fn(),
+}));
+
+jest.mock("@date-utils", () => ({
+  nowIso: jest.fn(),
+}));
+
+describe("publishPost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls authorization, publishes post, and returns message", async () => {
+    const { ensureAuthorized } = await import(
+      "../../../../actions/common/auth"
+    );
+    const { getConfig } = await import("../../config");
+    const { publishPost: repoPublishPost } = await import(
+      "@platform-core/repositories/blog.server"
+    );
+    const { nowIso } = await import("@date-utils");
+
+    const config = { id: "config" } as any;
+    getConfig.mockResolvedValue(config);
+    nowIso.mockReturnValue("2024-01-01T00:00:00.000Z");
+    repoPublishPost.mockResolvedValue(undefined);
+
+    const result = await publishPost("shop123", "post1");
+
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(getConfig).toHaveBeenCalledWith("shop123");
+    expect(repoPublishPost).toHaveBeenCalledWith(
+      config,
+      "post1",
+      "2024-01-01T00:00:00.000Z",
+    );
+    expect(result).toEqual({ message: "Post published" });
+  });
+
+  it("returns error when repository rejects", async () => {
+    const { ensureAuthorized } = await import(
+      "../../../../actions/common/auth"
+    );
+    const { getConfig } = await import("../../config");
+    const { publishPost: repoPublishPost } = await import(
+      "@platform-core/repositories/blog.server"
+    );
+    const { nowIso } = await import("@date-utils");
+
+    const config = { id: "config" } as any;
+    getConfig.mockResolvedValue(config);
+    nowIso.mockReturnValue("2024-01-01T00:00:00.000Z");
+    const error = new Error("fail");
+    repoPublishPost.mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await publishPost("shop123", "post1");
+
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(repoPublishPost).toHaveBeenCalledWith(
+      config,
+      "post1",
+      "2024-01-01T00:00:00.000Z",
+    );
+    expect(result).toEqual({ error: "Failed to publish post" });
+
+    consoleError.mockRestore();
+  });
+});
+

--- a/apps/cms/src/services/blog/posts/__tests__/unpublish.test.ts
+++ b/apps/cms/src/services/blog/posts/__tests__/unpublish.test.ts
@@ -1,0 +1,67 @@
+import { unpublishPost } from "../unpublish";
+
+jest.mock("../../../../actions/common/auth", () => ({
+  ensureAuthorized: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../config", () => ({
+  getConfig: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/blog.server", () => ({
+  unpublishPost: jest.fn(),
+}));
+
+describe("unpublishPost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls authorization, unpublishes post, and returns message", async () => {
+    const { ensureAuthorized } = await import(
+      "../../../../actions/common/auth"
+    );
+    const { getConfig } = await import("../../config");
+    const { unpublishPost: repoUnpublishPost } = await import(
+      "@platform-core/repositories/blog.server"
+    );
+
+    const config = { id: "config" } as any;
+    getConfig.mockResolvedValue(config);
+    repoUnpublishPost.mockResolvedValue(undefined);
+
+    const result = await unpublishPost("shop123", "post1");
+
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(getConfig).toHaveBeenCalledWith("shop123");
+    expect(repoUnpublishPost).toHaveBeenCalledWith(config, "post1");
+    expect(result).toEqual({ message: "Post unpublished" });
+  });
+
+  it("returns error when repository rejects", async () => {
+    const { ensureAuthorized } = await import(
+      "../../../../actions/common/auth"
+    );
+    const { getConfig } = await import("../../config");
+    const { unpublishPost: repoUnpublishPost } = await import(
+      "@platform-core/repositories/blog.server"
+    );
+
+    const config = { id: "config" } as any;
+    getConfig.mockResolvedValue(config);
+    const error = new Error("fail");
+    repoUnpublishPost.mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await unpublishPost("shop123", "post1");
+
+    expect(ensureAuthorized).toHaveBeenCalled();
+    expect(repoUnpublishPost).toHaveBeenCalledWith(config, "post1");
+    expect(result).toEqual({ error: "Failed to unpublish post" });
+
+    consoleError.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for publishing a blog post
- add tests for unpublishing a blog post
- add tests for deleting a blog post

## Testing
- `pnpm test apps/cms` *(fails: Missing tasks in project)*
- `pnpm --filter @apps/cms test` *(fails: marketing email API segments - loadCoreEnv is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c1848903e4832f9caa5a1b97fc9b4d