### PR TITLE
test: handle missing image orientation metadata

### DIFF
--- a/apps/cms/src/actions/__tests__/media.server.test.ts
+++ b/apps/cms/src/actions/__tests__/media.server.test.ts
@@ -188,6 +188,19 @@ describe('media.server helpers and actions', () => {
       );
     });
 
+    it('allows upload when metadata lacks dimensions even with required orientation', async () => {
+      sharpMetadataMock.mockResolvedValueOnce({});
+      ulidMock.mockReturnValueOnce('img456');
+      const formData = new FormData();
+      formData.append('file', new File(['data'], 'photo.jpg', { type: 'image/jpeg' }));
+      await expect(uploadMedia('shop', formData, 'landscape')).resolves.toEqual({
+        url: '/uploads/shop/img456.jpg',
+        title: undefined,
+        altText: undefined,
+        type: 'image',
+      });
+    });
+
     it('fails when sharp processing throws', async () => {
       sharpToBufferMock.mockRejectedValueOnce(new Error('fail'));
       const formData = new FormData();


### PR DESCRIPTION
## Summary
- cover uploadMedia for case where Sharp metadata lacks dimensions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test src/actions/__tests__/media.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4fc8ba0832fad6cc9ceef05a2be