### PR TITLE
fix: clean up TextBlockView test mock

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/TextBlock.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/TextBlock.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import React from "react";
 
-jest.mock("../TextBlockView", () => jest.fn((props) => <div {...props} />));
+jest.mock("../TextBlockView", () => jest.fn(() => <div />));
 jest.mock("../useLocalizedTextEditor");
 jest.mock("../useBlockTransform");
 
@@ -17,7 +17,7 @@ describe("TextBlock", () => {
   const useBlockTransformMock = useBlockTransform as unknown as jest.Mock;
 
   beforeEach(() => {
-    textBlockViewMock.mockImplementation((props) => <div {...props} />);
+    textBlockViewMock.mockImplementation(() => <div />);
     useBlockTransformMock.mockReturnValue({
       startResize: jest.fn(),
       startDrag: jest.fn(),


### PR DESCRIPTION
## Summary
- avoid forwarding all props in TextBlockView mock to DOM to silence React warnings

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TS2322 in packages/platform-core)
- `pnpm --filter @acme/ui run check:references` (fails: missing script)
- `pnpm --filter @acme/ui run build:ts` (fails: missing script)
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/page-builder/__tests__/TextBlock.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c52559dc88832f9090f1fb46bdfad0