### PR TITLE
Refactor inventory form into hooks and presentational components

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryForm.tsx
@@ -1,21 +1,13 @@
 "use client";
 
-import {
-  Button,
-  Card,
-  CardContent,
-  Table,
-  TableBody,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/atoms/shadcn";
+import { Button } from "@/components/atoms/shadcn";
 import type { InventoryItem } from "@platform-core/types/inventory";
-import { FormEvent, useRef, useState } from "react";
-import InventoryRow from "./InventoryRow";
+import { FormEvent, useCallback } from "react";
+import { InventoryTable } from "./InventoryTable";
+import { InventoryToolbar } from "./InventoryToolbar";
+import { useInventoryEditor } from "./hooks/useInventoryEditor";
+import { useInventoryFileTransfer } from "./hooks/useInventoryFileTransfer";
 import { useInventoryValidation } from "./useInventoryValidation";
-import { Tag } from "@ui/components/atoms";
-import { cn } from "@ui/utils/style";
 
 interface Props {
   shop: string;
@@ -28,106 +20,51 @@ interface Props {
 }
 
 export default function InventoryForm({ shop, initial, onSave }: Props) {
-  const [items, setItems] = useState<InventoryItem[]>(() => initial);
-  const [attributes, setAttributes] = useState<string[]>(() => {
-    const set = new Set<string>();
-    initial.forEach((i) =>
-      Object.keys(i.variantAttributes ?? {}).forEach((k) => set.add(k))
-    );
-    return Array.from(set);
-  });
-  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
-  const [error, setError] = useState<string | null>(null);
-  const fileInput = useRef<HTMLInputElement>(null);
   const validate = useInventoryValidation();
+  const {
+    items,
+    attributes,
+    status,
+    error,
+    updateItem,
+    addRow,
+    addAttribute,
+    deleteAttribute,
+    deleteRow,
+    replaceItems,
+    markSaved,
+    markError,
+  } = useInventoryEditor(initial);
 
-  const updateItem = (
-    index: number,
-    field: keyof InventoryItem | `variantAttributes.${string}`,
-    value: string
-  ) => {
-    setItems((prev) => {
-      const next = [...prev];
-      const item = { ...next[index] } as InventoryItem;
-      if (field.startsWith("variantAttributes.")) {
-        const key = field.split(".")[1];
-        item.variantAttributes = { ...item.variantAttributes, [key]: value };
-      } else if (field === "quantity") {
-        item.quantity = value === "" ? NaN : Number(value);
-      } else if (field === "lowStockThreshold") {
-        item.lowStockThreshold = value === "" ? undefined : Number(value);
-      } else if (field === "sku") {
-        item.sku = value;
-        item.productId = value;
-      } else if (field === "productId") {
-        item.productId = value;
-      } else if (field === "wearCount") {
-        item.wearCount = value === "" ? undefined : Number(value);
-      } else if (field === "wearAndTearLimit") {
-        item.wearAndTearLimit = value === "" ? undefined : Number(value);
-      } else if (field === "maintenanceCycle") {
-        item.maintenanceCycle = value === "" ? undefined : Number(value);
-      }
-      next[index] = item;
-      return next;
+  const { fileInputRef, triggerImport, handleFileChange, exportInventory } =
+    useInventoryFileTransfer({
+      shop,
+      onItemsLoaded: replaceItems,
+      onSuccess: markSaved,
+      onError: markError,
     });
-  };
 
-  const addRow = () => {
-    setItems((prev) => [
-      ...prev,
-      {
-        sku: "",
-        productId: "",
-        variantAttributes: Object.fromEntries(attributes.map((a) => [a, ""])),
-        quantity: NaN,
-        lowStockThreshold: undefined,
-      },
-    ]);
-  };
-
-  const addAttribute = () => {
+  const handleAddAttribute = useCallback(() => {
     const name = prompt("Attribute name")?.trim();
     if (!name || attributes.includes(name)) return;
-    setAttributes((prev) => [...prev, name]);
-    setItems((prev) =>
-      prev.map((i) => ({
-        ...i,
-        variantAttributes: { ...i.variantAttributes, [name]: "" },
-      }))
-    );
-  };
-
-  const deleteAttribute = (attr: string) => {
-    setAttributes((prev) => prev.filter((a) => a !== attr));
-    setItems((prev) =>
-      prev.map((i) => {
-        const rest = { ...i.variantAttributes };
-        delete rest[attr];
-        return { ...i, variantAttributes: rest };
-      })
-    );
-  };
-
-  const deleteRow = (idx: number) => {
-    setItems((prev) => prev.filter((_, i) => i !== idx));
-  };
+    addAttribute(name);
+  }, [addAttribute, attributes]);
 
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    const result = validate(items);
+    if (!result.success) {
+      markError(result.error);
+      return;
+    }
+
     try {
-      const result = validate(items);
-      if (!result.success) {
-        setStatus("error");
-        setError(result.error);
-        return;
-      }
       if (onSave) {
         await onSave(result.data);
-        setStatus("saved");
-        setError(null);
+        markSaved();
         return;
       }
+
       const res = await fetch(`/api/data/${shop}/inventory`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -135,194 +72,36 @@ export default function InventoryForm({ shop, initial, onSave }: Props) {
       });
       const body = await res.json().catch(() => ({}));
       if (!res.ok) {
-        setStatus("error");
-        setError(body.error || "Failed to save");
+        markError(body.error || "Failed to save");
         return;
       }
-      setStatus("saved");
-      setError(null);
+      markSaved();
     } catch (err) {
-      setStatus("error");
-      setError((err as Error).message);
+      const message = err instanceof Error ? err.message : "Failed to save";
+      markError(message);
     }
   };
-
-  const onImport = () => {
-    fileInput.current?.click();
-  };
-
-  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const data = new FormData();
-    data.set("file", file);
-    try {
-      const res = await fetch(`/api/data/${shop}/inventory/import`, {
-        method: "POST",
-        body: data,
-      });
-      const body = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(body.error || "Failed to import");
-      }
-      setItems(body.items);
-      setAttributes(() => {
-        const set = new Set<string>();
-        body.items.forEach((i: InventoryItem) =>
-          Object.keys(i.variantAttributes).forEach((k) => set.add(k))
-        );
-        return Array.from(set);
-      });
-      setStatus("saved");
-      setError(null);
-    } catch (err) {
-      setStatus("error");
-      setError((err as Error).message);
-    } finally {
-      if (fileInput.current) fileInput.current.value = "";
-    }
-  };
-
-  const onExport = (format: "json" | "csv") => {
-    const url = `/api/data/${shop}/inventory/export?format=${format}`;
-
-    // Fire the request in the background so the test can assert `fetch`
-    // was invoked. Any errors are reported asynchronously.
-    fetch(url)
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error("Failed to export");
-        }
-      })
-      .catch((err) => {
-        setStatus("error");
-        setError((err as Error).message);
-      });
-
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = format === "json" ? "inventory.json" : "inventory.csv";
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-  };
-
-  const statusLabel = status === "saved" ? "Inventory saved" : status === "error" ? "Needs attention" : "Draft";
-  const statusVariant = status === "saved" ? "success" : status === "error" ? "destructive" : "default";
 
   return (
     <form onSubmit={onSubmit} className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <Tag
-            variant={statusVariant}
-            className={cn(
-              "rounded-lg border border-white/10 bg-white/10 text-xs font-medium",
-              status === "saved" && "bg-emerald-500/20 text-emerald-100",
-              status === "error" && "bg-rose-500/20 text-rose-100"
-            )}
-          >
-            {statusLabel}
-          </Tag>
-          {status === "error" && error ? (
-            <span className="text-sm text-rose-200">{error}</span>
-          ) : null}
-          {status === "saved" && (
-            <span className="text-sm text-emerald-200">The latest changes are safe.</span>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            onClick={addRow}
-            className="h-9 rounded-lg bg-emerald-500 px-3 text-xs font-semibold text-white shadow-sm hover:bg-emerald-400"
-          >
-            Add row
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            className="h-9 rounded-lg border-white/30 px-3 text-xs text-white hover:bg-white/10"
-            onClick={addAttribute}
-          >
-            Add attribute
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
-            onClick={onImport}
-          >
-            Import JSON/CSV
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
-            onClick={() => onExport("json")}
-          >
-            Export JSON
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
-            onClick={() => onExport("csv")}
-          >
-            Export CSV
-          </Button>
-          <input
-            ref={fileInput}
-            type="file"
-            accept=".json,.csv"
-            className="hidden"
-            onChange={onFile}
-          />
-        </div>
-      </div>
+      <InventoryToolbar
+        status={status}
+        error={error}
+        onAddRow={addRow}
+        onAddAttribute={handleAddAttribute}
+        onImport={triggerImport}
+        onExport={exportInventory}
+        fileInputRef={fileInputRef}
+        onFileChange={handleFileChange}
+      />
 
-      <Card className="border border-white/10 bg-white/5 text-white">
-        <CardContent className="px-0 py-0">
-          <Table className="text-white">
-            <TableHeader className="bg-white/10">
-              <TableRow className="text-xs uppercase tracking-wide text-white/70">
-                <TableHead className="text-white">SKU</TableHead>
-                {attributes.map((attr) => (
-                  <TableHead key={attr} className="text-white">
-                    <div className="flex items-center justify-between gap-2">
-                      <span>{attr}</span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        className="h-7 rounded-lg px-2 text-xs text-white/70 hover:bg-white/10"
-                        onClick={() => deleteAttribute(attr)}
-                        aria-label={`delete-attr-${attr}`}
-                      >
-                        Remove
-                      </Button>
-                    </div>
-                  </TableHead>
-                ))}
-                <TableHead className="text-white">Quantity</TableHead>
-                <TableHead className="text-white">Low stock threshold</TableHead>
-                <TableHead className="text-white">&nbsp;</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {items.map((item, idx) => (
-                <InventoryRow
-                  key={idx}
-                  item={item}
-                  index={idx}
-                  attributes={attributes}
-                  updateItem={updateItem}
-                  deleteRow={deleteRow}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
+      <InventoryTable
+        items={items}
+        attributes={attributes}
+        onDeleteAttribute={deleteAttribute}
+        onUpdateItem={updateItem}
+        onDeleteRow={deleteRow}
+      />
 
       <div className="flex flex-wrap items-center gap-2">
         <Button

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryTable.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryTable.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  Button,
+  Card,
+  CardContent,
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/atoms/shadcn";
+import type { InventoryItem } from "@platform-core/types/inventory";
+import InventoryRow from "./InventoryRow";
+
+interface InventoryTableProps {
+  items: InventoryItem[];
+  attributes: string[];
+  onDeleteAttribute: (attribute: string) => void;
+  onUpdateItem: (
+    index: number,
+    field: keyof InventoryItem | `variantAttributes.${string}`,
+    value: string,
+  ) => void;
+  onDeleteRow: (index: number) => void;
+}
+
+export function InventoryTable({
+  items,
+  attributes,
+  onDeleteAttribute,
+  onUpdateItem,
+  onDeleteRow,
+}: InventoryTableProps) {
+  return (
+    <Card className="border border-white/10 bg-white/5 text-white">
+      <CardContent className="px-0 py-0">
+        <Table className="text-white">
+          <TableHeader className="bg-white/10">
+            <TableRow className="text-xs uppercase tracking-wide text-white/70">
+              <TableHead className="text-white">SKU</TableHead>
+              {attributes.map((attr) => (
+                <TableHead key={attr} className="text-white">
+                  <div className="flex items-center justify-between gap-2">
+                    <span>{attr}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="h-7 rounded-lg px-2 text-xs text-white/70 hover:bg-white/10"
+                      onClick={() => onDeleteAttribute(attr)}
+                      aria-label={`delete-attr-${attr}`}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                </TableHead>
+              ))}
+              <TableHead className="text-white">Quantity</TableHead>
+              <TableHead className="text-white">Low stock threshold</TableHead>
+              <TableHead className="text-white">&nbsp;</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item, idx) => (
+              <InventoryRow
+                key={idx}
+                item={item}
+                index={idx}
+                attributes={attributes}
+                updateItem={onUpdateItem}
+                deleteRow={onDeleteRow}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryToolbar.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/InventoryToolbar.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Button } from "@/components/atoms/shadcn";
+import { Tag } from "@ui/components/atoms";
+import { cn } from "@ui/utils/style";
+import type { ChangeEvent, RefObject } from "react";
+import type { InventoryStatus } from "./hooks/useInventoryEditor";
+
+interface InventoryToolbarProps {
+  status: InventoryStatus;
+  error: string | null;
+  onAddRow: () => void;
+  onAddAttribute: () => void;
+  onImport: () => void;
+  onExport: (format: "json" | "csv") => void;
+  fileInputRef: RefObject<HTMLInputElement>;
+  onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function InventoryToolbar({
+  status,
+  error,
+  onAddRow,
+  onAddAttribute,
+  onImport,
+  onExport,
+  fileInputRef,
+  onFileChange,
+}: InventoryToolbarProps) {
+  const statusLabel =
+    status === "saved"
+      ? "Inventory saved"
+      : status === "error"
+      ? "Needs attention"
+      : "Draft";
+  const statusVariant =
+    status === "saved"
+      ? "success"
+      : status === "error"
+      ? "destructive"
+      : "default";
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Tag
+          variant={statusVariant}
+          className={cn(
+            "rounded-lg border border-white/10 bg-white/10 text-xs font-medium",
+            status === "saved" && "bg-emerald-500/20 text-emerald-100",
+            status === "error" && "bg-rose-500/20 text-rose-100",
+          )}
+        >
+          {statusLabel}
+        </Tag>
+        {status === "error" && error ? (
+          <span className="text-sm text-rose-200">{error}</span>
+        ) : null}
+        {status === "saved" ? (
+          <span className="text-sm text-emerald-200">The latest changes are safe.</span>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          onClick={onAddRow}
+          className="h-9 rounded-lg bg-emerald-500 px-3 text-xs font-semibold text-white shadow-sm hover:bg-emerald-400"
+        >
+          Add row
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-9 rounded-lg border-white/30 px-3 text-xs text-white hover:bg-white/10"
+          onClick={onAddAttribute}
+        >
+          Add attribute
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
+          onClick={onImport}
+        >
+          Import JSON/CSV
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
+          onClick={() => onExport("json")}
+        >
+          Export JSON
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-9 rounded-lg text-xs text-white hover:bg-white/10"
+          onClick={() => onExport("csv")}
+        >
+          Export CSV
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,.csv"
+          className="hidden"
+          onChange={onFileChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/hooks/useInventoryEditor.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/hooks/useInventoryEditor.ts
@@ -1,0 +1,154 @@
+import { useCallback, useState } from "react";
+import type { InventoryItem } from "@platform-core/types/inventory";
+
+export type InventoryStatus = "idle" | "saved" | "error";
+
+function deriveAttributes(items: InventoryItem[]) {
+  const set = new Set<string>();
+  items.forEach((item) => {
+    Object.keys(item.variantAttributes ?? {}).forEach((key) => set.add(key));
+  });
+  return Array.from(set);
+}
+
+export function useInventoryEditor(initialItems: InventoryItem[]) {
+  const [items, setItems] = useState<InventoryItem[]>(() => initialItems);
+  const [attributes, setAttributes] = useState<string[]>(() =>
+    deriveAttributes(initialItems),
+  );
+  const [status, setStatus] = useState<InventoryStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const replaceItems = useCallback((nextItems: InventoryItem[]) => {
+    setItems(nextItems);
+    setAttributes(deriveAttributes(nextItems));
+  }, []);
+
+  const updateItem = useCallback(
+    (
+      index: number,
+      field: keyof InventoryItem | `variantAttributes.${string}`,
+      value: string,
+    ) => {
+      setItems((prev) => {
+        const next = [...prev];
+        const item = { ...next[index] } as InventoryItem;
+        if (field.startsWith("variantAttributes.")) {
+          const key = field.split(".")[1]!;
+          item.variantAttributes = {
+            ...item.variantAttributes,
+            [key]: value,
+          };
+        } else if (field === "quantity") {
+          item.quantity = value === "" ? NaN : Number(value);
+        } else if (field === "lowStockThreshold") {
+          item.lowStockThreshold = value === "" ? undefined : Number(value);
+        } else if (field === "sku") {
+          item.sku = value;
+          item.productId = value;
+        } else if (field === "productId") {
+          item.productId = value;
+        } else if (field === "wearCount") {
+          item.wearCount = value === "" ? undefined : Number(value);
+        } else if (field === "wearAndTearLimit") {
+          item.wearAndTearLimit = value === "" ? undefined : Number(value);
+        } else if (field === "maintenanceCycle") {
+          item.maintenanceCycle = value === "" ? undefined : Number(value);
+        }
+        next[index] = item;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const addRow = useCallback(() => {
+    setItems((prev) => [
+      ...prev,
+      {
+        sku: "",
+        productId: "",
+        variantAttributes: Object.fromEntries(
+          attributes.map((attribute) => [attribute, ""]),
+        ),
+        quantity: NaN,
+        lowStockThreshold: undefined,
+      },
+    ]);
+  }, [attributes]);
+
+  const addAttribute = useCallback(
+    (name: string) => {
+      setAttributes((prev) => {
+        if (!name || prev.includes(name)) {
+          return prev;
+        }
+        setItems((items) =>
+          items.map((item) => ({
+            ...item,
+            variantAttributes: {
+              ...item.variantAttributes,
+              [name]: item.variantAttributes?.[name] ?? "",
+            },
+          })),
+        );
+        return [...prev, name];
+      });
+    },
+    [],
+  );
+
+  const deleteAttribute = useCallback((attr: string) => {
+    setAttributes((prev) => {
+      if (!prev.includes(attr)) {
+        return prev;
+      }
+      setItems((items) =>
+        items.map((item) => {
+          if (!item.variantAttributes || !(attr in item.variantAttributes)) {
+            return item;
+          }
+          const nextAttributes = { ...item.variantAttributes };
+          delete nextAttributes[attr];
+          return { ...item, variantAttributes: nextAttributes };
+        }),
+      );
+      return prev.filter((name) => name !== attr);
+    });
+  }, []);
+
+  const deleteRow = useCallback((idx: number) => {
+    setItems((prev) => prev.filter((_, index) => index !== idx));
+  }, []);
+
+  const markSaved = useCallback(() => {
+    setStatus("saved");
+    setError(null);
+  }, []);
+
+  const markError = useCallback((message: string) => {
+    setStatus("error");
+    setError(message);
+  }, []);
+
+  const resetStatus = useCallback(() => {
+    setStatus("idle");
+    setError(null);
+  }, []);
+
+  return {
+    items,
+    attributes,
+    status,
+    error,
+    updateItem,
+    addRow,
+    addAttribute,
+    deleteAttribute,
+    deleteRow,
+    replaceItems,
+    markSaved,
+    markError,
+    resetStatus,
+  };
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/inventory/hooks/useInventoryFileTransfer.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/inventory/hooks/useInventoryFileTransfer.ts
@@ -1,0 +1,97 @@
+import { useCallback, useRef } from "react";
+import type { ChangeEvent } from "react";
+import type { InventoryItem } from "@platform-core/types/inventory";
+
+interface InventoryFileTransferOptions {
+  shop: string;
+  onItemsLoaded: (items: InventoryItem[]) => void;
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
+}
+
+export function useInventoryFileTransfer({
+  shop,
+  onItemsLoaded,
+  onSuccess,
+  onError,
+}: InventoryFileTransferOptions) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const triggerImport = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      const data = new FormData();
+      data.set("file", file);
+
+      try {
+        const res = await fetch(`/api/data/${shop}/inventory/import`, {
+          method: "POST",
+          body: data,
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(body.error || "Failed to import");
+        }
+        if (!Array.isArray(body.items)) {
+          throw new Error("Invalid response from server");
+        }
+
+        const items = body.items as InventoryItem[];
+        onItemsLoaded(items);
+        onSuccess?.();
+      } catch (err) {
+        const message =
+          err instanceof Error && err.message
+            ? err.message
+            : "Failed to import";
+        onError?.(message);
+      } finally {
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+      }
+    },
+    [shop, onItemsLoaded, onSuccess, onError],
+  );
+
+  const exportInventory = useCallback(
+    (format: "json" | "csv") => {
+      const url = `/api/data/${shop}/inventory/export?format=${format}`;
+
+      fetch(url)
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error("Failed to export");
+          }
+        })
+        .catch((err) => {
+          const message =
+            err instanceof Error && err.message
+              ? err.message
+              : "Failed to export";
+          onError?.(message);
+        });
+
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = format === "json" ? "inventory.json" : "inventory.csv";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    },
+    [shop, onError],
+  );
+
+  return {
+    fileInputRef,
+    triggerImport,
+    handleFileChange,
+    exportInventory,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the inventory editing state, mutations, and status handling into a reusable `useInventoryEditor` hook
- move import/export side effects into a dedicated `useInventoryFileTransfer` helper
- add toolbar and table presentational components and update `InventoryForm` to compose them

## Testing
- pnpm --filter @apps/cms exec jest --config ./jest.config.cjs --runTestsByPath src/app/cms/shop/[shop]/data/inventory/__tests__/InventoryForm.test.tsx --coverage=false --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68cbbba52244832f95d2a737eee70642