### PR TITLE
Add priceForDays baseDailyRate fallback test

### DIFF
--- a/packages/platform-core/__tests__/pricing.index.test.ts
+++ b/packages/platform-core/__tests__/pricing.index.test.ts
@@ -95,6 +95,12 @@ describe("pricing index", () => {
     await expect(priceForDays(sku, 6)).resolves.toBe(144);
   });
 
+  it("priceForDays uses baseDailyRate without price or dailyRate", async () => {
+    const { priceForDays } = await setup();
+    const sku = {} as any;
+    await expect(priceForDays(sku, 6)).resolves.toBe(48);
+  });
+
   it("computeDamageFee handles rule types and coverage", async () => {
     const { computeDamageFee } = await setup();
     await expect(computeDamageFee(undefined, 50)).resolves.toBe(0);


### PR DESCRIPTION
## Summary
- add test ensuring priceForDays uses pricing.baseDailyRate when sku lacks dailyRate and price

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in platform-core)*
- `pnpm run check:references` *(fails: missing script)*
- `pnpm run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/platform-core run test packages/platform-core/__tests__/pricing.index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c599b37f60832fb6094e739b566387