### PR TITLE
test: cover page builder route

### DIFF
--- a/apps/cms/__tests__/pageBuilderRoute.test.tsx
+++ b/apps/cms/__tests__/pageBuilderRoute.test.tsx
@@ -1,0 +1,105 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+type BuilderProps = {
+  page?: unknown;
+  history?: unknown;
+  onSave?: (formData: FormData) => unknown;
+  onPublish?: (formData: FormData) => unknown;
+};
+
+let capturedBuilderProps: BuilderProps | undefined;
+
+jest.mock("@platform-core/repositories/pages/index.server", () => ({
+  getPages: jest.fn(),
+}));
+jest.mock("@cms/actions/pages/update", () => ({
+  updatePage: jest.fn(),
+}));
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: jest.fn(() => {
+    return function PageBuilderStub(props: BuilderProps) {
+      capturedBuilderProps = props;
+      return <div data-testid="page-builder-stub" />;
+    };
+  }),
+}));
+
+import { getPages } from "@platform-core/repositories/pages/index.server";
+import { updatePage } from "@cms/actions/pages/update";
+import { notFound } from "next/navigation";
+import PageBuilderRoute from "../src/app/cms/shop/[shop]/pages/[page]/builder/page";
+
+const getPagesMock = jest.mocked(getPages);
+const updatePageMock = jest.mocked(updatePage);
+const notFoundMock = jest.mocked(notFound);
+
+describe("PageBuilderRoute", () => {
+  beforeEach(() => {
+    getPagesMock.mockReset();
+    updatePageMock.mockReset();
+    notFoundMock.mockReset();
+    capturedBuilderProps = undefined;
+  });
+
+  it("renders builder content and wires up save/publish actions", async () => {
+    const page = {
+      id: "page-1",
+      slug: "hero",
+      title: "Hero",
+      status: "draft",
+      history: [{ id: "rev-1" }],
+    } as any;
+
+    getPagesMock.mockResolvedValue([page]);
+
+    const Page = await PageBuilderRoute({
+      params: Promise.resolve({ shop: "acme", page: "hero" }),
+    });
+
+    render(Page);
+
+    expect(
+      screen.getByRole("heading", { name: "Edit page - acme/hero" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === "P" &&
+          (element.textContent?.includes(
+            "Hold Shift while resizing to snap a component to full width or height.",
+          ) ?? false),
+      ),
+    ).toBeInTheDocument();
+
+    expect(capturedBuilderProps?.page).toBe(page);
+    expect(capturedBuilderProps?.history).toBe(page.history);
+
+    expect(typeof capturedBuilderProps?.onSave).toBe("function");
+    expect(typeof capturedBuilderProps?.onPublish).toBe("function");
+
+    const saveData = new FormData();
+    await capturedBuilderProps!.onSave!(saveData);
+    expect(updatePageMock).toHaveBeenNthCalledWith(1, "acme", saveData);
+
+    const publishData = new FormData();
+    await capturedBuilderProps!.onPublish!(publishData);
+    expect(updatePageMock).toHaveBeenNthCalledWith(2, "acme", publishData);
+    expect(publishData.get("status")).toBe("published");
+  });
+
+  it("invokes notFound when the requested page does not exist", async () => {
+    getPagesMock.mockResolvedValue([] as any);
+
+    await PageBuilderRoute({
+      params: Promise.resolve({ shop: "acme", page: "missing" }),
+    });
+
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a PageBuilderRoute test that stubs platform calls and PageBuilder to verify rendering and action wiring
- exercise save/publish handlers plus the missing-page branch via a mocked notFound

## Testing
- pnpm --filter @apps/cms exec jest apps/cms/__tests__/pageBuilderRoute.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cba94f8088832f87f627b1d7615eb3