### PR TITLE
Improve media manager upload and replacement flows

### DIFF
--- a/packages/ui/src/components/atoms/Toast.d.ts
+++ b/packages/ui/src/components/atoms/Toast.d.ts
@@ -3,6 +3,7 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
     open: boolean;
     onClose?: () => void;
     message: string;
+    variant?: "default" | "success" | "error";
 }
 export declare const Toast: React.ForwardRefExoticComponent<ToastProps & React.RefAttributes<HTMLDivElement>>;
 //# sourceMappingURL=Toast.d.ts.map

--- a/packages/ui/src/components/atoms/Toast.tsx
+++ b/packages/ui/src/components/atoms/Toast.tsx
@@ -2,32 +2,59 @@
 import * as React from "react";
 import { cn } from "../../utils/style";
 
+type ToastVariant = "default" | "success" | "error";
+
 export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
   onClose?: () => void;
   message: string;
+  variant?: ToastVariant;
 }
 
+const VARIANT_STYLES: Record<ToastVariant, {
+  className: string;
+  token: string;
+  tokenFg: string;
+}> = {
+  default: {
+    className: "bg-fg text-bg",
+    token: "--color-fg",
+    tokenFg: "--color-bg",
+  },
+  success: {
+    className: "bg-success text-success-fg",
+    token: "--color-success",
+    tokenFg: "--color-success-fg",
+  },
+  error: {
+    className: "bg-destructive text-destructive-foreground",
+    token: "--color-danger",
+    tokenFg: "--color-danger-fg",
+  },
+};
+
 export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
-  ({ open, onClose, message, className, ...props }, ref) => {
+  ({ open, onClose, message, className, variant = "default", ...props }, ref) => {
     if (!open) return null;
+    const { className: variantClassName, token, tokenFg } = VARIANT_STYLES[variant];
     return (
       <div
         ref={ref}
         className={cn(
-          "bg-fg text-bg fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-md px-4 py-2 shadow-lg",
+          "fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-md px-4 py-2 shadow-lg",
+          variantClassName,
           className
         )}
-        data-token="--color-fg"
+        data-token={token}
         {...props}
       >
-        <span data-token="--color-bg">{message}</span>
+        <span data-token={tokenFg}>{message}</span>
         {onClose && (
           <button
             type="button"
             onClick={onClose}
             className="ml-2 font-bold"
-            data-token="--color-bg"
+            data-token={tokenFg}
           >
             ×
           </button>


### PR DESCRIPTION
## Summary
- update the media manager to surface upload errors, manage replacement state, and keep metadata edits selected until closed
- wire the upload panel error callback and highlight the file being replaced while replacements are pending
- extend the Toast component with built-in success/error variants and use it directly from the media manager

## Testing
- pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/src/components/atoms/__tests__/Toast.test.tsx *(fails: coverage thresholds not met when running the isolated suite)*

------
https://chatgpt.com/codex/tasks/task_e_68caff8d8314832f88c70135487bfb89