### PR TITLE
test: handle named plugin export

### DIFF
--- a/packages/platform-core/__tests__/plugins.loadFromDir.test.ts
+++ b/packages/platform-core/__tests__/plugins.loadFromDir.test.ts
@@ -54,6 +54,18 @@ describe("loadPluginFromDir and loadPlugins", () => {
     expect(plugin).toBe(pluginObj);
   });
 
+  it("returns plugin when module exports named plugin", async () => {
+    const resolvePluginEntry = jest
+      .fn()
+      .mockResolvedValue({ entryPath: "/plugin/index.js", isModule: false });
+    const pluginObj = { id: "named" } as any;
+    const importByType = jest.fn().mockResolvedValue({ plugin: pluginObj });
+    jest.doMock("../src/plugins/resolvers", () => ({ resolvePluginEntry, importByType }));
+    const { loadPlugin } = await import("../src/plugins");
+    const plugin = await loadPlugin("/plugin");
+    expect(plugin).toBe(pluginObj);
+  });
+
   it("discovers plugin directories and loads plugins", async () => {
     const resolvePluginEnvironment = jest
       .fn()


### PR DESCRIPTION
## Summary
- extend `loadPluginFromDir` tests to cover named `plugin` export without default

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `pnpm exec jest /workspace/base-shop/packages/platform-core/__tests__/plugins.loadFromDir.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3c05484832fac670b0b8b17b414