### PR TITLE
test: mock settings save form hook and validate toasts

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/hooks/__mocks__/useSettingsSaveForm.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/hooks/__mocks__/useSettingsSaveForm.ts
@@ -1,0 +1,122 @@
+import { useCallback, useMemo, useState } from "react";
+
+import type {
+  UseSettingsSaveFormOptions,
+  ValidationErrors,
+} from "../useSettingsSaveForm";
+
+type ToastStatus = "success" | "error";
+
+interface ToastLogEntry {
+  status: ToastStatus;
+  message: string;
+}
+
+const submitMock = jest.fn<void, [FormData]>();
+const toastLog: ToastLogEntry[] = [];
+
+export function __resetUseSettingsSaveFormMock() {
+  submitMock.mockReset();
+  toastLog.length = 0;
+}
+
+export function __getUseSettingsSaveFormSubmitMock() {
+  return submitMock;
+}
+
+export function __getUseSettingsSaveFormToastLog() {
+  return toastLog;
+}
+
+export const useSettingsSaveForm = <TResult,>(
+  options: UseSettingsSaveFormOptions<TResult>,
+) => {
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [toast, setToast] = useState({
+    open: false,
+    status: "success" as ToastStatus,
+    message: "",
+  });
+
+  const announce = useCallback((status: ToastStatus, message: string) => {
+    toastLog.push({ status, message });
+    setToast({ open: true, status, message });
+  }, []);
+
+  const announceSuccess = useCallback(
+    (message: string) => announce("success", message),
+    [announce],
+  );
+
+  const announceError = useCallback(
+    (message: string) => announce("error", message),
+    [announce],
+  );
+
+  const closeToast = useCallback(() => {
+    setToast((current) => ({ ...current, open: false }));
+  }, []);
+
+  const submit = useCallback(
+    async (formData: FormData) => {
+      submitMock(formData);
+      setSaving(true);
+      try {
+        const result = await options.action(formData);
+        const normalizedErrors =
+          options.normalizeErrors?.(result) ??
+          ((result && typeof result === "object" && "errors" in result
+            ? ((result as { errors?: ValidationErrors }).errors ?? {})
+            : {}) as ValidationErrors);
+
+        if (normalizedErrors && Object.keys(normalizedErrors).length > 0) {
+          setErrors(normalizedErrors);
+          announceError(options.errorMessage ?? "Unable to save settings.");
+          options.onError?.(result);
+          return { ok: false as const, result };
+        }
+
+        setErrors({});
+        options.onSuccess?.(result);
+        announceSuccess(options.successMessage ?? "Settings saved.");
+        return { ok: true as const, result };
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : options.errorMessage ?? "Unable to save settings.";
+        announceError(message);
+        return { ok: false as const, error };
+      } finally {
+        setSaving(false);
+      }
+    },
+    [announceError, announceSuccess, options],
+  );
+
+  const toastClassName = useMemo(() => {
+    return toast.status === "error"
+      ? "mock-error-toast"
+      : "mock-success-toast";
+  }, [toast.status]);
+
+  return {
+    saving,
+    errors,
+    setErrors,
+    submit,
+    toast,
+    toastClassName,
+    closeToast,
+    announceSuccess,
+    announceError,
+  };
+};
+
+export default useSettingsSaveForm;
+
+export type {
+  ValidationErrors,
+  UseSettingsSaveFormOptions,
+} from "../useSettingsSaveForm";

--- a/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx
@@ -1,9 +1,15 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 
 import PremierDeliveryEditor from "../PremierDeliveryEditor";
+import {
+  __getUseSettingsSaveFormToastLog,
+  __resetUseSettingsSaveFormMock,
+} from "../../hooks/useSettingsSaveForm";
+
+jest.mock("../../hooks/useSettingsSaveForm");
 
 expect.extend(toHaveNoViolations);
 
