### PR TITLE
test(email): add smtp early exit analytics test

### DIFF
--- a/packages/email/__tests__/analytics.test.ts
+++ b/packages/email/__tests__/analytics.test.ts
@@ -184,6 +184,26 @@ describe("syncCampaignAnalytics", () => {
     expect(trackEvent).not.toHaveBeenCalled();
   });
 
+  it("returns early when EMAIL_PROVIDER is smtp", async () => {
+    jest.resetModules();
+    const trackEvent = jest.fn();
+    jest.doMock("@platform-core/analytics", () => ({
+      __esModule: true,
+      trackEvent,
+    }));
+    jest.doMock("../src/providers/sendgrid", () => ({ SendgridProvider: jest.fn() }));
+    jest.doMock("../src/providers/resend", () => ({ ResendProvider: jest.fn() }));
+    const getCampaignStore = jest.fn();
+    jest.doMock("../src/storage", () => ({ __esModule: true, getCampaignStore }));
+
+    process.env.EMAIL_PROVIDER = "smtp";
+    const { syncCampaignAnalytics } = await import("../src/analytics");
+    await syncCampaignAnalytics();
+
+    expect(getCampaignStore).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
   it("sends stats for sent campaigns and falls back to empty stats on failure", async () => {
     jest.resetModules();
     const trackEvent = jest.fn();


### PR DESCRIPTION
## Summary
- test syncCampaignAnalytics for smtp provider

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter email run build:ts` *(fails: script not found)*
- `pnpm --filter email run check:references` *(fails: script not found)*
- `pnpm --filter email test` *(fails: process hung; aborted)*
- `pnpm --filter email exec jest packages/email/__tests__/analytics.test.ts -t "returns early when EMAIL_PROVIDER is smtp" --runInBand --detectOpenHandles --config packages/email/jest.config.cjs` *(fails: coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68c184e4449c832f9149aa99008df6c4