### PR TITLE
test(ui): add unknown preset safeguard

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/Presets.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/Presets.test.tsx
@@ -26,6 +26,17 @@ describe("Presets", () => {
     expect(handleChange).toHaveBeenLastCalledWith({});
   });
 
+  it("does not trigger onChange for unknown preset", () => {
+    const handleChange = jest.fn();
+    render(<Presets tokens={tokens} baseTokens={{}} onChange={handleChange} />);
+
+    fireEvent.change(screen.getByLabelText(/preset/i), {
+      target: { value: "unknown" },
+    });
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
   it("shows placeholder when no presets are available", async () => {
     jest.resetModules();
     jest.doMock("../presets.json", () => [], { virtual: true });


### PR DESCRIPTION
## Summary
- test presets to ensure unknown IDs don't trigger onChange

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm run test packages/ui/src/components/cms/style/__tests__/Presets.test.tsx` *(fails: Could not find task)*
- `pnpm exec jest packages/ui/src/components/cms/style/__tests__/Presets.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c57891a08c832fa7515cb9f47987c6