### PR TITLE
test: cover AnnouncementBarBlock link and closable

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/AnnouncementBarBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/AnnouncementBarBlock.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import AnnouncementBarBlock from "../AnnouncementBarBlock";
 
 describe("AnnouncementBarBlock", () => {
@@ -10,5 +11,22 @@ describe("AnnouncementBarBlock", () => {
   it("returns null when no text", () => {
     const { container } = render(<AnnouncementBarBlock />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders link with correct href", () => {
+    render(<AnnouncementBarBlock text="Promo" link="/sale" />);
+    const link = screen.getByRole("link", { name: "Promo" });
+    expect(link).toHaveAttribute("href", "/sale");
+  });
+
+  it("hides bar after close click", async () => {
+    render(<AnnouncementBarBlock text="Hello" closable />);
+    expect(
+      screen.getByRole("button", { name: "Close announcement" })
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Close announcement" })
+    );
+    expect(screen.queryByText("Hello")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add coverage for AnnouncementBarBlock link href
- ensure closable renders close button and hides bar

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2322 in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find label Width (Desktop))*

------
https://chatgpt.com/codex/tasks/task_e_68c5644aedac832f814d9d283053ff2a