### PR TITLE
test: ensure service label is used

### DIFF
--- a/packages/platform-core/__tests__/shipping-index.test.ts
+++ b/packages/platform-core/__tests__/shipping-index.test.ts
@@ -31,12 +31,13 @@ describe('getShippingRate', () => {
         windows: ['morning'],
         carriers: ['ups'],
         surcharge: 5,
+        serviceLabel: 'Overnight Delivery',
       },
     });
     expect(result).toEqual({
       rate: 0,
       surcharge: 5,
-      serviceLabel: 'Premier Delivery',
+      serviceLabel: 'Overnight Delivery',
     });
   });
 

--- a/packages/platform-core/src/shipping/__tests__/index.test.ts
+++ b/packages/platform-core/src/shipping/__tests__/index.test.ts
@@ -29,10 +29,10 @@ describe('shipping index', () => {
         windows: ['AM', 'PM'],
         carriers: ['bike', 'van'],
         surcharge: 4.5,
-        serviceLabel: 'Premier Delivery',
+        serviceLabel: 'Express Delivery',
       },
     });
-    expect(res).toEqual({ rate: 0, surcharge: 4.5, serviceLabel: 'Premier Delivery' });
+    expect(res).toEqual({ rate: 0, surcharge: 4.5, serviceLabel: 'Express Delivery' });
   });
 
   it('validates premier delivery configuration and rejects invalid region/window/carrier', async () => {


### PR DESCRIPTION
## Summary
- cover shipping rate when a custom premierDelivery.serviceLabel is provided
- assert premier shipping request returns the provided serviceLabel

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Cannot find module '@acme/ui')
- `pnpm run check:references` (fails: Missing script: check:references)
- `pnpm exec jest packages/platform-core/__tests__/shipping-index.test.ts packages-platform-core/src/shipping/__tests__/index.test.ts -t "returns rate for valid premier shipping|returns premier delivery rate with surcharge and label" --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3dcf5b0832f80f834d11e38eb47