### PR TITLE
Refactor SEO editor into modular hook and components

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoAdvancedSettings.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoAdvancedSettings.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Tooltip } from "@/components/atoms";
+import { Input } from "@/components/atoms/shadcn";
+
+import type { SeoData } from "./useSeoEditor";
+
+interface SeoAdvancedSettingsProps {
+  open: boolean;
+  onToggle(): void;
+  draft: SeoData;
+  updateField(field: keyof SeoData, value: string): void;
+}
+
+export function SeoAdvancedSettings({
+  open,
+  onToggle,
+  draft,
+  updateField,
+}: SeoAdvancedSettingsProps) {
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        className="text-sm font-medium text-primary"
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        {open ? "Hide advanced settings" : "Show advanced settings"}
+      </button>
+      {open && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-2">
+            <span className="flex items-center gap-2 text-sm font-medium">
+              Canonical Base
+              <Tooltip text="Base URL used to build canonical links.">?</Tooltip>
+            </span>
+            <Input
+              value={draft.canonicalBase}
+              onChange={(event) => updateField("canonicalBase", event.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-medium">Open Graph URL</span>
+            <Input
+              value={draft.ogUrl}
+              onChange={(event) => updateField("ogUrl", event.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-medium">Twitter Card</span>
+            <Input
+              value={draft.twitterCard}
+              onChange={(event) => updateField("twitterCard", event.target.value)}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditor.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditor.tsx
@@ -1,88 +1,25 @@
 "use client";
 
-import { FormEvent, useCallback, useMemo, useState } from "react";
+import { FormEvent, useState } from "react";
 
-import { Toast, Tooltip } from "@/components/atoms";
-import {
-  Button,
-  Card,
-  CardContent,
-  Input,
-  Textarea,
-} from "@/components/atoms/shadcn";
-import { setFreezeTranslations, updateSeo } from "@cms/actions/shops.server";
+import { Toast } from "@/components/atoms";
+import { Button, Card, CardContent } from "@/components/atoms/shadcn";
 import type { Locale } from "@acme/types";
 
-interface SeoData {
-  title?: string;
-  description?: string;
-  image?: string;
-  alt?: string;
-  canonicalBase?: string;
-  ogUrl?: string;
-  twitterCard?: string;
-}
+import { SeoAdvancedSettings } from "./SeoAdvancedSettings";
+import { SeoEditorHeader } from "./SeoEditorHeader";
+import { SeoSharedFields } from "./SeoSharedFields";
+import { useSeoEditor, type UseSeoEditorProps } from "./useSeoEditor";
 
-interface Props {
-  shop: string;
-  languages: readonly Locale[];
-  initialSeo: Partial<Record<string, SeoData>>;
-  initialFreeze?: boolean;
-}
-
-type SharedField =
-  | "title"
-  | "description"
-  | "image"
-  | "alt"
-  | "ogUrl"
-  | "twitterCard";
-
-const SHARED_FIELDS: readonly SharedField[] = [
-  "title",
-  "description",
-  "image",
-  "alt",
-  "ogUrl",
-  "twitterCard",
-];
-
-const SHARED_SET = new Set<SharedField>(SHARED_FIELDS);
-
-const EMPTY_DRAFT: SeoData = {
-  title: "",
-  description: "",
-  image: "",
-  alt: "",
-  canonicalBase: "",
-  ogUrl: "",
-  twitterCard: "",
-};
-
-const pickShared = (data: SeoData | undefined) => ({
-  title: data?.title ?? "",
-  description: data?.description ?? "",
-  image: data?.image ?? "",
-  alt: data?.alt ?? "",
-  ogUrl: data?.ogUrl ?? "",
-  twitterCard: data?.twitterCard ?? "",
-});
-
-const buildDraft = (
-  locale: Locale,
-  initial: Partial<Record<string, SeoData>>,
-): SeoData => ({
-  ...EMPTY_DRAFT,
-  ...initial[locale],
-});
-
-type TabsProps = {
+const Tabs = ({
+  value,
+  onValueChange,
+  items,
+}: {
   value: Locale;
   onValueChange(locale: Locale): void;
   items: { value: Locale; label: string }[];
-};
-
-function Tabs({ value, onValueChange, items }: TabsProps) {
+}) => {
   return (
     <div className="flex flex-wrap gap-2" role="tablist">
       {items.map((item) => {
@@ -106,206 +43,48 @@ function Tabs({ value, onValueChange, items }: TabsProps) {
       })}
     </div>
   );
-}
+};
 
-export default function SeoEditor({
-  shop,
-  languages,
-  initialSeo,
-  initialFreeze = false,
-}: Props) {
-  const initialDrafts = useMemo(
-    () =>
-      languages.reduce((acc, lang) => {
-        acc[lang] = buildDraft(lang, initialSeo);
-        return acc;
-      }, {} as Record<Locale, SeoData>),
-    [initialSeo, languages],
-  );
+export default function SeoEditor(props: UseSeoEditorProps) {
+  const { languages } = props;
+  const {
+    locale,
+    freeze,
+    saving,
+    generating,
+    warnings,
+    currentDraft,
+    updateField,
+    handleLocaleChange,
+    handleFreezeChange,
+    submit,
+    generate,
+    errorFor,
+  } = useSeoEditor(props);
 
-  const [locale, setLocale] = useState<Locale>(languages[0]);
-  const [drafts, setDrafts] = useState<Record<Locale, SeoData>>(
-    () => initialDrafts,
-  );
-  const [shared, setShared] = useState(() => pickShared(initialDrafts[languages[0]]));
-  const [freeze, setFreeze] = useState(initialFreeze);
-  const [saving, setSaving] = useState(false);
-  const [generating, setGenerating] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string[]>>({});
-  const [warnings, setWarnings] = useState<string[]>([]);
   const [toast, setToast] = useState<{ open: boolean; message: string }>(
     { open: false, message: "" },
   );
 
-  const currentDraft = drafts[locale] ?? buildDraft(locale, initialSeo);
-
-  const showToast = useCallback((message: string) => {
-    setToast({ open: true, message });
-  }, []);
-
-  const closeToast = useCallback(() => {
-    setToast((t) => ({ ...t, open: false }));
-  }, []);
-
-  const updateField = useCallback(
-    (field: keyof SeoData, value: string) => {
-      setDrafts((prev) => {
-        const next = { ...prev };
-        if (freeze && SHARED_SET.has(field as SharedField)) {
-          languages.forEach((lang) => {
-            const base = next[lang] ?? buildDraft(lang, initialSeo);
-            next[lang] = { ...base, [field]: value };
-          });
-        } else {
-          const base = next[locale] ?? buildDraft(locale, initialSeo);
-          next[locale] = { ...base, [field]: value };
-        }
-        return next;
-      });
-      if (SHARED_SET.has(field as SharedField)) {
-        setShared((prev) => ({ ...prev, [field]: value }));
-      }
-    },
-    [freeze, initialSeo, languages, locale],
-  );
-
-  const handleLocaleChange = useCallback(
-    (nextLocale: Locale) => {
-      setLocale(nextLocale);
-      if (freeze) {
-        setDrafts((prev) => {
-          const next = { ...prev };
-          const base = next[nextLocale] ?? buildDraft(nextLocale, initialSeo);
-          next[nextLocale] = { ...base, ...shared };
-          return next;
-        });
-      }
-      setErrors({});
-      setWarnings([]);
-    },
-    [freeze, initialSeo, shared],
-  );
-
-  const handleFreezeChange = useCallback(
-    async (checked: boolean) => {
-      setFreeze(checked);
-      await setFreezeTranslations(shop, checked);
-      if (checked) {
-        const sharedValues = pickShared(currentDraft);
-        setShared(sharedValues);
-        setDrafts((prev) => {
-          const next = { ...prev };
-          languages.forEach((lang) => {
-            const base = next[lang] ?? buildDraft(lang, initialSeo);
-            next[lang] = { ...base, ...sharedValues };
-          });
-          return next;
-        });
-      }
-    },
-    [currentDraft, initialSeo, languages, shop],
-  );
-
-  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setSaving(true);
-    const fd = new FormData();
-    fd.append("locale", locale);
-    fd.append("title", currentDraft.title ?? "");
-    fd.append("description", currentDraft.description ?? "");
-    fd.append("image", currentDraft.image ?? "");
-    fd.append("alt", currentDraft.alt ?? "");
-    fd.append("canonicalBase", currentDraft.canonicalBase ?? "");
-    fd.append("ogUrl", currentDraft.ogUrl ?? "");
-    fd.append("twitterCard", currentDraft.twitterCard ?? "");
-
-    try {
-      const result = await updateSeo(shop, fd);
-      if (result.errors) {
-        setErrors(result.errors);
-        setWarnings([]);
-        showToast("Unable to save metadata");
-      } else {
-        setErrors({});
-        const warningList = result.warnings ?? [];
-        setWarnings(warningList);
-        showToast(
-          warningList.length > 0
-            ? "Metadata saved with warnings"
-            : "Metadata saved",
-        );
-      }
-    } catch {
-      showToast("Unable to save metadata");
-    } finally {
-      setSaving(false);
-    }
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = await submit();
+    setToast({ open: true, message: result.message });
   };
 
-  const handleGenerate = useCallback(async () => {
-    setGenerating(true);
-    try {
-      const res = await fetch("/api/seo/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          shop,
-          id: `${shop}-${locale}`,
-          title: currentDraft.title,
-          description: currentDraft.description,
-        }),
-      });
+  const handleGenerate = async () => {
+    const result = await generate();
+    setToast({ open: true, message: result.message });
+  };
 
-      if (!res.ok) {
-        showToast("Unable to generate metadata");
-        return;
-      }
-
-      const data = (await res.json()) as {
-        title: string;
-        description: string;
-        alt: string;
-        image: string;
-      };
-      updateField("title", data.title);
-      updateField("description", data.description);
-      updateField("alt", data.alt);
-      updateField("image", data.image);
-      showToast("AI metadata generated");
-    } catch {
-      showToast("Unable to generate metadata");
-    } finally {
-      setGenerating(false);
-    }
-  }, [currentDraft.description, currentDraft.title, locale, shop, showToast, updateField]);
-
-  const errorFor = useCallback(
-    (field: keyof SeoData) => errors[field]?.join("; ") ?? "",
-    [errors],
-  );
+  const closeToast = () => setToast((t) => ({ ...t, open: false }));
 
   return (
     <>
       <Card>
         <CardContent className="space-y-6 p-6">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h3 className="text-lg font-semibold">SEO metadata</h3>
-              <p className="text-muted-foreground text-sm">
-                Manage localized titles, descriptions, and social previews.
-              </p>
-            </div>
-            <label className="flex items-center gap-2 text-sm font-medium">
-              <input
-                type="checkbox"
-                checked={freeze}
-                onChange={(event) => handleFreezeChange(event.target.checked)}
-              />
-              <span>Freeze translations</span>
-              <Tooltip text="Apply the same metadata across all locales.">?</Tooltip>
-            </label>
-          </div>
+          <SeoEditorHeader freeze={freeze} onFreezeChange={handleFreezeChange} />
 
           <Tabs
             value={locale}
@@ -313,85 +92,19 @@ export default function SeoEditor({
             items={languages.map((l) => ({ value: l, label: l.toUpperCase() }))}
           />
 
-          <form className="space-y-6" onSubmit={onSubmit}>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium">Title</span>
-                <Input
-                  value={currentDraft.title}
-                  onChange={(e) => updateField("title", e.target.value)}
-                />
-                {errorFor("title") && (
-                  <span className="text-xs text-destructive">{errorFor("title")}</span>
-                )}
-              </label>
-              <label className="flex flex-col gap-2 sm:col-span-2">
-                <span className="text-sm font-medium">Description</span>
-                <Textarea
-                  rows={3}
-                  value={currentDraft.description}
-                  onChange={(e) => updateField("description", e.target.value)}
-                />
-                {errorFor("description") && (
-                  <span className="text-xs text-destructive">
-                    {errorFor("description")}
-                  </span>
-                )}
-              </label>
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium">Image URL</span>
-                <Input
-                  value={currentDraft.image}
-                  onChange={(e) => updateField("image", e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium">Image Alt Text</span>
-                <Input
-                  value={currentDraft.alt}
-                  onChange={(e) => updateField("alt", e.target.value)}
-                />
-              </label>
-            </div>
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <SeoSharedFields
+              draft={currentDraft}
+              updateField={updateField}
+              errorFor={errorFor}
+            />
 
-            <div className="space-y-3">
-              <button
-                type="button"
-                className="text-sm font-medium text-primary"
-                aria-expanded={showAdvanced}
-                onClick={() => setShowAdvanced((open) => !open)}
-              >
-                {showAdvanced ? "Hide advanced settings" : "Show advanced settings"}
-              </button>
-              {showAdvanced && (
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <label className="flex flex-col gap-2">
-                    <span className="flex items-center gap-2 text-sm font-medium">
-                      Canonical Base
-                      <Tooltip text="Base URL used to build canonical links.">?</Tooltip>
-                    </span>
-                    <Input
-                      value={currentDraft.canonicalBase}
-                      onChange={(e) => updateField("canonicalBase", e.target.value)}
-                    />
-                  </label>
-                  <label className="flex flex-col gap-2">
-                    <span className="text-sm font-medium">Open Graph URL</span>
-                    <Input
-                      value={currentDraft.ogUrl}
-                      onChange={(e) => updateField("ogUrl", e.target.value)}
-                    />
-                  </label>
-                  <label className="flex flex-col gap-2">
-                    <span className="text-sm font-medium">Twitter Card</span>
-                    <Input
-                      value={currentDraft.twitterCard}
-                      onChange={(e) => updateField("twitterCard", e.target.value)}
-                    />
-                  </label>
-                </div>
-              )}
-            </div>
+            <SeoAdvancedSettings
+              open={showAdvanced}
+              onToggle={() => setShowAdvanced((open) => !open)}
+              draft={currentDraft}
+              updateField={updateField}
+            />
 
             {warnings.length > 0 && (
               <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-800">

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditorHeader.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoEditorHeader.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Tooltip } from "@/components/atoms";
+
+interface SeoEditorHeaderProps {
+  freeze: boolean;
+  onFreezeChange(checked: boolean): void | Promise<void>;
+}
+
+export function SeoEditorHeader({ freeze, onFreezeChange }: SeoEditorHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h3 className="text-lg font-semibold">SEO metadata</h3>
+        <p className="text-muted-foreground text-sm">
+          Manage localized titles, descriptions, and social previews.
+        </p>
+      </div>
+      <label className="flex items-center gap-2 text-sm font-medium">
+        <input
+          type="checkbox"
+          checked={freeze}
+          onChange={(event) => {
+            void onFreezeChange(event.target.checked);
+          }}
+        />
+        <span>Freeze translations</span>
+        <Tooltip text="Apply the same metadata across all locales.">?</Tooltip>
+      </label>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoSharedFields.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/SeoSharedFields.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Input, Textarea } from "@/components/atoms/shadcn";
+
+import type { SeoData } from "./useSeoEditor";
+
+interface SeoSharedFieldsProps {
+  draft: SeoData;
+  updateField(field: keyof SeoData, value: string): void;
+  errorFor(field: keyof SeoData): string;
+}
+
+export function SeoSharedFields({ draft, updateField, errorFor }: SeoSharedFieldsProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <label className="flex flex-col gap-2">
+        <span className="text-sm font-medium">Title</span>
+        <Input
+          value={draft.title}
+          onChange={(event) => updateField("title", event.target.value)}
+        />
+        {errorFor("title") && (
+          <span className="text-xs text-destructive">{errorFor("title")}</span>
+        )}
+      </label>
+      <label className="flex flex-col gap-2 sm:col-span-2">
+        <span className="text-sm font-medium">Description</span>
+        <Textarea
+          rows={3}
+          value={draft.description}
+          onChange={(event) => updateField("description", event.target.value)}
+        />
+        {errorFor("description") && (
+          <span className="text-xs text-destructive">{errorFor("description")}</span>
+        )}
+      </label>
+      <label className="flex flex-col gap-2">
+        <span className="text-sm font-medium">Image URL</span>
+        <Input
+          value={draft.image}
+          onChange={(event) => updateField("image", event.target.value)}
+        />
+      </label>
+      <label className="flex flex-col gap-2">
+        <span className="text-sm font-medium">Image Alt Text</span>
+        <Input
+          value={draft.alt}
+          onChange={(event) => updateField("alt", event.target.value)}
+        />
+      </label>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/seo/useSeoEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/seo/useSeoEditor.ts
@@ -1,0 +1,262 @@
+"use client";
+
+import { FormEvent, useCallback, useMemo, useState } from "react";
+
+import { setFreezeTranslations, updateSeo } from "@cms/actions/shops.server";
+import type { Locale } from "@acme/types";
+
+export interface SeoData {
+  title?: string;
+  description?: string;
+  image?: string;
+  alt?: string;
+  canonicalBase?: string;
+  ogUrl?: string;
+  twitterCard?: string;
+}
+
+export interface UseSeoEditorProps {
+  shop: string;
+  languages: readonly Locale[];
+  initialSeo: Partial<Record<string, SeoData>>;
+  initialFreeze?: boolean;
+}
+
+type SharedField =
+  | "title"
+  | "description"
+  | "image"
+  | "alt"
+  | "ogUrl"
+  | "twitterCard";
+
+const SHARED_FIELDS: readonly SharedField[] = [
+  "title",
+  "description",
+  "image",
+  "alt",
+  "ogUrl",
+  "twitterCard",
+];
+
+const SHARED_SET = new Set<SharedField>(SHARED_FIELDS);
+
+const EMPTY_DRAFT: SeoData = {
+  title: "",
+  description: "",
+  image: "",
+  alt: "",
+  canonicalBase: "",
+  ogUrl: "",
+  twitterCard: "",
+};
+
+const pickShared = (data: SeoData | undefined) => ({
+  title: data?.title ?? "",
+  description: data?.description ?? "",
+  image: data?.image ?? "",
+  alt: data?.alt ?? "",
+  ogUrl: data?.ogUrl ?? "",
+  twitterCard: data?.twitterCard ?? "",
+});
+
+const buildDraft = (
+  locale: Locale,
+  initial: Partial<Record<string, SeoData>>,
+): SeoData => ({
+  ...EMPTY_DRAFT,
+  ...initial[locale],
+});
+
+type SubmitResult = {
+  status: "error" | "success" | "warning";
+  message: string;
+};
+
+type GenerateResult = {
+  status: "error" | "success";
+  message: string;
+};
+
+export function useSeoEditor({
+  shop,
+  languages,
+  initialSeo,
+  initialFreeze = false,
+}: UseSeoEditorProps) {
+  const initialDrafts = useMemo(
+    () =>
+      languages.reduce((acc, lang) => {
+        acc[lang] = buildDraft(lang, initialSeo);
+        return acc;
+      }, {} as Record<Locale, SeoData>),
+    [initialSeo, languages],
+  );
+
+  const [locale, setLocale] = useState<Locale>(languages[0]);
+  const [drafts, setDrafts] = useState<Record<Locale, SeoData>>(
+    () => initialDrafts,
+  );
+  const [shared, setShared] = useState(() => pickShared(initialDrafts[languages[0]]));
+  const [freeze, setFreeze] = useState(initialFreeze);
+  const [saving, setSaving] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  const currentDraft = drafts[locale] ?? buildDraft(locale, initialSeo);
+
+  const updateField = useCallback(
+    (field: keyof SeoData, value: string) => {
+      setDrafts((prev) => {
+        const next = { ...prev };
+        if (freeze && SHARED_SET.has(field as SharedField)) {
+          languages.forEach((lang) => {
+            const base = next[lang] ?? buildDraft(lang, initialSeo);
+            next[lang] = { ...base, [field]: value };
+          });
+        } else {
+          const base = next[locale] ?? buildDraft(locale, initialSeo);
+          next[locale] = { ...base, [field]: value };
+        }
+        return next;
+      });
+      if (SHARED_SET.has(field as SharedField)) {
+        setShared((prev) => ({ ...prev, [field]: value }));
+      }
+    },
+    [freeze, initialSeo, languages, locale],
+  );
+
+  const handleLocaleChange = useCallback(
+    (nextLocale: Locale) => {
+      setLocale(nextLocale);
+      if (freeze) {
+        setDrafts((prev) => {
+          const next = { ...prev };
+          const base = next[nextLocale] ?? buildDraft(nextLocale, initialSeo);
+          next[nextLocale] = { ...base, ...shared };
+          return next;
+        });
+      }
+      setErrors({});
+      setWarnings([]);
+    },
+    [freeze, initialSeo, shared],
+  );
+
+  const handleFreezeChange = useCallback(
+    async (checked: boolean) => {
+      setFreeze(checked);
+      await setFreezeTranslations(shop, checked);
+      if (checked) {
+        const sharedValues = pickShared(currentDraft);
+        setShared(sharedValues);
+        setDrafts((prev) => {
+          const next = { ...prev };
+          languages.forEach((lang) => {
+            const base = next[lang] ?? buildDraft(lang, initialSeo);
+            next[lang] = { ...base, ...sharedValues };
+          });
+          return next;
+        });
+      }
+    },
+    [currentDraft, initialSeo, languages, shop],
+  );
+
+  const submit = useCallback(
+    async (event?: FormEvent<HTMLFormElement>): Promise<SubmitResult> => {
+      event?.preventDefault();
+      setSaving(true);
+      const fd = new FormData();
+      fd.append("locale", locale);
+      fd.append("title", currentDraft.title ?? "");
+      fd.append("description", currentDraft.description ?? "");
+      fd.append("image", currentDraft.image ?? "");
+      fd.append("alt", currentDraft.alt ?? "");
+      fd.append("canonicalBase", currentDraft.canonicalBase ?? "");
+      fd.append("ogUrl", currentDraft.ogUrl ?? "");
+      fd.append("twitterCard", currentDraft.twitterCard ?? "");
+
+      try {
+        const result = await updateSeo(shop, fd);
+        if (result.errors) {
+          setErrors(result.errors);
+          setWarnings([]);
+          return { status: "error", message: "Unable to save metadata" };
+        }
+
+        setErrors({});
+        const warningList = result.warnings ?? [];
+        setWarnings(warningList);
+        return warningList.length > 0
+          ? { status: "warning", message: "Metadata saved with warnings" }
+          : { status: "success", message: "Metadata saved" };
+      } catch {
+        return { status: "error", message: "Unable to save metadata" };
+      } finally {
+        setSaving(false);
+      }
+    },
+    [currentDraft, locale, shop],
+  );
+
+  const generate = useCallback(async (): Promise<GenerateResult> => {
+    setGenerating(true);
+    try {
+      const res = await fetch("/api/seo/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shop,
+          id: `${shop}-${locale}`,
+          title: currentDraft.title,
+          description: currentDraft.description,
+        }),
+      });
+
+      if (!res.ok) {
+        return { status: "error", message: "Unable to generate metadata" };
+      }
+
+      const data = (await res.json()) as {
+        title: string;
+        description: string;
+        alt: string;
+        image: string;
+      };
+
+      updateField("title", data.title);
+      updateField("description", data.description);
+      updateField("alt", data.alt);
+      updateField("image", data.image);
+      return { status: "success", message: "AI metadata generated" };
+    } catch {
+      return { status: "error", message: "Unable to generate metadata" };
+    } finally {
+      setGenerating(false);
+    }
+  }, [currentDraft.description, currentDraft.title, locale, shop, updateField]);
+
+  const errorFor = useCallback(
+    (field: keyof SeoData) => errors[field]?.join("; ") ?? "",
+    [errors],
+  );
+
+  return {
+    locale,
+    freeze,
+    saving,
+    generating,
+    warnings,
+    errors,
+    currentDraft,
+    updateField,
+    handleLocaleChange,
+    handleFreezeChange,
+    submit,
+    generate,
+    errorFor,
+  };
+}


### PR DESCRIPTION
## Summary
- extract locale, draft, and freeze logic into a reusable `useSeoEditor` hook
- move shared and advanced field groups plus the header UI into dedicated components
- update `SeoEditor` to use the hook/components while simplifying toast handling

## Testing
- pnpm --filter @apps/cms test -- --runTestsByPath apps/cms/__tests__/seoEditor.test.tsx *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb50f3830832faf08bd6fa9bcfdb3