### PR TITLE
Include functions directory in Jest coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -253,16 +253,19 @@ if (relativePath) {
   config.collectCoverageFrom = [
     'src/**/*.{ts,tsx}',
     'scripts/**/*.{ts,tsx}',
+    'functions/**/*.ts',
     '*.{ts,tsx}',
     '!**/__tests__/**',
     '!**/*.d.ts',
     '!**/*.test.{ts,tsx}',
     '!**/*.spec.{ts,tsx}',
   ];
-  config.coveragePathIgnorePatterns.push(
-    `/${scope}/(?!${subPath})/`,
-    scope === 'packages' ? '/apps/' : '/packages/'
-  );
+  const coverageIgnores = [];
+  if (subPath) {
+    coverageIgnores.push(`/${scope}/(?!${subPath})/`);
+  }
+  coverageIgnores.push(scope === 'packages' ? '/apps/' : '/packages/');
+  config.coveragePathIgnorePatterns.push(...coverageIgnores);
 }
 
 module.exports = resolveRoot(config);


### PR DESCRIPTION
## Summary
- collect coverage from functions TypeScript files
- guard coverage ignore patterns to avoid filtering functions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build)*
- `pnpm test` *(fails: @acme/plugin-sanity#test)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d36a8c74832f9a5f1ab69a8b873e