### PR TITLE
test(email): default TTL when SEGMENT_CACHE_TTL is zero

### DIFF
--- a/packages/email/__tests__/segments.test.ts
+++ b/packages/email/__tests__/segments.test.ts
@@ -114,6 +114,11 @@ describe("cacheTtl", () => {
     process.env.SEGMENT_CACHE_TTL = "-1";
     expect(cacheTtl()).toBe(60000);
   });
+
+  it("returns default when SEGMENT_CACHE_TTL is zero", () => {
+    process.env.SEGMENT_CACHE_TTL = "0";
+    expect(cacheTtl()).toBe(60000);
+  });
 });
 
 describe("segment cache", () => {


### PR DESCRIPTION
## Summary
- test email segment caching: zero SEGMENT_CACHE_TTL should fall back to default 60s

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in @acme/platform-core)*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c184f31adc832f9e31d31c439797aa