### PR TITLE
test(ui): skip FAQ entries missing answers

### DIFF
--- a/packages/ui/src/components/cms/blocks/FAQBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FAQBlock.tsx
@@ -17,7 +17,8 @@ export default function FAQBlock({
   minItems,
   maxItems,
 }: Props) {
-  const list = items.slice(0, maxItems ?? items.length);
+  const filtered = items.filter(({ question, answer }) => question && answer);
+  const list = filtered.slice(0, maxItems ?? filtered.length);
   if (!list.length || list.length < (minItems ?? 0)) return null;
   const accItems: AccordionItem[] = list.map(({ question, answer }) => ({
     title: question,

--- a/packages/ui/src/components/cms/blocks/__tests__/FAQBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/FAQBlock.test.tsx
@@ -3,15 +3,21 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import FAQBlock from "../FAQBlock";
 
 describe("FAQBlock", () => {
-  const items = [
+  const items: any[] = [
     { question: "Q1", answer: "A1" },
     { question: "Q2", answer: "A2" },
+    // Item missing an answer should be ignored
+    { question: "Q3" },
   ];
 
-  it("renders accordion items and toggles answers", () => {
+  it("renders multiple entries, skipping those without answers", () => {
     render(<FAQBlock items={items} />);
+    expect(screen.getByText("Q1")).toBeInTheDocument();
+    expect(screen.getByText("Q2")).toBeInTheDocument();
+    // Q3 has no answer and should be skipped
+    expect(screen.queryByText("Q3")).not.toBeInTheDocument();
     const btn = screen.getByRole("button", { name: /Q1/ });
-    fireEvent.click(btn);
+    fireEvent.click(btn, { detail: 1 });
     expect(screen.getByText("A1")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- ensure FAQBlock ignores entries without answers and only renders valid items
- test multiple FAQ entries render and toggle correctly

## Testing
- `pnpm --filter @acme/ui test --coverage=false packages/ui/src/components/cms/blocks/__tests__/FAQBlock.test.tsx`
- `pnpm -r build` *(fails: Type '... | null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5645b9498832fa8597dfd5769a086