### PR TITLE
test(ui): verify clearing button variant

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/ButtonEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ButtonEditor.test.tsx
@@ -23,8 +23,12 @@ describe("ButtonEditor", () => {
     });
     expect(handleInput).toHaveBeenNthCalledWith(2, "href", "/home");
 
-    fireEvent.click(screen.getByRole("combobox"));
+    const combobox = screen.getByRole("combobox");
+    fireEvent.click(combobox);
     fireEvent.click(await screen.findByRole("option", { name: "outline" }));
     expect(handleInput).toHaveBeenNthCalledWith(3, "variant", "outline");
+    const hiddenInput = document.querySelector("input");
+    fireEvent.input(hiddenInput!, { target: { value: "" } });
+    expect(handleInput).toHaveBeenNthCalledWith(4, "variant", undefined);
   });
 });


### PR DESCRIPTION
## Summary
- expand ButtonEditor test to ensure clearing variant triggers `undefined`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in platform-core)*
- `pnpm --filter @acme/ui run check:references` *(fails: Missing script)*
- `pnpm --filter @acme/ui run build:ts` *(fails: Missing script)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui`)*
- `pnpm --filter @acme/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68c578a7506c832f859f8e6fa89b6c1e