### PR TITLE
Enhance media file item loading states

### DIFF
--- a/packages/ui/src/components/cms/MediaFileItem.d.ts
+++ b/packages/ui/src/components/cms/MediaFileItem.d.ts
@@ -23,6 +23,11 @@ interface Props {
     }, selected: boolean) => void;
     selectionEnabled?: boolean;
     selected?: boolean;
+    deleting?: boolean;
+    replacing?: boolean;
+    disabled?: boolean;
+    onReplaceSuccess?: (newItem: MediaItem) => void;
+    onReplaceError?: (message: string) => void;
 }
-export default function MediaFileItem({ item, shop, onDelete, onReplace, onSelect, onOpenDetails, onBulkToggle, selectionEnabled, selected, }: Props): import("react/jsx-runtime").JSX.Element;
+export default function MediaFileItem({ item, shop, onDelete, onReplace, onSelect, onOpenDetails, onBulkToggle, selectionEnabled, selected, deleting, replacing, disabled, onReplaceSuccess, onReplaceError, }: Props): import("react/jsx-runtime").JSX.Element;
 export {};

--- a/packages/ui/src/components/cms/MediaFileItem.stories.tsx
+++ b/packages/ui/src/components/cms/MediaFileItem.stories.tsx
@@ -68,3 +68,17 @@ export const ReplacingInProgress: Story = {
     selectionEnabled: true,
   },
 };
+
+export const ReplacingActionState: Story = {
+  args: {
+    replacing: true,
+    selectionEnabled: true,
+  },
+};
+
+export const DeletingState: Story = {
+  args: {
+    deleting: true,
+    selectionEnabled: true,
+  },
+};

--- a/packages/ui/src/components/cms/__tests__/MediaFileItem.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/MediaFileItem.test.tsx
@@ -34,7 +34,9 @@ describe("MediaFileItem", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /media actions/i }));
-    await user.click(await screen.findByText("Delete"));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /delete media/i })
+    );
 
     expect(onDelete).toHaveBeenCalledWith(baseItem.url);
   });
@@ -43,6 +45,8 @@ describe("MediaFileItem", () => {
     jest.useFakeTimers();
     const onDelete = jest.fn().mockResolvedValue(undefined);
     const onReplace = jest.fn();
+    const onReplaceSuccess = jest.fn();
+    const onReplaceError = jest.fn();
     const replacement = { url: "http://example.com/new.jpg", type: "image" };
     (global.fetch as jest.Mock).mockResolvedValue(
       new Response(JSON.stringify(replacement), {
@@ -57,6 +61,8 @@ describe("MediaFileItem", () => {
         shop="shop"
         onDelete={onDelete}
         onReplace={onReplace}
+        onReplaceSuccess={onReplaceSuccess}
+        onReplaceError={onReplaceError}
       />
     );
 
@@ -70,6 +76,52 @@ describe("MediaFileItem", () => {
     await waitFor(() => expect(onReplace).toHaveBeenCalled());
     expect(onReplace).toHaveBeenCalledWith(baseItem.url, replacement);
     expect(onDelete).toHaveBeenCalledWith(baseItem.url);
+    expect(onReplaceSuccess).toHaveBeenCalledWith(replacement);
+    expect(onReplaceError).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("reports errors when a replacement fails", async () => {
+    jest.useFakeTimers();
+    const onDelete = jest.fn();
+    const onReplace = jest.fn();
+    const onReplaceSuccess = jest.fn();
+    const onReplaceError = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response(JSON.stringify({ error: "nope" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const { container } = render(
+      <MediaFileItem
+        item={baseItem}
+        shop="shop"
+        onDelete={onDelete}
+        onReplace={onReplace}
+        onReplaceSuccess={onReplaceSuccess}
+        onReplaceError={onReplaceError}
+      />
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() =>
+      expect(onReplaceError).toHaveBeenCalledWith("Failed to upload replacement")
+    );
+    expect(onReplaceSuccess).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onReplace).not.toHaveBeenCalled();
 
     act(() => {
       jest.runAllTimers();
@@ -109,7 +161,7 @@ describe("MediaFileItem", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Open details"));
+    fireEvent.click(screen.getByRole("button", { name: /open details/i }));
     expect(onOpenDetails).toHaveBeenCalledWith(baseItem);
   });
 
@@ -125,7 +177,7 @@ describe("MediaFileItem", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Select"));
+    fireEvent.click(screen.getByRole("button", { name: /select media/i }));
     expect(onSelect).toHaveBeenCalledWith(baseItem);
   });
 
@@ -162,5 +214,43 @@ describe("MediaFileItem", () => {
     expect(screen.getByText("featured")).toBeInTheDocument();
     expect(screen.getByText("homepage")).toBeInTheDocument();
     expect(screen.getByText(/12 KB/)).toBeInTheDocument();
+  });
+
+  it("disables actions and shows a spinner when deleting", () => {
+    render(
+      <MediaFileItem
+        item={baseItem}
+        shop="shop"
+        onDelete={jest.fn()}
+        onReplace={jest.fn()}
+        onOpenDetails={jest.fn()}
+        onSelect={jest.fn()}
+        deleting
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /media actions/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /open details/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /select media/i })).toBeDisabled();
+    expect(screen.getAllByText("Deleting media")).not.toHaveLength(0);
+  });
+
+  it("disables actions and shows replacement feedback when replacing", () => {
+    render(
+      <MediaFileItem
+        item={baseItem}
+        shop="shop"
+        onDelete={jest.fn()}
+        onReplace={jest.fn()}
+        onOpenDetails={jest.fn()}
+        onSelect={jest.fn()}
+        replacing
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /media actions/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /open details/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /select media/i })).toBeDisabled();
+    expect(screen.getAllByText("Replacing media")).not.toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- extend MediaFileItem props with deleting/replacing/disabled states and improve overlay accessibility
- call replace success/error callbacks before resetting local state and guard the delete action
- document and test loading visuals with new stories and Jest coverage for busy states

## Testing
- pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runInBand --runTestsByPath src/components/cms/__tests__/MediaFileItem.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cabdcd12c8832fb65581fb98d5cb7a