### PR TITLE
chore: silence updateShop validation warning

### DIFF
--- a/apps/cms/src/services/shops/themeService.ts
+++ b/apps/cms/src/services/shops/themeService.ts
@@ -12,7 +12,6 @@ export async function updateShop(
   const current = await fetchShop(shop);
   const { data, errors } = parseShopForm(formData);
   if (!data) {
-    console.warn(`[updateShop] validation failed for shop ${shop}`, errors);
     return { errors };
   }
   if (current.id !== data.id) throw new Error(`Shop ${data.id} not found in ${shop}`);


### PR DESCRIPTION
## Summary
- avoid console warnings when updateShop validation fails

## Testing
- `pnpm install --ignore-scripts`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --dir apps/cms exec jest __tests__/shops.validation.test.ts --runInBand` *(fails: test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d7425930832fb5f0618f981a9f30