### PR TITLE
test: mock pages endpoint for configurator steps

### DIFF
--- a/apps/cms/__tests__/msw/handlers.ts
+++ b/apps/cms/__tests__/msw/handlers.ts
@@ -25,6 +25,9 @@ export const handlers = [
     // For tests we reuse base tokens regardless of theme name
     return res(ctx.status(200), ctx.json(baseTokens));
   }),
+  rest.get("/cms/api/pages/:shopId", (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json([]))
+  ),
   rest.get("/cms/api/products/slug/:slug", (_req, res, ctx) =>
     res(
       ctx.status(200),


### PR DESCRIPTION
## Summary
- mock CMS pages API in cms tests

## Testing
- `pnpm --filter @apps/cms test -- configuratorSteps.test.tsx`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0ed9574832f8e6232e53e8283f0