### PR TITLE
test: handle resend error without message

### DIFF
--- a/packages/email/src/__tests__/resend.test.ts
+++ b/packages/email/src/__tests__/resend.test.ts
@@ -115,6 +115,30 @@ describe("ResendProvider", () => {
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("wraps object rejections without message in retryable ProviderError", async () => {
+    process.env.RESEND_API_KEY = "rs";
+    process.env.CAMPAIGN_FROM = "from@example.com";
+    send.mockRejectedValueOnce({ statusCode: 500 });
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { ResendProvider } = await import("../providers/resend");
+    const provider = new ResendProvider();
+    const promise = provider.send({
+      to: "t@example.com",
+      subject: "s",
+      html: "<p>h</p>",
+      text: "t",
+    });
+    const { ProviderError } = require("../providers/types");
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      message: "Unknown error",
+      retryable: true,
+    });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("logs warning when API key missing", async () => {
     process.env.CAMPAIGN_FROM = "from@example.com";
     const warnSpy = jest


### PR DESCRIPTION
## Summary
- add test verifying ResendProvider handles rejection objects lacking message

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test -- src/__tests__/resend.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c49a7050832faa48015e6730ae4b