### PR TITLE
test(announcement-bar): handle link change

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -128,6 +128,14 @@ describe("block editors", () => {
     fireEvent.change(screen.getByPlaceholderText(placeholder), {
       target: { value: "x" },
     });
-    expect(onChange).toHaveBeenCalled();
+    if (_name === "AnnouncementBarEditor") {
+      const url = "https://example.com";
+      fireEvent.change(screen.getByPlaceholderText("link"), {
+        target: { value: url },
+      });
+      expect(onChange).toHaveBeenLastCalledWith({ link: url });
+    } else {
+      expect(onChange).toHaveBeenCalled();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- extend AnnouncementBarEditor test to cover link input

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core build)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test -- src/components/cms/page-builder/__tests__/BlockEditors.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c534db4c14832f86fd29f8526f1c96