### PR TITLE
Add export page translation test

### DIFF
--- a/apps/cms/__tests__/exportPage.test.tsx
+++ b/apps/cms/__tests__/exportPage.test.tsx
@@ -1,0 +1,28 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const translate = jest.fn();
+
+jest.mock("@acme/i18n", () => ({
+  useTranslations: () => translate,
+}));
+
+import ExportPage from "../src/app/cms/shop/[shop]/pages/[page]/export/page";
+
+describe("ExportPage", () => {
+  const headingText = "Mocked export heading";
+
+  beforeEach(() => {
+    translate.mockReset();
+  });
+
+  it("renders heading from translations", () => {
+    translate.mockReturnValue(headingText);
+
+    render(<ExportPage />);
+
+    expect(translate).toHaveBeenCalledWith("cms.export.title");
+    expect(screen.getByRole("heading", { name: headingText })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for the export page that stubs translations and asserts the heading text

## Testing
- pnpm exec jest --config apps/cms/jest.config.cjs --runTestsByPath apps/cms/__tests__/exportPage.test.tsx --runInBand --detectOpenHandles --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cba95d7c00832fbe3aa8cb4e49ca7c