### PR TITLE
docs: expand ui guidance and cms workflows

### DIFF
--- a/docs/cms.md
+++ b/docs/cms.md
@@ -64,6 +64,32 @@ Library's `getByTestId` configured for `data-cy`.
 
 Progress saves automatically via the `cms-configurator-progress` key and the `/cms/api/configurator-progress` endpoint. Returning to `/cms/configurator` resumes from the last completed step.
 
+## Upgrade & rollback workflows
+
+Each shop dashboard (`/cms/shop/{shop}`) surfaces quick actions for the
+templating workflow:
+
+- **Upgrade & preview** triggers the `/api/upgrade-shop` endpoint. The CMS runs
+  `pnpm ts-node scripts/src/upgrade-shop.ts <shop>` on the server, stages the
+  latest template components and redirects to
+  `/cms/shop/{shop}/upgrade-preview` when successful. The upgrade preview page
+  summarises component changes (new vs. updated) and renders each entry with
+  sample props via `@ui/components/ComponentPreview`. When a package exposes a
+  changelog the preview lists it alongside the component so reviewers can open
+  the markdown file directly from the CMS. Use the CLI republish flow documented
+  in [upgrade-preview-republish](./upgrade-preview-republish.md) after confirming
+  the preview looks correct.
+- **View upgrade steps** simply surfaces a toast explaining that the background
+  job keeps running—useful if a review takes longer than expected.
+- **Rollback to previous version** calls `/api/shop/{shop}/rollback`, which
+  executes `pnpm ts-node scripts/src/rollback-shop.ts <shop>` and restores the
+  last published template snapshot. A toast confirms when the request is queued.
+
+Permissions mirror the underlying routes: `manage_pages` is required to stage
+upgrades or open the preview, while `manage_orders` is needed to trigger the
+rollback. Users without the necessary permission see a `401` response and the UI
+displays a failure toast.
+
 ## Configurator Resume & Page Drafts
 
 The shop configurator now resumes where you left off. If you log in via

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -108,7 +108,10 @@ To reuse answers across runs, create `profiles/<name>.json` and run
 with `--skip-prompts` to accept defaults for remaining questions and run
 non-interactively.
 
-Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages.
+Once scaffolded, open the CMS and use the [Page Builder](./cms.md#page-builder) to lay out your pages. The shop dashboard now
+includes quick actions for staging upgrades and requesting a rollback—use **Upgrade & preview** to run the templating script and
+review changes at `/cms/shop/<id>/upgrade-preview`, or **Rollback to previous version** to restore the last published template
+without leaving the CMS. See [Upgrade & rollback workflows](./cms.md#upgrade--rollback-workflows) for details.
 
 ### Rental shops
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- docs: expand atoms, molecules, organisms, templates and CMS block READMEs with usage guidance, prop reference tables and code samples.
+- docs: document Storybook scenarios for StatCard, SearchBar, ProductCarousel, AppShell and HeroBanner to clarify expected props and customization points.

--- a/packages/ui/src/components/atoms/README.md
+++ b/packages/ui/src/components/atoms/README.md
@@ -1,50 +1,71 @@
 # Atoms
 
-Small building blocks used throughout the UI.
+Small, reusable building blocks that power most UI layers in the design system.
 
-Shadcn-based primitives live in a sibling directory named `atoms/shadcn`. These wrappers expose the original shadcn/ui look and feel while fitting into our Atomic Design layers. Import them directly when you need the stock shadcn styles:
+Shadcn-based primitives live in [`atoms/shadcn`](./shadcn/README.md). They
+re-export the original shadcn/ui components with our typings so you can opt in
+to their baseline styling when needed.
 
 ```ts
 import { Button } from "@/components/atoms/shadcn";
 
+// or mix in our in-house atoms
+import { StatCard } from "@/components/atoms";
 ```
 
-If you need an in-house atom alongside a shadcn wrapper, alias the
-wrapper so its origin is obvious:
+When both variants are present in the same module, alias the shadcn import so
+its provenance remains clear:
 
 ```ts
-import { Button } from "@/components/atoms";
 import { Button as ShButton } from "@/components/atoms/shadcn";
 ```
 
-In-house atoms continue to live in this folder.
+Most atoms extend a native element (`HTMLDivElement`, `HTMLSpanElement`, …) so
+layout, spacing and accessibility attributes can be passed through via
+`className`, `aria-*` attributes, `onClick` handlers and similar props.
 
-All atoms should accept optional layout props. Use `width`, `height`, `padding` and
-`margin` to adjust their sizing or spacing. Values may be Tailwind classes
-(e.g. `w-8`) or numeric pixel values where supported.
+## Usage patterns
 
-Available components:
+- Import atoms from `@/components/atoms` inside apps and templates.
+- Co-locate styling tweaks with consumers by passing Tailwind classes through
+  `className` instead of modifying the component source.
+- Many visual atoms (e.g. `StatCard`, `ProductBadge`) accept `children` or
+  explicit props such as `label`/`value`. Prefer these documented props over
+  re-implementing bespoke UI in downstream apps.
 
-- `StatCard`
-- `LineChart`
-- `ProductBadge`
-  `RatingStars`
-- `StockStatus`
-- `ColorSwatch`
-- `Price`
-- `Avatar`
-- `Logo`
-- `Radio`
-- `Switch`
-- `Tag`
-- `Skeleton`
-- `Loader`
-- `Tooltip`
-- `Toast`
-- `PaginationDot`
-- `Icon`
-- `Popover`
-- `Chip`
-- `ARViewer`
-- `VideoPlayer`
-- `ZoomImage`
+## Component reference
+
+| Component | Key props | Example |
+| --- | --- | --- |
+| `StatCard` | `label: string`, `value: ReactNode`, `className?` | ```tsx
+<StatCard label="Revenue" value="$12k" className="bg-card" />
+``` |
+| `Price` | `amount: number`, `currency?: string` – defaults to the active currency context | ```tsx
+<Price amount={12900} currency="USD" className="text-2xl" />
+``` |
+| `LineChart` | `data: ChartData<'line'>`, `options?: ChartOptions<'line'>` | ```tsx
+<LineChart data={trendData} options={{ plugins: { legend: { display: false } } }} />
+``` |
+| `Tooltip` | `content: ReactNode`, render-prop children to anchor the tooltip | ```tsx
+<Tooltip content="Copied!">
+  <button type="button">Copy code</button>
+</Tooltip>
+``` |
+| `Loader` | `size?: number` (defaults to `20`) plus standard div attributes. Pair with off-screen text for accessibility. | ```tsx
+<div className="flex items-center gap-2" aria-live="polite">
+  <Loader size={28} />
+  <span className="sr-only">Fetching recommendations</span>
+</div>
+``` |
+
+Additional atoms follow the same pattern—props are intentionally narrow and
+pass-through HTML attributes allow fine-grained control. Inspect the component
+source or Storybook stories for less-common variants such as
+`ARViewer`, `ZoomImage` or the toast primitives.
+
+## Storybook examples
+
+Every atom ships with a Storybook story under `Atoms/*`. These stories
+demonstrate baseline configuration and common variations (loading, hover,
+accessibility states). Launch Storybook with `pnpm --filter @acme/ui storybook`
+to explore the playground and copy example code snippets.

--- a/packages/ui/src/components/atoms/StatCard.stories.tsx
+++ b/packages/ui/src/components/atoms/StatCard.stories.tsx
@@ -4,6 +4,20 @@ import { StatCard } from "./StatCard";
 const meta: Meta<typeof StatCard> = {
   title: "Atoms/StatCard",
   component: StatCard,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Display a primary metric and short label. Forward Tailwind classes through `className` to adjust colours or spacing, and provide any React node as the `value`.",
+      },
+    },
+  },
+  argTypes: {
+    className: {
+      control: false,
+      description: "Tailwind classes applied to the root card",
+    },
+  },
 };
 export default meta;
 
@@ -15,4 +29,21 @@ export const Sessions: StoryObj<typeof StatCard> = {
 };
 export const ConversionRate: StoryObj<typeof StatCard> = {
   args: { label: "Conversion Rate", value: "4.5%" },
+};
+
+export const WithCustomStyles: StoryObj<typeof StatCard> = {
+  args: {
+    label: "Net promoter score",
+    value: "+64",
+    className:
+      "bg-emerald-50 border border-emerald-200 [&>div]:text-emerald-900",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the `className` prop to align the card with brand palettes or contextual backgrounds.",
+      },
+    },
+  },
 };

