### PR TITLE
test: add coverage for app pages

### DIFF
--- a/packages/template-app/__tests__/order-timeline.test.tsx
+++ b/packages/template-app/__tests__/order-timeline.test.tsx
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import OrderTimeline from "../src/app/account/orders/[id]/timeline";
+import { listEvents } from "@platform-core/repositories/reverseLogisticsEvents.server";
+
+const events = [
+  { id: "1", sessionId: "s1", event: "received", createdAt: "2023-01-01" },
+  { id: "2", sessionId: "s1", event: "cleaned", createdAt: "2023-02-01" },
+  { id: "3", sessionId: "s2", event: "qaPassed", createdAt: "2023-03-01" },
+];
+
+jest.mock("@platform-core/repositories/reverseLogisticsEvents.server", () => ({
+  listEvents: jest.fn(),
+}));
+
+jest.mock("@acme/date-utils", () => ({ formatTimestamp: (d: string) => `f-${d}` }));
+
+jest.mock("../shop.json", () => ({ id: "shop1" }), { virtual: true });
+
+describe("OrderTimeline", () => {
+  it("filters and sorts events", async () => {
+    (listEvents as jest.Mock).mockResolvedValue(events);
+    const ui = (await OrderTimeline({ params: { id: "s1" } })) as ReactElement;
+    render(ui);
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Received");
+    expect(items[1]).toHaveTextContent("Cleaned");
+  });
+});

