### PR TITLE
refactor(api): use shared logger

### DIFF
--- a/apps/api/src/routes/components/[shopId].ts
+++ b/apps/api/src/routes/components/[shopId].ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, readdirSync } from "fs";
 import path from "path";
 import jwt from "jsonwebtoken";
 import { validateShopName } from "@acme/lib";
+import { logger } from "@acme/shared-utils";
 
 interface ComponentChange {
   name: string;
@@ -111,7 +112,7 @@ export const onRequest = async ({
   try {
     shopId = validateShopName(params.shopId);
   } catch {
-    console.warn("invalid shop id", { id: params.shopId });
+    logger.warn("invalid shop id", { id: params.shopId });
     return new Response(JSON.stringify({ error: "Invalid shop id" }), {
       status: 400,
       headers: { "Content-Type": "application/json" },
@@ -120,7 +121,7 @@ export const onRequest = async ({
 
   const authHeader = request.headers.get("authorization") || "";
   if (!authHeader.startsWith("Bearer ")) {
-    console.warn("missing bearer token", { shopId });
+    logger.warn("missing bearer token", { shopId });
     return new Response(JSON.stringify({ error: "Forbidden" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },
@@ -130,7 +131,7 @@ export const onRequest = async ({
   const token = authHeader.slice("Bearer ".length);
   const secret = process.env.UPGRADE_PREVIEW_TOKEN_SECRET;
   if (!secret) {
-    console.warn("invalid token", { shopId });
+    logger.warn("invalid token", { shopId });
     return new Response(JSON.stringify({ error: "Forbidden" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },
@@ -151,7 +152,7 @@ export const onRequest = async ({
       throw new Error("missing exp");
     }
   } catch {
-    console.warn("invalid token", { shopId });
+    logger.warn("invalid token", { shopId });
     return new Response(JSON.stringify({ error: "Forbidden" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },

--- a/apps/api/src/routes/components/__tests__/onRequestTestUtils.ts
+++ b/apps/api/src/routes/components/__tests__/onRequestTestUtils.ts
@@ -9,6 +9,7 @@ import { vol } from 'memfs';
 import jwt from 'jsonwebtoken';
 import { validateShopName } from '@acme/lib';
 import { onRequest } from '../[shopId]';
+import { logger } from '@acme/shared-utils';
 
 export const verify = jwt.verify as jest.Mock;
 export const validate = validateShopName as jest.Mock;
@@ -21,7 +22,7 @@ export function setup() {
   verify.mockReset();
   validate.mockReset().mockImplementation((s: string) => s);
   delete process.env.UPGRADE_PREVIEW_TOKEN_SECRET;
-  return jest.spyOn(console, 'warn').mockImplementation(() => {});
+  return jest.spyOn(logger, 'warn').mockImplementation(() => {});
 }
 
 export function createRequest({

--- a/apps/api/src/routes/components/__tests__/testHelpers.ts
+++ b/apps/api/src/routes/components/__tests__/testHelpers.ts
@@ -5,6 +5,7 @@ jest.mock('@acme/lib', () => ({ validateShopName: jest.fn((s: string) => s) }));
 import jwt from 'jsonwebtoken';
 import { vol } from 'memfs';
 import { validateShopName } from '@acme/lib';
+import { logger } from '@acme/shared-utils';
 
 export const verify = jwt.verify as jest.Mock;
 export const validate = validateShopName as jest.Mock;
@@ -17,7 +18,7 @@ export function setup() {
 }
 
 export function createWarnSpy() {
-  return jest.spyOn(console, 'warn').mockImplementation(() => {});
+  return jest.spyOn(logger, 'warn').mockImplementation(() => {});
 }
 
 export function createContext(

--- a/apps/api/src/routes/shop/[id]/publish-upgrade.ts
+++ b/apps/api/src/routes/shop/[id]/publish-upgrade.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { spawn } from "child_process";
 import jwt from "jsonwebtoken";
+import { logger } from "@acme/shared-utils";
 
 export function run(cmd: string, args: string[], cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -30,7 +31,7 @@ export const onRequestPost = async ({
   try {
     const id = params.id;
     if (!id || !/^[a-z0-9_-]+$/.test(id)) {
-      console.warn("invalid shop id", { id });
+      logger.warn("invalid shop id", { id });
       return new Response(JSON.stringify({ error: "Invalid shop id" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -39,7 +40,7 @@ export const onRequestPost = async ({
 
     const authHeader = request.headers.get("authorization") || "";
     if (!authHeader.startsWith("Bearer ")) {
-      console.warn("missing bearer token", { id });
+      logger.warn("missing bearer token", { id });
       return new Response(JSON.stringify({ error: "Unauthorized" }), {
         status: 401,
         headers: { "Content-Type": "application/json" },
@@ -49,7 +50,7 @@ export const onRequestPost = async ({
     const token = authHeader.slice("Bearer ".length);
     const secret = process.env.UPGRADE_PREVIEW_TOKEN_SECRET;
     if (!secret) {
-      console.warn("invalid token", { id });
+      logger.warn("invalid token", { id });
       return new Response(JSON.stringify({ error: "Forbidden" }), {
         status: 403,
         headers: { "Content-Type": "application/json" },
@@ -58,7 +59,7 @@ export const onRequestPost = async ({
     try {
       jwt.verify(token, secret);
     } catch {
-      console.warn("invalid token", { id });
+      logger.warn("invalid token", { id });
       return new Response(JSON.stringify({ error: "Forbidden" }), {
         status: 403,
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- replace direct console warnings with shared logger in shop publish-upgrade route
- replace console warnings with shared logger in components route
- update tests to mock `logger.warn`

## Testing
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm -F @apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68c69f9d18f0832f933c842fb0d79a2c