### PR TITLE
feat: add stock scheduler settings UI

### DIFF
--- a/apps/cms/src/actions/stockScheduler.server.ts
+++ b/apps/cms/src/actions/stockScheduler.server.ts
@@ -1,0 +1,17 @@
+"use server";
+
+// apps/cms/src/actions/stockScheduler.server.ts
+
+import { scheduleStockChecks, getStockCheckStatus } from "@platform-core/services/stockScheduler.server";
+import { readInventory } from "@platform-core/repositories/inventory.server";
+
+export async function updateStockScheduler(shop: string, formData: FormData) {
+  const intervalStr = formData.get("intervalMs");
+  const intervalMs = Number(intervalStr);
+  if (!intervalMs || intervalMs <= 0) return;
+  scheduleStockChecks(shop, () => readInventory(shop), intervalMs);
+}
+
+export async function getSchedulerStatus(shop: string) {
+  return getStockCheckStatus(shop);
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/page.tsx
@@ -107,6 +107,14 @@ export default async function SettingsPage({
       </p>
       <p className="mb-4 text-sm">
         <Link
+          href={`/cms/shop/${shop}/settings/stock-scheduler`}
+          className="text-primary underline"
+        >
+          Stock scheduler settings
+        </Link>
+      </p>
+      <p className="mb-4 text-sm">
+        <Link
           href={`/cms/shop/${shop}/settings/maintenance-scan`}
           className="text-primary underline"
         >

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+// apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
+
+import { Button, Input } from "@/components/atoms/shadcn";
+import { updateStockScheduler } from "@cms/actions/stockScheduler.server";
+import { useState, type FormEvent, type ChangeEvent } from "react";
+
+interface HistoryEntry {
+  timestamp: number;
+  alerts: number;
+}
+
+interface Props {
+  shop: string;
+  status: { intervalMs: number; lastRun?: number; history: HistoryEntry[] };
+}
+
+export default function StockSchedulerEditor({ shop, status }: Props) {
+  const [interval, setInterval] = useState(String(status.intervalMs));
+  const [saving, setSaving] = useState(false);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setInterval(e.target.value);
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    const fd = new FormData(e.currentTarget);
+    await updateStockScheduler(shop, fd);
+    setSaving(false);
+  };
+
+  return (
+    <div className="grid max-w-md gap-4">
+      <form onSubmit={onSubmit} className="grid gap-4">
+        <label className="flex flex-col gap-1">
+          <span>Check Interval (ms)</span>
+          <Input
+            type="number"
+            name="intervalMs"
+            value={interval}
+            onChange={handleChange}
+          />
+        </label>
+        <Button className="bg-primary text-white" disabled={saving} type="submit">
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </form>
+      <div>
+        <p className="text-sm">
+          Last run: {status.lastRun ? new Date(status.lastRun).toLocaleString() : "never"}
+        </p>
+      </div>
+      <div>
+        <h3 className="mt-4 font-medium">Recent Checks</h3>
+        {status.history.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No checks yet.</p>
+        ) : (
+          <table className="mt-2 text-sm">
+            <thead>
+              <tr>
+                <th className="pr-4 text-left">Time</th>
+                <th className="text-left">Alerts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {status.history
+                .slice()
+                .reverse()
+                .map((h) => (
+                  <tr key={h.timestamp}>
+                    <td className="pr-4">
+                      {new Date(h.timestamp).toLocaleString()}
+                    </td>
+                    <td>{h.alerts}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/page.tsx
@@ -1,0 +1,30 @@
+// apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/page.tsx
+import dynamic from "next/dynamic";
+import { getSchedulerStatus } from "@cms/actions/stockScheduler.server";
+
+const StockSchedulerEditor = dynamic(() => import("./StockSchedulerEditor"));
+void StockSchedulerEditor;
+
+export const revalidate = 0;
+
+interface Params {
+  shop: string;
+}
+
+export default async function StockSchedulerSettingsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { shop } = await params;
+  const status = (await getSchedulerStatus(shop)) ?? {
+    intervalMs: 0,
+    history: [],
+  };
+  return (
+    <div>
+      <h2 className="mb-4 text-xl font-semibold">Stock Scheduler – {shop}</h2>
+      <StockSchedulerEditor shop={shop} status={status} />
+    </div>
+  );
+}

--- a/packages/platform-core/__tests__/stockScheduler.test.ts
+++ b/packages/platform-core/__tests__/stockScheduler.test.ts
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
 
-const checkAndAlert = jest.fn();
+const checkAndAlert = jest.fn().mockResolvedValue([]);
 jest.mock("../src/services/stockAlert.server", () => ({
   checkAndAlert,
 }));
@@ -42,6 +42,20 @@ describe("scheduleStockChecks", () => {
     );
 
     consoleError.mockRestore();
+  });
+
+  it("exposes status information", async () => {
+    const mockGetItems = jest.fn().mockResolvedValue([]);
+    const { scheduleStockChecks, getStockCheckStatus } = await import(
+      "../src/services/stockScheduler.server"
+    );
+
+    scheduleStockChecks("shop", mockGetItems, 100);
+    await jest.advanceTimersByTimeAsync(100);
+
+    const status = getStockCheckStatus("shop");
+    expect(status?.intervalMs).toBe(100);
+    expect(status?.history).toHaveLength(1);
   });
 });
 

--- a/packages/platform-core/src/services/stockAlert.server.ts
+++ b/packages/platform-core/src/services/stockAlert.server.ts
@@ -37,7 +37,7 @@ export async function checkAndAlert(
   shop: string,
   items: InventoryItem[],
   email: EmailService = getEmailService(),
-): Promise<void> {
+): Promise<InventoryItem[]> {
   const settings = await getShopSettings(shop);
   const envRecipients =
     (coreEnv.STOCK_ALERT_RECIPIENTS as string | undefined) ??
@@ -53,7 +53,7 @@ export async function checkAndAlert(
     settings.stockAlert?.threshold ??
     (coreEnv.STOCK_ALERT_DEFAULT_THRESHOLD as number | undefined);
 
-  if (recipients.length === 0 && !webhook) return;
+  if (recipients.length === 0 && !webhook) return [];
 
   const log = await readLog(shop);
   const now = Date.now();
@@ -73,7 +73,7 @@ export async function checkAndAlert(
       return !last || last < suppressBefore;
     });
 
-  if (lowItems.length === 0) return;
+  if (lowItems.length === 0) return [];
 
   const lines = lowItems.map((i) => {
     const attrs = Object.entries(i.variantAttributes)
@@ -110,4 +110,5 @@ export async function checkAndAlert(
     log[variantKey(item.sku, item.variantAttributes)] = now;
   }
   await writeLog(shop, log);
+  return lowItems;
 }


### PR DESCRIPTION
## Summary
- add server utilities to expose stock check status and history
- build CMS stock scheduler settings page with interval form and history table
- log low-stock results and track scheduler runs

## Testing
- `pnpm install` *(fails: packages/platform-core postinstall: Failed)*
- `pnpm install --ignore-scripts`
- `pnpm -r --filter @acme/platform-core build` *(fails: tsc -b)*
- `pnpm test --filter @acme/platform-core` *(fails: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68c6cab639c8832f966e15963650d6fd