### PR TITLE
chore: downgrade redis error logs

### DIFF
--- a/packages/platform-core/src/cartStore/redisStore.ts
+++ b/packages/platform-core/src/cartStore/redisStore.ts
@@ -26,7 +26,7 @@ export class RedisCartStore implements CartStore {
       this.failures = 0;
       return result;
     } catch (err) {
-      console.error("Redis operation failed", err);
+      console.warn("Redis operation failed", err);
       this.failures += 1;
       if (this.failures >= MAX_REDIS_FAILURES) {
         console.error(


### PR DESCRIPTION
## Summary
- log recoverable Redis errors as warnings, only escalate to error when fallback mode is triggered

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core run build` *(fails: TypeScript errors)*
- `pnpm --filter @acme/platform-core run test src/cartStore/__tests__/redisStore.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c54e2fe0f4832f8638c21e92bf8ca4