### PR TITLE
Fix CMS layout sidebar toggles

### DIFF
--- a/apps/cms/src/app/cms/LayoutClient.client.tsx
+++ b/apps/cms/src/app/cms/LayoutClient.client.tsx
@@ -22,7 +22,9 @@ export default function LayoutClient({
       <div
         className={cn(
           "relative z-10 h-full w-72 shrink-0 border-r border-white/10 bg-slate-950/80 text-white backdrop-blur-xl transition-transform duration-300",
-          isMobileNavOpen ? "translate-x-0" : "-translate-x-full sm:translate-x-0"
+          isMobileNavOpen
+            ? "block translate-x-0"
+            : "hidden -translate-x-full sm:translate-x-0 sm:block"
         )}
       >
         <Sidebar
@@ -44,7 +46,7 @@ export default function LayoutClient({
               }
               label={
                 configuratorProgress.totalOptional
-                  ? `${configuratorProgress.completedRequired}/${configuratorProgress.totalRequired} required · ${configuratorProgress.completedOptional}/${configuratorProgress.totalOptional} optional`
+                  ? `${configuratorProgress.completedRequired}/${configuratorProgress.totalRequired} required, ${configuratorProgress.completedOptional}/${configuratorProgress.totalOptional} optional`
                   : `${configuratorProgress.completedRequired}/${configuratorProgress.totalRequired} required`
               }
             />


### PR DESCRIPTION
## Summary
- ensure the CMS sidebar container toggles block/hidden display classes alongside its translate transitions
- update the configurator progress label to use comma-separated required/optional counts

## Testing
- pnpm exec jest --ci --runInBand --detectOpenHandles --passWithNoTests --config ./jest.config.cjs --collectCoverage=false --testPathPattern=LayoutClient.client.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb19e597b4832faeea6271051604ae