### PR TITLE
test(ui): add ReviewsCarousel timer and fallback tests

### DIFF
--- a/packages/ui/src/components/home/ReviewsCarousel.tsx
+++ b/packages/ui/src/components/home/ReviewsCarousel.tsx
@@ -20,7 +20,7 @@ export default function ReviewsCarousel({
   const t = useTranslations();
   const [i, setI] = useState(0);
 
-  const list = reviews ?? DEFAULT_REVIEWS;
+  const list = reviews && reviews.length ? reviews : DEFAULT_REVIEWS;
   if (!list.length) return null;
 
   const next = useCallback(


### PR DESCRIPTION
## Summary
- ensure ReviewsCarousel falls back to default reviews when empty array provided
- verify carousel auto-advances every 8s with custom reviews
- restore default rendering and navigation tests

## Testing
- `pnpm -r build` *(fails: TypeScript error in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script check:references)*
- `pnpm run build:ts` *(fails: Missing script build:ts)*
- `pnpm run test packages/ui/src/components/home/__tests__/ReviewsCarousel.test.tsx` *(fails: Could not find task `packages/ui/src/components/home/__tests__/ReviewsCarousel.test.tsx` in project)*
- `pnpm exec jest packages/ui/src/components/home/__tests__/ReviewsCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c578967aec832f875448506cd71bb5