### PR TITLE
Add tests for FeaturedProductBlock fallback and extras

### DIFF
--- a/packages/ui/src/components/cms/blocks/FeaturedProductBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FeaturedProductBlock.tsx
@@ -45,6 +45,7 @@ export default function FeaturedProductBlock({
   if (!product) return null;
 
   const media = product.media?.[0];
+  const secondaryMedia = product.media?.[1];
 
   return (
     <div className="flex flex-col gap-4">
@@ -68,6 +69,28 @@ export default function FeaturedProductBlock({
           )}
         </div>
       )}
+      {secondaryMedia?.url && (
+        <div className="relative aspect-square w-full" data-cy="secondary-media">
+          {secondaryMedia.type === "image" ? (
+            <Image
+              src={secondaryMedia.url}
+              alt={secondaryMedia.altText ?? product.title ?? ""}
+              fill
+              sizes="(min-width: 768px) 50vw, 100vw"
+              className="rounded-md object-cover"
+            />
+          ) : (
+            <video
+              src={secondaryMedia.url}
+              className="h-full w-full rounded-md object-cover"
+              muted
+              playsInline
+            />
+          )}
+        </div>
+      )}
+      {product.badges?.sale && <span data-cy="badge-sale">Sale</span>}
+      {product.badges?.new && <span data-cy="badge-new">New</span>}
       <h3 className="text-xl font-semibold">{product.title}</h3>
       <Price amount={product.price ?? 0} className="text-lg font-medium" />
       <ProductVariantSelector

--- a/packages/ui/src/components/cms/blocks/__tests__/FeaturedProductBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/FeaturedProductBlock.test.tsx
@@ -37,4 +37,25 @@ describe("FeaturedProductBlock", () => {
     await userEvent.selectOptions(select, "S");
     expect(button).not.toBeDisabled();
   });
+
+  it("returns null when no product data is provided", () => {
+    const { container } = render(<FeaturedProductBlock />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows secondary media and badges when available", () => {
+    const skuWithExtras: SKU & { badges?: { sale?: boolean; new?: boolean } } = {
+      ...sku,
+      media: [
+        { url: "/img-primary.jpg", type: "image", altText: "Primary" },
+        { url: "/img-secondary.jpg", type: "image", altText: "Secondary" },
+      ],
+      badges: { sale: true, new: true },
+    };
+    render(<FeaturedProductBlock sku={skuWithExtras} />);
+    expect(screen.getByAltText("Primary")).toBeInTheDocument();
+    expect(screen.getByAltText("Secondary")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-sale")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-new")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- handle secondary media and product badges in `FeaturedProductBlock`
- add tests for missing product data and optional media/badge display

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type {...})*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui exec jest src/components/cms/blocks/__tests__/FeaturedProductBlock.test.tsx --runInBand --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5645bf0bc832fba1eb87da930e7f8