### PR TITLE
test(email): ignore invalid email events

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -525,6 +525,22 @@ describe("resolveSegment events", () => {
     expect(r2).toEqual(["a@example.com"]);
     expect(mockListEvents).toHaveBeenCalledTimes(1);
   });
+
+  it("ignores events without string emails", async () => {
+    mockReadFile.mockResolvedValue("[]");
+    mockStat.mockResolvedValue({ mtimeMs: 1 });
+    mockListEvents.mockResolvedValue([
+      { email: "a@example.com", type: "segment:vip" },
+      { email: undefined, type: "segment:vip" },
+      { type: "segment:vip" },
+      { email: 123, type: "segment:vip" },
+    ]);
+
+    const { resolveSegment } = await import("../segments");
+    const result = await resolveSegment("shop1", "vip");
+
+    expect(result).toEqual(["a@example.com"]);
+  });
 });
 
 describe("analyticsMTime", () => {


### PR DESCRIPTION
## Summary
- test segment resolution ignoring events with missing or non-string emails

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: missing script)*
- `pnpm run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/email test packages/email/src/__tests__/segments.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c488c334832fbd2c20228092b28e