### PR TITLE
Ensure uploadMedia stores file size and timestamp

### DIFF
--- a/apps/cms/src/actions/media.server.ts
+++ b/apps/cms/src/actions/media.server.ts
@@ -272,11 +272,16 @@ export async function uploadMedia(
   const filename = `${ulid()}${ext}`;
   await fs.writeFile(path.join(dir, filename), buffer);
 
+  const size = buffer.byteLength;
+  const uploadedAt = new Date().toISOString();
+
   const meta = await readMetadata(safeShop);
   const entry: MediaMetadataEntry = {
     title,
     altText,
     type,
+    size,
+    uploadedAt,
   };
   if (tags !== undefined) {
     entry.tags = tags;
@@ -290,6 +295,8 @@ export async function uploadMedia(
     title,
     altText,
     type,
+    size,
+    uploadedAt,
   };
   if (tags !== undefined) {
     result.tags = tags;


### PR DESCRIPTION
## Summary
- record the byte size and upload timestamp when saving new media entries
- return the enriched metadata from `uploadMedia` so callers receive size and timestamp information immediately

## Testing
- pnpm --filter @apps/cms exec jest --runInBand --config ./jest.config.cjs --runTestsByPath src/actions/__tests__/media.server.test.ts --coverageThreshold='{"global":{"statements":0,"branches":0,"functions":0,"lines":0}}'

------
https://chatgpt.com/codex/tasks/task_e_68cb1cc3d64c832f8d6635552e574a03