### PR TITLE
test: handle update errors in markReturned

### DIFF
--- a/packages/platform-core/src/__tests__/orders.test.ts
+++ b/packages/platform-core/src/__tests__/orders.test.ts
@@ -70,10 +70,11 @@ describe("orders", () => {
       expect(remaining).toBe(6);
     });
 
-    it("returns null when order is missing", async () => {
-      prismaMock.rentalOrder.update.mockRejectedValue(new Error("not found"));
-      const result = await markReturned("shop", "sess");
-      expect(result).toBeNull();
+    it("returns null when update throws", async () => {
+      prismaMock.rentalOrder.update.mockImplementation(() => {
+        throw new Error("not found");
+      });
+      await expect(markReturned("shop", "sess")).resolves.toBeNull();
     });
   });
 

--- a/packages/platform-machine/src/__tests__/orders.test.ts
+++ b/packages/platform-machine/src/__tests__/orders.test.ts
@@ -141,9 +141,10 @@ describe('orders', () => {
     });
 
     it('returns null on error', async () => {
-      prisma.rentalOrder.update.mockRejectedValueOnce(new Error('fail'));
-      const result = await markReturned('s', 'sess');
-      expect(result).toBeNull();
+      prisma.rentalOrder.update.mockImplementationOnce(() => {
+        throw new Error('fail');
+      });
+      await expect(markReturned('s', 'sess')).resolves.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- extend markReturned tests to handle thrown update errors returning null

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest --runInBand packages/platform-core/src/__tests__/orders.test.ts packages/platform-machine/src/__tests__/orders.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3d2bc1c832f91bc9829cb2794c4