### PR TITLE
test: silence inventory prisma console errors

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/inventory.prisma.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/inventory.prisma.server.test.ts
@@ -14,6 +14,7 @@ describe("prisma inventory repository", () => {
     process.env.DATA_ROOT = dataRoot;
     process.env.SKIP_STOCK_ALERT = "1";
     jest.resetModules();
+    jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- suppress console.error during Prisma inventory repository tests to keep output clean

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: TypeScript errors in unrelated modules)*
- `pnpm --filter @acme/platform-core run test` *(fails: json inventory repository logs and rethrows test)*

------
https://chatgpt.com/codex/tasks/task_e_68c55765f754832fa2e14c19e4478318