### PR TITLE
chore: add Jest test scripts for remaining packages

### DIFF
--- a/packages/plugins/paypal/package.json
+++ b/packages/plugins/paypal/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist *.tsbuildinfo",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../../jest.config.cjs"
   },
   "dependencies": {
     "@acme/types": "workspace:*",

--- a/packages/plugins/premier-shipping/package.json
+++ b/packages/plugins/premier-shipping/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist *.tsbuildinfo",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../../jest.config.cjs"
   },
   "dependencies": {
     "@acme/types": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist *.tsbuildinfo",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "exports": {
     "./settings": {


### PR DESCRIPTION
## Summary
- add Jest `test` script to `@acme/types`
- add Jest `test` script to `@acme/plugin-paypal`
- add Jest `test` script to `@acme/plugin-premier-shipping`

## Testing
- `pnpm --filter @acme/types test` *(fails: coverage threshold for functions (80%) not met)*
- `pnpm --filter @acme/plugin-paypal test`
- `pnpm --filter @acme/plugin-premier-shipping test`
- `pnpm turbo run test --filter=@acme/types --filter=@acme/plugin-paypal --filter=@acme/plugin-premier-shipping` *(fails: @acme/types#test)*

------
https://chatgpt.com/codex/tasks/task_e_68c54cd88420832f98d638c26fbfae27