### PR TITLE
fix: avoid undefined context in reportError

### DIFF
--- a/apps/cms/src/actions/pages/utils.ts
+++ b/apps/cms/src/actions/pages/utils.ts
@@ -37,7 +37,11 @@ export async function reportError(
   context?: Record<string, unknown>
 ): Promise<void> {
   try {
-    await captureException(err, context ? { extra: context } : undefined);
+    if (context) {
+      await captureException(err, { extra: context });
+    } else {
+      await captureException(err);
+    }
   } catch {
     /* ignore sentry failure */
   }


### PR DESCRIPTION
## Summary
- avoid passing undefined context to captureException when reporting errors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm exec jest --runTestsByPath apps/cms/src/__tests__/pages.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0695e80832f976b526d128be810