### PR TITLE
test(email): simulate email when only user set

### DIFF
--- a/packages/email/src/__tests__/sendEmail.test.ts
+++ b/packages/email/src/__tests__/sendEmail.test.ts
@@ -69,6 +69,39 @@ describe("sendEmail", () => {
     expect(getDefaultSender).not.toHaveBeenCalled();
   });
 
+  it("simulates email when only GMAIL_USER is set", async () => {
+    process.env = {
+      ...OLD_ENV,
+      GMAIL_USER: "test@example.com",
+      STRIPE_SECRET_KEY: "sk",
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
+      EMAIL_LOG_LEVEL: "info",
+    } as NodeJS.ProcessEnv;
+
+    const infoSpy = jest.fn();
+    const pinoMock = jest.fn(() => ({ info: infoSpy }));
+    jest.doMock("pino", () => ({
+      __esModule: true,
+      default: pinoMock,
+    }));
+    const createTransport = jest.fn();
+    jest.doMock("nodemailer", () => ({
+      __esModule: true,
+      default: { createTransport },
+      createTransport,
+    }));
+    const getDefaultSender = jest.fn();
+    jest.doMock("../config", () => ({ getDefaultSender }));
+
+    const { sendEmail } = await import("../sendEmail");
+    await sendEmail("a@b.com", "Hi", "There");
+
+    expect(createTransport).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith({ to: "a@b.com" }, "Email simulated");
+    expect(pinoMock).toHaveBeenCalledWith({ level: "info" });
+    expect(getDefaultSender).not.toHaveBeenCalled();
+  });
+
   it("defaults to silent log level when EMAIL_LOG_LEVEL is not set", async () => {
     process.env = {
       ...OLD_ENV,


### PR DESCRIPTION
## Summary
- cover sendEmail path where GMAIL_USER is defined but password missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9c23cb8832fa36e8e9e10acac2f