### PR TITLE
Refine reverse logistics editor validation

### DIFF
--- a/apps/cms/__tests__/reverseLogisticsEditor.test.tsx
+++ b/apps/cms/__tests__/reverseLogisticsEditor.test.tsx
@@ -5,6 +5,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 const updateReverseLogistics = jest.fn();
 jest.mock("@cms/actions/shops.server", () => ({ updateReverseLogistics }));
 jest.mock("@/components/atoms/shadcn", () => ({
+  Card: (props: any) => <div {...props} />,
+  CardContent: (props: any) => <div {...props} />,
   Button: (props: any) => <button {...props} />,
   Checkbox: (props: any) => <input type="checkbox" {...props} />,
   Input: (props: any) => <input {...props} />,

--- a/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/__tests__/ReverseLogisticsEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/reverse-logistics/__tests__/ReverseLogisticsEditor.test.tsx
@@ -12,9 +12,35 @@ const updateReverseLogistics = jest.fn();
 jest.mock("@cms/actions/shops.server", () => ({
   updateReverseLogistics: (...args: any[]) => updateReverseLogistics(...args),
 }));
+jest.mock("@/components/atoms", () => ({
+  Toast: ({ open, message, className, role = "status", ...props }: any) =>
+    open ? (
+      <div role={role} className={className} {...props}>
+        <span>{message}</span>
+      </div>
+    ) : null,
+  Switch: ({ id, name, checked, onChange, disabled, ...props }: any) => (
+    <input
+      id={id}
+      name={name}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      disabled={disabled}
+      {...props}
+    />
+  ),
+  Chip: ({ children, className, ...props }: any) => (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  ),
+}));
 jest.mock(
   "@/components/atoms/shadcn",
   () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Checkbox: ({ onCheckedChange, onClick, ...props }: any) => (
       <input
@@ -34,10 +60,41 @@ describe("ReverseLogisticsEditor", () => {
     jest.clearAllMocks();
   });
 
-  it("submits updated values and shows validation errors", async () => {
-    updateReverseLogistics.mockResolvedValue({
-      errors: { intervalMinutes: ["Too low"] },
+  it("prevents submission when the interval is invalid", async () => {
+    updateReverseLogistics.mockResolvedValue({});
+
+    render(
+      <ReverseLogisticsEditor
+        shop="shop-1"
+        initial={{ enabled: false, intervalMinutes: 10 }}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const interval = screen.getByRole("spinbutton");
+    await user.clear(interval);
+    await user.type(interval, "0");
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    const chip = await screen.findByText((content, element) => {
+      return (
+        content === "Interval must be greater than zero." &&
+        element?.classList.contains("bg-destructive/10")
+      );
     });
+
+    expect(chip).toHaveClass("text-destructive");
+    const toastMessage = (
+      await screen.findAllByText(/Interval must be greater than zero\./)
+    ).find((element) => element.closest('[role="status"]'));
+    expect(toastMessage).toBeDefined();
+    const toast = toastMessage!.closest('[role="status"]');
+    expect(toast).toHaveClass("bg-destructive");
+    expect(updateReverseLogistics).not.toHaveBeenCalled();
+  });
+
+  it("submits updated values, populates FormData, and shows a success toast", async () => {
+    updateReverseLogistics.mockResolvedValue({});
 
     const { container } = render(
       <ReverseLogisticsEditor
@@ -46,18 +103,22 @@ describe("ReverseLogisticsEditor", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("checkbox"));
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("Reverse logistics"));
     const interval = screen.getByRole("spinbutton");
-    await userEvent.clear(interval);
-    await userEvent.type(interval, "15");
-    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    await user.clear(interval);
+    await user.type(interval, "15");
+    await user.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(updateReverseLogistics).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(updateReverseLogistics).toHaveBeenCalledTimes(1));
     const fd = updateReverseLogistics.mock.calls[0][1] as FormData;
     expect(fd.get("enabled")).toBe("on");
     expect(fd.get("intervalMinutes")).toBe("15");
 
-    expect(await screen.findByText("Too low")).toBeInTheDocument();
+    const successMessage = await screen.findByText(/Reverse logistics updated\./);
+    const toast = successMessage.closest('[role="status"]');
+    expect(toast).toHaveClass("bg-success");
+    expect(toast).toHaveClass("text-success-fg");
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -75,10 +136,11 @@ describe("ReverseLogisticsEditor", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("checkbox")).not.toBeChecked();
+      expect(screen.getByLabelText("Reverse logistics")).not.toBeChecked();
       expect(screen.getByRole("spinbutton")).toHaveValue(45);
     });
   });


### PR DESCRIPTION
## Summary
- add a client-side interval guard and toast integration to the reverse logistics editor while continuing to rely on the shared settings save hook
- expand the reverse logistics editor tests to cover local validation feedback, successful submissions, and correct FormData
- update the shared CMS test mock to include the Card wrappers used by the reverse logistics editor

## Testing
- pnpm --filter @apps/cms exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs --no-coverage -- ReverseLogisticsEditor

------
https://chatgpt.com/codex/tasks/task_e_68cae25ce594832f8611208d4c12c1a4