### PR TITLE
Fix ShopLocalizationSection card import path

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopLocalizationSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopLocalizationSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent } from "@ui/components";
+import { Card, CardContent } from "@/components/atoms/shadcn";
 import type { MappingRowsController } from "../useShopEditorSubmit";
 
 import MappingListField, {


### PR DESCRIPTION
## Summary
- fix `ShopLocalizationSection` to import the CMS shadcn Card components so the jest mock provides the expected implementation

## Testing
- pnpm --filter @apps/cms exec jest --runTestsByPath src/app/cms/shop/[shop]/settings/sections/__tests__/ShopLocalizationSection.test.tsx --config jest.config.cjs --runInBand --detectOpenHandles --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb14f18dd8832f9b71c43f58d02b11