### PR TITLE
test: prevent jsdom navigation error

### DIFF
--- a/apps/cms/__tests__/dashboardRecommendations.integration.test.tsx
+++ b/apps/cms/__tests__/dashboardRecommendations.integration.test.tsx
@@ -106,6 +106,7 @@ test(
   async () => {
     render(<ConfiguratorDashboard />);
     const link = await screen.findByRole("link", { name: /step b/i });
+    link.addEventListener("click", (e) => e.preventDefault());
     fireEvent.click(link);
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/step a/i);


### PR DESCRIPTION
## Summary
- prevent jsdom navigation warnings in dashboard recommendations test by cancelling default link navigation

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type '... | null' is not assignable to type '*')*
- `pnpm --filter @apps/cms test apps/cms/__tests__/dashboardRecommendations.integration.test.tsx` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0e2ba9c832fae2949f575c7878d