### PR TITLE
test(cms): cover stock scheduler actions

### DIFF
--- a/apps/cms/src/actions/__tests__/stockScheduler.server.test.ts
+++ b/apps/cms/src/actions/__tests__/stockScheduler.server.test.ts
@@ -1,0 +1,85 @@
+import { jest } from "@jest/globals";
+
+jest.mock("@platform-core/services/stockScheduler.server", () => ({
+  scheduleStockChecks: jest.fn(),
+  getStockCheckStatus: jest.fn(),
+}));
+
+jest.mock("@platform-core/repositories/inventory.server", () => ({
+  readInventory: jest.fn(),
+}));
+
+import {
+  scheduleStockChecks,
+  getStockCheckStatus,
+} from "@platform-core/services/stockScheduler.server";
+import { readInventory } from "@platform-core/repositories/inventory.server";
+import {
+  updateStockScheduler,
+  getSchedulerStatus,
+} from "../stockScheduler.server";
+
+describe("stockScheduler actions", () => {
+  const shop = "shop-id";
+  const scheduleStockChecksMock =
+    scheduleStockChecks as jest.MockedFunction<typeof scheduleStockChecks>;
+  const getStockCheckStatusMock =
+    getStockCheckStatus as jest.MockedFunction<typeof getStockCheckStatus>;
+  const readInventoryMock = readInventory as jest.MockedFunction<typeof readInventory>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("updateStockScheduler", () => {
+    it.each([
+      { label: "missing interval", value: undefined },
+      { label: "empty interval", value: "" },
+      { label: "zero interval", value: "0" },
+      { label: "negative interval", value: "-5" },
+    ])("ignores %s", async ({ value }) => {
+      const formData = new FormData();
+      if (value !== undefined) {
+        formData.set("intervalMs", value);
+      }
+
+      await updateStockScheduler(shop, formData);
+
+      expect(scheduleStockChecksMock).not.toHaveBeenCalled();
+    });
+
+    it("schedules checks with a fetcher when interval is valid", async () => {
+      const formData = new FormData();
+      formData.set("intervalMs", "5000");
+      const inventory = [{ id: "1" }] as unknown as Awaited<ReturnType<typeof readInventory>>;
+      readInventoryMock.mockResolvedValue(inventory);
+
+      await updateStockScheduler(shop, formData);
+
+      expect(scheduleStockChecksMock).toHaveBeenCalledTimes(1);
+      const [passedShop, fetchInventory, interval] =
+        scheduleStockChecksMock.mock.calls[0];
+
+      expect(passedShop).toBe(shop);
+      expect(typeof fetchInventory).toBe("function");
+      expect(interval).toBe(5000);
+
+      await expect(fetchInventory()).resolves.toBe(inventory);
+      expect(readInventoryMock).toHaveBeenCalledWith(shop);
+    });
+  });
+
+  describe("getSchedulerStatus", () => {
+    it("returns the scheduler status from the service", async () => {
+      const status = {
+        intervalMs: 1000,
+        lastRun: Date.now(),
+        history: [],
+      } as Awaited<ReturnType<typeof getSchedulerStatus>>;
+      getStockCheckStatusMock.mockReturnValue(status);
+
+      await expect(getSchedulerStatus(shop)).resolves.toBe(status);
+      expect(getStockCheckStatusMock).toHaveBeenCalledWith(shop);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest coverage for updateStockScheduler to ensure invalid intervals skip scheduling and valid intervals wire the fetcher correctly
- check that getSchedulerStatus forwards the service response as expected

## Testing
- pnpm --filter @apps/cms test

------
https://chatgpt.com/codex/tasks/task_e_68cba97424b8832f9cde7468220e3c3e