### PR TITLE
test: handle analytics errors in scheduler

### DIFF
--- a/packages/email/__tests__/scheduler.test.ts
+++ b/packages/email/__tests__/scheduler.test.ts
@@ -168,4 +168,19 @@ describe("scheduler", () => {
       "b@example.com",
     ]);
   });
+
+  test("syncCampaignAnalytics resolves when analytics throws", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const mockAnalytics = jest
+        .fn()
+        .mockRejectedValue(new Error("fail"));
+      jest.doMock("../src/analytics", () => ({
+        __esModule: true,
+        syncCampaignAnalytics: mockAnalytics,
+      }));
+      const { syncCampaignAnalytics } = await import("../src/scheduler");
+      await expect(syncCampaignAnalytics()).resolves.toBeUndefined();
+      expect(mockAnalytics).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- verify scheduler's analytics syncing resolves even if analytics module throws

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm test --filter @acme/email` *(fails: ProviderError in send.core.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c18cd2a0b0832f8629e4a5dbd7e51d