### PR TITLE
test: ensure json field error not duplicated

### DIFF
--- a/packages/shared-utils/src/__tests__/jsonFieldHandler.test.ts
+++ b/packages/shared-utils/src/__tests__/jsonFieldHandler.test.ts
@@ -30,7 +30,9 @@ describe('jsonFieldHandler', () => {
     const handler = jsonFieldHandler('field', () => {}, setErrors);
 
     handler({ target: { value: 'not json' } } as any);
+    handler({ target: { value: 'still not json' } } as any);
 
+    expect(errors.field).toEqual(['Invalid JSON']);
     expect(errors).toEqual({
       other: ['Other error'],
       field: ['Invalid JSON'],


### PR DESCRIPTION
## Summary
- extend jsonFieldHandler tests to ensure repeated invalid JSON input does not add duplicate errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ... in packages/platform-core)*
- `pnpm --filter @acme/shared-utils test`

------
https://chatgpt.com/codex/tasks/task_e_68c5642a3374832fb6dc941bcacb17da