### PR TITLE
Refactor ShopEditor into modular orchestrator

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/EditorSectionsAccordion.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/EditorSectionsAccordion.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import type { FormEventHandler, ReactNode } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Button,
+  Card,
+  CardContent,
+  Input,
+} from "@/components/atoms/shadcn";
+import { Toast } from "@/components/atoms";
+
+import type { EditorSectionConfig } from "../editorSections";
+
+interface HiddenFieldConfig {
+  readonly name: string;
+  readonly value: string;
+}
+
+interface EditorToastState {
+  readonly open: boolean;
+  readonly status: "success" | "error";
+  readonly message: string;
+}
+
+export interface EditorSectionsAccordionProps {
+  readonly sections: readonly EditorSectionConfig[];
+  readonly onSubmit: FormEventHandler<HTMLFormElement>;
+  readonly saving: boolean;
+  readonly toast: EditorToastState;
+  readonly onToastClose: () => void;
+  readonly hiddenFields?: readonly HiddenFieldConfig[];
+}
+
+export default function EditorSectionsAccordion({
+  sections,
+  onSubmit,
+  saving,
+  toast,
+  onToastClose,
+  hiddenFields,
+}: EditorSectionsAccordionProps) {
+  const defaultOpenSections = sections.map((section) => section.key);
+  const toastClassName =
+    toast.status === "error"
+      ? "bg-destructive text-destructive-foreground"
+      : "bg-success text-success-fg";
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      {hiddenFields?.map((field) => (
+        <Input
+          key={field.name}
+          type="hidden"
+          name={field.name}
+          value={field.value}
+        />
+      ))}
+      <Accordion
+        type="multiple"
+        defaultValue={defaultOpenSections}
+        className="space-y-3"
+      >
+        {sections.map(({ key, title, description, component: Component, props, wrapWithCard }) => (
+          <AccordionItem key={key} value={key} data-section={key} className="border-none">
+            <AccordionTrigger className="rounded-md border border-border/60 bg-muted/40 px-4 py-3 text-left text-sm font-semibold">
+              <SectionHeader title={title} description={description} />
+            </AccordionTrigger>
+            <AccordionContent className="pt-3">
+              <SectionCard dataSectionKey={key} wrapWithCard={wrapWithCard}>
+                <Component {...props} />
+              </SectionCard>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+      <div className="flex justify-end">
+        <Button
+          className="h-10 px-6 text-sm font-semibold"
+          disabled={saving}
+          type="submit"
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+      <Toast
+        open={toast.open}
+        message={toast.message}
+        onClose={onToastClose}
+        className={toastClassName}
+        role="status"
+      />
+    </form>
+  );
+}
+
+function SectionHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-sm font-semibold">{title}</span>
+      {description ? (
+        <span className="text-xs text-muted-foreground">{description}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function SectionCard({
+  children,
+  dataSectionKey,
+  wrapWithCard = true,
+}: {
+  children: ReactNode;
+  dataSectionKey?: string;
+  wrapWithCard?: boolean;
+}) {
+  if (!wrapWithCard) {
+    return <div data-section={dataSectionKey}>{children}</div>;
+  }
+
+  return (
+    <Card className="border border-border/60" data-section={dataSectionKey}>
+      <CardContent className="space-y-6 p-6">{children}</CardContent>
+    </Card>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/editorSections.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/editorSections.tsx
@@ -1,0 +1,233 @@
+import type { ComponentType } from "react";
+import type { Shop } from "@acme/types";
+
+import {
+  ShopIdentitySection,
+  ShopLocalizationSection,
+  ShopOverridesSection,
+  ShopProvidersSection,
+  ShopSeoSection,
+  ShopThemeSection,
+  type ShopIdentitySectionErrors,
+  type ShopLocalizationSectionErrors,
+  type ShopOverridesSectionErrors,
+  type ShopProvidersSectionErrors,
+  type ShopSeoSectionErrors,
+  type ShopThemeSectionErrors,
+} from "./sections";
+import type {
+  ShopEditorIdentitySection,
+  ShopEditorLocalizationSection,
+  ShopEditorOverridesSection,
+  ShopEditorProvidersSection,
+} from "./useShopEditorSubmit";
+import type { ShopEditorErrorBags } from "./useShopEditorErrors";
+
+interface ShopEditorSeoState {
+  readonly catalogFilters: readonly string[];
+  readonly setCatalogFilters: (filters: string[]) => void;
+}
+
+export interface EditorSectionConfig<Props = unknown> {
+  readonly key: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly wrapWithCard?: boolean;
+  readonly component: ComponentType<Props>;
+  readonly props: Props;
+}
+
+interface CreateShopEditorSectionsArgs {
+  readonly shop: string;
+  readonly info: Shop;
+  readonly identity: ShopEditorIdentitySection;
+  readonly providers: ShopEditorProvidersSection;
+  readonly overrides: ShopEditorOverridesSection;
+  readonly localization: ShopEditorLocalizationSection;
+  readonly seo: ShopEditorSeoState;
+  readonly errors: ShopEditorErrorBags;
+}
+
+interface IdentitySectionWrapperProps {
+  readonly identity: ShopEditorIdentitySection;
+  readonly errors?: ShopIdentitySectionErrors;
+}
+
+function IdentitySectionWrapper({ identity, errors }: IdentitySectionWrapperProps) {
+  return (
+    <ShopIdentitySection
+      info={identity.info}
+      errors={errors}
+      onInfoChange={identity.handleTextChange}
+      onLuxuryFeatureChange={identity.handleLuxuryFeatureChange}
+    />
+  );
+}
+
+interface SeoSectionWrapperProps {
+  readonly seo: ShopEditorSeoState;
+  readonly errors?: ShopSeoSectionErrors;
+}
+
+function SeoSectionWrapper({ seo, errors }: SeoSectionWrapperProps) {
+  return (
+    <ShopSeoSection
+      catalogFilters={seo.catalogFilters}
+      onCatalogFiltersChange={seo.setCatalogFilters}
+      errors={errors}
+    />
+  );
+}
+
+interface ProvidersSectionWrapperProps {
+  readonly providers: ShopEditorProvidersSection;
+  readonly errors?: ShopProvidersSectionErrors;
+}
+
+function ProvidersSectionWrapper({ providers, errors }: ProvidersSectionWrapperProps) {
+  return (
+    <ShopProvidersSection
+      trackingProviders={providers.trackingProviders}
+      shippingProviders={providers.shippingProviders}
+      errors={errors}
+      onTrackingChange={providers.setTrackingProviders}
+    />
+  );
+}
+
+interface ThemeSectionWrapperProps {
+  readonly shop: string;
+  readonly tokenRows: ShopEditorOverridesSection["tokenRows"];
+  readonly themeDefaults?: Shop["themeDefaults"];
+  readonly themeOverrides?: Shop["themeOverrides"];
+  readonly errors?: ShopThemeSectionErrors;
+}
+
+function ThemeSectionWrapper({
+  shop,
+  tokenRows,
+  themeDefaults,
+  themeOverrides,
+  errors,
+}: ThemeSectionWrapperProps) {
+  return (
+    <ShopThemeSection
+      shop={shop}
+      tokenRows={tokenRows}
+      themeDefaults={themeDefaults}
+      themeOverrides={themeOverrides}
+      errors={errors}
+    />
+  );
+}
+
+interface OverridesSectionWrapperProps {
+  readonly overrides: ShopEditorOverridesSection;
+  readonly priceOverrides: ShopEditorLocalizationSection["priceOverrides"];
+  readonly errors?: ShopOverridesSectionErrors;
+}
+
+function OverridesSectionWrapper({
+  overrides,
+  priceOverrides,
+  errors,
+}: OverridesSectionWrapperProps) {
+  return (
+    <ShopOverridesSection
+      filterMappings={overrides.filterMappings}
+      priceOverrides={priceOverrides}
+      errors={errors}
+    />
+  );
+}
+
+interface LocalizationSectionWrapperProps {
+  readonly localization: ShopEditorLocalizationSection;
+  readonly errors?: ShopLocalizationSectionErrors;
+}
+
+function LocalizationSectionWrapper({
+  localization,
+  errors,
+}: LocalizationSectionWrapperProps) {
+  return (
+    <ShopLocalizationSection
+      localeOverrides={localization.localeOverrides}
+      availableLocales={localization.supportedLocales}
+      errors={errors}
+    />
+  );
+}
+
+export function createShopEditorSections({
+  shop,
+  info,
+  identity,
+  providers,
+  overrides,
+  localization,
+  seo,
+  errors,
+}: CreateShopEditorSectionsArgs): EditorSectionConfig[] {
+  return [
+    {
+      key: "identity",
+      title: "Identity",
+      description: "Update the shop name, theme, and luxury feature toggles.",
+      wrapWithCard: false,
+      component: IdentitySectionWrapper,
+      props: { identity, errors: errors.identity },
+    },
+    {
+      key: "seo",
+      title: "SEO",
+      description: "Configure catalog filters for storefront metadata.",
+      wrapWithCard: false,
+      component: SeoSectionWrapper,
+      props: { seo, errors: errors.seo },
+    },
+    {
+      key: "providers",
+      title: "Tracking providers",
+      description: "Manage analytics and fulfillment tracking integrations.",
+      wrapWithCard: false,
+      component: ProvidersSectionWrapper,
+      props: { providers, errors: errors.providers },
+    },
+    {
+      key: "theme",
+      title: "Theme tokens",
+      description: "Compare overrides with defaults and reset individual tokens.",
+      component: ThemeSectionWrapper,
+      props: {
+        shop,
+        tokenRows: overrides.tokenRows,
+        themeDefaults: info.themeDefaults,
+        themeOverrides: info.themeOverrides,
+        errors: errors.theme,
+      },
+    },
+    {
+      key: "overrides",
+      title: "Overrides",
+      description: "Fine-tune filter mappings and price localization.",
+      wrapWithCard: false,
+      component: OverridesSectionWrapper,
+      props: {
+        overrides,
+        priceOverrides: localization.priceOverrides,
+        errors: errors.overrides,
+      },
+    },
+    {
+      key: "localization",
+      title: "Localization overrides",
+      description: "Redirect locale content to custom destinations.",
+      wrapWithCard: false,
+      component: LocalizationSectionWrapper,
+      props: { localization, errors: errors.localization },
+    },
+  ];
+}
+
+export default createShopEditorSections;

--- a/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorErrors.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/useShopEditorErrors.ts
@@ -1,0 +1,169 @@
+import { useMemo } from "react";
+
+import type {
+  ShopIdentitySectionErrors,
+  ShopLocalizationSectionErrors,
+  ShopOverridesSectionErrors,
+  ShopProvidersSectionErrors,
+  ShopSeoSectionErrors,
+  ShopThemeSectionErrors,
+} from "./sections";
+import type {
+  MappingListFieldErrors,
+  MappingListFieldRowErrors,
+} from "./components/MappingListField";
+
+const LUXURY_FEATURE_ERROR_KEYS = [
+  "blog",
+  "contentMerchandising",
+  "raTicketing",
+  "requireStrongCustomerAuth",
+  "strictReturnConditions",
+  "trackingDashboard",
+  "premierDelivery",
+] as const;
+
+type MappingListFieldName =
+  | "filterMappings"
+  | "priceOverrides"
+  | "localeOverrides";
+
+export interface ShopEditorErrorBags {
+  readonly identity?: ShopIdentitySectionErrors;
+  readonly providers?: ShopProvidersSectionErrors;
+  readonly overrides?: ShopOverridesSectionErrors;
+  readonly localization?: ShopLocalizationSectionErrors;
+  readonly seo?: ShopSeoSectionErrors;
+  readonly theme?: ShopThemeSectionErrors;
+}
+
+function buildMappingListErrors(
+  errors: Readonly<Record<string, string[]>>,
+  field: MappingListFieldName,
+): MappingListFieldErrors | undefined {
+  const general = errors[field];
+  const rowEntries = new Map<number, MappingListFieldRowErrors>();
+
+  const dotPattern = new RegExp(`^${field}\\.(\\d+)(?:\\.(key|value|general))?$`);
+  const bracketPattern = new RegExp(
+    `^${field}\\[(\\d+)](?:\\.(key|value|general))?$`,
+  );
+
+  for (const [errorKey, messages] of Object.entries(errors)) {
+    const dotMatch = errorKey.match(dotPattern);
+    const bracketMatch = errorKey.match(bracketPattern);
+    const match = dotMatch ?? bracketMatch;
+    if (!match) {
+      continue;
+    }
+
+    const index = Number(match[1]);
+    if (Number.isNaN(index)) {
+      continue;
+    }
+
+    const fieldName = (match[2] as "key" | "value" | "general" | undefined) ?? "general";
+    const current = rowEntries.get(index) ?? {};
+
+    if (fieldName === "general") {
+      rowEntries.set(index, { ...current, general: messages });
+    } else {
+      rowEntries.set(index, { ...current, [fieldName]: messages });
+    }
+  }
+
+  const rows =
+    rowEntries.size > 0
+      ? Array.from(rowEntries.entries())
+          .sort(([left], [right]) => left - right)
+          .map(([, value]) => value)
+      : undefined;
+
+  if (!general && !rows) {
+    return undefined;
+  }
+
+  return { general, rows };
+}
+
+export function useShopEditorErrors(
+  errors: Readonly<Record<string, string[]>>,
+): ShopEditorErrorBags {
+  return useMemo(() => {
+    const identityErrors: ShopIdentitySectionErrors = {};
+    if (errors.name) {
+      identityErrors.name = errors.name;
+    }
+    if (errors.themeId) {
+      identityErrors.themeId = errors.themeId;
+    }
+    if (errors.fraudReviewThreshold) {
+      identityErrors.fraudReviewThreshold = errors.fraudReviewThreshold;
+    }
+    if (errors.luxuryFeatures) {
+      identityErrors.luxuryFeatures = errors.luxuryFeatures;
+    }
+
+    for (const feature of LUXURY_FEATURE_ERROR_KEYS) {
+      const messages = errors[feature];
+      if (messages) {
+        const field = `luxuryFeatures.${feature}` as const;
+        identityErrors[field] = messages;
+      }
+    }
+
+    const identityBag =
+      Object.keys(identityErrors).length > 0 ? identityErrors : undefined;
+
+    const providersBag = errors.trackingProviders
+      ? { trackingProviders: errors.trackingProviders }
+      : undefined;
+
+    const filterMappingErrors = buildMappingListErrors(errors, "filterMappings");
+    const priceOverrideErrors = buildMappingListErrors(errors, "priceOverrides");
+
+    const overridesErrors: ShopOverridesSectionErrors = {};
+    if (filterMappingErrors) {
+      overridesErrors.filterMappings = filterMappingErrors;
+    }
+    if (priceOverrideErrors) {
+      overridesErrors.priceOverrides = priceOverrideErrors;
+    }
+    const overridesBag =
+      Object.keys(overridesErrors).length > 0 ? overridesErrors : undefined;
+
+    const localizationBag = (() => {
+      const localeOverrideErrors = buildMappingListErrors(errors, "localeOverrides");
+      if (!localeOverrideErrors) {
+        return undefined;
+      }
+      return { localeOverrides: localeOverrideErrors } satisfies ShopLocalizationSectionErrors;
+    })();
+
+    const seoBag = errors.catalogFilters
+      ? ({ catalogFilters: errors.catalogFilters } satisfies ShopSeoSectionErrors)
+      : undefined;
+
+    const themeBag = (() => {
+      const result: ShopThemeSectionErrors = {};
+      if (errors.themeDefaults) {
+        result.themeDefaults = errors.themeDefaults;
+      }
+      if (errors.themeOverrides) {
+        result.themeOverrides = errors.themeOverrides;
+      }
+      return Object.keys(result).length > 0 ? result : undefined;
+    })();
+
+    return {
+      identity: identityBag,
+      providers: providersBag,
+      overrides: overridesBag,
+      localization: localizationBag,
+      seo: seoBag,
+      theme: themeBag,
+    } satisfies ShopEditorErrorBags;
+  }, [errors]);
+}
+
+export default useShopEditorErrors;


### PR DESCRIPTION
## Summary
- centralize section error mapping in a dedicated `useShopEditorErrors` helper
- extract section configuration into reusable wrappers and `createShopEditorSections`
- replace inline layout with an `EditorSectionsAccordion` component and slim `ShopEditor`

## Testing
- pnpm exec jest --config jest.config.cjs --coverage=false --runTestsByPath src/app/cms/shop/[shop]/settings/__tests__/ShopEditor.test.tsx
- pnpm exec jest --config jest.config.cjs --coverage=false --runTestsByPath src/app/cms/shop/[shop]/settings/__tests__/useShopEditorSubmit.test.ts
- pnpm exec jest --config jest.config.cjs --coverage=false --runTestsByPath __tests__/ShopEditor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cbbb9d2f50832f9e256c00c552c36f