### PR TITLE
test: cover reverse logistics event multi-field filtering

### DIFF
--- a/packages/platform-core/__tests__/reverseLogisticsEvent.delegate.test.ts
+++ b/packages/platform-core/__tests__/reverseLogisticsEvent.delegate.test.ts
@@ -36,4 +36,21 @@ describe("reverseLogisticsEvent delegate", () => {
       { id: "e1", type: "received", shop: "s1" },
     ]);
   });
+
+  it("findMany filters by multiple fields", async () => {
+    const delegate = createReverseLogisticsEventDelegate();
+    await delegate.createMany({
+      data: [
+        { id: "e1", type: "received", trackingNumber: "tn1" },
+        { id: "e2", type: "received", trackingNumber: "tn2" },
+        { id: "e3", type: "cleaning", trackingNumber: "tn1" },
+      ],
+    });
+    const filtered = await delegate.findMany({
+      where: { type: "received", trackingNumber: "tn1" },
+    });
+    expect(filtered).toEqual([
+      { id: "e1", type: "received", trackingNumber: "tn1" },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- test findMany works with multiple where fields including `trackingNumber`

## Testing
- `pnpm install`
- `pnpm --filter @acme/platform-core build` *(fails: TS2322 in orders)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core test -- reverseLogisticsEvent.delegate.test.ts` *(fails: coverage threshold not met)*
- `pnpm --filter @acme/platform-core exec jest --config ../../jest.config.cjs __tests__/reverseLogisticsEvent.delegate.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c599aa44d0832f8713d3816dde48ba