### PR TITLE
fix(platform-core): remove explicit any in analytics repo

### DIFF
--- a/packages/platform-core/src/repositories/analytics.server.ts
+++ b/packages/platform-core/src/repositories/analytics.server.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { AnalyticsAggregates, AnalyticsEvent } from "../analytics";
+import type { PrismaClient } from "@prisma/client";
 import { prisma } from "../db";
 import { resolveRepo } from "./repoResolver";
 
@@ -14,7 +15,10 @@ let repoPromise: Promise<AnalyticsRepository> | undefined;
 async function getRepo(): Promise<AnalyticsRepository> {
   if (!repoPromise) {
     repoPromise = resolveRepo<AnalyticsRepository>(
-      () => (prisma as any).analyticsEvent,
+      () =>
+        (
+          prisma as PrismaClient & { analyticsEvent?: unknown }
+        ).analyticsEvent,
       () =>
         import("./analytics.prisma.server").then(
           (m) => m.prismaAnalyticsRepository,


### PR DESCRIPTION
## Summary
- avoid explicit `any` in analytics repository by typing prisma delegate

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: File '../types/src/index.ts(37,37)' not under 'rootDir')*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec eslint packages/platform-core/src/repositories/analytics.server.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6dfa31794832f80d833909529913d