### PR TITLE
Fix telemetry filter test to use local datetime formatting

### DIFF
--- a/apps/cms/__tests__/telemetryPage.test.tsx
+++ b/apps/cms/__tests__/telemetryPage.test.tsx
@@ -31,6 +31,12 @@ function createEvent(partial: Partial<TelemetryEvent> = {}): TelemetryEvent {
   } as TelemetryEvent;
 }
 
+function toLocalDatetimeInput(date: Date): string {
+  const offsetMinutes = date.getTimezoneOffset();
+  const localDate = new Date(date.getTime() - offsetMinutes * 60 * 1000);
+  return localDate.toISOString().slice(0, 16);
+}
+
 describe("Telemetry analytics", () => {
   it("filters events by name and time range", () => {
     const now = Date.now();
@@ -41,8 +47,8 @@ describe("Telemetry analytics", () => {
     ];
     const filtered = filterTelemetryEvents(events, {
       name: "checkout",
-      start: new Date(now - 10 * 60 * 1000).toISOString().slice(0, 16),
-      end: new Date(now).toISOString().slice(0, 16),
+      start: toLocalDatetimeInput(new Date(now - 10 * 60 * 1000)),
+      end: toLocalDatetimeInput(new Date(now)),
     });
     expect(filtered).toHaveLength(1);
     expect(filtered[0].name).toBe("checkout.started");


### PR DESCRIPTION
## Summary
- add a helper in the telemetry analytics test to format Date values the same way as the datetime-local input
- update the filter test to use the helper so expectations hold regardless of the runner's timezone

## Testing
- pnpm exec jest --config apps/cms/jest.config.cjs --runTestsByPath apps/cms/__tests__/telemetryPage.test.tsx --coverage=false
- TZ=America/Los_Angeles pnpm exec jest --config apps/cms/jest.config.cjs --runTestsByPath apps/cms/__tests__/telemetryPage.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb1503d9d4832f8e28531a746f5e17