### PR TITLE
test: add createMany reverse logistics event test

### DIFF
--- a/packages/platform-core/src/__tests__/reverseLogisticsEvent.stub.test.ts
+++ b/packages/platform-core/src/__tests__/reverseLogisticsEvent.stub.test.ts
@@ -19,6 +19,28 @@ describe("reverseLogisticsEvent stub", () => {
     );
   });
 
+  it("createMany stores multiple events", async () => {
+    const delegate = createReverseLogisticsEventDelegate();
+
+    const result = await delegate.createMany({
+      data: [
+        { id: "m1", type: "received" },
+        { id: "m2", type: "repair" },
+      ],
+    });
+
+    expect(result).toEqual({ count: 2 });
+
+    const events = await delegate.findMany({ where: {} });
+    expect(events).toHaveLength(2);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "m1", type: "received" }),
+        expect.objectContaining({ id: "m2", type: "repair" }),
+      ]),
+    );
+  });
+
   it("findMany filters by given criteria", async () => {
     const delegate = createReverseLogisticsEventDelegate();
 


### PR DESCRIPTION
## Summary
- add coverage for `createMany` reverse logistics events stub

## Testing
- `pnpm -r build` *(fails: TS2322 - null is not assignable to type)*
- `pnpm exec jest packages/platform-core/src/__tests__/reverseLogisticsEvent.stub.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c5405701d4832f9d059892774a04fb