### PR TITLE
Fix Jest setup polyfill to load via CommonJS

### DIFF
--- a/test/setupFetchPolyfill.ts
+++ b/test/setupFetchPolyfill.ts
@@ -1,8 +1,19 @@
 // test/setupFetchPolyfill.ts   (new file at repo root)
 
-import fetch, { Headers, Request, Response } from "cross-fetch";
-import { webcrypto } from "node:crypto";
-import React from "react";
+type CrossFetchModule = typeof import("cross-fetch");
+
+const crossFetch = require("cross-fetch") as CrossFetchModule & {
+  default?: typeof globalThis.fetch;
+  fetch?: typeof globalThis.fetch;
+};
+
+const fetch: typeof globalThis.fetch =
+  crossFetch.default ??
+  crossFetch.fetch ??
+  (crossFetch as unknown as typeof globalThis.fetch);
+const { Headers, Request, Response } = crossFetch;
+const { webcrypto } = require("node:crypto") as typeof import("node:crypto");
+const React = require("react") as typeof import("react");
 
 const mutableEnv = process.env as Record<string, string>;
 mutableEnv.EMAIL_FROM ||= "test@example.com";


### PR DESCRIPTION
## Summary
- switch the shared Jest setup polyfill to `require` cross-fetch, crypto, and React so Jest can load it under a CommonJS runtime
- preserve typings by casting the required modules to their TypeScript shapes before wiring globals

## Testing
- pnpm exec jest packages/configurator/__tests__/providers.test.ts --config jest.config.cjs --runInBand --coverage=false
- pnpm --filter @acme/configurator test *(fails: existing env schema tests expect console errors when required variables are missing)*
- pnpm exec eslint test/setupFetchPolyfill.ts *(fails: @typescript-eslint parser cannot find the file in the configured project)*

------
https://chatgpt.com/codex/tasks/task_e_68cbba73f130832fb6f115b28e96abe9