### PR TITLE
test: verify useTextEditor editing behavior

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useTextEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useTextEditor.test.tsx
@@ -1,6 +1,27 @@
 import { renderHook, act } from "@testing-library/react";
 import type { Locale } from "@acme/i18n/locales";
 import type { PageComponent } from "@acme/types";
+
+const mockSetContent = jest.fn();
+const mockFocus = jest.fn();
+let html = "";
+
+jest.mock("@tiptap/react", () => ({
+  useEditor: jest.fn(({ content }: { content: string }) => {
+    html = content;
+    return {
+      commands: {
+        setContent: (c: string) => {
+          html = c;
+          mockSetContent(c);
+        },
+        focus: mockFocus,
+      },
+      getHTML: () => html,
+    };
+  }),
+}));
+
 import useTextEditor from "../useTextEditor";
 
 describe("useTextEditor", () => {
@@ -9,6 +30,12 @@ describe("useTextEditor", () => {
     type: "Text",
     text: { en: "<p>Hello</p>", fr: "<p>Bonjour</p>" },
   } as unknown as PageComponent;
+
+  beforeEach(() => {
+    mockSetContent.mockClear();
+    mockFocus.mockClear();
+    html = "";
+  });
 
   it("initializes editor with locale content", () => {
     const { result } = renderHook(() =>
@@ -24,6 +51,26 @@ describe("useTextEditor", () => {
     );
     expect(result.current?.getHTML()).toBe("<p>Hello</p>");
     act(() => rerender({ locale: "fr" }));
+    expect(mockSetContent).toHaveBeenCalledWith("<p>Bonjour</p>");
     expect(result.current?.getHTML()).toBe("<p>Bonjour</p>");
   });
+
+  it("updates content only when not editing and focuses when editing starts", () => {
+    const { rerender } = renderHook(
+      ({ locale, editing }) =>
+        useTextEditor(component, locale as Locale, editing),
+      { initialProps: { locale: "en", editing: false } }
+    );
+
+    mockSetContent.mockClear();
+    mockFocus.mockClear();
+
+    act(() => rerender({ locale: "fr", editing: true }));
+    expect(mockSetContent).not.toHaveBeenCalled();
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+
+    act(() => rerender({ locale: "fr", editing: false }));
+    expect(mockSetContent).toHaveBeenCalledWith("<p>Bonjour</p>");
+  });
 });
+


### PR DESCRIPTION
## Summary
- mock useEditor in useTextEditor tests to track setContent and focus
- ensure content updates only when not editing and focusing occurs when editing starts

## Testing
- `pnpm -r build` *(failed: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(missing script: check:references)*
- `pnpm run build:ts` *(missing script: build:ts)*
- `pnpm --filter @acme/ui test -- src/components/cms/page-builder/__tests__/useTextEditor.test.tsx` *(branch coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c573a5d434832f948e72665b49ecf6