### PR TITLE
test: ensure addToList posts to segments

### DIFF
--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -217,10 +217,17 @@ describe("ResendProvider", () => {
 
   it("addToList resolves even when fetch rejects", async () => {
     process.env.RESEND_API_KEY = "rs";
-    global.fetch = jest.fn().mockRejectedValueOnce(new Error("fail")) as any;
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("fail")) as any;
+    global.fetch = fetchMock;
     const { ResendProvider } = await import("../providers/resend");
     const provider = new ResendProvider();
     await expect(provider.addToList("cid", "lid")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.resend.com/segments/lid/contacts",
+      expect.objectContaining({ method: "POST" })
+    );
   });
 
   it("addToList posts correct payload", async () => {


### PR DESCRIPTION
## Summary
- test Resend addToList fetch POST to segment contacts endpoint

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test src/__tests__/resend.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c49c8584832f86bd2aeb66b8873f