### PR TITLE
Refactor shop editor accordion and toast handling

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -7,16 +7,14 @@ jest.mock(
   "@/components/atoms/shadcn",
   () => {
     return {
-      Accordion: ({ items }: any) => (
-        <div>
-          {items.map((item: any, index: number) => (
-            <div key={index}>
-              <button type="button">{item.title}</button>
-              <div>{item.content}</div>
-            </div>
-          ))}
-        </div>
+      Accordion: ({ children }: any) => <div>{children}</div>,
+      AccordionItem: ({ children }: any) => <div>{children}</div>,
+      AccordionTrigger: ({ children, ...props }: any) => (
+        <button type="button" {...props}>
+          {children}
+        </button>
       ),
+      AccordionContent: ({ children }: any) => <div>{children}</div>,
       Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
       CardContent: ({ children, ...props }: any) => (
         <div {...props}>{children}</div>
@@ -38,6 +36,19 @@ jest.mock("@cms/actions/shops.server", () => ({
   updateShop: jest.fn(),
   resetThemeOverride: jest.fn(),
 }));
+
+jest.mock(
+  "../src/app/cms/shop/[shop]/settings/sections/IdentitySection",
+  () => () => <div data-testid="identity-section" />,
+);
+jest.mock(
+  "../src/app/cms/shop/[shop]/settings/sections/ProvidersSection",
+  () => () => <div data-testid="providers-section" />,
+);
+jest.mock(
+  "../src/app/cms/shop/[shop]/settings/sections/LocalizationSection",
+  () => () => <div data-testid="localization-section" />,
+);
 
 describe("ShopEditor", () => {
   it("shows error for invalid mapping and prevents submission", async () => {
@@ -68,10 +79,10 @@ describe("ShopEditor", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: /filter mappings/i }),
+      screen.getByRole("button", { name: /^Filter mappings$/i }),
     );
     fireEvent.click(
-      await screen.findByRole("button", { name: /add mapping/i }),
+      await screen.findByRole("button", { name: /add filter mapping/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
@@ -14,7 +14,14 @@ jest.mock("@/hooks/useMappingRows", () => jest.fn((rows: any[]) => ({
 
 jest.mock("../useShopEditorSubmit", () => ({
   __esModule: true,
-  default: jest.fn(() => ({ saving: false, errors: {}, onSubmit: jest.fn() })),
+  default: jest.fn(() => ({
+    saving: false,
+    errors: {},
+    onSubmit: jest.fn(),
+    toast: { open: false, status: "success", message: "" },
+    toastClassName: "",
+    closeToast: jest.fn(),
+  })),
 }));
 
 describe("useShopEditorForm", () => {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
@@ -37,19 +37,44 @@ describe("useShopEditorSubmit", () => {
   });
 
   it("validates mappings", async () => {
-    const filter = { rows: [{ key: "", value: "" }], setRows: jest.fn() } as any;
-    const price = { rows: [{ key: "en", value: "bad" }], setRows: jest.fn() } as any;
-    const locale = { rows: [{ key: "k", value: "xx" }], setRows: jest.fn() } as any;
-    const setInfo = jest.fn();
-    const setTrackingProviders = jest.fn();
+    const filter = {
+      rows: [{ key: "", value: "" }],
+      setRows: jest.fn(),
+      add: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+    const price = {
+      rows: [{ key: "en", value: "bad" }],
+      setRows: jest.fn(),
+      add: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+    const locale = {
+      rows: [{ key: "k", value: "xx" }],
+      setRows: jest.fn(),
+      add: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+    const identity = {
+      info: { id: "s1", name: "Shop", themeId: "theme" } as any,
+      setInfo: jest.fn(),
+      handleChange: jest.fn(),
+    };
+    const providers = {
+      shippingProviders: [],
+      trackingProviders: [],
+      setTrackingProviders: jest.fn(),
+    };
     const { result } = renderHook(() =>
       useShopEditorSubmit({
         shop: "s1",
-        filterMappings: filter,
-        priceOverrides: price,
-        localeOverrides: locale,
-        setInfo,
-        setTrackingProviders,
+        identity,
+        localization: { priceOverrides: price, localeOverrides: locale },
+        providers,
+        overrides: { filterMappings: filter, tokenRows: [] },
       }),
     );
 
@@ -64,6 +89,8 @@ describe("useShopEditorSubmit", () => {
     expect(result.current.errors).toHaveProperty("filterMappings");
     expect(result.current.errors).toHaveProperty("priceOverrides");
     expect(result.current.errors).toHaveProperty("localeOverrides");
+    expect(result.current.toast.open).toBe(true);
+    expect(result.current.toast.status).toBe("error");
     const { updateShop } = require("@cms/actions/shops.server");
     expect(updateShop).not.toHaveBeenCalled();
   });

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -67,13 +67,14 @@ export function useShopEditorForm({
     tokenRows,
   };
 
-  const { saving, errors, onSubmit } = useShopEditorSubmit({
-    shop,
-    identity,
-    localization,
-    providers: providersState,
-    overrides,
-  });
+  const { saving, errors, onSubmit, toast, toastClassName, closeToast } =
+    useShopEditorSubmit({
+      shop,
+      identity,
+      localization,
+      providers: providersState,
+      overrides,
+    });
 
   return {
     info,
@@ -102,6 +103,9 @@ export function useShopEditorForm({
     providers: providersState,
     overrides,
     onSubmit,
+    toast,
+    toastClassName,
+    closeToast,
   } as const;
 }
 

--- a/packages/ui/src/components/atoms/shadcn/index.d.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.d.ts
@@ -6,7 +6,13 @@ export { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSepa
 export { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";
+export {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  type AccordionItemConfig,
+} from "../../molecules/Accordion";
 export { Progress, type ProgressProps } from "../Progress";
 export { Tag, type TagProps } from "../Tag";
 //# sourceMappingURL=index.d.ts.map

--- a/packages/ui/src/components/atoms/shadcn/index.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.ts
@@ -49,6 +49,12 @@ export {
 } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";
+export {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  type AccordionItemConfig,
+} from "../../molecules/Accordion";
 export { Progress, type ProgressProps } from "../Progress";
 export { Tag, type TagProps } from "../Tag";

--- a/packages/ui/src/components/cms/blocks/FAQBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FAQBlock.tsx
@@ -1,5 +1,8 @@
 // packages/ui/components/cms/blocks/FAQBlock.tsx
-import { Accordion, type AccordionItem } from "../../molecules/Accordion";
+import {
+  Accordion,
+  type AccordionItemConfig,
+} from "../../molecules/Accordion";
 
 interface FAQItem {
   question: string;
@@ -20,7 +23,7 @@ export default function FAQBlock({
   const filtered = items.filter(({ question, answer }) => question && answer);
   const list = filtered.slice(0, maxItems ?? filtered.length);
   if (!list.length || list.length < (minItems ?? 0)) return null;
-  const accItems: AccordionItem[] = list.map(({ question, answer }) => ({
+  const accItems: AccordionItemConfig[] = list.map(({ question, answer }) => ({
     title: question,
     content: answer,
   }));

--- a/packages/ui/src/components/molecules/Accordion.d.ts
+++ b/packages/ui/src/components/molecules/Accordion.d.ts
@@ -1,11 +1,44 @@
-import { type ReactNode } from "react";
-export interface AccordionItem {
+import { type ReactNode, type HTMLAttributes, type ButtonHTMLAttributes } from "react";
+export interface AccordionItemConfig {
     title: ReactNode;
     content: ReactNode;
 }
-export interface AccordionProps {
-    items: AccordionItem[];
+export type LegacyAccordionProps = {
+    items: AccordionItemConfig[];
+    className?: string;
+};
+export type AccordionSingleProps = {
+    type?: "single";
+    defaultValue?: string;
+    value?: string;
+    onValueChange?: (value: string | undefined) => void;
+    collapsible?: boolean;
+    className?: string;
+    children: ReactNode;
+};
+export type AccordionMultipleProps = {
+    type: "multiple";
+    defaultValue?: string[];
+    value?: string[];
+    onValueChange?: (value: string[]) => void;
+    className?: string;
+    children: ReactNode;
+};
+export type AccordionProps = LegacyAccordionProps | AccordionSingleProps | AccordionMultipleProps;
+export declare function Accordion(props: AccordionProps): import("react/jsx-runtime").JSX.Element;
+export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+    value: string;
+    disabled?: boolean;
+    children: ReactNode;
 }
-export declare function Accordion({ items }: AccordionProps): import("react/jsx-runtime").JSX.Element;
+export declare function AccordionItem(props: AccordionItemProps): import("react/jsx-runtime").JSX.Element;
+export interface AccordionTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    children: ReactNode;
+}
+export declare function AccordionTrigger(props: AccordionTriggerProps): import("react/jsx-runtime").JSX.Element;
+export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {
+    children: ReactNode;
+}
+export declare function AccordionContent(props: AccordionContentProps): import("react/jsx-runtime").JSX.Element;
 export default Accordion;
 //# sourceMappingURL=Accordion.d.ts.map

--- a/packages/ui/src/components/molecules/Accordion.tsx
+++ b/packages/ui/src/components/molecules/Accordion.tsx
@@ -1,67 +1,323 @@
 "use client";
-import { useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
-export interface AccordionItem {
+import { cn } from "../../utils/style";
+
+export interface AccordionItemConfig {
   title: ReactNode;
   content: ReactNode;
 }
 
-export interface AccordionProps {
-  items: AccordionItem[];
+type LegacyAccordionProps = {
+  items: AccordionItemConfig[];
+  className?: string;
+};
+
+type AccordionSingleProps = {
+  type?: "single";
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string | undefined) => void;
+  collapsible?: boolean;
+  className?: string;
+  children: ReactNode;
+};
+
+type AccordionMultipleProps = {
+  type: "multiple";
+  defaultValue?: string[];
+  value?: string[];
+  onValueChange?: (value: string[]) => void;
+  className?: string;
+  children: ReactNode;
+};
+
+export type AccordionProps =
+  | LegacyAccordionProps
+  | AccordionSingleProps
+  | AccordionMultipleProps;
+
+interface AccordionContextValue {
+  type: "single" | "multiple";
+  openValues: string[];
+  collapsible: boolean;
+  toggle: (value: string) => void;
 }
 
-export function Accordion({ items }: AccordionProps) {
-  const [open, setOpen] = useState<number[]>([]);
+const AccordionContext = createContext<AccordionContextValue | null>(null);
 
-  const toggle = (idx: number) => {
-    setOpen((prev) =>
-      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+function useAccordionContext() {
+  const context = useContext(AccordionContext);
+  if (!context) {
+    throw new Error("Accordion components must be used within <Accordion>");
+  }
+  return context;
+}
+
+interface AccordionItemContextValue {
+  value: string;
+  disabled?: boolean;
+  open: boolean;
+}
+
+const AccordionItemContext =
+  createContext<AccordionItemContextValue | null>(null);
+
+function useAccordionItemContext() {
+  const context = useContext(AccordionItemContext);
+  if (!context) {
+    throw new Error(
+      "AccordionTrigger and AccordionContent must be used within <AccordionItem>",
     );
-  };
+  }
+  return context;
+}
+
+function parseValue(
+  value: string | string[] | undefined,
+  type: "single" | "multiple",
+) {
+  if (value === undefined) return [] as string[];
+  if (Array.isArray(value)) {
+    return type === "single" ? value.slice(0, 1) : value;
+  }
+  return value ? [value] : [];
+}
+
+type AccordionRootProps = AccordionSingleProps | AccordionMultipleProps;
+
+function AccordionRoot(props: AccordionRootProps) {
+  const { className, children } = props;
+  const isMultiple = props.type === "multiple";
+  const type: "single" | "multiple" = isMultiple ? "multiple" : "single";
+
+  const defaultValue = isMultiple
+    ? parseValue(props.defaultValue, type)
+    : parseValue(props.defaultValue, type);
+
+  const value = isMultiple
+    ? parseValue(props.value, type)
+    : parseValue(props.value, type);
+
+  const onValueChange = isMultiple
+    ? props.onValueChange
+    : props.onValueChange;
+
+  const collapsible = isMultiple ? true : props.collapsible ?? false;
+
+  const [internalValues, setInternalValues] = useState<string[]>(
+    () => defaultValue,
+  );
+
+  const isControlled = props.value !== undefined;
+  const openValues = isControlled ? value : internalValues;
+
+  const setValues = useCallback(
+    (next: string[]) => {
+      if (!isControlled) {
+        setInternalValues(next);
+      }
+      if (isMultiple) {
+        onValueChange?.(next);
+      } else {
+        onValueChange?.(next[0]);
+      }
+    },
+    [isControlled, isMultiple, onValueChange],
+  );
+
+  const toggle = useCallback(
+    (valueToToggle: string) => {
+      if (isMultiple) {
+        const set = new Set(openValues);
+        if (set.has(valueToToggle)) {
+          set.delete(valueToToggle);
+        } else {
+          set.add(valueToToggle);
+        }
+        setValues(Array.from(set));
+      } else {
+        const isOpen = openValues[0] === valueToToggle;
+        if (isOpen) {
+          if (collapsible) {
+            setValues([]);
+          }
+        } else {
+          setValues([valueToToggle]);
+        }
+      }
+    },
+    [collapsible, isMultiple, openValues, setValues],
+  );
+
+  const contextValue = useMemo<AccordionContextValue>(
+    () => ({ type, openValues, collapsible, toggle }),
+    [type, openValues, collapsible, toggle],
+  );
 
   return (
-    <div className="space-y-2">
-      {items.map((item, idx) => {
-        const isOpen = open.includes(idx);
+    <AccordionContext.Provider value={contextValue}>
+      <div className={cn("space-y-2", className)}>{children}</div>
+    </AccordionContext.Provider>
+  );
+}
 
-        const handleKeyDown = (
-          event: React.KeyboardEvent<HTMLButtonElement>
-        ) => {
-          if (
-            event.key === " " ||
-            event.key === "Enter" ||
-            event.key === "Space" ||
-            event.key === "Spacebar"
-          ) {
-            event.preventDefault();
-            toggle(idx);
-          }
-        };
+function AccordionWithItems({ items, className }: LegacyAccordionProps) {
+  if (!items || items.length === 0) {
+    return <div className={cn("space-y-2", className)} />;
+  }
 
-        const handleClick = (
-          event: React.MouseEvent<HTMLButtonElement>
-        ) => {
-          if (event.detail !== 0) {
-            toggle(idx);
-          }
-        };
+  return (
+    <AccordionRoot type="multiple" className={className}>
+      {items.map((item, index) => (
+        <AccordionItem value={`item-${index}`} key={`item-${index}`}>
+          <AccordionTrigger>{item.title}</AccordionTrigger>
+          <AccordionContent>{item.content}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </AccordionRoot>
+  );
+}
 
-        return (
-          <div key={idx} className="rounded border">
-            <button
-              type="button"
-              aria-expanded={isOpen}
-              onClick={handleClick}
-              onKeyDown={handleKeyDown}
-              className="flex w-full items-center justify-between p-2 text-left"
-            >
-              <span>{item.title}</span>
-              <span>{isOpen ? "-" : "+"}</span>
-            </button>
-            {isOpen && <div className="border-t p-2">{item.content}</div>}
-          </div>
-        );
-      })}
+export function Accordion(props: AccordionProps) {
+  if ("items" in props) {
+    return <AccordionWithItems {...props} />;
+  }
+
+  return <AccordionRoot {...props} />;
+}
+
+export interface AccordionItemProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+export function AccordionItem({
+  value,
+  disabled = false,
+  className,
+  children,
+  ...props
+}: AccordionItemProps) {
+  const { openValues } = useAccordionContext();
+  const open = openValues.includes(value);
+
+  const contextValue = useMemo(
+    () => ({ value, disabled, open }),
+    [value, disabled, open],
+  );
+
+  return (
+    <AccordionItemContext.Provider value={contextValue}>
+      <div
+        {...props}
+        data-state={open ? "open" : "closed"}
+        data-disabled={disabled ? "" : undefined}
+        className={cn("rounded border border-border/60", className)}
+      >
+        {children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+}
+
+export interface AccordionTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+}
+
+export function AccordionTrigger({
+  children,
+  className,
+  onClick,
+  onKeyDown,
+  ...props
+}: AccordionTriggerProps) {
+  const { toggle } = useAccordionContext();
+  const { value, disabled, open } = useAccordionItemContext();
+
+  const handleClick = useCallback<
+    React.MouseEventHandler<HTMLButtonElement>
+  >(
+    (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      if (disabled) return;
+      toggle(value);
+    },
+    [disabled, onClick, toggle, value],
+  );
+
+  const handleKeyDown = useCallback<
+    React.KeyboardEventHandler<HTMLButtonElement>
+  >(
+    (event) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      if (disabled) return;
+      if (
+        event.key === " " ||
+        event.key === "Enter" ||
+        event.key === "Space" ||
+        event.key === "Spacebar"
+      ) {
+        event.preventDefault();
+        toggle(value);
+      }
+    },
+    [disabled, onKeyDown, toggle, value],
+  );
+
+  return (
+    <button
+      type="button"
+      {...props}
+      className={cn(
+        "flex w-full items-center justify-between p-2 text-left",
+        className,
+      )}
+      aria-expanded={open}
+      aria-disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      disabled={disabled}
+    >
+      <span>{children}</span>
+      <span aria-hidden="true">{open ? "-" : "+"}</span>
+    </button>
+  );
+}
+
+export interface AccordionContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function AccordionContent({
+  children,
+  className,
+  ...props
+}: AccordionContentProps) {
+  const { open } = useAccordionItemContext();
+
+  if (!open) return null;
+
+  return (
+    <div
+      {...props}
+      data-state="open"
+      className={cn("border-t p-2", className)}
+    >
+      {children}
     </div>
   );
 }

--- a/packages/ui/src/components/molecules/__tests__/Accordion.test.tsx
+++ b/packages/ui/src/components/molecules/__tests__/Accordion.test.tsx
@@ -2,10 +2,10 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Accordion } from "../Accordion";
-import type { AccordionItem } from "../Accordion";
+import type { AccordionItemConfig } from "../Accordion";
 
 describe("Accordion", () => {
-  const items: AccordionItem[] = [
+  const items: AccordionItemConfig[] = [
     { title: "Section 1", content: "Content 1" },
     { title: "Section 2", content: "Content 2" },
     { title: "Section 3", content: "Content 3" },

--- a/packages/ui/src/components/molecules/index.d.ts
+++ b/packages/ui/src/components/molecules/index.d.ts
@@ -12,5 +12,6 @@ export { QuantityInput } from "./QuantityInput";
 export { RatingSummary } from "./RatingSummary";
 export { SearchBar } from "./SearchBar";
 export { SustainabilityBadgeCluster } from "./SustainabilityBadgeCluster";
-export { Accordion } from "./Accordion";
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "./Accordion";
+export type { AccordionItemConfig, AccordionProps } from "./Accordion";
 //# sourceMappingURL=index.d.ts.map

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -13,4 +13,10 @@ export { QuantityInput } from "./QuantityInput";
 export { RatingSummary } from "./RatingSummary";
 export { SearchBar } from "./SearchBar";
 export { SustainabilityBadgeCluster } from "./SustainabilityBadgeCluster";
-export { Accordion } from "./Accordion";
+export {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "./Accordion";
+export type { AccordionItemConfig, AccordionProps } from "./Accordion";


### PR DESCRIPTION
## Summary
- replace the shop editor panel grid with the new Identity, Providers, Overrides, and Localization sections while wiring them into the shadcn accordion layout
- surface toast feedback from the shop editor submit hook and map validation errors into the new section props
- upgrade the shared Accordion component to expose trigger/content primitives without breaking legacy `items` usage

## Testing
- `CI=true pnpm exec jest --runTestsByPath packages/ui/src/components/molecules/__tests__/Accordion.test.tsx apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts apps/cms/__tests__/ShopEditor.test.tsx --runInBand --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68cadf3e7620832fa268c38dd4cd8389