### PR TITLE
fix: handle string theme tokens

### DIFF
--- a/packages/platform-core/__tests__/themeTokens.test.ts
+++ b/packages/platform-core/__tests__/themeTokens.test.ts
@@ -140,6 +140,21 @@ describe("loadThemeTokensBrowser", () => {
     });
   });
 
+  it("supports string token values", async () => {
+    const dir = join(__dirname, "../../themes/plain/src");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      join(dir, "index.ts"),
+      "export const tokens = { '--color-bg': '#456' };"
+    );
+    const tokens = await loadThemeTokensBrowser("plain");
+    expect(tokens["--color-bg"]).toBe("#456");
+    fs.rmSync(join(__dirname, "../../themes/plain"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
   it("falls back to tailwind-tokens when direct import fails", async () => {
     const dir = join(__dirname, "../../themes/fallback/tailwind-tokens/src");
     fs.mkdirSync(dir, { recursive: true });

--- a/packages/platform-core/src/themeTokens/index.ts
+++ b/packages/platform-core/src/themeTokens/index.ts
@@ -79,7 +79,9 @@ export async function loadThemeTokensBrowser(theme: string): Promise<TokenMap> {
     );
     if ("tokens" in mod) {
       return Object.fromEntries(
-        typedEntries((mod as { tokens: ThemeTokenMap }).tokens).map(([k, v]) => [k, v.light])
+        Object.entries(
+          (mod as { tokens: Record<string, string | { light: string }> }).tokens
+        ).map(([k, v]) => [k, typeof v === "string" ? v : v.light])
       ) as TokenMap;
     }
   } catch {


### PR DESCRIPTION
## Summary
- support both object and string values when loading theme tokens in browser
- add regression test for string-valued tokens

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core run build` *(fails: Type 'null' is not assignable...)*
- `pnpm exec jest packages/platform-core/__tests__/themeTokens.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c5576fbd90832f81ae980199aa4d78