### PR TITLE
test: avoid passing props to mocked dynamic component

### DIFF
--- a/apps/cms/__tests__/productEditPage.test.tsx
+++ b/apps/cms/__tests__/productEditPage.test.tsx
@@ -9,7 +9,7 @@ jest.mock("@platform-core/repositories/json.server", () => ({
   readSettings: (...args: any[]) => mockReadSettings(...args),
 }));
 
-jest.mock("next/dynamic", () => () => (props: any) => <div data-cy="editor" {...props} />);
+jest.mock("next/dynamic", () => () => () => <div data-cy="editor" />);
 const notFound = jest.fn();
 jest.mock("next/navigation", () => ({ notFound }));
 


### PR DESCRIPTION
## Summary
- prevent mocked next/dynamic from forwarding props to DOM in productEditPage test

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/platform-core build TypeScript errors)*
- `pnpm exec jest apps/cms/__tests__/productEditPage.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c6a00713dc832f8e7cc3dbd403e8e8