### PR TITLE
fix: pass correct tokenKey to FontToken

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx
@@ -9,6 +9,7 @@ describe("FontToken", () => {
   const renderToken = (props: Partial<React.ComponentProps<typeof FontToken>> = {}) =>
     render(
       FontToken({
+        tokenKey,
         key: tokenKey,
         value: "Arial",
         defaultValue: "Arial",


### PR DESCRIPTION
## Summary
- ensure FontToken tests supply the `tokenKey` prop so callbacks receive the expected value

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type... in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui lint` *(fails: React Hook useCallback has missing dependencies, unexpected any, etc.)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5380ffb70832fb21b83550aa73420