### PR TITLE
test: add order utils normalization tests

### DIFF
--- a/packages/platform-core/__tests__/orders.utils.test.ts
+++ b/packages/platform-core/__tests__/orders.utils.test.ts
@@ -1,0 +1,21 @@
+import { normalize, Order } from "../src/orders/utils";
+
+describe("normalize", () => {
+  it("returns null when given null", () => {
+    expect(normalize(null)).toBeNull();
+  });
+
+  it("replaces null properties with undefined", () => {
+    const order = {
+      id: "order1",
+      sessionId: "sess1",
+      shop: "shop1",
+      deposit: 0,
+      startedAt: "2023-01-01",
+      customerId: null,
+    } as unknown as Order;
+
+    const normalized = normalize(order);
+    expect(normalized?.customerId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- test that `normalize(null)` returns null
- ensure normalize converts null properties to undefined

## Testing
- `pnpm install` *(fails: packages/platform-core postinstall: Failed)*
- `pnpm -r build` *(fails: @acme/platform-core build: tsc -b)*
- `pnpm --filter @acme/platform-core test -- orders.utils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c51d4040d0832f892c17e4ea7a3d0b