### PR TITLE
Clean premier delivery form submission

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
@@ -43,10 +43,12 @@ describe("PremierDeliveryEditor", () => {
     const regionInput = screen.getAllByRole("textbox", { name: /regions/i })[0];
     await userEvent.clear(regionInput);
     await userEvent.type(regionInput, "Paris");
+    await userEvent.click(screen.getByRole("button", { name: /add region/i }));
 
     const windowInput = screen.getAllByRole("textbox", { name: /windows/i })[0];
     await userEvent.clear(windowInput);
     await userEvent.type(windowInput, "10-12");
+    await userEvent.click(screen.getByRole("button", { name: /add window/i }));
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
@@ -54,6 +56,8 @@ describe("PremierDeliveryEditor", () => {
     const fd = updatePremierDelivery.mock.calls[0][1] as FormData;
     expect(fd.getAll("regions")).toEqual(["Paris"]);
     expect(fd.getAll("windows")).toEqual(["10-12"]);
+    expect(fd.getAll("carriers")).toEqual([]);
+    expect(fd.has("surcharge")).toBe(false);
 
     expect(await screen.findByText("Too few regions")).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- add helpers in the premier delivery editor to sanitize collection entries and build clean FormData payloads
- update the submit handler so numeric inputs only send values when populated and blank collections are dropped
- extend the premier delivery editor test to cover filtering behavior and empty surcharge handling

## Testing
- pnpm test -- --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx *(fails: package @acme/next-config uses `node --test` which does not accept `--runTestsByPath`)*

------
https://chatgpt.com/codex/tasks/task_e_68cb00b5d488832f8bbec676ed7ce332