### PR TITLE
Add PreviewPane wizard interactions test

### DIFF
--- a/apps/cms/__tests__/wizardNewPreviewPane.test.tsx
+++ b/apps/cms/__tests__/wizardNewPreviewPane.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ScaffoldSpec } from "@acme/types/page/ScaffoldSpec";
+import PreviewPane from "../src/app/cms/shop/[shop]/wizard/new/components/PreviewPane";
+
+type PreviewRendererProps = {
+  spec: ScaffoldSpec;
+  deviceId?: string;
+};
+
+type DeviceSelectorProps = {
+  deviceId: string;
+  onChange: (id: string) => void;
+  showLegacyButtons?: boolean;
+};
+
+let latestDeviceId: string | undefined;
+
+const previewRendererMock = jest.fn((props: PreviewRendererProps) => {
+  latestDeviceId = props.deviceId;
+  return <div data-testid="preview-renderer" />;
+});
+
+jest.mock("@ui/components/cms/page-builder/PreviewRenderer", () => ({
+  __esModule: true,
+  default: (props: PreviewRendererProps) => previewRendererMock(props),
+}));
+
+jest.mock("@ui/components/common/DeviceSelector", () => ({
+  __esModule: true,
+  default: ({ deviceId, onChange }: DeviceSelectorProps) => (
+    <button
+      type="button"
+      onClick={() => onChange(deviceId === "desktop" ? "mobile" : "desktop")}
+    >
+      Switch device
+    </button>
+  ),
+}));
+
+describe("PreviewPane", () => {
+  beforeEach(() => {
+    latestDeviceId = undefined;
+    previewRendererMock.mockClear();
+  });
+
+  it("renders the preview and responds to device and action controls", async () => {
+    const user = userEvent.setup();
+    const spec: ScaffoldSpec = {
+      layout: "default",
+      sections: [],
+    };
+    const onBack = jest.fn();
+    const onConfirm = jest.fn();
+
+    render(<PreviewPane spec={spec} onBack={onBack} onConfirm={onConfirm} />);
+
+    expect(previewRendererMock).toHaveBeenCalled();
+    expect(latestDeviceId).toBe("desktop");
+
+    await user.click(screen.getByRole("button", { name: /switch device/i }));
+
+    await waitFor(() => {
+      expect(latestDeviceId).toBe("mobile");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a PreviewPane wizard test covering device switching and action buttons
- mock the preview renderer and device selector to control deviceId updates in the test

## Testing
- pnpm --filter @apps/cms exec -- jest --config ./jest.config.cjs --runTestsByPath __tests__/wizardNewPreviewPane.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbb53c13d4832fa4c6aea279feb8a6