### PR TITLE
test: cover BlogListing excerpt and link handling

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/BlogListing.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/BlogListing.test.tsx
@@ -4,16 +4,39 @@ import BlogListing from "../BlogListing";
 
 describe("BlogListing", () => {
   it("renders blog posts", () => {
-    render(<BlogListing posts={[{ title: "Post", url: "/post" }]} />);
+    render(
+      <BlogListing
+        posts={[
+          {
+            title: "Post",
+            url: "/post",
+            excerpt: "Excerpt",
+            shopUrl: "/shop",
+          },
+        ]}
+      />,
+    );
     expect(screen.getByRole("heading", { name: "Post" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Post" })).toHaveAttribute(
       "href",
       "/post",
+    );
+    expect(screen.getByText("Excerpt")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Shop the story" })).toHaveAttribute(
+      "href",
+      "/shop",
     );
   });
 
   it("returns null without posts", () => {
     const { container } = render(<BlogListing posts={[]} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders plain heading without url", () => {
+    render(<BlogListing posts={[{ title: "No Link" }]} />);
+    const heading = screen.getByRole("heading", { name: "No Link" });
+    expect(heading.tagName).toBe("H3");
+    expect(screen.queryByRole("link", { name: "No Link" })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- test BlogListing renders excerpt and "Shop the story" link
- ensure BlogListing falls back to plain heading when missing URL

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/plugins/paypal build: Failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test src/components/cms/blocks/__tests__/BlogListing.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5644bb9ec832fb08c736df6409ed4