### PR TITLE
test: verify setNodeRef assignment

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useBlockDnD.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useBlockDnD.test.tsx
@@ -1,24 +1,21 @@
 import { renderHook } from "@testing-library/react";
 import useBlockDnD from "../useBlockDnD";
+import useSortableBlock from "../useSortableBlock";
 
-const innerSetNodeRef = jest.fn();
-
-jest.mock("../useSortableBlock", () => ({
-  __esModule: true,
-  default: () => ({
-    setNodeRef: innerSetNodeRef,
-  }),
-}));
+jest.mock("../useSortableBlock");
 
 describe("useBlockDnD", () => {
   it("forwards setNodeRef and updates containerRef", () => {
+    const sortable = { setNodeRef: jest.fn() };
+    (useSortableBlock as jest.Mock).mockReturnValue(sortable);
+
     const { result } = renderHook(() => useBlockDnD("a", 0, undefined));
 
     const node = document.createElement("div");
     result.current.setNodeRef(node);
 
+    expect(sortable.setNodeRef).toHaveBeenCalledWith(node);
     expect(result.current.containerRef.current).toBe(node);
-    expect(innerSetNodeRef).toHaveBeenCalledWith(node);
   });
 });
 


### PR DESCRIPTION
## Summary
- mock useSortableBlock in useBlockDnD test to spy on setNodeRef
- assert setNodeRef forwards the node and updates containerRef

## Testing
- `pnpm -r build` *(fails: Type '{ id: string; deposit: number; ... } | null' is not assignable to type '{ id: string; deposit: number; ... }')*
- `pnpm --filter @acme/ui run test` *(fails: Unable to find a label with the text of: /Width \(Desktop\)/)*


------
https://chatgpt.com/codex/tasks/task_e_68c573974740832f87006f7631174db2