### PR TITLE
test: cover empty path in replaceShopInPath

### DIFF
--- a/packages/shared-utils/src/__tests__/replaceShopInPath.test.ts
+++ b/packages/shared-utils/src/__tests__/replaceShopInPath.test.ts
@@ -23,6 +23,10 @@ describe("replaceShopInPath", () => {
     });
   });
 
+  it("handles empty string", () => {
+    expect(replaceShopInPath("", "new")).toBe("/cms/shop/new");
+  });
+
   it("preserves query parameters", () => {
     expect(replaceShopInPath("/cms/shop?x=1", "new")).toBe(
       "/cms/shop/new?x=1"


### PR DESCRIPTION
## Summary
- cover replaceShopInPath with empty pathname

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2322 in platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68c5642db6a4832f8a2045c7d3889dd9