### PR TITLE
test: add ContactFormWithMap tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/ContactFormWithMap.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ContactFormWithMap.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react";
+import ContactFormWithMap from "../ContactFormWithMap";
+
+const DEFAULT_SRC =
+  "https://maps.google.com/maps?q=New%20York&t=&z=13&ie=UTF8&iwloc=&output=embed";
+
+describe("ContactFormWithMap", () => {
+  it("renders form and iframe with default mapSrc in a grid", () => {
+    const { container, getByTitle } = render(<ContactFormWithMap />);
+    const grid = container.firstChild as HTMLElement;
+    expect(grid).toHaveClass("grid");
+    const children = Array.from(grid.children);
+    expect(children).toHaveLength(2);
+    expect(children[0].tagName).toBe("FORM");
+    expect(children[1].tagName).toBe("IFRAME");
+    expect(getByTitle("map")).toHaveAttribute("src", DEFAULT_SRC);
+  });
+
+  it("allows overriding the mapSrc", () => {
+    const customSrc = "https://maps.google.com/maps?q=Paris";
+    const { getByTitle } = render(
+      <ContactFormWithMap mapSrc={customSrc} />,
+    );
+    expect(getByTitle("map")).toHaveAttribute("src", customSrc);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for ContactFormWithMap default map src and override

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type {...})*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui run test` *(fails: Unable to find a label with the text of: /Width \(Desktop\)/)*

------
https://chatgpt.com/codex/tasks/task_e_68c564579b28832faf9c6e495fc31337