### PR TITLE
test: extend page delegate coverage

### DIFF
--- a/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
+++ b/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
@@ -135,6 +135,7 @@ describe("page delegate", () => {
     expect(await d.findMany({ where: { shopId: "s1" } })).toEqual([
       { id: "1", shopId: "s1", title: "a" },
     ]);
+    expect(await d.findMany({ where: { shopId: "none" } })).toEqual([]);
     const upd = await d.update({ where: { id: "1" }, data: { title: "A" } });
     expect(upd.title).toBe("A");
     const upsertExisting = await d.upsert({
@@ -149,6 +150,27 @@ describe("page delegate", () => {
       create: { id: "3", shopId: "s1", title: "c" },
     });
     expect((await d.findMany()).length).toBe(3);
+  });
+
+  it("throws when updating a missing page", async () => {
+    const d = createPageDelegate();
+    await expect(
+      d.update({ where: { id: "missing" }, data: { title: "noop" } })
+    ).rejects.toThrow("Page not found");
+  });
+
+  it("deleteMany removes matching pages", async () => {
+    const d = createPageDelegate();
+    await d.createMany({
+      data: [
+        { id: "1", shopId: "s1" },
+        { id: "2", shopId: "s1" },
+        { id: "3", shopId: "s2" },
+      ],
+    });
+    const result = await d.deleteMany({ where: { shopId: "s1" } });
+    expect(result.count).toBe(2);
+    expect(await d.findMany()).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure findMany returns [] for unmatched filters in page delegate
- assert page delegate update errors when page is missing
- confirm deleteMany removes matching pages and reports count

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TypeScript errors in packages/platform-core src/orders/*)
- `pnpm --filter @acme/platform-core test` (fails: CartContext.test.tsx and subsequent OOM)


------
https://chatgpt.com/codex/tasks/task_e_68c599a6fecc832f982a148c52c1d62a