### PR TITLE
test(email): ensure sendDueCampaigns exits with no shops

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -482,6 +482,29 @@ describe("scheduler", () => {
     expect(campaign.sentAt).toBe(fake.toISOString());
   });
 
+  test("sendDueCampaigns exits early when no shops are returned", async () => {
+    memory[shop] = [
+      {
+        id: "c1",
+        recipients: ["a@example.com"],
+        subject: "Hi",
+        body: "<p>Hi</p>",
+        segment: null,
+        sendAt: new Date(now.getTime() - 1000).toISOString(),
+        templateId: null,
+      },
+    ];
+
+    listShops.mockResolvedValue([]);
+
+    await sendDueCampaigns();
+
+    expect(listShops).toHaveBeenCalled();
+    expect(readCampaigns).not.toHaveBeenCalled();
+    expect(writeCampaigns).not.toHaveBeenCalled();
+    expect(sendCampaignEmail).not.toHaveBeenCalled();
+  });
+
   test("sendDueCampaigns writes campaigns only when sending due items", async () => {
     const past = new Date(now.getTime() - 1000).toISOString();
     const future = new Date(now.getTime() + 60000).toISOString();


### PR DESCRIPTION
## Summary
- add unit test ensuring scheduler skips work when campaign store lists no shops

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc6fa46c832fb1c01ac37de5b9c7