### PR TITLE
fix: ensure redirect test uses fresh mocks

### DIFF
--- a/apps/cms/src/app/page.test.tsx
+++ b/apps/cms/src/app/page.test.tsx
@@ -1,6 +1,3 @@
-import { getServerSession } from "next-auth";
-import { redirect } from "next/navigation";
-
 jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
 jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
 
@@ -11,6 +8,8 @@ describe("IndexPage", () => {
   });
 
   it("redirects to /cms when a session exists", async () => {
+    const { getServerSession } = await import("next-auth");
+    const { redirect } = await import("next/navigation");
     (getServerSession as jest.Mock).mockResolvedValueOnce({ user: { id: "1" } });
     const { default: IndexPage } = await import("./page");
     await IndexPage();
@@ -18,6 +17,8 @@ describe("IndexPage", () => {
   });
 
   it("redirects to /login when no session exists", async () => {
+    const { getServerSession } = await import("next-auth");
+    const { redirect } = await import("next/navigation");
     (getServerSession as jest.Mock).mockResolvedValueOnce(null);
     const { default: IndexPage } = await import("./page");
     await IndexPage();


### PR DESCRIPTION
## Summary
- re-import Next.js auth/navigation utilities inside tests so mocks persist after `jest.resetModules`

## Testing
- `pnpm --filter @apps/cms test src/app/page.test.tsx`
- `pnpm -r build` *(fails: Type 'null' is not assignable...)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a05cc538832f814ae2c3fc3f9b42