### PR TITLE
test: add edge cases for ProductBundle

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx
@@ -23,8 +23,12 @@ import ProductBundle, { getRuntimeProps } from "../ProductBundle";
 import { PRODUCTS } from "@acme/platform-core/products";
 
 describe("ProductBundle", () => {
-  it("returns null when skus is empty", () => {
-    const { container } = render(<ProductBundle skus={[]} />);
+  it("returns null when skus is missing or empty", () => {
+    const { container, rerender } = render(<ProductBundle />);
+
+    expect(container.firstChild).toBeNull();
+
+    rerender(<ProductBundle skus={[]} />);
     expect(container.firstChild).toBeNull();
   });
 
@@ -50,6 +54,18 @@ describe("ProductBundle", () => {
       .getAllByTestId("price")
       .map((el) => Number(el.textContent));
     expect(prices).toEqual([10, 15, 50, 40]);
+  });
+
+  it("renders discount badge when discount prop is provided", () => {
+    const skus = [
+      { id: "1", title: "A", price: 10 },
+      { id: "2", title: "B", price: 15 },
+    ];
+    render(<ProductBundle skus={skus} discount={20} />);
+
+    const prices = screen.getAllByTestId("price");
+    expect(prices).toHaveLength(4);
+    expect(prices[2]).toHaveClass("line-through");
   });
 
   it("getRuntimeProps returns first two products", () => {


### PR DESCRIPTION
## Summary
- expand empty-product coverage for ProductBundle
- assert discount styling via strikethrough price when discount is present

## Testing
- `pnpm -r build` *(fails: Type '... | null' is not assignable to type '...')*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/blocks/__tests__/ProductBundle.test.tsx --config ../../jest.config.cjs --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c5646e319c832f9b0f2d406eeafca2