### PR TITLE
test: inventory delegate CRUD

### DIFF
--- a/packages/platform-core/__tests__/inventoryItem.delegate.test.ts
+++ b/packages/platform-core/__tests__/inventoryItem.delegate.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+import { createInventoryItemDelegate } from "../src/db/stubs";
+
+describe("createInventoryItemDelegate", () => {
+  it("deleteMany removes records and findMany returns only the requested shop", async () => {
+    const inventory = createInventoryItemDelegate();
+    await inventory.createMany({
+      data: [
+        { shopId: "s1", sku: "a", variantKey: "v1", quantity: 1 },
+        { shopId: "s1", sku: "b", variantKey: "v1", quantity: 2 },
+        { shopId: "s2", sku: "c", variantKey: "v1", quantity: 3 },
+      ],
+    });
+
+    await expect(
+      inventory.findMany({ where: { shopId: "s1" } })
+    ).resolves.toHaveLength(2);
+    await expect(
+      inventory.findMany({ where: { shopId: "s2" } })
+    ).resolves.toHaveLength(1);
+
+    await expect(
+      inventory.deleteMany({ where: { shopId: "s1" } })
+    ).resolves.toEqual({ count: 2 });
+
+    await expect(
+      inventory.findMany({ where: { shopId: "s1" } })
+    ).resolves.toHaveLength(0);
+    await expect(
+      inventory.findMany({ where: { shopId: "s2" } })
+    ).resolves.toHaveLength(1);
+  });
+
+  it("delete throws when the item is missing", async () => {
+    const inventory = createInventoryItemDelegate();
+    await inventory.createMany({
+      data: [{ shopId: "s1", sku: "a", variantKey: "v1", quantity: 1 }],
+    });
+
+    await expect(
+      inventory.delete({
+        where: {
+          shopId_sku_variantKey: { shopId: "s1", sku: "a", variantKey: "v1" },
+        },
+      })
+    ).resolves.toMatchObject({ sku: "a" });
+
+    await expect(
+      inventory.delete({
+        where: {
+          shopId_sku_variantKey: { shopId: "s1", sku: "a", variantKey: "v1" },
+        },
+      })
+    ).rejects.toThrow("InventoryItem not found");
+  });
+
+  it("upsert updates existing items and creates new ones", async () => {
+    const inventory = createInventoryItemDelegate();
+    const where = {
+      shopId_sku_variantKey: { shopId: "s1", sku: "a", variantKey: "v1" },
+    };
+
+    const created = await inventory.upsert({
+      where,
+      update: { quantity: 2 },
+      create: { shopId: "s1", sku: "a", variantKey: "v1", quantity: 1 },
+    });
+    expect(created.quantity).toBe(1);
+
+    const updated = await inventory.upsert({
+      where,
+      update: { quantity: 5 },
+      create: { shopId: "s1", sku: "a", variantKey: "v1", quantity: 1 },
+    });
+    expect(updated.quantity).toBe(5);
+
+    const createdNew = await inventory.upsert({
+      where: {
+        shopId_sku_variantKey: { shopId: "s1", sku: "b", variantKey: "v1" },
+      },
+      update: { quantity: 3 },
+      create: { shopId: "s1", sku: "b", variantKey: "v1", quantity: 2 },
+    });
+    expect(createdNew.quantity).toBe(2);
+
+    await expect(
+      inventory.findMany({ where: { shopId: "s1" } })
+    ).resolves.toHaveLength(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test inventory delegate deleteMany and findMany filtering
- ensure delete throws for missing items
- check upsert creates and updates records

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TypeScript errors in orders files)
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/inventoryItem.delegate.test.ts`
- `pnpm --filter @acme/platform-core test` (fails: ENOENT /packages/plugins)


------
https://chatgpt.com/codex/tasks/task_e_68c51d33ae6c832faa0106e3cde5f895