### PR TITLE
Use React act in NavigationEditor tests

### DIFF
--- a/apps/cms/__tests__/PageBuilder.integration.test.tsx
+++ b/apps/cms/__tests__/PageBuilder.integration.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import PageBuilder from "../src/components/cms/PageBuilder";
 
 let dndHandlers: any = {};

--- a/packages/ui/__tests__/NavigationEditor.test.tsx
+++ b/packages/ui/__tests__/NavigationEditor.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import NavigationEditor, { NavItem } from "../src/components/cms/NavigationEditor";
 
 let dndHandlers: any = {};

--- a/packages/ui/src/components/cms/__tests__/NavigationEditor.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/NavigationEditor.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import NavigationEditor, { NavItem } from "../NavigationEditor";
 
 var dndHandlers: any;


### PR DESCRIPTION
## Summary
- replace `react-dom/test-utils` act with React's `act` in NavigationEditor tests
- adjust PageBuilder integration test to use React's `act`

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm -r build` (fails: TypeScript errors in @acme/platform-core)
- `pnpm exec jest packages/ui/__tests__/NavigationEditor.test.tsx packages/ui/src/components/cms/__tests__/NavigationEditor.test.tsx apps/cms/__tests__/PageBuilder.integration.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c51f635a88832f965b333e9fb9893d