### PR TITLE
fix(ui): silence dialog description warning

### DIFF
--- a/packages/ui/src/components/organisms/FilterSidebar.client.tsx
+++ b/packages/ui/src/components/organisms/FilterSidebar.client.tsx
@@ -46,6 +46,7 @@ export function FilterSidebar({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-fg/50" />
         <DialogPrimitive.Content
+          aria-describedby={undefined}
           className={cn(
             widthClass,
             "bg-background fixed inset-y-0 left-0 z-50 border-r p-4 shadow-lg focus:outline-none"


### PR DESCRIPTION
## Summary
- explicitly set `aria-describedby` to `undefined` on FilterSidebar dialog content to avoid Radix warning

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/organisms/__tests__/FilterSidebar.test.tsx`
- `pnpm --filter @acme/ui test packages/ui/__tests__/FilterSidebar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5250e5848832f82809e88e916d7df