### PR TITLE
test(shop-bcd): add 404 page unit test

### DIFF
--- a/apps/shop-bcd/__tests__/404-page.test.tsx
+++ b/apps/shop-bcd/__tests__/404-page.test.tsx
@@ -1,0 +1,20 @@
+// apps/shop-bcd/__tests__/404-page.test.tsx
+
+jest.mock("../src/components/NotFoundContent", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+import { renderToString } from "react-dom/server";
+import NotFoundContent from "../src/components/NotFoundContent";
+import FourOhFourPage, { dynamic } from "../src/app/404/page";
+
+test("renders NotFoundContent", () => {
+  renderToString(<FourOhFourPage />);
+  expect(NotFoundContent).toHaveBeenCalled();
+});
+
+test("dynamic export is force-static", () => {
+  expect(dynamic).toBe("force-static");
+});
+


### PR DESCRIPTION
## Summary
- add test covering `src/app/404` page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm test --filter shop-bcd` *(terminated: long running)*
- `pnpm exec jest apps/shop-bcd/__tests__/404-page.test.tsx --config apps/shop-bcd/jest.config.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4606578832fb4a2ad6ca484d16c