### PR TITLE
test: ensure markCancelled propagates errors

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -246,6 +246,16 @@ describe("orders", () => {
       });
       expect(result).toEqual(mockOrder);
     });
+
+    it("propagates errors", async () => {
+      nowIsoMock.mockReturnValue("now");
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      await expect(markCancelled("shop", "sess")).rejects.toThrow("fail");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { cancelledAt: "now" },
+      });
+    });
   });
 
   describe("markReturned", () => {


### PR DESCRIPTION
## Summary
- ensure `markCancelled` surfaces update failures in tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm test --filter @acme/platform-core` *(fails: SIGABRT due to OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3d23488832fa1a269bedd838310