### PR TITLE
Add client validation and tests for stock alerts editor

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/StockAlertsEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/StockAlertsEditor.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import {
+  useCallback,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
 
 import { Toast } from "@/components/atoms";
 import { Button, Card, CardContent, Input, Textarea } from "@/components/atoms/shadcn";
@@ -8,7 +13,12 @@ import { FormField } from "@ui/components/molecules";
 import { updateStockAlert } from "@cms/actions/shops.server";
 
 import { ErrorChips } from "../components/ErrorChips";
-import { useSettingsSaveForm } from "../hooks/useSettingsSaveForm";
+import {
+  useSettingsSaveForm,
+  type ValidationErrors,
+} from "../hooks/useSettingsSaveForm";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
 
 type StockAlertState = {
   recipients: string;
@@ -30,24 +40,139 @@ export default function StockAlertsEditor({ shop, initial }: Props) {
     threshold: initial.threshold === undefined ? "" : String(initial.threshold),
   });
 
-  const { saving, errors, handleSubmit, toast, toastClassName, closeToast } =
-    useSettingsSaveForm<StockAlertResult>({
-      action: (formData) => updateStockAlert(shop, formData),
-      successMessage: "Stock alert settings saved.",
-      errorMessage: "Unable to update stock alerts.",
-      onSuccess: (result) => {
-        const next = result.settings?.stockAlert;
-        if (!next) return;
-        setState({
-          recipients: next.recipients.join(", "),
-          webhook: next.webhook ?? "",
-          threshold:
-            next.threshold === undefined || next.threshold === null
-              ? ""
-              : String(next.threshold),
-        });
-      },
-    });
+  const {
+    saving,
+    errors,
+    setErrors,
+    submit,
+    toast,
+    toastClassName,
+    closeToast,
+    announceError,
+  } = useSettingsSaveForm<StockAlertResult>({
+    action: (formData) => updateStockAlert(shop, formData),
+    successMessage: "Stock alert settings saved.",
+    errorMessage: "Unable to update stock alerts.",
+    onSuccess: (result) => {
+      const next = result.settings?.stockAlert;
+      if (!next) return;
+      setState({
+        recipients: next.recipients.join(", "),
+        webhook: next.webhook ?? "",
+        threshold:
+          next.threshold === undefined || next.threshold === null
+            ? ""
+            : String(next.threshold),
+      });
+    },
+  });
+
+  const clearFieldError = useCallback(
+    (field: string) => {
+      setErrors((current) => {
+        if (!current[field]) {
+          return current;
+        }
+        const next: ValidationErrors = { ...current };
+        delete next[field];
+        return next;
+      });
+    },
+    [setErrors],
+  );
+
+  const handleRecipientsChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = event.target;
+    setState((current) => ({ ...current, recipients: value }));
+    clearFieldError("recipients");
+  };
+
+  const handleWebhookChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setState((current) => ({ ...current, webhook: value }));
+    clearFieldError("webhook");
+  };
+
+  const handleThresholdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setState((current) => ({ ...current, threshold: value }));
+    clearFieldError("threshold");
+  };
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const recipients = state.recipients
+        .split(",")
+        .map((recipient) => recipient.trim())
+        .filter(Boolean);
+      const webhook = state.webhook.trim();
+      const thresholdValue = state.threshold.trim();
+
+      const validationErrors: ValidationErrors = {};
+      let toastMessage: string | undefined;
+
+      if (recipients.length === 0) {
+        validationErrors.recipients = ["Enter at least one recipient email."];
+        toastMessage = "Enter at least one recipient email.";
+      } else {
+        const invalidRecipients = recipients.filter(
+          (recipient) => !EMAIL_PATTERN.test(recipient),
+        );
+        if (invalidRecipients.length > 0) {
+          validationErrors.recipients = invalidRecipients.map(
+            (recipient) => `Invalid email: ${recipient}`,
+          );
+          toastMessage = "Enter valid recipient email addresses.";
+        }
+      }
+
+      let thresholdNumber: number | undefined;
+      if (thresholdValue !== "") {
+        const parsedThreshold = Number(thresholdValue);
+        if (!Number.isFinite(parsedThreshold) || !Number.isInteger(parsedThreshold)) {
+          validationErrors.threshold = ["Enter a whole number threshold."];
+          if (!toastMessage) {
+            toastMessage = "Enter a whole number threshold.";
+          }
+        } else if (parsedThreshold < 1) {
+          validationErrors.threshold = ["Enter a threshold of at least 1."];
+          if (!toastMessage) {
+            toastMessage = "Enter a threshold of at least 1.";
+          }
+        } else {
+          thresholdNumber = parsedThreshold;
+        }
+      }
+
+      if (Object.keys(validationErrors).length > 0) {
+        setErrors(validationErrors);
+        announceError(toastMessage ?? "Fix the validation errors and try again.");
+        return;
+      }
+
+      const normalizedFormData = new FormData();
+      normalizedFormData.set("recipients", recipients.join(","));
+      if (webhook) {
+        normalizedFormData.set("webhook", webhook);
+      }
+      if (thresholdNumber !== undefined) {
+        normalizedFormData.set("threshold", String(thresholdNumber));
+      }
+
+      setErrors({});
+      void submit(normalizedFormData);
+    },
+    [
+      announceError,
+      setErrors,
+      state.recipients,
+      state.threshold,
+      state.webhook,
+      submit,
+    ],
+  );
 
   return (
     <>
@@ -65,12 +190,7 @@ export default function StockAlertsEditor({ shop, initial }: Props) {
                 name="recipients"
                 rows={3}
                 value={state.recipients}
-                onChange={(event) =>
-                  setState((current) => ({
-                    ...current,
-                    recipients: event.target.value,
-                  }))
-                }
+                onChange={handleRecipientsChange}
                 placeholder="name@example.com, ops@example.com"
               />
               <p className="text-xs text-muted-foreground">
@@ -88,12 +208,7 @@ export default function StockAlertsEditor({ shop, initial }: Props) {
                 id="stock-alert-webhook"
                 name="webhook"
                 value={state.webhook}
-                onChange={(event) =>
-                  setState((current) => ({
-                    ...current,
-                    webhook: event.target.value,
-                  }))
-                }
+                onChange={handleWebhookChange}
                 placeholder="https://example.com/alerts"
                 autoComplete="off"
               />
@@ -111,12 +226,7 @@ export default function StockAlertsEditor({ shop, initial }: Props) {
                 type="number"
                 min="0"
                 value={state.threshold}
-                onChange={(event) =>
-                  setState((current) => ({
-                    ...current,
-                    threshold: event.target.value,
-                  }))
-                }
+                onChange={handleThresholdChange}
               />
               <p className="text-xs text-muted-foreground">
                 Alert when on-hand quantity falls at or below this amount.


### PR DESCRIPTION
## Summary
- integrate `useSettingsSaveForm` helpers to add client-side validation and form normalization for stock alerts
- sanitize recipients/webhook/threshold data before submission and surface validation toasts with error chips
- extend stock alert editor tests with UI mocks to cover validation failures, success toasts, and sanitized payloads

## Testing
- pnpm --filter @apps/cms exec jest --runTestsByPath src/app/cms/shop/[shop]/settings/stock-alerts/__tests__/StockAlertsEditor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cae27e2afc832fa96b54de4c5a4c3d