### PR TITLE
test: cover timezone changes for countdown

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx
@@ -53,6 +53,19 @@ describe("CountdownTimer", () => {
     expect(screen.getByText("00:05")).toBeInTheDocument();
   });
 
+  it("passes timezone to parseTargetDate", () => {
+    mockParseTargetDate.mockReturnValue(undefined);
+
+    render(
+      <CountdownTimer targetDate="future" timezone="America/New_York" />
+    );
+
+    expect(mockParseTargetDate).toHaveBeenCalledWith(
+      "future",
+      "America/New_York"
+    );
+  });
+
   it("shows completionText when time runs out", () => {
     mockParseTargetDate.mockReturnValue(new Date("2025-01-01T00:00:00Z"));
     mockGetTimeRemaining
@@ -93,6 +106,41 @@ describe("CountdownTimer", () => {
     });
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it("updates countdown when timezone changes", () => {
+    mockParseTargetDate
+      .mockReturnValueOnce(new Date("2025-01-01T00:00:00Z"))
+      .mockReturnValue(new Date("2025-01-01T01:00:00Z"));
+    mockGetTimeRemaining
+      .mockReturnValueOnce(5000)
+      .mockReturnValueOnce(5000)
+      .mockReturnValue(10000);
+    mockFormatDuration
+      .mockReturnValueOnce("00:05")
+      .mockReturnValue("00:10");
+
+    const { rerender } = render(
+      <CountdownTimer targetDate="future" timezone="UTC" />
+    );
+
+    expect(screen.getByText("00:05")).toBeInTheDocument();
+    expect(mockParseTargetDate).toHaveBeenCalledWith("future", "UTC");
+
+    act(() => {
+      rerender(
+        <CountdownTimer
+          targetDate="future"
+          timezone="America/Los_Angeles"
+        />
+      );
+    });
+
+    expect(mockParseTargetDate).toHaveBeenLastCalledWith(
+      "future",
+      "America/Los_Angeles"
+    );
+    expect(screen.getByText("00:10")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- test passing timezone to parseTargetDate
- test countdown updates when timezone changes

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/CountdownTimer.test.tsx`
- `pnpm -r build` *(fails: TypeScript error in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c5645808c4832fb0872ee1fc325207