### PR TITLE
test: expand product delegate coverage

### DIFF
--- a/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
+++ b/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
@@ -169,6 +169,7 @@ describe("product delegate", () => {
     expect(
       await d.findUnique({ where: { shopId_id: { shopId: "s9", id: "p1" } } })
     ).toBeNull();
+    expect(await d.findUnique({ where: { id: "p1" } })).toBeNull();
     const updated = await d.update({
       where: { shopId_id: { shopId: "s1", id: "p1" } },
       data: { name: "aa" },
@@ -190,6 +191,11 @@ describe("product delegate", () => {
     ).rejects.toThrow("Product not found");
     const delMany = await d.deleteMany({ where: { shopId: "s1" } });
     expect(delMany.count).toBe(2);
+    expect(await d.findMany({ where: { shopId: "s1" } })).toHaveLength(0);
+    await d.create({ data: { id: "p5", shopId: "s3", name: "e" } });
+    const delShop3 = await d.deleteMany({ where: { shopId: "s3" } });
+    expect(delShop3.count).toBe(1);
+    expect(await d.findMany({ where: { shopId: "s3" } })).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- add test coverage for product delegate findUnique when missing shop/id
- verify delete error and deleteMany after create clears shop records

## Testing
- `pnpm -r build` *(fails: Type '({ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; } | null)[]' is not assignable to type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; }[]'.)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: CartContext › handles localStorage errors when reading cache)*
- `pnpm --filter @acme/platform-core exec jest src/db/stubs/__tests__/delegates.test.ts --config ../../jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c599a8044c832fbea24d1fbb2358dc