### PR TITLE
test(shared-utils): handle duplicate object refs

### DIFF
--- a/packages/shared-utils/src/__tests__/toggleItem.test.ts
+++ b/packages/shared-utils/src/__tests__/toggleItem.test.ts
@@ -47,5 +47,16 @@ describe('toggleItem', () => {
     expect(added).not.toBe(input);
     expect(removed).not.toBe(input);
   });
+
+  it('adds duplicate objects when references differ', () => {
+    const input = [{ a: 1 }];
+    const result = toggleItem(input, { a: 1 });
+
+    expect(result).toEqual([{ a: 1 }, { a: 1 }]);
+    expect(result).not.toBe(input);
+    expect(result[0]).toBe(input[0]);
+    expect(result[1]).not.toBe(input[0]);
+    expect(input).toEqual([{ a: 1 }]);
+  });
 });
 


### PR DESCRIPTION
## Summary
- add test ensuring toggleItem adds identical object literals when references differ

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2322 in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/shared-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68c5642f85d8832fa79343438cc02ab2