### PR TITLE
test(email): prefer explicit campaign in Resend events

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -140,6 +140,24 @@ describe("mapResendEvent", () => {
     });
   });
 
+  it("prefers explicit campaign over campaign_id", async () => {
+    setupMocks();
+    const { mapResendEvent } = await import("../src/analytics");
+    const ev = {
+      type: "email.delivered",
+      data: {
+        campaign: "camp-explicit",
+        campaign_id: "camp-1",
+      },
+    } as const;
+    expect(mapResendEvent(ev)).toEqual<EmailAnalyticsEvent>({
+      type: "email_delivered",
+      campaign: "camp-explicit",
+      messageId: undefined,
+      recipient: undefined,
+    });
+  });
+
   it("handles events without data", async () => {
     setupMocks();
     const { mapResendEvent } = await import("../src/analytics");


### PR DESCRIPTION
## Summary
- test that mapResendEvent prefers the explicit `campaign`

## Testing
- `pnpm --filter email run build:ts` *(fails: missing script)*
- `pnpm --filter email run check:references` *(fails: missing script)*
- `pnpm --filter email test`


------
https://chatgpt.com/codex/tasks/task_e_68c184e303a4832f8aa5db2f1782a8da