--- a/packages/template-app/__tests__/product-page.test.tsx
+++ b/packages/template-app/__tests__/product-page.test.tsx
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactElement } from "react";
+import PdpClient from "../src/app/[lang]/product/[slug]/PdpClient.client";
+import ProductPage, {
+  generateStaticParams,
+  generateMetadata,
+} from "../src/app/[lang]/product/[slug]/page";
+import type { SKU } from "@acme/types";
+
+jest.mock("@platform-core/components/pdp/ImageGallery", () => () => (
+  <div data-testid="gallery" />
+));
+
+jest.mock("@platform-core/components/pdp/SizeSelector", () => (props: any) => (
+  <button data-cy="size" onClick={() => props.onSelect("M")} />
+));
+
+const addProps: any[] = [];
+jest.mock("@platform-core/components/shop/AddToCartButton.client", () => (props: any) => {
+  addProps.push(props);
+  return <button data-testid="add" />;
+});
+
+jest.mock("@ui/components/atoms/Price", () => ({
+  Price: ({ amount }: { amount: number }) => <span data-testid="price">{amount}</span>,
+}));
+
+import { notFound } from "next/navigation";
+jest.mock("next/navigation", () => ({ notFound: jest.fn() }));
+
+const getProduct = jest.fn();
+jest.mock("@platform-core/products", () => ({
+  getProductBySlug: (s: string) => getProduct(s),
+}));
+
+jest.mock("../src/components/CleaningInfo", () => () => (
+  <div data-testid="clean" />
+));
+jest.mock("../src/lib/seo", () => ({
+  getStructuredData: () => ({}),
+  serializeJsonLd: () => "{}",
+}));
+jest.mock("../shop.json", () => ({ showCleaningTransparency: true }), {
+  virtual: true,
+});
+
+const product: SKU = {
+  id: "sku1",
+  title: "Sneaker",
+  description: "Nice shoe",
+  price: 100,
+  deposit: 0,
+  media: [],
+  sizes: ["S", "M"],
+  slug: "sneaker",
+};
+
+describe("Pdp components", () => {
+  it("renders product and updates size and quantity", () => {
+    render(<PdpClient product={product} />);
+    expect(screen.getByText("Sneaker")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("size"));
+    expect(addProps[addProps.length - 1]).toMatchObject({ size: "M", quantity: 1 });
+    fireEvent.change(screen.getByLabelText("Quantity:"), { target: { value: "2" } });
+    expect(addProps[addProps.length - 1]).toMatchObject({ size: "M", quantity: 2 });
+  });
+
+  it("renders product page", async () => {
+    getProduct.mockReturnValue(product);
+    const ui = (await ProductPage({
+      params: Promise.resolve({ lang: "en", slug: "sneaker" }),
+    })) as ReactElement;
+    const [script, pdp, clean] = ui.props.children;
+    expect(pdp.props.product).toEqual(product);
+    expect(clean).toBeTruthy();
+  });
+
+  it("returns notFound when product missing", async () => {
+    getProduct.mockReturnValue(undefined);
+    await ProductPage({ params: Promise.resolve({ lang: "en", slug: "x" }) });
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("generates params and metadata", async () => {
+    const params = await generateStaticParams();
+    expect(params.length).toBeGreaterThan(0);
+    getProduct.mockReturnValue(product);
+    const meta = await generateMetadata({ params: Promise.resolve({ slug: "sneaker" }) });
+    expect(meta.title).toContain("Sneaker");
+  });
+});

--- a/packages/template-app/__tests__/returns-page.test.tsx
+++ b/packages/template-app/__tests__/returns-page.test.tsx
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import ReturnForm from "../src/app/account/returns/ReturnForm";
+import ReturnsPage from "../src/app/account/returns/page";
+import { getReturnLogistics, getReturnBagAndLabel } from "@platform-core/returnLogistics";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+
+// ---------- ReturnForm tests ----------
+
+describe("ReturnForm", () => {
+  it("submits and shows label and tracking", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ labelUrl: "url", tracking: "123" }),
+    }) as any;
+    render(<ReturnForm bagType="poly" tracking />);
+    fireEvent.change(screen.getByPlaceholderText("Session ID"), {
+      target: { value: "abc" },
+    });
+    const form = screen.getByText("Submit").closest("form")!;
+    fireEvent.submit(form);
+    await waitFor(() => expect(screen.getByText(/Print Label/)).toBeInTheDocument());
+    expect(screen.getByText(/Tracking: 123/)).toBeInTheDocument();
+  });
+});
+
+// ---------- ReturnsPage tests ----------
+
+jest.mock("@platform-core/returnLogistics", () => ({
+  getReturnLogistics: jest.fn(),
+  getReturnBagAndLabel: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/settings.server", () => ({
+  getShopSettings: jest.fn(),
+}));
+
+jest.mock("../src/components/CleaningInfo", () => () => <div data-testid="clean" />);
+jest.mock("../shop.json", () => ({ showCleaningTransparency: true }), { virtual: true });
+
+describe("ReturnsPage", () => {
+  it("shows message when mobile returns disabled", async () => {
+    (getReturnLogistics as jest.Mock).mockResolvedValue({ mobileApp: false });
+    const ui = (await ReturnsPage()) as ReactElement;
+    render(ui);
+    expect(screen.getByText(/Mobile returns are not enabled/)).toBeInTheDocument();
+  });
+
+  it("renders form with bag and tracking", async () => {
+    (getReturnLogistics as jest.Mock).mockResolvedValue({ mobileApp: true });
+    (getReturnBagAndLabel as jest.Mock).mockResolvedValue({ bagType: "poly", tracking: true });
+    (getShopSettings as jest.Mock).mockResolvedValue({ returnService: { bagEnabled: true } });
+    const ui = (await ReturnsPage()) as ReactElement;
+    const [form, clean] = ui.props.children;
+    expect(form.props.bagType).toBe("poly");
+    expect(form.props.tracking).toBe(true);
+    expect(clean).toBeTruthy();
+  });
+});

