### PR TITLE
refactor: remove explicit any in CMS utilities and routes

### DIFF
--- a/apps/cms/src/actions/pages/utils.ts
+++ b/apps/cms/src/actions/pages/utils.ts
@@ -8,7 +8,7 @@ import { tryJsonParse } from "../../utils/formData";
 import { captureException } from "@/utils/sentry.server";
 
 export function mapLocales(
-  data: Record<string, any>
+  data: Record<string, string | undefined>
 ): {
   title: Record<Locale, string>;
   description: Record<Locale, string>;

--- a/apps/cms/src/app/api/upload-csv/[shop]/route.ts
+++ b/apps/cms/src/app/api/upload-csv/[shop]/route.ts
@@ -11,6 +11,16 @@ import { fileTypeFromBuffer } from "file-type/core";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { validateShopName } from "@platform-core/shops";
 
+function isWebReadableStream(
+  stream: unknown,
+): stream is NodeReadableStream {
+  return (
+    typeof stream === "object" &&
+    stream !== null &&
+    typeof (stream as NodeReadableStream).getReader === "function"
+  );
+}
+
 const MAX_SIZE = 5 * 1024 * 1024; // 5MB
 
 export async function POST(
@@ -123,8 +133,8 @@ export async function POST(
       const body = req.body;
       if (body) {
         let stream: NodeJS.ReadableStream;
-        if (typeof (body as any).getReader === "function") {
-          stream = Readable.fromWeb(body as unknown as NodeReadableStream);
+        if (isWebReadableStream(body)) {
+          stream = Readable.fromWeb(body);
         } else if (Buffer.isBuffer(body)) {
           stream = Readable.from(body);
         } else if (body instanceof Readable) {


### PR DESCRIPTION
## Summary
- use explicit string map for locale data
- add file handling type guards in inventory import and CSV upload routes

## Testing
- `pnpm --filter @apps/cms lint`
- `pnpm --filter @apps/cms test`


------
https://chatgpt.com/codex/tasks/task_e_68c6daf21a0c832f988224a2c66b987a