### PR TITLE
test: import next mocks in ProductCard tests

### DIFF
--- a/packages/platform-core/src/components/shop/__tests__/ProductCard.test.tsx
+++ b/packages/platform-core/src/components/shop/__tests__/ProductCard.test.tsx
@@ -1,9 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { ProductCard, Price } from "../ProductCard";
 import React from "react";
-
-// Mock next/image to render a standard img element
-jest.mock("next/image", () => (props: any) => <img {...props} />);
+import "../../../../../../test/resetNextMocks";
 
 // Mock AddToCartButton to avoid context dependencies
 jest.mock("../AddToCartButton.client", () => ({


### PR DESCRIPTION
## Summary
- use shared resetNextMocks in ProductCard tests to strip invalid Next.js props

## Testing
- `pnpm exec jest packages/platform-core/src/components/shop/__tests__/ProductCard.test.tsx`
- `pnpm -r build` *(fails: Output file ... has not been built from source)*

------
https://chatgpt.com/codex/tasks/task_e_68c54db457f8832f9a276949e7b30a2e