### PR TITLE
chore(lib): silence fs path warnings

### DIFF
--- a/packages/lib/src/checkShopExists.server.ts
+++ b/packages/lib/src/checkShopExists.server.ts
@@ -17,6 +17,8 @@ const DATA_ROOT = resolveDataRoot();
 export async function checkShopExists(shop: string): Promise<boolean> {
   const sanitized = validateShopName(shop);
   try {
+    // The shop name is validated above, so joining with DATA_ROOT is safe.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const stat = await fs.stat(path.join(DATA_ROOT, sanitized));
     return stat.isDirectory();
   } catch {

--- a/packages/lib/src/generateMeta.ts
+++ b/packages/lib/src/generateMeta.ts
@@ -123,8 +123,11 @@ export async function generateMeta(product: ProductData): Promise<GeneratedMeta>
   })) as { data?: Array<{ b64_json?: string }> };
   const b64 = img.data?.[0]?.b64_json ?? "";
   const buffer = Buffer.from(b64, "base64");
-  const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
+  const safeId = product.id.replace(/[^a-z0-9_-]/gi, "");
+  const file = path.join(process.cwd(), "public", "og", `${safeId}.png`);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   await fs.mkdir(path.dirname(file), { recursive: true });
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   await fs.writeFile(file, buffer);
 
   return data;


### PR DESCRIPTION
## Summary
- silence dynamic fs path warnings in checkShopExists
- ensure product image path uses sanitized id

## Testing
- `pnpm -r build` *(fails: Invalid email environment variables)*
- `pnpm --filter @acme/lib lint`
- `pnpm --filter @acme/lib run check:references` *(fails: Missing script)*
- `pnpm --filter @acme/lib run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/lib run build`
- `pnpm --filter @acme/lib test` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df2b3a3c832fb2df02ac9de06583