### PR TITLE
test: verify gallery editor array limits

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/GalleryEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/GalleryEditor.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import GalleryEditor from "../GalleryEditor";
+
+const arrayEditorSpy = jest.fn(() => <div data-testid="array-editor" />);
+
+jest.mock("../useArrayEditor", () => ({
+  __esModule: true,
+  useArrayEditor: () => arrayEditorSpy,
+}));
+
+describe("GalleryEditor", () => {
+  beforeEach(() => {
+    arrayEditorSpy.mockClear();
+  });
+
+  it("uses useArrayEditor with images and item limits", () => {
+    const component: any = {
+      type: "Gallery",
+      images: [],
+      minItems: 1,
+      maxItems: 3,
+    };
+    const onChange = jest.fn();
+
+    render(<GalleryEditor component={component} onChange={onChange} />);
+
+    expect(arrayEditorSpy).toHaveBeenCalledWith(
+      "images",
+      component.images,
+      ["src", "alt"],
+      { minItems: component.minItems, maxItems: component.maxItems }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- test GalleryEditor uses `useArrayEditor` with image key and item limits

## Testing
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui`)*
- `pnpm test -- src/components/cms/page-builder/__tests__/GalleryEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c583ca4f84832fa79693d10680eb2c