### PR TITLE
test: ensure sendDueCampaigns handles no shops

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -513,6 +513,13 @@ describe("scheduler", () => {
     expect(writeCampaigns).toHaveBeenCalledTimes(1);
   });
 
+  test("sendDueCampaigns does nothing when there are no shops", async () => {
+    listShops.mockResolvedValue([]);
+    await sendDueCampaigns();
+    expect(sendCampaignEmail).not.toHaveBeenCalled();
+    expect(writeCampaigns).not.toHaveBeenCalled();
+  });
+
   test("sendDueCampaigns delivers due campaigns per shop", async () => {
     const past = new Date(now.getTime() - 1000).toISOString();
     const future = new Date(now.getTime() + 60000).toISOString();


### PR DESCRIPTION
## Summary
- add test verifying sendDueCampaigns skips processing when no shops exist

## Testing
- `pnpm --filter @acme/email run build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email run check:references` *(fails: script not found)*
- `pnpm --filter @acme/email run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/email test src/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9d3962c832fad9dda622318e214