### PR TITLE
test: add root pathname case for layout context

### DIFF
--- a/packages/platform-core/src/contexts/__tests__/LayoutContext.test.tsx
+++ b/packages/platform-core/src/contexts/__tests__/LayoutContext.test.tsx
@@ -107,6 +107,24 @@ describe("LayoutContext", () => {
     expect(getByTestId("toggle").textContent).toBe("closed");
   });
 
+  it("handles root pathname and still toggles nav", () => {
+    mockPathname.mockReturnValue("/");
+
+    const { getByTestId } = render(
+      <LayoutProvider>
+        <TestComponent />
+      </LayoutProvider>
+    );
+
+    expect(getByTestId("crumbs").textContent).toBe(JSON.stringify([]));
+
+    fireEvent.click(getByTestId("toggle"));
+    expect(getByTestId("toggle").textContent).toBe("open");
+
+    fireEvent.click(getByTestId("toggle"));
+    expect(getByTestId("toggle").textContent).toBe("closed");
+  });
+
   it("sets and clears configurator progress", () => {
     mockPathname.mockReturnValue(null);
 


### PR DESCRIPTION
## Summary
- add test for root path ensuring breadcrumbs empty and nav toggle works

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm --filter @acme/platform-core test -- src/contexts/__tests__/LayoutContext.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5606b20c4832f9116652292d8cbd3