### PR TITLE
test: handle readFile error

### DIFF
--- a/packages/platform-core/__tests__/resolvers.test.ts
+++ b/packages/platform-core/__tests__/resolvers.test.ts
@@ -71,6 +71,15 @@ describe("plugin resolvers", () => {
     expect(res).toEqual({ entryPath: null, isModule: false });
   });
 
+  it("logs error when readFile throws", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "plug-read-"));
+    jest.spyOn(fs, "readFile").mockRejectedValue(new Error("boom"));
+    const err = jest.spyOn(logger, "error").mockImplementation(() => {});
+    const res = await resolvePluginEntry(dir);
+    expect(err).toHaveBeenCalled();
+    expect(res).toEqual({ entryPath: null, isModule: false });
+  });
+
   it("importByType loads mjs and cjs modules", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "plug-"));
     const mjs = path.join(dir, "mod.mjs");


### PR DESCRIPTION
## Summary
- add tests for resolvePluginEntry when fs.readFile throws
- ensure logger.error is triggered and default result returned

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/platform-core run check:references` *(fails: missing script)*
- `pnpm --filter @acme/platform-core run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/platform-core test` *(fails: onRequestPost locks all dependencies - expected 200, received 403)*
- `pnpm exec jest --runTestsByPath packages/platform-core/src/plugins/__tests__/resolvers.test.ts packages/platform-core/__tests__/resolvers.test.ts --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c1cc52b904832f84af79e85886ff02