### PR TITLE
fix upgrade preview mocks to use data-cy

### DIFF
--- a/apps/shop-bcd/__tests__/upgradePreview.test.tsx
+++ b/apps/shop-bcd/__tests__/upgradePreview.test.tsx
@@ -6,10 +6,10 @@ describe("upgrade preview page", () => {
   beforeEach(() => {
     global.__UPGRADE_MOCKS__ = {
       "@ui/components/molecules/Breadcrumbs": () => (
-        <div data-testid="new-comp">new-breadcrumbs</div>
+        <div data-cy="new-comp">new-breadcrumbs</div>
       ),
       "@ui/components/molecules/Breadcrumbs.bak": () => (
-        <div data-testid="old-comp">old-breadcrumbs</div>
+        <div data-cy="old-comp">old-breadcrumbs</div>
       ),
     };
   });


### PR DESCRIPTION
## Summary
- use `data-cy` attribute in upgrade preview test mocks to align with test configuration

## Testing
- `pnpm --filter @apps/shop-bcd exec jest --runTestsByPath __tests__/upgradePreview.test.tsx --coverage=false`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a21530e8832fa8f10bc100075308