### PR TITLE
test: cover non-null normalize behavior

### DIFF
--- a/packages/platform-core/__tests__/orders.utils.test.ts
+++ b/packages/platform-core/__tests__/orders.utils.test.ts
@@ -18,4 +18,17 @@ describe("normalize", () => {
     const normalized = normalize(order);
     expect(normalized?.customerId).toBeUndefined();
   });
+
+  it("leaves non-null properties unchanged", () => {
+    const order = {
+      id: "order1",
+      sessionId: "sess1",
+      shop: "shop1",
+      deposit: 0,
+      startedAt: "2023-01-01",
+    } as unknown as Order;
+
+    const normalized = normalize(order);
+    expect(normalized).toEqual(order);
+  });
 });

--- a/packages/platform-core/src/orders/utils.ts
+++ b/packages/platform-core/src/orders/utils.ts
@@ -11,7 +11,7 @@ export function normalize<T extends Order = Order>(order: T | null): T | null {
   const o: T = { ...order };
   (Object.keys(o) as Array<keyof T>).forEach((k) => {
     if (o[k] === null) {
-      o[k] = undefined as T[keyof T];
+      o[k] = undefined!;
     }
   });
   return o;


### PR DESCRIPTION
## Summary
- refactor normalize to set undefined via non-null assertion
- ensure normalize leaves existing fields untouched

## Testing
- `pnpm exec jest packages/platform-core/__tests__/orders.utils.test.ts --runInBand --config jest.config.cjs --silent`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core run build`


------
https://chatgpt.com/codex/tasks/task_e_68c599b24b2c832fbd12a50ae4bedeee