### PR TITLE
test: add sendgrid api key absence test

### DIFF
--- a/packages/email/src/__tests__/sendgrid.test.ts
+++ b/packages/email/src/__tests__/sendgrid.test.ts
@@ -15,6 +15,15 @@ describe("SendgridProvider", () => {
     global.fetch = realFetch;
   });
 
+  it("does not set API key when SENDGRID_API_KEY is undefined", async () => {
+    delete process.env.SENDGRID_API_KEY;
+
+    const { SendgridProvider } = await import("../providers/sendgrid");
+    new SendgridProvider();
+
+    expect(sgMail.setApiKey).not.toHaveBeenCalled();
+  });
+
   it("forwards payload to @sendgrid/mail", async () => {
     process.env.SENDGRID_API_KEY = "sg";
     process.env.CAMPAIGN_FROM = "campaign@example.com";


### PR DESCRIPTION
## Summary
- ensure SendgridProvider doesn't set api key when SENDGRID_API_KEY is missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email exec jest src/__tests__/sendgrid.test.ts --runInBand --config jest.config.cjs` *(fails: Coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c49329b0832f9cb6bd734499162d