### PR TITLE
fix accordion keyboard toggle

### DIFF
--- a/packages/ui/src/components/molecules/Accordion.tsx
+++ b/packages/ui/src/components/molecules/Accordion.tsx
@@ -23,12 +23,36 @@ export function Accordion({ items }: AccordionProps) {
     <div className="space-y-2">
       {items.map((item, idx) => {
         const isOpen = open.includes(idx);
+
+        const handleKeyDown = (
+          event: React.KeyboardEvent<HTMLButtonElement>
+        ) => {
+          if (
+            event.key === " " ||
+            event.key === "Enter" ||
+            event.key === "Space" ||
+            event.key === "Spacebar"
+          ) {
+            event.preventDefault();
+            toggle(idx);
+          }
+        };
+
+        const handleClick = (
+          event: React.MouseEvent<HTMLButtonElement>
+        ) => {
+          if (event.detail !== 0) {
+            toggle(idx);
+          }
+        };
+
         return (
           <div key={idx} className="rounded border">
             <button
               type="button"
               aria-expanded={isOpen}
-              onClick={() => toggle(idx)}
+              onClick={handleClick}
+              onKeyDown={handleKeyDown}
               className="flex w-full items-center justify-between p-2 text-left"
             >
               <span>{item.title}</span>


### PR DESCRIPTION
## Summary
- ensure Accordion toggles only once when using keyboard by handling Enter/Space and filtering keyboard-generated clicks

## Testing
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs packages/ui/src/components/molecules/__tests__/Accordion.test.tsx`
- `pnpm --filter @acme/ui test` *(fails: unable to find label "Width (Desktop)"; ComponentEditor label missing; FAQBlock fails to find text)*
- `pnpm --filter @acme/ui run build` *(fails: numerous TS2322 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c549e77c14832f873683bee429a2b7