### PR TITLE
Fix CMS TypeScript build issues

### DIFF
--- a/apps/cms/src/actions/maintenance.server.ts
+++ b/apps/cms/src/actions/maintenance.server.ts
@@ -20,7 +20,7 @@ export async function updateMaintenanceSchedule(formData: FormData) {
   const initial = startMaintenanceScheduler();
   clearInterval(initial);
   const run = () =>
-    runMaintenanceScan().catch((err) =>
+    runMaintenanceScan().catch((err: unknown) =>
       logger.error("maintenance scan failed", { err }),
     );
   timer = setInterval(run, freq);

--- a/apps/cms/src/actions/pages/utils.ts
+++ b/apps/cms/src/actions/pages/utils.ts
@@ -18,8 +18,8 @@ export function mapLocales(
   const description: Record<Locale, string> = {} as Record<Locale, string>;
   const image: Record<Locale, string> = {} as Record<Locale, string>;
   LOCALES.forEach((l) => {
-    title[l] = data[`title_${l}`];
-    description[l] = data[`desc_${l}`];
+    title[l] = data[`title_${l}`] ?? "";
+    description[l] = data[`desc_${l}`] ?? "";
     image[l] = data.image ?? "";
   });
   return { title, description, image };

--- a/apps/cms/src/actions/products.server.ts
+++ b/apps/cms/src/actions/products.server.ts
@@ -163,7 +163,7 @@ export async function deleteProduct(shop: string, id: string): Promise<void> {
   "use server";
   await ensureAuthorized();
 
-  await deleteProductFromRepo<ProductPublication>(shop, id);
+  await deleteProductFromRepo(shop, id);
   redirect(`/cms/shop/${shop}/products`);
 }
 

--- a/apps/cms/src/actions/stockScheduler.server.ts
+++ b/apps/cms/src/actions/stockScheduler.server.ts
@@ -5,6 +5,12 @@
 import { scheduleStockChecks, getStockCheckStatus } from "@platform-core/services/stockScheduler.server";
 import { readInventory } from "@platform-core/repositories/inventory.server";
 
+interface StockCheckStatus {
+  intervalMs: number;
+  lastRun?: number;
+  history: { timestamp: number; alerts: number }[];
+}
+
 export async function updateStockScheduler(shop: string, formData: FormData) {
   const intervalStr = formData.get("intervalMs");
   const intervalMs = Number(intervalStr);
@@ -12,6 +18,6 @@ export async function updateStockScheduler(shop: string, formData: FormData) {
   scheduleStockChecks(shop, () => readInventory(shop), intervalMs);
 }
 
-export async function getSchedulerStatus(shop: string) {
-  return getStockCheckStatus(shop);
+export async function getSchedulerStatus(shop: string): Promise<StockCheckStatus | undefined> {
+  return getStockCheckStatus(shop) as StockCheckStatus | undefined;
 }

--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -48,7 +48,7 @@ export async function POST(
     } else if (hasArrayBuffer(file)) {
       const buf = await file.arrayBuffer();
       text = new TextDecoder().decode(buf);
-    } else if (file instanceof Blob) {
+    } else if (typeof file === "object" && (file as any) instanceof Blob) {
       text = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
         reader.onerror = () => reject(reader.error);

--- a/apps/cms/src/app/api/launch-shop/route.ts
+++ b/apps/cms/src/app/api/launch-shop/route.ts
@@ -114,7 +114,7 @@ export async function POST(req: Request) {
     }
   })();
 
-  return new Response(readable, {
+  return new Response(readable as any, {
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",

--- a/apps/cms/src/app/cms/wizard/WizardPreview.tsx
+++ b/apps/cms/src/app/cms/wizard/WizardPreview.tsx
@@ -114,9 +114,9 @@ const WizardPreview = forwardRef<HTMLDivElement, Props>(function WizardPreview(
     >
       <TranslationsProvider messages={enMessages}>
         <AppShell
-          header={<Header locale="en" />}
+          header={<Header locale="en" shopName="" />}
           sideNav={<SideNav />}
-          footer={<Footer />}
+          footer={<Footer shopName="" />}
         >
           {components.map((c) => (
             <Block key={c.id} component={c} />

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -105,6 +105,12 @@
       "@acme/platform-core/*": [
         "../../packages/platform-core/src/*", "../../packages/platform-core/dist/*"
       ],
+      "@acme/platform-machine": [
+        "../../packages/platform-machine/src/index.ts", "../../packages/platform-machine/dist/index"
+      ],
+      "@acme/platform-machine/*": [
+        "../../packages/platform-machine/src/*", "../../packages/platform-machine/dist/*"
+      ],
       "@acme/email": [
         "../../packages/email/src/index.ts", "../../packages/email/dist/index"
       ],
@@ -177,6 +183,7 @@
   "references": [
     { "path": "../../packages/ui" },
     { "path": "../../packages/platform-core" },
+    { "path": "../../packages/platform-machine" },
     { "path": "../../packages/auth" },
     { "path": "../../packages/lib" },
     { "path": "../../packages/shared-utils" },


### PR DESCRIPTION
## Summary
- add platform-machine package paths and references to CMS tsconfig
- fix type errors in CMS actions and API routes
- allow building and compiling CMS without missing module errors

## Testing
- `pnpm install`
- `pnpm -r build`
- `npx tsc -b apps/cms`


------
https://chatgpt.com/codex/tasks/task_e_68c813d9a290832fb0f5a7708f9ef162