### PR TITLE
test: silence Sanity verify dataset error log

### DIFF
--- a/apps/cms/src/app/api/sanity/verify/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/sanity/verify/__tests__/route.test.ts
@@ -29,6 +29,7 @@ describe('POST /api/sanity/verify', () => {
 
   afterEach(() => {
     (global as any).fetch = originalFetch;
+    jest.restoreAllMocks();
     jest.resetAllMocks();
   });
 
@@ -81,6 +82,7 @@ describe('POST /api/sanity/verify', () => {
   });
 
   it('returns 500 when dataset list fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
     const mockFetch = jest
       .fn()
       .mockResolvedValue(new Response('fail', { status: 500 }));
@@ -99,6 +101,7 @@ describe('POST /api/sanity/verify', () => {
       error: 'Failed to list datasets',
       errorCode: 'DATASET_LIST_ERROR',
     });
+    expect(consoleError).toHaveBeenCalledWith(expect.any(Error));
   });
 });
 


### PR DESCRIPTION
## Summary
- silence noisy dataset list errors in Sanity verify API test
- assert console.error is invoked when dataset listing fails

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ... in packages/platform-core)*
- `pnpm exec jest apps/cms/src/app/api/sanity/verify/__tests__/route.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5cee39238832fa52fa02bf9326cfa