### PR TITLE
test: guard product grid resize mock

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx
@@ -8,7 +8,7 @@ jest.mock("@acme/platform-core/contexts/CartContext", () => ({
 
 function mockResize(initialWidth: number) {
   let cb: ResizeObserverCallback;
-  let element: Element;
+  let element: Element | undefined;
   (global as any).ResizeObserver = class {
     constructor(callback: ResizeObserverCallback) {
       cb = callback;
@@ -26,6 +26,7 @@ function mockResize(initialWidth: number) {
   } as any;
 
   return (width: number) => {
+    if (!element) return;
     Object.defineProperty(element, "clientWidth", {
       value: width,
       configurable: true,


### PR DESCRIPTION
## Summary
- avoid errors in ProductGrid resize tests when no element observed

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/organisms/__tests__/ProductGrid.test.tsx --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c1c669302c832fb9d07b8d22373a04