### PR TITLE
Refactor telemetry analytics view into modular components

### DIFF
--- a/apps/cms/__tests__/telemetryPage.test.tsx
+++ b/apps/cms/__tests__/telemetryPage.test.tsx
@@ -18,10 +18,8 @@ jest.mock("@acme/ui", () => ({
     open ? <div role="status">{message}</div> : null,
 }));
 
-import {
-  TelemetryAnalyticsView,
-  filterTelemetryEvents,
-} from "../src/app/cms/telemetry/page";
+import { TelemetryAnalyticsView } from "../src/app/cms/telemetry/page";
+import { filterTelemetryEvents } from "../src/app/cms/telemetry/telemetryUtils";
 
 function createEvent(partial: Partial<TelemetryEvent> = {}): TelemetryEvent {
   return {

--- a/apps/cms/src/app/cms/telemetry/TelemetryEventTable.tsx
+++ b/apps/cms/src/app/cms/telemetry/TelemetryEventTable.tsx
@@ -1,0 +1,74 @@
+import { Tag } from "@acme/ui";
+
+import type { TelemetrySummaryRow } from "./telemetryUtils";
+
+interface TelemetryEventTableProps {
+  summaryRows: TelemetrySummaryRow[];
+  filteredCount: number;
+  totalCount: number;
+}
+
+export function TelemetryEventTable({
+  summaryRows,
+  filteredCount,
+  totalCount,
+}: TelemetryEventTableProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold">Event breakdown</h3>
+        <Tag variant="default" className="bg-white/10 text-white/70">
+          {summaryRows.length} tracked types
+        </Tag>
+      </div>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="telemetry-announce"
+        data-cy="telemetry-announce"
+        className="sr-only"
+      >
+        Showing {filteredCount} of {totalCount} events
+      </div>
+      <div className="overflow-x-auto">
+        <table
+          className="w-full min-w-[320px] border-separate border-spacing-0 text-left text-sm"
+          aria-label="Event type breakdown"
+        >
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-white/50">
+              <th className="border-b border-white/10 px-3 py-2">Event</th>
+              <th className="border-b border-white/10 px-3 py-2">Count</th>
+              <th className="border-b border-white/10 px-3 py-2">Last seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summaryRows.map((row) => (
+              <tr key={row.name} className="odd:bg-white/5 even:bg-white/0">
+                <td className="px-3 py-2 font-medium text-white">{row.name}</td>
+                <td className="px-3 py-2 text-white/80">{row.count}</td>
+                <td className="px-3 py-2 text-white/60">
+                  {new Date(row.lastSeen).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+            {summaryRows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={3}
+                  className="px-3 py-6 text-center text-sm text-white/60"
+                >
+                  <Tag variant="warning" className="bg-amber-500/20 text-amber-100">
+                    Filters active
+                  </Tag>{" "}
+                  Adjust the criteria to see event types.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/telemetry/TelemetryFiltersPanel.tsx
+++ b/apps/cms/src/app/cms/telemetry/TelemetryFiltersPanel.tsx
@@ -1,0 +1,161 @@
+import type { TelemetryEvent } from "@acme/telemetry";
+import { LineChart, Loader, Tag } from "@acme/ui";
+import { Card, CardContent, Input } from "@/components/atoms/shadcn";
+import { cn } from "@ui/utils/style";
+
+import { TelemetryEventTable } from "./TelemetryEventTable";
+import type {
+  SavedPreset,
+  TelemetryChartData,
+  TelemetryFilters,
+  TelemetrySummaryRow,
+} from "./telemetryUtils";
+
+interface TelemetryFiltersPanelProps {
+  presets: SavedPreset[];
+  activePreset: string;
+  onPresetSelect: (presetId: string) => void;
+  filters: TelemetryFilters;
+  onFiltersChange: (partial: Partial<TelemetryFilters>) => void;
+  filteredEvents: TelemetryEvent[];
+  chartData: TelemetryChartData;
+  isLoading: boolean;
+  summaryRows: TelemetrySummaryRow[];
+  totalEvents: number;
+}
+
+export function TelemetryFiltersPanel({
+  presets,
+  activePreset,
+  onPresetSelect,
+  filters,
+  onFiltersChange,
+  filteredEvents,
+  chartData,
+  isLoading,
+  summaryRows,
+  totalEvents,
+}: TelemetryFiltersPanelProps) {
+  return (
+    <section className="grid gap-6 lg:grid-cols-[340px,1fr]">
+      <Card className="border border-white/10 bg-slate-900/60 text-white">
+        <CardContent className="space-y-5 px-5 py-6">
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold">Saved filters</h3>
+            <p className="text-sm text-white/70">
+              Quickly pivot between moments that matter to your team.
+            </p>
+          </div>
+          <div className="grid gap-2">
+            {presets.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => onPresetSelect(preset.id)}
+                className={cn(
+                  "rounded-xl border px-3 py-2 text-left text-sm transition",
+                  activePreset === preset.id
+                    ? "border-sky-400 bg-sky-500/20 text-white"
+                    : "border-white/20 bg-white/5 text-white/80 hover:border-sky-300 hover:bg-sky-500/10",
+                )}
+                aria-pressed={activePreset === preset.id}
+              >
+                <span className="block font-semibold">{preset.label}</span>
+                <span className="block text-xs text-white/60">
+                  {preset.description}
+                </span>
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-white/10 bg-slate-900/60 text-white">
+        <CardContent className="space-y-5 px-5 py-6">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <label className="space-y-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+              Event name
+              <Input
+                value={filters.name}
+                onChange={(event) =>
+                  onFiltersChange({ name: event.target.value })
+                }
+                placeholder="Search events"
+                className="border-white/20 bg-white/5 text-white placeholder:text-white/50"
+              />
+            </label>
+            <label className="space-y-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+              Start
+              <Input
+                type="datetime-local"
+                value={filters.start}
+                onChange={(event) =>
+                  onFiltersChange({ start: event.target.value })
+                }
+                className="border-white/20 bg-white/5 text-white"
+              />
+            </label>
+            <label className="space-y-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+              End
+              <Input
+                type="datetime-local"
+                value={filters.end}
+                onChange={(event) =>
+                  onFiltersChange({ end: event.target.value })
+                }
+                className="border-white/20 bg-white/5 text-white"
+              />
+            </label>
+          </div>
+
+          <div className="relative rounded-2xl border border-white/10 bg-slate-950/70 p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <h3 className="text-base font-semibold">Event trend</h3>
+                <p className="text-xs text-white/60">
+                  Visualise when filtered events are landing.
+                </p>
+              </div>
+              {isLoading && (
+                <Loader
+                  aria-label="Loading telemetry"
+                  size={20}
+                  className="text-sky-300"
+                />
+              )}
+            </div>
+            {filteredEvents.length > 0 ? (
+              <div className="h-64">
+                <LineChart
+                  data={chartData}
+                  className="h-full w-full"
+                  options={{
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                      y: { beginAtZero: true, ticks: { precision: 0 } },
+                    },
+                    plugins: { legend: { display: false } },
+                  }}
+                />
+              </div>
+            ) : (
+              <div className="flex h-32 flex-col items-center justify-center gap-2 text-sm text-white/60">
+                <Tag variant="warning" className="bg-amber-500/20 text-amber-100">
+                  No events match the current filters
+                </Tag>
+                Try broadening your search window.
+              </div>
+            )}
+          </div>
+
+          <TelemetryEventTable
+            summaryRows={summaryRows}
+            filteredCount={filteredEvents.length}
+            totalCount={totalEvents}
+          />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/cms/src/app/cms/telemetry/TelemetryHeader.tsx
+++ b/apps/cms/src/app/cms/telemetry/TelemetryHeader.tsx
@@ -1,0 +1,33 @@
+import { Tag } from "@acme/ui";
+import { Button } from "@/components/atoms/shadcn";
+
+interface TelemetryHeaderProps {
+  onReload?: () => void | Promise<void>;
+}
+
+export function TelemetryHeader({ onReload }: TelemetryHeaderProps) {
+  return (
+    <header className="space-y-3">
+      <Tag variant="default" className="bg-sky-500/10 text-sky-300">
+        Telemetry analytics
+      </Tag>
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-white">Live product signals</h2>
+          <p className="text-sm text-white/70">
+            Track your key interactions in real time, compare spikes, and lock
+            filters you love as presets.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="border-white/30 text-white hover:bg-white/10"
+          onClick={() => onReload?.()}
+        >
+          Refresh data
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/apps/cms/src/app/cms/telemetry/TelemetrySummaryCards.tsx
+++ b/apps/cms/src/app/cms/telemetry/TelemetrySummaryCards.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent } from "@/components/atoms/shadcn";
+
+export interface TelemetrySummaryMetric {
+  label: string;
+  value: number | string;
+  description: string;
+}
+
+interface TelemetrySummaryCardsProps {
+  metrics: TelemetrySummaryMetric[];
+}
+
+export function TelemetrySummaryCards({
+  metrics,
+}: TelemetrySummaryCardsProps) {
+  return (
+    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {metrics.map((metric) => (
+        <Card
+          key={metric.label}
+          className="border border-white/10 bg-slate-900/70 text-white"
+        >
+          <CardContent className="space-y-1 px-4 py-3">
+            <p className="text-xs uppercase tracking-wide text-white/60">
+              {metric.label}
+            </p>
+            <p className="text-2xl font-semibold">{metric.value}</p>
+            <p className="text-xs text-white/60">{metric.description}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </section>
+  );
+}

--- a/apps/cms/src/app/cms/telemetry/page.tsx
+++ b/apps/cms/src/app/cms/telemetry/page.tsx
@@ -2,138 +2,25 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { TelemetryEvent } from "@acme/telemetry";
-import { LineChart, Loader, Tag, Toast } from "@acme/ui";
+import { Toast } from "@acme/ui";
+
+import { TelemetryFiltersPanel } from "./TelemetryFiltersPanel";
+import { TelemetryHeader } from "./TelemetryHeader";
+import { TelemetrySummaryCards } from "./TelemetrySummaryCards";
+import type { TelemetrySummaryMetric } from "./TelemetrySummaryCards";
 import {
-  Button,
-  Card,
-  CardContent,
-  Input,
-} from "@/components/atoms/shadcn";
-import { cn } from "@ui/utils/style";
-
-interface TelemetryFilters {
-  name: string;
-  start: string;
-  end: string;
-}
-
-interface TelemetrySummaryRow {
-  name: string;
-  count: number;
-  lastSeen: number;
-}
+  PRESETS,
+  buildChartData,
+  buildSummary,
+  filterTelemetryEvents,
+  type TelemetryFilters,
+} from "./telemetryUtils";
 
 interface TelemetryAnalyticsViewProps {
   events: TelemetryEvent[];
   isLoading: boolean;
   error?: string | null;
   onReload?: () => void | Promise<void>;
-}
-
-interface SavedPreset {
-  id: string;
-  label: string;
-  description: string;
-  apply: () => Partial<TelemetryFilters>;
-}
-
-const PRESETS: SavedPreset[] = [
-  {
-    id: "all",
-    label: "All events",
-    description: "Show every recorded signal",
-    apply: () => ({ name: "", start: "", end: "" }),
-  },
-  {
-    id: "last-hour",
-    label: "Last hour",
-    description: "Focus on the freshest spikes",
-    apply: () => {
-      const end = new Date();
-      const start = new Date(end.getTime() - 60 * 60 * 1000);
-      return { start: toDateInput(start), end: toDateInput(end) };
-    },
-  },
-  {
-    id: "day",
-    label: "24 hours",
-    description: "Track day-long health",
-    apply: () => {
-      const end = new Date();
-      const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
-      return { start: toDateInput(start), end: toDateInput(end) };
-    },
-  },
-  {
-    id: "checkout",
-    label: "Checkout",
-    description: "Only checkout related events",
-    apply: () => ({ name: "checkout" }),
-  },
-];
-
-function toDateInput(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getDate()}`.padStart(2, "0");
-  const hours = `${date.getHours()}`.padStart(2, "0");
-  const minutes = `${date.getMinutes()}`.padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
-}
-
-export function filterTelemetryEvents(
-  events: TelemetryEvent[],
-  { name, start, end }: TelemetryFilters,
-): TelemetryEvent[] {
-  const startTs = start ? new Date(start).getTime() : 0;
-  const endTs = end ? new Date(end).getTime() : Number.MAX_SAFE_INTEGER;
-  const normalizedName = name.trim().toLowerCase();
-  return events.filter((event) => {
-    const matchesName = normalizedName
-      ? event.name.toLowerCase().includes(normalizedName)
-      : true;
-    return matchesName && event.ts >= startTs && event.ts <= endTs;
-  });
-}
-
-function buildSummary(events: TelemetryEvent[]): TelemetrySummaryRow[] {
-  const map = new Map<string, TelemetrySummaryRow>();
-  for (const event of events) {
-    const existing = map.get(event.name);
-    if (existing) {
-      existing.count += 1;
-      existing.lastSeen = Math.max(existing.lastSeen, event.ts);
-    } else {
-      map.set(event.name, { name: event.name, count: 1, lastSeen: event.ts });
-    }
-  }
-  return Array.from(map.values()).sort((a, b) => b.count - a.count);
-}
-
-function buildChartData(events: TelemetryEvent[]) {
-  const buckets = new Map<string, number>();
-  for (const event of events) {
-    const date = new Date(event.ts);
-    const key = `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, "0")}-${`${date
-      .getDate()
-      .toString()
-      .padStart(2, "0")}`} ${`${date.getHours()}`.padStart(2, "0")}:00`;
-    buckets.set(key, (buckets.get(key) ?? 0) + 1);
-  }
-  const labels = Array.from(buckets.keys()).sort();
-  return {
-    labels,
-    datasets: [
-      {
-        label: "Events",
-        data: labels.map((label) => buckets.get(label) ?? 0),
-        borderColor: "#38bdf8",
-        backgroundColor: "rgba(56, 189, 248, 0.2)",
-        tension: 0.35,
-        fill: true,
-      },
-    ],
-  };
 }
 
 export function TelemetryAnalyticsView({
@@ -148,9 +35,10 @@ export function TelemetryAnalyticsView({
     end: "",
   });
   const [activePreset, setActivePreset] = useState<string>("all");
-  const [toast, setToast] = useState<{ open: boolean; message: string }>(
-    { open: false, message: "" },
-  );
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
 
   useEffect(() => {
     if (error) {
@@ -167,18 +55,23 @@ export function TelemetryAnalyticsView({
     () => buildSummary(filteredEvents),
     [filteredEvents],
   );
-  const chartData = useMemo(() => buildChartData(filteredEvents), [filteredEvents]);
+
+  const chartData = useMemo(
+    () => buildChartData(filteredEvents),
+    [filteredEvents],
+  );
 
   const firstSeen = filteredEvents.reduce<number | null>((acc, event) => {
     if (!acc) return event.ts;
     return Math.min(acc, event.ts);
   }, null);
+
   const lastSeen = filteredEvents.reduce<number | null>((acc, event) => {
     if (!acc) return event.ts;
     return Math.max(acc, event.ts);
   }, null);
 
-  const heroMetrics = [
+  const heroMetrics: TelemetrySummaryMetric[] = [
     {
       label: "Events",
       value: filteredEvents.length,
@@ -201,7 +94,7 @@ export function TelemetryAnalyticsView({
     },
   ];
 
-  function applyPreset(presetId: string) {
+  function handlePresetSelect(presetId: string) {
     const preset = PRESETS.find((p) => p.id === presetId);
     if (!preset) return;
     setActivePreset(presetId);
@@ -209,7 +102,7 @@ export function TelemetryAnalyticsView({
     setToast({ open: true, message: `${preset.label} preset applied.` });
   }
 
-  function updateFilters(partial: Partial<TelemetryFilters>) {
+  function handleFiltersChange(partial: Partial<TelemetryFilters>) {
     setActivePreset("custom");
     setFilters((prev) => ({ ...prev, ...partial }));
   }
@@ -223,211 +116,20 @@ export function TelemetryAnalyticsView({
         role="status"
         aria-live="assertive"
       />
-      <header className="space-y-3">
-        <Tag variant="default" className="bg-sky-500/10 text-sky-300">
-          Telemetry analytics
-        </Tag>
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div className="space-y-1">
-            <h2 className="text-2xl font-semibold text-white">Live product signals</h2>
-            <p className="text-sm text-white/70">
-              Track your key interactions in real time, compare spikes, and
-              lock filters you love as presets.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            className="border-white/30 text-white hover:bg-white/10"
-            onClick={() => onReload?.()}
-          >
-            Refresh data
-          </Button>
-        </div>
-      </header>
-
-      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        {heroMetrics.map((metric) => (
-          <Card
-            key={metric.label}
-            className="border border-white/10 bg-slate-900/70 text-white"
-          >
-            <CardContent className="space-y-1 px-4 py-3">
-              <p className="text-xs uppercase tracking-wide text-white/60">
-                {metric.label}
-              </p>
-              <p className="text-2xl font-semibold">{metric.value}</p>
-              <p className="text-xs text-white/60">{metric.description}</p>
-            </CardContent>
-          </Card>
-        ))}
-      </section>
-
-      <section className="grid gap-6 lg:grid-cols-[340px,1fr]">
-        <Card className="border border-white/10 bg-slate-900/60 text-white">
-          <CardContent className="space-y-5 px-5 py-6">
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold">Saved filters</h3>
-              <p className="text-sm text-white/70">
-                Quickly pivot between moments that matter to your team.
-              </p>
-            </div>
-            <div className="grid gap-2">
-              {PRESETS.map((preset) => (
-                <button
-                  key={preset.id}
-                  type="button"
-                  onClick={() => applyPreset(preset.id)}
-                  className={cn(
-                    "rounded-xl border px-3 py-2 text-left text-sm transition",
-                    activePreset === preset.id
-                      ? "border-sky-400 bg-sky-500/20 text-white"
-                      : "border-white/20 bg-white/5 text-white/80 hover:border-sky-300 hover:bg-sky-500/10"
-                  )}
-                  aria-pressed={activePreset === preset.id}
-                >
-                  <span className="block font-semibold">{preset.label}</span>
-                  <span className="block text-xs text-white/60">
-                    {preset.description}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="border border-white/10 bg-slate-900/60 text-white">
-          <CardContent className="space-y-5 px-5 py-6">
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              <label className="space-y-1 text-xs font-semibold uppercase tracking-wide text-white/60">
-                Event name
-                <Input
-                  value={filters.name}
-                  onChange={(event) => updateFilters({ name: event.target.value })}
-                  placeholder="Search events"
-                  className="border-white/20 bg-white/5 text-white placeholder:text-white/50"
-                />
-              </label>
-              <label className="space-y-1 text-xs font-semibold uppercase tracking-wide text-white/60">
-                Start
-                <Input
-                  type="datetime-local"
-                  value={filters.start}
-                  onChange={(event) => updateFilters({ start: event.target.value })}
-                  className="border-white/20 bg-white/5 text-white"
-                />
-              </label>
-              <label className="space-y-1 text-xs font-semibold uppercase tracking-wide text-white/60">
-                End
-                <Input
-                  type="datetime-local"
-                  value={filters.end}
-                  onChange={(event) => updateFilters({ end: event.target.value })}
-                  className="border-white/20 bg-white/5 text-white"
-                />
-              </label>
-            </div>
-
-            <div className="relative rounded-2xl border border-white/10 bg-slate-950/70 p-4">
-              <div className="mb-3 flex items-center justify-between">
-                <div>
-                  <h3 className="text-base font-semibold">Event trend</h3>
-                  <p className="text-xs text-white/60">
-                    Visualise when filtered events are landing.
-                  </p>
-                </div>
-                {isLoading && (
-                  <Loader
-                    aria-label="Loading telemetry"
-                    size={20}
-                    className="text-sky-300"
-                  />
-                )}
-              </div>
-              {filteredEvents.length > 0 ? (
-                <div className="h-64">
-                  <LineChart
-                    data={chartData}
-                    className="h-full w-full"
-                    options={{
-                      responsive: true,
-                      maintainAspectRatio: false,
-                      scales: {
-                        y: { beginAtZero: true, ticks: { precision: 0 } },
-                      },
-                      plugins: { legend: { display: false } },
-                    }}
-                  />
-                </div>
-              ) : (
-                <div className="flex h-32 flex-col items-center justify-center gap-2 text-sm text-white/60">
-                  <Tag variant="warning" className="bg-amber-500/20 text-amber-100">
-                    No events match the current filters
-                  </Tag>
-                  Try broadening your search window.
-                </div>
-              )}
-            </div>
-
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="text-base font-semibold">Event breakdown</h3>
-                <Tag variant="default" className="bg-white/10 text-white/70">
-                  {summaryRows.length} tracked types
-                </Tag>
-              </div>
-              <div
-                role="status"
-                aria-live="polite"
-                aria-atomic="true"
-                data-testid="telemetry-announce"
-                data-cy="telemetry-announce"
-                className="sr-only"
-              >
-                Showing {filteredEvents.length} of {events.length} events
-              </div>
-              <div className="overflow-x-auto">
-                <table
-                  className="w-full min-w-[320px] border-separate border-spacing-0 text-left text-sm"
-                  aria-label="Event type breakdown"
-                >
-                  <thead>
-                    <tr className="text-xs uppercase tracking-wide text-white/50">
-                      <th className="border-b border-white/10 px-3 py-2">Event</th>
-                      <th className="border-b border-white/10 px-3 py-2">Count</th>
-                      <th className="border-b border-white/10 px-3 py-2">Last seen</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {summaryRows.map((row) => (
-                      <tr key={row.name} className="odd:bg-white/5 even:bg-white/0">
-                        <td className="px-3 py-2 font-medium text-white">{row.name}</td>
-                        <td className="px-3 py-2 text-white/80">{row.count}</td>
-                        <td className="px-3 py-2 text-white/60">
-                          {new Date(row.lastSeen).toLocaleString()}
-                        </td>
-                      </tr>
-                    ))}
-                    {summaryRows.length === 0 && (
-                      <tr>
-                        <td
-                          colSpan={3}
-                          className="px-3 py-6 text-center text-sm text-white/60"
-                        >
-                          <Tag variant="warning" className="bg-amber-500/20 text-amber-100">
-                            Filters active
-                          </Tag>{" "}
-                          Adjust the criteria to see event types.
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </section>
+      <TelemetryHeader onReload={onReload} />
+      <TelemetrySummaryCards metrics={heroMetrics} />
+      <TelemetryFiltersPanel
+        presets={PRESETS}
+        activePreset={activePreset}
+        onPresetSelect={handlePresetSelect}
+        filters={filters}
+        onFiltersChange={handleFiltersChange}
+        filteredEvents={filteredEvents}
+        chartData={chartData}
+        isLoading={isLoading}
+        summaryRows={summaryRows}
+        totalEvents={events.length}
+      />
     </div>
   );
 }
@@ -469,4 +171,3 @@ export default function TelemetryPage() {
     />
   );
 }
-

--- a/apps/cms/src/app/cms/telemetry/telemetryUtils.ts
+++ b/apps/cms/src/app/cms/telemetry/telemetryUtils.ts
@@ -1,0 +1,139 @@
+import type { TelemetryEvent } from "@acme/telemetry";
+
+export interface TelemetryFilters {
+  name: string;
+  start: string;
+  end: string;
+}
+
+export interface TelemetrySummaryRow {
+  name: string;
+  count: number;
+  lastSeen: number;
+}
+
+export interface SavedPreset {
+  id: string;
+  label: string;
+  description: string;
+  apply: () => Partial<TelemetryFilters>;
+}
+
+export interface TelemetryChartData {
+  labels: string[];
+  datasets: Array<{
+    label: string;
+    data: number[];
+    borderColor: string;
+    backgroundColor: string;
+    tension: number;
+    fill: boolean;
+  }>;
+}
+
+function toDateInput(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  const hours = `${date.getHours()}`.padStart(2, "0");
+  const minutes = `${date.getMinutes()}`.padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export const PRESETS: SavedPreset[] = [
+  {
+    id: "all",
+    label: "All events",
+    description: "Show every recorded signal",
+    apply: () => ({ name: "", start: "", end: "" }),
+  },
+  {
+    id: "last-hour",
+    label: "Last hour",
+    description: "Focus on the freshest spikes",
+    apply: () => {
+      const end = new Date();
+      const start = new Date(end.getTime() - 60 * 60 * 1000);
+      return { start: toDateInput(start), end: toDateInput(end) };
+    },
+  },
+  {
+    id: "day",
+    label: "24 hours",
+    description: "Track day-long health",
+    apply: () => {
+      const end = new Date();
+      const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+      return { start: toDateInput(start), end: toDateInput(end) };
+    },
+  },
+  {
+    id: "checkout",
+    label: "Checkout",
+    description: "Only checkout related events",
+    apply: () => ({ name: "checkout" }),
+  },
+];
+
+export function filterTelemetryEvents(
+  events: TelemetryEvent[],
+  { name, start, end }: TelemetryFilters,
+): TelemetryEvent[] {
+  const startTs = start ? new Date(start).getTime() : 0;
+  const endTs = end ? new Date(end).getTime() : Number.MAX_SAFE_INTEGER;
+  const normalizedName = name.trim().toLowerCase();
+
+  return events.filter((event) => {
+    const matchesName = normalizedName
+      ? event.name.toLowerCase().includes(normalizedName)
+      : true;
+
+    return matchesName && event.ts >= startTs && event.ts <= endTs;
+  });
+}
+
+export function buildSummary(events: TelemetryEvent[]): TelemetrySummaryRow[] {
+  const map = new Map<string, TelemetrySummaryRow>();
+
+  for (const event of events) {
+    const existing = map.get(event.name);
+    if (existing) {
+      existing.count += 1;
+      existing.lastSeen = Math.max(existing.lastSeen, event.ts);
+    } else {
+      map.set(event.name, { name: event.name, count: 1, lastSeen: event.ts });
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.count - a.count);
+}
+
+export function buildChartData(events: TelemetryEvent[]): TelemetryChartData {
+  const buckets = new Map<string, number>();
+
+  for (const event of events) {
+    const date = new Date(event.ts);
+    const key = `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, "0")}-${`${date
+      .getDate()
+      .toString()
+      .padStart(2, "0")}`} ${`${date.getHours()}`.padStart(2, "0")}:00`;
+
+    buckets.set(key, (buckets.get(key) ?? 0) + 1);
+  }
+
+  const labels = Array.from(buckets.keys()).sort();
+
+  return {
+    labels,
+    datasets: [
+      {
+        label: "Events",
+        data: labels.map((label) => buckets.get(label) ?? 0),
+        borderColor: "#38bdf8",
+        backgroundColor: "rgba(56, 189, 248, 0.2)",
+        tension: 0.35,
+        fill: true,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- extract telemetry filtering helpers and presets into a dedicated telemetryUtils module
- add presentational components for the header, summary cards, filters panel, and event table
- refactor TelemetryAnalyticsView to compose the new components while the page handles only data loading

## Testing
- pnpm exec jest --runTestsByPath apps/cms/__tests__/telemetryPage.test.tsx --config ./jest.config.cjs --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbb5001d0c832f8cd76a6c51bf6cd4