### PR TITLE
test: ensure syncCampaignAnalytics handles module throw

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -568,6 +568,19 @@ describe("scheduler", () => {
     expect(fetchCampaignAnalytics).toHaveBeenCalled();
   });
 
+  test('syncCampaignAnalytics resolves when analytics module throws', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('../analytics', () => ({
+        __esModule: true,
+        syncCampaignAnalytics: jest.fn(() => {
+          throw new Error('fail');
+        }),
+      }));
+      const { syncCampaignAnalytics } = await import('../scheduler');
+      await expect(syncCampaignAnalytics()).resolves.toBeUndefined();
+    });
+  });
+
   test('createCampaign propagates send errors', async () => {
     (sendCampaignEmail as jest.Mock).mockRejectedValueOnce(new Error('boom'));
     await expect(


### PR DESCRIPTION
## Summary
- verify `syncCampaignAnalytics` resolves when the analytics module throws

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test -- src/__tests__/scheduler.test.ts` *(fails: coverage threshold not met)*
- `pnpm --filter @acme/email test` *(fails: send.core.test.ts and cli.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c18e43156c832f826e75bae2f24a4d