### PR TITLE
test(shared-utils): handle zero-length secret

### DIFF
--- a/packages/shared-utils/src/__tests__/genSecret.test.ts
+++ b/packages/shared-utils/src/__tests__/genSecret.test.ts
@@ -51,6 +51,14 @@ describe('genSecret', () => {
     expect(secret).toMatch(/^[0-9a-f]+$/);
   });
 
+  it('returns empty string when byte length is 0', () => {
+    const getRandomValues = jest.fn(() => new Uint8Array());
+    const mock = { getRandomValues } as Crypto;
+    Object.defineProperty(globalThis, 'crypto', { value: mock });
+    expect(genSecret(0)).toBe('');
+    expect(getRandomValues).toHaveBeenCalledWith(new Uint8Array(0));
+  });
+
   it.each([-1, 1.5])('throws for invalid byte length %p', (bytes) => {
     expect(() => genSecret(bytes as number)).toThrow(RangeError);
   });


### PR DESCRIPTION
## Summary
- test genSecret with zero byte length

## Testing
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68c561a61040832f94098b1b731f2a39