### PR TITLE
Handle missing UPS package status

### DIFF
--- a/packages/platform-core/__tests__/shipping-index.test.ts
+++ b/packages/platform-core/__tests__/shipping-index.test.ts
@@ -300,6 +300,16 @@ describe('getTrackingStatus', () => {
     });
   });
 
+  it('returns null when UPS response lacks packageStatus', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ trackDetails: [{}] }),
+    });
+
+    const result = await getTrackingStatus({ provider: 'ups', trackingNumber: 'abc' });
+    expect(result).toEqual({ status: null, steps: [] });
+  });
+
   it('falls back on network error', async () => {
     fetchMock.mockRejectedValue(new Error('network'));
     const result = await getTrackingStatus({ provider: 'dhl', trackingNumber: '123' });

--- a/packages/platform-core/src/shipping/index.ts
+++ b/packages/platform-core/src/shipping/index.ts
@@ -141,12 +141,13 @@ export async function getTrackingStatus({
       return { status: null, steps: [] };
     }
     const data = await res.json();
-    const status =
+    const rawStatus =
       provider === "dhl"
         ? data?.shipments?.[0]?.status?.status
         : data?.trackDetails?.[0]?.packageStatus?.statusType;
+    const status = typeof rawStatus === "string" ? rawStatus : null;
     return {
-      status: status ?? null,
+      status,
       steps: status ? [{ label: status, complete: true }] : [],
     };
   } catch {


### PR DESCRIPTION
## Summary
- Safely handle UPS tracking responses lacking package status
- Add regression test for missing UPS packageStatus

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/shipping-index.test.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3dc56bc832f913cde84ab89cdd5