### PR TITLE
chore: silence page repo error logs in tests

### DIFF
--- a/packages/platform-core/__tests__/pagesRepoMock.test.ts
+++ b/packages/platform-core/__tests__/pagesRepoMock.test.ts
@@ -61,9 +61,16 @@ beforeAll(async () => {
   repo = await import("../src/repositories/pages/index.server");
 });
 
+let consoleErrorSpy: jest.SpyInstance;
+
 beforeEach(() => {
   files.clear();
   jest.clearAllMocks();
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
 });
 
 describe("pages repository core logic", () => {


### PR DESCRIPTION
## Summary
- silence Prisma page repo errors in tests

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core build` *(fails: TypeScript error)*
- `pnpm --filter @acme/platform-core test`

------
https://chatgpt.com/codex/tasks/task_e_68c54d403328832f93653adb421429d9