### PR TITLE
test: cover billing webhook and mobile returns routes

### DIFF
--- a/packages/template-app/__tests__/billing-webhook.route.test.ts
+++ b/packages/template-app/__tests__/billing-webhook.route.test.ts
@@ -1,0 +1,104 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+// Ensure Response.json exists for NextResponse
+const ResponseWithJson = Response as unknown as typeof Response & {
+  json?: (data: unknown, init?: ResponseInit) => Response;
+};
+if (typeof ResponseWithJson.json !== "function") {
+  ResponseWithJson.json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+process.env.STRIPE_SECRET_KEY = "sk_test";
+process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+jest.mock("@acme/stripe", () => ({
+  stripe: {
+    webhooks: { constructEvent: jest.fn() },
+  },
+}));
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  readShop: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/users", () => ({
+  setStripeSubscriptionId: jest.fn(),
+}));
+
+import { stripe } from "@acme/stripe";
+import { readShop } from "@platform-core/repositories/shops.server";
+import { setStripeSubscriptionId } from "@platform-core/repositories/users";
+
+const makeReq = (body: unknown) =>
+  ({
+    text: async () => JSON.stringify(body),
+    headers: { get: () => "sig" } as Headers,
+  }) as unknown as NextRequest;
+
+describe("/api/billing/webhook POST", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns 400 when billing not enabled", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ billingProvider: "other" });
+    const { POST } = await import("../src/api/billing/webhook/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Billing not enabled" });
+  });
+
+  test("returns 400 on invalid signature", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ billingProvider: "stripe" });
+    (stripe.webhooks.constructEvent as jest.Mock).mockImplementation(() => {
+      throw new Error("bad sig");
+    });
+    const { POST } = await import("../src/api/billing/webhook/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Invalid signature");
+  });
+
+  test("handles subscription deleted", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ billingProvider: "stripe" });
+    (stripe.webhooks.constructEvent as jest.Mock).mockReturnValue({
+      type: "customer.subscription.deleted",
+      data: { object: { metadata: { userId: "u1" } } },
+    });
+    const { POST } = await import("../src/api/billing/webhook/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(200);
+    expect(setStripeSubscriptionId).toHaveBeenCalledWith("u1", null, "bcd");
+    expect(await res.json()).toEqual({ received: true });
+  });
+
+  test("handles subscription created", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ billingProvider: "stripe" });
+    (stripe.webhooks.constructEvent as jest.Mock).mockReturnValue({
+      type: "customer.subscription.created",
+      data: { object: { id: "sub123", metadata: { userId: "u1" } } },
+    });
+    const { POST } = await import("../src/api/billing/webhook/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(200);
+    expect(setStripeSubscriptionId).toHaveBeenCalledWith("u1", "sub123", "bcd");
+    expect(await res.json()).toEqual({ received: true });
+  });
+
+  test("ignores other events", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ billingProvider: "stripe" });
+    (stripe.webhooks.constructEvent as jest.Mock).mockReturnValue({
+      type: "invoice.paid",
+      data: { object: {} },
+    });
+    const { POST } = await import("../src/api/billing/webhook/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(200);
+    expect(setStripeSubscriptionId).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({ received: true });
+  });
+});
+

--- a/packages/template-app/__tests__/returns-mobile.route.test.ts
+++ b/packages/template-app/__tests__/returns-mobile.route.test.ts
@@ -1,0 +1,140 @@
+import { jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+// Ensure Response.json exists for NextResponse
+const ResponseWithJson = Response as unknown as typeof Response & {
+  json?: (data: unknown, init?: ResponseInit) => Response;
+};
+if (typeof ResponseWithJson.json !== "function") {
+  ResponseWithJson.json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  readShop: jest.fn(),
+}));
+
+jest.mock("@platform-core/returnLogistics", () => ({
+  getReturnLogistics: jest.fn(),
+  getReturnBagAndLabel: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/settings.server", () => ({
+  getShopSettings: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/rentalOrders.server", () => ({
+  markReturned: jest.fn(),
+}));
+
+jest.mock("@platform-core/orders", () => ({
+  setReturnTracking: jest.fn(),
+}));
+
+import { readShop } from "@platform-core/repositories/shops.server";
+import {
+  getReturnLogistics,
+  getReturnBagAndLabel,
+} from "@platform-core/returnLogistics";
+import { getShopSettings } from "@platform-core/repositories/settings.server";
+import { markReturned } from "@platform-core/repositories/rentalOrders.server";
+import { setReturnTracking } from "@platform-core/orders";
+
+const makeReq = (body: object) =>
+  ({
+    json: async () => body,
+  }) as unknown as NextRequest;
+
+beforeEach(() => {
+  (readShop as jest.Mock).mockResolvedValue({ returnsEnabled: true });
+  (getReturnLogistics as jest.Mock).mockResolvedValue({ mobileApp: true });
+  (getReturnBagAndLabel as jest.Mock).mockResolvedValue({
+    homePickupZipCodes: ["12345"],
+    returnCarrier: ["ups"],
+  });
+  (getShopSettings as jest.Mock).mockResolvedValue({
+    returnService: { homePickupEnabled: true, upsEnabled: true },
+  });
+  (markReturned as jest.Mock).mockResolvedValue({});
+  (setReturnTracking as jest.Mock).mockResolvedValue(undefined);
+  global.fetch = jest.fn().mockResolvedValue(new Response()) as any;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("/api/returns/mobile POST", () => {
+  test("returns 403 when returns disabled", async () => {
+    (readShop as jest.Mock).mockResolvedValue({ returnsEnabled: false });
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({ sessionId: "sess" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Returns disabled" });
+  });
+
+  test("returns 403 when mobile returns disabled", async () => {
+    (getReturnLogistics as jest.Mock).mockResolvedValue({ mobileApp: false });
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({ sessionId: "sess" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Mobile returns disabled" });
+  });
+
+  test("returns 400 when sessionId missing", async () => {
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing sessionId" });
+  });
+
+  test("returns 403 when home pickup disabled", async () => {
+    (getShopSettings as jest.Mock).mockResolvedValue({
+      returnService: { homePickupEnabled: false },
+    });
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({ sessionId: "sess", zip: "12345" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Home pickup disabled" });
+  });
+
+  test("returns 400 when ZIP not eligible", async () => {
+    (getReturnBagAndLabel as jest.Mock).mockResolvedValue({
+      homePickupZipCodes: ["99999"],
+      returnCarrier: ["ups"],
+    });
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({ sessionId: "sess", zip: "12345" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "ZIP not eligible" });
+  });
+
+  test("returns 404 when order not found", async () => {
+    (markReturned as jest.Mock).mockResolvedValue(null);
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({ sessionId: "sess" }));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Order not found" });
+  });
+
+  test("creates UPS label when enabled", async () => {
+    const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.123456789);
+    const { POST } = await import("../src/api/returns/mobile/route");
+    const res = await POST(makeReq({ sessionId: "sess" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.tracking).toBe("1Z123456789");
+    expect(data.labelUrl).toBe(
+      "https://www.ups.com/track?loc=en_US&tracknum=1Z123456789",
+    );
+    expect(setReturnTracking).toHaveBeenCalledWith(
+      "bcd",
+      "sess",
+      "1Z123456789",
+      "https://www.ups.com/track?loc=en_US&tracknum=1Z123456789",
+    );
+    randomSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for Stripe billing webhook handling subscription events and invalid signatures
- add tests for mobile returns flow including UPS label generation and error scenarios

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/template-app test` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cddab3b8832f8d89909ae4adf48e