### PR TITLE
test: cover reverse logistics event delegate

### DIFF
--- a/packages/platform-core/__tests__/reverseLogisticsEvent.delegate.test.ts
+++ b/packages/platform-core/__tests__/reverseLogisticsEvent.delegate.test.ts
@@ -1,0 +1,39 @@
+import { createReverseLogisticsEventDelegate } from "../src/db/stubs/reverseLogisticsEvent";
+
+describe("reverseLogisticsEvent delegate", () => {
+  it("createMany inserts multiple events and returns count", async () => {
+    const delegate = createReverseLogisticsEventDelegate();
+    const result = await delegate.createMany({
+      data: [
+        { id: "e1", type: "received" },
+        { id: "e2", type: "cleaning" },
+      ],
+    });
+    expect(result).toEqual({ count: 2 });
+    const events = await delegate.findMany({ where: {} });
+    expect(events).toHaveLength(2);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "e1", type: "received" }),
+        expect.objectContaining({ id: "e2", type: "cleaning" }),
+      ]),
+    );
+  });
+
+  it("findMany respects arbitrary where filters", async () => {
+    const delegate = createReverseLogisticsEventDelegate();
+    await delegate.createMany({
+      data: [
+        { id: "e1", type: "received", shop: "s1" },
+        { id: "e2", type: "received", shop: "s2" },
+        { id: "e3", type: "cleaning", shop: "s1" },
+      ],
+    });
+    const filtered = await delegate.findMany({
+      where: { type: "received", shop: "s1" },
+    });
+    expect(filtered).toEqual([
+      { id: "e1", type: "received", shop: "s1" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for reverse logistics event delegate createMany and filtering

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TS2322)
- `pnpm --filter @acme/platform-core test`
- `pnpm exec jest __tests__/reverseLogisticsEvent.delegate.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c51d379bc4832f902de43a21404caa