### PR TITLE
Fix inventory form integration test mocks

### DIFF
--- a/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
+++ b/apps/cms/__tests__/inventoryFormVariants.integration.test.tsx
@@ -9,6 +9,16 @@ jest.mock(
       Button: ({ children, ...props }: any) => (
         <button {...props}>{children}</button>
       ),
+      Card: ({ children, ...props }: any) => (
+        <div {...props} data-component="card">
+          {children}
+        </div>
+      ),
+      CardContent: ({ children, ...props }: any) => (
+        <div {...props} data-component="card-content">
+          {children}
+        </div>
+      ),
       Input: ({ ...props }: any) => <input {...props} />,
       Table: ({ children }: any) => <table>{children}</table>,
       TableBody: ({ children }: any) => <tbody>{children}</tbody>,
@@ -62,7 +72,7 @@ describe("InventoryForm integration", () => {
       },
     ];
     render(<InventoryForm shop="test" initial={initial} />);
-    fireEvent.click(screen.getByText("Save"));
+    fireEvent.click(screen.getByRole("button", { name: /save inventory/i }));
     await waitFor(() => expect(fetch).toHaveBeenCalled());
     expect(fetch).toHaveBeenCalledWith(
       "/api/data/test/inventory",


### PR DESCRIPTION
## Summary
- add Card and CardContent to the shadcn mock used in the inventory form integration test
- query the save button by its accessible label so the test matches the rendered markup

## Testing
- pnpm exec jest --config ./jest.config.cjs --runInBand --detectOpenHandles --coverage=false --runTestsByPath __tests__/inventoryFormVariants.integration.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb16c373c8832fb218b68ee01c43b8