### PR TITLE
test: strip next/image fill prop from mock

### DIFF
--- a/test/resetNextMocks.js
+++ b/test/resetNextMocks.js
@@ -1,7 +1,9 @@
 import React from "react";
 jest.mock("next/image", () => ({
     __esModule: true,
-    default: (props) => React.createElement("img", props),
+    // Remove the `fill` prop which Next.js handles internally so it isn't
+    // forwarded to the underlying `<img>` and triggering React warnings.
+    default: ({ fill: _fill, ...props }) => React.createElement("img", props),
 }));
 jest.mock("next/link", () => ({
     __esModule: true,

--- a/test/resetNextMocks.ts
+++ b/test/resetNextMocks.ts
@@ -2,7 +2,12 @@ import React from "react";
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: (props: any) => React.createElement("img", props),
+  // The real `next/image` component consumes the `fill` prop internally
+  // and does not forward it to the underlying `<img>` element. Our test
+  // mock mimics that behaviour by stripping the prop so React doesn't log
+  // a warning about an unknown DOM attribute.
+  default: ({ fill: _fill, ...props }: any) =>
+    React.createElement("img", props),
 }));
 
 jest.mock("next/link", () => ({


### PR DESCRIPTION
## Summary
- avoid passing `fill` to mocked `next/image` so tests don't emit DOM warnings

## Testing
- `pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx --config jest.config.cjs`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*


------
https://chatgpt.com/codex/tasks/task_e_68c5383c41e4832f90f3bff9c885a0bf