### PR TITLE
test(ui): cover card ref forwarding and class merging

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/card.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/card.test.tsx
@@ -4,52 +4,38 @@ import { render, screen } from "@testing-library/react";
 import { Card, CardContent } from "../card";
 
 describe("Card", () => {
-  it("renders with children and base styles", () => {
+  it("forwards ref, applies token, and merges className", () => {
+    const ref = React.createRef<HTMLDivElement>();
     const { container } = render(
-      <Card>
+      <Card ref={ref} className="extra">
         <CardContent>Content</CardContent>
       </Card>
     );
 
-    const card = container.firstChild as HTMLElement;
+    const card = container.firstChild as HTMLDivElement;
+    expect(ref.current).toBe(card);
     expect(card).toHaveAttribute("data-token", "--color-bg");
-    expect(card).toHaveClass("bg-card");
+    expect(card).toHaveClass("bg-card", "extra");
     expect(screen.getByText("Content")).toBeInTheDocument();
   });
 
-  it("merges className", () => {
-    const { container } = render(<Card className="extra" />);
-    const card = container.firstChild as HTMLElement;
-    expect(card).toHaveClass("bg-card", "extra");
-  });
-
   it("passes arbitrary HTML attributes", () => {
-    const { container } = render(
-      <Card id="card-id" data-foo="bar" />
-    );
+    const { container } = render(<Card id="card-id" data-foo="bar" />);
     const card = container.firstChild as HTMLElement;
     expect(card).toHaveAttribute("id", "card-id");
     expect(card).toHaveAttribute("data-foo", "bar");
   });
-
-  it("forwards ref", () => {
-    const ref = React.createRef<HTMLDivElement>();
-    render(<Card ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLDivElement);
-  });
 });
 
 describe("CardContent", () => {
-  it("merges className", () => {
-    const { container } = render(<CardContent className="inner" />);
-    const content = container.firstChild as HTMLElement;
-    expect(content).toHaveClass("p-6", "inner");
-  });
-
-  it("forwards ref", () => {
+  it("forwards ref and merges className", () => {
     const ref = React.createRef<HTMLDivElement>();
-    render(<CardContent ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    const { container } = render(
+      <CardContent ref={ref} className="inner" />
+    );
+    const content = container.firstChild as HTMLDivElement;
+    expect(ref.current).toBe(content);
+    expect(content).toHaveClass("p-6", "inner");
   });
 
   it("passes arbitrary HTML attributes", () => {


### PR DESCRIPTION
## Summary
- test Card ref forwarding, data token, and custom class merging
- test CardContent ref forwarding and class merging

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test`

------
https://chatgpt.com/codex/tasks/task_e_68c51e70fe1c832f979459029966c698