### PR TITLE
test: handle prisma update error

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -450,6 +450,12 @@ describe("orders", () => {
       });
       expect(result).toBeNull();
     });
+
+    it("returns null on error", async () => {
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      const result = await updateRisk("shop", "sess");
+      expect(result).toBeNull();
+    });
   });
 
   describe("getOrdersForCustomer", () => {


### PR DESCRIPTION
## Summary
- add test verifying updateRisk returns null when prisma throws

## Testing
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test` *(fails: onRequestPost expected 200 received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3d9d0b8832fb5912ccddabdc878