### PR TITLE
test: add product delegate coverage

### DIFF
--- a/packages/platform-core/__tests__/product.delegate.test.ts
+++ b/packages/platform-core/__tests__/product.delegate.test.ts
@@ -1,0 +1,41 @@
+import { createProductDelegate } from "../src/db/stubs/product";
+
+describe("createProductDelegate", () => {
+  it("returns null when findUnique is called without shopId_id", async () => {
+    const delegate = createProductDelegate();
+    await delegate.create({ data: { shopId: "s1", id: "p1" } });
+    const result = await delegate.findUnique({ where: { id: "p1" } });
+    expect(result).toBeNull();
+  });
+
+  it("throws when updating or deleting a missing product", async () => {
+    const delegate = createProductDelegate();
+    await expect(
+      delegate.update({
+        where: { shopId_id: { shopId: "s1", id: "missing" } },
+        data: { name: "test" },
+      })
+    ).rejects.toThrow("Product not found");
+    await expect(
+      delegate.delete({ where: { shopId_id: { shopId: "s1", id: "missing" } } })
+    ).rejects.toThrow("Product not found");
+  });
+
+  it("adds with createMany and removes with deleteMany", async () => {
+    const delegate = createProductDelegate();
+    const data = [
+      { shopId: "s1", id: "p1" },
+      { shopId: "s1", id: "p2" },
+      { shopId: "s2", id: "p3" },
+    ];
+    const created = await delegate.createMany({ data });
+    expect(created).toEqual({ count: 3 });
+    expect(await delegate.findMany({ where: { shopId: "s1" } })).toHaveLength(2);
+
+    const removed = await delegate.deleteMany({ where: { shopId: "s1" } });
+    expect(removed).toEqual({ count: 2 });
+    expect(await delegate.findMany({ where: { shopId: "s1" } })).toEqual([]);
+    expect(await delegate.findMany({ where: { shopId: "s2" } })).toHaveLength(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add product delegate tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable ...)*
- `pnpm --filter @acme/platform-core test` *(terminated: ENOENT: no such file or directory, scandir '/packages/plugins')*

------
https://chatgpt.com/codex/tasks/task_e_68c51d35a348832f981371043ecc1cf8