--- a/packages/ui/src/components/atoms/shadcn/README.md
+++ b/packages/ui/src/components/atoms/shadcn/README.md
@@ -1,31 +1,52 @@
-# Shadcn Atoms
+# Shadcn atoms
 
-Wrappers around [shadcn/ui](https://ui.shadcn.com/) primitives. They expose the original components with our TypeScript types and minimal styling tweaks so they can be used as regular atoms in the design system.
-
-Import from this directory to make it clear the component originates from shadcn:
+Thin wrappers around [shadcn/ui](https://ui.shadcn.com/) primitives. They expose
+upstream behaviour with our typings so consumers can opt into shadcn defaults
+while staying inside the `@acme/ui` package.
 
 ```ts
 import { Button, Input } from "@/components/atoms/shadcn";
+
+// combine with first-party atoms when needed
+import { StatCard } from "@/components/atoms";
 ```
 
-When using both the shadcn wrapper and an in-house atom of the same
-name, alias the shadcn import so the distinction remains clear:
+Alias the shadcn imports when an in-house atom shares the same component name to
+keep call sites clear:
 
 ```ts
 import { Button } from "@/components/atoms";
 import { Button as ShButton } from "@/components/atoms/shadcn";
+
+function Example() {
+  return (
+    <div className="flex gap-3">
+      <Button>Primary</Button>
+      <ShButton variant="secondary">Secondary</ShButton>
+    </div>
+  );
+}
 ```
 
-Available components:
+## Available wrappers
 
-- `Button`
-- `Input`
-- `Card`
-- `Checkbox`
-- `Dialog`
-- `Select`
-- `Table`
-- `Textarea`
+All wrappers accept the same props as their shadcn counterparts plus a
+`className` override:
 
-Run `pnpm shadcn:diff` after upgrading `@shadcn/ui` to check for
-upstream changes.
+| Component | Notes |
+| --- | --- |
+| `Button` | Supports `variant`, `size`, `asChild` and can be composed with icons. |
+| `Input` / `Textarea` | Controlled or uncontrolled text inputs with Tailwind-friendly classes. |
+| `Checkbox` | Emits `checked`/`onCheckedChange` values consistent with Radix. |
+| `Select` | Includes trigger, content and item sub-components. Import as `Select`, `SelectTrigger`, etc. |
+| `Dialog` | Provides modal primitives (`Dialog`, `DialogTrigger`, `DialogContent`, …). |
+| `Card`, `Table` | Structural wrappers for layout blocks and tabular data. |
+
+Refer to the generated Storybook stories under `Atoms/Shadcn/*` for interactive
+examples.
+
+## Maintenance
+
+- Run `pnpm shadcn:diff` after bumping `@shadcn/ui` to review upstream changes.
+- Keep wrapper props aligned with the upstream components to avoid mismatched
+  behaviour in the CMS and storefront apps.

--- a/packages/ui/src/components/cms/blocks/HeroBanner.stories.tsx
+++ b/packages/ui/src/components/cms/blocks/HeroBanner.stories.tsx
@@ -5,7 +5,54 @@ const meta: Meta<typeof HeroBanner> = {
   title: "CMS/Blocks/HeroBanner",
   component: HeroBanner,
   tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Page-builder hero slider. Provide `slides` from the CMS schema and optionally restrict rendering with `minItems`/`maxItems`.",
+      },
+    },
+  },
+  args: {
+    slides: [
+      {
+        src: "/hero/slide-1.jpg",
+        alt: "Man wearing eco sneaker on concrete",
+        headlineKey: "hero.slide1.headline",
+        ctaKey: "hero.cta",
+      },
+      {
+        src: "/hero/slide-2.jpg",
+        alt: "Close-up of recycled rubber sole",
+        headlineKey: "hero.slide2.headline",
+        ctaKey: "hero.cta",
+      },
+    ],
+  },
 };
 export default meta;
 
 export const Default: StoryObj<typeof HeroBanner> = {};
