### PR TITLE
Update premier delivery settings form handling

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/hooks/useSettingsSaveForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/hooks/useSettingsSaveForm.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import {
+  useServiceEditorForm,
+  type UseServiceEditorFormOptions,
+} from "./useServiceEditorForm";
+
+export function useSettingsSaveForm<TResult>(
+  options: UseServiceEditorFormOptions<TResult>,
+) {
+  const { closeToast, ...rest } = useServiceEditorForm(options);
+
+  return {
+    ...rest,
+    dismissToast: closeToast,
+  };
+}
+
+export type { ValidationErrors } from "./useServiceEditorForm";
+export type { UseServiceEditorFormOptions as UseSettingsSaveFormOptions } from "./useServiceEditorForm";
+
+export default useSettingsSaveForm;

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
@@ -12,13 +12,28 @@ const updatePremierDelivery = jest.fn();
 jest.mock("@cms/actions/shops.server", () => ({
   updatePremierDelivery: (...args: any[]) => updatePremierDelivery(...args),
 }));
+jest.mock("@/components/atoms", () => ({
+  Toast: ({ open, message, className, ...props }: any) =>
+    open ? (
+      <div role="status" className={className} {...props}>
+        {message}
+      </div>
+    ) : null,
+  Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
 jest.mock(
   "@/components/atoms/shadcn",
   () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-    Input: ({ name, "aria-label": ariaLabel, ...props }: any) => (
-      <input aria-label={ariaLabel ?? name} name={name} {...props} />
-    ),
+    Input: ({ name, id, "aria-label": ariaLabel, ...props }: any) => {
+      const inputProps: Record<string, unknown> = { id, name, ...props };
+      if (ariaLabel) {
+        inputProps["aria-label"] = ariaLabel;
+      }
+      return <input {...inputProps} />;
+    },
   }),
   { virtual: true },
 );
@@ -28,7 +43,7 @@ describe("PremierDeliveryEditor", () => {
     jest.clearAllMocks();
   });
 
-  it("submits regions and windows and displays validation errors", async () => {
+  it("submits sanitized form data and displays validation errors", async () => {
     updatePremierDelivery.mockResolvedValue({
       errors: { regions: ["Too few regions"] },
     });
@@ -40,22 +55,53 @@ describe("PremierDeliveryEditor", () => {
       />,
     );
 
-    const regionInput = screen.getAllByRole("textbox", { name: /regions/i })[0];
-    await userEvent.clear(regionInput);
-    await userEvent.type(regionInput, "Paris");
+    const serviceLabelInput = screen.getByLabelText(/service label/i);
+    await userEvent.clear(serviceLabelInput);
+    await userEvent.type(serviceLabelInput, " Premier Delivery Plus ");
 
-    const windowInput = screen.getAllByRole("textbox", { name: /windows/i })[0];
+    const surchargeInput = screen.getByLabelText(/surcharge/i);
+    await userEvent.clear(surchargeInput);
+    await userEvent.type(surchargeInput, "12");
+
+    const primaryRegionInput = screen.getAllByRole("textbox", { name: /regions/i })[0];
+    await userEvent.clear(primaryRegionInput);
+    await userEvent.type(primaryRegionInput, " Paris ");
+
+    await userEvent.click(screen.getByRole("button", { name: /add region/i }));
+    const regionsContainer = screen
+      .getByText("Regions")
+      .closest("div") as HTMLElement;
+    const extraRegionInput = within(regionsContainer).getAllByRole("textbox")[1];
+    await userEvent.type(extraRegionInput, "   ");
+
+    const windowInput = screen.getAllByRole("textbox", { name: /one-hour windows/i })[0];
     await userEvent.clear(windowInput);
     await userEvent.type(windowInput, "10-12");
 
+    const carrierInput = screen.getAllByRole("textbox", { name: /carriers/i })[0];
+    await userEvent.clear(carrierInput);
+    await userEvent.type(carrierInput, " Rapid Logistics  ");
+
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(updatePremierDelivery).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(updatePremierDelivery).toHaveBeenCalledTimes(1);
+    });
+
     const fd = updatePremierDelivery.mock.calls[0][1] as FormData;
+    expect(fd.get("serviceLabel")).toBe("Premier Delivery Plus");
+    expect(fd.get("surcharge")).toBe("12");
     expect(fd.getAll("regions")).toEqual(["Paris"]);
     expect(fd.getAll("windows")).toEqual(["10-12"]);
+    expect(fd.getAll("carriers")).toEqual(["Rapid Logistics"]);
 
-    expect(await screen.findByText("Too few regions")).toBeInTheDocument();
+    const errorToast = await screen.findByRole("status");
+    expect(errorToast).toHaveTextContent(
+      /Unable to update premier delivery settings\./,
+    );
+
+    const regionError = await screen.findByText("Too few regions");
+    expect(regionError).toHaveAttribute("data-token", "--color-danger");
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -73,31 +119,45 @@ describe("PremierDeliveryEditor", () => {
       />,
     );
 
-    const regionsFieldset = screen
+    const regionsContainer = screen
       .getByText("Regions")
-      .closest("fieldset") as HTMLElement;
-    const windowsFieldset = screen
-      .getByText("One-hour Windows")
-      .closest("fieldset") as HTMLElement;
+      .closest("div") as HTMLElement;
+    const windowsContainer = screen
+      .getByText(/One-hour windows/i)
+      .closest("div") as HTMLElement;
 
     await userEvent.click(screen.getByRole("button", { name: /add region/i }));
-    expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(2);
+    expect(within(regionsContainer).getAllByRole("textbox")).toHaveLength(2);
 
-    const regionInputs = within(regionsFieldset).getAllByRole("textbox");
+    const regionInputs = within(regionsContainer).getAllByRole("textbox");
     await userEvent.type(regionInputs[1], "Berlin");
-    await userEvent.click(within(regionsFieldset).getAllByRole("button", { name: /remove/i })[0]);
-    expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(1);
+    await userEvent.click(
+      within(regionsContainer).getAllByRole("button", { name: /remove/i })[0],
+    );
+    expect(within(regionsContainer).getAllByRole("textbox")).toHaveLength(1);
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const validationToast = await screen.findByRole("status");
+    expect(validationToast).toHaveTextContent(
+      /Unable to update premier delivery settings\./,
+    );
+
     expect(await screen.findByText("Invalid window")).toBeInTheDocument();
 
-    const windowInputs = within(windowsFieldset).getAllByRole("textbox");
+    const windowInputs = within(windowsContainer).getAllByRole("textbox");
     await userEvent.clear(windowInputs[0]);
     await userEvent.type(windowInputs[0], "11-12");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => {
       expect(screen.queryByText("Invalid window")).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /Premier delivery settings saved\./,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable `useSettingsSaveForm` hook that exposes the shared save flow with a dismiss handler
- switch `PremierDeliveryEditor` to the new hook and sanitize form data before submitting, trimming empty collection rows and passing the new fields to the action
- extend the tests with lightweight UI mocks to assert toast messaging, error chips, and the new form payload fields

## Testing
- pnpm --filter @apps/cms exec jest --config jest.config.cjs --runInBand --coverage=false --runTestsByPath src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cad6a6098c832f99a07017ec1b16ae