### PR TITLE
test: add revertSeo tests

### DIFF
--- a/apps/cms/src/services/shops/__tests__/revertSeo.test.ts
+++ b/apps/cms/src/services/shops/__tests__/revertSeo.test.ts
@@ -1,0 +1,53 @@
+import { revertSeo } from "../seoService";
+import { authorize, fetchDiffHistory, persistSettings } from "../helpers";
+
+jest.mock("../helpers", () => ({
+  authorize: jest.fn().mockResolvedValue(undefined),
+  fetchDiffHistory: jest.fn(),
+  persistSettings: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe("revertSeo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reconstructs settings when timestamp exists", async () => {
+    (fetchDiffHistory as jest.Mock).mockResolvedValue([
+      { timestamp: "2024-01-01", diff: { languages: ["en"] } },
+      {
+        timestamp: "2024-02-01",
+        diff: { seo: { en: { title: "T1", description: "D2" } } },
+      },
+      { timestamp: "2024-03-01", diff: { seo: { en: { image: "I3" } } } },
+    ]);
+    const expected = {
+      languages: ["en"],
+      seo: { en: { title: "T1", description: "D2" } },
+      luxuryFeatures: {
+        premierDelivery: false,
+        blog: false,
+        contentMerchandising: false,
+        raTicketing: false,
+        fraudReviewThreshold: 0,
+        requireStrongCustomerAuth: false,
+        strictReturnConditions: false,
+        trackingDashboard: false,
+      },
+      freezeTranslations: false,
+      updatedAt: "",
+      updatedBy: "",
+    };
+    const result = await revertSeo("shop", "2024-03-01");
+    expect(persistSettings).toHaveBeenCalledWith("shop", expected);
+    expect(result).toEqual(expected);
+  });
+
+  it("throws when timestamp not found", async () => {
+    (fetchDiffHistory as jest.Mock).mockResolvedValue([
+      { timestamp: "2024-01-01", diff: {} },
+    ]);
+    await expect(revertSeo("shop", "2024-02-01")).rejects.toThrow("Version not found");
+    expect(persistSettings).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for revertSeo to ensure history diffs are merged before persisting
- handle missing timestamps by asserting `Version not found` is thrown

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test apps/cms/src/services/shops/__tests__/revertSeo.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1cade71e4832f99e564b8aa9419e3