### PR TITLE
test: extend GiftCardEditor input tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/AdditionalEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/AdditionalEditors.test.tsx
@@ -232,12 +232,21 @@ describe("additional editors", () => {
       expected: { autoplay: true },
     },
     {
-      name: "GiftCardEditor",
+      name: "GiftCardEditor denominations",
       Comp: GiftCardEditor,
       component: { type: "GiftCardBlock", denominations: [], description: "" },
       getNode: () => screen.getByPlaceholderText("Amounts (comma separated)"),
-      fire: (node: HTMLElement) => fireEvent.change(node, { target: { value: "10,20" } }),
+      fire: (node: HTMLElement) => fireEvent.change(node, { target: { value: "10, foo, 20" } }),
       expected: { denominations: [10, 20] },
+    },
+    {
+      name: "GiftCardEditor description",
+      Comp: GiftCardEditor,
+      component: { type: "GiftCardBlock", denominations: [], description: "" },
+      getNode: () => screen.getByPlaceholderText("Description"),
+      fire: (node: HTMLElement) =>
+        fireEvent.change(node, { target: { value: "Terms apply" } }),
+      expected: { description: "Terms apply" },
     },
     {
       name: "CollectionListEditor",


### PR DESCRIPTION
## Summary
- ensure GiftCardEditor strips non-numeric denominations
- cover description updates for GiftCardEditor

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/ui test` *(fails: Tokens test adds custom font and clears input)*

------
https://chatgpt.com/codex/tasks/task_e_68c583cafd80832fa8892b9c19523c8b