### PR TITLE
test: ensure FontSelect handles empty options

### DIFF
--- a/packages/ui/src/components/cms/__tests__/FontSelect.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/FontSelect.test.tsx
@@ -86,4 +86,19 @@ describe("FontSelect", () => {
 
     expect(handleUpload).toHaveBeenCalled();
   });
+
+  it("renders empty select when no options are provided", () => {
+    const { container } = render(
+      <FontSelect
+        value={""}
+        options={[]}
+        onChange={jest.fn()}
+        onUpload={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+    expect(container.querySelector('input[type="file"]')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- test FontSelect handles empty `options` array

## Testing
- `pnpm --filter @acme/ui test src/components/cms/__tests__/FontSelect.test.tsx`
- `pnpm -r build` (fails: TypeScript errors in @acme/platform-core)
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c5643b5594832fbb4dd63fa63cac24