### PR TITLE
test: verify TestimonialsEditor item limit props

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/TestimonialsEditor.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/TestimonialsEditor.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import TestimonialsEditor from "../TestimonialsEditor";
+
+const arrayEditorSpy = jest.fn(() => <div data-testid="array-editor" />);
+
+jest.mock("../useArrayEditor", () => ({
+  __esModule: true,
+  useArrayEditor: () => arrayEditorSpy,
+}));
+
+describe("TestimonialsEditor", () => {
+  beforeEach(() => {
+    arrayEditorSpy.mockClear();
+  });
+
+  it("uses useArrayEditor with testimonials and item limits", () => {
+    const component: any = {
+      type: "Testimonials",
+      testimonials: [],
+      minItems: 1,
+      maxItems: 5,
+    };
+    const onChange = jest.fn();
+
+    render(<TestimonialsEditor component={component} onChange={onChange} />);
+
+    expect(arrayEditorSpy).toHaveBeenCalledWith(
+      "testimonials",
+      component.testimonials,
+      ["quote", "name"],
+      { minItems: component.minItems, maxItems: component.maxItems }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add test that mocks useArrayEditor to ensure TestimonialsEditor forwards minItems and maxItems

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @acme/ui test packages/ui/src/components/cms/page-builder/__tests__/TestimonialsEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5a9f272e0832faa4292c523c2b491