### PR TITLE
test: add user delegate coverage

### DIFF
--- a/packages/platform-core/__tests__/user.delegate.test.ts
+++ b/packages/platform-core/__tests__/user.delegate.test.ts
@@ -1,10 +1,28 @@
 import { createUserDelegate } from "../src/db/stubs/user";
 
 describe("createUserDelegate", () => {
-  it("returns the second user with findFirst", async () => {
+  it("findUnique returns a user when found", async () => {
+    const delegate = createUserDelegate();
+    const user = await delegate.findUnique({ where: { id: "user1" } });
+    expect(user).toEqual({ id: "user1", email: "u1@test.com" });
+  });
+
+  it("findUnique returns null when user is missing", async () => {
+    const delegate = createUserDelegate();
+    const user = await delegate.findUnique({ where: { id: "missing" } });
+    expect(user).toBeNull();
+  });
+
+  it("findFirst returns a user when found", async () => {
     const delegate = createUserDelegate();
     const user = await delegate.findFirst({ where: { id: "user2" } });
     expect(user).toEqual({ id: "user2", email: "u2@test.com" });
+  });
+
+  it("findFirst returns null when user is missing", async () => {
+    const delegate = createUserDelegate();
+    const user = await delegate.findFirst({ where: { id: "missing" } });
+    expect(user).toBeNull();
   });
 
   it("throws when updating a missing user", async () => {
@@ -14,3 +32,4 @@ describe("createUserDelegate", () => {
     ).rejects.toThrow("User not found");
   });
 });
+


### PR DESCRIPTION
## Summary
- add comprehensive tests for user delegate findUnique, findFirst, and update

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @acme/platform-core test` *(terminates with plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d3a0c20832f91086ad4f830bb8a