### PR TITLE
test: ensure undefined when clearing numeric field

### DIFF
--- a/packages/ui/src/components/cms/page-builder/panels/__tests__/ContentPanel.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/panels/__tests__/ContentPanel.test.tsx
@@ -152,6 +152,38 @@ describe("ContentPanel", () => {
     );
   });
 
+  test("forwards undefined to onChange when clearing numeric field", () => {
+    const handlers = {
+      onChange: jest.fn(),
+      handleInput: (field: any, value: any) => {
+        handlers.onChange({ [field]: value });
+      },
+    };
+
+    render(
+      <ContentPanel
+        component={{
+          id: "cClear2",
+          type: "Widget",
+          minItems: 1,
+          maxItems: 2,
+        } as any}
+        {...handlers}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Min Items"), {
+      target: { value: "abc" },
+    });
+    fireEvent.change(screen.getByLabelText("Min Items"), {
+      target: { value: "" },
+    });
+
+    expect(handlers.onChange).toHaveBeenLastCalledWith({
+      minItems: undefined,
+    });
+  });
+
   test("loads specific editor or fallback", async () => {
     const { rerender } = render(
       <ContentPanel


### PR DESCRIPTION
## Summary
- test that ContentPanel propagates undefined via onChange when clearing numeric item field

## Testing
- `pnpm --filter @acme/ui test`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c534dec9f8832fa1efe4ed64812715