### PR TITLE
test: cover instrumentation coercion

### DIFF
--- a/apps/cms/src/__tests__/instrumentation.node.test.ts
+++ b/apps/cms/src/__tests__/instrumentation.node.test.ts
@@ -45,4 +45,20 @@ describe("instrumentation register (node)", () => {
       rejection.stack ?? rejection,
     );
   });
+
+  it("coerces string inputs to Error objects", async () => {
+    await register();
+    handlers["uncaughtException"]?.("boom");
+    handlers["unhandledRejection"]?.("fail");
+    expect(consoleErrorSpy).toHaveBeenNthCalledWith(
+      1,
+      "[instrumentation] uncaughtException\n",
+      expect.stringContaining("Error: boom"),
+    );
+    expect(consoleErrorSpy).toHaveBeenNthCalledWith(
+      2,
+      "[instrumentation] unhandledRejection\n",
+      expect.stringContaining("Error: fail"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- test instrumentation handlers with string inputs

## Testing
- `pnpm exec jest apps/cms/src/__tests__/instrumentation.node.test.ts --config ./jest.config.cjs --runInBand --detectOpenHandles --coverage=false`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*


------
https://chatgpt.com/codex/tasks/task_e_68c1cae1815c832f8ae023b747ab7c7a