### PR TITLE
Add marketing analytics summary cards

### DIFF
--- a/apps/cms/src/app/cms/marketing/page.tsx
+++ b/apps/cms/src/app/cms/marketing/page.tsx
@@ -3,30 +3,128 @@ import { listEvents } from "@platform-core/repositories/analytics.server";
 import type { AnalyticsEvent } from "@platform-core/analytics";
 import MarketingOverview, {
   type CampaignAnalyticsItem,
+  type MarketingSummary,
+  type SegmentActivityMetric,
 } from "./components/MarketingOverview";
+
+function segmentIdFromEvent(event: AnalyticsEvent): string | null {
+  if (typeof event.segment === "string" && event.segment.trim()) {
+    return event.segment;
+  }
+  if (typeof event.type === "string" && event.type.startsWith("segment:")) {
+    const id = event.type.slice("segment:".length).trim();
+    return id ? id : null;
+  }
+  return null;
+}
 
 export default async function MarketingPage() {
   const shops = await listShops();
   const analytics: CampaignAnalyticsItem[] = [];
+  const summaryAccumulator = {
+    campaigns: new Set<string>(),
+    segments: new Map<string, number>(),
+    segmentSignals: 0,
+    sent: 0,
+    opened: 0,
+    clicked: 0,
+    unsubscribed: 0,
+    engagedContacts: new Set<string>(),
+  };
+
   for (const shop of shops) {
     const events: AnalyticsEvent[] = await listEvents(shop);
-    const campaigns = Array.from(
-      new Set(
-        events
-          .map((e: AnalyticsEvent) =>
-            typeof e.campaign === "string" ? e.campaign : null,
-          )
-          .filter(Boolean) as string[],
-      ),
-    );
-    if (campaigns.length > 0) {
-      analytics.push({ shop, campaigns });
+    const campaignSet = new Set<string>();
+    const segmentCounts = new Map<string, number>();
+    const shopEngaged = new Set<string>();
+    let sent = 0;
+    let opened = 0;
+    let clicked = 0;
+    let unsubscribed = 0;
+
+    for (const event of events) {
+      if (typeof event.campaign === "string") {
+        campaignSet.add(event.campaign);
+        summaryAccumulator.campaigns.add(`${shop}:${event.campaign}`);
+      }
+
+      switch (event.type) {
+        case "email_sent":
+          sent += 1;
+          summaryAccumulator.sent += 1;
+          break;
+        case "email_open":
+          opened += 1;
+          summaryAccumulator.opened += 1;
+          if (typeof event.email === "string") {
+            shopEngaged.add(event.email);
+            summaryAccumulator.engagedContacts.add(event.email);
+          }
+          break;
+        case "email_click":
+          clicked += 1;
+          summaryAccumulator.clicked += 1;
+          if (typeof event.email === "string") {
+            shopEngaged.add(event.email);
+            summaryAccumulator.engagedContacts.add(event.email);
+          }
+          break;
+        case "email_unsubscribe":
+          unsubscribed += 1;
+          summaryAccumulator.unsubscribed += 1;
+          break;
+        default:
+          break;
+      }
+
+      const segmentId = segmentIdFromEvent(event);
+      if (segmentId) {
+        segmentCounts.set(segmentId, (segmentCounts.get(segmentId) ?? 0) + 1);
+        summaryAccumulator.segments.set(
+          segmentId,
+          (summaryAccumulator.segments.get(segmentId) ?? 0) + 1,
+        );
+        summaryAccumulator.segmentSignals += 1;
+      }
+    }
+
+    if (campaignSet.size > 0) {
+      const segments: SegmentActivityMetric[] = Array.from(segmentCounts.entries())
+        .map(([id, count]) => ({ id, count }))
+        .sort((a, b) => b.count - a.count);
+
+      analytics.push({
+        shop,
+        campaigns: Array.from(campaignSet),
+        metrics: { sent, opened, clicked, unsubscribed },
+        segments,
+        engagedContacts: shopEngaged.size,
+      });
     }
   }
 
+  let topSegment: SegmentActivityMetric | undefined;
+  for (const [id, count] of summaryAccumulator.segments.entries()) {
+    if (!topSegment || count > topSegment.count) {
+      topSegment = { id, count };
+    }
+  }
+
+  const summary: MarketingSummary = {
+    totalCampaigns: summaryAccumulator.campaigns.size,
+    totalSegments: summaryAccumulator.segments.size,
+    sent: summaryAccumulator.sent,
+    opened: summaryAccumulator.opened,
+    clicked: summaryAccumulator.clicked,
+    unsubscribed: summaryAccumulator.unsubscribed,
+    engagedContacts: summaryAccumulator.engagedContacts.size,
+    segmentSignals: summaryAccumulator.segmentSignals,
+    topSegment,
+  };
+
   return (
     <div className="p-6">
-      <MarketingOverview analytics={analytics} />
+      <MarketingOverview analytics={analytics} summary={summary} />
     </div>
   );
 }

--- a/packages/ui/src/components/cms/marketing/shared/AnalyticsSummaryCard.tsx
+++ b/packages/ui/src/components/cms/marketing/shared/AnalyticsSummaryCard.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from "react";
+import {
+  Card,
+  CardContent,
+  Progress,
+  Skeleton,
+  Tag,
+  type TagProps,
+} from "../../../atoms";
+import { cn } from "../../../../utils/style";
+
+export interface AnalyticsSummaryMetric {
+  label: string;
+  value: ReactNode;
+  helper?: ReactNode;
+  badge?: { label: ReactNode; tone?: TagProps["variant"]; };
+  progress?: { value: number; label?: ReactNode };
+}
+
+export interface AnalyticsSummaryCardProps {
+  title: string;
+  description?: ReactNode;
+  status?: { label: ReactNode; tone?: TagProps["variant"]; icon?: ReactNode };
+  metrics: AnalyticsSummaryMetric[];
+  actions?: ReactNode;
+  footer?: ReactNode;
+  loading?: boolean;
+  className?: string;
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+}
+
+export function AnalyticsSummaryCard({
+  title,
+  description,
+  status,
+  metrics,
+  actions,
+  footer,
+  loading = false,
+  className,
+}: AnalyticsSummaryCardProps) {
+  return (
+    <Card className={cn("space-y-4", className)}>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-lg font-semibold">{title}</h3>
+              {status && (
+                <Tag variant={status.tone ?? "default"}>
+                  <span className="flex items-center gap-1">
+                    {status.icon}
+                    {status.label}
+                  </span>
+                </Tag>
+              )}
+            </div>
+            {description && (
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                {description}
+              </p>
+            )}
+          </div>
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </div>
+
+        <dl className="grid gap-4 sm:grid-cols-2">
+          {metrics.map((metric) => (
+            <div key={metric.label} className="space-y-2">
+              <dt className="text-muted-foreground text-xs uppercase tracking-wide">
+                {metric.label}
+              </dt>
+              <dd className="space-y-2">
+                {loading ? (
+                  <>
+                    <Skeleton className="h-7 w-24" />
+                    <Skeleton className="h-2 w-full" />
+                  </>
+                ) : (
+                  <>
+                    <div className="text-xl font-semibold leading-tight">
+                      {metric.value}
+                    </div>
+                    {metric.progress && (
+                      <Progress
+                        value={clampPercent(metric.progress.value)}
+                        label={metric.progress.label}
+                      />
+                    )}
+                  </>
+                )}
+                {!loading && metric.helper && (
+                  <p className="text-muted-foreground text-xs">{metric.helper}</p>
+                )}
+                {!loading && metric.badge && (
+                  <Tag variant={metric.badge.tone ?? "default"} className="text-[0.65rem]">
+                    {metric.badge.label}
+                  </Tag>
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        {footer && <div>{footer}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default AnalyticsSummaryCard;

--- a/packages/ui/src/components/cms/marketing/shared/index.ts
+++ b/packages/ui/src/components/cms/marketing/shared/index.ts
@@ -1,4 +1,5 @@
 export * from "./PreviewPanel";
+export * from "./AnalyticsSummaryCard";
 export * from "./SummaryCard";
 export * from "./StepIndicator";
 export * from "./types";


### PR DESCRIPTION
## Summary
- add a reusable AnalyticsSummaryCard component in the UI marketing package
- surface aggregated campaign and segment analytics on the marketing overview page
- show live campaign performance summaries in the email composer using existing data sources

## Testing
- pnpm --filter @apps/cms test *(fails: pre-existing CMS test suite errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cab8fdee64832f8024677e46450d52