### PR TITLE
test: ensure ProductGrid respects fixed column count

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
@@ -67,6 +67,23 @@ describe("ProductGrid responsive columns", () => {
     );
   });
 
+  it("keeps fixed columns when the columns prop is set", () => {
+    const resize = mockResize(300);
+    const { container } = render(
+      <ProductGrid products={products} columns={3} showPrice={false} />
+    );
+    let grid = container.firstChild as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe(
+      "repeat(3, minmax(0, 1fr))"
+    );
+
+    act(() => resize(2000));
+    grid = container.firstChild as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe(
+      "repeat(3, minmax(0, 1fr))"
+    );
+  });
+
   it("uses device breakpoints when provided", () => {
     const resize = mockResize(1200);
     const { container } = render(


### PR DESCRIPTION
## Summary
- add regression test verifying ProductGrid keeps fixed columns when `columns` prop is set

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' or its corresponding type declarations)*
- `pnpm --filter @acme/ui test` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c18f37d008832f94c7e2a6fb4cc1ca