### PR TITLE
Fix ShopOverridesSection test mocks

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/__tests__/ShopOverridesSection.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/__tests__/ShopOverridesSection.test.tsx
@@ -30,6 +30,14 @@ jest.mock(
   "@ui/components",
   () => {
     const React = require("react");
+    const {
+      Card,
+      CardContent,
+      Accordion,
+      AccordionItem,
+      AccordionTrigger,
+      AccordionContent,
+    } = require("@/components/atoms/shadcn");
 
     const SelectContent = Object.assign(
       ({ children, ...props }: any) => <div {...props}>{children}</div>,
@@ -139,6 +147,12 @@ jest.mock(
     );
 
     return {
+      Card,
+      CardContent,
+      Accordion,
+      AccordionItem,
+      AccordionTrigger,
+      AccordionContent,
       Button,
       FormField,
       Input,


### PR DESCRIPTION
## Summary
- ensure the @ui/components Jest mock re-exports the card and accordion primitives from the shared shadcn mock so components under test render properly

## Testing
- pnpm --filter @apps/cms test

------
https://chatgpt.com/codex/tasks/task_e_68cb14a9be80832f82aa38a963793eb0