### PR TITLE
test(cms): cover success page rendering

### DIFF
--- a/apps/cms/__tests__/successPage.test.tsx
+++ b/apps/cms/__tests__/successPage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import Success from "../src/app/success/page";
+
+describe("Success page", () => {
+  it("renders thank-you heading and receipt instructions", () => {
+    render(<Success />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Thanks for your order!",
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Your payment was received. Check your e-mail for the receipt.")
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a lightweight Success page test to guard the thank-you heading and receipt text

## Testing
- pnpm --filter @apps/cms exec jest --config jest.config.cjs --runTestsByPath __tests__/successPage.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cba953d638832f91decbf0ca839d07