### PR TITLE
test: wrap PageSidebar interactions in act

### DIFF
--- a/packages/ui/__tests__/PageSidebar.test.tsx
+++ b/packages/ui/__tests__/PageSidebar.test.tsx
@@ -3,7 +3,7 @@ import type { PageComponent } from "@acme/types";
 import PageSidebar from "../src/components/cms/page-builder/PageSidebar";
 
 describe("PageSidebar", () => {
-  it("dispatches correct actions for edits and duplication", () => {
+  it("dispatches correct actions for edits and duplication", async () => {
     const component: PageComponent = {
       id: "c1",
       type: "ProductCarousel",
@@ -11,7 +11,7 @@ describe("PageSidebar", () => {
       maxItems: 5,
     } as PageComponent;
     const dispatch = jest.fn();
-    const { getByText, getByLabelText } = render(
+    const { getByText, findByLabelText } = render(
       <PageSidebar
         components={[component]}
         selectedId={component.id}
@@ -21,7 +21,7 @@ describe("PageSidebar", () => {
 
     // onResize
     fireEvent.click(getByText("Layout"));
-    fireEvent.change(getByLabelText("Width (Desktop)", { exact: false }), {
+    fireEvent.change(await findByLabelText("Width (Desktop)", { exact: false }), {
       target: { value: "200" },
     });
     expect(dispatch).toHaveBeenCalledWith({
@@ -33,7 +33,7 @@ describe("PageSidebar", () => {
 
     // onChange
     fireEvent.click(getByText("Content"));
-    fireEvent.change(getByLabelText("Min Items", { exact: false }), {
+    fireEvent.change(await findByLabelText("Min Items", { exact: false }), {
       target: { value: "2" },
     });
     expect(dispatch).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- await dynamically loaded fields in PageSidebar test to prevent Suspense warnings

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui lint` *(fails: several lint errors)*
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/PageSidebar.test.tsx --coverage=false --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c51f5b129c832fb0e75d1b04e9c2a3