@@ -15,6 +21,9 @@ jest.mock("@cms/actions/shops.server", () => ({
 jest.mock(
   "@/components/atoms/shadcn",
   () => ({
+    __esModule: true,
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Input: ({ name, "aria-label": ariaLabel, ...props }: any) => (
       <input aria-label={ariaLabel ?? name} name={name} {...props} />
@@ -22,9 +31,20 @@ jest.mock(
   }),
   { virtual: true },
 );
+jest.mock("@/components/atoms", () => ({
+  __esModule: true,
+  Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  Toast: ({ open, message, className, ...props }: any) =>
+    open ? (
+      <div role="status" className={className} {...props}>
+        {message}
+      </div>
+    ) : null,
+}));
 
 describe("PremierDeliveryEditor", () => {
   beforeEach(() => {
+    __resetUseSettingsSaveFormMock();
     jest.clearAllMocks();
   });
 
@@ -50,16 +70,36 @@ describe("PremierDeliveryEditor", () => {
     await userEvent.type(windowInput, "10-12");
     await userEvent.click(screen.getByRole("button", { name: /add window/i }));
 
+    const carrierInput = screen.getAllByRole("textbox", { name: /carriers/i })[0];
+    await userEvent.clear(carrierInput);
+    await userEvent.type(carrierInput, "DHL Express");
+
+    const serviceLabelInput = screen.getByLabelText(/service label/i);
+    await userEvent.clear(serviceLabelInput);
+    await userEvent.type(serviceLabelInput, " Premier Delivery ");
+
+    const surchargeInput = screen.getByLabelText(/surcharge/i);
+    await userEvent.clear(surchargeInput);
+    await userEvent.type(surchargeInput, " 9.50 ");
+
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     expect(updatePremierDelivery).toHaveBeenCalledTimes(1);
     const fd = updatePremierDelivery.mock.calls[0][1] as FormData;
     expect(fd.getAll("regions")).toEqual(["Paris"]);
     expect(fd.getAll("windows")).toEqual(["10-12"]);
-    expect(fd.getAll("carriers")).toEqual([]);
-    expect(fd.has("surcharge")).toBe(false);
+    expect(fd.getAll("carriers")).toEqual(["DHL Express"]);
+    expect(fd.get("serviceLabel")).toBe("Premier Delivery");
+    expect(fd.get("surcharge")).toBe("9.5");
 
-    expect(await screen.findByText("Too few regions")).toBeInTheDocument();
+    const regionError = await screen.findByText("Too few regions");
+    expect(regionError).toHaveAttribute("data-token", "--color-danger");
+
+    const toastLog = __getUseSettingsSaveFormToastLog();
+    expect(toastLog.at(-1)).toEqual({
+      status: "error",
+      message: "Unable to update premier delivery settings.",
+    });
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -77,31 +117,37 @@ describe("PremierDeliveryEditor", () => {
       />,
     );
 
-    const regionsFieldset = screen
-      .getByText("Regions")
-      .closest("fieldset") as HTMLElement;
-    const windowsFieldset = screen
-      .getByText("One-hour Windows")
-      .closest("fieldset") as HTMLElement;
-
     await userEvent.click(screen.getByRole("button", { name: /add region/i }));
-    expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(2);
+    expect(screen.getAllByRole("textbox", { name: /regions/i })).toHaveLength(2);
 
-    const regionInputs = within(regionsFieldset).getAllByRole("textbox");
+    const regionInputs = screen.getAllByRole("textbox", { name: /regions/i });
     await userEvent.type(regionInputs[1], "Berlin");
-    await userEvent.click(within(regionsFieldset).getAllByRole("button", { name: /remove/i })[0]);
-    expect(within(regionsFieldset).getAllByRole("textbox")).toHaveLength(1);
+    await userEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    expect(screen.getAllByRole("textbox", { name: /regions/i })).toHaveLength(1);
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
-    expect(await screen.findByText("Invalid window")).toBeInTheDocument();
+    const toastLog = __getUseSettingsSaveFormToastLog();
+    expect(await screen.findByText("Invalid window")).toHaveAttribute(
+      "data-token",
+      "--color-danger",
+    );
+    expect(toastLog.at(-1)).toEqual({
+      status: "error",
+      message: "Unable to update premier delivery settings.",
+    });
 
-    const windowInputs = within(windowsFieldset).getAllByRole("textbox");
+    const windowInputs = screen.getAllByRole("textbox", { name: /windows/i });
     await userEvent.clear(windowInputs[0]);
     await userEvent.type(windowInputs[0], "11-12");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => {
       expect(screen.queryByText("Invalid window")).not.toBeInTheDocument();
+    });
+
+    expect(toastLog.at(-1)).toEqual({
+      status: "success",
+      message: "Premier delivery settings saved.",
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a jest mock for `useSettingsSaveForm` so settings editor tests can control submission results and toast state
- update StockAlertsEditor specs to assert validation chip styling and success/error toast messages
- expand PremierDeliveryEditor specs to verify new form data fields and toast behaviour for server errors and successes

## Testing
- pnpm exec jest --runInBand --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/stock-alerts/__tests__/StockAlertsEditor.test.tsx --config ./jest.config.cjs --coverage=false
- pnpm exec jest --runInBand --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/premier-delivery/__tests__/PremierDeliveryEditor.test.tsx --config ./jest.config.cjs --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb0656a278832fbfed47d546bf0f50