### PR TITLE
Add test for template re-registration

### DIFF
--- a/packages/email/__tests__/templates.test.ts
+++ b/packages/email/__tests__/templates.test.ts
@@ -24,6 +24,22 @@ describe("templates registry", () => {
     );
   });
 
+  it("uses the most recently registered template markup", async () => {
+    jest.doMock(
+      "@acme/email-templates",
+      () => ({ __esModule: true, marketingEmailTemplates: [] }),
+      { virtual: true }
+    );
+    const { registerTemplate, renderTemplate, clearTemplates } = await import(
+      "../src/templates"
+    );
+    registerTemplate("welcome", "<p>Hi</p>");
+    expect(renderTemplate("welcome", {})).toBe("<p>Hi</p>");
+    registerTemplate("welcome", "<p>Hello</p>");
+    expect(renderTemplate("welcome", {})).toBe("<p>Hello</p>");
+    clearTemplates();
+  });
+
   it("replaces placeholders and inserts empty string for missing variables", async () => {
     jest.doMock(
       "@acme/email-templates",


### PR DESCRIPTION
## Summary
- cover re-registration of email templates
- ensure latest template markup is rendered

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test -- __tests__/templates.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c184f886b8832f8cfd746ec30c39c3