### PR TITLE
test: silence console errors in media route

### DIFF
--- a/apps/cms/src/app/api/media/__tests__/route.test.ts
+++ b/apps/cms/src/app/api/media/__tests__/route.test.ts
@@ -16,8 +16,16 @@ beforeAll(async () => {
   ({ GET, POST, DELETE } = await import("../route"));
 });
 
+beforeEach(() => {
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
 afterEach(() => {
   jest.resetAllMocks();
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 describe("media route", () => {


### PR DESCRIPTION
## Summary
- silence `console.error` in media route tests to avoid noisy output

## Testing
- `pnpm test:cms apps/cms/src/app/api/media/__tests__/route.test.ts`
- `pnpm -r build` *(fails: packages/plugins/paypal build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cf97bc14832f88d37134938fd387