### PR TITLE
Fix Prisma client loading in ESM environments

### DIFF
--- a/packages/platform-core/src/db.ts
+++ b/packages/platform-core/src/db.ts
@@ -82,10 +82,13 @@ function loadPrismaClient():
   | undefined {
   if (PrismaCtor !== undefined) return PrismaCtor;
   try {
-    const moduleUrl = typeof __filename !== 'undefined'
+    const moduleIdentifier = typeof __filename !== 'undefined'
       ? __filename
-      : (Function('return import.meta.url')() as string);
-    const req = createRequire(moduleUrl);
+      : new URL(
+          './db.ts',
+          Function('return import.meta.url')() as string,
+        );
+    const req = createRequire(moduleIdentifier);
     PrismaCtor = (
       req("@prisma/client") as {
         PrismaClient: new (...args: unknown[]) => PrismaClientType;


### PR DESCRIPTION
## Summary
- sanitize the module identifier passed to createRequire when loading Prisma
- construct a file URL relative to db.ts so dynamic imports work under Next.js debugging

## Testing
- pnpm --filter @acme/platform-core build

------
https://chatgpt.com/codex/tasks/task_e_68c969d2f1dc832fb9bcff85944bbd5a