### PR TITLE
Include functions in Jest coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -250,11 +250,13 @@ const relativePath = path.relative(workspaceRoot, process.cwd()).replace(/\\/g, 
 if (relativePath) {
   const [scope, ...rest] = relativePath.split('/');
   const subPath = rest.join('/');
-  config.collectCoverageFrom = ['src/**/*.{ts,tsx}'];
-  config.coveragePathIgnorePatterns.push(
-    `/${scope}/(?!${subPath})/`,
-    scope === 'packages' ? '/apps/' : '/packages/'
-  );
+  config.collectCoverageFrom = ['src/**/*.{ts,tsx}', 'functions/**/*.ts'];
+
+  const ignorePatterns = [scope === 'packages' ? '/apps/' : '/packages/'];
+  if (scope !== 'functions') {
+    ignorePatterns.unshift(`/${scope}/(?!${subPath})/`);
+  }
+  config.coveragePathIgnorePatterns.push(...ignorePatterns);
 }
 
 module.exports = resolveRoot(config);


### PR DESCRIPTION
## Summary
- collect coverage from `functions/**/*.ts`
- avoid filtering `functions` in `coveragePathIgnorePatterns`

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable)*
- `pnpm test` *(fails: scripts#test)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cf58eb00832fb4539cc62b28d0d4