### PR TITLE
test: cover delivery route POST handler

### DIFF
--- a/apps/shop-bcd/src/app/api/delivery/route.test.ts
+++ b/apps/shop-bcd/src/app/api/delivery/route.test.ts
@@ -1,89 +1,248 @@
 /** @jest-environment node */
+
 import fs from "node:fs";
-import nodePath from "node:path";
-import { pathToFileURL } from "node:url";
-import ts from "typescript";
-import { NextRequest, NextResponse } from "next/server";
+import path from "node:path";
+import type { NextRequest } from "next/server";
 
 const parseJsonBody = jest.fn();
 const initPlugins = jest.fn();
+const nextResponseJson = jest.fn(
+  (body: unknown, init?: { status?: number }) => ({
+    status: init?.status ?? 200,
+    body,
+    json: async () => body,
+  })
+);
 
 jest.mock("@shared-utils", () => ({ parseJsonBody }));
 jest.mock("@platform-core/plugins", () => ({ initPlugins }));
+jest.mock("next/server", () => ({
+  NextResponse: { json: nextResponseJson },
+  NextRequest: class {},
+}));
 
-function req() {
-  return new NextRequest("http://test.local", { method: "POST" } as any);
-}
+const SHOP_JSON_PATH = "../../../../shop.json";
+const DEFAULT_SHOP = { shippingProviders: ["premier-shipping"] };
 
-function loadRoute(shopMock: any) {
-  const src = fs.readFileSync(nodePath.join(__dirname, "route.ts"), "utf8");
-  let js = ts.transpileModule(src, {
-    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2019 },
-  }).outputText;
-  js = js.replace(/const require = .*createRequire.*\n/, "");
-  js = js.replace(/import\.meta\.url/g, JSON.stringify(pathToFileURL(nodePath.join(__dirname, "route.ts")).href));
-  const mod: any = { exports: {} };
-  const mockRequire = (id: string) => {
-    if (id.endsWith("shop.json")) return { default: shopMock };
-    if (id === "node:path") return { default: nodePath };
-    return require(id);
-  };
-  const func = new Function("exports", "require", "module", "__filename", "__dirname", js);
-  func(mod.exports, mockRequire, mod, __filename, __dirname);
-  return mod.exports as { POST: typeof import("./route").POST };
-}
+const createRequest = (): NextRequest =>
+  ({ method: "POST" } as unknown as NextRequest);
 
-afterEach(() => {
+async function loadPost(
+  shopConfig = DEFAULT_SHOP
+): Promise<(typeof import("./route"))["POST"]> {
   jest.resetModules();
-  jest.clearAllMocks();
+  jest.doMock(SHOP_JSON_PATH, () => ({
+    __esModule: true,
+    default: shopConfig,
+  }));
+  const mod = await import("./route");
+  jest.dontMock(SHOP_JSON_PATH);
+  return mod.POST;
+}
+
+const originalPluginsDir = process.env.PREMIER_SHIPPING_PLUGINS_DIR;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  nextResponseJson.mockImplementation((body: unknown, init?: { status?: number }) => ({
+    status: init?.status ?? 200,
+    body,
+    json: async () => body,
+  }));
+  if (originalPluginsDir === undefined) {
+    delete process.env.PREMIER_SHIPPING_PLUGINS_DIR;
+  } else {
+    process.env.PREMIER_SHIPPING_PLUGINS_DIR = originalPluginsDir;
+  }
 });
 
