### PR TITLE
test: cover setupSanityBlog JSON failure

### DIFF
--- a/apps/cms/src/actions/__tests__/setupSanityBlog.test.ts
+++ b/apps/cms/src/actions/__tests__/setupSanityBlog.test.ts
@@ -229,5 +229,35 @@ describe("setupSanityBlog", () => {
     consoleErrorSpy.mockRestore();
     fetchSpy.mockRestore();
   });
+
+  it("returns UNKNOWN_ERROR when listRes.json throws", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error("json fail");
+        },
+      });
+
+    const res = await setupSanityBlog(creds, { enabled: true });
+
+    expect(res).toEqual({
+      success: false,
+      error: "json fail",
+      code: "UNKNOWN_ERROR",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[setupSanityBlog]",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression test to ensure setupSanityBlog handles errors thrown during dataset listing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest apps/cms/src/actions/__tests__/setupSanityBlog.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c1d4f81834832fb0607b27ed18c436