### PR TITLE
Expand MediaFileItem tests for accessibility and overlays

### DIFF
--- a/packages/ui/src/components/cms/__tests__/MediaFileItem.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/MediaFileItem.test.tsx
@@ -12,6 +12,16 @@ describe("MediaFileItem", () => {
     size: 12_288,
   };
 
+  const createDeferred = <T,>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+
   beforeEach(() => {
     // @ts-expect-error — tests control fetch
     global.fetch = jest.fn();
@@ -38,6 +48,69 @@ describe("MediaFileItem", () => {
     await user.click(deleteItem);
 
     expect(onDelete).toHaveBeenCalledWith(baseItem.url);
+  });
+
+  it("provides accessible controls for the media actions dropdown", async () => {
+    const user = userEvent.setup();
+    render(
+      <MediaFileItem
+        item={baseItem}
+        shop="shop"
+        onDelete={jest.fn()}
+        onReplace={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: /media actions/i });
+    expect(trigger).not.toHaveAttribute("aria-expanded", "true");
+
+    await user.click(trigger);
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "true"));
+
+    const pointerMenu = await screen.findByRole("menu");
+    const pointerItems = within(pointerMenu).getAllByRole("menuitem");
+    expect(pointerItems).toHaveLength(3);
+    expect(
+      within(pointerMenu).getByRole("menuitem", { name: /view details/i })
+    ).toBeInTheDocument();
+    expect(
+      within(pointerMenu).getByRole("menuitem", { name: /replace/i })
+    ).toBeInTheDocument();
+    expect(
+      within(pointerMenu).getByRole("menuitem", { name: /delete/i })
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "false"));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "true"));
+
+    const keyboardMenu = await screen.findByRole("menu");
+    const keyboardItems = within(keyboardMenu).getAllByRole("menuitem");
+    await waitFor(() => expect(keyboardItems[0]).toHaveFocus());
+
+    await user.keyboard("{ArrowDown}");
+    expect(keyboardItems[1]).toHaveFocus();
+    await user.keyboard("{ArrowDown}");
+    expect(keyboardItems[2]).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "false"));
+
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+    await user.keyboard("{Space}");
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "true"));
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "false"));
   });
 
   it("uploads a replacement file and forwards callbacks", async () => {
@@ -84,6 +157,62 @@ describe("MediaFileItem", () => {
     jest.useRealTimers();
   });
 
+  it("shows upload progress while replacing media", async () => {
+    jest.useFakeTimers();
+    const onDelete = jest.fn();
+    const onReplace = jest.fn();
+    const deferred = createDeferred<Response>();
+    const replacement = { url: "http://example.com/new.jpg", type: "image" };
+    (global.fetch as jest.Mock).mockReturnValue(deferred.promise);
+
+    const { container } = render(
+      <MediaFileItem
+        item={baseItem}
+        shop="shop"
+        onDelete={onDelete}
+        onReplace={onReplace}
+        onReplaceSuccess={jest.fn()}
+      />
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+
+    act(() => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    expect(await screen.findByText("4%"))
+      .toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(await screen.findByText("10%"))
+      .toBeInTheDocument();
+
+    await act(async () => {
+      deferred.resolve(
+        new Response(JSON.stringify(replacement), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+    });
+
+    expect(await screen.findByText("100%"))
+      .toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText(/replacing asset/i)).not.toBeInTheDocument()
+    );
+
+    jest.useRealTimers();
+  });
+
   it("notifies replace errors when the upload fails", async () => {
     jest.useFakeTimers();
     const onReplaceError = jest.fn();
@@ -115,15 +244,24 @@ describe("MediaFileItem", () => {
       expect(onReplaceError).toHaveBeenCalledWith("Failed to upload replacement")
     );
 
+    expect(screen.getByText(/replacing asset/i)).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to upload replacement")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /media actions/i })
+    ).toBeDisabled();
+
     act(() => {
       jest.runAllTimers();
     });
     jest.useRealTimers();
   });
 
-  it("renders multi-select controls and notifies when toggled", () => {
+  it("renders multi-select controls with accessible labels and toggles selection state", async () => {
+    const user = userEvent.setup();
     const onBulkToggle = jest.fn();
-    render(
+    const { rerender } = render(
       <MediaFileItem
         item={baseItem}
         shop="shop"
@@ -135,10 +273,29 @@ describe("MediaFileItem", () => {
       />
     );
 
-    const checkbox = screen.getByRole("checkbox");
-    fireEvent.click(checkbox);
+    const checkbox = screen.getByRole("checkbox", { name: "Select media" });
+    await user.click(checkbox);
 
-    expect(onBulkToggle).toHaveBeenCalledWith(baseItem, true);
+    expect(onBulkToggle).toHaveBeenNthCalledWith(1, baseItem, true);
+
+    rerender(
+      <MediaFileItem
+        item={baseItem}
+        shop="shop"
+        onDelete={jest.fn()}
+        onReplace={jest.fn()}
+        selectionEnabled
+        selected
+        onBulkToggle={onBulkToggle}
+      />
+    );
+
+    const deselectCheckbox = screen.getByRole("checkbox", {
+      name: "Deselect media",
+    });
+    await user.click(deselectCheckbox);
+
+    expect(onBulkToggle).toHaveBeenNthCalledWith(2, baseItem, false);
   });
 
   it("calls onSelect when the overlay button is pressed", () => {
@@ -210,27 +367,66 @@ describe("MediaFileItem", () => {
     expect(within(openDetailsButton).getByText(/replacing media/i)).toBeInTheDocument();
   });
 
-  it("renders a deleting overlay and disables selection", () => {
+  it("renders a deleting overlay and disables interactions", () => {
     const onSelect = jest.fn();
-    render(
+    const { container } = render(
       <MediaFileItem
         item={baseItem}
         shop="shop"
         onDelete={jest.fn()}
         onReplace={jest.fn()}
         onSelect={onSelect}
+        selectionEnabled
         deleting
       />
     );
 
     expect(screen.getByText(/deleting asset/i)).toBeInTheDocument();
-    const selectButton = screen.getByLabelText("Select media");
-    const openDetailsButton = screen.getByLabelText("Open details");
+    const mediaActions = screen.getByRole("button", { name: /media actions/i });
+    expect(mediaActions).toBeDisabled();
+    const selectButton = screen.getByRole("button", { name: "Select media" });
+    const openDetailsButton = screen.getByRole("button", { name: "Open details" });
+    const checkbox = screen.getByRole("checkbox", { name: "Select media" });
     expect(selectButton).toBeDisabled();
     expect(openDetailsButton).toBeDisabled();
+    expect(checkbox).toBeDisabled();
     expect(within(openDetailsButton).getByText(/deleting media/i)).toBeInTheDocument();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeDisabled();
     fireEvent.click(selectButton);
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("locks controls when replacement is reported externally", () => {
+    const { container } = render(
+      <MediaFileItem
+        item={{
+          ...baseItem,
+          status: "replacing",
+          replaceProgress: 45,
+        }}
+        shop="shop"
+        onDelete={jest.fn()}
+        onReplace={jest.fn()}
+        onSelect={jest.fn()}
+        selectionEnabled
+        selected
+      />
+    );
+
+    expect(screen.getByText(/replacing asset/i)).toBeInTheDocument();
+    expect(screen.getByText("45%"))
+      .toBeInTheDocument();
+    const mediaActions = screen.getByRole("button", { name: /media actions/i });
+    expect(mediaActions).toBeDisabled();
+    const selectButton = screen.getByRole("button", { name: "Select media" });
+    const openDetailsButton = screen.getByRole("button", { name: "Open details" });
+    const checkbox = screen.getByRole("checkbox", { name: "Deselect media" });
+    expect(selectButton).toBeDisabled();
+    expect(openDetailsButton).toBeDisabled();
+    expect(checkbox).toBeDisabled();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeDisabled();
   });
 
   it("renders tags and file size badges", () => {

--- a/test/__mocks__/@radix-ui/react-dropdown-menu.tsx
+++ b/test/__mocks__/@radix-ui/react-dropdown-menu.tsx
@@ -1,57 +1,266 @@
 import * as React from "react";
 
-type AnyProps = React.HTMLAttributes<HTMLElement> & { [key: string]: unknown };
+type DropdownMenuContextValue = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
-type Primitive = React.ForwardRefExoticComponent<AnyProps & React.RefAttributes<HTMLElement>>;
+const DropdownMenuContext = React.createContext<DropdownMenuContextValue | null>(null);
 
-function createPrimitive(displayName: string): Primitive {
-  return React.forwardRef<HTMLElement, AnyProps>(function Primitive(
-    { children, ...props },
-    ref
-  ) {
-    return (
-      <div ref={ref} data-radix-mock={displayName} {...props}>
-        {children}
-      </div>
-    );
-  });
-}
+type RootProps = React.HTMLAttributes<HTMLDivElement> & {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
 
-export const Root = createPrimitive("Root");
-export const Trigger = createPrimitive("Trigger");
-export const Group = createPrimitive("Group");
-export const Sub = createPrimitive("Sub");
-export const Portal = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
-export const RadioGroup = createPrimitive("RadioGroup");
-export const SubTrigger = createPrimitive("SubTrigger");
-export const SubContent = createPrimitive("SubContent");
-export const Content = createPrimitive("Content");
-const ItemPrimitive = React.forwardRef<HTMLElement, AnyProps>(function Item(
-  { children, onSelect, onClick, ...props },
+export const Root = React.forwardRef<HTMLDivElement, RootProps>(function Root(
+  { children, open: controlledOpen, defaultOpen = false, onOpenChange, ...props },
   ref
 ) {
+  const isControlled = controlledOpen != null;
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const open = isControlled ? Boolean(controlledOpen) : uncontrolledOpen;
+
+  const setOpen = React.useCallback<DropdownMenuContextValue["setOpen"]>(
+    (value) => {
+      const next =
+        typeof value === "function" ? (value as (prev: boolean) => boolean)(open) : value;
+      if (!isControlled) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange, open]
+  );
+
+  const context = React.useMemo<DropdownMenuContextValue>(() => ({ open, setOpen }), [open, setOpen]);
+
+  return (
+    <DropdownMenuContext.Provider value={context}>
+      <div ref={ref} data-radix-mock="Root" {...props}>
+        {children}
+      </div>
+    </DropdownMenuContext.Provider>
+  );
+});
+
+type TriggerProps = React.HTMLAttributes<HTMLElement> & {
+  asChild?: boolean;
+};
+
+const focusFirstItem = (container: HTMLElement | null) => {
+  const first = container?.querySelector<HTMLElement>("[role='menuitem']");
+  first?.focus();
+};
+
+const mergeClassNames = (
+  ...values: Array<string | undefined>
+): string | undefined => {
+  return values.filter(Boolean).join(" ") || undefined;
+};
+
+export const Trigger = React.forwardRef<HTMLElement, TriggerProps>(function Trigger(
+  { children, asChild: _asChild, onClick, onKeyDown, className, ...props },
+  ref
+) {
+  const context = React.useContext(DropdownMenuContext);
+  const open = context?.open ?? false;
+  const setOpen = context?.setOpen;
+
+  const childProps = React.isValidElement(children) ? children.props : {};
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    (childProps.onClick as ((event: React.MouseEvent<HTMLElement>) => void) | undefined)?.(event);
+    onClick?.(event);
+    if (!event.defaultPrevented && event.detail !== 0) {
+      setOpen?.((prev) => !prev);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    (childProps.onKeyDown as ((event: React.KeyboardEvent<HTMLElement>) => void) | undefined)?.(event);
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    if (event.key === "Enter" || event.key === " " || event.key === "Space" || event.key === "Spacebar") {
+      event.preventDefault();
+      setOpen?.(true);
+    } else if (event.key === "Escape") {
+      setOpen?.(false);
+    }
+  };
+
+  const sharedProps = {
+    ...props,
+    className: mergeClassNames(childProps.className, className),
+    "aria-haspopup": "menu" as const,
+    "aria-expanded": open ? "true" : "false",
+    onClick: handleClick,
+    onKeyDown: handleKeyDown,
+  };
+
+  if (React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...sharedProps,
+      ref,
+    });
+  }
+
+  return (
+    <button type="button" ref={ref as React.Ref<HTMLButtonElement>} {...sharedProps}>
+      {children}
+    </button>
+  );
+});
+
+const assignRef = <T,>(ref: React.Ref<T | null> | undefined, value: T | null) => {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    (ref as React.MutableRefObject<T>).current = value;
+  }
+};
+
+const focusSibling = (current: HTMLElement, direction: 1 | -1) => {
+  const container = current.closest("[data-radix-mock='Content']");
+  if (!container) return;
+  const items = Array.from(
+    container.querySelectorAll<HTMLElement>("[role='menuitem']:not([aria-disabled='true'])")
+  );
+  if (!items.length) return;
+  const index = items.indexOf(current);
+  const nextIndex = index === -1 ? 0 : (index + direction + items.length) % items.length;
+  items[nextIndex]?.focus();
+};
+
+type ContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  sideOffset?: number;
+};
+
+export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function Content(
+  { children, sideOffset: _sideOffset, onKeyDown, ...props },
+  ref
+) {
+  const context = React.useContext(DropdownMenuContext);
+  const open = context?.open ?? false;
+  const setOpen = context?.setOpen;
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      focusFirstItem(contentRef.current);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
   return (
     <div
-      ref={ref}
-      data-radix-mock="Item"
-      onClick={(event) => {
-        onSelect?.(event);
-        onClick?.(event);
-      }}
       {...props}
+      ref={(node) => {
+        contentRef.current = node;
+        assignRef(ref, node);
+      }}
+      role="menu"
+      data-radix-mock="Content"
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+        if (event.key === "Escape") {
+          setOpen?.(false);
+        }
+      }}
     >
       {children}
     </div>
   );
 });
 
-ItemPrimitive.displayName = "Item";
-export const Item = ItemPrimitive;
-export const CheckboxItem = createPrimitive("CheckboxItem");
-export const RadioItem = createPrimitive("RadioItem");
-export const ItemIndicator = createPrimitive("ItemIndicator");
-export const Label = createPrimitive("Label");
-export const Separator = createPrimitive("Separator");
+type ItemProps = React.HTMLAttributes<HTMLDivElement> & {
+  onSelect?: (event: Event) => void;
+  disabled?: boolean;
+};
+
+export const Item = React.forwardRef<HTMLDivElement, ItemProps>(function Item(
+  { children, onSelect, onClick, onKeyDown, disabled, ...props },
+  ref
+) {
+  const context = React.useContext(DropdownMenuContext);
+
+  const handleSelect = (event: React.SyntheticEvent<HTMLDivElement>) => {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+    onClick?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    onSelect?.(event.nativeEvent);
+    context?.setOpen(false);
+  };
+
+  return (
+    <div
+      {...props}
+      ref={ref}
+      data-radix-mock="Item"
+      role="menuitem"
+      tabIndex={-1}
+      aria-disabled={disabled ? "true" : undefined}
+      onClick={handleSelect}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          focusSibling(event.currentTarget, 1);
+        } else if (event.key === "ArrowUp") {
+          event.preventDefault();
+          focusSibling(event.currentTarget, -1);
+        } else if (
+          event.key === "Enter" ||
+          event.key === " " ||
+          event.key === "Space" ||
+          event.key === "Spacebar"
+        ) {
+          event.preventDefault();
+          handleSelect(event);
+        } else if (event.key === "Escape") {
+          context?.setOpen(false);
+        }
+      }}
+    >
+      {children}
+    </div>
+  );
+});
+
+const createPrimitive = <T extends HTMLElement>(displayName: string, role?: string) => {
+  return React.forwardRef<T, React.HTMLAttributes<T>>(function Primitive(
+    { children, ...props },
+    ref
+  ) {
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        data-radix-mock={displayName}
+        role={role}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  });
+};
+
+export const Group = createPrimitive<HTMLDivElement>("Group");
+export const Sub = createPrimitive<HTMLDivElement>("Sub");
+export const Portal = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+export const RadioGroup = createPrimitive<HTMLDivElement>("RadioGroup");
+export const SubTrigger = createPrimitive<HTMLDivElement>("SubTrigger");
+export const SubContent = createPrimitive<HTMLDivElement>("SubContent");
+export const CheckboxItem = createPrimitive<HTMLDivElement>("CheckboxItem");
+export const RadioItem = createPrimitive<HTMLDivElement>("RadioItem");
+export const ItemIndicator = createPrimitive<HTMLDivElement>("ItemIndicator");
+export const Label = createPrimitive<HTMLDivElement>("Label");
+export const Separator = createPrimitive<HTMLDivElement>("Separator", "separator");
 
 export default {
   Root,


### PR DESCRIPTION
## Summary
- add user-event driven coverage for the MediaFileItem dropdown, multi-select toggles, replacement progress, and overlay states
- enhance the Radix dropdown mock so aria attributes, focus movement, and keyboard controls are available in tests

## Testing
- pnpm exec jest --config jest.config.cjs packages/ui/src/components/cms/__tests__/MediaFileItem.test.tsx --runInBand --detectOpenHandles --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cad4fd9908832fb8084c5f769522ff