### PR TITLE
refactor: add settings save form hook

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/DepositsEditor.tsx
@@ -9,7 +9,7 @@ import { updateDeposit } from "@cms/actions/shops.server";
 
 import { ErrorChips } from "../components/ErrorChips";
 import { ServiceToggleField } from "../components/ServiceToggleField";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 type DepositState = {
   enabled: boolean;
@@ -30,7 +30,7 @@ export default function DepositsEditor({ shop, initial }: Props) {
   });
 
   const { saving, errors, handleSubmit, toast, toastClassName, closeToast } =
-    useServiceEditorForm<DepositResult>({
+    useSettingsSaveForm<DepositResult>({
       action: (formData) => updateDeposit(shop, formData),
       successMessage: "Deposit service updated.",
       errorMessage: "Unable to update deposit service.",

--- a/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/MaintenanceSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/MaintenanceSchedulerEditor.tsx
@@ -8,7 +8,7 @@ import { FormField } from "@ui/components/molecules";
 import { updateMaintenanceSchedule } from "@cms/actions/maintenance.server";
 
 import { ErrorChips } from "../components/ErrorChips";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 export default function MaintenanceSchedulerEditor() {
   const [frequency, setFrequency] = useState("");
@@ -22,13 +22,13 @@ export default function MaintenanceSchedulerEditor() {
     toastClassName,
     closeToast,
     announceError,
-  } = useServiceEditorForm<void>({
+  } = useSettingsSaveForm<void>({
     action: async (formData) => {
       await updateMaintenanceSchedule(formData);
     },
     successMessage: "Maintenance scan schedule updated.",
     errorMessage: "Unable to update maintenance scan schedule.",
-    extractErrors: () => undefined,
+    normalizeErrors: () => undefined,
   });
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/PremierDeliveryEditor.tsx
@@ -9,7 +9,7 @@ import { updatePremierDelivery } from "@cms/actions/shops.server";
 
 import { ErrorChips } from "../components/ErrorChips";
 import { StringCollectionField } from "../components/StringCollectionField";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 type PremierDeliveryState = {
   serviceLabel: string;
@@ -56,7 +56,7 @@ export default function PremierDeliveryEditor({ shop, initial }: Props) {
     toast,
     toastClassName,
     closeToast,
-  } = useServiceEditorForm<PremierDeliveryResult>({
+  } = useSettingsSaveForm<PremierDeliveryResult>({
     action: (formData) => updatePremierDelivery(shop, formData),
     successMessage: "Premier delivery settings saved.",
     errorMessage: "Unable to update premier delivery settings.",

--- a/apps/cms/src/app/cms/shop/[shop]/settings/returns/ReturnsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/returns/ReturnsEditor.tsx
@@ -7,7 +7,7 @@ import { Button, Card, CardContent } from "@/components/atoms/shadcn";
 import { updateUpsReturns } from "@cms/actions/shops.server";
 
 import { ServiceToggleField } from "../components/ServiceToggleField";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 type ReturnsState = {
   upsEnabled: boolean;
@@ -26,7 +26,7 @@ export default function ReturnsEditor({ shop, initial }: Props) {
   const [state, setState] = useState<ReturnsState>(initial);
 
   const { saving, errors, handleSubmit, toast, toastClassName, closeToast } =
-    useServiceEditorForm<ReturnsResult>({
+    useSettingsSaveForm<ReturnsResult>({
       action: (formData) => updateUpsReturns(shop, formData),
       successMessage: "Return options updated.",
       errorMessage: "Unable to update return options.",

--- a/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/ReverseLogisticsEditor.tsx
@@ -9,7 +9,7 @@ import { updateReverseLogistics } from "@cms/actions/shops.server";
 
 import { ErrorChips } from "../components/ErrorChips";
 import { ServiceToggleField } from "../components/ServiceToggleField";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 type ReverseLogisticsState = {
   enabled: boolean;
@@ -30,7 +30,7 @@ export default function ReverseLogisticsEditor({ shop, initial }: Props) {
   });
 
   const { saving, errors, handleSubmit, toast, toastClassName, closeToast } =
-    useServiceEditorForm<ReverseLogisticsResult>({
+    useSettingsSaveForm<ReverseLogisticsResult>({
       action: (formData) => updateReverseLogistics(shop, formData),
       successMessage: "Reverse logistics updated.",
       errorMessage: "Unable to update reverse logistics settings.",

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/StockAlertsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/StockAlertsEditor.tsx
@@ -8,7 +8,7 @@ import { FormField } from "@ui/components/molecules";
 import { updateStockAlert } from "@cms/actions/shops.server";
 
 import { ErrorChips } from "../components/ErrorChips";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 type StockAlertState = {
   recipients: string;
@@ -31,7 +31,7 @@ export default function StockAlertsEditor({ shop, initial }: Props) {
   });
 
   const { saving, errors, handleSubmit, toast, toastClassName, closeToast } =
-    useServiceEditorForm<StockAlertResult>({
+    useSettingsSaveForm<StockAlertResult>({
       action: (formData) => updateStockAlert(shop, formData),
       successMessage: "Stock alert settings saved.",
       errorMessage: "Unable to update stock alerts.",

--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
@@ -13,7 +13,7 @@ import {
   schedulerHistoryColumns,
 } from "../tableMappers";
 import { ErrorChips } from "../components/ErrorChips";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 interface HistoryEntry {
   timestamp: number;
@@ -42,14 +42,14 @@ export default function StockSchedulerEditor({ shop, status }: Props) {
     toastClassName,
     closeToast,
     announceError,
-  } = useServiceEditorForm<void>({
-    action: async (formData) => {
-      await updateStockScheduler(shop, formData);
-    },
-    successMessage: "Stock scheduler updated.",
-    errorMessage: "Unable to update stock scheduler.",
-    extractErrors: () => undefined,
-  });
+    } = useSettingsSaveForm<void>({
+      action: async (formData) => {
+        await updateStockScheduler(shop, formData);
+      },
+      successMessage: "Stock scheduler updated.",
+      errorMessage: "Unable to update stock scheduler.",
+      normalizeErrors: () => undefined,
+    });
 
   const handleIntervalChange = (event: ChangeEvent<HTMLInputElement>) => {
     setInterval(event.target.value);


### PR DESCRIPTION
## Summary
- add a reusable `useSettingsSaveForm` hook for CMS settings editors with toast helpers and optional error normalization
- swap the service editor components in the CMS settings area to consume the new hook

## Testing
- pnpm install
- pnpm -r build *(fails: @acme/ui build -> missing TagProps export)*
- pnpm --filter @acme/ui build *(fails: Module '../../../atoms' has no exported member 'TagProps')*


------
https://chatgpt.com/codex/tasks/task_e_68cad6a5bf8c832fb450e5260758a0b3