### PR TITLE
Run build in quickstart script

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -46,6 +46,9 @@ This wraps the `init-shop` configurator, validates the generated `.env`, and run
 pnpm quickstart-shop --config ./shop.config.json
 ```
 
+`quickstart-shop` automatically builds the workspace (`pnpm -r build`) before seeding data or starting the dev server, so you can
+run it without a manual build step.
+
 Example `shop.config.json`:
 
 ```json

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,6 +36,8 @@ pnpm quickstart-shop --id demo --theme base --template template-app --auto-plugi
 
 `--auto-plugins` selects any detected provider plugins, `--auto-env` populates required environment variables with placeholders, and `--presets` applies default navigation, pages, and a GitHub Actions workflow.
 
+`quickstart-shop` runs `pnpm -r build` automatically before seeding or launching the dev server, so you don't need to build the workspace ahead of time.
+
 Add `--seed` to copy sample products and inventory. Use `--seed-full` to also copy `shop.json`, navigation defaults, page templates, and settings so the shop is immediately populated. Pass `--pages-template <name>` to apply predefined page layouts (`hero`, `product-grid`, `contact`). The script also accepts `--config <file>` to prefill options and skip prompts:
 
 ```bash

--- a/scripts/src/quickstart-shop.ts
+++ b/scripts/src/quickstart-shop.ts
@@ -110,6 +110,20 @@ async function main(): Promise<void> {
   } as unknown as CreateShopOptions;
 
   const prefixedId = `shop-${shopId}`;
+
+  const buildResult = spawnSync("pnpm", ["-r", "build"], {
+    stdio: "inherit",
+  });
+
+  if (buildResult.error) {
+    console.error("Failed to run pnpm -r build:", buildResult.error.message);
+    process.exit(1);
+  }
+
+  if (buildResult.status !== 0) {
+    process.exit(buildResult.status ?? 1);
+  }
+
   try {
     await createShopAndSeed(
       prefixedId,


### PR DESCRIPTION
## Summary
- run `pnpm -r build` inside the quickstart script before shop creation so dependencies are built automatically
- document that `quickstart-shop` performs the workspace build in the install and setup guides

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9008c08ac832fa31bb0ee42e3813f