### PR TITLE
Log JSON inventory read errors and rethrow original

### DIFF
--- a/packages/platform-core/src/repositories/inventory.json.server.ts
+++ b/packages/platform-core/src/repositories/inventory.json.server.ts
@@ -67,7 +67,8 @@ async function read(shop: string): Promise<InventoryItem[]> {
     );
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw new Error(`Failed to read inventory for ${shop}`, { cause: err });
+    console.error(`Failed to read inventory for ${shop}`, err);
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- log and rethrow JSON inventory read errors instead of wrapping

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core/src/orders)*
- `pnpm --filter @acme/platform-core run check:references` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/platform-core/src/repositories/__tests__/inventory.json.server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c5590338cc832fab5269afc5e6f464