### PR TITLE
Add email env coercion and provider validation tests

### DIFF
--- a/packages/config/__tests__/email-env.test.ts
+++ b/packages/config/__tests__/email-env.test.ts
@@ -7,12 +7,15 @@ describe("email-env", () => {
   });
 
   describe("SMTP_PORT", () => {
-    it("accepts numeric strings", async () => {
+    it.each([
+      ["587", 587],
+      [" 25 ", 25],
+    ])("coerces %p to number %p", async (input, expected) => {
       const { emailEnv } = await withEnv(
-        { SMTP_PORT: "587" },
+        { SMTP_PORT: input },
         () => import("../src/env/email"),
       );
-      expect(emailEnv.SMTP_PORT).toBe(587);
+      expect(emailEnv.SMTP_PORT).toBe(expected);
     });
 
     it("rejects non-numeric values", async () => {
@@ -29,6 +32,8 @@ describe("email-env", () => {
       ["true", true],
       ["false", false],
       ["yes", true],
+      ["no", false],
+      ["1", true],
       ["0", false],
     ])("parses %p", async (input, expected) => {
       const { emailEnv } = await withEnv(
@@ -66,26 +71,81 @@ describe("email-env", () => {
   });
 
   describe("provider requirements", () => {
+    it.each([
+      ["smtp", {}],
+      ["sendgrid", { SENDGRID_API_KEY: "sg" }],
+      ["resend", { RESEND_API_KEY: "rk" }],
+    ])(
+      "requires EMAIL_FROM when EMAIL_PROVIDER=%s",
+      async (provider, extras) => {
+        const spy = jest
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        await expect(
+          withEnv(
+            { EMAIL_PROVIDER: provider as string, EMAIL_FROM: undefined, ...extras },
+            () => import("../src/env/email"),
+          ),
+        ).rejects.toThrow("Invalid email environment variables");
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toBe(
+          "❌ Invalid email environment variables:",
+        );
+        const err = spy.mock.calls[0][1];
+        expect(err.EMAIL_FROM._errors).toContain("Required");
+        spy.mockRestore();
+      },
+    );
+
+    it("allows missing EMAIL_FROM for noop provider", async () => {
+      const { emailEnv } = await withEnv(
+        { EMAIL_PROVIDER: "noop", EMAIL_FROM: undefined },
+        () => import("../src/env/email"),
+      );
+      expect(emailEnv.EMAIL_PROVIDER).toBe("noop");
+      expect(emailEnv.EMAIL_FROM).toBeUndefined();
+    });
+
     it("errors when SENDGRID_API_KEY is missing", async () => {
       const spy = jest.spyOn(console, "error").mockImplementation(() => {});
       await expect(
         withEnv(
-          { EMAIL_PROVIDER: "sendgrid", EMAIL_FROM: "from@example.com" },
+          {
+            EMAIL_PROVIDER: "sendgrid",
+            EMAIL_FROM: "from@example.com",
+            SENDGRID_API_KEY: undefined,
+          },
           () => import("../src/env/email"),
         ),
       ).rejects.toThrow("Invalid email environment variables");
       expect(spy).toHaveBeenCalled();
+      expect(spy.mock.calls[0][0]).toBe(
+          "❌ Invalid email environment variables:",
+      );
+      const err = spy.mock.calls[0][1];
+      expect(err.SENDGRID_API_KEY._errors).toContain("Required");
+      spy.mockRestore();
     });
 
     it("errors when RESEND_API_KEY is missing", async () => {
       const spy = jest.spyOn(console, "error").mockImplementation(() => {});
       await expect(
         withEnv(
-          { EMAIL_PROVIDER: "resend", EMAIL_FROM: "from@example.com" },
+          {
+            EMAIL_PROVIDER: "resend",
+            EMAIL_FROM: "from@example.com",
+            RESEND_API_KEY: undefined,
+          },
           () => import("../src/env/email"),
         ),
       ).rejects.toThrow("Invalid email environment variables");
       expect(spy).toHaveBeenCalled();
+      expect(spy.mock.calls[0][0]).toBe(
+          "❌ Invalid email environment variables:",
+      );
+      const err = spy.mock.calls[0][1];
+      expect(err.RESEND_API_KEY._errors).toContain("Required");
+      spy.mockRestore();
     });
 
     it("succeeds when required keys provided", async () => {


### PR DESCRIPTION
## Summary
- test SMTP_PORT numeric conversion and SMTP_SECURE boolean parsing
- verify EMAIL_PROVIDER-specific required variables and error logging

## Testing
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --filter @acme/config exec jest packages/config/__tests__/email-env.test.ts --runInBand --config jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c540946560832f86ec33b58ea1e165