### PR TITLE
test: expand cms schema guards

### DIFF
--- a/packages/config/src/env/__tests__/cms.schema.guard.test.ts
+++ b/packages/config/src/env/__tests__/cms.schema.guard.test.ts
@@ -57,6 +57,17 @@ describe("cmsEnvSchema guards", () => {
       expect(parsed.CMS_DRAFTS_ENABLED).toBe(expected);
     });
 
+    it.each([
+      [1, true],
+      [0, false],
+    ])("coerces numeric %s", async (value, expected) => {
+      process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
+      jest.resetModules();
+      const { cmsEnvSchema } = await import("../cms.schema.ts");
+      const parsed = cmsEnvSchema.parse({ CMS_DRAFTS_ENABLED: value as any });
+      expect(parsed.CMS_DRAFTS_ENABLED).toBe(expected);
+    });
+
     it("errors on invalid strings", async () => {
       process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
       jest.resetModules();
@@ -64,6 +75,54 @@ describe("cmsEnvSchema guards", () => {
       expect(() =>
         cmsEnvSchema.parse({ CMS_DRAFTS_ENABLED: "taco" }),
       ).toThrow();
+    });
+
+    it("errors on invalid numbers", async () => {
+      process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
+      jest.resetModules();
+      const { cmsEnvSchema } = await import("../cms.schema.ts");
+      expect(() => cmsEnvSchema.parse({ CMS_DRAFTS_ENABLED: 2 as any })).toThrow();
+    });
+  });
+
+  describe("boolish CMS_SEARCH_ENABLED", () => {
+    it.each([
+      [1, true],
+      [0, false],
+    ])("coerces numeric %s", async (value, expected) => {
+      process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
+      jest.resetModules();
+      const { cmsEnvSchema } = await import("../cms.schema.ts");
+      const parsed = cmsEnvSchema.parse({ CMS_SEARCH_ENABLED: value as any });
+      expect(parsed.CMS_SEARCH_ENABLED).toBe(expected);
+    });
+
+    it("errors on invalid numbers", async () => {
+      process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
+      jest.resetModules();
+      const { cmsEnvSchema } = await import("../cms.schema.ts");
+      expect(() => cmsEnvSchema.parse({ CMS_SEARCH_ENABLED: 2 as any })).toThrow();
+    });
+  });
+
+  describe.each([
+    ["SANITY_BASE_URL", "https://sanity.example.com/"],
+    ["CMS_BASE_URL", "https://cms.example.com/"],
+  ])("%s normalization", (field, url) => {
+    it("strips trailing slash", async () => {
+      process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
+      jest.resetModules();
+      const { cmsEnvSchema } = await import("../cms.schema.ts");
+      const parsed = cmsEnvSchema.parse({ [field]: url } as any);
+      expect(parsed[field as keyof typeof parsed]).toBe(url.slice(0, -1));
+    });
+
+    it("remains undefined when blank", async () => {
+      process.env = { NODE_ENV: "development" } as NodeJS.ProcessEnv;
+      jest.resetModules();
+      const { cmsEnvSchema } = await import("../cms.schema.ts");
+      const parsed = cmsEnvSchema.parse({ [field]: undefined } as any);
+      expect(parsed[field as keyof typeof parsed]).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- cover numeric CMS_DRAFTS_ENABLED and CMS_SEARCH_ENABLED inputs
- assert invalid numeric flag handling
- test base URLs strip trailing slashes and ignore blanks

## Testing
- `pnpm run check:references packages/config` *(fails: Missing script: check:references)*
- `pnpm run build:ts packages/config` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/config test` *(fails: various failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c51e823818832fb56959202ac319ad