### PR TITLE
test: add coverage for cms pages

### DIFF
--- a/apps/cms/src/app/cms/blog/posts/[id]/page.test.tsx
+++ b/apps/cms/src/app/cms/blog/posts/[id]/page.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { notFound } from "next/navigation";
+import { getPost } from "@cms/actions/blog.server";
+import { getSanityConfig } from "@platform-core/shops";
+import { getShopById } from "@platform-core/repositories/shop.server";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("next/navigation", () => ({ notFound: jest.fn() }));
+
+jest.mock("@cms/actions/blog.server", () => ({
+  getPost: jest.fn(),
+  updatePost: jest.fn(),
+}));
+
+jest.mock("@platform-core/shops", () => ({ getSanityConfig: jest.fn() }));
+
+jest.mock("@platform-core/repositories/shop.server", () => ({
+  getShopById: jest.fn(),
+}));
+
+jest.mock("../PostForm.client", () => ({
+  __esModule: true,
+  default: () => <div data-cy="post-form" />,
+}));
+
+jest.mock("../PublishButton.client", () => ({
+  __esModule: true,
+  default: () => <button data-cy="publish" />,
+}));
+
+jest.mock("../UnpublishButton.client", () => ({
+  __esModule: true,
+  default: () => <button data-cy="unpublish" />,
+}));
+
+jest.mock("../DeleteButton.client", () => ({
+  __esModule: true,
+  default: () => <button data-cy="delete" />,
+}));
+
+jest.mock("@acme/date-utils", () => ({
+  formatTimestamp: (ts: string) => `formatted ${ts}`,
+}));
+
+const mockNotFound = notFound as unknown as jest.Mock;
+const mockGetShop = getShopById as jest.Mock;
+const mockGetSanity = getSanityConfig as jest.Mock;
+const mockGetPost = getPost as jest.Mock;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("calls notFound when shopId missing", async () => {
+  const { default: Page } = await import("./page");
+  await Page({ params: { id: "1" }, searchParams: {} });
+  expect(mockNotFound).toHaveBeenCalled();
+});
+
+it("shows connect link when Sanity not configured", async () => {
+  mockGetShop.mockResolvedValue({ id: "s1" });
+  mockGetSanity.mockReturnValue(null);
+  const { default: Page } = await import("./page");
+  render(
+    await Page({ params: { id: "1" }, searchParams: { shopId: "s1" } })
+  );
+  expect(
+    screen.getByText("Sanity is not connected.")
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "Connect Sanity" })
+  ).toHaveAttribute("href", "/cms/blog/sanity/connect?shopId=s1");
+});
+
+it("renders post form when post exists", async () => {
+  mockGetShop.mockResolvedValue({ id: "s1" });
+  mockGetSanity.mockReturnValue({});
+  mockGetPost.mockResolvedValue({
+    _id: "p1",
+    published: true,
+    publishedAt: undefined,
+  });
+  const { default: Page } = await import("./page");
+  render(
+    await Page({ params: { id: "p1" }, searchParams: { shopId: "s1" } })
+  );
+  expect(screen.getByText("Edit Post")).toBeInTheDocument();
+  expect(screen.getByTestId("post-form")).toBeInTheDocument();
+  expect(screen.getByTestId("unpublish")).toBeInTheDocument();
+});
+
+it("calls notFound when post does not exist", async () => {
+  mockGetShop.mockResolvedValue({ id: "s1" });
+  mockGetSanity.mockReturnValue({});
+  mockGetPost.mockResolvedValue(null);
+  const { default: Page } = await import("./page");
+  await Page({ params: { id: "missing" }, searchParams: { shopId: "s1" } });
+  expect(mockNotFound).toHaveBeenCalled();
+});
+

