### PR TITLE
chore: tighten repo typings and silence fs filename warnings

### DIFF
--- a/packages/platform-core/src/repositories/returnAuthorization.json.server.ts
+++ b/packages/platform-core/src/repositories/returnAuthorization.json.server.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
 import "server-only";
 
 import { returnAuthorizationSchema, type ReturnAuthorization } from "@acme/types";

--- a/packages/platform-core/src/repositories/returnAuthorization.server.ts
+++ b/packages/platform-core/src/repositories/returnAuthorization.server.ts
@@ -19,7 +19,7 @@ let repoPromise: Promise<ReturnAuthorizationRepo> | undefined;
 async function getRepo(): Promise<ReturnAuthorizationRepo> {
   if (!repoPromise) {
     repoPromise = resolveRepo<ReturnAuthorizationRepo>(
-      () => (prisma as any).returnAuthorization,
+      () => (prisma as { returnAuthorization?: unknown }).returnAuthorization,
       () =>
         import("./returnAuthorization.prisma.server").then(
           (m) => m.prismaReturnAuthorizationRepository,

--- a/packages/platform-core/src/repositories/returnLogistics.json.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.json.server.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
 import "server-only";
 
 import { returnLogisticsSchema, type ReturnLogistics } from "@acme/types";

--- a/packages/platform-core/src/repositories/returnLogistics.server.ts
+++ b/packages/platform-core/src/repositories/returnLogistics.server.ts
@@ -14,7 +14,7 @@ let repoPromise: Promise<ReturnLogisticsRepo> | undefined;
 async function getRepo(): Promise<ReturnLogisticsRepo> {
   if (!repoPromise) {
     repoPromise = resolveRepo<ReturnLogisticsRepo>(
-      () => (prisma as any).returnLogistics,
+      () => (prisma as { returnLogistics?: unknown }).returnLogistics,
       () =>
         import("./returnLogistics.prisma.server").then(
           (m) => m.prismaReturnLogisticsRepository,

--- a/packages/platform-core/src/repositories/seoAudit.json.server.ts
+++ b/packages/platform-core/src/repositories/seoAudit.json.server.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
 import "server-only";
 
 import { promises as fs } from "fs";


### PR DESCRIPTION
## Summary
- silence security/detect-non-literal-fs-filename warnings in JSON repository modules
- replace explicit any casts with typed prisma accessors for return authorization and logistics repos

## Testing
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core run build`
- `pnpm --filter @acme/platform-core run test` *(fails: __tests__/inventory.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df76dfe4832fb70fa4f253403c38