### PR TITLE
Add auth secrets to env template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,7 @@
+# Authentication secrets (replace with secure random strings before deploying)
+NEXTAUTH_SECRET=dev-nextauth-secret-32-chars-long-string!
+SESSION_SECRET=dev-session-secret-32-chars-long-string!
+
 # Shipping provider API keys
 UPS_KEY=
 DHL_KEY=

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # Authentication secrets (replace with secure random strings before deploying)
-NEXTAUTH_SECRET=dev-nextauth-secret-32-chars-long-string!
-SESSION_SECRET=dev-session-secret-32-chars-long-string!
+NEXTAUTH_SECRET=544a9deff51f62dd8549011e3035c6bc
+SESSION_SECRET=de96b1ac792300079ca29bdafaf59a02
 
 # Shipping provider API keys
 UPS_KEY=

--- a/docs/.env.reference.md
+++ b/docs/.env.reference.md
@@ -46,6 +46,7 @@ This page describes the environment variables the platform expects. Each variabl
 | `SENDGRID_WEBHOOK_PUBLIC_KEY` | Public key to verify SendGrid webhook signatures. |
 | `RESEND_WEBHOOK_SECRET` | Secret used to verify Resend webhook signatures. |
 | `NEXTAUTH_SECRET` | Secret for NextAuth session signing (defaults to a dev secret in development; required in production). |
+| `SESSION_SECRET` | Secret used to encrypt customer sessions (defaults to a dev secret in development; required in production). |
 | `PREVIEW_TOKEN_SECRET` | Secret for HMAC preview tokens (unset disables preview token routes). |
 | `CHROMATIC_PROJECT_TOKEN` | Token for publishing Storybook builds to Chromatic. |
 | `GA_MEASUREMENT_ID` | Google Analytics measurement ID (without this and `GA_API_SECRET`, events are stored locally). |


### PR DESCRIPTION
## Summary
- add placeholder NextAuth and session secrets to the shared environment template
- document the new SESSION_SECRET requirement in the environment reference

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c8230430fc832f9905c6b27b06ba3d