### PR TITLE
fix(eslint-plugin-ds): avoid unsafe regex in color rule

### DIFF
--- a/packages/eslint-plugin-ds/src/rules/no-raw-color.ts
+++ b/packages/eslint-plugin-ds/src/rules/no-raw-color.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- rule uses loose node typing */
 import type { Rule } from "eslint";
 
-const HEX_COLOR = /#(?:[0-9a-fA-F]{3,4}){1,2}\b/;
+// Matches hex colors like #RGB, #RGBA, #RRGGBB, or #RRGGBBAA
+const HEX_COLOR =
+  /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/;
 
 const rule: Rule.RuleModule = {
   meta: {


### PR DESCRIPTION
## Summary
- replace nested hex color regex with explicit alternatives to satisfy security rule

## Testing
- `pnpm --filter @acme/eslint-plugin-ds lint`
- `pnpm --filter @acme/eslint-plugin-ds run clean && pnpm --filter @acme/eslint-plugin-ds run build`
- `pnpm --filter @acme/eslint-plugin-ds test`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm -r build` *(fails: Invalid email environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c6def82fa0832fa6e05eba4bd167de