### PR TITLE
test: cover inventory item delegate edge cases

### DIFF
--- a/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
+++ b/packages/platform-core/src/db/stubs/__tests__/delegates.test.ts
@@ -98,13 +98,6 @@ describe("inventoryItem delegate", () => {
       create: {},
     });
     expect(updated.stock).toBe(5);
-    await d.upsert({
-      where: {
-        shopId_sku_variantKey: { shopId: "s1", sku: "sku4", variantKey: "v4" },
-      },
-      update: {},
-      create: { shopId: "s1", sku: "sku4", variantKey: "v4", stock: 4 },
-    });
     const deleted = await d.delete({
       where: {
         shopId_sku_variantKey: { shopId: "s1", sku: "sku2", variantKey: "v2" },
@@ -114,12 +107,60 @@ describe("inventoryItem delegate", () => {
     await expect(
       d.delete({
         where: {
-          shopId_sku_variantKey: { shopId: "s1", sku: "none", variantKey: "none" },
+          shopId_sku_variantKey: {
+            shopId: "s1",
+            sku: "sku2",
+            variantKey: "v2",
+          },
         },
       })
     ).rejects.toThrow("InventoryItem not found");
+  });
+
+  it("creates a new record when upserting with a missing key", async () => {
+    const d = createInventoryItemDelegate();
+    const record = await d.upsert({
+      where: {
+        shopId_sku_variantKey: {
+          shopId: "s1",
+          sku: "sku4",
+          variantKey: "v4",
+        },
+      },
+      update: {},
+      create: { stock: 4 },
+    });
+    expect(record).toMatchObject({
+      shopId: "s1",
+      sku: "sku4",
+      variantKey: "v4",
+      stock: 4,
+    });
+    const found = await d.findUnique({
+      where: {
+        shopId_sku_variantKey: {
+          shopId: "s1",
+          sku: "sku4",
+          variantKey: "v4",
+        },
+      },
+    });
+    expect(found).not.toBeNull();
+  });
+
+  it("deleteMany removes only items matching shopId", async () => {
+    const d = createInventoryItemDelegate();
+    await d.createMany({
+      data: [
+        { shopId: "s1", sku: "sku1", variantKey: "v1", stock: 1 },
+        { shopId: "s1", sku: "sku2", variantKey: "v2", stock: 2 },
+        { shopId: "s2", sku: "sku3", variantKey: "v3", stock: 3 },
+      ],
+    });
     const result = await d.deleteMany({ where: { shopId: "s1" } });
     expect(result.count).toBe(2);
+    expect(await d.findMany({ where: { shopId: "s1" } })).toHaveLength(0);
+    expect(await d.findMany({ where: { shopId: "s2" } })).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- add tests for inventory item delegate delete error path
- verify upsert creates new record when key missing
- ensure deleteMany removes only matching shopId

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in @acme/platform-core build)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec jest packages/platform-core/src/db/stubs/__tests__/delegates.test.ts --config jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c599a66b94832f8d30037e490bc047