### PR TITLE
fix: avoid invalid markup in theme selector

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/ThemeEditorForm.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/ThemeEditorForm.tsx
@@ -70,7 +70,7 @@ export default function ThemeEditorForm({
         </SelectTrigger>
         <SelectContent>
           {themes.map((t) => (
-            <SelectItem key={t} value={t}>
+            <SelectItem key={t} value={t} textValue={t}>
               <div className="flex items-center gap-2">
                 <Image
                   src={`/themes/${t}.svg`}

--- a/apps/cms/src/app/cms/configurator/steps/__tests__/ThemeEditorForm.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/__tests__/ThemeEditorForm.test.tsx
@@ -15,7 +15,9 @@ jest.mock("@ui/components/atoms/shadcn", () => ({
     </select>
   ),
   SelectContent: ({ children }: any) => <>{children}</>,
-  SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+  SelectItem: ({ value, textValue }: any) => (
+    <option value={value}>{textValue}</option>
+  ),
   SelectTrigger: ({ children }: any) => <>{children}</>,
   SelectValue: () => null,
 }));


### PR DESCRIPTION
## Summary
- prevent invalid DOM nesting by providing textValue for SelectItem in ThemeEditorForm
- adjust ThemeEditorForm test mock to render option text from textValue

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --filter @apps/cms test -- src/app/cms/configurator/steps/__tests__/ThemeEditorForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5cea4d7d4832f98f4c4dd17ce9d39