### PR TITLE
Allow extra metadata to override coupon

### DIFF
--- a/packages/platform-core/__tests__/checkout-metadata.test.ts
+++ b/packages/platform-core/__tests__/checkout-metadata.test.ts
@@ -56,5 +56,14 @@ describe("buildCheckoutMetadata", () => {
     expect(result).not.toHaveProperty("sizes");
     expect(result).not.toHaveProperty("foo");
   });
+
+  test("allows extra to override defaults", () => {
+    const result = buildCheckoutMetadata({
+      ...base,
+      extra: { coupon: "OVERRIDE" },
+    });
+
+    expect(result.coupon).toBe("OVERRIDE");
+  });
 });
 

--- a/packages/platform-core/src/checkout/metadata.ts
+++ b/packages/platform-core/src/checkout/metadata.ts
@@ -30,19 +30,26 @@ export const buildCheckoutMetadata = ({
   clientIp?: string;
   sizes?: string;
   extra?: Record<string, string>;
-}) => ({
-  subtotal: subtotal.toString(),
-  depositTotal: depositTotal.toString(),
-  returnDate: returnDate ?? "",
-  rentalDays: rentalDays.toString(),
-  ...(sizes ? { sizes } : {}),
-  customerId: customerId ?? "",
-  discount: discount.toString(),
-  coupon: coupon ?? "",
-  currency,
-  taxRate: taxRate.toString(),
-  taxAmount: taxAmount.toString(),
-  ...(clientIp ? { client_ip: clientIp } : {}),
-  ...(extra ?? {}),
-});
+}) => {
+  const metadata = {
+    subtotal: subtotal.toString(),
+    depositTotal: depositTotal.toString(),
+    returnDate: returnDate ?? "",
+    rentalDays: rentalDays.toString(),
+    ...(sizes ? { sizes } : {}),
+    customerId: customerId ?? "",
+    discount: discount.toString(),
+    coupon: coupon ?? "",
+    currency,
+    taxRate: taxRate.toString(),
+    taxAmount: taxAmount.toString(),
+    ...(clientIp ? { client_ip: clientIp } : {}),
+  };
+
+  // Extra metadata keys are spread last so they can override defaults like `coupon`.
+  return {
+    ...metadata,
+    ...(extra ?? {}),
+  };
+};
 


### PR DESCRIPTION
## Summary
- Refactor checkout metadata builder to merge extra fields after defaults
- Test that extra metadata can override coupon

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/checkout-metadata.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3caf5dc832f912174951d7e6aad