### PR TITLE
test: mock config env for preview tests

### DIFF
--- a/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
+++ b/apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts
@@ -7,6 +7,20 @@ process.env.PREVIEW_TOKEN_SECRET = "testsecret";
 process.env.UPGRADE_PREVIEW_TOKEN_SECRET = "upgradesecret";
 process.env.NEXT_PUBLIC_SHOP_ID = "shop";
 
+jest.mock("@acme/config/env/core", () => {
+  const env = {
+    PREVIEW_TOKEN_SECRET: "testsecret",
+    UPGRADE_PREVIEW_TOKEN_SECRET: "upgradesecret",
+    NEXT_PUBLIC_SHOP_ID: "shop",
+  };
+  return { coreEnv: env, loadCoreEnv: () => env };
+});
+
+jest.mock("@acme/config/env/auth", () => {
+  const env = { UPGRADE_PREVIEW_TOKEN_SECRET: "upgradesecret" };
+  return { authEnv: env, loadAuthEnv: () => env };
+});
+
 if (typeof (Response as any).json !== "function") {
   (Response as any).json = (data: unknown, init?: ResponseInit) =>
     new Response(JSON.stringify(data), init);
@@ -35,10 +49,6 @@ test("valid upgrade token returns page JSON", async () => {
     getPages,
   }));
   jest.doMock("@auth", () => ({ __esModule: true, requirePermission: jest.fn() }));
-  jest.doMock("@acme/config", () => ({
-    __esModule: true,
-    env: { UPGRADE_PREVIEW_TOKEN_SECRET: "upgradesecret" },
-  }));
 
   const { GET: tokenGET } = await import(
     "../../src/app/api/preview-token/route"

--- a/apps/shop-bcd/routes/__tests__/preview.test.ts
+++ b/apps/shop-bcd/routes/__tests__/preview.test.ts
@@ -33,10 +33,13 @@ test("valid token returns page JSON", async () => {
     __esModule: true,
     getPages,
   }));
-  jest.doMock("@acme/config", () => ({
-    __esModule: true,
-    env: { PREVIEW_TOKEN_SECRET: "testsecret", NEXT_PUBLIC_SHOP_ID: "shop" },
-  }));
+  jest.doMock("@acme/config/env/core", () => {
+    const env = {
+      PREVIEW_TOKEN_SECRET: "testsecret",
+      NEXT_PUBLIC_SHOP_ID: "shop",
+    };
+    return { __esModule: true, coreEnv: env, loadCoreEnv: () => env };
+  });
 
   const { onRequest } = await import("../../src/routes/preview/[pageId]");
   const res = await onRequest({
@@ -54,10 +57,13 @@ test("missing page yields 404", async () => {
     __esModule: true,
     getPages,
   }));
-  jest.doMock("@acme/config", () => ({
-    __esModule: true,
-    env: { PREVIEW_TOKEN_SECRET: "testsecret", NEXT_PUBLIC_SHOP_ID: "shop" },
-  }));
+  jest.doMock("@acme/config/env/core", () => {
+    const env = {
+      PREVIEW_TOKEN_SECRET: "testsecret",
+      NEXT_PUBLIC_SHOP_ID: "shop",
+    };
+    return { __esModule: true, coreEnv: env, loadCoreEnv: () => env };
+  });
 
   const { onRequest } = await import("../../src/routes/preview/[pageId]");
   const res = await onRequest({
@@ -74,10 +80,13 @@ test("invalid token yields 401", async () => {
     __esModule: true,
     getPages,
   }));
-  jest.doMock("@acme/config", () => ({
-    __esModule: true,
-    env: { PREVIEW_TOKEN_SECRET: "testsecret", NEXT_PUBLIC_SHOP_ID: "shop" },
-  }));
+  jest.doMock("@acme/config/env/core", () => {
+    const env = {
+      PREVIEW_TOKEN_SECRET: "testsecret",
+      NEXT_PUBLIC_SHOP_ID: "shop",
+    };
+    return { __esModule: true, coreEnv: env, loadCoreEnv: () => env };
+  });
 
   const { onRequest } = await import("../../src/routes/preview/[pageId]");
   const res = await onRequest({

--- a/apps/shop-bcd/src/app/api/publish/__tests__/route.integration.test.ts
+++ b/apps/shop-bcd/src/app/api/publish/__tests__/route.integration.test.ts
@@ -11,12 +11,16 @@ jest.mock("next/headers", () => ({
   cookies: jest.fn(() => mockCookies),
 }));
 
-jest.mock("@acme/config/env/core", () => ({
-  coreEnv: {
+jest.mock("@acme/config/env/core", () => {
+  const env = {
     SESSION_SECRET: "test-session-secret-32-chars-long-string!",
     COOKIE_DOMAIN: "example.com",
-  },
-}));
+  };
+  return {
+    coreEnv: env,
+    loadCoreEnv: () => env,
+  };
+});
 
 jest.mock("fs", () => {
   const actual = jest.requireActual("fs");


### PR DESCRIPTION
## Summary
- mock `loadCoreEnv` in publish route tests
- stub config env modules in preview route tests

## Testing
- `pnpm exec jest apps/shop-bcd/src/app/api/publish/__tests__/route.integration.test.ts apps/shop-bcd/routes/__tests__/preview.test.ts apps/shop-bcd/routes/__tests__/preview-upgrade.test.ts`
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*


------
https://chatgpt.com/codex/tasks/task_e_68c6a202c054832fb131a14835de4f08