### PR TITLE
test(email): handle blank CAMPAIGN_FROM in getDefaultSender

### DIFF
--- a/packages/email/src/__tests__/config.test.ts
+++ b/packages/email/src/__tests__/config.test.ts
@@ -28,6 +28,17 @@ describe("getDefaultSender", () => {
     expect(getDefaultSender()).toBe("user@example.com");
   });
 
+  it("uses GMAIL_USER when CAMPAIGN_FROM is only whitespace", async () => {
+    process.env = {
+      ...OLD_ENV,
+      CAMPAIGN_FROM: "   ",
+      GMAIL_USER: "User@Example.Com",
+    } as NodeJS.ProcessEnv;
+
+    const { getDefaultSender } = await import("../config");
+    expect(getDefaultSender()).toBe("user@example.com");
+  });
+
   it("throws when sender is missing", async () => {
     process.env = { ...OLD_ENV } as NodeJS.ProcessEnv;
     delete process.env.CAMPAIGN_FROM;


### PR DESCRIPTION
## Summary
- add coverage for CAMPAIGN_FROM containing only whitespace

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email run test` *(fails: coverage thresholds and existing suite failures)*
- `pnpm --filter @acme/email run test -- packages/email/src/__tests__/config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9c78f50832fb5b8739439c13169