### PR TITLE
Improve MediaFileItem loading and accessibility

### DIFF
--- a/packages/ui/src/components/cms/MediaFileItem.d.ts
+++ b/packages/ui/src/components/cms/MediaFileItem.d.ts
@@ -22,6 +22,9 @@ interface Props {
     selected?: boolean;
     deleting?: boolean;
     replacing?: boolean;
+    disabled?: boolean;
+    onReplaceSuccess?: (newItem: MediaItem) => void;
+    onReplaceError?: (message: string) => void;
 }
-export default function MediaFileItem({ item, shop, onDelete, onReplace, onSelect, onBulkToggle, selectionEnabled, selected, deleting, replacing, }: Props): import("react/jsx-runtime").JSX.Element;
+export default function MediaFileItem({ item, shop, onDelete, onReplace, onSelect, onBulkToggle, selectionEnabled, selected, deleting, replacing, disabled, onReplaceSuccess, onReplaceError, }: Props): import("react/jsx-runtime").JSX.Element;
 export {};

--- a/packages/ui/src/components/cms/MediaFileItem.stories.tsx
+++ b/packages/ui/src/components/cms/MediaFileItem.stories.tsx
@@ -63,5 +63,13 @@ export const ReplacingInProgress: Story = {
       tags: ["catalog"],
     },
     selectionEnabled: true,
+    replacing: true,
+  },
+};
+
+export const Deleting: Story = {
+  args: {
+    deleting: true,
+    selectionEnabled: true,
   },
 };

--- a/test/__mocks__/@radix-ui/react-dropdown-menu.tsx
+++ b/test/__mocks__/@radix-ui/react-dropdown-menu.tsx
@@ -26,7 +26,27 @@ export const RadioGroup = createPrimitive("RadioGroup");
 export const SubTrigger = createPrimitive("SubTrigger");
 export const SubContent = createPrimitive("SubContent");
 export const Content = createPrimitive("Content");
-export const Item = createPrimitive("Item");
+const ItemPrimitive = React.forwardRef<HTMLElement, AnyProps>(function Item(
+  { children, onSelect, onClick, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      data-radix-mock="Item"
+      onClick={(event) => {
+        onSelect?.(event);
+        onClick?.(event);
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+});
+
+ItemPrimitive.displayName = "Item";
+export const Item = ItemPrimitive;
 export const CheckboxItem = createPrimitive("CheckboxItem");
 export const RadioItem = createPrimitive("RadioItem");
 export const ItemIndicator = createPrimitive("ItemIndicator");


### PR DESCRIPTION
## Summary
- extend `MediaFileItem` with disabled state, replacement callbacks, and spinner-based loading indicators for overlay and dropdown actions
- add Storybook coverage for replacing and deleting states and tighten test expectations around loading messaging and callbacks
- update the dropdown menu mock so tests can trigger `onSelect` without Radix internals

## Testing
- `pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runTestsByPath src/components/cms/__tests__/MediaFileItem.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68cac3f04158832fab09d912c752f9b7