### PR TITLE
Include scripts in Jest coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -250,7 +250,15 @@ const relativePath = path.relative(workspaceRoot, process.cwd()).replace(/\\/g, 
 if (relativePath) {
   const [scope, ...rest] = relativePath.split('/');
   const subPath = rest.join('/');
-  config.collectCoverageFrom = ['src/**/*.{ts,tsx}'];
+  config.collectCoverageFrom = [
+    'src/**/*.{ts,tsx}',
+    'scripts/**/*.{ts,tsx}',
+    '*.{ts,tsx}',
+    '!**/__tests__/**',
+    '!**/*.d.ts',
+    '!**/*.test.{ts,tsx}',
+    '!**/*.spec.{ts,tsx}',
+  ];
   config.coveragePathIgnorePatterns.push(
     `/${scope}/(?!${subPath})/`,
     scope === 'packages' ? '/apps/' : '/packages/'


### PR DESCRIPTION
## Summary
- extend Jest coverage to include `scripts` and root TypeScript files
- exclude declaration and test files from coverage collection

## Testing
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --filter scripts test` *(fails: missing tsconfig.test.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cf419d2c832fb4bfbfbbf0893467