### PR TITLE
test: handle missing campaign file

### DIFF
--- a/packages/email/src/__tests__/cli.test.ts
+++ b/packages/email/src/__tests__/cli.test.ts
@@ -151,6 +151,21 @@ test("campaign list outputs campaigns", async () => {
   expect(JSON.parse(output)).toEqual(campaigns);
 });
 
+test("campaign list outputs [] when file missing", async () => {
+  fsMock.promises.readFile.mockRejectedValueOnce(
+    Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+  );
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  const { run } = await import("../cli");
+  await run(["node", "email", "campaign", "list", "shop"]);
+
+  expect(fsMock.promises.readFile).toHaveBeenCalledWith(
+    path.join(dataRoot, "shop", "campaigns.json"),
+    "utf8",
+  );
+  expect(logSpy).toHaveBeenCalledWith("[]");
+});
+
 test("campaign send invokes scheduler", async () => {
   const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   const { run } = await import("../cli");


### PR DESCRIPTION
## Summary
- test campaign list when campaigns file is missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test packages/email/src/__tests__/cli.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c4917c2c832fb32ccc1dfb81027d