### PR TITLE
Fix email env mock and product slug handling

### DIFF
--- a/apps/cms/__tests__/marketingEmailApi.test.ts
+++ b/apps/cms/__tests__/marketingEmailApi.test.ts
@@ -21,9 +21,11 @@ const coreEnv: Record<string, any> = {};
 jest.doMock("@acme/config", () => ({ __esModule: true, env: coreEnv }), {
   virtual: true,
 });
-jest.doMock("@acme/config/env/core", () => ({ __esModule: true, coreEnv }), {
-  virtual: true,
-});
+jest.doMock(
+  "@acme/config/env/core",
+  () => ({ __esModule: true, loadCoreEnv: () => coreEnv }),
+  { virtual: true },
+);
 
 process.env.CART_COOKIE_SECRET = "secret";
 process.env.STRIPE_SECRET_KEY = "sk_test";

--- a/apps/cms/src/services/blog/posts/create.ts
+++ b/apps/cms/src/services/blog/posts/create.ts
@@ -21,7 +21,7 @@ export async function createPost(
   let products: string[] = [];
   try {
     body = JSON.parse(content);
-    products = collectProductSlugs(body);
+    products = collectProductSlugs(body) ?? [];
   } catch {
     body = [];
     products = [];
@@ -31,13 +31,12 @@ export async function createPost(
     .split(",")
     .map((p) => p.trim())
     .filter(Boolean);
-  const existingSlugs = await filterExistingProductSlugs(shopId, [
-    ...products,
-    ...manualProducts,
-  ]);
-  if (existingSlugs) {
-    products = existingSlugs;
-  }
+  const combinedProducts = [...products, ...manualProducts];
+  const existingSlugs = await filterExistingProductSlugs(
+    shopId,
+    combinedProducts,
+  );
+  products = existingSlugs === null ? combinedProducts : existingSlugs;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const mainImage = String(formData.get("mainImage") ?? "");

--- a/apps/cms/src/services/blog/posts/update.ts
+++ b/apps/cms/src/services/blog/posts/update.ts
@@ -22,7 +22,7 @@ export async function updatePost(
   let products: string[] = [];
   try {
     body = JSON.parse(content);
-    products = collectProductSlugs(body);
+    products = collectProductSlugs(body) ?? [];
   } catch {
     body = [];
     products = [];
@@ -32,13 +32,12 @@ export async function updatePost(
     .split(",")
     .map((p) => p.trim())
     .filter(Boolean);
-  const existingSlugs = await filterExistingProductSlugs(shopId, [
-    ...products,
-    ...manualProducts,
-  ]);
-  if (existingSlugs) {
-    products = existingSlugs;
-  }
+  const combinedProducts = [...products, ...manualProducts];
+  const existingSlugs = await filterExistingProductSlugs(
+    shopId,
+    combinedProducts,
+  );
+  products = existingSlugs === null ? combinedProducts : existingSlugs;
   const slug = String(formData.get("slug") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const mainImage = String(formData.get("mainImage") ?? "");


### PR DESCRIPTION
## Summary
- fix config env mock for marketing email API tests
- default to empty slugs and retain manual product slugs on create/update

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest apps/cms/__tests__/marketingEmailApi.test.ts --coverage=false`
- `pnpm exec jest apps/cms/src/services/blog/posts/__tests__/create.test.ts apps/cms/src/services/blog/posts/__tests__/update.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1b5d5d40c832f827de77b6d16f107