### PR TITLE
test: ensure DeviceSelector highlights active device

### DIFF
--- a/packages/ui/src/components/__tests__/DeviceSelector.test.tsx
+++ b/packages/ui/src/components/__tests__/DeviceSelector.test.tsx
@@ -95,4 +95,17 @@ describe("DeviceSelector", () => {
     fireEvent.change(select, { target: { value: newPreset.id } });
     expect(setDeviceId).toHaveBeenNthCalledWith(4, newPreset.id);
   });
+
+  it("applies active variant to current device", () => {
+    render(<Wrapper />);
+
+    const desktopBtn = screen.getByRole("button", { name: "desktop" });
+    expect(desktopBtn).toHaveAttribute("variant", "default");
+
+    fireEvent.click(screen.getByRole("button", { name: "tablet" }));
+
+    expect(desktopBtn).toHaveAttribute("variant", "outline");
+    const tabletBtn = screen.getByRole("button", { name: "tablet" });
+    expect(tabletBtn).toHaveAttribute("variant", "default");
+  });
 });


### PR DESCRIPTION
## Summary
- cover variant state in DeviceSelector tests

## Testing
- `pnpm exec jest packages/ui/src/components/__tests__/ComponentPreview.test.tsx packages/ui/src/components/__tests__/DeviceSelector.test.tsx packages/ui/src/components/__tests__/DynamicRenderer.test.tsx packages/ui/src/components/__tests__/ThemeToggle.test.tsx --config jest.config.cjs --runInBand --coverage --collectCoverageFrom="packages/ui/src/components/{ComponentPreview.tsx,DeviceSelector.tsx,DynamicRenderer.tsx,ThemeToggle.tsx}"`


------
https://chatgpt.com/codex/tasks/task_e_68c55e900264832f9bd8d0665fbdc40e