### PR TITLE
test: cover ProductComparisonBlock edge cases

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductComparisonBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductComparisonBlock.tsx
@@ -30,7 +30,11 @@ export default function ProductComparisonBlock({ skus = [], attributes }: Props)
             <td className="border px-2 py-1">{sku.title}</td>
             {attributes.map((attr) => (
               <td key={attr} className="border px-2 py-1">
-                {String(sku[attr] ?? "")}
+                {typeof sku[attr] === "boolean"
+                  ? sku[attr]
+                    ? "✓"
+                    : "✕"
+                  : String(sku[attr] ?? "")}
               </td>
             ))}
           </tr>

--- a/packages/ui/src/components/cms/blocks/__tests__/ProductComparisonBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductComparisonBlock.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import type { SKU } from "@acme/types";
 import ProductComparisonBlock from "../ProductComparisonBlock";
 
@@ -23,28 +23,48 @@ describe("ProductComparisonBlock", () => {
     price: 200,
     deposit: 20,
     stock: 10,
-    forSale: true,
-    forRental: false,
+    forSale: false,
+    forRental: true,
     media: [],
     sizes: [],
     description: "",
   };
 
-  it("renders a comparison table", () => {
+  it("renders checkmarks and crosses for boolean attributes", () => {
     render(
       <ProductComparisonBlock
         skus={[sku1, sku2]}
-        attributes={["price", "stock"]}
+        attributes={["price", "stock", "forSale", "forRental"]}
       />
     );
     expect(screen.getByText("Product One")).toBeInTheDocument();
     expect(screen.getByText("Product Two")).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: /price/i })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: /stock/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /forsale/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /forrental/i })).toBeInTheDocument();
     expect(screen.getByText("100")).toBeInTheDocument();
     expect(screen.getByText("200")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("10")).toBeInTheDocument();
+
+    const rows = screen.getAllByRole("row");
+    const row1 = rows[1];
+    expect(within(row1).getByText("✓")).toBeInTheDocument();
+    expect(within(row1).getByText("✕")).toBeInTheDocument();
+    const row2 = rows[2];
+    expect(within(row2).getByText("✕")).toBeInTheDocument();
+    expect(within(row2).getByText("✓")).toBeInTheDocument();
+  });
+
+  it("returns null when no products are provided", () => {
+    render(
+      <ProductComparisonBlock
+        skus={[]}
+        attributes={["price", "stock", "forSale"]}
+      />
+    );
+    expect(screen.queryByRole("table")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- show check or cross icons for boolean feature comparison
- test ProductComparisonBlock renders feature icons and handles empty product list

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui run test` *(fails: Unable to find a label with the text of: /Width (Desktop)/)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/blocks/__tests__/ProductComparisonBlock.test.tsx --runInBand --detectOpenHandles --config ../../jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c564716ccc832fb83f4ef3a034e4ba