### PR TITLE
test: silence redis store console errors

### DIFF
--- a/packages/platform-core/__tests__/cartStore/redis.test.ts
+++ b/packages/platform-core/__tests__/cartStore/redis.test.ts
@@ -11,6 +11,18 @@ import { RedisCartStore } from "../../src/cartStore/redisStore";
 import type { CartStore } from "../../src/cartStore";
 
 describe("RedisCartStore", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   const hsetMock = jest.fn();
   const hgetallMock = jest.fn();
   const expireMock = jest.fn();


### PR DESCRIPTION
## Summary
- silence console.error output in RedisCartStore tests by mocking the logger

## Testing
- `pnpm install` *(fails: postinstall prisma generate)*
- `pnpm -r build` *(fails: TypeScript errors in packages/ui)*
- `pnpm --filter platform-core run check:references` *(fails: missing script)*
- `pnpm --filter platform-core run build:ts` *(fails: missing script)*
- `pnpm --filter platform-core exec jest __tests__/cartStore/redis.test.ts --config ../../jest.config.cjs --runInBand --detectOpenHandles --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c54df013ac832f9039ca3bfe8e9b6c