### PR TITLE
test: expand shop editor hooks coverage

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts
@@ -2,69 +2,104 @@ import { renderHook, act } from "@testing-library/react";
 import { providersByType } from "@acme/configurator/providers";
 import { LOCALES } from "@acme/types";
 import useMappingRows from "@/hooks/useMappingRows";
+import useShopEditorSubmit from "../useShopEditorSubmit";
 import useShopEditorForm from "../useShopEditorForm";
 
 jest.mock("@acme/configurator/providers", () => ({
   providersByType: jest.fn(),
 }));
 
-jest.mock("@/hooks/useMappingRows", () => jest.fn((rows: any[]) => ({
-  rows,
-  add: jest.fn(),
-  update: jest.fn(),
-  remove: jest.fn(),
-  setRows: jest.fn(),
-}))); 
+jest.mock("@/hooks/useMappingRows", () => jest.fn());
 
 jest.mock("../useShopEditorSubmit", () => ({
   __esModule: true,
-  default: jest.fn(() => ({
-    saving: false,
-    errors: {},
-    toast: { open: false, status: "success", message: "" },
-    closeToast: jest.fn(),
-    onSubmit: jest.fn(),
-  })),
+  default: jest.fn(),
 }));
+
+type MockMappingController = {
+  rows: Array<{ key: string; value: string }>;
+  add: jest.Mock;
+  update: jest.Mock;
+  remove: jest.Mock;
+  setRows: jest.Mock;
+};
 
 describe("useShopEditorForm", () => {
   const initialShop: any = {
     id: "s1",
     name: "Shop",
     themeId: "theme",
-    filterMappings: [],
-    priceOverrides: [],
-    localeOverrides: [],
+    luxuryFeatures: {
+      blog: false,
+      contentMerchandising: false,
+      raTicketing: false,
+      requireStrongCustomerAuth: false,
+      strictReturnConditions: false,
+      trackingDashboard: false,
+      premierDelivery: false,
+      fraudReviewThreshold: 0,
+    },
+    filterMappings: { color: "red" },
+    priceOverrides: { en: 10 },
+    localeOverrides: { homepage: "en" },
+    themeDefaults: { background: "#fff" },
+    themeOverrides: { accent: "#000" },
   };
   const initialTracking = ["ups"];
 
-  const providersByTypeMock = providersByType as jest.MockedFunction<
-    typeof providersByType
-  >;
-  const useMappingRowsMock = useMappingRows as jest.MockedFunction<
-    typeof useMappingRows
-  >;
+  const providersByTypeMock =
+    providersByType as jest.MockedFunction<typeof providersByType>;
+  const useMappingRowsMock =
+    useMappingRows as jest.MockedFunction<typeof useMappingRows>;
+  const useShopEditorSubmitMock =
+    useShopEditorSubmit as jest.MockedFunction<typeof useShopEditorSubmit>;
+
+  const shippingProviders = [
+    { id: "ups", name: "UPS", type: "shipping" },
+    { id: "dhl", name: "DHL", type: "shipping" },
+  ];
+
+  let submitState: ReturnType<typeof useShopEditorSubmit>;
 
   beforeEach(() => {
-    providersByTypeMock.mockReturnValue([
-      { id: "ups", name: "UPS", type: "shipping" },
-      { id: "dhl", name: "DHL", type: "shipping" },
-    ] as any);
+    providersByTypeMock.mockReturnValue(shippingProviders as any);
 
-    useMappingRowsMock.mockImplementation((rows: any[]) => ({
-      rows,
-      add: jest.fn(),
-      update: jest.fn(),
-      remove: jest.fn(),
-      setRows: jest.fn(),
-    }));
+    useMappingRowsMock.mockImplementation((initial: any = {}) => {
+      const entries = Array.isArray(initial)
+        ? initial.map(({ key, value }: { key: string; value: string }) => [
+            key,
+            value,
+          ])
+        : Object.entries(initial ?? {});
+      const controller: MockMappingController = {
+        rows: entries.map(([key, value]) => ({
+          key: String(key),
+          value: String(value),
+        })),
+        add: jest.fn(),
+        update: jest.fn(),
+        remove: jest.fn(),
+        setRows: jest.fn(),
+      };
+      return controller;
+    });
+
+    submitState = {
+      saving: false,
+      errors: {} as Record<string, string[]>,
+      toast: { open: false, status: "success" as const, message: "" },
+      closeToast: jest.fn(),
+      onSubmit: jest.fn(),
+    } as unknown as ReturnType<typeof useShopEditorSubmit>;
+
+    useShopEditorSubmitMock.mockReturnValue(submitState);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("initial form state matches defaults", () => {
+  it("exposes derived values and nested sections", () => {
     const { result } = renderHook(() =>
       useShopEditorForm({
         shop: "s1",
@@ -73,19 +108,54 @@ describe("useShopEditorForm", () => {
       }),
     );
 
-    expect(result.current.info).toEqual(initialShop);
-    expect(result.current.trackingProviders).toEqual(initialTracking);
+    expect(useMappingRowsMock).toHaveBeenCalledTimes(3);
+
+    expect(result.current.shippingProviders).toBe(shippingProviders);
     expect(result.current.shippingProviderOptions).toEqual([
       { label: "UPS", value: "ups" },
       { label: "DHL", value: "dhl" },
     ]);
+    expect(result.current.supportedLocales).toEqual([...LOCALES]);
     expect(result.current.localeOptions).toEqual(
       LOCALES.map((locale) => ({ label: locale, value: locale })),
     );
-    expect(result.current.supportedLocales).toEqual([...LOCALES]);
+    expect(result.current.filterMappings).toEqual([
+      { key: "color", value: "red" },
+    ]);
+    expect(result.current.priceOverrides).toEqual([
+      { key: "en", value: "10" },
+    ]);
+    expect(result.current.localeOverrides).toEqual([
+      { key: "homepage", value: "en" },
+    ]);
+
+    expect(result.current.identity.info).toEqual(result.current.info);
+    expect(result.current.localization.priceOverrides.rows).toEqual(
+      result.current.priceOverrides,
+    );
+    expect(result.current.localization.localeOverrides.rows).toEqual(
+      result.current.localeOverrides,
+    );
+    expect(result.current.providers.shippingProviders).toBe(
+      shippingProviders,
+    );
+    expect(result.current.overrides.filterMappings.rows).toEqual(
+      result.current.filterMappings,
+    );
+
+    expect(result.current.toast).toBe(submitState.toast);
+    expect(result.current.errors).toBe(submitState.errors);
+
+    expect(useShopEditorSubmitMock).toHaveBeenCalledWith({
+      shop: "s1",
+      identity: result.current.identity,
+      localization: result.current.localization,
+      providers: result.current.providers,
+      overrides: result.current.overrides,
+    });
   });
 
-  it("updateField modifies state", () => {
+  it("section handlers update state and controllers", () => {
     const { result } = renderHook(() =>
       useShopEditorForm({
         shop: "s1",
@@ -95,71 +165,64 @@ describe("useShopEditorForm", () => {
     );
 
     act(() => {
-      result.current.handleTextChange("name", "New Shop");
+      result.current.identity.handleTextChange("name", "Updated Shop");
     });
-
-    expect(result.current.info.name).toBe("New Shop");
-  });
-
-  it("toggle handlers update luxury features", () => {
-    const { result } = renderHook(() =>
-      useShopEditorForm({
-        shop: "s1",
-        initial: initialShop,
-        initialTrackingProviders: initialTracking,
-      }),
-    );
+    expect(result.current.info.name).toBe("Updated Shop");
+    expect(result.current.identity.info.name).toBe("Updated Shop");
 
     act(() => {
-      result.current.handleCheckboxChange("blog", true);
-      result.current.handleLuxuryFeatureChange("fraudReviewThreshold", 10);
+      result.current.identity.handleLuxuryFeatureChange(
+        "fraudReviewThreshold",
+        15,
+      );
     });
+    expect(result.current.info.luxuryFeatures.fraudReviewThreshold).toBe(15);
 
+    act(() => {
+      result.current.identity.handleCheckboxChange("blog", true);
+    });
     expect(result.current.info.luxuryFeatures.blog).toBe(true);
-    expect(result.current.info.luxuryFeatures.fraudReviewThreshold).toBe(10);
-  });
-
-  it("mapping change delegates to controllers", () => {
-    const { result } = renderHook(() =>
-      useShopEditorForm({
-        shop: "s1",
-        initial: initialShop,
-        initialTrackingProviders: initialTracking,
-      }),
-    );
-
-    const [filterController] = useMappingRowsMock.mock.results.map(
-      (entry) => entry.value,
-    );
 
     act(() => {
-      result.current.handleMappingChange("filterMappings", 0, "key", "color");
+      result.current.providers.setTrackingProviders(["dhl"]);
     });
-
-    expect(filterController.update).toHaveBeenCalledWith(0, "key", "color");
-  });
-
-  it("resetForm restores defaults", () => {
-    const { result } = renderHook(() =>
-      useShopEditorForm({
-        shop: "s1",
-        initial: initialShop,
-        initialTrackingProviders: initialTracking,
-      }),
-    );
+    expect(result.current.trackingProviders).toEqual(["dhl"]);
+    expect(result.current.providers.trackingProviders).toEqual(["dhl"]);
 
     act(() => {
-      result.current.handleTextChange("name", "New Shop");
-      result.current.setTrackingProviders(["dhl"]);
+      result.current.localization.priceOverrides.add();
     });
+    expect(
+      (
+        result.current.localization.priceOverrides as unknown as MockMappingController
+      ).add,
+    ).toHaveBeenCalled();
 
     act(() => {
-      result.current.setInfo(initialShop);
-      result.current.setTrackingProviders(initialTracking);
+      result.current.localization.localeOverrides.update(0, "value", "de");
     });
+    expect(
+      (
+        result.current.localization.localeOverrides as unknown as MockMappingController
+      ).update,
+    ).toHaveBeenCalledWith(0, "value", "de");
 
-    expect(result.current.info).toEqual(initialShop);
-    expect(result.current.trackingProviders).toEqual(initialTracking);
+    act(() => {
+      result.current.overrides.filterMappings.remove(0);
+    });
+    expect(
+      (
+        result.current.overrides.filterMappings as unknown as MockMappingController
+      ).remove,
+    ).toHaveBeenCalledWith(0);
+
+    act(() => {
+      result.current.handleMappingChange("filterMappings", 1, "key", "size");
+    });
+    expect(
+      (
+        result.current.overrides.filterMappings as unknown as MockMappingController
+      ).update,
+    ).toHaveBeenCalledWith(1, "key", "size");
   });
 });
-

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
@@ -1,30 +1,151 @@
 import { renderHook, act } from "@testing-library/react";
+import type { MappingRow } from "@/hooks/useMappingRows";
 import {
   useShopEditorSubmit,
   buildStringMapping,
   buildNumberMapping,
+  type MappingRowsController,
+  type ShopEditorIdentitySection,
+  type ShopEditorLocalizationSection,
+  type ShopEditorOverridesSection,
+  type ShopEditorProvidersSection,
 } from "../useShopEditorSubmit";
+import { updateShop } from "@cms/actions/shops.server";
 
 jest.mock("@cms/actions/shops.server", () => ({
   updateShop: jest.fn(),
 }));
 
-const createForm = () => {
+type MockMappingController = MappingRowsController & {
+  setRows: jest.Mock;
+  add: jest.Mock;
+  update: jest.Mock;
+  remove: jest.Mock;
+};
+
+type MockIdentitySection = ShopEditorIdentitySection & {
+  setInfo: jest.Mock;
+};
+
+type MockProvidersSection = ShopEditorProvidersSection & {
+  setTrackingProviders: jest.Mock;
+};
+
+type MockLocalizationSection = ShopEditorLocalizationSection & {
+  priceOverrides: MockMappingController;
+  localeOverrides: MockMappingController;
+};
+
+type MockOverridesSection = ShopEditorOverridesSection & {
+  filterMappings: MockMappingController;
+};
+
+const updateShopMock = updateShop as jest.MockedFunction<typeof updateShop>;
+
+const createMappingController = (
+  rows: MappingRow[] = [],
+): MockMappingController =>
+  ({
+    rows,
+    setRows: jest.fn(),
+    add: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  } as unknown as MockMappingController);
+
+const createIdentitySection = (): MockIdentitySection =>
+  ({
+    info: {
+      id: "s1",
+      name: "Shop",
+      themeId: "theme",
+      luxuryFeatures: {
+        blog: false,
+        contentMerchandising: false,
+        raTicketing: false,
+        requireStrongCustomerAuth: false,
+        strictReturnConditions: false,
+        trackingDashboard: false,
+        premierDelivery: false,
+        fraudReviewThreshold: 0,
+      },
+    } as any,
+    setInfo: jest.fn(),
+    handleChange: jest.fn(),
+    handleTextChange: jest.fn(),
+    handleCheckboxChange: jest.fn(),
+    handleLuxuryFeatureChange: jest.fn(),
+  } as unknown as MockIdentitySection);
+
+const createProvidersSection = (
+  trackingProviders: string[] = ["ups"],
+): MockProvidersSection =>
+  ({
+    shippingProviders: [],
+    shippingProviderOptions: [],
+    trackingProviders,
+    setTrackingProviders: jest.fn(),
+  } as unknown as MockProvidersSection);
+
+const createLocalizationSection = (
+  priceRows: MappingRow[] = [{ key: "en", value: "10" }],
+  localeRows: MappingRow[] = [{ key: "homepage", value: "en" }],
+): MockLocalizationSection =>
+  ({
+    priceOverrides: createMappingController(priceRows),
+    localeOverrides: createMappingController(localeRows),
+    localeOptions: [],
+    supportedLocales: [],
+  } as MockLocalizationSection);
+
+const createOverridesSection = (
+  filterRows: MappingRow[] = [{ key: "color", value: "red" }],
+): MockOverridesSection =>
+  ({
+    filterMappings: createMappingController(filterRows),
+    tokenRows: [],
+  } as MockOverridesSection);
+
+const createSections = (options?: {
+  filterRows?: MappingRow[];
+  priceRows?: MappingRow[];
+  localeRows?: MappingRow[];
+  trackingProviders?: string[];
+}) => {
+  const identity = createIdentitySection();
+  const localization = createLocalizationSection(
+    options?.priceRows,
+    options?.localeRows,
+  );
+  const providers = createProvidersSection(options?.trackingProviders);
+  const overrides = createOverridesSection(options?.filterRows);
+  return { identity, localization, providers, overrides };
+};
+
+const createForm = (fields: Record<string, string | string[]>) => {
   const form = document.createElement("form");
-  const id = document.createElement("input");
-  id.name = "id";
-  id.value = "s1";
-  form.appendChild(id);
-  const name = document.createElement("input");
-  name.name = "name";
-  name.value = "Shop";
-  form.appendChild(name);
-  const theme = document.createElement("input");
-  theme.name = "themeId";
-  theme.value = "theme";
-  form.appendChild(theme);
+  Object.entries(fields).forEach(([name, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((val) => {
+        const input = document.createElement("input");
+        input.name = name;
+        input.value = val;
+        form.appendChild(input);
+      });
+    } else {
+      const input = document.createElement("input");
+      input.name = name;
+      input.value = value;
+      form.appendChild(input);
+    }
+  });
   return form;
 };
+
+const submitEvent = (form: HTMLFormElement) => ({
+  preventDefault() {},
+  currentTarget: form,
+});
 
 describe("useShopEditorSubmit", () => {
   afterEach(() => {
@@ -32,39 +153,181 @@ describe("useShopEditorSubmit", () => {
   });
 
   it("builds mapping objects", () => {
-    expect(buildStringMapping([{ key: " a ", value: " b " }])).toEqual({ a: "b" });
-    expect(buildNumberMapping([{ key: "en", value: "10" }])).toEqual({ en: 10 });
+    expect(buildStringMapping([{ key: " a ", value: " b " }])).toEqual({
+      a: "b",
+    });
+    expect(buildNumberMapping([{ key: "en", value: "10" }])).toEqual({
+      en: 10,
+    });
   });
 
-  it("validates mappings", async () => {
-    const filter = { rows: [{ key: "", value: "" }], setRows: jest.fn() } as any;
-    const price = { rows: [{ key: "en", value: "bad" }], setRows: jest.fn() } as any;
-    const locale = { rows: [{ key: "k", value: "xx" }], setRows: jest.fn() } as any;
-    const setInfo = jest.fn();
-    const setTrackingProviders = jest.fn();
+  it("validates mappings and surfaces toast errors", async () => {
+    const sections = createSections({
+      filterRows: [{ key: "", value: "" }],
+      priceRows: [{ key: "en", value: "bad" }],
+      localeRows: [{ key: "banner", value: "xx" }],
+    });
+
     const { result } = renderHook(() =>
       useShopEditorSubmit({
         shop: "s1",
-        filterMappings: filter,
-        priceOverrides: price,
-        localeOverrides: locale,
-        setInfo,
-        setTrackingProviders,
+        identity: sections.identity,
+        localization: sections.localization,
+        providers: sections.providers,
+        overrides: sections.overrides,
       }),
     );
 
-    const form = createForm();
+    const form = createForm({ id: "s1", name: "Shop", themeId: "theme" });
+
     await act(async () => {
-      await result.current.onSubmit({
-        preventDefault() {},
-        currentTarget: form,
-      } as any);
+      await result.current.onSubmit(submitEvent(form) as any);
     });
 
-    expect(result.current.errors).toHaveProperty("filterMappings");
-    expect(result.current.errors).toHaveProperty("priceOverrides");
-    expect(result.current.errors).toHaveProperty("localeOverrides");
-    const { updateShop } = require("@cms/actions/shops.server");
-    expect(updateShop).not.toHaveBeenCalled();
+    expect(result.current.errors).toEqual({
+      filterMappings: ["All filter mappings must have key and value"],
+      priceOverrides: [
+        "All price overrides require locale and numeric value",
+      ],
+      localeOverrides: [
+        "All locale overrides require key and valid locale",
+      ],
+    });
+    expect(result.current.toast).toEqual({
+      open: true,
+      status: "error",
+      message: "Please resolve the highlighted validation issues.",
+    });
+    expect(updateShopMock).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.closeToast();
+    });
+    expect(result.current.toast.open).toBe(false);
+  });
+
+  it("submits successfully and updates sections", async () => {
+    const sections = createSections();
+    const responseShop = {
+      id: "s1",
+      name: "Updated Shop",
+      themeId: "theme",
+      filterMappings: { size: "large" },
+      priceOverrides: { en: 20 },
+      localeOverrides: { banner: "de" },
+      luxuryFeatures: sections.identity.info.luxuryFeatures,
+    };
+    updateShopMock.mockResolvedValue({ shop: responseShop });
+
+    const form = createForm({
+      id: "s1",
+      name: "Shop",
+      themeId: "theme",
+      trackingProviders: ["dhl", "ups"],
+    });
+
+    const { result } = renderHook(() =>
+      useShopEditorSubmit({
+        shop: "s1",
+        identity: sections.identity,
+        localization: sections.localization,
+        providers: sections.providers,
+        overrides: sections.overrides,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(submitEvent(form) as any);
+    });
+
+    expect(updateShopMock).toHaveBeenCalledWith("s1", expect.any(FormData));
+    expect(sections.identity.setInfo).toHaveBeenCalledWith(responseShop);
+    expect(sections.providers.setTrackingProviders).toHaveBeenCalledWith([
+      "dhl",
+      "ups",
+    ]);
+    expect(sections.overrides.filterMappings.setRows).toHaveBeenCalledWith([
+      { key: "size", value: "large" },
+    ]);
+    expect(sections.localization.priceOverrides.setRows).toHaveBeenCalledWith([
+      { key: "en", value: "20" },
+    ]);
+    expect(sections.localization.localeOverrides.setRows).toHaveBeenCalledWith([
+      { key: "banner", value: "de" },
+    ]);
+    expect(result.current.errors).toEqual({});
+    expect(result.current.toast).toEqual({
+      open: true,
+      status: "success",
+      message: "Shop settings saved successfully.",
+    });
+    expect(result.current.saving).toBe(false);
+  });
+
+  it("handles server validation errors", async () => {
+    const sections = createSections();
+    updateShopMock.mockResolvedValue({
+      errors: { name: ["Required"] },
+    });
+
+    const form = createForm({ id: "s1", name: "Shop", themeId: "theme" });
+
+    const { result } = renderHook(() =>
+      useShopEditorSubmit({
+        shop: "s1",
+        identity: sections.identity,
+        localization: sections.localization,
+        providers: sections.providers,
+        overrides: sections.overrides,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(submitEvent(form) as any);
+    });
+
+    expect(result.current.errors).toEqual({ name: ["Required"] });
+    expect(result.current.toast).toEqual({
+      open: true,
+      status: "error",
+      message:
+        "We couldn't save your changes. Please review the errors and try again.",
+    });
+    expect(sections.identity.setInfo).not.toHaveBeenCalled();
+  });
+
+  it("handles unexpected failures with an error toast", async () => {
+    const sections = createSections();
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    updateShopMock.mockRejectedValue(new Error("Network error"));
+
+    const form = createForm({ id: "s1", name: "Shop", themeId: "theme" });
+
+    const { result } = renderHook(() =>
+      useShopEditorSubmit({
+        shop: "s1",
+        identity: sections.identity,
+        localization: sections.localization,
+        providers: sections.providers,
+        overrides: sections.overrides,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(submitEvent(form) as any);
+    });
+
+    expect(result.current.toast).toEqual({
+      open: true,
+      status: "error",
+      message:
+        "Something went wrong while saving your changes. Please try again.",
+    });
+    expect(result.current.errors).toEqual({});
+    expect(sections.identity.setInfo).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- refresh the shop editor form tests to use the new section-based submit hook API and verify derived options plus handler mutations
- broaden the submit hook test suite with reusable section mocks covering validation errors, success, and failure toast scenarios

## Testing
- pnpm exec jest --config ./jest.config.cjs --runInBand --coverage=false --runTestsByPath 'src/app/cms/shop/[shop]/settings/__tests__/useShopEditorForm.test.ts' 'src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts'

------
https://chatgpt.com/codex/tasks/task_e_68cb01046f98832f875b590a9d6dbde8