### PR TITLE
test: strip unsupported next/image props from mock

### DIFF
--- a/test/resetNextMocks.js
+++ b/test/resetNextMocks.js
@@ -1,7 +1,9 @@
 import React from "react";
 jest.mock("next/image", () => ({
     __esModule: true,
-    default: (props) => React.createElement("img", props),
+    // Strip Next.js specific props that aren't valid on a normal `<img>` to
+    // avoid React warnings during tests.
+    default: ({ unoptimized, priority, fill, ...rest }) => React.createElement("img", rest),
 }));
 jest.mock("next/link", () => ({
     __esModule: true,

--- a/test/resetNextMocks.ts
+++ b/test/resetNextMocks.ts
@@ -2,7 +2,13 @@ import React from "react";
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: (props: any) => React.createElement("img", props),
+  // The real `next/image` component accepts a number of props that aren't
+  // valid on a standard `<img>` element. Passing them through in tests causes
+  // React to log warnings like "Received `true` for a non-boolean attribute
+  // `unoptimized`". Strip those props before rendering a plain `<img>` to keep
+  // the test output clean.
+  default: ({ unoptimized, priority, fill, ...rest }: any) =>
+    React.createElement("img", rest),
 }));
 
 jest.mock("next/link", () => ({


### PR DESCRIPTION
## Summary
- ensure next/image test mock omits unsupported props like `unoptimized`

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm --filter @acme/ui test packages/ui/src/components/account/__tests__/MfaSetup.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c537eec2cc832fb6b35653f1b00bd3