### PR TITLE
Refactor ShopEditor into accordion card layout

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -7,6 +7,20 @@ jest.mock(
   "@/components/atoms/shadcn",
   () => {
     return {
+      Accordion: ({ items }: any) => (
+        <div>
+          {items.map((item: any, index: number) => (
+            <div key={index}>
+              <button type="button">{item.title}</button>
+              <div>{item.content}</div>
+            </div>
+          ))}
+        </div>
+      ),
+      Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      CardContent: ({ children, ...props }: any) => (
+        <div {...props}>{children}</div>
+      ),
       Button: ({ asChild, children, ...props }: any) => (
         <button {...props}>{children}</button>
       ),
@@ -53,7 +67,12 @@ describe("ShopEditor", () => {
       <ShopEditor shop="shop" initial={initial} initialTrackingProviders={[]} />,
     );
 
-    fireEvent.click(screen.getByText(/add mapping/i));
+    fireEvent.click(
+      screen.getByRole("button", { name: /filter mappings/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: /add mapping/i }),
+    );
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     expect(

--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -1,15 +1,24 @@
 // apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
 
 "use client";
-import { Button, Input } from "@/components/atoms/shadcn";
+import {
+  Accordion,
+  type AccordionItem,
+  Button,
+  Card,
+  CardContent,
+  Input,
+} from "@/components/atoms/shadcn";
 import type { Shop } from "@acme/types";
-import GeneralSettings from "./GeneralSettings";
-import SEOSettings from "./SEOSettings";
-import ThemeTokens from "./ThemeTokens";
+import { type ReactNode } from "react";
+
 import FilterMappings from "./FilterMappings";
+import LocaleOverrides from "./LocaleOverrides";
 import PriceOverrides from "./PriceOverrides";
 import ProviderSelect from "./ProviderSelect";
-import LocaleOverrides from "./LocaleOverrides";
+import SEOSettings from "./SEOSettings";
+import ThemeTokens from "./ThemeTokens";
+import GeneralSettings from "./GeneralSettings";
 import { useShopEditorForm } from "./useShopEditorForm";
 
 export { default as GeneralSettings } from "./GeneralSettings";
@@ -49,51 +58,150 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
     onSubmit,
   } = form;
 
+  const sections: SectionConfig[] = [
+    {
+      key: "general",
+      title: "General",
+      description: "Update the shop name, theme, and luxury feature toggles.",
+      render: () => (
+        <div className="grid gap-4 md:grid-cols-2">
+          <GeneralSettings
+            info={info}
+            setInfo={setInfo}
+            errors={errors}
+            handleChange={handleChange}
+          />
+        </div>
+      ),
+    },
+    {
+      key: "seo",
+      title: "SEO",
+      description: "Configure catalog filters for storefront metadata.",
+      render: () => <SEOSettings info={info} setInfo={setInfo} errors={errors} />,
+    },
+    {
+      key: "providers",
+      title: "Tracking providers",
+      description: "Manage analytics and fulfillment tracking integrations.",
+      render: () => (
+        <ProviderSelect
+          trackingProviders={trackingProviders}
+          setTrackingProviders={setTrackingProviders}
+          errors={errors}
+          shippingProviders={shippingProviders}
+        />
+      ),
+    },
+    {
+      key: "theme",
+      title: "Theme tokens",
+      description: "Compare overrides with defaults and reset individual tokens.",
+      render: () => (
+        <ThemeTokens shop={shop} tokenRows={tokenRows} info={info} errors={errors} />
+      ),
+    },
+    {
+      key: "filter-mappings",
+      title: "Filter mappings",
+      description: "Link storefront filters to upstream data keys.",
+      render: () => (
+        <FilterMappings
+          mappings={filterMappings}
+          addMapping={addFilterMapping}
+          updateMapping={updateFilterMapping}
+          removeMapping={removeFilterMapping}
+          errors={errors}
+        />
+      ),
+    },
+    {
+      key: "price-overrides",
+      title: "Price overrides",
+      description: "Adjust localized pricing for specific catalog entries.",
+      render: () => (
+        <PriceOverrides
+          overrides={priceOverrides}
+          addOverride={addPriceOverride}
+          updateOverride={updatePriceOverride}
+          removeOverride={removePriceOverride}
+          errors={errors}
+        />
+      ),
+    },
+    {
+      key: "locale-overrides",
+      title: "Locale overrides",
+      description: "Redirect locale content to custom destinations.",
+      render: () => (
+        <LocaleOverrides
+          overrides={localeOverrides}
+          addOverride={addLocaleOverride}
+          updateOverride={updateLocaleOverride}
+          removeOverride={removeLocaleOverride}
+          errors={errors}
+        />
+      ),
+    },
+  ];
+
+  const accordionItems: AccordionItem[] = sections.map(
+    ({ title, description, render, key }) => ({
+      title: <SectionHeader title={title} description={description} />,
+      content: (
+        <SectionCard dataSectionKey={key}>
+          {render()}
+        </SectionCard>
+      ),
+    }),
+  );
+
   return (
-    <form
-      onSubmit={onSubmit}
-      className="@container grid max-w-md gap-4 @sm:grid-cols-2"
-    >
+    <form onSubmit={onSubmit} className="space-y-6">
       <Input type="hidden" name="id" value={info.id} />
-      <GeneralSettings
-      info={info}
-      setInfo={setInfo}
-      errors={errors}
-      handleChange={handleChange}
-      />
-      <SEOSettings info={info} setInfo={setInfo} errors={errors} />
-      <ProviderSelect
-        trackingProviders={trackingProviders}
-        setTrackingProviders={setTrackingProviders}
-        errors={errors}
-        shippingProviders={shippingProviders}
-      />
-      <ThemeTokens shop={shop} tokenRows={tokenRows} info={info} errors={errors} />
-      <FilterMappings
-        mappings={filterMappings}
-        addMapping={addFilterMapping}
-        updateMapping={updateFilterMapping}
-        removeMapping={removeFilterMapping}
-        errors={errors}
-      />
-      <PriceOverrides
-        overrides={priceOverrides}
-        addOverride={addPriceOverride}
-        updateOverride={updatePriceOverride}
-        removeOverride={removePriceOverride}
-        errors={errors}
-      />
-      <LocaleOverrides
-        overrides={localeOverrides}
-        addOverride={addLocaleOverride}
-        updateOverride={updateLocaleOverride}
-        removeOverride={removeLocaleOverride}
-        errors={errors}
-      />
-      <Button className="bg-primary text-white" disabled={saving} type="submit">
-        {saving ? "Saving…" : "Save"}
-      </Button>
+      <Accordion items={accordionItems} />
+      <div className="flex justify-end">
+        <Button
+          className="h-10 px-6 text-sm font-semibold"
+          disabled={saving}
+          type="submit"
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
     </form>
+  );
+}
+
+interface SectionConfig {
+  key: string;
+  title: string;
+  description?: string;
+  render: () => ReactNode;
+}
+
+function SectionHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-sm font-semibold">{title}</span>
+      {description ? (
+        <span className="text-xs text-muted-foreground">{description}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function SectionCard({
+  children,
+  dataSectionKey,
+}: {
+  children: ReactNode;
+  dataSectionKey?: string;
+}) {
+  return (
+    <Card className="border border-border/60" data-section={dataSectionKey}>
+      <CardContent className="space-y-6 p-6">{children}</CardContent>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- render the shop editor sections inside an accordion backed card layout while keeping theme token hidden inputs intact
- add lightweight helpers for section headers/cards so the existing submit flow continues unchanged
- update the ShopEditor test to mock the new shadcn pieces and expand the filter mappings section before interacting

## Testing
- pnpm --filter @apps/cms exec jest apps/cms/__tests__/ShopEditor.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cad68a7aa8832f88665cfc57225eb5