### PR TITLE
fix shared-utils tests

### DIFF
--- a/packages/shared-utils/__tests__/parseJsonBody.api.test.ts
+++ b/packages/shared-utils/__tests__/parseJsonBody.api.test.ts
@@ -39,6 +39,7 @@ describe('parseJsonBody API route integration', () => {
       method: 'POST',
       body: JSON.stringify({ foo: 'bar' }),
     });
+    req.headers.delete('content-type');
     const res = await handler(req);
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ foo: 'bar' });

--- a/packages/shared-utils/src/__tests__/genSecret.test.ts
+++ b/packages/shared-utils/src/__tests__/genSecret.test.ts
@@ -1,4 +1,4 @@
-import { genSecret } from './genSecret';
+import { genSecret } from '../genSecret';
 
 describe('genSecret', () => {
   const original = globalThis.crypto;

--- a/packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { parseJsonBody, parseLimit } from './parseJsonBody';
+import { parseJsonBody, parseLimit } from '../../parseJsonBody';
 
 describe('parseLimit', () => {
   it.each([


### PR DESCRIPTION
## Summary
- fix parseJsonBody API test to remove default content-type
- correct relative imports in shared-utils tests

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/shared-utils run test` *(fails: running tests across workspace triggers unrelated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c5185cb4832f9ba9e40019af0a62