### PR TITLE
Ensure Jest fetch polyfill runs after environment setup

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -154,8 +154,12 @@ const config = {
     // their ESM builds can run in Jest.
     "/node_modules/(?!(jose|next-auth|ulid|@upstash/redis|uncrypto|@acme)/)",
   ],
-  setupFiles: ["dotenv/config", " /test/setupFetchPolyfill.ts"],
-  setupFilesAfterEnv: [" /jest.setup.ts", " /test/polyfills/messageChannel.js"],
+  setupFiles: ["dotenv/config"],
+  setupFilesAfterEnv: [
+    " /test/setupFetchPolyfill.ts",
+    " /jest.setup.ts",
+    " /test/polyfills/messageChannel.js",
+  ],
   testPathIgnorePatterns: [
     " /test/e2e/",
     " /.storybook/",


### PR DESCRIPTION
## Summary
- move the fetch polyfill helper into `setupFilesAfterEnv` so Jest runs it through ts-jest before execution

## Testing
- pnpm exec jest packages/config/src/env/__tests__/load-env-errors.test.ts --config jest.config.cjs --runInBand --coverage=false
- pnpm exec jest packages/config/__tests__/cmsEnvFailure.test.ts --config jest.config.cjs --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbb4ee9080832f903e095cb77b1fb7