### PR TITLE
fix: quiet TemplateSelector test warnings

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/components/TemplateSelector.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/components/TemplateSelector.tsx
@@ -83,13 +83,15 @@ export default function TemplateSelector({
                 className="w-full text-left"
               >
                 <div className="flex items-center gap-2">
-                  <Image
-                    src={t.preview}
-                    alt={`${t.name} preview`}
-                    width={32}
-                    height={32}
-                    className="h-8 w-8 rounded object-cover"
-                  />
+                  {t.preview && (
+                    <Image
+                      src={t.preview}
+                      alt={`${t.name} preview`}
+                      width={32}
+                      height={32}
+                      className="h-8 w-8 rounded object-cover"
+                    />
+                  )}
                   {t.name}
                 </div>
               </button>

--- a/apps/cms/src/app/cms/configurator/steps/components/__tests__/TemplateSelector.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/components/__tests__/TemplateSelector.test.tsx
@@ -21,10 +21,12 @@ jest.mock("@ui/components/atoms/shadcn", () => {
     Button: ({ children, onClick, ...props }: any) => (
       <button onClick={onClick} {...props}>{children}</button>
     ),
-    Select: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Select: ({ children, onOpenChange, onValueChange, open, value, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
     SelectTrigger: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     SelectContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    SelectItem: ({ children, onSelect, ...props }: any) => (
+    SelectItem: ({ children, onSelect, asChild, ...props }: any) => (
       <div onClick={(e) => onSelect && onSelect(e)} {...props}>{children}</div>
     ),
     SelectValue: ({ placeholder }: any) => <div>{placeholder}</div>,


### PR DESCRIPTION
## Summary
- avoid rendering empty preview images in TemplateSelector
- strip unsupported props from mocked shadcn components to eliminate React warnings

## Testing
- `node node_modules/jest/bin/jest.js apps/cms/src/app/cms/configurator/steps/components/__tests__/TemplateSelector.test.tsx --runInBand --env=jsdom` *(fails: process hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ce54c280832fbf8f1ac87a182f19