### PR TITLE
test: silence shopselector error

### DIFF
--- a/packages/ui/__tests__/ShopSelector.test.tsx
+++ b/packages/ui/__tests__/ShopSelector.test.tsx
@@ -106,6 +106,9 @@ describe("ShopSelector", () => {
   });
 
   it("falls back to error text when fetch rejects", async () => {
+    const consoleErrorMock = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const fetchMock = jest
       .spyOn(global, "fetch")
       .mockRejectedValueOnce(new Error("Network error"));
@@ -115,6 +118,7 @@ describe("ShopSelector", () => {
     expect(await screen.findByText("Network error")).toBeInTheDocument();
     expect(screen.queryByTestId("shop-select")).not.toBeInTheDocument();
     fetchMock.mockRestore();
+    consoleErrorMock.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- silence console error in ShopSelector reject test by mocking `console.error`

## Testing
- `pnpm exec jest packages/ui/__tests__/ShopSelector.test.tsx --config jest.config.cjs`
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c538457e00832fa2c643289baf72bb