### PR TITLE
test: cache analytics providers

### DIFF
--- a/packages/platform-core/src/analytics/__tests__/index.test.ts
+++ b/packages/platform-core/src/analytics/__tests__/index.test.ts
@@ -48,7 +48,7 @@ describe("trackEvent providers", () => {
     await expect(fs.readFile(file, "utf8")).rejects.toBeDefined();
   });
 
-  test("console provider logs event", async () => {
+  test("console provider logs events and is cached", async () => {
     readShop.mockResolvedValue({ analyticsEnabled: true });
     getShopSettings.mockResolvedValue({
       analytics: { provider: "console", enabled: true },
@@ -56,9 +56,17 @@ describe("trackEvent providers", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const { trackEvent } = await import("../index");
     await trackEvent(shop, { type: "page_view", page: "home" });
+    await trackEvent(shop, { type: "page_view", page: "about" });
+    expect(readShop).toHaveBeenCalledTimes(1);
+    expect(getShopSettings).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledTimes(2);
     expect(logSpy).toHaveBeenCalledWith(
       "analytics",
       expect.objectContaining({ type: "page_view", page: "home" })
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "analytics",
+      expect.objectContaining({ type: "page_view", page: "about" })
     );
     logSpy.mockRestore();
   });

--- a/packages/template-app/__tests__/analytics-provider.test.ts
+++ b/packages/template-app/__tests__/analytics-provider.test.ts
@@ -37,6 +37,10 @@ describe("analytics provider resolution", () => {
     jest.resetModules();
     readShop.mockReset();
     getShopSettings.mockReset();
+    readFile.mockClear();
+    writeFile.mockClear();
+    appendFile.mockClear();
+    mkdir.mockClear();
     files.clear();
     (globalThis.fetch as any) = jest.fn().mockResolvedValue({ ok: true });
     process.env.DATA_ROOT = "/data";
@@ -102,6 +106,7 @@ describe("analytics provider resolution", () => {
     await trackEvent(shop, { type: "page_view", page: "about" });
     expect(readShop).toHaveBeenCalledTimes(1);
     expect(getShopSettings).toHaveBeenCalledTimes(1);
+    expect(appendFile).toHaveBeenCalledTimes(2);
   });
 
   test("updateAggregates increments metrics", async () => {


### PR DESCRIPTION
## Summary
- ensure console analytics provider reuses cached instance
- reset fs mocks and verify write calls in analytics provider tests

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/platform-core/src/analytics/__tests__/index.test.ts packages/template-app/__tests__/analytics-provider.test.ts --runTestsByPath --coverage=false --testTimeout=30000`

------
https://chatgpt.com/codex/tasks/task_e_68c1d3c6ba7c832f9ed217bb5e67fee8