### PR TITLE
refactor(i18n): parse multilingual field without dynamic regex

### DIFF
--- a/packages/i18n/src/parseMultilingualInput.ts
+++ b/packages/i18n/src/parseMultilingualInput.ts
@@ -11,10 +11,13 @@ export function parseMultilingualInput(
   locales: readonly Locale[]
 ): MultilingualField | null {
   if (typeof name !== "string") return null;
-  const match = name.match(new RegExp(`^(title|desc)_(${locales.join("|")})$`));
-  if (!match) return null;
-  const [, field, locale] = match as [unknown, "title" | "desc", Locale];
-  return { field, locale };
+  const parts = name.split("_");
+  if (parts.length !== 2) return null;
+  const [field, locale] = parts as [string, string];
+  if ((field === "title" || field === "desc") && locales.includes(locale as Locale)) {
+    return { field: field as "title" | "desc", locale: locale as Locale };
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid dynamic RegExp by parsing field and locale with string logic

## Testing
- `pnpm --filter @acme/i18n lint` *(fails: Error [ERR_INTERNAL_ASSERTION]: Node >=20 required)*
- `pnpm --filter @acme/i18n run check:references` *(fails: script not found)*
- `pnpm --filter @acme/i18n run build:ts` *(fails: script not found)*
- `pnpm --filter @acme/i18n test`

------
https://chatgpt.com/codex/tasks/task_e_68c6df106e0c832f8e2366785d9f6427