### PR TITLE
feat(ui): forward media replace callbacks

### DIFF
--- a/packages/ui/__tests__/Library.test.tsx
+++ b/packages/ui/__tests__/Library.test.tsx
@@ -47,6 +47,8 @@ test("filters files by search", () => {
       shop="s"
       onDelete={() => {}}
       onReplace={() => {}}
+      onReplaceSuccess={undefined}
+      onReplaceError={undefined}
     />
   );
   expect(screen.getAllByText("Delete")).toHaveLength(2);
@@ -57,6 +59,8 @@ test("filters files by search", () => {
 });
 
 test("derives selection helper from selectedUrl", () => {
+  const onReplaceSuccess = jest.fn();
+  const onReplaceError = jest.fn();
   render(
     <Library
       files={[
@@ -67,11 +71,15 @@ test("derives selection helper from selectedUrl", () => {
       onDelete={() => {}}
       onReplace={() => {}}
       selectedUrl="/dog.jpg"
+      onReplaceSuccess={onReplaceSuccess}
+      onReplaceError={onReplaceError}
     />
   );
 
   expect(mockMediaFileList).toHaveBeenCalledTimes(1);
   const props = mockMediaFileList.mock.calls[0][0];
+  expect(props.onReplaceSuccess).toBe(onReplaceSuccess);
+  expect(props.onReplaceError).toBe(onReplaceError);
   expect(props.isItemSelected).toBeInstanceOf(Function);
   expect(props.isItemSelected({ url: "/dog.jpg" })).toBe(true);
   expect(props.isItemSelected({ url: "/a.jpg" })).toBe(false);

--- a/packages/ui/src/components/cms/MediaFileList.d.ts
+++ b/packages/ui/src/components/cms/MediaFileList.d.ts
@@ -8,6 +8,8 @@ interface Props {
     shop: string;
     onDelete: (url: string) => void;
     onReplace: (oldUrl: string, item: MediaItem) => void;
+    onReplaceSuccess?: (item: MediaItem) => void;
+    onReplaceError?: (message: string) => void;
     onSelect?: (item: WithUrl | null) => void;
     onBulkToggle?: (item: WithUrl, selected: boolean) => void;
     selectionEnabled?: boolean;
@@ -15,5 +17,5 @@ interface Props {
     isDeleting?: (item: WithUrl) => boolean;
     isReplacing?: (item: WithUrl) => boolean;
 }
-export default function MediaFileList({ files, shop, onDelete, onReplace, onSelect, onBulkToggle, selectionEnabled, isItemSelected, isDeleting, isReplacing, }: Props): import("react/jsx-runtime").JSX.Element;
+export default function MediaFileList({ files, shop, onDelete, onReplace, onReplaceSuccess, onReplaceError, onSelect, onBulkToggle, selectionEnabled, isItemSelected, isDeleting, isReplacing, }: Props): import("react/jsx-runtime").JSX.Element;
 export {};

--- a/packages/ui/src/components/cms/MediaFileList.tsx
+++ b/packages/ui/src/components/cms/MediaFileList.tsx
@@ -12,6 +12,8 @@ interface Props {
   shop: string;
   onDelete: (url: string) => void;
   onReplace: (oldUrl: string, item: MediaItem) => void;
+  onReplaceSuccess?: (item: MediaItem) => void;
+  onReplaceError?: (message: string) => void;
   onSelect?: (item: WithUrl | null) => void;
   onBulkToggle?: (item: WithUrl, selected: boolean) => void;
   selectionEnabled?: boolean;
@@ -25,6 +27,8 @@ export default function MediaFileList({
   shop,
   onDelete,
   onReplace,
+  onReplaceSuccess,
+  onReplaceError,
   onSelect,
   onBulkToggle,
   selectionEnabled = false,
@@ -41,6 +45,8 @@ export default function MediaFileList({
           shop={shop}
           onDelete={onDelete}
           onReplace={onReplace}
+          onReplaceSuccess={onReplaceSuccess}
+          onReplaceError={onReplaceError}
           onSelect={onSelect}
           onBulkToggle={onBulkToggle}
           selectionEnabled={selectionEnabled}

--- a/packages/ui/src/components/cms/MediaManager.tsx
+++ b/packages/ui/src/components/cms/MediaManager.tsx
@@ -89,6 +89,18 @@ function MediaManagerBase({
     setSelectedUrl((prev) => (prev === oldUrl ? item.url : prev));
   }, []);
 
+  const handleReplaceSuccess = useCallback((item: MediaItem) => {
+    if (!hasUrl(item)) {
+      console.error("Replacement media item is missing a URL", item);
+      return;
+    }
+    setSelectedUrl(item.url);
+  }, []);
+
+  const handleReplaceError = useCallback((message: string) => {
+    console.error("Failed to replace media item", message);
+  }, []);
+
   const handleSelect = useCallback((item: MediaItemWithUrl | null) => {
     setSelectedUrl(item?.url ?? null);
   }, []);
@@ -139,6 +151,8 @@ function MediaManagerBase({
         shop={shop}
         onDelete={handleDelete}
         onReplace={handleReplace}
+        onReplaceSuccess={handleReplaceSuccess}
+        onReplaceError={handleReplaceError}
         onSelect={handleSelect}
       />
       {selectedItem ? (

--- a/packages/ui/src/components/cms/__tests__/media-manager.spec.tsx
+++ b/packages/ui/src/components/cms/__tests__/media-manager.spec.tsx
@@ -104,5 +104,38 @@ describe("MediaManager", () => {
     await waitFor(() => expect(libraryProps.files[0].url).toBe("1b"));
     expect(libraryProps.files[1].url).toBe("2");
   });
+
+  it("provides replace feedback callbacks", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <MediaManager
+        shop="s"
+        initialFiles={initialFiles}
+        onDelete={jest.fn()}
+        onMetadataUpdate={jest.fn()}
+      />
+    );
+
+    expect(typeof libraryProps.onReplaceSuccess).toBe("function");
+    expect(typeof libraryProps.onReplaceError).toBe("function");
+
+    act(() => {
+      libraryProps.onReplaceSuccess?.({ url: "3", type: "image" });
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      libraryProps.onReplaceSuccess?.({ type: "image" });
+    });
+    expect(errorSpy).toHaveBeenNthCalledWith(1, "Replacement media item is missing a URL", { type: "image" });
+
+    libraryProps.onReplaceError?.("something went wrong");
+    expect(errorSpy).toHaveBeenLastCalledWith(
+      "Failed to replace media item",
+      "something went wrong"
+    );
+
+    errorSpy.mockRestore();
+  });
 });
 

--- a/packages/ui/src/components/cms/media/Library.d.ts
+++ b/packages/ui/src/components/cms/media/Library.d.ts
@@ -8,6 +8,8 @@ interface LibraryProps {
     shop: string;
     onDelete: (url: string) => void;
     onReplace: (oldUrl: string, item: MediaItem) => void;
+    onReplaceSuccess?: (item: MediaItem) => void;
+    onReplaceError?: (message: string) => void;
     onSelect?: (item: WithUrl | null) => void;
     onBulkToggle?: (item: WithUrl, selected: boolean) => void;
     selectionEnabled?: boolean;
@@ -18,5 +20,5 @@ interface LibraryProps {
     emptyLibraryMessage?: string;
     emptyResultsMessage?: string;
 }
-export default function Library({ files, shop, onDelete, onReplace, onSelect, onBulkToggle, selectionEnabled, isItemSelected, selectedUrl, isDeleting, isReplacing, emptyLibraryMessage, emptyResultsMessage, }: LibraryProps): ReactElement;
+export default function Library({ files, shop, onDelete, onReplace, onReplaceSuccess, onReplaceError, onSelect, onBulkToggle, selectionEnabled, isItemSelected, selectedUrl, isDeleting, isReplacing, emptyLibraryMessage, emptyResultsMessage, }: LibraryProps): ReactElement;
 export {};

--- a/packages/ui/src/components/cms/media/Library.tsx
+++ b/packages/ui/src/components/cms/media/Library.tsx
@@ -21,6 +21,8 @@ interface LibraryProps {
   shop: string;
   onDelete: (url: string) => void;
   onReplace: (oldUrl: string, item: MediaItem) => void;
+  onReplaceSuccess?: (item: MediaItem) => void;
+  onReplaceError?: (message: string) => void;
   onSelect?: (item: WithUrl | null) => void;
   onBulkToggle?: (item: WithUrl, selected: boolean) => void;
   selectionEnabled?: boolean;
@@ -37,6 +39,8 @@ export default function Library({
   shop,
   onDelete,
   onReplace,
+  onReplaceSuccess,
+  onReplaceError,
   onSelect,
   onBulkToggle,
   selectionEnabled = false,
@@ -105,6 +109,8 @@ export default function Library({
           shop={shop}
           onDelete={onDelete}
           onReplace={onReplace}
+          onReplaceSuccess={onReplaceSuccess}
+          onReplaceError={onReplaceError}
           onSelect={onSelect}
           onBulkToggle={onBulkToggle}
           selectionEnabled={selectionEnabled}


### PR DESCRIPTION
## Summary
- extend the media library and file list components with optional replace success/error callbacks and update their declaration files
- forward the callbacks through MediaManager so consumers can react to replacement outcomes
- refresh unit tests to cover the new props and ensure MediaManager exposes the feedback handlers

## Testing
- pnpm exec jest --config jest.config.cjs --runTestsByPath packages/ui/__tests__/Library.test.tsx packages/ui/src/components/cms/__tests__/MediaFileList.test.tsx packages/ui/src/components/cms/__tests__/media-manager.spec.tsx --coverage=false --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cad6969bac832fb0233c7354f61a0f