### PR TITLE
fix: remove deprecated checkbox handler

### DIFF
--- a/apps/cms/__tests__/reverseLogisticsEditor.test.tsx
+++ b/apps/cms/__tests__/reverseLogisticsEditor.test.tsx
@@ -1,7 +1,6 @@
 import "@testing-library/jest-dom";
-import React from "react";
+import React, { act } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
 
 const updateReverseLogistics = jest.fn();
 jest.mock("@cms/actions/shops.server", () => ({ updateReverseLogistics }));

--- a/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor.tsx
@@ -39,8 +39,9 @@ export default function ReverseLogisticsEditor({ shop, initial }: Props) {
         <Checkbox
           name="enabled"
           checked={state.enabled}
-          onCheckedChange={(v: boolean) =>
-            setState((s) => ({ ...s, enabled: Boolean(v) }))
+          onChange={() => {}}
+          onClick={() =>
+            setState((s) => ({ ...s, enabled: !s.enabled }))
           }
         />
         <span>Enable reverse logistics service</span>


### PR DESCRIPTION
## Summary
- fix ReverseLogisticsEditor to avoid deprecated `onCheckedChange` warnings
- use `React.act` instead of `react-dom/test-utils` in tests

## Testing
- `pnpm install`
- `pnpm -r build` (fails: Type 'null' is not assignable to type ... in packages/platform-core)
- `pnpm --filter @apps/cms exec jest __tests__/reverseLogisticsEditor.test.tsx --runInBand` (fails: coverage threshold not met)


------
https://chatgpt.com/codex/tasks/task_e_68c69ffee430832f90e4ca9e988b8f62