### PR TITLE
Enhance CMS account and RBAC management

### DIFF
--- a/apps/cms/src/app/cms/__tests__/accountRequestsPanel.test.tsx
+++ b/apps/cms/src/app/cms/__tests__/accountRequestsPanel.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PendingUser } from "@cms/actions/accounts.server";
+import type { Role } from "@cms/auth/roles";
+import AccountRequestsPanel, {
+  type ApproveAction,
+} from "../account-requests/AccountRequestsPanel.client";
+import { ROLE_DETAILS } from "../components/roleDetails";
+
+jest.mock("@/components/atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Button: ({ children, asChild, ...props }: any) =>
+      asChild && React.isValidElement(children)
+        ? React.cloneElement(children, props)
+        : React.createElement("button", props, children),
+    Card: ({ children, ...props }: any) =>
+      React.createElement("section", props, children),
+    CardContent: ({ children, ...props }: any) =>
+      React.createElement("div", props, children),
+    Tag: ({ children, ...props }: any) =>
+      React.createElement("span", props, children),
+  };
+});
+
+jest.mock("@/components/atoms", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Toast: ({ open, message, className }: any) =>
+      open
+        ? React.createElement(
+            "div",
+            { role: "status", className },
+            message
+          )
+        : null,
+    Tooltip: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  };
+});
+
+const roles: Role[] = [
+  "admin",
+  "viewer",
+  "ShopAdmin",
+  "CatalogManager",
+  "ThemeEditor",
+];
+
+describe("AccountRequestsPanel", () => {
+  const request: PendingUser = {
+    id: "req-1",
+    name: "Avery Banner",
+    email: "avery@example.com",
+    password: "hashed",
+  };
+
+  it("renders pending requests with metadata, tags, and helper text", () => {
+    const approve: ApproveAction = jest.fn();
+    render(
+      <AccountRequestsPanel
+        requests={[request]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onApprove={approve}
+      />
+    );
+
+    expect(
+      screen.queryByRole("heading", { name: /account requests/i })
+    ).toBeNull();
+    expect(screen.getByText("Avery Banner")).toBeInTheDocument();
+    expect(screen.getByText("avery@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/pending approval/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Administrator/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/select at least one role to include with the approval/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows a toast when attempting to approve without selecting roles", async () => {
+    const approve: ApproveAction = jest.fn();
+    render(
+      <AccountRequestsPanel
+        requests={[request]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onApprove={approve}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /approve request/i }));
+
+    expect(approve).not.toHaveBeenCalled();
+    expect(
+      await screen.findByRole("status", {
+        name: "",
+      })
+    ).toHaveTextContent(/select at least one role/i);
+  });
+
+  it("submits selected roles and removes the card on success", async () => {
+    const approve = jest.fn<ReturnType<ApproveAction>, Parameters<ApproveAction>>(
+      async () => ({ status: "success", message: "Approved" })
+    );
+
+    render(
+      <AccountRequestsPanel
+        requests={[request]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onApprove={approve}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Administrator/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Approve request/i }));
+
+    await waitFor(() =>
+      expect(approve).toHaveBeenCalledWith({
+        id: "req-1",
+        name: "Avery Banner",
+        roles: ["admin"],
+      })
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("account-request-card")).toBeNull()
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(/approved/i);
+  });
+});

--- a/apps/cms/src/app/cms/__tests__/rbacManagementPanel.test.tsx
+++ b/apps/cms/src/app/cms/__tests__/rbacManagementPanel.test.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { UserWithRoles } from "@cms/actions/rbac.server";
+import type { Role } from "@cms/auth/roles";
+import RbacManagementPanel, {
+  type InviteUserAction,
+  type SaveUserAction,
+} from "../rbac/RbacManagementPanel.client";
+import { ROLE_DETAILS } from "../components/roleDetails";
+import type { ActionResult } from "../components/actionResult";
+
+jest.mock("@/components/atoms/shadcn", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Button: ({ children, asChild, ...props }: any) =>
+      asChild && React.isValidElement(children)
+        ? React.cloneElement(children, props)
+        : React.createElement("button", props, children),
+    Card: ({ children, ...props }: any) =>
+      React.createElement("section", props, children),
+    CardContent: ({ children, ...props }: any) =>
+      React.createElement("div", props, children),
+    Input: ({ children, ...props }: any) =>
+      React.createElement("input", props, children),
+    Tag: ({ children, ...props }: any) =>
+      React.createElement("span", props, children),
+  };
+});
+
+jest.mock("@/components/atoms", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Toast: ({ open, message, className }: any) =>
+      open
+        ? React.createElement(
+            "div",
+            { role: "status", className },
+            message
+          )
+        : null,
+    Tooltip: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  };
+});
+
+const roles: Role[] = [
+  "admin",
+  "viewer",
+  "ShopAdmin",
+  "CatalogManager",
+  "ThemeEditor",
+];
+
+describe("RbacManagementPanel", () => {
+  const user: UserWithRoles = {
+    id: "user-1",
+    name: "Jordan Lee",
+    email: "jordan@example.com",
+    password: "hashed",
+    roles: "viewer",
+  };
+
+  it("renders user metadata with role badges", () => {
+    const save: SaveUserAction = jest.fn();
+    const invite: InviteUserAction = jest.fn();
+    render(
+      <RbacManagementPanel
+        users={[user]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onSaveUser={save}
+        onInvite={invite}
+      />
+    );
+
+    const userCard = screen.getByText("Jordan Lee").closest("section");
+    if (!userCard) {
+      throw new Error("User card not found");
+    }
+    const scoped = within(userCard);
+    expect(scoped.getByText("Jordan Lee")).toBeInTheDocument();
+    expect(scoped.getByText("jordan@example.com")).toBeInTheDocument();
+    expect(scoped.getByText(/1 role active/i)).toBeInTheDocument();
+    expect(scoped.getByRole("button", { name: /Administrator/i })).toBeInTheDocument();
+  });
+
+  it("prevents saving when all roles are cleared and surfaces a toast", async () => {
+    const save: SaveUserAction = jest.fn();
+    const invite: InviteUserAction = jest.fn();
+    render(
+      <RbacManagementPanel
+        users={[user]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onSaveUser={save}
+        onInvite={invite}
+      />
+    );
+
+    const userCard = screen.getByText("Jordan Lee").closest("section");
+    if (!userCard) {
+      throw new Error("User card not found");
+    }
+    const scoped = within(userCard);
+
+    fireEvent.click(scoped.getByRole("button", { name: /^Viewer$/i }));
+    fireEvent.click(scoped.getByRole("button", { name: /Save changes/i }));
+
+    expect(save).not.toHaveBeenCalled();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      /assign at least one role/i
+    );
+    expect(screen.getByText(/role assignment required/i)).toBeInTheDocument();
+  });
+
+  it("submits updated roles and updates the active badge", async () => {
+    const save = jest.fn<Promise<ActionResult>, Parameters<SaveUserAction>>(
+      async () => ({ status: "success", message: "Roles saved" })
+    );
+    const invite: InviteUserAction = jest.fn();
+
+    render(
+      <RbacManagementPanel
+        users={[user]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onSaveUser={save}
+        onInvite={invite}
+      />
+    );
+
+    const userCard = screen.getByText("Jordan Lee").closest("section");
+    if (!userCard) {
+      throw new Error("User card not found");
+    }
+    const scoped = within(userCard);
+
+    fireEvent.click(scoped.getByRole("button", { name: /Administrator/i }));
+    fireEvent.click(scoped.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() =>
+      expect(save).toHaveBeenCalledWith({
+        id: "user-1",
+        roles: ["viewer", "admin"],
+      })
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent(/roles saved/i);
+    expect(screen.getByText(/2 roles active/i)).toBeInTheDocument();
+  });
+
+  it("invites a new user, resets the form, and appends the entry", async () => {
+    const save: SaveUserAction = jest.fn();
+    const invite = jest.fn<
+      Promise<ActionResult & { user?: UserWithRoles }>,
+      Parameters<InviteUserAction>
+    >(async () => ({
+      status: "success",
+      message: "Invite sent",
+      user: {
+        id: "user-2",
+        name: "Alex Kim",
+        email: "alex@example.com",
+        password: "hashed",
+        roles: ["admin"],
+      },
+    }));
+
+    render(
+      <RbacManagementPanel
+        users={[user]}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onSaveUser={save}
+        onInvite={invite}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Alex Kim" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "alex@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/temporary password/i), {
+      target: { value: "secret" },
+    });
+    const inviteCard = screen
+      .getByRole("heading", { name: /Invite User/i })
+      .closest("section");
+    if (!inviteCard) {
+      throw new Error("Unable to locate invite card");
+    }
+    const inviteWithin = within(inviteCard);
+    fireEvent.click(inviteWithin.getByRole("button", { name: /Administrator/i }));
+    fireEvent.click(inviteWithin.getByRole("button", { name: /Send invite/i }));
+
+    await waitFor(() =>
+      expect(invite).toHaveBeenCalledWith({
+        name: "Alex Kim",
+        email: "alex@example.com",
+        password: "secret",
+        roles: ["admin"],
+      })
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent(/invite sent/i);
+    expect(screen.getByText("Alex Kim")).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).toHaveValue("");
+    expect(screen.getByLabelText(/email/i)).toHaveValue("");
+  });
+});

--- a/apps/cms/src/app/cms/account-requests/AccountRequestsPanel.client.tsx
+++ b/apps/cms/src/app/cms/account-requests/AccountRequestsPanel.client.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useCallback, useMemo, useState, useTransition } from "react";
+import { Button, Card, CardContent, Tag } from "@/components/atoms/shadcn";
+import { Toast, Tooltip } from "@/components/atoms";
+import type { PendingUser } from "@cms/actions/accounts.server";
+import type { Role } from "@cms/auth/roles";
+import type { ActionResult, ActionStatus } from "../components/actionResult";
+import type { RoleDetail } from "../components/roleDetails";
+
+interface ApprovePayload {
+  id: string;
+  name: string;
+  roles: Role[];
+}
+
+export type ApproveAction = (payload: ApprovePayload) => Promise<ActionResult>;
+
+type ToastState = ActionResult & { open: boolean };
+
+type SelectionState = Record<string, Role[]>;
+
+const DEFAULT_TOAST: ToastState = {
+  open: false,
+  status: "success",
+  message: "",
+};
+
+function normalizeSelections(requests: PendingUser[]): SelectionState {
+  return requests.reduce<SelectionState>((acc, request) => {
+    acc[request.id] = [];
+    return acc;
+  }, {});
+}
+
+type AccountRequestsPanelProps = {
+  requests: PendingUser[];
+  roles: Role[];
+  roleDetails: Record<Role, RoleDetail>;
+  onApprove: ApproveAction;
+};
+
+export default function AccountRequestsPanel({
+  requests,
+  roles,
+  roleDetails,
+  onApprove,
+}: AccountRequestsPanelProps) {
+  const [items, setItems] = useState<PendingUser[]>(() => [...requests]);
+  const [selections, setSelections] = useState<SelectionState>(() =>
+    normalizeSelections(requests)
+  );
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>(DEFAULT_TOAST);
+  const [isPending, startTransition] = useTransition();
+
+  const showToast = useCallback((status: ActionStatus, message: string) => {
+    setToast({ open: true, status, message });
+  }, []);
+
+  const closeToast = useCallback(() => {
+    setToast((current) => ({ ...current, open: false }));
+  }, []);
+
+  const toggleRole = useCallback(
+    (requestId: string, role: Role) => {
+      setSelections((prev) => {
+        const current = prev[requestId] ?? [];
+        const exists = current.includes(role);
+        const next = exists
+          ? current.filter((value) => value !== role)
+          : [...current, role];
+        return { ...prev, [requestId]: next };
+      });
+    },
+    []
+  );
+
+  const handleApprove = useCallback(
+    (request: PendingUser) => {
+      const selected = selections[request.id] ?? [];
+      if (selected.length === 0) {
+        showToast(
+          "error",
+          `Select at least one role before approving ${request.name}.`
+        );
+        return;
+      }
+
+      setPendingId(request.id);
+      startTransition(() => {
+        onApprove({ id: request.id, name: request.name, roles: selected })
+          .then((result) => {
+            showToast(result.status, result.message);
+            if (result.status === "success") {
+              setItems((prev) => prev.filter((item) => item.id !== request.id));
+            }
+          })
+          .catch((error: unknown) => {
+            const message =
+              error instanceof Error
+                ? error.message
+                : "Failed to approve account request.";
+            showToast("error", message);
+          })
+          .finally(() => {
+            setPendingId((current) => (current === request.id ? null : current));
+          });
+      });
+    },
+    [onApprove, selections, showToast]
+  );
+
+  const helperFor = useCallback(
+    (requestId: string) => {
+      const selected = selections[requestId] ?? [];
+      if (selected.length === 0) {
+        return "Select at least one role to include with the approval.";
+      }
+      const readable = selected
+        .map((role) => roleDetails[role]?.title ?? role)
+        .join(", ");
+      return `Grant ${readable} privileges when approving.`;
+    },
+    [roleDetails, selections]
+  );
+
+  const toastClassName = useMemo(() => {
+    return toast.status === "error"
+      ? "bg-destructive text-destructive-foreground"
+      : "bg-success text-success-fg";
+  }, [toast.status]);
+
+  if (items.length === 0) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-foreground">All requests reviewed</span>
+              <Tag variant="success">Up to date</Tag>
+            </div>
+            <p>New account requests will appear here automatically.</p>
+          </CardContent>
+        </Card>
+        <Toast
+          open={toast.open}
+          message={toast.message}
+          className={toastClassName}
+          onClose={closeToast}
+          role="status"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {items.map((request) => {
+        const selected = selections[request.id] ?? [];
+        return (
+          <Card key={request.id} data-testid="account-request-card">
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <p className="text-base font-semibold text-foreground">
+                    {request.name}
+                  </p>
+                  <p className="text-sm text-muted-foreground">{request.email}</p>
+                </div>
+                <Tag variant="warning">Pending approval</Tag>
+              </div>
+
+              <section
+                className="space-y-3"
+                aria-labelledby={`roles-${request.id}`}
+              >
+                <p
+                  id={`roles-${request.id}`}
+                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Assign roles
+                </p>
+                <div
+                  className="flex flex-wrap gap-2"
+                  role="group"
+                  aria-label={`Assign roles for ${request.name}`}
+                >
+                  {roles.map((role) => {
+                    const detail = roleDetails[role];
+                    const isSelected = selected.includes(role);
+                    return (
+                      <Button
+                        key={role}
+                        type="button"
+                        variant={isSelected ? "default" : "outline"}
+                        aria-pressed={isSelected}
+                        onClick={() => toggleRole(request.id, role)}
+                        className="h-auto px-3 py-2 text-sm"
+                      >
+                        <span className="flex items-center gap-2">
+                          <span className="font-medium">
+                            {detail?.title ?? role}
+                          </span>
+                          {detail && (
+                            <Tooltip text={detail.description}>
+                              <span
+                                aria-hidden="true"
+                                className="text-xs text-muted-foreground underline decoration-dotted"
+                              >
+                                ?
+                              </span>
+                            </Tooltip>
+                          )}
+                        </span>
+                      </Button>
+                    );
+                  })}
+                </div>
+                <p className="text-xs text-muted-foreground">{helperFor(request.id)}</p>
+              </section>
+
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  type="button"
+                  onClick={() => handleApprove(request)}
+                  disabled={isPending && pendingId === request.id}
+                  className="flex-1"
+                >
+                  {isPending && pendingId === request.id
+                    ? "Approving…"
+                    : "Approve request"}
+                </Button>
+                <Button variant="outline" asChild className="flex-1">
+                  <a
+                    href={`mailto:${request.email}`}
+                    className="block w-full text-center"
+                    aria-label={`Email ${request.name}`}
+                  >
+                    Email requester
+                  </a>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+      <Toast
+        open={toast.open}
+        message={toast.message}
+        className={toastClassName}
+        onClose={closeToast}
+        role="status"
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/account-requests/page.tsx
+++ b/apps/cms/src/app/cms/account-requests/page.tsx
@@ -1,13 +1,68 @@
 // apps/cms/src/app/cms/account-requests/page.tsx
 
-import { Button } from "@/components/atoms/shadcn";
 import { approveAccount, listPendingUsers } from "@cms/actions/accounts.server";
 import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
 import { getServerSession } from "next-auth";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+import AccountRequestsPanel from "./AccountRequestsPanel.client";
+import type { ApproveAction } from "./AccountRequestsPanel.client";
+import type { ActionResult } from "../components/actionResult";
+import { ROLE_DETAILS } from "../components/roleDetails";
 
 export const revalidate = 0;
+
+const roles: Role[] = [
+  "admin",
+  "viewer",
+  "ShopAdmin",
+  "CatalogManager",
+  "ThemeEditor",
+];
+
+const approveRequest: ApproveAction = async ({
+  id,
+  name,
+  roles: selectedRoles,
+}) => {
+  "use server";
+
+  const normalizedName = name.trim() || "The requester";
+  const uniqueRoles = Array.from(new Set(selectedRoles));
+  if (!id) {
+    return {
+      status: "error",
+      message: "This request could not be processed because it is missing an identifier.",
+    } satisfies ActionResult;
+  }
+  if (uniqueRoles.length === 0) {
+    return {
+      status: "error",
+      message: `Select at least one role before approving ${normalizedName}.`,
+    } satisfies ActionResult;
+  }
+
+  const formData = new FormData();
+  formData.set("id", id);
+  uniqueRoles.forEach((role) => formData.append("roles", role));
+
+  try {
+    await approveAccount(formData);
+    revalidatePath("/cms/account-requests");
+    const readableRoles = uniqueRoles.join(", ");
+    return {
+      status: "success",
+      message: `${normalizedName}'s account was approved with ${readableRoles} access.`,
+    } satisfies ActionResult;
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to approve the account request.";
+    return { status: "error", message } satisfies ActionResult;
+  }
+};
 
 export default async function AccountRequestsPage() {
   const session = await getServerSession(authOptions);
@@ -17,43 +72,15 @@ export default async function AccountRequestsPage() {
 
   const pending = await listPendingUsers();
 
-  async function approve(formData: FormData) {
-    "use server";
-    await approveAccount(formData);
-  }
-
-  const roles: Role[] = [
-    "admin",
-    "viewer",
-    "ShopAdmin",
-    "CatalogManager",
-    "ThemeEditor",
-  ];
-
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">Account Requests</h2>
-      {pending.length === 0 ? (
-        <p>No pending requests.</p>
-      ) : (
-        pending.map((r) => (
-          <form key={r.id} action={approve} className="mb-4 rounded border p-3">
-            <input type="hidden" name="id" value={r.id} />
-            <p>
-              <b>{r.name}</b> ({r.email})
-            </p>
-            <div className="my-2 flex flex-wrap gap-2">
-              {roles.map((role) => (
-                <label key={role} className="flex items-center gap-1 text-sm">
-                  <input type="checkbox" name="roles" value={role} />
-                  {role}
-                </label>
-              ))}
-            </div>
-            <Button type="submit">Approve</Button>
-          </form>
-        ))
-      )}
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold text-foreground">Account Requests</h2>
+      <AccountRequestsPanel
+        requests={pending}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onApprove={approveRequest}
+      />
     </div>
   );
 }

--- a/apps/cms/src/app/cms/components/actionResult.ts
+++ b/apps/cms/src/app/cms/components/actionResult.ts
@@ -1,0 +1,8 @@
+// apps/cms/src/app/cms/components/actionResult.ts
+
+export type ActionStatus = "success" | "error";
+
+export interface ActionResult {
+  status: ActionStatus;
+  message: string;
+}

--- a/apps/cms/src/app/cms/components/roleDetails.ts
+++ b/apps/cms/src/app/cms/components/roleDetails.ts
@@ -1,0 +1,41 @@
+// apps/cms/src/app/cms/components/roleDetails.ts
+
+import type { Role } from "@cms/auth/roles";
+
+export interface RoleDetail {
+  title: string;
+  description: string;
+}
+
+export const ROLE_DETAILS: Record<Role, RoleDetail> = {
+  admin: {
+    title: "Administrator",
+    description:
+      "Full access to storefront operations, analytics, and permission management.",
+  },
+  viewer: {
+    title: "Viewer",
+    description:
+      "Read-only visibility into dashboards, orders, and merchandising data.",
+  },
+  ShopAdmin: {
+    title: "Shop admin",
+    description:
+      "Manages storefront settings, orders, sessions, and customer support tasks.",
+  },
+  CatalogManager: {
+    title: "Catalog manager",
+    description:
+      "Controls product data, pricing, and availability across channels.",
+  },
+  ThemeEditor: {
+    title: "Theme editor",
+    description:
+      "Updates visual theming, layouts, and content blocks without code deployments.",
+  },
+  customer: {
+    title: "Customer",
+    description:
+      "Shopper role with purchasing, account management, and order history capabilities.",
+  },
+} as const;

--- a/apps/cms/src/app/cms/rbac/RbacManagementPanel.client.tsx
+++ b/apps/cms/src/app/cms/rbac/RbacManagementPanel.client.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import { useCallback, useMemo, useState, useTransition } from "react";
+import { Button, Card, CardContent, Input, Tag } from "@/components/atoms/shadcn";
+import { Toast, Tooltip } from "@/components/atoms";
+import type { UserWithRoles } from "@cms/actions/rbac.server";
+import type { Role } from "@cms/auth/roles";
+import type { ActionResult, ActionStatus } from "../components/actionResult";
+import type { RoleDetail } from "../components/roleDetails";
+
+interface SavePayload {
+  id: string;
+  roles: Role[];
+}
+
+interface InvitePayload {
+  name: string;
+  email: string;
+  password: string;
+  roles: Role[];
+}
+
+export type SaveUserAction = (payload: SavePayload) => Promise<ActionResult>;
+export type InviteUserAction = (
+  payload: InvitePayload
+) => Promise<ActionResult & { user?: UserWithRoles }>;
+
+type ToastState = ActionResult & { open: boolean };
+
+type SelectionState = Record<string, Role[]>;
+
+const DEFAULT_TOAST: ToastState = { open: false, status: "success", message: "" };
+
+function toRoleArray(value: UserWithRoles["roles"]): Role[] {
+  if (Array.isArray(value)) return [...value];
+  if (value) return [value];
+  return [];
+}
+
+function areRoleSelectionsEqual(a: Role[], b: Role[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = [...a].sort();
+  const right = [...b].sort();
+  return left.every((role, index) => role === right[index]);
+}
+
+type RbacManagementPanelProps = {
+  users: UserWithRoles[];
+  roles: Role[];
+  roleDetails: Record<Role, RoleDetail>;
+  onSaveUser: SaveUserAction;
+  onInvite: InviteUserAction;
+};
+
+export default function RbacManagementPanel({
+  users,
+  roles,
+  roleDetails,
+  onSaveUser,
+  onInvite,
+}: RbacManagementPanelProps) {
+  const [knownUsers, setKnownUsers] = useState<UserWithRoles[]>(() => [...users]);
+  const [selections, setSelections] = useState<SelectionState>(() =>
+    users.reduce<SelectionState>((acc, user) => {
+      acc[user.id] = toRoleArray(user.roles);
+      return acc;
+    }, {})
+  );
+  const [initialSelections, setInitialSelections] = useState<SelectionState>(() => ({
+    ...users.reduce<SelectionState>((acc, user) => {
+      acc[user.id] = toRoleArray(user.roles);
+      return acc;
+    }, {}),
+  }));
+  const [pendingUserId, setPendingUserId] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>(DEFAULT_TOAST);
+  const [isSaving, startSaveTransition] = useTransition();
+  const [isInviting, startInviteTransition] = useTransition();
+
+  const [inviteForm, setInviteForm] = useState({
+    name: "",
+    email: "",
+    password: "",
+    roles: [] as Role[],
+  });
+
+  const showToast = useCallback((status: ActionStatus, message: string) => {
+    setToast({ open: true, status, message });
+  }, []);
+
+  const closeToast = useCallback(() => {
+    setToast((current) => ({ ...current, open: false }));
+  }, []);
+
+  const toggleSelection = useCallback((userId: string, role: Role) => {
+    setSelections((prev) => {
+      const current = prev[userId] ?? [];
+      const exists = current.includes(role);
+      const next = exists
+        ? current.filter((value) => value !== role)
+        : [...current, role];
+      return { ...prev, [userId]: next };
+    });
+  }, []);
+
+  const tagForUser = useCallback(
+    (userId: string) => {
+      const current = selections[userId] ?? [];
+      const initial = initialSelections[userId] ?? [];
+      if (current.length === 0) {
+        return { variant: "warning" as const, label: "Role assignment required" };
+      }
+      if (!areRoleSelectionsEqual(current, initial)) {
+        return { variant: "warning" as const, label: "Pending changes" };
+      }
+      return {
+        variant: "success" as const,
+        label: `${current.length} ${current.length === 1 ? "role" : "roles"} active`,
+      };
+    },
+    [initialSelections, selections]
+  );
+
+  const helperTextFor = useCallback(
+    (userId: string) => {
+      const selected = selections[userId] ?? [];
+      if (selected.length === 0) {
+        return "Assign at least one role so the user can sign in.";
+      }
+      const readable = selected
+        .map((role) => roleDetails[role]?.title ?? role)
+        .join(", ");
+      return `Selected roles: ${readable}. Hover each option to review its permissions.`;
+    },
+    [roleDetails, selections]
+  );
+
+  const handleReset = useCallback((userId: string) => {
+    setSelections((prev) => ({
+      ...prev,
+      [userId]: [...(initialSelections[userId] ?? [])],
+    }));
+  }, [initialSelections]);
+
+  const handleSave = useCallback(
+    (user: UserWithRoles) => {
+      const selected = selections[user.id] ?? [];
+      if (selected.length === 0) {
+        showToast(
+          "error",
+          `Assign at least one role before saving changes for ${user.name}.`
+        );
+        return;
+      }
+
+      setPendingUserId(user.id);
+      startSaveTransition(() => {
+        onSaveUser({ id: user.id, roles: selected })
+          .then((result) => {
+            showToast(result.status, result.message);
+            if (result.status === "success") {
+              setInitialSelections((prev) => ({
+                ...prev,
+                [user.id]: [...selected],
+              }));
+            }
+          })
+          .catch((error: unknown) => {
+            const message =
+              error instanceof Error
+                ? error.message
+                : "Failed to update user roles.";
+            showToast("error", message);
+          })
+          .finally(() => {
+            setPendingUserId((current) => (current === user.id ? null : current));
+          });
+      });
+    },
+    [onSaveUser, selections, showToast]
+  );
+
+  const updateInviteRoles = useCallback((role: Role) => {
+    setInviteForm((prev) => {
+      const exists = prev.roles.includes(role);
+      const nextRoles = exists
+        ? prev.roles.filter((value) => value !== role)
+        : [...prev.roles, role];
+      return { ...prev, roles: nextRoles };
+    });
+  }, []);
+
+  const resetInviteForm = useCallback(() => {
+    setInviteForm({ name: "", email: "", password: "", roles: [] });
+  }, []);
+
+  const handleInviteSubmit = useCallback(() => {
+    const trimmedName = inviteForm.name.trim();
+    const trimmedEmail = inviteForm.email.trim();
+    const password = inviteForm.password;
+    const selectedRoles = inviteForm.roles;
+    const issues: string[] = [];
+    if (!trimmedName) {
+      issues.push("Enter a name.");
+    }
+    if (!trimmedEmail) {
+      issues.push("Provide an email address.");
+    }
+    if (!password) {
+      issues.push("Set a temporary password.");
+    }
+    if (selectedRoles.length === 0) {
+      issues.push("Assign at least one role.");
+    }
+    if (issues.length > 0) {
+      showToast("error", issues.join(" "));
+      return;
+    }
+
+    startInviteTransition(() => {
+      onInvite({
+        name: trimmedName,
+        email: trimmedEmail,
+        password,
+        roles: selectedRoles,
+      })
+        .then((result) => {
+          showToast(result.status, result.message);
+          if (result.status === "success") {
+            resetInviteForm();
+            if (result.user) {
+              const invited = result.user;
+              setKnownUsers((prev) => {
+                const index = prev.findIndex((item) => item.id === invited.id);
+                if (index === -1) {
+                  return [...prev, invited];
+                }
+                const copy = [...prev];
+                copy[index] = invited;
+                return copy;
+              });
+              const roleValues = toRoleArray(invited.roles);
+              setSelections((prev) => ({
+                ...prev,
+                [invited.id]: roleValues,
+              }));
+              setInitialSelections((prev) => ({
+                ...prev,
+                [invited.id]: roleValues,
+              }));
+            }
+          }
+        })
+        .catch((error: unknown) => {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to invite the user.";
+          showToast("error", message);
+        });
+    });
+  }, [inviteForm, onInvite, resetInviteForm, showToast]);
+
+  const toastClassName = useMemo(() => {
+    return toast.status === "error"
+      ? "bg-destructive text-destructive-foreground"
+      : "bg-success text-success-fg";
+  }, [toast.status]);
+
+  return (
+    <div className="space-y-6">
+      {knownUsers.map((user) => {
+        const { variant, label } = tagForUser(user.id);
+        const selected = selections[user.id] ?? [];
+        return (
+          <Card key={user.id} data-testid="rbac-user-card">
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <p className="text-base font-semibold text-foreground">{user.name}</p>
+                  <p className="text-sm text-muted-foreground">{user.email}</p>
+                </div>
+                <Tag variant={variant}>{label}</Tag>
+              </div>
+
+              <section
+                className="space-y-3"
+                aria-labelledby={`role-picker-${user.id}`}
+              >
+                <p
+                  id={`role-picker-${user.id}`}
+                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Manage permissions
+                </p>
+                <div
+                  className="flex flex-wrap gap-2"
+                  role="group"
+                  aria-label={`Select roles for ${user.name}`}
+                >
+                  {roles.map((role) => {
+                    const detail = roleDetails[role];
+                    const isSelected = selected.includes(role);
+                    return (
+                      <Button
+                        key={role}
+                        type="button"
+                        variant={isSelected ? "default" : "outline"}
+                        aria-pressed={isSelected}
+                        onClick={() => toggleSelection(user.id, role)}
+                        className="h-auto px-3 py-2 text-sm"
+                      >
+                        <span className="flex items-center gap-2">
+                          <span className="font-medium">
+                            {detail?.title ?? role}
+                          </span>
+                          {detail && (
+                            <Tooltip text={detail.description}>
+                              <span
+                                aria-hidden="true"
+                                className="text-xs text-muted-foreground underline decoration-dotted"
+                              >
+                                ?
+                              </span>
+                            </Tooltip>
+                          )}
+                        </span>
+                      </Button>
+                    );
+                  })}
+                </div>
+                <p className="text-xs text-muted-foreground">{helperTextFor(user.id)}</p>
+              </section>
+
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  type="button"
+                  onClick={() => handleSave(user)}
+                  disabled={isSaving && pendingUserId === user.id}
+                  className="flex-1"
+                >
+                  {isSaving && pendingUserId === user.id
+                    ? "Saving…"
+                    : "Save changes"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleReset(user.id)}
+                  className="flex-1"
+                  disabled={isSaving && pendingUserId === user.id}
+                >
+                  Reset selection
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      <Card>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-base font-semibold text-foreground">Invite User</h3>
+            <Tag variant="warning">Manual invite</Tag>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium text-foreground">Name</span>
+              <Input
+                name="name"
+                value={inviteForm.name}
+                onChange={(event) =>
+                  setInviteForm((prev) => ({ ...prev, name: event.target.value }))
+                }
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium text-foreground">Email</span>
+              <Input
+                name="email"
+                type="email"
+                value={inviteForm.email}
+                onChange={(event) =>
+                  setInviteForm((prev) => ({ ...prev, email: event.target.value }))
+                }
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+              <span className="font-medium text-foreground">Temporary password</span>
+              <Input
+                name="password"
+                type="password"
+                value={inviteForm.password}
+                onChange={(event) =>
+                  setInviteForm((prev) => ({
+                    ...prev,
+                    password: event.target.value,
+                  }))
+                }
+              />
+            </label>
+          </div>
+
+          <section className="space-y-3" aria-labelledby="invite-roles">
+            <p
+              id="invite-roles"
+              className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Assign starter roles
+            </p>
+            <div
+              className="flex flex-wrap gap-2"
+              role="group"
+              aria-label="Assign roles for the invitation"
+            >
+              {roles.map((role) => {
+                const detail = roleDetails[role];
+                const isSelected = inviteForm.roles.includes(role);
+                return (
+                  <Button
+                    key={role}
+                    type="button"
+                    variant={isSelected ? "default" : "outline"}
+                    aria-pressed={isSelected}
+                    onClick={() => updateInviteRoles(role)}
+                    className="h-auto px-3 py-2 text-sm"
+                  >
+                    <span className="flex items-center gap-2">
+                      <span className="font-medium">
+                        {detail?.title ?? role}
+                      </span>
+                      {detail && (
+                        <Tooltip text={detail.description}>
+                          <span
+                            aria-hidden="true"
+                            className="text-xs text-muted-foreground underline decoration-dotted"
+                          >
+                            ?
+                          </span>
+                        </Tooltip>
+                      )}
+                    </span>
+                  </Button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {inviteForm.roles.length === 0
+                ? "Choose at least one role so the invitee has access on first sign-in."
+                : `Selected roles: ${inviteForm.roles
+                    .map((role) => roleDetails[role]?.title ?? role)
+                    .join(", ")}.`}
+            </p>
+          </section>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              type="button"
+              onClick={handleInviteSubmit}
+              disabled={isInviting}
+              className="flex-1"
+            >
+              {isInviting ? "Sending invite…" : "Send invite"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={resetInviteForm}
+              disabled={isInviting}
+              className="flex-1"
+            >
+              Clear form
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Toast
+        open={toast.open}
+        message={toast.message}
+        className={toastClassName}
+        onClose={closeToast}
+        role="status"
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/rbac/page.tsx
+++ b/apps/cms/src/app/cms/rbac/page.tsx
@@ -1,17 +1,123 @@
 // apps/cms/src/app/cms/rbac/page.tsx
-import { Button, Input } from "@ui/components/atoms/shadcn";
+
 import {
   inviteUser,
   listUsers,
   updateUserRoles,
 } from "@cms/actions/rbac.server";
+import type { UserWithRoles } from "@cms/actions/rbac.server";
 import { authOptions } from "@cms/auth/options";
 import type { Role } from "@cms/auth/roles";
 import { getServerSession } from "next-auth";
 import Link from "next/link";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+import RbacManagementPanel from "./RbacManagementPanel.client";
+import type {
+  InviteUserAction,
+  SaveUserAction,
+} from "./RbacManagementPanel.client";
+import type { ActionResult } from "../components/actionResult";
+import { ROLE_DETAILS } from "../components/roleDetails";
 
 export const revalidate = 0;
+
+const roles: Role[] = [
+  "admin",
+  "viewer",
+  "ShopAdmin",
+  "CatalogManager",
+  "ThemeEditor",
+];
+
+const saveUserRoles: SaveUserAction = async ({ id, roles: selectedRoles }) => {
+  "use server";
+
+  const uniqueRoles = Array.from(new Set(selectedRoles));
+  if (!id) {
+    return {
+      status: "error",
+      message: "Unable to update roles because the user identifier is missing.",
+    } satisfies ActionResult;
+  }
+  if (uniqueRoles.length === 0) {
+    return {
+      status: "error",
+      message: "Assign at least one role before saving changes.",
+    } satisfies ActionResult;
+  }
+
+  const formData = new FormData();
+  formData.set("id", id);
+  uniqueRoles.forEach((role) => formData.append("roles", role));
+
+  try {
+    await updateUserRoles(formData);
+    revalidatePath("/cms/rbac");
+    return {
+      status: "success",
+      message: "Roles updated successfully.",
+    } satisfies ActionResult;
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to update user roles.";
+    return { status: "error", message } satisfies ActionResult;
+  }
+};
+
+const inviteUserAction: InviteUserAction = async ({
+  name,
+  email,
+  password,
+  roles: selectedRoles,
+}) => {
+  "use server";
+
+  const trimmedName = name.trim();
+  const trimmedEmail = email.trim();
+  const uniqueRoles = Array.from(new Set(selectedRoles));
+
+  const issues: string[] = [];
+  if (!trimmedName) issues.push("Enter a name.");
+  if (!trimmedEmail) issues.push("Provide an email address.");
+  if (!password) issues.push("Set a temporary password.");
+  if (uniqueRoles.length === 0) issues.push("Assign at least one role.");
+
+  const existing = await listUsers();
+  if (trimmedEmail && existing.some((user) => user.email === trimmedEmail)) {
+    issues.push("That email is already associated with another user.");
+  }
+
+  if (issues.length > 0) {
+    return { status: "error", message: issues.join(" ") } satisfies ActionResult;
+  }
+
+  const formData = new FormData();
+  formData.set("name", trimmedName);
+  formData.set("email", trimmedEmail);
+  formData.set("password", password);
+  uniqueRoles.forEach((role) => formData.append("roles", role));
+
+  try {
+    await inviteUser(formData);
+    revalidatePath("/cms/rbac");
+    const refreshed = await listUsers();
+    const invitedUser = refreshed.find((user) => user.email === trimmedEmail);
+    return {
+      status: "success",
+      message: `${trimmedName} has been invited to the CMS.`,
+      user: invitedUser as UserWithRoles | undefined,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to send the invitation.";
+    return { status: "error", message } satisfies ActionResult;
+  }
+};
 
 export default async function RbacPage() {
   const session = await getServerSession(authOptions);
@@ -19,86 +125,32 @@ export default async function RbacPage() {
     redirect("/cms");
   }
 
-  const users: Awaited<ReturnType<typeof listUsers>> = await listUsers();
-
-  async function save(formData: FormData) {
-    "use server";
-    await updateUserRoles(formData);
-  }
-
-  async function invite(formData: FormData) {
-    "use server";
-    await inviteUser(formData);
-  }
-
-  const roles: Role[] = [
-    "admin",
-    "viewer",
-    "ShopAdmin",
-    "CatalogManager",
-    "ThemeEditor",
-  ];
+  const users = await listUsers();
 
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">User Roles</h2>
-      <p className="mb-4 text-sm">
-        See the
-        <Link href="/docs/permissions.md" target="_blank" rel="noreferrer" className="underline">
-          permission guide
-        </Link>
-        for default role mappings.
-      </p>
-      {users.map((u) => (
-        <form key={u.id} action={save} className="mb-4 rounded border p-3">
-          <input type="hidden" name="id" value={u.id} />
-          <p>
-            <b>{u.name}</b> ({u.email})
-          </p>
-          <div className="my-2 flex flex-wrap gap-2">
-            {roles.map((role) => (
-              <label key={role} className="flex items-center gap-1 text-sm">
-                <input
-                  type="checkbox"
-                  name="roles"
-                  value={role}
-                  defaultChecked={
-                    Array.isArray(u.roles)
-                      ? u.roles.includes(role)
-                      : u.roles === role
-                  }
-                />
-                {role}
-              </label>
-            ))}
-          </div>
-          <Button type="submit">Save</Button>
-        </form>
-      ))}
-
-      <h3 className="mt-8 text-lg font-semibold">Invite User</h3>
-      <form action={invite} className="mt-2 space-y-2 rounded border p-3">
-        <label className="block text-sm">
-          <span>Name</span>
-          <Input name="name" className="mt-1" />
-        </label>
-        <label className="block text-sm">
-          <span>Email</span>
-          <Input type="email" name="email" className="mt-1" />
-        </label>
-        <label className="block text-sm">
-          <span>Password</span>
-          <Input type="password" name="password" className="mt-1" />
-        </label>
-        <div className="flex flex-wrap gap-2">
-          {roles.map((role) => (
-            <label key={role} className="flex items-center gap-1 text-sm">
-              <input type="checkbox" name="roles" value={role} /> {role}
-            </label>
-          ))}
-        </div>
-        <Button type="submit">Invite</Button>
-      </form>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold text-foreground">User Roles</h2>
+        <p className="text-sm text-muted-foreground">
+          See the
+          <Link
+            href="/docs/permissions.md"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 underline"
+          >
+            permission guide
+          </Link>
+          for default role mappings and examples.
+        </p>
+      </div>
+      <RbacManagementPanel
+        users={users}
+        roles={roles}
+        roleDetails={ROLE_DETAILS}
+        onSaveUser={saveUserRoles}
+        onInvite={inviteUserAction}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the account request list with a card-based `AccountRequestsPanel` that surfaces segmented role toggles, helper tooltips, and toast feedback for approval actions
- introduce a reusable `RbacManagementPanel` to manage user roles and invitations with contextual badges, segmented controls, and toast-based validation results
- cover the new flows with React Testing Library specs to verify structure changes, validation feedback, and toast interactions

## Testing
- pnpm -r build *(fails: upstream Next.js build errors unrelated to this change)*
- pnpm --filter @apps/cms test -- accountRequestsPanel *(fails: repository-wide coverage thresholds unmet when running targeted suite)*
- pnpm --filter @apps/cms test -- rbacManagementPanel *(fails: repository-wide coverage thresholds unmet when running targeted suite)*

------
https://chatgpt.com/codex/tasks/task_e_68caa35349e0832fa2c21f530d424d71