### PR TITLE
test(ui): add Content component className and ref tests

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/Content.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/Content.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { Content } from "../Content";
+
+describe("Content", () => {
+  it("merges className with defaults", () => {
+    const { container } = render(<Content className="custom" />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveClass("flex-1");
+    expect(div).toHaveClass("p-4");
+    expect(div).toHaveClass("custom");
+  });
+
+  it("forwards refs", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Content ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});


### PR DESCRIPTION
## Summary
- test Content component className merging
- test Content ref forwarding

## Testing
- `pnpm install && pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/ui test` *(fails: Invalid core environment variables)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/Content.test.tsx` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c18f386ad8832fa21c61cd82e8bdda