### PR TITLE
refactor: tighten seed typing

### DIFF
--- a/packages/platform-core/prisma/seed.ts
+++ b/packages/platform-core/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
+import type { Prisma } from "@prisma/client";
 
 import { prisma } from "../src/db";
 import { nowIso } from "@acme/date-utils";
@@ -24,13 +25,14 @@ async function main() {
   if (!skipInventory) {
     const shopsDir = path.resolve(__dirname, "../../../data/shops");
     const dirs = await readdir(shopsDir, { withFileTypes: true });
-    const data: any[] = [];
+    const data: Prisma.InventoryItemCreateManyInput[] = [];
 
     for (const dir of dirs) {
       if (!dir.isDirectory()) continue;
       const shop = dir.name;
       const file = path.join(shopsDir, shop, "inventory.json");
       try {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
         const raw = await readFile(file, "utf8");
         const items = JSON.parse(raw) as Array<{
           sku: string;


### PR DESCRIPTION
## Summary
- tighten prisma seed typing
- silence non-literal path warning when loading inventory files

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid email environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec eslint packages/platform-core/prisma/seed.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6dfed3278832fbfddd4b6ed576cf4