### PR TITLE
test: ignore malformed unsubscribe emails

### DIFF
--- a/packages/email/__tests__/scheduler.test.ts
+++ b/packages/email/__tests__/scheduler.test.ts
@@ -223,6 +223,8 @@ describe("scheduler", () => {
   test("filters out unsubscribed recipients", async () => {
     mockListEvents.mockResolvedValueOnce([
       { type: "email_unsubscribe", email: "a@example.com" },
+      // non-string email should be ignored
+      { type: "email_unsubscribe", email: 123 as any },
     ]);
 
     await createCampaign({

--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -116,6 +116,8 @@ describe("scheduler", () => {
     (listEvents as jest.Mock).mockResolvedValue([
       { type: "page_view" },
       { type: "email_unsubscribe", email: "b@example.com" },
+      // non-string email should be ignored
+      { type: "email_unsubscribe", email: 123 as any },
       { type: "signup", email: "c@example.com" },
     ]);
     await sendDueCampaigns();


### PR DESCRIPTION
## Summary
- test scheduler ignores unsubscribe events with non-string emails

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm exec jest --ci --runInBand --detectOpenHandles --config packages/email/jest.config.cjs packages/email/__tests__/scheduler.test.ts packages/email/src/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc7208f0832fa799557bc8e638a5