### PR TITLE
test(email): handle json rejection in createContact

### DIFF
--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -207,6 +207,16 @@ describe("ResendProvider", () => {
     );
   });
 
+  it("createContact returns empty string when json rejects", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      json: jest.fn().mockRejectedValueOnce(new Error("fail")),
+    }) as any;
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    await expect(provider.createContact("user@example.com")).resolves.toBe("");
+  });
+
   it("createContact returns empty string when fetch rejects", async () => {
     process.env.RESEND_API_KEY = "rs";
     global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;


### PR DESCRIPTION
## Summary
- test createContact resolves empty string when response json fails

## Testing
- `pnpm --filter @acme/email test src/__tests__/resend.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c48c7240832f9ca336c40844aaae