### PR TITLE
Fix CMS shop list integration test

### DIFF
--- a/test/__mocks__/componentStub.js
+++ b/test/__mocks__/componentStub.js
@@ -23,17 +23,25 @@ function ComponentStub(props) {
     return React.createElement(
       "ul",
       null,
-      props.shops.map((shop) =>
-        React.createElement(
+      props.shops.map((shop) => {
+        const href = props.card.href(shop);
+        const title = resolveValue(props.card.title, shop) || shop;
+        const description = resolveValue(props.card.description, shop) || "";
+        const ctaLabel = resolveValue(props.card.ctaLabel, shop) || href;
+
+        return React.createElement(
           "li",
           { key: shop },
+          React.createElement("h3", null, title),
+          description ? React.createElement("p", null, description) : null,
           React.createElement(
             "a",
-            { href: props.card.href(shop) },
-            resolveValue(props.card.ctaLabel, shop) || props.card.href(shop)
+            { href, "data-cy": "shop-chooser-cta" },
+            React.createElement("span", { className: "sr-only" }, shop),
+            React.createElement("span", { "aria-hidden": "true" }, ctaLabel)
           )
-        )
-      )
+        );
+      })
     );
   }
 


### PR DESCRIPTION
## Summary
- update the shared component stub used in CMS tests to render shop titles and CTA markup
- expose shop identifiers via screen-reader text so integration tests can assert the rendered shops

## Testing
- CI=true pnpm exec jest --runInBand --coverage=false src/__tests__/cmsAccess.integration.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb1c800c48832fbaf4925b53295043