### PR TITLE
test: add EditPreviewPage tests

### DIFF
--- a/apps/cms/__tests__/editPreviewPage.test.tsx
+++ b/apps/cms/__tests__/editPreviewPage.test.tsx
@@ -1,0 +1,38 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { promises as fs } from "fs";
+
+// Path to component relative to this test file
+import EditPreviewPage from "../src/app/cms/shop/[shop]/edit-preview/EditPreviewPage";
+
+describe("EditPreviewPage", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders list of changed components", async () => {
+    jest
+      .spyOn(fs, "readFile")
+      .mockResolvedValue(
+        JSON.stringify({
+          components: [
+            { file: "a.tsx", componentName: "CompA" },
+            { file: "b.tsx", componentName: "CompB" },
+          ],
+        }),
+      );
+
+    const Page = await EditPreviewPage({ shop: "demo" });
+    render(Page);
+    expect(screen.getByText("CompA")).toBeInTheDocument();
+    expect(screen.getByText("CompB")).toBeInTheDocument();
+  });
+
+  it("renders fallback when no changes", async () => {
+    jest.spyOn(fs, "readFile").mockRejectedValue(new Error("not found"));
+    const Page = await EditPreviewPage({ shop: "demo" });
+    render(Page);
+    expect(screen.getByText("No changes.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for EditPreviewPage listing and fallback

## Testing
- `pnpm install`
- `pnpm -r build` (failed: TypeScript errors in packages/platform-core)
- `pnpm --filter @apps/cms test editPreviewPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6ba4bd764832f8a6cf9e7346b6b5e