### PR TITLE
test: expand page builder controls coverage

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/usePageBuilderControls.test.ts
+++ b/packages/ui/src/components/cms/page-builder/__tests__/usePageBuilderControls.test.ts
@@ -5,55 +5,72 @@ import { STATUS } from "../PageBuilderTour";
 describe("usePageBuilderControls", () => {
   const baseState = { gridCols: 12 } as any;
 
-  test("rotateDevice swaps width/height and updates viewport", () => {
+  test("rotateDevice switches orientation and adjusts dimensions", () => {
     const dispatch = jest.fn();
     const { result } = renderHook(() =>
       usePageBuilderControls({ state: baseState, dispatch })
     );
-    const initial = result.current.device;
+
+    const { width, height } = result.current.device;
+    expect(result.current.orientation).toBe("portrait");
+
     act(() => {
       result.current.rotateDevice();
     });
-    expect(result.current.device.width).toBe(initial.height);
-    expect(result.current.device.height).toBe(initial.width);
-    expect(result.current.viewport).toBe(result.current.device.type);
+
+    expect(result.current.orientation).toBe("landscape");
+    expect(result.current.device.width).toBe(height);
+    expect(result.current.device.height).toBe(width);
   });
 
-  test("startTour sets runTour and handleTourCallback clears and persists", () => {
+  test("handleTourCallback finishes tour and sets localStorage", () => {
     const dispatch = jest.fn();
-    localStorage.setItem("page-builder-tour", "done");
+    localStorage.clear();
     const { result } = renderHook(() =>
       usePageBuilderControls({ state: baseState, dispatch })
     );
-    expect(result.current.runTour).toBe(false);
+
     act(() => {
       result.current.startTour();
     });
     expect(result.current.runTour).toBe(true);
+
     act(() => {
       result.current.handleTourCallback({ status: STATUS.FINISHED } as any);
     });
+
     expect(result.current.runTour).toBe(false);
     expect(localStorage.getItem("page-builder-tour")).toBe("done");
   });
 
-  test("toggleGrid and setGridCols dispatch actions", () => {
+  test("toggleGrid dispatches current grid cols", () => {
     const dispatch = jest.fn();
     const { result } = renderHook(() =>
       usePageBuilderControls({ state: baseState, dispatch })
     );
+
     act(() => {
       result.current.toggleGrid();
     });
+
     expect(result.current.showGrid).toBe(true);
-    expect(dispatch).toHaveBeenNthCalledWith(1, {
+    expect(dispatch).toHaveBeenCalledWith({
       type: "set-grid-cols",
       gridCols: baseState.gridCols,
     });
+  });
+
+  test("setGridCols dispatches provided value", () => {
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      usePageBuilderControls({ state: baseState, dispatch })
+    );
+
     act(() => {
       result.current.setGridCols(24);
     });
-    expect(dispatch).toHaveBeenNthCalledWith(2, {
+
+    expect(dispatch).toHaveBeenCalledWith({
       type: "set-grid-cols",
       gridCols: 24,
     });


### PR DESCRIPTION
## Summary
- improve rotateDevice coverage verifying orientation and dimension swap
- ensure page builder tour completion sets flag and resets runTour
- test grid control actions for current and provided columns

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm test` *(fails: scripts#test)*

------
https://chatgpt.com/codex/tasks/task_e_68c573a972b8832fbd43a1b0b84c63dc