### PR TITLE
Add unit test for shop page metadata and props

### DIFF
--- a/apps/cms/src/app/[lang]/shop/__tests__/page.test.tsx
+++ b/apps/cms/src/app/[lang]/shop/__tests__/page.test.tsx
@@ -1,0 +1,61 @@
+import type { SKU } from "@acme/types";
+
+const mockSkus: SKU[] = [
+  {
+    id: "01H000000000000000000001",
+    slug: "mock-sku-1",
+    title: "Mock SKU 1",
+    price: 1000,
+    deposit: 0,
+    stock: 5,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: ["M"],
+    description: "First mock SKU",
+  },
+  {
+    id: "01H000000000000000000002",
+    slug: "mock-sku-2",
+    title: "Mock SKU 2",
+    price: 2000,
+    deposit: 0,
+    stock: 8,
+    forSale: true,
+    forRental: false,
+    media: [],
+    sizes: ["L"],
+    description: "Second mock SKU",
+  },
+];
+
+const mockShopClient = jest.fn(() => null);
+
+jest.mock("@platform-core/lib/products", () => ({
+  PRODUCTS: mockSkus,
+}));
+
+jest.mock("../ShopClient.client", () => ({
+  __esModule: true,
+  default: mockShopClient,
+}));
+
+import { metadata, default as ShopIndexPage } from "../page";
+
+describe("ShopIndexPage", () => {
+  beforeEach(() => {
+    mockShopClient.mockClear();
+  });
+
+  it("exports the expected metadata title", () => {
+    expect(metadata.title).toBe("Shop · Base-Shop");
+  });
+
+  it("passes the SKU list to the client component without extra props", () => {
+    const element = ShopIndexPage();
+
+    expect(element.type).toBe(mockShopClient);
+    expect(element.props.skus).toBe(mockSkus);
+    expect(element.props).toEqual({ skus: mockSkus });
+  });
+});


### PR DESCRIPTION
## Summary
- add a jest test that stubs the platform products list and client component for the shop index page
- assert the exported metadata title and the props passed to the client component

## Testing
- pnpm exec jest --config ./jest.config.cjs --runInBand --runTestsByPath "apps/cms/src/app/[lang]/shop/__tests__/page.test.tsx" --coverage=false


------
https://chatgpt.com/codex/tasks/task_e_68cba9690b14832f8aafcb592aab63d9