### PR TITLE
Add navigation tests and controls for ReviewsCarousel

### DIFF
--- a/packages/ui/__tests__/ReviewsCarousel.test.tsx
+++ b/packages/ui/__tests__/ReviewsCarousel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ReviewsCarousel from "../src/components/home/ReviewsCarousel";
 
 const translations: Record<string, string> = {};
@@ -44,6 +45,25 @@ describe("ReviewsCarousel", () => {
     expect(screen.getByText(/Luca quote/)).toBeInTheDocument();
   });
 
+  it("allows navigating reviews with next and previous controls", async () => {
+    Object.assign(translations, {
+      "review.anna.quote": "Anna quote",
+      "review.anna.name": "Anna",
+      "review.luca.quote": "Luca quote",
+      "review.luca.name": "Luca",
+    });
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(<ReviewsCarousel />);
+    expect(screen.getByText(/Anna quote/)).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/next review/i));
+    expect(screen.getByText(/Luca quote/)).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/previous review/i));
+    expect(screen.getByText(/Anna quote/)).toBeInTheDocument();
+  });
+
   it("renders provided reviews", () => {
     Object.assign(translations, { quote1: "Great", name1: "Bob" });
     render(
@@ -53,14 +73,9 @@ describe("ReviewsCarousel", () => {
     expect(screen.getByText(/Bob/)).toBeInTheDocument();
   });
 
-  it("falls back to defaults when passed an empty array", () => {
-    Object.assign(translations, {
-      "review.anna.quote": "Anna quote",
-      "review.anna.name": "Anna",
-    });
-    render(<ReviewsCarousel reviews={[]} />);
-    expect(screen.getByText(/Anna quote/)).toBeInTheDocument();
-    expect(screen.getByText(/—\s*Anna/)).toBeInTheDocument();
+  it("returns null when no reviews are provided", () => {
+    const { container } = render(<ReviewsCarousel reviews={[]} />);
+    expect(container.firstChild).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/home/ReviewsCarousel.tsx
+++ b/packages/ui/src/components/home/ReviewsCarousel.tsx
@@ -13,16 +13,22 @@ const DEFAULT_REVIEWS: Review[] = [
 ];
 
 export default function ReviewsCarousel({
-  reviews = DEFAULT_REVIEWS,
+  reviews,
 }: {
   reviews?: Review[];
 }) {
   const t = useTranslations();
   const [i, setI] = useState(0);
 
-  const list = reviews.length ? reviews : DEFAULT_REVIEWS;
+  const list = reviews ?? DEFAULT_REVIEWS;
+  if (!list.length) return null;
+
   const next = useCallback(
     () => setI((n) => (n + 1) % list.length),
+    [list.length]
+  );
+  const prev = useCallback(
+    () => setI((n) => (n - 1 + list.length) % list.length),
     [list.length]
   );
   useEffect(() => {
@@ -43,6 +49,22 @@ export default function ReviewsCarousel({
         </blockquote>
         <div className="font-semibold text-muted" data-token="--color-muted">
           — {t(nameKey)}
+        </div>
+        <div className="mt-8 flex justify-center gap-4">
+          <button
+            aria-label="Previous review"
+            className="px-2"
+            onClick={prev}
+          >
+            ‹
+          </button>
+          <button
+            aria-label="Next review"
+            className="px-2"
+            onClick={next}
+          >
+            ›
+          </button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- test manual next/previous review navigation
- return null when no reviews supplied
- add prev/next buttons to ReviewsCarousel component

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/plugins/paypal build: Failed, packages/theme build: Failed, packages/plugins/premier-shipping build: Failed, packages/stripe prebuild: Failed)*
- `pnpm --filter @acme/ui run check:references` *(fails: script missing)*
- `pnpm --filter @acme/ui run build:ts` *(fails: script missing)*
- `pnpm --filter @acme/ui test -- __tests__/ReviewsCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c564762334832fa4c8093d8abb6f8a