### PR TITLE
test: add pricing table plan highlight test

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/PricingTable.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/PricingTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import PricingTable from "../PricingTable";
 
 describe("PricingTable", () => {
@@ -21,5 +21,51 @@ describe("PricingTable", () => {
     expect(screen.getByText("Feature A")).toBeInTheDocument();
     const cta = screen.getByRole("link", { name: "Choose Basic" });
     expect(cta).toHaveAttribute("href", "/basic");
+  });
+
+  it("renders multiple plans and highlights the recommended one", () => {
+    render(
+      <PricingTable
+        plans={[
+          {
+            title: "Basic",
+            price: "$10/mo",
+            features: ["Feature A", "Feature B"],
+            ctaLabel: "Choose Basic",
+            ctaHref: "/basic",
+          },
+          {
+            title: "Pro",
+            price: "$20/mo",
+            features: ["Feature A", "Feature C"],
+            ctaLabel: "Choose Pro",
+            ctaHref: "/pro",
+            featured: true,
+          },
+          {
+            title: "Enterprise",
+            price: "$30/mo",
+            features: ["Feature A", "Feature B", "Feature C"],
+            ctaLabel: "Choose Enterprise",
+            ctaHref: "/enterprise",
+          },
+        ]}
+      />
+    );
+
+    const basicCard = screen.getByText("Basic").closest("div")!;
+    expect(within(basicCard).getByText("Feature B")).toBeInTheDocument();
+    expect(within(basicCard).queryByText("Feature C")).toBeNull();
+    expect(basicCard).not.toHaveClass("border-primary");
+
+    const proCard = screen.getByText("Pro").closest("div")!;
+    expect(within(proCard).getByText("Feature C")).toBeInTheDocument();
+    expect(within(proCard).queryByText("Feature B")).toBeNull();
+    expect(proCard).toHaveClass("border-primary");
+
+    const enterpriseCard = screen.getByText("Enterprise").closest("div")!;
+    expect(within(enterpriseCard).getByText("Feature B")).toBeInTheDocument();
+    expect(within(enterpriseCard).getByText("Feature C")).toBeInTheDocument();
+    expect(enterpriseCard).not.toHaveClass("border-primary");
   });
 });


### PR DESCRIPTION
## Summary
- expand pricing table tests to cover multiple plans with feature visibility
- verify only the featured plan is highlighted

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test -- src/components/cms/blocks/__tests__/PricingTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5646d83e8832f8418a5c661170b0e