### PR TITLE
Refactor upgrade summary view to use DataTable

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/UpgradeSummary.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/UpgradeSummary.tsx
@@ -1,5 +1,7 @@
 // apps/cms/src/app/cms/shop/[shop]/UpgradeSummary.tsx
 
+import DataTable, { type Column } from "@ui/components/cms/DataTable";
+
 interface ComponentChange {
   name: string;
   from: string | null;
@@ -12,6 +14,38 @@ interface ComponentResponse {
 }
 
 export const revalidate = 0;
+
+const componentColumns: Column<ComponentChange>[] = [
+  {
+    header: "Package",
+    render: (row) => row.name,
+  },
+  {
+    header: "Current",
+    render: (row) => row.from ?? "-",
+  },
+  {
+    header: "New",
+    render: (row) => row.to,
+  },
+  {
+    header: "Changelog",
+    width: "120px",
+    render: (row) =>
+      row.changelog ? (
+        <a
+          href={row.changelog}
+          target="_blank"
+          rel="noreferrer"
+          className="text-primary underline"
+        >
+          View
+        </a>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+];
 
 export default async function UpgradeSummary({ shop }: { shop: string }) {
   const res = await fetch(`/api/components/${shop}?diff`, {
@@ -34,38 +68,8 @@ export default async function UpgradeSummary({ shop }: { shop: string }) {
   }
 
   return (
-    <table className="mt-4 w-full text-left text-sm">
-      <thead>
-        <tr>
-          <th className="pr-4">Package</th>
-          <th className="pr-4">Current</th>
-          <th className="pr-4">New</th>
-          <th className="pr-4">Changelog</th>
-        </tr>
-      </thead>
-      <tbody>
-        {components.map((c) => (
-          <tr key={c.name}>
-            <td className="pr-4">{c.name}</td>
-            <td className="pr-4">{c.from ?? "-"}</td>
-            <td className="pr-4">{c.to}</td>
-            <td>
-              {c.changelog ? (
-                <a
-                  href={c.changelog}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-primary underline"
-                >
-                  View
-                </a>
-              ) : (
-                <span className="text-muted-foreground">—</span>
-              )}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="mt-4">
+      <DataTable rows={components} columns={componentColumns} />
+    </div>
   );
 }

--- a/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeSummary.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeSummary.test.tsx
@@ -1,0 +1,87 @@
+// React 19 requires this flag to silence act warnings in tests
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { render, screen } from "@testing-library/react";
+import UpgradeSummary from "@/app/cms/shop/[shop]/UpgradeSummary";
+
+describe("UpgradeSummary", () => {
+  const shop = "demo-shop";
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("renders upgrade rows in a DataTable", async () => {
+    const components = [
+      {
+        name: "@acme/ui",
+        from: "1.0.0",
+        to: "1.1.0",
+        changelog: "https://example.com/ui",
+      },
+      {
+        name: "@acme/theme",
+        from: null,
+        to: "2.0.0",
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ components }),
+    });
+
+    const view = await UpgradeSummary({ shop });
+    render(view);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Package" })
+    ).toBeInTheDocument();
+    components.forEach((component) => {
+      expect(screen.getByText(component.name)).toBeInTheDocument();
+      expect(screen.getByText(component.to)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getAllByText("—")).not.toHaveLength(0);
+
+    expect(
+      screen.getByRole("link", { name: /view/i })
+    ).toHaveAttribute("href", components[0].changelog);
+  });
+
+  it("renders an empty state when there are no upgrades", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ components: [] }),
+    });
+
+    const view = await UpgradeSummary({ shop });
+    render(view);
+
+    expect(
+      screen.getByText("No component upgrades found.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error message when the upgrade request fails", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+
+    const view = await UpgradeSummary({ shop });
+    render(view);
+
+    expect(
+      screen.getByText("Failed to load upgrade information.")
+    ).toBeInTheDocument();
+  });
+});
+

--- a/packages/ui/src/components/cms/marketing/shared/PreviewPanel.tsx
+++ b/packages/ui/src/components/cms/marketing/shared/PreviewPanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Card, CardContent } from "../../../atoms/shadcn";
+import { CodeBlock } from "../../../molecules";
 import { cn } from "../../../../utils/style";
 
 export interface PreviewPanelProps<TData> {
@@ -25,6 +26,17 @@ export function PreviewPanel<TData>({
   emptyLabel = "Preview not available",
 }: PreviewPanelProps<TData>) {
   const content = renderPreview?.(data);
+  const fallbackPreview = data ? JSON.stringify(data, null, 2) : emptyLabel;
+
+  const previewBody = content ? (
+    <div className="p-4">{content}</div>
+  ) : (
+    <CodeBlock
+      code={fallbackPreview}
+      className="p-4"
+      preClassName="bg-transparent text-xs text-muted-foreground border-none p-0 pr-12"
+    />
+  );
 
   return (
     <Card className={cn("space-y-4", className)}>
@@ -38,13 +50,7 @@ export function PreviewPanel<TData>({
           </div>
           {actions && <div className="flex items-center gap-2">{actions}</div>}
         </div>
-        <div className="rounded-lg border bg-muted/40 p-4 text-sm">
-          {content ?? (
-            <pre className="text-xs text-muted-foreground">
-              {data ? JSON.stringify(data, null, 2) : emptyLabel}
-            </pre>
-          )}
-        </div>
+        <div className="rounded-lg border bg-muted/40 text-sm">{previewBody}</div>
         {footer}
       </CardContent>
     </Card>

--- a/packages/ui/src/components/cms/marketing/shared/__tests__/PreviewPanel.test.tsx
+++ b/packages/ui/src/components/cms/marketing/shared/__tests__/PreviewPanel.test.tsx
@@ -1,0 +1,59 @@
+// React 19 requires this flag to silence act warnings in tests
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PreviewPanel } from "../PreviewPanel";
+
+describe("PreviewPanel", () => {
+  const title = "API payload";
+  const data = { message: "hello", count: 2 };
+  const json = JSON.stringify(data, null, 2);
+  let originalNavigator: Navigator;
+  let writeTextMock: jest.Mock;
+
+  beforeEach(() => {
+    writeTextMock = jest.fn().mockResolvedValue(undefined);
+    originalNavigator = navigator;
+    const mockNavigator = Object.create(originalNavigator) as Navigator;
+    Object.defineProperty(mockNavigator, "clipboard", {
+      configurable: true,
+      value: { writeText: writeTextMock } as Clipboard,
+    });
+    Object.defineProperty(global, "navigator", {
+      configurable: true,
+      value: mockNavigator,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, "navigator", {
+      configurable: true,
+      value: originalNavigator,
+    });
+  });
+
+  it("renders the JSON fallback inside a code block", () => {
+    render(<PreviewPanel title={title} data={data} />);
+
+    expect(
+      screen.getByRole("heading", { name: title })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/"message": "hello"/i)
+    ).toBeInTheDocument();
+  });
+
+  it("copies the preview payload to the clipboard", async () => {
+    const user = userEvent.setup();
+
+    render(<PreviewPanel title={title} data={data} />);
+
+    const copyButton = screen.getByRole("button", { name: /copy/i });
+    await user.click(copyButton);
+
+    await waitFor(() => expect(copyButton).toHaveTextContent(/copied/i));
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace the upgrade summary HTML table with the shared CMS DataTable component and supply column metadata
- add coverage for UpgradeSummary to validate error, empty, and populated states
- swap the marketing PreviewPanel fallback to the CodeBlock component and assert the copy affordance renders and toggles its state
- introduce a PreviewPanel unit test that exercises the JSON fallback and copy control

## Testing
- pnpm --filter @apps/cms exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath /workspace/base-shop/apps/cms/src/app/cms/shop/[shop]/__tests__/UpgradeSummary.test.tsx --coverage --coverageThreshold='{ "global": { "branches": 0, "functions": 0, "lines": 0, "statements": 0 } }'
- pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config ../../jest.config.cjs --runTestsByPath /workspace/base-shop/packages/ui/src/components/cms/marketing/shared/__tests__/PreviewPanel.test.tsx --coverage --coverageThreshold='{ "global": { "branches": 0, "functions": 0, "lines": 0, "statements": 0 } }'

------
https://chatgpt.com/codex/tasks/task_e_68cac7524fc4832fbc2d941e31c98823