### PR TITLE
test: silence UpgradeButton error logs

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeButton.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeButton.test.tsx
@@ -21,14 +21,12 @@ describe("UpgradeButton", () => {
       value: { ...originalLocation, href: "" },
       writable: true,
     });
-    const originalError = console.error;
     consoleErrorSpy = jest
       .spyOn(console, "error")
-      .mockImplementation((msg, ...args) => {
+      .mockImplementation((msg) => {
         if (typeof msg === "string" && msg.includes("act(")) {
           return;
         }
-        originalError(msg as any, ...args);
       });
   });
 


### PR DESCRIPTION
## Summary
- stop forwarding console.error in UpgradeButton tests

## Testing
- `pnpm exec jest --config apps/cms/jest.config.cjs --runTestsByPath apps/cms/src/app/cms/shop/\[shop\]/__tests__/UpgradeButton.test.tsx`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d8b99430832f8f2082a76356efdd