### PR TITLE
test: add themes index page coverage

### DIFF
--- a/apps/cms/__tests__/themesIndexPage.test.tsx
+++ b/apps/cms/__tests__/themesIndexPage.test.tsx
@@ -1,0 +1,57 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const mockShops = ["andromeda", "betelgeuse"];
+
+const listShopsMock = jest.fn().mockResolvedValue(mockShops);
+const shopChooserMock = jest.fn((props: any) => <div data-testid="shop-chooser" />);
+
+jest.mock("../src/app/cms/themes/../../../lib/listShops", () => ({
+  listShops: listShopsMock,
+}));
+
+jest.mock("@/components/cms/ShopChooser", () => ({
+  __esModule: true,
+  default: shopChooserMock,
+}));
+
+import ThemesIndexPage from "../src/app/cms/themes/page";
+
+describe("ThemesIndexPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listShopsMock.mockResolvedValue(mockShops);
+  });
+
+  it("renders hero copy and passes expected props to ShopChooser", async () => {
+    const Page = await ThemesIndexPage();
+
+    render(Page);
+
+    expect(screen.getByText("Themes · Choose a shop")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Tailor the look and feel per shop" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Select a shop to swap themes, adjust palettes, and preview storefronts before publishing."
+      )
+    ).toBeInTheDocument();
+
+    expect(shopChooserMock).toHaveBeenCalledTimes(1);
+    const props = shopChooserMock.mock.calls[0][0];
+
+    expect(props.shops).toEqual(mockShops);
+    expect(props.tag).toBe("Themes · Studios");
+    expect(props.heading).toBe("Theme studios");
+    expect(props.subheading).toBe(
+      "Apply curated experiences, manage theme versions, and schedule releases for each storefront."
+    );
+
+    mockShops.forEach((shop) => {
+      expect(props.card.href(shop)).toBe(`/cms/shop/${shop}/themes`);
+      expect(props.card.analyticsPayload(shop)).toEqual({ area: "themes", shop });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for the CMS themes index page hero content
- verify ShopChooser receives the expected props and helper behavior

## Testing
- pnpm --filter @apps/cms exec jest --runInBand --detectOpenHandles --config jest.config.cjs --runTestsByPath __tests__/themesIndexPage.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbb53d69b4832f9ae9b268987fb510