### PR TITLE
test: cover NaN in formatPrice

### DIFF
--- a/packages/shared-utils/src/__tests__/formatPrice.test.ts
+++ b/packages/shared-utils/src/__tests__/formatPrice.test.ts
@@ -134,6 +134,14 @@ describe("formatPrice", () => {
     expect(formatPrice(0)).toBe(expected);
   });
 
+  it("formats NaN amount", () => {
+    const expected = new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+    }).format(NaN);
+    expect(formatPrice(NaN)).toBe(expected);
+  });
+
   it.each([null, undefined])("formats %p as NaN", (value) => {
     const expected = new Intl.NumberFormat(undefined, {
       style: "currency",


### PR DESCRIPTION
## Summary
- cover NaN amount case for formatPrice

## Testing
- `pnpm --filter @acme/shared-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68c561a4b91c832faac41d08e4d787ee