### PR TITLE
Fix dashboard tests with updated stubs

### DIFF
--- a/apps/cms/src/app/cms/dashboard/page.test.tsx
+++ b/apps/cms/src/app/cms/dashboard/page.test.tsx
@@ -14,16 +14,23 @@ it("renders shop links", async () => {
   mockList.mockResolvedValue(["one", "two"]);
   const { default: Page } = await import("./page");
   render(await Page());
-  expect(screen.getByText("Choose a shop")).toBeInTheDocument();
-  const link = screen.getByRole("link", { name: "one" });
-  expect(link).toHaveAttribute("href", "/cms/dashboard/one");
-  expect(screen.getByRole("link", { name: "two" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", { name: "Choose a storefront to inspect" })
+  ).toBeInTheDocument();
+  const links = screen.getAllByRole("link", { name: "View dashboard" });
+  expect(links).toHaveLength(2);
+  expect(links[0]).toHaveAttribute("href", "/cms/dashboard/one");
+  expect(links[1]).toHaveAttribute("href", "/cms/dashboard/two");
 });
 
 it("shows message when no shops", async () => {
   mockList.mockResolvedValue([]);
   const { default: Page } = await import("./page");
   render(await Page());
-  expect(screen.getByText("No shops found.")).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      "No shops found. Create a shop in the configurator to unlock dashboards."
+    ),
+  ).toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary
- teach the shadcn test stub to handle `asChild` buttons, expose `Tag`, and accept progress labels so server components render without warnings
- update the CMS dashboard test assertions to match the latest copy and button labels

## Testing
- pnpm exec jest apps/cms/src/app/cms/dashboard/page.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb19d7f28c832fae71ed37b18ee63d