### PR TITLE
refactor: use types package for style overrides

### DIFF
--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -34,3 +34,6 @@ export * from "./settings";
 export * from "./shop-seo";
 export * from "./shop-locale";
 export * from "./shop-theme";
+export type { StyleOverrides } from "./style/StyleOverrides";
+export * from "./ds";
+export * from "./theme";

--- a/packages/ui/src/components/cms/page-builder/StylePanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/StylePanel.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { PageComponent } from "@acme/types";
-import type { StyleOverrides } from "../../../../../types/src/style/StyleOverrides";
+import type { StyleOverrides } from "@acme/types/style/StyleOverrides";
 import { Input } from "../../atoms/shadcn";
 import { useTranslations } from "@acme/i18n";
 import useContrastWarnings from "../../../hooks/useContrastWarnings";

--- a/packages/ui/src/utils/style/cssVars.ts
+++ b/packages/ui/src/utils/style/cssVars.ts
@@ -1,4 +1,4 @@
-import type { StyleOverrides } from "../../../../types/src/style/StyleOverrides";
+import type { StyleOverrides } from "@acme/types/style/StyleOverrides";
 
 export function cssVars(overrides?: StyleOverrides): Record<string, string> {
   if (!overrides) return {};


### PR DESCRIPTION
## Summary
- import StyleOverrides via @acme/types package
- expose StyleOverrides in types package declarations

## Testing
- `pnpm run check:references` (fails: Missing script)
- `pnpm run build:ts` (fails: Missing script)
- `pnpm --filter @acme/ui build`
- `pnpm --filter @acme/email-templates build`


------
https://chatgpt.com/codex/tasks/task_e_68c735a48c24832fab4c99c090735360