### PR TITLE
Refactor email schedule form state management

### DIFF
--- a/packages/ui/src/components/cms/marketing/emailScheduling/EmailScheduleForm.tsx
+++ b/packages/ui/src/components/cms/marketing/emailScheduling/EmailScheduleForm.tsx
@@ -1,49 +1,28 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
 import {
   Button,
   Card,
   CardContent,
   Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Textarea,
 } from "../../../atoms/shadcn";
-import { Switch, Toast } from "../../../atoms";
+import { Toast } from "../../../atoms";
 import { cn } from "../../../../utils/style";
 import {
-  defaultEmailScheduleValues,
-  getEmailSchedulePreview,
   type EmailScheduleFormValues,
   type EmailSchedulePreviewData,
 } from "./types";
+import { ScheduleTimingFields } from "./ScheduleTimingFields";
+import { FollowUpControls } from "./FollowUpControls";
+import {
+  type EmailScheduleErrors,
+  useEmailScheduleFormState,
+} from "./hooks/useEmailScheduleFormState";
 import {
   type AsyncSubmissionHandler,
   type SubmissionStatus,
-  type ValidationErrors,
 } from "../shared";
-
-type EmailScheduleField = keyof EmailScheduleFormValues;
-type EmailScheduleErrors = ValidationErrors<EmailScheduleField>;
-
-const timezoneOptions = [
-  "America/New_York",
-  "America/Los_Angeles",
-  "Europe/Berlin",
-  "Europe/London",
-  "Asia/Tokyo",
-];
-
-const segmentOptions = [
-  "All subscribers",
-  "VIP customers",
-  "Winback cohort",
-  "Abandoned checkout",
-];
 
 export interface EmailScheduleFormProps {
   defaultValues?: Partial<EmailScheduleFormValues>;
@@ -56,19 +35,6 @@ export interface EmailScheduleFormProps {
   busy?: boolean;
 }
 
-function validate(values: EmailScheduleFormValues): EmailScheduleErrors {
-  const errors: EmailScheduleErrors = {};
-  if (!values.subject) errors.subject = "Subject is required.";
-  if (!values.sendDate) errors.sendDate = "Choose a send date.";
-  if (!values.sendTime) errors.sendTime = "Choose a send time.";
-  if (!values.timezone) errors.timezone = "Select a timezone.";
-  if (!values.segment) errors.segment = "Select a segment.";
-  if (values.followUpEnabled && values.followUpDelayHours <= 0) {
-    errors.followUpDelayHours = "Delay must be greater than zero.";
-  }
-  return errors;
-}
-
 export function EmailScheduleForm({
   defaultValues,
   validationErrors,
@@ -79,81 +45,21 @@ export function EmailScheduleForm({
   className,
   busy,
 }: EmailScheduleFormProps) {
-  const [values, setValues] = useState<EmailScheduleFormValues>({
-    ...defaultEmailScheduleValues,
-    ...defaultValues,
+  const {
+    values,
+    errors,
+    status,
+    toast,
+    updateValue,
+    handleSubmit,
+    dismissToast,
+  } = useEmailScheduleFormState({
+    defaultValues,
+    validationErrors,
+    onSubmit,
+    onPreviewChange,
+    onStatusChange,
   });
-  const [internalErrors, setInternalErrors] =
-    useState<EmailScheduleErrors>({});
-  const [status, setStatus] = useState<SubmissionStatus>("idle");
-  const [toast, setToast] = useState<{ open: boolean; message: string }>(
-    { open: false, message: "" }
-  );
-
-  useEffect(() => {
-    setValues({ ...defaultEmailScheduleValues, ...defaultValues });
-  }, [defaultValues]);
-
-  useEffect(() => {
-    onPreviewChange?.(getEmailSchedulePreview(values));
-  }, [values, onPreviewChange]);
-
-  const errors = useMemo(
-    () => ({ ...internalErrors, ...(validationErrors ?? {}) }),
-    [internalErrors, validationErrors]
-  );
-
-  const update = <K extends EmailScheduleField>(
-    key: K,
-    value: EmailScheduleFormValues[K]
-  ) => {
-    setValues((prev) => ({ ...prev, [key]: value }));
-    setInternalErrors((prev) => {
-      if (!prev[key]) return prev;
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-  };
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setStatus("validating");
-    onStatusChange?.("validating");
-    const nextErrors = validate(values);
-    setInternalErrors(nextErrors);
-    if (Object.keys(nextErrors).length > 0) {
-      setStatus("error");
-      onStatusChange?.("error");
-      setToast({
-        open: true,
-        message: "Please resolve the highlighted fields.",
-      });
-      return;
-    }
-
-    if (!onSubmit) {
-      setStatus("success");
-      onStatusChange?.("success");
-      setToast({ open: true, message: "Draft schedule saved." });
-      return;
-    }
-
-    try {
-      setStatus("submitting");
-      onStatusChange?.("submitting");
-      await onSubmit(values);
-      setStatus("success");
-      onStatusChange?.("success");
-      setToast({ open: true, message: "Email scheduled." });
-    } catch (error) {
-      setStatus("error");
-      onStatusChange?.("error");
-      const fallback =
-        error instanceof Error ? error.message : "Scheduling failed.";
-      setToast({ open: true, message: fallback });
-    }
-  };
 
   return (
     <form
@@ -170,9 +76,11 @@ export function EmailScheduleForm({
             <Input
               id="email-subject"
               value={values.subject}
-              onChange={(event) => update("subject", event.target.value)}
+              onChange={(event) => updateValue("subject", event.target.value)}
               aria-invalid={errors.subject ? "true" : "false"}
-              aria-describedby={errors.subject ? "email-subject-error" : undefined}
+              aria-describedby={
+                errors.subject ? "email-subject-error" : undefined
+              }
             />
             {errors.subject && (
               <p
@@ -193,159 +101,19 @@ export function EmailScheduleForm({
               id="email-preheader"
               rows={2}
               value={values.preheader}
-              onChange={(event) => update("preheader", event.target.value)}
+              onChange={(event) => updateValue("preheader", event.target.value)}
             />
           </div>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardContent className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-1">
-            <label htmlFor="email-send-date" className="text-sm font-medium">
-              Send date
-            </label>
-            <Input
-              id="email-send-date"
-              type="date"
-              value={values.sendDate}
-              onChange={(event) => update("sendDate", event.target.value)}
-              aria-invalid={errors.sendDate ? "true" : "false"}
-              aria-describedby={errors.sendDate ? "email-send-date-error" : undefined}
-            />
-            {errors.sendDate && (
-              <p
-                id="email-send-date-error"
-                className="text-danger text-xs"
-                data-token="--color-danger"
-              >
-                {errors.sendDate}
-              </p>
-            )}
-          </div>
+      <ScheduleTimingFields values={values} errors={errors} onUpdate={updateValue} />
 
-          <div className="space-y-1">
-            <label htmlFor="email-send-time" className="text-sm font-medium">
-              Send time
-            </label>
-            <Input
-              id="email-send-time"
-              type="time"
-              value={values.sendTime}
-              onChange={(event) => update("sendTime", event.target.value)}
-              aria-invalid={errors.sendTime ? "true" : "false"}
-              aria-describedby={errors.sendTime ? "email-send-time-error" : undefined}
-            />
-            {errors.sendTime && (
-              <p
-                id="email-send-time-error"
-                className="text-danger text-xs"
-                data-token="--color-danger"
-              >
-                {errors.sendTime}
-              </p>
-            )}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium">Timezone</label>
-            <Select
-              value={values.timezone}
-              onValueChange={(value) => update("timezone", value)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select timezone" />
-              </SelectTrigger>
-              <SelectContent>
-                {timezoneOptions.map((zone) => (
-                  <SelectItem key={zone} value={zone}>
-                    {zone}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.timezone && (
-              <p className="text-danger text-xs" data-token="--color-danger">
-                {errors.timezone}
-              </p>
-            )}
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-sm font-medium">Segment</label>
-            <Select
-              value={values.segment}
-              onValueChange={(value) => update("segment", value)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select segment" />
-              </SelectTrigger>
-              <SelectContent>
-                {segmentOptions.map((segment) => (
-                  <SelectItem key={segment} value={segment}>
-                    {segment}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.segment && (
-              <p className="text-danger text-xs" data-token="--color-danger">
-                {errors.segment}
-              </p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between gap-2">
-            <div>
-              <h3 className="text-sm font-medium">Follow-up email</h3>
-              <p className="text-muted-foreground text-xs">
-                Send a reminder to non-openers after a delay.
-              </p>
-            </div>
-            <Switch
-              checked={values.followUpEnabled}
-              onChange={(event) => update("followUpEnabled", event.target.checked)}
-              aria-checked={values.followUpEnabled}
-            />
-          </div>
-          {values.followUpEnabled && (
-            <div className="space-y-1">
-              <label htmlFor="follow-up-delay" className="text-sm font-medium">
-                Delay in hours
-              </label>
-              <Input
-                id="follow-up-delay"
-                type="number"
-                min={1}
-                value={String(values.followUpDelayHours)}
-                onChange={(event) =>
-                  update(
-                    "followUpDelayHours",
-                    Number(event.target.value || 0)
-                  )
-                }
-                aria-invalid={errors.followUpDelayHours ? "true" : "false"}
-                aria-describedby={
-                  errors.followUpDelayHours ? "follow-up-delay-error" : undefined
-                }
-              />
-              {errors.followUpDelayHours && (
-                <p
-                  id="follow-up-delay-error"
-                  className="text-danger text-xs"
-                  data-token="--color-danger"
-                >
-                  {errors.followUpDelayHours}
-                </p>
-              )}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <FollowUpControls
+        values={values}
+        error={errors.followUpDelayHours}
+        onUpdate={updateValue}
+      />
 
       <div className="flex justify-end">
         <Button type="submit" disabled={busy || status === "submitting"}>
@@ -353,11 +121,7 @@ export function EmailScheduleForm({
         </Button>
       </div>
 
-      <Toast
-        open={toast.open}
-        message={toast.message}
-        onClose={() => setToast((prev) => ({ ...prev, open: false }))}
-      />
+      <Toast open={toast.open} message={toast.message} onClose={dismissToast} />
     </form>
   );
 }

--- a/packages/ui/src/components/cms/marketing/emailScheduling/FollowUpControls.tsx
+++ b/packages/ui/src/components/cms/marketing/emailScheduling/FollowUpControls.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Card, CardContent, Input } from "../../../atoms/shadcn";
+import { Switch } from "../../../atoms";
+import type { EmailScheduleErrors } from "./hooks/useEmailScheduleFormState";
+import type { EmailScheduleFormValues } from "./types";
+
+type FollowUpField = "followUpEnabled" | "followUpDelayHours";
+
+type FollowUpValues = Pick<EmailScheduleFormValues, FollowUpField>;
+
+type FollowUpError = EmailScheduleErrors["followUpDelayHours"];
+
+export interface FollowUpControlsProps {
+  values: FollowUpValues;
+  error?: FollowUpError;
+  onUpdate: <K extends FollowUpField>(
+    key: K,
+    value: EmailScheduleFormValues[K]
+  ) => void;
+}
+
+export function FollowUpControls({ values, error, onUpdate }: FollowUpControlsProps) {
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-medium">Follow-up email</h3>
+            <p className="text-muted-foreground text-xs">
+              Send a reminder to non-openers after a delay.
+            </p>
+          </div>
+          <Switch
+            checked={values.followUpEnabled}
+            onChange={(event) => onUpdate("followUpEnabled", event.target.checked)}
+            aria-checked={values.followUpEnabled}
+          />
+        </div>
+        {values.followUpEnabled && (
+          <div className="space-y-1">
+            <label htmlFor="follow-up-delay" className="text-sm font-medium">
+              Delay in hours
+            </label>
+            <Input
+              id="follow-up-delay"
+              type="number"
+              min={1}
+              value={String(values.followUpDelayHours)}
+              onChange={(event) =>
+                onUpdate("followUpDelayHours", Number(event.target.value || 0))
+              }
+              aria-invalid={error ? "true" : "false"}
+              aria-describedby={error ? "follow-up-delay-error" : undefined}
+            />
+            {error && (
+              <p
+                id="follow-up-delay-error"
+                className="text-danger text-xs"
+                data-token="--color-danger"
+              >
+                {error}
+              </p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default FollowUpControls;

--- a/packages/ui/src/components/cms/marketing/emailScheduling/ScheduleTimingFields.tsx
+++ b/packages/ui/src/components/cms/marketing/emailScheduling/ScheduleTimingFields.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../../atoms/shadcn";
+import type { EmailScheduleErrors } from "./hooks/useEmailScheduleFormState";
+import type { EmailScheduleFormValues } from "./types";
+
+const timezoneOptions = [
+  "America/New_York",
+  "America/Los_Angeles",
+  "Europe/Berlin",
+  "Europe/London",
+  "Asia/Tokyo",
+] as const;
+
+const segmentOptions = [
+  "All subscribers",
+  "VIP customers",
+  "Winback cohort",
+  "Abandoned checkout",
+] as const;
+
+type ScheduleTimingField = "sendDate" | "sendTime" | "timezone" | "segment";
+
+type ScheduleTimingValues = Pick<EmailScheduleFormValues, ScheduleTimingField>;
+type ScheduleTimingErrors = Pick<EmailScheduleErrors, ScheduleTimingField>;
+
+export interface ScheduleTimingFieldsProps {
+  values: ScheduleTimingValues;
+  errors: ScheduleTimingErrors;
+  onUpdate: <K extends ScheduleTimingField>(
+    key: K,
+    value: EmailScheduleFormValues[K]
+  ) => void;
+}
+
+export function ScheduleTimingFields({
+  values,
+  errors,
+  onUpdate,
+}: ScheduleTimingFieldsProps) {
+  return (
+    <Card>
+      <CardContent className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <label htmlFor="email-send-date" className="text-sm font-medium">
+            Send date
+          </label>
+          <Input
+            id="email-send-date"
+            type="date"
+            value={values.sendDate}
+            onChange={(event) => onUpdate("sendDate", event.target.value)}
+            aria-invalid={errors.sendDate ? "true" : "false"}
+            aria-describedby={
+              errors.sendDate ? "email-send-date-error" : undefined
+            }
+          />
+          {errors.sendDate && (
+            <p
+              id="email-send-date-error"
+              className="text-danger text-xs"
+              data-token="--color-danger"
+            >
+              {errors.sendDate}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="email-send-time" className="text-sm font-medium">
+            Send time
+          </label>
+          <Input
+            id="email-send-time"
+            type="time"
+            value={values.sendTime}
+            onChange={(event) => onUpdate("sendTime", event.target.value)}
+            aria-invalid={errors.sendTime ? "true" : "false"}
+            aria-describedby={
+              errors.sendTime ? "email-send-time-error" : undefined
+            }
+          />
+          {errors.sendTime && (
+            <p
+              id="email-send-time-error"
+              className="text-danger text-xs"
+              data-token="--color-danger"
+            >
+              {errors.sendTime}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Timezone</label>
+          <Select
+            value={values.timezone}
+            onValueChange={(value) => onUpdate("timezone", value)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select timezone" />
+            </SelectTrigger>
+            <SelectContent>
+              {timezoneOptions.map((zone) => (
+                <SelectItem key={zone} value={zone}>
+                  {zone}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.timezone && (
+            <p className="text-danger text-xs" data-token="--color-danger">
+              {errors.timezone}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Segment</label>
+          <Select
+            value={values.segment}
+            onValueChange={(value) => onUpdate("segment", value)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select segment" />
+            </SelectTrigger>
+            <SelectContent>
+              {segmentOptions.map((segment) => (
+                <SelectItem key={segment} value={segment}>
+                  {segment}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.segment && (
+            <p className="text-danger text-xs" data-token="--color-danger">
+              {errors.segment}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ScheduleTimingFields;

--- a/packages/ui/src/components/cms/marketing/emailScheduling/hooks/index.ts
+++ b/packages/ui/src/components/cms/marketing/emailScheduling/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useEmailScheduleFormState";

--- a/packages/ui/src/components/cms/marketing/emailScheduling/hooks/useEmailScheduleFormState.ts
+++ b/packages/ui/src/components/cms/marketing/emailScheduling/hooks/useEmailScheduleFormState.ts
@@ -1,0 +1,162 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  defaultEmailScheduleValues,
+  getEmailSchedulePreview,
+  type EmailScheduleFormValues,
+  type EmailSchedulePreviewData,
+} from "../types";
+import {
+  type AsyncSubmissionHandler,
+  type SubmissionStatus,
+  type ValidationErrors,
+} from "../../shared";
+
+export type EmailScheduleField = keyof EmailScheduleFormValues;
+export type EmailScheduleErrors = ValidationErrors<EmailScheduleField>;
+
+export interface EmailScheduleToastState {
+  open: boolean;
+  message: string;
+}
+
+export interface UseEmailScheduleFormStateOptions {
+  defaultValues?: Partial<EmailScheduleFormValues>;
+  validationErrors?: EmailScheduleErrors;
+  onSubmit?: AsyncSubmissionHandler<EmailScheduleFormValues>;
+  onPreviewChange?: (preview: EmailSchedulePreviewData) => void;
+  onStatusChange?: (status: SubmissionStatus) => void;
+}
+
+export interface EmailScheduleFormState {
+  values: EmailScheduleFormValues;
+  errors: EmailScheduleErrors;
+  status: SubmissionStatus;
+  toast: EmailScheduleToastState;
+  updateValue: <K extends EmailScheduleField>(
+    key: K,
+    value: EmailScheduleFormValues[K]
+  ) => void;
+  handleSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
+  dismissToast: () => void;
+}
+
+function validate(values: EmailScheduleFormValues): EmailScheduleErrors {
+  const errors: EmailScheduleErrors = {};
+  if (!values.subject) errors.subject = "Subject is required.";
+  if (!values.sendDate) errors.sendDate = "Choose a send date.";
+  if (!values.sendTime) errors.sendTime = "Choose a send time.";
+  if (!values.timezone) errors.timezone = "Select a timezone.";
+  if (!values.segment) errors.segment = "Select a segment.";
+  if (values.followUpEnabled && values.followUpDelayHours <= 0) {
+    errors.followUpDelayHours = "Delay must be greater than zero.";
+  }
+  return errors;
+}
+
+export function useEmailScheduleFormState({
+  defaultValues,
+  validationErrors,
+  onSubmit,
+  onPreviewChange,
+  onStatusChange,
+}: UseEmailScheduleFormStateOptions): EmailScheduleFormState {
+  const [values, setValues] = useState<EmailScheduleFormValues>({
+    ...defaultEmailScheduleValues,
+    ...defaultValues,
+  });
+  const [internalErrors, setInternalErrors] = useState<EmailScheduleErrors>({});
+  const [status, setStatus] = useState<SubmissionStatus>("idle");
+  const [toast, setToast] = useState<EmailScheduleToastState>({
+    open: false,
+    message: "",
+  });
+
+  useEffect(() => {
+    setValues({ ...defaultEmailScheduleValues, ...defaultValues });
+  }, [defaultValues]);
+
+  useEffect(() => {
+    onPreviewChange?.(getEmailSchedulePreview(values));
+  }, [values, onPreviewChange]);
+
+  const errors = useMemo(
+    () => ({ ...internalErrors, ...(validationErrors ?? {}) }),
+    [internalErrors, validationErrors]
+  );
+
+  const updateValue = useCallback(
+    <K extends EmailScheduleField>(
+      key: K,
+      value: EmailScheduleFormValues[K]
+    ) => {
+      setValues((prev) => ({ ...prev, [key]: value }));
+      setInternalErrors((prev) => {
+        if (!prev[key]) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    },
+    []
+  );
+
+  const dismissToast = useCallback(() => {
+    setToast((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setStatus("validating");
+      onStatusChange?.("validating");
+
+      const nextErrors = validate(values);
+      setInternalErrors(nextErrors);
+      if (Object.keys(nextErrors).length > 0) {
+        setStatus("error");
+        onStatusChange?.("error");
+        setToast({
+          open: true,
+          message: "Please resolve the highlighted fields.",
+        });
+        return;
+      }
+
+      if (!onSubmit) {
+        setStatus("success");
+        onStatusChange?.("success");
+        setToast({ open: true, message: "Draft schedule saved." });
+        return;
+      }
+
+      try {
+        setStatus("submitting");
+        onStatusChange?.("submitting");
+        await onSubmit(values);
+        setStatus("success");
+        onStatusChange?.("success");
+        setToast({ open: true, message: "Email scheduled." });
+      } catch (error) {
+        setStatus("error");
+        onStatusChange?.("error");
+        const fallback =
+          error instanceof Error ? error.message : "Scheduling failed.";
+        setToast({ open: true, message: fallback });
+      }
+    },
+    [values, onSubmit, onStatusChange]
+  );
+
+  return {
+    values,
+    errors,
+    status,
+    toast,
+    updateValue,
+    handleSubmit,
+    dismissToast,
+  };
+}

--- a/packages/ui/src/components/cms/marketing/emailScheduling/index.ts
+++ b/packages/ui/src/components/cms/marketing/emailScheduling/index.ts
@@ -1,4 +1,7 @@
 export * from "./EmailScheduleForm";
 export * from "./EmailSchedulePreviewPanel";
 export * from "./EmailScheduleSummaryCard";
+export * from "./FollowUpControls";
+export * from "./ScheduleTimingFields";
+export * from "./hooks";
 export * from "./types";


### PR DESCRIPTION
## Summary
- extract email scheduling form validation, submission, and toast logic into a reusable `useEmailScheduleFormState` hook
- factor schedule timing and follow-up field groups into dedicated subcomponents powered by the hook
- simplify `EmailScheduleForm` to compose the hook and new field clusters while exporting the new helpers

## Testing
- `pnpm --filter @acme/ui lint` *(fails: repo ESLint configuration cannot resolve numerous Storybook files in the project service)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbb9c5d34832f856710c5381621a7