### PR TITLE
Fix storefront tests by adding tsconfig and using data-cy attributes

### DIFF
--- a/apps/storefront/src/contexts/__tests__/CurrencyContext.test.tsx
+++ b/apps/storefront/src/contexts/__tests__/CurrencyContext.test.tsx
@@ -11,7 +11,7 @@ function Display() {
   const [currency, setCurrency] = useCurrency();
   return (
     <>
-      <span data-testid="currency">{currency}</span>
+      <span data-cy="currency">{currency}</span>
       <button onClick={() => setCurrency("USD")}>usd</button>
       <button onClick={() => setCurrency("GBP")}>gbp</button>
     </>

--- a/apps/storefront/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/storefront/src/contexts/__tests__/ThemeContext.test.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider, useTheme } from "../../../../../packages/platform-core/s
 function Toggle() {
   const { theme, setTheme } = useTheme();
   return (
-    <button onClick={() => setTheme(theme === "dark" ? "base" : "dark")} data-testid="toggle">
+    <button onClick={() => setTheme(theme === "dark" ? "base" : "dark")} data-cy="toggle">
       {theme}
     </button>
   );

--- a/apps/storefront/tsconfig.json
+++ b/apps/storefront/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "@acme/config/tsconfig.app.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "../..",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@acme/platform-core": [
+        "../../packages/platform-core/src/index.ts", "../../packages/platform-core/dist/index.d.ts"
+      ],
+      "@acme/platform-core/*": [
+        "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    { "path": "../../packages/platform-core" }
+  ]
+}

--- a/apps/storefront/tsconfig.test.json
+++ b/apps/storefront/tsconfig.test.json
@@ -1,0 +1,10 @@
+// apps/storefront/tsconfig.test.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom", "jest", "node"],
+    "allowJs": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript configs for storefront app and tests
- switch storefront context tests to use `data-cy` attributes matching Testing Library setup

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Output file has not been built from source file)*
- `pnpm --filter @apps/storefront test -- apps/storefront`


------
https://chatgpt.com/codex/tasks/task_e_68c6984b2df8832f9e2f8f477c1f8b14