### PR TITLE
Log env validation failures during tests

### DIFF
--- a/packages/config/src/env/cms.ts
+++ b/packages/config/src/env/cms.ts
@@ -2,12 +2,10 @@ import { cmsEnvSchema, type CmsEnv } from "./cms.schema.js";
 
 const parsed = cmsEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  if (!process.env.JEST_WORKER_ID) {
-    console.error(
-      "❌ Invalid CMS environment variables:",
-      parsed.error.format(),
-    );
-  }
+  console.error(
+    "❌ Invalid CMS environment variables:",
+    parsed.error.format(),
+  );
   throw new Error("Invalid CMS environment variables");
 }
 

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -32,7 +32,6 @@ export type PaymentsEnv = z.infer<typeof paymentsEnvSchema>;
 export function loadPaymentsEnv(
   raw: NodeJS.ProcessEnv = process.env,
 ): PaymentsEnv {
-  const isTest = process.env.NODE_ENV === "test";
   if (raw.PAYMENTS_GATEWAY === "disabled") {
     return paymentsEnvSchema.parse({});
   }
@@ -41,50 +40,40 @@ export function loadPaymentsEnv(
     raw.PAYMENTS_PROVIDER &&
     raw.PAYMENTS_PROVIDER !== "stripe"
   ) {
-    if (!isTest) {
-      console.error(
-        "❌ Unsupported PAYMENTS_PROVIDER:",
-        raw.PAYMENTS_PROVIDER,
-      );
-    }
+    console.error(
+      "❌ Unsupported PAYMENTS_PROVIDER:",
+      raw.PAYMENTS_PROVIDER,
+    );
     throw new Error("Invalid payments environment variables");
   }
 
   if (raw.PAYMENTS_PROVIDER === "stripe") {
     if (!raw.STRIPE_SECRET_KEY) {
-      if (!isTest) {
-        console.error(
-          "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe",
-        );
-      }
+      console.error(
+        "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe",
+      );
       throw new Error("Invalid payments environment variables");
     }
     if (!raw.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {
-      if (!isTest) {
-        console.error(
-          "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
-        );
-      }
+      console.error(
+        "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
+      );
       throw new Error("Invalid payments environment variables");
     }
     if (!raw.STRIPE_WEBHOOK_SECRET) {
-      if (!isTest) {
-        console.error(
-          "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
-        );
-      }
+      console.error(
+        "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
+      );
       throw new Error("Invalid payments environment variables");
     }
   }
 
   const parsed = paymentsEnvSchema.safeParse(raw);
   if (!parsed.success) {
-    if (!isTest) {
-      console.warn(
-        "⚠️ Invalid payments environment variables:",
-        parsed.error.format(),
-      );
-    }
+    console.warn(
+      "⚠️ Invalid payments environment variables:",
+      parsed.error.format(),
+    );
     return paymentsEnvSchema.parse({});
   }
 


### PR DESCRIPTION
## Summary
- always log CMS environment validation errors so tests can assert on the formatted output
- remove the NODE_ENV test guard in the payments loader so warnings and errors fire even under Jest

## Testing
- pnpm exec jest src/__tests__/paymentsEnv.test.ts src/__tests__/cms-urls.test.ts --config ../../jest.config.cjs --runInBand --coverage=false (from packages/auth)


------
https://chatgpt.com/codex/tasks/task_e_68cbaa584624832f96f216f4aa976878