### PR TITLE
Refactor overrides & localization settings to MappingListField

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/LocaleOverrides.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/LocaleOverrides.test.tsx
@@ -3,15 +3,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import ShopLocalizationSection from "../sections/ShopLocalizationSection";
 
 jest.mock(
-  "@/components/atoms/shadcn",
-  () => ({
-    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  }),
-  { virtual: true },
-);
-
-jest.mock(
   "@ui/components",
   () => {
     const React = require("react");
@@ -58,7 +49,17 @@ jest.mock(
     };
     const SelectValue = ({ placeholder, children }: any) => children ?? placeholder;
     return {
+      Accordion: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      AccordionContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      AccordionItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      AccordionTrigger: ({ children, ...props }: any) => (
+        <button type="button" {...props}>
+          {children}
+        </button>
+      ),
       Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+      Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
       FormField: ({ children, label, htmlFor, error }: any) => (
         <div>
           <label htmlFor={htmlFor}>{label}</label>
@@ -122,6 +123,8 @@ describe("ShopLocalizationSection", () => {
     fireEvent.click(screen.getByText(/Remove/i));
     expect(localeController.remove).toHaveBeenCalledWith(0);
 
-    expect(screen.getByText(/must not be empty/i)).toBeInTheDocument();
+    const chip = screen.getByText(/must not be empty/i);
+    expect(chip).toHaveAttribute("data-token", "--color-danger");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/PriceOverrides.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/PriceOverrides.test.tsx
@@ -3,25 +3,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import ShopOverridesSection from "../sections/ShopOverridesSection";
 
 jest.mock(
-  "@/components/atoms/shadcn",
-  () => ({
-    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-    Input: (props: any) => <input {...props} />,
-    Accordion: ({ children }: any) => <div>{children}</div>,
-    AccordionItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    AccordionTrigger: ({ children, ...props }: any) => (
-      <button type="button" {...props}>
-        {children}
-      </button>
-    ),
-    AccordionContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  }),
-  { virtual: true },
-);
-
-jest.mock(
   "@ui/components",
   () => {
     const React = require("react");
@@ -68,7 +49,17 @@ jest.mock(
     };
     const SelectValue = ({ placeholder, children }: any) => children ?? placeholder;
     return {
+      Accordion: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      AccordionContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      AccordionItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      AccordionTrigger: ({ children, ...props }: any) => (
+        <button type="button" {...props}>
+          {children}
+        </button>
+      ),
       Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+      Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
       FormField: ({ children, label, htmlFor, error }: any) => (
         <div>
           <label htmlFor={htmlFor}>{label}</label>
@@ -146,6 +137,8 @@ describe("ShopOverridesSection", () => {
     fireEvent.click(screen.getAllByText(/Remove/i)[0]);
     expect(filterController.remove).toHaveBeenCalledWith(0);
 
-    expect(screen.getByText(/must not be empty/i)).toBeInTheDocument();
+    const chip = screen.getByText(/must not be empty/i);
+    expect(chip).toHaveAttribute("data-token", "--color-danger");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopLocalizationSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopLocalizationSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent } from "@/components/atoms/shadcn";
+import { Card, CardContent } from "@ui/components";
 import type { MappingRowsController } from "../useShopEditorSubmit";
 
 import MappingListField, {

--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopOverridesSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopOverridesSection.tsx
@@ -7,7 +7,7 @@ import {
   AccordionTrigger,
   Card,
   CardContent,
-} from "@/components/atoms/shadcn";
+} from "@ui/components";
 import type { MappingRowsController } from "../useShopEditorSubmit";
 
 import MappingListField, {


### PR DESCRIPTION
## Summary
- update shop override and localization sections to consume Accordion/Card primitives from `@ui/components`
- rely on `MappingListField` for both sections so inline error chips surface consistently
- refresh override tests to mock the `@ui/components` barrel and assert chip-based validation output

## Testing
- pnpm exec jest PriceOverrides.test.tsx --runInBand --config ./jest.config.cjs --coverage=false
- pnpm exec jest LocaleOverrides.test.tsx --runInBand --config ./jest.config.cjs --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb0c42ef6c832fa806601b2b630575