### PR TITLE
feat: quiet env validation in tests

### DIFF
--- a/packages/config/src/env/cms.ts
+++ b/packages/config/src/env/cms.ts
@@ -2,10 +2,12 @@ import { cmsEnvSchema, type CmsEnv } from "./cms.schema.js";
 
 const parsed = cmsEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  console.error(
-    "❌ Invalid CMS environment variables:",
-    parsed.error.format(),
-  );
+  if (!process.env.JEST_WORKER_ID) {
+    console.error(
+      "❌ Invalid CMS environment variables:",
+      parsed.error.format(),
+    );
+  }
   throw new Error("Invalid CMS environment variables");
 }
 

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -77,10 +77,12 @@ export const emailEnvSchema = z
 const parsed = emailEnvSchema.safeParse(process.env);
 
 if (!parsed.success) {
-  console.error(
-    "❌ Invalid email environment variables:",
-    parsed.error.format()
-  );
+  if (!isTest) {
+    console.error(
+      "❌ Invalid email environment variables:",
+      parsed.error.format()
+    );
+  }
   throw new Error("Invalid email environment variables");
 }
 


### PR DESCRIPTION
## Summary
- suppress auth env logs when validation fails during tests
- silence cms env validation in Jest runs
- add test-aware logging guards for core and email env configs

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter @apps/api test __tests__/env/config-validation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c697108e20832f9c81a3b64fd91064