### PR TITLE
test(auth): null if credentials missing

### DIFF
--- a/apps/cms/src/auth/__tests__/options.test.ts
+++ b/apps/cms/src/auth/__tests__/options.test.ts
@@ -2,6 +2,15 @@ import { createAuthOptions } from "../options";
 import type { Role } from "@acme/types";
 
 describe("authorize", () => {
+  it("returns null when no credentials provided", async () => {
+    const options = createAuthOptions();
+    const authorize = (options.providers[0] as any).options.authorize as (
+      credentials?: unknown
+    ) => Promise<unknown>;
+
+    await expect(authorize(undefined)).resolves.toBeNull();
+  });
+
   it("throws on plain-text password", async () => {
     const readRbac = jest.fn().mockResolvedValue({
       users: {


### PR DESCRIPTION
## Summary
- test that calling authorize with no credentials returns null

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test apps/cms/src/auth/__tests__/options.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d501e764832f8b8f86ffb2903761