### PR TITLE
feat(ui): extend boxProps coverage for responsive styles

### DIFF
--- a/packages/ui/src/utils/style/__tests__/boxProps.test.ts
+++ b/packages/ui/src/utils/style/__tests__/boxProps.test.ts
@@ -37,6 +37,12 @@ describe("boxProps", () => {
     expect(result.style).toEqual({ width: 200, height: "100%" });
   });
 
+  it("uses style when height is a non-tailwind string", () => {
+    const result = boxProps({ height: "40px" });
+    expect(result.classes).toBe("");
+    expect(result.style).toEqual({ height: "40px" });
+  });
+
   it("uses style for percentage width values", () => {
     const result = boxProps({ width: "50%" });
     expect(result.classes).toBe("");
@@ -53,12 +59,27 @@ describe("boxProps", () => {
     expect(result.classes).toBe("md:p-4");
   });
 
+  it("includes responsive width and height utility classes", () => {
+    const result = boxProps({ width: "md:w-10", height: "lg:h-20" });
+    expect(result).toEqual({ classes: "md:w-10 lg:h-20", style: {} });
+  });
+
   it("aggregates padding class when only padding provided", () => {
     expect(boxProps({ padding: "p-4" })).toEqual({ classes: "p-4", style: {} });
   });
 
   it("aggregates margin class when only margin provided", () => {
     expect(boxProps({ margin: "m-2" })).toEqual({ classes: "m-2", style: {} });
+  });
+
+  it("aggregates padding and margin classes together", () => {
+    const result = boxProps({ padding: "p-2", margin: "m-3" });
+    expect(result).toEqual({ classes: "p-2 m-3", style: {} });
+  });
+
+  it("preserves zero width and height in style", () => {
+    const result = boxProps({ width: 0, height: 0 });
+    expect(result).toEqual({ classes: "", style: { width: 0, height: 0 } });
   });
 
   it("mixes class and style when only one dimension uses tailwind", () => {

--- a/packages/ui/src/utils/style/boxProps.ts
+++ b/packages/ui/src/utils/style/boxProps.ts
@@ -11,7 +11,7 @@ export function boxProps({ width, height, padding, margin }: BoxOptions) {
   const style: React.CSSProperties = {};
 
   if (width !== undefined) {
-    if (typeof width === "string" && width.startsWith("w-")) {
+    if (typeof width === "string" && (width.startsWith("w-") || width.includes(":w-"))) {
       classes.push(width);
     } else {
       style.width = width;
@@ -19,7 +19,7 @@ export function boxProps({ width, height, padding, margin }: BoxOptions) {
   }
 
   if (height !== undefined) {
-    if (typeof height === "string" && height.startsWith("h-")) {
+    if (typeof height === "string" && (height.startsWith("h-") || height.includes(":h-"))) {
       classes.push(height);
     } else {
       style.height = height;


### PR DESCRIPTION
## Summary
- handle responsive width and height classes in `boxProps`
- expand test coverage for `boxProps`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/src/utils/style/__tests__/boxProps.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c54089f5b0832f86f46937a5f7e1a9