### PR TITLE
fix: specify ts-jest output dir

### DIFF
--- a/packages/platform-core/tsconfig.test.json
+++ b/packages/platform-core/tsconfig.test.json
@@ -7,7 +7,8 @@
     "types": ["@testing-library/jest-dom", "jest", "node"],
     /* no JS output for tests */
     "noEmit": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "outDir": ".ts-jest"
   },
 
   "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*"]


### PR DESCRIPTION
## Summary
- fix ts-jest configuration in platform-core tests by setting outDir

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core test src/hooks/__tests__/usePublishLocations.test.tsx`
- `pnpm --filter @acme/platform-core build` *(fails: Type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; } | null' is not assignable to type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; }'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c54d531364832fbe995c9fed4e17d2