### PR TITLE
test: cover subscription usage delegate

### DIFF
--- a/packages/platform-core/src/db/stubs/__tests__/subscriptionUsage.upsert.test.ts
+++ b/packages/platform-core/src/db/stubs/__tests__/subscriptionUsage.upsert.test.ts
@@ -1,0 +1,34 @@
+/** @jest-environment node */
+import { createSubscriptionUsageDelegate } from "../subscriptionUsage";
+
+describe("createSubscriptionUsageDelegate.upsert", () => {
+  it("creates a new record then updates it and handles missing lookups", async () => {
+    const d = createSubscriptionUsageDelegate();
+
+    // findUnique should return null when no record exists
+    expect(await d.findUnique({ where: { id: "u1" } })).toBeNull();
+
+    // creation branch of upsert
+    const created = await d.upsert({
+      where: { id: "u1" },
+      update: { count: 999 },
+      create: { id: "u1", count: 1 },
+    });
+    expect(created).toEqual({ id: "u1", count: 1 });
+
+    // update branch of upsert
+    const updated = await d.upsert({
+      where: { id: "u1" },
+      update: { count: 2 },
+      create: { id: "u1", count: 2 },
+    });
+    expect(updated).toEqual({ id: "u1", count: 2 });
+
+    // verify findUnique after update and for missing record
+    expect(await d.findUnique({ where: { id: "u1" } })).toEqual({
+      id: "u1",
+      count: 2,
+    });
+    expect(await d.findUnique({ where: { id: "missing" } })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for subscription usage delegate covering upsert creation and update

## Testing
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test packages/platform-core/src/db/stubs/__tests__/subscriptionUsage.upsert.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c599ab336c832fa8ced347c5347964