### PR TITLE
fix(ui): describe FilterSidebar dialog

### DIFF
--- a/packages/ui/src/components/organisms/FilterSidebar.client.tsx
+++ b/packages/ui/src/components/organisms/FilterSidebar.client.tsx
@@ -54,6 +54,9 @@ export function FilterSidebar({
           <DialogPrimitive.Title className="mb-4 text-lg font-semibold">
             Filters
           </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Use filters to refine results
+          </DialogPrimitive.Description>
           <form
             aria-label="Filters"
             className="space-y-4"


### PR DESCRIPTION
## Summary
- add a visually hidden description to FilterSidebar's dialog content

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest packages/ui/__tests__/FilterSidebar.test.tsx --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c525290408832fa232c4c9490af3d6