### PR TITLE
test: strip next/link prefetch prop

### DIFF
--- a/test/resetNextMocks.ts
+++ b/test/resetNextMocks.ts
@@ -13,6 +13,6 @@ jest.mock("next/image", () => ({
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children, ...rest }: any) =>
+  default: ({ href, prefetch, children, ...rest }: any) =>
     React.createElement("a", { href, ...rest }, children),
 }));


### PR DESCRIPTION
## Summary
- stop forwarding `prefetch` prop in `next/link` mock to avoid React warnings in tests

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `cd apps/cms && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c69fead67c832f9ac8d655896912d8