### PR TITLE
test: add createShop service tests

### DIFF
--- a/apps/cms/src/app/cms/wizard/services/__tests__/createShop.test.ts
+++ b/apps/cms/src/app/cms/wizard/services/__tests__/createShop.test.ts
@@ -1,0 +1,107 @@
+import { createShop } from "../createShop";
+import { validateShopName } from "@platform-core/shops";
+import { createShopOptionsSchema } from "@platform-core/createShop/schema";
+
+jest.mock("@platform-core/shops", () => ({
+  validateShopName: jest.fn(),
+}));
+
+jest.mock("@platform-core/createShop/schema", () => ({
+  createShopOptionsSchema: { safeParse: jest.fn() },
+}));
+
+describe("createShop", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (validateShopName as jest.Mock).mockImplementation(() => {});
+    global.fetch = jest.fn() as any;
+  });
+
+  const baseState: any = {
+    storeName: "Store",
+    logo: {},
+    contactInfo: "",
+    type: "sale",
+    template: "temp",
+    theme: "theme",
+    payment: {},
+    shipping: {},
+    pageTitle: {},
+    pageDescription: {},
+    socialImage: "",
+    navItems: [],
+    pages: [],
+    checkoutComponents: [],
+    analyticsProvider: "",
+    analyticsId: "",
+  };
+
+  it("returns error for invalid shop name", async () => {
+    (validateShopName as jest.Mock).mockImplementation(() => {
+      throw new Error("bad name");
+    });
+
+    const result = await createShop("bad", baseState);
+
+    expect(result).toEqual({ ok: false, error: "bad name" });
+    expect(createShopOptionsSchema.safeParse).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns fieldErrors when schema validation fails", async () => {
+    (createShopOptionsSchema.safeParse as jest.Mock).mockReturnValue({
+      success: false,
+      error: {
+        issues: [
+          { path: ["name"], message: "Required" },
+          { path: ["shipping", "provider"], message: "Invalid" },
+        ],
+      },
+    });
+
+    const result = await createShop("shop", baseState);
+
+    expect(result).toEqual({
+      ok: false,
+      fieldErrors: {
+        name: ["Required"],
+        "shipping.provider": ["Invalid"],
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns deployment when fetch succeeds", async () => {
+    (createShopOptionsSchema.safeParse as jest.Mock).mockReturnValue({
+      success: true,
+      data: {},
+    });
+
+    const deployment = { id: "dep" };
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ deployment }),
+    });
+
+    const result = await createShop("shop", baseState);
+
+    expect(result).toEqual({ ok: true, deployment });
+  });
+
+  it("returns error when fetch fails", async () => {
+    (createShopOptionsSchema.safeParse as jest.Mock).mockReturnValue({
+      success: true,
+      data: {},
+    });
+
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "fail" }),
+    });
+
+    const result = await createShop("shop", baseState);
+
+    expect(result).toEqual({ ok: false, error: "fail" });
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover createShop service edge cases
- exercise happy and error paths via mocked dependencies

## Testing
- `pnpm --filter cms test src/app/cms/wizard/services/__tests__/createShop.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6badb5854832f9afe9f3ae8f739e7