### PR TITLE
test: silence createShop error logs

### DIFF
--- a/apps/cms/src/actions/__tests__/createShop.server.test.ts
+++ b/apps/cms/src/actions/__tests__/createShop.server.test.ts
@@ -21,8 +21,15 @@ jest.mock("../common/auth.ts", () => ({
 }));
 
 describe("createNewShop", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.resetAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it("Successful shop creation with RBAC update for new user", async () => {
@@ -159,10 +166,6 @@ describe("createNewShop", () => {
     (prisma.page.deleteMany as jest.Mock).mockRejectedValue(
       new Error("rollback fail")
     );
-    const consoleErrorSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-
     await expect(createNewShop("shop1", {} as any)).rejects.toThrow(
       "Failed to assign ShopAdmin role"
     );
@@ -170,7 +173,6 @@ describe("createNewShop", () => {
       "Failed to roll back shop creation",
       expect.any(Error)
     );
-    consoleErrorSpy.mockRestore();
   });
 
   it("Ensure user without id skips RBAC update", async () => {


### PR DESCRIPTION
## Summary
- spy on console.error in createShop tests to avoid noisy logs
- remove local spy in rollback-failure test

## Testing
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --filter @apps/cms exec jest src/actions/__tests__/createShop.server.test.ts --runTestsByPath --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5d05136e0832fbee0db82321741d7