### PR TITLE
refactor: harden createShop fs usage

### DIFF
--- a/packages/platform-core/src/createShop/createShop.ts
+++ b/packages/platform-core/src/createShop/createShop.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import { join } from "path";
 import { prisma } from "../db";
 import { validateShopName } from "../shops";
@@ -13,6 +12,7 @@ import {
   defaultDeploymentAdapter,
   type ShopDeploymentAdapter,
 } from "./deploymentAdapter";
+import { ensureDir, writeJSON } from "./fsUtils";
 import type { Shop } from "@acme/types";
 
 /**
@@ -73,8 +73,8 @@ export async function createShop(
 
   try {
     const dir = join("data", "shops", id);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(join(dir, "shop.json"), JSON.stringify(shopData, null, 2));
+    ensureDir(dir);
+    writeJSON(join(dir, "shop.json"), shopData);
   } catch {
     // ignore filesystem write errors
   }

--- a/packages/platform-core/src/createShop/deploy.ts
+++ b/packages/platform-core/src/createShop/deploy.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import { dirname, join } from "path";
 import { genSecret } from "@acme/shared-utils";
 import type { DeployShopResult } from "./deployTypes";
@@ -6,7 +5,13 @@ import {
   defaultDeploymentAdapter,
   type ShopDeploymentAdapter,
 } from "./deploymentAdapter";
-import { repoRoot } from "./fsUtils";
+import {
+  repoRoot,
+  fileExists,
+  readFile,
+  ensureDir,
+  writeFile,
+} from "./fsUtils";
 
 export function deployShopImpl(
   id: string,
@@ -21,11 +26,11 @@ export function deployShopImpl(
     adapter.scaffold(newApp);
     const envRel = join(newApp, ".env");
     const envAbs = join(repoRoot(), envRel);
-    const envSrc = fs.existsSync(envAbs) ? envAbs : envRel;
+    const envSrc = fileExists(envAbs) ? envAbs : envRel;
 
     let env = "";
     try {
-      env = fs.readFileSync(envSrc, "utf8");
+      env = readFile(envSrc);
     } catch {
       /* no existing env file */
     }
@@ -43,8 +48,8 @@ export function deployShopImpl(
     const cwdPath = join(process.cwd(), envRel);
     for (const p of new Set([envAbs, cwdPath, envSrc])) {
       try {
-        fs.mkdirSync(dirname(p), { recursive: true });
-        fs.writeFileSync(p, env);
+        ensureDir(dirname(p));
+        writeFile(p, env);
       } catch {
         /* ignore write errors */
       }

--- a/packages/platform-core/src/createShop/deployTypes.ts
+++ b/packages/platform-core/src/createShop/deployTypes.ts
@@ -7,5 +7,5 @@ export interface DeployStatusBase {
   error?: string;
 }
 
-export interface DeployShopResult extends DeployStatusBase {}
+export type DeployShopResult = DeployStatusBase;
 

--- a/packages/platform-core/src/createShop/deploymentAdapter.ts
+++ b/packages/platform-core/src/createShop/deploymentAdapter.ts
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "child_process";
 import { join } from "path";
-import { writeFileSync, mkdirSync } from "fs";
+import { ensureDir, writeJSON } from "./fsUtils";
 
 import type { DeployShopResult } from "./deployTypes";
 
@@ -39,9 +39,9 @@ export class CloudflareDeploymentAdapter implements ShopDeploymentAdapter {
   writeDeployInfo(id: string, info: DeployShopResult): void {
     try {
       const dir = join("data", "shops", id);
-      mkdirSync(dir, { recursive: true });
+      ensureDir(dir);
       const file = join(dir, "deploy.json");
-      writeFileSync(file, JSON.stringify(info, null, 2));
+      writeJSON(file, info);
     } catch {
       // ignore write errors
     }

--- a/packages/platform-core/src/createShop/fsUtils.d.ts
+++ b/packages/platform-core/src/createShop/fsUtils.d.ts
@@ -22,3 +22,7 @@ export declare function writeFile(path: string, content: string): void;
  * Write an object to disk as formatted JSON with trailing newline.
  */
 export declare function writeJSON(path: string, data: unknown): void;
+/**
+ * Check if a file or directory exists.
+ */
+export declare function fileExists(path: string): boolean;

--- a/packages/platform-core/src/createShop/fsUtils.ts
+++ b/packages/platform-core/src/createShop/fsUtils.ts
@@ -68,6 +68,13 @@ export function repoRoot(): string {
 }
 
 /**
+ * Check if a file or directory exists.
+ */
+export function fileExists(path: string): boolean {
+  return existsSync(path);
+}
+
+/**
  * Ensure a directory exists, creating it recursively when missing.
  */
 export function ensureDir(path: string): void {


### PR DESCRIPTION
## Summary
- use shared fsUtils helpers to manage shop creation and deployment files
- convert empty DeployShopResult interface to type alias
- add fileExists helper to support lint-safe path checks

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid email environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm --filter @acme/platform-core lint` *(fails: lint errors in other files)*
- `pnpm exec eslint packages/platform-core/src/createShop/{createShop.ts,deploy.ts,deploymentAdapter.ts,deployTypes.ts}`

------
https://chatgpt.com/codex/tasks/task_e_68c6dfd8ecc8832f977aa13870df6327