### PR TITLE
test: cover payments env edge cases

### DIFF
--- a/packages/config/__tests__/loadPaymentsEnv.test.ts
+++ b/packages/config/__tests__/loadPaymentsEnv.test.ts
@@ -6,24 +6,30 @@ afterEach(() => {
 
 describe("loadPaymentsEnv", () => {
   it("returns defaults when gateway disabled", async () => {
-    const { loadPaymentsEnv, paymentsEnvSchema } = await import("../src/env/payments");
+    const { loadPaymentsEnv, paymentsEnvSchema } = await import(
+      "../src/env/payments"
+    );
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const env = loadPaymentsEnv({
       PAYMENTS_GATEWAY: "disabled",
       PAYMENTS_PROVIDER: "paypal",
       STRIPE_SECRET_KEY: "",
     } as NodeJS.ProcessEnv);
     expect(env).toEqual(paymentsEnvSchema.parse({}));
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
   });
 
   it("throws for unsupported provider", async () => {
     const { loadPaymentsEnv } = await import("../src/env/payments");
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     expect(() =>
-      loadPaymentsEnv({ PAYMENTS_PROVIDER: "paypal" } as NodeJS.ProcessEnv),
+      loadPaymentsEnv({ PAYMENTS_PROVIDER: "paypal" } as NodeJS.ProcessEnv)
     ).toThrow("Invalid payments environment variables");
     expect(spy).toHaveBeenCalledWith(
       "❌ Unsupported PAYMENTS_PROVIDER:",
-      "paypal",
+      "paypal"
     );
   });
 
@@ -34,10 +40,25 @@ describe("loadPaymentsEnv", () => {
       loadPaymentsEnv({
         PAYMENTS_PROVIDER: "stripe",
         STRIPE_WEBHOOK_SECRET: "whsec",
-      } as NodeJS.ProcessEnv),
+      } as NodeJS.ProcessEnv)
     ).toThrow("Invalid payments environment variables");
     expect(spy).toHaveBeenCalledWith(
-      "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe",
+      "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe"
+    );
+  });
+
+  it("throws when NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY missing", async () => {
+    const { loadPaymentsEnv } = await import("../src/env/payments");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      loadPaymentsEnv({
+        PAYMENTS_PROVIDER: "stripe",
+        STRIPE_SECRET_KEY: "sk",
+        STRIPE_WEBHOOK_SECRET: "whsec",
+      } as NodeJS.ProcessEnv)
+    ).toThrow("Invalid payments environment variables");
+    expect(spy).toHaveBeenCalledWith(
+      "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe"
     );
   });
 
@@ -49,15 +70,17 @@ describe("loadPaymentsEnv", () => {
         PAYMENTS_PROVIDER: "stripe",
         STRIPE_SECRET_KEY: "sk",
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk",
-      } as NodeJS.ProcessEnv),
+      } as NodeJS.ProcessEnv)
     ).toThrow("Invalid payments environment variables");
     expect(spy).toHaveBeenCalledWith(
-      "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
+      "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe"
     );
   });
 
   it("warns and defaults on invalid currency", async () => {
-    const { loadPaymentsEnv, paymentsEnvSchema } = await import("../src/env/payments");
+    const { loadPaymentsEnv, paymentsEnvSchema } = await import(
+      "../src/env/payments"
+    );
     const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const env = loadPaymentsEnv({
       STRIPE_SECRET_KEY: "sk",
@@ -67,7 +90,7 @@ describe("loadPaymentsEnv", () => {
     } as NodeJS.ProcessEnv);
     expect(spy).toHaveBeenCalledWith(
       "⚠️ Invalid payments environment variables:",
-      expect.any(Object),
+      expect.any(Object)
     );
     expect(env).toEqual(paymentsEnvSchema.parse({}));
   });


### PR DESCRIPTION
## Summary
- ensure disabled payments gateway returns schema defaults without warnings
- add test for missing Stripe publishable key and extend payments env coverage

## Testing
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --filter @acme/config exec jest __tests__/loadPaymentsEnv.test.ts --runInBand --config jest.preset.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c54095a28c832fb843ed545f5c0441