### PR TITLE
Allow Next build to proceed without auth secrets

### DIFF
--- a/packages/config/src/env/__tests__/auth.env.loader.test.ts
+++ b/packages/config/src/env/__tests__/auth.env.loader.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { REDIS_URL, REDIS_TOKEN } from './authEnvTestUtils';
+import {
+  DEV_NEXTAUTH_SECRET,
+  DEV_SESSION_SECRET,
+  REDIS_URL,
+  REDIS_TOKEN,
+} from './authEnvTestUtils';
 
 const JWT_SECRET = 'jwt-secret-32-chars-long-string!!!';
 const OAUTH_CLIENT_ID = 'client-id';
@@ -49,6 +54,20 @@ describe('config/env/auth', () => {
         'Invalid auth environment variables',
       );
     }));
+
+  it('allows dev defaults during Next production build phase', async () =>
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        NEXT_PHASE: 'phase-production-build',
+      },
+      async () => {
+        const { loadAuthEnv } = await reload();
+        const env = loadAuthEnv();
+        expect(env.NEXTAUTH_SECRET).toBe(DEV_NEXTAUTH_SECRET);
+        expect(env.SESSION_SECRET).toBe(DEV_SESSION_SECRET);
+      },
+    ));
 
   it('requires JWT_SECRET for jwt provider', async () =>
     withEnv({ NODE_ENV: 'development', AUTH_PROVIDER: 'jwt' }, async () => {

--- a/packages/config/src/env/auth.ts
+++ b/packages/config/src/env/auth.ts
@@ -6,7 +6,12 @@ const isTest =
   process.env.NODE_ENV === "test" ||
   process.env.JEST_WORKER_ID !== undefined ||
   (isJest && process.env.NODE_ENV !== "production");
-const isProd = process.env.NODE_ENV === "production" && !isTest;
+const nextPhase = process.env.NEXT_PHASE?.toLowerCase();
+// Next.js sets NEXT_PHASE=phase-production-build during `next build`.
+// Allow development defaults in that phase so the bundle can compile without real secrets.
+const isNextProductionBuildPhase = nextPhase === "phase-production-build";
+const isProd =
+  process.env.NODE_ENV === "production" && !isTest && !isNextProductionBuildPhase;
 
 // Normalize AUTH_TOKEN_TTL from the process environment so validation succeeds
 // even if the shell exported a plain number or included stray whitespace.


### PR DESCRIPTION
## Summary
- treat the Next.js production build phase as non-production for auth env validation so dev defaults remain available during `next build`
- add a regression test ensuring `NEXT_PHASE=phase-production-build` still loads the development auth secrets

## Testing
- pnpm exec tsx <<'TS'
process.env.NODE_ENV = 'production';
process.env.NEXT_PHASE = 'phase-production-build';
const { loadAuthEnv } = await import('./packages/config/src/env/auth.ts');
const env = loadAuthEnv();
console.log(env.NEXTAUTH_SECRET);
console.log(env.SESSION_SECRET);
TS
- CI=1 pnpm --filter @apps/shop-bcd exec next build

------
https://chatgpt.com/codex/tasks/task_e_68c8ffeed3fc832fbe58a7a468d62461