### PR TITLE
test: cover select refs and portal

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/select.test.tsx
@@ -163,25 +163,31 @@ describe("Select", () => {
     const user = userEvent.setup();
     await user.click(screen.getByTestId("trigger"));
 
+    const trigger = screen.getByTestId("trigger");
     const content = await screen.findByTestId("content");
     const label = await screen.findByTestId("label");
     const item = await screen.findByTestId("item");
     const separator = await screen.findByTestId("separator");
 
-    expect(triggerRef.current).toBe(screen.getByTestId("trigger"));
+    expect(triggerRef.current).toBe(trigger);
     expect(triggerRef.current).toHaveAttribute("data-foo", "trigger");
+    expect(trigger).toHaveClass("border-input");
 
     expect(contentRef.current).toBe(content);
     expect(content).toHaveAttribute("data-foo", "content");
+    expect(content).toHaveClass("bg-popover");
 
     expect(labelRef.current).toBe(label);
     expect(label).toHaveAttribute("data-foo", "label");
+    expect(label).toHaveClass("px-2");
 
     expect(itemRef.current).toBe(item);
     expect(item).toHaveAttribute("data-foo", "item");
+    expect(item).toHaveClass("pl-8");
 
     expect(separatorRef.current).toBe(separator);
     expect(separator).toHaveAttribute("data-foo", "separator");
+    expect(separator).toHaveClass("bg-muted");
   });
 
   it("SelectContent renders in a portal", async () => {


### PR DESCRIPTION
## Summary
- verify Select subcomponents forward refs and custom attributes while keeping default classes
- ensure SelectContent renders via portal outside the original container

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: missing script)*
- `pnpm run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/ui run test`


------
https://chatgpt.com/codex/tasks/task_e_68c51e742fcc832f88f5b33e4de97c07