### PR TITLE
test: handle update error

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -549,6 +549,13 @@ describe("orders", () => {
       });
       expect(result).toBeNull();
     });
+
+    it("returns null on error", async () => {
+      prismaMock.rentalOrder.update.mockRejectedValueOnce(new Error("fail"));
+      await expect(
+        setReturnTracking("shop", "sess", "tn", "url")
+      ).resolves.toBeNull();
+    });
   });
 
   describe("setReturnStatus", () => {

--- a/packages/platform-machine/src/__tests__/orders.test.ts
+++ b/packages/platform-machine/src/__tests__/orders.test.ts
@@ -210,8 +210,9 @@ describe('orders', () => {
 
     it('returns null on error', async () => {
       prisma.rentalOrder.update.mockRejectedValueOnce(new Error('fail'));
-      const result = await setReturnTracking('s', 'sess', 'TN', 'url');
-      expect(result).toBeNull();
+      await expect(
+        setReturnTracking('s', 'sess', 'TN', 'url')
+      ).resolves.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- test setReturnTracking returns null when update throws
- refactor machine test to use resolves

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/platform-core test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3dae2a8832fba1d739b73bbf9e1