### PR TITLE
refactor(platform-core): remove any types from db stubs

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -45,7 +45,7 @@ function createTestPrismaStub(): Pick<
   | 'reverseLogisticsEvent'
   | 'customerMfa'
   | '$transaction'
-> & { inventoryItem: InventoryItemDelegate } {
+  > & { inventoryItem: InventoryItemDelegate } {
   const stub = {
     rentalOrder: createRentalOrderDelegate() as unknown as PrismaClientType['rentalOrder'],
     shop: createShopDelegate() as unknown as PrismaClientType['shop'],
@@ -57,22 +57,40 @@ function createTestPrismaStub(): Pick<
     reverseLogisticsEvent: createReverseLogisticsEventDelegate() as unknown as PrismaClientType['reverseLogisticsEvent'],
     product: createProductDelegate() as unknown as PrismaClientType['product'],
     inventoryItem: createInventoryItemDelegate(),
-  } as any;
+  } as unknown as Pick<
+    PrismaClientType,
+    | 'rentalOrder'
+    | 'shop'
+    | 'page'
+    | 'customerProfile'
+    | 'subscriptionUsage'
+    | 'user'
+    | 'reverseLogisticsEvent'
+    | 'customerMfa'
+    | '$transaction'
+  > & { inventoryItem: InventoryItemDelegate };
 
-  stub.$transaction = async (fn: (tx: typeof stub) => any) => fn(stub);
+  stub.$transaction = async <T>(fn: (tx: typeof stub) => T): Promise<T> =>
+    fn(stub);
 
   return stub;
 }
-let PrismaCtor: any;
+let PrismaCtor: (new (...args: unknown[]) => PrismaClientType) | undefined;
 
