### PR TITLE
test: cover customer profile upsert and findFirst

### DIFF
--- a/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
+++ b/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
@@ -69,6 +69,16 @@ describe("customerProfile delegate", () => {
       create: { customerId: "c1", name: "A2", email: "a@test.com" },
     });
     expect(updated.name).toBe("A2");
+    const created = await d.upsert({
+      where: { customerId: "c3" },
+      update: { name: "C" },
+      create: { customerId: "c3", name: "C", email: "c@test.com" },
+    });
+    expect(created.name).toBe("C");
+    const none = await d.findFirst({
+      where: { email: "c@test.com", NOT: { customerId: "c3" } },
+    });
+    expect(none).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- extend customer profile delegate tests to cover update and creation via upsert
- assert findFirst returns null when NOT excludes all matches

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm --filter @acme/platform-core test` *(fails: Command was killed with SIGABRT (Aborted))*

------
https://chatgpt.com/codex/tasks/task_e_68c599a5b52c832faf0c8864135393ea