### PR TITLE
Ensure error alerts have accessible names

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopProvidersSection.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/ShopProvidersSection.tsx
@@ -53,7 +53,11 @@ export default function ShopProvidersSection({
           label="Tracking providers"
           error={
             errorMessage ? (
-              <span id={errorId} role="alert">
+              <span
+                id={errorId}
+                role="alert"
+                aria-label={errorMessage}
+              >
                 {errorMessage}
               </span>
             ) : undefined


### PR DESCRIPTION
## Summary
- ensure the provider error alert exposes its message as an accessible name so assistive queries can locate it

## Testing
- CI=true pnpm exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath "src/app/cms/shop/[shop]/settings/__tests__/ProviderSelect.test.tsx" --no-coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb19c58f64832fa0c45e4fc9fb46c3