### PR TITLE
test: cover RangeInput edges

### DIFF
--- a/packages/ui/src/components/cms/__tests__/RangeInput.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/RangeInput.test.tsx
@@ -40,4 +40,28 @@ describe("RangeInput", () => {
     expect(input).toHaveAttribute("min", "10");
     expect(input).toHaveAttribute("max", "20");
   });
+
+  it("displays min boundary and handles values below it", () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <RangeInput value="10px" onChange={handleChange} min={10} max={20} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    const span = container.querySelector("span") as HTMLSpanElement;
+    expect(span).toHaveTextContent("10px");
+    fireEvent.change(input, { target: { value: "9" } });
+    expect(handleChange).toHaveBeenCalledWith("9px");
+  });
+
+  it("displays max boundary and handles values above it", () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <RangeInput value="20px" onChange={handleChange} min={10} max={20} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    const span = container.querySelector("span") as HTMLSpanElement;
+    expect(span).toHaveTextContent("20px");
+    fireEvent.change(input, { target: { value: "21" } });
+    expect(handleChange).toHaveBeenCalledWith("21px");
+  });
 });


### PR DESCRIPTION
## Summary
- add boundary tests ensuring `RangeInput` shows min/max values and fires `onChange` when moving beyond edges

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find labels in PageBuilder.resize.test.tsx and ComponentEditor.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c564417380832f8e069de30b00df74