### PR TITLE
test: add CampaignFilter client tests

### DIFF
--- a/apps/cms/__tests__/CampaignFilter.client.test.tsx
+++ b/apps/cms/__tests__/CampaignFilter.client.test.tsx
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CampaignFilter } from "../src/app/cms/dashboard/[shop]/components/CampaignFilter.client";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+describe("CampaignFilter", () => {
+  it("updates router query string when options are selected and deselected", () => {
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    (usePathname as jest.Mock).mockReturnValue("/cms/dashboard/test");
+    (useSearchParams as jest.Mock).mockReturnValue(
+      new URLSearchParams() as unknown as ReadonlyURLSearchParams,
+    );
+
+    render(<CampaignFilter campaigns={["spring", "summer"]} />);
+    const select = screen.getByRole<HTMLSelectElement>("listbox");
+    const [spring, summer] = Array.from(select.options);
+
+    spring.selected = true;
+    fireEvent.change(select);
+    expect(push).toHaveBeenCalledWith("/cms/dashboard/test?campaign=spring");
+
+    push.mockClear();
+    spring.selected = true;
+    summer.selected = true;
+    fireEvent.change(select);
+    expect(push).toHaveBeenCalledWith(
+      "/cms/dashboard/test?campaign=spring&campaign=summer",
+    );
+
+    push.mockClear();
+    spring.selected = false;
+    summer.selected = false;
+    fireEvent.change(select);
+    expect(push).toHaveBeenCalledWith("/cms/dashboard/test");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add client-side tests for CampaignFilter to verify query updates when selecting and deselecting campaigns

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*
- `pnpm --filter @apps/cms test apps/cms/__tests__/CampaignFilter.client.test.tsx` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba3781d8832f894b0cc2d621d601