### PR TITLE
chore: downgrade shop validation logging

### DIFF
--- a/apps/cms/src/services/shops/themeService.ts
+++ b/apps/cms/src/services/shops/themeService.ts
@@ -12,7 +12,7 @@ export async function updateShop(
   const current = await fetchShop(shop);
   const { data, errors } = parseShopForm(formData);
   if (!data) {
-    console.error(`[updateShop] validation failed for shop ${shop}`, errors);
+    console.warn(`[updateShop] validation failed for shop ${shop}`, errors);
     return { errors };
   }
   if (current.id !== data.id) throw new Error(`Shop ${data.id} not found in ${shop}`);


### PR DESCRIPTION
## Summary
- use console.warn instead of console.error when shop update validation fails

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm test:cms -- apps/cms/__tests__/shops.validation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0955294832f8b165ecdd0d9842b