### PR TITLE
test: silence delete post error

### DIFF
--- a/apps/cms/__tests__/services/blog/delete.test.ts
+++ b/apps/cms/__tests__/services/blog/delete.test.ts
@@ -30,8 +30,16 @@ describe('deletePost', () => {
 
   it('returns error when repository throws', async () => {
     repoDeletePost.mockRejectedValue(new Error('fail'));
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     const result = await deletePost('shop', '123');
     expect(result).toEqual({ error: 'Failed to delete post' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to delete post',
+      expect.any(Error),
+    );
+    consoleErrorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- avoid noisy `console.error` output in deletePost service test by stubbing and asserting the logger

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm test:cms apps/cms/__tests__/services/blog/delete.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5cfdd8164832f9e99cd742a7c7cd3