### PR TITLE
Ensure CMS env tests remove Jest worker id

### DIFF
--- a/packages/auth/src/__tests__/cmsEnvTestUtils.ts
+++ b/packages/auth/src/__tests__/cmsEnvTestUtils.ts
@@ -14,5 +14,5 @@ export async function withEnv(
   vars: Record<string, string | undefined>,
   fn: () => Promise<void> | void,
 ): Promise<void> {
-  await baseWithEnv({ ...baseEnv, ...vars }, fn);
+  await baseWithEnv({ ...baseEnv, JEST_WORKER_ID: undefined, ...vars }, fn);
 }


### PR DESCRIPTION
## Summary
- ensure the cms env test helper clears `JEST_WORKER_ID` so invalid configuration tests capture the console error output

## Testing
- pnpm --filter @acme/auth test -- --runTestsByPath packages/auth/src/__tests__/pagination-limit.test.ts *(fails due to coverage thresholds when run in isolation)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaa661fc4832fa3f3cd4a87a9622d