### PR TITLE
test: cover refund update failures

### DIFF
--- a/packages/platform-core/__tests__/orders.refunds.test.ts
+++ b/packages/platform-core/__tests__/orders.refunds.test.ts
@@ -62,6 +62,40 @@ describe("orders/refunds", () => {
       expect(prisma.rentalOrder.update).not.toHaveBeenCalled();
     });
 
+    it("returns null when update throws", async () => {
+      const order = {
+        id: "1",
+        shop: "s",
+        sessionId: "sess",
+        deposit: 0,
+        refundTotal: 0,
+      };
+      prisma.rentalOrder.findUnique.mockResolvedValue(order);
+      prisma.rentalOrder.update.mockImplementation(() => {
+        throw new Error("db");
+      });
+      const res = await refundOrder("s", "sess");
+      expect(res).toBeNull();
+      expect(stripe.checkout.sessions.retrieve).not.toHaveBeenCalled();
+      expect(stripe.refunds.create).not.toHaveBeenCalled();
+    });
+
+    it("returns null when update returns null", async () => {
+      const order = {
+        id: "1",
+        shop: "s",
+        sessionId: "sess",
+        deposit: 0,
+        refundTotal: 0,
+      };
+      prisma.rentalOrder.findUnique.mockResolvedValue(order);
+      prisma.rentalOrder.update.mockResolvedValue(null);
+      const res = await refundOrder("s", "sess");
+      expect(res).toBeNull();
+      expect(stripe.checkout.sessions.retrieve).not.toHaveBeenCalled();
+      expect(stripe.refunds.create).not.toHaveBeenCalled();
+    });
+
     it.each([
       { deposit: 100, refundTotal: 0, amount: undefined, refundable: 100 },
       { deposit: 200, refundTotal: 50, amount: 100, refundable: 100 },

--- a/packages/platform-core/src/__tests__/orders.refunds.test.ts
+++ b/packages/platform-core/src/__tests__/orders.refunds.test.ts
@@ -134,6 +134,22 @@ describe("orders/refunds", () => {
       expect(stripe.refunds.create).not.toHaveBeenCalled();
     });
 
+    it("returns null when update returns null", async () => {
+      const order = {
+        id: "1",
+        shop: "s",
+        sessionId: "sess",
+        deposit: 0,
+        refundTotal: 0,
+      };
+      prisma.rentalOrder.findUnique.mockResolvedValue(order);
+      prisma.rentalOrder.update.mockResolvedValue(null);
+      const res = await refundOrder("s", "sess");
+      expect(res).toBeNull();
+      expect(stripe.checkout.sessions.retrieve).not.toHaveBeenCalled();
+      expect(stripe.refunds.create).not.toHaveBeenCalled();
+    });
+
     it.each([
       { deposit: 100, refundTotal: 0, amount: undefined, refundable: 100 },
       { deposit: 200, refundTotal: 50, amount: 100, refundable: 100 },


### PR DESCRIPTION
## Summary
- test refundOrder returning null when update throws or returns null
- ensure both update scenarios are handled

## Testing
- `pnpm --filter @acme/platform-core test __tests__/orders.refunds.test.ts src/__tests__/orders.refunds.test.ts`
- `pnpm run check:references` *(fails: Missing script "check:references")*
- `pnpm run build:ts` *(fails: Missing script "build:ts")*
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*


------
https://chatgpt.com/codex/tasks/task_e_68c599b00224832f83caa11808cfc1b4