### PR TITLE
fix(ui): set ts-jest outDir

### DIFF
--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -4,7 +4,7 @@
     "types": ["@testing-library/jest-dom", "jest", "node"],
     "noEmit": true,
     "rootDir": ".",
-    "outDir": "dist"
+    "outDir": ".ts-jest"
   },
   "include": ["src/**/*", "__tests__/**/*"],
   "exclude": []


### PR DESCRIPTION
## Summary
- point ui test tsconfig to .ts-jest output dir to satisfy ts-jest

## Testing
- `pnpm --filter @acme/ui test -- useAutoSave.test.tsx` *(fails: Jest: "global" coverage threshold for branches (80%) not met: 66.66%)*

------
https://chatgpt.com/codex/tasks/task_e_68c5173b5010832fa87d3e69df3b5e6a