### PR TITLE
test: bubble sharp orientation error

### DIFF
--- a/apps/cms/src/actions/__tests__/media.server.test.ts
+++ b/apps/cms/src/actions/__tests__/media.server.test.ts
@@ -197,6 +197,20 @@ describe('media.server helpers and actions', () => {
       );
     });
 
+    it('propagates orientation errors from sharp', async () => {
+      sharpToBufferMock.mockRejectedValueOnce(
+        new Error('orientation must be a multiple of 90'),
+      );
+      const formData = new FormData();
+      formData.append(
+        'file',
+        new File(['data'], 'img.jpg', { type: 'image/jpeg' }),
+      );
+      await expect(uploadMedia('shop', formData)).rejects.toThrow(
+        'orientation must be a multiple of 90',
+      );
+    });
+
     it('rejects invalid mime types', async () => {
       const formData = new FormData();
       formData.append('file', new File(['data'], 'doc.txt', { type: 'text/plain' }));


### PR DESCRIPTION
## Summary
- ensure `uploadMedia` propagates orientation errors from sharp
- add test for sharp orientation errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @apps/cms test apps/cms/src/actions/__tests__/media.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4fa3a48832fb330611b73c2baac