### PR TITLE
test: ensure valid csrf token passes middleware

### DIFF
--- a/apps/cms/src/__tests__/middleware.test.ts
+++ b/apps/cms/src/__tests__/middleware.test.ts
@@ -180,6 +180,22 @@ describe("middleware", () => {
     expect(res.status).toBe(403);
   });
 
+  it("allows mutating api requests with valid csrf token", async () => {
+    getTokenMock.mockResolvedValue({ role: "admin" } as any);
+
+    const req = new NextRequest("http://example.com/api/test", {
+      method: "POST",
+      headers: {
+        "x-csrf-token": "token",
+        cookie: "csrf_token=token",
+      },
+    });
+    const res = await middleware(req);
+
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+    expect(res.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
   it("allows repeated login attempts without rate limiting", async () => {
     const headers = {
       "x-forwarded-for": "1.2.3.4",


### PR DESCRIPTION
## Summary
- test that matching CSRF header and cookie yields `x-middleware-next`
- assert middleware applies `Content-Security-Policy`

## Testing
- `pnpm exec jest apps/cms/src/__tests__/middleware.test.ts`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d4fd74cc832fa12c847cc1deae63