### PR TITLE
feat(cms): add late fee settings and audit

### DIFF
--- a/apps/cms/src/actions/shops.server.ts
+++ b/apps/cms/src/actions/shops.server.ts
@@ -11,6 +11,7 @@ import {
   setFreezeTranslations as serviceSetFreezeTranslations,
   updateCurrencyAndTax as serviceUpdateCurrencyAndTax,
   updateDeposit as serviceUpdateDeposit,
+  updateLateFee as serviceUpdateLateFee,
   updateReverseLogistics as serviceUpdateReverseLogistics,
   updateUpsReturns as serviceUpdateUpsReturns,
   updatePremierDelivery as serviceUpdatePremierDelivery,
@@ -63,6 +64,10 @@ export async function updateCurrencyAndTax(
 
 export async function updateDeposit(shop: string, formData: FormData) {
   return serviceUpdateDeposit(shop, formData);
+}
+
+export async function updateLateFee(shop: string, formData: FormData) {
+  return serviceUpdateLateFee(shop, formData);
 }
 
 export async function updateReverseLogistics(shop: string, formData: FormData) {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/LateFeesEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/LateFeesEditor.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Button, Checkbox, Input } from "@ui/components/atoms/shadcn";
+import { updateLateFee } from "@cms/actions/shops.server";
+import { useState, type ChangeEvent, type FormEvent } from "react";
+
+interface Props {
+  shop: string;
+  initial: { enabled: boolean; intervalMinutes: number };
+}
+
+export default function LateFeesEditor({ shop, initial }: Props) {
+  const [state, setState] = useState(initial);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setState((s) => ({ ...s, [name]: Number(value) }));
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+
+    const fd = new FormData();
+    if (state.enabled) {
+      fd.set("enabled", "on");
+    }
+    fd.set("intervalMinutes", String(state.intervalMinutes));
+    const result = await updateLateFee(shop, fd);
+    if (result.errors) {
+      setErrors(result.errors);
+    } else if (result.settings?.lateFeeService) {
+      setState(result.settings.lateFeeService);
+      setErrors({});
+    }
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="grid max-w-md gap-4">
+      <label className="flex items-center gap-2">
+        <Checkbox
+          name="enabled"
+          checked={state.enabled}
+          onCheckedChange={(v: boolean) =>
+            setState((s) => ({ ...s, enabled: Boolean(v) }))
+          }
+        />
+        <span>Enable late fee service</span>
+      </label>
+      <label className="flex flex-col gap-1">
+        <span>Interval (minutes)</span>
+        <Input
+          type="number"
+          name="intervalMinutes"
+          value={state.intervalMinutes}
+          onChange={handleChange}
+        />
+        {errors.intervalMinutes && (
+          <span className="text-sm text-red-600">
+            {errors.intervalMinutes.join("; ")}
+          </span>
+        )}
+      </label>
+      <Button className="bg-primary text-white" disabled={saving} type="submit">
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/LateFeesTable.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/LateFeesTable.tsx
@@ -1,0 +1,27 @@
+import { readOrders } from "@platform-core/repositories/rentalOrders.server";
+
+export default async function LateFeesTable({ shop }: { shop: string }) {
+  const orders = await readOrders(shop);
+  const charges = orders.filter((o) => o.lateFeeCharged);
+  if (charges.length === 0) {
+    return <p className="text-sm">No late fees charged.</p>;
+  }
+  return (
+    <table className="mt-4 w-full text-left text-sm">
+      <thead>
+        <tr>
+          <th className="pr-4">Order</th>
+          <th className="pr-4">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {charges.map((o) => (
+          <tr key={o.sessionId}>
+            <td className="pr-4">{o.sessionId}</td>
+            <td>${o.lateFeeCharged?.toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesEditor.test.tsx
@@ -1,0 +1,48 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LateFeesEditor from "../LateFeesEditor";
+
+const parseLateFeeForm = jest.fn(() => ({ data: { enabled: true, intervalMinutes: 5 } }));
+
+jest.mock("@cms/actions/shops.server", () => ({
+  updateLateFee: async (_shop: string, formData: FormData) => {
+    parseLateFeeForm(formData);
+    return { errors: { intervalMinutes: ["Invalid"] } };
+  },
+}));
+jest.mock("../../../../../../../services/shops/validation", () => ({ parseLateFeeForm }));
+jest.mock(
+  "@ui/components/atoms/shadcn",
+  () => ({
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Checkbox: ({ onCheckedChange, ...props }: any) => (
+      <input
+        type="checkbox"
+        onChange={(e) => onCheckedChange?.(e.target.checked)}
+        {...props}
+      />
+    ),
+    Input: (props: any) => <input {...props} />,
+  }),
+  { virtual: true },
+);
+
+describe("LateFeesEditor", () => {
+  it("submits updated values and shows validation errors", async () => {
+    render(<LateFeesEditor shop="s1" initial={{ enabled: false, intervalMinutes: 1 }} />);
+
+    await userEvent.click(screen.getByRole("checkbox"));
+    const interval = screen.getByRole("spinbutton");
+    await userEvent.clear(interval);
+    await userEvent.type(interval, "5");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(parseLateFeeForm).toHaveBeenCalledTimes(1);
+    const fd = parseLateFeeForm.mock.calls[0][0] as FormData;
+    expect(fd.get("enabled")).toBe("on");
+    expect(fd.get("intervalMinutes")).toBe("5");
+
+    expect(await screen.findByText("Invalid")).toBeInTheDocument();
+  });
+});

--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/page.tsx
@@ -1,0 +1,36 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/late-fees/page.tsx
+
+import { getSettings } from "@cms/actions/shops.server";
+import dynamic from "next/dynamic";
+import LateFeesTable from "./LateFeesTable";
+
+const LateFeesEditor = dynamic(() => import("./LateFeesEditor"));
+void LateFeesEditor;
+
+export const revalidate = 0;
+
+interface Params {
+  shop: string;
+}
+
+export default async function LateFeesSettingsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { shop } = await params;
+  const settings = await getSettings(shop);
+  const lateFeeService = settings.lateFeeService ?? {
+    enabled: false,
+    intervalMinutes: 60,
+  };
+
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Late Fees – {shop}</h2>
+      <LateFeesEditor shop={shop} initial={lateFeeService} />
+      <h3 className="mt-8 mb-2 text-lg font-semibold">Charged late fees</h3>
+      <LateFeesTable shop={shop} />
+    </div>
+  );
+}

--- a/apps/cms/src/services/shops/settingsService.ts
+++ b/apps/cms/src/services/shops/settingsService.ts
@@ -3,6 +3,7 @@ import { authorize, fetchSettings, persistSettings } from "./helpers";
 import {
   parseCurrencyTaxForm,
   parseDepositForm,
+  parseLateFeeForm,
   parseReverseLogisticsForm,
   parseUpsReturnsForm,
   parsePremierDeliveryForm,
@@ -54,6 +55,27 @@ export async function updateDeposit(
   const updated: ShopSettings = {
     ...current,
     depositService: {
+      enabled: data.enabled,
+      intervalMinutes: data.intervalMinutes,
+    },
+  };
+  await persistSettings(shop, updated);
+  return { settings: updated };
+}
+
+export async function updateLateFee(
+  shop: string,
+  formData: FormData,
+): Promise<{ settings?: ShopSettings; errors?: Record<string, string[]> }> {
+  await authorize();
+  const { data, errors } = parseLateFeeForm(formData);
+  if (!data) {
+    return { errors };
+  }
+  const current = await fetchSettings(shop);
+  const updated: ShopSettings = {
+    ...current,
+    lateFeeService: {
       enabled: data.enabled,
       intervalMinutes: data.intervalMinutes,
     },

--- a/apps/cms/src/services/shops/validation/__tests__/parseForms.test.ts
+++ b/apps/cms/src/services/shops/validation/__tests__/parseForms.test.ts
@@ -2,6 +2,7 @@ import {
   parseAiCatalogForm,
   parseCurrencyTaxForm,
   parseDepositForm,
+  parseLateFeeForm,
   parseGenerateSeoForm,
   parsePremierDeliveryForm,
   parseReverseLogisticsForm,
@@ -68,6 +69,25 @@ describe("parseDepositForm", () => {
     fd.set("enabled", "on");
     fd.set("intervalMinutes", "0");
     const result = parseDepositForm(fd);
+    expect(result.errors?.intervalMinutes).toBeDefined();
+  });
+});
+
+describe("parseLateFeeForm", () => {
+  it("parses valid data", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("intervalMinutes", "5");
+    const result = parseLateFeeForm(fd);
+    expect(result.data).toBeDefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("returns errors for invalid data", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("intervalMinutes", "0");
+    const result = parseLateFeeForm(fd);
     expect(result.errors?.intervalMinutes).toBeDefined();
   });
 });

--- a/apps/cms/src/services/shops/validation/__tests__/parseLateFeeForm.test.ts
+++ b/apps/cms/src/services/shops/validation/__tests__/parseLateFeeForm.test.ts
@@ -1,0 +1,36 @@
+import { parseLateFeeForm } from "../parseLateFeeForm";
+
+describe("parseLateFeeForm", () => {
+  it("converts boolean and number fields", () => {
+    const fd = new FormData();
+    fd.set("enabled", "on");
+    fd.set("intervalMinutes", "5");
+    const result = parseLateFeeForm(fd);
+    expect(result.data).toEqual({ enabled: true, intervalMinutes: 5 });
+  });
+
+  it("treats missing or off enabled as false", () => {
+    const fdMissing = new FormData();
+    fdMissing.set("intervalMinutes", "5");
+    expect(parseLateFeeForm(fdMissing).data?.enabled).toBe(false);
+
+    const fdOff = new FormData();
+    fdOff.set("enabled", "off");
+    fdOff.set("intervalMinutes", "5");
+    expect(parseLateFeeForm(fdOff).data?.enabled).toBe(false);
+  });
+
+  it("returns validation errors", () => {
+    const fdZero = new FormData();
+    fdZero.set("enabled", "on");
+    fdZero.set("intervalMinutes", "0");
+    expect(parseLateFeeForm(fdZero).errors).toEqual({
+      intervalMinutes: ["Must be at least 1"],
+    });
+
+    const fdNaN = new FormData();
+    fdNaN.set("enabled", "on");
+    fdNaN.set("intervalMinutes", "bad");
+    expect(parseLateFeeForm(fdNaN).errors?.intervalMinutes).toBeTruthy();
+  });
+});

--- a/apps/cms/src/services/shops/validation/index.ts
+++ b/apps/cms/src/services/shops/validation/index.ts
@@ -3,6 +3,7 @@ export * from "./parseSeoForm";
 export * from "./parseGenerateSeoForm";
 export * from "./parseCurrencyTaxForm";
 export * from "./parseDepositForm";
+export * from "./parseLateFeeForm";
 export * from "./parseReverseLogisticsForm";
 export * from "./parseUpsReturnsForm";
 export * from "./parsePremierDeliveryForm";

--- a/apps/cms/src/services/shops/validation/parseLateFeeForm.ts
+++ b/apps/cms/src/services/shops/validation/parseLateFeeForm.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { formDataToObject } from "../../../utils/formData";
+
+const lateFeeSchema = z
+  .object({
+    enabled: z.preprocess((v) => v === "on", z.boolean()),
+    intervalMinutes: z.coerce.number().int().min(1, "Must be at least 1"),
+  })
+  .strict();
+
+export function parseLateFeeForm(formData: FormData): {
+  data?: z.infer<typeof lateFeeSchema>;
+  errors?: Record<string, string[]>;
+} {
+  const parsed = lateFeeSchema.safeParse(formDataToObject(formData));
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors };
+  }
+  return { data: parsed.data };
+}
+
+export type LateFeeForm = z.infer<typeof lateFeeSchema>;


### PR DESCRIPTION
## Summary
- add CMS page and editor to toggle late fee service and set interval
- support updating late fee settings through new server action and validation
- show table of charged late fees for auditing

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable)*
- `pnpm --filter @apps/cms test 'src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesEditor.test.tsx' 'src/services/shops/validation/__tests__/parseLateFeeForm.test.ts' 'src/services/shops/validation/__tests__/parseForms.test.ts'` *(coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c7875908832f98f1369bfcb86b7a