### PR TITLE
feat(cms): enhance media metadata handling

### DIFF
--- a/apps/cms/src/actions/__tests__/media.server.test.ts
+++ b/apps/cms/src/actions/__tests__/media.server.test.ts
@@ -13,6 +13,7 @@ const fsMock = {
   mkdir: jest.fn(),
   readdir: jest.fn(),
   unlink: jest.fn(),
+  stat: jest.fn(),
 };
 jest.mock('fs', () => ({ promises: fsMock }));
 
@@ -40,7 +41,8 @@ import * as mediaHelpers from '../media.helpers';
 import { ensureAuthorized } from '../common/auth';
 import { validateShopName } from '@platform-core/shops';
 
-const { listMedia, uploadMedia, deleteMedia } = mediaActions;
+const { listMedia, uploadMedia, deleteMedia, updateMediaMetadata, getMediaOverview } =
+  mediaActions;
 const { uploadsDir, metadataPath, readMetadata, writeMetadata } = mediaHelpers;
 
 describe('media.server helpers and actions', () => {
@@ -53,6 +55,10 @@ describe('media.server helpers and actions', () => {
     fsMock.mkdir.mockResolvedValue(undefined);
     fsMock.readdir.mockResolvedValue([]);
     fsMock.unlink.mockResolvedValue(undefined);
+    fsMock.stat.mockResolvedValue({
+      size: 1024,
+      mtime: new Date('2024-01-01T00:00:00.000Z'),
+    });
     writeJsonFileMock.mockResolvedValue(undefined);
     ulidMock.mockReturnValue('id123');
     sharpMetadataMock.mockResolvedValue({ width: 200, height: 100 });
@@ -92,6 +98,31 @@ describe('media.server helpers and actions', () => {
       });
     });
 
+    it('normalizes metadata with extended fields', async () => {
+      fsMock.readFile.mockResolvedValueOnce(
+        JSON.stringify({
+          'img.jpg': {
+            title: 't',
+            altText: 'alt',
+            type: 'video',
+            tags: 'tag1, tag2',
+            uploadedAt: '2024-01-02T00:00:00.000Z',
+            size: 2048,
+          },
+        }),
+      );
+      await expect(readMetadata('shop')).resolves.toEqual({
+        'img.jpg': {
+          title: 't',
+          altText: 'alt',
+          type: 'video',
+          tags: ['tag1', 'tag2'],
+          uploadedAt: '2024-01-02T00:00:00.000Z',
+          size: 2048,
+        },
+      });
+    });
+
     it('writeMetadata writes to metadata.json', async () => {
       await writeMetadata('shop', { foo: { title: 'bar' } });
       expect(writeJsonFileMock).toHaveBeenCalledWith(
@@ -112,8 +143,22 @@ describe('media.server helpers and actions', () => {
       fsMock.readdir.mockResolvedValueOnce(['a.jpg', 'metadata.json', 'b.mp4']);
       fsMock.readFile.mockResolvedValueOnce(
         JSON.stringify({
-          'a.jpg': { title: 'A', altText: 'A alt', type: 'image' },
-          'b.mp4': { title: 'B', altText: 'B alt', type: 'video' },
+          'a.jpg': {
+            title: 'A',
+            altText: 'A alt',
+            type: 'image',
+            tags: ['hero'],
+            uploadedAt: '2024-01-05T00:00:00.000Z',
+            size: 321,
+          },
+          'b.mp4': {
+            title: 'B',
+            altText: 'B alt',
+            type: 'video',
+            tags: [],
+            uploadedAt: '2024-01-06T00:00:00.000Z',
+            size: 654,
+          },
         }),
       );
 
@@ -122,18 +167,25 @@ describe('media.server helpers and actions', () => {
           url: '/uploads/shop/a.jpg',
           title: 'A',
           altText: 'A alt',
+          tags: ['hero'],
           type: 'image',
+          uploadedAt: '2024-01-05T00:00:00.000Z',
+          size: 321,
         },
         {
           url: '/uploads/shop/b.mp4',
           title: 'B',
           altText: 'B alt',
+          tags: [],
           type: 'video',
+          uploadedAt: '2024-01-06T00:00:00.000Z',
+          size: 654,
         },
       ]);
       expect(fsMock.readdir).toHaveBeenCalledWith(
         path.join(process.cwd(), 'public', 'uploads', 'shop'),
       );
+      expect(fsMock.stat).not.toHaveBeenCalled();
     });
 
     it('returns files without metadata when metadata read fails', async () => {
@@ -146,13 +198,19 @@ describe('media.server helpers and actions', () => {
           url: '/uploads/shop/a.jpg',
           title: undefined,
           altText: undefined,
+          tags: undefined,
           type: 'image',
+          uploadedAt: '2024-01-01T00:00:00.000Z',
+          size: 1024,
         },
         {
           url: '/uploads/shop/b.jpg',
           title: undefined,
           altText: undefined,
+          tags: undefined,
           type: 'image',
+          uploadedAt: '2024-01-01T00:00:00.000Z',
+          size: 1024,
         },
       ]);
 
@@ -160,9 +218,38 @@ describe('media.server helpers and actions', () => {
       errorSpy.mockRestore();
     });
 
+    it('fills missing metadata from file stats', async () => {
+      fsMock.readdir.mockResolvedValueOnce(['a.jpg']);
+      fsMock.readFile.mockResolvedValueOnce(
+        JSON.stringify({ 'a.jpg': { title: 'A' } }),
+      );
+      fsMock.stat.mockResolvedValueOnce({
+        size: 2048,
+        mtime: new Date('2024-02-01T12:00:00.000Z'),
+      });
+
+      await expect(listMedia('shop')).resolves.toEqual([
+        {
+          url: '/uploads/shop/a.jpg',
+          title: 'A',
+          altText: undefined,
+          tags: undefined,
+          type: 'image',
+          uploadedAt: '2024-02-01T12:00:00.000Z',
+          size: 2048,
+        },
+      ]);
+      expect(fsMock.stat).toHaveBeenCalledWith(
+        path.join(process.cwd(), 'public', 'uploads', 'shop', 'a.jpg'),
+      );
+    });
+
     it('throws when fs.readdir rejects', async () => {
       fsMock.readdir.mockRejectedValueOnce(new Error('boom'));
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await expect(listMedia('shop')).rejects.toThrow('Failed to list media');
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 
@@ -217,12 +304,18 @@ describe('media.server helpers and actions', () => {
       ulidMock.mockReturnValueOnce('img456');
       const formData = new FormData();
       formData.append('file', new File(['data'], 'photo.jpg', { type: 'image/jpeg' }));
+      const now = new Date('2024-03-01T00:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
       await expect(uploadMedia('shop', formData, 'landscape')).resolves.toEqual({
         url: '/uploads/shop/img456.jpg',
         title: undefined,
         altText: undefined,
+        tags: undefined,
         type: 'image',
+        size: 4,
+        uploadedAt: '2024-03-01T00:00:00.000Z',
       });
+      jest.useRealTimers();
     });
 
     it('fails when sharp processing throws', async () => {
@@ -271,11 +364,16 @@ describe('media.server helpers and actions', () => {
       formData.append('file', new File(['img'], 'photo.jpg', { type: 'image/jpeg' }));
       formData.append('title', 'My Image');
       formData.append('altText', 'alt');
+      const now = new Date('2024-05-01T12:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
       await expect(uploadMedia('shop', formData)).resolves.toEqual({
         url: '/uploads/shop/img123.jpg',
         title: 'My Image',
         altText: 'alt',
+        tags: undefined,
         type: 'image',
+        size: 3,
+        uploadedAt: '2024-05-01T12:00:00.000Z',
       });
       expect(sharpMock).toHaveBeenCalled();
       expect(fsMock.writeFile).toHaveBeenCalledWith(
@@ -290,21 +388,215 @@ describe('media.server helpers and actions', () => {
           'shop',
           'metadata.json',
         ),
-        { 'img123.jpg': { title: 'My Image', altText: 'alt', type: 'image' } },
+        {
+          'img123.jpg': {
+            title: 'My Image',
+            altText: 'alt',
+            type: 'image',
+            size: 3,
+            uploadedAt: '2024-05-01T12:00:00.000Z',
+          },
+        },
       );
+      jest.useRealTimers();
+    });
+
+    it('persists tags parsed from form data', async () => {
+      ulidMock.mockReturnValueOnce('img999');
+      const formData = new FormData();
+      formData.append('file', new File(['img'], 'photo.jpg', { type: 'image/jpeg' }));
+      formData.append('tags', '["featured"," hero "]');
+      const now = new Date('2024-07-01T00:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      await expect(uploadMedia('shop', formData)).resolves.toEqual({
+        url: '/uploads/shop/img999.jpg',
+        title: undefined,
+        altText: undefined,
+        tags: ['featured', 'hero'],
+        type: 'image',
+        size: 3,
+        uploadedAt: '2024-07-01T00:00:00.000Z',
+      });
+
+      expect(writeJsonFileMock).toHaveBeenCalledWith(
+        path.join(
+          process.cwd(),
+          'public',
+          'uploads',
+          'shop',
+          'metadata.json',
+        ),
+        {
+          'img999.jpg': expect.objectContaining({
+            tags: ['featured', 'hero'],
+            size: 3,
+            uploadedAt: '2024-07-01T00:00:00.000Z',
+          }),
+        },
+      );
+      jest.useRealTimers();
     });
 
     it('uploads a video file', async () => {
       ulidMock.mockReturnValueOnce('vid123');
       const formData = new FormData();
       formData.append('file', new File(['vid'], 'movie.mp4', { type: 'video/mp4' }));
+      const now = new Date('2024-06-01T00:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
       await expect(uploadMedia('shop', formData)).resolves.toEqual({
         url: '/uploads/shop/vid123.mp4',
         title: undefined,
         altText: undefined,
+        tags: undefined,
         type: 'video',
+        size: 3,
+        uploadedAt: '2024-06-01T00:00:00.000Z',
       });
+      jest.useRealTimers();
       expect(sharpMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateMediaMetadata', () => {
+    it('updates metadata fields and returns updated item', async () => {
+      fsMock.readFile.mockResolvedValueOnce(
+        JSON.stringify({
+          'file.jpg': {
+            title: 'Old',
+            altText: 'Old alt',
+            type: 'image',
+            tags: ['legacy'],
+            uploadedAt: '2024-01-01T00:00:00.000Z',
+            size: 400,
+          },
+        }),
+      );
+      fsMock.stat.mockResolvedValueOnce({
+        size: 400,
+        mtime: new Date('2024-01-01T00:00:00.000Z'),
+      });
+
+      await expect(
+        updateMediaMetadata('shop', '/uploads/shop/file.jpg', {
+          title: 'New title',
+          altText: null,
+          tags: ['fresh', ' hero'],
+        }),
+      ).resolves.toEqual({
+        url: '/uploads/shop/file.jpg',
+        title: 'New title',
+        altText: undefined,
+        tags: ['fresh', 'hero'],
+        type: 'image',
+        size: 400,
+        uploadedAt: '2024-01-01T00:00:00.000Z',
+      });
+
+      expect(writeJsonFileMock).toHaveBeenCalledWith(
+        path.join(
+          process.cwd(),
+          'public',
+          'uploads',
+          'shop',
+          'metadata.json',
+        ),
+        {
+          'file.jpg': {
+            title: 'New title',
+            type: 'image',
+            tags: ['fresh', 'hero'],
+            size: 400,
+            uploadedAt: '2024-01-01T00:00:00.000Z',
+          },
+        },
+      );
+    });
+
+    it('throws when media file is missing', async () => {
+      const error = Object.assign(new Error('missing'), { code: 'ENOENT' });
+      fsMock.stat.mockRejectedValueOnce(error);
+      await expect(
+        updateMediaMetadata('shop', '/uploads/shop/missing.jpg', {}),
+      ).rejects.toThrow('Media file not found');
+    });
+  });
+
+  describe('getMediaOverview', () => {
+    it('aggregates media details', async () => {
+      fsMock.readdir.mockResolvedValueOnce(['a.jpg', 'b.mp4']);
+      fsMock.readFile.mockResolvedValueOnce(
+        JSON.stringify({
+          'a.jpg': {
+            title: 'A',
+            type: 'image',
+            uploadedAt: '2024-01-02T00:00:00.000Z',
+            size: 200,
+          },
+        }),
+      );
+      fsMock.stat.mockResolvedValueOnce({
+        size: 500,
+        mtime: new Date('2024-01-03T00:00:00.000Z'),
+      });
+
+      await expect(getMediaOverview('shop')).resolves.toEqual({
+        files: [
+          {
+            url: '/uploads/shop/a.jpg',
+            title: 'A',
+            altText: undefined,
+            tags: undefined,
+            type: 'image',
+            size: 200,
+            uploadedAt: '2024-01-02T00:00:00.000Z',
+          },
+          {
+            url: '/uploads/shop/b.mp4',
+            title: undefined,
+            altText: undefined,
+            tags: undefined,
+            type: 'video',
+            size: 500,
+            uploadedAt: '2024-01-03T00:00:00.000Z',
+          },
+        ],
+        totalBytes: 700,
+        imageCount: 1,
+        videoCount: 1,
+        recentUploads: [
+          {
+            url: '/uploads/shop/b.mp4',
+            title: undefined,
+            altText: undefined,
+            tags: undefined,
+            type: 'video',
+            size: 500,
+            uploadedAt: '2024-01-03T00:00:00.000Z',
+          },
+          {
+            url: '/uploads/shop/a.jpg',
+            title: 'A',
+            altText: undefined,
+            tags: undefined,
+            type: 'image',
+            size: 200,
+            uploadedAt: '2024-01-02T00:00:00.000Z',
+          },
+        ],
+      });
+    });
+
+    it('returns empty overview when directory is missing', async () => {
+      const error = Object.assign(new Error('missing'), { code: 'ENOENT' });
+      fsMock.readdir.mockRejectedValueOnce(error);
+      await expect(getMediaOverview('shop')).resolves.toEqual({
+        files: [],
+        totalBytes: 0,
+        imageCount: 0,
+        videoCount: 0,
+        recentUploads: [],
+      });
     });
   });
 

--- a/apps/cms/src/actions/media.helpers.ts
+++ b/apps/cms/src/actions/media.helpers.ts
@@ -9,6 +9,9 @@ export type MediaMetadataEntry = {
   title?: string;
   altText?: string;
   type?: "image" | "video";
+  tags?: string[];
+  uploadedAt?: string;
+  size?: number;
 };
 
 export type MediaMetadata = Record<string, MediaMetadataEntry>;
@@ -22,10 +25,107 @@ export function metadataPath(shop: string): string {
   return path.join(uploadsDir(shop), "metadata.json");
 }
 
+function normalizeTags(value: unknown): string[] | undefined {
+  if (value == null) return undefined;
+
+  const pushTag = (acc: string[], tag: unknown) => {
+    if (typeof tag !== "string") return acc;
+    const trimmed = tag.trim();
+    if (trimmed) acc.push(trimmed);
+    return acc;
+  };
+
+  if (Array.isArray(value)) {
+    const tags = value.reduce<string[]>(pushTag, []);
+    return tags.length ? Array.from(new Set(tags)) : undefined;
+  }
+
+  if (typeof value === "string") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      /* ignore – treat as delimited string */
+    }
+
+    if (Array.isArray(parsed)) {
+      const tags = parsed.reduce<string[]>(pushTag, []);
+      return tags.length ? Array.from(new Set(tags)) : undefined;
+    }
+
+    if (typeof parsed === "string") {
+      const single = parsed.trim();
+      return single ? [single] : undefined;
+    }
+
+    const tags = value
+      .split(/[,\n]/)
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    return tags.length ? Array.from(new Set(tags)) : undefined;
+  }
+
+  return undefined;
+}
+
+function sanitizeMetadataEntry(value: unknown): MediaMetadataEntry {
+  if (typeof value === "string") {
+    return { title: value };
+  }
+
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+  const entry: MediaMetadataEntry = {};
+
+  if (typeof record.title === "string") {
+    entry.title = record.title;
+  }
+  if (typeof record.altText === "string") {
+    entry.altText = record.altText;
+  }
+
+  if (record.type === "video") {
+    entry.type = "video";
+  } else if (record.type === "image") {
+    entry.type = "image";
+  }
+
+  const tags = normalizeTags(record.tags);
+  if (tags) {
+    entry.tags = tags;
+  } else if (Array.isArray(record.tags) && record.tags.length === 0) {
+    entry.tags = [];
+  }
+
+  if (typeof record.uploadedAt === "string") {
+    entry.uploadedAt = record.uploadedAt;
+  }
+
+  if (typeof record.size === "number" && Number.isFinite(record.size)) {
+    entry.size = record.size;
+  }
+
+  return entry;
+}
+
 export async function readMetadata(shop: string): Promise<MediaMetadata> {
   try {
     const data = await fs.readFile(metadataPath(shop), "utf8");
-    return JSON.parse(data) as MediaMetadata;
+    const parsed = JSON.parse(data) as unknown;
+
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).map(([key, value]) => [
+        key,
+        sanitizeMetadataEntry(value),
+      ])
+    );
   } catch {
     return {};
   }

--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -4,6 +4,7 @@
 import { validateShopName } from "@platform-core/shops";
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { promises as fs } from "fs";
+import type { Stats } from "fs";
 import * as path from "path";
 import sharp from "sharp";
 import { ulid } from "ulid";
@@ -13,6 +14,167 @@ import {
   uploadsDir,
   writeMetadata,
 } from "./media.helpers";
+import type { MediaMetadataEntry } from "./media.helpers";
+
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".mov",
+  ".mkv",
+  ".webm",
+  ".avi",
+  ".m4v",
+]);
+
+function inferMediaType(
+  filename: string,
+  declaredType?: MediaMetadataEntry["type"]
+): "image" | "video" {
+  if (declaredType === "video") return "video";
+  if (declaredType === "image") return "image";
+  const ext = path.extname(filename).toLowerCase();
+  return VIDEO_EXTENSIONS.has(ext) ? "video" : "image";
+}
+
+function cleanTagsList(tags: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  for (const tag of tags) {
+    if (typeof tag !== "string") continue;
+    const trimmed = tag.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return Array.from(seen);
+}
+
+function parseTagsString(value: string): string[] {
+  if (!value) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (Array.isArray(parsed)) {
+    return cleanTagsList(parsed.filter((tag): tag is string => typeof tag === "string"));
+  }
+
+  if (typeof parsed === "string") {
+    return cleanTagsList([parsed]);
+  }
+
+  return cleanTagsList(value.split(/[,\n]/));
+}
+
+function extractTagsFromFormData(formData: FormData): string[] | undefined {
+  const keys = ["tags", "tags[]"];
+  const collected: string[] = [];
+  let seen = false;
+
+  for (const key of keys) {
+    const entries = formData.getAll(key);
+    if (entries.length > 0) {
+      seen = true;
+    }
+
+    for (const entry of entries) {
+      if (typeof entry !== "string") continue;
+      collected.push(...parseTagsString(entry));
+    }
+  }
+
+  if (!seen) return undefined;
+  const cleaned = cleanTagsList(collected);
+  return cleaned.length ? cleaned : [];
+}
+
+function normalizeTagsForStorage(
+  tags: string[] | null | undefined
+): string[] | undefined {
+  if (tags === undefined) {
+    return undefined;
+  }
+  if (tags === null) {
+    return [];
+  }
+  const cleaned = cleanTagsList(tags);
+  return cleaned.length ? cleaned : [];
+}
+
+async function toMediaItem(
+  shop: string,
+  dir: string,
+  filename: string,
+  entry?: MediaMetadataEntry,
+  stats?: Stats
+): Promise<MediaItem> {
+  let size = entry?.size;
+  let uploadedAt = entry?.uploadedAt;
+
+  if (stats) {
+    if (size == null) size = stats.size;
+    if (uploadedAt == null) uploadedAt = stats.mtime.toISOString();
+  } else if (size == null || uploadedAt == null) {
+    try {
+      const stat = await fs.stat(path.join(dir, filename));
+      if (size == null) size = stat.size;
+      if (uploadedAt == null) uploadedAt = stat.mtime.toISOString();
+    } catch {
+      /* ignore missing stat information */
+    }
+  }
+
+  return {
+    url: path.posix.join("/uploads", shop, filename),
+    title: entry?.title,
+    altText: entry?.altText,
+    tags: entry?.tags,
+    type: inferMediaType(filename, entry?.type),
+    size,
+    uploadedAt,
+  };
+}
+
+async function collectMediaItems(shop: string): Promise<MediaItem[]> {
+  const safeShop = validateShopName(shop);
+  const dir = uploadsDir(safeShop);
+  const files = await fs.readdir(dir);
+  const meta = await readMetadata(safeShop);
+
+  const mediaFiles = files.filter((f) => f !== "metadata.json");
+  const items = await Promise.all(
+    mediaFiles.map((filename) => toMediaItem(safeShop, dir, filename, meta[filename]))
+  );
+
+  return items;
+}
+
+function buildOverview(files: MediaItem[]) {
+  const totalBytes = files.reduce((sum, file) => sum + (file.size ?? 0), 0);
+  let imageCount = 0;
+  let videoCount = 0;
+  for (const file of files) {
+    if (file.type === "video") {
+      videoCount += 1;
+    } else {
+      imageCount += 1;
+    }
+  }
+
+  const recentUploads = [...files]
+    .sort((a, b) => {
+      const aTime = a.uploadedAt ? Date.parse(a.uploadedAt) : 0;
+      const bTime = b.uploadedAt ? Date.parse(b.uploadedAt) : 0;
+      const safeA = Number.isFinite(aTime) ? aTime : 0;
+      const safeB = Number.isFinite(bTime) ? bTime : 0;
+      return safeB - safeA;
+    })
+    .slice(0, 5);
+
+  return { files, totalBytes, imageCount, videoCount, recentUploads };
+}
+
+export type MediaOverview = ReturnType<typeof buildOverview>;
 
 /* -------------------------------------------------------------------------- */
 /*  List                                                                      */
@@ -22,18 +184,7 @@ export async function listMedia(shop: string): Promise<MediaItem[]> {
   await ensureAuthorized();
 
   try {
-    const dir = uploadsDir(shop);
-    const files = await fs.readdir(dir);
-    const meta = await readMetadata(shop);
-
-    return files
-      .filter((f) => f !== "metadata.json")
-      .map((f) => ({
-        url: path.posix.join("/uploads", shop, f),
-        title: meta[f]?.title,
-        altText: meta[f]?.altText,
-        type: meta[f]?.type ?? "image",
-      }));
+    return await collectMediaItems(shop);
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
       return [];
@@ -62,6 +213,7 @@ export async function uploadMedia(
 
   const title = formData.get("title")?.toString();
   const altText = formData.get("altText")?.toString();
+  const tags = extractTagsFromFormData(formData);
   let type: "image" | "video";
   let buffer: Buffer;
 
@@ -111,7 +263,8 @@ export async function uploadMedia(
 
   /* -------------------------------- save file ----------------------------- */
 
-  const dir = uploadsDir(shop);
+  const safeShop = validateShopName(shop);
+  const dir = uploadsDir(safeShop);
   await fs.mkdir(dir, { recursive: true });
 
   const ext =
@@ -119,16 +272,141 @@ export async function uploadMedia(
   const filename = `${ulid()}${ext}`;
   await fs.writeFile(path.join(dir, filename), buffer);
 
-  const meta = await readMetadata(shop);
-  meta[filename] = { title, altText, type };
-  await writeMetadata(shop, meta);
+  const size = buffer.length;
+  const uploadedAt = new Date().toISOString();
 
-  return {
-    url: path.posix.join("/uploads", shop, filename),
+  const meta = await readMetadata(safeShop);
+  const entry: MediaMetadataEntry = {
     title,
     altText,
     type,
+    size,
+    uploadedAt,
   };
+  if (tags !== undefined) {
+    entry.tags = tags;
+  }
+
+  meta[filename] = entry;
+  await writeMetadata(safeShop, meta);
+
+  return {
+    url: path.posix.join("/uploads", safeShop, filename),
+    title,
+    altText,
+    tags: entry.tags,
+    type,
+    size,
+    uploadedAt,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Update metadata                                                           */
+/* -------------------------------------------------------------------------- */
+
+export type UpdateMediaMetadataFields = {
+  title?: string | null;
+  altText?: string | null;
+  tags?: string[] | null;
+};
+
+export async function updateMediaMetadata(
+  shop: string,
+  fileUrl: string,
+  fields: UpdateMediaMetadataFields
+): Promise<MediaItem> {
+  await ensureAuthorized();
+
+  const safeShop = validateShopName(shop);
+  const prefix = path.posix.join("/uploads", safeShop) + "/";
+  const normalized = path.posix.normalize(fileUrl);
+
+  if (!normalized.startsWith(prefix)) throw new Error("Invalid file path");
+
+  const filename = normalized.slice(prefix.length);
+  const dir = uploadsDir(safeShop);
+  const fullPath = path.join(dir, filename);
+
+  const relative = path.relative(dir, fullPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Invalid file path");
+  }
+
+  let stats: Stats | undefined;
+  try {
+    stats = await fs.stat(fullPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      throw new Error("Media file not found");
+    }
+    throw err;
+  }
+
+  const meta = await readMetadata(safeShop);
+  const existing = meta[filename] ?? {};
+  const updated: MediaMetadataEntry = { ...existing };
+
+  if ("title" in fields) {
+    if (fields.title == null) {
+      delete updated.title;
+    } else {
+      updated.title = fields.title;
+    }
+  }
+
+  if ("altText" in fields) {
+    if (fields.altText == null) {
+      delete updated.altText;
+    } else {
+      updated.altText = fields.altText;
+    }
+  }
+
+  if ("tags" in fields) {
+    const normalizedTags = normalizeTagsForStorage(fields.tags);
+    if (normalizedTags === undefined) {
+      delete updated.tags;
+    } else {
+      updated.tags = normalizedTags;
+    }
+  }
+
+  if (!updated.type) {
+    updated.type = inferMediaType(filename, existing.type);
+  }
+
+  if (updated.size == null && stats) {
+    updated.size = stats.size;
+  }
+
+  if (!updated.uploadedAt) {
+    updated.uploadedAt = existing.uploadedAt ?? stats?.mtime.toISOString();
+  }
+
+  meta[filename] = updated;
+  await writeMetadata(safeShop, meta);
+
+  return toMediaItem(safeShop, dir, filename, updated, stats);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Overview                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export async function getMediaOverview(shop: string) {
+  await ensureAuthorized();
+
+  try {
+    const files = await collectMediaItems(shop);
+    return buildOverview(files);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return buildOverview([]);
+    }
+    console.error("Failed to load media overview", err);
+    throw new Error("Failed to load media overview");
+  }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/cms/src/app/api/media/route.ts
+++ b/apps/cms/src/app/api/media/route.ts
@@ -1,13 +1,64 @@
-import { deleteMedia, listMedia, uploadMedia } from "@cms/actions/media.server";
+import {
+  deleteMedia,
+  getMediaOverview,
+  listMedia,
+  updateMediaMetadata,
+  uploadMedia,
+  type UpdateMediaMetadataFields,
+} from "@cms/actions/media.server";
 import { NextResponse } from "next/server";
+
+function parseTagsValue(value: unknown): string[] | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (Array.isArray(value)) {
+    return value
+      .map((tag) => (tag?.toString?.() ?? "").trim())
+      .filter((tag) => tag.length > 0);
+  }
+  if (typeof value === "string") {
+    if (!value.trim()) return [];
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((tag) =>
+            typeof tag === "string" ? tag.trim() : (tag?.toString?.() ?? "").trim()
+          )
+          .filter((tag) => tag.length > 0);
+      }
+      if (typeof parsed === "string") {
+        const trimmed = parsed.trim();
+        return trimmed ? [trimmed] : [];
+      }
+    } catch {
+      /* ignore */
+    }
+
+    return value
+      .split(/[,\n]/)
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  }
+
+  return undefined;
+}
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const shop = url.searchParams.get("shop");
+  const summaryParam = url.searchParams.get("summary");
+  const wantsSummary =
+    summaryParam !== null && summaryParam !== "false" && summaryParam !== "0";
   if (!shop) {
     return NextResponse.json({ error: "Missing shop" }, { status: 400 });
   }
   try {
+    if (wantsSummary) {
+      const overview = await getMediaOverview(shop);
+      return NextResponse.json(overview);
+    }
+
     const files = await listMedia(shop);
     return NextResponse.json(files);
   } catch (err) {
@@ -61,3 +112,60 @@ export async function DELETE(req: Request) {
     );
   }
 }
+
+export async function PATCH(req: Request) {
+  const url = new URL(req.url);
+  const shop = url.searchParams.get("shop");
+  if (!shop) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 400 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const body = payload as Record<string, unknown>;
+  const fileUrl = (body.file ?? body.fileUrl ?? body.url) as unknown;
+
+  if (typeof fileUrl !== "string" || !fileUrl) {
+    return NextResponse.json({ error: "Missing file" }, { status: 400 });
+  }
+
+  const fields: UpdateMediaMetadataFields = {};
+
+  if ("title" in body) {
+    fields.title = body.title == null ? null : body.title.toString();
+  }
+
+  if ("altText" in body) {
+    fields.altText = body.altText == null ? null : body.altText.toString();
+  }
+
+  if ("tags" in body) {
+    const parsedTags = parseTagsValue(body.tags);
+    if (parsedTags === undefined && body.tags !== undefined) {
+      return NextResponse.json({ error: "Invalid tags" }, { status: 400 });
+    }
+    fields.tags = parsedTags ?? undefined;
+  }
+
+  try {
+    const item = await updateMediaMetadata(shop, fileUrl, fields);
+    return NextResponse.json(item);
+  } catch (err) {
+    console.error("Metadata update failed", err);
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 400 }
+    );
+  }
+}
+
+export const PUT = PATCH;

--- a/packages/types/src/MediaItem.d.ts
+++ b/packages/types/src/MediaItem.d.ts
@@ -4,4 +4,6 @@ export interface MediaItem {
     altText?: string;
     tags?: string[];
     type: "image" | "video";
+    uploadedAt?: string;
+    size?: number;
 }

--- a/packages/types/src/MediaItem.ts
+++ b/packages/types/src/MediaItem.ts
@@ -4,4 +4,6 @@ export interface MediaItem {
   altText?: string;
   tags?: string[];
   type: "image" | "video";
+  uploadedAt?: string;
+  size?: number;
 }

--- a/packages/ui/types-compat/acme-types-augmentation.d.ts
+++ b/packages/ui/types-compat/acme-types-augmentation.d.ts
@@ -7,6 +7,9 @@ declare module "@acme/types" {
     alt?: string;
     width?: number;
     height?: number;
+    tags?: string[];
+    uploadedAt?: string;
+    size?: number;
     [k: string]: any;
   }
   export type ImageOrientation = "landscape" | "portrait" | "square" | string;


### PR DESCRIPTION
## Summary
- extend media metadata helpers and server actions to normalize and persist tags, upload timestamps, and file sizes, adding update and overview helpers
- expose enriched metadata through the media API including a summary view and metadata patch endpoint
- update shared MediaItem typings and unit/API tests to cover the new metadata fields and actions

## Testing
- pnpm --filter @apps/cms exec jest --coverage=false --runInBand apps/cms/src/actions/__tests__/media.server.test.ts apps/cms/src/app/api/media/__tests__/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68caad30b324832f841b2d23c3e03e15