### PR TITLE
test: cover rental order update error paths

### DIFF
--- a/packages/platform-core/__tests__/orders.status.test.ts
+++ b/packages/platform-core/__tests__/orders.status.test.ts
@@ -92,10 +92,14 @@ describe("orders/status", () => {
   });
 
   it("returns null when markReturned update throws", async () => {
-    prisma.rentalOrder.update.mockImplementation(() => {
-      throw new Error("not found");
-    });
+    prisma.rentalOrder.update.mockRejectedValue(new Error("not found"));
     await expect(markReturned("shop", "sess")).resolves.toBeNull();
+  });
+
+  it("returns null when markReturned update yields null and damage fee undefined", async () => {
+    prisma.rentalOrder.update.mockResolvedValue(null);
+    const result = await markReturned("shop", "sess", undefined);
+    expect(result).toBeNull();
   });
 
   it("sets return tracking", async () => {
@@ -116,11 +120,8 @@ describe("orders/status", () => {
   });
 
   it("returns null when return tracking update throws", async () => {
-    prisma.rentalOrder.update.mockImplementation(() => {
-      throw new Error("fail");
-    });
-    const result = await setReturnTracking("shop", "sess", "trk", "url");
-    expect(result).toBeNull();
+    prisma.rentalOrder.update.mockRejectedValue(new Error("fail"));
+    await expect(setReturnTracking("shop", "sess", "trk", "url")).resolves.toBeNull();
   });
 
   it("sets return status", async () => {
@@ -141,11 +142,8 @@ describe("orders/status", () => {
   });
 
   it("returns null when return status update throws", async () => {
-    prisma.rentalOrder.update.mockImplementation(() => {
-      throw new Error("fail");
-    });
-    const result = await setReturnStatus("shop", "trk", "rec");
-    expect(result).toBeNull();
+    prisma.rentalOrder.update.mockRejectedValue(new Error("fail"));
+    await expect(setReturnStatus("shop", "trk", "rec")).resolves.toBeNull();
   });
 });
 

--- a/packages/platform-core/src/orders/status.ts
+++ b/packages/platform-core/src/orders/status.ts
@@ -96,6 +96,7 @@ export async function setReturnStatus(
       where: { shop_trackingNumber: { shop, trackingNumber } },
       data: { returnStatus },
     });
+    if (!order) return null;
     return normalize(order as Order);
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- ensure setReturnStatus explicitly returns null when update yields null
- test markReturned when update yields null without damage fee
- verify error paths for setReturnTracking and setReturnStatus

## Testing
- `pnpm -r build` *(fails: TypeScript errors in platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test` *(fails: CartContext test and OOM)*
- `pnpm --filter @acme/platform-core test -- __tests__/orders.status.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c599b13854832f9179999eca34e649