### PR TITLE
test: cover template app utilities

### DIFF
--- a/packages/template-app/__tests__/cancelled-page.test.tsx
+++ b/packages/template-app/__tests__/cancelled-page.test.tsx
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import Cancelled from "../src/app/cancelled/page";
+import { useSearchParams } from "next/navigation";
+
+jest.mock("next/navigation", () => ({ useSearchParams: jest.fn() }));
+
+const mockUse = useSearchParams as jest.Mock;
+
+describe("Cancelled page", () => {
+  it("shows error message when provided", () => {
+    mockUse.mockReturnValue(new URLSearchParams("error=oops"));
+    render(<Cancelled />);
+    expect(screen.getByText("oops")).toBeInTheDocument();
+  });
+
+  it("renders without error", () => {
+    mockUse.mockReturnValue(new URLSearchParams(""));
+    render(<Cancelled />);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText("Payment cancelled")).toBeInTheDocument();
+  });
+});
+

--- a/packages/template-app/__tests__/cleaning-info.test.tsx
+++ b/packages/template-app/__tests__/cleaning-info.test.tsx
@@ -1,0 +1,16 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import CleaningInfo from "../src/components/CleaningInfo";
+
+describe("CleaningInfo", () => {
+  it("renders cleaning text", () => {
+    render(<CleaningInfo />);
+    expect(
+      screen.getByText(/eco-friendly wash/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/machine-washed and fully sanitized/i),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/packages/template-app/__tests__/dynamic-renderer.test.tsx
+++ b/packages/template-app/__tests__/dynamic-renderer.test.tsx
@@ -1,0 +1,40 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import DynamicRenderer from "../src/components/DynamicRenderer";
+
+jest.mock("@platform-core/products", () => ({ PRODUCTS: [{ id: "sku1" }] }));
+
+const productGridMock = jest.fn(() => <div data-testid="grid" />);
+jest.mock("@platform-core/components/shop/ProductGrid", () => ({
+  ProductGrid: (props: any) => productGridMock(props),
+}));
+
+describe("DynamicRenderer", () => {
+  it("warns on unknown component", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    render(
+      <DynamicRenderer
+        components={[{ id: "1", type: "Unknown" } as any]}
+        locale="en"
+      />,
+    );
+    expect(warn).toHaveBeenCalledWith("Unknown component type: Unknown");
+    warn.mockRestore();
+  });
+
+  it("renders product grid with products", () => {
+    render(
+      <DynamicRenderer
+        components={[{ id: "2", type: "ProductGrid" } as any]}
+        locale="en"
+      />,
+    );
+    expect(productGridMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skus: [{ id: "sku1" }],
+        locale: "en",
+      }),
+    );
+  });
+});
+

--- a/packages/template-app/__tests__/preview-client.test.tsx
+++ b/packages/template-app/__tests__/preview-client.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import PreviewClient from "../src/app/preview/[pageId]/PreviewClient";
+
+jest.mock("@/components/DynamicRenderer", () => ({
+  __esModule: true,
+  default: (props: any) => <div data-cy="renderer" {...props} />,
+}));
+
+jest.mock("@ui/src/components/DeviceSelector", () => ({
+  __esModule: true,
+  default: (props: any) => <div data-cy="selector" {...props} />,
+}));
+
+jest.mock("@ui/utils/devicePresets", () => ({
+  devicePresets: [
+    { id: "phone", width: 10, height: 20 },
+    { id: "tablet", width: 30, height: 40 },
+  ],
+}));
+
+jest.mock("@ui/src/hooks/usePreviewDevice", () => ({
+  usePreviewDevice: () => ["phone", jest.fn()],
+}));
+
+describe("PreviewClient", () => {
+  it("renders device selector and dynamic renderer", () => {
+    render(
+      <PreviewClient
+        components={[{ id: "1", type: "Text" } as any]}
+        locale="en"
+        initialDeviceId="phone"
+      />,
+    );
+    expect(screen.getByTestId("selector")).toBeInTheDocument();
+    expect(screen.getByTestId("renderer")).toBeInTheDocument();
+    const container = screen.getByTestId("renderer").parentElement;
+    expect(container).toHaveStyle({ width: "10px", height: "20px" });
+  });
+});
+

--- a/packages/template-app/__tests__/publish-route.test.ts
+++ b/packages/template-app/__tests__/publish-route.test.ts
@@ -1,0 +1,57 @@
+import { POST } from "../src/app/api/publish/route";
+import { promises as fs } from "fs";
+
+jest.mock("fs", () => ({ promises: { readFile: jest.fn() } }));
+const readFile = fs.readFile as unknown as jest.Mock;
+
+jest.mock("@auth", () => ({ requirePermission: jest.fn() }));
+const requirePermission = jest.requireMock("@auth").requirePermission as jest.Mock;
+
+jest.mock("child_process", () => ({ spawnSync: jest.fn() }));
+const spawnSync = jest.requireMock("child_process").spawnSync as jest.Mock;
+
+describe("api publish route", () => {
+  beforeEach(() => {
+    readFile.mockReset();
+    requirePermission.mockReset();
+    spawnSync.mockReset();
+  });
+
+  it("returns 401 when unauthorized", async () => {
+    requirePermission.mockRejectedValue(new Error("no"));
+    const res = await POST();
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("validates shop id", async () => {
+    requirePermission.mockResolvedValue(undefined);
+    readFile.mockResolvedValue(JSON.stringify({ id: "invalid!" }));
+    const res = await POST();
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid shop ID");
+  });
+
+  it("returns 500 on publish failure", async () => {
+    requirePermission.mockResolvedValue(undefined);
+    readFile.mockResolvedValue(JSON.stringify({ id: "shop" }));
+    spawnSync.mockReturnValue({ status: 1 });
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Publish failed");
+  });
+
+  it("returns ok on success", async () => {
+    requirePermission.mockResolvedValue(undefined);
+    readFile.mockResolvedValue(JSON.stringify({ id: "shop" }));
+    spawnSync.mockReturnValue({ status: 0 });
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ status: "ok" });
+  });
+});
+

--- a/packages/template-app/__tests__/returns-mobile-page.test.tsx
+++ b/packages/template-app/__tests__/returns-mobile-page.test.tsx
@@ -1,0 +1,40 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import MobileReturnPage from "../src/app/returns/mobile/page";
+
+jest.mock("@platform-core/returnLogistics", () => ({
+  getReturnLogistics: jest.fn(),
+  getReturnBagAndLabel: jest.fn(),
+}));
+const rl = jest.requireMock("@platform-core/returnLogistics");
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  getShopSettings: jest.fn(),
+  readShop: jest.fn(),
+}));
+const shops = jest.requireMock("@platform-core/repositories/shops.server");
+
+jest.mock("../src/components/CleaningInfo", () => () => <div data-cy="cleaning" />);
+jest.mock("../src/app/returns/mobile/Scanner", () => () => <div data-cy="scanner" />);
+
+describe("MobileReturnPage", () => {
+  it("shows disabled message when mobile app off", async () => {
+    rl.getReturnLogistics.mockResolvedValue({ mobileApp: false });
+    rl.getReturnBagAndLabel.mockResolvedValue({});
+    shops.getShopSettings.mockResolvedValue({});
+    shops.readShop.mockResolvedValue({});
+    render((await MobileReturnPage()) as any);
+    expect(screen.getByText(/not enabled/)).toBeInTheDocument();
+  });
+
+  it("renders scanner and cleaning info", async () => {
+    rl.getReturnLogistics.mockResolvedValue({ mobileApp: true });
+    rl.getReturnBagAndLabel.mockResolvedValue({ homePickupZipCodes: ["1"] });
+    shops.getShopSettings.mockResolvedValue({ returnService: { homePickupEnabled: true } });
+    shops.readShop.mockResolvedValue({ showCleaningTransparency: true });
+    render((await MobileReturnPage()) as any);
+    expect(screen.getByTestId("scanner")).toBeInTheDocument();
+    expect(screen.getByTestId("cleaning")).toBeInTheDocument();
+  });
+});
+

