### PR TITLE
test: expand BlockChildren coverage

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockChildren.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockChildren.test.tsx
@@ -46,6 +46,18 @@ describe("BlockChildren", () => {
     expect(container.querySelector("[data-placeholder]")).toBeInTheDocument();
   });
 
+  it("does not show placeholder when isOver is false", () => {
+    const childComponents: PageComponent[] = [
+      { id: "c1", type: "Foo" } as any,
+    ];
+    const { container } = render(
+      <BlockChildren {...createProps({ childComponents, isOver: false })} />
+    );
+    expect(
+      container.querySelector("[data-placeholder]")
+    ).not.toBeInTheDocument();
+  });
+
   it("renders each child as CanvasItem with correct props", () => {
     const dispatch = jest.fn();
     const childComponents: PageComponent[] = [
@@ -76,6 +88,19 @@ describe("BlockChildren", () => {
         locale: "en",
       })
     );
+  });
+
+  it("dispatches remove action when a child onRemove is triggered", () => {
+    const dispatch = jest.fn();
+    const childComponents: PageComponent[] = [
+      { id: "c1", type: "Foo" } as any,
+    ];
+    render(
+      <BlockChildren {...createProps({ childComponents, dispatch })} />
+    );
+    const props = mockCanvasItem.mock.calls[0][0];
+    props.onRemove();
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "c1" });
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure BlockChildren hides placeholder when not dragging
- verify removing a child dispatches remove action

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui` in project)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find a label with the text of: /Width \(Desktop\)/)*
- `pnpm test src/components/cms/page-builder/__tests__/BlockChildren.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c578a31594832fb8709e0638961d7e