### PR TITLE
test: fallback to prisma on unknown settings backend

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/settings.backendSelection.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/settings.backendSelection.test.ts
@@ -80,5 +80,23 @@ describe("settings repository backend selection", () => {
     expect(mockPrisma.diffHistory).toHaveBeenCalledWith("shop");
     expect(mockJson.getShopSettings).not.toHaveBeenCalled();
   });
+
+  it("falls back to the Prisma repository when SETTINGS_BACKEND is unknown", async () => {
+    process.env.SETTINGS_BACKEND = "unknown";
+    const {
+      getShopSettings,
+      saveShopSettings,
+      diffHistory,
+    } = await import("../settings.server");
+
+    await getShopSettings("shop");
+    await saveShopSettings("shop", {} as any);
+    await diffHistory("shop");
+
+    expect(mockPrisma.getShopSettings).toHaveBeenCalledWith("shop");
+    expect(mockPrisma.saveShopSettings).toHaveBeenCalledWith("shop", {});
+    expect(mockPrisma.diffHistory).toHaveBeenCalledWith("shop");
+    expect(mockJson.getShopSettings).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add test for unknown SETTINGS_BACKEND to ensure Prisma repository is used

## Testing
- `pnpm test packages/platform-core/src/repositories/__tests__/settings.backendSelection.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c560752b10832fb53b4fe38f318654