### PR TITLE
chore(api): align coverage settings

### DIFF
--- a/apps/api/jest.config.cjs
+++ b/apps/api/jest.config.cjs
@@ -9,7 +9,14 @@ module.exports = {
   setupFilesAfterEnv: [
     "<rootDir>/apps/api/jest.setup.ts",
   ],
-  collectCoverageFrom: ["apps/api/src/**/*.{ts,tsx}", "!apps/api/src/**/*.d.ts"],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "apps/api/src/**/*.{ts,tsx}",
+    "!apps/api/src/**/*.d.ts",
+    "!apps/api/src/**/?(*.)+(spec|test).{ts,tsx}",
+    "!apps/api/src/**/__tests__/**",
+  ],
+  coveragePathIgnorePatterns: base.coveragePathIgnorePatterns,
   coverageReporters: ["text", "json", "lcov"],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
## Summary
- exclude API tests and declarations from coverage and reuse shared ignore patterns

## Testing
- `pnpm --filter @apps/api test`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e9670c4832f885dc11ac0364e69