### PR TITLE
test: add CSRF header and cookie absence tests

### DIFF
--- a/apps/cms/src/__tests__/middleware.test.ts
+++ b/apps/cms/src/__tests__/middleware.test.ts
@@ -131,6 +131,26 @@ describe("middleware", () => {
     expect(res.status).toBe(403);
   });
 
+  it("rejects mutating api requests with csrf cookie but no header", async () => {
+    const req = new NextRequest("http://example.com/api/test", {
+      method: "POST",
+      headers: { cookie: "csrf_token=token" },
+    });
+    const res = await middleware(req);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects mutating api requests with csrf header but no cookie", async () => {
+    const req = new NextRequest("http://example.com/api/test", {
+      method: "POST",
+      headers: { "x-csrf-token": "token" },
+    });
+    const res = await middleware(req);
+
+    expect(res.status).toBe(403);
+  });
+
   it("allows repeated login attempts without rate limiting", async () => {
     const headers = {
       "x-forwarded-for": "1.2.3.4",


### PR DESCRIPTION
## Summary
- add middleware tests ensuring mutating API requests require both CSRF header and cookie

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test apps/cms/src/__tests__/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1b955d0c4832f822900bcb8ed05bf