### PR TITLE
Add test for CMS data index page hero and CTAs

### DIFF
--- a/apps/cms/__tests__/dataIndexPage.test.tsx
+++ b/apps/cms/__tests__/dataIndexPage.test.tsx
@@ -1,0 +1,38 @@
+import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+
+import DataIndex from "../src/app/cms/shop/[shop]/data/page";
+
+jest.mock("@ui/components/atoms", () => ({
+  __esModule: true,
+  Tag: ({ children, ...props }: { children?: ReactNode }) => (
+    <span {...props}>{children}</span>
+  ),
+}));
+
+describe("DataIndex page", () => {
+  it("renders hero and shop-specific cards", async () => {
+    const page = await DataIndex({
+      params: Promise.resolve({ shop: "acme" }),
+    });
+
+    render(page);
+
+    expect(screen.getByText("Data operations · acme")).toBeInTheDocument();
+
+    const cardHeadings = screen.getAllByRole("heading", { level: 2 });
+    expect(cardHeadings).toHaveLength(3);
+
+    const expectedCtas = [
+      { text: "Manage inventory", href: "/cms/shop/acme/data/inventory" },
+      { text: "Configure pricing", href: "/cms/shop/acme/data/rental/pricing" },
+      { text: "Optimize returns", href: "/cms/shop/acme/data/return-logistics" },
+    ];
+
+    for (const { text, href } of expectedCtas) {
+      const link = screen.getByRole("link", { name: text });
+      expect(link).toHaveAttribute("href", href);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated test for the CMS data index page to cover the hero tag and CTA links
- mock the Tag atom for lightweight rendering during the test

## Testing
- pnpm --filter @apps/cms exec jest --runTestsByPath __tests__/dataIndexPage.test.tsx --config jest.config.cjs --runInBand --detectOpenHandles --passWithNoTests --ci --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cba986b50c832fbd2bd45650fd80c5