### PR TITLE
fix: avoid spreading key prop into FontToken

### DIFF
--- a/packages/ui/src/components/cms/style/FontToken.tsx
+++ b/packages/ui/src/components/cms/style/FontToken.tsx
@@ -4,7 +4,8 @@ import { FontSelect } from "../index";
 import type { TokenInfo } from "../../../hooks/useTokenEditor";
 import type { ChangeEvent, ReactElement } from "react";
 
-interface FontTokenProps extends TokenInfo {
+interface FontTokenProps extends Omit<TokenInfo, "key"> {
+  tokenKey: string;
   options: string[];
   type: "mono" | "sans";
   googleFonts: string[];
@@ -14,7 +15,7 @@ interface FontTokenProps extends TokenInfo {
 }
 
 export function FontToken({
-  key: tokenKey,
+  tokenKey,
   value,
   defaultValue,
   isOverridden,
@@ -27,7 +28,6 @@ export function FontToken({
 }: FontTokenProps): ReactElement {
   return (
     <label
-      key={tokenKey}
       data-token-key={tokenKey}
       className={`flex flex-col gap-1 text-sm ${
         isOverridden ? "border-l-2 border-l-info pl-2" : ""

--- a/packages/ui/src/components/cms/style/Tokens.tsx
+++ b/packages/ui/src/components/cms/style/Tokens.tsx
@@ -141,11 +141,14 @@ export default function Tokens({
     }
 
     if (info.key.startsWith("--font")) {
-      const options = info.key.includes("mono") ? monoFonts : sansFonts;
-      const type: "mono" | "sans" = info.key.includes("mono") ? "mono" : "sans";
+      const { key: tokenKey, ...rest } = info;
+      const options = tokenKey.includes("mono") ? monoFonts : sansFonts;
+      const type: "mono" | "sans" = tokenKey.includes("mono") ? "mono" : "sans";
       return (
         <FontToken
-          {...info}
+          key={tokenKey}
+          tokenKey={tokenKey}
+          {...rest}
           options={options}
           type={type}
           googleFonts={googleFonts}


### PR DESCRIPTION
## Summary
- avoid spreading React's special `key` prop into `FontToken`
- pass explicit `tokenKey` prop and key within `Tokens` renderer

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run build` *(fails: TypeScript errors)*
- `pnpm --filter @acme/ui test src/components/cms/style/__tests__/Tokens.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c524acb6b0832fa70e70eeaae764e3