### PR TITLE
test: invoke run with argv

### DIFF
--- a/packages/email/src/__tests__/cli.test.ts
+++ b/packages/email/src/__tests__/cli.test.ts
@@ -132,10 +132,9 @@ test("campaign list outputs campaigns", async () => {
 });
 
 test("campaign send invokes scheduler", async () => {
-  process.argv = ["node", "email", "campaign", "send"];
   const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   const { run } = await import("../cli");
-  await run();
+  await run(["node", "email", "campaign", "send"]);
   expect(sendDueCampaigns).toHaveBeenCalled();
   expect(logSpy).toHaveBeenCalledWith("Sent due campaigns");
 });


### PR DESCRIPTION
## Summary
- update CLI test to call `run()` with explicit args and verify `sendDueCampaigns`

## Testing
- `pnpm -r build` *(fails: TS2307: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c184fd8960832f99d290b61519534b