+
+export const SingleSlide: StoryObj<typeof HeroBanner> = {
+  args: {
+    slides: [
+      {
+        src: "/hero/slide-3.jpg",
+        alt: "Pair of sneakers on mossy rock",
+        headlineKey: "hero.slide3.headline",
+        ctaKey: "hero.cta",
+      },
+    ],
+    minItems: 1,
+    maxItems: 1,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Clamp `minItems`/`maxItems` when a campaign supplies a single hero so the block renders predictably across layouts.",
+      },
+    },
+  },
+};

--- a/packages/ui/src/components/cms/blocks/README.md
+++ b/packages/ui/src/components/cms/blocks/README.md
@@ -1,7 +1,36 @@
-# CMS Blocks
+# CMS blocks
 
-Reusable content blocks for the page builder. Each block accepts optional
-`width`, `height`, `margin` and `padding` props so editors can control layout
-per instance. Blocks that render lists of items—such as `ProductGrid`,
-`ProductCarousel` and `RecommendationCarousel`—also support `minItems` and
-`maxItems` to clamp how many entries are shown at different viewport sizes.
+Reusable content blocks consumed by the CMS page builder. Blocks expose a
+predictable prop interface so the builder can serialise configuration and render
+previews on the fly.
+
+Most blocks honour the shared layout props (`width`, `height`, `padding`,
+`margin`) in addition to their functional props.
+
+## Usage
+
+- Import blocks via `@/components/cms/blocks/*` when composing custom previews.
+- Within the CMS, block props are edited through form controls and persisted as
+  JSON. The components here map those props to design-system primitives.
+- Blocks that fetch remote data (`ProductGrid`, `CollectionList`) handle loading
+  and state management internally so the builder can stay declarative.
+
+## Block reference
+
+| Block | Key props | Notes |
+| --- | --- | --- |
+| `HeroBanner` | `slides?: Slide[]`, optional `minItems`/`maxItems` | Renders the marketing hero carousel. The list is trimmed to `maxItems`; returning fewer than `minItems` hides the block. |
+| `CollectionList` | `collections: Category[]`, responsive sizing props, `gapClassName?` | Responsive grid that adapts column count using a `ResizeObserver`. Pass Tailwind gap classes to control spacing. |
+| `ProductGrid` | `skus?: SKU[]`, optional `collectionId` (fetches via CMS API), `minItems`/`maxItems`, device-specific counts | Falls back to CMS fixtures when `skus` is omitted. When `collectionId` is set the block fetches live data and memoises results. |
+| `ProductCarousel` / `RecommendationCarousel` | `products: SKU[]`, `minItems`, `maxItems`, device-specific props | Proxy to the organism carousels with identical responsive behaviour. Useful for hero rails and personalised lists. |
+| `TestimonialSlider` / `ReviewsCarousel` | `items: Testimonial[]`, optional autoplay duration | Displays editorial content with accessible focus management for keyboard users. |
+| `StoreLocatorBlock` | `locations: Location[]` | Wraps the map organism and handles geolocation props generated in the CMS UI. |
+| `FormBuilderBlock` | `fields`, `ctaLabel`, `successMessage` | Declarative form definition that renders input atoms and posts submissions to the CMS API. |
+
+Additional content blocks—`GiftCardBlock`, `ValueProps`, `NewsletterSignup`,
+`PricingTable`, etc.—follow the same pattern: props map one-to-one with the
+builder schema so editors can drag, drop and configure content without touching
+code.
+
+Refer to the Storybook entries under `CMS/Blocks/*` for full examples, including
+typical prop payloads emitted by the page builder.

--- a/packages/ui/src/components/molecules/README.md
+++ b/packages/ui/src/components/molecules/README.md
@@ -1,23 +1,59 @@
 # Molecules
 
-Composable building blocks made from atoms.
+Composable building blocks that combine multiple atoms into richer UI elements.
+Most molecules expose optional layout helpers (`width`, `height`, `padding`,
+`margin`) via the shared `boxProps` utility so pages can adjust spacing without
+forking the component.
 
-Molecules now support optional sizing and spacing props.
-`width`, `height`, `padding` and `margin` let you tweak layout per instance.
+## Usage
 
-Available components:
+```ts
+import {
+  SearchBar,
+  PaginationControl,
+  PriceCluster,
+  QuantityInput,
+} from "@/components/molecules";
+```
 
