### PR TITLE
Update premier delivery editor with shared form handling

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/ErrorChips.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/ErrorChips.tsx
@@ -12,7 +12,7 @@ export function ErrorChips({ errors }: ErrorChipsProps) {
   }
 
   return (
-    <div className="flex flex-wrap gap-2 pt-1">
+    <span className="inline-flex flex-wrap gap-2 pt-1">
       {errors.map((error, index) => (
         <Chip
           key={`${error}-${index}`}
@@ -22,7 +22,7 @@ export function ErrorChips({ errors }: ErrorChipsProps) {
           {error}
         </Chip>
       ))}
-    </div>
+    </span>
   );
 }
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
@@ -13,12 +13,32 @@ jest.mock("@cms/actions/shops.server", () => ({
   updatePremierDelivery: (...args: any[]) => updatePremierDelivery(...args),
 }));
 jest.mock(
+  "@/components/atoms",
+  () => ({
+    Toast: ({ open, message, className, role = "status", onClose }: any) =>
+      open ? (
+        <div role={role} className={className}>
+          <span>{message}</span>
+          {onClose ? (
+            <button type="button" onClick={onClose}>
+              Close
+            </button>
+          ) : null}
+        </div>
+      ) : null,
+    Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  }),
+  { virtual: true },
+);
+jest.mock(
   "@/components/atoms/shadcn",
   () => ({
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-    Input: ({ name, "aria-label": ariaLabel, ...props }: any) => (
-      <input aria-label={ariaLabel ?? name} name={name} {...props} />
+    Input: ({ id, name, "aria-label": ariaLabel, ...props }: any) => (
+      <input id={id} aria-label={ariaLabel} name={name} {...props} />
     ),
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   }),
   { virtual: true },
 );
@@ -28,7 +48,7 @@ describe("PremierDeliveryEditor", () => {
     jest.clearAllMocks();
   });
 
-  it("submits regions and windows and displays validation errors", async () => {
+  it("submits sanitized form data and displays validation errors", async () => {
     updatePremierDelivery.mockResolvedValue({
       errors: { regions: ["Too few regions"] },
     });
@@ -36,9 +56,23 @@ describe("PremierDeliveryEditor", () => {
     const { container } = render(
       <PremierDeliveryEditor
         shop="lux"
-        initial={{ regions: ["NY"], windows: ["8-10"] }}
+        initial={{
+          regions: ["NY"],
+          windows: ["8-10"],
+          carriers: ["Sky"],
+          serviceLabel: "Rush",
+          surcharge: 12,
+        }}
       />,
     );
+
+    const serviceLabelInput = screen.getByLabelText(/service label/i);
+    await userEvent.clear(serviceLabelInput);
+    await userEvent.type(serviceLabelInput, " Premier Delivery ");
+
+    const surchargeInput = screen.getByLabelText(/surcharge/i);
+    await userEvent.clear(surchargeInput);
+    await userEvent.type(surchargeInput, "5");
 
     const regionInput = screen.getAllByRole("textbox", { name: /regions/i })[0];
     await userEvent.clear(regionInput);
@@ -48,14 +82,30 @@ describe("PremierDeliveryEditor", () => {
     await userEvent.clear(windowInput);
     await userEvent.type(windowInput, "10-12");
 
+    const carrierInputs = screen.getAllByRole("textbox", { name: /carriers/i });
+    await userEvent.clear(carrierInputs[0]);
+    await userEvent.type(carrierInputs[0], "Acme Express");
+    await userEvent.click(screen.getByRole("button", { name: /add carrier/i }));
+
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     expect(updatePremierDelivery).toHaveBeenCalledTimes(1);
     const fd = updatePremierDelivery.mock.calls[0][1] as FormData;
     expect(fd.getAll("regions")).toEqual(["Paris"]);
     expect(fd.getAll("windows")).toEqual(["10-12"]);
+    expect(fd.getAll("carriers")).toEqual(["Acme Express"]);
+    expect(fd.get("serviceLabel")).toEqual("Premier Delivery");
+    expect(fd.get("surcharge")).toEqual("5");
 
     expect(await screen.findByText("Too few regions")).toBeInTheDocument();
+    expect(screen.getByText("Too few regions")).toHaveAttribute(
+      "data-token",
+      "--color-danger",
+    );
+
+    expect(
+      await screen.findByText(/unable to update premier delivery settings\./i),
+    ).toBeInTheDocument();
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -73,25 +123,40 @@ describe("PremierDeliveryEditor", () => {
       />,
     );
 
-    const regionsFieldset = screen
-      .getByText("Regions")
-      .closest("fieldset") as HTMLElement;
-    const windowsFieldset = screen
-      .getByText("One-hour Windows")
-      .closest("fieldset") as HTMLElement;
+    const regionsField = screen.getByText("Regions").closest("div");
+    const windowsField = screen.getByText(/One-hour windows/i).closest("div");
+    if (!regionsField || !windowsField) {
+      throw new Error("Expected collection fields to render");
+    }
+    const getRegionInputs = () => within(regionsField).getAllByRole("textbox");
+    const getWindowInputs = () => within(windowsField).getAllByRole("textbox");
 
     await userEvent.click(screen.getByRole("button", { name: /add region/i }));
-    expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(2);
+    await waitFor(() => {
+      expect(getRegionInputs()).toHaveLength(2);
+    });
 
-    const regionInputs = within(regionsFieldset).getAllByRole("textbox");
+    let regionInputs = getRegionInputs();
     await userEvent.type(regionInputs[1], "Berlin");
-    await userEvent.click(within(regionsFieldset).getAllByRole("button", { name: /remove/i })[0]);
-    expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(1);
+
+    const firstRegionRow = regionInputs[0].closest("div");
+    if (!firstRegionRow) {
+      throw new Error("Expected a region input row container");
+    }
+    await userEvent.click(
+      within(firstRegionRow).getByRole("button", { name: /remove/i }),
+    );
+    await waitFor(() => {
+      expect(getRegionInputs()).toHaveLength(1);
+    });
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
     expect(await screen.findByText("Invalid window")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/unable to update premier delivery settings\./i),
+    ).toBeInTheDocument();
 
-    const windowInputs = within(windowsFieldset).getAllByRole("textbox");
+    const windowInputs = getWindowInputs();
     await userEvent.clear(windowInputs[0]);
     await userEvent.type(windowInputs[0], "11-12");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
@@ -99,5 +164,9 @@ describe("PremierDeliveryEditor", () => {
     await waitFor(() => {
       expect(screen.queryByText("Invalid window")).not.toBeInTheDocument();
     });
+
+    expect(
+      await screen.findByText(/premier delivery settings saved\./i),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- wrap the premier delivery editor in the shared card layout and expose inputs for service label, surcharge, and carriers alongside the existing collections
- replace the bespoke submit handler with `useSettingsSaveForm`, sanitizing collection values before posting and surfacing toast messaging from the hook
- trim error chip markup and expand the test suite to cover new form fields, toast feedback, and validation rendering

## Testing
- pnpm exec jest --runInBand --no-coverage --testPathPattern PremierDeliveryEditor

------
https://chatgpt.com/codex/tasks/task_e_68cae1cba6b0832fb04d27fe5268476d