### PR TITLE
Ensure shipping env loader always logs validation errors

### DIFF
--- a/packages/config/src/env/shipping.ts
+++ b/packages/config/src/env/shipping.ts
@@ -73,12 +73,10 @@ export function loadShippingEnv(
 ): ShippingEnv {
   const parsed = shippingEnvSchema.safeParse(raw);
   if (!parsed.success) {
-    if (process.env.NODE_ENV !== "test") {
-      console.error(
-        "❌ Invalid shipping environment variables:",
-        parsed.error.format()
-      );
-    }
+    console.error(
+      "❌ Invalid shipping environment variables:",
+      parsed.error.format()
+    );
     throw new Error("Invalid shipping environment variables");
   }
   return parsed.data;
@@ -87,12 +85,10 @@ export function loadShippingEnv(
 // ---------- existing eager parse (kept for back-compat) ----------
 const parsed = shippingEnvSchema.safeParse(process.env);
 if (!parsed.success) {
-  if (process.env.NODE_ENV !== "test") {
-    console.error(
-      "❌ Invalid shipping environment variables:",
-      parsed.error.format()
-    );
-  }
+  console.error(
+    "❌ Invalid shipping environment variables:",
+    parsed.error.format()
+  );
   throw new Error("Invalid shipping environment variables");
 }
 export const shippingEnv = parsed.data;


### PR DESCRIPTION
## Summary
- remove the NODE_ENV check that suppressed console.error logging during validation failures
- ensure both the loader and eager parse path emit the invalid configuration details before throwing

## Testing
- pnpm exec jest --config jest.config.cjs --no-coverage --runTestsByPath packages/configurator/src/__tests__/env.shipping.test.ts packages/config/src/env/__tests__/shipping.env.test.ts packages/auth/src/__tests__/env.shipping.test.ts packages/config/src/env/__tests__/shipping.env.loader.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbbac988ec832fb086860d560ba9cf