### PR TITLE
test: add empty token validation

### DIFF
--- a/packages/auth/src/__tests__/session.test.ts
+++ b/packages/auth/src/__tests__/session.test.ts
@@ -411,6 +411,16 @@ it("validateCsrfToken returns false when token mismatches cookie", async () => {
   await expect(validateCsrfToken("different")).resolves.toBe(false);
 });
 
+it("validateCsrfToken returns false for empty token", async () => {
+  const { validateCsrfToken, CSRF_TOKEN_COOKIE } = await import("../session");
+
+  mockCookies.get.mockImplementation((name: string) =>
+    name === CSRF_TOKEN_COOKIE ? { value: "csrf" } : undefined
+  );
+
+  await expect(validateCsrfToken("")).resolves.toBe(false);
+});
+
 it("createCustomerSession uses 'unknown' user-agent when header absent", async () => {
   const {
     createCustomerSession,


### PR DESCRIPTION
## Summary
- cover empty token case for CSRF validation

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script check:references)*
- `pnpm run build:ts` *(fails: Missing script build:ts)*
- `pnpm --filter @acme/auth exec jest packages/auth/src/__tests__/session.test.ts --config ../../jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c1d34b3c1c832fbdd3e3ebd87fc127