### PR TITLE
Refine stock scheduler editor save flow

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/stock-scheduler/StockSchedulerEditor.tsx
@@ -53,24 +53,27 @@ export default function StockSchedulerEditor({ shop, status }: Props) {
 
   const handleIntervalChange = (event: ChangeEvent<HTMLInputElement>) => {
     setInterval(event.target.value);
-    if (errors.intervalMs?.length) {
-      setErrors((current) => {
-        const next = { ...current };
-        delete next.intervalMs;
-        return next;
-      });
+    if (!errors.intervalMs?.length) {
+      return;
     }
+    setErrors(({ intervalMs: _interval, ...rest }) => rest);
   };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
-    const value = Number(formData.get("intervalMs"));
-    if (!value || value <= 0) {
+    const rawInterval = formData.get("intervalMs");
+    const numericInterval = Number(rawInterval);
+    const hasValidInterval =
+      Number.isFinite(numericInterval) && numericInterval > 0;
+
+    if (!hasValidInterval) {
       setErrors({ intervalMs: ["Enter an interval greater than zero."] });
       announceError("Interval must be at least 1 millisecond.");
       return;
     }
+
+    formData.set("intervalMs", numericInterval.toString());
     void submit(formData);
   };
 


### PR DESCRIPTION
## Summary
- sanitize and validate the stock scheduler interval before invoking the shared save hook
- clear interval errors on edit and render toast-driven feedback through the shared settings helper
- expand the stock scheduler editor test to cover invalid interval handling and mock toast rendering

## Testing
- pnpm --filter @apps/cms test -- StockSchedulerEditor *(fails: global coverage threshold unmet when running the focused suite)*
- pnpm --filter @apps/cms exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --coverage=false -- StockSchedulerEditor

------
https://chatgpt.com/codex/tasks/task_e_68cae2ff5f74832f860038119cfea97e