### PR TITLE
Align orders pages with tests

### DIFF
--- a/apps/cms/src/app/cms/orders/[shop]/page.tsx
+++ b/apps/cms/src/app/cms/orders/[shop]/page.tsx
@@ -96,23 +96,18 @@ export default async function ShopOrdersPage({
             <div className="space-y-4">
               <Progress value={readiness} label={`${readiness}% of orders on schedule`} />
               <div className="flex flex-wrap items-center gap-3">
-                <Button
-                  asChild
-                  className="h-11 rounded-xl bg-emerald-500 px-5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 hover:bg-emerald-400"
+                <Link
+                  href={`/cms/shop/${shop}/settings/returns`}
+                  className="inline-flex h-11 items-center rounded-xl bg-emerald-500 px-5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200"
                 >
-                  <Link href={`/cms/shop/${shop}/settings/returns`}>
-                    Review return policies
-                  </Link>
-                </Button>
-                <Button
-                  asChild
-                  variant="outline"
-                  className="h-11 rounded-xl border-white/30 px-5 text-sm font-semibold text-white hover:bg-white/10"
+                  Review return policies
+                </Link>
+                <Link
+                  href={`/cms/shop/${shop}/data/return-logistics`}
+                  className="inline-flex h-11 items-center rounded-xl border border-white/30 px-5 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                 >
-                  <Link href={`/cms/shop/${shop}/data/return-logistics`}>
-                    Open logistics data
-                  </Link>
-                </Button>
+                  Open logistics data
+                </Link>
               </div>
             </div>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -163,7 +158,7 @@ export default async function ShopOrdersPage({
                 {totalOrders} total orders
               </Tag>
             </div>
-            <div className="grid gap-3">
+            <ul className="grid gap-3" role="list">
               {orders.map((order) => {
                 const expected = order.expectedReturnDate
                   ? new Date(order.expectedReturnDate)
@@ -173,89 +168,115 @@ export default async function ShopOrdersPage({
                   : false;
                 const riskLevel = order.riskLevel ?? "Unknown";
                 const riskScore = typeof order.riskScore === "number" ? order.riskScore : "N/A";
+                const riskLevelLower = riskLevel.toString().toLowerCase();
+                const highlight =
+                  order.flaggedForReview || riskLevelLower === "high" || isOverdue;
 
                 return (
-                  <Card
+                  <li
                     key={order.id ?? order.sessionId}
                     className={cn(
-                      "border border-white/10 bg-white/5 text-white",
-                      order.flaggedForReview && "border-rose-400/40 bg-rose-500/10",
-                      isOverdue && "border-amber-400/40 bg-amber-500/10"
+                      "list-none rounded-2xl border border-transparent",
+                      highlight && "border-red-500 bg-red-50"
                     )}
                   >
-                    <CardContent className="space-y-3 px-5 py-5">
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div className="space-y-1">
-                          <div className="text-sm font-semibold">
-                            Order {order.id ?? "unknown"}
-                          </div>
-                          <p className="text-xs text-white/70">
-                            Session: {order.sessionId ?? "—"}
-                          </p>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          {order.flaggedForReview && (
-                            <Tag variant="warning" className="bg-rose-500/20 text-rose-100">
-                              Flagged for review
-                            </Tag>
-                          )}
-                          <Tag
-                            variant={riskLevel.toLowerCase() === "high" ? "destructive" : "default"}
-                            className={cn(
-                              "bg-white/15 text-white",
-                              riskLevel.toLowerCase() === "high" && "bg-rose-500/30 text-rose-100"
-                            )}
-                          >
-                            Risk: {riskLevel}
-                          </Tag>
-                          <Tag className="bg-white/10 text-white/80" variant="default">
-                            Score: {riskScore}
-                          </Tag>
-                        </div>
-                      </div>
-                      {expected && Number.isFinite(expected.getTime()) && (
-                        <p className="text-sm text-white/80">
-                          Expected return: {expected.toLocaleDateString()} {" "}
-                          {isOverdue && <span className="text-amber-200">(overdue)</span>}
-                        </p>
+                    <Card
+                      className={cn(
+                        "border border-white/10 bg-white/5 text-white",
+                        order.flaggedForReview && "border-rose-400/40 bg-rose-500/10",
+                        isOverdue && "border-amber-400/40 bg-amber-500/10"
                       )}
-                      <div className="text-sm text-white/70">
-                        Flagged: {order.flaggedForReview ? "Yes" : "No"}
-                      </div>
-                      <div className="flex flex-wrap gap-3">
-                        <form action={returnAction}>
-                          <input type="hidden" name="sessionId" value={order.sessionId ?? ""} />
-                          <Button
-                            type="submit"
-                            variant="outline"
-                            className="h-9 rounded-lg border-white/30 bg-white/10 text-white hover:bg-white/20"
-                          >
-                            Mark returned
-                          </Button>
-                        </form>
-                        <form action={refundAction}>
-                          <input type="hidden" name="sessionId" value={order.sessionId ?? ""} />
-                          <Button
-                            type="submit"
-                            variant="ghost"
-                            className="h-9 rounded-lg text-white hover:bg-white/10"
-                          >
-                            Refund order
-                          </Button>
-                        </form>
-                      </div>
-                    </CardContent>
-                  </Card>
+                    >
+                      <CardContent className="space-y-3 px-5 py-5">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="space-y-1">
+                            <div className="text-sm font-semibold">
+                              Order: {order.id ?? "unknown"}
+                            </div>
+                            <p className="text-xs text-white/70">
+                              Session: {order.sessionId ?? "—"}
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            {order.flaggedForReview && (
+                              <Tag variant="warning" className="bg-rose-500/20 text-rose-100">
+                                Flagged for review
+                              </Tag>
+                            )}
+                            <Tag
+                              variant={riskLevelLower === "high" ? "destructive" : "default"}
+                              className={cn(
+                                "bg-white/15 text-white",
+                                riskLevelLower === "high" && "bg-rose-500/30 text-rose-100"
+                              )}
+                            >
+                              Risk Level: {riskLevel}
+                            </Tag>
+                            <Tag className="bg-white/10 text-white/80" variant="default">
+                              Risk Score: {riskScore}
+                            </Tag>
+                          </div>
+                        </div>
+                        <p className="text-sm text-white/80">
+                          {order.expectedReturnDate ? (
+                            <>
+                              Return: {order.expectedReturnDate}
+                              {expected && Number.isFinite(expected.getTime()) && (
+                                <span
+                                  aria-hidden="true"
+                                  className="ml-2 text-white/70"
+                                >
+                                  ({expected.toLocaleDateString()})
+                                </span>
+                              )}
+                              {isOverdue && (
+                                <span className="text-amber-200"> (overdue)</span>
+                              )}
+                            </>
+                          ) : (
+                            <>Return: —</>
+                          )}
+                        </p>
+                        <div className="text-sm text-white/70">
+                          Flagged for Review: {order.flaggedForReview ? "Yes" : "No"}
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                          <form action={returnAction}>
+                            <input type="hidden" name="sessionId" value={order.sessionId ?? ""} />
+                            <Button
+                              type="submit"
+                              variant="outline"
+                              className="h-9 rounded-lg border-white/30 bg-white/10 text-white hover:bg-white/20"
+                            >
+                              Mark returned
+                            </Button>
+                          </form>
+                          <form action={refundAction}>
+                            <input type="hidden" name="sessionId" value={order.sessionId ?? ""} />
+                            <Button
+                              type="submit"
+                              variant="ghost"
+                              className="h-9 rounded-lg text-white hover:bg-white/10"
+                            >
+                              Refund order
+                            </Button>
+                          </form>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </li>
                 );
               })}
               {orders.length === 0 && (
-                <Card className="border border-white/10 bg-white/5 text-white">
-                  <CardContent className="px-6 py-8 text-center text-sm text-white/70">
-                    No orders found for this shop yet.
-                  </CardContent>
-                </Card>
+                <li className="list-none">
+                  <Card className="border border-white/10 bg-white/5 text-white">
+                    <CardContent className="px-6 py-8 text-center text-sm text-white/70">
+                      No orders found for this shop yet.
+                    </CardContent>
+                  </Card>
+                </li>
               )}
-            </div>
+            </ul>
           </CardContent>
         </Card>
       </section>

--- a/apps/cms/src/app/cms/orders/page.tsx
+++ b/apps/cms/src/app/cms/orders/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/orders/page.tsx
 
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@acme/ui/components/cms/ShopChooser";
 import { Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 

--- a/packages/ui/src/components/cms/ShopChooser.tsx
+++ b/packages/ui/src/components/cms/ShopChooser.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { track } from "@acme/telemetry";
-import { Button, Card, CardContent } from "../atoms/shadcn";
+import { Card, CardContent } from "../atoms/shadcn";
 import { Tag } from "../atoms";
 import { cn } from "../../utils/style";
 
@@ -160,29 +160,25 @@ export default function ShopChooser({
                       </p>
                     </div>
 
-                    <Button
-                      asChild
-                      variant="outline"
+                    <Link
+                      href={href}
+                      data-cy="shop-chooser-cta"
+                      aria-labelledby={cardTitleId}
+                      aria-describedby={descriptionId}
+                      onClick={() =>
+                        handleTrack(
+                          card.analyticsEventName,
+                          card.analyticsPayload?.(shop)
+                        )
+                      }
                       className={cn(
-                        "mt-auto h-11 w-full rounded-xl border-white/30 bg-white/10 text-sm font-semibold text-white shadow-sm transition hover:bg-white/20 focus-visible:ring-white/60",
+                        "mt-auto inline-flex h-11 w-full items-center justify-center rounded-xl border border-white/30 bg-white/10 text-sm font-semibold text-white shadow-sm transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60",
                         card.ctaClassName
                       )}
                     >
-                      <Link
-                        href={href}
-                        data-cy="shop-chooser-cta"
-                        aria-labelledby={cardTitleId}
-                        aria-describedby={descriptionId}
-                        onClick={() =>
-                          handleTrack(
-                            card.analyticsEventName,
-                            card.analyticsPayload?.(shop)
-                          )
-                        }
-                      >
-                        {resolvedCtaLabel}
-                      </Link>
-                    </Button>
+                      <span className="sr-only">{shop}</span>
+                      <span aria-hidden="true">{resolvedCtaLabel}</span>
+                    </Link>
                   </article>
                 </li>
               );
@@ -201,23 +197,19 @@ export default function ShopChooser({
               </h3>
               <p className="text-sm text-white/70">{emptyState.description}</p>
             </div>
-            <Button
-              asChild
-              className="h-11 w-full rounded-xl bg-emerald-500 text-sm font-semibold text-white shadow-md shadow-emerald-500/30 transition hover:bg-emerald-400 focus-visible:ring-emerald-200"
+            <Link
+              href={emptyState.ctaHref}
+              data-cy="shop-chooser-empty-cta"
+              onClick={() =>
+                handleTrack(
+                  emptyState.analyticsEventName,
+                  emptyState.analyticsPayload
+                )
+              }
+              className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-emerald-500 text-sm font-semibold text-white shadow-md shadow-emerald-500/30 transition hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200"
             >
-              <Link
-                href={emptyState.ctaHref}
-                data-cy="shop-chooser-empty-cta"
-                onClick={() =>
-                  handleTrack(
-                    emptyState.analyticsEventName,
-                    emptyState.analyticsPayload
-                  )
-                }
-              >
-                {emptyState.ctaLabel}
-              </Link>
-            </Button>
+              {emptyState.ctaLabel}
+            </Link>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- load the ShopChooser UI component for the orders index page via the shared UI package so it renders in tests
- render ShopChooser calls to action with link elements that expose the shop name via screen-reader text
- adjust the shop orders page markup to provide list semantics, explicit status text, and highlight classes that match the tests

## Testing
- pnpm exec jest --config jest.config.cjs --runTestsByPath apps/cms/__tests__/ordersPages.test.tsx *(fails: coverage thresholds not met despite tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_68cb16291df8832f9010340c4ab21776