### PR TITLE
test: handle update product repo errors

### DIFF
--- a/apps/cms/src/actions/__tests__/products.server.test.ts
+++ b/apps/cms/src/actions/__tests__/products.server.test.ts
@@ -146,6 +146,21 @@ describe('products.server actions', () => {
       expect(result.product?.title.en).toBe('new');
     });
 
+    it('rethrows repository errors and captures exception', async () => {
+      const error = new Error('repo failure');
+      (updateProductInRepo as jest.Mock).mockRejectedValue(error);
+      const fd = new FormData();
+      fd.append('id', 'p1');
+      fd.append('price', '10');
+      fd.append('title_en', 'new');
+      fd.append('desc_en', 'new');
+      fd.append('media', '[]');
+      await expect(updateProduct(shop, fd)).rejects.toThrow('repo failure');
+      expect(captureException).toHaveBeenCalledWith(error, {
+        extra: { productId: 'p1' },
+      });
+    });
+
     it('throws when unauthorized', async () => {
       (ensureAuthorized as jest.Mock).mockRejectedValue(new Error('unauthorized'));
       await expect(updateProduct(shop, new FormData())).rejects.toThrow('unauthorized');

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -133,8 +133,13 @@ export async function updateProduct(
     updated_at: nowIso(),
   };
 
-  const saved = await updateProductInRepo<ProductPublication>(shop, updated);
-  return { product: saved };
+  try {
+    const saved = await updateProductInRepo<ProductPublication>(shop, updated);
+    return { product: saved };
+  } catch (error) {
+    await captureException(error, { extra: { productId: id } });
+    throw error;
+  }
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- capture and rethrow errors from `updateProductInRepo`
- add test ensuring `updateProduct` logs errors and rethrows

## Testing
- `pnpm exec jest apps/cms/src/actions/__tests__/products.server.test.ts --config ./jest.config.cjs --runInBand --detectOpenHandles --passWithNoTests --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1cadffd44832fbc30dd57ad3dda1f