### PR TITLE
test: assert nodemailer transport configuration

### DIFF
--- a/packages/email/src/__tests__/sendEmail.test.ts
+++ b/packages/email/src/__tests__/sendEmail.test.ts
@@ -19,15 +19,25 @@ describe("sendEmail", () => {
     } as NodeJS.ProcessEnv;
 
     const sendMail = jest.fn().mockResolvedValue(undefined);
+    const createTransport = jest.fn(() => ({ sendMail }));
     jest.doMock("nodemailer", () => ({
       __esModule: true,
-      default: { createTransport: () => ({ sendMail }) },
-      createTransport: () => ({ sendMail }),
+      default: { createTransport },
+      createTransport,
     }));
     const getDefaultSender = jest.fn(() => "sender@example.com");
     jest.doMock("../config", () => ({ getDefaultSender }));
 
     const { sendEmail } = await import("../sendEmail");
+
+    expect(createTransport).toHaveBeenCalledWith({
+      service: "gmail",
+      auth: {
+        user: "test@example.com",
+        pass: "secret",
+      },
+    });
+
     await sendEmail("a@b.com", "Hello", "World");
 
     expect(sendMail).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- assert nodemailer.createTransport called with Gmail auth in sendEmail tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/sendEmail.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9c48db8832f9a24c3f8811c81a6