### PR TITLE
feat(cms): add media overview hero

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/media/__tests__/MediaOverviewHero.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/media/__tests__/MediaOverviewHero.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, within } from "@testing-library/react";
+import type { MediaItem } from "@acme/types";
+import MediaOverviewHero from "../components/MediaOverviewHero";
+
+describe("MediaOverviewHero", () => {
+  it("renders key stats and recent uploads", () => {
+    const mockRecent: MediaItem[] = [
+      {
+        url: "/uploads/demo-shop/hero-one.jpg",
+        title: "Campaign hero",
+        type: "image",
+        uploadedAt: "2024-03-01T14:15:00.000Z",
+      },
+      {
+        url: "/uploads/demo-shop/launch-teaser.mp4",
+        altText: "Launch teaser",
+        type: "video",
+        uploadedAt: "2024-02-28T09:30:00.000Z",
+      },
+    ];
+
+    render(
+      <MediaOverviewHero
+        shop="demo-shop"
+        totalBytes={10 * 1024 * 1024}
+        assetCount={42}
+        recentUploads={mockRecent}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /manage your media library/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Asset library · demo-shop/i)).toBeInTheDocument();
+    expect(screen.getByText("10 MB")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+
+    const recentList = screen.getByRole("list", { name: /recent media uploads/i });
+    const listItems = within(recentList).getAllByRole("listitem");
+    expect(listItems).toHaveLength(mockRecent.length);
+
+    const formattedTimestamp = new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(mockRecent[0].uploadedAt!));
+    const [firstRecent, videoRecent] = listItems;
+    expect(
+      within(firstRecent).getByText(formattedTimestamp)
+    ).toBeInTheDocument();
+    expect(within(firstRecent).getByText("Campaign hero")).toBeInTheDocument();
+    expect(within(videoRecent).getByText(/Video/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /upload media/i })).toBeInTheDocument();
+  });
+});

