### PR TITLE
Skip initial page history entry for new saves

### DIFF
--- a/packages/platform-core/src/repositories/pages/pages.json.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.json.server.ts
@@ -95,8 +95,10 @@ export async function savePage(
   if (idx === -1) pages.push(page);
   else pages[idx] = page;
   await writePages(shop, pages);
-  const patch = diffPages(previous, page);
-  await appendHistory(shop, patch);
+  if (previous) {
+    const patch = diffPages(previous, page);
+    await appendHistory(shop, patch);
+  }
   return page;
 }
 


### PR DESCRIPTION
## Summary
- avoid recording diff history when a page is first saved

## Testing
- `pnpm --filter @acme/platform-core test`


------
https://chatgpt.com/codex/tasks/task_e_68c54d5d6214832fa5805918241aac13