### PR TITLE
test: silence rollback error

### DIFF
--- a/apps/cms/src/app/api/shop/[shop]/rollback/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/shop/[shop]/rollback/__tests__/route.test.ts
@@ -4,14 +4,21 @@ jest.mock("@auth", () => ({ requirePermission }));
 const execFile = jest.fn();
 jest.mock("child_process", () => ({ execFile }));
 
+let consoleErrorSpy: jest.SpyInstance;
+
 let POST: typeof import("../route").POST;
 
 beforeAll(async () => {
   ({ POST } = await import("../route"));
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 });
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
 });
 
 describe("POST", () => {
@@ -40,5 +47,6 @@ describe("POST", () => {
     const res = await POST(req(), { params: { shop: "bad" } });
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: "Rollback failed" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- mock console.error in rollback route tests to keep Jest output clean
- verify the rollback error is logged when invalid diff IDs are provided

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type '({ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; } | null)[]' is not assignable to type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; }[]'.* )
- `pnpm --filter @apps/cms exec jest --ci --runInBand --detectOpenHandles --config jest.config.cjs --runTestsByPath src/app/api/shop/\[shop\]/rollback/__tests__/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce7046b0832f9c17a901115cd2b1