### PR TITLE
test(platform-core): verify initPlugins rejects on init error

### DIFF
--- a/packages/platform-core/__tests__/plugins.test.ts
+++ b/packages/platform-core/__tests__/plugins.test.ts
@@ -197,5 +197,21 @@ describe("plugins", () => {
     );
     error.mockRestore();
   });
+
+  it("rejects when plugin init throws", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "plugin-initfail-"));
+    await fs.writeFile(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name: "initfail", main: "index.js" })
+    );
+    await fs.writeFile(
+      path.join(dir, "index.js"),
+      "module.exports = { default: { id: 'initfail', init: () => { throw new Error('init boom'); } } };\n"
+    );
+    const { initPlugins } = await import("../src/plugins");
+    await expect(
+      initPlugins({ plugins: [dir], directories: [] })
+    ).rejects.toThrow("init boom");
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression tests for plugin init failure to ensure initPlugins rejects

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Cannot find module '@acme/ui')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/platform-core/src/__tests__/plugins.test.ts packages/platform-core/__tests__/plugins.test.ts --runInBand --config jest.config.cjs` *(global coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3c2e964832f818f06bfea5a5dab