### PR TITLE
test: add autoOpen PopupModal tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/popup-modal.spec.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/popup-modal.spec.tsx
@@ -13,8 +13,8 @@ describe("PopupModal", () => {
     jest.clearAllMocks();
   });
 
-  it('opens immediately when trigger="load"', () => {
-    render(<PopupModal trigger="load" content="Hello" />);
+  it("opens automatically when autoOpen is true", () => {
+    render(<PopupModal autoOpen content="Hello" />);
 
     expect(screen.getByText("Hello")).toBeInTheDocument();
   });
@@ -45,7 +45,7 @@ describe("PopupModal", () => {
   });
 
   it('closes when overlay is clicked', () => {
-    render(<PopupModal trigger="load" content="Overlay close" />);
+    render(<PopupModal autoOpen content="Overlay close" />);
 
     const overlay = screen.getByText("Overlay close").parentElement?.parentElement!;
     fireEvent.click(overlay);
@@ -54,7 +54,7 @@ describe("PopupModal", () => {
   });
 
   it('closes when close button is clicked', () => {
-    render(<PopupModal trigger="load" content="Button close" />);
+    render(<PopupModal autoOpen content="Button close" />);
 
     const button = screen.getByRole("button", { name: /close/i });
     fireEvent.click(button);
@@ -63,7 +63,7 @@ describe("PopupModal", () => {
   });
 
   it('closes when Escape key is pressed', () => {
-    render(<PopupModal trigger="load" content="Escape close" />);
+    render(<PopupModal autoOpen content="Escape close" />);
 
     fireEvent.keyDown(document, { key: "Escape" });
 
@@ -75,7 +75,7 @@ describe("PopupModal", () => {
     const malicious = '<img src="x" onerror="alert(1)"><script>alert("xss")</script>';
 
     const { container } = render(
-      <PopupModal trigger="load" content={malicious} />,
+      <PopupModal autoOpen content={malicious} />,
     );
 
     expect(spy).toHaveBeenCalledWith(malicious);


### PR DESCRIPTION
## Summary
- ensure PopupModal automatically opens when `autoOpen` is true
- cover closing via overlay click and close button

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui test -- packages/ui/src/components/cms/blocks/__tests__/popup-modal.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5646c96c4832fb90319f98d3ad06d