### PR TITLE
test(shared-utils): add punctuation-only case for slugify

### DIFF
--- a/packages/shared-utils/src/__tests__/slugify.test.ts
+++ b/packages/shared-utils/src/__tests__/slugify.test.ts
@@ -25,6 +25,10 @@ describe('slugify', () => {
     expect(slugify('---Hello---')).toBe('hello');
   });
 
+  it('returns empty string when string is only punctuation', () => {
+    expect(slugify('!!!')).toBe('');
+  });
+
   it('returns an empty string for null/undefined input', () => {
     expect(slugify(null)).toBe('');
     // @ts-expect-error Test undefined input


### PR DESCRIPTION
## Summary
- test slugify behavior when input is solely punctuation

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm --filter @acme/shared-utils run test`

------
https://chatgpt.com/codex/tasks/task_e_68c5642ed420832fa0ae12c8237ba052