### PR TITLE
Fix grid column type guard in CMS page builder controls

### DIFF
--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderControls.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderControls.ts
@@ -92,7 +92,8 @@ const usePageBuilderControls = ({ state, dispatch }: Params) => {
   const startTour = useCallback(() => setRunTour(true), []);
 
   const [showGrid, setShowGrid] = useState(false);
-  const gridCols = state.gridCols;
+  const gridCols =
+    typeof state.gridCols === "number" ? state.gridCols : 12;
   const toggleGrid = useCallback(() => {
     setShowGrid((g) => !g);
     dispatch({ type: "set-grid-cols", gridCols });


### PR DESCRIPTION
## Summary
- ensure the page builder controls derive a numeric grid column count with a fallback before dispatching actions

## Testing
- pnpm --filter @acme/ui build

------
https://chatgpt.com/codex/tasks/task_e_68c944b69634832f923f1288ab50ee42