### PR TITLE
test(ui): add CustomHtmlEditor interaction test

### DIFF
--- a/packages/ui/__tests__/CustomHtmlEditor.test.tsx
+++ b/packages/ui/__tests__/CustomHtmlEditor.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import CustomHtmlEditor from "../src/components/cms/page-builder/CustomHtmlEditor";
+
+const handleInput = jest.fn();
+jest.mock("../src/components/cms/page-builder/useComponentInputs", () => ({
+  __esModule: true,
+  default: () => ({ handleInput }),
+}));
+
+describe("CustomHtmlEditor", () => {
+  it("calls handleInput with updated html", () => {
+    render(
+      <CustomHtmlEditor
+        component={{ type: "CustomHtml", html: "" }}
+        onChange={jest.fn()}
+      />,
+    );
+    const textarea = screen.getByLabelText("HTML");
+    fireEvent.change(textarea, { target: { value: "<p>test</p>" } });
+    expect(handleInput).toHaveBeenCalledWith("html", "<p>test</p>");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying CustomHtmlEditor delegates textarea changes to handleInput

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in @acme/platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm test packages/ui` *(fails: Could not find task `packages/ui`)*
- `pnpm --filter @acme/ui test CustomHtmlEditor.test.tsx` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c583c595dc832f82412e743efa2660