### PR TITLE
chore: remove inventory read logging

### DIFF
--- a/packages/platform-core/src/repositories/inventory.json.server.ts
+++ b/packages/platform-core/src/repositories/inventory.json.server.ts
@@ -67,8 +67,7 @@ async function read(shop: string): Promise<InventoryItem[]> {
     );
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
-    console.error(`Failed to read inventory for ${shop}`, err);
-    throw err;
+    throw new Error(`Failed to read inventory for ${shop}`, { cause: err });
   }
 }
 


### PR DESCRIPTION
## Summary
- drop console.error from JSON inventory reader
- rethrow errors with context instead

## Testing
- `pnpm run check:references --filter @acme/platform-core` *(fails: Missing script: check:references)*
- `pnpm run build:ts --filter @acme/platform-core` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/inventory.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c54d7442ec832f93f1043afc4b81f3