### PR TITLE
fix lint in shop and subscription repositories

### DIFF
--- a/packages/platform-core/src/repositories/shop.server.ts
+++ b/packages/platform-core/src/repositories/shop.server.ts
@@ -15,13 +15,15 @@ type ShopRepo = {
 
 let repoPromise: Promise<ShopRepo> | undefined;
 
+type PrismaWithShop = { shop?: unknown };
+
 async function getRepo(): Promise<ShopRepo> {
   if (process.env.NODE_ENV === "test") {
     repoPromise = undefined;
   }
   if (!repoPromise) {
     repoPromise = resolveRepo<ShopRepo>(
-      () => (prisma as any).shop,
+      () => (prisma as PrismaWithShop).shop,
       () => import("./shop.prisma.server"),
       () => import("./shop.json.server"),
       { backendEnvVar: "SHOP_BACKEND" },

--- a/packages/platform-core/src/repositories/subscriptions.server.ts
+++ b/packages/platform-core/src/repositories/subscriptions.server.ts
@@ -5,7 +5,7 @@ import { prisma } from "../db";
 export async function updateSubscriptionPaymentStatus(
   customerId: string,
   subscriptionId: string,
-  status: "succeeded" | "failed",
+  _status: "succeeded" | "failed",
 ): Promise<void> {
   await prisma.user.update({
     where: { id: customerId },

--- a/packages/platform-core/src/repositories/subscriptions.ts
+++ b/packages/platform-core/src/repositories/subscriptions.ts
@@ -1,14 +1,14 @@
 export async function updateSubscriptionPaymentStatus(
-  customerId: string,
-  subscriptionId: string,
-  status: "succeeded" | "failed",
+  _customerId: string,
+  _subscriptionId: string,
+  _status: "succeeded" | "failed",
 ): Promise<void> {
   // no-op placeholder for non-server environments
 }
 
 export async function syncSubscriptionData(
-  customerId: string,
-  subscriptionId: string | null,
+  _customerId: string,
+  _subscriptionId: string | null,
 ): Promise<void> {
   // no-op placeholder for non-server environments
 }


### PR DESCRIPTION
## Summary
- avoid `any` when accessing Prisma shop delegate
- prefix unused args in subscription helpers

## Testing
- `pnpm install`
- `pnpm -r build`
- `pnpm exec eslint packages/platform-core/src/repositories/shop.server.ts packages/platform-core/src/repositories/subscriptions.server.ts packages/platform-core/src/repositories/subscriptions.ts`
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df5fe3a4832f88c7e7dba1a19bd2