### PR TITLE
Add tsconfig.test for shop-bcd app

### DIFF
--- a/apps/shop-bcd/tsconfig.test.json
+++ b/apps/shop-bcd/tsconfig.test.json
@@ -1,0 +1,10 @@
+// apps/shop-bcd/tsconfig.test.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom", "jest", "node"],
+    "allowJs": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -62,6 +62,7 @@
       { "path": "./packages/theme/tsconfig.test.json" },
       { "path": "./packages/zod-utils/tsconfig.test.json" },
     { "path": "./apps/cms/tsconfig.test.json" },
-    { "path": "./apps/dashboard/tsconfig.test.json" }
+    { "path": "./apps/dashboard/tsconfig.test.json" },
+    { "path": "./apps/shop-bcd/tsconfig.test.json" }
   ]
 }


### PR DESCRIPTION
## Summary
- add `tsconfig.test.json` for `shop-bcd`
- reference shop-bcd tests from root `tsconfig.test.json`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build: TS2322)*
- `pnpm --filter @apps/shop-bcd test -- apps/shop-bcd` *(fails: TypeError: readOrders is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c697e891b8832fa956bf69d2335c3c