### PR TITLE
fix stock alert test and deposit config resolution

### DIFF
--- a/packages/platform-core/src/services/__tests__/stockAlert.test.ts
+++ b/packages/platform-core/src/services/__tests__/stockAlert.test.ts
@@ -182,7 +182,8 @@ describe("checkAndAlert", () => {
     expect(sendEmail.mock.calls[0][0]).toBe("shop@example.com");
     const body = sendEmail.mock.calls[0][2] as string;
     expect(body).toContain("new");
-    expect(body).not.toContain("old");
+    // Use a word boundary to avoid matching substrings like "threshold"
+    expect(body).not.toMatch(/\bold\b/);
 
     expect(writeFile).toHaveBeenCalledWith(
       expect.stringContaining("shop/stock-alert-log.json"),


### PR DESCRIPTION
## Summary
- avoid false positives in stock alert suppression test
- prioritize shop settings over core env in deposit release config and handle invalid intervals

## Testing
- `pnpm exec jest packages/platform-core/src/services/__tests__/stockAlert.test.ts`
- `pnpm exec jest packages/platform-machine/__tests__/releaseDepositsService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c4f30074832fa3ec4d22ef37e888