### PR TITLE
Use relative URL for shop logout redirect

### DIFF
--- a/apps/shop-bcd/src/app/logout/route.ts
+++ b/apps/shop-bcd/src/app/logout/route.ts
@@ -4,5 +4,10 @@ import { destroyCustomerSession } from "@auth";
 
 export async function GET(req: Request) {
   await destroyCustomerSession();
-  return NextResponse.redirect(new URL("/", req.url));
+  return new NextResponse(null, {
+    status: 307,
+    headers: {
+      location: "/",
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- return a 307 response with a relative `/` location when logging out

## Testing
- `pnpm --filter @apps/shop-bcd test apps/shop-bcd/__tests__/logout.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6a22ed0a4832fabd9d888a3c2fbfb