### PR TITLE
test: cover gallery captions and empty array

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx
@@ -5,20 +5,22 @@ import Gallery from "../Gallery";
 
 describe("Gallery", () => {
   const images = [
-    { src: "/a.jpg", alt: "a" },
+    { src: "/a.jpg", alt: "a", caption: "Caption A" },
     { src: "/b.jpg", alt: "b" },
   ];
 
-  it("renders images", () => {
+  it("renders images with optional captions", () => {
     const { container } = render(<Gallery images={images} />);
     expect(screen.getByAltText("a")).toBeInTheDocument();
     expect(screen.getAllByRole("img")).toHaveLength(2);
+    expect(screen.getByText("Caption A")).toBeInTheDocument();
+    expect(container.querySelectorAll("figcaption")).toHaveLength(1);
     expect(container.firstChild).toHaveClass("grid");
     expect(container.firstChild).toHaveClass("sm:grid-cols-2");
     expect(container.firstChild).toHaveClass("md:grid-cols-3");
   });
 
-  it("returns null without images", () => {
+  it("returns null with empty images array", () => {
     const { container } = render(<Gallery images={[]} />);
     expect(container.firstChild).toBeNull();
   });


### PR DESCRIPTION
## Summary
- extend Gallery tests for caption rendering
- add null return test for empty images array

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/Gallery.test.tsx` *(fails: Unable to find an element with the text: Caption A)*

------
https://chatgpt.com/codex/tasks/task_e_68c564634e7c832fafac612aaf832f36