### PR TITLE
Add newsletter submission tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import NewsletterSignup from "../NewsletterSignup";
 
 describe("NewsletterSignup", () => {
@@ -14,5 +15,50 @@ describe("NewsletterSignup", () => {
     expect(screen.getByText("Stay updated")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Your email")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Join" })).toBeInTheDocument();
+  });
+
+  it("clears form and shows success message on successful submission", async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    // @ts-expect-error - overriding fetch for test
+    global.fetch = fetchMock;
+    render(
+      <NewsletterSignup
+        action="/api/newsletter"
+        placeholder="Your email"
+        submitLabel="Join"
+      />
+    );
+    const input = screen.getByPlaceholderText("Your email") as HTMLInputElement;
+    await user.type(input, "test@example.com");
+    await user.click(screen.getByRole("button", { name: "Join" }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/newsletter",
+      expect.objectContaining({
+        method: "post",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com" }),
+      })
+    );
+    expect(await screen.findByText(/success/i)).toBeInTheDocument();
+    expect(input.value).toBe("");
+  });
+
+  it("shows error message on failed submission", async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false });
+    // @ts-expect-error - overriding fetch for test
+    global.fetch = fetchMock;
+    render(
+      <NewsletterSignup
+        action="/api/newsletter"
+        placeholder="Your email"
+        submitLabel="Join"
+      />
+    );
+    const input = screen.getByPlaceholderText("Your email");
+    await user.type(input, "test@example.com");
+    await user.click(screen.getByRole("button", { name: "Join" }));
+    expect(await screen.findByText(/error/i)).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/cms/blocks/molecules.tsx
+++ b/packages/ui/src/components/cms/blocks/molecules.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { Locale } from "@acme/i18n/locales";
-import { memo } from "react";
+import { memo, useState } from "react";
 import type { BlockRegistryEntry } from "./types";
 import type { CategoryCollectionTemplateProps } from "../../templates/CategoryCollectionTemplate";
 import { CategoryCollectionTemplate } from "../../templates/CategoryCollectionTemplate";
@@ -33,14 +33,43 @@ export const NewsletterForm = memo(function NewsletterForm({
   const label =
     typeof submitLabel === "string" ? submitLabel : (submitLabel[locale] ?? "");
 
+  const [value, setValue] = useState("");
+  const [message, setMessage] = useState("");
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    try {
+      const res = await fetch(action, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: value }),
+      });
+      if (res.ok) {
+        setMessage("Success");
+        setValue("");
+      } else {
+        setMessage("Error");
+      }
+    } catch {
+      setMessage("Error");
+    }
+  }
+
   return (
-    <form action={action} method={method} className="flex gap-2">
+    <form
+      action={action}
+      method={method}
+      className="flex gap-2"
+      onSubmit={handleSubmit}
+    >
       <input
         type="email"
         name="email"
         placeholder={ph}
         className="flex-1 rounded border p-2"
         data-token="--color-bg"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
       />
       <button
         type="submit"
@@ -49,6 +78,7 @@ export const NewsletterForm = memo(function NewsletterForm({
       >
         <span data-token="--color-primary-fg">{label}</span>
       </button>
+      {message && <p role="status">{message}</p>}
     </form>
   );
 });


### PR DESCRIPTION
## Summary
- handle newsletter submissions with fetch and status messaging
- verify newsletter signup success, error, and form reset with new tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/NewsletterSignup.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c5646bc43c832fb674b5691efece8d