### PR TITLE
test: add shipping env edge cases

### DIFF
--- a/packages/auth/src/__tests__/shippingEnvSchema.test.ts
+++ b/packages/auth/src/__tests__/shippingEnvSchema.test.ts
@@ -37,6 +37,56 @@ describe("shippingEnvSchema", () => {
     ).toThrow();
   });
 
+  it("parses ALLOWED_COUNTRIES list", async () => {
+    const { loadShippingEnv } = await import("@acme/config/env/shipping");
+    const env = loadShippingEnv({
+      ALLOWED_COUNTRIES: "us, ca , ,de,",
+    } as any);
+    expect(env.ALLOWED_COUNTRIES).toEqual(["US", "CA", "DE"]);
+  });
+
+  describe("LOCAL_PICKUP_ENABLED", () => {
+    it.each([
+      ["yes", true],
+      ["no", false],
+      ["1", true],
+      ["0", false],
+    ])("parses %s", async (input, expected) => {
+      const { loadShippingEnv } = await import("@acme/config/env/shipping");
+      const env = loadShippingEnv({
+        LOCAL_PICKUP_ENABLED: input,
+      } as any);
+      expect(env.LOCAL_PICKUP_ENABLED).toBe(expected);
+    });
+  });
+
+  describe("DEFAULT_COUNTRY", () => {
+    it("uppercases value", async () => {
+      const { loadShippingEnv } = await import("@acme/config/env/shipping");
+      const env = loadShippingEnv({ DEFAULT_COUNTRY: " us " } as any);
+      expect(env.DEFAULT_COUNTRY).toBe("US");
+    });
+
+    it("rejects invalid length", async () => {
+      const { loadShippingEnv } = await import("@acme/config/env/shipping");
+      expect(() =>
+        loadShippingEnv({ DEFAULT_COUNTRY: "USA" } as any),
+      ).toThrow();
+    });
+  });
+
+  describe("provider requirements", () => {
+    it("requires keys for ups and dhl", async () => {
+      const { loadShippingEnv } = await import("@acme/config/env/shipping");
+      expect(() =>
+        loadShippingEnv({ SHIPPING_PROVIDER: "ups" } as any),
+      ).toThrow();
+      expect(() =>
+        loadShippingEnv({ SHIPPING_PROVIDER: "dhl" } as any),
+      ).toThrow();
+    });
+  });
+
   it("returns empty object when keys missing", async () => {
     const { loadShippingEnv } = await import("@acme/config/env/shipping");
     const env = loadShippingEnv({} as NodeJS.ProcessEnv);
@@ -55,6 +105,15 @@ describe("shippingEnvSchema", () => {
       await expect(
         withEnv(
           { DEFAULT_SHIPPING_ZONE: "galaxy" },
+          () => import("@acme/config/env/shipping"),
+        ),
+      ).rejects.toThrow("Invalid shipping environment variables");
+    });
+
+    it("throws when provider key missing during import", async () => {
+      await expect(
+        withEnv(
+          { SHIPPING_PROVIDER: "ups" },
           () => import("@acme/config/env/shipping"),
         ),
       ).rejects.toThrow("Invalid shipping environment variables");

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -28,7 +28,7 @@ export const shippingEnvSchema = z
       (v) =>
         v == null
           ? true
-          : /^(true|false|1|0|yes)$/i.test(v.trim()),
+          : /^(true|false|1|0|yes|no)$/i.test(v.trim()),
       {
         message: "must be a boolean",
       },


### PR DESCRIPTION
## Summary
- add comprehensive shipping env tests
- allow "no" for LOCAL_PICKUP_ENABLED

## Testing
- `pnpm install`
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/auth test packages/auth/src/__tests__/shippingEnvSchema.test.ts` (coverage thresholds unmet)


------
https://chatgpt.com/codex/tasks/task_e_68c54096a5b0832faa57fa0458048ebd