### PR TITLE
test: add settings index page coverage

### DIFF
--- a/apps/cms/__tests__/settingsIndexPage.test.tsx
+++ b/apps/cms/__tests__/settingsIndexPage.test.tsx
@@ -1,0 +1,46 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const mockShops = ["alpine", "brooklyn"];
+
+const listShopsMock = jest.fn().mockResolvedValue(mockShops);
+const shopChooserMock = jest.fn((props: any) => <div data-testid="shop-chooser" />);
+
+jest.mock("../src/app/cms/settings/../../../lib/listShops", () => ({
+  listShops: listShopsMock,
+}));
+
+jest.mock("@/components/cms/ShopChooser", () => ({
+  __esModule: true,
+  default: shopChooserMock,
+}));
+
+import SettingsIndexPage from "../src/app/cms/settings/page";
+
+describe("SettingsIndexPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listShopsMock.mockResolvedValue(mockShops);
+  });
+
+  it("renders hero copy and wires ShopChooser props", async () => {
+    const Page = await SettingsIndexPage();
+
+    render(Page);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Govern storefront policies with confidence" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Create a new shop" })).toHaveAttribute("href", "/cms/configurator");
+    expect(screen.getByRole("link", { name: "Browse existing shops" })).toHaveAttribute("href", "#shop-selection");
+
+    expect(shopChooserMock).toHaveBeenCalledTimes(1);
+    const props = shopChooserMock.mock.calls[0][0];
+    expect(props.shops).toEqual(mockShops);
+    expect(props.tag).toBe("Settings · Configuration hubs");
+    mockShops.forEach((shop) => {
+      expect(props.card.href(shop)).toBe(`/cms/shop/${shop}/settings`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused test for the CMS settings index page
- verify the hero content and ensure ShopChooser receives the correct props

## Testing
- pnpm --filter @apps/cms exec jest --config jest.config.cjs --runTestsByPath __tests__/settingsIndexPage.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cba97f8084832fbea9d28424d9b729