### PR TITLE
test: cover segment validation and sanitization

### DIFF
--- a/packages/email/src/__tests__/scheduler.test.ts
+++ b/packages/email/src/__tests__/scheduler.test.ts
@@ -714,6 +714,19 @@ describe("scheduler", () => {
     ).rejects.toThrow('boom');
   });
 
+  test('createCampaign rejects when emitSend fails', async () => {
+    (emitSend as jest.Mock).mockRejectedValueOnce(new Error('hook fail'));
+    await expect(
+      createCampaign({
+        shop,
+        recipients: ['a@example.com'],
+        subject: 'Hi',
+        body: '<p>Hi</p>',
+      })
+    ).rejects.toThrow('hook fail');
+    expect(memory[shop]).toBeUndefined();
+  });
+
   test('createCampaign rejects when segment yields no recipients', async () => {
     (resolveSegment as jest.Mock).mockResolvedValue([]);
     await expect(

--- a/packages/email/src/__tests__/segments.test.ts
+++ b/packages/email/src/__tests__/segments.test.ts
@@ -349,6 +349,21 @@ describe("resolveSegment filters", () => {
     const result = await resolveSegment("shop1", "vips");
     expect(result.sort()).toEqual(["a@example.com", "b@example.com"].sort());
   });
+
+  it("skips events with non-string emails", async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify([{ id: "seg", filters: [] }])
+    );
+    mockStat.mockResolvedValue({ mtimeMs: 1 });
+    mockListEvents.mockResolvedValue([
+      { email: 123 },
+      { email: { value: "a@example.com" } },
+    ]);
+
+    const { resolveSegment } = await import("../segments");
+    const result = await resolveSegment("shop1", "seg");
+    expect(result).toEqual([]);
+  });
 });
 
 describe("cacheTtl", () => {

--- a/packages/email/src/__tests__/send.core.test.ts
+++ b/packages/email/src/__tests__/send.core.test.ts
@@ -261,6 +261,25 @@ describe("send core helpers", () => {
       );
     });
 
+    it("removes style attributes during sanitization", async () => {
+      const providerSend = jest.fn().mockResolvedValue(undefined);
+      SendgridProvider.mockImplementation(() => ({ send: providerSend }));
+      mockSanitizeHtml.mockImplementation(() => "<p>Hi</p>");
+      await jest.isolateModulesAsync(async () => {
+        process.env.EMAIL_PROVIDER = "sendgrid";
+        process.env.SENDGRID_API_KEY = "sg";
+        const { sendCampaignEmail } = await import("../send");
+        await sendCampaignEmail({
+          to: "t",
+          subject: "s",
+          html: '<p style="color:red">Hi</p>',
+        });
+      });
+      expect(providerSend).toHaveBeenCalledWith(
+        expect.objectContaining({ html: "<p>Hi</p>" })
+      );
+    });
+
     it("does not sanitize HTML when disabled", async () => {
       const providerSend = jest.fn().mockResolvedValue(undefined);
       SendgridProvider.mockImplementation(() => ({ send: providerSend }));


### PR DESCRIPTION
## Summary
- ensure resolveSegment ignores events with non-string emails
- verify sendCampaignEmail strips style attributes when sanitizing
- assert createCampaign fails when emitSend hook rejects

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/email test`


------
https://chatgpt.com/codex/tasks/task_e_68c1cb173cb0832f8366a3f56502a9a7