-describe("POST", () => {
-  it("returns 400 when premier-shipping not listed", async () => {
-    const { POST } = loadRoute({ shippingProviders: [] });
-    const res = await POST(req());
-
-    expect(res.status).toBe(400);
-    expect(parseJsonBody).not.toHaveBeenCalled();
-  });
-
-  it("returns 400 on validation errors", async () => {
-    const { POST } = loadRoute({ shippingProviders: ["premier-shipping"] });
-    parseJsonBody.mockResolvedValue({
-      success: false,
-      response: NextResponse.json({ error: "bad" }, { status: 400 }),
-    });
-    const res = await POST(req());
-
-    expect(res.status).toBe(400);
-    expect(parseJsonBody).toHaveBeenCalled();
-  });
-
-  it("schedules pickup when request is valid", async () => {
-    const { POST } = loadRoute({ shippingProviders: ["premier-shipping"] });
-    const schedulePickup = jest.fn();
-    initPlugins.mockResolvedValue({
-      shipping: new Map([["premier-shipping", { schedulePickup }]]),
-    } as any);
-    parseJsonBody.mockResolvedValue({
-      success: true,
-      data: {
-        region: "us",
-        date: "2024-01-01",
-        window: "9-11",
-        carrier: "ups",
-      },
-    });
-    const res = await POST(req());
-
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ ok: true });
-    expect(schedulePickup).toHaveBeenCalledWith(
-      "us",
-      "2024-01-01",
-      "9-11",
-      "ups",
-    );
-  });
+afterAll(() => {
+  if (originalPluginsDir === undefined) {
+    delete process.env.PREMIER_SHIPPING_PLUGINS_DIR;
+  } else {
+    process.env.PREMIER_SHIPPING_PLUGINS_DIR = originalPluginsDir;
+  }
 });
 
