### PR TITLE
test: reset RangeToken without default

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/RangeToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/RangeToken.test.tsx
@@ -42,4 +42,16 @@ describe("RangeToken", () => {
     fireEvent.click(screen.getByText("Reset"));
     expect(setToken).toHaveBeenCalledWith(tokenKey, "8px");
   });
+
+  it("resets with no default value", () => {
+    const setToken = jest.fn();
+    renderToken({
+      value: "12px",
+      defaultValue: undefined,
+      isOverridden: true,
+      setToken,
+    });
+    fireEvent.click(screen.getByText("Reset"));
+    expect(setToken).toHaveBeenCalledWith(tokenKey, "");
+  });
 });


### PR DESCRIPTION
## Summary
- test RangeToken reset when no default value

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run test -- packages/ui/src/components/cms/style/__tests__/RangeToken.test.tsx` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5789330e4832fb91b6586cff3d2b8