### PR TITLE
test(ui): add onChange handler in textarea test

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
@@ -86,7 +86,14 @@ describe("Textarea", () => {
   });
 
   it("floats label when controlled value is set", () => {
-    render(<Textarea label="Message" floatingLabel value="Hello" />);
+    render(
+      <Textarea
+        label="Message"
+        floatingLabel
+        value="Hello"
+        onChange={() => {}}
+      />
+    );
     const label = screen.getByText("Message");
     expect(label).toHaveClass("-translate-y-3", "text-xs");
   });


### PR DESCRIPTION
## Summary
- provide a noop `onChange` handler for controlled `Textarea` test to avoid React's read-only warning

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c525a51c0c832fbd43966babd2e250