### PR TITLE
feat: enrich CMS shop editor form options and handlers

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
@@ -1,8 +1,11 @@
 import { renderHook, act } from "@testing-library/react";
+import { providersByType } from "@acme/configurator/providers";
+import { LOCALES } from "@acme/types";
+import useMappingRows from "@/hooks/useMappingRows";
 import useShopEditorForm from "../useShopEditorForm";
 
 jest.mock("@acme/configurator/providers", () => ({
-  providersByType: jest.fn(() => []),
+  providersByType: jest.fn(),
 }));
 
 jest.mock("@/hooks/useMappingRows", () => jest.fn((rows: any[]) => ({
@@ -10,7 +13,8 @@ jest.mock("@/hooks/useMappingRows", () => jest.fn((rows: any[]) => ({
   add: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
-})));
+  setRows: jest.fn(),
+}))); 
 
 jest.mock("../useShopEditorSubmit", () => ({
   __esModule: true,
@@ -28,6 +32,32 @@ describe("useShopEditorForm", () => {
   };
   const initialTracking = ["ups"];
 
+  const providersByTypeMock = providersByType as jest.MockedFunction<
+    typeof providersByType
+  >;
+  const useMappingRowsMock = useMappingRows as jest.MockedFunction<
+    typeof useMappingRows
+  >;
+
+  beforeEach(() => {
+    providersByTypeMock.mockReturnValue([
+      { id: "ups", name: "UPS", type: "shipping" },
+      { id: "dhl", name: "DHL", type: "shipping" },
+    ] as any);
+
+    useMappingRowsMock.mockImplementation((rows: any[]) => ({
+      rows,
+      add: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      setRows: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("initial form state matches defaults", () => {
     const { result } = renderHook(() =>
       useShopEditorForm({
@@ -39,6 +69,14 @@ describe("useShopEditorForm", () => {
 
     expect(result.current.info).toEqual(initialShop);
     expect(result.current.trackingProviders).toEqual(initialTracking);
+    expect(result.current.shippingProviderOptions).toEqual([
+      { label: "UPS", value: "ups" },
+      { label: "DHL", value: "dhl" },
+    ]);
+    expect(result.current.localeOptions).toEqual(
+      LOCALES.map((locale) => ({ label: locale, value: locale })),
+    );
+    expect(result.current.supportedLocales).toEqual([...LOCALES]);
   });
 
   it("updateField modifies state", () => {
@@ -51,12 +89,48 @@ describe("useShopEditorForm", () => {
     );
 
     act(() => {
-      result.current.handleChange({
-        target: { name: "name", value: "New Shop" },
-      } as any);
+      result.current.handleTextChange("name", "New Shop");
     });
 
     expect(result.current.info.name).toBe("New Shop");
+  });
+
+  it("toggle handlers update luxury features", () => {
+    const { result } = renderHook(() =>
+      useShopEditorForm({
+        shop: "s1",
+        initial: initialShop,
+        initialTrackingProviders: initialTracking,
+      }),
+    );
+
+    act(() => {
+      result.current.handleCheckboxChange("blog", true);
+      result.current.handleLuxuryFeatureChange("fraudReviewThreshold", 10);
+    });
+
+    expect(result.current.info.luxuryFeatures.blog).toBe(true);
+    expect(result.current.info.luxuryFeatures.fraudReviewThreshold).toBe(10);
+  });
+
+  it("mapping change delegates to controllers", () => {
+    const { result } = renderHook(() =>
+      useShopEditorForm({
+        shop: "s1",
+        initial: initialShop,
+        initialTrackingProviders: initialTracking,
+      }),
+    );
+
+    const [filterController] = useMappingRowsMock.mock.results.map(
+      (entry) => entry.value,
+    );
+
+    act(() => {
+      result.current.handleMappingChange("filterMappings", 0, "key", "color");
+    });
+
+    expect(filterController.update).toHaveBeenCalledWith(0, "key", "color");
   });
 
   it("resetForm restores defaults", () => {
@@ -69,9 +143,7 @@ describe("useShopEditorForm", () => {
     );
 
     act(() => {
-      result.current.handleChange({
-        target: { name: "name", value: "New Shop" },
-      } as any);
+      result.current.handleTextChange("name", "New Shop");
       result.current.setTrackingProviders(["dhl"]);
     });
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorSubmit.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorSubmit.ts
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from "react";
 import type { ChangeEvent } from "react";
+import type { Provider } from "@acme/configurator/providers";
 import type { Shop } from "@acme/types";
 import { shopSchema } from "@cms/actions/schemas";
 import { updateShop } from "@cms/actions/shops.server";
@@ -14,19 +15,44 @@ export interface MappingRowsController {
   readonly remove: (index: number) => void;
 }
 
+export interface SelectOption {
+  readonly label: string;
+  readonly value: string;
+}
+
+export type IdentityField = "name" | "themeId";
+
+export type LuxuryFeatureKey = keyof Shop["luxuryFeatures"];
+
+export type LuxuryCheckboxKey = {
+  [K in LuxuryFeatureKey]: Shop["luxuryFeatures"][K] extends boolean ? K : never;
+}[LuxuryFeatureKey];
+
 export interface ShopEditorIdentitySection {
   readonly info: Shop;
   readonly setInfo: React.Dispatch<React.SetStateAction<Shop>>;
   readonly handleChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  readonly handleTextChange: (field: IdentityField, value: string) => void;
+  readonly handleCheckboxChange: (
+    feature: LuxuryCheckboxKey,
+    checked: boolean,
+  ) => void;
+  readonly handleLuxuryFeatureChange: <K extends LuxuryFeatureKey>(
+    feature: K,
+    value: Shop["luxuryFeatures"][K],
+  ) => void;
 }
 
 export interface ShopEditorLocalizationSection {
   readonly priceOverrides: MappingRowsController;
   readonly localeOverrides: MappingRowsController;
+  readonly localeOptions: readonly SelectOption[];
+  readonly supportedLocales: readonly string[];
 }
 
 export interface ShopEditorProvidersSection {
-  readonly shippingProviders: string[];
+  readonly shippingProviders: readonly Provider[];
+  readonly shippingProviderOptions: readonly SelectOption[];
   readonly trackingProviders: string[];
   readonly setTrackingProviders: React.Dispatch<React.SetStateAction<string[]>>;
 }


### PR DESCRIPTION
## Summary
- memoize shipping provider and locale option lists in `useShopEditorForm` alongside shared mapping update helpers
- extend the shop editor submit types with new handler signatures and provider/locale metadata
- refresh the hook unit test to cover the expanded API surface

## Testing
- pnpm --filter @apps/cms exec jest --runInBand --coverage=false useShopEditorForm.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cae056b858832f8d8c9b0b37641496