### PR TITLE
test: cover listMedia without metadata

### DIFF
--- a/apps/cms/src/actions/__tests__/media.server.test.ts
+++ b/apps/cms/src/actions/__tests__/media.server.test.ts
@@ -136,6 +136,30 @@ describe('media.server helpers and actions', () => {
       );
     });
 
+    it('returns files without metadata when metadata read fails', async () => {
+      fsMock.readdir.mockResolvedValueOnce(['a.jpg', 'b.jpg']);
+      fsMock.readFile.mockRejectedValueOnce(new Error('fail'));
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(listMedia('shop')).resolves.toEqual([
+        {
+          url: '/uploads/shop/a.jpg',
+          title: undefined,
+          altText: undefined,
+          type: 'image',
+        },
+        {
+          url: '/uploads/shop/b.jpg',
+          title: undefined,
+          altText: undefined,
+          type: 'image',
+        },
+      ]);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
     it('throws when fs.readdir rejects', async () => {
       fsMock.readdir.mockRejectedValueOnce(new Error('boom'));
       await expect(listMedia('shop')).rejects.toThrow('Failed to list media');


### PR DESCRIPTION
## Summary
- add unit test for listMedia when metadata file cannot be read

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui' in packages/platform-core build)*
- `pnpm test:cms apps/cms/src/actions/__tests__/media.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4f990c8832fb6d66eac4bd491e7