### PR TITLE
test: ensure read-only PagesTable rendering

### DIFF
--- a/packages/ui/src/components/cms/__tests__/PagesTable.client.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/PagesTable.client.test.tsx
@@ -28,15 +28,17 @@ describe("PagesTable", () => {
     },
   ];
 
-  it("renders only slug and status columns when read-only", () => {
-    render(<PagesTable shop={shop} pages={pages} canWrite={false} />);
+  it("renders only slug and status columns when canWrite is omitted", () => {
+    render(<PagesTable shop={shop} pages={pages} />);
     const headers = screen
       .getAllByRole("columnheader")
       .map((h) => h.textContent?.trim());
     expect(headers).toEqual(["Slug", "Status"]);
-    expect(screen.queryByText("Actions")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "New Page" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Edit" })
     ).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- test PagesTable without `canWrite`
- check absence of edit and new page links in read-only mode

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in platform-core)*
- `pnpm run check:references` *(missing script)*
- `pnpm run build:ts` *(missing script)*
- `pnpm --filter @acme/ui run test packages/ui/src/components/cms/__tests__/PagesTable.client.test.tsx` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c564404cb4832fa2e478cf91852306