### PR TITLE
Refine shop editor form payload grouping

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -6,7 +6,10 @@ import { providersByType } from "@acme/configurator/providers";
 import type { Shop } from "@acme/types";
 import useMappingRows from "@/hooks/useMappingRows";
 import useShopEditorSubmit, {
-  type MappingRowsController,
+  type ShopEditorIdentitySection,
+  type ShopEditorLocalizationSection,
+  type ShopEditorOverridesSection,
+  type ShopEditorProvidersSection,
 } from "./useShopEditorSubmit";
 import { mapThemeTokenRows } from "./tableMappers";
 
@@ -30,15 +33,6 @@ export function useShopEditorForm({
   const priceOverrides = useMappingRows(initial.priceOverrides);
   const localeOverrides = useMappingRows(initial.localeOverrides);
 
-  const { saving, errors, onSubmit } = useShopEditorSubmit({
-    shop,
-    filterMappings: filterMappings as MappingRowsController,
-    priceOverrides: priceOverrides as MappingRowsController,
-    localeOverrides: localeOverrides as MappingRowsController,
-    setInfo,
-    setTrackingProviders,
-  });
-
   const shippingProviders = providersByType("shipping");
 
   const tokenRows = useMemo(
@@ -50,6 +44,36 @@ export function useShopEditorForm({
     const { name, value } = e.target;
     setInfo((prev) => ({ ...prev, [name]: value }));
   };
+
+  const identity: ShopEditorIdentitySection = {
+    info,
+    setInfo,
+    handleChange,
+  };
+
+  const localization: ShopEditorLocalizationSection = {
+    priceOverrides,
+    localeOverrides,
+  };
+
+  const providersState: ShopEditorProvidersSection = {
+    shippingProviders,
+    trackingProviders,
+    setTrackingProviders,
+  };
+
+  const overrides: ShopEditorOverridesSection = {
+    filterMappings,
+    tokenRows,
+  };
+
+  const { saving, errors, onSubmit } = useShopEditorSubmit({
+    shop,
+    identity,
+    localization,
+    providers: providersState,
+    overrides,
+  });
 
   return {
     info,
@@ -73,6 +97,10 @@ export function useShopEditorForm({
     handleChange,
     tokenRows,
     shippingProviders,
+    identity,
+    localization,
+    providers: providersState,
+    overrides,
     onSubmit,
   } as const;
 }


### PR DESCRIPTION
## Summary
- expose typed identity, localization, provider, and override sections from `useShopEditorForm` for upcoming settings components
- refactor `useShopEditorSubmit` to define the shared section interfaces and continue assembling the correct form payload

## Testing
- pnpm --filter @apps/cms exec jest --runInBand --coverage=false --testPathPattern "apps/cms/src/app/cms/shop/\\[shop\\]/settings/__tests__/useShopEditorForm.test.ts"


------
https://chatgpt.com/codex/tasks/task_e_68cad685f768832f89c8e6c9debcef83