### PR TITLE
Fix CMS shop list rendering in tests

### DIFF
--- a/apps/cms/src/app/cms/media/page.tsx
+++ b/apps/cms/src/app/cms/media/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/media/page.tsx
 
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@ui/components/cms/ShopChooser";
 import { Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 

--- a/apps/cms/src/app/cms/orders/page.tsx
+++ b/apps/cms/src/app/cms/orders/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/orders/page.tsx
 
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@ui/components/cms/ShopChooser";
 import { Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 

--- a/apps/cms/src/app/cms/products/page.tsx
+++ b/apps/cms/src/app/cms/products/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/products/page.tsx
 
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@ui/components/cms/ShopChooser";
 import { Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 

--- a/apps/cms/src/app/cms/settings/page.tsx
+++ b/apps/cms/src/app/cms/settings/page.tsx
@@ -1,7 +1,7 @@
 // apps/cms/src/app/cms/settings/page.tsx
 
 import Link from "next/link";
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@ui/components/cms/ShopChooser";
 import { Button, Card, CardContent, Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 

--- a/apps/cms/src/app/cms/shop/page.tsx
+++ b/apps/cms/src/app/cms/shop/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/shop/page.tsx
 
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@ui/components/cms/ShopChooser";
 import { Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 
@@ -34,7 +34,7 @@ export default async function ShopIndexPage() {
         shops={shops}
         card={{
           icon: "🏪",
-          title: (shop) => shop.toUpperCase(),
+          title: (shop) => shop,
           description: (shop) =>
             `Coordinate configuration, launches, and health checks for ${shop}.`,
           ctaLabel: () => "Open shop overview",

--- a/apps/cms/src/app/cms/themes/page.tsx
+++ b/apps/cms/src/app/cms/themes/page.tsx
@@ -1,6 +1,6 @@
 // apps/cms/src/app/cms/themes/page.tsx
 
-import ShopChooser from "@/components/cms/ShopChooser";
+import ShopChooser from "@ui/components/cms/ShopChooser";
 import { Tag } from "@ui/components/atoms";
 import { listShops } from "../../../lib/listShops";
 


### PR DESCRIPTION
## Summary
- ensure the CMS shop index uses the real ShopChooser component and preserves shop name casing
- align the other CMS workspace entry pages to import ShopChooser from the UI package

## Testing
- pnpm --filter @apps/cms exec jest src/__tests__/cmsAccess.integration.test.tsx -t "allows authenticated" --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb1982941c832fa9ffb67ee57886ab