### PR TITLE
fix: add dialog description for wishlist drawer

### DIFF
--- a/packages/ui/src/components/organisms/WishlistDrawer.tsx
+++ b/packages/ui/src/components/organisms/WishlistDrawer.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogTitle,
   DialogTrigger,
 } from "../atoms/shadcn";
@@ -45,6 +46,9 @@ export function WishlistDrawer({
         )}
       >
         <DialogTitle className="mb-4">Wishlist</DialogTitle>
+        <DialogDescription className="sr-only">
+          Items currently saved to your wishlist
+        </DialogDescription>
         {items.length === 0 ? (
           <p className="text-muted-foreground text-sm">
             Your wishlist is empty.


### PR DESCRIPTION
## Summary
- add sr-only DialogDescription for WishlistDrawer

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/organisms/__tests__/WishlistDrawer.test.tsx --runInBand --config ../../jest.config.cjs --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c525440484832fb72eb91c26e52d1d