### PR TITLE
fix: use data-cy attribute in ProductBundle test

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
@@ -3,7 +3,9 @@ import { render, screen } from "@testing-library/react";
 
 jest.mock("../../../atoms/Price", () => ({
   Price: ({ amount, className }: { amount: number; className?: string }) => (
-    <span data-testid="price" className={className}>{amount}</span>
+    <span data-cy="price" className={className}>
+      {amount}
+    </span>
   ),
 }));
 


### PR DESCRIPTION
## Summary
- align ProductBundle test with Testing Library's `data-cy` attribute

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TS2322 in packages/platform-core)
- `pnpm --filter @acme/ui test -- src/components/cms/blocks/__tests__/ProductBundle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c54573667c832fa127996180535681