+it("returns 400 when premier shipping is unavailable", async () => {
+  const POST = await loadPost({ shippingProviders: [] });
+  const response = await POST(createRequest());
+
+  expect(response.status).toBe(400);
+  expect(nextResponseJson).toHaveBeenCalledWith(
+    { error: "Premier shipping not available" },
+    { status: 400 }
+  );
+  expect(parseJsonBody).not.toHaveBeenCalled();
+});
+
+it("returns validation error responses from parseJsonBody", async () => {
+  const POST = await loadPost();
+  const validationResponse = { status: 422 } as const;
+  parseJsonBody.mockResolvedValue({ success: false, response: validationResponse });
+
+  const response = await POST(createRequest());
+
+  expect(response).toBe(validationResponse);
+  expect(nextResponseJson).not.toHaveBeenCalled();
+});
+
+it("returns 400 when the premier shipping provider is missing", async () => {
+  const POST = await loadPost();
+  parseJsonBody.mockResolvedValue({
+    success: true,
+    data: { region: "us", date: "2024-01-01", window: "9-11" },
+  });
+  initPlugins.mockResolvedValue({ shipping: new Map() });
+  const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+
+  const response = await POST(createRequest());
+
+  expect(response.status).toBe(400);
+  expect(nextResponseJson).toHaveBeenCalledWith(
+    { error: "Premier shipping not available" },
+    { status: 400 }
+  );
+  expect(initPlugins).toHaveBeenCalledTimes(1);
+  existsSpy.mockRestore();
+});
+
+it("schedules pickups with the parsed payload", async () => {
+  const POST = await loadPost();
+  const schedulePickup = jest.fn();
+  parseJsonBody.mockResolvedValue({
+    success: true,
+    data: {
+      region: "us",
+      date: "2024-01-01",
+      window: "9-11",
+      carrier: "ups",
+    },
+  });
+  initPlugins.mockResolvedValue({
+    shipping: new Map([["premier-shipping", { schedulePickup }]]),
+  });
+  const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+
+  const response = await POST(createRequest());
+
+  expect(schedulePickup).toHaveBeenCalledWith("us", "2024-01-01", "9-11", "ups");
+  expect(nextResponseJson).toHaveBeenCalled();
+  const lastCall =
+    nextResponseJson.mock.calls[nextResponseJson.mock.calls.length - 1]!;
+  expect(lastCall[0]).toEqual({ ok: true });
+  expect(lastCall[1]).toBeUndefined();
+  await expect(response.json()).resolves.toEqual({ ok: true });
+  expect(response.status).toBe(200);
+  existsSpy.mockRestore();
+});
+
+it("returns provider errors as 400 responses", async () => {
+  const POST = await loadPost();
+  const schedulePickup = jest.fn().mockRejectedValue(new Error("boom"));
+  parseJsonBody.mockResolvedValue({
+    success: true,
+    data: {
+      region: "us",
+      date: "2024-01-01",
+      window: "9-11",
+      carrier: "ups",
+    },
+  });
+  initPlugins.mockResolvedValue({
+    shipping: new Map([["premier-shipping", { schedulePickup }]]),
+  });
+  const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+
+  const response = await POST(createRequest());
+
+  expect(response.status).toBe(400);
+  expect(nextResponseJson).toHaveBeenLastCalledWith(
+    { error: "boom" },
+    { status: 400 }
+  );
+  existsSpy.mockRestore();
+});
+
+it("uses PREMIER_SHIPPING_PLUGINS_DIR when resolving plugins", async () => {
+  const expectedDir = path.resolve("/custom/plugins");
+  process.env.PREMIER_SHIPPING_PLUGINS_DIR = "/custom/plugins";
+
+  const POST = await loadPost();
+  const schedulePickup = jest.fn();
+  parseJsonBody.mockResolvedValue({
+    success: true,
+    data: {
+      region: "us",
+      date: "2024-01-01",
+      window: "9-11",
+      carrier: "ups",
+    },
+  });
+  initPlugins.mockResolvedValue({
+    shipping: new Map([["premier-shipping", { schedulePickup }]]),
+  });
+  const existsSpy = jest
+    .spyOn(fs, "existsSync")
+    .mockImplementation((target: fs.PathLike) => {
+      if (typeof target !== "string") {
+        return false;
+      }
+      return path.resolve(target) === expectedDir;
+    });
+
+  const response = await POST(createRequest());
+
+  expect(initPlugins).toHaveBeenCalledWith(
+    expect.objectContaining({ directories: [expectedDir] })
+  );
+  await expect(response.json()).resolves.toEqual({ ok: true });
+  existsSpy.mockRestore();
+});
+
+it("falls back to locating packages/plugins relative to cwd", async () => {
+  const startingCwd = "/repo/apps/shop-bcd";
+  const parentCwd = path.dirname(startingCwd);
+  const rootCwd = path.dirname(parentCwd);
+  const rootPluginsDir = path.resolve(path.join(rootCwd, "packages", "plugins"));
+  const searchResults = new Map<string, boolean>([
+    [path.resolve(path.join(startingCwd, "packages", "plugins")), false],
+    [path.resolve(path.join(parentCwd, "packages", "plugins")), false],
+    [rootPluginsDir, true],
+  ]);
+
+  const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(startingCwd);
+  const existsSpy = jest
+    .spyOn(fs, "existsSync")
+    .mockImplementation((target: fs.PathLike) => {
+      if (typeof target !== "string") {
+        return false;
+      }
+      const normalized = path.resolve(target);
+      return searchResults.get(normalized) ?? false;
+    });
+
+  const POST = await loadPost();
+  const schedulePickup = jest.fn();
+  parseJsonBody.mockResolvedValue({
+    success: true,
+    data: {
+      region: "us",
+      date: "2024-01-01",
+      window: "9-11",
+      carrier: "ups",
+    },
+  });
+  initPlugins.mockResolvedValue({
+    shipping: new Map([["premier-shipping", { schedulePickup }]]),
+  });
+
+  const response = await POST(createRequest());
+
+  expect(initPlugins).toHaveBeenCalledWith(
+    expect.objectContaining({ directories: [rootPluginsDir] })
+  );
+  await expect(response.json()).resolves.toEqual({ ok: true });
+  existsSpy.mockRestore();
+  cwdSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- replace the delivery API route test harness with a helper that resets module state and mocks shared utilities/NextResponse
- add coverage for missing premier shipping configuration, validation errors, missing providers, successful scheduling, provider failures, and plugin directory resolution paths

## Testing
- `pnpm --filter @apps/shop-bcd test` *(fails: Jest global branch coverage threshold 80% not met; observed 75.71%)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaa72b3fc832f8a2b6d8513d74e9c