### PR TITLE
refactor: remove explicit any usage in repositories

### DIFF
--- a/packages/platform-core/src/repositories/coupons.server.ts
+++ b/packages/platform-core/src/repositories/coupons.server.ts
@@ -10,7 +10,7 @@ let repoPromise: Promise<CouponsRepository> | undefined;
 async function getRepo(): Promise<CouponsRepository> {
   if (!repoPromise) {
     repoPromise = resolveRepo<CouponsRepository>(
-      () => (prisma as any).coupon,
+      () => (prisma as { coupon?: unknown }).coupon,
       () =>
         import("./coupons.prisma.server").then(
           (m) => m.prismaCouponsRepository,

--- a/packages/platform-core/src/repositories/inventory.json.server.ts
+++ b/packages/platform-core/src/repositories/inventory.json.server.ts
@@ -198,8 +198,15 @@ export const jsonInventoryRepository: InventoryRepository = {
 
 // When running under Jest, expose a spyable version of `update` so tests can
 // verify that the JSON repository was used as a fallback.
-if (typeof (globalThis as any).jest?.fn === "function") {
-  jsonInventoryRepository.update = (globalThis as any).jest.fn(
+const g = globalThis as unknown as {
+  jest?: {
+    fn: (
+      fn: InventoryRepository["update"],
+    ) => InventoryRepository["update"];
+  };
+};
+if (g.jest?.fn) {
+  jsonInventoryRepository.update = g.jest.fn(
     jsonInventoryRepository.update,
   );
 }


### PR DESCRIPTION
## Summary
- remove `any` cast when resolving coupon repository
- replace global `any` cast in inventory JSON repository with typed jest hook

## Testing
- `pnpm install`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core build`
- `pnpm exec eslint packages/platform-core/src/repositories/coupons.server.ts packages/platform-core/src/repositories/inventory.json.server.ts`
- `pnpm --filter @acme/platform-core test` *(fails: __tests__/inventory.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df954720832fb9a4b0a902ef47d4