### PR TITLE
test: warn when revalidation fails

### DIFF
--- a/apps/cms/src/services/shops/__tests__/seoService.test.ts
+++ b/apps/cms/src/services/shops/__tests__/seoService.test.ts
@@ -70,6 +70,24 @@ describe("seo service", () => {
     expect(revalidatePath).toHaveBeenCalledWith("/cms/shop/shop/settings/seo");
   });
 
+  it("warns when revalidation fails but returns settings", async () => {
+    (revalidatePath as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("fail");
+    });
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const fd = new FormData();
+    fd.append("locale", "en");
+    fd.append("title", "Title");
+    fd.append("description", "Desc");
+    const result = await updateSeo("shop", fd);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[updateSeo] failed to revalidate path for shop shop",
+      expect.any(Error),
+    );
+    expect(result.settings).toBeDefined();
+    warnSpy.mockRestore();
+  });
+
   it("returns errors when persistence fails", async () => {
     (persistSettings as jest.Mock).mockRejectedValueOnce(new Error("db"));
     const fd = new FormData();


### PR DESCRIPTION
## Summary
- ensure `updateSeo` logs a warning and still returns settings when `revalidatePath` throws

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms exec jest src/services/shops/__tests__/seoService.test.ts --config jest.config.cjs --runInBand --coverage=false --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c1cadc7210832fbfa71de4e36a8e91