### PR TITLE
test: cover text locales and navigation edge cases

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/Block.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/Block.test.tsx
@@ -54,6 +54,20 @@ describe("Block", () => {
     expect(container.innerHTML).not.toContain("onerror");
   });
 
+  it("renders locale-specific text when provided a map", () => {
+    render(
+      <Block
+        component={{
+          id: "8",
+          type: "Text" as any,
+          text: { en: "Hello", fr: "Bonjour" },
+        }}
+        locale="fr"
+      />,
+    );
+    expect(screen.getByText("Bonjour")).toBeInTheDocument();
+  });
+
   it("returns null for unknown component type", () => {
     const { container } = render(
       <Block component={{ id: "4", type: "Baz" as any }} locale="en" />,
@@ -94,6 +108,18 @@ describe("Block", () => {
     expect(link.parentElement?.tagName.toLowerCase()).not.toBe("a");
   });
 
+  it("does not wrap or pass href when navigating without href", () => {
+    render(
+      <Block
+        component={{ id: "9", type: "Foo" as any, clickAction: "navigate" }}
+        locale="en"
+      />,
+    );
+    const foo = screen.getByTestId("foo");
+    expect(foo.closest("a")).toBeNull();
+    expect(foo).not.toHaveAttribute("href");
+  });
+
   it.each([
     ["fade", "pb-animate-fade"],
     ["slide", "pb-animate-slide"],
@@ -109,7 +135,10 @@ describe("Block", () => {
 
   it("does not wrap block or apply animation class when animation is undefined", () => {
     const { container } = render(
-      <Block component={{ id: "7", type: "Foo" as any }} locale="en" />,
+      <Block
+        component={{ id: "10", type: "Foo" as any, animation: undefined }}
+        locale="en"
+      />,
     );
     const element = screen.getByTestId("foo");
     expect(container.firstChild).toBe(element);


### PR DESCRIPTION
## Summary
- test Text block uses locale-specific string
- ensure navigate action without href adds no anchor or link
- cover undefined animation with no wrapper/class

## Testing
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui`)*
- `pnpm --filter @acme/ui test` *(fails: PageBuilder.resize.test.tsx, ComponentEditor.test.tsx; process out of memory)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c578a24ebc832f9193db0342f0e03f