### PR TITLE
Refactor shop editor to use new accordion sections

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/ShopEditor.tsx
@@ -3,22 +3,32 @@
 "use client";
 import {
   Accordion,
-  type AccordionItem,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Button,
   Card,
   CardContent,
   Input,
 } from "@/components/atoms/shadcn";
+import { Toast } from "@/components/atoms";
 import type { Shop } from "@acme/types";
 import { type ReactNode } from "react";
 
-import FilterMappings from "./FilterMappings";
-import LocaleOverrides from "./LocaleOverrides";
-import PriceOverrides from "./PriceOverrides";
-import ProviderSelect from "./ProviderSelect";
 import SEOSettings from "./SEOSettings";
 import ThemeTokens from "./ThemeTokens";
-import GeneralSettings from "./GeneralSettings";
+import IdentitySection, {
+  type IdentitySectionErrors,
+} from "./sections/IdentitySection";
+import LocalizationSection, {
+  type LocalizationSectionErrors,
+} from "./sections/LocalizationSection";
+import OverridesSection, {
+  type OverridesSectionErrors,
+} from "./sections/OverridesSection";
+import ProvidersSection, {
+  type ProvidersSectionErrors,
+} from "./sections/ProvidersSection";
 import { useShopEditorForm } from "./useShopEditorForm";
 
 export { default as GeneralSettings } from "./GeneralSettings";
@@ -36,43 +46,88 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
   const {
     info,
     setInfo,
-    trackingProviders,
-    setTrackingProviders,
     errors,
     tokenRows,
     saving,
-    filterMappings,
-    addFilterMapping,
-    updateFilterMapping,
-    removeFilterMapping,
-    priceOverrides,
-    addPriceOverride,
-    updatePriceOverride,
-    removePriceOverride,
-    localeOverrides,
-    addLocaleOverride,
-    updateLocaleOverride,
-    removeLocaleOverride,
-    handleChange,
-    shippingProviders,
+    identity,
+    providers,
+    overrides,
+    localization,
+    toast,
+    closeToast,
     onSubmit,
   } = form;
 
