### PR TITLE
refactor: remove explicit any in settings and seo audit repos

### DIFF
--- a/packages/platform-core/src/repositories/seoAudit.server.ts
+++ b/packages/platform-core/src/repositories/seoAudit.server.ts
@@ -19,9 +19,11 @@ let repoPromise: Promise<SeoAuditRepo> | undefined;
 async function getRepo(): Promise<SeoAuditRepo> {
   if (!repoPromise) {
     repoPromise = resolveRepo<SeoAuditRepo>(
-      () => (prisma as any).seoAudit,
-      () => import("./seoAudit.prisma.server") as unknown as Promise<SeoAuditRepo>,
-      () => import("./seoAudit.json.server") as unknown as Promise<SeoAuditRepo>,
+      () => (prisma as { seoAudit?: unknown }).seoAudit,
+      () =>
+        import("./seoAudit.prisma.server") as unknown as Promise<SeoAuditRepo>,
+      () =>
+        import("./seoAudit.json.server") as unknown as Promise<SeoAuditRepo>,
       { backendEnvVar: "SEO_AUDIT_BACKEND" },
     );
   }

--- a/packages/platform-core/src/repositories/settings.prisma.server.ts
+++ b/packages/platform-core/src/repositories/settings.prisma.server.ts
@@ -69,7 +69,7 @@ export async function diffHistory(
     });
     return rows.map((r: { timestamp: string; diff: unknown }) => ({
       timestamp: r.timestamp,
-      diff: r.diff as any,
+      diff: shopSettingsSchema.partial().parse(r.diff),
     }));
   } catch {
     return jsonSettingsRepository.diffHistory(shop);

--- a/packages/platform-core/src/repositories/settings.server.ts
+++ b/packages/platform-core/src/repositories/settings.server.ts
@@ -19,7 +19,7 @@ let repoPromise: Promise<SettingsRepo> | undefined;
 async function getRepo(): Promise<SettingsRepo> {
   if (!repoPromise) {
     repoPromise = resolveRepo<SettingsRepo>(
-      () => (prisma as any).setting,
+      () => (prisma as { setting?: unknown }).setting,
       () =>
         import("./settings.prisma.server").then(
           (m) => m.prismaSettingsRepository,


### PR DESCRIPTION
## Summary
- replace prisma `any` casts with typed unknown delegates
- parse settings diff rows instead of using `any`

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid email environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core test` *(fails: inventory.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df6c8030832fa01eea4d05fa482e