### PR TITLE
test: cover preview and error pages

### DIFF
--- a/packages/template-app/__tests__/edit-preview-page.test.tsx
+++ b/packages/template-app/__tests__/edit-preview-page.test.tsx
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@ui/src/components/ComponentPreview", () => ({
+  __esModule: true,
+  default: ({ component }: any) => <div>{component.componentName}</div>,
+}));
+
+describe("EditPreviewPage", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("loads changes and links", async () => {
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          components: [
+            { file: "f.tsx", componentName: "Comp", oldChecksum: "1", newChecksum: "2" },
+          ],
+          pages: ["p1"],
+        }),
+      })
+      .mockResolvedValueOnce({ json: async () => ({ token: "tok" }) });
+
+    const { default: Page } = await import("../src/app/edit-preview/page");
+    render(<Page />);
+
+    await waitFor(() => expect(screen.getByText("Comp")).toBeInTheDocument());
+    expect(screen.getByText("/preview/p1")).toHaveAttribute(
+      "href",
+      "/preview/p1?upgrade=tok",
+    );
+  });
+
+  it("shows error when publish fails", async () => {
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({ json: async () => ({ components: [], pages: [] }) })
+      .mockResolvedValueOnce({ json: async () => ({ error: "fail" }) });
+
+    const { default: Page } = await import("../src/app/edit-preview/page");
+    render(<Page />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Approve & publish" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent("fail");
+  });
+});

--- a/packages/template-app/__tests__/pages-404.test.tsx
+++ b/packages/template-app/__tests__/pages-404.test.tsx
@@ -1,0 +1,11 @@
+/** @jest-environment jsdom */
+import { render } from "@testing-library/react";
+
+describe("Pages Router 404 page", () => {
+  it("renders message and link", () => {
+    const NotFound = require("../src/pages/404").default;
+    const { getByText } = render(<NotFound />);
+    expect(getByText("404 — Page not found")).toBeInTheDocument();
+    expect(getByText("Go to homepage")).toHaveAttribute("href", "/");
+  });
+});

--- a/packages/template-app/__tests__/pages-error.test.tsx
+++ b/packages/template-app/__tests__/pages-error.test.tsx
@@ -1,0 +1,18 @@
+/** @jest-environment jsdom */
+import { render } from "@testing-library/react";
+
+describe("_error page", () => {
+  it("renders provided status code", () => {
+    const { default: ErrorPage } = require("../src/pages/_error");
+    const { getByText } = render(<ErrorPage statusCode={404} />);
+    expect(getByText("404 — Something went wrong")).toBeInTheDocument();
+  });
+
+  it("getInitialProps returns status code", () => {
+    const mod = require("../src/pages/_error");
+    const getInitialProps = mod.default.getInitialProps as (ctx: any) => any;
+    expect(getInitialProps({ res: { statusCode: 418 } })).toEqual({ statusCode: 418 });
+    expect(getInitialProps({ err: { statusCode: 400 } })).toEqual({ statusCode: 400 });
+    expect(getInitialProps({})).toEqual({ statusCode: 500 });
+  });
+});

--- a/packages/template-app/__tests__/preview-api.route.test.ts
+++ b/packages/template-app/__tests__/preview-api.route.test.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+
+const ResponseWithJson = Response as unknown as typeof Response & {
+  json?: (data: unknown, init?: ResponseInit) => Response;
+};
+if (typeof ResponseWithJson.json !== "function") {
+  ResponseWithJson.json = (data: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), init);
+}
+
+describe("/api/preview POST", () => {
+  it("returns ok and sets cookie when versions provided", async () => {
+    const { POST } = await import("../src/app/api/preview/route");
+    const res = await POST({ json: async () => ({ versions: { a: 1 } }) } as unknown as NextRequest);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(res.cookies.get("component-versions")?.value).toBe(
+      JSON.stringify({ a: 1 })
+    );
+  });
+
+  it("does not set cookie when versions missing", async () => {
+    const { POST } = await import("../src/app/api/preview/route");
+    const res = await POST({ json: async () => ({}) } as unknown as NextRequest);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(res.cookies.get("component-versions")).toBeUndefined();
+  });
+});

--- a/packages/template-app/__tests__/success-page.test.tsx
+++ b/packages/template-app/__tests__/success-page.test.tsx
@@ -1,0 +1,13 @@
+/** @jest-environment jsdom */
+import { render } from "@testing-library/react";
+
+describe("Success page", () => {
+  it("renders thank you message", async () => {
+    const { default: Success } = await import("../src/app/success/page");
+    const { getByText } = render(<Success />);
+    expect(getByText("Thanks for your order!")).toBeInTheDocument();
+    expect(
+      getByText("Your payment was received. Check your e-mail for the receipt.")
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/template-app/__tests__/upgrade-preview-page.test.tsx
+++ b/packages/template-app/__tests__/upgrade-preview-page.test.tsx
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@ui/src/components/ComponentPreview", () => ({
+  __esModule: true,
+  default: ({ component }: any) => <div>{component.componentName}</div>,
+}));
+
+describe("UpgradePreviewPage", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("loads changes and links", async () => {
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          components: [
+            { file: "f.tsx", componentName: "Comp", oldChecksum: "1", newChecksum: "2" },
+          ],
+          pages: ["p1"],
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ token: "tok" }),
+      });
+
+    const { default: Page } = await import("../src/app/upgrade-preview/page");
+    render(<Page />);
+
+    await waitFor(() => expect(screen.getByText("Comp")).toBeInTheDocument());
+    expect(screen.getByText("/preview/p1")).toHaveAttribute(
+      "href",
+      "/preview/p1?upgrade=tok",
+    );
+  });
+
+  it("shows error when publish fails", async () => {
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({ json: async () => ({ components: [], pages: [] }) })
+      .mockResolvedValueOnce({ json: async () => ({ error: "fail" }) });
+
+    const { default: Page } = await import("../src/app/upgrade-preview/page");
+    render(<Page />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Approve & publish" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent("fail");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for success page
- cover 404 and _error pages in pages router
- test upgrade/edit preview pages and preview API route

## Testing
- `pnpm -r build` (fails: Can't resolve '@acme/email')
- `pnpm --filter @acme/template-app test`


------
https://chatgpt.com/codex/tasks/task_e_68c6d4d1dd34832fa3a817864729a01e