### PR TITLE
test: cover markNeedsAttention flag behavior

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -10,6 +10,7 @@ import {
   markReturned,
   markRefunded,
   refundOrder,
+  markNeedsAttention,
   updateRisk,
   getOrdersForCustomer,
   setReturnTracking,
@@ -447,6 +448,29 @@ describe("orders", () => {
       expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
         where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
         data: {},
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("markNeedsAttention", () => {
+    it("flags order for review", async () => {
+      const flagged = { id: "1", flaggedForReview: true };
+      prismaMock.rentalOrder.update.mockResolvedValue(flagged);
+      const result = await markNeedsAttention("shop", "sess");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { flaggedForReview: true },
+      });
+      expect(result).toEqual(flagged);
+    });
+
+    it("returns null when update fails", async () => {
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      const result = await markNeedsAttention("shop", "sess");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { flaggedForReview: true },
       });
       expect(result).toBeNull();
     });


### PR DESCRIPTION
## Summary
- add tests for markNeedsAttention when rental order update succeeds or fails

## Testing
- `pnpm -r build` *(fails: cannot find module '@acme/ui' during build)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: publish-upgrade.test.ts received 403 vs expected 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3d568c0832f9bb654471f1f117d