### PR TITLE
test: add coverage for cms pages

### DIFF
--- a/apps/cms/__tests__/ProductEditor.client.test.tsx
+++ b/apps/cms/__tests__/ProductEditor.client.test.tsx
@@ -1,0 +1,26 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render } from "@testing-library/react";
+
+const updateProduct = jest.fn();
+jest.mock("@cms/actions/products.server", () => ({ updateProduct }));
+let receivedProps: any;
+jest.mock("@ui/components/cms/ProductEditorForm", () => (props: any) => {
+  receivedProps = props;
+  return <div data-testid="form" />;
+});
+
+import ProductEditor from "../src/app/cms/shop/[shop]/products/[id]/edit/ProductEditor.client";
+
+describe("ProductEditor client", () => {
+  it("renders form and calls update on save", () => {
+    const product = { id: "p1" } as any;
+    render(
+      <ProductEditor shop="s1" initialProduct={product} languages={["en"]} />,
+    );
+    expect(receivedProps.product.variants).toEqual({});
+    const fd = new FormData();
+    receivedProps.onSave(fd);
+    expect(updateProduct).toHaveBeenCalledWith("s1", fd);
+  });
+});

--- a/apps/cms/__tests__/newPageBuilderRoute.test.tsx
+++ b/apps/cms/__tests__/newPageBuilderRoute.test.tsx
@@ -1,0 +1,17 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@cms/actions/pages/create", () => ({ createPage: jest.fn() }));
+jest.mock("next/dynamic", () => () => () => <div data-cy="builder" />);
+
+import NewPageBuilderRoute from "../src/app/cms/shop/[shop]/pages/new/builder/page";
+
+describe("NewPageBuilderRoute", () => {
+  it("renders header and builder", async () => {
+    const Page = await NewPageBuilderRoute({ params: Promise.resolve({ shop: "s1" }) });
+    render(Page);
+    expect(screen.getByText("New page - s1")).toBeInTheDocument();
+    expect(screen.getByTestId("builder")).toBeInTheDocument();
+  });
+});

--- a/apps/cms/__tests__/newProductPage.test.tsx
+++ b/apps/cms/__tests__/newProductPage.test.tsx
@@ -1,0 +1,20 @@
+import "@testing-library/jest-dom";
+import React from "react";
+
+const createDraftRecord = jest.fn();
+jest.mock("@cms/actions/products.server", () => ({ createDraftRecord }));
+const redirect = jest.fn();
+jest.mock("next/navigation", () => ({ redirect }));
+
+import NewProductPage from "../src/app/cms/shop/[shop]/products/new/page";
+
+describe("NewProductPage", () => {
+  it("creates draft and redirects", async () => {
+    createDraftRecord.mockResolvedValue({ id: "p1" });
+    await NewProductPage({ params: Promise.resolve({ shop: "s1" }) });
+    expect(createDraftRecord).toHaveBeenCalledWith("s1");
+    expect(redirect).toHaveBeenCalledWith(
+      "/cms/shop/s1/products/p1/edit",
+    );
+  });
+});

