### PR TITLE
test: add product page unit tests

### DIFF
--- a/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.test.tsx
+++ b/apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.test.tsx
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, configure } from "@testing-library/react";
+configure({ testIdAttribute: "data-testid" });
+import PdpClient from "./PdpClient.client";
+
+const addToCartMock = jest.fn();
+
+jest.mock("@platform-core/components/shop/AddToCartButton.client", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    addToCartMock(props);
+    return <button data-testid="add-to-cart" disabled={props.disabled} />;
+  },
+}));
+
+jest.mock("@platform-core/components/pdp/ImageGallery", () => ({
+  __esModule: true,
+  default: () => <div data-testid="image-gallery" />,
+}));
+
+jest.mock("@ui/components/atoms/Price", () => ({
+  __esModule: true,
+  Price: ({ amount }: any) => <span>{amount}</span>,
+}));
+
+describe("PdpClient", () => {
+  const product = {
+    id: "sku1",
+    slug: "sku1",
+    title: "Test SKU",
+    description: "A test product",
+    price: 100,
+    media: [],
+    sizes: ["S", "M"],
+  } as any;
+
+  beforeEach(() => {
+    addToCartMock.mockClear();
+  });
+
+  it("enables AddToCartButton only when size selected and updates quantity", () => {
+    render(<PdpClient product={product} />);
+
+    // Initially disabled
+    expect(screen.getByTestId("add-to-cart")).toBeDisabled();
+    expect(addToCartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sku: product,
+        size: undefined,
+        disabled: true,
+        quantity: 1,
+      })
+    );
+
+    // Select size
+    fireEvent.click(screen.getByRole("button", { name: "M" }));
+
+    expect(screen.getByTestId("add-to-cart")).not.toBeDisabled();
+    expect(addToCartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sku: product,
+        size: "M",
+        disabled: false,
+        quantity: 1,
+      })
+    );
+
+    // Change quantity
+    fireEvent.change(screen.getByLabelText("Quantity:"), {
+      target: { value: "2" },
+    });
+
+    expect(addToCartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sku: product,
+        size: "M",
+        disabled: false,
+        quantity: 2,
+      })
+    );
+  });
+});
+

--- a/apps/cms/src/app/[lang]/product/[slug]/page.test.tsx
+++ b/apps/cms/src/app/[lang]/product/[slug]/page.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { LOCALES } from "@acme/i18n";
+
+jest.mock("@platform-core/products", () => ({ getProductBySlug: jest.fn() }));
+jest.mock("next/navigation", () => ({ notFound: jest.fn() }));
+jest.mock("./PdpClient.client", () => ({ __esModule: true, default: jest.fn(() => null) }));
+
+describe("ProductDetailPage", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("generateStaticParams returns all locale/slug pairs", async () => {
+    const { generateStaticParams } = await import("./page");
+    const params = await generateStaticParams();
+    const expectedSlugs = ["green-sneaker", "sand-sneaker", "black-sneaker"];
+    const expected = LOCALES.flatMap((lang) =>
+      expectedSlugs.map((slug) => ({ lang, slug }))
+    );
+    expect(params).toEqual(expected);
+  });
+
+  it("generateMetadata returns product title when found", async () => {
+    const products = require("@platform-core/products");
+    products.getProductBySlug.mockReturnValue({ title: "Demo" });
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: "en", slug: "demo" }),
+    });
+    expect(products.getProductBySlug).toHaveBeenCalledWith("demo");
+    expect(metadata).toEqual({ title: "Demo · Base‑Shop" });
+  });
+
+  it("generateMetadata returns fallback title when product missing", async () => {
+    const products = require("@platform-core/products");
+    products.getProductBySlug.mockReturnValue(undefined);
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: "en", slug: "missing" }),
+    });
+    expect(metadata).toEqual({ title: "Product not found" });
+  });
+
+  it("invokes notFound when product is missing", async () => {
+    const products = require("@platform-core/products");
+    products.getProductBySlug.mockReturnValue(undefined);
+    const { default: ProductDetailPage } = await import("./page");
+    const nav = require("next/navigation");
+    await ProductDetailPage({
+      params: Promise.resolve({ lang: "en", slug: "missing" }),
+    });
+    expect(nav.notFound).toHaveBeenCalled();
+  });
+
+  it("returns PdpClient element when product exists", async () => {
+    const product = { title: "Demo", description: "", media: [], sizes: [], price: 0 } as any;
+    const products = require("@platform-core/products");
+    products.getProductBySlug.mockReturnValue(product);
+    const { default: ProductDetailPage } = await import("./page");
+    const PdpClient = require("./PdpClient.client").default as React.FC<any>;
+    const nav = require("next/navigation");
+    const result = await ProductDetailPage({
+      params: Promise.resolve({ lang: "en", slug: "demo" }),
+    });
+    expect(result).toEqual(<PdpClient product={product} />);
+    expect(nav.notFound).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add client-side PDP tests verifying cart controls
- add product page tests for static params, metadata, and notFound handling

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type '... | null' is not assignable to type '...')*
- `pnpm --filter @apps/cms exec jest "apps/cms/src/app/[lang]/product/[slug]/page.test.tsx" "apps/cms/src/app/[lang]/product/[slug]/PdpClient.client.test.tsx"`


------
https://chatgpt.com/codex/tasks/task_e_68c6a289c324832fa2c5be749d5909b6