### PR TITLE
test: add seo editor tests

### DIFF
--- a/apps/cms/__tests__/seoEditor.test.tsx
+++ b/apps/cms/__tests__/seoEditor.test.tsx
@@ -1,0 +1,146 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SeoEditor from "../src/app/cms/shop/[shop]/settings/seo/SeoEditor";
+
+const setFreezeTranslationsMock = jest.fn();
+const updateSeoMock = jest.fn();
+
+jest.mock("@cms/actions/shops.server", () => ({
+  setFreezeTranslations: (...args: unknown[]) => setFreezeTranslationsMock(...args),
+  updateSeo: (...args: unknown[]) => updateSeoMock(...args),
+}));
+
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => {
+    return {
+      Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+      Input: (props: any) => <input {...props} />,
+      Textarea: (props: any) => <textarea {...props} />,
+    };
+  },
+  { virtual: true },
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (global as any).fetch = jest.fn();
+});
+
+describe("SeoEditor", () => {
+  it("updates fields when switching locale without freeze", async () => {
+    const user = userEvent.setup();
+    render(
+      <SeoEditor
+        shop="s1"
+        languages={["en", "fr"]}
+        initialSeo={{
+          en: { title: "Hello", description: "Desc EN", canonicalBase: "en.com" },
+          fr: { title: "Bonjour", description: "Desc FR", canonicalBase: "fr.com" },
+        }}
+      />,
+    );
+
+    const localeSelect = screen.getByRole("combobox");
+    expect(screen.getByLabelText("Title")).toHaveValue("Hello");
+
+    await user.selectOptions(localeSelect, "fr");
+
+    expect(screen.getByLabelText("Title")).toHaveValue("Bonjour");
+    expect(screen.getByLabelText("Description")).toHaveValue("Desc FR");
+  });
+
+  it("keeps fields when switching locale with freeze enabled", async () => {
+    const user = userEvent.setup();
+    render(
+      <SeoEditor
+        shop="s1"
+        languages={["en", "fr"]}
+        initialSeo={{
+          en: { title: "Hello", description: "Desc EN", canonicalBase: "en.com" },
+          fr: { title: "Bonjour", description: "Desc FR", canonicalBase: "fr.com" },
+        }}
+      />,
+    );
+
+    const freezeCheckbox = screen.getByRole("checkbox", {
+      name: /freeze translations/i,
+    });
+    await user.click(freezeCheckbox);
+    expect(setFreezeTranslationsMock).toHaveBeenCalledWith("s1", true);
+
+    const titleInput = screen.getByLabelText("Title");
+    await user.clear(titleInput);
+    await user.type(titleInput, "Custom");
+
+    await user.selectOptions(screen.getByRole("combobox"), "fr");
+
+    expect(titleInput).toHaveValue("Custom");
+    expect(screen.getByLabelText("Canonical Base")).toHaveValue("fr.com");
+  });
+
+  it("generates metadata", async () => {
+    const user = userEvent.setup();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        title: "Gen title",
+        description: "Gen description",
+        alt: "Gen alt",
+        image: "img.png",
+      }),
+    });
+
+    render(
+      <SeoEditor shop="s1" languages={["en"]} initialSeo={{ en: {} }} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /generate metadata/i }));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/seo/generate",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+
+    expect(screen.getByLabelText("Title")).toHaveValue("Gen title");
+    expect(screen.getByLabelText("Description")).toHaveValue("Gen description");
+    expect(screen.getByLabelText("Image URL")).toHaveValue("img.png");
+    expect(screen.getByLabelText("Image Alt")).toHaveValue("Gen alt");
+  });
+
+  it("shows errors from save", async () => {
+    const user = userEvent.setup();
+    updateSeoMock.mockResolvedValueOnce({
+      errors: { title: ["Too short"] },
+    });
+
+    render(
+      <SeoEditor shop="s1" languages={["en"]} initialSeo={{ en: {} }} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(updateSeoMock).toHaveBeenCalled();
+    expect(await screen.findByText("Too short")).toBeInTheDocument();
+  });
+
+  it("shows warnings from save", async () => {
+    const user = userEvent.setup();
+    updateSeoMock.mockResolvedValueOnce({
+      warnings: ["Check alt text"],
+    });
+
+    render(
+      <SeoEditor shop="s1" languages={["en"]} initialSeo={{ en: {} }} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(updateSeoMock).toHaveBeenCalled();
+    expect(await screen.findByText("Check alt text")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for SEO editor covering locale switching, metadata generation, and save validation

## Testing
- `pnpm install --ignore-scripts`
- `pnpm -r build` (fails: Type 'null' is not assignable...)
- `pnpm test:cms apps/cms/__tests__/seoEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6ba851f70832fab4a6e5caa5befc3