### PR TITLE
fix: configure ProductBundle test ids

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { configure, render, screen } from "@testing-library/react";
+
+configure({ testIdAttribute: "data-testid" });
 
 jest.mock("../../../atoms/Price", () => ({
   Price: ({ amount, className }: { amount: number; className?: string }) => (


### PR DESCRIPTION
## Summary
- ensure ProductBundle tests use `data-testid`

## Testing
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c545c4b09c832f96c8d9f0f8492a20