### PR TITLE
fix: filter next/image fill prop in tests

### DIFF
--- a/test/resetNextMocks.js
+++ b/test/resetNextMocks.js
@@ -1,7 +1,8 @@
 import React from "react";
 jest.mock("next/image", () => ({
     __esModule: true,
-    default: (props) => React.createElement("img", props),
+    // Strip Next.js-specific props like `fill` to prevent DOM warnings
+    default: ({ fill, ...props }) => React.createElement("img", props),
 }));
 jest.mock("next/link", () => ({
     __esModule: true,

--- a/test/resetNextMocks.ts
+++ b/test/resetNextMocks.ts
@@ -2,7 +2,8 @@ import React from "react";
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: (props: any) => React.createElement("img", props),
+  // Omit Next.js-specific props like `fill` to avoid React warnings
+  default: ({ fill, ...props }: any) => React.createElement("img", props),
 }));
 
 jest.mock("next/link", () => ({


### PR DESCRIPTION
## Summary
- filter the `fill` prop from the `next/image` Jest mock to avoid React warnings during tests
- update generated JS mock to match

## Testing
- `pnpm install`
- `pnpm --filter @acme/ui run build`
- `pnpm exec jest packages/ui/src/components/molecules/__tests__/Image360Viewer.test.tsx --config jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c53862ba84832f88a6e2d4c925ef75