### PR TITLE
Adjust env loaders for production behavior

### DIFF
--- a/packages/config/src/env/auth.ts
+++ b/packages/config/src/env/auth.ts
@@ -1,17 +1,14 @@
 import "@acme/zod-utils/initZod";
 import { z } from "zod";
 
-const isJest = typeof (globalThis as { jest?: unknown }).jest !== "undefined";
-const isTest =
-  process.env.NODE_ENV === "test" ||
-  process.env.JEST_WORKER_ID !== undefined ||
-  (isJest && process.env.NODE_ENV !== "production");
+const nodeEnv = process.env.NODE_ENV;
+const isTest = nodeEnv === "test";
 const nextPhase = process.env.NEXT_PHASE?.toLowerCase();
 // Next.js sets NEXT_PHASE=phase-production-build during `next build`.
 // Allow development defaults in that phase so the bundle can compile without real secrets.
 const isNextProductionBuildPhase = nextPhase === "phase-production-build";
 const isProd =
-  process.env.NODE_ENV === "production" && !isTest && !isNextProductionBuildPhase;
+  nodeEnv === "production" && !isTest && !isNextProductionBuildPhase;
 
 // Normalize AUTH_TOKEN_TTL from the process environment so validation succeeds
 // even if the shell exported a plain number or included stray whitespace.

--- a/packages/config/src/env/payments.ts
+++ b/packages/config/src/env/payments.ts
@@ -32,7 +32,6 @@ export type PaymentsEnv = z.infer<typeof paymentsEnvSchema>;
 export function loadPaymentsEnv(
   raw: NodeJS.ProcessEnv = process.env,
 ): PaymentsEnv {
-  const isTest = process.env.NODE_ENV === "test";
   if (raw.PAYMENTS_GATEWAY === "disabled") {
     return paymentsEnvSchema.parse({});
   }
@@ -41,50 +40,40 @@ export function loadPaymentsEnv(
     raw.PAYMENTS_PROVIDER &&
     raw.PAYMENTS_PROVIDER !== "stripe"
   ) {
-    if (!isTest) {
-      console.error(
-        "❌ Unsupported PAYMENTS_PROVIDER:",
-        raw.PAYMENTS_PROVIDER,
-      );
-    }
+    console.error(
+      "❌ Unsupported PAYMENTS_PROVIDER:",
+      raw.PAYMENTS_PROVIDER,
+    );
     throw new Error("Invalid payments environment variables");
   }
 
   if (raw.PAYMENTS_PROVIDER === "stripe") {
     if (!raw.STRIPE_SECRET_KEY) {
-      if (!isTest) {
-        console.error(
-          "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe",
-        );
-      }
+      console.error(
+        "❌ Missing STRIPE_SECRET_KEY when PAYMENTS_PROVIDER=stripe",
+      );
       throw new Error("Invalid payments environment variables");
     }
     if (!raw.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {
-      if (!isTest) {
-        console.error(
-          "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
-        );
-      }
+      console.error(
+        "❌ Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY when PAYMENTS_PROVIDER=stripe",
+      );
       throw new Error("Invalid payments environment variables");
     }
     if (!raw.STRIPE_WEBHOOK_SECRET) {
-      if (!isTest) {
-        console.error(
-          "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
-        );
-      }
+      console.error(
+        "❌ Missing STRIPE_WEBHOOK_SECRET when PAYMENTS_PROVIDER=stripe",
+      );
       throw new Error("Invalid payments environment variables");
     }
   }
 
   const parsed = paymentsEnvSchema.safeParse(raw);
   if (!parsed.success) {
-    if (!isTest) {
-      console.warn(
-        "⚠️ Invalid payments environment variables:",
-        parsed.error.format(),
-      );
-    }
+    console.warn(
+      "⚠️ Invalid payments environment variables:",
+      parsed.error.format(),
+    );
     return paymentsEnvSchema.parse({});
   }
 


### PR DESCRIPTION
## Summary
- treat `NODE_ENV=production` as production when loading auth env so production secrets are required during tests
- always surface payments env validation errors/warnings instead of suppressing them under NODE_ENV=test

## Testing
- pnpm --filter @acme/auth exec jest packages/auth/src/__tests__/env.auth.test.ts --runInBand --config ../../jest.config.cjs --detectOpenHandles --coverage=false
- pnpm --filter @acme/auth exec jest packages/auth/src/__tests__/env.payments.test.ts --runInBand --config ../../jest.config.cjs --detectOpenHandles --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbaa43f104832fb8e832ad669970b8