### PR TITLE
Allow API GET routes to pass without auth

### DIFF
--- a/apps/cms/src/__tests__/middleware.test.ts
+++ b/apps/cms/src/__tests__/middleware.test.ts
@@ -30,6 +30,15 @@ describe("middleware", () => {
     expect(res.headers.get("x-middleware-next")).toBe("1");
   });
 
+  it("allows GET api requests without tokens", async () => {
+    const req = new NextRequest("http://example.com/api/test");
+    const res = await middleware(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+    expect(getTokenMock).not.toHaveBeenCalled();
+  });
+
   it("redirects unauthenticated requests to /login with callbackUrl", async () => {
     getTokenMock.mockResolvedValue(null);
 

--- a/apps/cms/src/middleware.ts
+++ b/apps/cms/src/middleware.ts
@@ -122,10 +122,15 @@ export async function middleware(req: NextRequest) {
     }
   }
 
+  /* Allow API routes to handle authentication and authorization */
+  if (pathname.startsWith("/api")) {
+    logger.debug("api route", { path: pathname });
+    return applySecurityHeaders(NextResponse.next());
+  }
+
   /* Skip static assets, auth endpoints, and login/signup pages */
   if (
     pathname.startsWith("/_next") ||
-    pathname.startsWith("/api/auth") ||
     pathname === "/login" ||
     pathname === "/signup" ||
     pathname === "/favicon.ico"


### PR DESCRIPTION
## Summary
- allow API routes to skip auth after CSRF checks
- test GET /api requests proceed without tokens

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4feee1c832fb93d46f474bec174