### PR TITLE
test(email): ensure unsubscribeUrl encodes parameters

### DIFF
--- a/packages/email/__tests__/scheduler.test.ts
+++ b/packages/email/__tests__/scheduler.test.ts
@@ -1,5 +1,6 @@
 import { setCampaignStore } from "../src/storage";
 import type { CampaignStore, Campaign } from "../src/storage";
+import { unsubscribeUrl } from "../src/scheduler";
 
 jest.mock("@platform-core/repositories/analytics.server", () => ({
   __esModule: true,
@@ -189,5 +190,18 @@ describe("scheduler", () => {
       "a@example.com",
       "b@example.com",
     ]);
+  });
+
+  test("unsubscribeUrl percent-encodes parameters", () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    const shop = "shop/ü? ";
+    const campaign = "camp &aign/?";
+    const recipient = "user+tag@example.com";
+    const url = unsubscribeUrl(shop, campaign, recipient);
+    expect(url).toBe(
+      `/api/marketing/email/unsubscribe?shop=${encodeURIComponent(shop)}&campaign=${encodeURIComponent(
+        campaign,
+      )}&email=${encodeURIComponent(recipient)}`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add test covering unsubscribeUrl encoding for special characters

## Testing
- `pnpm --filter email run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter email run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter email test`

------
https://chatgpt.com/codex/tasks/task_e_68c18ed8d1dc832f83f544522945d0d9