### PR TITLE
test: enhance utils coverage

### DIFF
--- a/packages/ui/src/utils/__tests__/buildProductFormData.test.ts
+++ b/packages/ui/src/utils/__tests__/buildProductFormData.test.ts
@@ -69,5 +69,23 @@ describe("buildProductFormData", () => {
       ])
     );
   });
+
+  it("handles null media items, multiple publish targets, and empty variants", () => {
+    const file = new File(["hi"], "img.png", { type: "image/png" });
+    const product = {
+      ...baseProduct,
+      media: [null, { id: "3", alt: "third", file }],
+      variants: { size: [undefined as any, ""] },
+    };
+    const fd = buildProductFormData(product, ["loc1", "loc2"], locales);
+
+    expect(fd.get("file_1")).toBe(file);
+    expect(fd.get("file_0")).toBeNull();
+    expect(fd.get("publish")).toBe("loc1,loc2");
+    expect(fd.get("media")).toBe(
+      JSON.stringify([null, { id: "3", alt: "third" }])
+    );
+    expect(fd.get("variant_size")).toBe("");
+  });
 });
 

--- a/packages/ui/src/utils/__tests__/colorUtils.test.ts
+++ b/packages/ui/src/utils/__tests__/colorUtils.test.ts
@@ -36,16 +36,19 @@ describe("colorUtils", () => {
   test("isHex validates hex colors", () => {
     expect(isHex("#fff")).toBe(true);
     expect(isHex("fff")).toBe(false);
+    expect(isHex("#ABCDEF")).toBe(true);
   });
 
   test("isHsl validates HSL colors", () => {
     expect(isHsl("120 100% 50%"));
     expect(isHsl("#fff")).toBe(false);
+    expect(isHsl("120 100 50%" as any)).toBe(false);
   });
 
   test("hexToRgb converts shorthand and longhand hex", () => {
     expect(hexToRgb("#ffffff")).toEqual([255, 255, 255]);
     expect(hexToRgb("#abc")).toEqual([170, 187, 204]);
+    expect(hexToRgb("#ABCDEF")).toEqual([171, 205, 239]);
   });
 
   test("hexToRgb throws on invalid input", () => {
@@ -55,5 +58,11 @@ describe("colorUtils", () => {
   test("getContrastColor chooses black or white based on brightness", () => {
     expect(getContrastColor("#ffffff")).toBe("#000000");
     expect(getContrastColor("#000000")).toBe("#ffffff");
+    expect(getContrastColor("#777777")).toBe("#ffffff");
+  });
+
+  test("hexToHsl handles black and invalid input", () => {
+    expect(hexToHsl("#000000")).toBe("0 0% 0%");
+    expect(() => hexToHsl("bad" as any)).toThrow("Invalid hex color");
   });
 });


### PR DESCRIPTION
## Summary
- expand buildProductFormData tests for null media, publish targets, empty variants
- broaden colorUtils test cases for hex/HSL validation and conversions

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: Type error in packages/platform-core)*
- `pnpm --filter @acme/ui test packages/ui/src/utils/__tests__/buildProductFormData.test.ts packages/ui/src/utils/__tests__/colorUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c55faef828832f8168268fdadc5ea9