### PR TITLE
test(auth): ensure session store errors prevent cookie writes

### DIFF
--- a/packages/auth/src/__tests__/session.test.ts
+++ b/packages/auth/src/__tests__/session.test.ts
@@ -149,6 +149,17 @@ it("createCustomerSession uses extended maxAge when remember is true", async () 
   );
 });
 
+it("createCustomerSession propagates store errors without setting cookies", async () => {
+  const { createCustomerSession } = await import("../session");
+
+  mockSessionStore.set.mockRejectedValueOnce(new Error("store fail"));
+
+  await expect(
+    createCustomerSession({ customerId: "cust", role: "customer" })
+  ).rejects.toThrow("store fail");
+  expect(mockCookies.set).not.toHaveBeenCalled();
+});
+
 it("createCustomerSession throws when SESSION_SECRET is undefined", async () => {
   const { createCustomerSession } = await import("../session");
   const originalSecret = process.env.SESSION_SECRET;


### PR DESCRIPTION
## Summary
- add regression test for createCustomerSession rejecting when session store fails

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2307 Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/auth exec jest packages/auth/src/__tests__/session.test.ts --runInBand --config ../../jest.config.cjs` *(fails: Expected number of calls: 0 Received number of calls: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d34be7f0832fbb098613a85c91d7