### PR TITLE
test(platform-core): clamp listShops limit

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/shops.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/shops.server.test.ts
@@ -391,6 +391,20 @@ describe("shops.repository", () => {
       );
     });
 
+    it.each([0, -5])(
+      "clamps limit within bounds (limit=%s)",
+      async (limit) => {
+        count.mockResolvedValue(1);
+        findMany.mockResolvedValue([]);
+
+        await listShops(1, limit);
+
+        expect(findMany).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: 0, take: 1 })
+        );
+      },
+    );
+
     it("returns items from the last page when page equals max", async () => {
       count.mockResolvedValue(5);
       findMany.mockResolvedValue([{ id: "shop5" }]);


### PR DESCRIPTION
## Summary
- test listShops handles zero or negative limits

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/src/repositories/__tests__/shops.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c56078af80832f91bb73c94bb060b0