### PR TITLE
Fix configurator alias for dev builds

### DIFF
--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -123,6 +123,14 @@ const nextConfig = {
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
       "@": path.resolve(__dirname, "src"),
+      "@acme/configurator": path.resolve(
+        __dirname,
+        "../../packages/configurator/src",
+      ),
+      "@acme/configurator/providers": path.resolve(
+        __dirname,
+        "../../packages/configurator/src/providers.ts",
+      ),
       "drizzle-orm": false,
       "entities/decode": ENTITIES_DECODE_PATH,
       "entities/lib/decode.js": ENTITIES_DECODE_PATH,


### PR DESCRIPTION
## Summary
- add webpack aliases for `@acme/configurator` and its providers entry so Next.js can resolve the source files when the package hasn't been built yet

## Testing
- pnpm --filter @apps/cms dev
- pnpm --filter @apps/cms build *(fails: ESLint missing `@next/eslint-plugin-next`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c16a274c832fa47e11d7f312f9d3