--- a/apps/cms/src/app/cms/blog/posts/new/page.test.tsx
+++ b/apps/cms/src/app/cms/blog/posts/new/page.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { getSanityConfig } from "@platform-core/shops";
+import { getShopById } from "@platform-core/repositories/shop.server";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("@cms/actions/blog.server", () => ({
+  createPost: jest.fn(),
+}));
+
+jest.mock("@platform-core/shops", () => ({ getSanityConfig: jest.fn() }));
+
+jest.mock("@platform-core/repositories/shop.server", () => ({
+  getShopById: jest.fn(),
+}));
+
+jest.mock("../PostForm.client", () => ({
+  __esModule: true,
+  default: () => <div data-cy="post-form" />,
+}));
+
+const mockGetShop = getShopById as jest.Mock;
+const mockGetSanity = getSanityConfig as jest.Mock;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("shows message when no shop selected", async () => {
+  const { default: Page } = await import("./page");
+  render(await Page({ searchParams: {} }));
+  expect(screen.getByText("No shop selected.")).toBeInTheDocument();
+});
+
+it("shows connect link when Sanity not configured", async () => {
+  mockGetShop.mockResolvedValue({ id: "s1" });
+  mockGetSanity.mockReturnValue(null);
+  const { default: Page } = await import("./page");
+  render(await Page({ searchParams: { shopId: "s1" } }));
+  expect(screen.getByText("Sanity is not connected.")).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "Connect Sanity" })
+  ).toHaveAttribute("href", "/cms/blog/sanity/connect?shopId=s1");
+});
+
+it("renders form when sanity configured", async () => {
+  mockGetShop.mockResolvedValue({ id: "s1" });
+  mockGetSanity.mockReturnValue({});
+  const { default: Page } = await import("./page");
+  render(await Page({ searchParams: { shopId: "s1" } }));
+  expect(screen.getByText("New Post")).toBeInTheDocument();
+  expect(screen.getByTestId("post-form")).toBeInTheDocument();
+});
+

--- a/apps/cms/src/app/cms/campaigns/page.test.tsx
+++ b/apps/cms/src/app/cms/campaigns/page.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import CampaignPage from "./page";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("CampaignPage", () => {
+  it("shows Sent on success", async () => {
+    (global.fetch as any) = jest.fn().mockResolvedValue({ ok: true });
+    render(<CampaignPage />);
+    await userEvent.type(screen.getByPlaceholderText("Recipient"), "a@b.com");
+    await userEvent.type(screen.getByPlaceholderText("Subject"), "Hello");
+    await userEvent.type(screen.getByPlaceholderText("HTML body"), "Body");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/campaigns",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(await screen.findByText("Sent")).toBeInTheDocument();
+  });
+
+  it("shows Failed on error", async () => {
+    (global.fetch as any) = jest.fn().mockResolvedValue({ ok: false });
+    render(<CampaignPage />);
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByText("Failed")).toBeInTheDocument();
+  });
+});
+

