### PR TITLE
fix: silence ImagePicker warnings

### DIFF
--- a/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImagePicker.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogTitle,
   DialogTrigger,
   Input,
@@ -74,6 +75,9 @@ function ImagePicker({ onSelect, children }: Props) {
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="max-w-xl space-y-4">
         <DialogTitle>Select image</DialogTitle>
+        <DialogDescription className="sr-only">
+          Choose an image from the media library
+        </DialogDescription>
         <div className="flex items-center gap-2">
           <Input
             ref={inputRef}

--- a/packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ImagePicker.test.tsx
@@ -1,3 +1,4 @@
+import "../../../../../../../test/resetNextMocks";
 import { fireEvent, render, screen } from "@testing-library/react";
 import ImagePicker from "../ImagePicker";
 
@@ -26,8 +27,6 @@ jest.mock("@ui/hooks/useFileUpload", () => () => ({
   handleUpload: jest.fn(),
   error: "",
 }));
-
-jest.mock("next/image", () => (props: any) => <img {...props} />);
 
 describe("ImagePicker", () => {
   it("selects image and calls onSelect", () => {


### PR DESCRIPTION
## Summary
- add accessible description to ImagePicker dialog to satisfy Radix warning
- reuse shared Next.js mocks in ImagePicker tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm --filter ui build` *(fails: TypeScript errors in @acme/ui)*
- `pnpm --filter ui run check:references` *(fails: script missing)*
- `pnpm --filter ui run build:ts` *(fails: script missing)*
- `pnpm --filter ui test src/components/cms/page-builder/__tests__/ImagePicker.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5459dc3f4832fb560acc485a377fc