### PR TITLE
Record page creation history in pages repo

### DIFF
--- a/packages/platform-core/src/repositories/pages/__tests__/json.server.test.ts
+++ b/packages/platform-core/src/repositories/pages/__tests__/json.server.test.ts
@@ -32,7 +32,8 @@ describe("pages.json.server", () => {
     expect(pages).toHaveLength(1);
     expect(pages[0].createdBy).toBe("tester");
     let history = await repo.diffHistory(shop);
-    expect(history).toHaveLength(0);
+    expect(history).toHaveLength(1);
+    expect(history[0].diff).toEqual(page);
 
     const historyState: HistoryState = {
       past: [],
@@ -50,7 +51,7 @@ describe("pages.json.server", () => {
     expect(updated.slug).toBe("start");
     expect(pages[0].history).toEqual(historyState);
     history = await repo.diffHistory(shop);
-    expect(history).toHaveLength(1);
+    expect(history).toHaveLength(2);
 
     await repo.deletePage(shop, page.id);
     pages = await repo.getPages(shop);

--- a/packages/platform-core/src/repositories/pages/__tests__/prisma.server.test.ts
+++ b/packages/platform-core/src/repositories/pages/__tests__/prisma.server.test.ts
@@ -65,9 +65,9 @@ describe("pages.prisma.server", () => {
     prismaMock.page.upsert.mockResolvedValue({});
     await repo.savePage(shop, page, undefined);
     expect(prismaMock.page.upsert).toHaveBeenCalled();
-    expect(fsMock.appendFile).not.toHaveBeenCalled();
+    expect(fsMock.appendFile).toHaveBeenCalledTimes(1);
     await repo.savePage(shop, { ...page, slug: "new" }, page);
-    expect(fsMock.appendFile).toHaveBeenCalled();
+    expect(fsMock.appendFile).toHaveBeenCalledTimes(2);
   });
 
   it("updates via prisma and records history", async () => {

--- a/packages/platform-core/src/repositories/pages/pages.json.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.json.server.ts
@@ -95,10 +95,8 @@ export async function savePage(
   if (idx === -1) pages.push(page);
   else pages[idx] = page;
   await writePages(shop, pages);
-  if (previous) {
-    const patch = diffPages(previous, page);
-    await appendHistory(shop, patch);
-  }
+  const patch = diffPages(previous, page);
+  await appendHistory(shop, patch);
   return page;
 }
 

--- a/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
+++ b/packages/platform-core/src/repositories/pages/pages.prisma.server.ts
@@ -98,9 +98,7 @@ export async function savePage(
       },
     });
     const patch = diffPages(previous, page);
-    if (previous) {
-      await appendHistory(shop, patch);
-    }
+    await appendHistory(shop, patch);
     return page;
   } catch (err) {
     console.error(`Failed to save page ${page.id} for ${shop}`, err);


### PR DESCRIPTION
## Summary
- always append page creation diffs to history
- update prisma and json page repo tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test --coverage=false __tests__/pagesRepoFallback.test.ts src/repositories/pages/__tests__/prisma.server.test.ts src/repositories/pages/__tests__/json.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c558013f78832f8c3ef50e9ab116ff