### PR TITLE
test: add blog post form and action button tests

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/__tests__/DeleteButton.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/DeleteButton.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import DeleteButton from "@cms/app/cms/blog/posts/DeleteButton.client";
+
+const mockDelete = jest.fn();
+
+jest.mock("@cms/actions/blog.server", () => ({
+  deletePost: (...args: any) => mockDelete(...args),
+}));
+
+let mockUseFormState: any;
+jest.mock("react-dom", () => ({
+  useFormState: (...args: any[]) => mockUseFormState(...args),
+}));
+mockUseFormState = jest.fn((action: any, init: any) => [init, action]);
+
+jest.mock("@ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Toast: ({ open, message }: any) => (open ? <div role="alert">{message}</div> : null),
+}));
+
+describe("DeleteButton", () => {
+  beforeEach(() => {
+    mockDelete.mockReset();
+  });
+
+  it("calls deletePost on submit", () => {
+    render(<DeleteButton id="1" shopId="shop" />);
+    const form = document.querySelector("form") as HTMLFormElement;
+    fireEvent.submit(form);
+    expect(mockDelete).toHaveBeenCalledWith("shop", "1", expect.any(FormData));
+  });
+});
+

--- a/apps/cms/src/app/cms/blog/posts/__tests__/PostForm.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/PostForm.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import PostForm from "@cms/app/cms/blog/posts/PostForm.client";
+
+jest.mock("react-dom", () => ({
+  useFormState: (_action: any, init: any) => [init, jest.fn()],
+}));
+
+jest.mock("@ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Input: ({ label, error, ...props }: any) => (
+    <div>
+      <input aria-label={label} {...props} />
+      {error && <span>{error}</span>}
+    </div>
+  ),
+  Switch: ({ onChange, ...props }: any) => (
+    <input type="checkbox" onChange={onChange} {...props} />
+  ),
+  Textarea: ({ label, ...props }: any) => <textarea aria-label={label} {...props} />,
+  Toast: ({ open, message }: any) => (open ? <div role="alert">{message}</div> : null),
+}));
+
+jest.mock("@cms/app/cms/blog/posts/MainImageField", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("@cms/app/cms/blog/posts/RichTextEditor", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("@cms/app/cms/blog/posts/invalidProductContext", () => ({
+  InvalidProductProvider: ({ children }: any) => <div>{children}</div>,
+  useInvalidProductContext: () => ({ invalidProducts: {} }),
+}));
+
+jest.mock("@portabletext/react", () => ({ PortableText: () => <div /> }));
+jest.mock("@cms/app/cms/blog/posts/schema", () => ({ previewComponents: {} }));
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams("shopId=shop1"),
+}));
+
+describe("PostForm", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock) = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  it("slugifies title and shows error when slug exists", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ exists: true }),
+    });
+
+    render(<PostForm action={async () => ({})} submitLabel="Save" />);
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "My Post" },
+    });
+
+    expect(screen.getByLabelText("Slug")).toHaveValue("my-post");
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    expect(await screen.findByText("Slug already exists")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+});
+

--- a/apps/cms/src/app/cms/blog/posts/__tests__/PublishButton.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/PublishButton.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import PublishButton from "@cms/app/cms/blog/posts/PublishButton.client";
+
+const mockPublish = jest.fn();
+
+jest.mock("@cms/actions/blog.server", () => ({
+  publishPost: (...args: any) => mockPublish(...args),
+}));
+
+let mockUseFormState: any;
+jest.mock("react-dom", () => ({
+  useFormState: (...args: any[]) => mockUseFormState(...args),
+}));
+mockUseFormState = jest.fn((action: any, init: any) => [init, action]);
+
+jest.mock("@ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Toast: ({ open, message }: any) => (open ? <div role="alert">{message}</div> : null),
+}));
+
+describe("PublishButton", () => {
+  beforeEach(() => {
+    mockPublish.mockReset();
+  });
+
+  it("calls publishPost on submit", () => {
+    render(<PublishButton id="1" shopId="shop" />);
+    const form = document.querySelector("form") as HTMLFormElement;
+    fireEvent.submit(form);
+    expect(mockPublish).toHaveBeenCalledWith("shop", "1", expect.any(FormData));
+  });
+});
+

--- a/apps/cms/src/app/cms/blog/posts/__tests__/UnpublishButton.spec.tsx
+++ b/apps/cms/src/app/cms/blog/posts/__tests__/UnpublishButton.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import UnpublishButton from "@cms/app/cms/blog/posts/UnpublishButton.client";
+
+const mockUnpublish = jest.fn();
+
+jest.mock("@cms/actions/blog.server", () => ({
+  unpublishPost: (...args: any) => mockUnpublish(...args),
+}));
+
+let mockUseFormState: any;
+jest.mock("react-dom", () => ({
+  useFormState: (...args: any[]) => mockUseFormState(...args),
+}));
+mockUseFormState = jest.fn((action: any, init: any) => [init, action]);
+
+jest.mock("@ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Toast: ({ open, message }: any) => (open ? <div role="alert">{message}</div> : null),
+}));
+
+describe("UnpublishButton", () => {
+  beforeEach(() => {
+    mockUnpublish.mockReset();
+  });
+
+  it("calls unpublishPost on submit", () => {
+    render(<UnpublishButton id="1" shopId="shop" />);
+    const form = document.querySelector("form") as HTMLFormElement;
+    fireEvent.submit(form);
+    expect(mockUnpublish).toHaveBeenCalledWith("shop", "1", expect.any(FormData));
+  });
+});
+


### PR DESCRIPTION
## Summary
- test PostForm slug validation with mocked fetch
- ensure blog post action buttons invoke correct server actions

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript error in packages/platform-core)*
- `pnpm --filter @apps/cms exec jest --coverage=false apps/cms/src/app/cms/blog/posts/__tests__/PostForm.spec.tsx apps/cms/src/app/cms/blog/posts/__tests__/DeleteButton.spec.tsx apps/cms/src/app/cms/blog/posts/__tests__/PublishButton.spec.tsx apps/cms/src/app/cms/blog/posts/__tests__/UnpublishButton.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6a28b5464832f8bfff1ddcbc40de5