### PR TITLE
test: mock settings save hook interactions

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx
@@ -2,12 +2,24 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
+import { useState, type FormEvent } from "react";
 
 import MaintenanceSchedulerEditor from "../MaintenanceSchedulerEditor";
+import type { ValidationErrors } from "../../hooks/useSettingsSaveForm";
 
 expect.extend(toHaveNoViolations);
 
 const updateMaintenanceSchedule = jest.fn();
+
+const submitMock = jest.fn();
+const handleSubmitMock = jest.fn();
+const toastOutcomes: Array<{ status: "success" | "error"; message: string }> = [];
+
+const useSettingsSaveFormMock = jest.fn();
+
+jest.mock("../../hooks/useSettingsSaveForm", () => ({
+  useSettingsSaveForm: (...args: any[]) => useSettingsSaveFormMock(...args),
+}));
 
 jest.mock("@cms/actions/maintenance.server", () => ({
   updateMaintenanceSchedule: (...args: any[]) => updateMaintenanceSchedule(...args),
@@ -42,6 +54,109 @@ jest.mock(
 describe("MaintenanceSchedulerEditor", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    toastOutcomes.length = 0;
+    submitMock.mockReset();
+    handleSubmitMock.mockReset();
+
+    useSettingsSaveFormMock.mockImplementation(
+      ({
+        action,
+        successMessage = "Settings saved.",
+        errorMessage = "Unable to save settings.",
+        onSuccess,
+        onError,
+        normalizeErrors,
+      }: {
+        action: (formData: FormData) => Promise<any>;
+        successMessage?: string;
+        errorMessage?: string;
+        onSuccess?: (result: any) => void;
+        onError?: (result: any) => void;
+        normalizeErrors?: (result: any) => ValidationErrors | undefined;
+      }) => {
+        const [saving, setSaving] = useState(false);
+        const [errors, setErrorsState] = useState<ValidationErrors>({});
+        const [toast, setToast] = useState({
+          open: false,
+          status: "success" as const,
+          message: "",
+        });
+
+        const setErrors = (updater: ValidationErrors | ((current: ValidationErrors) => ValidationErrors)) => {
+          setErrorsState((current) =>
+            typeof updater === "function"
+              ? (updater as (current: ValidationErrors) => ValidationErrors)(current)
+              : updater,
+          );
+        };
+
+        const recordToast = (status: "success" | "error", message: string) => {
+          const event = { status, message };
+          toastOutcomes.push(event);
+          setToast({ open: true, status, message });
+        };
+
+        const closeToast = () => setToast((current) => ({ ...current, open: false }));
+
+        const getNormalizedErrors =
+          normalizeErrors ??
+          ((result: unknown) => {
+            if (result && typeof result === "object" && "errors" in result) {
+              return (result as { errors?: ValidationErrors }).errors;
+            }
+            return undefined;
+          });
+
+        const submit = async (formData: FormData) => {
+          submitMock(formData);
+          setSaving(true);
+          try {
+            const result = await action(formData);
+            const normalizedErrors = getNormalizedErrors(result) ?? {};
+            if (Object.keys(normalizedErrors).length > 0) {
+              setErrorsState(normalizedErrors);
+              recordToast("error", errorMessage);
+              onError?.(result);
+              return { ok: false, result };
+            }
+
+            setErrorsState({});
+            onSuccess?.(result);
+            recordToast("success", successMessage);
+            return { ok: true, result };
+          } catch (error) {
+            const message = error instanceof Error ? error.message : errorMessage;
+            recordToast("error", message);
+            return { ok: false, error };
+          } finally {
+            setSaving(false);
+          }
+        };
+
+        const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          handleSubmitMock(formData);
+          return submit(formData);
+        };
+
+        return {
+          saving,
+          errors,
+          setErrors,
+          submit,
+          handleSubmit,
+          toast,
+          toastClassName:
+            toast.status === "error"
+              ? "bg-destructive text-destructive-foreground"
+              : "bg-success text-success-fg",
+          closeToast,
+          announceError: (message: string) => recordToast("error", message),
+          announceSuccess: (message: string) => recordToast("success", message),
+        };
+      },
+    );
   });
 
   it("submits the configured frequency and surfaces success feedback", async () => {
@@ -54,6 +169,10 @@ describe("MaintenanceSchedulerEditor", () => {
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await screen.findByText("Maintenance scan schedule updated.");
+    expect(toastOutcomes).toContainEqual({
+      status: "success",
+      message: "Maintenance scan schedule updated.",
+    });
     expect(updateMaintenanceSchedule).toHaveBeenCalledTimes(1);
     const fd = updateMaintenanceSchedule.mock.calls[0][0] as FormData;
     expect(fd.get("frequency")).toBe("4500");
@@ -75,6 +194,10 @@ describe("MaintenanceSchedulerEditor", () => {
     expect(
       await screen.findByText("Frequency must be at least 1 millisecond."),
     ).toBeInTheDocument();
+    expect(toastOutcomes).toContainEqual({
+      status: "error",
+      message: "Frequency must be at least 1 millisecond.",
+    });
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
@@ -2,19 +2,49 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
+import { useState, type FormEvent } from "react";
 
 import PremierDeliveryEditor from "../PremierDeliveryEditor";
+import type { ValidationErrors } from "../../hooks/useSettingsSaveForm";
 
 expect.extend(toHaveNoViolations);
 
 const updatePremierDelivery = jest.fn();
 
+const submitMock = jest.fn();
+const handleSubmitMock = jest.fn();
+const toastOutcomes: Array<{ status: "success" | "error"; message: string }> = [];
+
+const useSettingsSaveFormMock = jest.fn();
+
+jest.mock("../../hooks/useSettingsSaveForm", () => ({
+  useSettingsSaveForm: (...args: any[]) => useSettingsSaveFormMock(...args),
+}));
+
 jest.mock("@cms/actions/shops.server", () => ({
   updatePremierDelivery: (...args: any[]) => updatePremierDelivery(...args),
 }));
 jest.mock(
+  "@/components/atoms",
+  () => ({
+    Toast: ({ open, message, children, ...props }: any) =>
+      open ? (
+        <div {...props}>
+          {message}
+          {children}
+        </div>
+      ) : null,
+    Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  }),
+  { virtual: true },
+);
+jest.mock(
   "@/components/atoms/shadcn",
   () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => (
+      <div {...props}>{children}</div>
+    ),
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Input: ({ name, "aria-label": ariaLabel, ...props }: any) => (
       <input aria-label={ariaLabel ?? name} name={name} {...props} />
@@ -26,6 +56,109 @@ jest.mock(
 describe("PremierDeliveryEditor", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    toastOutcomes.length = 0;
+    submitMock.mockReset();
+    handleSubmitMock.mockReset();
+
+    useSettingsSaveFormMock.mockImplementation(
+      ({
+        action,
+        successMessage = "Settings saved.",
+        errorMessage = "Unable to save settings.",
+        onSuccess,
+        onError,
+        normalizeErrors,
+      }: {
+        action: (formData: FormData) => Promise<any>;
+        successMessage?: string;
+        errorMessage?: string;
+        onSuccess?: (result: any) => void;
+        onError?: (result: any) => void;
+        normalizeErrors?: (result: any) => ValidationErrors | undefined;
+      }) => {
+        const [saving, setSaving] = useState(false);
+        const [errors, setErrorsState] = useState<ValidationErrors>({});
+        const [toast, setToast] = useState({
+          open: false,
+          status: "success" as const,
+          message: "",
+        });
+
+        const setErrors = (updater: ValidationErrors | ((current: ValidationErrors) => ValidationErrors)) => {
+          setErrorsState((current) =>
+            typeof updater === "function"
+              ? (updater as (current: ValidationErrors) => ValidationErrors)(current)
+              : updater,
+          );
+        };
+
+        const recordToast = (status: "success" | "error", message: string) => {
+          const event = { status, message };
+          toastOutcomes.push(event);
+          setToast({ open: true, status, message });
+        };
+
+        const closeToast = () => setToast((current) => ({ ...current, open: false }));
+
+        const getNormalizedErrors =
+          normalizeErrors ??
+          ((result: unknown) => {
+            if (result && typeof result === "object" && "errors" in result) {
+              return (result as { errors?: ValidationErrors }).errors;
+            }
+            return undefined;
+          });
+
+        const submit = async (formData: FormData) => {
+          submitMock(formData);
+          setSaving(true);
+          try {
+            const result = await action(formData);
+            const normalizedErrors = getNormalizedErrors(result) ?? {};
+            if (Object.keys(normalizedErrors).length > 0) {
+              setErrorsState(normalizedErrors);
+              recordToast("error", errorMessage);
+              onError?.(result);
+              return { ok: false, result };
+            }
+
+            setErrorsState({});
+            onSuccess?.(result);
+            recordToast("success", successMessage);
+            return { ok: true, result };
+          } catch (error) {
+            const message = error instanceof Error ? error.message : errorMessage;
+            recordToast("error", message);
+            return { ok: false, error };
+          } finally {
+            setSaving(false);
+          }
+        };
+
+        const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          handleSubmitMock(formData);
+          return submit(formData);
+        };
+
+        return {
+          saving,
+          errors,
+          setErrors,
+          submit,
+          handleSubmit,
+          toast,
+          toastClassName:
+            toast.status === "error"
+              ? "bg-destructive text-destructive-foreground"
+              : "bg-success text-success-fg",
+          closeToast,
+          announceError: (message: string) => recordToast("error", message),
+          announceSuccess: (message: string) => recordToast("success", message),
+        };
+      },
+    );
   });
 
   it("submits regions and windows and displays validation errors", async () => {
@@ -40,13 +173,25 @@ describe("PremierDeliveryEditor", () => {
       />,
     );
 
-    const regionInput = screen.getAllByRole("textbox", { name: /regions/i })[0];
+    const serviceLabelInput = screen.getByLabelText("Service label");
+    await userEvent.clear(serviceLabelInput);
+    await userEvent.type(serviceLabelInput, "Express Premier");
+
+    const surchargeInput = screen.getByLabelText("Surcharge");
+    await userEvent.clear(surchargeInput);
+    await userEvent.type(surchargeInput, "3.5");
+
+    const regionInput = screen.getAllByLabelText(/Regions/i)[0];
     await userEvent.clear(regionInput);
     await userEvent.type(regionInput, "Paris");
 
-    const windowInput = screen.getAllByRole("textbox", { name: /windows/i })[0];
+    const windowInput = screen.getAllByLabelText(/One-hour windows/i)[0];
     await userEvent.clear(windowInput);
     await userEvent.type(windowInput, "10-12");
+
+    const carrierInput = screen.getAllByLabelText(/Preferred carriers/i)[0];
+    await userEvent.clear(carrierInput);
+    await userEvent.type(carrierInput, "Acme Express");
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
@@ -54,8 +199,17 @@ describe("PremierDeliveryEditor", () => {
     const fd = updatePremierDelivery.mock.calls[0][1] as FormData;
     expect(fd.getAll("regions")).toEqual(["Paris"]);
     expect(fd.getAll("windows")).toEqual(["10-12"]);
+    expect(fd.getAll("carriers")).toEqual(["Acme Express"]);
+    expect(fd.get("surcharge")).toBe("3.5");
+    expect(fd.get("serviceLabel")).toBe("Express Premier");
 
-    expect(await screen.findByText("Too few regions")).toBeInTheDocument();
+    const validationChip = await screen.findByText("Too few regions");
+    expect(validationChip).toBeInTheDocument();
+    expect(validationChip).toHaveAttribute("data-token", "--color-danger");
+    expect(toastOutcomes).toContainEqual({
+      status: "error",
+      message: "Unable to update premier delivery settings.",
+    });
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -73,12 +227,10 @@ describe("PremierDeliveryEditor", () => {
       />,
     );
 
-    const regionsFieldset = screen
-      .getByText("Regions")
-      .closest("fieldset") as HTMLElement;
+    const regionsFieldset = screen.getByText("Regions").parentElement as HTMLElement;
     const windowsFieldset = screen
-      .getByText("One-hour Windows")
-      .closest("fieldset") as HTMLElement;
+      .getByText(/One-hour windows/i)
+      .parentElement as HTMLElement;
 
     await userEvent.click(screen.getByRole("button", { name: /add region/i }));
     expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(2);
@@ -89,7 +241,13 @@ describe("PremierDeliveryEditor", () => {
     expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(1);
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
-    expect(await screen.findByText("Invalid window")).toBeInTheDocument();
+    const windowError = await screen.findByText("Invalid window");
+    expect(windowError).toBeInTheDocument();
+    expect(windowError).toHaveAttribute("data-token", "--color-danger");
+    expect(toastOutcomes).toContainEqual({
+      status: "error",
+      message: "Unable to update premier delivery settings.",
+    });
 
     const windowInputs = within(windowsFieldset).getAllByRole("textbox");
     await userEvent.clear(windowInputs[0]);
@@ -98,6 +256,10 @@ describe("PremierDeliveryEditor", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("Invalid window")).not.toBeInTheDocument();
+    });
+    expect(toastOutcomes).toContainEqual({
+      status: "success",
+      message: "Premier delivery settings saved.",
     });
   });
 });


### PR DESCRIPTION
## Summary
- mock `useSettingsSaveForm` in the maintenance scheduler tests so submissions and toast messages can be asserted
- extend the premier delivery editor tests to record toast outcomes, ensure validation chip styling, and verify new form data fields

## Testing
- pnpm --filter @apps/cms exec jest --config ./jest.config.cjs --runInBand --detectOpenHandles --coverage=false --runTestsByPath "src/app/cms/shop/[shop]/settings/maintenance-scan/__tests__/MaintenanceSchedulerEditor.test.tsx" "src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx"

------
https://chatgpt.com/codex/tasks/task_e_68cb00b6d784832f9b3875b794a35698