### PR TITLE
chore(email): limit jest coverage to email package

### DIFF
--- a/packages/email/jest.config.cjs
+++ b/packages/email/jest.config.cjs
@@ -5,6 +5,8 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, '..', '..'),
   roots: ['<rootDir>/packages/email'],
+  collectCoverageFrom: ['packages/email/src/**/*.{ts,tsx}'],
+  coveragePathIgnorePatterns: ['/packages/(?!email)/'],
   moduleNameMapper: {
     ...baseConfig.moduleNameMapper,
     '^\\./fsStore\\.js$': '<rootDir>/packages/email/src/storage/fsStore.ts',


### PR DESCRIPTION
## Summary
- restrict jest coverage collection to email package sources
- ignore other packages when generating coverage

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TS2322 in packages/platform-core)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/email test` *(partial run; logs generated)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ad7a6e94832f823d436b4f075f7d