### PR TITLE
test: cover blank and invalid form data

### DIFF
--- a/apps/cms/src/services/shops/__tests__/formData.test.ts
+++ b/apps/cms/src/services/shops/__tests__/formData.test.ts
@@ -9,8 +9,13 @@ describe("form data helpers", () => {
     const formData = new FormData();
     formData.append("filterMappingsKey", "brand");
     formData.append("filterMappingsValue", "Brand");
+    formData.append("filterMappingsKey", ""); // blank key
+    formData.append("filterMappingsValue", "ShouldOmit");
     formData.append("filterMappingsKey", "color");
     formData.append("filterMappingsValue", "Color");
+    formData.append("filterMappingsKey", "size");
+    formData.append("filterMappingsValue", ""); // blank value
+    formData.append("filterMappingsKey", "orphanKey"); // no matching value
 
     expect(parseFilterMappings(formData)).toBe(
       JSON.stringify({ brand: "Brand", color: "Color" }),
@@ -21,11 +26,16 @@ describe("form data helpers", () => {
     const formData = new FormData();
     formData.append("priceOverridesKey", "USD");
     formData.append("priceOverridesValue", "10");
-    formData.append("priceOverridesKey", "EUR");
-    formData.append("priceOverridesValue", "9");
+    formData.append("priceOverridesKey", "");
+    formData.append("priceOverridesValue", "5"); // blank key
+    formData.append("priceOverridesKey", "GBP");
+    formData.append("priceOverridesValue", "not-a-number"); // non-numeric
+    formData.append("priceOverridesKey", "CAD");
+    formData.append("priceOverridesValue", "7");
+    formData.append("priceOverridesKey", "EUR"); // missing value
 
     expect(parsePriceOverrides(formData)).toBe(
-      JSON.stringify({ USD: 10, EUR: 9 }),
+      JSON.stringify({ USD: 10, CAD: 7 }),
     );
   });
 
@@ -33,9 +43,16 @@ describe("form data helpers", () => {
     const formData = new FormData();
     formData.append("localeOverridesKey", "en");
     formData.append("localeOverridesValue", "de");
+    formData.append("localeOverridesKey", "");
+    formData.append("localeOverridesValue", "shouldOmit"); // blank key
+    formData.append("localeOverridesKey", "fr");
+    formData.append("localeOverridesValue", ""); // blank value
+    formData.append("localeOverridesKey", "es");
+    formData.append("localeOverridesValue", "it");
+    formData.append("localeOverridesKey", "orphan"); // no matching value
 
     expect(parseLocaleOverrides(formData)).toBe(
-      JSON.stringify({ en: "de" }),
+      JSON.stringify({ en: "de", es: "it" }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- verify filter mapping parser drops blank keys, values, and unmatched pairs
- ensure price override parser ignores blank keys, missing values, and non-numeric prices
- check locale override parser filters blank entries and mismatched key/value counts

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' when building @acme/platform-core)*
- `pnpm exec jest apps/cms/src/services/shops/__tests__/formData.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1cadb69bc832faed5007a969e152c