### PR TITLE
test: handle empty segment recipients

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -16,7 +16,7 @@ jest.mock("../analytics", () => ({
   syncCampaignAnalytics: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock("../segments", () => ({
-  resolveSegment: jest.fn(),
+  resolveSegment: jest.fn().mockResolvedValue([]),
 }));
 jest.mock("../templates", () => ({
   renderTemplate: jest.fn(),
@@ -610,6 +610,18 @@ describe("scheduler", () => {
         body: '<p>Hi</p>',
       })
     ).rejects.toThrow('boom');
+  });
+
+  test('createCampaign rejects when segment yields no recipients', async () => {
+    (resolveSegment as jest.Mock).mockResolvedValueOnce([]);
+    await expect(
+      createCampaign({
+        shop,
+        segment: 'seg',
+        subject: 'Hi',
+        body: '<p>Hi</p>',
+      })
+    ).rejects.toThrow('Missing fields');
   });
 
   test("deliverCampaign batches recipients and adds unsubscribe link", async () => {


### PR DESCRIPTION
## Summary
- mock segment resolution to return empty array
- ensure createCampaign rejects when no recipients are resolved

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9d0f9ec832f8461c5fa24e28efd