### PR TITLE
refactor(ui): prepare media manager dependencies

### DIFF
--- a/packages/ui/src/components/cms/MediaManager.d.ts
+++ b/packages/ui/src/components/cms/MediaManager.d.ts
@@ -1,10 +1,10 @@
 import { ReactElement } from "react";
 import type { MediaItem } from "@acme/types";
-import MediaDetailsPanel, { type MediaDetailsFormValues } from "./media/MediaDetailsPanel";
+import MediaDetailsPanel, { type MediaDetailsFormValues } from "./media/details/MediaDetailsPanel";
 export type {
     MediaDetailsFormValues,
     MediaDetailsPanelProps,
-} from "./media/MediaDetailsPanel";
+} from "./media/details/MediaDetailsPanel";
 interface Props {
     shop: string;
     initialFiles: MediaItem[];

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -5,7 +5,17 @@ import { memo, ReactElement, useCallback, useMemo, useState } from "react";
 import type { MediaItem } from "@acme/types";
 import MediaDetailsPanel, {
   type MediaDetailsFormValues,
-} from "./media/MediaDetailsPanel";
+} from "./media/details/MediaDetailsPanel";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../atoms/shadcn";
+import { Spinner, Toast } from "../atoms";
 import Library from "./media/Library";
 import UploadPanel from "./media/UploadPanel";
 
@@ -145,7 +155,7 @@ function MediaManagerBase({
         <MediaDetailsPanel
           open
           item={selectedItem}
-          pending={metadataPending}
+          loading={metadataPending}
           onSubmit={handleMetadataSubmit}
           onClose={handleCloseDetails}
         />
@@ -162,7 +172,7 @@ export { MediaDetailsPanel };
 export type {
   MediaDetailsFormValues,
   MediaDetailsPanelProps,
-} from "./media/MediaDetailsPanel";
+} from "./media/details/MediaDetailsPanel";
 
 export default memo(MediaManagerBase);
 

--- a/packages/ui/src/components/cms/media/details/MediaDetailsPanel.d.ts
+++ b/packages/ui/src/components/cms/media/details/MediaDetailsPanel.d.ts
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+
+import type {
+  MediaDetailsFormValues,
+  MediaDetailsPanelProps as BaseMediaDetailsPanelProps,
+} from "../MediaDetailsPanel";
+
+export interface MediaDetailsPanelProps
+  extends Omit<BaseMediaDetailsPanelProps, "pending"> {
+  loading: BaseMediaDetailsPanelProps["pending"];
+}
+
+export default function MediaDetailsPanel(props: MediaDetailsPanelProps): ReactElement;
+export { MediaDetailsPanel };
+export type { MediaDetailsFormValues };

--- a/packages/ui/src/components/cms/media/details/MediaDetailsPanel.tsx
+++ b/packages/ui/src/components/cms/media/details/MediaDetailsPanel.tsx
@@ -1,0 +1,24 @@
+// packages/ui/src/components/cms/media/details/MediaDetailsPanel.tsx
+"use client";
+
+import type { ReactElement } from "react";
+
+import BaseMediaDetailsPanel, {
+  type MediaDetailsFormValues,
+  type MediaDetailsPanelProps as BaseMediaDetailsPanelProps,
+} from "../MediaDetailsPanel";
+
+export interface MediaDetailsPanelProps
+  extends Omit<BaseMediaDetailsPanelProps, "pending"> {
+  loading: BaseMediaDetailsPanelProps["pending"];
+}
+
+export default function MediaDetailsPanel({
+  loading,
+  ...props
+}: MediaDetailsPanelProps): ReactElement {
+  return <BaseMediaDetailsPanel pending={loading} {...props} />;
+}
+
+export { MediaDetailsPanel };
+export type { MediaDetailsFormValues };


### PR DESCRIPTION
## Summary
- point MediaManager at the new media/details MediaDetailsPanel wrapper that exposes the loading prop and re-export its types
- preload the UI dependencies (shadcn dialog primitives, button, toast, spinner) needed for the upcoming confirmation flow and mirror the type changes in the declaration file
- add a thin wrapper module under media/details to translate loading into the legacy panel’s pending prop and expose matching declarations

## Testing
- ⚠️ `pnpm --filter @acme/ui test -- MediaManager.test.tsx` *(fails: coverage thresholds already below configured minimums)*
- ⚠️ `pnpm --filter @acme/ui build` *(fails: existing TagProps export missing in @ui/components/atoms)*

------
https://chatgpt.com/codex/tasks/task_e_68cad690c2b8832fa2011b6ec3c6f830