### PR TITLE
test: add plugin page interactions test

### DIFF
--- a/apps/cms/__tests__/pluginsPage.test.tsx
+++ b/apps/cms/__tests__/pluginsPage.test.tsx
@@ -1,0 +1,46 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@platform-core/plugins", () => ({
+  loadPlugins: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: any; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import PluginsPage from "../src/app/cms/plugins/page";
+
+describe("PluginsPage", () => {
+  it("toggles plugin config textarea and updates state", async () => {
+    const samplePlugins = [
+      { id: "p1", name: "Test Plugin", defaultConfig: { foo: "bar" } },
+    ];
+    const { loadPlugins } = require("@platform-core/plugins");
+    loadPlugins.mockResolvedValue(samplePlugins);
+
+    render(await PluginsPage());
+
+    const user = userEvent.setup();
+
+    const checkbox = screen.getByRole("checkbox", { name: "Test Plugin" });
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    await user.click(checkbox);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue(
+      JSON.stringify(samplePlugins[0].defaultConfig, null, 2)
+    );
+
+    await user.clear(textarea);
+    await user.type(textarea, "updated");
+    expect(textarea).toHaveValue("updated");
+
+    await user.click(checkbox);
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add test for CMS plugins page

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type)*
- `pnpm --filter @apps/cms test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ba3fc3b4832faa297923e6e489ad