### PR TITLE
Handle same-customer profile updates

### DIFF
--- a/packages/platform-core/__tests__/customerProfiles.test.ts
+++ b/packages/platform-core/__tests__/customerProfiles.test.ts
@@ -51,5 +51,22 @@ describe("customer profiles", () => {
     });
     expect(result).toBe(updated);
   });
+
+  it("upserts when findFirst returns the same customerId", async () => {
+    const existing = { customerId: "abc", email: "same@example.com" } as any;
+    prisma.customerProfile.findFirst.mockResolvedValue(existing);
+    const updated = { customerId: "abc", name: "Name", email: "same@example.com" } as any;
+    prisma.customerProfile.upsert.mockResolvedValue(updated);
+
+    await expect(
+      updateCustomerProfile("abc", { name: "Name", email: "same@example.com" })
+    ).resolves.toBe(updated);
+
+    expect(prisma.customerProfile.upsert).toHaveBeenCalledWith({
+      where: { customerId: "abc" },
+      update: { name: "Name", email: "same@example.com" },
+      create: { customerId: "abc", name: "Name", email: "same@example.com" },
+    });
+  });
 });
 

--- a/packages/platform-core/src/customerProfiles.ts
+++ b/packages/platform-core/src/customerProfiles.ts
@@ -37,7 +37,7 @@ export async function updateCustomerProfile(
       NOT: { customerId },
     },
   });
-  if (existing) {
+  if (existing && existing.customerId !== customerId) {
     throw new Error("Conflict: email already in use");
   }
   return prisma.customerProfile.upsert({


### PR DESCRIPTION
## Summary
- avoid duplicate email conflict when findFirst returns same customerId
- add regression test ensuring update proceeds when email belongs to same customer

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test` *(fails: Invalid core environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3cd4a20832fb604481bca138089