### PR TITLE
fix(ui): resolve ts build errors

### DIFF
--- a/packages/ui/src/components/atoms/Logo.tsx
+++ b/packages/ui/src/components/atoms/Logo.tsx
@@ -34,7 +34,6 @@ export const Logo = React.forwardRef<HTMLImageElement, LogoProps>(
       fallbackText,
       width = 32,
       height = 32,
-      srcSet,
       sizes,
       ...props
     },
@@ -45,15 +44,6 @@ export const Logo = React.forwardRef<HTMLImageElement, LogoProps>(
     const imageSrc = responsive?.src ?? src;
     const imageWidth = responsive?.width ?? width;
     const imageHeight = responsive?.height ?? height;
-
-    const computedSrcSet =
-      srcSet ??
-      (sources
-        ? Object.values(sources)
-            .filter((s) => s.width)
-            .map((s) => `${s.src} ${s.width}w`)
-            .join(", ")
-        : undefined);
 
     const altText = alt ?? fallbackText;
 
@@ -71,7 +61,6 @@ export const Logo = React.forwardRef<HTMLImageElement, LogoProps>(
         alt={altText}
         width={imageWidth}
         height={imageHeight}
-        srcSet={computedSrcSet}
         sizes={sizes}
         className={cn(widthClass, heightClass, className)}
         {...props}

--- a/packages/ui/src/components/cms/blocks/Lookbook.tsx
+++ b/packages/ui/src/components/cms/blocks/Lookbook.tsx
@@ -84,7 +84,9 @@ export default function Lookbook({ items = [], onItemsChange }: Props) {
       {list.map((item, idx) => (
         <div
           key={idx}
-          ref={(el) => (containerRefs.current[idx] = el)}
+          ref={(el) => {
+            containerRefs.current[idx] = el;
+          }}
           className="relative h-full w-full"
         >
           {item.src && (

--- a/packages/ui/src/components/cms/page-builder/ImageSourcePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/ImageSourcePanel.tsx
@@ -76,7 +76,7 @@ function ImageSourcePanel({ src, alt, onChange }: Props) {
         <Input
           value={url}
           onChange={handleUrl}
-          placeholder={t("cms.image.url")}
+          placeholder={t("cms.image.url") as string}
           className="flex-1"
         />
         <ImagePicker onSelect={handleSelect}>
@@ -96,7 +96,7 @@ function ImageSourcePanel({ src, alt, onChange }: Props) {
       <Input
         value={altText}
         onChange={handleAlt}
-        placeholder={t("cms.image.alt")}
+        placeholder={t("cms.image.alt") as string}
         disabled={decorative}
       />
       <label className="flex items-center gap-2 text-sm">

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -54,19 +54,19 @@ export default function StylePanel({ component, handleInput }: Props) {
       <Input
         label={t("cms.style.foreground")}
         value={color.fg ?? ""}
-        placeholder={t("cms.style.colorPlaceholder")}
+        placeholder={t("cms.style.colorPlaceholder") as string}
         onChange={(e) => update("color", "fg", e.target.value)}
       />
       <Input
         label={t("cms.style.background")}
         value={color.bg ?? ""}
-        placeholder={t("cms.style.colorPlaceholder")}
+        placeholder={t("cms.style.colorPlaceholder") as string}
         onChange={(e) => update("color", "bg", e.target.value)}
       />
       <Input
         label={t("cms.style.border")}
         value={color.border ?? ""}
-        placeholder={t("cms.style.colorPlaceholder")}
+        placeholder={t("cms.style.colorPlaceholder") as string}
         onChange={(e) => update("color", "border", e.target.value)}
       />
       <Input

--- a/packages/ui/src/components/organisms/Header.tsx
+++ b/packages/ui/src/components/organisms/Header.tsx
@@ -26,11 +26,22 @@ export interface HeaderProps extends React.HTMLAttributes<HTMLElement> {
   logoVariants?: LogoVariants;
   /** Shop name for text fallback */
   shopName: string;
+  /** Whether to display the search bar */
+  showSearch?: boolean;
 }
 
 export const Header = React.forwardRef<HTMLElement, HeaderProps>(
   (
-    { nav = [], searchSuggestions = [], locale, logoVariants, shopName, className, ...props },
+    {
+      nav = [],
+      searchSuggestions = [],
+      locale,
+      logoVariants,
+      shopName,
+      showSearch = true,
+      className,
+      ...props
+    },
     ref,
   ) => {
     const viewport = useViewport();
@@ -87,9 +98,11 @@ export const Header = React.forwardRef<HTMLElement, HeaderProps>(
           </div>
 
           <div className="flex flex-1 justify-end gap-4">
-            <div className="max-w-xs flex-1">
-              <SearchBar suggestions={searchSuggestions} label="Search products" />
-            </div>
+            {showSearch && (
+              <div className="max-w-xs flex-1">
+                <SearchBar suggestions={searchSuggestions} label="Search products" />
+              </div>
+            )}
             <LanguageSwitcher current={locale} />
           </div>
         </div>

--- a/packages/ui/src/components/templates/AppShell.stories.tsx
+++ b/packages/ui/src/components/templates/AppShell.stories.tsx
@@ -16,11 +16,11 @@ export default meta;
 
 export const Default: StoryObj<typeof AppShell> = {
   render: () => (
-    <AppShell
-      header={<Header locale="en">Header</Header>}
-      sideNav={<SideNav>Nav</SideNav>}
-      footer={<Footer>Footer</Footer>}
-    >
+      <AppShell
+        header={<Header locale="en" shopName="Demo">Header</Header>}
+        sideNav={<SideNav>Nav</SideNav>}
+        footer={<Footer shopName="Demo">Footer</Footer>}
+      >
       <Content>Content</Content>
     </AppShell>
   ),


### PR DESCRIPTION
## Summary
- simplify Logo component and drop unsupported `srcSet`
- add optional `showSearch` to Header with conditional search bar
- fix refs and translation placeholders in CMS panels and stories

## Testing
- `pnpm --filter @acme/ui build`
- `pnpm -r build`
- `pnpm --filter @acme/ui test` *(fails: Unable to find a label with the text of: Width (Desktop))*

------
https://chatgpt.com/codex/tasks/task_e_68c726c2df58832faff67b10e02e3b40