### PR TITLE
test: silence CheckoutForm console errors

### DIFF
--- a/packages/ui/__tests__/CheckoutForm.test.tsx
+++ b/packages/ui/__tests__/CheckoutForm.test.tsx
@@ -8,6 +8,7 @@ const confirmPayment = jest.fn();
 const push = jest.fn();
 const useStripeMock = jest.fn();
 const useElementsMock = jest.fn();
+let consoleError: jest.SpyInstance;
 
 jest.mock("@acme/i18n", () => ({
   useTranslations: () => (key: string) => key,
@@ -50,6 +51,11 @@ beforeEach(() => {
   (RHF.useForm as jest.Mock).mockImplementation(
     (jest.requireActual("react-hook-form") as any).useForm
   );
+  consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
 });
 
 describe("CheckoutForm", () => {


### PR DESCRIPTION
## Summary
- silence CheckoutForm tests by mocking `console.error`

## Testing
- `pnpm -r build` *(fails: TypeScript errors in platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/CheckoutForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c537e268b8832fbac6b1b0a6cd5cd6