--- a/apps/cms/src/app/cms/shop/[shop]/media/components/MediaOverviewHero.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/media/components/MediaOverviewHero.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import Image from "next/image";
+import { useCallback } from "react";
+import type { MediaItem } from "@acme/types";
+import {
+  Button,
+  Card,
+  CardContent,
+  Progress,
+} from "@/components/atoms/shadcn";
+import {
+  ClockIcon,
+  ImageIcon,
+  StackIcon,
+  UploadIcon,
+  VideoIcon,
+} from "@radix-ui/react-icons";
+
+interface MediaOverviewHeroProps {
+  shop: string;
+  totalBytes: number;
+  assetCount: number;
+  recentUploads: MediaItem[];
+  uploaderTargetId?: string;
+  storageLimitBytes?: number | null;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+
+  const units = ["B", "KB", "MB", "GB", "TB"] as const;
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const size = bytes / 1024 ** exponent;
+  const precision = size >= 10 || exponent === 0 ? 0 : 1;
+
+  return `${size.toFixed(precision)} ${units[exponent]}`;
+}
+
+function formatTimestamp(value?: string): string {
+  if (!value) {
+    return "Timestamp unavailable";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Timestamp unavailable";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function getDisplayName(item: MediaItem): string {
+  if (item.title && item.title.trim().length > 0) {
+    return item.title;
+  }
+
+  if (item.altText && item.altText.trim().length > 0) {
+    return item.altText;
+  }
+
+  try {
+    const decoded = decodeURIComponent(item.url.split("/").pop() ?? item.url);
+    return decoded || item.url;
+  } catch {
+    return item.url;
+  }
+}
+
+export default function MediaOverviewHero({
+  shop,
+  totalBytes,
+  assetCount,
+  recentUploads,
+  uploaderTargetId,
+  storageLimitBytes,
+}: MediaOverviewHeroProps) {
+  const usagePercent =
+    typeof storageLimitBytes === "number" && storageLimitBytes > 0
+      ? Math.min(100, Math.round((totalBytes / storageLimitBytes) * 100))
+      : null;
+  const storageSummary =
+    typeof storageLimitBytes === "number" && storageLimitBytes > 0
+      ? `${formatBytes(totalBytes)} of ${formatBytes(storageLimitBytes)}`
+      : formatBytes(totalBytes);
+
+  const mostRecentUpload = recentUploads[0];
+  const headingId = "media-overview-heading";
+
+  const handleUploadClick = useCallback(() => {
+    if (!uploaderTargetId) return;
+
+    const element = document.getElementById(uploaderTargetId);
+    if (element instanceof HTMLElement) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" });
+      element.focus({ preventScroll: true });
+    }
+  }, [uploaderTargetId]);
+
+  return (
+    <section aria-labelledby={headingId} role="region">
+      <Card>
+        <CardContent className="flex flex-col gap-6 p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Asset library · {shop}
+              </p>
+              <h1 id={headingId} className="text-2xl font-semibold">
+                Manage your media library
+              </h1>
+              <p className="max-w-xl text-sm text-muted-foreground">
+                Track storage usage, monitor recent uploads, and keep your asset
+                library ready for new campaigns.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                onClick={handleUploadClick}
+                className="inline-flex items-center gap-2"
+              >
+                <UploadIcon className="h-4 w-4" aria-hidden />
+                Upload media
+              </Button>
+            </div>
+          </div>
+
+          <dl className="grid gap-4 sm:grid-cols-3" aria-label="Media usage statistics">
+            <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+              <dt className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <StackIcon className="h-4 w-4" aria-hidden />
+                Storage used
+              </dt>
+              <dd className="mt-2 text-lg font-semibold text-foreground">
+                {storageSummary}
+              </dd>
+              {usagePercent !== null && (
+                <div className="mt-4 space-y-1">
+                  <Progress value={usagePercent} aria-label="Storage usage" />
+                  <p className="text-xs text-muted-foreground">
+                    {usagePercent}% of plan capacity
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+              <dt className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <ImageIcon className="h-4 w-4" aria-hidden />
+                Assets in library
+              </dt>
+              <dd className="mt-2 text-lg font-semibold text-foreground">
+                {assetCount.toLocaleString()}
+              </dd>
+              <p className="text-xs text-muted-foreground">
+                Includes images and videos stored in your workspace.
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+              <dt className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <ClockIcon className="h-4 w-4" aria-hidden />
+                Last upload
+              </dt>
+              <dd className="mt-2 text-lg font-semibold text-foreground">
+                {mostRecentUpload
+                  ? formatTimestamp(mostRecentUpload.uploadedAt)
+                  : "No uploads yet"}
+              </dd>
+              {mostRecentUpload && (
+                <p className="text-xs text-muted-foreground">
+                  {getDisplayName(mostRecentUpload)}
+                </p>
+              )}
+            </div>
+          </dl>
+
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold">Recent uploads</h2>
+            {recentUploads.length > 0 ? (
+              <ul
+                className="flex gap-4 overflow-x-auto pb-2"
+                aria-label="Recent media uploads"
+              >
+                {recentUploads.map((item) => {
+                  const name = getDisplayName(item);
+                  const timestamp = formatTimestamp(item.uploadedAt);
+
+                  return (
+                    <li
+                      key={item.url}
+                      className="min-w-[11rem] flex-shrink-0"
+                    >
+                      <div className="space-y-2">
+                        <div className="relative h-28 w-full overflow-hidden rounded-md border border-border/60 bg-muted">
+                          {item.url ? (
+                            <Image
+                              src={item.url}
+                              alt={name}
+                              width={160}
+                              height={160}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full items-center justify-center text-muted-foreground">
+                              <ImageIcon className="h-6 w-6" aria-hidden />
+                            </div>
+                          )}
+                          {item.type === "video" && (
+                            <span className="absolute left-2 top-2 inline-flex items-center gap-1 rounded-full bg-black/60 px-2 py-1 text-xs text-white">
+                              <VideoIcon className="h-3 w-3" aria-hidden />
+                              Video
+                            </span>
+                          )}
+                        </div>
+                        <div className="space-y-1">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {name}
+                          </p>
+                          <p className="text-xs text-muted-foreground">{timestamp}</p>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Upload images or videos to populate your media activity feed.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/media/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/media/page.tsx
@@ -1,10 +1,10 @@
 // apps/cms/src/app/cms/shop/[shop]/media/page.tsx
 
-import { deleteMedia, listMedia } from "@cms/actions/media.server";
+import { deleteMedia, getMediaOverview } from "@cms/actions/media.server";
 import { checkShopExists } from "@acme/lib";
 import MediaManager from "@ui/components/cms/MediaManager";
 import { notFound } from "next/navigation";
-import type { MediaItem } from "@acme/types";
+import MediaOverviewHero from "./components/MediaOverviewHero";
 
 interface Params {
   shop: string;
@@ -21,12 +21,25 @@ export default async function MediaPage({
 
   if (!(await checkShopExists(shop))) return notFound();
 
-  const files: MediaItem[] = await listMedia(shop);
+  const overview = await getMediaOverview(shop);
+  const { files, totalBytes, recentUploads } = overview;
+  const uploaderTargetId = "media-manager-uploader";
 
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">Media – {shop}</h2>
-      <MediaManager shop={shop} initialFiles={files} onDelete={deleteMedia} />
+    <div className="space-y-6">
+      <MediaOverviewHero
+        shop={shop}
+        totalBytes={totalBytes}
+        assetCount={files.length}
+        recentUploads={recentUploads}
+        uploaderTargetId={uploaderTargetId}
+      />
+      <MediaManager
+        shop={shop}
+        initialFiles={files}
+        onDelete={deleteMedia}
+        uploaderTargetId={uploaderTargetId}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/cms/MediaManager.d.ts
+++ b/packages/ui/src/components/cms/MediaManager.d.ts
@@ -8,7 +8,13 @@ interface Props {
      * Implemented in – and supplied by – the host application (e.g. `apps/cms`).
      */
     onDelete: (shop: string, src: string) => void | Promise<void>;
+    uploaderTargetId?: string;
 }
-declare function MediaManagerBase({ shop, initialFiles, onDelete, }: Props): ReactElement;
+declare function MediaManagerBase({
+    shop,
+    initialFiles,
+    onDelete,
+    uploaderTargetId,
+}: Props): ReactElement;
 declare const _default: import("react").MemoExoticComponent<typeof MediaManagerBase>;
 export default _default;

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -19,6 +19,7 @@ interface Props {
    * Implemented in – and supplied by – the host application (e.g. `apps/cms`).
    */
   onDelete: (shop: string, src: string) => void | Promise<void>;
+  uploaderTargetId?: string;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -29,6 +30,7 @@ function MediaManagerBase({
   shop,
   initialFiles,
   onDelete,
+  uploaderTargetId,
 }: Props): ReactElement {
   const [files, setFiles] = useState<MediaItem[]>(initialFiles);
 
@@ -58,7 +60,11 @@ function MediaManagerBase({
 
   return (
     <div className="space-y-6">
-      <UploadPanel shop={shop} onUploaded={handleUploaded} />
+      <UploadPanel
+        shop={shop}
+        onUploaded={handleUploaded}
+        focusTargetId={uploaderTargetId}
+      />
       <Library
         files={files}
         shop={shop}

--- a/packages/ui/src/components/cms/media/UploadPanel.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.tsx
@@ -10,9 +10,14 @@ import { ChangeEvent, ReactElement, useState } from "react";
 interface UploadPanelProps {
   shop: string;
   onUploaded: (item: MediaItem) => void;
+  focusTargetId?: string;
 }
 
-export default function UploadPanel({ shop, onUploaded }: UploadPanelProps): ReactElement {
+export default function UploadPanel({
+  shop,
+  onUploaded,
+  focusTargetId,
+}: UploadPanelProps): ReactElement {
   const [dragActive, setDragActive] = useState(false);
   const feedbackId = "media-upload-feedback";
 
@@ -43,6 +48,7 @@ export default function UploadPanel({ shop, onUploaded }: UploadPanelProps): Rea
   return (
     <div className="space-y-2">
       <div
+        id={focusTargetId}
         tabIndex={0}
         role="button"
         aria-label="Drop image or video here or press Enter to browse"

--- a/test/__mocks__/shadcnDialogStub.tsx
+++ b/test/__mocks__/shadcnDialogStub.tsx
@@ -1,5 +1,29 @@
 import React, { createContext, useContext } from "react";
 
+export function Card({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function CardContent({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function Progress({ value = 0, ...props }: React.HTMLAttributes<HTMLDivElement> & { value?: number }) {
+  return (
+    <div role="progressbar" aria-valuenow={value} {...props}>
+      {props.children}
+    </div>
+  );
+}
+
 interface DialogContextValue {
   open: boolean;
   onOpenChange: (open: boolean) => void;


### PR DESCRIPTION
## Summary
- fetch media overview data for the CMS media page and render a new hero
- add a MediaOverviewHero component with storage stats, recent uploads, and CTA wiring to the uploader
- expose an uploader target ID on MediaManager/UploadPanel and cover the hero with a focused test

## Testing
- pnpm exec jest --config jest.config.cjs --coverage=false --runTestsByPath "src/app/cms/shop/[shop]/media/__tests__/MediaOverviewHero.test.tsx"

------
https://chatgpt.com/codex/tasks/task_e_68cab9ea84c0832f9aac9349467297ae