### PR TITLE
Add deposit editor validation and toast tests

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/ErrorChips.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/ErrorChips.tsx
@@ -12,7 +12,7 @@ export function ErrorChips({ errors }: ErrorChipsProps) {
   }
 
   return (
-    <div className="flex flex-wrap gap-2 pt-1">
+    <span className="flex flex-wrap gap-2 pt-1">
       {errors.map((error, index) => (
         <Chip
           key={`${error}-${index}`}
@@ -22,7 +22,7 @@ export function ErrorChips({ errors }: ErrorChipsProps) {
           {error}
         </Chip>
       ))}
-    </div>
+    </span>
   );
 }
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/deposits/__tests__/DepositsEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/deposits/__tests__/DepositsEditor.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 
@@ -13,15 +13,47 @@ const parseDepositForm = jest.fn(() => ({
 
 const updateDeposit = jest.fn();
 
+const CLIENT_VALIDATION_MESSAGE = "Enter an interval of at least one minute.";
+const SERVER_ERROR_MESSAGE = "Unable to update deposit service.";
+const SUCCESS_MESSAGE = "Deposit service updated.";
+
 jest.mock("@cms/actions/shops.server", () => ({
   updateDeposit: (...args: any[]) => updateDeposit(...args),
 }));
 jest.mock("../../../../../../../services/shops/validation", () => ({
   parseDepositForm,
 }));
+jest.mock("@/components/atoms", () => ({
+  Toast: ({ open, message, className, onClose, ...props }: any) =>
+    open ? (
+      <div role="status" className={className} {...props}>
+        <span>{message}</span>
+        {onClose ? (
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        ) : null}
+      </div>
+    ) : null,
+  Switch: ({ checked, onChange, ...props }: any) => (
+    <label>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange?.(event)}
+        {...props}
+      />
+    </label>
+  ),
+  Chip: ({ children, ...props }: any) => (
+    <span {...props}>{children}</span>
+  ),
+}));
 jest.mock(
   "@ui/components/atoms/shadcn",
   () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Checkbox: ({ onCheckedChange, ...props }: any) => (
       <input
@@ -40,6 +72,27 @@ describe("DepositsEditor", () => {
     jest.clearAllMocks();
   });
 
+  it("prevents submission when the interval is invalid", async () => {
+    render(
+      <DepositsEditor shop="s1" initial={{ enabled: true, intervalMinutes: 1 }} />,
+    );
+
+    const interval = screen.getByRole("spinbutton");
+    await userEvent.clear(interval);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(updateDeposit).not.toHaveBeenCalled();
+
+    const field = interval.closest("div");
+    expect(field).not.toBeNull();
+    expect(
+      await within(field as HTMLElement).findByText(CLIENT_VALIDATION_MESSAGE),
+    ).toBeInTheDocument();
+
+    const toast = await screen.findByRole("status");
+    expect(toast).toHaveTextContent(CLIENT_VALIDATION_MESSAGE);
+  });
+
   it("submits updated values, surfaces validation errors, and passes accessibility checks", async () => {
     updateDeposit.mockImplementation(async (_shop: string, formData: FormData) => {
       parseDepositForm(formData);
@@ -56,12 +109,19 @@ describe("DepositsEditor", () => {
     await userEvent.type(interval, "5");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(parseDepositForm).toHaveBeenCalledTimes(1);
-    const fd = parseDepositForm.mock.calls[0][0] as FormData;
-    expect(fd.get("enabled")).toBe("on");
-    expect(fd.get("intervalMinutes")).toBe("5");
+    await waitFor(() => {
+      expect(updateDeposit).toHaveBeenCalledTimes(1);
+      expect(parseDepositForm).toHaveBeenCalledTimes(1);
+    });
+
+    const [, formData] = updateDeposit.mock.calls[0] as [string, FormData];
+    expect(formData.get("enabled")).toBe("on");
+    expect(formData.get("intervalMinutes")).toBe("5");
 
     expect(await screen.findByText("Invalid")).toBeInTheDocument();
+
+    const toast = await screen.findByRole("status");
+    expect(toast).toHaveTextContent(SERVER_ERROR_MESSAGE);
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -93,5 +153,8 @@ describe("DepositsEditor", () => {
     });
 
     expect(parseDepositForm).toHaveBeenCalledTimes(1);
+
+    const toast = await screen.findByRole("status");
+    expect(toast).toHaveTextContent(SUCCESS_MESSAGE);
   });
 });


### PR DESCRIPTION
## Summary
- add client-side interval validation to the deposit editor and surface inline error chips and toasts
- clear persisted field errors when inputs change and update error chips markup for valid nesting
- extend deposit editor tests to cover toast messaging, client validation, and form data handling

## Testing
- pnpm exec jest --runInBand --config ./jest.config.cjs --testPathPattern 'DepositsEditor\.test\.tsx' --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cae20e6e84832fad8255a584a7cc4c