### PR TITLE
fix(configurator): enforce required env vars in CLI

### DIFF
--- a/packages/configurator/src/index.ts
+++ b/packages/configurator/src/index.ts
@@ -1,8 +1,25 @@
 import { envSchema } from "@acme/config/env";
 import { spawnSync } from "node:child_process";
 
+const REQUIRED_ENV_VARS = [
+  "STRIPE_SECRET_KEY",
+  "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+  "CART_COOKIE_SECRET",
+] as const;
+
 try {
   envSchema.parse(process.env);
+
+  const missing = REQUIRED_ENV_VARS.filter((key) => {
+    const value = process.env[key];
+    return typeof value !== "string" || value.trim() === "";
+  });
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}`,
+    );
+  }
 } catch (err) {
   console.error("Invalid environment variables:\n", err);
   process.exit(1);


### PR DESCRIPTION
## Summary
- ensure the configurator CLI enforces the same required environment variables as the published bin script
- throw an explicit error when the Stripe or cart secrets are missing so tests can verify graceful exits

## Testing
- CI=true pnpm exec jest --runInBand packages/configurator/__tests__/cli.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbbabb7ef8832f9dd4676f7af5b7ac