### PR TITLE
Ensure email env errors are logged in tests

### DIFF
--- a/packages/config/src/env/email.ts
+++ b/packages/config/src/env/email.ts
@@ -83,12 +83,8 @@ const rawEnv: NodeJS.ProcessEnv = {
 const parsed = emailEnvSchema.safeParse(rawEnv);
 
 if (!parsed.success) {
-  if (!isTest) {
-    console.error(
-      "❌ Invalid email environment variables:",
-      parsed.error.format()
-    );
-  }
+  const formattedError = parsed.error.format();
+  console.error("❌ Invalid email environment variables:", formattedError);
   throw new Error("Invalid email environment variables");
 }
 


### PR DESCRIPTION
## Summary
- always report email environment schema failures to `console.error`, even under Jest
- capture the formatted Zod error before rethrowing so the thrown error still bubbles up

## Testing
- pnpm exec jest --coverage=false packages/auth/src/__tests__/env.email.test.ts
- pnpm exec jest --coverage=false packages/config/__tests__/email-env.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbaa2b3910832fa332a35c61a99749