### PR TITLE
test(platform-core): cover readReturnAuthorizations rejection

### DIFF
--- a/packages/platform-core/__tests__/returnAuthorization.test.ts
+++ b/packages/platform-core/__tests__/returnAuthorization.test.ts
@@ -12,7 +12,9 @@ describe("returnAuthorization", () => {
   });
 
   it("forwards repository results unchanged", async () => {
-    const { listReturnAuthorizations } = await import("../src/returnAuthorization");
+    const { listReturnAuthorizations } = await import(
+      "../src/returnAuthorization"
+    );
     const repo = await import("../src/repositories/returnAuthorization.server");
     const list = [
       { raId: "RA1", orderId: "o1", status: "pending", inspectionNotes: "" },
@@ -23,8 +25,21 @@ describe("returnAuthorization", () => {
     expect(result).toBe(list);
   });
 
+  it("propagates errors from readReturnAuthorizations", async () => {
+    const { listReturnAuthorizations } = await import(
+      "../src/returnAuthorization"
+    );
+    const repo = await import("../src/repositories/returnAuthorization.server");
+    const err = new Error("read failed");
+    (repo.readReturnAuthorizations as jest.Mock).mockRejectedValue(err);
+    await expect(listReturnAuthorizations()).rejects.toBe(err);
+    expect(repo.readReturnAuthorizations).toHaveBeenCalled();
+  });
+
   it("generates an RA-prefixed ID and persists via addReturnAuthorization", async () => {
-    const { createReturnAuthorization } = await import("../src/returnAuthorization");
+    const { createReturnAuthorization } = await import(
+      "../src/returnAuthorization"
+    );
     const repo = await import("../src/repositories/returnAuthorization.server");
     const nowSpy = jest.spyOn(Date, "now").mockReturnValue(123456);
     const ra = await createReturnAuthorization({ orderId: "o1" });

--- a/packages/platform-core/src/__tests__/returnAuthorization.test.ts
+++ b/packages/platform-core/src/__tests__/returnAuthorization.test.ts
@@ -12,7 +12,9 @@ describe("returnAuthorization", () => {
   });
 
   it("builds RA IDs and delegates to addReturnAuthorization", async () => {
-    const { createReturnAuthorization } = await import("../returnAuthorization");
+    const { createReturnAuthorization } = await import(
+      "../returnAuthorization"
+    );
     const repo = await import("../repositories/returnAuthorization.server");
     const nowSpy = jest.spyOn(Date, "now").mockReturnValue(123456);
     const ra = await createReturnAuthorization({ orderId: "o1" });
@@ -31,5 +33,14 @@ describe("returnAuthorization", () => {
     const result = await listReturnAuthorizations();
     expect(repo.readReturnAuthorizations).toHaveBeenCalled();
     expect(result).toBe(list);
+  });
+
+  it("propagates errors from readReturnAuthorizations", async () => {
+    const { listReturnAuthorizations } = await import("../returnAuthorization");
+    const repo = await import("../repositories/returnAuthorization.server");
+    const err = new Error("read failed");
+    (repo.readReturnAuthorizations as jest.Mock).mockRejectedValue(err);
+    await expect(listReturnAuthorizations()).rejects.toBe(err);
+    expect(repo.readReturnAuthorizations).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add tests ensuring listReturnAuthorizations propagates repository rejection

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core build` *(fails: Cannot find module '@acme/ui')*
- `pnpm install`
- `pnpm --filter @acme/platform-core exec jest src/__tests__/returnAuthorization.test.ts __tests__/returnAuthorization.test.ts --runInBand --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3cf7a54832f87e0946fd1077faf