### PR TITLE
test: handle reset without default value in TextToken

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx
@@ -38,6 +38,18 @@ describe("TextToken", () => {
     expect(setToken).toHaveBeenCalledWith(tokenKey, "hello");
   });
 
+  it("resets to empty string when default value is undefined", () => {
+    const setToken = jest.fn();
+    renderToken({
+      value: "world",
+      defaultValue: undefined,
+      isOverridden: true,
+      setToken,
+    });
+    fireEvent.click(screen.getByText("Reset"));
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "");
+  });
+
   it("renders without default value", () => {
     renderToken({ defaultValue: undefined });
     expect(screen.queryByText(/Default:/)).toBeNull();


### PR DESCRIPTION
## Summary
- add test ensuring TextToken resets to empty string when no default value is provided

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm run test packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx` *(fails: Missing task `packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx` in project)*
- `pnpm --filter @acme/ui exec jest packages/ui/src/components/cms/style/__tests__/TextToken.test.tsx --config ../../jest.config.cjs --runInBand --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68c57893cbe4832fa2bc26ee200c9f35