### PR TITLE
test: add customerMfa delegate tests

### DIFF
--- a/packages/platform-core/__tests__/customerMfa.delegate.test.ts
+++ b/packages/platform-core/__tests__/customerMfa.delegate.test.ts
@@ -1,0 +1,37 @@
+import { createCustomerMfaDelegate } from "../src/db/stubs";
+
+describe("createCustomerMfaDelegate", () => {
+  const where = { customerId: "cust1" };
+
+  it("upsert creates a new record when none exists", async () => {
+    const delegate = createCustomerMfaDelegate();
+    const record = await delegate.upsert({
+      where,
+      create: { ...where, secret: "sec1", enabled: false },
+      update: { secret: "new", enabled: true },
+    });
+    expect(record).toEqual({ ...where, secret: "sec1", enabled: false });
+  });
+
+  it("upsert merges with an existing record", async () => {
+    const delegate = createCustomerMfaDelegate();
+    await delegate.upsert({
+      where,
+      create: { ...where, secret: "sec1", enabled: false },
+      update: { secret: "new", enabled: true },
+    });
+    const merged = await delegate.upsert({
+      where,
+      create: { ...where, secret: "sec2", enabled: false },
+      update: { enabled: true },
+    });
+    expect(merged).toEqual({ ...where, secret: "sec1", enabled: true });
+  });
+
+  it("update throws when customerId is missing", async () => {
+    const delegate = createCustomerMfaDelegate();
+    await expect(
+      delegate.update({ where: { customerId: "missing" }, data: { enabled: true } })
+    ).rejects.toThrow("CustomerMfa not found");
+  });
+});


### PR DESCRIPTION
## Summary
- add customer multi-factor auth delegate tests for create, merge, and error paths

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: 4 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d31c108832fb03a984b6fcb8f16