### PR TITLE
test: add delivery schedule route tests

### DIFF
--- a/apps/shop-bcd/src/app/api/delivery/schedule/route.test.ts
+++ b/apps/shop-bcd/src/app/api/delivery/schedule/route.test.ts
@@ -1,0 +1,52 @@
+// apps/shop-bcd/src/app/api/delivery/schedule/route.test.ts
+import { type NextRequest } from "next/server";
+import { ResponseCookies } from "next/dist/compiled/@edge-runtime/cookies";
+
+const parseJsonBody = jest.fn();
+const getShopSettings = jest.fn();
+
+jest.mock("@shared-utils", () => ({ parseJsonBody }));
+jest.mock("@platform-core/repositories/settings.server", () => ({ getShopSettings }));
+
+let POST: typeof import("./route").POST;
+
+beforeAll(async () => {
+  ({ POST } = await import("./route"));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function makeReq(body: Record<string, any>): NextRequest {
+  parseJsonBody.mockResolvedValue({ success: true, data: body });
+  return {} as NextRequest;
+}
+
+describe("POST", () => {
+  it("returns 400 when region or window not allowed", async () => {
+    getShopSettings.mockResolvedValue({
+      luxuryFeatures: { premierDelivery: true },
+      premierDelivery: { regions: ["north"], windows: ["morning"] },
+    });
+    const res = await POST(makeReq({ region: "south", window: "morning" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("sets cookie and returns 200 when allowed", async () => {
+    getShopSettings.mockResolvedValue({
+      luxuryFeatures: { premierDelivery: true },
+      premierDelivery: { regions: ["north"], windows: ["morning"] },
+    });
+    const setSpy = jest.spyOn(ResponseCookies.prototype, "set");
+    const res = await POST(makeReq({ region: "north", window: "morning", carrier: "ups" }));
+    expect(res.status).toBe(200);
+    expect(setSpy).toHaveBeenCalledWith(
+      "delivery",
+      JSON.stringify({ region: "north", window: "morning", carrier: "ups" }),
+      { path: "/" },
+    );
+    setSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for delivery schedule route
- mock parseJsonBody and getShopSettings to supply settings and assert status codes

## Testing
- `pnpm -r build` *(fails: TypeScript errors in @acme/platform-core)*
- `pnpm test apps/shop-bcd/src/app/api/delivery/schedule/route.test.ts` *(fails: Could not find task `apps/shop-bcd/src/app/api/delivery/schedule/route.test.ts` in project)*
- `pnpm exec jest apps/shop-bcd/src/app/api/delivery/schedule/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6a47206bc832fb0d1d773ab4fd9d1