### PR TITLE
test: handle GA fetch errors

### DIFF
--- a/packages/platform-core/src/analytics/__tests__/index.test.ts
+++ b/packages/platform-core/src/analytics/__tests__/index.test.ts
@@ -79,6 +79,21 @@ describe("trackEvent providers", () => {
     );
   });
 
+  test("google analytics provider ignores fetch rejections", async () => {
+    readShop.mockResolvedValue({ analyticsEnabled: true });
+    getShopSettings.mockResolvedValue({
+      analytics: { provider: "ga", id: "G-XYZ" },
+    });
+    process.env.GA_API_SECRET = "secret";
+    const fetchMock = jest.fn().mockRejectedValue(new Error("network"));
+    (globalThis.fetch as any) = fetchMock;
+    const { trackEvent } = await import("../index");
+    await expect(
+      trackEvent(shop, { type: "page_view", page: "home" })
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test("falls back to file provider when GA secrets missing", async () => {
     readShop.mockResolvedValue({ analyticsEnabled: true });
     getShopSettings.mockResolvedValue({


### PR DESCRIPTION
## Summary
- ensure Google Analytics provider ignores fetch rejections

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui'; missing build outputs)*
- `pnpm --filter @acme/platform-core test -- packages/platform-core/src/analytics/__tests__/index.test.ts` *(fails: coverage thresholds not met, but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3c7b528832f945210522995a6a9