### PR TITLE
fix: correct i18n import paths in ComponentEditor tests

### DIFF
--- a/packages/ui/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/__tests__/ComponentEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, fireEvent, act } from "@testing-library/react";
 import { TranslationsProvider } from "@acme/i18n";
-import en from "@acme/i18n/src/en.json";
+import en from "@acme/i18n/en.json";
 import ComponentEditor from "../src/components/cms/page-builder/ComponentEditor";
 import type { PageComponent } from "@acme/types";
 

--- a/packages/ui/src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { TranslationsProvider } from "@acme/i18n";
-import en from "@acme/i18n/src/en.json";
+import en from "@acme/i18n/en.json";
 import ComponentEditor from "../ComponentEditor";
 
 describe("ComponentEditor", () => {


### PR DESCRIPTION
## Summary
- fix ComponentEditor test imports to use `@acme/i18n/en.json`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest src/components/cms/page-builder/__tests__/ComponentEditor.test.tsx __tests__/ComponentEditor.test.tsx --config ../../jest.config.cjs --runInBand`
- `pnpm --filter @acme/ui test` *(fails: Unable to find an element by: [data-cy="price"])*

------
https://chatgpt.com/codex/tasks/task_e_68c537f87940832f94a82560155ed164