### PR TITLE
Include middleware files in Jest coverage

### DIFF
--- a/apps/api/jest.config.cjs
+++ b/apps/api/jest.config.cjs
@@ -9,7 +9,11 @@ module.exports = {
   setupFilesAfterEnv: [
     "<rootDir>/apps/api/jest.setup.ts",
   ],
-  collectCoverageFrom: ["apps/api/src/**/*.{ts,tsx}", "!apps/api/src/**/*.d.ts"],
+  collectCoverageFrom: [
+    "apps/api/src/**/*.{ts,tsx}",
+    "apps/api/middleware.ts",
+    "!apps/api/src/**/*.d.ts",
+  ],
   coverageReporters: ["text", "json", "lcov"],
   coverageThreshold: {
     global: {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -221,6 +221,16 @@ const config = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs', 'node', 'd.ts'],
   collectCoverage: true,
   coverageDirectory: path.join(process.cwd(), 'coverage'),
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    'scripts/**/*.{ts,tsx}',
+    'middleware.ts',
+    '*.{ts,tsx}',
+    '!**/__tests__/**',
+    '!**/*.d.ts',
+    '!**/*.test.{ts,tsx}',
+    '!**/*.spec.{ts,tsx}',
+  ],
   coveragePathIgnorePatterns: [
     ' /test/msw/',
     ' /test/msw/server.ts',
@@ -253,6 +263,7 @@ if (relativePath) {
   config.collectCoverageFrom = [
     'src/**/*.{ts,tsx}',
     'scripts/**/*.{ts,tsx}',
+    'middleware.ts',
     '*.{ts,tsx}',
     '!**/__tests__/**',
     '!**/*.d.ts',

--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -22,7 +22,7 @@ coveragePathIgnorePatterns.push(
 module.exports = {
   ...base,
   rootDir: workspaceRoot,
-  collectCoverageFrom: [`${packagePath}/src/**/*.{ts,tsx}`],
+  collectCoverageFrom: [`${packagePath}/src/**/*.{ts,tsx}`, `${packagePath}/middleware.ts`],
   // Use a plain Node environment for configuration tests. These tests don't
   // depend on DOM APIs and running them under jsdom pulls in additional
   // transitive dependencies like `parse5`, which in turn requires the

--- a/packages/email/jest.config.cjs
+++ b/packages/email/jest.config.cjs
@@ -5,7 +5,10 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, '..', '..'),
   roots: ['<rootDir>/packages/email'],
-  collectCoverageFrom: ['packages/email/src/**/*.{ts,tsx}'],
+  collectCoverageFrom: [
+    'packages/email/src/**/*.{ts,tsx}',
+    'packages/email/middleware.ts',
+  ],
   coveragePathIgnorePatterns: ['/packages/(?!email)/'],
   moduleNameMapper: {
     ...baseConfig.moduleNameMapper,

--- a/packages/tailwind-config/jest.config.cjs
+++ b/packages/tailwind-config/jest.config.cjs
@@ -5,6 +5,9 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, "..", ".."),
   roots: ["<rootDir>/packages/tailwind-config"],
-  collectCoverageFrom: ["packages/tailwind-config/src/**/*.{ts,tsx}"],
+  collectCoverageFrom: [
+    "packages/tailwind-config/src/**/*.{ts,tsx}",
+    "packages/tailwind-config/middleware.ts",
+  ],
   coveragePathIgnorePatterns: ["/packages/(?!tailwind-config)/", "/apps/"],
 };


### PR DESCRIPTION
## Summary
- collect coverage from `middleware.ts` in root and package-level Jest configs
- ensure middleware files are included in shared Jest preset

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type...)*
- `pnpm -r run check:references` *(fails: None of the selected packages has a "check:references" script)*
- `pnpm -r run build:ts` *(fails: None of the selected packages has a "build:ts" script)*
- `pnpm --filter @acme/template-app test` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d329ba80832f9966b711f8c352e9