### PR TITLE
Add ShopLocalizationSection test

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/__tests__/ShopLocalizationSection.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/__tests__/ShopLocalizationSection.test.tsx
@@ -1,0 +1,135 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { MappingRowsController } from "../../useShopEditorSubmit";
+import ShopLocalizationSection from "../ShopLocalizationSection";
+
+jest.mock(
+  "@/components/atoms/shadcn",
+  () => ({
+    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "@ui/components",
+  () => {
+    const React = require("react");
+    const SelectContent = Object.assign(
+      ({ children }: any) => <>{children}</>,
+      { displayName: "MockSelectContent" },
+    );
+    const SelectTrigger = Object.assign(
+      ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      { displayName: "MockSelectTrigger" },
+    );
+    const Select = ({ children, value, onValueChange, name }: any) => {
+      const arrayChildren = React.Children.toArray(children);
+      const content = arrayChildren.find(
+        (child: any) => child?.type?.displayName === "MockSelectContent",
+      );
+      const items = content
+        ? React.Children.toArray((content as any).props.children).map((child: any) => ({
+            value: child.props.value,
+            label: child.props.children,
+          }))
+        : [];
+      const trigger = arrayChildren.find(
+        (child: any) => child?.type?.displayName === "MockSelectTrigger",
+      );
+      const triggerProps = trigger ? ((trigger as any).props ?? {}) : {};
+      const { id, ["aria-describedby"]: ariaDescribedBy } = triggerProps as {
+        id?: string;
+        ["aria-describedby"]?: string;
+      };
+
+      return (
+        <select
+          id={id}
+          name={name}
+          value={value ?? ""}
+          aria-describedby={ariaDescribedBy}
+          onChange={(event) => onValueChange?.(event.target.value)}
+        >
+          <option value="" disabled>
+            {trigger ? trigger.props.children : undefined}
+          </option>
+          {items.map((item: any) => (
+            <option key={item.value} value={item.value}>
+              {item.label}
+            </option>
+          ))}
+        </select>
+      );
+    };
+    const SelectValue = ({ placeholder, children }: any) => children ?? placeholder;
+    return {
+      Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+      FormField: ({ children, label, htmlFor, error }: any) => (
+        <div>
+          <label htmlFor={htmlFor}>{label}</label>
+          {children}
+          {error}
+        </div>
+      ),
+      Input: (props: any) => <input {...props} />,
+      Select,
+      SelectTrigger,
+      SelectValue,
+      SelectContent,
+      SelectItem: ({ value, children }: any) => (
+        <option value={value}>{children}</option>
+      ),
+      Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+    };
+  },
+  { virtual: true },
+);
+
+describe("ShopLocalizationSection", () => {
+  it("maps form interactions through the row controller", () => {
+    const add: MappingRowsController["add"] = jest.fn();
+    const update: MappingRowsController["update"] = jest.fn();
+    const remove: MappingRowsController["remove"] = jest.fn();
+
+    const controller = {
+      rows: [{ key: "", value: "" }],
+      add,
+      update,
+      remove,
+    } as unknown as MappingRowsController;
+
+    render(
+      <ShopLocalizationSection
+        localeOverrides={controller}
+        availableLocales={["en", "fr"]}
+        errors={{ localeOverrides: { general: ["must not be empty"] } }}
+      />,
+    );
+
+    const keyInput = screen.getByLabelText("Field key");
+    const localeSelect = screen.getByLabelText("Locale");
+
+    expect(keyInput).toBeInTheDocument();
+    expect(localeSelect).toBeInTheDocument();
+
+    fireEvent.change(keyInput, { target: { value: "/collections/sale" } });
+    fireEvent.change(localeSelect, { target: { value: "fr" } });
+
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update.mock.calls.map(([, field, value]) => [field, value])).toEqual([
+      ["key", "/collections/sale"],
+      ["value", "fr"],
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add locale override/i }));
+    expect(add).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/i }));
+    expect(remove).toHaveBeenCalledWith(0);
+
+    expect(screen.getByText("must not be empty")).toHaveClass("text-destructive");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest test for the ShopLocalizationSection that reuses the lightweight UI mocks and exercises the controller interactions, add/remove buttons, and error chip rendering

## Testing
- pnpm test --filter ShopLocalizationSection *(fails: No package found with name 'ShopLocalizationSection' in workspace)*
- pnpm --filter @apps/cms test -- ShopLocalizationSection *(fails: global coverage thresholds are enforced when running only this spec)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0eb8bb88832fa1f7e7efdbf14346