### PR TITLE
test: ensure ResendProvider skips sanity check fetch when API key missing

### DIFF
--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -48,6 +48,17 @@ describe("ResendProvider", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("resolves without API key and does not fetch during sanity check", async () => {
+    delete process.env.RESEND_API_KEY;
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as any;
+    const { ResendProvider } = await import("../providers/resend");
+    await expect(
+      new ResendProvider({ sanityCheck: true }).ready
+    ).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects when sanity check fetch fails", async () => {
     process.env.RESEND_API_KEY = "rs";
     const err = new Error("fail");


### PR DESCRIPTION
## Summary
- test ResendProvider `ready` resolves without API key and does not call `fetch`

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test` *(fails: "global" coverage threshold for branches (80%) not met: 13.61%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c49fac9c832fa9aa8f1771b4e9b9