### PR TITLE
refactor: avoid logging on missing page

### DIFF
--- a/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
@@ -116,6 +116,9 @@ export async function deletePage(shop: string, id: string): Promise<void> {
       throw new Error(`Page ${id} not found in ${shop}`);
     }
   } catch (err) {
+    if (err instanceof Error && err.message.includes("not found")) {
+      throw err;
+    }
     console.error(`Failed to delete page ${id} for ${shop}`, err);
     const jsonRepo = await loadJsonRepo();
     await jsonRepo.deletePage(shop, id);


### PR DESCRIPTION
## Summary
- avoid logging when a page deletion fails because the page does not exist

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run test -- src/repositories/pages/__tests__/prisma.server.test.ts` *(fails: coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68c54d683068832fb2e8d8392ce68920