### PR TITLE
fix email-templates types path

### DIFF
--- a/packages/email-templates/tsconfig.json
+++ b/packages/email-templates/tsconfig.json
@@ -10,10 +10,15 @@
     "baseUrl": ".",
     "paths": {
       "@acme/ui": ["../ui/dist/index.d.ts", "types-compat/ui"],
-      "@acme/ui/*": ["../ui/dist/*"]
+      "@acme/ui/*": ["../ui/dist/*"],
+      "@acme/types": ["../types/src/index", "../types/dist/index.d.ts"],
+      "@acme/types/*": ["../types/src/*", "../types/dist/*"]
     }
   },
   "include": ["src/**/*", "types-compat/**/*.d.ts"],
-  "exclude": ["dist", "**/__tests__/**", ".turbo", "node_modules"]
+  "exclude": ["dist", "**/__tests__/**", ".turbo", "node_modules"],
+  "references": [
+    { "path": "../types" }
+  ]
 }
 


### PR DESCRIPTION
## Summary
- map `@acme/types` in email-templates `tsconfig.json` and add project reference

## Testing
- `pnpm -r build` *(fails: Module not found: Can't resolve './animations.css')*
- `npx tsc -b packages/platform-core`
- `npx tsc -b packages/email-templates`
- `pnpm run check:references` *(fails: Missing script: check:references)*
- `pnpm run build:ts` *(fails: Missing script: build:ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f99470c4832f9f60b26e5806e755