### PR TITLE
refactor(email): fix lint errors

### DIFF
--- a/packages/email/src/abandonedCart.ts
+++ b/packages/email/src/abandonedCart.ts
@@ -53,15 +53,15 @@ export interface AbandonedCart {
 }
 
 function buildCartHtml(cart: unknown): string {
-  const items = Array.isArray((cart as any)?.items)
-    ? (cart as any).items
-    : [];
+  const cartWithItems = cart as { items?: unknown[] };
+  const items = Array.isArray(cartWithItems.items) ? cartWithItems.items : [];
   if (items.length === 0) return "<p>You left items in your cart.</p>";
   const list = items
-    .map((item: any) => {
+    .map((item) => {
+      const obj = item as { name?: unknown; title?: unknown };
       const name =
         typeof item === "object" && item !== null
-          ? (item as any).name ?? (item as any).title ?? String(item)
+          ? obj.name ?? obj.title ?? String(item)
           : String(item);
       return `<li>${escapeHtml(String(name))}</li>`;
     })

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -7,7 +7,6 @@ try {
     typeof require !== "undefined"
       ? require
       : createRequire(process.cwd() + "/");
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { setEmailService } = req(
     "@acme/platform-core/services/emailService"
   );

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -76,14 +76,14 @@ export class SendgridProvider implements CampaignProvider {
           campaignId: options.campaignId,
           error,
         });
-        const status = hasProviderErrorFields(error)
-          ? error.code ??
+        let status: number | string | undefined;
+        if (hasProviderErrorFields(error)) {
+          status =
+            error.code ??
             error.response?.statusCode ??
             error.statusCode ??
-            (typeof (error as any).status !== "undefined"
-              ? (error as any).status
-              : undefined)
-          : undefined;
+            error.status;
+        }
         const numericStatus =
           typeof status === "string" ? parseInt(status, 10) : status;
         const retryable =

--- a/packages/email/src/segments/index.ts
+++ b/packages/email/src/segments/index.ts
@@ -3,7 +3,6 @@ import { listEvents } from "@platform-core/repositories/analytics.server";
 import type { AnalyticsEvent } from "@platform-core/analytics";
 import { readSegments, analyticsMTime, SegmentCache, cacheTtl } from "./storage";
 import { matches } from "./filters";
-import type { SegmentDef } from "./filters";
 import { createContact, addToList, listSegments } from "./providers";
 
 export { createContact, addToList, listSegments };


### PR DESCRIPTION
## Summary
- remove `any` usages in email cart and Sendgrid provider
- drop unused segment type import
- clean up stale lint directive

## Testing
- `pnpm --filter @acme/email lint`
- `pnpm --filter @acme/email test --silent`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ded990b8832f98aa106a953c2d30