### PR TITLE
Ensure HeroBanner handles missing images and locales

### DIFF
--- a/packages/ui/__tests__/HeroBanner.test.tsx
+++ b/packages/ui/__tests__/HeroBanner.test.tsx
@@ -88,5 +88,34 @@ describe("HeroBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: "Previous slide" }));
     expect(screen.getByText("Slide Three")).toBeInTheDocument();
   });
+
+  it("renders CTA link with locale from pathname", () => {
+    Object.assign(translations, {
+      "hero.slide1.headline": "Slide One",
+      "hero.cta": "Shop now",
+    });
+    mockPathname.mockReturnValue("/fr");
+    render(<HeroBanner />);
+    const link = screen.getByRole("link", { name: "Shop now" });
+    expect(link).toHaveAttribute("href", "/fr/shop");
+  });
+
+  it("skips slides missing image src", () => {
+    const slides: Slide[] = [
+      { src: "", alt: "a", headlineKey: "a.head", ctaKey: "a.cta" },
+      { src: "/b.jpg", alt: "b", headlineKey: "b.head", ctaKey: "b.cta" },
+    ];
+    Object.assign(translations, {
+      "a.head": "Alpha",
+      "a.cta": "Buy A",
+      "b.head": "Beta",
+      "b.cta": "Buy B",
+    });
+
+    render(<HeroBanner slides={slides} />);
+    expect(screen.getByAltText("b")).toBeInTheDocument();
+    expect(screen.queryByAltText("a")).not.toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+  });
 });
 

--- a/packages/ui/src/components/home/HeroBanner.client.tsx
+++ b/packages/ui/src/components/home/HeroBanner.client.tsx
@@ -46,9 +46,13 @@ export default function HeroBanner({
   const safePath = rawPathname ?? "/";
   const langPrefix = safePath.split("/")[1] || "en";
 
+  const sanitizedSlides = (slides.length ? slides : DEFAULT_SLIDES).filter(
+    (s) => s.src
+  );
+  const slideData = sanitizedSlides.length ? sanitizedSlides : DEFAULT_SLIDES;
+
   const [index, setIndex] = useState(0);
 
-  const slideData = slides.length ? slides : DEFAULT_SLIDES;
   const next = useCallback(
     () => setIndex((i) => (i + 1) % slideData.length),
     [slideData.length]


### PR DESCRIPTION
## Summary
- skip slides without image source in `HeroBanner`
- add tests for locale-aware CTA links and missing slide images

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test -- packages/ui/__tests__/HeroBanner.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c564663838832fad77cf879176298a