### PR TITLE
fix shared-utils test imports for esm

### DIFF
--- a/packages/shared-utils/__tests__/formatCurrency.test.ts
+++ b/packages/shared-utils/__tests__/formatCurrency.test.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from '../src/formatCurrency';
+import { formatCurrency } from '../src/formatCurrency.ts';
 
 describe('formatCurrency', () => {
   it('formats using the runtime default locale when no locale is provided', () => {

--- a/packages/shared-utils/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/__tests__/formatPrice.test.ts
@@ -1,4 +1,4 @@
-import { formatPrice } from '../src/formatPrice';
+import { formatPrice } from '../src/formatPrice.ts';
 
 describe('formatPrice', () => {
   it('formats positive amounts', () => {

--- a/packages/shared-utils/src/__tests__/formatCurrency.test.ts
+++ b/packages/shared-utils/src/__tests__/formatCurrency.test.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from "../formatCurrency";
+import { formatCurrency } from "../formatCurrency.ts";
 
 describe("formatCurrency", () => {
   it("defaults to USD when currency is omitted", () => {

--- a/packages/shared-utils/src/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/src/__tests__/formatPrice.test.ts
@@ -1,4 +1,4 @@
-import { formatPrice } from "../formatPrice";
+import { formatPrice } from "../formatPrice.ts";
 
 describe("formatPrice", () => {
   it("defaults to USD when currency is omitted", () => {

--- a/packages/shared-utils/src/__tests__/legacy/formatCurrency.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/formatCurrency.test.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from '../../formatCurrency';
+import { formatCurrency } from '../../formatCurrency.ts';
 
 describe('formatCurrency', () => {
   it('uses USD and current locale by default', () => {

--- a/packages/shared-utils/src/__tests__/legacy/formatPrice.test.ts
+++ b/packages/shared-utils/src/__tests__/legacy/formatPrice.test.ts
@@ -1,4 +1,4 @@
-import { formatPrice } from '../../formatPrice';
+import { formatPrice } from '../../formatPrice.ts';
 
 describe('formatPrice', () => {
   it('formats using USD by default', () => {


### PR DESCRIPTION
## Summary
- ensure legacy and current shared-utils tests import TypeScript sources with explicit extensions to avoid module resolution errors

## Testing
- `pnpm --filter @acme/shared-utils exec jest packages/shared-utils/src/__tests__/legacy/formatCurrency.test.ts packages/shared-utils/src/__tests__/legacy/formatPrice.test.ts packages/shared-utils/__tests__/formatCurrency.test.ts packages/shared-utils/__tests__/formatPrice.test.ts packages/shared-utils/src/__tests__/formatCurrency.test.ts packages/shared-utils/src/__tests__/formatPrice.test.ts --config ../../jest.config.cjs --runInBand`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ca28a8ec832f97ad5c64124915bf