### PR TITLE
test: silence upgrade-shop error

### DIFF
--- a/apps/cms/src/app/api/upgrade-shop/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/upgrade-shop/__tests__/route.test.ts
@@ -23,12 +23,18 @@ jest.mock('child_process', () => ({
 }));
 
 let POST: typeof import('../route').POST;
+let consoleErrorSpy: jest.SpyInstance;
 
 beforeAll(async () => {
   ({ POST } = await import('../route'));
 });
 
+beforeEach(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
 afterEach(() => {
+  consoleErrorSpy.mockRestore();
   jest.resetAllMocks();
 });
 


### PR DESCRIPTION
## Summary
- silence console.error during upgrade-shop route tests

## Testing
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm exec jest --ci --runInBand --forceExit apps/cms/src/app/api/upgrade-shop/__tests__/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5cf88cda4832f8479b5dcf8b0c5d6