### PR TITLE
test: wrap cart provider updates

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/CartClear.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/CartClear.test.tsx
@@ -52,6 +52,8 @@ describe("clear action", () => {
       </CartProvider>
     );
 
+    await waitFor(() => expect(cartState).toEqual(cartWithItem));
+
     await act(async () => {
       await dispatch({ type: "clear" });
     });
@@ -79,6 +81,8 @@ describe("clear action", () => {
         <CartDisplay />
       </CartProvider>
     );
+
+    await waitFor(() => expect(cartState).toEqual(cartWithItem));
 
     await expect(dispatch({ type: "clear" })).rejects.toThrow("msg");
   });


### PR DESCRIPTION
## Summary
- await cart state hydration before clearing to avoid act warning

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core exec jest src/contexts/__tests__/CartClear.test.tsx --runInBand --detectOpenHandles --config ../../jest.config.cjs --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68c557d189b0832fbbb7e368309751fc