### PR TITLE
test: await cart provider updates

### DIFF
--- a/packages/platform-core/__tests__/productCard.test.tsx
+++ b/packages/platform-core/__tests__/productCard.test.tsx
@@ -20,17 +20,19 @@ describe("ProductCard", () => {
     global.fetch = originalFetch;
   });
 
-  function renderCard(sku: SKU) {
-    return render(
+  async function renderCard(sku: SKU) {
+    const utils = render(
       <CurrencyProvider>
         <CartProvider>
           <ProductCard sku={sku} />
         </CartProvider>
       </CurrencyProvider>
     );
+    await screen.findByRole("button", { name: /add to cart/i });
+    return utils;
   }
 
-  it("skips media when SKU has none", () => {
+  it("skips media when SKU has none", async () => {
     const sku = {
       id: "n1",
       slug: "no-media",
@@ -40,7 +42,7 @@ describe("ProductCard", () => {
       sizes: [],
     } as unknown as SKU;
 
-    const { container } = renderCard(sku);
+    const { container } = await renderCard(sku);
     expect(container.querySelector("img")).toBeNull();
     expect(container.querySelector("video")).toBeNull();
   });
@@ -55,12 +57,12 @@ describe("ProductCard", () => {
       sizes: [],
     } as unknown as SKU;
 
-    renderCard(sku);
+    await renderCard(sku);
     const img = await screen.findByAltText("Image media");
     expect(img).toBeInTheDocument();
   });
 
-  it("renders first media item as video", () => {
+  it("renders first media item as video", async () => {
     const sku = {
       id: "v1",
       slug: "video-media",
@@ -70,28 +72,28 @@ describe("ProductCard", () => {
       sizes: [],
     } as unknown as SKU;
 
-    const { container } = renderCard(sku);
+    const { container } = await renderCard(sku);
     const video = container.querySelector("video");
     expect(video).toBeInTheDocument();
     expect(video).toHaveAttribute("src", "/test.mp4");
   });
 
-  it("links to product detail page", () => {
+  it("links to product detail page", async () => {
     const sku = PRODUCTS[0];
-    renderCard(sku);
+    await renderCard(sku);
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", `../product/${sku.slug}`);
   });
 
-  it("includes AddToCartButton", () => {
+  it("includes AddToCartButton", async () => {
     const sku = PRODUCTS[0];
-    renderCard(sku);
+    await renderCard(sku);
     expect(
       screen.getByRole("button", { name: /add to cart/i })
     ).toBeInTheDocument();
   });
 
-  it("displays price using currency from context", () => {
+  it("displays price using currency from context", async () => {
     window.localStorage.setItem("PREFERRED_CURRENCY", "USD");
     const sku = {
       id: "p1",
@@ -101,7 +103,7 @@ describe("ProductCard", () => {
       media: [],
       sizes: [],
     } as unknown as SKU;
-    renderCard(sku);
+    await renderCard(sku);
     expect(screen.getByText("$10.00")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- await cart provider updates in ProductCard tests

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: 4 failed, 247 passed, 251 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c54d9c8488832f881b360422dea98c