### PR TITLE
test: deduplicate segment event emails

### DIFF
--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -494,12 +494,14 @@ describe("resolveSegment events", () => {
     delete process.env.SEGMENT_CACHE_TTL;
   });
 
-  it("resolves emails from segment events when no definition exists", async () => {
+  it("deduplicates emails from segment events when no definition exists", async () => {
     mockReadFile.mockResolvedValue("[]");
     mockStat.mockResolvedValue({ mtimeMs: 1 });
     mockListEvents.mockResolvedValue([
       { email: "a@example.com", type: "segment", segment: "vip" },
+      { email: "a@example.com", type: "segment:vip" },
       { email: "b@example.com", type: "segment:vip" },
+      { email: "b@example.com", type: "segment", segment: "vip" },
       { email: "c@example.com", type: "segment", segment: "other" },
       { email: "d@example.com", type: "segment:other" },
     ]);


### PR DESCRIPTION
## Summary
- ensure resolveSegment deduplicates emails when events contain duplicates

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm --filter @acme/email test -- packages/email/src/__tests__/segments.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c4880bdc832fb7e276fd28b98058