### PR TITLE
test: cover VideoBlock autoplay and muted attributes

### DIFF
--- a/packages/ui/src/components/cms/blocks/VideoBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/VideoBlock.tsx
@@ -1,6 +1,7 @@
 // packages/ui/src/components/cms/blocks/VideoBlock.tsx
 "use client";
 
+import { useEffect, useRef } from "react";
 import { VideoPlayer } from "../../atoms/VideoPlayer";
 
 interface Props {
@@ -12,6 +13,16 @@ interface Props {
 
 /** CMS wrapper for the VideoPlayer atom */
 export default function VideoBlock({ src, autoplay }: Props) {
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (ref.current && autoplay) {
+      ref.current.setAttribute("muted", "");
+    }
+  }, [autoplay]);
+
   if (!src) return null;
-  return <VideoPlayer src={src} autoPlay={autoplay} muted={autoplay} />;
+  return (
+    <VideoPlayer ref={ref} src={src} autoPlay={autoplay} muted={autoplay} />
+  );
 }

--- a/packages/ui/src/components/cms/blocks/__tests__/VideoBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/VideoBlock.test.tsx
@@ -9,11 +9,11 @@ describe("VideoBlock", () => {
     expect(video).toHaveAttribute("src", "movie.mp4");
   });
 
-  it("supports autoplay", () => {
+  it("applies autoplay and muted attributes", () => {
     const { container } = render(<VideoBlock src="movie.mp4" autoplay />);
-    const video = container.querySelector("video") as HTMLVideoElement;
-    expect(video.autoplay).toBe(true);
-    expect(video.muted).toBe(true);
+    const video = container.querySelector("video");
+    expect(video).toHaveAttribute("autoplay");
+    expect(video).toHaveAttribute("muted");
   });
 
   it("plays when play is called", () => {


### PR DESCRIPTION
## Summary
- ensure VideoBlock applies autoplay and muted attributes when autoplay enabled
- verify VideoBlock returns null without src

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/VideoBlock.test.tsx`
- `pnpm --filter @acme/ui build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5648227b4832f891853abdbebfde2