### PR TITLE
test: ensure no delay when email batch delay zero

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -349,6 +349,28 @@ describe("scheduler", () => {
     delete process.env.EMAIL_BATCH_DELAY_MS;
   });
 
+  test(
+    "createCampaign does not schedule delay when batch delay is zero",
+    async () => {
+      process.env.EMAIL_BATCH_SIZE = "1";
+      process.env.EMAIL_BATCH_DELAY_MS = "0";
+      const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+      const promise = createCampaign({
+        shop,
+        recipients: ["a@example.com", "b@example.com"],
+        subject: "Hi",
+        body: "<p>Hi %%UNSUBSCRIBE%%</p>",
+      });
+      await jest.runAllTimersAsync();
+      await promise;
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      setTimeoutSpy.mockRestore();
+      delete process.env.EMAIL_BATCH_SIZE;
+      delete process.env.EMAIL_BATCH_DELAY_MS;
+    },
+    10000,
+  );
+
   test("createCampaign writes campaign to store", async () => {
     await createCampaign({
       shop,

--- a/packages/email/src/scheduler.ts
+++ b/packages/email/src/scheduler.ts
@@ -84,7 +84,10 @@ async function deliverCampaign(shop: string, c: Campaign): Promise<void> {
   recipients = await filterUnsubscribed(shop, recipients);
   const hasPlaceholder = baseHtml.includes("%%UNSUBSCRIBE%%");
   const batchSize = Number(process.env.EMAIL_BATCH_SIZE) || 100;
-  const batchDelay = Number(process.env.EMAIL_BATCH_DELAY_MS) || 1000;
+  const batchDelay =
+    process.env.EMAIL_BATCH_DELAY_MS === undefined
+      ? 1000
+      : Number(process.env.EMAIL_BATCH_DELAY_MS);
   for (let i = 0; i < recipients.length; i += batchSize) {
     const batch = recipients.slice(i, i + batchSize);
     for (const r of batch) {


### PR DESCRIPTION
## Summary
- add regression test for zero batch delay in email scheduler
- treat EMAIL_BATCH_DELAY_MS=0 as no delay

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm -r build` (fails: TS2307 Cannot find module '@acme/ui')
- `pnpm --filter @acme/email test` (fails: coverage thresholds not met)


------
https://chatgpt.com/codex/tasks/task_e_68c1bc70ef5c832fac920a5ae15d4256