### PR TITLE
test: cover mobile and tablet items

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/AdditionalEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/AdditionalEditors.test.tsx
@@ -162,6 +162,22 @@ describe("additional editors", () => {
       expected: { endpoint: "api" },
     },
     {
+      name: "RecommendationCarouselEditor tabletItems",
+      Comp: RecommendationCarouselEditor,
+      component: { type: "RecommendationCarousel", endpoint: "", desktopItems: 0, tabletItems: 0, mobileItems: 0 },
+      getNode: () => screen.getByLabelText("Tablet Items"),
+      fire: (node: HTMLElement) => fireEvent.change(node, { target: { value: "2" } }),
+      expected: { tabletItems: 2 },
+    },
+    {
+      name: "RecommendationCarouselEditor mobileItems",
+      Comp: RecommendationCarouselEditor,
+      component: { type: "RecommendationCarousel", endpoint: "", desktopItems: 0, tabletItems: 0, mobileItems: 0 },
+      getNode: () => screen.getByLabelText("Mobile Items"),
+      fire: (node: HTMLElement) => fireEvent.change(node, { target: { value: "3" } }),
+      expected: { mobileItems: 3 },
+    },
+    {
       name: "SearchBarEditor",
       Comp: SearchBarEditor,
       component: { type: "SearchBar", placeholder: "", limit: undefined },


### PR DESCRIPTION
## Summary
- test RecommendationCarouselEditor tablet items
- test RecommendationCarouselEditor mobile items

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test` *(fails: Could not locate module @acme/i18n/src/en.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c534de32e8832faa9cce90f883915e