-function loadPrismaClient(): any {
+function loadPrismaClient():
+  | (new (...args: unknown[]) => PrismaClientType)
+  | undefined {
   if (PrismaCtor !== undefined) return PrismaCtor;
   try {
     const moduleUrl = typeof __filename !== 'undefined'
       ? __filename
       : (Function('return import.meta.url')() as string);
     const req = createRequire(moduleUrl);
-    PrismaCtor = (req("@prisma/client") as { PrismaClient: any }).PrismaClient;
+    PrismaCtor = (
+      req("@prisma/client") as {
+        PrismaClient: new (...args: unknown[]) => PrismaClientType;
+      }
+    ).PrismaClient;
   } catch {
     PrismaCtor = undefined;
   }

--- a/packages/platform-core/src/db/stubs/customerMfa.ts
+++ b/packages/platform-core/src/db/stubs/customerMfa.ts
@@ -7,7 +7,11 @@ export type CustomerMfa = {
 export function createCustomerMfaDelegate() {
   const customerMfas: CustomerMfa[] = [];
   return {
-    upsert: async ({ where, update, create }: any) => {
+    upsert: async ({ where, update, create }: {
+      where: { customerId: string };
+      update: Partial<CustomerMfa>;
+      create: CustomerMfa;
+    }): Promise<CustomerMfa> => {
       const idx = customerMfas.findIndex((m) => m.customerId === where.customerId);
       if (idx >= 0) {
         customerMfas[idx] = { ...customerMfas[idx], ...update };
@@ -17,15 +21,18 @@ export function createCustomerMfaDelegate() {
       customerMfas.push(record);
       return record;
     },
-    findUnique: async ({ where }: any) =>
+    findUnique: async ({ where }: { where: { customerId: string } }): Promise<CustomerMfa | null> =>
       customerMfas.find((m) => m.customerId === where.customerId) || null,
-    update: async ({ where, data }: any) => {
+    update: async ({ where, data }: {
+      where: { customerId: string };
+      data: Partial<CustomerMfa>;
+    }): Promise<CustomerMfa> => {
       const idx = customerMfas.findIndex((m) => m.customerId === where.customerId);
       if (idx < 0) throw new Error("CustomerMfa not found");
       customerMfas[idx] = { ...customerMfas[idx], ...data };
       return customerMfas[idx];
     },
-  } as any;
+  };
 }
 
 export const customerMfaDelegate = createCustomerMfaDelegate();

--- a/packages/platform-core/src/db/stubs/customerProfile.ts
+++ b/packages/platform-core/src/db/stubs/customerProfile.ts
@@ -7,9 +7,13 @@ export type CustomerProfile = {
 export function createCustomerProfileDelegate() {
   const customerProfiles: CustomerProfile[] = [];
   return {
-    findUnique: async ({ where }: any) =>
+    findUnique: async ({ where }: { where: { customerId: string } }): Promise<CustomerProfile | null> =>
       customerProfiles.find((p) => p.customerId === where.customerId) || null,
-    findFirst: async ({ where }: any) => {
+    findFirst: async ({
+      where,
+    }: {
+      where?: { email?: string; NOT?: { customerId?: string } };
+    }): Promise<CustomerProfile | null> => {
       const email = where?.email;
       const notCustomerId = where?.NOT?.customerId;
       return (
@@ -18,7 +22,15 @@ export function createCustomerProfileDelegate() {
         ) || null
       );
     },
-    upsert: async ({ where, update, create }: any) => {
+    upsert: async ({
+      where,
+      update,
+      create,
+    }: {
+      where: { customerId: string };
+      update: Partial<CustomerProfile>;
+      create: CustomerProfile;
+    }): Promise<CustomerProfile> => {
       const idx = customerProfiles.findIndex((p) => p.customerId === where.customerId);
       if (idx >= 0) {
         customerProfiles[idx] = { ...customerProfiles[idx], ...update };
@@ -28,5 +40,5 @@ export function createCustomerProfileDelegate() {
       customerProfiles.push(profile);
       return profile;
     },
-  } as any;
+  };
 }

--- a/packages/platform-core/src/db/stubs/inventoryItem.ts
+++ b/packages/platform-core/src/db/stubs/inventoryItem.ts
@@ -1,18 +1,35 @@
+export interface InventoryItemRecord {
+  shopId: string;
+  sku: string;
+  variantKey: string;
+  [key: string]: unknown;
+}
+
+type ShopSkuVariantKey = {
+  shopId: string;
+  sku: string;
+  variantKey: string;
+};
+
 export type InventoryItemDelegate = {
-  findMany(args: any): Promise<any[]>;
-  deleteMany(args: any): Promise<{ count: number }>;
-  createMany(args: any): Promise<{ count: number }>;
-  findUnique(args: any): Promise<any | null>;
-  delete(args: any): Promise<any>;
-  upsert(args: any): Promise<any>;
+  findMany(args: { where: { shopId: string } }): Promise<InventoryItemRecord[]>;
+  deleteMany(args: { where: { shopId: string } }): Promise<{ count: number }>;
+  createMany(args: { data: InventoryItemRecord[] }): Promise<{ count: number }>;
+  findUnique(args: { where: { shopId_sku_variantKey: ShopSkuVariantKey } }): Promise<InventoryItemRecord | null>;
+  delete(args: { where: { shopId_sku_variantKey: ShopSkuVariantKey } }): Promise<InventoryItemRecord>;
+  upsert(args: {
+    where: { shopId_sku_variantKey: ShopSkuVariantKey };
+    update: Partial<InventoryItemRecord>;
+    create: Partial<InventoryItemRecord>;
+  }): Promise<InventoryItemRecord>;
 };
 
 export function createInventoryItemDelegate(): InventoryItemDelegate {
-  const inventoryItems: { shopId: string; [key: string]: any }[] = [];
+  const inventoryItems: InventoryItemRecord[] = [];
   return {
-    findMany: async ({ where: { shopId } }: any) =>
+    findMany: async ({ where: { shopId } }) =>
       inventoryItems.filter((i) => i.shopId === shopId),
-    deleteMany: async ({ where: { shopId } }: any) => {
+    deleteMany: async ({ where: { shopId } }) => {
       let count = 0;
       for (let i = inventoryItems.length - 1; i >= 0; i--) {
         if (inventoryItems[i].shopId === shopId) {
@@ -22,11 +39,11 @@ export function createInventoryItemDelegate(): InventoryItemDelegate {
       }
       return { count };
     },
-    createMany: async ({ data }: any) => {
-      inventoryItems.push(...data.map((item: any) => ({ ...item })));
+    createMany: async ({ data }) => {
+      inventoryItems.push(...data.map((item) => ({ ...item })));
       return { count: data.length };
     },
-    findUnique: async ({ where: { shopId_sku_variantKey } }: any) => {
+    findUnique: async ({ where: { shopId_sku_variantKey } }) => {
       const { shopId, sku, variantKey } = shopId_sku_variantKey;
       return (
         inventoryItems.find(
@@ -34,7 +51,7 @@ export function createInventoryItemDelegate(): InventoryItemDelegate {
         ) || null
       );
     },
-    delete: async ({ where: { shopId_sku_variantKey } }: any) => {
+    delete: async ({ where: { shopId_sku_variantKey } }) => {
       const { shopId, sku, variantKey } = shopId_sku_variantKey;
       const idx = inventoryItems.findIndex(
         (i) => i.shopId === shopId && i.sku === sku && i.variantKey === variantKey,
@@ -43,7 +60,7 @@ export function createInventoryItemDelegate(): InventoryItemDelegate {
       const [removed] = inventoryItems.splice(idx, 1);
       return removed;
     },
-    upsert: async ({ where: { shopId_sku_variantKey }, update, create }: any) => {
+    upsert: async ({ where: { shopId_sku_variantKey }, update, create }) => {
       const { shopId, sku, variantKey } = shopId_sku_variantKey;
       const idx = inventoryItems.findIndex(
         (i) => i.shopId === shopId && i.sku === sku && i.variantKey === variantKey,
@@ -52,7 +69,12 @@ export function createInventoryItemDelegate(): InventoryItemDelegate {
         inventoryItems[idx] = { ...inventoryItems[idx], ...update };
         return inventoryItems[idx];
       }
-      const record = { ...create, shopId, sku, variantKey };
+      const record: InventoryItemRecord = {
+        shopId,
+        sku,
+        variantKey,
+        ...create,
+      };
       inventoryItems.push(record);
       return record;
     },


### PR DESCRIPTION
## Summary
- replace `any` in Prisma test stub with typed helpers
- type customerMfa, customerProfile and inventory item stub delegates

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: Invalid email environment variables)*
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*
- `pnpm exec eslint packages/platform-core/src/db.ts packages/platform-core/src/db/stubs/customerMfa.ts packages/platform-core/src/db/stubs/customerProfile.ts packages-platform-core/src/db/stubs/inventoryItem.ts`
- `pnpm --filter @acme/platform-core exec jest packages/platform-core/src/db/stubs/__tests__/delegates.test.ts` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dfc4f0a8832fa15b5ba46b9b2f00