### PR TITLE
test: add shop delegate test

### DIFF
--- a/packages/platform-core/__tests__/shop.delegate.test.ts
+++ b/packages/platform-core/__tests__/shop.delegate.test.ts
@@ -1,0 +1,8 @@
+import { createShopDelegate } from "../src/db/stubs/shop";
+
+describe("createShopDelegate", () => {
+  it("returns an object with data when findUnique is called", async () => {
+    const delegate = createShopDelegate();
+    await expect(delegate.findUnique()).resolves.toMatchObject({ data: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for createShopDelegate ensuring findUnique resolves to an object with a data property

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TypeScript errors)
- `pnpm --filter @acme/platform-core test` (fails: multiple test failures)

------
https://chatgpt.com/codex/tasks/task_e_68c51d38507c832f83065342d71c4fce