### PR TITLE
Fix PageBuilder history state typing

### DIFF
--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
@@ -1,5 +1,12 @@
 "use client";
-import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+  type Reducer,
+} from "react";
 import type { Page, PageComponent, HistoryState } from "@acme/types";
 import { historyStateSchema, reducer, type Action } from "../state";
 
@@ -32,7 +39,11 @@ export function usePageBuilderState({
     []
   );
 
-  const [state, rawDispatch] = useReducer(reducer, undefined, (): HistoryState => {
+  const typedReducer: Reducer<HistoryState, Action> = reducer;
+  const [state, rawDispatch] = useReducer(
+    typedReducer,
+    undefined,
+    (): HistoryState => {
     const initial = migrate(page.components);
     const fromServer = history ?? page.history;
     const parsedServer = fromServer
@@ -59,7 +70,10 @@ export function usePageBuilderState({
     }
   });
 
-  const typedState = useMemo(() => historyStateSchema.parse(state), [state]);
+  const typedState = useMemo<HistoryState>(
+    () => historyStateSchema.parse(state),
+    [state]
+  );
   const components = typedState.present;
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState("");


### PR DESCRIPTION
## Summary
- ensure the page builder hook wraps the reducer in a typed instance so the undo history exposes its fields
- annotate the parsed history data as a HistoryState to keep downstream consumers strongly typed

## Testing
- pnpm --filter @acme/ui build
- pnpm --filter @apps/cms build *(fails: Module not found: Can't resolve '@acme/configurator/providers' and missing @babel/runtime helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68c94dcca2a8832f8297320dd55dc9ec