### PR TITLE
test: retry provider with empty error object

### DIFF
--- a/packages/email/src/__tests__/send.core.test.ts
+++ b/packages/email/src/__tests__/send.core.test.ts
@@ -481,11 +481,11 @@ describe("send core helpers", () => {
       expect(provider.send).toHaveBeenCalledTimes(1);
     });
 
-    it("retries up to max attempts when error lacks retryable but has provider fields", async () => {
+    it("retries up to default limit when provider rejects with empty object", async () => {
       jest.useFakeTimers();
       mockHasProviderErrorFields.mockReturnValue(true);
       const { sendWithRetry } = await import("../send");
-      const err = { code: 500 };
+      const err = {};
       const provider = { send: jest.fn().mockRejectedValue(err) };
       const expectation = expect(
         sendWithRetry(provider as any, { to: "t", subject: "s" })


### PR DESCRIPTION
## Summary
- ensure sendWithRetry handles empty provider errors and retries up to default limit

## Testing
- `pnpm --filter @acme/email test src/__tests__/send.core.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in packages/platform-core build)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c4842860832fa1947da751b790b9