### PR TITLE
test: add initShop service tests

### DIFF
--- a/apps/cms/src/app/cms/wizard/services/__tests__/initShop.test.ts
+++ b/apps/cms/src/app/cms/wizard/services/__tests__/initShop.test.ts
@@ -1,0 +1,55 @@
+jest.mock("@platform-core/shops", () => ({
+  validateShopName: jest.fn(),
+}));
+
+import { Buffer } from "buffer";
+import { validateShopName } from "@platform-core/shops";
+
+describe("initShop", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (validateShopName as jest.Mock).mockImplementation(() => {});
+    global.fetch = jest.fn() as any;
+  });
+
+  it("converts CSV file to base64 via Buffer", async () => {
+    const data = "id,name\n1,2";
+    const arrayBuffer = new TextEncoder().encode(data).buffer;
+    const file = { arrayBuffer: jest.fn().mockResolvedValue(arrayBuffer) } as any;
+    const fromSpy = jest.spyOn(Buffer, "from");
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const { initShop } = await import("../initShop");
+    await initShop("shop", file);
+    expect(file.arrayBuffer).toHaveBeenCalled();
+    expect(fromSpy).toHaveBeenCalled();
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.csv).toBe(Buffer.from(data).toString("base64"));
+    fromSpy.mockRestore();
+  });
+
+  it("parses comma and newline separated categories", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const { initShop } = await import("../initShop");
+    await initShop("shop", undefined, "a, b\nc\n\n d ");
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.categories).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns ok true on fetch success", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const { initShop } = await import("../initShop");
+    const result = await initShop("shop");
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns ok false and error on fetch failure", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "fail" }),
+    });
+    const { initShop } = await import("../initShop");
+    const result = await initShop("shop");
+    expect(result).toEqual({ ok: false, error: "fail" });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for initShop service

## Testing
- `pnpm --filter cms test src/app/cms/wizard/services/__tests__/initShop.test.ts` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c6badeb880832f889d83b58d1db6ae