### PR TITLE
Warn missing translations only in development

### DIFF
--- a/packages/i18n/__tests__/Translations.test.tsx
+++ b/packages/i18n/__tests__/Translations.test.tsx
@@ -18,6 +18,8 @@ describe("Translations", () => {
   });
 
   it("falls back to default when key missing", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     render(
@@ -32,6 +34,7 @@ describe("Translations", () => {
     );
 
     warnSpy.mockRestore();
+    process.env.NODE_ENV = original;
   });
 
   it("switching locale re-renders content", () => {

--- a/packages/i18n/__tests__/translations-provider.test.tsx
+++ b/packages/i18n/__tests__/translations-provider.test.tsx
@@ -19,6 +19,8 @@ describe("TranslationsProvider and useTranslations", () => {
   });
 
   it("falls back to the key and warns when a translation is missing", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     render(
@@ -33,6 +35,7 @@ describe("TranslationsProvider and useTranslations", () => {
     );
 
     warnSpy.mockRestore();
+    process.env.NODE_ENV = original;
   });
 
   it("memoises the translation function and updates when messages change", () => {

--- a/packages/i18n/src/Translations.tsx
+++ b/packages/i18n/src/Translations.tsx
@@ -120,7 +120,9 @@ export function useTranslations(): (
   return useCallback(
     (key: string, vars?: Record<string, ReactNode>): ReactNode => {
       if (messages[key] === undefined) {
-        console.warn(`Missing translation for key: ${key}`);
+        if (process.env.NODE_ENV === "development") {
+          console.warn(`Missing translation for key: ${key}`);
+        }
         return key;
       }
 

--- a/packages/i18n/src/__tests__/Translations.provider.test.tsx
+++ b/packages/i18n/src/__tests__/Translations.provider.test.tsx
@@ -30,6 +30,8 @@ describe("TranslationsProvider", () => {
   });
 
   it("falls back to key and warns when missing", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     const { getByText } = render(
       <TranslationsProvider messages={{}}>
@@ -39,6 +41,7 @@ describe("TranslationsProvider", () => {
     getByText("missing");
     expect(warn).toHaveBeenCalledWith("Missing translation for key: missing");
     warn.mockRestore();
+    process.env.NODE_ENV = original;
   });
 });
 

--- a/packages/i18n/src/__tests__/Translations.test.tsx
+++ b/packages/i18n/src/__tests__/Translations.test.tsx
@@ -85,6 +85,8 @@ describe("TranslationsProvider and useTranslations", () => {
   });
 
   it("warns and falls back to the key when translation is missing", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     const wrapper = ({ children }: PropsWithChildren) => (
       <TranslationsProvider messages={{}}>{children}</TranslationsProvider>
@@ -93,9 +95,12 @@ describe("TranslationsProvider and useTranslations", () => {
     expect(result.current("unknown")).toBe("unknown");
     expect(warn).toHaveBeenCalledWith("Missing translation for key: unknown");
     warn.mockRestore();
+    process.env.NODE_ENV = original;
   });
 
   it("warns and falls back when missing translation includes variables", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     const wrapper = ({ children }: PropsWithChildren) => (
       <TranslationsProvider messages={{}}>{children}</TranslationsProvider>
@@ -105,6 +110,7 @@ describe("TranslationsProvider and useTranslations", () => {
     expect(result.current("unknown", { name: "Sam" })).toBe("unknown");
     expect(warn).toHaveBeenCalledWith("Missing translation for key: unknown");
     warn.mockRestore();
+    process.env.NODE_ENV = original;
   });
 
   it("interpolates placeholders when variables are provided", () => {


### PR DESCRIPTION
## Summary
- warn about missing translations only when `NODE_ENV` is `development`
- adjust i18n tests to set `NODE_ENV` when checking warning behavior

## Testing
- `pnpm --filter @acme/i18n run clean`
- `pnpm --filter @acme/i18n run build`
- `pnpm --filter @acme/i18n test`
- `pnpm --filter @acme/template-app test`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c538a1cf34832fbbb57309fe429e1d