### PR TITLE
Add tests for late fees table

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesTable.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesTable.test.tsx
@@ -1,0 +1,54 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import LateFeesTable from "../LateFeesTable";
+import { mapLateFeeRows } from "../../tableMappers";
+
+const readOrders = jest.fn();
+const DataTable = jest.fn(() => null);
+
+jest.mock("@platform-core/repositories/rentalOrders.server", () => ({
+  readOrders: (...args: unknown[]) => readOrders(...args),
+}));
+
+jest.mock("@ui/components/cms/DataTable", () => ({
+  __esModule: true,
+  default: (props: unknown) => DataTable(props),
+}));
+
+describe("LateFeesTable", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders a message when no late fees are charged", async () => {
+    readOrders.mockResolvedValueOnce([]);
+
+    render(await LateFeesTable({ shop: "s1" }));
+
+    expect(screen.getByText("No late fees charged.")).toBeInTheDocument();
+    expect(DataTable).not.toHaveBeenCalled();
+  });
+
+  it("passes mapped late-fee rows to the DataTable", async () => {
+    const orders = [
+      { sessionId: "order-1", lateFeeCharged: 12 },
+      { sessionId: "order-2", lateFeeCharged: null },
+      { sessionId: "order-3", lateFeeCharged: 0 },
+      { sessionId: "order-4", lateFeeCharged: 4.5 },
+    ];
+    readOrders.mockResolvedValueOnce(orders);
+
+    render(await LateFeesTable({ shop: "s2" }));
+
+    expect(DataTable).toHaveBeenCalledTimes(1);
+    const tableProps = DataTable.mock.calls[0][0] as { rows: ReturnType<typeof mapLateFeeRows> };
+    const expectedRows = mapLateFeeRows([orders[0], orders[3]]);
+
+    expect(tableProps.rows).toEqual(expectedRows);
+    expect(tableProps.rows.map((row) => row.orderId)).toEqual([
+      "order-1",
+      "order-4",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a LateFeesTable test suite covering empty and charged late fee states
- verify the table rows passed to DataTable come from mapLateFeeRows and skip orders without charges

## Testing
- CI=true pnpm exec jest --config apps/cms/jest.config.cjs --runInBand --coverage=false --runTestsByPath apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesTable.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cba955c864832fa38e423bf218a31c