### PR TITLE
test(ui): cover FooterBlock link groups and social links

### DIFF
--- a/packages/ui/__tests__/FooterBlock.test.tsx
+++ b/packages/ui/__tests__/FooterBlock.test.tsx
@@ -31,10 +31,23 @@ describe("FooterBlock", () => {
     expect(link).toHaveAttribute("href", "/about");
   });
 
-  it("renders without links when none provided", () => {
+  it("renders with empty link groups", () => {
     const { container } = render(
-      <FooterBlock locale={"en" as any} links={[]} />,
+      <FooterBlock locale={"en" as any} shopName="Brand" linkGroups={[]} />,
     );
     expect(container.querySelector("a")).toBeNull();
+    expect(screen.getByText("Brand")).toBeInTheDocument();
+  });
+
+  it("renders social links when provided", () => {
+    render(
+      <FooterBlock
+        locale={"en" as any}
+        shopName="Brand"
+        socialLinks={{ facebook: "https://facebook.com/example" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "facebook" });
+    expect(link).toHaveAttribute("href", "https://facebook.com/example");
   });
 });

--- a/packages/ui/src/components/cms/blocks/FooterBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FooterBlock.tsx
@@ -1,15 +1,37 @@
 import type { Locale } from "@acme/i18n/locales";
 import { Footer, type FooterLink } from "../../organisms/Footer";
 import type { LogoVariants } from "../../organisms/types";
+import SocialLinks, { type SocialLinksProps } from "./SocialLinks";
+
+interface LinkGroup {
+  title?: string;
+  links?: FooterLink[];
+}
 
 interface Props {
   links?: FooterLink[];
+  linkGroups?: LinkGroup[];
+  socialLinks?: SocialLinksProps;
   logoVariants?: LogoVariants;
   shopName: string;
   locale: Locale;
 }
 
 /** CMS wrapper for the Footer organism */
-export default function FooterBlock({ links = [], logoVariants, shopName }: Props) {
-  return <Footer links={links} logoVariants={logoVariants} shopName={shopName} />;
+export default function FooterBlock({
+  links = [],
+  linkGroups = [],
+  socialLinks,
+  logoVariants,
+  shopName,
+}: Props) {
+  const groupedLinks = linkGroups.flatMap((g) => g.links ?? []);
+  const footerLinks = groupedLinks.length ? groupedLinks : links;
+
+  return (
+    <div>
+      <Footer links={footerLinks} logoVariants={logoVariants} shopName={shopName} />
+      {socialLinks && <SocialLinks {...socialLinks} className="mt-4" />}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- allow `FooterBlock` to accept link groups and optional social links
- test rendering with empty link groups
- verify social links appear when provided

## Testing
- `CI=true pnpm --filter @acme/ui exec jest __tests__/FooterBlock.test.tsx --config ../../jest.config.cjs --runInBand --coverage --coverageThreshold='{"global":{"branches":0,"lines":0,"functions":0,"statements":0}}'`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c5645d6f60832f814bda2387405ff6