### PR TITLE
Use settings save hook for maintenance scheduler

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/hooks/useSettingsSaveForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/hooks/useSettingsSaveForm.ts
@@ -1,0 +1,7 @@
+export type {
+  ValidationErrors,
+  UseServiceEditorFormOptions as UseSettingsSaveFormOptions,
+} from "./useServiceEditorForm";
+
+export { useServiceEditorForm as useSettingsSaveForm } from "./useServiceEditorForm";
+export { useServiceEditorForm as default } from "./useServiceEditorForm";

--- a/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/MaintenanceSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/MaintenanceSchedulerEditor.tsx
@@ -8,7 +8,7 @@ import { FormField } from "@ui/components/molecules";
 import { updateMaintenanceSchedule } from "@cms/actions/maintenance.server";
 
 import { ErrorChips } from "../components/ErrorChips";
-import { useServiceEditorForm } from "../hooks/useServiceEditorForm";
+import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
 
 export default function MaintenanceSchedulerEditor() {
   const [frequency, setFrequency] = useState("");
@@ -22,7 +22,7 @@ export default function MaintenanceSchedulerEditor() {
     toastClassName,
     closeToast,
     announceError,
-  } = useServiceEditorForm<void>({
+  } = useSettingsSaveForm<void>({
     action: async (formData) => {
       await updateMaintenanceSchedule(formData);
     },

--- a/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 
@@ -12,9 +12,30 @@ const updateMaintenanceSchedule = jest.fn();
 jest.mock("@cms/actions/maintenance.server", () => ({
   updateMaintenanceSchedule: (...args: any[]) => updateMaintenanceSchedule(...args),
 }));
+jest.mock("@/components/atoms", () => ({
+  Toast: ({ open, message, ...props }: any) =>
+    open ? (
+      <div role="status" {...props}>
+        <span>{message}</span>
+      </div>
+    ) : null,
+}));
+jest.mock("../../components/ErrorChips", () => ({
+  ErrorChips: ({ errors }: { errors?: string[] }) => (
+    <>
+      {errors?.map((error, index) => (
+        <span key={`${error}-${index}`}>{error}</span>
+      ))}
+    </>
+  ),
+}));
 jest.mock(
   "@/components/atoms/shadcn",
   () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Input: (props: any) => <input {...props} />,
   }),
@@ -26,7 +47,7 @@ describe("MaintenanceSchedulerEditor", () => {
     jest.clearAllMocks();
   });
 
-  it("submits the configured frequency", async () => {
+  it("submits the configured frequency and announces success", async () => {
     updateMaintenanceSchedule.mockResolvedValue(undefined);
 
     const { container } = render(<MaintenanceSchedulerEditor />);
@@ -35,11 +56,35 @@ describe("MaintenanceSchedulerEditor", () => {
     await userEvent.type(input, "4500");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(updateMaintenanceSchedule).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(updateMaintenanceSchedule).toHaveBeenCalledTimes(1);
+    });
+    const toastMessage = await screen.findByText(
+      "Maintenance scan schedule updated.",
+    );
+    expect(toastMessage.closest("div")).toHaveAttribute("role", "status");
+
     const fd = updateMaintenanceSchedule.mock.calls[0][0] as FormData;
-    expect(fd.get("frequency")).toBe("4500");
+    expect(Number(fd.get("frequency"))).toBe(4500);
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it("shows validation feedback for invalid values", async () => {
+    render(<MaintenanceSchedulerEditor />);
+
+    const input = screen.getByRole("spinbutton");
+    await userEvent.type(input, "0");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(updateMaintenanceSchedule).not.toHaveBeenCalled();
+    const chip = await screen.findByText("Enter a frequency greater than zero.");
+    expect(chip).toBeInTheDocument();
+
+    const toastMessage = await screen.findByText(
+      "Frequency must be at least 1 millisecond.",
+    );
+    expect(toastMessage.closest("div")).toHaveAttribute("role", "status");
   });
 });


### PR DESCRIPTION
## Summary
- update the maintenance scheduler editor to use `useSettingsSaveForm`, keeping the card + FormField/ErrorChips layout and client-side frequency guard
- add a settings save form hook re-export alongside stubbing toast/error chip renderers in tests
- extend the maintenance scheduler tests to verify toast messaging, numeric FormData submission, and validation chip rendering

## Testing
- pnpm test:cms --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx --testNamePattern "(submits|shows)"

------
https://chatgpt.com/codex/tasks/task_e_68cad6ae9008832fb1c0bdbfc36bfb5a