### PR TITLE
test: cover CMS dashboard and 404 pages

### DIFF
--- a/apps/cms/src/app/cms/not-found.client.test.tsx
+++ b/apps/cms/src/app/cms/not-found.client.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { usePathname } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("links back to /cms when no shop segment exists", async () => {
+  (usePathname as jest.Mock).mockReturnValue("/cms/unknown");
+  const { default: CmsNotFound } = await import("./not-found.client");
+  render(<CmsNotFound />);
+  expect(screen.getByText("404 – Page not found")).toBeInTheDocument();
+  const link = screen.getByRole("link", { name: /Back to dashboard/i });
+  expect(link).toHaveAttribute("href", "/cms");
+});
+
+it("links back to the shop dashboard when shop segment is present", async () => {
+  (usePathname as jest.Mock).mockReturnValue("/cms/shop/test/anything");
+  const { default: CmsNotFound } = await import("./not-found.client");
+  render(<CmsNotFound />);
+  const link = screen.getByRole("link", { name: /Back to dashboard/i });
+  expect(link).toHaveAttribute("href", "/cms/shop/test");
+});

--- a/apps/cms/src/app/cms/not-found.test.tsx
+++ b/apps/cms/src/app/cms/not-found.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("./not-found.client", () => ({
+  __esModule: true,
+  default: () => <div data-cy="cms-not-found" />,
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("wraps the CmsNotFound client component", async () => {
+  const { default: NotFound } = await import("./not-found");
+  render(<NotFound />);
+  expect(screen.getByTestId("cms-not-found")).toBeInTheDocument();
+});

--- a/apps/cms/src/app/cms/page.test.tsx
+++ b/apps/cms/src/app/cms/page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { getServerSession } from "next-auth";
+import { listPendingUsers } from "@cms/actions/accounts.server";
+import { readRbac } from "@cms/lib/server/rbacStore";
+import fs from "fs/promises";
+
+jest.mock("@/components/atoms/shadcn", () => ({
+  Button: ({ children, ...props }: { children?: React.ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock("@cms/actions/accounts.server", () => ({
+  approveAccount: jest.fn(),
+  listPendingUsers: jest.fn(),
+}));
+
+jest.mock("@cms/auth/options", () => ({ authOptions: {} }));
+
+jest.mock("@cms/lib/server/rbacStore", () => ({
+  readRbac: jest.fn().mockResolvedValue({ users: {} }),
+}));
+
+jest.mock("@platform-core/dataRoot", () => ({
+  resolveDataRoot: () => "/data",
+}));
+
+jest.mock("@ui/components/templates", () => ({
+  DashboardTemplate: ({ stats }: { stats: Array<{ label: string; value: React.ReactNode }> }) => (
+    <div data-testid="dashboard">{stats.map((s) => `${s.label}:${s.value}`).join(",")}</div>
+  ),
+}));
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+
+jest.mock("fs/promises", () => ({
+  readdir: jest.fn(),
+  readFile: jest.fn(),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const mockSession = getServerSession as jest.Mock;
+const mockReaddir = fs.readdir as unknown as jest.Mock;
+const mockListPending = listPendingUsers as jest.Mock;
+
+it("shows create shop link for admin when no shops exist", async () => {
+  mockSession.mockResolvedValueOnce({ user: { role: "admin" } });
+  mockReaddir.mockResolvedValueOnce([]);
+  mockListPending.mockResolvedValueOnce([]);
+
+  const { default: CmsDashboardPage } = await import("./page");
+  render(await CmsDashboardPage());
+
+  expect(
+    screen.getByText("No shops found. Get started by creating your first shop.")
+  ).toBeInTheDocument();
+  const link = screen.getByRole("link", { name: "Create Shop" });
+  expect(link).toHaveAttribute("href", "/cms/configurator");
+  expect(screen.getByText("No pending requests.")).toBeInTheDocument();
+});
+
+it("hides admin controls for non-admin users", async () => {
+  mockSession.mockResolvedValueOnce({ user: { role: "viewer" } });
+  mockReaddir.mockResolvedValueOnce([]);
+
+  const { default: CmsDashboardPage } = await import("./page");
+  render(await CmsDashboardPage());
+
+  expect(
+    screen.getByText("No shops found. Get started by creating your first shop.")
+  ).toBeInTheDocument();
+  expect(screen.queryByRole("link", { name: "Create Shop" })).toBeNull();
+  expect(screen.queryByText("Account Requests")).toBeNull();
+  expect(mockListPending).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add tests for CMS dashboard page
- verify not found client routing logic
- ensure not-found wrapper renders client component

## Testing
- `pnpm --filter @apps/cms test --coverage=false src/app/cms/page.test.tsx src/app/cms/not-found.client.test.tsx src/app/cms/not-found.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6a28bf294832f9f812ad39a454ac8