### PR TITLE
fix returns editor test mocks

### DIFF
--- a/apps/cms/__tests__/returnsEditor.test.tsx
+++ b/apps/cms/__tests__/returnsEditor.test.tsx
@@ -1,13 +1,18 @@
 import "@testing-library/jest-dom";
-import React from "react";
+import React, { act } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
 
 const updateUpsReturns = jest.fn();
 jest.mock("@cms/actions/shops.server", () => ({ updateUpsReturns }));
 jest.mock("@/components/atoms/shadcn", () => ({
   Button: (props: any) => <button {...props} />,
-  Checkbox: (props: any) => <input type="checkbox" {...props} />,
+  Checkbox: ({ onCheckedChange, ...props }: any) => (
+    <input
+      type="checkbox"
+      onChange={(e) => onCheckedChange?.((e.target as HTMLInputElement).checked)}
+      {...props}
+    />
+  ),
 }));
 
 import ReturnsEditor from "../src/app/cms/shop/[shop]/settings/returns/ReturnsEditor";


### PR DESCRIPTION
## Summary
- fix ReturnsEditor test to use React's `act`
- map `onCheckedChange` in Checkbox mock to `onChange` to avoid warnings

## Testing
- `pnpm --filter @apps/cms exec jest apps/cms/__tests__/returnsEditor.test.tsx`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a054ea5c832f8fa2dd9c0c706f90