### PR TITLE
test: avoid device selector prop warnings

### DIFF
--- a/packages/template-app/__tests__/preview-client.test.tsx
+++ b/packages/template-app/__tests__/preview-client.test.tsx
@@ -9,7 +9,8 @@ jest.mock("@/components/DynamicRenderer", () => ({
 
 jest.mock("@ui/src/components/DeviceSelector", () => ({
   __esModule: true,
-  default: (props: any) => <div data-cy="selector" {...props} />,
+  // Ignore incoming props to avoid passing test-only values to the DOM
+  default: () => <div data-cy="selector" />,
 }));
 
 jest.mock("@ui/utils/devicePresets", () => ({


### PR DESCRIPTION
## Summary
- stop DeviceSelector mock from forwarding props in PreviewClient test

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Module not found: Can't resolve '@acme/email')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/template-app test __tests__/preview-client.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6d3d5d88c832f84761c324fb26c18