### PR TITLE
test: ensure DataTable handles selection without callback

### DIFF
--- a/packages/ui/src/components/cms/__tests__/DataTable.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/DataTable.test.tsx
@@ -48,6 +48,28 @@ describe("DataTable", () => {
     expect(checkboxes[0].checked).toBe(false);
   });
 
+  it("handles selection without callback", () => {
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <DataTable rows={rows} columns={columns} selectable />
+    );
+
+    const rowElements = screen.getAllByRole("row");
+    const checkbox = screen.getAllByRole("checkbox")[0] as HTMLInputElement;
+
+    fireEvent.click(rowElements[1]);
+    expect(checkbox.checked).toBe(true);
+
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it("ignores clicks when not selectable", () => {
     const handleChange = jest.fn();
     render(<DataTable rows={rows} columns={columns} onSelectionChange={handleChange} />);


### PR DESCRIPTION
## Summary
- add regression test for DataTable selectable usage without onSelectionChange

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/__tests__/DataTable.test.tsx --config ../../jest.config.cjs --runInBand --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c5643978c0832fafb32167ebc2898b