### PR TITLE
Fix configurator page test awaiting server component

### DIFF
--- a/apps/cms/src/app/cms/configurator/[stepId]/page.test.tsx
+++ b/apps/cms/src/app/cms/configurator/[stepId]/page.test.tsx
@@ -1,5 +1,5 @@
+import type { ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
-import React from "react";
 
 jest.mock("../ConfiguratorContext", () => ({
   ConfiguratorProvider: ({ children }: any) => (
@@ -18,7 +18,11 @@ afterEach(() => {
 
 it("wraps StepPage with provider", async () => {
   const { default: Page } = await import("./page");
-  render(<Page params={{ stepId: "abc" }} />);
+  const ui = (await Page({
+    params: Promise.resolve({ stepId: "abc" }),
+  })) as ReactElement;
+
+  render(ui);
   expect(screen.getByTestId("provider")).toBeInTheDocument();
   expect(screen.getByTestId("step-page")).toHaveTextContent("abc");
 });


### PR DESCRIPTION
## Summary
- adjust the configurator step page test to treat the page as an async server component
- render the resolved element returned by the page to keep the provider and step id assertions intact

## Testing
- pnpm exec jest --config apps/cms/jest.config.cjs --runInBand --coverage=false --runTestsByPath 'apps/cms/src/app/cms/configurator/[stepId]/page.test.tsx'

------
https://chatgpt.com/codex/tasks/task_e_68cb1a24f3f0832f864f3dfc545a8b40