### PR TITLE
test: fix shops and legacy parseJsonBody tests

### DIFF
--- a/packages/platform-machine/src/__tests__/shops.server.test.ts
+++ b/packages/platform-machine/src/__tests__/shops.server.test.ts
@@ -27,6 +27,13 @@ jest.mock("@acme/types", () => ({
 }));
 
 jest.mock("@acme/platform-core/repositories/shop.server", () => ({
+  getShopById: jest.fn(async (shop: string) => {
+    const { prisma } = jest.requireMock("@acme/platform-core/db");
+    const { shopSchema } = jest.requireMock("@acme/types");
+    const rec = await prisma.shop.findUnique({ where: { id: shop } });
+    if (!rec) throw new Error(`Shop ${shop} not found`);
+    return shopSchema.parse(rec.data);
+  }),
   updateShopInRepo: jest.fn(async (_shop: string, patch: any) => patch),
 }));
 

--- a/packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { parseJsonBody, parseLimit } from './parseJsonBody';
+import { parseJsonBody, parseLimit } from '../../parseJsonBody';
 
 describe('parseLimit', () => {
   it.each([


### PR DESCRIPTION
## Summary
- mock getShopById for shop repository tests to ensure DB path is exercised
- correct legacy parseJsonBody test to reference actual implementation

## Testing
- `pnpm exec jest packages/shared-utils/src/__tests__/legacy/parseJsonBody.test.ts packages/platform-machine/src/__tests__/shops.server.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c4fdb7c0832f8ff8e22680e30eab