### PR TITLE
test: cover suggestContrastColor edge cases

### DIFF
--- a/packages/ui/src/components/cms/__tests__/ColorInput.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ColorInput.test.tsx
@@ -42,8 +42,22 @@ describe("suggestContrastColor", () => {
     }
   });
 
+  it("darkens a lighter color and exits once contrast is sufficient", () => {
+    const reference = "#000000";
+    const suggestion = suggestContrastColor("#ffffff", reference, 4.5);
+    expect(suggestion).toBe("#f2f2f2");
+    if (suggestion) {
+      expect(getContrast(suggestion, reference)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
   it("returns null after exhausting iteration limit for very high ratios", () => {
     const suggestion = suggestContrastColor("#000000", "#ffffff", 100);
+    expect(suggestion).toBeNull();
+  });
+
+  it("returns null when luminance adjustment exceeds bounds", () => {
+    const suggestion = suggestContrastColor("0 0% 98%", "#000000", 100);
     expect(suggestion).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- add test to ensure lighter colors darken and meet contrast requirements
- add test verifying null when contrast adjustment exceeds luminance bounds

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type...)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run test` *(fails: Unable to find a label with the text...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5643872d8832f9d4f6b31e1a2028a