+  const luxuryFeatureErrorKeys = [
+    "blog",
+    "contentMerchandising",
+    "raTicketing",
+    "requireStrongCustomerAuth",
+    "strictReturnConditions",
+    "trackingDashboard",
+    "premierDelivery",
+  ] as const;
+
+  const identityErrors: IdentitySectionErrors = {};
+  if (errors.name) {
+    identityErrors.name = errors.name;
+  }
+  if (errors.themeId) {
+    identityErrors.themeId = errors.themeId;
+  }
+  if (errors.fraudReviewThreshold) {
+    identityErrors.fraudReviewThreshold = errors.fraudReviewThreshold;
+  }
+  if (errors.luxuryFeatures) {
+    identityErrors.luxuryFeatures = errors.luxuryFeatures;
+  }
+  for (const feature of luxuryFeatureErrorKeys) {
+    const messages = errors[feature];
+    if (messages) {
+      const field = `luxuryFeatures.${feature}` as const;
+      identityErrors[field] = messages;
+    }
+  }
+
+  const providersErrors: ProvidersSectionErrors | undefined =
+    errors.trackingProviders
+      ? { trackingProviders: errors.trackingProviders }
+      : undefined;
+
+  const overridesErrors: OverridesSectionErrors = {};
+  if (errors.filterMappings) {
+    overridesErrors.filterMappings = errors.filterMappings;
+  }
+  if (errors.priceOverrides) {
+    overridesErrors.priceOverrides = errors.priceOverrides;
+  }
+  const overridesSectionErrors =
+    Object.keys(overridesErrors).length > 0 ? overridesErrors : undefined;
+
+  const localizationErrors: LocalizationSectionErrors | undefined =
+    errors.localeOverrides
+      ? { localeOverrides: errors.localeOverrides }
+      : undefined;
+
+  const toastClassName =
+    toast.status === "error"
+      ? "bg-destructive text-destructive-foreground"
+      : "bg-success text-success-fg";
+
   const sections: SectionConfig[] = [
     {
-      key: "general",
-      title: "General",
+      key: "identity",
+      title: "Identity",
       description: "Update the shop name, theme, and luxury feature toggles.",
       render: () => (
-        <div className="grid gap-4 md:grid-cols-2">
-          <GeneralSettings
-            info={info}
-            setInfo={setInfo}
-            errors={errors}
-            handleChange={handleChange}
-          />
-        </div>
+        <IdentitySection
+          values={identity.info}
+          errors={identityErrors}
+          onFieldChange={identity.handleTextChange}
+          onLuxuryFeatureChange={identity.handleLuxuryFeatureChange}
+        />
       ),
+      wrapWithCard: false,
     },
     {
       key: "seo",
@@ -85,13 +140,14 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
       title: "Tracking providers",
       description: "Manage analytics and fulfillment tracking integrations.",
       render: () => (
-        <ProviderSelect
-          trackingProviders={trackingProviders}
-          setTrackingProviders={setTrackingProviders}
-          errors={errors}
-          shippingProviders={shippingProviders}
+        <ProvidersSection
+          values={providers.trackingProviders}
+          providers={providers.shippingProviders}
+          errors={providersErrors}
+          onChange={providers.setTrackingProviders}
         />
       ),
+      wrapWithCard: false,
     },
     {
       key: "theme",
@@ -102,64 +158,63 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
       ),
     },
     {
-      key: "filter-mappings",
-      title: "Filter mappings",
-      description: "Link storefront filters to upstream data keys.",
+      key: "overrides",
+      title: "Overrides",
+      description: "Fine-tune filter mappings and price localization.",
       render: () => (
-        <FilterMappings
-          mappings={filterMappings}
-          addMapping={addFilterMapping}
-          updateMapping={updateFilterMapping}
-          removeMapping={removeFilterMapping}
-          errors={errors}
+        <OverridesSection
+          filterMappings={overrides.filterMappings.rows}
+          priceOverrides={localization.priceOverrides.rows}
+          errors={overridesSectionErrors}
+          onAddFilterMapping={overrides.filterMappings.add}
+          onUpdateFilterMapping={overrides.filterMappings.update}
+          onRemoveFilterMapping={overrides.filterMappings.remove}
+          onAddPriceOverride={localization.priceOverrides.add}
+          onUpdatePriceOverride={localization.priceOverrides.update}
+          onRemovePriceOverride={localization.priceOverrides.remove}
         />
       ),
+      wrapWithCard: false,
     },
     {
-      key: "price-overrides",
-      title: "Price overrides",
-      description: "Adjust localized pricing for specific catalog entries.",
-      render: () => (
-        <PriceOverrides
-          overrides={priceOverrides}
-          addOverride={addPriceOverride}
-          updateOverride={updatePriceOverride}
-          removeOverride={removePriceOverride}
-          errors={errors}
-        />
-      ),
-    },
-    {
-      key: "locale-overrides",
-      title: "Locale overrides",
+      key: "localization",
+      title: "Localization overrides",
       description: "Redirect locale content to custom destinations.",
       render: () => (
-        <LocaleOverrides
-          overrides={localeOverrides}
-          addOverride={addLocaleOverride}
-          updateOverride={updateLocaleOverride}
-          removeOverride={removeLocaleOverride}
-          errors={errors}
+        <LocalizationSection
+          values={localization.localeOverrides.rows}
+          errors={localizationErrors}
+          onAdd={localization.localeOverrides.add}
+          onUpdate={localization.localeOverrides.update}
+          onRemove={localization.localeOverrides.remove}
+          availableLocales={localization.supportedLocales}
         />
       ),
+      wrapWithCard: false,
     },
   ];
