### PR TITLE
test: handle null update in rental reservation

### DIFF
--- a/packages/platform-core/__tests__/rentalAllocation.test.ts
+++ b/packages/platform-core/__tests__/rentalAllocation.test.ts
@@ -259,4 +259,49 @@ describe("reserveRentalInventory", () => {
       wearCount: 7,
     });
   });
+
+  it("returns null when updateInventoryItem fails to update", async () => {
+    const { reserveRentalInventory } = await import(
+      "../src/orders/rentalAllocation"
+    );
+    const repo = await import("../src/repositories/inventory.server");
+    const mockUpdate = repo.updateInventoryItem as jest.Mock;
+
+    const candidate: InventoryItem = {
+      sku: "s1",
+      productId: "p1",
+      quantity: 1,
+      variantAttributes: {},
+      wearCount: 0,
+    };
+
+    const items: InventoryItem[] = [candidate];
+
+    const sku: SKU = {
+      id: "sku-update-null",
+      slug: "slug-update-null",
+      title: "Test SKU",
+      price: 0,
+      deposit: 0,
+      stock: 1,
+      forSale: false,
+      forRental: true,
+      media: [],
+      sizes: [],
+      description: "",
+    };
+
+    mockUpdate.mockResolvedValue(null);
+
+    const result = await reserveRentalInventory(
+      "shop",
+      items,
+      sku,
+      "2024-05-11",
+      "2024-05-12",
+    );
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- cover case where updateInventoryItem returns null despite available candidate

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/rentalAllocation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d2f4ac50832fb8411f59d492475d