### PR TITLE
test: add customer profile delegate tests

### DIFF
--- a/packages/platform-core/src/__tests__/customerProfile.stub.test.ts
+++ b/packages/platform-core/src/__tests__/customerProfile.stub.test.ts
@@ -37,6 +37,32 @@ describe("createCustomerProfileDelegate", () => {
     ).resolves.toEqual({ customerId: "c2", name: "Bob", email: "a@example.com" });
   });
 
+  it("findFirst returns null when no profile matches the email", async () => {
+    const delegate = createCustomerProfileDelegate();
+    await delegate.upsert({
+      where: { customerId: "c1" },
+      create: { customerId: "c1", name: "Alice", email: "alice@example.com" },
+      update: {},
+    });
+
+    await expect(
+      delegate.findFirst({ where: { email: "bob@example.com" } }),
+    ).resolves.toBeNull();
+  });
+
+  it("upsert creates a new profile when customerId does not exist", async () => {
+    const delegate = createCustomerProfileDelegate();
+    const profile = { customerId: "c1", name: "Alice", email: "alice@example.com" };
+
+    await expect(
+      delegate.upsert({
+        where: { customerId: "c1" },
+        create: profile,
+        update: { name: "ignored" },
+      }),
+    ).resolves.toEqual(profile);
+  });
+
   it("upsert updates an existing profile", async () => {
     const delegate = createCustomerProfileDelegate();
 


### PR DESCRIPTION
## Summary
- add test for findFirst returning null when no email match
- add test for upserting new customer profile

## Testing
- `pnpm exec jest --runTestsByPath src/__tests__/customerProfile.stub.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c54054ba30832fbe8d25acb48dfb82