### PR TITLE
Add regression test for export page translation

### DIFF
--- a/apps/cms/__tests__/pageExportRoute.test.tsx
+++ b/apps/cms/__tests__/pageExportRoute.test.tsx
@@ -1,0 +1,21 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const MOCK_TRANSLATION = "Mock export heading";
+
+jest.mock("@acme/i18n", () => ({
+  useTranslations: () => () => MOCK_TRANSLATION,
+}));
+
+import ExportPage from "../src/app/cms/shop/[shop]/pages/[page]/export/page";
+
+describe("Export page route", () => {
+  it("renders the translated heading", () => {
+    render(<ExportPage />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: MOCK_TRANSLATION })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test for the export page that verifies the heading renders a mocked translation string

## Testing
- pnpm --filter @apps/cms test -- --runTestsByPath apps/cms/__tests__/pageExportRoute.test.tsx *(fails: global coverage threshold unmet when running single test)*

------
https://chatgpt.com/codex/tasks/task_e_68cba94ffd68832f87dcc8179573d639