### PR TITLE
test(ui): mock editor registry in ContentPanel test

### DIFF
--- a/packages/ui/__tests__/ContentPanel.test.tsx
+++ b/packages/ui/__tests__/ContentPanel.test.tsx
@@ -9,6 +9,10 @@ jest.mock("../src/components/atoms/shadcn", () => {
     ),
   };
 });
+jest.mock("../src/components/cms/page-builder/editorRegistry", () => ({
+  __esModule: true,
+  default: {},
+}));
 import { render, fireEvent, screen } from "@testing-library/react";
 import ContentPanel from "../src/components/cms/page-builder/panels/ContentPanel";
 import type { PageComponent } from "@acme/types";


### PR DESCRIPTION
## Summary
- mock `editorRegistry` in ContentPanel unit test to prevent React Suspense from resolving outside of `act`

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/ContentPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c51f1ec62c832f85c9568b09c08036