### PR TITLE
fix date parsing for date-only strings

### DIFF
--- a/packages/date-utils/src/index.ts
+++ b/packages/date-utils/src/index.ts
@@ -72,6 +72,9 @@ export function formatDate(
   timezone?: string
 ): string {
   const d = typeof date === "string" ? parseISO(date) : date;
+  if (/[YD]/.test(fmt)) {
+    throw new RangeError("Invalid format pattern");
+  }
   return timezone ? formatInTimeZone(d, timezone, fmt) : format(d, fmt);
 }
 
@@ -102,7 +105,7 @@ export function parseTargetDate(
         ? hasZone
           ? parseISO(targetDate)
           : parseISO(`${targetDate}Z`)
-        : parseISO(targetDate);
+        : parseISO(`${targetDate}T00:00:00Z`);
     }
     return Number.isNaN(date.getTime()) ? null : date;
   } catch {


### PR DESCRIPTION
## Summary
- ensure formatDate rejects unsupported uppercase tokens before formatting
- parseTargetDate treats date-only inputs as UTC midnight

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/date-utils test -- packages/date-utils/__tests__/date.test.ts packages/date-utils/__tests__/parseTargetDate.boundary.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1cbf7bc7c832fb019158cfa2da32d