### PR TITLE
test: add navigation and autoplay tests for ImageSlider

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/ImageSlider.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ImageSlider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import ImageSlider from "../ImageSlider";
 
 describe("ImageSlider", () => {
@@ -14,7 +14,7 @@ describe("ImageSlider", () => {
     expect(screen.getByAltText("a")).toBeInTheDocument();
   });
 
-  it("advances to next slide", () => {
+  it("navigates next and previous slides", () => {
     render(
       <ImageSlider
         slides={[
@@ -25,6 +25,25 @@ describe("ImageSlider", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: /next slide/i }));
     expect(screen.getByAltText("b")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /previous slide/i }));
+    expect(screen.getByAltText("a")).toBeInTheDocument();
+  });
+
+  it("autoplays to next slide after interval", () => {
+    jest.useFakeTimers();
+    render(
+      <ImageSlider
+        slides={[
+          { src: "/a.jpg", alt: "a" },
+          { src: "/b.jpg", alt: "b" },
+        ]}
+      />
+    );
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(screen.getByAltText("b")).toBeInTheDocument();
+    jest.useRealTimers();
   });
 
   it("returns null when below minItems", () => {


### PR DESCRIPTION
## Summary
- add next/prev navigation test for ImageSlider
- verify autoplay advances slides using timers

## Testing
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/ImageSlider.test.tsx`
- `pnpm -r build` (fails: TypeScript errors in platform-core)
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c564672c0c832f8b2647b5ac46bc56