### PR TITLE
Fix ShopEditor tests to handle accordion mocks

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -7,15 +7,32 @@ jest.mock(
   "@/components/atoms/shadcn",
   () => {
     return {
-      Accordion: ({ items }: any) => (
-        <div>
-          {items.map((item: any, index: number) => (
-            <div key={index}>
-              <button type="button">{item.title}</button>
-              <div>{item.content}</div>
-            </div>
-          ))}
-        </div>
+      Accordion: ({ items, children, ...props }: any) => {
+        const accordionItems = Array.isArray(items) ? items : [];
+
+        return (
+          <div {...props}>
+            {accordionItems.length > 0
+              ? accordionItems.map((item: any, index: number) => (
+                  <div key={index}>
+                    <button type="button">{item.title}</button>
+                    <div>{item.content}</div>
+                  </div>
+                ))
+              : children}
+          </div>
+        );
+      },
+      AccordionItem: ({ children, ...props }: any) => (
+        <div {...props}>{children}</div>
+      ),
+      AccordionTrigger: ({ children, ...props }: any) => (
+        <button type="button" {...props}>
+          {children}
+        </button>
+      ),
+      AccordionContent: ({ children, ...props }: any) => (
+        <div {...props}>{children}</div>
       ),
       Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
       CardContent: ({ children, ...props }: any) => (
@@ -68,10 +85,7 @@ describe("ShopEditor", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: /filter mappings/i }),
-    );
-    fireEvent.click(
-      await screen.findByRole("button", { name: /add mapping/i }),
+      await screen.findByRole("button", { name: /add filter mapping/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 

--- a/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/__tests__/ShopEditor.test.tsx
@@ -174,6 +174,11 @@ describe("ShopEditor", () => {
       ],
     } as any;
 
+    const seo = {
+      catalogFilters: info.catalogFilters,
+      setCatalogFilters: jest.fn(),
+    } as any;
+
     mockUseShopEditorForm.mockReturnValue({
       info,
       setInfo: jest.fn(),
@@ -190,6 +195,7 @@ describe("ShopEditor", () => {
       providers,
       overrides,
       localization,
+      seo,
       toast: {
         open: true,
         status: "error",


### PR DESCRIPTION
## Summary
- update the ShopEditor test harness to provide full accordion shadcn mocks and to target the Add filter mapping button
- supply the mocked ShopEditor form state with a seo field so the component test renders successfully

## Testing
- pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs --coverage=false --runTestsByPath apps/cms/__tests__/ShopEditor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb164bb07c832f966bff3c91643059