### PR TITLE
test: verify return authorization props

### DIFF
--- a/packages/platform-core/__tests__/returnAuthorization.test.ts
+++ b/packages/platform-core/__tests__/returnAuthorization.test.ts
@@ -27,8 +27,14 @@ describe("returnAuthorization", () => {
     const { createReturnAuthorization } = await import("../src/returnAuthorization");
     const repo = await import("../src/repositories/returnAuthorization.server");
     const nowSpy = jest.spyOn(Date, "now").mockReturnValue(123456);
-    const ra = await createReturnAuthorization({ orderId: "o1" });
+    const ra = await createReturnAuthorization({
+      orderId: "o1",
+      status: "received",
+      inspectionNotes: "Looks good",
+    });
     expect(ra.raId).toBe(`RA${(123456).toString(36).toUpperCase()}`);
+    expect(ra.status).toBe("received");
+    expect(ra.inspectionNotes).toBe("Looks good");
     expect(repo.addReturnAuthorization).toHaveBeenCalledWith(ra);
     nowSpy.mockRestore();
   });

--- a/packages/platform-core/src/__tests__/returnAuthorization.test.ts
+++ b/packages/platform-core/src/__tests__/returnAuthorization.test.ts
@@ -15,8 +15,14 @@ describe("returnAuthorization", () => {
     const { createReturnAuthorization } = await import("../returnAuthorization");
     const repo = await import("../repositories/returnAuthorization.server");
     const nowSpy = jest.spyOn(Date, "now").mockReturnValue(123456);
-    const ra = await createReturnAuthorization({ orderId: "o1" });
+    const ra = await createReturnAuthorization({
+      orderId: "o1",
+      status: "received",
+      inspectionNotes: "Looks good",
+    });
     expect(ra.raId).toBe(`RA${(123456).toString(36).toUpperCase()}`);
+    expect(ra.status).toBe("received");
+    expect(ra.inspectionNotes).toBe("Looks good");
     expect(repo.addReturnAuthorization).toHaveBeenCalledWith(ra);
     nowSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- ensure return authorization tests cover custom status and inspection notes

## Testing
- `pnpm --filter @acme/platform-core run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter @acme/platform-core run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter @acme/platform-core run build` *(fails: Cannot find module '@acme/ui')*
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/__tests__/returnAuthorization.test.ts packages/platform-core/src/__tests__/returnAuthorization.test.ts --runInBand --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1d3ce5228832f92bf8210be9c8755