### PR TITLE
Silence payments env logs during tests

### DIFF
--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -32,6 +32,7 @@ export type PaymentsEnv = z.infer<typeof paymentsEnvSchema>;
 export function loadPaymentsEnv(
   raw: NodeJS.ProcessEnv = process.env,
 ): PaymentsEnv {
+  const isTest = process.env.NODE_ENV === "test";
   if (raw.PAYMENTS_GATEWAY === "disabled") {
     return paymentsEnvSchema.parse({});
   }
@@ -40,38 +41,50 @@ export function loadPaymentsEnv(
     raw.PAYMENTS_PROVIDER &&
     raw.PAYMENTS_PROVIDER !== "stripe"
   ) {
-    console.error(
-      "❌ Unsupported PAYMENTS_PROVIDER:",
-      raw.PAYMENTS_PROVIDER,
-    );
+    if (!isTest) {
+      console.error(
+        "❌ Unsupported PAYMENTS_PROVIDER:",
+        raw.PAYMENTS_PROVIDER,
+      );
+    }
     throw new Error("Invalid payments environment variables");
   }
 
   if (raw.PAYMENTS_PROVIDER === "stripe") {
     if (!raw.STRIPE_SECRET_KEY) {
-      console.error("❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe");
+      if (!isTest) {
+        console.error(
+          "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe",
+        );
+      }
       throw new Error("Invalid payments environment variables");
     }
     if (!raw.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {
-      console.error(
-        "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
-      );
+      if (!isTest) {
+        console.error(
+          "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
+        );
+      }
       throw new Error("Invalid payments environment variables");
     }
     if (!raw.STRIPE_WEBHOOK_SECRET) {
-      console.error(
-        "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
-      );
+      if (!isTest) {
+        console.error(
+          "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
+        );
+      }
       throw new Error("Invalid payments environment variables");
     }
   }
 
   const parsed = paymentsEnvSchema.safeParse(raw);
   if (!parsed.success) {
-    console.warn(
-      "⚠️ Invalid payments environment variables:",
-      parsed.error.format(),
-    );
+    if (!isTest) {
+      console.warn(
+        "⚠️ Invalid payments environment variables:",
+        parsed.error.format(),
+      );
+    }
     return paymentsEnvSchema.parse({});
   }
 


### PR DESCRIPTION
## Summary
- avoid noisy console output in `loadPaymentsEnv` when running tests

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @apps/cms test -- __tests__/envSchemas.test.ts` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0d287b8832f8c6acb708e8f0362