### PR TITLE
Fix MFA verification window and log shipping env errors

### DIFF
--- a/packages/auth/src/mfa.ts
+++ b/packages/auth/src/mfa.ts
@@ -31,7 +31,11 @@ export async function verifyMfa(
     where: { customerId },
   });
   if (!record) return false;
-  const valid = authenticator.verify({ token, secret: record.secret });
+  const valid = authenticator.verify({
+    token,
+    secret: record.secret,
+    window: 1,
+  });
   if (valid && !record.enabled) {
     await prisma.customerMfa.update({
       where: { customerId },

--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -73,7 +73,7 @@ export function loadShippingEnv(
 ): ShippingEnv {
   const parsed = shippingEnvSchema.safeParse(raw);
   if (!parsed.success) {
-    if (raw === process.env && process.env.NODE_ENV !== "test") {
+    if (process.env.NODE_ENV !== "test") {
       console.error(
         "❌ Invalid shipping environment variables:",
         parsed.error.format()


### PR DESCRIPTION
## Summary
- ensure MFA verification allows one time-step window when checking otplib tokens
- always log shipping env validation errors outside of test runs so invalid input triggers console errors even for supplied env objects

## Testing
- pnpm --filter @acme/auth test -- --runTestsByPath packages/auth/src/__tests__/legacy/mfa.test.ts packages/auth/src/__tests__/env.shipping.test.ts *(fails: coverage thresholds enforced when running partial suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaa394398832fbfb733a1d79f674d