### PR TITLE
test: add password reset page tests

### DIFF
--- a/apps/shop-bcd/src/app/password-reset/[token]/page.test.tsx
+++ b/apps/shop-bcd/src/app/password-reset/[token]/page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import PasswordResetPage from "./page";
+import { useParams } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn(),
+}));
+
+const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
+const originalFetch = global.fetch;
+
+describe("PasswordResetPage", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("shows success message when password reset succeeds", async () => {
+    mockUseParams.mockReturnValue({ token: "abc" } as any);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }) as any;
+
+    render(<PasswordResetPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("New password"), {
+      target: { value: "pw" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset password/i }));
+
+    expect(await screen.findByText("Password updated")).toBeInTheDocument();
+  });
+
+  it("shows error message when password reset fails", async () => {
+    mockUseParams.mockReturnValue({ token: "abc" } as any);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Bad token" }),
+    }) as any;
+
+    render(<PasswordResetPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("New password"), {
+      target: { value: "pw" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset password/i }));
+
+    expect(await screen.findByText("Bad token")).toBeInTheDocument();
+  });
+});
+

--- a/apps/shop-bcd/src/app/password-reset/request/page.test.tsx
+++ b/apps/shop-bcd/src/app/password-reset/request/page.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import PasswordResetRequestPage from "./page";
+
+const originalFetch = global.fetch;
+
+describe("PasswordResetRequestPage", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("shows success message on successful request", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }) as any;
+
+    render(<PasswordResetRequestPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Email"), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    expect(
+      await screen.findByText("Check your email for a reset link")
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message on failed request", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "No account found" }),
+    }) as any;
+
+    render(<PasswordResetRequestPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Email"), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    expect(await screen.findByText("No account found")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for password reset token page
- add tests for password reset request page

## Testing
- `pnpm exec jest --runTestsByPath src/app/password-reset/[token]/page.test.tsx --config ../../jest.config.cjs --runInBand --detectOpenHandles`
- `pnpm exec jest src/app/password-reset/request/page.test.tsx --config ../../jest.config.cjs --runInBand --detectOpenHandles`

------
https://chatgpt.com/codex/tasks/task_e_68c6a47669d4832fb31f6dcc4bd44b1d