--- a/apps/cms/src/app/cms/configurator/[stepId]/page.test.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/page.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("../ConfiguratorContext", () => ({
+  ConfiguratorProvider: ({ children }: any) => (
+    <div data-cy="provider">{children}</div>
+  ),
+}));
+
+jest.mock("./step-page", () => ({
+  __esModule: true,
+  default: ({ stepId }: any) => <div data-cy="step-page">{stepId}</div>,
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("wraps StepPage with provider", async () => {
+  const { default: Page } = await import("./page");
+  render(<Page params={{ stepId: "abc" }} />);
+  expect(screen.getByTestId("provider")).toBeInTheDocument();
+  expect(screen.getByTestId("step-page")).toHaveTextContent("abc");
+});
+

--- a/apps/cms/src/app/cms/configurator/[stepId]/step-page.test.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/step-page.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import StepPage from "./step-page";
+
+jest.mock("../ConfiguratorContext", () => ({
+  useConfigurator: () => ({ state: { completed: {} } }),
+}));
+
+jest.mock("../steps", () => ({
+  ConfiguratorProgress: ({ currentStepId }: any) => (
+    <div data-cy="progress">{currentStepId}</div>
+  ),
+  getSteps: () => [
+    { id: "prev" },
+    { id: "current" },
+    { id: "next" },
+  ],
+  stepIndex: { current: 1 },
+  steps: {
+    current: {
+      id: "current",
+      component: ({ prevStepId, nextStepId }: any) => (
+        <div data-cy="step" data-prev={prevStepId} data-next={nextStepId} />
+      ),
+    },
+  },
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("returns null for unknown step", () => {
+  const { container } = render(<StepPage stepId="missing" />);
+  expect(container.firstChild).toBeNull();
+});
+
+it("renders progress and step component", () => {
+  render(<StepPage stepId="current" />);
+  expect(screen.getByTestId("progress")).toHaveTextContent("current");
+  const step = screen.getByTestId("step");
+  expect(step.getAttribute("data-prev")).toBe("prev");
+  expect(step.getAttribute("data-next")).toBe("next");
+});
+

--- a/apps/cms/src/app/cms/dashboard/[shop]/page.test.tsx
+++ b/apps/cms/src/app/cms/dashboard/[shop]/page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { listEvents, readAggregates } from "@platform-core/repositories/analytics.server";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { buildMetrics } from "@cms/lib/analytics";
+
+jest.mock("@platform-core/repositories/analytics.server", () => ({
+  listEvents: jest.fn(),
+  readAggregates: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  readShop: jest.fn(),
+}));
+
+jest.mock("@cms/lib/analytics", () => ({
+  buildMetrics: jest.fn(),
+}));
+
+jest.mock("./components/CampaignFilter.client", () => ({
+  __esModule: true,
+  CampaignFilter: ({ campaigns }: any) => (
+    <div data-cy="campaign-filter">{campaigns.join(",")}</div>
+  ),
+}));
+
+jest.mock("./components/Charts.client", () => ({
+  __esModule: true,
+  Charts: () => <div data-cy="charts" />,
+}));
+
+jest.mock("@acme/ui", () => ({
+  Progress: () => <div data-cy="progress" />,
+}));
+
+const mockListEvents = listEvents as jest.Mock;
+const mockReadAggregates = readAggregates as jest.Mock;
+const mockReadShop = readShop as jest.Mock;
+const mockBuildMetrics = buildMetrics as jest.Mock;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("renders campaign filter and charts", async () => {
+  mockListEvents.mockResolvedValue([{ campaign: "A" }]);
+  mockReadAggregates.mockResolvedValue({});
+  mockReadShop.mockResolvedValue({ domain: { name: "example.com", status: "active" } });
+  mockBuildMetrics.mockReturnValue({
+    traffic: [],
+    sales: [],
+    conversion: [],
+    emailOpens: [],
+    emailClicks: [],
+    campaignSales: [],
+    discountRedemptions: [],
+    discountRedemptionsByCode: [],
+    aiCrawl: [],
+    topDiscountCodes: [],
+    totals: {
+      emailOpens: 0,
+      emailClicks: 0,
+      campaignSales: 0,
+      discountRedemptions: 0,
+      aiCrawl: 0,
+    },
+    maxTotal: 1,
+  });
+
+  const { default: Page } = await import("./page");
+  render(
+    await Page({ params: { shop: "s1" }, searchParams: {} })
+  );
+
+  expect(screen.getByText("Dashboard: s1")).toBeInTheDocument();
+  expect(screen.getByTestId("campaign-filter")).toHaveTextContent("A");
+  expect(screen.getByTestId("charts")).toBeInTheDocument();
+});
+

--- a/apps/cms/src/app/cms/dashboard/page.test.tsx
+++ b/apps/cms/src/app/cms/dashboard/page.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { listShops } from "../../../lib/listShops";
+
+jest.mock("../../../lib/listShops", () => ({ listShops: jest.fn() }));
+
+const mockList = listShops as jest.Mock;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it("renders shop links", async () => {
+  mockList.mockResolvedValue(["one", "two"]);
+  const { default: Page } = await import("./page");
+  render(await Page());
+  expect(screen.getByText("Choose a shop")).toBeInTheDocument();
+  const link = screen.getByRole("link", { name: "one" });
+  expect(link).toHaveAttribute("href", "/cms/dashboard/one");
+  expect(screen.getByRole("link", { name: "two" })).toBeInTheDocument();
+});
+
+it("shows message when no shops", async () => {
+  mockList.mockResolvedValue([]);
+  const { default: Page } = await import("./page");
+  render(await Page());
+  expect(screen.getByText("No shops found.")).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- add tests for CMS blog post pages, campaigns, configurator steps, and dashboards

## Testing
- `pnpm --filter @apps/cms exec jest --runInBand --coverage=false apps/cms/src/app/cms/blog/posts/new/page.test.tsx apps/cms/src/app/cms/campaigns/page.test.tsx apps/cms/src/app/cms/configurator/[stepId]/step-page.test.tsx apps/cms/src/app/cms/configurator/[stepId]/page.test.tsx apps/cms/src/app/cms/dashboard/page.test.tsx apps/cms/src/app/cms/dashboard/[shop]/page.test.tsx apps/cms/src/app/cms/blog/posts/[id]/page.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c6b9343404832f9a81dd32ae487093