### PR TITLE
test(i18n): expand multilingual input coverage

### DIFF
--- a/packages/i18n/src/__tests__/parseMultilingualInput.more.test.ts
+++ b/packages/i18n/src/__tests__/parseMultilingualInput.more.test.ts
@@ -36,13 +36,23 @@ describe("normalizeMultilingualInput edge cases", () => {
   const locales = ["en", "it"] as const;
 
   it("populates the first locale from a plain string", () => {
-    expect(normalizeMultilingualInput(" Hello ", locales)).toEqual({
-      en: "Hello",
+    const localLocales = ["it", "en"] as const;
+    expect(normalizeMultilingualInput(" Hello ", localLocales)).toEqual({
+      it: "Hello",
     });
+  });
+
+  it("drops whitespace-only strings", () => {
+    expect(normalizeMultilingualInput("   ", locales)).toEqual({});
   });
 
   it("trims values and drops empty or unknown locales", () => {
     const input = { en: " Hi ", it: "  ", fr: "Bonjour", de: 1 as any };
     expect(normalizeMultilingualInput(input, locales)).toEqual({ en: "Hi" });
+  });
+
+  it("ignores unknown locale keys", () => {
+    const input = { fr: "Bonjour" };
+    expect(normalizeMultilingualInput(input, locales)).toEqual({});
   });
 });

--- a/packages/i18n/src/__tests__/parseMultilingualInput.test.ts
+++ b/packages/i18n/src/__tests__/parseMultilingualInput.test.ts
@@ -25,8 +25,9 @@ describe("parseMultilingualInput", () => {
     expect(parseMultilingualInput("title__en", locales)).toBeNull();
     expect(parseMultilingualInput("title-en", locales)).toBeNull();
     expect(
-      parseMultilingualInput({ en: "x", it: "y" } as any, locales)
+      parseMultilingualInput({ name: "title_en" } as any, locales)
     ).toBeNull();
+    expect(parseMultilingualInput(123 as any, locales)).toBeNull();
     expect(parseMultilingualInput(null as any, locales)).toBeNull();
     expect(parseMultilingualInput(undefined as any, locales)).toBeNull();
   });


### PR DESCRIPTION
## Summary
- add parseMultilingualInput tests for numeric and object names
- expand normalizeMultilingualInput coverage for plain strings, whitespace-only values, and unknown locales

## Testing
- `pnpm --filter @acme/i18n test`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5605d9e30832f9d430749af7e7989