### PR TITLE
test: track design system import view

### DIFF
--- a/apps/cms/__tests__/designSystemImportPage.test.tsx
+++ b/apps/cms/__tests__/designSystemImportPage.test.tsx
@@ -1,0 +1,30 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+
+const track = jest.fn();
+
+jest.mock("@acme/telemetry", () => ({
+  track,
+}));
+
+jest.mock("@acme/i18n", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import DesignSystemImportPage from "../src/app/cms/shop/[shop]/import/design-system/page";
+
+describe("DesignSystemImportPage", () => {
+  afterEach(() => {
+    track.mockClear();
+  });
+
+  it("tracks page view once", async () => {
+    render(<DesignSystemImportPage />);
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenCalledWith("designsystem:import:view", {});
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test design system import page telemetry

## Testing
- `pnpm --filter @apps/cms exec jest __tests__/designSystemImportPage.test.tsx --config jest.config.cjs --coverage=false`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba4d59e4832fbd8dab1b4a36b9ea