### PR TITLE
test: cover block transform guides precedence

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/useBlockTransform.test.ts
+++ b/packages/ui/src/components/cms/page-builder/__tests__/useBlockTransform.test.ts
@@ -13,58 +13,116 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test("returns resize guides when present", () => {
-  mockUseCanvasResize.mockReturnValue({
-    startResize: jest.fn(),
-    guides: { x: 1, y: 2 },
-    snapping: false,
+describe("useBlockTransform", () => {
+  test("returns resize guides when present", () => {
+    mockUseCanvasResize.mockReturnValue({
+      startResize: jest.fn(),
+      guides: { x: 1, y: 2 },
+      snapping: false,
+    });
+    mockUseCanvasDrag.mockReturnValue({
+      startDrag: jest.fn(),
+      guides: { x: 3, y: 4 },
+      snapping: true,
+    });
+    const ref = { current: null } as any;
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useBlockTransform("c1", {
+        widthKey: "w",
+        heightKey: "h",
+        widthVal: "10px",
+        heightVal: "10px",
+        dispatch,
+        gridCols: 12,
+        containerRef: ref,
+      }),
+    );
+    expect(result.current.guides).toEqual({ x: 1, y: 2 });
+    expect(result.current.snapping).toBe(true);
   });
-  mockUseCanvasDrag.mockReturnValue({
-    startDrag: jest.fn(),
-    guides: { x: 3, y: 4 },
-    snapping: true,
-  });
-  const ref = { current: null } as any;
-  const dispatch = jest.fn();
-  const { result } = renderHook(() =>
-    useBlockTransform("c1", {
-      widthKey: "w",
-      heightKey: "h",
-      widthVal: "10px",
-      heightVal: "10px",
-      dispatch,
-      gridCols: 12,
-      containerRef: ref,
-    }),
-  );
-  expect(result.current.guides).toEqual({ x: 1, y: 2 });
-  expect(result.current.snapping).toBe(true);
-});
 
-test("falls back to drag guides", () => {
-  mockUseCanvasResize.mockReturnValue({
-    startResize: jest.fn(),
-    guides: { x: null, y: null },
-    snapping: true,
+  test("falls back to drag guides", () => {
+    mockUseCanvasResize.mockReturnValue({
+      startResize: jest.fn(),
+      guides: { x: null, y: null },
+      snapping: true,
+    });
+    mockUseCanvasDrag.mockReturnValue({
+      startDrag: jest.fn(),
+      guides: { x: 5, y: 6 },
+      snapping: false,
+    });
+    const ref = { current: null } as any;
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useBlockTransform("c1", {
+        widthKey: "w",
+        heightKey: "h",
+        widthVal: "10px",
+        heightVal: "10px",
+        dispatch,
+        gridCols: 12,
+        containerRef: ref,
+      }),
+    );
+    expect(result.current.guides).toEqual({ x: 5, y: 6 });
+    expect(result.current.snapping).toBe(true);
   });
-  mockUseCanvasDrag.mockReturnValue({
-    startDrag: jest.fn(),
-    guides: { x: 5, y: 6 },
-    snapping: false,
+
+  test("uses resize guides when only one axis snaps", () => {
+    mockUseCanvasResize.mockReturnValue({
+      startResize: jest.fn(),
+      guides: { x: 7, y: null },
+      snapping: false,
+    });
+    mockUseCanvasDrag.mockReturnValue({
+      startDrag: jest.fn(),
+      guides: { x: 8, y: 9 },
+      snapping: false,
+    });
+    const ref = { current: null } as any;
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useBlockTransform("c1", {
+        widthKey: "w",
+        heightKey: "h",
+        widthVal: "10px",
+        heightVal: "10px",
+        dispatch,
+        gridCols: 12,
+        containerRef: ref,
+      }),
+    );
+    expect(result.current.guides).toEqual({ x: 7, y: null });
+    expect(result.current.snapping).toBe(false);
   });
-  const ref = { current: null } as any;
-  const dispatch = jest.fn();
-  const { result } = renderHook(() =>
-    useBlockTransform("c1", {
-      widthKey: "w",
-      heightKey: "h",
-      widthVal: "10px",
-      heightVal: "10px",
-      dispatch,
-      gridCols: 12,
-      containerRef: ref,
-    }),
-  );
-  expect(result.current.guides).toEqual({ x: 5, y: 6 });
-  expect(result.current.snapping).toBe(true);
+
+  test("reports non-snapping when neither hook snaps", () => {
+    mockUseCanvasResize.mockReturnValue({
+      startResize: jest.fn(),
+      guides: { x: null, y: null },
+      snapping: false,
+    });
+    mockUseCanvasDrag.mockReturnValue({
+      startDrag: jest.fn(),
+      guides: { x: 10, y: 11 },
+      snapping: false,
+    });
+    const ref = { current: null } as any;
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useBlockTransform("c1", {
+        widthKey: "w",
+        heightKey: "h",
+        widthVal: "10px",
+        heightVal: "10px",
+        dispatch,
+        gridCols: 12,
+        containerRef: ref,
+      }),
+    );
+    expect(result.current.guides).toEqual({ x: 10, y: 11 });
+    expect(result.current.snapping).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- restore original useBlockTransform tests and add coverage for non-snapping fallback

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: @acme/stripe prebuild: Command failed with signal "SIGTERM")*
- `pnpm --filter @acme/ui test` *(terminated early)*
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runTestsByPath src/components/cms/page-builder/__tests__/useBlockTransform.test.ts --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c57397d750832f843d3b4a84dea872