### PR TITLE
test: add deposit and coverage tests

### DIFF
--- a/packages/platform-core/__tests__/pricing.index.test.ts
+++ b/packages/platform-core/__tests__/pricing.index.test.ts
@@ -106,4 +106,20 @@ describe("pricing index", () => {
       computeDamageFee("scuff", 50, [], true),
     ).resolves.toBe(10);
   });
+
+  it('computeDamageFee uses deposit when rule is "deposit"', async () => {
+    const { computeDamageFee } = await setup();
+    await expect(computeDamageFee("lost", 75)).resolves.toBe(75);
+  });
+
+  it('computeDamageFee ignores invalid coverage codes', async () => {
+    const pricing = {
+      ...defaultPricing,
+      damageFees: { ...defaultPricing.damageFees, scratch: 25 },
+    };
+    const { computeDamageFee } = await setup(pricing);
+    await expect(
+      computeDamageFee("scratch", 50, ["scratch"]),
+    ).resolves.toBe(25);
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage tests for deposit rule and invalid coverage codes in computeDamageFee

## Testing
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/pricing.index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c599b45c0c832fb5705aab68bafbef