### PR TITLE
test: add GridSettings tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/GridSettings.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/GridSettings.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import GridSettings from "../GridSettings";
+
+describe("GridSettings", () => {
+  it("calls toggleGrid when button clicked", () => {
+    const toggleGrid = jest.fn();
+    const setGridCols = jest.fn();
+    render(
+      <GridSettings
+        showGrid={false}
+        toggleGrid={toggleGrid}
+        gridCols={4}
+        setGridCols={setGridCols}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Show grid" });
+    fireEvent.click(button);
+    expect(toggleGrid).toHaveBeenCalled();
+  });
+
+  it("parses input value as number", () => {
+    const toggleGrid = jest.fn();
+    const setGridCols = jest.fn();
+    render(
+      <GridSettings
+        showGrid
+        toggleGrid={toggleGrid}
+        gridCols={8}
+        setGridCols={setGridCols}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "12" } });
+    expect(setGridCols).toHaveBeenCalledWith(12);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test GridSettings toggling grid display
- test parsing grid column input

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/page-builder/__tests__/GridSettings.test.tsx --runInBand --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c534e251a4832f8bc66329105debf9