### PR TITLE
test: verify RootLayout font and theme

### DIFF
--- a/apps/shop-bcd/__tests__/layout.test.tsx
+++ b/apps/shop-bcd/__tests__/layout.test.tsx
@@ -1,0 +1,35 @@
+import { renderToString } from "react-dom/server";
+import RootLayout from "../src/app/layout";
+import { initTheme } from "@platform-core/utils";
+
+jest.mock("next/font/google", () => ({
+  Geist: () => ({ variable: "--font-geist-sans" }),
+  Geist_Mono: () => ({ variable: "--font-geist-mono" }),
+}));
+
+jest.mock("@platform-core/contexts/CartContext", () => ({
+  CartProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-cy="cart-provider">{children}</div>
+  ),
+}));
+
+test("RootLayout applies fonts, theme script, and cart provider", () => {
+  const markup = renderToString(
+    <RootLayout>
+      <div data-cy="child" />
+    </RootLayout>
+  );
+
+  const doc = new DOMParser().parseFromString(markup, "text/html");
+
+  const html = doc.querySelector("html")!;
+  expect(html.className).toContain("--font-geist-sans");
+  expect(html.className).toContain("--font-geist-mono");
+
+  const script = doc.querySelector("script")!;
+  expect(script.textContent).toBe(initTheme);
+
+  const provider = doc.querySelector('[data-cy="cart-provider"]')!;
+  const child = doc.querySelector('[data-cy="child"]')!;
+  expect(provider.contains(child)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add layout test ensuring RootLayout uses Geist fonts, theme script and CartProvider

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm test --filter @apps/shop-bcd` *(fails: login-api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a45eab8c832fbdecdd298c9656b4