### PR TITLE
Add autoplay and navigation tests for TestimonialSlider

### DIFF
--- a/packages/ui/__tests__/TestimonialSlider.test.tsx
+++ b/packages/ui/__tests__/TestimonialSlider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import TestimonialSlider from "../src/components/cms/blocks/TestimonialSlider";
 
 describe("TestimonialSlider", () => {
@@ -43,5 +43,48 @@ describe("TestimonialSlider", () => {
     });
     expect(screen.getByText("Great")).toBeInTheDocument();
     expect(screen.queryByText("Nice")).not.toBeInTheDocument();
+  });
+
+  it("autoplays to next testimonial", () => {
+    render(
+      <TestimonialSlider
+        testimonials={[
+          { quote: "Great", name: "A" },
+          { quote: "Nice", name: "B" },
+        ]}
+      />
+    );
+    expect(screen.getByText("Great")).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText("Nice")).toBeInTheDocument();
+  });
+
+  it("advances with next button", () => {
+    render(
+      <TestimonialSlider
+        testimonials={[
+          { quote: "Great", name: "A" },
+          { quote: "Nice", name: "B" },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
+    expect(screen.getByText("Nice")).toBeInTheDocument();
+  });
+
+  it("goes back with previous button", () => {
+    render(
+      <TestimonialSlider
+        testimonials={[
+          { quote: "Great", name: "A" },
+          { quote: "Nice", name: "B" },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
+    fireEvent.click(screen.getByRole("button", { name: "Previous slide" }));
+    expect(screen.getByText("Great")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
+++ b/packages/ui/src/components/cms/blocks/TestimonialSlider.tsx
@@ -14,21 +14,41 @@ export default function TestimonialSlider({
 }) {
   const list = testimonials.slice(0, maxItems ?? testimonials.length);
   const [i, setI] = useState(0);
+  const next = () => setI((n) => (n + 1) % list.length);
+  const prev = () => setI((n) => (n - 1 + list.length) % list.length);
+
   useEffect(() => {
     if (!list.length) return;
-    const id = setInterval(
-      () => setI((n) => (n + 1) % list.length),
-      5000
-    );
+    const id = setInterval(next, 5000);
     return () => clearInterval(id);
   }, [list.length]);
 
   if (!list.length || list.length < (minItems ?? 0)) return null;
   const t = list[i % list.length];
   return (
-    <section className="space-y-2 text-center">
+    <section className="relative space-y-2 text-center">
       <blockquote className="italic">{t.quote}</blockquote>
       {t.name && <footer className="text-sm text-muted">— {t.name}</footer>}
+      {list.length > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={prev}
+            aria-label="Previous slide"
+            className="absolute left-2 top-1/2 -translate-y-1/2"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            aria-label="Next slide"
+            className="absolute right-2 top-1/2 -translate-y-1/2"
+          >
+            ›
+          </button>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add next/previous controls to TestimonialSlider
- verify autoplay, next, and previous navigation with new tests

## Testing
- `pnpm --filter @acme/ui run test -- __tests__/TestimonialSlider.test.tsx`
- `pnpm -r build` (fails: TypeScript errors in packages/platform-core)
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c5647f3da8832fa266d3c4d78d7818