### PR TITLE
test(ui): cover navigation item without children

### DIFF
--- a/packages/ui/src/components/cms/__tests__/NavigationPreview.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/NavigationPreview.test.tsx
@@ -44,6 +44,14 @@ describe("NavigationPreview", () => {
     expect(link).toHaveAttribute("href", "#");
   });
 
+  it("does not render nested list for items without children", () => {
+    const { getByText } = render(
+      <NavigationPreview items={[{ id: "1", label: "Solo", url: "/solo" }]} />,
+    );
+    const listItem = getByText("Solo").closest("li");
+    expect(listItem?.querySelector("ul")).toBeNull();
+  });
+
   it("renders dropdown menu with child links and tokens", () => {
     const { getByText } = render(<NavigationPreview items={items} />);
     const childLink = getByText("Child");


### PR DESCRIPTION
## Summary
- add test ensuring NavigationPreview skips nested list when item has no children

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/__tests__/NavigationPreview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5643f1e74832f86a6de2b8b3fe61f