### PR TITLE
test: add announcement bar editor tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/AnnouncementBarEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/AnnouncementBarEditor.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import AnnouncementBarEditor from "../AnnouncementBarEditor";
+
+describe("AnnouncementBarEditor", () => {
+  it("propagates text and link changes separately", () => {
+    const onChange = jest.fn();
+    render(
+      <AnnouncementBarEditor
+        component={{ type: "AnnouncementBar", text: "", link: "" }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("text"), {
+      target: { value: "Hello" },
+    });
+    expect(onChange).toHaveBeenNthCalledWith(1, { text: "Hello" });
+
+    fireEvent.change(screen.getByPlaceholderText("link"), {
+      target: { value: "https://example.com" },
+    });
+    expect(onChange).toHaveBeenNthCalledWith(2, {
+      link: "https://example.com",
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover AnnouncementBarEditor onChange handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @acme/stripe prebuild: pnpm --filter @acme/config run build)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68c578a0e98c832fa030defb1945c10a