-- `PriceCluster`
-- `RatingSummary`
-- `SearchBar` – search input with autocomplete suggestions.
-- `PromoCodeInput`
-- `FormField`
-- `PaginationControl`
-- `PaymentMethodSelector`
-- `SustainabilityBadgeCluster`
-- `CurrencySwitcher`
-- `QuantityInput`
-- `Breadcrumbs` – navigation trail from a list of links.
-- `Image360Viewer`
-- `LanguageSwitcher`
-- `MediaSelector`
+Molecules tend to orchestrate behaviour (search suggestions, quantity counters,
+form labels) so downstream apps only need to forward event handlers.
+
+## Component reference
+
+| Component | Key props | Example |
+| --- | --- | --- |
+| `SearchBar` | `suggestions: string[]`, `label: string`, optional `onSearch`/`onSelect` callbacks. Maintains highlighted suggestion state for keyboard users. | ```tsx
+<SearchBar
+  label="Search products"
+  suggestions={popularQueries}
+  onSearch={(value) => router.push(`/search?q=${encodeURIComponent(value)}`)}
+/>
+``` |
+| `PaginationControl` | `page: number`, `pageCount: number`, `onPageChange?: (page) => void`. Renders up to five buttons and previous/next controls. | ```tsx
+<PaginationControl page={page} pageCount={totalPages} onPageChange={setPage} />
+``` |
+| `PriceCluster` | `price: number`, optional `compare` and `currency`. Automatically displays a discount badge when `compare` is higher than `price`. | ```tsx
+<PriceCluster price={49} compare={79} currency="USD" />
+``` |
+| `QuantityInput` | `value`, optional `min`, `max`, `onChange`. Emits next value when the +/- buttons are pressed. | ```tsx
+<QuantityInput value={qty} min={1} max={10} onChange={setQty} />
+``` |
+| `FormField` | `label`, optional `htmlFor`, `error`, `required`, layout props. Wraps custom form controls with accessible labelling and error messaging. | ```tsx
+import { Input } from "@/components/atoms/shadcn";
+
+<FormField label="Email" htmlFor="email" required error={errors.email}>
+  <Input id="email" type="email" value={form.email} onChange={handleChange} />
+</FormField>
+``` |
+
+Other molecules—such as `Breadcrumbs`, `CurrencySwitcher`,
+`PaymentMethodSelector` and the sustainability badges—follow the same patterns:
+explicit props for configuration plus layout overrides via `boxProps`.
+
+## Examples
+
+Storybook showcases each molecule under the `Molecules/*` hierarchy. Prefer the
+documented events and layout props over manipulating DOM structure manually; the
+components encapsulate keyboard interactions, ARIA attributes and theming tokens
+that the CMS and storefront rely on.

--- a/packages/ui/src/components/molecules/SearchBar.stories.tsx
+++ b/packages/ui/src/components/molecules/SearchBar.stories.tsx
@@ -3,6 +3,14 @@ import { SearchBar } from "./SearchBar";
 
 const meta: Meta<typeof SearchBar> = {
   component: SearchBar,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Typeahead search input with keyboard-accessible suggestions. Supply `suggestions` for local filtering or call `onSearch` to trigger server-side queries.",
+      },
+    },
+  },
   args: {
     suggestions: ["Apple", "Banana", "Cherry", "Date"],
     placeholder: "Search…",
@@ -16,3 +24,18 @@ const meta: Meta<typeof SearchBar> = {
 export default meta;
 
 export const Default: StoryObj<typeof SearchBar> = {};
+
+export const PrefilledQuery: StoryObj<typeof SearchBar> = {
+  args: {
+    query: "sneakers",
+    suggestions: ["Sneakers", "Sneakers green", "Sneakers leather"],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Populate the `query` prop to mirror a search term sourced from URL params or CMS filters.",
+      },
+    },
+  },
+};

