### PR TITLE
test(ui): cover canvas spacing

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useCanvasSpacing.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useCanvasSpacing.test.tsx
@@ -1,93 +1,31 @@
 import { render, fireEvent } from "@testing-library/react";
 import React from "react";
-import useCanvasSpacing from "../useCanvasSpacing";
+import useCanvasSpacing, { parseSpacing } from "../useCanvasSpacing";
 
 // jsdom may not define PointerEvent
 if (typeof window !== "undefined" && !(window as any).PointerEvent) {
   (window as any).PointerEvent = MouseEvent as any;
 }
 
-describe("useCanvasSpacing", () => {
-  test("adjusts padding and overlay", () => {
-    const dispatch = jest.fn();
-    let hook: ReturnType<typeof useCanvasSpacing> | undefined;
-    function Wrapper() {
-      const ref = React.useRef<HTMLDivElement>(null);
-      hook = useCanvasSpacing({
-        componentId: "c1",
-        marginKey: "marginDesktop",
-        paddingKey: "paddingDesktop",
-        marginVal: "0px",
-        paddingVal: "10px",
-        dispatch,
-        containerRef: ref,
-      });
-      return (
-        <div
-          ref={ref}
-          data-cy="box"
-          onPointerDown={(e) => hook!.startSpacing(e, "padding", "top")}
-        />
-      );
-    }
-    const { getByTestId } = render(<Wrapper />);
-    const box = getByTestId("box") as HTMLElement;
-    Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
-    Object.defineProperty(box, "offsetHeight", { value: 50, writable: true });
-    fireEvent.pointerDown(box, { clientX: 0, clientY: 0 });
-    fireEvent.pointerMove(window, { clientX: 0, clientY: 5 });
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ paddingDesktop: "15px 10px 10px 10px" })
-    );
-    expect(hook!.overlay).toEqual({
-      type: "padding",
-      side: "top",
-      top: 0,
-      left: 0,
-      width: 100,
-      height: 15,
-    });
+describe("parseSpacing", () => {
+  test.each([
+    ["10px", [10, 10, 10, 10]],
+    ["10px 20px", [10, 20, 10, 20]],
+    ["10px 20px 30px", [10, 20, 30, 20]],
+    ["10px 20px 30px 40px", [10, 20, 30, 40]],
+  ])("parses %s", (input, expected) => {
+    expect(parseSpacing(input as string)).toEqual(expected);
   });
+});
 
-  test("clamps padding to zero", () => {
-    const dispatch = jest.fn();
-    let hook: ReturnType<typeof useCanvasSpacing> | undefined;
-    function Wrapper() {
-      const ref = React.useRef<HTMLDivElement>(null);
-      hook = useCanvasSpacing({
-        componentId: "c1",
-        marginKey: "marginDesktop",
-        paddingKey: "paddingDesktop",
-        marginVal: "0px",
-        paddingVal: "5px",
-        dispatch,
-        containerRef: ref,
-      });
-      return (
-        <div
-          ref={ref}
-          data-cy="box"
-          onPointerDown={(e) => hook!.startSpacing(e, "padding", "left")}
-        />
-      );
-    }
-    const { getByTestId } = render(<Wrapper />);
-    const box = getByTestId("box") as HTMLElement;
-    Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
-    Object.defineProperty(box, "offsetHeight", { value: 50, writable: true });
-    fireEvent.pointerDown(box, { clientX: 0, clientY: 0 });
-    fireEvent.pointerMove(window, { clientX: -10, clientY: 0 });
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ paddingDesktop: "5px 5px 5px 0px" })
-    );
-    expect(hook!.overlay).toMatchObject({
-      type: "padding",
-      side: "left",
-      width: 0,
-    });
-  });
-
-  test("updates margin overlay", () => {
+describe("startSpacing", () => {
+  function run(
+    type: "margin" | "padding",
+    side: "top" | "right" | "bottom" | "left",
+    move: { clientX: number; clientY: number },
+    expectedPatch: string,
+    overlay: { top: number; left: number; width: number; height: number }
+  ) {
     const dispatch = jest.fn();
     let hook: ReturnType<typeof useCanvasSpacing> | undefined;
     function Wrapper() {
@@ -97,7 +35,7 @@ describe("useCanvasSpacing", () => {
         marginKey: "marginDesktop",
         paddingKey: "paddingDesktop",
         marginVal: "10px",
-        paddingVal: "0px",
+        paddingVal: "10px",
         dispatch,
         containerRef: ref,
       });
@@ -105,7 +43,7 @@ describe("useCanvasSpacing", () => {
         <div
           ref={ref}
           data-cy="box"
-          onPointerDown={(e) => hook!.startSpacing(e, "margin", "top")}
+          onPointerDown={(e) => hook!.startSpacing(e, type, side)}
         />
       );
     }
@@ -114,17 +52,114 @@ describe("useCanvasSpacing", () => {
     Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
     Object.defineProperty(box, "offsetHeight", { value: 50, writable: true });
     fireEvent.pointerDown(box, { clientX: 0, clientY: 0 });
-    fireEvent.pointerMove(window, { clientX: 0, clientY: 20 });
+    fireEvent.pointerMove(window, move);
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ marginDesktop: "30px 10px 10px 10px" })
+      expect.objectContaining(
+        type === "margin"
+          ? { marginDesktop: expectedPatch }
+          : { paddingDesktop: expectedPatch }
+      )
     );
-    expect(hook!.overlay).toEqual({
-      type: "margin",
-      side: "top",
-      top: -30,
-      left: 0,
-      width: 100,
-      height: 30,
+    expect(hook!.overlay).toEqual({ type, side, ...overlay });
+  }
+
+  describe("padding", () => {
+    test.each([
+      [
+        "top",
+        { clientX: 0, clientY: 5 },
+        "15px 10px 10px 10px",
+        { top: 0, left: 0, width: 100, height: 15 },
+      ],
+      [
+        "right",
+        { clientX: 5, clientY: 0 },
+        "10px 15px 10px 10px",
+        { top: 0, left: 85, width: 15, height: 50 },
+      ],
+      [
+        "bottom",
+        { clientX: 0, clientY: 5 },
+        "10px 10px 15px 10px",
+        { top: 35, left: 0, width: 100, height: 15 },
+      ],
+      [
+        "left",
+        { clientX: 5, clientY: 0 },
+        "10px 10px 10px 15px",
+        { top: 0, left: 0, width: 15, height: 50 },
+      ],
+    ])("adjusts %s", (side, move, patch, o) => {
+      run("padding", side as any, move as any, patch as string, o as any);
+    });
+
+    test("clamps to zero", () => {
+      const dispatch = jest.fn();
+      let hook: ReturnType<typeof useCanvasSpacing> | undefined;
+      function Wrapper() {
+        const ref = React.useRef<HTMLDivElement>(null);
+        hook = useCanvasSpacing({
+          componentId: "c1",
+          marginKey: "marginDesktop",
+          paddingKey: "paddingDesktop",
+          marginVal: "0px",
+          paddingVal: "5px",
+          dispatch,
+          containerRef: ref,
+        });
+        return (
+          <div
+            ref={ref}
+            data-cy="box"
+            onPointerDown={(e) => hook!.startSpacing(e, "padding", "left")}
+          />
+        );
+      }
+      const { getByTestId } = render(<Wrapper />);
+      const box = getByTestId("box") as HTMLElement;
+      Object.defineProperty(box, "offsetWidth", { value: 100, writable: true });
+      Object.defineProperty(box, "offsetHeight", { value: 50, writable: true });
+      fireEvent.pointerDown(box, { clientX: 0, clientY: 0 });
+      fireEvent.pointerMove(window, { clientX: -10, clientY: 0 });
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ paddingDesktop: "5px 5px 5px 0px" })
+      );
+      expect(hook!.overlay).toMatchObject({
+        type: "padding",
+        side: "left",
+        width: 0,
+      });
+    });
+  });
+
+  describe("margin", () => {
+    test.each([
+      [
+        "top",
+        { clientX: 0, clientY: 20 },
+        "30px 10px 10px 10px",
+        { top: -30, left: 0, width: 100, height: 30 },
+      ],
+      [
+        "right",
+        { clientX: 20, clientY: 0 },
+        "10px 30px 10px 10px",
+        { top: 0, left: 100, width: 30, height: 50 },
+      ],
+      [
+        "bottom",
+        { clientX: 0, clientY: 20 },
+        "10px 10px 30px 10px",
+        { top: 50, left: 0, width: 100, height: 30 },
+      ],
+      [
+        "left",
+        { clientX: 20, clientY: 0 },
+        "10px 10px 10px 30px",
+        { top: 0, left: -30, width: 30, height: 50 },
+      ],
+    ])("adjusts %s", (side, move, patch, o) => {
+      run("margin", side as any, move as any, patch as string, o as any);
     });
   });
 });

--- a/packages/ui/src/components/cms/page-builder/useCanvasSpacing.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasSpacing.ts
@@ -24,7 +24,7 @@ interface Overlay {
   height: number;
 }
 
-function parseSpacing(value?: string): [number, number, number, number] {
+export function parseSpacing(value?: string): [number, number, number, number] {
   if (!value) return [0, 0, 0, 0];
   const parts = value
     .split(/\s+/)


### PR DESCRIPTION
## Summary
- export parseSpacing for testing
- add coverage for parseSpacing and all margin/padding sides
- restore padding clamp test to ensure negative movement doesn't produce negative spacing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui run test` *(fails: PageBuilder.resize.test.tsx, ComponentEditor.test.tsx; process aborted with SIGABRT)*

------
https://chatgpt.com/codex/tasks/task_e_68c5739c0ea4832fb46f2a3c395ee694