### PR TITLE
test: mock publish locations in useProductEditorFormState

### DIFF
--- a/packages/ui/src/hooks/__tests__/use-product-editor-form-state.spec.tsx
+++ b/packages/ui/src/hooks/__tests__/use-product-editor-form-state.spec.tsx
@@ -7,6 +7,10 @@ import {
   type ProductSaveResult,
 } from "../useProductEditorFormState";
 
+jest.mock("@platform-core/hooks/usePublishLocations", () => ({
+  usePublishLocations: () => ({ locations: [], reload: jest.fn() }),
+}));
+
 const product: ProductPublication & { variants: Record<string, string[]> } = {
   id: "p1",
   sku: "sku1",


### PR DESCRIPTION
## Summary
- mock `usePublishLocations` in `use-product-editor-form-state.spec.tsx` to avoid unhandled requests

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TypeScript errors in packages/platform-core)
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/ui run test src/hooks/__tests__/use-product-editor-form-state.spec.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c5258dcbc4832faedfeb17a484a2e4