### PR TITLE
test: add Spacer block tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/Spacer.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Spacer.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import Spacer from "../Spacer";
+
+describe("Spacer", () => {
+  it("uses height 1rem by default", () => {
+    const { container } = render(<Spacer />);
+    expect(container.firstChild).toHaveStyle({ height: "1rem" });
+  });
+
+  it("applies custom height", () => {
+    const { container } = render(<Spacer height="2rem" />);
+    expect(container.firstChild).toHaveStyle({ height: "2rem" });
+  });
+
+  it("is aria-hidden", () => {
+    const { container } = render(<Spacer />);
+    expect(container.firstChild).toHaveAttribute("aria-hidden", "true");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Spacer block verifying default and custom height
- ensure Spacer is aria-hidden

## Testing
- `pnpm install`
- `pnpm --filter @acme/ui build` *(fails: Type '{ id: string; ...; } | null' is not assignable to type '{ id: string; ...; }')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/Spacer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5647cc7b8832fa4cefe86795177f5