--- a/packages/template-app/__tests__/shop-page.test.tsx
+++ b/packages/template-app/__tests__/shop-page.test.tsx
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+/** @jest-environment jsdom */
+import { render, act } from "@testing-library/react";
+import type { ReactElement } from "react";
+import ShopClient from "../src/app/[lang]/shop/ShopClient.client";
+import ShopPage from "../src/app/[lang]/shop/page";
+import type { SKU } from "@acme/types";
+
+const push = jest.fn();
+let change: any;
+let gridProps: any;
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams("q=red"),
+  useRouter: () => ({ push }),
+  usePathname: () => "/en/shop",
+}));
+
+jest.mock("@platform-core/components/shop/FilterBar", () => (props: any) => {
+  change = props.onChange;
+  return <div data-testid="filters" />;
+});
+
+jest.mock("@platform-core/components/shop/ProductGrid", () => ({
+  ProductGrid: (props: any) => {
+    gridProps = props;
+    return <div data-testid="grid" />;
+  },
+}));
+
+jest.mock("../src/lib/seo", () => ({
+  getStructuredData: () => ({}),
+  serializeJsonLd: () => "{}",
+}));
+
+const skus: SKU[] = [
+  { id: "1", title: "Red Shoe", slug: "red-shoe", price: 10, sizes: ["M"], deposit: 0, media: [] },
+  { id: "2", title: "Blue Shoe", slug: "blue-shoe", price: 20, sizes: ["M"], deposit: 0, media: [] },
+];
+
+describe("Shop components", () => {
+  it("filters products by query and pushes on change", () => {
+    render(<ShopClient skus={skus} />);
+    expect(gridProps.skus).toHaveLength(1);
+    act(() => {
+      change({ color: "red" });
+    });
+    expect(push).toHaveBeenCalled();
+  });
+
+  it("renders shop page", async () => {
+    const ui = (await ShopPage({ params: Promise.resolve({ lang: "en" }) })) as ReactElement;
+    const [, shop] = ui.props.children;
+    expect(shop.props.skus).toHaveLength(3);
+  });
+});

--- a/packages/template-app/__tests__/subscribe-page.test.tsx
+++ b/packages/template-app/__tests__/subscribe-page.test.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from "react";
+import SubscribePage from "../src/app/[lang]/subscribe/page";
+import { resolveLocale } from "@i18n/locales";
+import { stripe } from "@acme/stripe";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { getCustomerSession } from "@auth";
+import { setStripeSubscriptionId } from "@platform-core/repositories/users";
+import { setUserPlan } from "@platform-core/repositories/subscriptionUsage.server";
+import { notFound } from "next/navigation";
+
+jest.mock("@i18n/locales", () => ({ resolveLocale: jest.fn() }));
+jest.mock("@acme/stripe", () => ({ stripe: { subscriptions: { create: jest.fn() } } }));
+jest.mock("@platform-core/repositories/shops.server", () => ({ readShop: jest.fn() }));
+jest.mock("@auth", () => ({ getCustomerSession: jest.fn() }));
+jest.mock("@platform-core/repositories/users", () => ({ setStripeSubscriptionId: jest.fn() }));
+jest.mock("@platform-core/repositories/subscriptionUsage.server", () => ({ setUserPlan: jest.fn() }));
+jest.mock("@acme/config/env/core", () => ({ coreEnv: {} }));
+jest.mock("next/navigation", () => ({ notFound: jest.fn() }));
+
+describe("SubscribePage", () => {
+  it("calls notFound when disabled", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ subscriptionsEnabled: false });
+    await SubscribePage({ params: Promise.resolve({ lang: "en" }) });
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("submits plan and creates subscription", async () => {
+    const stripeCreate = (stripe.subscriptions.create as jest.Mock).mockResolvedValue({ id: "sub1" });
+    (readShop as jest.Mock).mockResolvedValue({
+      subscriptionsEnabled: true,
+      rentalSubscriptions: [{ id: "basic", itemsIncluded: 1, swapLimit: 1, shipmentsPerMonth: 1 }],
+    });
+    (getCustomerSession as jest.Mock).mockResolvedValue({ customerId: "cus" });
+    const ui = (await SubscribePage({ params: Promise.resolve({ lang: "en" }) })) as ReactElement;
+    const form = ui.props.children[1];
+    const action = form.props.action as (fd: FormData) => Promise<void>;
+    const fd = new FormData();
+    fd.set("plan", "basic");
+    await action(fd);
+    expect(stripeCreate).toHaveBeenCalled();
+    expect(setStripeSubscriptionId).toHaveBeenCalledWith("cus", "sub1", "shop");
+    expect(setUserPlan).toHaveBeenCalledWith("shop", "cus", "basic");
+  });
+});

