### PR TITLE
fix: provide onChange handler for controlled Switch

### DIFF
--- a/packages/ui/src/components/atoms/__tests__/Switch.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/Switch.test.tsx
@@ -15,7 +15,7 @@ describe("Switch", () => {
   });
 
   it("supports controlled checked prop", () => {
-    render(<Switch checked />);
+    render(<Switch checked onChange={() => {}} />);
     expect(screen.getByRole("checkbox")).toBeChecked();
   });
 


### PR DESCRIPTION
## Summary
- add no-op onChange handler to Switch controlled test to avoid React warning

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/src/components/atoms/__tests__/Switch.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c5385107b8832f98f3dab88d39c476