### PR TITLE
feat: pause recommendation carousel autoplay on hover

### DIFF
--- a/packages/ui/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/__tests__/RecommendationCarousel.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor, act } from "@testing-library/react";
+import { render, waitFor, act, fireEvent } from "@testing-library/react";
 import { RecommendationCarousel } from "../src/components/organisms/RecommendationCarousel";
 import type { SKU } from "@acme/types";
 
@@ -71,5 +71,37 @@ describe("RecommendationCarousel", () => {
     } as unknown as Response);
     const { container } = render(<RecommendationCarousel endpoint="/api" />);
     await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+
+  it("pauses autoplay on hover and resumes afterward", async () => {
+    jest.useFakeTimers();
+    const { container } = render(<RecommendationCarousel endpoint="/api" />);
+    await waitFor(() => expect(container.querySelector(".flex")).toBeTruthy());
+    const scroller = container.querySelector(".flex") as HTMLDivElement;
+    const scrollSpy = jest.fn();
+    Object.defineProperty(scroller, "scrollTo", { value: scrollSpy });
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    const outer = container.firstChild as HTMLElement;
+    act(() => {
+      fireEvent.mouseEnter(outer);
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      fireEvent.mouseLeave(outer);
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(scrollSpy).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
   });
 });

--- a/packages/ui/src/components/organisms/RecommendationCarousel.tsx
+++ b/packages/ui/src/components/organisms/RecommendationCarousel.tsx
@@ -47,6 +47,30 @@ export function RecommendationCarousel({
   const [itemsPerSlide, setItemsPerSlide] = React.useState(
     desktopItems ?? minItems
   );
+  const scrollerRef = React.useRef<HTMLDivElement>(null);
+  const autoplayRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
+  const indexRef = React.useRef(0);
+
+  const stopAutoplay = React.useCallback(() => {
+    if (autoplayRef.current) {
+      clearInterval(autoplayRef.current);
+      autoplayRef.current = null;
+    }
+  }, []);
+
+  const startAutoplay = React.useCallback(() => {
+    stopAutoplay();
+    if (!scrollerRef.current || products.length <= 1) return;
+    autoplayRef.current = setInterval(() => {
+      const scroller = scrollerRef.current;
+      if (!scroller) return;
+      indexRef.current = (indexRef.current + 1) % products.length;
+      scroller.scrollTo({
+        left: scroller.clientWidth * indexRef.current,
+        behavior: "smooth",
+      });
+    }, 3000);
+  }, [products.length, stopAutoplay]);
 
   React.useEffect(() => {
     const calculateItems = () => {
@@ -102,11 +126,24 @@ export function RecommendationCarousel({
     [width]
   );
 
+  React.useEffect(() => {
+    startAutoplay();
+    return stopAutoplay;
+  }, [startAutoplay, stopAutoplay]);
+
   if (!products.length) return null;
 
   return (
-    <div className={cn("overflow-hidden", className)} {...props}>
-      <div className={cn("flex snap-x overflow-x-auto pb-4", gapClassName)}>
+    <div
+      className={cn("overflow-hidden", className)}
+      onMouseEnter={stopAutoplay}
+      onMouseLeave={startAutoplay}
+      {...props}
+    >
+      <div
+      ref={scrollerRef}
+        className={cn("flex snap-x overflow-x-auto pb-4", gapClassName)}
+      >
         {products.map((p) => (
           <div key={p.id} style={slideStyle} className="snap-start">
             <ProductCard product={p} className="h-full" />


### PR DESCRIPTION
## Summary
- add autoplay controls to RecommendationCarousel
- test hover pause and resume behavior

## Testing
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm --filter @acme/ui run check:references` *(not found)*
- `pnpm --filter @acme/ui run build:ts` *(not found)*
- `pnpm --filter @acme/ui run build` *(fails: TypeScript errors in @acme/ui)*
- `pnpm --filter @acme/ui test packages/ui/__tests__/RecommendationCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c564752e30832fa3e3034f6f7e9e59