### PR TITLE
Introduce accordion sections and toast handling in ShopEditor

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
@@ -14,7 +14,14 @@ jest.mock("@/hooks/useMappingRows", () => jest.fn((rows: any[]) => ({
 
 jest.mock("../useShopEditorSubmit", () => ({
   __esModule: true,
-  default: jest.fn(() => ({ saving: false, errors: {}, onSubmit: jest.fn() })),
+  default: jest.fn(() => ({
+    saving: false,
+    errors: {},
+    onSubmit: jest.fn(),
+    toast: { open: false, status: "success", message: "" },
+    toastClassName: "",
+    closeToast: jest.fn(),
+  })),
 }));
 
 describe("useShopEditorForm", () => {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
@@ -64,6 +64,9 @@ describe("useShopEditorSubmit", () => {
     expect(result.current.errors).toHaveProperty("filterMappings");
     expect(result.current.errors).toHaveProperty("priceOverrides");
     expect(result.current.errors).toHaveProperty("localeOverrides");
+    expect(result.current.toast.open).toBe(true);
+    expect(result.current.toast.status).toBe("error");
+    expect(result.current.toast.message).toBe("Please fix the highlighted errors.");
     const { updateShop } = require("@cms/actions/shops.server");
     expect(updateShop).not.toHaveBeenCalled();
   });

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/FilterMappingsSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/FilterMappingsSection.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { MappingRow } from "@/hooks/useMappingRows";
+
+import FilterMappings from "../FilterMappings";
+
+interface FilterMappingsSectionProps {
+  mappings: MappingRow[];
+  addMapping: () => void;
+  updateMapping: (index: number, field: "key" | "value", value: string) => void;
+  removeMapping: (index: number) => void;
+  errors: Record<string, string[]>;
+}
+
+export default function FilterMappingsSection({
+  mappings,
+  addMapping,
+  updateMapping,
+  removeMapping,
+  errors,
+}: FilterMappingsSectionProps) {
+  return (
+    <div className="space-y-4">
+      <FilterMappings
+        mappings={mappings}
+        addMapping={addMapping}
+        updateMapping={updateMapping}
+        removeMapping={removeMapping}
+        errors={errors}
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/GeneralSettingsSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/GeneralSettingsSection.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { ChangeEvent, Dispatch, SetStateAction } from "react";
+
+import type { Shop } from "@acme/types";
+
+import GeneralSettings from "../GeneralSettings";
+
+interface GeneralSettingsSectionProps {
+  info: Shop;
+  setInfo: Dispatch<SetStateAction<Shop>>;
+  errors: Record<string, string[]>;
+  handleChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function GeneralSettingsSection({
+  info,
+  setInfo,
+  errors,
+  handleChange,
+}: GeneralSettingsSectionProps) {
+  return (
+    <div className="space-y-6">
+      <GeneralSettings
+        info={info}
+        setInfo={setInfo}
+        errors={errors}
+        handleChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/OverridesSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/OverridesSection.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { MappingRow } from "@/hooks/useMappingRows";
+
+import LocaleOverrides from "../LocaleOverrides";
+import PriceOverrides from "../PriceOverrides";
+
+interface OverridesSectionProps {
+  priceOverrides: MappingRow[];
+  addPriceOverride: () => void;
+  updatePriceOverride: (index: number, field: "key" | "value", value: string) => void;
+  removePriceOverride: (index: number) => void;
+  priceErrors: Record<string, string[]>;
+  localeOverrides: MappingRow[];
+  addLocaleOverride: () => void;
+  updateLocaleOverride: (index: number, field: "key" | "value", value: string) => void;
+  removeLocaleOverride: (index: number) => void;
+  localeErrors: Record<string, string[]>;
+}
+
+export default function OverridesSection({
+  priceOverrides,
+  addPriceOverride,
+  updatePriceOverride,
+  removePriceOverride,
+  priceErrors,
+  localeOverrides,
+  addLocaleOverride,
+  updateLocaleOverride,
+  removeLocaleOverride,
+  localeErrors,
+}: OverridesSectionProps) {
+  return (
+    <div className="space-y-6">
+      <PriceOverrides
+        overrides={priceOverrides}
+        addOverride={addPriceOverride}
+        updateOverride={updatePriceOverride}
+        removeOverride={removePriceOverride}
+        errors={priceErrors}
+      />
+      <LocaleOverrides
+        overrides={localeOverrides}
+        addOverride={addLocaleOverride}
+        updateOverride={updateLocaleOverride}
+        removeOverride={removeLocaleOverride}
+        errors={localeErrors}
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/TrackingProvidersSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/TrackingProvidersSection.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+
+import type { Provider } from "@acme/configurator/providers";
+
+import ProviderSelect from "../ProviderSelect";
+
+interface TrackingProvidersSectionProps {
+  trackingProviders: string[];
+  setTrackingProviders: Dispatch<SetStateAction<string[]>>;
+  shippingProviders: Provider[];
+  errors: Record<string, string[]>;
+}
+
+export default function TrackingProvidersSection({
+  trackingProviders,
+  setTrackingProviders,
+  shippingProviders,
+  errors,
+}: TrackingProvidersSectionProps) {
+  return (
+    <div className="space-y-4">
+      <ProviderSelect
+        trackingProviders={trackingProviders}
+        setTrackingProviders={setTrackingProviders}
+        shippingProviders={shippingProviders}
+        errors={errors}
+      />
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/index.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/index.ts
@@ -1,0 +1,4 @@
+export { default as GeneralSettingsSection } from "./GeneralSettingsSection";
+export { default as TrackingProvidersSection } from "./TrackingProvidersSection";
+export { default as FilterMappingsSection } from "./FilterMappingsSection";
+export { default as OverridesSection } from "./OverridesSection";

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -30,14 +30,15 @@ export function useShopEditorForm({
   const priceOverrides = useMappingRows(initial.priceOverrides);
   const localeOverrides = useMappingRows(initial.localeOverrides);
 
-  const { saving, errors, onSubmit } = useShopEditorSubmit({
-    shop,
-    filterMappings: filterMappings as MappingRowsController,
-    priceOverrides: priceOverrides as MappingRowsController,
-    localeOverrides: localeOverrides as MappingRowsController,
-    setInfo,
-    setTrackingProviders,
-  });
+  const { saving, errors, onSubmit, toast, toastClassName, closeToast } =
+    useShopEditorSubmit({
+      shop,
+      filterMappings: filterMappings as MappingRowsController,
+      priceOverrides: priceOverrides as MappingRowsController,
+      localeOverrides: localeOverrides as MappingRowsController,
+      setInfo,
+      setTrackingProviders,
+    });
 
   const shippingProviders = providersByType("shipping");
 
@@ -74,6 +75,9 @@ export function useShopEditorForm({
     tokenRows,
     shippingProviders,
     onSubmit,
+    toast,
+    toastClassName,
+    closeToast,
   } as const;
 }
 

--- a/packages/ui/src/components/atoms/shadcn/accordion.tsx
+++ b/packages/ui/src/components/atoms/shadcn/accordion.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { createContext, useCallback, useContext, useId, useMemo, useState } from "react";
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "../../utils/style";
+
+interface AccordionContextValue {
+  type: "single" | "multiple";
+  collapsible: boolean;
+  openValues: string[];
+  toggle: (value: string) => void;
+}
+
+const AccordionContext = createContext<AccordionContextValue | undefined>(undefined);
+
+function useAccordionContext() {
+  const context = useContext(AccordionContext);
+  if (!context) {
+    throw new Error("Accordion components must be used within <Accordion>");
+  }
+  return context;
+}
+
+function toArray(value: string | string[] | undefined, type: "single" | "multiple") {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return type === "single" ? value.slice(0, 1) : value;
+  }
+  return [value];
+}
+
+export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+  type?: "single" | "multiple";
+  defaultValue?: string | string[];
+  collapsible?: boolean;
+  children: ReactNode;
+}
+
+export function Accordion({
+  type = "multiple",
+  defaultValue,
+  collapsible = true,
+  className,
+  children,
+  ...props
+}: AccordionProps) {
+  const [openValues, setOpenValues] = useState<string[]>(() =>
+    toArray(defaultValue, type),
+  );
+
+  const toggle = useCallback(
+    (value: string) => {
+      setOpenValues((previous) => {
+        const isActive = previous.includes(value);
+        if (type === "single") {
+          if (isActive) {
+            return collapsible ? [] : previous;
+          }
+          return [value];
+        }
+        if (isActive) {
+          return previous.filter((item) => item !== value);
+        }
+        return [...previous, value];
+      });
+    },
+    [collapsible, type],
+  );
+
+  const contextValue = useMemo(
+    () => ({ type, collapsible, openValues, toggle }),
+    [type, collapsible, openValues, toggle],
+  );
+
+  return (
+    <AccordionContext.Provider value={contextValue}>
+      <div className={cn("divide-y rounded-lg border", className)} {...props}>
+        {children}
+      </div>
+    </AccordionContext.Provider>
+  );
+}
+
+interface AccordionItemContextValue {
+  value: string;
+  isOpen: boolean;
+  triggerId: string;
+  contentId: string;
+}
+
+const AccordionItemContext = createContext<AccordionItemContextValue | undefined>(
+  undefined,
+);
+
+function useAccordionItemContext() {
+  const context = useContext(AccordionItemContext);
+  if (!context) {
+    throw new Error("Accordion components must be rendered inside <AccordionItem>");
+  }
+  return context;
+}
+
+export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+export function AccordionItem({ value, className, children, ...props }: AccordionItemProps) {
+  const { openValues } = useAccordionContext();
+  const isOpen = openValues.includes(value);
+  const id = useId();
+  const triggerId = `${id}-trigger`;
+  const contentId = `${id}-content`;
+
+  const itemContext = useMemo(
+    () => ({ value, isOpen, triggerId, contentId }),
+    [value, isOpen, triggerId, contentId],
+  );
+
+  return (
+    <AccordionItemContext.Provider value={itemContext}>
+      <div
+        data-state={isOpen ? "open" : "collapsed"}
+        className={cn("border-b last:border-b-0", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+}
+
+export interface AccordionTriggerProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function AccordionTrigger({ className, children, ...props }: AccordionTriggerProps) {
+  const { toggle } = useAccordionContext();
+  const { value, isOpen, contentId, triggerId } = useAccordionItemContext();
+
+  return (
+    <button
+      type="button"
+      id={triggerId}
+      aria-controls={contentId}
+      aria-expanded={isOpen}
+      data-state={isOpen ? "open" : "collapsed"}
+      onClick={() => toggle(value)}
+      className={cn(
+        "flex w-full items-center justify-between px-4 py-4 text-left text-sm font-medium transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props}
+    >
+      <span>{children}</span>
+      <span aria-hidden className="ml-2 text-lg leading-none">
+        {isOpen ? "−" : "+"}
+      </span>
+    </button>
+  );
+}
+
+export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function AccordionContent({ className, children, ...props }: AccordionContentProps) {
+  const { isOpen, contentId, triggerId } = useAccordionItemContext();
+
+  return (
+    <div
+      id={contentId}
+      role="region"
+      aria-labelledby={triggerId}
+      hidden={!isOpen}
+      data-state={isOpen ? "open" : "collapsed"}
+      className={cn("px-4 pb-6 pt-0", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/atoms/shadcn/index.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.ts
@@ -49,6 +49,19 @@ export {
 } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";
+export {
+  Accordion,
+  type AccordionProps,
+  AccordionItem,
+  type AccordionItemProps,
+  AccordionTrigger,
+  type AccordionTriggerProps,
+  AccordionContent,
+  type AccordionContentProps,
+} from "./accordion";
+export {
+  Accordion as LegacyAccordion,
+  type AccordionItem as LegacyAccordionItem,
+} from "../../molecules/Accordion";
 export { Progress, type ProgressProps } from "../Progress";
 export { Tag, type TagProps } from "../Tag";

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -3,7 +3,7 @@
 
 import type { PageComponent } from "@acme/types";
 import { memo } from "react";
-import { Accordion } from "../../atoms/shadcn";
+import { LegacyAccordion } from "../../atoms/shadcn";
 import LayoutPanel from "./panels/LayoutPanel";
 import ContentPanel from "./panels/ContentPanel";
 import InteractionsPanel from "./panels/InteractionsPanel";
@@ -41,7 +41,7 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
   if (!component) return null;
 
   return (
-    <Accordion
+    <LegacyAccordion
       items={[
         {
           title: "Layout",


### PR DESCRIPTION
## Summary
- restructure the shop editor to render the new section components inside a collapsible accordion and surface toast feedback
- expose toast metadata from the submit/form hooks so validation chips and notifications wire through each section
- add shadcn accordion primitives while retaining a legacy wrapper for existing consumers

## Testing
- CI=1 pnpm --filter @apps/cms exec jest --runInBand --config jest.config.cjs --coverage=false --runTestsByPath src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cad69f0554832fa764e571da49fb90