### PR TITLE
Silence auth env validation errors in email tests

### DIFF
--- a/packages/email/src/__tests__/env.auth.test.ts
+++ b/packages/email/src/__tests__/env.auth.test.ts
@@ -105,12 +105,14 @@ describe("auth env validation", () => {
   });
 
   it("throws for jwt provider without secret", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     await expect(
       withEnv(
         { NODE_ENV: "development", AUTH_PROVIDER: "jwt" },
         () => import("@acme/config/src/env/auth.ts"),
       ),
     ).rejects.toThrow("Invalid auth environment variables");
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("loads for jwt provider with secret", async () => {
@@ -126,6 +128,7 @@ describe("auth env validation", () => {
   });
 
   it("throws for oauth provider missing client id", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     await expect(
       withEnv(
         {
@@ -136,9 +139,11 @@ describe("auth env validation", () => {
         () => import("@acme/config/src/env/auth.ts"),
       ),
     ).rejects.toThrow("Invalid auth environment variables");
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("throws for oauth provider missing client secret", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     await expect(
       withEnv(
         {
@@ -149,6 +154,7 @@ describe("auth env validation", () => {
         () => import("@acme/config/src/env/auth.ts"),
       ),
     ).rejects.toThrow("Invalid auth environment variables");
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("loads when oauth provider has credentials", async () => {


### PR DESCRIPTION
## Summary
- prevent noisy auth env validation logs in email package tests by spying on `console.error`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable...)*
- `pnpm --filter @acme/email run build` *(fails: Type 'null' is not assignable...)*
- `pnpm --filter @acme/email run check:references` *(fails: script missing)*
- `pnpm --filter @acme/email run test -- src/__tests__/env.auth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c55d238f24832fabe867ce95c003c4