### PR TITLE
test: expand cart provider coverage

### DIFF
--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -53,14 +53,17 @@ export function CartProvider({ children }: { children: ReactNode }) {
         throw new Error("Cart fetch failed");
       } catch (err) {
         console.error(err);
+        let cached: string | null = null;
         try {
-          const cached = localStorage.getItem(STORAGE_KEY);
+          cached = localStorage.getItem(STORAGE_KEY);
           if (cached) {
             setState(JSON.parse(cached) as CartState);
           }
         } catch {
           /* noop */
         }
+
+        if (!cached) return;
 
         sync = async () => {
           try {


### PR DESCRIPTION
## Summary
- add tests for CartProvider offline and failure scenarios
- cover default quantity and unknown actions in cart dispatch
- guard CartProvider sync listener when no cache is present

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @acme/platform-core test -- src/contexts/__tests__/CartProvider.test.tsx src/contexts/__tests__/CartDispatch.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c56069ea0c832f95de1472dd91447a