### PR TITLE
test: cover env refinement and TTL normalization

### DIFF
--- a/packages/config/src/env/__tests__/depositReleaseEnvRefinement.test.ts
+++ b/packages/config/src/env/__tests__/depositReleaseEnvRefinement.test.ts
@@ -266,6 +266,32 @@ describe("depositReleaseEnvRefinement", () => {
     });
   });
 
+  it("adds issue for non-boolean *_ENABLED values", () => {
+    const ctx = { addIssue: jest.fn() } as unknown as z.RefinementCtx;
+    depositReleaseEnvRefinement(
+      { DEPOSIT_RELEASE_FOO_ENABLED: "yes" },
+      ctx,
+    );
+    expect(ctx.addIssue).toHaveBeenCalledWith({
+      code: z.ZodIssueCode.custom,
+      path: ["DEPOSIT_RELEASE_FOO_ENABLED"],
+      message: "must be true or false",
+    });
+  });
+
+  it("adds issue for non-numeric *_INTERVAL_MS values", () => {
+    const ctx = { addIssue: jest.fn() } as unknown as z.RefinementCtx;
+    depositReleaseEnvRefinement(
+      { DEPOSIT_RELEASE_FOO_INTERVAL_MS: "soon" },
+      ctx,
+    );
+    expect(ctx.addIssue).toHaveBeenCalledWith({
+      code: z.ZodIssueCode.custom,
+      path: ["DEPOSIT_RELEASE_FOO_INTERVAL_MS"],
+      message: "must be a number",
+    });
+  });
+
   it("ignores unrelated environment keys", () => {
     const ctx = { addIssue: jest.fn() } as unknown as z.RefinementCtx;
     depositReleaseEnvRefinement(


### PR DESCRIPTION
## Summary
- test requireEnv's boolean and number error handling
- verify deposit release refinement rejects non-boolean ENABLED and non-numeric INTERVAL_MS values
- ensure coreEnvSchema normalizes numeric and string AUTH_TOKEN_TTL inputs

## Testing
- `pnpm run check:references packages/config` *(fails: Missing script: check:references)*
- `pnpm run build:ts packages/config` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/config test` *(fails: 15 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c51e83c4a0832f8b6e09eddc96ebaa