### PR TITLE
test: add default error handling test

### DIFF
--- a/packages/platform-core/src/components/shop/__tests__/AddToCartButton.client.test.tsx
+++ b/packages/platform-core/src/components/shop/__tests__/AddToCartButton.client.test.tsx
@@ -90,6 +90,14 @@ describe("AddToCartButton", () => {
     jest.useRealTimers();
   });
 
+  it("shows default error when dispatch rejects without a proper Error", async () => {
+    mockDispatch.mockRejectedValueOnce("oops");
+    render(<AddToCartButton sku={sku} />);
+    const button = screen.getByRole("button", { name: /add to cart/i });
+    fireEvent.click(button);
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to add to cart");
+  });
+
   it("clears error and dispatches on retry", async () => {
     mockDispatch.mockRejectedValueOnce(new Error("Out of stock"));
     mockDispatch.mockResolvedValueOnce(undefined);


### PR DESCRIPTION
## Summary
- add test for default error message when add to cart dispatch rejects

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Type 'null' is not assignable...)
- `pnpm test packages/platform-core/src/components/shop/__tests__/AddToCartButton.client.test.tsx` (fails: Could not find path)
- `pnpm exec jest packages/platform-core/src/components/shop/__tests__/AddToCartButton.client.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c56066e308832fa44dc3183f2d7923