### PR TITLE
test: silence redis console errors

### DIFF
--- a/packages/platform-core/src/cartStore/__tests__/redisStore.basic.test.ts
+++ b/packages/platform-core/src/cartStore/__tests__/redisStore.basic.test.ts
@@ -30,11 +30,17 @@ describe("RedisCartStore basic operations", () => {
   let redis: MockRedis;
   let fallback: MemoryCartStore;
   let store: RedisCartStore;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     redis = new MockRedis();
     fallback = new MemoryCartStore(ttl);
     store = new RedisCartStore(redis as any, ttl, fallback);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it("sets and gets cart items", async () => {


### PR DESCRIPTION
## Summary
- mock `console.error` in RedisCartStore tests to avoid noisy logs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in platform-core build)*
- `pnpm run check:references` *(missing script)*
- `pnpm run build:ts` *(missing script)*
- `pnpm --filter @acme/platform-core test -- --runTestsByPath src/cartStore/__tests__/redisStore.basic.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c54d7da230832fbefc24f39d249898