### PR TITLE
test: cover late fees settings page

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesSettingsPage.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesSettingsPage.test.tsx
@@ -1,0 +1,91 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+const getSettings = jest.fn();
+const lateFeesEditorMock = jest.fn(() => <div data-testid="late-fees-editor" />);
+const lateFeesTableMock = jest.fn(() => <div data-testid="late-fees-table" />);
+
+jest.mock("@cms/actions/shops.server", () => ({
+  getSettings: (...args: any[]) => getSettings(...args),
+}));
+
+jest.mock("next/dynamic", () => {
+  return (importer: () => Promise<any>) => {
+    const key = importer.toString();
+    if (key.includes("LateFeesEditor")) {
+      return (props: any) => lateFeesEditorMock(props);
+    }
+
+    return () => null;
+  };
+});
+
+jest.mock("../LateFeesEditor", () => ({
+  __esModule: true,
+  default: (props: any) => lateFeesEditorMock(props),
+}));
+
+jest.mock("../LateFeesTable", () => ({
+  __esModule: true,
+  default: (props: any) => lateFeesTableMock(props),
+}));
+
+import LateFeesSettingsPage from "../page";
+
+describe("LateFeesSettingsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders settings when late fee service is configured", async () => {
+    getSettings.mockResolvedValue({
+      lateFeeService: {
+        enabled: true,
+        intervalMinutes: 30,
+      },
+    });
+
+    const Page = await LateFeesSettingsPage({
+      params: Promise.resolve({ shop: "demo-shop" }),
+    });
+
+    render(Page);
+
+    expect(
+      screen.getByRole("heading", { name: "Late Fees – demo-shop" }),
+    ).toBeInTheDocument();
+
+    expect(lateFeesEditorMock).toHaveBeenCalledTimes(1);
+    expect(lateFeesEditorMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        shop: "demo-shop",
+        initial: { enabled: true, intervalMinutes: 30 },
+      }),
+    );
+
+    expect(lateFeesTableMock).toHaveBeenCalledTimes(1);
+    expect(lateFeesTableMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ shop: "demo-shop" }),
+    );
+
+    expect(getSettings).toHaveBeenCalledWith("demo-shop");
+  });
+
+  it("falls back to defaults when settings omit the late fee service", async () => {
+    getSettings.mockResolvedValue({});
+
+    const Page = await LateFeesSettingsPage({
+      params: Promise.resolve({ shop: "demo-shop" }),
+    });
+
+    render(Page);
+
+    expect(lateFeesEditorMock).toHaveBeenCalledTimes(1);
+    expect(lateFeesEditorMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        shop: "demo-shop",
+        initial: { enabled: false, intervalMinutes: 60 },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for the late fees settings page to validate the heading and editor/table props
- confirm the editor defaults when late fee service settings are missing

## Testing
- pnpm --filter @apps/cms exec jest --runInBand --detectOpenHandles --config jest.config.cjs --coverage=false --runTestsByPath src/app/cms/shop/[shop]/settings/late-fees/__tests__/LateFeesSettingsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cba98853e8832f8ba40b0901edf169