### PR TITLE
test(ui): add useComponentResize edge cases

### DIFF
--- a/packages/ui/__tests__/useComponentResize.test.ts
+++ b/packages/ui/__tests__/useComponentResize.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from "@testing-library/react";
+import useComponentResize from "../src/components/cms/page-builder/useComponentResize";
+
+describe("useComponentResize", () => {
+  it("trims whitespace and handles empty values", () => {
+    const onResize = jest.fn();
+    const { result } = renderHook(() => useComponentResize(onResize));
+
+    act(() => result.current.handleResize("widthDesktop", " 200px "));
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: "200px" });
+
+    act(() => result.current.handleResize("widthDesktop", "   "));
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: undefined });
+
+    act(() => result.current.handleResize("widthDesktop", ""));
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: undefined });
+  });
+
+  it("sets full size to 100%", () => {
+    const onResize = jest.fn();
+    const { result } = renderHook(() => useComponentResize(onResize));
+
+    act(() => result.current.handleFullSize("widthDesktop"));
+    expect(onResize).toHaveBeenCalledWith({ widthDesktop: "100%" });
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated tests for useComponentResize, covering whitespace, empty values, and full-size behavior

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm test --filter @acme/ui` *(fails: unable to find label `Width (Desktop)` in PageBuilder.resize.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c5739f01d0832fb0cfc33c990c6eeb