### PR TITLE
test: restore SocialProof order event coverage

### DIFF
--- a/packages/ui/src/components/cms/blocks/SocialProof.d.ts
+++ b/packages/ui/src/components/cms/blocks/SocialProof.d.ts
@@ -1,10 +1,17 @@
+import { Testimonial } from "./Testimonials";
+interface RatingProps {
+    rating: number;
+    count?: number;
+}
 interface Props {
     /** URL returning an array of order events */
-    source: string;
+    source?: string;
     /** How often to rotate messages in ms */
     frequency?: number;
+    rating?: RatingProps;
+    testimonials?: Testimonial[];
 }
-/** Display recent order events like "Alice bought X 5 min ago" */
-export default function SocialProof({ source, frequency }: Props): import("react/jsx-runtime").JSX.Element | null;
+export default function SocialProof({ source, frequency, rating, testimonials }: Props): import("react/jsx-runtime").JSX.Element | null;
 export {};
 //# sourceMappingURL=SocialProof.d.ts.map
+

--- a/packages/ui/src/components/cms/blocks/SocialProof.d.ts.map
+++ b/packages/ui/src/components/cms/blocks/SocialProof.d.ts.map
@@ -1,1 +1,2 @@
-{"version":3,"file":"SocialProof.d.ts","sourceRoot":"","sources":["SocialProof.tsx"],"names":[],"mappings":"AAYA,UAAU,KAAK;IACb,6CAA6C;IAC7C,MAAM,EAAE,MAAM,CAAC;IACf,yCAAyC;IACzC,SAAS,CAAC,EAAE,MAAM,CAAC;CACpB;AAED,kEAAkE;AAClE,MAAM,CAAC,OAAO,UAAU,WAAW,CAAC,EAAE,MAAM,EAAE,SAAgB,EAAE,EAAE,KAAK,kDAoCtE"}
+{"version":3,"file":"SocialProof.d.ts","sourceRoot":"","sources":["SocialProof.tsx"],"names":[],"mappings":""}
+

--- a/packages/ui/src/components/cms/blocks/SocialProof.tsx
+++ b/packages/ui/src/components/cms/blocks/SocialProof.tsx
@@ -2,6 +2,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { RatingSummary } from "../../molecules/RatingSummary";
+import Testimonials, { Testimonial } from "./Testimonials";
+
+interface RatingProps {
+  rating: number;
+  count?: number;
+}
 
 interface OrderEvent {
   customer: string;
@@ -12,17 +19,31 @@ interface OrderEvent {
 
 interface Props {
   /** URL returning an array of order events */
-  source: string;
+  source?: string;
   /** How often to rotate messages in ms */
   frequency?: number;
+  rating?: RatingProps;
+  testimonials?: Testimonial[];
 }
 
-/** Display recent order events like "Alice bought X 5 min ago" */
-export default function SocialProof({ source, frequency = 5000 }: Props) {
+/**
+ * Display social proof via a rating summary and testimonials, or fall back to
+ * rotating order events fetched from a remote source.
+ */
+export default function SocialProof({
+  source,
+  frequency = 5000,
+  rating,
+  testimonials,
+}: Props) {
+  const hasRating = Boolean(rating);
+  const hasTestimonials = Boolean(testimonials && testimonials.length > 0);
+
   const [events, setEvents] = useState<OrderEvent[]>([]);
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
+    if (!source || hasRating || hasTestimonials) return;
     let active = true;
     fetch(source)
       .then((res) => res.json())
@@ -33,18 +54,35 @@ export default function SocialProof({ source, frequency = 5000 }: Props) {
     return () => {
       active = false;
     };
-  }, [source]);
+  }, [source, hasRating, hasTestimonials]);
 
   useEffect(() => {
-    if (events.length === 0) return;
+    if (events.length === 0 || hasRating || hasTestimonials) return;
     const id = setInterval(
       () => setIndex((i) => (i + 1) % events.length),
-      frequency
+      frequency,
     );
     return () => clearInterval(id);
-  }, [events, frequency]);
+  }, [events, frequency, hasRating, hasTestimonials]);
 
-  if (events.length === 0) return null;
+  if (hasRating || hasTestimonials) {
+    return (
+      <div className="space-y-4 text-center">
+        {hasRating && (
+          <RatingSummary
+            rating={rating!.rating}
+            count={rating!.count}
+            className="justify-center"
+          />
+        )}
+        {hasTestimonials && (
+          <Testimonials testimonials={testimonials} />
+        )}
+      </div>
+    );
+  }
+
+  if (!source || events.length === 0) return null;
 
   const event = events[index];
   const minutes = Math.floor((Date.now() - event.timestamp) / 60000);

--- a/packages/ui/src/components/cms/blocks/__tests__/SocialProof.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/SocialProof.test.tsx
@@ -1,4 +1,3 @@
-// packages/ui/src/components/cms/blocks/__tests__/SocialProof.test.tsx
 import { render, screen, waitFor } from "@testing-library/react";
 import SocialProof from "../SocialProof";
 
@@ -20,11 +19,29 @@ describe("SocialProof", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText(/Alice bought Shoes 5 min ago/i)
-      ).toBeInTheDocument()
+        screen.getByText(/Alice bought Shoes 5 min ago/i),
+      ).toBeInTheDocument(),
     );
 
     (global as any).fetch = originalFetch;
+  });
+
+  it("renders ratings when provided", () => {
+    render(<SocialProof rating={{ rating: 4.5, count: 10 }} />);
+    expect(screen.getByText("4.5")).toBeInTheDocument();
+    expect(screen.queryByText(/Great service!/i)).not.toBeInTheDocument();
+  });
+
+  it("renders testimonials when provided", () => {
+    const testimonials = [{ quote: "Great service!", name: "Bob" }];
+    render(<SocialProof testimonials={testimonials} />);
+    expect(screen.getByText(/Great service!/i)).toBeInTheDocument();
+    expect(screen.queryByText("4.5")).not.toBeInTheDocument();
+  });
+
+  it("returns null when no data is supplied", () => {
+    const { container } = render(<SocialProof />);
+    expect(container.firstChild).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- support rating summaries/testimonials alongside order events in SocialProof
- reinstate order event test while keeping rating and testimonial checks

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type '{ id: string; deposit: number; sessionId: string; ... } | null' is not assignable to type '{ id: string; deposit: number; sessionId: string; ... }[]')*
- `pnpm --filter @acme/ui run build` *(fails: Type 'ReactNode' is not assignable to type 'string | undefined')*
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs packages/ui/src/components/cms/blocks/__tests__/SocialProof.test.tsx --runInBand --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68c5647b72c0832f9fe5100bf34835ce