### PR TITLE
test: silence env core error logs

### DIFF
--- a/packages/platform-machine/src/__tests__/env.core.test.ts
+++ b/packages/platform-machine/src/__tests__/env.core.test.ts
@@ -248,9 +248,15 @@ describe("coreEnv NODE_ENV behavior", () => {
         JEST_WORKER_ID: undefined,
       },
       async () => {
+        const errorSpy = jest
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+
         await expect(import("@acme/config/env/core")).rejects.toThrow(
           "Invalid core environment variables",
         );
+
+        errorSpy.mockRestore();
       },
     );
   });


### PR DESCRIPTION
## Summary
- silence env core error logs in platform-machine tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/stripe prebuild: Failed, packages/platform-core build: Failed, packages/platform-machine build: Failed, etc.)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-machine test -- --runTestsByPath src/__tests__/env.core.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c55b5ea984832fa11e0eda2954c2a7