### PR TITLE
fix: correct shared-utils test imports

### DIFF
--- a/packages/shared-utils/src/__tests__/genSecret.test.ts
+++ b/packages/shared-utils/src/__tests__/genSecret.test.ts
@@ -1,4 +1,4 @@
-import { genSecret } from './genSecret';
+import { genSecret } from '../genSecret';
 
 describe('genSecret', () => {
   const original = globalThis.crypto;

--- a/packages/shared-utils/src/__tests__/legacy/buildResponse.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/buildResponse.test.ts
@@ -1,4 +1,4 @@
-import { buildResponse, type ProxyResponse } from './buildResponse';
+import { buildResponse, type ProxyResponse } from '../../buildResponse';
 
 describe('buildResponse', () => {
   it('creates a Response with decoded body, status and headers', async () => {

--- a/packages/shared-utils/src/__tests__/legacy/fetchJson.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/fetchJson.test.ts
@@ -1,4 +1,4 @@
-import { fetchJson } from "./fetchJson";
+import { fetchJson } from "../../fetchJson";
 import { z } from "zod";
 
 describe("fetchJson", () => {

--- a/packages/shared-utils/src/__tests__/legacy/formatCurrency.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/formatCurrency.test.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from './formatCurrency';
+import { formatCurrency } from '../../formatCurrency';
 
 describe('formatCurrency', () => {
   it('uses USD and current locale by default', () => {

--- a/packages/shared-utils/src/__tests__/legacy/formatPrice.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/formatPrice.test.ts
@@ -1,4 +1,4 @@
-import { formatPrice } from './formatPrice';
+import { formatPrice } from '../../formatPrice';
 
 describe('formatPrice', () => {
   it('formats using USD by default', () => {

--- a/packages/shared-utils/src/__tests__/legacy/getCsrfToken.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/getCsrfToken.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import { JSDOM } from 'jsdom';
-import { getCsrfToken } from './getCsrfToken';
+import { getCsrfToken } from '../../getCsrfToken';
 
 describe('getCsrfToken', () => {
   const originalLocation = globalThis.location;

--- a/packages/shared-utils/src/__tests__/legacy/getShopFromPath.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/getShopFromPath.test.ts
@@ -1,4 +1,4 @@
-import { getShopFromPath } from "./getShopFromPath";
+import { getShopFromPath } from "../../getShopFromPath";
 
 describe("getShopFromPath", () => {
   it("returns the shop slug even with extra slashes", () => {

--- a/packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { parseJsonBody, parseLimit } from './parseJsonBody';
+import { parseJsonBody, parseLimit } from '../../parseJsonBody';
 
 describe('parseLimit', () => {
   it.each([

--- a/packages/shared-utils/src/__tests__/replaceShopInPath.test.ts
+++ b/packages/shared-utils/src/__tests__/replaceShopInPath.test.ts
@@ -1,4 +1,4 @@
-import { replaceShopInPath } from "./replaceShopInPath";
+import { replaceShopInPath } from "../replaceShopInPath";
 
 describe("replaceShopInPath", () => {
   it("replaces existing shop slug", () => {

--- a/packages/shared-utils/src/__tests__/toggleItem.test.ts
+++ b/packages/shared-utils/src/__tests__/toggleItem.test.ts
@@ -1,4 +1,4 @@
-import { toggleItem } from './toggleItem';
+import { toggleItem } from '../toggleItem';
 
 describe('toggleItem', () => {
   it('adds item when missing without mutating the original array', () => {


### PR DESCRIPTION
## Summary
- fix shared-utils legacy test import paths
- update remaining tests to reference modules correctly

## Testing
- `pnpm exec jest packages/shared-utils/src/__tests__ --runInBand --detectOpenHandles --config jest.config.cjs`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c50e9ac0832faa036111ff5108bd