### PR TITLE
test(platform-core): silence redis store errors

### DIFF
--- a/packages/platform-core/src/cartStore/__tests__/legacy/redisStore.test.ts
+++ b/packages/platform-core/src/cartStore/__tests__/legacy/redisStore.test.ts
@@ -6,6 +6,15 @@ import type { SKU } from "@acme/types";
 
 const MAX_REDIS_FAILURES = 3;
 
+// Silence expected error output from RedisCartStore during tests
+const consoleErrorSpy = jest
+  .spyOn(console, "error")
+  .mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
 class MockRedis {
   private failCount = 0;
   constructor(private failUntil = 0) {}
@@ -32,7 +41,7 @@ class MockRedis {
 
   hset = jest.fn(async (key: string, value: Record<string, any>) => {
     this.maybeFail();
-     this.isExpired(key);
+    this.isExpired(key);
     const obj = this.data.get(key) ?? {};
     Object.assign(obj, value);
     this.data.set(key, obj);
@@ -54,7 +63,7 @@ class MockRedis {
   del = jest.fn(async (key: string) => {
     this.maybeFail();
     this.data.delete(key);
-     this.expires.delete(key);
+    this.expires.delete(key);
     return 1;
   });
 
@@ -193,4 +202,3 @@ describe("RedisCartStore mocks", () => {
     jest.useRealTimers();
   });
 });
-


### PR DESCRIPTION
## Summary
- silence expected RedisCartStore errors during tests to keep output clean

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/src/cartStore/__tests__/legacy/redisStore.test.ts`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core/orders)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c54dab7b30832fb33526cc4048d14b