### PR TITLE
test: cover SocialLinks new window and omissions

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/SocialLinks.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/SocialLinks.test.tsx
@@ -36,6 +36,27 @@ describe("SocialLinks", () => {
     });
   });
 
+  it("opens links in a new window", () => {
+    render(<SocialLinks facebook="https://facebook.com/example" />);
+    expect(
+      screen.getByRole("link", { name: "facebook" })
+    ).toHaveAttribute("target", "_blank");
+  });
+
+  it("does not render links without URL", () => {
+    render(
+      <SocialLinks
+        facebook="https://facebook.com/example"
+        instagram=""
+      />
+    );
+
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+    expect(
+      screen.queryByRole("link", { name: "instagram" })
+    ).not.toBeInTheDocument();
+  });
+
   it("merges provided className", () => {
     const { container } = render(
       <SocialLinks facebook="https://facebook.com/example" className="custom" />


### PR DESCRIPTION
## Summary
- add tests for SocialLinks opening in new window
- ensure omitted links are not rendered

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable...)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/blocks/__tests__/SocialLinks.test.tsx` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5647a1b88832f9d6fdf99d1406fcf