### PR TITLE
Handle synchronous form actions in useSanityConnection tests

### DIFF
--- a/apps/cms/__tests__/useSanityConnection.test.ts
+++ b/apps/cms/__tests__/useSanityConnection.test.ts
@@ -2,12 +2,10 @@ import { renderHook, act } from "@testing-library/react";
 import { startTransition } from "react";
 import { useSanityConnection } from "../src/app/cms/blog/sanity/connect/useSanityConnection";
 
-async function callFormAction(
-  action: (formData: FormData) => Promise<unknown>,
-) {
+async function callFormAction(action: (formData: FormData) => unknown) {
   await new Promise<void>((resolve) => {
     startTransition(() => {
-      action(new FormData()).then(() => resolve());
+      Promise.resolve(action(new FormData())).then(() => resolve());
     });
   });
 }


### PR DESCRIPTION
## Summary
- allow test helper `callFormAction` to accept sync or async form actions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/lib build: Output file has not been built)*
- `pnpm test:cms apps/cms/__tests__/useSanityConnection.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5d856674c832fac53d16b23ad6973