### PR TITLE
test: cover logger metadata defaults

### DIFF
--- a/packages/shared-utils/src/__tests__/logger.test.ts
+++ b/packages/shared-utils/src/__tests__/logger.test.ts
@@ -61,6 +61,20 @@ describe('logger', () => {
     expect(pinoInstance[level]).toHaveBeenCalledWith(meta, message);
   });
 
+  it.each([
+    ['error'],
+    ['warn'],
+    ['info'],
+    ['debug'],
+  ])('%s forwards message with empty metadata when omitted', async (level) => {
+    const { logger } = await import('../logger');
+    const message = `${level} only`;
+    // @ts-expect-error - index signature for logger methods
+    logger[level](message);
+    // @ts-expect-error - index signature for pino instance methods
+    expect(pinoInstance[level]).toHaveBeenCalledWith({}, message);
+  });
+
   it('logs plain objects and Error instances appropriately', async () => {
     const { logger } = await import('../logger');
     const obj = { id: 1 };


### PR DESCRIPTION
## Summary
- test that logger methods send `{}` metadata when no meta is provided

## Testing
- `pnpm exec jest src/__tests__/logger.test.ts --runInBand --detectOpenHandles --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c5642b6e68832fbfca6a5c8d61c95a