### PR TITLE
Fix cms build errors from explicit any usage

### DIFF
--- a/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
+++ b/apps/cms/src/app/api/data/[shop]/inventory/import/route.ts
@@ -28,6 +28,10 @@ function hasArrayBuffer(
   );
 }
 
+function isBlob(value: unknown): value is Blob {
+  return typeof Blob !== "undefined" && value instanceof Blob;
+}
+
 export async function POST(
   req: NextRequest,
   context: { params: Promise<{ shop: string }> }
@@ -48,7 +52,7 @@ export async function POST(
     } else if (hasArrayBuffer(file)) {
       const buf = await file.arrayBuffer();
       text = new TextDecoder().decode(buf);
-    } else if (typeof file === "object" && (file as any) instanceof Blob) {
+    } else if (isBlob(file)) {
       text = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
         reader.onerror = () => reject(reader.error);

--- a/apps/cms/src/app/api/launch-shop/route.ts
+++ b/apps/cms/src/app/api/launch-shop/route.ts
@@ -114,7 +114,8 @@ export async function POST(req: Request) {
     }
   })();
 
-  return new Response(readable as any, {
+  const stream = readable as unknown as ReadableStream<Uint8Array>;
+  return new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",


### PR DESCRIPTION
## Summary
- replace the `Blob` branch in the inventory import route with a proper type guard instead of casting to `any`
- return the transform stream from the launch-shop route as a typed `ReadableStream<Uint8Array>` instead of `any`

## Testing
- pnpm --reporter=append-only --filter @apps/cms build *(fails: existing type error in packages/ui/src/components/cms/page-builder/PageBuilder.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c92aeb93ec832fa9b773abf82e1c0f