### PR TITLE
fix config env any usage and lint ignore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default [
       "apps/*/src/**/*.d.ts",
       "apps/*/src/**/*.js.map",
       "scripts/**/*.js",
+      "packages/config/test/**",
       "**/__tests__/**",
       "**/__mocks__/**",
       "**/*.test.*",

--- a/packages/config/src/env/auth.ts
+++ b/packages/config/src/env/auth.ts
@@ -1,7 +1,7 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
-const isJest = typeof (globalThis as any).jest !== "undefined";
+const isJest = typeof (globalThis as { jest?: unknown }).jest !== "undefined";
 const isTest =
   process.env.NODE_ENV === "test" ||
   process.env.JEST_WORKER_ID !== undefined ||

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -7,7 +7,7 @@ import { emailEnvSchema } from "./email.js";
 import { paymentsEnvSchema } from "./payments.js";
 import { shippingEnvSchema } from "./shipping.js";
 import { createRequire } from "module";
-const isJest = typeof (globalThis as any).jest !== "undefined";
+const isJest = typeof (globalThis as { jest?: unknown }).jest !== "undefined";
 const isTest =
   process.env.NODE_ENV === "test" ||
   process.env.JEST_WORKER_ID !== undefined ||
@@ -240,7 +240,6 @@ export function loadCoreEnv(raw: NodeJS.ProcessEnv = process.env): CoreEnv {
 // Lazy proxy; no import-time parse in dev.
 let __cachedCoreEnv: CoreEnv | null = null;
 const nodeRequire =
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   typeof require !== "undefined" ? require : createRequire(eval("import.meta.url"));
 const envMode = process.env.NODE_ENV;
 function getCoreEnv(): CoreEnv {

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -1,7 +1,7 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
-const isJest = typeof (globalThis as any).jest !== "undefined";
+const isJest = typeof (globalThis as { jest?: unknown }).jest !== "undefined";
 const isTest =
   process.env.NODE_ENV === "test" ||
   process.env.JEST_WORKER_ID !== undefined ||

--- a/packages/config/src/env/index.ts
+++ b/packages/config/src/env/index.ts
@@ -1,14 +1,15 @@
 // packages/config/src/env/index.ts
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
+import type { AnyZodObject, ZodRawShape } from "zod";
 import { coreEnvSchema } from "./core.js";
 
 export const envSchema = coreEnvSchema;
 
 export function mergeEnvSchemas(
-  ...schemas: Array<z.ZodObject<any>>
-): z.ZodObject<any> {
-  const shape = Object.assign({}, ...schemas.map((s) => s.shape));
+  ...schemas: Array<AnyZodObject>
+): AnyZodObject {
+  const shape: ZodRawShape = Object.assign({}, ...schemas.map((s) => s.shape));
   return z.object(shape);
 }
 

--- a/packages/config/tsconfig.eslint.json
+++ b/packages/config/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "__tests__/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- replace `any` in config env helpers with explicit types
- use typed schemas in `mergeEnvSchemas`
- ignore `packages/config/test` during lint and add eslint tsconfig

## Testing
- `pnpm --filter @acme/config build`
- `pnpm --filter @acme/config lint` (fails: warnings only)
- `pnpm --filter @acme/config test` (fails: SyntaxError: Cannot use import statement outside a module)
- `pnpm --filter @acme/config run check:references` (fails: missing script)
- `pnpm --filter @acme/config run build:ts` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c6dba96694832f9b5b818b2f792da7