### PR TITLE
test: stub LayoutPanel selects to avoid DOM warnings

### DIFF
--- a/packages/ui/__tests__/LayoutPanel.test.tsx
+++ b/packages/ui/__tests__/LayoutPanel.test.tsx
@@ -8,11 +8,15 @@ jest.mock("../src/components/atoms/shadcn", () => {
       </label>
     ),
     Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
-    Select: ({ children, ...rest }: any) => <select {...rest}>{children}</select>,
+    // Use simple non-form elements for Select-related mocks to avoid DOM nesting
+    // issues and uncontrolled warnings in tests.
+    Select: ({ children }: any) => <div>{children}</div>,
     SelectTrigger: ({ children }: any) => <div>{children}</div>,
-    SelectValue: ({ placeholder }: any) => <option>{placeholder}</option>,
+    SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
     SelectContent: ({ children }: any) => <div>{children}</div>,
-    SelectItem: ({ children, ...rest }: any) => <option {...rest}>{children}</option>,
+    SelectItem: ({ children, onSelect }: any) => (
+      <div onClick={() => onSelect?.()}>{children}</div>
+    ),
   };
 });
 import { render, fireEvent, screen } from "@testing-library/react";


### PR DESCRIPTION
## Summary
- simplify LayoutPanel test mocks for Select components to avoid invalid DOM nesting and unknown property warnings

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test __tests__/LayoutPanel.test.tsx` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c51f4dd588832fa5874139a39e0db1