### PR TITLE
test: silence updatePost error output

### DIFF
--- a/apps/cms/src/services/blog/posts/__tests__/update.test.ts
+++ b/apps/cms/src/services/blog/posts/__tests__/update.test.ts
@@ -116,11 +116,14 @@ describe("updatePost", () => {
 
   it("surfaces repository update errors", async () => {
     const { getConfig, filterExistingProductSlugs } = await import(
-      "../../config"
+      "../../config",
     );
     const { updatePost: repoUpdatePost, slugExists } = await import(
-      "@platform-core/repositories/blog.server"
+      "@platform-core/repositories/blog.server",
     );
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
     const config = { id: "config" } as any;
     getConfig.mockResolvedValue(config);
@@ -138,6 +141,11 @@ describe("updatePost", () => {
 
     expect(repoUpdatePost).toHaveBeenCalled();
     expect(result).toEqual({ error: "Failed to update post" });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to update post",
+      error,
+    );
+    consoleErrorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- stub console.error in updatePost unit test to keep output clean and verify the log call

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Type 'null' is not assignable to type ...)
- `pnpm --filter @apps/cms exec jest apps/cms/src/services/blog/posts/__tests__/update.test.ts --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5cf7f47f0832fa1b903d40003b6a9