### PR TITLE
chore: silence fs filename lint in platform-machine

### DIFF
--- a/packages/platform-machine/src/maintenanceScheduler.ts
+++ b/packages/platform-machine/src/maintenanceScheduler.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- Paths are derived from internal configuration */
 import { readdir } from "fs/promises";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { readInventory } from "@platform-core/repositories/inventory.server";

--- a/packages/platform-machine/src/processReverseLogisticsEventsOnce.ts
+++ b/packages/platform-machine/src/processReverseLogisticsEventsOnce.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- Paths are derived from internal configuration */
 import { markAvailable, markCleaning, markQa, markReceived, markRepair } from "@platform-core/repositories/rentalOrders.server";
 import { reverseLogisticsEvents } from "@platform-core/repositories/reverseLogisticsEvents.server";
 import { resolveDataRoot } from "@platform-core/dataRoot";

--- a/packages/platform-machine/src/releaseDepositsService.ts
+++ b/packages/platform-machine/src/releaseDepositsService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- Paths are derived from internal configuration */
 import { coreEnv } from "@acme/config/env/core";
 import {
   markRefunded,

--- a/packages/platform-machine/src/resolveConfig.ts
+++ b/packages/platform-machine/src/resolveConfig.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- Paths are derived from internal configuration */
 import { coreEnv } from "@acme/config/env/core";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { readFile } from "fs/promises";

--- a/packages/platform-machine/src/startReverseLogisticsService.ts
+++ b/packages/platform-machine/src/startReverseLogisticsService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- Paths are derived from internal configuration */
 import { readdir } from "fs/promises";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { logger } from "@platform-core/utils";

--- a/packages/platform-machine/src/writeReverseLogisticsEvent.ts
+++ b/packages/platform-machine/src/writeReverseLogisticsEvent.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- Paths are derived from internal configuration */
 import type { ReverseLogisticsEventName } from "@acme/types";
 import { resolveDataRoot } from "@platform-core/dataRoot";
 import { mkdir, writeFile } from "fs/promises";


### PR DESCRIPTION
## Summary
- silence security/detect-non-literal-fs-filename lint warnings in platform-machine files

## Testing
- `pnpm --filter @acme/platform-machine lint`
- `pnpm --filter @acme/platform-machine test` *(fails: Invalid core/auth/payment env variables)*
- `pnpm --filter @acme/platform-machine run check:references` *(fails: missing script)*
- `pnpm --filter @acme/platform-machine run build:ts` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e0101208832f8af21ec685947575