### PR TITLE
test: ignore invalid unsubscribe event

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -151,6 +151,30 @@ describe("scheduler", () => {
     ]);
   });
 
+  test("filterUnsubscribed keeps recipients when event email is not a string", async () => {
+    const past = new Date(now.getTime() - 1000).toISOString();
+    memory[shop] = [
+      {
+        id: "c1",
+        recipients: ["a@example.com", "b@example.com"],
+        subject: "Hi",
+        body: "<p>Hi</p>",
+        segment: null,
+        sendAt: past,
+        templateId: null,
+      },
+    ];
+    (listEvents as jest.Mock).mockResolvedValue([
+      { type: "email_unsubscribe", email: 123 as any },
+    ]);
+    await sendDueCampaigns();
+    expect(sendCampaignEmail).toHaveBeenCalledTimes(2);
+    expect((sendCampaignEmail as jest.Mock).mock.calls.map((c) => c[0].to)).toEqual([
+      "a@example.com",
+      "b@example.com",
+    ]);
+  });
+
   test(
     "sendDueCampaigns marks campaign sent when all recipients unsubscribed",
     async () => {


### PR DESCRIPTION
## Summary
- add regression test to ignore unsubscribe events with non-string email

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/email test --silent` *(fails: global coverage threshold for branches (80%) not met: 13.61%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c4858744832fb6b0d81d8eb8d96c