### PR TITLE
test(ui): expand boxProps coverage

### DIFF
--- a/packages/ui/src/utils/style/__tests__/boxProps.test.ts
+++ b/packages/ui/src/utils/style/__tests__/boxProps.test.ts
@@ -5,6 +5,22 @@ describe("boxProps", () => {
     expect(boxProps({})).toEqual({ classes: "", style: {} });
   });
 
+  it("returns class when only tailwind width provided", () => {
+    expect(boxProps({ width: "w-10" })).toEqual({ classes: "w-10", style: {} });
+  });
+
+  it("uses style when only numeric width provided", () => {
+    expect(boxProps({ width: 100 })).toEqual({ classes: "", style: { width: 100 } });
+  });
+
+  it("returns class when only tailwind height provided", () => {
+    expect(boxProps({ height: "h-8" })).toEqual({ classes: "h-8", style: {} });
+  });
+
+  it("uses style when only numeric height provided", () => {
+    expect(boxProps({ height: 50 })).toEqual({ classes: "", style: { height: 50 } });
+  });
+
   it("returns classes for tailwind width/height", () => {
     const result = boxProps({
       width: "w-16",
@@ -35,6 +51,14 @@ describe("boxProps", () => {
   it("supports responsive utility classes", () => {
     const result = boxProps({ padding: "md:p-4" });
     expect(result.classes).toBe("md:p-4");
+  });
+
+  it("aggregates padding class when only padding provided", () => {
+    expect(boxProps({ padding: "p-4" })).toEqual({ classes: "p-4", style: {} });
+  });
+
+  it("aggregates margin class when only margin provided", () => {
+    expect(boxProps({ margin: "m-2" })).toEqual({ classes: "m-2", style: {} });
   });
 
   it("mixes class and style when only one dimension uses tailwind", () => {


### PR DESCRIPTION
## Summary
- cover single-dimension width/height values, both numeric and Tailwind classes
- ensure padding-only and margin-only inputs produce aggregated classes

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui exec jest src/utils/style/__tests__/boxProps.test.ts` *(fails: Babel parser error)*

------
https://chatgpt.com/codex/tasks/task_e_68c51e795690832fbfbfe12a5d7a7cb1