### PR TITLE
test: expand GiftCardBlock tests

### DIFF
--- a/packages/ui/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/__tests__/GiftCardBlock.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import GiftCardBlock from "../src/components/cms/blocks/GiftCardBlock";
 
+const addToCartMock = jest.fn();
 jest.mock("@acme/platform-core/components/shop/AddToCartButton.client", () => ({
   __esModule: true,
-  default: () => <button>Purchase</button>,
+  default: (props: any) => {
+    addToCartMock(props);
+    return <button>Purchase</button>;
+  },
 }));
 
 jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
@@ -11,6 +15,10 @@ jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
 }));
 
 describe("GiftCardBlock", () => {
+  beforeEach(() => {
+    addToCartMock.mockClear();
+  });
+
   it("exposes data-token attributes", () => {
     render(<GiftCardBlock denominations={[25, 50]} />);
     const buttons = screen.getAllByRole("button");
@@ -20,5 +28,29 @@ describe("GiftCardBlock", () => {
       "--color-bg"
     );
     expect(buttons[1]).toHaveAttribute("data-token", "--color-bg");
+  });
+
+  it("updates selected amount and passes sku to AddToCartButton", () => {
+    render(<GiftCardBlock denominations={[25, 50]} />);
+    const [first, second] = screen
+      .getAllByRole("button")
+      .filter((btn) => btn.textContent !== "Purchase");
+
+    fireEvent.click(second);
+
+    expect(addToCartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sku: expect.objectContaining({ price: 50 }),
+      })
+    );
+    expect(second).toHaveAttribute("data-token", "--color-fg");
+    expect(first).toHaveAttribute("data-token", "--color-bg");
+  });
+
+  it("renders terms and conditions when provided", () => {
+    render(
+      <GiftCardBlock denominations={[25, 50]} description="Terms apply" />
+    );
+    expect(screen.getByText("Terms apply")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx
@@ -1,20 +1,52 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import GiftCardBlock from "../GiftCardBlock";
 
+const addToCartMock = jest.fn();
 jest.mock("@acme/platform-core/components/shop/AddToCartButton.client", () => ({
   __esModule: true,
-  default: () => <button>Purchase</button>,
+  default: (props: any) => {
+    addToCartMock(props);
+    return <button>Purchase</button>;
+  },
 }));
 jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
   useCurrency: () => ["USD", jest.fn()],
 }));
 
 describe("GiftCardBlock", () => {
+  beforeEach(() => {
+    addToCartMock.mockClear();
+  });
+
   it("renders denominations and purchase button", () => {
     render(<GiftCardBlock denominations={[25, 50]} description="Gift" />);
     expect(screen.getByText("Gift")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "$25.00" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "$50.00" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /purchase/i })).toBeInTheDocument();
+  });
+
+  it("updates selected amount and passes sku to AddToCartButton", () => {
+    render(<GiftCardBlock denominations={[25, 50]} />);
+    const [first, second] = screen
+      .getAllByRole("button")
+      .filter((btn) => btn.textContent !== "Purchase");
+
+    fireEvent.click(second);
+
+    expect(addToCartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sku: expect.objectContaining({ price: 50 }),
+      })
+    );
+    expect(second).toHaveAttribute("data-token", "--color-fg");
+    expect(first).toHaveAttribute("data-token", "--color-bg");
+  });
+
+  it("renders terms and conditions when provided", () => {
+    render(
+      <GiftCardBlock denominations={[25, 50]} description="Terms apply" />
+    );
+    expect(screen.getByText("Terms apply")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- verify denomination selection updates token and SKU
- ensure terms/conditions text renders when provided

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm exec jest packages/ui/__tests__/GiftCardBlock.test.tsx packages/ui/src/components/cms/blocks/__tests__/GiftCardBlock.test.tsx --config ./jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c564640698832f819f94e4759e8963