### PR TITLE
test(ui): add ValueProps component tests

### DIFF
--- a/packages/ui/src/components/home/__tests__/ValueProps.test.tsx
+++ b/packages/ui/src/components/home/__tests__/ValueProps.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import ValueProps from "../ValueProps";
+
+jest.mock("@acme/i18n", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("ValueProps", () => {
+  it("renders three default items", () => {
+    render(<ValueProps />);
+
+    expect(screen.getByText("value.eco.title")).toBeInTheDocument();
+    expect(screen.getByText("value.ship.title")).toBeInTheDocument();
+    expect(screen.getByText("value.return.title")).toBeInTheDocument();
+    expect(screen.getAllByRole("article")).toHaveLength(3);
+  });
+
+  it("renders provided items instead of defaults", () => {
+    const items = [
+      { icon: "⭐", title: "Quality", desc: "Top quality" },
+      { icon: "🔥", title: "Speed", desc: "Fast shipping" },
+      { icon: "🎉", title: "Fun", desc: "Enjoy" },
+    ];
+
+    render(<ValueProps items={items} />);
+
+    for (const { title, desc } of items) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(screen.getByText(desc)).toBeInTheDocument();
+    }
+
+    expect(screen.queryByText("value.eco.title")).toBeNull();
+    expect(screen.queryByText("value.ship.title")).toBeNull();
+    expect(screen.queryByText("value.return.title")).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for ValueProps covering defaults and custom items

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm run test packages/ui/src/components/home/__tests__/ValueProps.test.tsx` *(fails: Could not find task)*
- `pnpm exec jest packages/ui/src/components/home/__tests__/ValueProps.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c57898e8f0832f99777d0bd6305ac0