### PR TITLE
test(sendgrid): verify auth header

### DIFF
--- a/packages/email/src/__tests__/sendgrid.test.ts
+++ b/packages/email/src/__tests__/sendgrid.test.ts
@@ -270,14 +270,19 @@ describe("SendgridProvider", () => {
     it("returns normalized stats on success", async () => {
       process.env.SENDGRID_API_KEY = "sg";
       const stats = { delivered: "2", opens: "3", clicks: 1 };
-      global.fetch = jest.fn().mockResolvedValue({
+      const fetch = jest.fn().mockResolvedValue({
         json: jest.fn().mockResolvedValue(stats),
       });
+      global.fetch = fetch;
       const { SendgridProvider } = await import("../providers/sendgrid");
       const { mapSendGridStats } = await import("../stats");
       const provider = new SendgridProvider();
       await expect(provider.getCampaignStats("1")).resolves.toEqual(
         mapSendGridStats(stats),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.sendgrid.com/v3/campaigns/1/stats",
+        { headers: { Authorization: "Bearer sg" } },
       );
     });
 


### PR DESCRIPTION
## Summary
- test sendgrid getCampaignStats uses Authorization header with API key

## Testing
- `pnpm --filter @acme/email test -- sendgrid.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c1c497e50c832fb31fa11bf9c94531