### PR TITLE
test: cover remote image probe edge cases

### DIFF
--- a/packages/ui/src/hooks/__tests__/remote-image-probe.spec.ts
+++ b/packages/ui/src/hooks/__tests__/remote-image-probe.spec.ts
@@ -43,4 +43,26 @@ describe("useRemoteImageProbe", () => {
     expect(result.current.error).toBe("not-image");
     expect(result.current.valid).toBe(false);
   });
+
+  it("resets valid when url is empty", async () => {
+    const { result } = renderHook(() => useRemoteImageProbe());
+    await act(async () => {
+      await result.current.probe("http://example.com/a.png");
+    });
+    expect(result.current.valid).toBe(true);
+    await act(async () => {
+      await result.current.probe("");
+    });
+    expect(result.current.valid).toBeNull();
+  });
+
+  it("captures fetch errors", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useRemoteImageProbe());
+    await act(async () => {
+      await result.current.probe("http://example.com/a.png");
+    });
+    expect(result.current.error).toBe("boom");
+    expect(result.current.valid).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for empty URL resetting validity in remote image probe
- add tests for fetch rejection handling in remote image probe

## Testing
- `pnpm install && pnpm -r build` *(fails: @acme/platform-core build Exit status 2)*
- `pnpm --filter @acme/ui test` *(fails: multiple suites; terminated)*
- `pnpm --filter @acme/ui test packages/ui/src/hooks/__tests__/remote-image-probe.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c18f36cc80832f983523f394912602