### PR TITLE
test(email): add missing recipients error case

### DIFF
--- a/packages/email/__tests__/scheduler.test.ts
+++ b/packages/email/__tests__/scheduler.test.ts
@@ -88,6 +88,18 @@ describe("scheduler", () => {
     expect(mockedSend).toHaveBeenCalledTimes(1);
   });
 
+  test("missing fields when no recipients and no segment", async () => {
+    await expect(
+      createCampaign({
+        shop,
+        recipients: [],
+        subject: "Hi",
+        body: "<p>Hi</p>",
+      }),
+    ).rejects.toThrow("Missing fields");
+    expect(memory[shop]).toBeUndefined();
+  });
+
   test("concurrency limit exceeded path", async () => {
     jest.useRealTimers();
     process.env.EMAIL_BATCH_SIZE = "1";


### PR DESCRIPTION
## Summary
- add scheduler test expecting `Missing fields` when recipients are empty and no segment

## Testing
- `pnpm --filter email run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter email run build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter email run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter email test`


------
https://chatgpt.com/codex/tasks/task_e_68c184eaa678832fba629184c3075e71