### PR TITLE
test(ui): filter blank form options

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/FormBuilderEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/FormBuilderEditor.test.tsx
@@ -97,5 +97,24 @@ describe("FormBuilderEditor", () => {
         },
       ],
     });
+
+    fireEvent.change(
+      screen.getByPlaceholderText("options (comma separated)"),
+      { target: { value: " a, b , ,c,, " } }
+    );
+    expect(onChange).toHaveBeenLastCalledWith({
+      fields: [
+        {
+          type: "select",
+          name: "foo",
+          label: "Foo Label",
+          options: [
+            { label: "a", value: "a" },
+            { label: "b", value: "b" },
+            { label: "c", value: "c" },
+          ],
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend FormBuilderEditor tests to cover spaced and empty select options

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm test packages/ui` *(fails: task `packages/ui` not found)*
- `pnpm --filter @acme/ui test` *(fails: Tokens.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c583c895c8832f9451152197b51f41