### PR TITLE
test(ui): provide translations in ComponentEditor tests

### DIFF
--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -1,4 +1,6 @@
 import { render, fireEvent, act } from "@testing-library/react";
+import { TranslationsProvider } from "@acme/i18n";
+import en from "@acme/i18n/src/en.json";
 import ComponentEditor from "../src/components/cms/page-builder/ComponentEditor";
 import type { PageComponent } from "@acme/types";
 
@@ -10,11 +12,13 @@ describe("ComponentEditor", () => {
     } as PageComponent;
     const onResize = jest.fn();
     const { getByLabelText, getAllByText, getByText } = render(
-      <ComponentEditor
-        component={component}
-        onChange={() => {}}
-        onResize={onResize}
-      />
+      <TranslationsProvider messages={en}>
+        <ComponentEditor
+          component={component}
+          onChange={() => {}}
+          onResize={onResize}
+        />
+      </TranslationsProvider>
     );
     fireEvent.click(getByText("Layout"));
     fireEvent.change(getByLabelText("Width (Desktop)", { exact: false }), {
@@ -48,7 +52,9 @@ describe("ComponentEditor", () => {
     } as PageComponent;
     const onChange = jest.fn();
     const { getByLabelText, getByText } = render(
-      <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
+      <TranslationsProvider messages={en}>
+        <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
+      </TranslationsProvider>
     );
     fireEvent.click(getByText("Content"));
     fireEvent.change(getByLabelText("Min Items", { exact: false }), {
@@ -70,7 +76,9 @@ describe("ComponentEditor", () => {
     } as PageComponent;
     const onChange = jest.fn();
     const { getByLabelText, getByText } = render(
-      <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
+      <TranslationsProvider messages={en}>
+        <ComponentEditor component={component} onChange={onChange} onResize={() => {}} />
+      </TranslationsProvider>
     );
     fireEvent.click(getByText("Content"));
     fireEvent.change(getByLabelText("Min Items", { exact: false }), {
@@ -89,16 +97,18 @@ describe("ComponentEditor", () => {
       type: "Image",
     } as PageComponent;
     const { findByPlaceholderText, getByText } = render(
-      <ComponentEditor
-        component={component}
-        onChange={() => {}}
-        onResize={() => {}}
-      />
+      <TranslationsProvider messages={en}>
+        <ComponentEditor
+          component={component}
+          onChange={() => {}}
+          onResize={() => {}}
+        />
+      </TranslationsProvider>
     );
     fireEvent.click(getByText("Content"));
-    // Image source field uses translation keys as placeholders
+    // Image source field uses translations as placeholders
     expect(
-      await findByPlaceholderText("cms.image.url")
+      await findByPlaceholderText("Image URL")
     ).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx
@@ -1,4 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { TranslationsProvider } from "@acme/i18n";
+import en from "@acme/i18n/src/en.json";
 import ComponentEditor from "../ComponentEditor";
 
 describe("ComponentEditor", () => {
@@ -12,11 +14,13 @@ describe("ComponentEditor", () => {
     const onResize = jest.fn();
 
     render(
-      <ComponentEditor
-        component={component}
-        onChange={onChange}
-        onResize={onResize}
-      />
+      <TranslationsProvider messages={en}>
+        <ComponentEditor
+          component={component}
+          onChange={onChange}
+          onResize={onResize}
+        />
+      </TranslationsProvider>
     );
 
     // Update content via the specific editor


### PR DESCRIPTION
## Summary
- wrap ComponentEditor tests with TranslationsProvider
- expect localized placeholder text for image URL

## Testing
- `pnpm install` *(fails: command not found)*
- `pnpm -r build` *(fails: command not found)*
- `pnpm --filter @acme/ui run check:references` *(fails: command not found)*
- `pnpm --filter @acme/ui run build:ts` *(fails: command not found)*
- `pnpm --filter @acme/ui test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c524caed6c832f9f7a6f1d2727a69e