--- a/packages/template-app/__tests__/swap-page.test.tsx
+++ b/packages/template-app/__tests__/swap-page.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import SwapPage from "../src/app/account/swaps/page";
+import { notFound } from "next/navigation";
+import { getCart } from "@platform-core/cartStore";
+import { getCustomerSession } from "@auth";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { getUserPlan, getRemainingSwaps } from "@platform-core/repositories/subscriptionUsage.server";
+
+jest.mock("next/navigation", () => ({ notFound: jest.fn() }));
+
+jest.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => ({ value: "cookie" }) }),
+}));
+
+jest.mock("@platform-core/cartCookie", () => ({
+  CART_COOKIE: "c",
+  decodeCartCookie: () => "cart1",
+}));
+
+jest.mock("@platform-core/cartStore", () => ({
+  getCart: jest.fn(),
+  removeItem: jest.fn(),
+  incrementQty: jest.fn(),
+}));
+
+jest.mock("@auth", () => ({ getCustomerSession: jest.fn() }));
+
+jest.mock("@platform-core/repositories/shops.server", () => ({ readShop: jest.fn() }));
+
+jest.mock("@platform-core/repositories/subscriptionUsage.server", () => ({
+  getUserPlan: jest.fn(),
+  getRemainingSwaps: jest.fn(),
+  incrementSwapCount: jest.fn(),
+}));
+
+jest.mock("@acme/config/env/core", () => ({ coreEnv: {} }));
+
+jest.mock("@date-utils", () => ({ nowIso: jest.fn(() => "2023-01-15") }));
+
+jest.mock("@platform-core/products", () => ({ getProductById: jest.fn() }));
+
+describe("SwapPage", () => {
+  it("calls notFound when subscriptions disabled", async () => {
+    readShop.mockResolvedValue({ subscriptionsEnabled: false });
+    await SwapPage();
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("renders cart with disabled swap when no swaps left", async () => {
+    readShop.mockResolvedValue({
+      subscriptionsEnabled: true,
+      rentalSubscriptions: [],
+    });
+    getCart.mockResolvedValue({
+      sku1: {
+        sku: {
+          id: "sku1",
+          title: "Item",
+          price: 0,
+          deposit: 0,
+          sizes: [],
+          media: [],
+          slug: "item",
+        },
+        qty: 1,
+      },
+    });
+    getCustomerSession.mockResolvedValue({ customerId: "cust" });
+    getUserPlan.mockResolvedValue(undefined);
+    getRemainingSwaps.mockResolvedValue(0);
+    const ui = (await SwapPage()) as ReactElement;
+    render(ui);
+    expect(screen.getByText("Item")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Swap" })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add product page tests for PDP and metadata
- cover shop listing filters
- add tests for subscribe, returns, orders timeline, and swaps pages

## Testing
- `pnpm -F template-app test --coverage=false packages/template-app/__tests__/product-page.test.tsx packages/template-app/__tests__/shop-page.test.tsx packages/template-app/__tests__/subscribe-page.test.tsx packages/template-app/__tests__/order-timeline.test.tsx packages/template-app/__tests__/returns-page.test.tsx packages/template-app/__tests__/swap-page.test.tsx`
- `pnpm -r build` *(fails: TypeScript errors in packages/platform-core)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cda2d734832fa1ea8319f6d4f1a5