### PR TITLE
feat: add tab navigation tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/Tabs.tsx
+++ b/packages/ui/src/components/cms/blocks/Tabs.tsx
@@ -31,6 +31,15 @@ export default function TabsBlock({
             type="button"
             key={i}
             onClick={() => setCurrent(i)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowRight") {
+                e.preventDefault();
+                setCurrent((i + 1) % labels.length);
+              } else if (e.key === "ArrowLeft") {
+                e.preventDefault();
+                setCurrent((i - 1 + labels.length) % labels.length);
+              }
+            }}
             className={cn(
               "border-b-2 px-3 py-1 text-sm",
               i === safeIndex

--- a/packages/ui/src/components/cms/blocks/__tests__/Tabs.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Tabs.test.tsx
@@ -26,5 +26,45 @@ describe("TabsBlock", () => {
     expect(buttons[1]).toHaveClass("border-primary");
     expect(screen.getByText("Content Two")).toBeInTheDocument();
   });
+
+  it("shows the matching panel when different tabs are clicked", () => {
+    render(
+      <TabsBlock labels={["One", "Two", "Three"]}>
+        <div>Panel One</div>
+        <div>Panel Two</div>
+        <div>Panel Three</div>
+      </TabsBlock>
+    );
+
+    const buttons = screen.getAllByRole("button");
+
+    fireEvent.click(buttons[1]);
+    expect(screen.getByText("Panel Two")).toBeInTheDocument();
+    expect(screen.queryByText("Panel One")).not.toBeInTheDocument();
+
+    fireEvent.click(buttons[2]);
+    expect(screen.getByText("Panel Three")).toBeInTheDocument();
+    expect(screen.queryByText("Panel Two")).not.toBeInTheDocument();
+  });
+
+  it("supports keyboard navigation with arrow keys", () => {
+    render(
+      <TabsBlock labels={["One", "Two", "Three"]}>
+        <div>Panel One</div>
+        <div>Panel Two</div>
+        <div>Panel Three</div>
+      </TabsBlock>
+    );
+
+    const buttons = screen.getAllByRole("button");
+
+    fireEvent.keyDown(buttons[0], { key: "ArrowRight" });
+    expect(buttons[1]).toHaveClass("border-primary");
+    expect(screen.getByText("Panel Two")).toBeInTheDocument();
+
+    fireEvent.keyDown(buttons[1], { key: "ArrowLeft" });
+    expect(buttons[0]).toHaveClass("border-primary");
+    expect(screen.getByText("Panel One")).toBeInTheDocument();
+  });
 });
 


### PR DESCRIPTION
## Summary
- support arrow key navigation in Tabs block
- test tab clicks and keyboard navigation

## Testing
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/Tabs.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5647ddd9c832fb9b20de372c2bf54