### PR TITLE
Refine product editor workspace layout

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/ProductEditHero.client.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/ProductEditHero.client.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback } from "react";
+import Link from "next/link";
+import { Button } from "@ui/components/atoms/shadcn";
+import { Chip } from "@ui/components/atoms";
+
+interface HeroProps {
+  shop: string;
+  productId: string;
+  status: string;
+  sku: string;
+  publishTarget: string;
+  formId: string;
+}
+
+export default function ProductEditHero({
+  shop,
+  productId,
+  status,
+  sku,
+  publishTarget,
+  formId,
+}: HeroProps) {
+  const handleDiscard = useCallback(() => {
+    window.history.back();
+  }, []);
+
+  const summary = [
+    { label: "Status", value: status },
+    { label: "SKU", value: sku },
+    { label: "Publish target", value: publishTarget },
+  ];
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-3">
+          <h1 className="text-2xl font-semibold">
+            Edit product &ndash; {shop}/{productId}
+          </h1>
+          <div className="flex flex-wrap gap-2">
+            {summary.map(({ label, value }) => (
+              <Chip
+                key={label}
+                className="bg-muted px-3 py-1 text-xs uppercase tracking-wide"
+              >
+                <span className="text-[0.65rem] font-medium text-muted-foreground">
+                  {label}
+                </span>
+                <span className="ml-1 font-semibold text-foreground">{value}</span>
+              </Chip>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleDiscard}
+          >
+            Discard changes
+          </Button>
+          <Button type="submit" form={formId}>
+            Save changes
+          </Button>
+        </div>
+      </div>
+      <div>
+        <Button
+          asChild
+          variant="ghost"
+          className="px-0 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <Link href={`/shop/${shop}/products/${productId}`}>View product</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/ProductEditor.client.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/ProductEditor.client.tsx
@@ -10,12 +10,14 @@ interface Props {
   shop: string;
   initialProduct: ProductPublication & { variants?: Record<string, string[]> };
   languages: readonly Locale[];
+  formId?: string;
 }
 
 export default function ProductEditor({
   shop,
   initialProduct,
   languages,
+  formId = "product-editor-form",
 }: Props) {
   const onSave = (fd: FormData) => updateProduct(shop, fd);
   return (
@@ -23,6 +25,7 @@ export default function ProductEditor({
       product={{ ...initialProduct, variants: initialProduct.variants ?? {} }}
       onSave={onSave}
       locales={languages}
+      formId={formId}
     />
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/products/[id]/edit/page.tsx
@@ -6,6 +6,8 @@ import {
 } from "@platform-core/repositories/json.server";
 import dynamic from "next/dynamic";
 import { notFound } from "next/navigation";
+import { Card, CardContent } from "@ui/components/atoms/shadcn";
+import ProductEditHero from "./ProductEditHero.client";
 
 /* ------------------------------------------------------------------ */
 /*  Lazy-load wrapper (client component)                              */
@@ -29,16 +31,30 @@ export default async function ProductEditPage({
   ]);
   if (!product) return notFound();
 
+  const formId = "product-editor-form";
+
   return (
-    <>
-      <h1 className="mb-6 text-2xl font-semibold">
-        Edit product &ndash; {shop}/{id}
-      </h1>
-      <ProductEditor
+    <div className="flex h-full flex-col gap-6">
+      <ProductEditHero
         shop={shop}
-        initialProduct={product}
-        languages={[...settings.languages]}
+        productId={id}
+        status={product.status}
+        sku={product.sku}
+        publishTarget={product.shop ?? shop}
+        formId={formId}
       />
-    </>
+      <Card className="flex flex-1 flex-col overflow-hidden">
+        <CardContent className="flex flex-1 flex-col overflow-hidden p-0">
+          <div className="flex-1 overflow-y-auto p-6">
+            <ProductEditor
+              shop={shop}
+              initialProduct={product}
+              languages={[...settings.languages]}
+              formId={formId}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/packages/ui/__tests__/ProductEditorForm.test.tsx
+++ b/packages/ui/__tests__/ProductEditorForm.test.tsx
@@ -38,7 +38,7 @@ describe("ProductEditorForm", () => {
     );
 
     // shows validation error
-    expect(screen.getByText("Required")).toBeInTheDocument();
+    expect(screen.getByText(/Required/)).toBeInTheDocument();
 
     // change a field
     const priceInput = screen.getByLabelText(/Price/);

--- a/packages/ui/src/components/atoms/IconButton.tsx
+++ b/packages/ui/src/components/atoms/IconButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "../../utils/style";
+
+export type IconButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+export type IconButtonSize = "sm" | "md";
+
+export interface IconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
+}
+
+const baseClasses =
+  "inline-flex items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50";
+
+const variantClasses: Record<IconButtonVariant, string> = {
+  primary: "bg-primary text-primary-fg hover:bg-primary/90",
+  secondary: "bg-muted text-foreground hover:bg-muted/80",
+  ghost: "hover:bg-accent hover:text-accent-foreground",
+  danger: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+};
+
+const tokenByVariant: Record<IconButtonVariant, string> = {
+  primary: "--color-primary",
+  secondary: "--color-accent",
+  ghost: "--color-accent",
+  danger: "--color-danger",
+};
+
+const sizeClasses: Record<IconButtonSize, string> = {
+  sm: "h-8 w-8 text-base",
+  md: "h-10 w-10 text-lg",
+};
+
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({
+    className,
+    variant = "ghost",
+    size = "sm",
+    type = "button",
+    ...props
+  }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      data-token={tokenByVariant[variant]}
+      className={cn(baseClasses, variantClasses[variant], sizeClasses[size], className)}
+      {...props}
+    />
+  ),
+);
+
+IconButton.displayName = "IconButton";
+
+export default IconButton;

--- a/packages/ui/src/components/atoms/index.d.ts
+++ b/packages/ui/src/components/atoms/index.d.ts
@@ -9,6 +9,7 @@ export { Textarea, type TextareaProps } from "./primitives/textarea";
 export { ARViewer } from "./ARViewer";
 export { Avatar } from "./Avatar";
 export { Chip } from "./Chip";
+export { IconButton } from "./IconButton";
 export { ColorSwatch } from "./ColorSwatch";
 export { Icon } from "./Icon";
 export { LineChart } from "./LineChart";

--- a/packages/ui/src/components/atoms/index.ts
+++ b/packages/ui/src/components/atoms/index.ts
@@ -35,6 +35,7 @@ export { Textarea, type TextareaProps } from "./primitives/textarea";
 export { ARViewer } from "./ARViewer";
 export { Avatar } from "./Avatar";
 export { Chip } from "./Chip";
+export { IconButton } from "./IconButton";
 export { ColorSwatch } from "./ColorSwatch";
 export { FileSelector } from "./FileSelector";
 export { Icon } from "./Icon";

--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -1,13 +1,39 @@
 /* packages/ui/components/cms/ProductEditorForm.tsx */
 "use client";
 
-import { Button, Card, CardContent, Input } from "../atoms/shadcn";
+import {
+  Accordion,
+  Card,
+  CardContent,
+  Input,
+  Textarea,
+} from "../atoms/shadcn";
+import { Chip, IconButton, Toast } from "../atoms";
 import type { MediaItem } from "@acme/types";
 import type { Locale } from "@acme/i18n";
 import { useProductEditorFormState } from "../../hooks/useProductEditorFormState";
-import type { ProductWithVariants, ProductSaveResult } from "../../hooks/useProductEditorFormState";
-import MultilingualFields from "./MultilingualFields";
+import type {
+  ProductWithVariants,
+  ProductSaveResult,
+} from "../../hooks/useProductEditorFormState";
 import PublishLocationSelector from "./PublishLocationSelector";
+import Tabs from "./blocks/Tabs";
+import { usePublishLocations } from "@acme/platform-core/hooks/usePublishLocations";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  Cross2Icon,
+  DragHandleDots2Icon,
+  PlusIcon,
+} from "@radix-ui/react-icons";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 
 /* eslint-disable @next/next/no-img-element */
 
@@ -22,7 +48,15 @@ interface BaseProps {
   onSave(fd: FormData): Promise<ProductSaveResult>;
   /** Locales enabled for the current shop */
   locales: readonly Locale[];
+  /** Optional id shared with external toolbars */
+  formId?: string;
 }
+
+const localeLabel: Partial<Record<Locale, string>> = {
+  en: "English",
+  de: "Deutsch",
+  it: "Italiano",
+};
 
 /* -------------------------------------------------------------------------- */
 /*  Component                                                                 */
@@ -32,6 +66,7 @@ export default function ProductEditorForm({
   product: init,
   onSave,
   locales,
+  formId = "product-editor-form",
 }: BaseProps) {
   const {
     product,
@@ -48,150 +83,322 @@ export default function ProductEditorForm({
     removeVariantValue,
   } = useProductEditorFormState(init, locales, onSave);
 
-  /* ---------------- UI ---------------- */
-  return (
-    <Card className="mx-auto max-w-3xl">
-      <CardContent>
-        <form onSubmit={handleSubmit} className="@container grid gap-6">
-          {Object.keys(errors).length > 0 && (
-            <div className="text-sm text-danger" data-token="--color-danger">
-              {(
-                Object.entries(errors as Record<string, string[]>) as [
-                  string,
-                  string[]
-                ][]
-              ).map(([k, v]) => (
-                <p key={k}>{v.join("; ")}</p>
-              ))}
-            </div>
-          )}
-          <Input type="hidden" name="id" value={product.id} />
+  const { locations } = usePublishLocations();
 
-          {/* Price ------------------------------------------------------ */}
-          <label className="flex max-w-xs flex-col gap-1">
-            <span>Price&nbsp;(cents)</span>
-            <Input
-              type="number"
-              name="price"
-              value={product.price}
-              onChange={handleChange}
-              required
-            />
-          </label>
+  const errorEntries = useMemo(
+    () => Object.entries(errors as Record<string, string[]>),
+    [errors],
+  );
+  const hasErrors = errorEntries.length > 0;
 
-          {/* Variant attributes -------------------------------------- */}
-          {(
-            Object.entries(product.variants as Record<string, string[]>) as [
-              string,
-              string[]
-            ][]
-          ).map(([attr, values]) => (
-            <div key={attr} className="flex flex-col gap-2">
-              <span>{`Variant ${attr}`}</span>
-              {values.map((v: string, i: number) => (
-                <div
-                  key={i}
-                  className="flex max-w-xs items-center gap-2"
-                >
-                  <Input
-                    name={`variant_${attr}_${i}`}
-                    value={v}
-                    onChange={handleChange}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => removeVariantValue(attr, i)}
-                    className="rounded bg-fg/50 px-1 text-xs text-bg"
-                  >
-                    ✕
-                  </button>
-                </div>
-              ))}
-              <button
-                type="button"
-                onClick={() => addVariantValue(attr)}
-                className="w-fit rounded border px-2 py-1 text-xs"
-              >
-                Add
-              </button>
-            </div>
-          ))}
+  const [toast, setToast] = useState<{ open: boolean; message: string }>(
+    { open: false, message: "" },
+  );
+  const closeToast = useCallback(() => {
+    setToast({ open: false, message: "" });
+  }, []);
+  const prevSavingRef = useRef(false);
 
-          {/* Publish locations ----------------------------------------- */}
-          <PublishLocationSelector
-            selectedIds={publishTargets}
-            onChange={setPublishTargets}
-            showReload
-          />
+  useEffect(() => {
+    if (saving && !prevSavingRef.current) {
+      setToast({ open: true, message: "Saving product…" });
+    } else if (!saving && prevSavingRef.current) {
+      setToast({
+        open: true,
+        message: hasErrors
+          ? "We couldn't save your changes. Check the highlighted sections."
+          : "Product saved successfully.",
+      });
+    }
+    prevSavingRef.current = saving;
+  }, [saving, hasErrors]);
 
-          {/* Image upload --------------------------------------------- */}
-          {uploader}
+  useEffect(() => {
+    if (!toast.open) return undefined;
+    const id = window.setTimeout(() => {
+      setToast((prev) => ({ ...prev, open: false }));
+    }, 4000);
+    return () => window.clearTimeout(id);
+  }, [toast.open]);
 
-          {product.media.length > 0 && (
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-              {product.media.map((img: MediaItem, idx: number) => (
-                <div
-                  key={img.url}
-                  className="relative h-32 w-full overflow-hidden rounded-md border"
-                >
-                  {img.type === "image" ? (
-                    <img
-                      src={img.url}
-                      alt={img.altText || ""}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <video
-                      src={img.url}
-                      className="h-full w-full object-cover"
-                      controls
-                    />
-                  )}
-                  <div className="absolute inset-x-1 top-1 flex justify-between gap-1">
-                    {idx > 0 && (
-                      <button
-                        type="button"
-                        onClick={() => moveMedia(idx, idx - 1)}
-                        className="rounded bg-fg/50 px-1 text-xs text-bg"
-                      >
-                        ↑
-                      </button>
-                    )}
-                    {idx < product.media.length - 1 && (
-                      <button
-                        type="button"
-                        onClick={() => moveMedia(idx, idx + 1)}
-                        className="rounded bg-fg/50 px-1 text-xs text-bg"
-                      >
-                        ↓
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => removeMedia(idx)}
-                      className="ml-auto rounded bg-fg/50 px-1 text-xs text-bg"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+  const onFormSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      handleSubmit(event);
+    },
+    [handleSubmit],
+  );
 
-          {/* Multilingual fields -------------------------------------- */}
-          <MultilingualFields
-            locales={locales}
-            product={product}
+  const selectedLocations = useMemo(
+    () =>
+      publishTargets.map(
+        (id) => locations.find((loc) => loc.id === id)?.name ?? id,
+      ),
+    [publishTargets, locations],
+  );
+
+  const variantEntries = useMemo(
+    () =>
+      Object.entries(product.variants as Record<string, string[]>) as [
+        string,
+        string[],
+      ][],
+    [product.variants],
+  );
+
+  const accordionItems = locales.map((locale) => ({
+    title: (
+      <div className="flex items-center gap-2">
+        <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
+          {locale}
+        </Chip>
+        <span className="text-sm text-muted-foreground">
+          {localeLabel[locale] ?? locale.toUpperCase()}
+        </span>
+      </div>
+    ),
+    content: (
+      <div className="space-y-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Title</span>
+          <Input
+            name={`title_${locale}`}
+            value={product.title[locale]}
             onChange={handleChange}
           />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Description</span>
+          <Textarea
+            rows={5}
+            name={`desc_${locale}`}
+            value={product.description[locale]}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+    ),
+  }));
 
-          {/* Save ------------------------------------------------------ */}
-          <Button type="submit" disabled={saving} className="w-fit">
-            {saving ? "Saving…" : "Save"}
-          </Button>
-        </form>
-      </CardContent>
-    </Card>
+  return (
+    <>
+      <Toast open={toast.open} message={toast.message} onClose={closeToast} />
+      <form
+        id={formId}
+        data-testid="product-editor-form"
+        onSubmit={onFormSubmit}
+        aria-busy={saving}
+        className="flex flex-col gap-6"
+      >
+        <Input type="hidden" name="id" value={product.id} />
+
+        {hasErrors && (
+          <div
+            className="rounded-lg border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger"
+            data-token="--color-danger"
+          >
+            <p className="font-medium">We found some issues:</p>
+            <ul className="mt-2 space-y-1">
+              {errorEntries.map(([field, messages]) => (
+                <li key={field}>
+                  <span className="font-semibold capitalize">{field}</span>: {messages.join(", ")}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <Tabs
+          labels={[
+            "Pricing",
+            "Variants",
+            "Publish locations",
+            "Media gallery",
+            "Localized content",
+          ]}
+          className="space-y-4"
+        >
+          <div className="space-y-4">
+            <Card>
+              <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-2 sm:max-w-xs">
+                  <label className="text-sm font-medium">Price (cents)</label>
+                  <Input
+                    type="number"
+                    name="price"
+                    value={product.price}
+                    onChange={handleChange}
+                    required
+                    min={0}
+                  />
+                </div>
+                {product.currency && (
+                  <Chip className="bg-muted px-3 py-1 text-xs uppercase tracking-wide">
+                    {product.currency}
+                  </Chip>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-4">
+            {variantEntries.length === 0 && (
+              <Card>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">
+                    This product has no variant dimensions configured.
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+            {variantEntries.map(([attr, values]) => (
+              <Card key={attr}>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
+                      {attr}
+                    </Chip>
+                    <IconButton
+                      aria-label={`Add option to ${attr}`}
+                      onClick={() => addVariantValue(attr)}
+                      variant="secondary"
+                    >
+                      <PlusIcon />
+                    </IconButton>
+                  </div>
+                  <div className="space-y-3">
+                    {values.map((value: string, index: number) => (
+                      <div key={index} className="flex items-center gap-2">
+                        <Input
+                          name={`variant_${attr}_${index}`}
+                          value={value}
+                          onChange={handleChange}
+                          className="flex-1"
+                        />
+                        <IconButton
+                          aria-label={`Remove ${attr} option ${index + 1}`}
+                          onClick={() => removeVariantValue(attr, index)}
+                          variant="ghost"
+                        >
+                          <Cross2Icon />
+                        </IconButton>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <div className="space-y-4">
+            <Card>
+              <CardContent className="space-y-4">
+                <PublishLocationSelector
+                  selectedIds={publishTargets}
+                  onChange={setPublishTargets}
+                  showReload
+                />
+                {publishTargets.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {selectedLocations.map((label) => (
+                      <Chip key={label} className="bg-muted px-3 py-1 text-xs">
+                        {label}
+                      </Chip>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Select one or more destinations to publish this product.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-4">
+            <Card>
+              <CardContent className="space-y-4">
+                {uploader}
+                {product.media.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    Add imagery or video to showcase this product.
+                  </p>
+                )}
+                {product.media.length > 0 && (
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {product.media.map((item: MediaItem, index: number) => (
+                      <div
+                        key={`${item.url}-${index}`}
+                        className="group relative overflow-hidden rounded-xl border"
+                      >
+                        {item.type === "image" ? (
+                          <img
+                            src={item.url}
+                            alt={item.altText || ""}
+                            className="h-48 w-full object-cover"
+                          />
+                        ) : (
+                          <video
+                            src={item.url}
+                            className="h-48 w-full object-cover"
+                            controls
+                          />
+                        )}
+                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-black/20 opacity-0 transition-opacity group-hover:opacity-100" />
+                        <div className="absolute inset-x-3 top-3 flex items-center justify-between gap-2 opacity-0 transition-opacity group-hover:opacity-100">
+                          <div className="flex items-center gap-1">
+                            <IconButton
+                              aria-label={`Move media ${index + 1} up`}
+                              onClick={() => moveMedia(index, index - 1)}
+                              disabled={index === 0}
+                              variant="secondary"
+                            >
+                              <ArrowUpIcon />
+                            </IconButton>
+                            <IconButton
+                              aria-label={`Move media ${index + 1} down`}
+                              onClick={() => moveMedia(index, index + 1)}
+                              disabled={index === product.media.length - 1}
+                              variant="secondary"
+                            >
+                              <ArrowDownIcon />
+                            </IconButton>
+                          </div>
+                          <IconButton
+                            aria-label={`Remove media ${index + 1}`}
+                            onClick={() => removeMedia(index)}
+                            variant="danger"
+                          >
+                            <Cross2Icon />
+                          </IconButton>
+                        </div>
+                        <div className="absolute bottom-3 left-3 opacity-0 transition-opacity group-hover:opacity-100">
+                          <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-2 py-1 text-xs font-medium shadow">
+                            <DragHandleDots2Icon aria-hidden />
+                            Drag
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-4">
+            <Card>
+              <CardContent>
+                <Accordion items={accordionItems} />
+              </CardContent>
+            </Card>
+          </div>
+        </Tabs>
+
+        <button type="submit" className="sr-only">
+          Save
+        </button>
+      </form>
+    </>
   );
 }

--- a/packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx
@@ -48,8 +48,8 @@ describe("ProductEditorForm", () => {
       />
     );
 
-    expect(getByText("Required")).toBeInTheDocument();
-    expect(getByText("Too short")).toBeInTheDocument();
+    expect(getByText(/Required/)).toBeInTheDocument();
+    expect(getByText(/Too short/)).toBeInTheDocument();
   });
 
   it("allows adding and removing variant values", () => {
@@ -76,7 +76,7 @@ describe("ProductEditorForm", () => {
     };
     (useProductEditorFormState as jest.Mock).mockReturnValue(hookState);
 
-    const { getByText, getByRole } = render(
+    const { getByRole } = render(
       <ProductEditorForm
         product={hookState.product}
         onSave={jest.fn()}
@@ -84,10 +84,14 @@ describe("ProductEditorForm", () => {
       />
     );
 
-    fireEvent.click(getByText("Add"));
+    fireEvent.click(getByRole("button", { name: "Variants" }));
+
+    fireEvent.click(getByRole("button", { name: "Add option to size" }));
     expect(hookState.addVariantValue).toHaveBeenCalledWith("size");
 
-    fireEvent.click(getByRole("button", { name: "✕" }));
+    fireEvent.click(
+      getByRole("button", { name: "Remove size option 1" })
+    );
     expect(hookState.removeVariantValue).toHaveBeenCalledWith("size", 0);
   });
 
@@ -115,7 +119,7 @@ describe("ProductEditorForm", () => {
     };
     (useProductEditorFormState as jest.Mock).mockReturnValue(hookState);
 
-    const { getByTestId } = render(
+    const { getByRole, getByTestId } = render(
       <ProductEditorForm
         product={hookState.product}
         onSave={jest.fn()}
@@ -123,6 +127,7 @@ describe("ProductEditorForm", () => {
       />
     );
 
+    fireEvent.click(getByRole("button", { name: "Publish locations" }));
     fireEvent.click(getByTestId("publish-selector"));
     expect(hookState.setPublishTargets).toHaveBeenCalledWith(["loc1"]);
   });
@@ -154,7 +159,7 @@ describe("ProductEditorForm", () => {
     };
     (useProductEditorFormState as jest.Mock).mockReturnValue(hookState);
 
-    const { getAllByText } = render(
+    const { getByRole } = render(
       <ProductEditorForm
         product={hookState.product}
         onSave={jest.fn()}
@@ -162,13 +167,15 @@ describe("ProductEditorForm", () => {
       />
     );
 
-    fireEvent.click(getAllByText("↓")[0]);
+    fireEvent.click(getByRole("button", { name: "Media gallery" }));
+
+    fireEvent.click(getByRole("button", { name: "Move media 1 down" }));
     expect(hookState.moveMedia).toHaveBeenCalledWith(0, 1);
 
-    fireEvent.click(getAllByText("↑")[0]);
+    fireEvent.click(getByRole("button", { name: "Move media 2 up" }));
     expect(hookState.moveMedia).toHaveBeenCalledWith(1, 0);
 
-    fireEvent.click(getAllByText("✕")[1]);
+    fireEvent.click(getByRole("button", { name: "Remove media 2" }));
     expect(hookState.removeMedia).toHaveBeenCalledWith(1);
   });
 
@@ -196,7 +203,7 @@ describe("ProductEditorForm", () => {
     };
     (useProductEditorFormState as jest.Mock).mockReturnValue(hookState);
 
-    const { getByRole } = render(
+    const { getByTestId, getByText } = render(
       <ProductEditorForm
         product={hookState.product}
         onSave={jest.fn()}
@@ -204,10 +211,11 @@ describe("ProductEditorForm", () => {
       />
     );
 
-    const button = getByRole("button", { name: "Saving…" });
-    expect(button).toBeDisabled();
+    const form = getByTestId("product-editor-form");
+    expect(form).toHaveAttribute("aria-busy", "true");
+    expect(getByText("Saving product…")).toBeInTheDocument();
 
-    fireEvent.submit(button.closest("form")!);
+    fireEvent.submit(form);
     expect(hookState.handleSubmit).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a client hero header with action toolbar and integrate the editor form into a scrollable workspace
- rework the product editor form into tabbed card sections with improved media controls, localized accordion fields, toast feedback, and shared IconButton styling
- expose the new IconButton atom and update product editor tests to match the revised interaction points

## Testing
- pnpm --filter @acme/ui test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca95f266ec832fa392e786f88d548d