### PR TITLE
test: cover risk update null

### DIFF
--- a/packages/platform-core/__tests__/orders.risk.test.ts
+++ b/packages/platform-core/__tests__/orders.risk.test.ts
@@ -23,11 +23,31 @@ describe("orders/risk", () => {
       const result = await markNeedsAttention("shop", "sess");
       expect(result).toBeNull();
     });
+
+    it("returns normalized order on success", async () => {
+      prisma.rentalOrder.update.mockResolvedValue({
+        id: "1",
+        flaggedForReview: true,
+        riskLevel: null,
+      });
+      const result = await markNeedsAttention("shop", "sess");
+      expect(result).toEqual({
+        id: "1",
+        flaggedForReview: true,
+        riskLevel: undefined,
+      });
+    });
   });
 
   describe("updateRisk", () => {
     it("returns null on update error", async () => {
       prisma.rentalOrder.update.mockRejectedValue(new Error("update failed"));
+      const result = await updateRisk("shop", "sess");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when update returns null", async () => {
+      prisma.rentalOrder.update.mockResolvedValue(null);
       const result = await updateRisk("shop", "sess");
       expect(result).toBeNull();
     });

--- a/packages/platform-core/src/__tests__/orders.risk.test.ts
+++ b/packages/platform-core/src/__tests__/orders.risk.test.ts
@@ -46,6 +46,12 @@ describe("orders/risk", () => {
       expect(result).toBeNull();
     });
 
+    it("returns null when update returns null", async () => {
+      prisma.rentalOrder.update.mockResolvedValue(null);
+      const result = await updateRisk("shop", "sess");
+      expect(result).toBeNull();
+    });
+
     it.each([
       [{ riskLevel: "low" }, "low", undefined, undefined],
       [{ riskScore: 5 }, undefined, 5, undefined],

--- a/packages/platform-core/src/orders/risk.ts
+++ b/packages/platform-core/src/orders/risk.ts
@@ -12,7 +12,7 @@ export async function markNeedsAttention(
       where: { shop_sessionId: { shop, sessionId } },
       data: { flaggedForReview: true },
     });
-    return normalize(order as Order);
+    return order ? normalize(order as Order) : null;
   } catch {
     return null;
   }
@@ -34,8 +34,7 @@ export async function updateRisk(
         ...(typeof flaggedForReview === "boolean" ? { flaggedForReview } : {}),
       },
     });
-    if (!order) return null;
-    return normalize(order as Order);
+    return order ? normalize(order as Order) : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- handle null returns from `markNeedsAttention` and `updateRisk`
- test `markNeedsAttention` success path and null updates in `updateRisk`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type '({ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; } | null)[]' is not assignable to type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; }[]'.`)
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test -- src/__tests__/orders.risk.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c599b090b4832fb6b742640e765693