### PR TITLE
Fix uploadMedia metadata payload

### DIFF
--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -272,16 +272,11 @@ export async function uploadMedia(
   const filename = `${ulid()}${ext}`;
   await fs.writeFile(path.join(dir, filename), buffer);
 
-  const size = buffer.length;
-  const uploadedAt = new Date().toISOString();
-
   const meta = await readMetadata(safeShop);
   const entry: MediaMetadataEntry = {
     title,
     altText,
     type,
-    size,
-    uploadedAt,
   };
   if (tags !== undefined) {
     entry.tags = tags;
@@ -290,15 +285,16 @@ export async function uploadMedia(
   meta[filename] = entry;
   await writeMetadata(safeShop, meta);
 
-  return {
+  const result: MediaItem = {
     url: path.posix.join("/uploads", safeShop, filename),
     title,
     altText,
-    tags: entry.tags,
     type,
-    size,
-    uploadedAt,
   };
+  if (tags !== undefined) {
+    result.tags = tags;
+  }
+  return result;
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- stop persisting size and uploadedAt metadata when uploading new media
- avoid returning undefined tags from the uploadMedia response

## Testing
- pnpm --filter @apps/cms exec jest --ci --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath src/__tests__/media.server.test.ts --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb19f81f40832f9d43b04285ce50f6