--- a/packages/template-app/__tests__/returns-mobile-scanner.test.tsx
+++ b/packages/template-app/__tests__/returns-mobile-scanner.test.tsx
@@ -1,0 +1,13 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import Scanner from "../src/app/returns/mobile/Scanner";
+
+describe("Scanner", () => {
+  it("shows error when scanning unsupported", async () => {
+    render(<Scanner allowedZips={[]} />);
+    expect(
+      await screen.findByText("Scanning not supported on this device."),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/packages/template-app/__tests__/returns-pickup-page.test.tsx
+++ b/packages/template-app/__tests__/returns-pickup-page.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import PickupPage from "../src/app/returns/pickup/page";
+
+jest.mock("@platform-core/returnLogistics", () => ({
+  getReturnBagAndLabel: jest.fn(),
+}));
+const rl = jest.requireMock("@platform-core/returnLogistics");
+
+jest.mock("@platform-core/repositories/shops.server", () => ({
+  getShopSettings: jest.fn(),
+  readShop: jest.fn(),
+}));
+const shops = jest.requireMock("@platform-core/repositories/shops.server");
+
+jest.mock("../src/components/CleaningInfo", () => () => <div data-cy="cleaning" />);
+
+describe("PickupPage", () => {
+  it("confirms scheduling for allowed zip", async () => {
+    rl.getReturnBagAndLabel.mockResolvedValue({ homePickupZipCodes: ["123"] });
+    shops.getShopSettings.mockResolvedValue({ returnService: { homePickupEnabled: true } });
+    shops.readShop.mockResolvedValue({ showCleaningTransparency: true });
+    render((await PickupPage({ searchParams: Promise.resolve({ zip: "123" }) })) as any);
+    expect(screen.getByText(/scheduled for ZIP 123/)).toBeInTheDocument();
+    expect(screen.getByTestId("cleaning")).toBeInTheDocument();
+  });
+
+  it("shows form when zip missing", async () => {
+    rl.getReturnBagAndLabel.mockResolvedValue({ homePickupZipCodes: ["123"] });
+    shops.getShopSettings.mockResolvedValue({ returnService: { homePickupEnabled: true } });
+    shops.readShop.mockResolvedValue({ showCleaningTransparency: false });
+    render((await PickupPage({ searchParams: Promise.resolve({}) })) as any);
+    expect(screen.getByPlaceholderText("ZIP code")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add publish route tests for auth and error paths
- ensure cancelled, preview, and returns pages render as expected
- verify dynamic content renderer and cleaning info output

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Type 'null' is not assignable to type ...)*
- `pnpm --filter @acme/template-app test` *(fails: global coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cd880b88832faa5b86cd8a5c2119