### PR TITLE
chore: include cms media components in coverage

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -53,7 +53,6 @@ module.exports = {
   coverageReporters: ["text", "lcov"],
   coveragePathIgnorePatterns: [
     "/node_modules/",
-    "<rootDir>/apps/cms/src/components/cms/media/",
   ],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
## Summary
- remove CMS media components directory from coverage ignore list

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Type 'null' is not assignable to type...)
- `pnpm --filter @apps/cms test` (fails: pages.server captures and rethrows service errors)


------
https://chatgpt.com/codex/tasks/task_e_68c5cf50f604832f967ac72158c62c0b