### PR TITLE
fix(ui): add dialog description for live chat

### DIFF
--- a/packages/ui/src/components/organisms/LiveChatWidget.tsx
+++ b/packages/ui/src/components/organisms/LiveChatWidget.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -94,6 +95,9 @@ export function LiveChatWidget({
         {" "}
         <DialogHeader>
           <DialogTitle>How can we help?</DialogTitle>
+          <DialogDescription className="sr-only">
+            Chat with our support team
+          </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-2 overflow-y-auto py-2">
           {messages.map((m, i) => (


### PR DESCRIPTION
## Summary
- add hidden `DialogDescription` to LiveChatWidget to satisfy accessibility expectations and remove console warnings

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/LiveChatWidget.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5251dcf54832fad4a61d482bec22a