### PR TITLE
test: handle update errors in markRefunded

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -292,6 +292,14 @@ describe("orders", () => {
       expect(result).toBeNull();
     });
 
+    it("returns null when update throws", async () => {
+      prismaMock.rentalOrder.update.mockImplementation(() => {
+        throw new Error("fail");
+      });
+      const result = await markRefunded("shop", "sess");
+      expect(result).toBeNull();
+    });
+
     it("refunds full amount via Stripe before marking order", async () => {
       nowIsoMock.mockReturnValue("now");
       prismaMock.rentalOrder.update.mockResolvedValue({ id: "1", refundedAt: "now" });

--- a/packages/platform-core/src/__tests__/orders.test.ts
+++ b/packages/platform-core/src/__tests__/orders.test.ts
@@ -92,8 +92,10 @@ describe("orders", () => {
       expect(result?.refundedAt).toBe("now");
     });
 
-    it("returns null when order not found", async () => {
-      prismaMock.rentalOrder.update.mockRejectedValue(new Error("missing"));
+    it("returns null when update throws", async () => {
+      prismaMock.rentalOrder.update.mockImplementation(() => {
+        throw new Error("missing");
+      });
       const result = await markRefunded("shop", "sess");
       expect(result).toBeNull();
     });

--- a/packages/platform-core/src/repositories/__tests__/rentalOrders.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/rentalOrders.server.test.ts
@@ -117,7 +117,9 @@ describe("rental orders read and refund", () => {
   it("markRefunded returns null on error", async () => {
     jest
       .spyOn(prisma.rentalOrder, "update")
-      .mockRejectedValue(new Error("fail"));
+      .mockImplementation(() => {
+        throw new Error("fail");
+      });
     await expect(markRefunded(shop, sessionId)).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- cover markRefunded returning null when prisma update throws
- ensure repository-level markRefunded test simulates thrown update errors
- add similar safety test in platform-core orders suite

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/__tests__/orders.test.ts --config ../../jest.config.cjs --runInBand`
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/repositories/__tests__/rentalOrders.server.test.ts --config ../../jest.config.cjs --runInBand`
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/__tests__/orders.test.ts --config ../../jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3d375e0832f8daa553655863628