### PR TITLE
test: handle update failures for delivery and cancellation

### DIFF
--- a/packages/platform-core/__tests__/orders.test.ts
+++ b/packages/platform-core/__tests__/orders.test.ts
@@ -232,6 +232,16 @@ describe("orders", () => {
       });
       expect(result).toEqual(mockOrder);
     });
+
+    it("propagates errors", async () => {
+      nowIsoMock.mockReturnValue("now");
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      await expect(markDelivered("shop", "sess")).rejects.toThrow("fail");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { deliveredAt: "now" },
+      });
+    });
   });
 
   describe("markCancelled", () => {
@@ -245,6 +255,16 @@ describe("orders", () => {
         data: { cancelledAt: "now" },
       });
       expect(result).toEqual(mockOrder);
+    });
+
+    it("propagates errors", async () => {
+      nowIsoMock.mockReturnValue("now");
+      prismaMock.rentalOrder.update.mockRejectedValue(new Error("fail"));
+      await expect(markCancelled("shop", "sess")).rejects.toThrow("fail");
+      expect(prismaMock.rentalOrder.update).toHaveBeenCalledWith({
+        where: { shop_sessionId: { shop: "shop", sessionId: "sess" } },
+        data: { cancelledAt: "now" },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- cover markDelivered error propagation and argument expectations
- cover markCancelled error propagation and argument expectations

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/__tests__/orders.test.ts --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c1d3d18610832fa5bbc2864a760b6a