### PR TITLE
chore(email): log provider failures as warnings

### DIFF
--- a/packages/email/src/__tests__/legacy/send.test.ts
+++ b/packages/email/src/__tests__/legacy/send.test.ts
@@ -163,6 +163,8 @@ describe("sendCampaignEmail", () => {
 
   it("retries failing provider then falls back in order", async () => {
     const timeoutSpy = jest.spyOn(global, "setTimeout");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     mockSendgridSend = jest.fn().mockRejectedValue(new ProviderError("fail", true));
     mockResendSend = jest.fn().mockResolvedValue(undefined);
     mockSendMail = jest.fn();
@@ -186,7 +188,11 @@ describe("sendCampaignEmail", () => {
     expect(timeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 200);
     expect(mockResendSend).toHaveBeenCalledTimes(1);
     expect(mockSendMail).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
     timeoutSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("falls back to Nodemailer when no provider available", async () => {

--- a/packages/email/src/__tests__/sendCampaign.failure.test.ts
+++ b/packages/email/src/__tests__/sendCampaign.failure.test.ts
@@ -214,7 +214,7 @@ describe('sendCampaignEmail failure paths', () => {
     mockSanitizeHtml.mockImplementation((html: string) => html);
     mockHasProviderErrorFields.mockImplementation();
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     setupEnv();
 

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -66,13 +66,16 @@ export async function sendCampaignEmail(
   }
   const optsWithText = await prepareContent(opts, sanitize);
   let lastError: unknown;
-  for (const name of providerOrder) {
+  for (let i = 0; i < providerOrder.length; i++) {
+    const name = providerOrder[i];
+    const isLastProvider = i === providerOrder.length - 1;
+    const log = isLastProvider ? console.error : console.warn;
     if (name === "smtp") {
       try {
         await sendWithNodemailer(optsWithText);
         return;
       } catch (err) {
-        console.error("Campaign email send failed", {
+        log("Campaign email send failed", {
           provider: name,
           recipient: optsWithText.to,
           campaignId: optsWithText.campaignId,
@@ -88,7 +91,7 @@ export async function sendCampaignEmail(
       await sendWithRetry(current, optsWithText);
       return;
     } catch (err) {
-      console.error("Campaign email send failed", {
+      log("Campaign email send failed", {
         provider: name,
         recipient: optsWithText.to,
         campaignId: optsWithText.campaignId,


### PR DESCRIPTION
## Summary
- log intermediate email provider failures as warnings
- adjust tests for new warning behavior

## Testing
- `pnpm --filter @acme/email exec jest --ci --runInBand --detectOpenHandles --config ./jest.config.cjs --coverageDirectory ../../coverage/email --outputFile /tmp/test.json --json`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c55cb5d1e0832fb9aee812763009a3