-
-  const accordionItems: AccordionItem[] = sections.map(
-    ({ title, description, render, key }) => ({
-      title: <SectionHeader title={title} description={description} />,
-      content: (
-        <SectionCard dataSectionKey={key}>
-          {render()}
-        </SectionCard>
-      ),
-    }),
-  );
 
   return (
     <form onSubmit={onSubmit} className="space-y-6">
       <Input type="hidden" name="id" value={info.id} />
-      <Accordion items={accordionItems} />
+      <Accordion
+        type="multiple"
+        defaultValue={sections.map((section) => section.key)}
+        className="space-y-3"
+      >
+        {sections.map(({ key, title, description, render, wrapWithCard }) => (
+          <AccordionItem key={key} value={key} data-section={key} className="border-none">
+            <AccordionTrigger className="rounded-md border border-border/60 bg-muted/40 px-4 py-3 text-left text-sm font-semibold">
+              <SectionHeader title={title} description={description} />
+            </AccordionTrigger>
+            <AccordionContent className="pt-3">
+              <SectionCard dataSectionKey={key} wrapWithCard={wrapWithCard}>
+                {render()}
+              </SectionCard>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
       <div className="flex justify-end">
         <Button
           className="h-10 px-6 text-sm font-semibold"
@@ -169,6 +224,13 @@ export default function ShopEditor({ shop, initial, initialTrackingProviders }: 
           {saving ? "Saving…" : "Save"}
         </Button>
       </div>
+      <Toast
+        open={toast.open}
+        message={toast.message}
+        onClose={closeToast}
+        className={toastClassName}
+        role="status"
+      />
     </form>
   );
 }
@@ -178,6 +240,7 @@ interface SectionConfig {
   title: string;
   description?: string;
   render: () => ReactNode;
+  wrapWithCard?: boolean;
 }
 
 function SectionHeader({ title, description }: { title: string; description?: string }) {
@@ -194,10 +257,16 @@ function SectionHeader({ title, description }: { title: string; description?: st
 function SectionCard({
   children,
   dataSectionKey,
+  wrapWithCard = true,
 }: {
   children: ReactNode;
   dataSectionKey?: string;
+  wrapWithCard?: boolean;
 }) {
+  if (!wrapWithCard) {
+    return <div data-section={dataSectionKey}>{children}</div>;
+  }
+
   return (
     <Card className="border border-border/60" data-section={dataSectionKey}>
       <CardContent className="space-y-6 p-6">{children}</CardContent>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
@@ -18,7 +18,13 @@ jest.mock("@/hooks/useMappingRows", () => jest.fn((rows: any[]) => ({
 
 jest.mock("../useShopEditorSubmit", () => ({
   __esModule: true,
-  default: jest.fn(() => ({ saving: false, errors: {}, onSubmit: jest.fn() })),
+  default: jest.fn(() => ({
+    saving: false,
+    errors: {},
+    toast: { open: false, status: "success", message: "" },
+    closeToast: jest.fn(),
+    onSubmit: jest.fn(),
+  })),
 }));
 
 describe("useShopEditorForm", () => {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/OverridesSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/OverridesSection.tsx
@@ -2,6 +2,9 @@
 
 import {
   Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Button,
   Card,
   CardContent,
@@ -192,11 +195,23 @@ export default function OverridesSection({
         </div>
 
         <Accordion
-          items={[
-            { title: "Filter mappings", content: filterContent },
-            { title: "Price overrides", content: priceContent },
-          ]}
-        />
+          type="multiple"
+          defaultValue={["filter-mappings", "price-overrides"]}
+          className="space-y-3"
+        >
+          <AccordionItem value="filter-mappings" className="border-none">
+            <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+              Filter mappings
+            </AccordionTrigger>
+            <AccordionContent className="pt-3">{filterContent}</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="price-overrides" className="border-none">
+            <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+              Price overrides
+            </AccordionTrigger>
+            <AccordionContent className="pt-3">{priceContent}</AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </CardContent>
     </Card>
   );

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorForm.ts
@@ -147,7 +147,7 @@ export function useShopEditorForm({
     tokenRows,
   };
 
-  const { saving, errors, onSubmit } = useShopEditorSubmit({
+  const { saving, errors, toast, closeToast, onSubmit } = useShopEditorSubmit({
     shop,
     identity,
     localization,
@@ -162,6 +162,8 @@ export function useShopEditorForm({
     setTrackingProviders,
     saving,
     errors,
+    toast,
+    closeToast,
     filterMappings: filterMappings.rows,
     addFilterMapping: filterMappings.add,
     updateFilterMapping: filterMappings.update,

--- a/packages/ui/src/components/atoms/index.ts
+++ b/packages/ui/src/components/atoms/index.ts
@@ -1,4 +1,14 @@
 export { Button, type ButtonProps } from "./primitives/button";
+export {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  type AccordionProps,
+  type AccordionItemProps,
+  type AccordionTriggerProps,
+  type AccordionContentProps,
+} from "./primitives/accordion";
 export { Card, CardContent } from "./primitives/card";
 export { Checkbox, type CheckboxProps } from "./primitives/checkbox";
 export {

--- a/packages/ui/src/components/atoms/primitives/accordion.tsx
+++ b/packages/ui/src/components/atoms/primitives/accordion.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+} from "react";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+
+import { cn } from "../../../utils/style";
+
+type AccordionType = "single" | "multiple";
+
+interface AccordionContextValue {
+  readonly type: AccordionType;
+  readonly openValues: readonly string[];
+  readonly toggle: (value: string) => void;
+  readonly collapsible: boolean;
+}
+
+const AccordionContext = createContext<AccordionContextValue | null>(null);
+
+function useAccordionContext() {
+  const context = useContext(AccordionContext);
+  if (!context) {
+    throw new Error("Accordion components must be used within <Accordion>");
+  }
+  return context;
+}
+
+const AccordionItemContext = createContext<string | null>(null);
+
+function useAccordionItemValue() {
+  const value = useContext(AccordionItemContext);
+  if (!value) {
+    throw new Error(
+      "AccordionTrigger and AccordionContent must be rendered inside AccordionItem",
+    );
+  }
+  return value;
+}
+
+export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+  readonly type?: AccordionType;
+  readonly defaultValue?: string | string[];
+  readonly collapsible?: boolean;
+}
+
+function toArray(value: string | string[] | undefined) {
+  if (!value) return [] as string[];
+  return Array.isArray(value) ? value : [value];
+}
+
+export function Accordion({
+  type = "single",
+  defaultValue,
+  collapsible = true,
+  children,
+  className,
+  ...props
+}: AccordionProps) {
+  const initialValues = useMemo(() => {
+    const normalized = toArray(defaultValue);
+    if (type === "single") {
+      return normalized.length > 0 ? [normalized[0]] : [];
+    }
+    return Array.from(new Set(normalized));
+  }, [defaultValue, type]);
+
+  const [openValues, setOpenValues] = useState<string[]>(initialValues);
+
+  const toggle = useCallback(
+    (value: string) => {
+      setOpenValues((current) => {
+        const isOpen = current.includes(value);
+        if (type === "single") {
+          if (isOpen) {
+            return collapsible ? [] : current;
+          }
+          return [value];
+        }
+        if (isOpen) {
+          return current.filter((entry) => entry !== value);
+        }
+        return [...current, value];
+      });
+    },
+    [type, collapsible],
+  );
+
+  const context = useMemo<AccordionContextValue>(
+    () => ({ type, openValues, toggle, collapsible }),
+    [type, openValues, toggle, collapsible],
+  );
+
+  return (
+    <AccordionContext.Provider value={context}>
+      <div className={cn("space-y-2", className)} {...props}>
+        {children}
+      </div>
+    </AccordionContext.Provider>
+  );
+}
+
+export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+  readonly value: string;
+}
+
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
+  ({ value, className, children, ...props }, ref) => {
+    const { openValues } = useAccordionContext();
+    const isOpen = openValues.includes(value);
+    return (
+      <AccordionItemContext.Provider value={value}>
+        <div
+          ref={ref}
+          data-state={isOpen ? "open" : "closed"}
+          data-value={value}
+          className={cn("rounded-md border border-border/60", className)}
+          {...props}
+        >
+          {children}
+        </div>
+      </AccordionItemContext.Provider>
+    );
+  },
+);
+AccordionItem.displayName = "AccordionItem";
+
+export interface AccordionTriggerProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const AccordionTrigger = forwardRef<
+  HTMLButtonElement,
+  AccordionTriggerProps
+>(({ className, children, onClick, ...props }, ref) => {
+  const value = useAccordionItemValue();
+  const { openValues, toggle } = useAccordionContext();
+  const isOpen = openValues.includes(value);
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    toggle(value);
+  };
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-expanded={isOpen}
+      data-state={isOpen ? "open" : "closed"}
+      onClick={handleClick}
+      className={cn(
+        "flex w-full items-center justify-between gap-2 rounded-md px-4 py-2 text-left text-sm font-semibold transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      {...props}
+    >
+      <span className="flex-1">{children}</span>
+      <ChevronDownIcon
+        aria-hidden
+        className={cn(
+          "h-4 w-4 shrink-0 transition-transform duration-200",
+          isOpen ? "rotate-180" : "rotate-0",
+        )}
+      />
+    </button>
+  );
+});
+AccordionTrigger.displayName = "AccordionTrigger";
+
+export interface AccordionContentProps
+  extends HTMLAttributes<HTMLDivElement> {}
+
+export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
+  ({ className, children, ...props }, ref) => {
+    const value = useAccordionItemValue();
+    const { openValues } = useAccordionContext();
+    const isOpen = openValues.includes(value);
+
+    return (
+      <div
+        ref={ref}
+        data-state={isOpen ? "open" : "closed"}
+        hidden={!isOpen}
+        className={cn("px-4 pb-4 text-sm", className, !isOpen && "hidden")}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+AccordionContent.displayName = "AccordionContent";
+

--- a/packages/ui/src/components/atoms/primitives/index.ts
+++ b/packages/ui/src/components/atoms/primitives/index.ts
@@ -1,5 +1,6 @@
 // packages/ui/components/atoms/primitives/index.ts
 export * from "./button";
+export * from "./accordion";
 export * from "./card";
 export * from "./checkbox";
 export * from "./dropdown-menu";

--- a/packages/ui/src/components/atoms/shadcn/index.ts
+++ b/packages/ui/src/components/atoms/shadcn/index.ts
@@ -49,6 +49,15 @@ export {
 } from "../primitives/table";
 export { Textarea, type TextareaProps } from "../primitives/textarea";
 export { Button, type ButtonProps } from "./Button";
-export { Accordion, type AccordionItem } from "../../molecules/Accordion";
+export {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  type AccordionProps,
+  type AccordionItemProps,
+  type AccordionTriggerProps,
+  type AccordionContentProps,
+} from "../primitives/accordion";
 export { Progress, type ProgressProps } from "../Progress";
 export { Tag, type TagProps } from "../Tag";

--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -3,6 +3,9 @@
 
 import {
   Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Card,
   CardContent,
   Input,
@@ -146,8 +149,9 @@ export default function ProductEditorForm({
     [product.variants],
   );
 
-  const accordionItems = locales.map((locale) => ({
-    title: (
+  const localePanels = locales.map((locale) => ({
+    locale,
+    trigger: (
       <div className="flex items-center gap-2">
         <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
           {locale}
@@ -389,7 +393,20 @@ export default function ProductEditorForm({
           <div className="space-y-4">
             <Card>
               <CardContent>
-                <Accordion items={accordionItems} />
+                <Accordion
+                  type="multiple"
+                  defaultValue={locales as string[]}
+                  className="space-y-3"
+                >
+                  {localePanels.map(({ locale, trigger, content }) => (
+                    <AccordionItem key={locale} value={locale} className="border-none">
+                      <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+                        {trigger}
+                      </AccordionTrigger>
+                      <AccordionContent className="pt-3">{content}</AccordionContent>
+                    </AccordionItem>
+                  ))}
+                </Accordion>
               </CardContent>
             </Card>
           </div>

--- a/packages/ui/src/components/cms/blocks/FAQBlock.tsx
+++ b/packages/ui/src/components/cms/blocks/FAQBlock.tsx
@@ -1,5 +1,10 @@
 // packages/ui/components/cms/blocks/FAQBlock.tsx
-import { Accordion, type AccordionItem } from "../../molecules/Accordion";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../../atoms/shadcn";
 
 interface FAQItem {
   question: string;
@@ -20,9 +25,25 @@ export default function FAQBlock({
   const filtered = items.filter(({ question, answer }) => question && answer);
   const list = filtered.slice(0, maxItems ?? filtered.length);
   if (!list.length || list.length < (minItems ?? 0)) return null;
-  const accItems: AccordionItem[] = list.map(({ question, answer }) => ({
-    title: question,
-    content: answer,
-  }));
-  return <Accordion items={accItems} />;
+  return (
+    <Accordion
+      type="multiple"
+      defaultValue={list.map((_, index) => `faq-${index}`)}
+      className="space-y-2"
+    >
+      {list.map(({ question, answer }, index) => {
+        const value = `faq-${index}`;
+        return (
+          <AccordionItem key={value} value={value} className="border-none">
+            <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+              {question}
+            </AccordionTrigger>
+            <AccordionContent className="pt-2 text-sm text-muted-foreground">
+              {answer}
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
+    </Accordion>
+  );
 }

--- a/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
+++ b/packages/ui/src/components/cms/page-builder/ComponentEditor.tsx
@@ -3,7 +3,12 @@
 
 import type { PageComponent } from "@acme/types";
 import { memo } from "react";
-import { Accordion } from "../../atoms/shadcn";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../../atoms/shadcn";
 import LayoutPanel from "./panels/LayoutPanel";
 import ContentPanel from "./panels/ContentPanel";
 import InteractionsPanel from "./panels/InteractionsPanel";
@@ -42,45 +47,55 @@ function ComponentEditor({ component, onChange, onResize }: Props) {
 
   return (
     <Accordion
-      items={[
-        {
-          title: "Layout",
-          content: (
-            <LayoutPanel
-              component={component}
-              handleInput={handleInput}
-              handleResize={handleResize}
-              handleFullSize={handleFullSize}
-            />
-          ),
-        },
-        {
-          title: "Content",
-          content: (
-            <ContentPanel
-              component={component}
-              onChange={onChange}
-              handleInput={handleInput}
-            />
-          ),
-        },
-        {
-          title: "Style",
-          content: (
-            <StylePanel component={component} handleInput={handleInput} />
-          ),
-        },
-        {
-          title: "Interactions",
-          content: (
-            <InteractionsPanel
-              component={component}
-              handleInput={handleInput}
-            />
-          ),
-        },
-      ]}
-    />
+      type="multiple"
+      defaultValue={["layout", "content", "style", "interactions"]}
+      className="space-y-3"
+    >
+      <AccordionItem value="layout" className="border-none">
+        <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+          Layout
+        </AccordionTrigger>
+        <AccordionContent className="pt-3">
+          <LayoutPanel
+            component={component}
+            handleInput={handleInput}
+            handleResize={handleResize}
+            handleFullSize={handleFullSize}
+          />
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="content" className="border-none">
+        <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+          Content
+        </AccordionTrigger>
+        <AccordionContent className="pt-3">
+          <ContentPanel
+            component={component}
+            onChange={onChange}
+            handleInput={handleInput}
+          />
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="style" className="border-none">
+        <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+          Style
+        </AccordionTrigger>
+        <AccordionContent className="pt-3">
+          <StylePanel component={component} handleInput={handleInput} />
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="interactions" className="border-none">
+        <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+          Interactions
+        </AccordionTrigger>
+        <AccordionContent className="pt-3">
+          <InteractionsPanel
+            component={component}
+            handleInput={handleInput}
+          />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }
 


### PR DESCRIPTION
## Summary
- restructure the Shop editor to render the new section components within a multi-panel accordion and wire up toast notifications
- expose the toast state from `useShopEditorForm` and update the overrides section to the new accordion API
- add accordion primitives to `@acme/ui` and migrate FAQ, page builder, and product editor panels to the new components

## Testing
- pnpm exec jest --runTestsByPath src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts --runInBand --coverage=false


------
https://chatgpt.com/codex/tasks/task_e_68cae5b1ce84832fb1d607102e5d20de