### PR TITLE
Add OrderTrackingTimeline tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/OrderTrackingTimeline.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/OrderTrackingTimeline.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { OrderTrackingTimeline } from "../OrderTrackingTimeline";
+
+describe("OrderTrackingTimeline", () => {
+  it("returns null when tracking is disabled", () => {
+    const { container } = render(
+      <OrderTrackingTimeline trackingEnabled={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when steps array is empty", () => {
+    const { container } = render(<OrderTrackingTimeline steps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when shipping and return steps are empty", () => {
+    const { container } = render(
+      <OrderTrackingTimeline shippingSteps={[]} returnSteps={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders shipping and return steps with correct completion styling", () => {
+    const shippingSteps = [{ label: "Shipped", complete: true }];
+    const returnSteps = [{ label: "Returned", complete: false }];
+
+    render(
+      <OrderTrackingTimeline
+        shippingSteps={shippingSteps}
+        returnSteps={returnSteps}
+      />
+    );
+
+    const shippedBullet = screen.getByText("Shipped").previousSibling as HTMLElement;
+    expect(shippedBullet).toHaveClass(
+      "bg-primary",
+      "text-primary-foreground"
+    );
+
+    const returnedBullet = screen.getByText("Returned").previousSibling as HTMLElement;
+    expect(returnedBullet).toHaveClass(
+      "bg-muted",
+      "text-muted-foreground"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for OrderTrackingTimeline covering disabled tracking, empty steps, and completion styling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/ui build` *(fails: TS errors in UI package)*
- `pnpm --filter @acme/ui run check:references` *(fails: missing script)*
- `pnpm --filter @acme/ui test` *(fails: Command was killed with SIGABRT)*

------
https://chatgpt.com/codex/tasks/task_e_68c185f2de9c832fad2f09d5608ca3e1