### PR TITLE
test: cover featured product editor patches

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/FeaturedProductEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/FeaturedProductEditor.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import FeaturedProductEditor from "../FeaturedProductEditor";
+
+describe("FeaturedProductEditor", () => {
+  it("updates sku and collectionId separately", () => {
+    const onChange = jest.fn();
+    render(
+      <FeaturedProductEditor
+        component={{ type: "FeaturedProduct", sku: "", collectionId: "" }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("sku"), {
+      target: { value: "sku1" },
+    });
+    expect(onChange).toHaveBeenNthCalledWith(1, { sku: "sku1" });
+
+    fireEvent.change(screen.getByPlaceholderText("collectionId"), {
+      target: { value: "col1" },
+    });
+    expect(onChange).toHaveBeenNthCalledWith(2, { collectionId: "col1" });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test verifying FeaturedProductEditor emits patches when sku or collectionId changes

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui`)*
- `pnpm --filter @acme/ui test` *(fails: JavaScript heap out of memory)*
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runInBand --coverage=false src/components/cms/page-builder/__tests__/FeaturedProductEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c583c7d6e4832f92c4bc2ca1bbc338