### PR TITLE
feat: add test script for shop-bcd app

### DIFF
--- a/apps/shop-bcd/package.json
+++ b/apps/shop-bcd/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev -p 3004",
     "build": "pnpm exec next build",
     "start": "next start -p 3004",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "pnpm exec jest --ci --runInBand --detectOpenHandles --config ../../jest.config.cjs"
   },
   "dependencies": {
     "@acme/config": "workspace:*",


### PR DESCRIPTION
## Summary
- add Jest test script for shop-bcd app

## Testing
- `pnpm --filter @apps/shop-bcd test` *(fails: TypeError: readOrders is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c54cd09dd4832fbaa7a3ba80f581ac