### PR TITLE
test: cover discounts page interactions

### DIFF
--- a/apps/cms/__tests__/discountsPage.test.tsx
+++ b/apps/cms/__tests__/discountsPage.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DiscountsPage from "../src/app/cms/marketing/discounts/page";
+
+describe("DiscountsPage", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    // @ts-expect-error jsdom window
+    window.fetch = originalFetch;
+  });
+
+  test("handles creating, toggling, deleting, and empty state", async () => {
+    let discounts: any[] = [];
+
+    const fetchMock = jest.fn(
+      async (url: RequestInfo, options?: RequestInit) => {
+        const method = options?.method ?? "GET";
+        const u = typeof url === "string" ? url : url.toString();
+
+        if (u.startsWith("/api/marketing/discounts")) {
+          if (method === "GET") {
+            return { ok: true, json: async () => [...discounts] } as any;
+          }
+          if (method === "POST") {
+            const body = JSON.parse(options!.body as string);
+            const entry = {
+              code: body.code,
+              description: body.description,
+              discountPercent: body.discountPercent,
+              active: true,
+            };
+            const idx = discounts.findIndex((d) => d.code === body.code);
+            if (idx >= 0) discounts[idx] = entry;
+            else discounts.push(entry);
+            discounts = [...discounts];
+            return { ok: true, json: async () => ({}) } as any;
+          }
+          if (method === "PUT") {
+            const body = JSON.parse(options!.body as string);
+            const idx = discounts.findIndex((d) => d.code === body.code);
+            if (idx >= 0) {
+              discounts[idx] = { ...discounts[idx], active: body.active };
+              discounts = [...discounts];
+            }
+            return { ok: true, json: async () => ({}) } as any;
+          }
+          if (method === "DELETE") {
+            const urlObj = new URL(u, "http://localhost");
+            const code = urlObj.searchParams.get("code");
+            discounts = discounts.filter((d) => d.code !== code);
+            return { ok: true, json: async () => ({}) } as any;
+          }
+        }
+
+        throw new Error(`Unhandled fetch call: ${u}`);
+      },
+    );
+
+    global.fetch = fetchMock as any;
+    // @ts-expect-error jsdom window
+    window.fetch = fetchMock as any;
+
+    const user = userEvent.setup();
+    render(<DiscountsPage />);
+
+    // initial empty state
+    expect(await screen.findByText("No discounts.")).toBeInTheDocument();
+
+    // create a discount
+    await user.type(screen.getByPlaceholderText("Code"), "SAVE10");
+    await user.type(screen.getByPlaceholderText("Description"), "10% off");
+    const percent = screen.getByPlaceholderText("Discount %");
+    await user.clear(percent);
+    await user.type(percent, "10");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(await screen.findByText("SAVE10")).toBeInTheDocument();
+
+    // toggle activation
+    await user.click(screen.getByRole("button", { name: "Active" }));
+    expect(await screen.findByRole("button", { name: "Inactive" })).toBeInTheDocument();
+
+    // delete the discount
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(await screen.findByText("No discounts.")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add CMS discounts page test covering create, toggle, delete and empty fallback

## Testing
- `pnpm install`
- `pnpm -r build` (fails: TypeScript errors)
- `pnpm --filter @apps/cms test -- apps/cms/__tests__/discountsPage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c6ba3c46b4832f94203ca993f5bbeb