### PR TITLE
test: silence create-shop route errors

### DIFF
--- a/apps/cms/__tests__/api.create-shop.test.ts
+++ b/apps/cms/__tests__/api.create-shop.test.ts
@@ -5,9 +5,13 @@ if (typeof (Response as any).json !== "function") {
     new Response(JSON.stringify(data), init);
 }
 
+beforeEach(() => {
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
 afterEach(() => {
   jest.resetModules();
-  jest.resetAllMocks();
+  jest.restoreAllMocks();
 });
 
 describe("create-shop API", () => {
@@ -113,7 +117,7 @@ if (typeof (Response as any).json !== "function") {
 
 afterEach(() => {
   jest.resetModules();
-  jest.resetAllMocks();
+  jest.restoreAllMocks();
 });
 
 describe("publish-locations API", () => {


### PR DESCRIPTION
## Summary
- silence create-shop API tests by mocking console.error

## Testing
- `pnpm --filter @apps/cms test -- __tests__/api.create-shop.test.ts`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0fc350c832fb269a3ab06985c19