### PR TITLE
test(ui): restore checkbox tests and toggle cycle

### DIFF
--- a/packages/ui/src/components/atoms/primitives/__tests__/checkbox.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/checkbox.test.tsx
@@ -15,17 +15,23 @@ describe("Checkbox", () => {
     expect(checkbox).toHaveAttribute("data-state", "checked");
   });
 
-  it("calls onCheckedChange when toggled", async () => {
+  it("calls onCheckedChange and updates indicator through toggle cycle", async () => {
     const onCheckedChange = jest.fn();
     render(<Checkbox onCheckedChange={onCheckedChange} />);
-    const user = userEvent.setup();
     const checkbox = screen.getByRole("checkbox");
+    const user = userEvent.setup();
+
+    expect(checkbox.querySelector("svg")).toBeNull();
 
     await user.click(checkbox);
-    await user.click(checkbox);
-
+    expect(checkbox).toHaveAttribute("data-state", "checked");
     expect(onCheckedChange).toHaveBeenNthCalledWith(1, true);
+    expect(checkbox.querySelector("svg")).not.toBeNull();
+
+    await user.click(checkbox);
+    expect(checkbox).toHaveAttribute("data-state", "unchecked");
     expect(onCheckedChange).toHaveBeenNthCalledWith(2, false);
+    expect(checkbox.querySelector("svg")).toBeNull();
   });
 
   it("merges custom className", () => {


### PR DESCRIPTION
## Summary
- reinstate removed checkbox tests
- verify full toggle cycle updates data-state, onCheckedChange, and indicator

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/ui/src/components/atoms/primitives/checkbox.test.tsx` *(fails: Missing task)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/atoms/primitives/__tests__/checkbox.test.tsx --config ../../jest.config.cjs --runInBand --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c5407bdb68832f9f673564641a85a1