### PR TITLE
test(email): preserve script when sanitization disabled

### DIFF
--- a/packages/email/__tests__/send.test.ts
+++ b/packages/email/__tests__/send.test.ts
@@ -190,6 +190,26 @@ describe("sendCampaignEmail", () => {
     expect(calledWith.html).toBe("<p>Hello</p>");
   });
 
+  it("does not sanitize html when sanitize is false", async () => {
+    mockSendgridSend = jest.fn().mockResolvedValue(undefined);
+    mockResendSend = jest.fn();
+    mockSendMail = jest.fn();
+
+    setupEnv();
+
+    const { sendCampaignEmail } = await import("../src/send");
+
+    await sendCampaignEmail({
+      to: "to@example.com",
+      subject: "Subject",
+      html: '<p>Hello</p><script>alert("x")</script>',
+      sanitize: false,
+    });
+
+    const calledWith = mockSendgridSend.mock.calls[0][0];
+    expect(calledWith.html).toBe('<p>Hello</p><script>alert("x")</script>');
+  });
+
   it("renders template when templateId is provided", async () => {
     mockSendgridSend = jest.fn().mockResolvedValue(undefined);
     mockResendSend = jest.fn();


### PR DESCRIPTION
## Summary
- extend sendCampaignEmail tests to ensure HTML `<script>` tags remain when `sanitize` is false

## Testing
- `pnpm --filter email run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter email run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter email test` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c184e070a4832fa340fa551e7260c5