### PR TITLE
test(ui): cover action and method patches

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/BlockEditors.test.tsx
@@ -134,6 +134,12 @@ describe("block editors", () => {
         target: { value: url },
       });
       expect(onChange).toHaveBeenLastCalledWith({ link: url });
+    } else if (_name === "ContactFormEditor") {
+      fireEvent.change(screen.getByPlaceholderText("method"), {
+        target: { value: "post" },
+      });
+      expect(onChange).toHaveBeenNthCalledWith(1, { action: "x" });
+      expect(onChange).toHaveBeenNthCalledWith(2, { method: "post" });
     } else {
       expect(onChange).toHaveBeenCalled();
     }


### PR DESCRIPTION
## Summary
- extend ContactFormEditor block test to assert action and method patches

## Testing
- `pnpm --filter @acme/ui test`
- `pnpm --filter @acme/ui test -- src/components/cms/page-builder/__tests__/BlockEditors.test.tsx` *(fails: Jest "global" coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c583c3614c832f966c052282bd1da6