### PR TITLE
test: add sendWithRetry error handling tests

### DIFF
--- a/packages/email/__tests__/send.core.test.ts
+++ b/packages/email/__tests__/send.core.test.ts
@@ -94,6 +94,44 @@ describe("sendWithRetry", () => {
     ).rejects.toThrow("fail");
     expect(send).toHaveBeenCalledTimes(1);
   });
+
+  it("stops when error has retryable false", async () => {
+    const error = { retryable: false };
+    const send = jest.fn().mockRejectedValue(error);
+    const timeoutSpy = jest.spyOn(global, "setTimeout");
+    await expect(
+      sendWithRetry({ send } as any, {
+        to: "t",
+        subject: "s",
+        html: "<p>h</p>",
+        text: "h",
+      })
+    ).rejects.toBe(error);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).not.toHaveBeenCalled();
+    timeoutSpy.mockRestore();
+  });
+
+  it("retries unknown errors three times", async () => {
+    jest.useFakeTimers();
+    const error = {};
+    const send = jest.fn().mockRejectedValue(error);
+    const timeoutSpy = jest.spyOn(global, "setTimeout");
+    const promise = sendWithRetry({ send } as any, {
+      to: "t",
+      subject: "s",
+      html: "<p>h</p>",
+      text: "h",
+    });
+    await jest.advanceTimersByTimeAsync(100);
+    await jest.advanceTimersByTimeAsync(200);
+    await expect(promise).rejects.toBe(error);
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 100);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 200);
+    timeoutSpy.mockRestore();
+    jest.useRealTimers();
+  });
 });
 
 describe("sendWithNodemailer", () => {


### PR DESCRIPTION
## Summary
- test sendWithRetry stops immediately when provider error sets `retryable: false`
- test unknown provider errors trigger three attempts with fake timers

## Testing
- `pnpm --filter email run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter email run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter email test`

------
https://chatgpt.com/codex/tasks/task_e_68c184dda564832fb495bb756e22c344