### PR TITLE
Include middleware files in coverage collection

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -220,6 +220,7 @@ const config = {
   passWithNoTests: true,
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs', 'node', 'd.ts'],
   collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', 'middleware.ts', 'packages/*/middleware.ts'],
   coverageDirectory: path.join(process.cwd(), 'coverage'),
   coveragePathIgnorePatterns: [
     ' /test/msw/',
@@ -250,7 +251,7 @@ const relativePath = path.relative(workspaceRoot, process.cwd()).replace(/\\/g, 
 if (relativePath) {
   const [scope, ...rest] = relativePath.split('/');
   const subPath = rest.join('/');
-  config.collectCoverageFrom = ['src/**/*.{ts,tsx}'];
+  config.collectCoverageFrom = ['src/**/*.{ts,tsx}', 'middleware.ts'];
   config.coveragePathIgnorePatterns.push(
     `/${scope}/(?!${subPath})/`,
     scope === 'packages' ? '/apps/' : '/packages/'

--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -22,7 +22,7 @@ coveragePathIgnorePatterns.push(
 module.exports = {
   ...base,
   rootDir: workspaceRoot,
-  collectCoverageFrom: [`${packagePath}/src/**/*.{ts,tsx}`],
+  collectCoverageFrom: [`${packagePath}/src/**/*.{ts,tsx}`, `${packagePath}/middleware.ts`],
   // Use a plain Node environment for configuration tests. These tests don't
   // depend on DOM APIs and running them under jsdom pulls in additional
   // transitive dependencies like `parse5`, which in turn requires the

--- a/packages/email/jest.config.cjs
+++ b/packages/email/jest.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, '..', '..'),
   roots: ['<rootDir>/packages/email'],
-  collectCoverageFrom: ['packages/email/src/**/*.{ts,tsx}'],
+  collectCoverageFrom: ['packages/email/src/**/*.{ts,tsx}', 'packages/email/middleware.ts'],
   coveragePathIgnorePatterns: ['/packages/(?!email)/'],
   moduleNameMapper: {
     ...baseConfig.moduleNameMapper,

--- a/packages/tailwind-config/jest.config.cjs
+++ b/packages/tailwind-config/jest.config.cjs
@@ -5,6 +5,6 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, "..", ".."),
   roots: ["<rootDir>/packages/tailwind-config"],
-  collectCoverageFrom: ["packages/tailwind-config/src/**/*.{ts,tsx}"],
+  collectCoverageFrom: ["packages/tailwind-config/src/**/*.{ts,tsx}", "packages/tailwind-config/middleware.ts"],
   coveragePathIgnorePatterns: ["/packages/(?!tailwind-config)/", "/apps/"],
 };


### PR DESCRIPTION
## Summary
- include repository and package `middleware.ts` files in Jest coverage
- keep coveragePathIgnorePatterns unaffected for middleware paths

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm test` *(fails: root-tests#test command exited 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cf4a93a0832fb7ee2a4c044610d2