### PR TITLE
fix: tighten shared-utils typings

### DIFF
--- a/packages/shared-utils/src/fetchJson.ts
+++ b/packages/shared-utils/src/fetchJson.ts
@@ -10,8 +10,12 @@ export async function fetchJson<T>(
   if (res.ok) {
     let data: unknown;
     try {
-      if (typeof (res as any).json === "function") {
-        data = await (res as any).json();
+      type JsonCapableResponse = Response & {
+        json?: () => Promise<unknown>;
+      };
+      const resWithJson = res as JsonCapableResponse;
+      if (typeof resWithJson.json === "function") {
+        data = await resWithJson.json();
       } else {
         const text = await res.text();
         data = text ? JSON.parse(text) : undefined;

--- a/packages/shared-utils/src/getCsrfToken.ts
+++ b/packages/shared-utils/src/getCsrfToken.ts
@@ -2,15 +2,20 @@ type SimpleReq = { headers?: Record<string, string | undefined>; url?: string };
 
 export function getCsrfToken(req?: Request | SimpleReq): string | undefined {
   if (req) {
-    const headers: any = (req as any).headers;
-    const getHeader = typeof headers?.get === "function"
-      ? (name: string) => headers.get(name)
-      : (name: string) => headers?.[name];
+    const headers = (
+      req as unknown as {
+        headers?: Headers | Record<string, string | undefined>;
+      }
+    ).headers;
+    const getHeader = typeof (headers as Headers)?.get === "function"
+      ? (name: string) => (headers as Headers).get(name) ?? undefined
+      : (name: string) =>
+          (headers as Record<string, string | undefined>)?.[name];
 
     const headerToken = getHeader("x-csrf-token")?.trim();
     if (headerToken) return headerToken;
 
-    const reqUrl = (req as any).url;
+    const reqUrl = (req as unknown as { url?: string }).url;
     if (reqUrl) {
       const queryToken = new URL(reqUrl, "http://dummy").searchParams
         .get("csrf_token")

--- a/packages/shared-utils/src/parseJsonBody.ts
+++ b/packages/shared-utils/src/parseJsonBody.ts
@@ -87,7 +87,7 @@ export async function parseJsonBody<T>(
     } else {
       throw new Error("No body parser available");
     }
-  } catch (err: unknown) {
+  } catch {
     return {
       success: false,
       response: NextResponse.json(


### PR DESCRIPTION
## Summary
- eliminate `any` usages in `fetchJson` and `getCsrfToken`
- remove unused catch variable in `parseJsonBody`

## Testing
- `pnpm --filter @acme/shared-utils run check:references` *(fails: script not found)*
- `pnpm --filter @acme/shared-utils lint`
- `pnpm --filter @acme/shared-utils build`
- `pnpm --filter @acme/shared-utils test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e038d82c832f94f797195bd4d6a9