### PR TITLE
Add unit tests and docs for campaign marketing components

### DIFF
--- a/docs/campaign-marketing-test-plan.md
+++ b/docs/campaign-marketing-test-plan.md
@@ -1,0 +1,57 @@
+# Campaign Marketing Components – Testing Notes
+
+## Testing Checklist
+- **Workspace setup**
+  - Install dependencies with `pnpm install` and build packages via `pnpm -r build` before running targeted tests.【F:AGENTS.md†L3-L9】
+- **UI package (@acme/ui)**
+  - Primary test runner: Jest with React Testing Library, executed through `pnpm exec jest` as wired in the package’s `test` script.【F:packages/ui/package.json†L18-L22】
+  - Component tests reside under `src/components/**/__tests__` and use the `*.test.tsx` suffix (for example, existing CMS suites under `components/cms/__tests__`).【56cef8†L1-L2】
+- **CMS app (@apps/cms)**
+  - Run suites with `pnpm exec jest --config ./jest.config.cjs` via the app-level `test` script.【F:apps/cms/package.json†L4-L10】
+  - Jest loads environment helpers (`jest.env.ts`, `jest.setup.ts`) and applies additional setup (`jest.setup.after.ts`, `jest.setup.polyfills.ts`, MSW server) before each test file, so new suites should rely on those shared polyfills and network mocks.【F:apps/cms/jest.config.cjs†L18-L29】【F:apps/cms/jest.setup.after.ts†L6-L153】【F:apps/cms/__tests__/msw/server.ts†L1-L10】
+  - Existing page suites (e.g., `campaigns/page.test.tsx`) assert UI feedback with Testing Library utilities—follow the same style for new tests.【F:apps/cms/src/app/cms/campaigns/page.test.tsx†L1-L36】
+
+## Component Inventory
+
+### `CampaignForm`
+- **Path:** `packages/ui/src/components/cms/marketing/campaign/CampaignForm.tsx`.【F:packages/ui/src/components/cms/marketing/campaign/CampaignForm.tsx†L1-L200】
+- **Public props:** accepts defaults, optional sections, server `validationErrors`, lifecycle callbacks (`onSubmit`, `onStatusChange`, `onPreviewChange`), UI messaging overrides, and secondary/back actions.【F:packages/ui/src/components/cms/marketing/campaign/CampaignForm.tsx†L44-L200】
+- **Key behaviors:**
+  - Validates required fields per visible sections and enforces numeric/date rules before submission.【F:packages/ui/src/components/cms/marketing/campaign/CampaignForm.tsx†L62-L100】
+  - Emits status transitions and toast feedback on validation success/failure or async submission outcomes.【F:packages/ui/src/components/cms/marketing/campaign/CampaignForm.tsx†L145-L186】
+  - Streams preview payloads through `onPreviewChange` whenever form state mutates.【F:packages/ui/src/components/cms/marketing/campaign/CampaignForm.tsx†L132-L135】
+- **Helpers:** `defaultCampaignValues`, enumerated section field map, and `getCampaignPreview` from `types.ts` to seed form state and derive preview data.【F:packages/ui/src/components/cms/marketing/campaign/types.ts†L20-L80】
+
+### `CampaignWizard`
+- **Path:** `packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx`.【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L1-L200】
+- **Public props:** optional initial values, async `onSubmit`, validation error passthrough, `onPreviewChange`, `finishLabel`, customizable messaging, styling hook.【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L30-L77】
+- **Key behaviors:**
+  - Manages ordered steps (`plan → audience → schedule → review`) with section-specific form rendering and guarded navigation.【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L40-L118】【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L158-L199】
+  - Regenerates preview data and bubbles updates upward when form values change.【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L78-L123】
+  - Finalizes with toast messaging that reflects submission success, completion without persistence, or error scenarios.【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L125-L155】
+- **Helpers:** consumes `CampaignForm`, `CampaignPreviewPanel`, `CampaignSummaryCard`, and shared `StepIndicator` utilities for layout and progress tracking.【F:packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx†L7-L199】
+
+### `CampaignPreviewPanel`
+- **Path:** `packages/ui/src/components/cms/marketing/campaign/CampaignPreviewPanel.tsx`.【F:packages/ui/src/components/cms/marketing/campaign/CampaignPreviewPanel.tsx†L1-L76】
+- **Public props:** accepts preview `data`, optional `className`, and `actions` slot passed through to the wrapped `PreviewPanel`.【F:packages/ui/src/components/cms/marketing/campaign/CampaignPreviewPanel.tsx†L6-L24】
+- **Key behaviors:** renders formatted headline, objective tag, schedule/budget tiles, channels, audience summary, and KPI snippet via the shared preview shell.【F:packages/ui/src/components/cms/marketing/campaign/CampaignPreviewPanel.tsx†L24-L70】
+- **Helpers:** leverages generic `PreviewPanel` to keep summary rendering composable.【F:packages/ui/src/components/cms/marketing/shared/PreviewPanel.tsx†L1-L34】
+
+## UI Component Test Plan
+- **CampaignForm**
+  - Missing required inputs trigger validation status, toast, and `aria-invalid` flags; assert `onStatusChange` sequence and toast copy.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignForm.test.tsx†L8-L37】
+  - Successful submission forwards sanitized values, reports `submitting → success`, and surfaces the success toast message.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignForm.test.tsx†L39-L66】
+  - Server `validationErrors` render immediately and clear on field edits to confirm merge logic.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignForm.test.tsx†L68-L83】
+  - Preview updates propagate as users edit inputs, validating real-time preview hooks.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignForm.test.tsx†L85-L103】
+- **CampaignWizard**
+  - Step progression: continue through plan → audience → schedule, enter review, and ensure final submit passes accumulated values and success toast.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignWizard.test.tsx†L11-L42】
+  - Back navigation restores earlier sections, confirming guarded step selection.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignWizard.test.tsx†L44-L55】
+  - Preview callback reflects edits and submission failures surface error toast messaging.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignWizard.test.tsx†L57-L85】
+- **CampaignPreviewPanel**
+  - Snapshot summary assertions cover headline, schedule, budget, channels, audience, KPI, plus optional action slot rendering.【F:packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignPreviewPanel.test.tsx†L1-L38】
+
+## CMS Usage Check
+A repository search shows no current imports of `@ui/components/cms/marketing/campaign/*` inside `apps/cms`, so no CMS pages consume these components yet and no additional RTL suites were updated for them in this cycle.【559147†L1-L2】【7102f1†L1-L1】 Existing marketing pages continue to rely on legacy composer/sender components, whose tests already verify toast feedback.【F:apps/cms/src/app/cms/campaigns/page.test.tsx†L1-L36】
+
+## Playwright Status
+`apps/cms` does not provide a Playwright configuration or E2E spec directory—`find` searches return no configuration files—so new scenarios were not authored. Establishing E2E coverage would require introducing a `playwright.config` plus scaffolding for fixtures and selectors.【041418†L1-L2】 Alternative end-to-end coverage today relies on Cypress flows defined at the workspace root (`pnpm run e2e`).

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -199,6 +199,8 @@ const config = {
     "^@acme/platform-core/(.*)$": " /packages/platform-core/src/$1",
     "^@acme/platform-core/contexts/CurrencyContext$":
       " /test/__mocks__/currencyContextMock.tsx",
+    "^@radix-ui/react-dropdown-menu$":
+      " /test/__mocks__/@radix-ui/react-dropdown-menu.tsx",
     "^@acme/sanity$": " /packages/sanity/src/index.ts",
     "^@acme/sanity/(.*)$": " /packages/sanity/src/$1",
     "^@acme/platform-machine/src/(.*)$": " /packages/platform-machine/src/$1",

--- a/packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignForm.test.tsx
+++ b/packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignForm.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CampaignForm } from "../CampaignForm";
+import { defaultCampaignValues, type CampaignFormValues } from "../types";
+
+describe("CampaignForm", () => {
+  function renderForm(overrides: Partial<React.ComponentProps<typeof CampaignForm>> = {}) {
+    return render(
+      <CampaignForm
+        sections={["basics"]}
+        {...overrides}
+      />
+    );
+  }
+
+  it("validates required fields before submission", async () => {
+    const onSubmit = jest.fn();
+    const onStatusChange = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({ onSubmit, onStatusChange });
+
+    await user.click(screen.getByRole("button", { name: /save campaign/i }));
+
+    expect(onStatusChange).toHaveBeenCalledWith("validating");
+    await waitFor(() => expect(onStatusChange).toHaveBeenCalledWith("error"));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    const nameInput = screen.getByLabelText(/campaign name/i);
+    expect(nameInput).toHaveAttribute("aria-invalid", "true");
+
+    expect(
+      await screen.findByText(/Please review the highlighted fields\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("submits valid input and surfaces success feedback", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const onStatusChange = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({ onSubmit, onStatusChange });
+
+    await user.type(screen.getByLabelText(/campaign name/i), "Holiday launch");
+    await user.type(screen.getByLabelText(/overview/i), "Seasonal promotion details");
+
+    const budgetInput = screen.getByLabelText(/total budget/i);
+    await user.clear(budgetInput);
+    await user.type(budgetInput, "5000");
+
+    await user.click(screen.getByRole("button", { name: /save campaign/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    const submittedValues = onSubmit.mock.calls[0][0] as CampaignFormValues;
+    expect(submittedValues.name).toBe("Holiday launch");
+    expect(submittedValues.description).toBe("Seasonal promotion details");
+    expect(submittedValues.budget).toBe(5000);
+
+    expect(onStatusChange).toHaveBeenCalledWith("submitting");
+    expect(onStatusChange).toHaveBeenCalledWith("success");
+
+    expect(
+      await screen.findByText(/Campaign saved successfully\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders server-side validation errors and clears them on change", async () => {
+    const user = userEvent.setup();
+
+    renderForm({
+      defaultValues: { ...defaultCampaignValues, budget: 10 },
+      validationErrors: { budget: "Budget is below the minimum" },
+    });
+
+    const budgetInput = screen.getByLabelText(/total budget/i);
+    expect(budgetInput).toHaveAttribute("aria-invalid", "true");
+    expect(
+      screen.getByText("Budget is below the minimum")
+    ).toBeInTheDocument();
+
+    await user.clear(budgetInput);
+    await user.type(budgetInput, "150");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Budget is below the minimum")).not.toBeInTheDocument();
+    });
+    expect(budgetInput).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("emits preview updates when values change", async () => {
+    const onPreviewChange = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({
+      defaultValues: { ...defaultCampaignValues, name: "Initial" },
+      onPreviewChange,
+    });
+
+    await waitFor(() => expect(onPreviewChange).toHaveBeenCalled());
+    onPreviewChange.mockClear();
+
+    await user.clear(screen.getByLabelText(/campaign name/i));
+    await user.type(screen.getByLabelText(/campaign name/i), "Summer Campaign");
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ title: "Summer Campaign" })
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignPreviewPanel.test.tsx
+++ b/packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignPreviewPanel.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { CampaignPreviewPanel } from "../CampaignPreviewPanel";
+import type { CampaignPreviewData } from "../types";
+
+const samplePreview: CampaignPreviewData = {
+  title: "Holiday Campaign",
+  objective: "awareness",
+  timeframe: "2025-11-01 → 2025-11-30",
+  audienceSummary: "Returning customers in the loyalty program",
+  channels: ["email", "social"],
+  budgetLabel: "$12,000",
+  kpi: "Engagement",
+};
+
+describe("CampaignPreviewPanel", () => {
+  it("renders campaign summary details", () => {
+    render(<CampaignPreviewPanel data={samplePreview} />);
+
+    expect(
+      screen.getByRole("heading", { name: /Campaign preview/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(samplePreview.title)).toBeInTheDocument();
+    expect(screen.getByText(samplePreview.objective)).toBeInTheDocument();
+    expect(screen.getByText(samplePreview.timeframe)).toBeInTheDocument();
+    expect(screen.getByText(samplePreview.budgetLabel)).toBeInTheDocument();
+    expect(screen.getByText(samplePreview.audienceSummary)).toBeInTheDocument();
+    expect(screen.getByText(samplePreview.kpi)).toBeInTheDocument();
+
+    samplePreview.channels.forEach((channel) => {
+      expect(screen.getByText(channel)).toBeInTheDocument();
+    });
+  });
+
+  it("renders supplied actions", () => {
+    render(
+      <CampaignPreviewPanel
+        data={samplePreview}
+        actions={<button type="button">Edit preview</button>}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /Edit preview/i })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignWizard.test.tsx
+++ b/packages/ui/src/components/cms/marketing/campaign/__tests__/CampaignWizard.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CampaignWizard } from "../CampaignWizard";
+import type { CampaignFormValues } from "../types";
+
+const validValues: CampaignFormValues = {
+  name: "Launch Plan",
+  objective: "sales",
+  description: "Multi-channel launch plan",
+  audience: "VIP customers",
+  budget: 7500,
+  startDate: "2025-03-01",
+  endDate: "2025-03-31",
+  channels: ["email", "sms"],
+  kpi: "Revenue",
+};
+
+describe("CampaignWizard", () => {
+  it("advances through steps and submits at review", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    render(<CampaignWizard initialValues={validValues} onSubmit={onSubmit} />);
+
+    expect(screen.getByLabelText(/Campaign name/i)).toHaveValue(validValues.name);
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    expect(await screen.findByLabelText(/Audience filters/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    const reviewButton = await screen.findByRole("button", { name: /review campaign/i });
+    await user.click(reviewButton);
+
+    expect(await screen.findByText(/Campaign preview/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /submit for approval/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining(validValues));
+    expect(
+      await screen.findByText(/Campaign submitted for approval\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("allows returning to earlier steps", async () => {
+    const user = userEvent.setup();
+
+    render(<CampaignWizard initialValues={validValues} />);
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    expect(await screen.findByLabelText(/Audience filters/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Back$/i }));
+    expect(await screen.findByLabelText(/Campaign name/i)).toBeInTheDocument();
+  });
+
+  it("propagates preview updates and handles submission errors", async () => {
+    const user = userEvent.setup();
+    const onPreviewChange = jest.fn();
+    const onSubmit = jest.fn().mockRejectedValue(new Error("Network failure"));
+
+    render(
+      <CampaignWizard
+        initialValues={validValues}
+        onSubmit={onSubmit}
+        onPreviewChange={onPreviewChange}
+      />
+    );
+
+    await waitFor(() => expect(onPreviewChange).toHaveBeenCalled());
+    onPreviewChange.mockClear();
+
+    await user.clear(screen.getByLabelText(/Campaign name/i));
+    await user.type(screen.getByLabelText(/Campaign name/i), "Updated Launch");
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ title: "Updated Launch" })
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    await user.click(await screen.findByRole("button", { name: /review campaign/i }));
+
+    await user.click(screen.getByRole("button", { name: /submit for approval/i }));
+
+    expect(await screen.findByText(/Network failure/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/hooks/useTokenEditor.tsx
+++ b/packages/ui/src/hooks/useTokenEditor.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ChangeEvent,
 } from "react";
@@ -70,6 +71,11 @@ export function useTokenEditor(
   const [monoFonts, setMonoFonts] = useState<string[]>([...defaultMonoFonts]);
   const [googleFonts] = useState<string[]>(googleFontList);
   const [newFont, setNewFont] = useState("");
+  const newFontRef = useRef(newFont);
+
+  useEffect(() => {
+    newFontRef.current = newFont;
+  }, [newFont]);
 
   useEffect(() => {
     Object.entries(tokens).forEach(([k, v]) => {
@@ -113,11 +119,12 @@ export function useTokenEditor(
   );
 
   const addCustomFont = useCallback(() => {
-    if (!newFont.trim()) return;
-    setSansFonts((f) => (f.includes(newFont) ? f : [...f, newFont]));
-    setMonoFonts((f) => (f.includes(newFont) ? f : [...f, newFont]));
+    const value = newFontRef.current;
+    if (!value.trim()) return;
+    setSansFonts((f) => (f.includes(value) ? f : [...f, value]));
+    setMonoFonts((f) => (f.includes(value) ? f : [...f, value]));
     setNewFont("");
-  }, [newFont]);
+  }, [setSansFonts, setMonoFonts, setNewFont]);
 
   const loadGoogleFont = useCallback((name: string) => {
     const id = `google-font-${name}`;

--- a/test/__mocks__/@radix-ui/react-dropdown-menu.tsx
+++ b/test/__mocks__/@radix-ui/react-dropdown-menu.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+
+type AnyProps = React.HTMLAttributes<HTMLElement> & { [key: string]: unknown };
+
+type Primitive = React.ForwardRefExoticComponent<AnyProps & React.RefAttributes<HTMLElement>>;
+
+function createPrimitive(displayName: string): Primitive {
+  return React.forwardRef<HTMLElement, AnyProps>(function Primitive(
+    { children, ...props },
+    ref
+  ) {
+    return (
+      <div ref={ref} data-radix-mock={displayName} {...props}>
+        {children}
+      </div>
+    );
+  });
+}
+
+export const Root = createPrimitive("Root");
+export const Trigger = createPrimitive("Trigger");
+export const Group = createPrimitive("Group");
+export const Sub = createPrimitive("Sub");
+export const Portal = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+export const RadioGroup = createPrimitive("RadioGroup");
+export const SubTrigger = createPrimitive("SubTrigger");
+export const SubContent = createPrimitive("SubContent");
+export const Content = createPrimitive("Content");
+export const Item = createPrimitive("Item");
+export const CheckboxItem = createPrimitive("CheckboxItem");
+export const RadioItem = createPrimitive("RadioItem");
+export const ItemIndicator = createPrimitive("ItemIndicator");
+export const Label = createPrimitive("Label");
+export const Separator = createPrimitive("Separator");
+
+export default {
+  Root,
+  Trigger,
+  Group,
+  Sub,
+  Portal,
+  RadioGroup,
+  SubTrigger,
+  SubContent,
+  Content,
+  Item,
+  CheckboxItem,
+  RadioItem,
+  ItemIndicator,
+  Label,
+  Separator,
+};


### PR DESCRIPTION
## Summary
- document testing conventions and component behaviors for the new campaign marketing workflow
- add Jest suites that exercise CampaignForm validation, CampaignWizard navigation, and CampaignPreviewPanel rendering
- provide a Radix dropdown menu stub, keep useTokenEditor.addCustomFont stable for spying, and adapt the Tokens suite

## Testing
- pnpm --filter @acme/ui test *(fails: existing UI suite depends on additional mocks/transforms)*

------
https://chatgpt.com/codex/tasks/task_e_68cabaaadc64832fba310ade59d694af