### PR TITLE
test: add ColorToken no default test

### DIFF
--- a/packages/ui/src/components/cms/style/__tests__/ColorToken.test.tsx
+++ b/packages/ui/src/components/cms/style/__tests__/ColorToken.test.tsx
@@ -18,6 +18,25 @@ describe("ColorToken", () => {
     mockedUseTokenColors.mockReset();
   });
 
+  it("renders without default value", () => {
+    const setToken = jest.fn();
+    mockedUseTokenColors.mockReturnValue(undefined as any);
+    render(
+      <ColorToken
+        tokenKey="--color-bg"
+        value="0 0% 100%"
+        isOverridden={false}
+        tokens={{}}
+        baseTokens={baseTokens}
+        setToken={setToken}
+      />
+    );
+
+    expect(screen.queryByText(/Default:/)).toBeNull();
+    expect(screen.queryByText("Reset")).toBeNull();
+    expect(screen.queryByText(/Low contrast/)).toBeNull();
+  });
+
   it("renders with default value", () => {
     const setToken = jest.fn();
     render(


### PR DESCRIPTION
## Summary
- add test covering ColorToken when default value is absent and low-contrast hook returns undefined

## Testing
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm run test packages/ui/src/components/cms/style/__tests__/ColorToken.test.tsx` *(fails: Missing tasks in project)*

------
https://chatgpt.com/codex/tasks/task_e_68c578902964832f91e83c1e0f3ae23c