### PR TITLE
Add validation tests for shop forms

### DIFF
--- a/apps/cms/src/services/shops/validation/__tests__/parseAiCatalogForm.test.ts
+++ b/apps/cms/src/services/shops/validation/__tests__/parseAiCatalogForm.test.ts
@@ -1,0 +1,31 @@
+import { parseAiCatalogForm } from "../parseAiCatalogForm";
+
+describe("parseAiCatalogForm", () => {
+  it("parses valid form data", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("pageSize", "20");
+    fd.append("fields", "id");
+    fd.append("fields", "title");
+
+    const result = parseAiCatalogForm(fd);
+    expect(result.data).toEqual({
+      enabled: true,
+      pageSize: 20,
+      fields: ["id", "title"],
+    });
+  });
+
+  it("returns errors for invalid inputs", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("pageSize", "0");
+    fd.append("fields", "invalid");
+
+    const result = parseAiCatalogForm(fd);
+    expect(result.errors).toEqual({
+      pageSize: [expect.any(String)],
+      fields: [expect.any(String)],
+    });
+  });
+});

--- a/apps/cms/src/services/shops/validation/__tests__/parseGenerateSeoForm.test.ts
+++ b/apps/cms/src/services/shops/validation/__tests__/parseGenerateSeoForm.test.ts
@@ -1,0 +1,35 @@
+import { parseGenerateSeoForm } from "../parseGenerateSeoForm";
+
+describe("parseGenerateSeoForm", () => {
+  it("parses valid form data", () => {
+    const fd = new FormData();
+    fd.set("id", "abc");
+    fd.set("locale", "en");
+    fd.set("title", "My title");
+    fd.set("description", "desc");
+
+    const result = parseGenerateSeoForm(fd);
+    expect(result.data).toEqual({
+      id: "abc",
+      locale: "en",
+      title: "My title",
+      description: "desc",
+    });
+  });
+
+  it("returns errors for invalid inputs", () => {
+    const fd = new FormData();
+    fd.set("id", "");
+    fd.set("locale", "xx");
+    fd.set("title", "");
+    fd.set("description", "");
+
+    const result = parseGenerateSeoForm(fd);
+    expect(result.errors).toEqual({
+      id: [expect.any(String)],
+      locale: [expect.any(String)],
+      title: [expect.any(String)],
+      description: [expect.any(String)],
+    });
+  });
+});

--- a/apps/cms/src/services/shops/validation/__tests__/parseReverseLogisticsForm.test.ts
+++ b/apps/cms/src/services/shops/validation/__tests__/parseReverseLogisticsForm.test.ts
@@ -1,0 +1,23 @@
+import { parseReverseLogisticsForm } from "../parseReverseLogisticsForm";
+
+describe("parseReverseLogisticsForm", () => {
+  it("parses valid data", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("intervalMinutes", "10");
+
+    const result = parseReverseLogisticsForm(fd);
+    expect(result.data).toEqual({ enabled: true, intervalMinutes: 10 });
+  });
+
+  it("returns errors for invalid interval", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("intervalMinutes", "0");
+
+    const result = parseReverseLogisticsForm(fd);
+    expect(result.errors).toEqual({
+      intervalMinutes: [expect.any(String)],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage tests for AI catalog form validation
- test SEO generation form validation
- add reverse logistics form tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test` *(fails: TypeError: (0 , core_1.loadCoreEnv) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b95ddf00832f83cec536435b81c1