### PR TITLE
fix: handle blog post not found

### DIFF
--- a/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/shop-bcd/src/app/[lang]/blog/[slug]/page.tsx
@@ -6,16 +6,13 @@ import shopJson from "../../../../../shop.json";
 
 type BlogShop = Pick<Shop, "id" | "luxuryFeatures" | "editorialBlog">;
 const shop: BlogShop = shopJson;
-const sanityModulePath = require.resolve("@acme/sanity");
-
 export default async function BlogPostPage({
   params,
 }: {
   params: { lang: string; slug: string };
 }) {
   if (!shop.luxuryFeatures.blog) {
-    notFound();
-    return null;
+    return notFound();
   }
   const post = await fetchPostBySlug(shop.id, params.slug);
   if (!(fetchPostBySlug as any).mock) {
@@ -25,8 +22,7 @@ export default async function BlogPostPage({
     }
   }
   if (!post) {
-    notFound();
-    return null;
+    return notFound();
   }
   return (
     <article className="space-y-4">

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -184,6 +184,8 @@ const config = {
     '^@acme/platform-core/(.*)\\.js$': ' /packages/platform-core/src/$1',
     '^@acme/platform-core/(.*)$': ' /packages/platform-core/src/$1',
     '^@acme/platform-core/contexts/CurrencyContext$': ' /test/__mocks__/currencyContextMock.tsx',
+    '^@acme/sanity$': ' /packages/sanity/src/index.ts',
+    '^@acme/sanity/(.*)$': ' /packages/sanity/src/$1',
     '^@acme/platform-machine/src/(.*)$': ' /packages/platform-machine/src/$1',
     '^@acme/shared-utils/src/(.*)$': ' /packages/shared-utils/src/$1',
     '^@acme/plugin-sanity$': ' /test/__mocks__/pluginSanityStub.ts',


### PR DESCRIPTION
## Summary
- ensure blog post pages return 404 when blog disabled or post missing
- map `@acme/sanity` for Jest to aid mocking in tests

## Testing
- `pnpm -r build` *(fails: Type 'null' is not assignable...)*
- `CI=1 pnpm exec jest apps/shop-bcd/__tests__/blog-pages.test.tsx --runInBand` *(fails: fetchPostBySlug mock not called)*
- `CI=1 pnpm exec jest apps/shop-bcd/__tests__/account-profile-api.integration.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68c6b00405f0832fb6a98c27df67dff0