### PR TITLE
Simplify generateStaticParams test for shop-bcd

### DIFF
--- a/apps/shop-bcd/__tests__/generateStaticParams.test.ts
+++ b/apps/shop-bcd/__tests__/generateStaticParams.test.ts
@@ -1,13 +1,10 @@
 // apps/shop-bcd/__tests__/generateStaticParams.test.ts
-jest.mock("@acme/i18n", () => ({
-  LOCALES: ["en", "de"],
-}));
-
 import generateStaticParams from "../src/app/[lang]/generateStaticParams";
+import { LOCALES } from "@acme/i18n";
 
 test("returns locales as lang objects", () => {
-  expect(generateStaticParams()).toEqual([
-    { lang: "en" },
-    { lang: "de" },
-  ]);
+  expect(generateStaticParams()).toEqual(
+    LOCALES.map((lang) => ({ lang }))
+  );
 });
+


### PR DESCRIPTION
## Summary
- remove unnecessary i18n mock
- test generateStaticParams using real locales

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: packages/template-app build: Failed)*
- `pnpm test __tests__/generateStaticParams.test.ts` *(hangs while running)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b291ac04832fb4bb72b07d432c03