### PR TITLE
test: add dialog ref and className tests

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/dialog.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/dialog.test.tsx
@@ -1,4 +1,5 @@
 import "../../../../../../../test/resetNextMocks";
+import * as React from "react";
 import { render, screen, configure } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -15,11 +16,18 @@ import {
 configure({ testIdAttribute: "data-testid" });
 
 describe("Dialog", () => {
-  it("merges custom classes on overlay and content", () => {
+  it("forwards refs and merges custom classes on overlay and content", () => {
+    const overlayRef = React.createRef<HTMLDivElement>();
+    const contentRef = React.createRef<HTMLDivElement>();
+
     render(
       <Dialog open>
-        <DialogOverlay data-testid="overlay" className="custom-overlay" />
-        <DialogContent className="custom-content">
+        <DialogOverlay
+          ref={overlayRef}
+          data-testid="overlay"
+          className="custom-overlay"
+        />
+        <DialogContent ref={contentRef} className="custom-content">
           <DialogHeader>
             <DialogTitle>Title</DialogTitle>
             <DialogDescription>Description</DialogDescription>
@@ -29,39 +37,79 @@ describe("Dialog", () => {
     );
 
     const overlay = screen.getByTestId("overlay");
+    expect(overlayRef.current).toBe(overlay);
     expect(overlay).toHaveClass("custom-overlay");
     expect(overlay).toHaveClass("bg-fg/50");
 
     const content = screen.getByRole("dialog");
+    expect(contentRef.current).toBe(content);
     expect(content).toHaveClass("custom-content");
     expect(content).toHaveClass("bg-background");
   });
 
-  it("renders subcomponents with correct classes", () => {
+  it("forwards refs and merges custom classes on subcomponents", () => {
+    const headerRef = React.createRef<HTMLDivElement>();
+    const footerRef = React.createRef<HTMLDivElement>();
+    const titleRef = React.createRef<HTMLHeadingElement>();
+    const descriptionRef = React.createRef<HTMLParagraphElement>();
+
     render(
       <Dialog open>
         <DialogContent>
-          <DialogHeader data-testid="header">
-            <DialogTitle data-testid="title">Title</DialogTitle>
-            <DialogDescription data-testid="description">
+          <DialogHeader
+            ref={headerRef}
+            data-testid="header"
+            className="custom-header"
+          >
+            <DialogTitle
+              ref={titleRef}
+              data-testid="title"
+              className="custom-title"
+            >
+              Title
+            </DialogTitle>
+            <DialogDescription
+              ref={descriptionRef}
+              data-testid="description"
+              className="custom-description"
+            >
               Description
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter data-testid="footer">Footer</DialogFooter>
+          <DialogFooter
+            ref={footerRef}
+            data-testid="footer"
+            className="custom-footer"
+          >
+            Footer
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     );
 
-    expect(screen.getByTestId("header")).toHaveClass(
+    const header = screen.getByTestId("header");
+    expect(headerRef.current).toBe(header);
+    expect(header).toHaveClass("custom-header");
+    expect(header).toHaveClass(
       "flex flex-col space-y-1.5 text-center sm:text-left"
     );
-    expect(screen.getByTestId("footer")).toHaveClass(
+
+    const footer = screen.getByTestId("footer");
+    expect(footerRef.current).toBe(footer);
+    expect(footer).toHaveClass("custom-footer");
+    expect(footer).toHaveClass(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
     );
-    expect(screen.getByTestId("title")).toHaveClass("text-lg font-semibold");
-    expect(screen.getByTestId("description")).toHaveClass(
-      "text-muted-foreground text-sm"
-    );
+
+    const title = screen.getByTestId("title");
+    expect(titleRef.current).toBe(title);
+    expect(title).toHaveClass("custom-title");
+    expect(title).toHaveClass("text-lg font-semibold");
+
+    const description = screen.getByTestId("description");
+    expect(descriptionRef.current).toBe(description);
+    expect(description).toHaveClass("custom-description");
+    expect(description).toHaveClass("text-muted-foreground text-sm");
   });
 
   it("dismisses when close button is clicked", async () => {


### PR DESCRIPTION
## Summary
- add ref and custom className coverage for dialog overlay and content
- verify refs and classes propagate through dialog header, footer, title and description

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ... in platform-core)*
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/primitives/__tests__/dialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c51e71b690832faa3d11a880fbdbd7