### PR TITLE
test: cover block without animation

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/Block.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/Block.test.tsx
@@ -85,5 +85,14 @@ describe("Block", () => {
     );
     expect(screen.getByTestId("foo").parentElement).toHaveClass(className);
   });
+
+  it("does not wrap block or apply animation class when animation is undefined", () => {
+    const { container } = render(
+      <Block component={{ id: "7", type: "Foo" as any }} locale="en" />,
+    );
+    const element = screen.getByTestId("foo");
+    expect(container.firstChild).toBe(element);
+    expect(container.querySelector('[class*="pb-animate-"]')).toBeNull();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression test ensuring blocks without animation value are not wrapped or given pb-animate classes

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runInBand --collectCoverage=false src/components/cms/page-builder/__tests__/Block.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c534dceb48832f9cdf71bbe8d44570