### PR TITLE
Connect media metadata updates in CMS

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/media/page.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/media/page.tsx
@@ -1,6 +1,10 @@
 // apps/cms/src/app/cms/shop/[shop]/media/page.tsx
 
-import { deleteMedia, getMediaOverview } from "@cms/actions/media.server";
+import {
+  deleteMedia,
+  getMediaOverview,
+  updateMediaMetadata,
+} from "@cms/actions/media.server";
 import { checkShopExists } from "@acme/lib";
 import MediaManager from "@ui/components/cms/MediaManager";
 import { notFound } from "next/navigation";
@@ -38,6 +42,7 @@ export default async function MediaPage({
         shop={shop}
         initialFiles={files}
         onDelete={deleteMedia}
+        onMetadataUpdate={updateMediaMetadata}
         uploaderTargetId={uploaderTargetId}
       />
     </div>

--- a/packages/ui/__tests__/MediaManager.a11y.test.tsx
+++ b/packages/ui/__tests__/MediaManager.a11y.test.tsx
@@ -25,7 +25,14 @@ const MediaManager = require("@ui/components/cms/MediaManager").default;
 
 describe("MediaManager accessibility", () => {
   it("links drop zone to live feedback region", () => {
-    render(<MediaManager shop="s" initialFiles={[]} onDelete={jest.fn()} />);
+    render(
+      <MediaManager
+        shop="s"
+        initialFiles={[]}
+        onDelete={jest.fn()}
+        onMetadataUpdate={jest.fn()}
+      />
+    );
     const dropzone = screen.getByRole("button", {
       name: /drop image or video/i,
     });

--- a/packages/ui/src/components/cms/MediaManager.d.ts
+++ b/packages/ui/src/components/cms/MediaManager.d.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import type { MediaItem } from "@acme/types";
-import MediaDetailsPanel from "./media/MediaDetailsPanel";
+import MediaDetailsPanel, { type MediaDetailsFormValues } from "./media/MediaDetailsPanel";
 export type {
     MediaDetailsFormValues,
     MediaDetailsPanelProps,
@@ -13,12 +13,18 @@ interface Props {
      * Implemented in – and supplied by – the host application (e.g. `apps/cms`).
      */
     onDelete: (shop: string, src: string) => void | Promise<void>;
+    onMetadataUpdate: (
+        shop: string,
+        src: string,
+        fields: MediaDetailsFormValues
+    ) => MediaItem | Promise<MediaItem>;
     uploaderTargetId?: string;
 }
 declare function MediaManagerBase({
     shop,
     initialFiles,
     onDelete,
+    onMetadataUpdate,
     uploaderTargetId,
 }: Props): ReactElement;
 declare const _default: import("react").MemoExoticComponent<typeof MediaManagerBase>;

--- a/packages/ui/src/components/cms/MediaManager.stories.tsx
+++ b/packages/ui/src/components/cms/MediaManager.stories.tsx
@@ -12,6 +12,11 @@ const meta: Meta<typeof MediaManager> = {
     shop: "demo",
     initialFiles: files,
     onDelete: () => alert("delete"),
+    onMetadataUpdate: async (_shop, url, fields) => ({
+      url,
+      type: "image",
+      ...fields,
+    }),
   },
   argTypes: {
     shop: { control: "text" },

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -1,15 +1,19 @@
 // packages/ui/src/components/cms/MediaManager.tsx
 "use client";
 
-import { memo, ReactElement, useCallback, useState } from "react";
+import { memo, ReactElement, useCallback, useMemo, useState } from "react";
 import type { MediaItem } from "@acme/types";
-import MediaDetailsPanel from "./media/MediaDetailsPanel";
+import MediaDetailsPanel, {
+  type MediaDetailsFormValues,
+} from "./media/MediaDetailsPanel";
 import Library from "./media/Library";
 import UploadPanel from "./media/UploadPanel";
 
 /* -------------------------------------------------------------------------- */
 /*  Types                                                                     */
 /* -------------------------------------------------------------------------- */
+
+type MediaItemWithUrl = MediaItem & { url: string };
 
 interface Props {
   shop: string;
@@ -20,7 +24,20 @@ interface Props {
    * Implemented in – and supplied by – the host application (e.g. `apps/cms`).
    */
   onDelete: (shop: string, src: string) => void | Promise<void>;
+  onMetadataUpdate: (
+    shop: string,
+    src: string,
+    fields: MediaDetailsFormValues
+  ) => MediaItem | Promise<MediaItem>;
   uploaderTargetId?: string;
+}
+
+function hasUrl(item: MediaItem): item is MediaItemWithUrl {
+  return typeof item.url === "string" && item.url.length > 0;
+}
+
+function ensureHasUrl(items: MediaItem[]): MediaItemWithUrl[] {
+  return items.filter(hasUrl);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -31,33 +48,84 @@ function MediaManagerBase({
   shop,
   initialFiles,
   onDelete,
+  onMetadataUpdate,
   uploaderTargetId,
 }: Props): ReactElement {
-  const [files, setFiles] = useState<MediaItem[]>(initialFiles);
+  const [files, setFiles] = useState<MediaItemWithUrl[]>(() =>
+    ensureHasUrl(initialFiles)
+  );
+  const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+  const [metadataPending, setMetadataPending] = useState(false);
+
+  const selectedItem = useMemo(() => {
+    if (!selectedUrl) return null;
+    return files.find((file) => file.url === selectedUrl) ?? null;
+  }, [files, selectedUrl]);
 
   const handleDelete = useCallback(
     async (src: string) => {
-       
       if (!confirm("Delete this image?")) return;
       await onDelete(shop, src);
       setFiles((prev) => prev.filter((f) => f.url !== src));
+      setSelectedUrl((prev) => (prev === src ? null : prev));
     },
     [onDelete, shop]
   );
 
-  const handleUploaded = useCallback(
-    (item: MediaItem) => {
-      setFiles((prev) => [item, ...prev]);
+  const handleUploaded = useCallback((item: MediaItem) => {
+    if (!hasUrl(item)) {
+      console.error("Uploaded media item is missing a URL", item);
+      return;
+    }
+    setFiles((prev) => [item, ...prev]);
+  }, []);
+
+  const handleReplace = useCallback((oldUrl: string, item: MediaItem) => {
+    if (!hasUrl(item)) {
+      console.error("Replacement media item is missing a URL", item);
+      return;
+    }
+    setFiles((prev) => prev.map((f) => (f.url === oldUrl ? item : f)));
+    setSelectedUrl((prev) => (prev === oldUrl ? item.url : prev));
+  }, []);
+
+  const handleSelect = useCallback((item: MediaItemWithUrl | null) => {
+    setSelectedUrl(item?.url ?? null);
+  }, []);
+
+  const handleMetadataSubmit = useCallback(
+    async (fields: MediaDetailsFormValues) => {
+      if (!selectedItem) return;
+
+      const currentUrl = selectedItem.url;
+      setMetadataPending(true);
+      try {
+        const updated = await onMetadataUpdate(shop, currentUrl, fields);
+        if (!hasUrl(updated)) {
+          console.error("Updated media item is missing a URL", updated);
+          return;
+        }
+
+        setFiles((prev) =>
+          prev.map((file) =>
+            file.url === currentUrl
+              ? ({ ...file, ...updated } as MediaItemWithUrl)
+              : file
+          )
+        );
+        setSelectedUrl(updated.url);
+      } catch (error) {
+        console.error("Failed to update media metadata", error);
+      } finally {
+        setMetadataPending(false);
+      }
     },
-    []
+    [onMetadataUpdate, selectedItem, shop]
   );
 
-  const handleReplace = useCallback(
-    (oldUrl: string, item: MediaItem) => {
-      setFiles((prev) => prev.map((f) => (f.url === oldUrl ? item : f)));
-    },
-    []
-  );
+  const handleCloseDetails = useCallback(() => {
+    setSelectedUrl(null);
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -71,7 +139,17 @@ function MediaManagerBase({
         shop={shop}
         onDelete={handleDelete}
         onReplace={handleReplace}
+        onSelect={handleSelect}
       />
+      {selectedItem ? (
+        <MediaDetailsPanel
+          open
+          item={selectedItem}
+          pending={metadataPending}
+          onSubmit={handleMetadataSubmit}
+          onClose={handleCloseDetails}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/ui/src/components/cms/__tests__/media-manager.spec.tsx
+++ b/packages/ui/src/components/cms/__tests__/media-manager.spec.tsx
@@ -29,7 +29,14 @@ describe("MediaManager", () => {
   it("does nothing when deletion is not confirmed", async () => {
     window.confirm = jest.fn(() => false);
     const onDelete = jest.fn();
-    render(<MediaManager shop="s" initialFiles={initialFiles} onDelete={onDelete} />);
+    render(
+      <MediaManager
+        shop="s"
+        initialFiles={initialFiles}
+        onDelete={onDelete}
+        onMetadataUpdate={jest.fn()}
+      />
+    );
 
     await act(async () => {
       await libraryProps.onDelete("1");
@@ -42,7 +49,14 @@ describe("MediaManager", () => {
   it("deletes item when confirmed", async () => {
     window.confirm = jest.fn(() => true);
     const onDelete = jest.fn();
-    render(<MediaManager shop="s" initialFiles={initialFiles} onDelete={onDelete} />);
+    render(
+      <MediaManager
+        shop="s"
+        initialFiles={initialFiles}
+        onDelete={onDelete}
+        onMetadataUpdate={jest.fn()}
+      />
+    );
 
     await act(async () => {
       await libraryProps.onDelete("1");
@@ -55,7 +69,14 @@ describe("MediaManager", () => {
 
   it("adds uploaded items", async () => {
     const onDelete = jest.fn();
-    render(<MediaManager shop="s" initialFiles={initialFiles} onDelete={onDelete} />);
+    render(
+      <MediaManager
+        shop="s"
+        initialFiles={initialFiles}
+        onDelete={onDelete}
+        onMetadataUpdate={jest.fn()}
+      />
+    );
 
     act(() => {
       uploadProps.onUploaded({ url: "3", type: "image" });
@@ -67,7 +88,14 @@ describe("MediaManager", () => {
 
   it("replaces existing items", async () => {
     const onDelete = jest.fn();
-    render(<MediaManager shop="s" initialFiles={initialFiles} onDelete={onDelete} />);
+    render(
+      <MediaManager
+        shop="s"
+        initialFiles={initialFiles}
+        onDelete={onDelete}
+        onMetadataUpdate={jest.fn()}
+      />
+    );
 
     act(() => {
       libraryProps.onReplace("1", { url: "1b", type: "image" });


### PR DESCRIPTION
## Summary
- wire the `updateMediaMetadata` action into the CMS media page so MediaManager can persist edits
- enhance the shared MediaManager to track selections, show the MediaDetailsPanel, and invoke a new `onMetadataUpdate` callback while keeping the local file list in sync
- update storybook, types, and unit tests (CMS and UI) with the new prop, lightweight shadcn mocks, and assertions that metadata changes reach the action

## Testing
- pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runInBand --coverage=false --runTestsByPath __tests__/MediaManager.test.tsx __tests__/MediaManager.a11y.test.tsx src/components/cms/__tests__/media-manager.spec.tsx
- pnpm --filter @apps/cms exec jest --config ../../jest.config.cjs --runInBand --coverage=false --runTestsByPath src/components/cms/media/__tests__/MediaManager.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cac74b034c832fa480433050489cf4