### PR TITLE
test: handle empty google font select

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx
@@ -65,4 +65,14 @@ describe("FontToken", () => {
     expect(setGoogleFont).toHaveBeenCalledWith("sans", "Roboto");
     expect(googleSelect.value).toBe("");
   });
+
+  it("ignores empty google font selection", () => {
+    const setGoogleFont = jest.fn();
+    const { container } = renderToken({ setGoogleFont });
+    const selects = container.querySelectorAll("select");
+    const googleSelect = selects[1] as HTMLSelectElement;
+    fireEvent.change(googleSelect, { target: { value: "" } });
+    expect(setGoogleFont).not.toHaveBeenCalled();
+    expect(googleSelect.value).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary
- test that FontToken ignores empty Google Font selections and retains empty select

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/ui run test packages/ui/src/components/cms/style/__tests__/FontToken.test.tsx` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c57890e72c832f8bef9d2e01eb6e5a