### PR TITLE
Avoid passing undefined session options

### DIFF
--- a/apps/shop-bcd/src/app/api/login/route.ts
+++ b/apps/shop-bcd/src/app/api/login/route.ts
@@ -90,7 +90,15 @@ export async function POST(req: Request) {
     }
   }
 
-  await createCustomerSession(valid, { remember: parsed.data.remember });
+  const sessionOptions =
+    parsed.data.remember !== undefined
+      ? { remember: parsed.data.remember }
+      : undefined;
+  if (sessionOptions) {
+    await createCustomerSession(valid, sessionOptions);
+  } else {
+    await createCustomerSession(valid);
+  }
 
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- only send session options to createCustomerSession when remember flag provided

## Testing
- `pnpm -r build` *(fails: Type '{ id: string; deposit: number; sessionId: string; ... } | null' is not assignable to type ...)*
- `pnpm exec jest apps/shop-bcd/__tests__/login-mfa.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c6a2372834832f91d7bed302ba6b40