### PR TITLE
Refactor CMS settings tables

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
@@ -1,24 +1,50 @@
 // apps/cms/src/app/cms/shop/[shop]/settings/ThemeTokens.tsx
 "use client";
+
 import { Button } from "@/components/atoms/shadcn";
 import { resetThemeOverride } from "@cms/actions/shops.server";
 import type { Shop } from "@acme/types";
 import Link from "next/link";
-
-interface TokenRow {
-  token: string;
-  defaultValue: string;
-  overrideValue?: string;
-}
+import DataTable from "@ui/components/cms/DataTable";
+import {
+  createThemeTokenColumns,
+  themeTokenRowClassName,
+  type ThemeTokenRow,
+} from "./tableMappers";
 
 interface Props {
   shop: string;
-  tokenRows: TokenRow[];
+  tokenRows: ThemeTokenRow[];
   info: Shop;
   errors: Record<string, string[]>;
 }
 
 export default function ThemeTokens({ shop, tokenRows, info, errors }: Props) {
+  const columns = createThemeTokenColumns({
+    onReset: ({ token }) => (
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          (
+            resetThemeOverride as unknown as (
+              shop: string,
+              token: string,
+              formData: FormData,
+            ) => void
+          )(shop, token, new FormData());
+        }}
+      >
+        <Button
+          type="submit"
+          variant="ghost"
+          className="h-auto p-0 text-primary hover:bg-transparent"
+        >
+          Reset
+        </Button>
+      </form>
+    ),
+  });
+
   return (
     <div className="col-span-2 flex flex-col gap-1">
       <div className="flex items-center justify-between">
@@ -30,64 +56,11 @@ export default function ThemeTokens({ shop, tokenRows, info, errors }: Props) {
           Edit Theme
         </Link>
       </div>
-      <table className="mt-2 w-full text-sm">
-        <thead>
-          <tr className="text-left">
-            <th className="px-2 py-1">Token</th>
-            <th className="px-2 py-1">Values</th>
-            <th className="px-2 py-1">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {tokenRows.map(({ token, defaultValue, overrideValue }) => {
-            const hasOverride = overrideValue !== undefined;
-            const changed = hasOverride && overrideValue !== defaultValue;
-            return (
-              <tr key={token} className={changed ? "bg-yellow-50" : undefined}>
-                <td className="border-t px-2 py-1 font-medium">{token}</td>
-                <td className="border-t px-2 py-1">
-                  <div className="flex items-center gap-4">
-                    <div className="flex items-center gap-1">
-                      <span className="font-mono">{defaultValue}</span>
-                      <span className="text-xs text-muted-foreground">default</span>
-                    </div>
-                    {hasOverride && (
-                      <div className="flex items-center gap-1">
-                        <span className="font-mono">{overrideValue}</span>
-                        <span className="text-xs text-muted-foreground">override</span>
-                      </div>
-                    )}
-                  </div>
-                </td>
-                <td className="border-t px-2 py-1">
-                  {hasOverride && (
-                    <form
-                      onSubmit={(e) => {
-                        e.preventDefault();
-                        (
-                          resetThemeOverride as unknown as (
-                            shop: string,
-                            token: string,
-                            formData: FormData,
-                          ) => void
-                        )(shop, token, new FormData());
-                      }}
-                    >
-                      <Button
-                        type="submit"
-                        variant="ghost"
-                        className="h-auto p-0 text-primary hover:bg-transparent"
-                      >
-                        Reset
-                      </Button>
-                    </form>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <DataTable
+        rows={tokenRows}
+        columns={columns}
+        rowClassName={themeTokenRowClassName}
+      />
       <input
         type="hidden"
         name="themeDefaults"

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ThemeTokens.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ThemeTokens.test.tsx
@@ -15,14 +15,21 @@ jest.mock("@cms/actions/shops.server", () => ({
 }));
 
 import ThemeTokens from "../ThemeTokens";
+import { mapThemeTokenRows } from "../tableMappers";
 
 describe("ThemeTokens", () => {
   it("renders values, highlights changes, resets overrides, and serializes info", () => {
-    const tokenRows = [
-      { token: "color-primary", defaultValue: "#fff", overrideValue: "#000" },
-      { token: "spacing", defaultValue: "4", overrideValue: "4" },
-      { token: "font", defaultValue: "Arial" },
-    ];
+    const tokenRows = mapThemeTokenRows(
+      {
+        "color-primary": "#fff",
+        spacing: "4",
+        font: "Arial",
+      },
+      {
+        "color-primary": "#000",
+        spacing: "4",
+      },
+    );
     const info = {
       themeDefaults: { "color-primary": "#fff", spacing: "4", font: "Arial" },
       themeOverrides: { "color-primary": "#000", spacing: "4" },

--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/LateFeesTable.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/LateFeesTable.tsx
@@ -1,3 +1,5 @@
+import DataTable from "@ui/components/cms/DataTable";
+import { lateFeeColumns, mapLateFeeRows } from "../tableMappers";
 import { readOrders } from "@platform-core/repositories/rentalOrders.server";
 
 export default async function LateFeesTable({ shop }: { shop: string }) {
@@ -6,22 +8,12 @@ export default async function LateFeesTable({ shop }: { shop: string }) {
   if (charges.length === 0) {
     return <p className="text-sm">No late fees charged.</p>;
   }
+
+  const rows = mapLateFeeRows(charges);
+
   return (
-    <table className="mt-4 w-full text-left text-sm">
-      <thead>
-        <tr>
-          <th className="pr-4">Order</th>
-          <th className="pr-4">Amount</th>
-        </tr>
-      </thead>
-      <tbody>
-        {charges.map((o) => (
-          <tr key={o.sessionId}>
-            <td className="pr-4">{o.sessionId}</td>
-            <td>${o.lateFeeCharged?.toFixed(2)}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="mt-4">
+      <DataTable rows={rows} columns={lateFeeColumns} />
+    </div>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/VersionTimeline.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/VersionTimeline.tsx
@@ -12,6 +12,7 @@ import { revertSeo } from "@cms/actions/shops.server";
 import type { SettingsDiffEntry } from "@platform-core/repositories/settings.server";
 import { diffHistory } from "@platform-core/repositories/settings.server";
 import { formatTimestamp } from "@acme/date-utils";
+import { CodeBlock } from "@ui/components/molecules";
 import { useEffect, useState } from "react";
 
 interface VersionTimelineProps {
@@ -76,9 +77,10 @@ export default function VersionTimeline({
                       Revert
                     </Button>
                   </div>
-                  <pre className="bg-muted overflow-auto rounded p-2 text-xs">
-                    {JSON.stringify(entry.diff, null, 2)}
-                  </pre>
+                  <CodeBlock
+                    code={JSON.stringify(entry.diff, null, 2)}
+                    preClassName="text-xs"
+                  />
                 </li>
               ))}
             </ul>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
@@ -4,7 +4,12 @@
 
 import { Button, Input } from "@/components/atoms/shadcn";
 import { updateStockScheduler } from "@cms/actions/stockScheduler.server";
-import { useState, type FormEvent, type ChangeEvent } from "react";
+import DataTable from "@ui/components/cms/DataTable";
+import {
+  mapSchedulerHistoryRows,
+  schedulerHistoryColumns,
+} from "../tableMappers";
+import { useMemo, useState, type FormEvent, type ChangeEvent } from "react";
 
 interface HistoryEntry {
   timestamp: number;
@@ -19,6 +24,11 @@ interface Props {
 export default function StockSchedulerEditor({ shop, status }: Props) {
   const [interval, setInterval] = useState(String(status.intervalMs));
   const [saving, setSaving] = useState(false);
+
+  const historyRows = useMemo(
+    () => mapSchedulerHistoryRows(status.history),
+    [status.history],
+  );
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInterval(e.target.value);
@@ -55,30 +65,12 @@ export default function StockSchedulerEditor({ shop, status }: Props) {
       </div>
       <div>
         <h3 className="mt-4 font-medium">Recent Checks</h3>
-        {status.history.length === 0 ? (
+        {historyRows.length === 0 ? (
           <p className="text-sm text-muted-foreground">No checks yet.</p>
         ) : (
-          <table className="mt-2 text-sm">
-            <thead>
-              <tr>
-                <th className="pr-4 text-left">Time</th>
-                <th className="text-left">Alerts</th>
-              </tr>
-            </thead>
-            <tbody>
-              {status.history
-                .slice()
-                .reverse()
-                .map((h) => (
-                  <tr key={h.timestamp}>
-                    <td className="pr-4">
-                      {new Date(h.timestamp).toLocaleString()}
-                    </td>
-                    <td>{h.alerts}</td>
-                  </tr>
-                ))}
-            </tbody>
-          </table>
+          <div className="mt-2">
+            <DataTable rows={historyRows} columns={schedulerHistoryColumns} />
+          </div>
         )}
       </div>
     </div>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/tableMappers.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/tableMappers.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from "react";
+import type { Column } from "@ui/components/cms/DataTable";
+
+const HEX_RE = /^#(?:[0-9a-fA-F]{3}){1,2}$/;
+const HSL_RE = /^\d+(?:\.\d+)?\s+\d+(?:\.\d+)?%\s+\d+(?:\.\d+)?%$/;
+
+function isColor(value?: string): value is string {
+  return Boolean(value) && (HEX_RE.test(value) || HSL_RE.test(value));
+}
+
+function swatchColor(value: string) {
+  return HSL_RE.test(value) ? `hsl(${value})` : value;
+}
+
+export interface ThemeTokenRow {
+  token: string;
+  defaultValue?: string;
+  overrideValue?: string;
+  hasOverride: boolean;
+  changed: boolean;
+}
+
+export function mapThemeTokenRows(
+  defaults: Record<string, string | undefined>,
+  overrides: Record<string, string | undefined>,
+): ThemeTokenRow[] {
+  const tokens = Array.from(
+    new Set([...Object.keys(defaults ?? {}), ...Object.keys(overrides ?? {})]),
+  );
+
+  return tokens
+    .sort((a, b) => a.localeCompare(b))
+    .map((token) => {
+      const defaultValue = defaults?.[token];
+      const overrideValue = overrides?.[token];
+      const hasOverride = overrideValue !== undefined && overrideValue !== null;
+      const changed = hasOverride && overrideValue !== defaultValue;
+      return {
+        token,
+        defaultValue,
+        overrideValue,
+        hasOverride,
+        changed,
+      } satisfies ThemeTokenRow;
+    });
+}
+
+export function createThemeTokenColumns({
+  onReset,
+}: {
+  onReset?: (row: ThemeTokenRow) => ReactNode;
+} = {}): Column<ThemeTokenRow>[] {
+  const baseColumns: Column<ThemeTokenRow>[] = [
+    {
+      header: "Token",
+      width: "25%",
+      render: (row) => <span className="font-mono">{row.token}</span>,
+    },
+    {
+      header: "Values",
+      render: (row) => (
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-1">
+            <span className="font-mono">{row.defaultValue ?? "—"}</span>
+            {isColor(row.defaultValue) && (
+              <span
+                aria-hidden
+                className="ml-1 inline-block h-4 w-4 rounded border align-middle"
+                style={{ backgroundColor: swatchColor(row.defaultValue) }}
+              />
+            )}
+            <span className="text-xs text-muted-foreground">default</span>
+          </div>
+          {row.hasOverride && (
+            <div className="flex items-center gap-1">
+              <span className="font-mono">{row.overrideValue ?? "—"}</span>
+              {isColor(row.overrideValue) && (
+                <span
+                  aria-hidden
+                  className="ml-1 inline-block h-4 w-4 rounded border align-middle"
+                  style={{ backgroundColor: swatchColor(row.overrideValue) }}
+                />
+              )}
+              <span className="text-xs text-muted-foreground">override</span>
+            </div>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  if (!onReset) return baseColumns;
+
+  return [
+    ...baseColumns,
+    {
+      header: "Actions",
+      width: "120px",
+      render: (row) => (row.hasOverride ? onReset(row) : null),
+    },
+  ];
+}
+
+export function themeTokenRowClassName(row: ThemeTokenRow) {
+  return row.changed ? "bg-yellow-50" : undefined;
+}
+
+export interface SchedulerHistoryRow {
+  timestamp: number;
+  alerts: number;
+  runAt: string;
+}
+
+export function mapSchedulerHistoryRows(
+  history: { timestamp: number; alerts: number }[],
+): SchedulerHistoryRow[] {
+  return history
+    .slice()
+    .reverse()
+    .map((entry) => ({
+      timestamp: entry.timestamp,
+      alerts: entry.alerts,
+      runAt: new Date(entry.timestamp).toLocaleString(),
+    }));
+}
+
+export const schedulerHistoryColumns: Column<SchedulerHistoryRow>[] = [
+  {
+    header: "Time",
+    render: (row) => row.runAt,
+  },
+  {
+    header: "Alerts",
+    width: "96px",
+    render: (row) => row.alerts,
+  },
+];
+
+export interface LateFeeRow {
+  orderId: string;
+  amount: number;
+  formattedAmount: string;
+}
+
+export function mapLateFeeRows(
+  charges: { sessionId: string; lateFeeCharged?: number | null }[],
+): LateFeeRow[] {
+  return charges.map((order) => {
+    const amount = order.lateFeeCharged ?? 0;
+    return {
+      orderId: order.sessionId,
+      amount,
+      formattedAmount: `$${amount.toFixed(2)}`,
+    } satisfies LateFeeRow;
+  });
+}
+
+export const lateFeeColumns: Column<LateFeeRow>[] = [
+  {
+    header: "Order",
+    render: (row) => row.orderId,
+  },
+  {
+    header: "Amount",
+    width: "120px",
+    render: (row) => <span className="tabular-nums">{row.formattedAmount}</span>,
+  },
+];
+

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -8,6 +8,7 @@ import useMappingRows from "@/hooks/useMappingRows";
 import useShopEditorSubmit, {
   type MappingRowsController,
 } from "./useShopEditorSubmit";
+import { mapThemeTokenRows } from "./tableMappers";
 
 interface HookArgs {
   shop: string;
@@ -40,18 +41,10 @@ export function useShopEditorForm({
 
   const shippingProviders = providersByType("shipping");
 
-  const tokenRows = useMemo(() => {
-    const defaults = info.themeDefaults ?? {};
-    const overrides = info.themeOverrides ?? {};
-    const tokens = Array.from(
-      new Set([...Object.keys(defaults), ...Object.keys(overrides)]),
-    );
-    return tokens.map((token) => ({
-      token,
-      defaultValue: defaults[token],
-      overrideValue: overrides[token],
-    }));
-  }, [info.themeDefaults, info.themeOverrides]);
+  const tokenRows = useMemo(
+    () => mapThemeTokenRows(info.themeDefaults ?? {}, info.themeOverrides ?? {}),
+    [info.themeDefaults, info.themeOverrides],
+  );
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;

--- a/packages/ui/src/components/cms/DataTable.tsx
+++ b/packages/ui/src/components/cms/DataTable.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useState } from "react";
 import { toggleItem } from "@acme/shared-utils";
+import { cn } from "../../utils/style";
 import {
   Table,
   TableBody,
@@ -23,6 +24,7 @@ export interface DataTableProps<T> {
   /** Enable checkbox row selection */
   selectable?: boolean;
   onSelectionChange?: (rows: T[]) => void;
+  rowClassName?: (row: T, index: number) => string | undefined;
 }
 
 export default function DataTable<T>({
@@ -30,6 +32,7 @@ export default function DataTable<T>({
   columns,
   selectable = false,
   onSelectionChange,
+  rowClassName,
 }: DataTableProps<T>) {
   const [selected, setSelected] = useState<number[]>([]);
 
@@ -40,8 +43,8 @@ export default function DataTable<T>({
   };
 
   return (
-    <div className="overflow-x-auto">
-      <Table className="min-w-full">
+    <div className="w-full overflow-x-auto">
+      <Table className="min-w-full w-full">
         <TableHeader>
           <TableRow>
             {selectable && <TableHead className="w-4" />}
@@ -59,7 +62,10 @@ export default function DataTable<T>({
               key={i}
               data-state={selected.includes(i) ? "selected" : undefined}
               onClick={selectable ? () => toggle(i) : undefined}
-              className={selectable ? "cursor-pointer" : undefined}
+              className={cn(
+                selectable ? "cursor-pointer" : undefined,
+                rowClassName?.(row, i),
+              )}
             >
               {selectable && (
                 <TableCell className="w-4">

--- a/packages/ui/src/components/molecules/CodeBlock.tsx
+++ b/packages/ui/src/components/molecules/CodeBlock.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "../atoms";
+import { cn } from "../../utils/style";
+
+export interface CodeBlockProps {
+  code: string;
+  className?: string;
+  preClassName?: string;
+  copyLabel?: string;
+  copiedLabel?: string;
+}
+
+export default function CodeBlock({
+  code,
+  className,
+  preClassName,
+  copyLabel = "Copy",
+  copiedLabel = "Copied",
+}: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeout = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  async function handleCopy() {
+    try {
+      if (!navigator.clipboard?.writeText) {
+        setCopied(false);
+        return;
+      }
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className={cn("relative", className)}>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={handleCopy}
+        className="absolute right-3 top-3 z-10 h-auto px-2 py-1 text-xs"
+      >
+        {copied ? copiedLabel : copyLabel}
+      </Button>
+      <pre
+        className={cn(
+          "bg-muted text-xs font-mono leading-relaxed overflow-x-auto rounded-md border border-border p-4 pr-16",
+          preClassName,
+        )}
+      >
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -1,5 +1,6 @@
 export { default as Breadcrumbs } from "./Breadcrumbs";
 export { default as CurrencySwitcher } from "./CurrencySwitcher.client";
+export { default as CodeBlock } from "./CodeBlock";
 export { FormField } from "./FormField";
 export { Image360Viewer } from "./Image360Viewer";
 export { default as LanguageSwitcher } from "./LanguageSwitcher";


### PR DESCRIPTION
## Summary
- add shared row and column mappers for CMS settings tables and update pages to use the DataTable component
- introduce a reusable CodeBlock molecule and swap JSON <pre> usage for the new component
- enhance the DataTable API to support row styling and full-width layouts

## Testing
- `pnpm exec jest --config jest.config.cjs --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ThemeTokens.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68cabdddeee4832fa21d5930cd5a0c36