### PR TITLE
test: add generateStaticParams test

### DIFF
--- a/apps/shop-bcd/__tests__/generateStaticParams.test.ts
+++ b/apps/shop-bcd/__tests__/generateStaticParams.test.ts
@@ -1,0 +1,13 @@
+// apps/shop-bcd/__tests__/generateStaticParams.test.ts
+jest.mock("@acme/i18n", () => ({
+  LOCALES: ["en", "de"],
+}));
+
+import generateStaticParams from "../src/app/[lang]/generateStaticParams";
+
+test("returns locales as lang objects", () => {
+  expect(generateStaticParams()).toEqual([
+    { lang: "en" },
+    { lang: "de" },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add unit test for generateStaticParams to ensure locales map to lang params

## Testing
- `pnpm -r build` *(fails: Type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; } | null' is not assignable to type '{ id: string; deposit: number; sessionId: string; shop: string; startedAt: string; status?: "received" | "cleaning" | "repair" | "qa" | "available" | undefined; expectedReturnDate?: string | undefined; ... 17 more ...; returnStatus?: string | undefined; }')*
- `pnpm test --filter @apps/shop-bcd` *(fails: Test Suites: 5 failed, 32 passed, 37 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a4621834832fbd9a9664c51abda0