### PR TITLE
test: add null editor coverage

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useLocalizedTextEditor.test.ts
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useLocalizedTextEditor.test.ts
@@ -3,13 +3,17 @@ import type { Locale } from "@acme/i18n/locales";
 import useLocalizedTextEditor from "../useLocalizedTextEditor";
 
 const getHTML = jest.fn(() => "<p>Edited</p>");
+const mockUseTextEditor = jest.fn();
 
 jest.mock("../useTextEditor", () => ({
   __esModule: true,
-  default: () => ({
-    getHTML,
-  }),
+  default: (...args: unknown[]) => mockUseTextEditor(...args),
 }));
+
+beforeEach(() => {
+  mockUseTextEditor.mockReset();
+  mockUseTextEditor.mockReturnValue({ getHTML });
+});
 
 describe("useLocalizedTextEditor", () => {
   const component = {
@@ -27,7 +31,24 @@ describe("useLocalizedTextEditor", () => {
     expect(result.current.editing).toBe(true);
   });
 
-  it("finishEditing returns patch with locale-specific HTML and resets editing", () => {
+  it("finishEditing returns null when editor is missing", () => {
+    mockUseTextEditor.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useLocalizedTextEditor(component as any, "en" as Locale)
+    );
+
+    act(() => result.current.startEditing());
+
+    let patch;
+    act(() => {
+      patch = result.current.finishEditing();
+    });
+
+    expect(patch).toBeNull();
+  });
+
+  it("finishEditing merges locale into text and resets editing", () => {
     const { result } = renderHook(() =>
       useLocalizedTextEditor(component as any, "en" as Locale)
     );


### PR DESCRIPTION
## Summary
- improve useLocalizedTextEditor tests to cover null editor case

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm --filter @acme/ui test` *(fails: Unable to find a label with the text of: Width (Desktop))*

------
https://chatgpt.com/codex/tasks/task_e_68c573a17648832f89c518fa2fbc2cde