### PR TITLE
feat(cms): add reusable mapping list field

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/ErrorChips.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/ErrorChips.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Chip } from "@/components/atoms";
+import { Chip } from "@ui/components";
 
 interface ErrorChipsProps {
   errors?: string[];

--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListField.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListField.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+
+import {
+  Button,
+  FormField,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@ui/components";
+
+import type { MappingRowsController } from "../useShopEditorSubmit";
+
+import ErrorChips from "./ErrorChips";
+
+type MappingFieldName = "key" | "value";
+
+export interface MappingListFieldRowErrors {
+  readonly key?: string[];
+  readonly value?: string[];
+  readonly general?: string[];
+}
+
+export interface MappingListFieldErrors {
+  readonly general?: string[];
+  readonly rows?: readonly MappingListFieldRowErrors[];
+}
+
+interface BaseFieldConfig<Field extends MappingFieldName> {
+  readonly field: Field;
+  readonly label: string;
+  readonly name: string;
+  readonly placeholder?: string;
+  readonly required?: boolean;
+}
+
+export interface MappingListFieldInputConfig<
+  Field extends MappingFieldName,
+> extends BaseFieldConfig<Field> {
+  readonly kind?: "input";
+  readonly type?: ComponentProps<typeof Input>["type"];
+  readonly inputMode?: ComponentProps<typeof Input>["inputMode"];
+  readonly autoComplete?: string;
+}
+
+export interface MappingListFieldSelectOption {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface MappingListFieldSelectConfig<
+  Field extends MappingFieldName,
+> extends BaseFieldConfig<Field> {
+  readonly kind: "select";
+  readonly options: readonly MappingListFieldSelectOption[];
+}
+
+export type MappingListFieldFieldConfig<Field extends MappingFieldName> =
+  | MappingListFieldInputConfig<Field>
+  | MappingListFieldSelectConfig<Field>;
+
+export interface MappingListFieldProps {
+  readonly controller: MappingRowsController;
+  readonly idPrefix: string;
+  readonly keyField: MappingListFieldFieldConfig<"key">;
+  readonly valueField: MappingListFieldFieldConfig<"value">;
+  readonly emptyMessage?: ReactNode;
+  readonly addButtonLabel: string;
+  readonly removeButtonLabel?: string;
+  readonly errors?: MappingListFieldErrors;
+  readonly rowClassName?: string;
+  readonly className?: string;
+}
+
+const DEFAULT_REMOVE_LABEL = "Remove";
+const BASE_ROW_CLASSNAME = "grid gap-4 sm:items-end";
+const DEFAULT_ROW_TEMPLATE = "sm:grid-cols-[2fr,1fr,auto]";
+const BASE_CONTAINER_CLASSNAME = "space-y-4";
+
+function hasErrors(messages?: readonly string[]) {
+  return Array.isArray(messages) && messages.length > 0;
+}
+
+function isSelectField<Field extends MappingFieldName>(
+  field: MappingListFieldFieldConfig<Field>,
+): field is MappingListFieldSelectConfig<Field> {
+  return field.kind === "select";
+}
+
+function joinClassNames(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function composeDescribedBy(...ids: Array<string | undefined>) {
+  const filtered = ids.filter(Boolean);
+  return filtered.length > 0 ? filtered.join(" ") : undefined;
+}
+
+function renderError(errors?: string[], id?: string) {
+  if (!hasErrors(errors)) {
+    return undefined;
+  }
+
+  return (
+    <span id={id}>
+      <ErrorChips errors={errors} />
+    </span>
+  );
+}
+
+function getRowClassName(rowClassName?: string) {
+  return joinClassNames(BASE_ROW_CLASSNAME, rowClassName ?? DEFAULT_ROW_TEMPLATE);
+}
+
+export default function MappingListField({
+  controller,
+  idPrefix,
+  keyField,
+  valueField,
+  emptyMessage,
+  addButtonLabel,
+  removeButtonLabel = DEFAULT_REMOVE_LABEL,
+  errors,
+  rowClassName,
+  className,
+}: MappingListFieldProps) {
+  const rows = controller.rows;
+  const rowErrors = errors?.rows ?? [];
+  const containerClassName = joinClassNames(BASE_CONTAINER_CLASSNAME, className);
+
+  return (
+    <div className={containerClassName}>
+      {rows.length === 0 ? (
+        emptyMessage ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : null
+      ) : (
+        rows.map((row, index) => {
+          const keyId = `${idPrefix}-${keyField.field}-${index}`;
+          const valueId = `${idPrefix}-${valueField.field}-${index}`;
+          const currentRowErrors = rowErrors[index];
+          const keyMessages = currentRowErrors?.key;
+          const valueMessages = currentRowErrors?.value;
+          const generalMessages = currentRowErrors?.general;
+          const keyErrorId = hasErrors(keyMessages)
+            ? `${idPrefix}-${index}-${keyField.field}-errors`
+            : undefined;
+          const valueErrorId = hasErrors(valueMessages)
+            ? `${idPrefix}-${index}-${valueField.field}-errors`
+            : undefined;
+          const rowErrorId = hasErrors(generalMessages)
+            ? `${idPrefix}-${index}-row-errors`
+            : undefined;
+
+          const keyFieldNode = (
+            <FormField
+              label={keyField.label}
+              htmlFor={keyId}
+              required={keyField.required}
+              error={renderError(keyMessages, keyErrorId)}
+            >
+              {isSelectField(keyField) ? (
+                <Select
+                  name={keyField.name}
+                  value={row[keyField.field] === "" ? undefined : row[keyField.field]}
+                  onValueChange={(value) =>
+                    controller.update(index, keyField.field, value)
+                  }
+                >
+                  <SelectTrigger
+                    id={keyId}
+                    aria-describedby={composeDescribedBy(
+                      keyErrorId,
+                      rowErrorId,
+                    )}
+                  >
+                    <SelectValue placeholder={keyField.placeholder} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {keyField.options.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  id={keyId}
+                  name={keyField.name}
+                  value={row[keyField.field]}
+                  onChange={(event) =>
+                    controller.update(index, keyField.field, event.target.value)
+                  }
+                  placeholder={keyField.placeholder}
+                  aria-describedby={composeDescribedBy(keyErrorId, rowErrorId)}
+                  type={keyField.type}
+                  inputMode={keyField.inputMode}
+                  autoComplete={keyField.autoComplete}
+                />
+              )}
+            </FormField>
+          );
+
+          const valueFieldNode = (
+            <FormField
+              label={valueField.label}
+              htmlFor={valueId}
+              required={valueField.required}
+              error={renderError(valueMessages, valueErrorId)}
+            >
+              {isSelectField(valueField) ? (
+                <Select
+                  name={valueField.name}
+                  value={
+                    row[valueField.field] === ""
+                      ? undefined
+                      : row[valueField.field]
+                  }
+                  onValueChange={(value) =>
+                    controller.update(index, valueField.field, value)
+                  }
+                >
+                  <SelectTrigger
+                    id={valueId}
+                    aria-describedby={composeDescribedBy(
+                      valueErrorId,
+                      rowErrorId,
+                    )}
+                  >
+                    <SelectValue placeholder={valueField.placeholder} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {valueField.options.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  id={valueId}
+                  name={valueField.name}
+                  value={row[valueField.field]}
+                  onChange={(event) =>
+                    controller.update(
+                      index,
+                      valueField.field,
+                      event.target.value,
+                    )
+                  }
+                  placeholder={valueField.placeholder}
+                  aria-describedby={composeDescribedBy(valueErrorId, rowErrorId)}
+                  type={valueField.type}
+                  inputMode={valueField.inputMode}
+                  autoComplete={valueField.autoComplete}
+                />
+              )}
+            </FormField>
+          );
+
+          return (
+            <div key={`${idPrefix}-row-${index}`} className={getRowClassName(rowClassName)}>
+              {keyFieldNode}
+              {valueFieldNode}
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => controller.remove(index)}
+                className="self-start sm:self-auto"
+              >
+                {removeButtonLabel}
+              </Button>
+              {hasErrors(generalMessages) ? (
+                <div className="sm:col-span-3">
+                  <span id={rowErrorId}>
+                    <ErrorChips errors={generalMessages} />
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          );
+        })
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button
+          type="button"
+          onClick={controller.add}
+          className="w-full sm:w-auto"
+        >
+          {addButtonLabel}
+        </Button>
+        {hasErrors(errors?.general) ? (
+          <ErrorChips errors={errors?.general} />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopLocalizationSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopLocalizationSection.tsx
@@ -1,23 +1,17 @@
 "use client";
 
-import {
-  Button,
-  Card,
-  CardContent,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/atoms/shadcn";
-import { FormField } from "@ui/components/molecules";
+import { Card, CardContent } from "@/components/atoms/shadcn";
 import type { MappingRowsController } from "../useShopEditorSubmit";
+
+import MappingListField, {
+  type MappingListFieldErrors,
+  type MappingListFieldSelectOption,
+} from "../components/MappingListField";
 
 const DEFAULT_LOCALES = ["en", "de", "it"] as const;
 
 export type ShopLocalizationSectionErrors = Partial<
-  Record<"localeOverrides", string[]>
+  Record<"localeOverrides", MappingListFieldErrors>
 >;
 
 export interface ShopLocalizationSectionProps {
@@ -26,18 +20,13 @@ export interface ShopLocalizationSectionProps {
   readonly availableLocales?: readonly string[];
 }
 
-function formatError(messages?: string[]) {
-  return messages && messages.length > 0 ? messages.join("; ") : undefined;
-}
-
 export default function ShopLocalizationSection({
   localeOverrides,
   errors,
   availableLocales = DEFAULT_LOCALES,
 }: ShopLocalizationSectionProps) {
-  const rows = localeOverrides.rows;
-  const errorMessage = formatError(errors?.localeOverrides);
-  const errorId = errorMessage ? "locale-overrides-error" : undefined;
+  const options: readonly MappingListFieldSelectOption[] =
+    availableLocales.map((locale) => ({ label: locale, value: locale }));
 
   return (
     <Card>
@@ -50,78 +39,29 @@ export default function ShopLocalizationSection({
           </p>
         </div>
 
-        <div className="space-y-4">
-          {rows.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No locale overrides configured.
-            </p>
-          ) : (
-            rows.map((row, index) => {
-              const keyId = `locale-override-key-${index}`;
-              const valueId = `locale-override-value-${index}`;
-              return (
-                <div
-                  key={keyId}
-                  className="grid gap-4 sm:grid-cols-[2fr,1fr,auto] sm:items-end"
-                >
-                  <FormField label="Field key" htmlFor={keyId}>
-                    <Input
-                      id={keyId}
-                      name="localeOverridesKey"
-                      value={row.key}
-                      onChange={(event) =>
-                        localeOverrides.update(index, "key", event.target.value)
-                      }
-                      placeholder="/collections/new"
-                    />
-                  </FormField>
-                  <FormField label="Locale" htmlFor={valueId}>
-                    <Select
-                      name="localeOverridesValue"
-                      value={row.value === "" ? undefined : row.value}
-                      onValueChange={(value) =>
-                        localeOverrides.update(index, "value", value)
-                      }
-                    >
-                      <SelectTrigger id={valueId} aria-describedby={errorId}>
-                        <SelectValue placeholder="Select locale" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {availableLocales.map((locale) => (
-                          <SelectItem key={locale} value={locale}>
-                            {locale}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </FormField>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={() => localeOverrides.remove(index)}
-                  >
-                    Remove
-                  </Button>
-                </div>
-              );
-            })
-          )}
-        </div>
-
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <Button
-            type="button"
-            onClick={localeOverrides.add}
-            className="w-full sm:w-auto"
-          >
-            Add locale override
-          </Button>
-          {errorMessage ? (
-            <p id={errorId} className="text-sm text-destructive" role="alert">
-              {errorMessage}
-            </p>
-          ) : null}
-        </div>
+        <MappingListField
+          controller={localeOverrides}
+          idPrefix="locale-override"
+          keyField={{
+            field: "key",
+            label: "Field key",
+            name: "localeOverridesKey",
+            placeholder: "/collections/new",
+          }}
+          valueField={{
+            field: "value",
+            kind: "select",
+            label: "Locale",
+            name: "localeOverridesValue",
+            placeholder: "Select locale",
+            options,
+          }}
+          emptyMessage="No locale overrides configured."
+          addButtonLabel="Add locale override"
+          removeButtonLabel="Remove"
+          errors={errors?.localeOverrides}
+          rowClassName="sm:grid-cols-[2fr,1fr,auto]"
+        />
       </CardContent>
     </Card>
   );

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopOverridesSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopOverridesSection.tsx
@@ -5,16 +5,17 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-  Button,
   Card,
   CardContent,
-  Input,
 } from "@/components/atoms/shadcn";
-import { FormField } from "@ui/components/molecules";
 import type { MappingRowsController } from "../useShopEditorSubmit";
 
+import MappingListField, {
+  type MappingListFieldErrors,
+} from "../components/MappingListField";
+
 export type ShopOverridesSectionErrors = Partial<
-  Record<"filterMappings" | "priceOverrides", string[]>
+  Record<"filterMappings" | "priceOverrides", MappingListFieldErrors>
 >;
 
 export interface ShopOverridesSectionProps {
@@ -23,156 +24,59 @@ export interface ShopOverridesSectionProps {
   readonly errors?: ShopOverridesSectionErrors;
 }
 
-function formatError(messages?: string[]) {
-  return messages && messages.length > 0 ? messages.join("; ") : undefined;
-}
-
 export default function ShopOverridesSection({
   filterMappings,
   priceOverrides,
   errors,
 }: ShopOverridesSectionProps) {
-  const filterError = formatError(errors?.filterMappings);
-  const priceError = formatError(errors?.priceOverrides);
-  const filterErrorId = filterError ? "filter-mappings-error" : undefined;
-  const priceErrorId = priceError ? "price-overrides-error" : undefined;
-
   const filterContent = (
-    <div className="space-y-4">
-      {filterMappings.rows.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No filter mappings configured. Add mappings to translate storefront
-          facets into catalog attributes.
-        </p>
-      ) : (
-        filterMappings.rows.map((row, index) => {
-          const keyId = `filter-mapping-key-${index}`;
-          const valueId = `filter-mapping-value-${index}`;
-          return (
-            <div
-              key={keyId}
-              className="grid gap-4 sm:grid-cols-[2fr,2fr,auto] sm:items-end"
-            >
-              <FormField label="Filter key" htmlFor={keyId}>
-                <Input
-                  id={keyId}
-                  name="filterMappingsKey"
-                  value={row.key}
-                  onChange={(event) =>
-                    filterMappings.update(index, "key", event.target.value)
-                  }
-                  placeholder="color"
-                  aria-describedby={filterErrorId}
-                />
-              </FormField>
-              <FormField label="Catalog attribute" htmlFor={valueId}>
-                <Input
-                  id={valueId}
-                  name="filterMappingsValue"
-                  value={row.value}
-                  onChange={(event) =>
-                    filterMappings.update(index, "value", event.target.value)
-                  }
-                  placeholder="attributes.color"
-                  aria-describedby={filterErrorId}
-                />
-              </FormField>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => filterMappings.remove(index)}
-              >
-                Remove
-              </Button>
-            </div>
-          );
-        })
-      )}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <Button
-          type="button"
-          onClick={filterMappings.add}
-          className="w-full sm:w-auto"
-        >
-          Add filter mapping
-        </Button>
-        {filterError ? (
-          <p id={filterErrorId} className="text-sm text-destructive" role="alert">
-            {filterError}
-          </p>
-        ) : null}
-      </div>
-    </div>
+    <MappingListField
+      controller={filterMappings}
+      idPrefix="filter-mapping"
+      keyField={{
+        field: "key",
+        label: "Filter key",
+        name: "filterMappingsKey",
+        placeholder: "color",
+      }}
+      valueField={{
+        field: "value",
+        label: "Catalog attribute",
+        name: "filterMappingsValue",
+        placeholder: "attributes.color",
+      }}
+      emptyMessage="No filter mappings configured. Add mappings to translate storefront facets into catalog attributes."
+      addButtonLabel="Add filter mapping"
+      removeButtonLabel="Remove"
+      errors={errors?.filterMappings}
+      rowClassName="sm:grid-cols-[2fr,2fr,auto]"
+    />
   );
 
   const priceContent = (
-    <div className="space-y-4">
-      {priceOverrides.rows.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No price overrides defined. Configure overrides to adjust pricing for
-          specific locales.
-        </p>
-      ) : (
-        priceOverrides.rows.map((row, index) => {
-          const keyId = `price-override-key-${index}`;
-          const valueId = `price-override-value-${index}`;
-          return (
-            <div
-              key={keyId}
-              className="grid gap-4 sm:grid-cols-[2fr,1fr,auto] sm:items-end"
-            >
-              <FormField label="Locale" htmlFor={keyId}>
-                <Input
-                  id={keyId}
-                  name="priceOverridesKey"
-                  value={row.key}
-                  onChange={(event) =>
-                    priceOverrides.update(index, "key", event.target.value)
-                  }
-                  placeholder="en-GB"
-                  aria-describedby={priceErrorId}
-                />
-              </FormField>
-              <FormField label="Override (minor units)" htmlFor={valueId}>
-                <Input
-                  id={valueId}
-                  type="number"
-                  inputMode="numeric"
-                  name="priceOverridesValue"
-                  value={row.value}
-                  onChange={(event) =>
-                    priceOverrides.update(index, "value", event.target.value)
-                  }
-                  placeholder="12000"
-                  aria-describedby={priceErrorId}
-                />
-              </FormField>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => priceOverrides.remove(index)}
-              >
-                Remove
-              </Button>
-            </div>
-          );
-        })
-      )}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <Button
-          type="button"
-          onClick={priceOverrides.add}
-          className="w-full sm:w-auto"
-        >
-          Add price override
-        </Button>
-        {priceError ? (
-          <p id={priceErrorId} className="text-sm text-destructive" role="alert">
-            {priceError}
-          </p>
-        ) : null}
-      </div>
-    </div>
+    <MappingListField
+      controller={priceOverrides}
+      idPrefix="price-override"
+      keyField={{
+        field: "key",
+        label: "Locale",
+        name: "priceOverridesKey",
+        placeholder: "en-GB",
+      }}
+      valueField={{
+        field: "value",
+        label: "Override (minor units)",
+        name: "priceOverridesValue",
+        placeholder: "12000",
+        type: "number",
+        inputMode: "numeric",
+      }}
+      emptyMessage="No price overrides defined. Configure overrides to adjust pricing for specific locales."
+      addButtonLabel="Add price override"
+      removeButtonLabel="Remove"
+      errors={errors?.priceOverrides}
+      rowClassName="sm:grid-cols-[2fr,1fr,auto]"
+    />
   );
 
   return (


### PR DESCRIPTION
## Summary
- add a generic MappingListField component that renders key/value mapping rows with shared UI primitives
- refactor overrides and localization sections to consume the shared field and accept structured validation errors
- adapt ShopEditor error shaping and update related tests and mocks

## Testing
- pnpm exec jest --config apps/cms/jest.config.cjs --runTestsByPath 'apps/cms/src/app/cms/shop/[shop]/settings/__tests__/PriceOverrides.test.tsx' 'apps/cms/src/app/cms/shop/[shop]/settings/__tests__/LocaleOverrides.test.tsx' --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb0223b828832f919a534dc356ed29