### PR TITLE
test(email): handle readdir rejection in fs store

### DIFF
--- a/packages/email/src/__tests__/fsStore.test.ts
+++ b/packages/email/src/__tests__/fsStore.test.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from "node:fs";
+import { fsCampaignStore } from "../storage/fsStore";
+
+jest.mock("@acme/lib", () => ({
+  __esModule: true,
+  validateShopName: (s: string) => s,
+}));
+
+describe("fsCampaignStore listShops error handling", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("resolves to [] when fs.readdir rejects", async () => {
+    jest.spyOn(fs, "readdir").mockRejectedValue(new Error("fail"));
+    await expect(fsCampaignStore.listShops()).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for fsCampaignStore.listShops returning [] when fs.readdir rejects

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c48e21fc832fae379ed3776d22d7