### PR TITLE
test(listOrders): verify rejection path

### DIFF
--- a/packages/platform-core/src/orders.d.ts
+++ b/packages/platform-core/src/orders.d.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { RentalOrder } from "@acme/types";
 
 export type Order = RentalOrder;
+export declare function normalize<T extends Order>(order: T): T;
 export declare function listOrders(shop: string): Promise<Order[]>;
 export declare const readOrders: typeof listOrders;
 export declare function addOrder(shop: string, sessionId: string, deposit: number, expectedReturnDate?: string, returnDueDate?: string, customerId?: string, riskLevel?: string, riskScore?: number, flaggedForReview?: boolean): Promise<Order>;

--- a/packages/platform-core/src/orders.ts
+++ b/packages/platform-core/src/orders.ts
@@ -14,7 +14,7 @@ export type Order = RentalOrder;
 // Normalize Prisma results by replacing `null` fields with `undefined`.
 // When given a falsy value (e.g. `null`), return it directly so callers can
 // surface "not found" conditions instead of an empty object.
-function normalize<T extends Order>(order: T): T {
+export function normalize<T extends Order>(order: T): T {
   if (!order) return order;
   const o = { ...order } as Record<keyof T, T[keyof T]>;
   (Object.keys(o) as Array<keyof T>).forEach((k) => {


### PR DESCRIPTION
## Summary
- export `normalize` from orders module for better testability
- ensure listOrders rejects without normalizing when Prisma query fails

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm exec jest packages/platform-core/__tests__/orders.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3d0edbc832fb60312f8086cb458