### PR TITLE
Handle missing media directory gracefully

### DIFF
--- a/apps/cms/__tests__/media.api.test.ts
+++ b/apps/cms/__tests__/media.api.test.ts
@@ -27,6 +27,7 @@ describe("media route", () => {
   });
 
   it("POST returns 400 when upload fails", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     jest.doMock("@cms/actions/media.server", () => ({
       listMedia: jest.fn(),
       deleteMedia: jest.fn(),
@@ -44,6 +45,7 @@ describe("media route", () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({ error: "Upload failed" });
+    spy.mockRestore();
   });
 
   it("DELETE without shop or file returns 400", async () => {

--- a/apps/cms/__tests__/media.test.ts
+++ b/apps/cms/__tests__/media.test.ts
@@ -83,7 +83,7 @@ function mockSharp({
 describe("media actions", () => {
   afterEach(() => jest.resetAllMocks());
 
-  it("listMedia throws when dir missing", async () => {
+  it("listMedia returns empty array when dir missing", async () => {
     await withTmpDir(() =>
       withDevEnv(async () => {
         mockAuth();
@@ -92,9 +92,7 @@ describe("media actions", () => {
         const { listMedia } = await import(
           /* @vite-ignore */ "../src/actions/media.server.ts"
         );
-        await expect(listMedia("shop1")).rejects.toThrow(
-          "Failed to list media"
-        );
+        await expect(listMedia("shop1")).resolves.toEqual([]);
       })
     );
   }, 15_000);

--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -66,6 +66,9 @@ export async function listMedia(shop: string): Promise<MediaItem[]> {
         type: meta[f]?.type ?? "image",
       }));
   } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return [];
+    }
     console.error("Failed to list media", err);
     throw new Error("Failed to list media");
   }


### PR DESCRIPTION
## Summary
- avoid errors when listing media for shops without an uploads directory
- adjust media action tests and silence noisy console output in API tests

## Testing
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm exec jest apps/cms/__tests__/media.test.ts apps/cms/__tests__/media.api.test.ts --runInBand` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0b1c30c832fa99b013ed6887123