### PR TITLE
test: add success page tests

### DIFF
--- a/apps/shop-bcd/src/app/[lang]/success/page.test.tsx
+++ b/apps/shop-bcd/src/app/[lang]/success/page.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import Success from './page';
+
+describe('Success page (localized)', () => {
+  it('renders thank-you heading and receipt message', () => {
+    render(<Success />);
+    expect(
+      screen.getByRole('heading', {
+        name: /Thanks for your order!/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Check your e-mail for the receipt./i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/shop-bcd/src/app/success/page.test.tsx
+++ b/apps/shop-bcd/src/app/success/page.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import Success from './page';
+
+describe('Success page', () => {
+  it('renders thank-you heading and receipt message', () => {
+    render(<Success />);
+    expect(
+      screen.getByRole('heading', {
+        name: /Thanks for your order!/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Check your e-mail for the receipt./i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for success page variants to confirm thank-you and receipt messages render

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm test --filter @apps/shop-bcd` *(fails: pre-existing test failures)*
- `pnpm --filter @apps/shop-bcd exec jest --runTestsByPath src/app/[lang]/success/page.test.tsx src/app/success/page.test.tsx --config ../../jest.config.cjs --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c6a46fb78c832f9c2b9df67dc57597