### PR TITLE
Add shop repository error propagation tests

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/shop.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/shop.server.test.ts
@@ -89,6 +89,23 @@ describe("shop.server wrapper", () => {
     expect(result).toEqual({ id: "shop1", name: "Updated" });
   });
 
+  it("propagates errors from getShopById", async () => {
+    const error = new Error("get failed");
+    repo.getShopById.mockRejectedValue(error);
+    await expect(getShopById("shop1")).rejects.toThrow(error);
+    expect(resolveRepo).toHaveBeenCalled();
+    expect(repo.getShopById).toHaveBeenCalledWith("shop1");
+  });
+
+  it("propagates errors from updateShopInRepo", async () => {
+    const error = new Error("update failed");
+    const patch = { id: "shop1", name: "Updated" };
+    repo.updateShopInRepo.mockRejectedValue(error);
+    await expect(updateShopInRepo("shop1", patch)).rejects.toThrow(error);
+    expect(resolveRepo).toHaveBeenCalled();
+    expect(repo.updateShopInRepo).toHaveBeenCalledWith("shop1", patch);
+  });
+
   it("clears repoPromise in test env and forwards params", async () => {
     const originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "test";


### PR DESCRIPTION
## Summary
- test getShopById and updateShopInRepo error propagation

## Testing
- `pnpm test packages/platform-core/src/repositories/__tests__/shop.server.test.ts` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c56076727c832f81f95bcdacffc418