### PR TITLE
Fix ShopEditor test accordion mock

### DIFF
--- a/apps/cms/__tests__/ShopEditor.test.tsx
+++ b/apps/cms/__tests__/ShopEditor.test.tsx
@@ -7,15 +7,63 @@ jest.mock(
   "@/components/atoms/shadcn",
   () => {
     return {
-      Accordion: ({ items }: any) => (
-        <div>
-          {items.map((item: any, index: number) => (
-            <div key={index}>
-              <button type="button">{item.title}</button>
-              <div>{item.content}</div>
+      Accordion: ({ items, children, ...props }: any) => {
+        const normalizedItems = Array.isArray(items) ? items : undefined;
+
+        if (normalizedItems?.length) {
+          return (
+            <div {...props}>
+              {normalizedItems.map((item: any, index: number) => (
+                <div key={index}>
+                  <button type="button">{item.title}</button>
+                  <div>{item.content}</div>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          );
+        }
+
+        return <div {...props}>{children}</div>;
+      },
+      AccordionItem: ({ children, ...props }: any) => (
+        <div {...props}>{children}</div>
+      ),
+      AccordionTrigger: ({ children, ...props }: any) => {
+        const { ["aria-label"]: ariaLabelProp, ...restProps } = props;
+
+        const resolveLabel = (value: any): string | undefined => {
+          if (typeof value === "string") {
+            return value;
+          }
+          if (Array.isArray(value)) {
+            for (const child of value) {
+              const childLabel = resolveLabel(child);
+              if (childLabel) {
+                return childLabel;
+              }
+            }
+            return undefined;
+          }
+          if (value?.props?.title) {
+            return value.props.title;
+          }
+          return undefined;
+        };
+
+        const label = resolveLabel(children);
+
+        return (
+          <button
+            type="button"
+            aria-label={ariaLabelProp ?? label}
+            {...restProps}
+          >
+            {children}
+          </button>
+        );
+      },
+      AccordionContent: ({ children, ...props }: any) => (
+        <div {...props}>{children}</div>
       ),
       Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
       CardContent: ({ children, ...props }: any) => (
@@ -67,11 +115,14 @@ describe("ShopEditor", () => {
       <ShopEditor shop="shop" initial={initial} initialTrackingProviders={[]} />,
     );
 
+    const filterMappingsToggle = screen.getByRole("button", {
+      name: /filter mappings/i,
+    });
+    if (!screen.queryByRole("button", { name: /add filter mapping/i })) {
+      fireEvent.click(filterMappingsToggle);
+    }
     fireEvent.click(
-      screen.getByRole("button", { name: /filter mappings/i }),
-    );
-    fireEvent.click(
-      await screen.findByRole("button", { name: /add mapping/i }),
+      await screen.findByRole("button", { name: /add filter mapping/i }),
     );
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 


### PR DESCRIPTION
## Summary
- update the shadcn accordion mock to support children-based usage and preserve accessible labels
- adjust the ShopEditor test to click the filter mapping accordion only when necessary and target the updated button label

## Testing
- pnpm --filter @apps/cms exec jest apps/cms/__tests__/ShopEditor.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cb1b6759e0832fa274e48706083575