### PR TITLE
test: add handleInput coverage for countdown editor

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/CountdownTimerEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/CountdownTimerEditor.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import CountdownTimerEditor from "../CountdownTimerEditor";
+
+const handleInput = jest.fn();
+jest.mock("../useComponentInputs", () => ({
+  __esModule: true,
+  default: () => ({ handleInput }),
+}));
+
+describe("CountdownTimerEditor", () => {
+  afterEach(() => {
+    handleInput.mockClear();
+  });
+
+  it.each([
+    ["Target Date", "targetDate", "2025-01-01T00:00"],
+    ["Timezone", "timezone", "UTC"],
+    ["Completion Text", "completionText", "Done"],
+    ["Styles", "styles", "text-lg"],
+  ])("calls handleInput for %s changes", (label, field, value) => {
+    const component: any = {
+      type: "CountdownTimer",
+      targetDate: "",
+      timezone: "",
+      completionText: "",
+      styles: "",
+    };
+
+    const onChange = jest.fn();
+    render(<CountdownTimerEditor component={component} onChange={onChange} />);
+
+    const input = screen.getByLabelText(label);
+    fireEvent.change(input, { target: { value } });
+    expect(handleInput).toHaveBeenCalledWith(field, value);
+  });
+});


### PR DESCRIPTION
## Summary
- test CountdownTimerEditor with parameterized inputs

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/email build failed)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test packages/ui` *(fails: Missing tasks in project)*
- `pnpm test --filter @acme/ui` *(fails: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68c583c48ce0832f874aa304a8a704fc