### PR TITLE
test: add user delegate findFirst and update tests

### DIFF
--- a/packages/platform-core/__tests__/user.delegate.test.ts
+++ b/packages/platform-core/__tests__/user.delegate.test.ts
@@ -19,14 +19,22 @@ describe("createUserDelegate", () => {
     expect(user).toEqual({ id: "user2", email: "u2@test.com" });
   });
 
-  it("findFirst returns null when user is missing", async () => {
+  it("findFirst returns null for a non-matching where", async () => {
     const delegate = createUserDelegate();
-    const user = await delegate.findFirst({ where: { id: "missing" } });
+    const user = await delegate.findFirst({
+      where: { email: "u1@test.com", NOT: { id: "user1" } },
+    });
     expect(user).toBeNull();
   });
 
-  it("throws when updating a missing user", async () => {
+  it("updates users and throws when the user is missing", async () => {
     const delegate = createUserDelegate();
+    await expect(
+      delegate.update({ where: { id: "user1" }, data: { email: "new@test.com" } })
+    ).resolves.toEqual({ id: "user1", email: "new@test.com" });
+    await expect(
+      delegate.findUnique({ where: { id: "user1" } })
+    ).resolves.toEqual({ id: "user1", email: "new@test.com" });
     await expect(
       delegate.update({ where: { id: "missing" }, data: { email: "nope" } })
     ).rejects.toThrow("User not found");


### PR DESCRIPTION
## Summary
- test user delegate findFirst returns null for unmatched criteria
- ensure updating users persists changes and throws when missing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in @acme/platform-core)*
- `pnpm run check:references` *(fails: missing script)*
- `pnpm run build:ts` *(fails: missing script)*
- `pnpm --filter @acme/platform-core test packages/platform-core/__tests__/user.delegate.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c599abc394832f8c688f52c9e4c229