### PR TITLE
test: add cms layout and page tests

### DIFF
--- a/apps/cms/src/app/layout.test.tsx
+++ b/apps/cms/src/app/layout.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { Geist, Geist_Mono } from "next/font/google";
+import React from "react";
+
+// Mock the context providers to expose DOM markers for assertions
+jest.mock("@/contexts/CurrencyContext", () => ({
+  CurrencyProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="currency-provider">{children}</div>
+  ),
+  useCurrency: () => ["EUR", jest.fn()],
+}));
+
+jest.mock("@/contexts/CartContext", () => ({
+  CartProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="cart-provider">{children}</div>
+  ),
+  useCart: () => [{}, jest.fn()],
+}));
+
+describe("RootLayout", () => {
+  it("applies Geist fonts and wraps children with providers", async () => {
+    const { default: RootLayout } = await import("./layout");
+
+    render(
+      <RootLayout>
+        <span>child content</span>
+      </RootLayout>
+    );
+
+    // Verify fonts are applied to the html element
+    const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" });
+    const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
+
+    expect(document.documentElement).toHaveClass(geistSans.variable);
+    expect(document.documentElement).toHaveClass(geistMono.variable);
+
+    // Ensure children are wrapped with CurrencyProvider and CartProvider
+    const currency = screen.getByTestId("currency-provider");
+    const cart = screen.getByTestId("cart-provider");
+    expect(currency).toContainElement(cart);
+    expect(cart).toContainElement(screen.getByText("child content"));
+  });
+});
+

--- a/apps/cms/src/app/page.test.tsx
+++ b/apps/cms/src/app/page.test.tsx
@@ -1,0 +1,27 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
+
+describe("IndexPage", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("redirects to /cms when a session exists", async () => {
+    (getServerSession as jest.Mock).mockResolvedValueOnce({ user: { id: "1" } });
+    const { default: IndexPage } = await import("./page");
+    await IndexPage();
+    expect(redirect).toHaveBeenCalledWith("/cms");
+  });
+
+  it("redirects to /login when no session exists", async () => {
+    (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+    const { default: IndexPage } = await import("./page");
+    await IndexPage();
+    expect(redirect).toHaveBeenCalledWith("/login");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add RootLayout test verifying Geist fonts and provider wrapping
- add page test verifying redirect based on session

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm test:cms` *(fails: missing environment variables and other failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c69b744d14832f9fcebfae787bd79f