### PR TITLE
test: cover Slot with function refs

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/slot.test.tsx
@@ -58,6 +58,25 @@ describe("Slot", () => {
     expect(childRef.current).toBe(child);
   });
 
+  it("handles function refs along with Slot ref", () => {
+    let slotNode: HTMLDivElement | null = null;
+    let childNode: HTMLDivElement | null = null;
+    const slotRef = (node: HTMLDivElement | null) => {
+      slotNode = node;
+    };
+    const childRef = (node: HTMLDivElement | null) => {
+      childNode = node;
+    };
+    render(
+      <Slot ref={slotRef}>
+        <div data-testid="child" ref={childRef} />
+      </Slot>
+    );
+    const child = screen.getByTestId("child");
+    expect(slotNode).toBe(child);
+    expect(childNode).toBe(child);
+  });
+
   it("passes event handlers through to the child", async () => {
     const handleClick = jest.fn();
     render(


### PR DESCRIPTION
## Summary
- test Slot with function refs on both parent and child elements

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Type '... | null' is not assignable...)
- `pnpm --filter @acme/ui test` (fails: Unable to process '/workspace/base-shop/packages/ui/__tests__/useAutoSave.test.tsx')

------
https://chatgpt.com/codex/tasks/task_e_68c51e7579ec832f9252a44935ccfe9c