### PR TITLE
test: cache products repo

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/products.server.prisma.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/products.server.prisma.test.ts
@@ -3,16 +3,19 @@ import { jest } from "@jest/globals";
 describe("products repository via prisma", () => {
   const shop = "demo";
   let repo: { write: jest.Mock; duplicate: jest.Mock };
+  let resolveRepo: jest.Mock;
 
   beforeEach(() => {
     jest.resetModules();
     repo = { write: jest.fn(), duplicate: jest.fn() };
+    resolveRepo = jest.fn().mockResolvedValue(repo);
     process.env.PRODUCTS_BACKEND = "prisma";
     process.env.DATABASE_URL = "postgres://example";
     jest.doMock("../../db", () => ({ prisma: { product: {} } }));
     jest.doMock("../products.prisma.server", () => ({
       prismaProductsRepository: repo,
     }));
+    jest.doMock("../repoResolver", () => ({ resolveRepo }));
   });
 
   afterEach(() => {
@@ -30,6 +33,18 @@ describe("products repository via prisma", () => {
   it("duplicateProductInRepo forwards shop and id to repo.duplicate", async () => {
     const { duplicateProductInRepo } = await import("../products.server");
     await duplicateProductInRepo(shop, "1");
+    expect(repo.duplicate).toHaveBeenCalledWith(shop, "1");
+  });
+
+  it("caches repo across calls", async () => {
+    const { writeRepo, duplicateProductInRepo } = await import(
+      "../products.server",
+    );
+    const catalogue = [{ id: "1" } as any];
+    await writeRepo(shop, catalogue);
+    await duplicateProductInRepo(shop, "1");
+    expect(resolveRepo).toHaveBeenCalledTimes(1);
+    expect(repo.write).toHaveBeenCalledWith(shop, catalogue);
     expect(repo.duplicate).toHaveBeenCalledWith(shop, "1");
   });
 });


### PR DESCRIPTION
## Summary
- ensure prisma repo resolves once and is reused across write and duplicate operations
- confirm writeRepo and duplicateProductInRepo invoke underlying prisma repository

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/repositories/__tests__/products.server.prisma.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5406b02bc832fb1384d814118bae4