### PR TITLE
fix: reset env core mock in auth session tests

### DIFF
--- a/packages/auth/__tests__/session.test.ts
+++ b/packages/auth/__tests__/session.test.ts
@@ -37,6 +37,8 @@ describe("session token", () => {
     process.env.COOKIE_DOMAIN = "example.com";
     mockCookies.mockReset();
     jest.resetModules();
+    // Ensure no lingering mocks from isolate tests
+    jest.unmock("@acme/config/env/core");
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary
- reset mocked `@acme/config/env/core` before each auth session test to avoid stale `SESSION_SECRET`

## Testing
- `pnpm install`
- `pnpm exec jest --runTestsByPath packages/auth/__tests__/session.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1b67a9108832fa402571c79416768