### PR TITLE
test: cover section styling and attributes

### DIFF
--- a/packages/ui/src/components/cms/blocks/Section.tsx
+++ b/packages/ui/src/components/cms/blocks/Section.tsx
@@ -1,11 +1,27 @@
 "use client";
-import type { ReactNode } from "react";
+import type { ReactNode, HTMLAttributes } from "react";
 
-export interface SectionProps {
+export interface SectionProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
-  className?: string;
+  /** Padding applied to the section */
+  padding?: string;
+  /** Background color for the section */
+  backgroundColor?: string;
 }
 
-export default function Section({ children, className }: SectionProps) {
-  return <div className={className}>{children}</div>;
+export default function Section({
+  children,
+  padding,
+  backgroundColor,
+  style,
+  ...rest
+}: SectionProps) {
+  return (
+    <div
+      {...rest}
+      style={{ ...style, padding, backgroundColor }}
+    >
+      {children}
+    </div>
+  );
 }

--- a/packages/ui/src/components/cms/blocks/__tests__/Section.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/Section.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import Section from "../Section";
+
+describe("Section", () => {
+  it("applies custom padding and background color", () => {
+    const { container } = render(
+      <Section padding="2rem" backgroundColor="rgb(255, 0, 0)">
+        Content
+      </Section>
+    );
+    const section = container.firstChild as HTMLElement;
+    expect(section).toHaveStyle({
+      padding: "2rem",
+      backgroundColor: "rgb(255, 0, 0)",
+    });
+  });
+
+  it("forwards id and className to the DOM", () => {
+    const { container } = render(
+      <Section id="my-section" className="custom-class">
+        Content
+      </Section>
+    );
+    const section = container.firstChild as HTMLElement;
+    expect(section).toHaveAttribute("id", "my-section");
+    expect(section).toHaveClass("custom-class");
+  });
+});


### PR DESCRIPTION
## Summary
- allow Section block to accept padding and background color props while forwarding other attributes
- test Section padding/background styles and id/className propagation

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/Section.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c56477a2b0832f8b6c6d1b86e224bd