### PR TITLE
test(auth): default to memory store for invalid env value

### DIFF
--- a/packages/auth/src/__tests__/store.test.ts
+++ b/packages/auth/src/__tests__/store.test.ts
@@ -53,6 +53,18 @@ describe("createSessionStore", () => {
     expect(store).toBeInstanceOf(MemorySessionStore);
   });
 
+  it("falls back to MemorySessionStore when SESSION_STORE is invalid", async () => {
+    process.env.SESSION_STORE = "foo";
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { createSessionStore } = await import("../store");
+    const { MemorySessionStore } = await import("../memoryStore");
+
+    const store = await createSessionStore();
+    expect(store).toBeInstanceOf(MemorySessionStore);
+  });
+
   it("setSessionStoreFactory overrides default store", async () => {
     process.env.UPSTASH_REDIS_REST_URL = "https://example";
     process.env.UPSTASH_REDIS_REST_TOKEN = STRONG_TOKEN;


### PR DESCRIPTION
## Summary
- ensure createSessionStore returns MemorySessionStore when SESSION_STORE env value is unrecognized

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/auth run test` *(fails: console errors and did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d34fd2b4832fb8a53e5c35beed1b