### PR TITLE
test: mock publish locations

### DIFF
--- a/test/msw/__tests__/server.test.ts
+++ b/test/msw/__tests__/server.test.ts
@@ -54,4 +54,18 @@ describe("msw server handlers", () => {
     const json = await res.json();
     expect(json).toEqual({});
   });
+
+  test("GET /api/publish-locations returns sample data", async () => {
+    const res = await fetch("http://localhost/api/publish-locations");
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([
+      {
+        id: "homepage-hero",
+        name: "Homepage hero",
+        path: "homepage/hero",
+        requiredOrientation: "landscape",
+      },
+    ]);
+  });
 });

--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -58,6 +58,19 @@ export const handlers = [
       ctx.body(stream)
     );
   }),
+  rest.get("/api/publish-locations", (_req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.json([
+        {
+          id: "homepage-hero",
+          name: "Homepage hero",
+          path: "homepage/hero",
+          requiredOrientation: "landscape",
+        },
+      ])
+    )
+  ),
   // Allow cart API requests to reach fetch mocks or the real network.
   //
   // Using relative paths here ensures requests like `/api/cart` – which the


### PR DESCRIPTION
## Summary
- mock /api/publish-locations in shared MSW server
- test publish locations handler

## Testing
- `pnpm exec jest packages/ui/__tests__/ProductEditorForm.test.tsx test/msw/__tests__/server.test.ts`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*

------
https://chatgpt.com/codex/tasks/task_e_68c52584e914832f9013011778a37ae1