### PR TITLE
Default to noop email provider when missing config

### DIFF
--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -204,7 +204,12 @@ export type CoreEnv = z.infer<typeof coreEnvSchema>;
 function parseCoreEnv(raw: NodeJS.ProcessEnv = process.env): CoreEnv {
   const env = isTest
     ? { EMAIL_FROM: "test@example.com", EMAIL_PROVIDER: "noop", ...raw }
-    : raw;
+    : {
+        ...raw,
+        ...(raw.EMAIL_FROM || raw.EMAIL_PROVIDER
+          ? {}
+          : { EMAIL_PROVIDER: "noop" }),
+      };
   const parsed = coreEnvSchema.safeParse(env);
   if (!parsed.success) {
     if (isTest) {

--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -73,8 +73,14 @@ export const emailEnvSchema = z
       });
     }
   });
-
-const parsed = emailEnvSchema.safeParse(process.env);
+const rawEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  EMAIL_PROVIDER:
+    process.env.EMAIL_FROM || process.env.EMAIL_PROVIDER
+      ? process.env.EMAIL_PROVIDER
+      : "noop",
+};
+const parsed = emailEnvSchema.safeParse(rawEnv);
 
 if (!parsed.success) {
   if (!isTest) {


### PR DESCRIPTION
## Summary
- Default email provider to `noop` when neither `EMAIL_FROM` nor `EMAIL_PROVIDER` is set
- Ensure core env loading applies the same default for missing email settings

## Testing
- `pnpm install`
- `pnpm -r build` *(fails: TypeScript errors in packages/ui)*
- `pnpm run check:references` *(fails: Missing script)*
- `pnpm run build:ts` *(fails: Missing script)*
- `pnpm --filter @acme/config test` *(fails: Jest cannot parse ES module)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fa69e444832fb18cc40bc03c0c09