### PR TITLE
refactor: migrate to useActionState

### DIFF
--- a/apps/cms/__tests__/useSanityConnection.test.ts
+++ b/apps/cms/__tests__/useSanityConnection.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
+import { startTransition } from "react";
 import { useSanityConnection } from "../src/app/cms/blog/sanity/connect/useSanityConnection";
 
 jest.mock("@cms/actions/saveSanityConfig", () => ({
@@ -80,7 +81,11 @@ describe("useSanityConnection", () => {
     expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
     await act(async () => {
       result.current.handleDatasetSubmit();
-      await result.current.formAction(new FormData());
+      let promise: Promise<any> | undefined;
+      startTransition(() => {
+        promise = result.current.formAction(new FormData());
+      });
+      await promise;
     });
     expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(2);
   });
@@ -92,7 +97,11 @@ describe("useSanityConnection", () => {
     });
     const { result } = renderHook(() => useSanityConnection("shop"));
     await act(async () => {
-      await result.current.formAction(new FormData());
+      let promise: Promise<any> | undefined;
+      startTransition(() => {
+        promise = result.current.formAction(new FormData());
+      });
+      await promise;
     });
     expect(result.current.state.error).toBe("bad");
     expect(result.current.state.errorCode).toBe("DATASET_CREATE_ERROR");

--- a/apps/cms/src/app/cms/blog/posts/DeleteButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/DeleteButton.client.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/blog/posts/DeleteButton.client.tsx
 "use client";
 
-import { useFormState } from "react-dom";
+import { useActionState } from "react";
 import { Button, Toast } from "@ui";
 import { deletePost } from "@cms/actions/blog.server";
 import type { FormState } from "./PostForm.client";
@@ -13,7 +13,7 @@ interface Props {
 
 export default function DeleteButton({ id, shopId }: Props) {
   const action = deletePost.bind(null, shopId, id);
-  const [state, formAction] = useFormState<FormState>(action, {
+  const [state, formAction] = useActionState<FormState, FormData>(action, {
     message: "",
     error: "",
   });

--- a/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
@@ -1,8 +1,7 @@
 // apps/cms/src/app/cms/blog/posts/PostForm.client.tsx
 "use client";
 
-import { useFormState } from "react-dom";
-import { useState, useEffect } from "react";
+import { useActionState, useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { Button, Input, Switch, Textarea, Toast } from "@ui";
 import { slugify } from "@acme/shared-utils";
@@ -42,7 +41,10 @@ interface Props {
 }
 
 function PostFormContent({ action, submitLabel, post }: Props) {
-  const [state, formAction] = useFormState(action, { message: "", error: "" });
+  const [state, formAction] = useActionState<FormState, FormData>(
+    action,
+    { message: "", error: "" },
+  );
   const [title, setTitle] = useState(post?.title ?? "");
   const [slug, setSlug] = useState(post?.slug ?? "");
   const [editSlug, setEditSlug] = useState(false);

--- a/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/blog/posts/PublishButton.client.tsx
 "use client";
 
-import { useFormState } from "react-dom";
+import { useActionState } from "react";
 import { Button, Toast } from "@ui";
 import { publishPost } from "@cms/actions/blog.server";
 import type { FormState } from "./PostForm.client";
@@ -13,7 +13,7 @@ interface Props {
 
 export default function PublishButton({ id, shopId }: Props) {
   const action = publishPost.bind(null, shopId, id);
-  const [state, formAction] = useFormState<FormState>(action, {
+  const [state, formAction] = useActionState<FormState, FormData>(action, {
     message: "",
     error: "",
   });

--- a/apps/cms/src/app/cms/blog/posts/UnpublishButton.client.tsx
+++ b/apps/cms/src/app/cms/blog/posts/UnpublishButton.client.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/blog/posts/UnpublishButton.client.tsx
 "use client";
 
-import { useFormState } from "react-dom";
+import { useActionState } from "react";
 import { Button, Toast } from "@ui";
 import { unpublishPost } from "@cms/actions/blog.server";
 import type { FormState } from "./PostForm.client";
@@ -13,7 +13,7 @@ interface Props {
 
 export default function UnpublishButton({ id, shopId }: Props) {
   const action = unpublishPost.bind(null, shopId, id);
-  const [state, formAction] = useFormState<FormState>(action, {
+  const [state, formAction] = useActionState<FormState, FormData>(action, {
     message: "",
     error: "",
   });

--- a/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
@@ -1,8 +1,7 @@
 // apps/cms/src/app/cms/blog/sanity/connect/ConnectForm.client.tsx
 "use client";
 
-import { useFormState } from "react-dom";
-import { useState, useEffect } from "react";
+import { useActionState, useState, useEffect } from "react";
 import { Button } from "@/components/atoms/shadcn";
 import { Toast } from "@ui";
 import { deleteSanityConfig } from "@cms/actions/deleteSanityConfig";
@@ -53,10 +52,10 @@ export default function ConnectForm({ shopId, initial }: Props) {
   } = useSanityConnection(shopId, initial);
 
   const disconnectAction = deleteSanityConfig.bind(null, shopId);
-  const [disconnectState, disconnectFormAction] = useFormState<FormState>(
-    disconnectAction,
-    initialState,
-  );
+  const [disconnectState, disconnectFormAction] = useActionState<
+    FormState,
+    FormData
+  >(disconnectAction, initialState);
 
   const [step, setStep] = useState<1 | 2 | 3>(1);
 

--- a/apps/cms/src/app/cms/blog/sanity/connect/__tests__/ConnectForm.test.tsx
+++ b/apps/cms/src/app/cms/blog/sanity/connect/__tests__/ConnectForm.test.tsx
@@ -53,16 +53,6 @@ jest.mock("../useSanityConnection", () => {
 
 jest.mock("react-dom", () => ({
   ...jest.requireActual("react-dom"),
-  useFormState: (action: any, initialState: any) => {
-    const React = require("react");
-    const [state, setState] = React.useState(initialState);
-    const formAction = async (formData: any) => {
-      const res = await action(initialState, formData);
-      setState(res);
-      return res;
-    };
-    return [state, formAction];
-  },
   useFormStatus: () => ({ pending: false }),
 }));
 

--- a/apps/cms/src/app/cms/blog/sanity/connect/useSanityConnection.ts
+++ b/apps/cms/src/app/cms/blog/sanity/connect/useSanityConnection.ts
@@ -1,8 +1,13 @@
 // apps/cms/src/app/cms/blog/sanity/connect/useSanityConnection.ts
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useFormState } from "react-dom";
+import {
+  useActionState,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { saveSanityConfig } from "@cms/actions/saveSanityConfig";
 import { defaultDataset } from "./constants";
 
@@ -19,7 +24,7 @@ export function useSanityConnection(
   initial?: { projectId: string; dataset: string; token?: string },
 ) {
   const saveAction = saveSanityConfig.bind(null, shopId);
-  const [state, formAction] = useFormState<FormState, FormData>(
+  const [state, formAction] = useActionState<FormState, FormData>(
     async (_prevState: FormState, formData: FormData) =>
       saveAction(formData),
     initialState,


### PR DESCRIPTION
## Summary
- use React's `useActionState` instead of deprecated `useFormState`
- update CMS blog components to new hook
- adjust tests to use `startTransition`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm test:cms` *(fails: Invalid core environment variables, etc.)*
- `pnpm exec jest apps/cms/__tests__/useSanityConnection.test.ts`
- `pnpm exec jest apps/cms/src/app/cms/blog/sanity/connect/__tests__/ConnectForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0809878832fb53f8c350a2e76a3