### PR TITLE
test(shared-utils): trim csrf token

### DIFF
--- a/packages/shared-utils/src/__tests__/getCsrfToken.node.test.ts
+++ b/packages/shared-utils/src/__tests__/getCsrfToken.node.test.ts
@@ -15,8 +15,20 @@ describe('getCsrfToken on server', () => {
     expect(getCsrfToken(req)).toBe('header-token');
   });
 
+  it('trims whitespace from x-csrf-token header', () => {
+    const req = new Request('https://example.com', {
+      headers: { 'x-csrf-token': '  spaced-token  ' },
+    });
+    expect(getCsrfToken(req)).toBe('spaced-token');
+  });
+
   it('returns token from query parameter', () => {
     const req = new Request('https://example.com?csrf_token=query-token');
+    expect(getCsrfToken(req)).toBe('query-token');
+  });
+
+  it('trims whitespace from query parameter token', () => {
+    const req = new Request('https://example.com?csrf_token=%20query-token%20');
     expect(getCsrfToken(req)).toBe('query-token');
   });
 

--- a/packages/shared-utils/src/__tests__/getCsrfToken.test.ts
+++ b/packages/shared-utils/src/__tests__/getCsrfToken.test.ts
@@ -32,8 +32,20 @@ describe('getCsrfToken', () => {
     expect(getCsrfToken(req)).toBe('header-token');
   });
 
+  it('trims whitespace from x-csrf-token header', () => {
+    const req = new Request('https://example.com', {
+      headers: { 'x-csrf-token': '  spaced-token  ' },
+    });
+    expect(getCsrfToken(req)).toBe('spaced-token');
+  });
+
   it('extracts token from query string', () => {
     const req = new Request('https://example.com?csrf_token=query-token');
+    expect(getCsrfToken(req)).toBe('query-token');
+  });
+
+  it('trims whitespace from query string token', () => {
+    const req = new Request('https://example.com?csrf_token=%20query-token%20');
     expect(getCsrfToken(req)).toBe('query-token');
   });
 


### PR DESCRIPTION
## Summary
- test node and browser CSRF token helpers handle whitespace in headers and query params

## Testing
- `pnpm --filter @acme/shared-utils run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm --filter @acme/shared-utils run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter @acme/shared-utils test packages/shared-utils/src/__tests__/getCsrfToken.test.ts packages/shared-utils/src/__tests__/getCsrfToken.node.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c564279f90832f96dde11e1a78b8cb