--- a/packages/ui/src/components/organisms/ProductCarousel.stories.tsx
+++ b/packages/ui/src/components/organisms/ProductCarousel.stories.tsx
@@ -47,9 +47,23 @@ function AutoCarousel(props: ProductCarouselProps & { autoplay?: boolean }) {
 
 const meta: Meta<typeof AutoCarousel> = {
   component: AutoCarousel,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Horizontal product rail with responsive item counts. Control density with `minItems`/`maxItems` or explicit device props and enable quick previews with `enableQuickView`.",
+      },
+    },
+  },
   args: {
     products,
     autoplay: false,
+    minItems: 1,
+    maxItems: 4,
+  },
+  argTypes: {
+    minItems: { control: { type: "number", min: 1, max: 6 } },
+    maxItems: { control: { type: "number", min: 1, max: 6 } },
   },
 };
 export default meta;
@@ -57,10 +71,26 @@ export default meta;
 export const Default: StoryObj<typeof AutoCarousel> = {};
 export const Autoplay: StoryObj<typeof AutoCarousel> = {
   args: { autoplay: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Set `autoplay` when showcasing the carousel in marketing contexts. In production pass a timer that respects reduced-motion preferences.",
+      },
+    },
+  },
 };
 
 export const Bounded: StoryObj<typeof AutoCarousel> = {
   args: { minItems: 2, maxItems: 3 },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Clamp the visible slides to create symmetric layouts on desktop while still collapsing to a single item on mobile.",
+      },
+    },
+  },
 };
 
 export const Wide: StoryObj<typeof AutoCarousel> = {

--- a/packages/ui/src/components/organisms/README.md
+++ b/packages/ui/src/components/organisms/README.md
@@ -1,43 +1,61 @@
 # Organisms
 
-Composite layout sections composed of atoms and molecules.
+Composite layout sections composed of atoms and molecules. Each organism owns a
+specific UX workflow—product discovery, navigation, checkout review—and exposes
+props that let apps plug in data while preserving consistent theming.
 
-Organisms must expose `width`, `height`, `padding` and `margin`
-props to control their rendered dimensions.
+Most organisms forward optional layout props (`width`, `height`, `padding`,
+`margin`) and accept `className` overrides for additional Tailwind classes.
 
-Current components:
+## Usage
 
-- `Header`
-- `SideNav`
-- `Footer`
-- `Content`
-- `StatsGrid`
-- `DataTable`
-  `ProductCard`
-- `ProductCarousel`
-- `ProductGrid`
-- `ProductFeatures`
-- `ProductVariantSelector`
-- `ReviewsList`
-- `StoreLocatorMap`
-- `LiveChatWidget`
-- `OrderTrackingTimeline`
-- `AccountPanel`
-- `DeliveryScheduler`
-- `CheckoutStepper`
-- `FilterSidebar`
-- `WishlistDrawer`
-- `QAModule`
-- `MiniCart`
-- `StickyAddToCartBar`
-- `RecommendationCarousel`
-- `CategoryCard`
-- `ProductGallery`
-- `OrderSummary`
+```ts
+import {
+  ProductCarousel,
+  FilterSidebar,
+  MiniCart,
+  OrderSummary,
+} from "@/components/organisms";
+```
 
-## Responsive Product Displays
+Pair them with the relevant context providers from `@acme/platform-core` (e.g.
+`useCart`, `useLayout`) when the component expects shared state.
+
+## Component reference
+
+| Component | Purpose & key props | Example |
+| --- | --- | --- |
+| `ProductCarousel` | `products: SKU[]`, responsive sizing via `minItems`/`maxItems` or explicit `desktopItems`/`tabletItems`/`mobileItems`. Optional quick view (`enableQuickView`) with `onAddToCart`. | ```tsx
+<ProductCarousel
+  products={featuredProducts}
+  minItems={2}
+  maxItems={4}
+  enableQuickView
+  onAddToCart={(sku) => console.log("Add", sku.id)}
+/> 
+``` |
+| `FilterSidebar` | Receives `onChange` callback and optional `width`. Opens a Radix dialog that emits selected filters, debounced for better performance. | ```tsx
+<FilterSidebar width="w-72" onChange={(filters) => setFilters(filters)} />
+``` |
+| `MiniCart` | Fly-out drawer bound to the cart context. Accepts a custom `trigger` node and optional drawer `width`. Handles quantity updates, removals and error toasts. | ```tsx
+import { Button } from "@/components/atoms/shadcn";
+
+<MiniCart trigger={<Button>Open cart</Button>} width={360} />
+``` |
+| `OrderSummary` | Displays line items and totals. Accepts optional `cart` and `totals` props for server-rendered data and falls back to the cart context otherwise. | ```tsx
+<OrderSummary cart={serverCart} totals={validatedTotals} />
+``` |
+| `CheckoutStepper` | Guides customers through checkout stages. Provide a `steps: string[]` list and the zero-based `currentStep` index to highlight progress. |
+
+Other organisms—`Header`, `Footer`, `WishlistDrawer`, `LiveChatWidget`,
+`StoreLocatorMap`, `ProductGallery`, etc.—follow the same approach: data and
+callbacks enter via explicit props and layout tokens are exposed through
+`className` or the shared `boxProps` helpers.
+
+### Responsive product displays
 
 `ProductGrid`, `ProductCarousel` and `RecommendationCarousel` can display
-different numbers of products per viewport. Configure `desktopItems`,
-`tabletItems` and `mobileItems` for explicit device counts. When left unset,
-the components fall back to responsive `minItems`/`maxItems` bounds.
+different numbers of products per viewport. Provide explicit counts via the
+`desktopItems`, `tabletItems` and `mobileItems` props or rely on the adaptive
+`minItems`/`maxItems` bounds to let the component choose a value based on
+available width.

--- a/packages/ui/src/components/templates/AppShell.stories.tsx
+++ b/packages/ui/src/components/templates/AppShell.stories.tsx
@@ -11,17 +11,46 @@ const meta: Meta<typeof AppShell> = {
   title: "Layout/AppShell",
   component: AppShell,
   tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "High-level layout wrapper that provides theme and navigation context. Supply header, side navigation and footer slots to compose full page chrome.",
+      },
+    },
+  },
 };
 export default meta;
 
 export const Default: StoryObj<typeof AppShell> = {
   render: () => (
-      <AppShell
-        header={<Header locale="en" shopName="Demo">Header</Header>}
-        sideNav={<SideNav>Nav</SideNav>}
-        footer={<Footer shopName="Demo">Footer</Footer>}
-      >
+    <AppShell
+      header={<Header locale="en" shopName="Demo">Header</Header>}
+      sideNav={<SideNav>Nav</SideNav>}
+      footer={<Footer shopName="Demo">Footer</Footer>}
+    >
       <Content>Content</Content>
     </AppShell>
   ),
+};
+
+export const WithCustomBackground: StoryObj<typeof AppShell> = {
+  render: () => (
+    <AppShell
+      className="bg-slate-50"
+      header={<Header locale="en" shopName="Demo">Header</Header>}
+      sideNav={<SideNav>Nav</SideNav>}
+      footer={<Footer shopName="Demo">Footer</Footer>}
+    >
+      <Content>Content</Content>
+    </AppShell>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass Tailwind classes through `className` to match application-specific backgrounds or spacing requirements.",
+      },
+    },
+  },
 };

