### PR TITLE
test: ensure getCustomerProfile returns profile

### DIFF
--- a/packages/platform-core/__tests__/customerProfiles.test.ts
+++ b/packages/platform-core/__tests__/customerProfiles.test.ts
@@ -21,6 +21,20 @@ describe("customer profiles", () => {
     jest.clearAllMocks();
   });
 
+  it("returns the profile when found", async () => {
+    const profile = {
+      customerId: "abc",
+      name: "Test",
+      email: "test@example.com",
+    } as any;
+    prisma.customerProfile.findUnique.mockResolvedValue(profile);
+
+    await expect(getCustomerProfile("abc")).resolves.toBe(profile);
+    expect(prisma.customerProfile.findUnique).toHaveBeenCalledWith({
+      where: { customerId: "abc" },
+    });
+  });
+
   it("calls findUnique and throws when profile is missing", async () => {
     prisma.customerProfile.findUnique.mockResolvedValue(null);
     await expect(getCustomerProfile("abc")).rejects.toThrow("Customer profile not found");


### PR DESCRIPTION
## Summary
- test customer profile retrieval succeeds when prisma returns a profile

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/platform-core test __tests__/customerProfiles.test.ts` (fails: coverage threshold not met)


------
https://chatgpt.com/codex/tasks/task_e_68c1d3cc5024832f8a6ba7a6e5b8634d