### PR TITLE
Fix Next auth dependency resolution in CMS dev server

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -101,6 +101,20 @@ const nextConfig = {
       "react-dom/server": REACT_DOM_SERVER,
     };
 
+    if (config.resolve.alias["oidc-token-hash"] === undefined) {
+      try {
+        const nextAuthEntry = require.resolve("next-auth");
+        const nextAuthRequire = createRequire(nextAuthEntry);
+        const resolvedOidcTokenHash = realpathSync(
+          nextAuthRequire.resolve("oidc-token-hash"),
+        );
+
+        config.resolve.alias["oidc-token-hash"] = resolvedOidcTokenHash;
+      } catch {
+        // next-auth is optional for some builds; skip aliasing when absent.
+      }
+    }
+
     if (!isServer) {
       config.resolve.alias["@sentry/node"] = false;
       config.resolve.alias["@sentry/opentelemetry"] = false;


### PR DESCRIPTION
## Summary
- add a defensive webpack alias that resolves `oidc-token-hash` via the installed `next-auth` package so Turbopack can bundle `openid-client`

## Testing
- pnpm --filter @apps/cms lint
- pnpm --filter @apps/cms dev (terminated after verifying compilation)


------
https://chatgpt.com/codex/tasks/task_e_68c995b0d3b4832fae762d1530683bb2