### PR TITLE
test: add exportsToCandidates candidate tests

### DIFF
--- a/packages/platform-core/__tests__/plugin-resolvers.test.ts
+++ b/packages/platform-core/__tests__/plugin-resolvers.test.ts
@@ -1,0 +1,45 @@
+import path from "node:path";
+import { exportsToCandidates } from "../src/plugins/resolvers";
+
+describe("exportsToCandidates", () => {
+  it("returns path for string exports", () => {
+    const dir = "/test";
+    const candidates = exportsToCandidates(dir, "./dist/index.js");
+    expect(candidates).toEqual([path.resolve(dir, "./dist/index.js")]);
+  });
+
+  it("returns paths for object exports", () => {
+    const dir = "/test";
+    const exportsField = {
+      ".": {
+        import: "./dist/index.mjs",
+        default: "./dist/index.js",
+        require: "./dist/index.cjs",
+      },
+    };
+    const candidates = exportsToCandidates(dir, exportsField);
+    expect(candidates).toEqual([
+      path.resolve(dir, "./dist/index.mjs"),
+      path.resolve(dir, "./dist/index.js"),
+      path.resolve(dir, "./dist/index.cjs"),
+    ]);
+  });
+
+  it("returns empty array for malformed exports", () => {
+    const candidates = exportsToCandidates("/test", 42 as unknown);
+    expect(candidates).toEqual([]);
+  });
+
+  it("dedupes duplicate paths", () => {
+    const dir = "/test";
+    const exportsField = {
+      ".": {
+        import: "./dist/index.js",
+        default: "./dist/index.js",
+        require: "./dist/index.js",
+      },
+    };
+    const candidates = exportsToCandidates(dir, exportsField);
+    expect(candidates).toEqual([path.resolve(dir, "./dist/index.js")]);
+  });
+});

--- a/packages/platform-core/src/plugins/resolvers.ts
+++ b/packages/platform-core/src/plugins/resolvers.ts
@@ -32,27 +32,25 @@ export function exportsToCandidates(
   try {
     if (typeof exportsField === "string") {
       candidates.push(path.resolve(dir, exportsField));
-      return candidates;
-    }
-    const root = (exportsField as Record<string, unknown>)["."] ?? exportsField;
+    } else {
+      const root = (exportsField as Record<string, unknown>)["."] ?? exportsField;
 
-    if (typeof root === "string") {
-      candidates.push(path.resolve(dir, root));
-      return candidates;
-    }
-
-    if (root && typeof root === "object") {
-      const entryObj = root as Record<string, string>;
-      if (entryObj.import) candidates.push(path.resolve(dir, entryObj.import));
-      if (entryObj.default)
-        candidates.push(path.resolve(dir, entryObj.default));
-      if (entryObj.require)
-        candidates.push(path.resolve(dir, entryObj.require));
+      if (typeof root === "string") {
+        candidates.push(path.resolve(dir, root));
+      } else if (root && typeof root === "object") {
+        const entryObj = root as Record<string, string>;
+        if (entryObj.import)
+          candidates.push(path.resolve(dir, entryObj.import));
+        if (entryObj.default)
+          candidates.push(path.resolve(dir, entryObj.default));
+        if (entryObj.require)
+          candidates.push(path.resolve(dir, entryObj.require));
+      }
     }
   } catch {
     // ignore malformed exports
   }
-  return candidates;
+  return unique(candidates);
 }
 
 export async function resolvePluginEntry(dir: string): Promise<{


### PR DESCRIPTION
## Summary
- dedupe plugin resolver export candidates
- add tests for various export configurations

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/plugin-resolvers.test.ts`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cc52503c832fa0598f61003e0e00