### PR TITLE
test: mock seo state in ShopEditor unit test

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ShopEditor.test.tsx
@@ -190,6 +190,10 @@ describe("ShopEditor", () => {
       providers,
       overrides,
       localization,
+      seo: {
+        catalogFilters: info.catalogFilters,
+        setCatalogFilters: jest.fn(),
+      },
       toast: {
         open: true,
         status: "error",


### PR DESCRIPTION
## Summary
- add the seo state to the mocked ShopEditor form hook so the unit test reflects the hook contract

## Testing
- pnpm -w exec jest --config apps/cms/jest.config.cjs --runInBand --detectOpenHandles --findRelatedTests apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ShopEditor.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb14cd0ab0832fb76930dfa8d76982