### PR TITLE
fix: remove template selector console errors

### DIFF
--- a/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
+++ b/apps/cms/src/app/cms/configurator/components/TemplateSelector.tsx
@@ -98,13 +98,15 @@ export default function TemplateSelector({
                 disabled={t.disabled}
               >
                 <div className="flex items-center gap-2">
-                  <Image
-                    src={t.preview}
-                    alt={`${t.name} preview`}
-                    width={32}
-                    height={32}
-                    className="h-8 w-8 rounded object-cover"
-                  />
+                  {t.preview && (
+                    <Image
+                      src={t.preview}
+                      alt={`${t.name} preview`}
+                      width={32}
+                      height={32}
+                      className="h-8 w-8 rounded object-cover"
+                    />
+                  )}
                   {t.name}
                 </div>
               </button>

--- a/apps/cms/src/app/cms/configurator/components/__tests__/TemplateSelector.test.tsx
+++ b/apps/cms/src/app/cms/configurator/components/__tests__/TemplateSelector.test.tsx
@@ -21,11 +21,19 @@ jest.mock("@/components/atoms/shadcn", () => {
     Button: ({ children, onClick, ...props }: any) => (
       <button onClick={onClick} {...props}>{children}</button>
     ),
-    Select: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    SelectTrigger: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    SelectContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    SelectItem: ({ children, onSelect, disabled, ...props }: any) => (
-      <div onClick={(e) => !disabled && onSelect && onSelect(e)} {...props}>{children}</div>
+    Select: ({ children, open, onOpenChange, onValueChange, value, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
+    SelectTrigger: ({ children, asChild, ...props }: any) => <div {...props}>{children}</div>,
+    SelectContent: ({ children, asChild, ...props }: any) => <div {...props}>{children}</div>,
+    SelectItem: ({ children, onSelect, disabled, asChild, ...props }: any) => (
+      <div
+        onClick={(e) => !disabled && onSelect && onSelect(e)}
+        aria-disabled={disabled}
+        {...props}
+      >
+        {children}
+      </div>
     ),
     SelectValue: ({ placeholder }: any) => <div>{placeholder}</div>,
   };


### PR DESCRIPTION
## Summary
- conditionally render template preview image to avoid empty `src`
- mock shadcn Select components to strip non-DOM props in tests

## Testing
- `pnpm test:cms apps/cms/src/app/cms/configurator/components/__tests__/TemplateSelector.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5cec6f11c832fa5b076c34481bdbb