### PR TITLE
Refactor product editor into modular tabs

### DIFF
--- a/packages/ui/src/components/cms/LocaleContentAccordion.tsx
+++ b/packages/ui/src/components/cms/LocaleContentAccordion.tsx
@@ -1,0 +1,41 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../atoms/shadcn";
+import type { Locale } from "@acme/i18n";
+import type { ReactNode } from "react";
+
+export interface LocalePanelConfig {
+  locale: Locale;
+  trigger: ReactNode;
+  content: ReactNode;
+}
+
+interface LocaleContentAccordionProps {
+  panels: LocalePanelConfig[];
+  defaultOpenLocales: readonly Locale[];
+}
+
+export default function LocaleContentAccordion({
+  panels,
+  defaultOpenLocales,
+}: LocaleContentAccordionProps) {
+  return (
+    <Accordion
+      type="multiple"
+      defaultValue={defaultOpenLocales as string[]}
+      className="space-y-3"
+    >
+      {panels.map(({ locale, trigger, content }) => (
+        <AccordionItem key={locale} value={locale} className="border-none">
+          <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
+            {trigger}
+          </AccordionTrigger>
+          <AccordionContent className="pt-3">{content}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}

--- a/packages/ui/src/components/cms/LocaleContentTab.tsx
+++ b/packages/ui/src/components/cms/LocaleContentTab.tsx
@@ -1,0 +1,77 @@
+import { Card, CardContent, Input, Textarea } from "../atoms/shadcn";
+import { Chip } from "../atoms";
+import LocaleContentAccordion, {
+  type LocalePanelConfig,
+} from "./LocaleContentAccordion";
+import type { Locale } from "@acme/i18n";
+import type { ChangeEvent } from "react";
+
+interface LocaleContentTabProps {
+  locales: readonly Locale[];
+  title: Partial<Record<Locale, string>>;
+  description: Partial<Record<Locale, string>>;
+  onFieldChange: (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
+}
+
+const localeLabel: Partial<Record<Locale, string>> = {
+  en: "English",
+  de: "Deutsch",
+  it: "Italiano",
+};
+
+export default function LocaleContentTab({
+  locales,
+  title,
+  description,
+  onFieldChange,
+}: LocaleContentTabProps) {
+  const localePanels: LocalePanelConfig[] = locales.map((locale) => ({
+    locale,
+    trigger: (
+      <div className="flex items-center gap-2">
+        <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
+          {locale}
+        </Chip>
+        <span className="text-sm text-muted-foreground">
+          {localeLabel[locale] ?? locale.toUpperCase()}
+        </span>
+      </div>
+    ),
+    content: (
+      <div className="space-y-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Title</span>
+          <Input
+            name={`title_${locale}`}
+            value={title[locale] ?? ""}
+            onChange={(event) => onFieldChange(event)}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Description</span>
+          <Textarea
+            rows={5}
+            name={`desc_${locale}`}
+            value={description[locale] ?? ""}
+            onChange={(event) => onFieldChange(event)}
+          />
+        </label>
+      </div>
+    ),
+  }));
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent>
+          <LocaleContentAccordion
+            panels={localePanels}
+            defaultOpenLocales={locales}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/MediaGalleryTab.tsx
+++ b/packages/ui/src/components/cms/MediaGalleryTab.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable @next/next/no-img-element */
+import { Card, CardContent } from "../atoms/shadcn";
+import { IconButton } from "../atoms";
+import type { MediaItem } from "@acme/types";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  Cross2Icon,
+  DragHandleDots2Icon,
+} from "@radix-ui/react-icons";
+import type { ReactNode } from "react";
+
+interface MediaGalleryTabProps {
+  uploader: ReactNode;
+  media: MediaItem[];
+  onMoveMedia: (from: number, to: number) => void;
+  onRemoveMedia: (index: number) => void;
+}
+
+export default function MediaGalleryTab({
+  uploader,
+  media,
+  onMoveMedia,
+  onRemoveMedia,
+}: MediaGalleryTabProps) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="space-y-4">
+          {uploader}
+          {media.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Add imagery or video to showcase this product.
+            </p>
+          )}
+          {media.length > 0 && (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {media.map((item: MediaItem, index: number) => (
+                <div
+                  key={`${item.url}-${index}`}
+                  className="group relative overflow-hidden rounded-xl border"
+                >
+                  {item.type === "image" ? (
+                    <img
+                      src={item.url}
+                      alt={item.altText || ""}
+                      className="h-48 w-full object-cover"
+                    />
+                  ) : (
+                    <video
+                      src={item.url}
+                      className="h-48 w-full object-cover"
+                      controls
+                    />
+                  )}
+                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-black/20 opacity-0 transition-opacity group-hover:opacity-100" />
+                  <div className="absolute inset-x-3 top-3 flex items-center justify-between gap-2 opacity-0 transition-opacity group-hover:opacity-100">
+                    <div className="flex items-center gap-1">
+                      <IconButton
+                        aria-label={`Move media ${index + 1} up`}
+                        onClick={() => onMoveMedia(index, index - 1)}
+                        disabled={index === 0}
+                        variant="secondary"
+                      >
+                        <ArrowUpIcon />
+                      </IconButton>
+                      <IconButton
+                        aria-label={`Move media ${index + 1} down`}
+                        onClick={() => onMoveMedia(index, index + 1)}
+                        disabled={index === media.length - 1}
+                        variant="secondary"
+                      >
+                        <ArrowDownIcon />
+                      </IconButton>
+                    </div>
+                    <IconButton
+                      aria-label={`Remove media ${index + 1}`}
+                      onClick={() => onRemoveMedia(index)}
+                      variant="danger"
+                    >
+                      <Cross2Icon />
+                    </IconButton>
+                  </div>
+                  <div className="absolute bottom-3 left-3 opacity-0 transition-opacity group-hover:opacity-100">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-2 py-1 text-xs font-medium shadow">
+                      <DragHandleDots2Icon aria-hidden />
+                      Drag
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/PricingTab.tsx
+++ b/packages/ui/src/components/cms/PricingTab.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, Input } from "../atoms/shadcn";
+import { Chip } from "../atoms";
+import type { ChangeEvent } from "react";
+
+interface PricingTabProps {
+  price: number;
+  currency?: string | null;
+  onPriceChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function PricingTab({
+  price,
+  currency,
+  onPriceChange,
+}: PricingTabProps) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-2 sm:max-w-xs">
+            <label className="text-sm font-medium">Price (cents)</label>
+            <Input
+              type="number"
+              name="price"
+              value={price}
+              onChange={onPriceChange}
+              required
+              min={0}
+            />
+          </div>
+          {currency && (
+            <Chip className="bg-muted px-3 py-1 text-xs uppercase tracking-wide">
+              {currency}
+            </Chip>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/ProductEditorForm.tsx
+++ b/packages/ui/src/components/cms/ProductEditorForm.tsx
@@ -1,44 +1,23 @@
 /* packages/ui/components/cms/ProductEditorForm.tsx */
 "use client";
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-  Card,
-  CardContent,
-  Input,
-  Textarea,
-} from "../atoms/shadcn";
-import { Chip, IconButton, Toast } from "../atoms";
-import type { MediaItem } from "@acme/types";
+import { Input } from "../atoms/shadcn";
+import { Toast } from "../atoms";
 import type { Locale } from "@acme/i18n";
+import Tabs from "./blocks/Tabs";
+import PricingTab from "./PricingTab";
+import VariantsTab from "./VariantsTab";
+import PublishLocationsTab from "./PublishLocationsTab";
+import MediaGalleryTab from "./MediaGalleryTab";
+import LocaleContentTab from "./LocaleContentTab";
 import { useProductEditorFormState } from "../../hooks/useProductEditorFormState";
 import type {
   ProductWithVariants,
   ProductSaveResult,
 } from "../../hooks/useProductEditorFormState";
-import PublishLocationSelector from "./PublishLocationSelector";
-import Tabs from "./blocks/Tabs";
+import { useProductEditorNotifications } from "../../hooks/useProductEditorNotifications";
 import { usePublishLocations } from "@acme/platform-core/hooks/usePublishLocations";
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  Cross2Icon,
-  DragHandleDots2Icon,
-  PlusIcon,
-} from "@radix-ui/react-icons";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type FormEvent,
-} from "react";
-
-/* eslint-disable @next/next/no-img-element */
+import { useCallback, useMemo, type FormEvent } from "react";
 
 /* -------------------------------------------------------------------------- */
 /*  Types                                                                     */
@@ -54,12 +33,6 @@ interface BaseProps {
   /** Optional id shared with external toolbars */
   formId?: string;
 }
-
-const localeLabel: Partial<Record<Locale, string>> = {
-  en: "English",
-  de: "Deutsch",
-  it: "Italiano",
-};
 
 /* -------------------------------------------------------------------------- */
 /*  Component                                                                 */
@@ -94,35 +67,10 @@ export default function ProductEditorForm({
   );
   const hasErrors = errorEntries.length > 0;
 
-  const [toast, setToast] = useState<{ open: boolean; message: string }>(
-    { open: false, message: "" },
-  );
-  const closeToast = useCallback(() => {
-    setToast({ open: false, message: "" });
-  }, []);
-  const prevSavingRef = useRef(false);
-
-  useEffect(() => {
-    if (saving && !prevSavingRef.current) {
-      setToast({ open: true, message: "Saving product…" });
-    } else if (!saving && prevSavingRef.current) {
-      setToast({
-        open: true,
-        message: hasErrors
-          ? "We couldn't save your changes. Check the highlighted sections."
-          : "Product saved successfully.",
-      });
-    }
-    prevSavingRef.current = saving;
-  }, [saving, hasErrors]);
-
-  useEffect(() => {
-    if (!toast.open) return undefined;
-    const id = window.setTimeout(() => {
-      setToast((prev) => ({ ...prev, open: false }));
-    }, 4000);
-    return () => window.clearTimeout(id);
-  }, [toast.open]);
+  const { toast, closeToast } = useProductEditorNotifications({
+    saving,
+    hasErrors,
+  });
 
   const onFormSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -132,63 +80,12 @@ export default function ProductEditorForm({
     [handleSubmit],
   );
 
-  const selectedLocations = useMemo(
-    () =>
-      publishTargets.map(
-        (id) => locations.find((loc) => loc.id === id)?.name ?? id,
-      ),
-    [publishTargets, locations],
-  );
-
-  const variantEntries = useMemo(
-    () =>
-      Object.entries(product.variants as Record<string, string[]>) as [
-        string,
-        string[],
-      ][],
-    [product.variants],
-  );
-
-  const localePanels = locales.map((locale) => ({
-    locale,
-    trigger: (
-      <div className="flex items-center gap-2">
-        <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
-          {locale}
-        </Chip>
-        <span className="text-sm text-muted-foreground">
-          {localeLabel[locale] ?? locale.toUpperCase()}
-        </span>
-      </div>
-    ),
-    content: (
-      <div className="space-y-4">
-        <label className="flex flex-col gap-1">
-          <span className="text-sm font-medium">Title</span>
-          <Input
-            name={`title_${locale}`}
-            value={product.title[locale]}
-            onChange={handleChange}
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-sm font-medium">Description</span>
-          <Textarea
-            rows={5}
-            name={`desc_${locale}`}
-            value={product.description[locale]}
-            onChange={handleChange}
-          />
-        </label>
-      </div>
-    ),
-  }));
-
   return (
     <>
       <Toast open={toast.open} message={toast.message} onClose={closeToast} />
       <form
         id={formId}
+        data-cy="product-editor-form"
         data-testid="product-editor-form"
         onSubmit={onFormSubmit}
         aria-busy={saving}
@@ -205,7 +102,8 @@ export default function ProductEditorForm({
             <ul className="mt-2 space-y-1">
               {errorEntries.map(([field, messages]) => (
                 <li key={field}>
-                  <span className="font-semibold capitalize">{field}</span>: {messages.join(", ")}
+                  <span className="font-semibold capitalize">{field}</span>: {" "}
+                  {messages.join(", ")}
                 </li>
               ))}
             </ul>
@@ -222,194 +120,38 @@ export default function ProductEditorForm({
           ]}
           className="space-y-4"
         >
-          <div className="space-y-4">
-            <Card>
-              <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex flex-col gap-2 sm:max-w-xs">
-                  <label className="text-sm font-medium">Price (cents)</label>
-                  <Input
-                    type="number"
-                    name="price"
-                    value={product.price}
-                    onChange={handleChange}
-                    required
-                    min={0}
-                  />
-                </div>
-                {product.currency && (
-                  <Chip className="bg-muted px-3 py-1 text-xs uppercase tracking-wide">
-                    {product.currency}
-                  </Chip>
-                )}
-              </CardContent>
-            </Card>
-          </div>
+          <PricingTab
+            price={product.price}
+            currency={product.currency}
+            onPriceChange={(event) => handleChange(event)}
+          />
 
-          <div className="space-y-4">
-            {variantEntries.length === 0 && (
-              <Card>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground">
-                    This product has no variant dimensions configured.
-                  </p>
-                </CardContent>
-              </Card>
-            )}
-            {variantEntries.map(([attr, values]) => (
-              <Card key={attr}>
-                <CardContent className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
-                      {attr}
-                    </Chip>
-                    <IconButton
-                      aria-label={`Add option to ${attr}`}
-                      onClick={() => addVariantValue(attr)}
-                      variant="secondary"
-                    >
-                      <PlusIcon />
-                    </IconButton>
-                  </div>
-                  <div className="space-y-3">
-                    {values.map((value: string, index: number) => (
-                      <div key={index} className="flex items-center gap-2">
-                        <Input
-                          name={`variant_${attr}_${index}`}
-                          value={value}
-                          onChange={handleChange}
-                          className="flex-1"
-                        />
-                        <IconButton
-                          aria-label={`Remove ${attr} option ${index + 1}`}
-                          onClick={() => removeVariantValue(attr, index)}
-                          variant="ghost"
-                        >
-                          <Cross2Icon />
-                        </IconButton>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+          <VariantsTab
+            variants={product.variants}
+            onVariantChange={(event) => handleChange(event)}
+            onAddVariantValue={addVariantValue}
+            onRemoveVariantValue={removeVariantValue}
+          />
 
-          <div className="space-y-4">
-            <Card>
-              <CardContent className="space-y-4">
-                <PublishLocationSelector
-                  selectedIds={publishTargets}
-                  onChange={setPublishTargets}
-                  showReload
-                />
-                {publishTargets.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {selectedLocations.map((label) => (
-                      <Chip key={label} className="bg-muted px-3 py-1 text-xs">
-                        {label}
-                      </Chip>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    Select one or more destinations to publish this product.
-                  </p>
-                )}
-              </CardContent>
-            </Card>
-          </div>
+          <PublishLocationsTab
+            selectedIds={publishTargets}
+            locations={locations}
+            onChange={setPublishTargets}
+          />
 
-          <div className="space-y-4">
-            <Card>
-              <CardContent className="space-y-4">
-                {uploader}
-                {product.media.length === 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    Add imagery or video to showcase this product.
-                  </p>
-                )}
-                {product.media.length > 0 && (
-                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {product.media.map((item: MediaItem, index: number) => (
-                      <div
-                        key={`${item.url}-${index}`}
-                        className="group relative overflow-hidden rounded-xl border"
-                      >
-                        {item.type === "image" ? (
-                          <img
-                            src={item.url}
-                            alt={item.altText || ""}
-                            className="h-48 w-full object-cover"
-                          />
-                        ) : (
-                          <video
-                            src={item.url}
-                            className="h-48 w-full object-cover"
-                            controls
-                          />
-                        )}
-                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-black/20 opacity-0 transition-opacity group-hover:opacity-100" />
-                        <div className="absolute inset-x-3 top-3 flex items-center justify-between gap-2 opacity-0 transition-opacity group-hover:opacity-100">
-                          <div className="flex items-center gap-1">
-                            <IconButton
-                              aria-label={`Move media ${index + 1} up`}
-                              onClick={() => moveMedia(index, index - 1)}
-                              disabled={index === 0}
-                              variant="secondary"
-                            >
-                              <ArrowUpIcon />
-                            </IconButton>
-                            <IconButton
-                              aria-label={`Move media ${index + 1} down`}
-                              onClick={() => moveMedia(index, index + 1)}
-                              disabled={index === product.media.length - 1}
-                              variant="secondary"
-                            >
-                              <ArrowDownIcon />
-                            </IconButton>
-                          </div>
-                          <IconButton
-                            aria-label={`Remove media ${index + 1}`}
-                            onClick={() => removeMedia(index)}
-                            variant="danger"
-                          >
-                            <Cross2Icon />
-                          </IconButton>
-                        </div>
-                        <div className="absolute bottom-3 left-3 opacity-0 transition-opacity group-hover:opacity-100">
-                          <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-2 py-1 text-xs font-medium shadow">
-                            <DragHandleDots2Icon aria-hidden />
-                            Drag
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </div>
+          <MediaGalleryTab
+            uploader={uploader}
+            media={product.media}
+            onMoveMedia={moveMedia}
+            onRemoveMedia={removeMedia}
+          />
 
-          <div className="space-y-4">
-            <Card>
-              <CardContent>
-                <Accordion
-                  type="multiple"
-                  defaultValue={locales as string[]}
-                  className="space-y-3"
-                >
-                  {localePanels.map(({ locale, trigger, content }) => (
-                    <AccordionItem key={locale} value={locale} className="border-none">
-                      <AccordionTrigger className="rounded-md border border-border/60 bg-muted/30 px-4 py-2 text-left text-sm font-semibold">
-                        {trigger}
-                      </AccordionTrigger>
-                      <AccordionContent className="pt-3">{content}</AccordionContent>
-                    </AccordionItem>
-                  ))}
-                </Accordion>
-              </CardContent>
-            </Card>
-          </div>
+          <LocaleContentTab
+            locales={locales}
+            title={product.title}
+            description={product.description}
+            onFieldChange={(event) => handleChange(event)}
+          />
         </Tabs>
 
         <button type="submit" className="sr-only">

--- a/packages/ui/src/components/cms/PublishLocationsTab.tsx
+++ b/packages/ui/src/components/cms/PublishLocationsTab.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent } from "../atoms/shadcn";
+import { Chip } from "../atoms";
+import PublishLocationSelector from "./PublishLocationSelector";
+import type { PublishLocation } from "@acme/types";
+import { useMemo } from "react";
+
+interface PublishLocationsTabProps {
+  selectedIds: string[];
+  locations: PublishLocation[];
+  onChange: (ids: string[]) => void;
+}
+
+export default function PublishLocationsTab({
+  selectedIds,
+  locations,
+  onChange,
+}: PublishLocationsTabProps) {
+  const selectedLabels = useMemo(
+    () =>
+      selectedIds.map(
+        (id) => locations.find((location) => location.id === id)?.name ?? id,
+      ),
+    [selectedIds, locations],
+  );
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="space-y-4">
+          <PublishLocationSelector
+            selectedIds={selectedIds}
+            onChange={onChange}
+            showReload
+          />
+          {selectedIds.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {selectedLabels.map((label) => (
+                <Chip key={label} className="bg-muted px-3 py-1 text-xs">
+                  {label}
+                </Chip>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Select one or more destinations to publish this product.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cms/VariantsTab.tsx
+++ b/packages/ui/src/components/cms/VariantsTab.tsx
@@ -1,0 +1,76 @@
+import { Card, CardContent, Input } from "../atoms/shadcn";
+import { Chip, IconButton } from "../atoms";
+import { Cross2Icon, PlusIcon } from "@radix-ui/react-icons";
+import type { ChangeEvent } from "react";
+
+interface VariantsTabProps {
+  variants: Record<string, string[]>;
+  onVariantChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onAddVariantValue: (attr: string) => void;
+  onRemoveVariantValue: (attr: string, index: number) => void;
+}
+
+export default function VariantsTab({
+  variants,
+  onVariantChange,
+  onAddVariantValue,
+  onRemoveVariantValue,
+}: VariantsTabProps) {
+  const variantEntries = Object.entries(variants) as [string, string[]][];
+
+  if (variantEntries.length === 0) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              This product has no variant dimensions configured.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {variantEntries.map(([attr, values]) => (
+        <Card key={attr}>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <Chip className="bg-muted px-2 py-1 text-xs uppercase tracking-wide">
+                {attr}
+              </Chip>
+              <IconButton
+                aria-label={`Add option to ${attr}`}
+                onClick={() => onAddVariantValue(attr)}
+                variant="secondary"
+              >
+                <PlusIcon />
+              </IconButton>
+            </div>
+            <div className="space-y-3">
+              {values.map((value: string, index: number) => (
+                <div key={index} className="flex items-center gap-2">
+                  <Input
+                    name={`variant_${attr}_${index}`}
+                    value={value}
+                    onChange={onVariantChange}
+                    className="flex-1"
+                  />
+                  <IconButton
+                    aria-label={`Remove ${attr} option ${index + 1}`}
+                    onClick={() => onRemoveVariantValue(attr, index)}
+                    variant="ghost"
+                  >
+                    <Cross2Icon />
+                  </IconButton>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/hooks/__tests__/useProductEditorNotifications.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useProductEditorNotifications.test.tsx
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import { useProductEditorNotifications } from "../useProductEditorNotifications";
+
+describe("useProductEditorNotifications", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("opens the toast when saving starts", () => {
+    const { result, rerender } = renderHook(
+      ({ saving, hasErrors }: { saving: boolean; hasErrors: boolean }) =>
+        useProductEditorNotifications({ saving, hasErrors }),
+      { initialProps: { saving: false, hasErrors: false } },
+    );
+
+    expect(result.current.toast.open).toBe(false);
+
+    rerender({ saving: true, hasErrors: false });
+
+    expect(result.current.toast.open).toBe(true);
+    expect(result.current.toast.message).toBe("Saving product…");
+  });
+
+  it("shows success or error messages when saving finishes", () => {
+    const { result, rerender } = renderHook(
+      ({ saving, hasErrors }: { saving: boolean; hasErrors: boolean }) =>
+        useProductEditorNotifications({ saving, hasErrors }),
+      { initialProps: { saving: true, hasErrors: false } },
+    );
+
+    rerender({ saving: false, hasErrors: false });
+    expect(result.current.toast.message).toBe("Product saved successfully.");
+
+    rerender({ saving: true, hasErrors: false });
+    rerender({ saving: false, hasErrors: true });
+    expect(result.current.toast.message).toBe(
+      "We couldn't save your changes. Check the highlighted sections.",
+    );
+  });
+
+  it("automatically closes the toast after the timeout", () => {
+    const { result } = renderHook(() =>
+      useProductEditorNotifications({ saving: true, hasErrors: false, autoCloseMs: 1000 }),
+    );
+
+    expect(result.current.toast.open).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.toast.open).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from "./useCart";
 export * from "./useImageUpload";
 export * from "./useFileUpload";
 export * from "./useImageOrientationValidation";
+export * from "./useProductEditorNotifications";
 export * from "./useProductEditorFormState";
 export * from "./useProductFilters";
 export * from "./useTokenEditor";

--- a/packages/ui/src/hooks/useProductEditorNotifications.ts
+++ b/packages/ui/src/hooks/useProductEditorNotifications.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+interface NotificationMessages {
+  saving: string;
+  success: string;
+  error: string;
+}
+
+export interface UseProductEditorNotificationsOptions {
+  saving: boolean;
+  hasErrors: boolean;
+  autoCloseMs?: number;
+  messages?: Partial<NotificationMessages>;
+}
+
+export interface ProductEditorToastState {
+  open: boolean;
+  message: string;
+}
+
+const DEFAULT_MESSAGES: NotificationMessages = {
+  saving: "Saving product…",
+  success: "Product saved successfully.",
+  error: "We couldn't save your changes. Check the highlighted sections.",
+};
+
+/**
+ * Controls toast messaging for the product editor so the form can stay lean.
+ */
+export function useProductEditorNotifications({
+  saving,
+  hasErrors,
+  autoCloseMs = 4000,
+  messages: messageOverrides,
+}: UseProductEditorNotificationsOptions) {
+  const messages = useMemo(
+    () => ({ ...DEFAULT_MESSAGES, ...messageOverrides }),
+    [messageOverrides],
+  );
+
+  const [toast, setToast] = useState<ProductEditorToastState>({
+    open: false,
+    message: "",
+  });
+  const prevSavingRef = useRef(false);
+
+  useEffect(() => {
+    if (saving && !prevSavingRef.current) {
+      setToast({ open: true, message: messages.saving });
+    } else if (!saving && prevSavingRef.current) {
+      setToast({
+        open: true,
+        message: hasErrors ? messages.error : messages.success,
+      });
+    }
+    prevSavingRef.current = saving;
+  }, [saving, hasErrors, messages]);
+
+  useEffect(() => {
+    if (!toast.open) {
+      return undefined;
+    }
+
+    const timer = window.setTimeout(() => {
+      setToast((prev) => ({ ...prev, open: false }));
+    }, autoCloseMs);
+
+    return () => window.clearTimeout(timer);
+  }, [toast.open, autoCloseMs]);
+
+  const closeToast = useCallback(() => {
+    setToast((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  return { toast, closeToast } as const;
+}
+
+export default useProductEditorNotifications;


### PR DESCRIPTION
## Summary
- add a dedicated `useProductEditorNotifications` hook to manage toast lifecycle in the product editor and cover it with unit tests
- split the product editor into focused tab components for pricing, variants, publish locations, media, and locale content plus a reusable accordion renderer
- simplify `ProductEditorForm` to orchestrate state, notifications, and tab rendering

## Testing
- pnpm exec jest --config jest.config.cjs --runInBand --coverage=false --runTestsByPath packages/ui/src/components/cms/__tests__/ProductEditorForm.test.tsx packages/ui/src/hooks/__tests__/useProductEditorNotifications.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cbb516ede8832fba4cdd3bceacb37d