### PR TITLE
Revamp CMS data pricing experience

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/page.tsx
@@ -1,4 +1,52 @@
 import Link from "next/link";
+import { Button, Card, CardContent } from "@/components/atoms/shadcn";
+import { Tag } from "@ui/components/atoms";
+import { ArrowRightIcon } from "@radix-ui/react-icons";
+
+const cards = [
+  {
+    title: "Inventory health",
+    eyebrow: "Stock accuracy",
+    description:
+      "Import CSV updates, adjust quantities, and monitor wear thresholds before they impact fulfillment.",
+    bullets: [
+      "Bulk upload or export inventory snapshots",
+      "Track low-stock alerts and maintenance cycles",
+      "Map variant attributes without leaving the grid",
+    ],
+    href: (shop: string) => `/cms/shop/${shop}/data/inventory`,
+    cta: "Manage inventory",
+    accent: "from-slate-900 via-slate-950 to-black",
+  },
+  {
+    title: "Rental pricing",
+    eyebrow: "Revenue levers",
+    description:
+      "Fine-tune daily rates, long-term discounts, and damage coverage with guided inputs or raw JSON control.",
+    bullets: [
+      "Preview deposit rules before publishing",
+      "Validate pricing tiers with inline feedback",
+      "Switch between form and JSON editors instantly",
+    ],
+    href: (shop: string) => `/cms/shop/${shop}/data/rental/pricing`,
+    cta: "Configure pricing",
+    accent: "from-emerald-500/10 via-teal-500/10 to-cyan-500/10",
+  },
+  {
+    title: "Return logistics",
+    eyebrow: "Post-rental flows",
+    description:
+      "Coordinate carrier preferences, pickup coverage, and in-store drop-offs in a single orchestration hub.",
+    bullets: [
+      "Clarify customer-facing return promises",
+      "Audit pickup ZIP coverage at a glance",
+      "Document bag and packaging requirements",
+    ],
+    href: (shop: string) => `/cms/shop/${shop}/data/return-logistics`,
+    cta: "Optimize returns",
+    accent: "from-rose-500/10 via-fuchsia-500/10 to-purple-500/10",
+  },
+] as const;
 
 export default async function DataIndex({
   params,
@@ -7,25 +55,66 @@ export default async function DataIndex({
 }) {
   const { shop } = await params;
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">Data</h2>
-      <ul className="list-disc pl-5 space-y-1">
-        <li>
-          <Link href={`/cms/shop/${shop}/data/inventory`} className="text-primary underline">
-            Inventory
-          </Link>
-        </li>
-        <li>
-          <Link href={`/cms/shop/${shop}/data/rental/pricing`} className="text-primary underline">
-            Rental Pricing
-          </Link>
-        </li>
-        <li>
-          <Link href={`/cms/shop/${shop}/data/return-logistics`} className="text-primary underline">
-            Return Logistics
-          </Link>
-        </li>
-      </ul>
+    <div className="space-y-8 text-white">
+      <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-950 shadow-xl">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.18),_transparent_55%)]" />
+        <div className="relative space-y-4 px-6 py-8">
+          <Tag variant="default" className="bg-white/10 text-white/70">
+            Data operations · {shop}
+          </Tag>
+          <h1 className="text-3xl font-semibold md:text-4xl">Guide your merchandising source of truth</h1>
+          <p className="text-sm text-white/70 md:text-base">
+            Keep every dataset in lockstep—from stock availability to deposit policies and return coverage—before you roll
+            updates to the storefront.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { label: "Systems synced", value: "Inventory · Pricing · Logistics" },
+              { label: "Recommended cadence", value: "Weekly merchandising review" },
+              { label: "Workflow owner", value: "Operations & merchandising" },
+            ].map((item) => (
+              <div
+                key={item.label}
+                className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-white/70 backdrop-blur"
+              >
+                <p className="font-semibold uppercase tracking-wide">{item.label}</p>
+                <p className="mt-1 text-sm text-white">{item.value}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {cards.map((card) => (
+          <Card
+            key={card.title}
+            className={`border border-white/10 bg-gradient-to-br ${card.accent} text-white shadow-lg shadow-black/20`}
+          >
+            <CardContent className="flex h-full flex-col gap-4 p-6">
+              <div className="space-y-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-white/70">{card.eyebrow}</span>
+                <h2 className="text-xl font-semibold leading-tight">{card.title}</h2>
+                <p className="text-sm text-white/70">{card.description}</p>
+              </div>
+              <ul className="flex flex-1 list-disc flex-col gap-2 pl-5 text-sm text-white/70">
+                {card.bullets.map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+              <Button
+                asChild
+                className="group mt-auto inline-flex h-11 items-center justify-between rounded-xl border border-white/20 bg-white/10 px-4 text-sm font-semibold text-white transition hover:bg-white/20"
+              >
+                <Link href={card.href(shop)}>
+                  <span>{card.cta}</span>
+                  <ArrowRightIcon className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
     </div>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/PricingForm.tsx
@@ -1,64 +1,920 @@
 "use client";
 
-import { Button, Textarea } from "@ui/components/atoms/shadcn";
-import { pricingSchema, type PricingMatrix } from "@acme/types";
-import { useState } from "react";
-import type { FormEvent, ChangeEvent } from "react";
+import {
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Input,
+  Textarea,
+} from "@/components/atoms/shadcn";
+import { Toast, Tag } from "@/components/atoms";
+import {
+  coverageCodeSchema,
+  type CoverageCode,
+  pricingSchema,
+  type PricingMatrix,
+} from "@acme/types";
+import { cn } from "@ui/utils/style";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
 
 interface Props {
   shop: string;
   initial: PricingMatrix;
 }
 
-export default function PricingForm({ shop, initial }: Props) {
-  const [text, setText] = useState(
-    () => JSON.stringify(initial, null, 2)
-  );
-  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
-  const [error, setError] = useState<string | null>(null);
+type DurationDraft = {
+  id: string;
+  minDays: string;
+  rate: string;
+};
 
-  const onSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const json = JSON.parse(text);
-      const parsed = pricingSchema.safeParse(json);
-      if (!parsed.success) {
-        setStatus("error");
-        setError(parsed.error.issues.map((i) => i.message).join(", "));
+type DamageDraft = {
+  id: string;
+  code: string;
+  mode: "amount" | "deposit";
+  amount: string;
+};
+
+type CoverageDraft = {
+  code: CoverageCode;
+  enabled: boolean;
+  fee: string;
+  waiver: string;
+};
+
+type ValidationResult =
+  | { success: true; data: PricingMatrix }
+  | { success: false; errors: Record<string, string> };
+
+const coverageCodes = coverageCodeSchema.options as readonly CoverageCode[];
+
+export default function PricingForm({ shop, initial }: Props) {
+  const [baseRate, setBaseRate] = useState(() => initial.baseDailyRate.toString());
+  const [durationRows, setDurationRows] = useState<DurationDraft[]>(() =>
+    initial.durationDiscounts.map((tier, index) => ({
+      id: `duration-${index}`,
+      minDays: tier.minDays.toString(),
+      rate: tier.rate.toString(),
+    }))
+  );
+  const [damageRows, setDamageRows] = useState<DamageDraft[]>(() =>
+    Object.entries(initial.damageFees).map(([code, value], index) => ({
+      id: `damage-${index}`,
+      code,
+      mode: typeof value === "number" ? "amount" : "deposit",
+      amount: typeof value === "number" ? value.toString() : "",
+    }))
+  );
+  const [coverageRows, setCoverageRows] = useState<CoverageDraft[]>(() =>
+    coverageCodes.map((code) => {
+      const entry = initial.coverage?.[code];
+      return {
+        code,
+        enabled: Boolean(entry),
+        fee: entry ? entry.fee.toString() : "",
+        waiver: entry ? entry.waiver.toString() : "",
+      };
+    })
+  );
+  const [activeTab, setActiveTab] = useState<"guided" | "json">("guided");
+  const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(initial, null, 2));
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [progressMessage, setProgressMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const rowCounter = useRef(initial.durationDiscounts.length + damageRows.length + 1);
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case "saving":
+        return "Saving changes";
+      case "saved":
+        return "Pricing saved";
+      case "error":
+        return "Needs attention";
+      default:
+        return "Draft";
+    }
+  }, [status]);
+
+  const statusVariant = status === "saved" ? "success" : status === "error" ? "destructive" : "default";
+
+  const emitToast = (message: string) => {
+    setToast({ open: true, message });
+  };
+
+  const closeToast = () => setToast({ open: false, message: "" });
+
+  const hydrateFromMatrix = useCallback((matrix: PricingMatrix) => {
+    setBaseRate(matrix.baseDailyRate.toString());
+    setDurationRows(
+      matrix.durationDiscounts.map((tier, index) => ({
+        id: `duration-${index}-${Date.now()}`,
+        minDays: tier.minDays.toString(),
+        rate: tier.rate.toString(),
+      }))
+    );
+    setDamageRows(
+      Object.entries(matrix.damageFees).map(([code, value], index) => ({
+        id: `damage-${index}-${Date.now()}`,
+        code,
+        mode: typeof value === "number" ? "amount" : "deposit",
+        amount: typeof value === "number" ? value.toString() : "",
+      }))
+    );
+    setCoverageRows(
+      coverageCodes.map((code) => {
+        const entry = matrix.coverage?.[code];
+        return {
+          code,
+          enabled: Boolean(entry),
+          fee: entry ? entry.fee.toString() : "",
+          waiver: entry ? entry.waiver.toString() : "",
+        };
+      })
+    );
+    setJsonDraft(JSON.stringify(matrix, null, 2));
+    setFieldErrors({});
+    setJsonError(null);
+  }, []);
+
+  const buildPricingFromForm = useCallback((): ValidationResult => {
+    const errors: Record<string, string> = {};
+    const baseInput = baseRate.trim();
+    const base = Number(baseInput);
+    if (baseInput === "" || !Number.isFinite(base)) {
+      errors.baseDailyRate = "Enter a base daily rate";
+    }
+
+    const durations: PricingMatrix["durationDiscounts"] = [];
+    durationRows.forEach((row) => {
+      const keyBase = `duration-${row.id}`;
+      const hasValues = row.minDays.trim() !== "" || row.rate.trim() !== "";
+      if (!hasValues) {
         return;
       }
-      setStatus("saved");
-      setError(null);
-      const res = await fetch(`/api/data/${shop}/rental/pricing`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(parsed.data),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        setStatus("error");
-        setError(body.error || "Failed to save");
+      const minDays = Number(row.minDays);
+      const rate = Number(row.rate);
+      if (row.minDays.trim() === "" || !Number.isFinite(minDays) || minDays <= 0) {
+        errors[`${keyBase}-minDays`] = "Provide minimum rental days";
       }
+      if (row.rate.trim() === "" || !Number.isFinite(rate) || rate <= 0) {
+        errors[`${keyBase}-rate`] = "Provide a positive multiplier";
+      }
+      if (!errors[`${keyBase}-minDays`] && !errors[`${keyBase}-rate`]) {
+        durations.push({ minDays, rate });
+      }
+    });
+
+    const damageFees: PricingMatrix["damageFees"] = {};
+    damageRows.forEach((row) => {
+      const keyBase = `damage-${row.id}`;
+      if (row.code.trim() === "") {
+        errors[`${keyBase}-code`] = "Enter a damage code";
+        return;
+      }
+      if (damageFees[row.code.trim()]) {
+        errors[`${keyBase}-code`] = "Damage codes must be unique";
+        return;
+      }
+      if (row.mode === "deposit") {
+        damageFees[row.code.trim()] = "deposit";
+        return;
+      }
+      if (row.amount.trim() === "") {
+        errors[`${keyBase}-amount`] = "Enter a fee";
+        return;
+      }
+      const parsedAmount = Number(row.amount);
+      if (!Number.isFinite(parsedAmount)) {
+        errors[`${keyBase}-amount`] = "Fee must be a number";
+        return;
+      }
+      damageFees[row.code.trim()] = parsedAmount;
+    });
+
+    const coverage: PricingMatrix["coverage"] = {};
+    coverageRows.forEach((row) => {
+      if (!row.enabled) {
+        return;
+      }
+      const fee = Number(row.fee);
+      const waiver = Number(row.waiver);
+      if (row.fee.trim() === "" || !Number.isFinite(fee) || fee < 0) {
+        errors[`coverage-${row.code}-fee`] = "Enter a non-negative fee";
+      }
+      if (row.waiver.trim() === "" || !Number.isFinite(waiver) || waiver < 0) {
+        errors[`coverage-${row.code}-waiver`] = "Enter a non-negative waiver";
+      }
+      if (!errors[`coverage-${row.code}-fee`] && !errors[`coverage-${row.code}-waiver`]) {
+        coverage[row.code] = { fee, waiver };
+      }
+    });
+
+    if (Object.keys(errors).length > 0) {
+      return { success: false, errors };
+    }
+
+    const candidate: PricingMatrix = {
+      baseDailyRate: Number.isFinite(base) ? base : 0,
+      durationDiscounts: durations,
+      damageFees,
+      coverage,
+    };
+    const parsed = pricingSchema.safeParse(candidate);
+    if (!parsed.success) {
+      const aggregate = parsed.error.issues.map((issue) => issue.message).join("; ");
+      return { success: false, errors: { root: aggregate } };
+    }
+    return { success: true, data: parsed.data };
+  }, [baseRate, coverageRows, damageRows, durationRows]);
+
+  const parseJsonDraft = useCallback((): ValidationResult => {
+    try {
+      const json = JSON.parse(jsonDraft);
+      const parsed = pricingSchema.safeParse(json);
+      if (!parsed.success) {
+        return {
+          success: false,
+          errors: {
+            json: parsed.error.issues.map((issue) => issue.message).join("; "),
+          },
+        };
+      }
+      return { success: true, data: parsed.data };
+    } catch (err) {
+      return { success: false, errors: { json: (err as Error).message } };
+    }
+  }, [jsonDraft]);
+
+  const handleTabChange = (next: "guided" | "json") => {
+    if (next === activeTab) return;
+    if (next === "json") {
+      const result = buildPricingFromForm();
+      if (!result.success) {
+        setFieldErrors(result.errors);
+        setStatus("error");
+        emitToast("Resolve highlighted fields before viewing JSON.");
+        return;
+      }
+      setJsonDraft(JSON.stringify(result.data, null, 2));
+      setJsonError(null);
+      setActiveTab("json");
+      return;
+    }
+
+    const parsed = parseJsonDraft();
+    if (!parsed.success) {
+      setJsonError(parsed.errors.json ?? "JSON is invalid");
+      setStatus("error");
+      emitToast("Fix JSON errors before returning to the form.");
+      return;
+    }
+    hydrateFromMatrix(parsed.data);
+    setActiveTab("guided");
+  };
+
+  const handleApplyJson = () => {
+    const parsed = parseJsonDraft();
+    if (!parsed.success) {
+      setJsonError(parsed.errors.json ?? "JSON is invalid");
+      setStatus("error");
+      emitToast(parsed.errors.json ?? "JSON could not be parsed.");
+      return;
+    }
+    hydrateFromMatrix(parsed.data);
+    setStatus("saved");
+    emitToast("JSON parsed and applied to the guided editor.");
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setProgressMessage(`Importing ${file.name}…`);
+    try {
+      const text = await file.text();
+      const parsed = pricingSchema.safeParse(JSON.parse(text));
+      if (!parsed.success) {
+        throw new Error(parsed.error.issues.map((issue) => issue.message).join("; "));
+      }
+      hydrateFromMatrix(parsed.data);
+      setStatus("saved");
+      setProgressMessage(`Pricing imported from ${file.name}`);
+      emitToast(`Imported pricing from ${file.name}`);
     } catch (err) {
       setStatus("error");
-      setError((err as Error).message);
+      setProgressMessage("Import failed");
+      emitToast((err as Error).message || "Import failed");
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = "";
     }
   };
 
+  const handleExport = () => {
+    const result = buildPricingFromForm();
+    if (!result.success) {
+      setFieldErrors(result.errors);
+      setStatus("error");
+      emitToast("Fix validation errors before exporting.");
+      return;
+    }
+    try {
+      setProgressMessage("Preparing export…");
+      const blob = new Blob([JSON.stringify(result.data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "pricing.json";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setProgressMessage("Pricing JSON export started");
+      emitToast("Pricing JSON download started");
+    } catch (err) {
+      setStatus("error");
+      setProgressMessage("Export failed");
+      emitToast((err as Error).message || "Export failed");
+    }
+  };
+
+  const addDurationRow = () => {
+    const id = `duration-${rowCounter.current++}`;
+    setDurationRows((prev) => [...prev, { id, minDays: "", rate: "" }]);
+  };
+
+  const removeDurationRow = (id: string) => {
+    setDurationRows((prev) => prev.filter((row) => row.id !== id));
+  };
+
+  const addDamageRow = () => {
+    const id = `damage-${rowCounter.current++}`;
+    setDamageRows((prev) => [...prev, { id, code: "", mode: "amount", amount: "" }]);
+  };
+
+  const removeDamageRow = (id: string) => {
+    setDamageRows((prev) => prev.filter((row) => row.id !== id));
+  };
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setStatus("saving");
+    const result = buildPricingFromForm();
+    if (!result.success) {
+      setFieldErrors(result.errors);
+      setStatus("error");
+      emitToast("Fix validation issues before saving.");
+      return;
+    }
+    try {
+      const response = await fetch(`/api/data/${shop}/rental/pricing`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(result.data),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to save pricing");
+      }
+      setStatus("saved");
+      setFieldErrors({});
+      setJsonDraft(JSON.stringify(result.data, null, 2));
+      emitToast("Pricing saved");
+    } catch (err) {
+      setStatus("error");
+      emitToast((err as Error).message || "Failed to save pricing");
+    }
+  };
+
+  const guidedTab = (
+    <div className="space-y-6" role="tabpanel" aria-labelledby="pricing-tab-guided">
+      <section className="space-y-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-white" htmlFor="base-daily-rate">
+            Base daily rate
+          </label>
+          <Input
+            id="base-daily-rate"
+            type="number"
+            min={0}
+            step="0.01"
+            value={baseRate}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => setBaseRate(event.target.value)}
+            aria-invalid={fieldErrors.baseDailyRate ? "true" : undefined}
+            aria-describedby={fieldErrors.baseDailyRate ? "base-daily-rate-error" : undefined}
+            className="bg-slate-900/80 text-white"
+          />
+          <p className="text-xs text-white/60">
+            This rate is used whenever a SKU does not specify its own price.
+          </p>
+          {fieldErrors.baseDailyRate ? (
+            <p id="base-daily-rate-error" className="text-xs text-rose-300">
+              {fieldErrors.baseDailyRate}
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-white/80">Duration discounts</h3>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-9 rounded-lg border-white/30 text-xs text-white hover:bg-white/10"
+            onClick={addDurationRow}
+          >
+            Add discount tier
+          </Button>
+        </div>
+        <p className="text-xs text-white/60">
+          Offer incentives for longer rentals. Leave a row blank to remove it.
+        </p>
+        <div className="space-y-4">
+          {durationRows.length === 0 ? (
+            <p className="rounded-lg border border-dashed border-white/20 px-4 py-3 text-sm text-white/60">
+              No duration tiers configured. Add one to reward longer bookings.
+            </p>
+          ) : null}
+          {durationRows.map((row) => {
+            const minDaysError = fieldErrors[`duration-${row.id}-minDays`];
+            const rateError = fieldErrors[`duration-${row.id}-rate`];
+            return (
+              <div
+                key={row.id}
+                className="grid gap-3 rounded-xl border border-white/10 bg-slate-900/60 p-4 sm:grid-cols-[1fr_1fr_auto]"
+              >
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-medium uppercase tracking-wide text-white/70">Min days</span>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={row.minDays}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      setDurationRows((prev) =>
+                        prev.map((item) =>
+                          item.id === row.id ? { ...item, minDays: event.target.value } : item
+                        )
+                      )
+                    }
+                    aria-invalid={minDaysError ? "true" : undefined}
+                    aria-describedby={minDaysError ? `${row.id}-minDays-error` : undefined}
+                    className="bg-slate-950/80 text-white"
+                  />
+                  {minDaysError ? (
+                    <span id={`${row.id}-minDays-error`} className="text-xs text-rose-300">
+                      {minDaysError}
+                    </span>
+                  ) : null}
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-medium uppercase tracking-wide text-white/70">Rate multiplier</span>
+                  <Input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={row.rate}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      setDurationRows((prev) =>
+                        prev.map((item) =>
+                          item.id === row.id ? { ...item, rate: event.target.value } : item
+                        )
+                      )
+                    }
+                    aria-invalid={rateError ? "true" : undefined}
+                    aria-describedby={rateError ? `${row.id}-rate-error` : undefined}
+                    className="bg-slate-950/80 text-white"
+                  />
+                  {rateError ? (
+                    <span id={`${row.id}-rate-error`} className="text-xs text-rose-300">
+                      {rateError}
+                    </span>
+                  ) : null}
+                </label>
+                <div className="flex items-start justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-9 rounded-lg text-xs text-white/70 hover:bg-white/10"
+                    onClick={() => removeDurationRow(row.id)}
+                    aria-label={`remove-duration-${row.id}`}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-white/80">Damage fees</h3>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-9 rounded-lg border-white/30 text-xs text-white hover:bg-white/10"
+            onClick={addDamageRow}
+          >
+            Add damage rule
+          </Button>
+        </div>
+        <p className="text-xs text-white/60">
+          Map damage codes to a fixed fee or reuse the deposit amount.
+        </p>
+        <div className="space-y-4">
+          {damageRows.length === 0 ? (
+            <p className="rounded-lg border border-dashed border-white/20 px-4 py-3 text-sm text-white/60">
+              No damage fees yet. Add codes for your most common incidents.
+            </p>
+          ) : null}
+          {damageRows.map((row) => {
+            const codeError = fieldErrors[`damage-${row.id}-code`];
+            const amountError = fieldErrors[`damage-${row.id}-amount`];
+            const isDeposit = row.mode === "deposit";
+            return (
+              <div
+                key={row.id}
+                className="grid gap-3 rounded-xl border border-white/10 bg-slate-900/60 p-4 sm:grid-cols-[1fr_1fr_auto]"
+              >
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-medium uppercase tracking-wide text-white/70">Damage code</span>
+                  <Input
+                    value={row.code}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      setDamageRows((prev) =>
+                        prev.map((item) =>
+                          item.id === row.id ? { ...item, code: event.target.value } : item
+                        )
+                      )
+                    }
+                    aria-invalid={codeError ? "true" : undefined}
+                    aria-describedby={codeError ? `${row.id}-code-error` : undefined}
+                    className="bg-slate-950/80 text-white"
+                  />
+                  {codeError ? (
+                    <span id={`${row.id}-code-error`} className="text-xs text-rose-300">
+                      {codeError}
+                    </span>
+                  ) : null}
+                </label>
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs font-medium uppercase tracking-wide text-white/70">Resolution</span>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant={isDeposit ? "ghost" : "outline"}
+                      className={cn(
+                        "h-9 flex-1 rounded-lg text-xs",
+                        isDeposit ? "border-white/10 bg-white/10 text-white" : "border-white/30 text-white"
+                      )}
+                      onClick={() =>
+                        setDamageRows((prev) =>
+                          prev.map((item) =>
+                            item.id === row.id ? { ...item, mode: "amount" } : item
+                          )
+                        )
+                      }
+                    >
+                      Fixed fee
+                    </Button>
+                    <Button
+                      type="button"
+                      variant={isDeposit ? "outline" : "ghost"}
+                      className={cn(
+                        "h-9 flex-1 rounded-lg text-xs",
+                        isDeposit ? "border-white/30 text-white" : "border-white/10 bg-white/10 text-white"
+                      )}
+                      onClick={() =>
+                        setDamageRows((prev) =>
+                          prev.map((item) =>
+                            item.id === row.id ? { ...item, mode: "deposit", amount: "" } : item
+                          )
+                        )
+                      }
+                    >
+                      Use deposit
+                    </Button>
+                  </div>
+                  {!isDeposit ? (
+                    <div className="flex flex-col gap-1">
+                      <Input
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={row.amount}
+                        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                          setDamageRows((prev) =>
+                            prev.map((item) =>
+                              item.id === row.id ? { ...item, amount: event.target.value } : item
+                            )
+                          )
+                        }
+                        aria-invalid={amountError ? "true" : undefined}
+                        aria-describedby={amountError ? `${row.id}-amount-error` : undefined}
+                        className="bg-slate-950/80 text-white"
+                      />
+                      {amountError ? (
+                        <span id={`${row.id}-amount-error`} className="text-xs text-rose-300">
+                          {amountError}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <p className="text-xs text-white/60">Deposit amount will be charged instead of a fixed fee.</p>
+                  )}
+                </div>
+                <div className="flex items-start justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-9 rounded-lg text-xs text-white/70 hover:bg-white/10"
+                    onClick={() => removeDamageRow(row.id)}
+                    aria-label={`remove-damage-${row.id}`}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-white/80">Coverage fees</h3>
+        <p className="text-xs text-white/60">
+          Enable optional coverage to offset repair costs. Leave unchecked to skip offering the coverage.
+        </p>
+        <div className="grid gap-4 md:grid-cols-3">
+          {coverageRows.map((row) => {
+            const feeError = fieldErrors[`coverage-${row.code}-fee`];
+            const waiverError = fieldErrors[`coverage-${row.code}-waiver`];
+            return (
+              <Card key={row.code} className="border border-white/10 bg-slate-900/60 text-white">
+                <CardContent className="space-y-3 p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-semibold capitalize">{row.code}</span>
+                    <div className="flex items-center gap-2 text-xs text-white/70">
+                      <Checkbox
+                        id={`coverage-${row.code}`}
+                        checked={row.enabled}
+                        onCheckedChange={(checked) =>
+                          setCoverageRows((prev) =>
+                            prev.map((item) =>
+                              item.code === row.code
+                                ? { ...item, enabled: Boolean(checked) }
+                                : item
+                            )
+                          )
+                        }
+                      />
+                      <label htmlFor={`coverage-${row.code}`}>Offer coverage</label>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs uppercase tracking-wide text-white/70" htmlFor={`coverage-fee-${row.code}`}>
+                      Coverage fee
+                    </label>
+                    <Input
+                      id={`coverage-fee-${row.code}`}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={row.fee}
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        setCoverageRows((prev) =>
+                          prev.map((item) =>
+                            item.code === row.code ? { ...item, fee: event.target.value } : item
+                          )
+                        )
+                      }
+                      disabled={!row.enabled}
+                      aria-invalid={feeError ? "true" : undefined}
+                      aria-describedby={feeError ? `coverage-${row.code}-fee-error` : undefined}
+                      className="bg-slate-950/80 text-white disabled:opacity-40"
+                    />
+                    {feeError ? (
+                      <span id={`coverage-${row.code}-fee-error`} className="text-xs text-rose-300">
+                        {feeError}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs uppercase tracking-wide text-white/70" htmlFor={`coverage-waiver-${row.code}`}>
+                      Waiver limit
+                    </label>
+                    <Input
+                      id={`coverage-waiver-${row.code}`}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={row.waiver}
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        setCoverageRows((prev) =>
+                          prev.map((item) =>
+                            item.code === row.code ? { ...item, waiver: event.target.value } : item
+                          )
+                        )
+                      }
+                      disabled={!row.enabled}
+                      aria-invalid={waiverError ? "true" : undefined}
+                      aria-describedby={waiverError ? `coverage-${row.code}-waiver-error` : undefined}
+                      className="bg-slate-950/80 text-white disabled:opacity-40"
+                    />
+                    {waiverError ? (
+                      <span id={`coverage-${row.code}-waiver-error`} className="text-xs text-rose-300">
+                        {waiverError}
+                      </span>
+                    ) : null}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-white/10 bg-slate-900/60 p-4">
+        <h3 className="text-sm font-semibold text-white">Need a quick checklist?</h3>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-white/70">
+          <li>Verify base rate aligns with current merchandising calendar.</li>
+          <li>Mirror long-stay discounts shared by finance to avoid manual overrides.</li>
+          <li>Confirm damage codes match warehouse dispositions and deposit policy.</li>
+        </ul>
+      </section>
+    </div>
+  );
+
+  const jsonTab = (
+    <div className="space-y-4" role="tabpanel" aria-labelledby="pricing-tab-json">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-white" htmlFor="pricing-json-editor">
+          Pricing JSON configuration
+        </label>
+        <Textarea
+          id="pricing-json-editor"
+          value={jsonDraft}
+          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setJsonDraft(event.target.value)}
+          rows={18}
+          className="bg-slate-950/80 text-white"
+          aria-invalid={jsonError ? "true" : undefined}
+          aria-describedby={jsonError ? "pricing-json-error" : undefined}
+        />
+        <p className="text-xs text-white/60">
+          Edit directly to paste pricing from other systems. Validation runs before you return to the guided editor.
+        </p>
+        {jsonError ? (
+          <p id="pricing-json-error" className="text-xs text-rose-300">
+            {jsonError}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          className="h-10 rounded-xl bg-emerald-500 px-4 text-sm font-semibold text-white hover:bg-emerald-400"
+          onClick={handleApplyJson}
+        >
+          Apply JSON to form
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-10 rounded-xl border-white/30 px-4 text-sm text-white hover:bg-white/10"
+          onClick={() => handleTabChange("guided")}
+        >
+          Return to guided editor
+        </Button>
+      </div>
+    </div>
+  );
+
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <Textarea
-        value={text}
-        onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
-        rows={10}
+    <form onSubmit={onSubmit} className="space-y-6 text-white">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={handleFileChange}
       />
-      {status === "saved" && (
-        <p className="text-sm text-green-600">Saved!</p>
-      )}
-      {status === "error" && error && (
-        <p className="text-sm text-red-600">{error}</p>
-      )}
-      <Button type="submit">Save</Button>
+      <div className="space-y-5 rounded-2xl border border-white/10 bg-white/5 p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Tag
+                variant={statusVariant}
+                className={cn(
+                  "rounded-lg border border-white/10 bg-white/10 px-3 py-1 text-xs font-medium",
+                  status === "saved" && "bg-emerald-500/20 text-emerald-100",
+                  status === "error" && "bg-rose-500/20 text-rose-100"
+                )}
+              >
+                {statusLabel}
+              </Tag>
+              {progressMessage ? (
+                <span className="text-xs text-white/70" role="status">
+                  {progressMessage}
+                </span>
+              ) : null}
+            </div>
+            {fieldErrors.root ? (
+              <span className="text-xs text-rose-300">{fieldErrors.root}</span>
+            ) : null}
+            <p className="text-xs text-white/60">
+              Save regularly to push updates to pricing services. Import JSON from finance or export to share with operations.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
+              onClick={handleImportClick}
+            >
+              Import JSON
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
+              onClick={handleExport}
+            >
+              Export JSON
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-slate-950/70">
+          <div className="flex gap-2 border-b border-white/10 bg-slate-900/50 p-2" role="tablist">
+            {[{ id: "guided", label: "Guided form" }, { id: "json", label: "Advanced JSON" }].map((tab) => {
+              const isActive = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  role="tab"
+                  id={`pricing-tab-${tab.id}`}
+                  aria-selected={isActive}
+                  aria-controls={`pricing-panel-${tab.id}`}
+                  onClick={() => handleTabChange(tab.id as typeof activeTab)}
+                  className={cn(
+                    "flex-1 rounded-xl px-4 py-2 text-sm font-semibold transition",
+                    isActive
+                      ? "bg-emerald-500/20 text-white shadow-inner"
+                      : "text-white/60 hover:bg-white/10"
+                  )}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+          <div
+            id={`pricing-panel-${activeTab}`}
+            className="space-y-4 p-5"
+            role="tabpanel"
+            aria-labelledby={`pricing-tab-${activeTab}`}
+          >
+            {activeTab === "guided" ? guidedTab : jsonTab}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="submit"
+          className="h-10 rounded-xl bg-emerald-500 px-5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 hover:bg-emerald-400"
+        >
+          Save pricing
+        </Button>
+        <span className="text-xs text-white/60">
+          Updates apply immediately to rental quotes after saving.
+        </span>
+      </div>
+
+      <Toast open={toast.open} message={toast.message} onClose={closeToast} />
     </form>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/__tests__/PricingForm.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/__tests__/PricingForm.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+
+jest.mock("@/components/atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Button: React.forwardRef<HTMLButtonElement, ComponentProps<"button">>(
+      ({ children, ...props }, ref) => (
+        <button ref={ref} {...props}>
+          {children}
+        </button>
+      )
+    ),
+    Card: ({ children, ...props }: ComponentProps<"div">) => (
+      <div {...props}>{children}</div>
+    ),
+    CardContent: ({ children, ...props }: ComponentProps<"div">) => (
+      <div {...props}>{children}</div>
+    ),
+    Checkbox: ({ checked, onCheckedChange, ...props }: any) => (
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onCheckedChange?.(event.target.checked)}
+        {...props}
+      />
+    ),
+    Input: React.forwardRef<HTMLInputElement, ComponentProps<"input">>((props, ref) => (
+      <input ref={ref} {...props} />
+    )),
+    Textarea: React.forwardRef<HTMLTextAreaElement, ComponentProps<"textarea">>(
+      ({ children, ...props }, ref) => (
+        <textarea ref={ref} {...props}>
+          {children}
+        </textarea>
+      )
+    ),
+  };
+});
+
+jest.mock("@/components/atoms", () => ({
+  __esModule: true,
+  Toast: ({ open, message }: { open: boolean; message: string }) =>
+    open ? <div role="alert">{message}</div> : null,
+  Tag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+import PricingForm from "../PricingForm";
+
+describe("PricingForm", () => {
+  const initial = {
+    baseDailyRate: 50,
+    durationDiscounts: [
+      { minDays: 7, rate: 0.9 },
+      { minDays: 30, rate: 0.75 },
+    ],
+    damageFees: {
+      scuff: 20,
+      lost: "deposit" as const,
+    },
+    coverage: {
+      scuff: { fee: 5, waiver: 20 },
+    },
+  };
+
+  beforeEach(() => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch;
+  });
+
+  it("surfaces field validation when base rate is missing", async () => {
+    render(<PricingForm shop="demo" initial={initial} />);
+    const input = screen.getByLabelText(/Base daily rate/i);
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save pricing/i }));
+    expect(await screen.findByText(/Enter a base daily rate/i)).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("supports editing via advanced JSON tab", async () => {
+    render(<PricingForm shop="demo" initial={initial} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /Advanced JSON/i }));
+
+    const textarea = await screen.findByLabelText(/Pricing JSON configuration/i);
+    const next = {
+      ...initial,
+      baseDailyRate: 75,
+      durationDiscounts: [{ minDays: 14, rate: 0.85 }],
+    };
+    fireEvent.change(textarea, {
+      target: { value: JSON.stringify(next, null, 2) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Apply JSON to form/i }));
+
+    fireEvent.click(screen.getByRole("tab", { name: /Guided form/i }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("75")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("14")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/page.tsx
@@ -2,6 +2,10 @@ import { checkShopExists } from "@acme/lib";
 import { readPricing } from "@platform-core/repositories/pricing.server";
 import { notFound } from "next/navigation";
 import PricingForm from "./PricingForm";
+import { Card, CardContent } from "@/components/atoms/shadcn";
+import { Tag } from "@ui/components/atoms";
+import { cn } from "@ui/utils/style";
+import { formatNumber } from "@acme/shared-utils";
 
 export const revalidate = 0;
 
@@ -13,10 +17,83 @@ export default async function PricingPage({
   const { shop } = await params;
   if (!(await checkShopExists(shop))) return notFound();
   const initial = await readPricing();
+
+  const tiers = initial.durationDiscounts.length;
+  const depositCodes = Object.entries(initial.damageFees).filter(([, value]) => value === "deposit").length;
+  const coverageEnabled = Object.keys(initial.coverage ?? {}).length;
+
+  const quickStats = [
+    {
+      label: "Base daily rate",
+      value: `$${formatNumber(initial.baseDailyRate, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+      caption: "Default fallback when no SKU override exists",
+      accent: "bg-emerald-500/20 text-emerald-100",
+    },
+    {
+      label: "Discount tiers",
+      value: tiers ? String(tiers) : "None",
+      caption: tiers ? "Longer bookings receive incentives" : "Add tiers to reward duration",
+      accent: tiers ? "bg-sky-500/20 text-sky-100" : "bg-slate-500/30 text-slate-100",
+    },
+    {
+      label: "Deposit defaults",
+      value: depositCodes ? `${depositCodes} damage codes` : "None",
+      caption: depositCodes ? "Automatically reserve deposits when triggered" : "No deposit rules configured",
+      accent: depositCodes ? "bg-amber-500/20 text-amber-100" : "bg-slate-500/30 text-slate-100",
+    },
+    {
+      label: "Coverage entries",
+      value: coverageEnabled ? String(coverageEnabled) : "Optional",
+      caption: coverageEnabled ? "Fee & waiver rules live for customers" : "Add coverage to offset risk",
+      accent: coverageEnabled ? "bg-indigo-500/20 text-indigo-100" : "bg-slate-500/30 text-slate-100",
+    },
+  ];
+
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">Rental Pricing</h2>
-      <PricingForm shop={shop} initial={initial} />
+    <div className="space-y-8 text-white">
+      <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-950 shadow-xl">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)]" />
+        <div className="relative space-y-4 px-6 py-8">
+          <Tag variant="default" className="bg-white/10 text-white/70">
+            Rental pricing · {shop}
+          </Tag>
+          <h1 className="text-3xl font-semibold md:text-4xl">Tune rates, deposits, and coverage with confidence</h1>
+          <p className="text-sm text-white/70 md:text-base">
+            Build predictable rental revenue by balancing base rates, long-stay discounts, and how you recover for damage or loss.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {quickStats.map((stat) => (
+              <div
+                key={stat.label}
+                className={cn(
+                  "rounded-2xl border border-white/10 px-4 py-3 text-xs text-white/70 backdrop-blur",
+                  stat.accent
+                )}
+              >
+                <p className="font-semibold uppercase tracking-wide">{stat.label}</p>
+                <p className="mt-1 text-lg font-semibold text-white">{stat.value}</p>
+                <p className="text-xs text-white/70">{stat.caption}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <Card className="border border-white/10 bg-slate-950/70 text-white shadow-lg">
+          <CardContent className="space-y-4 px-6 py-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold">Pricing controls</h2>
+                <p className="max-w-2xl text-sm text-white/70">
+                  Work through the guided editor, import JSON from finance, or export the latest rules to share with merchandising partners.
+                </p>
+              </div>
+            </div>
+            <PricingForm shop={shop} initial={initial} />
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh the data hub landing page with a hero and action cards for inventory, pricing, and return logistics
- introduce a pricing dashboard hero with quick stats and wrap the form in a guided workflow card
- replace the raw pricing textarea with a tabbed guided/JSON editor, inline validation, import/export messaging, and toast feedback
- add unit coverage to verify guided validation and JSON editor behaviour

## Testing
- pnpm --filter @apps/cms exec jest --runTestsByPath /workspace/base-shop/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/__tests__/PricingForm.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68ca95ffb47c832f96035ed4bc5e9b0d