### PR TITLE
test: cover empty body with no headers

### DIFF
--- a/packages/shared-utils/src/__tests__/buildResponse.test.ts
+++ b/packages/shared-utils/src/__tests__/buildResponse.test.ts
@@ -130,4 +130,20 @@ describe('buildResponse', () => {
     );
     await expect(res.text()).resolves.toBe(text);
   });
+
+  it('handles undefined body and no headers', async () => {
+    const proxy: ProxyResponse = {
+      response: {
+        status: 200,
+        headers: {},
+        body: undefined,
+      },
+    };
+
+    const res = buildResponse(proxy);
+
+    expect(res.status).toBe(200);
+    expect([...res.headers.entries()]).toHaveLength(0);
+    await expect(res.text()).resolves.toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- test buildResponse handles undefined body with no headers

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TypeScript error in @acme/platform-core)
- `pnpm --filter @acme/shared-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68c561a0b5f8832fbe925648c80cbde1