### PR TITLE
test: suppress revalidate warnings in seo timeline test

### DIFF
--- a/apps/cms/__tests__/seoTimelineRevert.test.ts
+++ b/apps/cms/__tests__/seoTimelineRevert.test.ts
@@ -65,6 +65,7 @@ describe("SEO revert via timeline", () => {
   it("reverts settings and records history", async () => {
     await withRepo(async (dir) => {
       mockAuth();
+      jest.doMock("next/cache", () => ({ revalidatePath: jest.fn() }));
 
       // Dynamic imports must come *after* jest.doMock + cwd swap
       const actions = await import("../src/actions/shops.server");


### PR DESCRIPTION
## Summary
- mock next/cache revalidation in seo timeline test to avoid noisy warnings

## Testing
- `pnpm -r build` (fails: TypeScript errors in @acme/platform-core)
- `cd apps/cms && pnpm test __tests__/seoTimelineRevert.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0a00864832f85fb1635e467729b