--- a/apps/cms/__tests__/productEditPage.test.tsx
+++ b/apps/cms/__tests__/productEditPage.test.tsx
@@ -1,0 +1,36 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const mockGetProductById = jest.fn();
+const mockReadSettings = jest.fn();
+jest.mock("@platform-core/repositories/json.server", () => ({
+  getProductById: (...args: any[]) => mockGetProductById(...args),
+  readSettings: (...args: any[]) => mockReadSettings(...args),
+}));
+
+jest.mock("next/dynamic", () => () => (props: any) => <div data-cy="editor" {...props} />);
+const notFound = jest.fn();
+jest.mock("next/navigation", () => ({ notFound }));
+
+import ProductEditPage from "../src/app/cms/shop/[shop]/products/[id]/edit/page";
+
+describe("ProductEditPage", () => {
+  it("renders editor when product found", async () => {
+    mockGetProductById.mockResolvedValue({ id: "p1" });
+    mockReadSettings.mockResolvedValue({ languages: ["en"] });
+    const Page = await ProductEditPage({
+      params: Promise.resolve({ shop: "s1", id: "p1" }),
+    });
+    render(Page);
+    expect(screen.getByText("Edit product – s1/p1")).toBeInTheDocument();
+    expect(screen.getByTestId("editor")).toBeInTheDocument();
+  });
+
+  it("calls notFound when product missing", async () => {
+    mockGetProductById.mockResolvedValue(null);
+    mockReadSettings.mockResolvedValue({ languages: ["en"] });
+    await ProductEditPage({ params: Promise.resolve({ shop: "s1", id: "p1" }) });
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/apps/cms/__tests__/returnsEditor.test.tsx
+++ b/apps/cms/__tests__/returnsEditor.test.tsx
@@ -1,0 +1,45 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+
+const updateUpsReturns = jest.fn();
+jest.mock("@cms/actions/shops.server", () => ({ updateUpsReturns }));
+jest.mock("@/components/atoms/shadcn", () => ({
+  Button: (props: any) => <button {...props} />,
+  Checkbox: (props: any) => <input type="checkbox" {...props} />,
+}));
+
+import ReturnsEditor from "../src/app/cms/shop/[shop]/settings/returns/ReturnsEditor";
+
+describe("ReturnsEditor", () => {
+  it("submits form and updates state", async () => {
+    updateUpsReturns.mockResolvedValue({
+      settings: {
+        returnService: {
+          upsEnabled: true,
+          bagEnabled: true,
+          homePickupEnabled: false,
+        },
+      },
+    });
+    render(
+      <ReturnsEditor
+        shop="s1"
+        initial={{
+          upsEnabled: false,
+          bagEnabled: false,
+          homePickupEnabled: false,
+        }}
+      />,
+    );
+    const save = screen.getByRole("button", { name: /save/i });
+    const form = save.closest("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+    expect(updateUpsReturns).toHaveBeenCalledWith("s1", expect.any(FormData));
+    expect(screen.getByLabelText("Enable UPS returns")).toBeChecked();
+    expect(screen.getByLabelText("Provide return bags")).toBeChecked();
+  });
+});

--- a/apps/cms/__tests__/returnsSettingsPage.test.tsx
+++ b/apps/cms/__tests__/returnsSettingsPage.test.tsx
@@ -1,0 +1,21 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const getSettings = jest.fn();
+jest.mock("@cms/actions/shops.server", () => ({ getSettings }));
+jest.mock("next/dynamic", () => () => () => <div data-cy="editor" />);
+
+import ReturnsSettingsPage from "../src/app/cms/shop/[shop]/settings/returns/page";
+
+describe("ReturnsSettingsPage", () => {
+  it("renders editor with settings", async () => {
+    getSettings.mockResolvedValue({
+      returnService: { upsEnabled: true, bagEnabled: true, homePickupEnabled: false },
+    });
+    const Page = await ReturnsSettingsPage({ params: Promise.resolve({ shop: "s1" }) });
+    render(Page);
+    expect(screen.getByText("Returns – s1")).toBeInTheDocument();
+    expect(screen.getByTestId("editor")).toBeInTheDocument();
+  });
+});

--- a/apps/cms/__tests__/reverseLogisticsEditor.test.tsx
+++ b/apps/cms/__tests__/reverseLogisticsEditor.test.tsx
@@ -1,0 +1,39 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+
+const updateReverseLogistics = jest.fn();
+jest.mock("@cms/actions/shops.server", () => ({ updateReverseLogistics }));
+jest.mock("@/components/atoms/shadcn", () => ({
+  Button: (props: any) => <button {...props} />,
+  Checkbox: (props: any) => <input type="checkbox" {...props} />,
+  Input: (props: any) => <input {...props} />,
+}));
+
+import ReverseLogisticsEditor from "../src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor";
+
+describe("ReverseLogisticsEditor", () => {
+  it("submits form and updates state", async () => {
+    updateReverseLogistics.mockResolvedValue({
+      settings: {
+        reverseLogisticsService: { enabled: true, intervalMinutes: 30 },
+      },
+    });
+    render(
+      <ReverseLogisticsEditor
+        shop="s1"
+        initial={{ enabled: false, intervalMinutes: 60 }}
+      />,
+    );
+    const intervalInput = screen.getByLabelText("Interval (minutes)") as HTMLInputElement;
+    expect(intervalInput.value).toBe("60");
+    const save = screen.getByRole("button", { name: /save/i });
+    const form = save.closest("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+    expect(updateReverseLogistics).toHaveBeenCalledWith("s1", expect.any(FormData));
+    expect(intervalInput.value).toBe("30");
+  });
+});

--- a/apps/cms/__tests__/reverseLogisticsSettingsPage.test.tsx
+++ b/apps/cms/__tests__/reverseLogisticsSettingsPage.test.tsx
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const getSettings = jest.fn();
+jest.mock("@cms/actions/shops.server", () => ({ getSettings }));
+jest.mock("next/dynamic", () => () => () => <div data-cy="editor" />);
+
+import ReverseLogisticsSettingsPage from "../src/app/cms/shop/[shop]/settings/reverse-logistics/page";
+
+describe("ReverseLogisticsSettingsPage", () => {
+  it("renders editor with settings", async () => {
+    getSettings.mockResolvedValue({
+      reverseLogisticsService: { enabled: true, intervalMinutes: 10 },
+    });
+    const Page = await ReverseLogisticsSettingsPage({
+      params: Promise.resolve({ shop: "s1" }),
+    });
+    render(Page);
+    expect(screen.getByText("Reverse Logistics – s1")).toBeInTheDocument();
+    expect(screen.getByTestId("editor")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CMS page builder, product routes, and settings

## Testing
- `pnpm --filter @apps/cms test -- __tests__/newPageBuilderRoute.test.tsx`
- `pnpm --filter @apps/cms test -- __tests__/newProductPage.test.tsx`
- `pnpm --filter @apps/cms test -- __tests__/returnsEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c68bc98ca4832fb0bc6a27df5dd208