--- a/packages/ui/src/components/templates/README.md
+++ b/packages/ui/src/components/templates/README.md
@@ -1,32 +1,52 @@
 # Templates
 
-Shared page-level layouts used across apps. Currently includes:
+Shared page-level layouts that compose atoms, molecules and organisms into
+complete experiences. Templates wire up data slots, orchestrate context
+providers and expose configuration hooks so apps can swap in bespoke content.
 
-- `AppShell` – flex layout with slots for header, side navigation and footer. It
-  automatically wraps children with `LayoutProvider` so breadcrumbs and mobile
-  navigation state are available via `useLayout()`.
-  - `DashboardTemplate` – basic stats overview.
-- `AnalyticsDashboardTemplate` – stats, line chart and table for dashboards.
-- `ProductGalleryTemplate` – grid or carousel listing of products. Supports
-  `minItems` and `maxItems` to control the responsive number of items per row or
-  slide.
-- `ProductDetailTemplate` – hero-style view for a single product.
-- `FeaturedProductTemplate` – showcase layout for highlighting a product.
-- `ProductComparisonTemplate` – side-by-side view of multiple products.
-- `HomepageTemplate` – layout with hero and recommendation slots.
-- `CartTemplate` – editable list of cart items with totals.
-- `CategoryCollectionTemplate` – grid of category cards.
-- `SearchResultsTemplate` – search bar with optional filters and paginated
-  product results. Accepts `minItems` and `maxItems` to adjust the responsive
-  product grid and an `isLoading` prop to display a loading skeleton.
-- `CheckoutTemplate` – multi-step layout for collecting checkout information.
-- `OrderConfirmationTemplate` – summary of purchased items and totals.
-- `WishlistTemplate` – list of saved items with add-to-cart and remove actions.
-- `AccountDashboardTemplate` – overview of user details, stats and order list.
-- `StoreLocatorTemplate` – map view with a list of store locations.
-- `LiveShoppingEventTemplate` – live video with chat and product highlights.
-- `LoyaltyHubTemplate` – dashboard for customer loyalty stats and history.
-- `Error404Template` – simple page not found layout.
-- `Error500Template` – generic server error page.
-- `OrderTrackingTemplate` – progress tracker for shipping status.
-- `ProductMediaGalleryTemplate` – gallery view focused on media assets.
+## Usage
+
+```tsx
+import { AppShell, DashboardTemplate } from "@/components/templates";
+import { Header, Footer, SideNav } from "@/components/organisms";
+
+export default function DashboardPage() {
+  return (
+    <AppShell
+      header={<Header locale="en" shopName="Acme" />}
+      sideNav={<SideNav />}
+      footer={<Footer shopName="Acme" />}
+    >
+      <DashboardTemplate stats={stats} />
+    </AppShell>
+  );
+}
+```
+
+`AppShell` wraps children with the shared `ThemeProvider` and `LayoutProvider` so
+breadcrumbs, mobile navigation and tokens are available via `useLayout()` and
+`useTheme()`.
+
+## Template reference
+
+| Template | Purpose & key props |
+| --- | --- |
+| `AppShell` | Page chrome with header, side navigation and footer slots. Accepts `className` overrides and renders children inside a responsive main area. Automatically wires `ThemeProvider` and `LayoutProvider`. |
+| `DashboardTemplate` / `AnalyticsDashboardTemplate` | Dashboard layouts that expect a `stats: StatItem[]` array plus optional chart/table data. Pair with `StatsGrid` or analytics organisms for detail panes. |
+| `ProductDetailTemplate` | Hero layout for a single `product: SKU`. Supports optional `badges`, `onAddToCart` callback and custom `ctaLabel`. Automatically renders media, pricing and description blocks. |
+| `SearchResultsTemplate` | Search landing page with `suggestions`, `results`, pagination details and optional filters. Accepts `minItems`/`maxItems` to control grid density and `isLoading` to show skeletons. |
+| `CheckoutTemplate` | Multi-step checkout workflow. Provide `steps: { label; content }[]`, optionally `initialStep`, and respond to `onStepChange`/`onComplete` callbacks. |
+| `ProductGalleryTemplate` / `RecommendationCarouselTemplate` | Catalog browsing layouts that forward `minItems`/`maxItems` and device-specific props to the underlying carousel/grid organisms. |
+| `OrderConfirmationTemplate`, `CartTemplate`, `WishlistTemplate` | Post-purchase and account flows that accept line items, totals and callback handlers for editing cart state. |
+
+Additional templates such as `StoreLocatorTemplate`, `LiveShoppingEventTemplate`,
+`LoyaltyHubTemplate`, `OrderTrackingTemplate` and error pages (`Error404Template`,
+`Error500Template`) provide specialised shells for their respective workflows. In
+each case the API mirrors the underlying organisms—pass data via named props and
+attach event handlers for interactivity.
+
+## Examples
+
+Storybook groups templates under `Templates/*`. These stories demonstrate the
+expected data shapes (sample SKUs, analytics stats, streaming metadata). Use
+them as a reference when supplying props from the CMS or storefront apps.


### PR DESCRIPTION
## Summary
- expand UI package READMEs with usage guidance, prop tables, and Storybook annotations for representative components
- document the CMS upgrade preview and rollback flows in the CMS guide and setup primer
- add a changelog entry capturing the documentation refresh for @acme/ui

## Testing
- pnpm --filter @acme/ui lint *(fails: TypeScript project service cannot resolve numerous Storybook files in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caad20ad28832fb7b8eb859c4d2a2f