### PR TITLE
test: add preview page tests

### DIFF
--- a/apps/shop-bcd/src/app/preview/[pageId]/PreviewClient.test.tsx
+++ b/apps/shop-bcd/src/app/preview/[pageId]/PreviewClient.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PreviewClient from "./PreviewClient";
+
+// Mock the preview device hook to use local state
+jest.mock("@ui/hooks", () => ({
+  usePreviewDevice: (initial: string) => React.useState(initial),
+}));
+
+// Provide a small set of device presets
+jest.mock("@ui/utils/devicePresets", () => ({
+  devicePresets: [
+    { id: "a", label: "A", width: 100, height: 200 },
+    { id: "b", label: "B", width: 300, height: 400 },
+  ],
+}));
+
+// Stub DeviceSelector to switch to the second device when clicked
+const DeviceSelector = ({ setDeviceId }: any) => (
+  <button data-cy="select" onClick={() => setDeviceId("b")}>select</button>
+);
+jest.mock("@ui/components/DeviceSelector", () => ({ __esModule: true, default: (props: any) => DeviceSelector(props) }));
+
+// Stub DynamicRenderer so we can detect render
+const DynamicRenderer = jest.fn(() => <div data-cy="dynamic" />);
+jest.mock("@ui/components/DynamicRenderer", () => ({ __esModule: true, default: (props: any) => DynamicRenderer(props) }));
+
+describe("PreviewClient", () => {
+  it("changes width and height when a different device is selected and renders DynamicRenderer", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <PreviewClient components={[]} locale="en" initialDeviceId="a" />,
+    );
+
+    const frame = container.querySelector(".mx-auto") as HTMLDivElement;
+    expect(frame.style.width).toBe("100px");
+    expect(frame.style.height).toBe("200px");
+    expect(screen.getByTestId("dynamic")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("select"));
+
+    expect(frame.style.width).toBe("300px");
+    expect(frame.style.height).toBe("400px");
+  });
+});

--- a/apps/shop-bcd/src/app/preview/[pageId]/page.test.tsx
+++ b/apps/shop-bcd/src/app/preview/[pageId]/page.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+const notFound = jest.fn();
+jest.mock("next/navigation", () => ({ notFound: () => notFound() }));
+
+jest.mock("./PreviewClient", () => (props: any) => (
+  <div data-cy="preview-client" {...props} />
+));
+
+jest.mock("@ui/utils/devicePresets", () => ({
+  devicePresets: [
+    { id: "preset1", label: "Preset 1", width: 100, height: 200 },
+    { id: "preset2", label: "Preset 2", width: 300, height: 400 },
+  ],
+  getLegacyPreset: jest.fn((view: string) => ({ id: `${view}-id` })),
+}));
+
+import PreviewPage from "./page";
+import { getLegacyPreset } from "@ui/utils/devicePresets";
+
+jest.mock("@acme/types", () => ({
+  pageSchema: { parse: (data: any) => data },
+}));
+
+afterEach(() => {
+  (global.fetch as any)?.mockReset?.();
+  notFound.mockClear();
+  (getLegacyPreset as jest.Mock).mockClear();
+});
+
+describe("PreviewPage", () => {
+  const baseParams = { params: { pageId: "1" }, searchParams: {} } as any;
+  const makeSuccess = () =>
+    new Response(
+      JSON.stringify({ components: [], seo: { title: { en: "T" } } }),
+      { status: 200 },
+    );
+
+  it("calls notFound on 404", async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    await expect(PreviewPage(baseParams)).rejects.toThrow("Failed to load preview");
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("returns 401 response when unauthorized", async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    const res = (await PreviewPage(baseParams)) as Response;
+    expect(res.status).toBe(401);
+  });
+
+  it("throws on other error statuses", async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    await expect(PreviewPage(baseParams)).rejects.toThrow("Failed to load preview");
+  });
+
+  it("uses device search param for initialDeviceId", async () => {
+    global.fetch = jest.fn().mockResolvedValue(makeSuccess());
+    const element: any = await PreviewPage({
+      ...baseParams,
+      searchParams: { device: "preset2" },
+    });
+    expect(element.props.initialDeviceId).toBe("preset2");
+  });
+
+  it("uses view search param for legacy presets", async () => {
+    global.fetch = jest.fn().mockResolvedValue(makeSuccess());
+    const element: any = await PreviewPage({
+      ...baseParams,
+      searchParams: { view: "mobile" },
+    });
+    expect(getLegacyPreset).toHaveBeenCalledWith("mobile");
+    expect(element.props.initialDeviceId).toBe("mobile-id");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for preview client device selection and rendering
- add server preview page tests for fetch error handling and device initialization

## Testing
- `pnpm -r build` *(fails: packages/platform-core build errors)*
- `pnpm test` *(fails: root-tests missing tsconfig.test.json)*
- `pnpm exec jest --runInBand --testPathPattern="apps/shop-bcd/src/app/preview/\\[pageId\\]/(PreviewClient|page).test.tsx"`

------
https://chatgpt.com/codex/tasks/task_e_68c6a477b96c832fbb69a6bceed69830