### PR TITLE
test: verify custom segment cache ttl

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -325,6 +325,12 @@ describe("cacheTtl", () => {
     jest.resetModules();
   });
 
+  it("returns custom ttl when set", async () => {
+    process.env.SEGMENT_CACHE_TTL = "5000";
+    const { cacheTtl } = await import("../segments");
+    expect(cacheTtl()).toBe(5000);
+  });
+
   it("returns default when ttl is negative", async () => {
     process.env.SEGMENT_CACHE_TTL = "-1";
     const { cacheTtl } = await import("../segments");


### PR DESCRIPTION
## Summary
- add unit test to ensure SEGMENT_CACHE_TTL is honored

## Testing
- `pnpm --filter @acme/email test packages/email/src/__tests__/segments.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*


------
https://chatgpt.com/codex/tasks/task_e_68c1bc7a6b04832fa5274b2b58a490df