### PR TITLE
test(pricing): verify pricing and exchange rate caching

### DIFF
--- a/packages/platform-core/__tests__/pricing.index.test.ts
+++ b/packages/platform-core/__tests__/pricing.index.test.ts
@@ -33,6 +33,19 @@ async function setup(pricingData = defaultPricing, rateData = defaultRates) {
 }
 
 describe("pricing index", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("getPricing caches file reads", async () => {
+    const { getPricing, readFile } = await setup();
+    await getPricing();
+    expect(readFile).toHaveBeenCalledTimes(1);
+    await getPricing();
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
+
   it(
     "convertCurrency handles base currency, missing rate, bankers rounding ties, and floor rounding",
     async () => {
@@ -49,6 +62,14 @@ describe("pricing index", () => {
       );
     },
   );
+
+  it("convertCurrency caches exchange rates", async () => {
+    const { convertCurrency, readFile } = await setup();
+    await convertCurrency(1, "USD");
+    expect(readFile).toHaveBeenCalledTimes(1);
+    await convertCurrency(1, "USD");
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
 
   it("applyDurationDiscount selects the appropriate tier", async () => {
     jest.resetModules();


### PR DESCRIPTION
## Summary
- ensure pricing reads are cached by invoking `getPricing` twice and confirming only one `readFile` call
- verify `loadExchangeRates` caching by calling `convertCurrency` twice without additional file reads
- reset Jest mocks after each test to avoid leakage

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/pricing.index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c543bad984832fb6ca8a70df145d38