### PR TITLE
Fix MFA verification window and log invalid core env

### DIFF
--- a/packages/auth/src/mfa.ts
+++ b/packages/auth/src/mfa.ts
@@ -31,7 +31,11 @@ export async function verifyMfa(
     where: { customerId },
   });
   if (!record) return false;
-  const valid = authenticator.verify({ token, secret: record.secret });
+  const valid = authenticator.verify({
+    token,
+    secret: record.secret,
+    window: 1,
+  });
   if (valid && !record.enabled) {
     await prisma.customerMfa.update({
       where: { customerId },

--- a/packages/config/src/env/core.ts
+++ b/packages/config/src/env/core.ts
@@ -224,14 +224,12 @@ function parseCoreEnv(raw: NodeJS.ProcessEnv = process.env): CoreEnv {
         });
       }
     }
-    if (!isTest) {
-      console.error("❌ Invalid core environment variables:");
-      parsed.error.issues.forEach((issue: z.ZodIssue) => {
-        const pathArr = (issue.path ?? []) as Array<string | number>;
-        const path = pathArr.length ? pathArr.join(".") : "(root)";
-        console.error(`  • ${path}: ${issue.message}`);
-      });
-    }
+    console.error("❌ Invalid core environment variables:");
+    parsed.error.issues.forEach((issue: z.ZodIssue) => {
+      const pathArr = (issue.path ?? []) as Array<string | number>;
+      const path = pathArr.length ? pathArr.join(".") : "(root)";
+      console.error(`  • ${path}: ${issue.message}`);
+    });
     throw new Error("Invalid core environment variables");
   }
   return parsed.data;


### PR DESCRIPTION
## Summary
- add an otplib verification window so adjacent MFA tokens are accepted
- always print detailed messages for invalid core environment variables, even when running under Jest

## Testing
- pnpm --filter @acme/auth exec jest src/__tests__/mfa.test.ts --runInBand --config ../../jest.config.cjs --coverage=false
- pnpm --filter @acme/auth exec jest src/__tests__/env.core.extra.test.ts --runInBand --config ../../jest.config.cjs --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbaa1a3364832fada251d4de56cae0