### PR TITLE
Fix buildProductFormData media typing

### DIFF
--- a/packages/ui/src/utils/buildProductFormData.ts
+++ b/packages/ui/src/utils/buildProductFormData.ts
@@ -3,7 +3,11 @@ import type { Locale } from "@acme/i18n";
 import type { MediaItem } from "@acme/types";
 import type { ProductWithVariants } from "../hooks/useProductInputs";
 
-type MediaWithFile = MediaItem & { file?: File; [key: string]: unknown };
+type MediaWithFile = MediaItem & { file?: File };
+
+function hasFileProperty(item: MediaItem): item is MediaWithFile {
+  return "file" in item;
+}
 
 export function buildProductFormData(
   product: ProductWithVariants,
@@ -22,10 +26,15 @@ export function buildProductFormData(
 
   // Extract file attachments from media items and append them separately
   const mediaWithoutFiles = product.media.map(
-    (item: MediaWithFile, index: number): Omit<MediaWithFile, "file"> => {
+    (item: MediaItem, index: number): MediaItem => {
+      if (!hasFileProperty(item)) {
+        return item;
+      }
+
       if (item.file instanceof File) {
         fd.append(`file_${index}`, item.file);
       }
+
       const { file: _file, ...rest } = item;
       void _file;
       return rest;


### PR DESCRIPTION
## Summary
- relax buildProductFormData media handling to accept MediaItem inputs and add a type guard
- only strip media file fields when present while still uploading attached files

## Testing
- pnpm --filter @acme/ui build
- CI=1 pnpm --filter @apps/cms build

------
https://chatgpt.com/codex/tasks/task_e_68c95e231da0832f9536103ba695e7a2