### PR TITLE
test: reserve items when maintenance cycle is infinite

### DIFF
--- a/packages/platform-core/__tests__/rentalAllocation.test.ts
+++ b/packages/platform-core/__tests__/rentalAllocation.test.ts
@@ -151,5 +151,56 @@ describe("reserveRentalInventory", () => {
       wearCount: 2,
     });
   });
+
+  it("selects items even when wearCount hits a finite cycle if maintenance cycle is infinite", async () => {
+    const { reserveRentalInventory } = await import("../src/orders/rentalAllocation");
+    const repo = await import("../src/repositories/inventory.server");
+    const mockUpdate = repo.updateInventoryItem as jest.Mock;
+
+    const candidate: InventoryItem = {
+      sku: "s1",
+      productId: "p1",
+      quantity: 1,
+      variantAttributes: {},
+      wearCount: 6,
+    };
+
+    const items: InventoryItem[] = [candidate];
+
+    const sku: SKU = {
+      id: "sku-4",
+      slug: "slug-4",
+      title: "Test SKU",
+      price: 0,
+      deposit: 0,
+      stock: 1,
+      forSale: false,
+      forRental: true,
+      media: [],
+      sizes: [],
+      description: "",
+      wearAndTearLimit: 10,
+      maintenanceCycle: Infinity,
+    };
+
+    mockUpdate.mockImplementation(async (_shop, _sku, _attrs, mutate) => {
+      return mutate(candidate);
+    });
+
+    const result = await reserveRentalInventory(
+      "shop",
+      items,
+      sku,
+      "2024-05-11",
+      "2024-05-12",
+    );
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      ...candidate,
+      quantity: 0,
+      wearCount: 7,
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- ensure rental items with wear counts at maintenance cycle boundaries are still selected when the SKU has an infinite maintenance cycle

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' or its corresponding type declarations)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/__tests__/rentalAllocation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1cc4ffda4832fa31e23da63bc1a61