### PR TITLE
test(ui): add HeaderBlock prop forwarding tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/HeaderBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/HeaderBlock.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import HeaderBlock from "../HeaderBlock";
+
+jest.mock("../../../organisms/Header", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Header: jest.fn((props) => <div data-testid="header" {...props} />),
+  };
+});
+
+const { Header } = require("../../../organisms/Header") as {
+  Header: jest.Mock;
+};
+
+describe("HeaderBlock", () => {
+  afterEach(() => {
+    Header.mockClear();
+  });
+
+  it("passes empty nav array and forwards shopName and locale", () => {
+    render(<HeaderBlock shopName="Shop" locale="en" />);
+    expect(Header).toHaveBeenCalledTimes(1);
+    expect(Header.mock.calls[0][0]).toEqual({
+      nav: [],
+      logoVariants: undefined,
+      shopName: "Shop",
+      locale: "en",
+    });
+  });
+
+  it("forwards provided nav and logoVariants", () => {
+    const nav = [{ title: "Home", href: "/" }];
+    const logoVariants = { desktop: { src: "logo.png" } };
+    render(
+      <HeaderBlock
+        nav={nav}
+        logoVariants={logoVariants}
+        shopName="Shop"
+        locale="en"
+      />,
+    );
+    expect(Header).toHaveBeenCalledTimes(1);
+    expect(Header.mock.calls[0][0]).toEqual({
+      nav,
+      logoVariants,
+      shopName: "Shop",
+      locale: "en",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test HeaderBlock passes default empty nav and forwards shopName/locale
- test nav and logoVariants props are relayed to Header

## Testing
- `pnpm -r build` (fails: Type '({ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: ... } | null)[]' is not assignable to type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: ... }[]')
- `pnpm --filter @acme/ui test -- src/components/cms/blocks/__tests__/HeaderBlock.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5277f6118832fac396fc5ba0318ed