### PR TITLE
test(email): bubble up template rendering errors

### DIFF
--- a/packages/email/src/__tests__/send.core.test.ts
+++ b/packages/email/src/__tests__/send.core.test.ts
@@ -205,6 +205,26 @@ describe("send core helpers", () => {
       );
     });
 
+    it("surfaces renderTemplate errors", async () => {
+      const err = new Error("render fail");
+      mockRenderTemplate.mockImplementation(() => {
+        throw err;
+      });
+      await jest.isolateModulesAsync(async () => {
+        process.env.EMAIL_PROVIDER = "sendgrid";
+        process.env.SENDGRID_API_KEY = "sg";
+        const { sendCampaignEmail } = await import("../send");
+        await expect(
+          sendCampaignEmail({
+            to: "to@example.com",
+            subject: "Sub",
+            templateId: "welcome",
+            sanitize: false,
+          })
+        ).rejects.toThrow("render fail");
+      });
+    });
+
     it("sanitizes HTML when enabled", async () => {
       const providerSend = jest.fn().mockResolvedValue(undefined);
       SendgridProvider.mockImplementation(() => ({ send: providerSend }));


### PR DESCRIPTION
## Summary
- add coverage for renderTemplate exceptions in sendCampaignEmail

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test packages/email/src/__tests__/send.core.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc97c6f4832f9afd1c9a04a18787