### PR TITLE
Mock translations in BlockEditors test to silence warnings

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -15,6 +15,10 @@ import FeaturedProductEditor from "../FeaturedProductEditor";
 import FormBuilderEditor from "../FormBuilderEditor";
 import ProductBundleEditor from "../ProductBundleEditor";
 
+jest.mock("@acme/i18n", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
 jest.mock("../ImagePicker", () => ({
   __esModule: true,
   default: ({ children }: any) => <>{children}</>,


### PR DESCRIPTION
## Summary
- mock `useTranslations` in BlockEditors test to avoid missing translation warnings

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5256f5ee8832faa9878be4ba924bf