### PR TITLE
test(email): mark unsubscribed campaigns as sent

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -150,6 +150,30 @@ describe("scheduler", () => {
   });
 
   test(
+    "sendDueCampaigns marks campaign sent when all recipients unsubscribed",
+    async () => {
+      const past = new Date(now.getTime() - 1000).toISOString();
+      memory[shop] = [
+        {
+          id: "c2",
+          recipients: ["a@example.com"],
+          subject: "Hi",
+          body: "<p>Hi %%UNSUBSCRIBE%%</p>",
+          segment: null,
+          sendAt: past,
+          templateId: null,
+        },
+      ];
+      (listEvents as jest.Mock).mockResolvedValue([
+        { type: "email_unsubscribe", email: "a@example.com" },
+      ]);
+      await sendDueCampaigns();
+      expect(sendCampaignEmail).not.toHaveBeenCalled();
+      expect(memory[shop][0].sentAt).toBeDefined();
+    },
+  );
+
+  test(
     "createCampaign filters unsubscribed recipients using analytics events",
     async () => {
       (listEvents as jest.Mock).mockResolvedValueOnce([


### PR DESCRIPTION
## Summary
- test email scheduler marks campaigns sent when all recipients unsubscribed

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test packages/email/src/__tests__/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc995490832f96c1a67308f8a1d8