### PR TITLE
test: verify security header on redirect

### DIFF
--- a/apps/cms/src/__tests__/middleware.test.ts
+++ b/apps/cms/src/__tests__/middleware.test.ts
@@ -42,6 +42,17 @@ describe("middleware", () => {
     );
   });
 
+  it("includes security headers on redirect responses", async () => {
+    getTokenMock.mockResolvedValue(null);
+
+    const req = new NextRequest("http://example.com/cms");
+    const res = await middleware(req);
+
+    expect(res.headers.get("Permissions-Policy")).toBe(
+      "camera=(), microphone=(), geolocation=()",
+    );
+  });
+
   it("allows non-CMS paths without invoking canRead", async () => {
     getTokenMock.mockResolvedValue({ role: "viewer" } as any);
 


### PR DESCRIPTION
## Summary
- test middleware redirect adds Permissions-Policy header when unauthenticated

## Testing
- `pnpm --filter @apps/cms test`
- `pnpm --filter @apps/cms exec jest apps/cms/src/__tests__/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4ffc08c832fadf89b819f6d78e3