### PR TITLE
test: handle missing SMTP_URL in nodemailer transport

### DIFF
--- a/packages/email/src/__tests__/send.core.test.ts
+++ b/packages/email/src/__tests__/send.core.test.ts
@@ -525,6 +525,25 @@ describe("send core helpers", () => {
   });
 
   describe("sendWithNodemailer", () => {
+    it("creates transport with undefined SMTP_URL", async () => {
+      delete process.env.SMTP_URL;
+      const { sendWithNodemailer } = await import("../send");
+      await sendWithNodemailer({
+        to: "to@example.com",
+        subject: "Sub",
+        html: "<p>H</p>",
+        text: "T",
+      });
+      expect(mockCreateTransport).toHaveBeenCalledWith({ url: undefined });
+      expect(mockSendMail).toHaveBeenCalledWith({
+        from: "from@example.com",
+        to: "to@example.com",
+        subject: "Sub",
+        html: "<p>H</p>",
+        text: "T",
+      });
+    });
+
     it("creates transport with SMTP_URL and forwards fields", async () => {
       process.env.SMTP_URL = "smtp://test";
       const { sendWithNodemailer } = await import("../send");


### PR DESCRIPTION
## Summary
- add test ensuring nodemailer transport handles absent SMTP_URL

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: TS2307: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test -- packages/email/src/__tests__/send.core.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c1c484d390832f89258ab2f3378dfc