### PR TITLE
chore: scope jest coverage per package

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -244,4 +244,17 @@ const config = {
   rootDir: process.cwd(), // ensure paths resolve relative to each package
 };
 
+// Limit coverage collection to the current workspace package/app
+const workspaceRoot = __dirname;
+const relativePath = path.relative(workspaceRoot, process.cwd()).replace(/\\/g, '/');
+if (relativePath) {
+  const [scope, ...rest] = relativePath.split('/');
+  const subPath = rest.join('/');
+  config.collectCoverageFrom = ['src/**/*.{ts,tsx}'];
+  config.coveragePathIgnorePatterns.push(
+    `/${scope}/(?!${subPath})/`,
+    scope === 'packages' ? '/apps/' : '/packages/'
+  );
+}
+
 module.exports = resolveRoot(config);

--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -2,15 +2,27 @@
 const path = require("path");
 const base = require("../../jest.config.cjs");
 
+const workspaceRoot = path.resolve(__dirname, "../..");
+const packagePath = path
+  .relative(workspaceRoot, process.cwd())
+  .replace(/\\/g, "/");
+const [scope, ...rest] = packagePath.split("/");
+const subPath = rest.join("/");
+
 const coveragePathIgnorePatterns = (base.coveragePathIgnorePatterns || []).filter(
   (pattern) =>
     !pattern.includes("/packages/config/src/env/__tests__/")
+);
+coveragePathIgnorePatterns.push(
+  `/${scope}/(?!${subPath})/`,
+  scope === "packages" ? "/apps/" : "/packages/"
 );
 
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
-  rootDir: path.resolve(__dirname, "../.."),
+  rootDir: workspaceRoot,
+  collectCoverageFrom: [`${packagePath}/src/**/*.{ts,tsx}`],
   // Use a plain Node environment for configuration tests. These tests don't
   // depend on DOM APIs and running them under jsdom pulls in additional
   // transitive dependencies like `parse5`, which in turn requires the

--- a/packages/tailwind-config/jest.config.cjs
+++ b/packages/tailwind-config/jest.config.cjs
@@ -5,4 +5,6 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, "..", ".."),
   roots: ["<rootDir>/packages/tailwind-config"],
+  collectCoverageFrom: ["packages/tailwind-config/src/**/*.{ts,tsx}"],
+  coveragePathIgnorePatterns: ["/packages/(?!tailwind-config)/", "/apps/"],
 };


### PR DESCRIPTION
## Summary
- limit Jest coverage to each workspace's src files
- dynamically ignore other packages and apps during coverage
- add explicit coverage config for tailwind-config package

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm --filter @acme/tailwind-config test`
- `pnpm --filter @acme/zod-utils test` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cb27d128832faeb04d679934cde7