### PR TITLE
test: ensure fs store writes to disk

### DIFF
--- a/packages/email/src/__tests__/fsStore.test.ts
+++ b/packages/email/src/__tests__/fsStore.test.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { DATA_ROOT } from "@platform-core/dataRoot";
+import { fsCampaignStore } from "../storage/fsStore";
+
+describe("fsCampaignStore.writeCampaigns", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates directory and writes campaigns.json", async () => {
+    const mkdir = jest.spyOn(fs, "mkdir").mockResolvedValue(undefined as any);
+    const writeFile = jest
+      .spyOn(fs, "writeFile")
+      .mockResolvedValue(undefined as any);
+
+    const shop = "shop";
+    const campaigns: any[] = [];
+
+    await fsCampaignStore.writeCampaigns(shop, campaigns);
+
+    expect(mkdir).toHaveBeenCalledWith(path.join(DATA_ROOT, shop), {
+      recursive: true,
+    });
+    expect(writeFile).toHaveBeenCalledWith(
+      path.join(DATA_ROOT, shop, "campaigns.json"),
+      JSON.stringify(campaigns, null, 2),
+      "utf8",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying fsCampaignStore.writeCampaigns invokes fs.mkdir and fs.writeFile with correct paths

## Testing
- `node -v` *(fails: command not found)*
- `pnpm install` *(fails: pnpm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c48f64ac832fbcecfd63a0971122