### PR TITLE
feat(cms): expose shop editor select options and handlers

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -1,14 +1,50 @@
 // apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
 "use client";
 
-import { useMemo, useState, ChangeEvent } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
 import { providersByType } from "@acme/configurator/providers";
-import type { Shop } from "@acme/types";
+import { LOCALES, type Shop } from "@acme/types";
 import useMappingRows from "@/hooks/useMappingRows";
 import useShopEditorSubmit, {
   type MappingRowsController,
 } from "./useShopEditorSubmit";
 import { mapThemeTokenRows } from "./tableMappers";
+
+export interface SelectOption {
+  label: string;
+  value: string;
+}
+
+export type MappingControllerKey =
+  | "filterMappings"
+  | "priceOverrides"
+  | "localeOverrides";
+
+const setValueAtPath = <T extends Record<string, unknown>>(
+  source: T,
+  [head, ...rest]: string[],
+  value: unknown,
+): T => {
+  if (!head) {
+    return source;
+  }
+
+  if (rest.length === 0) {
+    return {
+      ...source,
+      [head]: value,
+    } as T;
+  }
+
+  const current = source[head];
+  const nextSource =
+    current && typeof current === "object" ? (current as Record<string, unknown>) : {};
+
+  return {
+    ...source,
+    [head]: setValueAtPath(nextSource, rest, value),
+  } as T;
+};
 
 interface HookArgs {
   shop: string;
@@ -39,17 +75,87 @@ export function useShopEditorForm({
     setTrackingProviders,
   });
 
-  const shippingProviders = providersByType("shipping");
+  const shippingProviders = useMemo(
+    () => providersByType("shipping"),
+    [],
+  );
+
+  const shippingProviderOptions = useMemo<SelectOption[]>(
+    () =>
+      shippingProviders.map((provider) => ({
+        label: provider.name,
+        value: provider.id,
+      })),
+    [shippingProviders],
+  );
+
+  const localeOptions = useMemo<SelectOption[]>(
+    () =>
+      LOCALES.map((locale) => ({
+        label: locale.toUpperCase(),
+        value: locale,
+      })),
+    [],
+  );
 
   const tokenRows = useMemo(
     () => mapThemeTokenRows(info.themeDefaults ?? {}, info.themeOverrides ?? {}),
     [info.themeDefaults, info.themeOverrides],
   );
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setInfo((prev) => ({ ...prev, [name]: value }));
-  };
+  const updateInfoField = useCallback(
+    (path: string, value: unknown) => {
+      const segments = path.split(".");
+      setInfo((prev) => setValueAtPath(prev, segments, value));
+    },
+    [],
+  );
+
+  const handleTextChange = useCallback(
+    (name: string, value: string) => {
+      updateInfoField(name, value);
+    },
+    [updateInfoField],
+  );
+
+  const handleCheckboxChange = useCallback(
+    (name: string, checked: boolean | "indeterminate") => {
+      updateInfoField(name, Boolean(checked));
+    },
+    [updateInfoField],
+  );
+
+  const handleMappingChange = useCallback(
+    (
+      controller: MappingControllerKey,
+      index: number,
+      field: "key" | "value",
+      value: string,
+    ) => {
+      if (controller === "filterMappings") {
+        filterMappings.update(index, field, value);
+        return;
+      }
+      if (controller === "priceOverrides") {
+        priceOverrides.update(index, field, value);
+        return;
+      }
+      localeOverrides.update(index, field, value);
+    },
+    [filterMappings, priceOverrides, localeOverrides],
+  );
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const { name, value, type, checked } = e.target;
+      if (type === "checkbox") {
+        handleCheckboxChange(name, checked);
+      } else {
+        handleTextChange(name, value);
+      }
+    },
+    [handleCheckboxChange, handleTextChange],
+  );
 
   return {
     info,
@@ -71,8 +177,13 @@ export function useShopEditorForm({
     updateLocaleOverride: localeOverrides.update,
     removeLocaleOverride: localeOverrides.remove,
     handleChange,
+    handleTextChange,
+    handleCheckboxChange,
+    handleMappingChange,
     tokenRows,
     shippingProviders,
+    shippingProviderOptions,
+    localeOptions,
     onSubmit,
   } as const;
 }


### PR DESCRIPTION
## Summary
- derive shipping provider and locale select option lists alongside new text, checkbox, and mapping handlers for the shop editor form hook
- memoize provider lookups and centralize nested info updates so downstream sections can stay stateless
- extend the shop editor form hook tests to cover the new option arrays and handler behaviors

## Testing
- pnpm --filter @apps/cms exec jest --coverage=false --runTestsByPath 'src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts'

------
https://chatgpt.com/codex/tasks/task_e_68cad69d88b0832f80c623732a0090bf