### PR TITLE
chore: add test scripts for misc workspaces

### DIFF
--- a/__tests__/package.json
+++ b/__tests__/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest --config ../jest.config.cjs"
+  }
+}

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@apps/storefront",
+  "private": true,
+  "scripts": {
+    "test": "jest --config ../../jest.config.cjs"
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "functions",
+  "private": true,
+  "scripts": {
+    "test": "jest --config ../jest.config.cjs"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "packages/*",
     "packages/*/*",
     "apps-script",
-    "packages/plugins/sanity"
+    "packages/plugins/sanity",
+    "functions",
+    "scripts",
+    "__tests__"
   ],
   "scripts": {
     "dev": "turbo run dev --parallel",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,6 +438,8 @@ importers:
         specifier: ^4.20.4
         version: 4.23.0(@cloudflare/workers-types@4.20250704.0)
 
+  __tests__: {}
+
   apps/api:
     devDependencies:
       supertest:
@@ -573,6 +575,10 @@ importers:
       next:
         specifier: ^15.3.5
         version: 15.3.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409)
+
+  apps/storefront: {}
+
+  functions: {}
 
   packages/auth:
     dependencies:
@@ -1057,6 +1063,8 @@ importers:
       zod:
         specifier: 3.25.73
         version: 3.25.73
+
+  scripts: {}
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,9 @@ packages:
   - "packages/*/"
   - "packages/plugins/*"
   - "packages/themes/*" # Include theme packages so @themes/base, etc. resolve
+  - "functions"
+  - "scripts"
+  - "__tests__"
 
 onlyBuiltDependencies:
   - "@tailwindcss/oxide"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "scripts",
+  "private": true,
+  "scripts": {
+    "test": "jest --config ../jest.config.cjs"
+  }
+}


### PR DESCRIPTION
## Summary
- add test scripts for root tests, storefront, functions, and scripts
- include new packages in workspace configuration

## Testing
- `pnpm --filter root-tests test` *(fails: TypeError: Cannot read properties of undefined (reading 'findMany'))*
- `pnpm --filter @apps/storefront test` *(fails: TestingLibraryElementError: Unable to find an element by: [data-cy="toggle"])*
- `pnpm --filter functions test` *(fails: Invalid auth environment variables)*
- `pnpm --filter scripts test` *(fails: Jest: "global" coverage threshold for branches (80%) not met: 68.8%)*

------
https://chatgpt.com/codex/tasks/task_e_68c54cccd734832f8ca1a940368f2df9