### PR TITLE
Add shop chooser CTA data-index coverage

### DIFF
--- a/apps/cms/__tests__/ordersPages.test.tsx
+++ b/apps/cms/__tests__/ordersPages.test.tsx
@@ -18,8 +18,8 @@ jest.mock("next/link", () => {
   const React = require("react");
   return {
     __esModule: true,
-    default: ({ href, children }: any) =>
-      React.createElement("a", { href }, children),
+    default: ({ href, children, ...rest }: any) =>
+      React.createElement("a", { href, ...rest }, children),
   };
 });
 
@@ -27,17 +27,17 @@ describe("Orders pages", () => {
   afterEach(() => jest.resetAllMocks());
 
   it("lists shops on index page", async () => {
-    listShops.mockResolvedValue(["shop-a", "shop-b"]);
+    const shops = ["shop-a", "shop-b"];
+    listShops.mockResolvedValue(shops);
     const Page = (await import("../src/app/cms/orders/page")).default;
     render(await Page());
-    expect(screen.getByRole("link", { name: "shop-a" })).toHaveAttribute(
-      "href",
-      "/cms/orders/shop-a",
-    );
-    expect(screen.getByRole("link", { name: "shop-b" })).toHaveAttribute(
-      "href",
-      "/cms/orders/shop-b",
-    );
+    const ctas = screen.getAllByTestId("shop-chooser-cta");
+    expect(ctas).toHaveLength(shops.length);
+    ctas.forEach((cta, index) => {
+      expect(cta).toHaveAttribute("data-index", String(index));
+      expect(cta).toHaveAttribute("href", `/cms/orders/${shops[index]}`);
+      expect(cta).toHaveAccessibleName(shops[index].toUpperCase());
+    });
   });
 
   it("shows order details and calls actions", async () => {

--- a/packages/ui/src/components/cms/ShopChooser.tsx
+++ b/packages/ui/src/components/cms/ShopChooser.tsx
@@ -163,6 +163,7 @@ export default function ShopChooser({
                     <Link
                       href={href}
                       data-cy="shop-chooser-cta"
+                      data-index={index}
                       aria-labelledby={cardTitleId}
                       aria-describedby={descriptionId}
                       onClick={() =>

--- a/packages/ui/src/components/cms/__tests__/ShopChooser.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/ShopChooser.test.tsx
@@ -43,6 +43,14 @@ describe("ShopChooser", () => {
     expect(screen.getByText("Workspace heading")).toBeInTheDocument();
     const links = screen.getAllByTestId("shop-chooser-cta");
     expect(links).toHaveLength(3);
+    expect(links.map((link) => link.getAttribute("data-index"))).toEqual([
+      "0",
+      "1",
+      "2",
+    ]);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual(
+      baseProps.shops.map((shop) => `/cms/test/${shop}`)
+    );
 
     links.forEach((link) =>
       link.addEventListener("click", (event) => event.preventDefault())

--- a/test/__mocks__/componentStub.js
+++ b/test/__mocks__/componentStub.js
@@ -23,7 +23,7 @@ function ComponentStub(props) {
     return React.createElement(
       "ul",
       null,
-      props.shops.map((shop) => {
+      props.shops.map((shop, index) => {
         const href = props.card.href(shop);
         const title = resolveValue(props.card.title, shop) || shop;
         const description = resolveValue(props.card.description, shop) || "";
@@ -36,7 +36,7 @@ function ComponentStub(props) {
           description ? React.createElement("p", null, description) : null,
           React.createElement(
             "a",
-            { href, "data-cy": "shop-chooser-cta" },
+            { href, "data-cy": "shop-chooser-cta", "data-index": String(index) },
             React.createElement("span", { className: "sr-only" }, shop),
             React.createElement("span", { "aria-hidden": "true" }, ctaLabel)
           )


### PR DESCRIPTION
## Summary
- add a `data-index` attribute to shop chooser CTA links so tests can locate each entry
- extend the shared component stub and unit tests to assert the generated shop-aware URLs
- update the CMS orders page test to validate every CTA against the expected shop slug

## Testing
- pnpm exec jest --runInBand --coverage=false packages/ui/src/components/cms/__tests__/ShopChooser.test.tsx
- pnpm exec jest --runInBand --coverage=false apps/cms/__tests__/ordersPages.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cba95c6dc0832fa7d84b9d823a3b6d