### PR TITLE
Fix order normalization typing and inventory check types

### DIFF
--- a/packages/platform-core/src/orders/utils.ts
+++ b/packages/platform-core/src/orders/utils.ts
@@ -6,7 +6,9 @@ export type Order = RentalOrder;
 // Normalize Prisma results by replacing `null` fields with `undefined`.
 // When given a falsy value (e.g. `null`), return it directly so callers can
 // surface "not found" conditions instead of an empty object.
-export function normalize<T extends Order = Order>(order: T | null): T | null {
+export function normalize<T extends Order>(order: T): T;
+export function normalize<T extends Order>(order: null): null;
+export function normalize<T extends Order>(order: T | null): T | null {
   if (!order) return order;
   const o: T = { ...order };
   (Object.keys(o) as Array<keyof T>).forEach((k) => {

--- a/scripts/src/inventory/check-inventory.ts
+++ b/scripts/src/inventory/check-inventory.ts
@@ -23,12 +23,15 @@ async function checkShop(shopId: string): Promise<boolean> {
     jsonKeys.add(`${item.sku}|${key}`);
   }
 
-  const dbItems = await prisma.inventoryItem.findMany({
-    where: { shopId },
-    select: { sku: true, variantKey: true },
-  });
+  const dbItems: Array<{ sku: string; variantKey: string }> =
+    await prisma.inventoryItem.findMany({
+      where: { shopId },
+      select: { sku: true, variantKey: true },
+    });
 
-  const dbKeys = new Set(dbItems.map((i) => `${i.sku}|${i.variantKey}`));
+  const dbKeys = new Set<string>(
+    dbItems.map((i) => `${i.sku}|${i.variantKey}`),
+  );
 
   const missing = [...jsonKeys].filter((k) => !dbKeys.has(k));
   const extra = [...dbKeys].filter((k) => !jsonKeys.has(k));


### PR DESCRIPTION
## Summary
- ensure `normalize` returns non-null when given an order
- add explicit types for inventory db lookup keys

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@acme/email')*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/platform-core build`
- `npx tsc -b scripts`


------
https://chatgpt.com/codex/tasks/task_e_68c6d1f87a14832fa30c5bed515d422e