### PR TITLE
Add CMS success page test coverage

### DIFF
--- a/apps/cms/src/app/success/page.test.tsx
+++ b/apps/cms/src/app/success/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+
+describe("Success page", () => {
+  it("renders thank-you heading and receipt message", async () => {
+    const { default: Success } = await import("./page");
+    render(<Success />);
+
+    expect(
+      screen.getByRole("heading", { name: /Thanks for your order!/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Check your e-mail for the receipt./i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest test for the CMS success page so the thank-you heading and receipt copy are asserted

## Testing
- pnpm --filter @apps/cms exec jest --config ./jest.config.cjs --runTestsByPath src/app/success/page.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cba95e2d54832f970c52bc5cef12c9