### PR TITLE
Refine maintenance scheduler form validation

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/MaintenanceSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/MaintenanceSchedulerEditor.tsx
@@ -46,11 +46,13 @@ export default function MaintenanceSchedulerEditor() {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const value = Number(formData.get("frequency"));
-    if (!value || value <= 0) {
+
+    if (!Number.isFinite(value) || value <= 0) {
       setErrors({ frequency: ["Enter a frequency greater than zero."] });
       announceError("Frequency must be at least 1 millisecond.");
       return;
     }
+    formData.set("frequency", String(value));
     void submit(formData);
   };
 
@@ -62,7 +64,6 @@ export default function MaintenanceSchedulerEditor() {
             <FormField
               label="Scan frequency (ms)"
               htmlFor="maintenance-frequency"
-              error={<ErrorChips errors={errors.frequency} />}
               className="gap-3"
             >
               <Input
@@ -73,6 +74,7 @@ export default function MaintenanceSchedulerEditor() {
                 value={frequency}
                 onChange={handleChange}
               />
+              <ErrorChips errors={errors.frequency} />
               <p className="text-xs text-muted-foreground">
                 Configure how often the automated maintenance scan should run.
               </p>

--- a/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx
@@ -13,8 +13,26 @@ jest.mock("@cms/actions/maintenance.server", () => ({
   updateMaintenanceSchedule: (...args: any[]) => updateMaintenanceSchedule(...args),
 }));
 jest.mock(
+  "@/components/atoms",
+  () => ({
+    Toast: ({ open, message, children, ...props }: any) =>
+      open ? (
+        <div {...props}>
+          {message}
+          {children}
+        </div>
+      ) : null,
+    Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  }),
+  { virtual: true },
+);
+jest.mock(
   "@/components/atoms/shadcn",
   () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Input: (props: any) => <input {...props} />,
   }),
@@ -26,7 +44,7 @@ describe("MaintenanceSchedulerEditor", () => {
     jest.clearAllMocks();
   });
 
-  it("submits the configured frequency", async () => {
+  it("submits the configured frequency and surfaces success feedback", async () => {
     updateMaintenanceSchedule.mockResolvedValue(undefined);
 
     const { container } = render(<MaintenanceSchedulerEditor />);
@@ -35,9 +53,28 @@ describe("MaintenanceSchedulerEditor", () => {
     await userEvent.type(input, "4500");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
+    await screen.findByText("Maintenance scan schedule updated.");
     expect(updateMaintenanceSchedule).toHaveBeenCalledTimes(1);
     const fd = updateMaintenanceSchedule.mock.calls[0][0] as FormData;
     expect(fd.get("frequency")).toBe("4500");
+    expect(Number(fd.get("frequency"))).toBe(4500);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("validates a positive frequency before submission", async () => {
+    const { container } = render(<MaintenanceSchedulerEditor />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(updateMaintenanceSchedule).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("Enter a frequency greater than zero."),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Frequency must be at least 1 millisecond."),
+    ).toBeInTheDocument();
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();


### PR DESCRIPTION
## Summary
- sanitize the maintenance scan form submission with numeric frequency validation and error chips inside the FormField
- ensure invalid submissions trigger hook-driven error toasts before calling the update action
- extend the maintenance scheduler tests to cover toast feedback, numeric FormData, and chip rendering with local component mocks

## Testing
- CI=true pnpm --filter @apps/cms exec jest maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cae31f0564832fbc77d4be3198d3ad