### PR TITLE
chore: set default email sender

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,6 @@
 UPS_KEY=
 DHL_KEY=
 
+# Email settings
+EMAIL_FROM=peter.cowling1976@gmail.com
+


### PR DESCRIPTION
## Summary
- add EMAIL_FROM to env template for build

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/ui)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ef4a930c832f93ea7eb961344fef