### PR TITLE
Handle missing account profile with 404 response

### DIFF
--- a/apps/shop-bcd/src/app/api/account/profile/route.ts
+++ b/apps/shop-bcd/src/app/api/account/profile/route.ts
@@ -28,7 +28,15 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const profile = await getCustomerProfile(session.customerId);
+  let profile;
+  try {
+    profile = await getCustomerProfile(session.customerId);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Customer profile not found") {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+    throw err;
+  }
   if (!profile) {
     return NextResponse.json({ error: "Profile not found" }, { status: 404 });
   }
@@ -58,7 +66,15 @@ export async function PUT(req: NextRequest) {
     }
     throw err;
   }
-  const profile = await getCustomerProfile(session.customerId);
+  let profile;
+  try {
+    profile = await getCustomerProfile(session.customerId);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Customer profile not found") {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+    throw err;
+  }
   if (!profile) {
     return NextResponse.json({ error: "Profile not found" }, { status: 404 });
   }


### PR DESCRIPTION
## Summary
- catch missing customer profile errors in account profile API route

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm --filter @apps/shop-bcd test -- __tests__/account-profile-api.integration.test.ts`
- `pnpm --filter @apps/shop-bcd test -- __tests__/account-profile-api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6a24a8598832f8a82f13e2c2fd62f