### PR TITLE
test: wrap pending timers in act

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx
@@ -28,7 +28,9 @@ describe("CountdownTimer", () => {
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
     jest.clearAllMocks();
   });


### PR DESCRIPTION
## Summary
- wrap `runOnlyPendingTimers` in `act` to prevent unwrapped state updates in CountdownTimer tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @acme/ui run test -- src/components/cms/blocks/__tests__/CountdownTimer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c525b7adb4832fb8ef4650c19215f1