### PR TITLE
chore: limit jest coverage to local sources

### DIFF
--- a/apps/dashboard/jest.config.cjs
+++ b/apps/dashboard/jest.config.cjs
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const path = require("path");
 const base = require("@acme/config/jest.preset.cjs");
 const { "^@/(.*)$": _unused, ...baseModuleNameMapper } = base.moduleNameMapper;
 
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
+  // Run from repo root for consistent relative paths
+  rootDir: path.resolve(__dirname, "..", ".."),
   testEnvironment: "jsdom",
   roots: ["<rootDir>/apps/dashboard/src", "<rootDir>/apps/dashboard/__tests__"],
   moduleNameMapper: {
@@ -12,4 +15,15 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/apps/dashboard/src/$1",
     "^entities/decode$": "<rootDir>/node_modules/entities/lib/decode.js",
   },
+  // Restrict coverage to dashboard src and ignore tests/declarations
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "apps/dashboard/src/**/*.{ts,tsx}",
+    "!apps/dashboard/src/**/*.d.ts",
+    "!apps/dashboard/src/**/?(*.)+(spec|test).{ts,tsx}",
+    "!apps/dashboard/src/**/__tests__/**",
+  ],
+  // Reuse preset’s ignore patterns so other apps/packages aren’t instrumented
+  coveragePathIgnorePatterns: base.coveragePathIgnorePatterns,
+  coverageReporters: ["text", "lcov"],
 };

--- a/apps/shop-bcd/jest.config.cjs
+++ b/apps/shop-bcd/jest.config.cjs
@@ -1,11 +1,22 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const path = require("path");
 const base = require("@acme/config/jest.preset.cjs");
 
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
+  rootDir: path.resolve(__dirname, "..", ".."),
   roots: [
     "<rootDir>/apps/shop-bcd/src",
     "<rootDir>/apps/shop-bcd/__tests__"
   ],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "apps/shop-bcd/src/**/*.{ts,tsx}",
+    "!apps/shop-bcd/src/**/*.d.ts",
+    "!apps/shop-bcd/src/**/?(*.)+(spec|test).{ts,tsx}",
+    "!apps/shop-bcd/src/**/__tests__/**",
+  ],
+  coveragePathIgnorePatterns: base.coveragePathIgnorePatterns,
+  coverageReporters: ["text", "lcov"],
 };

--- a/packages/email/jest.config.cjs
+++ b/packages/email/jest.config.cjs
@@ -5,8 +5,15 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, '..', '..'),
   roots: ['<rootDir>/packages/email'],
-  collectCoverageFrom: ['packages/email/src/**/*.{ts,tsx}'],
-  coveragePathIgnorePatterns: ['/packages/(?!email)/'],
+  // Limit coverage to this package and exclude declarations/tests
+  collectCoverageFrom: [
+    "packages/email/src/**/*.{ts,tsx}",
+    "!packages/email/src/**/*.d.ts",
+    "!packages/email/src/**/?(*.)+(spec|test).{ts,tsx}",
+    "!packages/email/src/**/__tests__/**",
+  ],
+  // Inherit ignore patterns from the root config so other apps/packages are excluded
+  coveragePathIgnorePatterns: baseConfig.coveragePathIgnorePatterns,
   moduleNameMapper: {
     ...baseConfig.moduleNameMapper,
     '^\\./fsStore\\.js$': '<rootDir>/packages/email/src/storage/fsStore.ts',

--- a/packages/tailwind-config/jest.config.cjs
+++ b/packages/tailwind-config/jest.config.cjs
@@ -5,6 +5,12 @@ module.exports = {
   ...baseConfig,
   rootDir: path.resolve(__dirname, "..", ".."),
   roots: ["<rootDir>/packages/tailwind-config"],
-  collectCoverageFrom: ["packages/tailwind-config/src/**/*.{ts,tsx}"],
-  coveragePathIgnorePatterns: ["/packages/(?!tailwind-config)/", "/apps/"],
+  // Restrict coverage to this package only and exclude declarations/tests
+  collectCoverageFrom: [
+    "packages/tailwind-config/src/**/*.{ts,tsx}",
+    "!packages/tailwind-config/src/**/*.d.ts",
+    "!packages/tailwind-config/src/**/?(*.)+(spec|test).{ts,tsx}",
+    "!packages/tailwind-config/src/**/__tests__/**",
+  ],
+  coveragePathIgnorePatterns: baseConfig.coveragePathIgnorePatterns,
 };


### PR DESCRIPTION
## Summary
- scope dashboard and shop jest configs to own codebase and reuse preset coverage ignores
- align email and tailwind-config coverage with preset defaults

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in platform-core)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @apps/dashboard test`
- `pnpm --filter @apps/shop-bcd test` *(fails: File not found tsconfig.test.json)*
- `pnpm --filter @acme/email test`
- `pnpm --filter @acme/tailwind-config test`


------
https://chatgpt.com/codex/tasks/task_e_68c68149d938832f90beba2bf1192a14