### PR TITLE
test(cms): add charts client test

### DIFF
--- a/apps/cms/__tests__/Charts.client.test.tsx
+++ b/apps/cms/__tests__/Charts.client.test.tsx
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render } from "@testing-library/react";
+import type { Series, MultiSeries } from "../src/lib/analytics";
+
+const lineProps: any[] = [];
+jest.mock("react-chartjs-2", () => ({
+  Line: (props: any) => {
+    lineProps.push(props);
+    return null;
+  },
+}));
+
+import { Charts } from "../src/app/cms/dashboard/[shop]/components/Charts.client";
+
+describe("Charts", () => {
+  it("renders charts with correct labels and colors", () => {
+    const series: Series = { labels: ["Jan", "Feb"], data: [1, 2] };
+    const multi: MultiSeries = {
+      labels: ["Jan", "Feb"],
+      datasets: [
+        { label: "Code1", data: [1, 2] },
+        { label: "Code2", data: [3, 4] },
+      ],
+    };
+
+    render(
+      <Charts
+        traffic={series}
+        conversion={series}
+        sales={series}
+        emailOpens={series}
+        emailClicks={series}
+        campaignSales={series}
+        discountRedemptions={series}
+        discountRedemptionsByCode={multi}
+        aiCrawl={series}
+      />,
+    );
+
+    expect(lineProps).toHaveLength(9);
+
+    const expectedColors = [
+      "rgb(75, 192, 192)",
+      "rgb(153, 102, 255)",
+      "rgb(255, 99, 132)",
+      "rgb(54, 162, 235)",
+      "rgb(255, 205, 86)",
+      "rgb(255, 159, 64)",
+      "rgb(201, 203, 207)",
+      null,
+      "rgb(99, 132, 255)",
+    ];
+
+    for (let i = 0; i < expectedColors.length; i++) {
+      if (expectedColors[i]) {
+        expect(lineProps[i].data.labels).toEqual(series.labels);
+        expect(lineProps[i].data.datasets[0].borderColor).toBe(
+          expectedColors[i],
+        );
+      }
+    }
+
+    expect(lineProps[7].data.labels).toEqual(multi.labels);
+    expect(lineProps[7].data.datasets[0].borderColor).toBe(
+      "rgb(255, 99, 132)",
+    );
+    expect(lineProps[7].data.datasets[1].borderColor).toBe(
+      "rgb(54, 162, 235)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- test Charts component renders data with correct labels and colors

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @apps/cms test __tests__/Charts.client.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c6ba38b814832fb9ea93f002ef7f32