### PR TITLE
test: avoid unknown prop warnings in HeaderBlock

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/HeaderBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/HeaderBlock.test.tsx
@@ -5,7 +5,7 @@ jest.mock("../../../organisms/Header", () => {
   const React = require("react");
   return {
     __esModule: true,
-    Header: jest.fn((props) => <div data-testid="header" {...props} />),
+    Header: jest.fn(() => <div data-testid="header" />),
   };
 });
 


### PR DESCRIPTION
## Summary
- avoid unknown prop warnings in HeaderBlock test

## Testing
- `pnpm --filter @acme/ui exec jest src/components/cms/blocks/__tests__/HeaderBlock.test.tsx --runInBand --detectOpenHandles --config ../../jest.config.cjs`
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*

------
https://chatgpt.com/codex/tasks/task_e_68c545b3d0d0832f8c60f344b411e13b