### PR TITLE
test: add resolveDataRoot fallback coverage

### DIFF
--- a/packages/email/__tests__/resolveDataRoot-parent.test.ts
+++ b/packages/email/__tests__/resolveDataRoot-parent.test.ts
@@ -23,5 +23,21 @@ describe("resolveDataRoot", () => {
       await fs.rm(tmp, { recursive: true, force: true });
     }
   });
+
+  it("falls back to cwd/data/shops when none found", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "email-cli-test-"));
+    const nested = path.join(tmp, "nested", "workdir");
+    await fs.mkdir(nested, { recursive: true });
+
+    const original = process.cwd();
+    try {
+      process.chdir(nested);
+      const resolved = resolveDataRoot();
+      expect(resolved).toBe(path.resolve(nested, "data", "shops"));
+    } finally {
+      process.chdir(original);
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- test resolveDataRoot falls back to `<cwd>/data/shops` when no `data/shops` directory exists

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test __tests__/resolveDataRoot-parent.test.ts` *(fails: coverage thresholds not met)*


------
https://chatgpt.com/codex/tasks/task_e_68c184fa98c0832f9972dbe25f7130e8