### PR TITLE
Refactor marketing overview components

### DIFF
--- a/apps/cms/src/app/cms/marketing/components/MarketingOverview.tsx
+++ b/apps/cms/src/app/cms/marketing/components/MarketingOverview.tsx
@@ -1,325 +1,40 @@
-import Link from "next/link";
-import { Button, Card, CardContent, Tag } from "@ui/components/atoms";
-import { AnalyticsSummaryCard } from "@ui/components/cms/marketing";
+import { MarketingOverviewHero } from "./MarketingOverviewHero";
+import { MarketingRecentPerformance } from "./MarketingRecentPerformance";
+import { MarketingSummaryCards } from "./MarketingSummaryCards";
+import { MarketingToolsGrid } from "./MarketingToolsGrid";
+import {
+  useMarketingOverview,
+  type UseMarketingOverviewResult,
+} from "./useMarketingOverview";
+import type {
+  CampaignAnalyticsItem,
+  MarketingSummary,
+} from "./MarketingOverview.types";
 
-export interface CampaignEngagementMetrics {
-  sent: number;
-  opened: number;
-  clicked: number;
-  unsubscribed: number;
-}
-
-export interface SegmentActivityMetric {
-  id: string;
-  count: number;
-}
-
-export interface CampaignAnalyticsItem {
-  shop: string;
-  campaigns: string[];
-  metrics: CampaignEngagementMetrics;
-  segments: SegmentActivityMetric[];
-  engagedContacts: number;
-}
-
-export interface MarketingSummary {
-  totalCampaigns: number;
-  totalSegments: number;
-  sent: number;
-  opened: number;
-  clicked: number;
-  unsubscribed: number;
-  engagedContacts: number;
-  segmentSignals: number;
-  topSegment?: SegmentActivityMetric;
-}
-
-interface MarketingOverviewProps {
+export interface MarketingOverviewProps {
   analytics: CampaignAnalyticsItem[];
   summary: MarketingSummary;
 }
 
-function formatPercent(value: number): string {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  });
-}
-
-const marketingTools = [
-  {
-    title: "Email automations",
-    description:
-      "Design campaign flows, apply templates, and preview content before scheduling delivery.",
-    helper:
-      "Use segments to personalise copy and automatically include unsubscribe links in every send.",
-    actionLabel: "Open email composer",
-    href: "/cms/marketing/email",
-  },
-  {
-    title: "Discount programs",
-    description:
-      "Create stackable codes, toggle availability, and monitor redemptions directly from analytics.",
-    helper:
-      "Codes sync to storefront checkout within a minute and respect scheduling windows by default.",
-    actionLabel: "Manage discounts",
-    href: "/cms/marketing/discounts",
-  },
-  {
-    title: "Audience segments",
-    description:
-      "Group customers by behaviour, channel, or metadata and reuse segments across campaigns.",
-    helper:
-      "Segments update nightly from analytics events and can be previewed from the dashboard view.",
-    actionLabel: "Build segments",
-    href: "/cms/segments",
-  },
-];
-
 export function MarketingOverview({ analytics, summary }: MarketingOverviewProps) {
-  const openRatePercent = summary.sent > 0 ? (summary.opened / summary.sent) * 100 : 0;
-  const clickRatePercent = summary.sent > 0 ? (summary.clicked / summary.sent) * 100 : 0;
-  const topSegmentShare =
-    summary.topSegment && summary.segmentSignals > 0
-      ? (summary.topSegment.count / summary.segmentSignals) * 100
-      : 0;
-  const campaignsLabel =
-    summary.totalCampaigns === 1
-      ? "1 campaign"
-      : `${summary.totalCampaigns.toLocaleString()} campaigns`;
-  const segmentsLabel =
-    summary.totalSegments === 1
-      ? "1 segment"
-      : `${summary.totalSegments.toLocaleString()} segments`;
+  const { summaryCards, tools, recentPerformance, showRecentPerformance }: UseMarketingOverviewResult =
+    useMarketingOverview({ analytics, summary });
 
   return (
     <div className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-foreground">Marketing workspace</h1>
-        <p className="max-w-2xl text-sm text-muted-foreground">
-          Launch campaigns, manage incentives, and keep sales aligned with the latest customer signals.
-          Start with a guided tool and revisit recent activity across shops.
-        </p>
-      </header>
-
-      <section className="grid gap-4 lg:grid-cols-2">
-        <AnalyticsSummaryCard
-          title="Campaign engagement"
-          status={{
-            label: summary.sent > 0 ? "Active" : "Idle",
-            tone: summary.sent > 0 ? "success" : "default",
-          }}
-          description="High-level performance from recent email campaigns across all shops."
-          metrics={[
-            {
-              label: "Emails sent",
-              value: summary.sent.toLocaleString(),
-              helper:
-                summary.sent > 0
-                  ? `${campaignsLabel} delivered ${summary.sent.toLocaleString()} messages.`
-                  : "Queue a campaign to start collecting engagement data.",
-              badge:
-                summary.unsubscribed > 0
-                  ? {
-                      label: `${summary.unsubscribed.toLocaleString()} unsubscribed`,
-                      tone: "destructive",
-                    }
-                  : undefined,
-            },
-            {
-              label: "Open rate",
-              value: `${formatPercent(Math.max(0, Math.min(100, openRatePercent)))}%`,
-              progress: {
-                value: openRatePercent,
-                label: `${summary.opened.toLocaleString()} opens`,
-              },
-              helper:
-                summary.sent > 0
-                  ? undefined
-                  : "Open rates appear once campaigns finish sending.",
-            },
-            {
-              label: "Click rate",
-              value: `${formatPercent(Math.max(0, Math.min(100, clickRatePercent)))}%`,
-              progress: {
-                value: clickRatePercent,
-                label: `${summary.clicked.toLocaleString()} clicks`,
-              },
-              helper:
-                summary.sent > 0
-                  ? undefined
-                  : "Click rates appear once recipients interact with a campaign.",
-            },
-            {
-              label: "Engaged contacts",
-              value: summary.engagedContacts.toLocaleString(),
-              helper:
-                summary.engagedContacts > 0
-                  ? "Unique recipients who opened or clicked a campaign."
-                  : "Engagement numbers update after the first send.",
-            },
-          ]}
-        />
-        <AnalyticsSummaryCard
-          title="Audience segments"
-          status={{
-            label: summary.totalSegments > 0 ? "Segments active" : "No segments",
-            tone: summary.totalSegments > 0 ? "success" : "default",
-          }}
-          description="Monitor how analytics signals populate saved segments before targeting campaigns."
-          metrics={[
-            {
-              label: "Active segments",
-              value: summary.totalSegments.toLocaleString(),
-              helper:
-                summary.totalSegments > 0
-                  ? `${segmentsLabel} available to target from the composer.`
-                  : "Create a segment to group customers by shared behaviour.",
-              badge:
-                summary.engagedContacts > 0
-                  ? {
-                      label: `${summary.engagedContacts.toLocaleString()} engaged contacts`,
-                      tone: "success",
-                    }
-                  : undefined,
-            },
-            {
-              label: "Segment signals",
-              value: summary.segmentSignals.toLocaleString(),
-              helper:
-                summary.segmentSignals > 0
-                  ? "Recent events matched segment rules."
-                  : "No events have been attributed to segments yet.",
-            },
-            {
-              label: "Top segment",
-              value: summary.topSegment ? summary.topSegment.id : "—",
-              helper:
-                summary.topSegment
-                  ? `${summary.topSegment.count.toLocaleString()} matching events`
-                  : "Signals appear once contacts meet segment conditions.",
-              progress:
-                summary.topSegment && summary.segmentSignals > 0
-                  ? {
-                      value: topSegmentShare,
-                      label: `${formatPercent(Math.max(0, Math.min(100, topSegmentShare)))}% of segment signals`,
-                    }
-                  : undefined,
-            },
-            {
-              label: "Unique campaigns",
-              value: summary.totalCampaigns.toLocaleString(),
-              helper:
-                summary.totalCampaigns > 0
-                  ? "Campaigns tracked across all shops."
-                  : "Campaign data updates once analytics events are recorded.",
-            },
-          ]}
-        />
-      </section>
-
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {marketingTools.map((tool) => (
-          <Card key={tool.title}>
-            <CardContent className="flex h-full flex-col justify-between gap-6">
-              <div className="space-y-3">
-                <h2 className="text-lg font-semibold text-foreground">{tool.title}</h2>
-                <p className="text-sm text-muted-foreground">{tool.description}</p>
-              </div>
-              <div className="space-y-3">
-                <Button asChild className="w-full justify-center">
-                  <Link href={tool.href}>{tool.actionLabel}</Link>
-                </Button>
-                <p className="text-xs text-muted-foreground">{tool.helper}</p>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </section>
-
-      {analytics.length > 0 && (
-        <section className="space-y-4">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">Recent campaign performance</h2>
-            <p className="text-sm text-muted-foreground">
-              Jump into a shop dashboard to review opens, clicks, and downstream orders for each campaign.
-            </p>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2">
-            {analytics.map((item) => {
-              const shopOpenRate = item.metrics.sent > 0 ? (item.metrics.opened / item.metrics.sent) * 100 : 0;
-              const shopClickRate = item.metrics.sent > 0 ? (item.metrics.clicked / item.metrics.sent) * 100 : 0;
-
-              return (
-                <Card key={item.shop}>
-                  <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div>
-                          <h3 className="text-base font-semibold text-foreground">{item.shop}</h3>
-                          <span className="text-xs uppercase tracking-wide text-muted-foreground">
-                            {item.campaigns.length} active
-                          </span>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Tag variant="success" className="text-xs">
-                            Open {formatPercent(Math.max(0, Math.min(100, shopOpenRate)))}%
-                          </Tag>
-                          <Tag variant="default" className="text-xs">
-                            Click {formatPercent(Math.max(0, Math.min(100, shopClickRate)))}%
-                          </Tag>
-                          {item.metrics.unsubscribed > 0 && (
-                            <Tag variant="destructive" className="text-xs">
-                              {item.metrics.unsubscribed.toLocaleString()} unsubscribed
-                            </Tag>
-                          )}
-                        </div>
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        {item.engagedContacts > 0
-                          ? `${item.engagedContacts.toLocaleString()} engaged contacts`
-                          : "No engagement recorded yet."}
-                      </p>
-                    </div>
-
-                    <ul className="space-y-2 text-sm">
-                      {item.campaigns.map((campaign) => (
-                        <li key={campaign}>
-                          <Link
-                            href={`/cms/dashboard/${item.shop}?campaign=${encodeURIComponent(
-                              campaign,
-                            )}`}
-                            className="text-primary underline decoration-dotted underline-offset-4"
-                          >
-                            {campaign}
-                          </Link>
-                        </li>
-                      ))}
-                    </ul>
-
-                    {item.segments.length > 0 && (
-                      <div className="space-y-2">
-                        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          Active segments
-                        </h4>
-                        <div className="flex flex-wrap gap-2">
-                          {item.segments.slice(0, 4).map((segment) => (
-                            <Tag key={segment.id} variant="default" className="text-[0.65rem]">
-                              {segment.id} · {segment.count.toLocaleString()}
-                            </Tag>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              );
-            })}
-          </div>
-        </section>
-      )}
+      <MarketingOverviewHero />
+      <MarketingSummaryCards cards={summaryCards} />
+      <MarketingToolsGrid tools={tools} />
+      {showRecentPerformance && <MarketingRecentPerformance items={recentPerformance} />}
     </div>
   );
 }
+
+export type {
+  CampaignAnalyticsItem,
+  CampaignEngagementMetrics,
+  MarketingSummary,
+  SegmentActivityMetric,
+} from "./MarketingOverview.types";
 
 export default MarketingOverview;

--- a/apps/cms/src/app/cms/marketing/components/MarketingOverview.types.ts
+++ b/apps/cms/src/app/cms/marketing/components/MarketingOverview.types.ts
@@ -1,0 +1,31 @@
+export interface CampaignEngagementMetrics {
+  sent: number;
+  opened: number;
+  clicked: number;
+  unsubscribed: number;
+}
+
+export interface SegmentActivityMetric {
+  id: string;
+  count: number;
+}
+
+export interface CampaignAnalyticsItem {
+  shop: string;
+  campaigns: string[];
+  metrics: CampaignEngagementMetrics;
+  segments: SegmentActivityMetric[];
+  engagedContacts: number;
+}
+
+export interface MarketingSummary {
+  totalCampaigns: number;
+  totalSegments: number;
+  sent: number;
+  opened: number;
+  clicked: number;
+  unsubscribed: number;
+  engagedContacts: number;
+  segmentSignals: number;
+  topSegment?: SegmentActivityMetric;
+}

--- a/apps/cms/src/app/cms/marketing/components/MarketingOverviewHero.tsx
+++ b/apps/cms/src/app/cms/marketing/components/MarketingOverviewHero.tsx
@@ -1,0 +1,13 @@
+export function MarketingOverviewHero() {
+  return (
+    <header className="space-y-2">
+      <h1 className="text-2xl font-semibold text-foreground">Marketing workspace</h1>
+      <p className="max-w-2xl text-sm text-muted-foreground">
+        Launch campaigns, manage incentives, and keep sales aligned with the latest customer signals.
+        Start with a guided tool and revisit recent activity across shops.
+      </p>
+    </header>
+  );
+}
+
+export default MarketingOverviewHero;

--- a/apps/cms/src/app/cms/marketing/components/MarketingRecentPerformance.tsx
+++ b/apps/cms/src/app/cms/marketing/components/MarketingRecentPerformance.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { Card, CardContent, Tag } from "@ui/components/atoms";
+import type { MarketingRecentPerformanceItem } from "./useMarketingOverview";
+
+export interface MarketingRecentPerformanceProps {
+  items: MarketingRecentPerformanceItem[];
+}
+
+export function MarketingRecentPerformance({ items }: MarketingRecentPerformanceProps) {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Recent campaign performance</h2>
+        <p className="text-sm text-muted-foreground">
+          Jump into a shop dashboard to review opens, clicks, and downstream orders for each campaign.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {items.map((item) => (
+          <Card key={item.shop}>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold text-foreground">{item.shop}</h3>
+                    <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {item.activeLabel}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Tag variant={item.openRateTag.variant} className="text-xs">
+                      {item.openRateTag.label}
+                    </Tag>
+                    <Tag variant={item.clickRateTag.variant} className="text-xs">
+                      {item.clickRateTag.label}
+                    </Tag>
+                    {item.unsubscribedTag && (
+                      <Tag variant={item.unsubscribedTag.variant} className="text-xs">
+                        {item.unsubscribedTag.label}
+                      </Tag>
+                    )}
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">{item.engagedContactsMessage}</p>
+              </div>
+
+              <ul className="space-y-2 text-sm">
+                {item.campaigns.map((campaign) => (
+                  <li key={campaign.name}>
+                    <Link
+                      href={campaign.href}
+                      className="text-primary underline decoration-dotted underline-offset-4"
+                    >
+                      {campaign.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+
+              {item.segments.length > 0 && (
+                <div className="space-y-2">
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Active segments
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {item.segments.map((segment) => (
+                      <Tag key={segment.id} variant="default" className="text-[0.65rem]">
+                        {segment.label}
+                      </Tag>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default MarketingRecentPerformance;

--- a/apps/cms/src/app/cms/marketing/components/MarketingSummaryCards.tsx
+++ b/apps/cms/src/app/cms/marketing/components/MarketingSummaryCards.tsx
@@ -1,0 +1,17 @@
+import { AnalyticsSummaryCard, type AnalyticsSummaryCardProps } from "@ui/components/cms/marketing";
+
+export interface MarketingSummaryCardsProps {
+  cards: AnalyticsSummaryCardProps[];
+}
+
+export function MarketingSummaryCards({ cards }: MarketingSummaryCardsProps) {
+  return (
+    <section className="grid gap-4 lg:grid-cols-2">
+      {cards.map((card) => (
+        <AnalyticsSummaryCard key={card.title} {...card} />
+      ))}
+    </section>
+  );
+}
+
+export default MarketingSummaryCards;

--- a/apps/cms/src/app/cms/marketing/components/MarketingToolsGrid.tsx
+++ b/apps/cms/src/app/cms/marketing/components/MarketingToolsGrid.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Button, Card, CardContent } from "@ui/components/atoms";
+import type { MarketingTool } from "../lib/marketingOverview";
+
+export interface MarketingToolsGridProps {
+  tools: MarketingTool[];
+}
+
+export function MarketingToolsGrid({ tools }: MarketingToolsGridProps) {
+  return (
+    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {tools.map((tool) => (
+        <Card key={tool.title}>
+          <CardContent className="flex h-full flex-col justify-between gap-6">
+            <div className="space-y-3">
+              <h2 className="text-lg font-semibold text-foreground">{tool.title}</h2>
+              <p className="text-sm text-muted-foreground">{tool.description}</p>
+            </div>
+            <div className="space-y-3">
+              <Button asChild className="w-full justify-center">
+                <Link href={tool.href}>{tool.actionLabel}</Link>
+              </Button>
+              <p className="text-xs text-muted-foreground">{tool.helper}</p>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </section>
+  );
+}
+
+export default MarketingToolsGrid;

--- a/apps/cms/src/app/cms/marketing/components/useMarketingOverview.ts
+++ b/apps/cms/src/app/cms/marketing/components/useMarketingOverview.ts
@@ -1,0 +1,231 @@
+import { useMemo } from "react";
+import type { AnalyticsSummaryCardProps } from "@ui/components/cms/marketing";
+import { clampPercent, formatPercent, marketingTools, type MarketingTool } from "../lib/marketingOverview";
+import type {
+  CampaignAnalyticsItem,
+  MarketingSummary,
+} from "./MarketingOverview.types";
+
+type TagVariant = "default" | "success" | "warning" | "destructive";
+
+export interface MarketingRecentPerformanceTag {
+  label: string;
+  variant: TagVariant;
+}
+
+export interface MarketingRecentPerformanceCampaign {
+  name: string;
+  href: string;
+}
+
+export interface MarketingRecentPerformanceSegment {
+  id: string;
+  label: string;
+}
+
+export interface MarketingRecentPerformanceItem {
+  shop: string;
+  activeLabel: string;
+  openRateTag: MarketingRecentPerformanceTag;
+  clickRateTag: MarketingRecentPerformanceTag;
+  unsubscribedTag?: MarketingRecentPerformanceTag;
+  engagedContactsMessage: string;
+  campaigns: MarketingRecentPerformanceCampaign[];
+  segments: MarketingRecentPerformanceSegment[];
+}
+
+interface UseMarketingOverviewProps {
+  analytics: CampaignAnalyticsItem[];
+  summary: MarketingSummary;
+}
+
+export interface UseMarketingOverviewResult {
+  summaryCards: AnalyticsSummaryCardProps[];
+  tools: MarketingTool[];
+  recentPerformance: MarketingRecentPerformanceItem[];
+  showRecentPerformance: boolean;
+}
+
+export function useMarketingOverview({
+  analytics,
+  summary,
+}: UseMarketingOverviewProps): UseMarketingOverviewResult {
+  const summaryCards = useMemo<AnalyticsSummaryCardProps[]>(() => {
+    const openRatePercent = summary.sent > 0 ? (summary.opened / summary.sent) * 100 : 0;
+    const clickRatePercent = summary.sent > 0 ? (summary.clicked / summary.sent) * 100 : 0;
+    const topSegmentShare =
+      summary.topSegment && summary.segmentSignals > 0
+        ? (summary.topSegment.count / summary.segmentSignals) * 100
+        : 0;
+    const campaignsLabel =
+      summary.totalCampaigns === 1
+        ? "1 campaign"
+        : `${summary.totalCampaigns.toLocaleString()} campaigns`;
+    const segmentsLabel =
+      summary.totalSegments === 1
+        ? "1 segment"
+        : `${summary.totalSegments.toLocaleString()} segments`;
+
+    return [
+      {
+        title: "Campaign engagement",
+        status: {
+          label: summary.sent > 0 ? "Active" : "Idle",
+          tone: summary.sent > 0 ? "success" : "default",
+        },
+        description: "High-level performance from recent email campaigns across all shops.",
+        metrics: [
+          {
+            label: "Emails sent",
+            value: summary.sent.toLocaleString(),
+            helper:
+              summary.sent > 0
+                ? `${campaignsLabel} delivered ${summary.sent.toLocaleString()} messages.`
+                : "Queue a campaign to start collecting engagement data.",
+            badge:
+              summary.unsubscribed > 0
+                ? {
+                    label: `${summary.unsubscribed.toLocaleString()} unsubscribed`,
+                    tone: "destructive",
+                  }
+                : undefined,
+          },
+          {
+            label: "Open rate",
+            value: `${formatPercent(clampPercent(openRatePercent))}%`,
+            progress: {
+              value: openRatePercent,
+              label: `${summary.opened.toLocaleString()} opens`,
+            },
+            helper:
+              summary.sent > 0
+                ? undefined
+                : "Open rates appear once campaigns finish sending.",
+          },
+          {
+            label: "Click rate",
+            value: `${formatPercent(clampPercent(clickRatePercent))}%`,
+            progress: {
+              value: clickRatePercent,
+              label: `${summary.clicked.toLocaleString()} clicks`,
+            },
+            helper:
+              summary.sent > 0
+                ? undefined
+                : "Click rates appear once recipients interact with a campaign.",
+          },
+          {
+            label: "Engaged contacts",
+            value: summary.engagedContacts.toLocaleString(),
+            helper:
+              summary.engagedContacts > 0
+                ? "Unique recipients who opened or clicked a campaign."
+                : "Engagement numbers update after the first send.",
+          },
+        ],
+      },
+      {
+        title: "Audience segments",
+        status: {
+          label: summary.totalSegments > 0 ? "Segments active" : "No segments",
+          tone: summary.totalSegments > 0 ? "success" : "default",
+        },
+        description: "Monitor how analytics signals populate saved segments before targeting campaigns.",
+        metrics: [
+          {
+            label: "Active segments",
+            value: summary.totalSegments.toLocaleString(),
+            helper:
+              summary.totalSegments > 0
+                ? `${segmentsLabel} available to target from the composer.`
+                : "Create a segment to group customers by shared behaviour.",
+            badge:
+              summary.engagedContacts > 0
+                ? {
+                    label: `${summary.engagedContacts.toLocaleString()} engaged contacts`,
+                    tone: "success",
+                  }
+                : undefined,
+          },
+          {
+            label: "Segment signals",
+            value: summary.segmentSignals.toLocaleString(),
+            helper:
+              summary.segmentSignals > 0
+                ? "Recent events matched segment rules."
+                : "No events have been attributed to segments yet.",
+          },
+          {
+            label: "Top segment",
+            value: summary.topSegment ? summary.topSegment.id : "—",
+            helper:
+              summary.topSegment
+                ? `${summary.topSegment.count.toLocaleString()} matching events`
+                : "Signals appear once contacts meet segment conditions.",
+            progress:
+              summary.topSegment && summary.segmentSignals > 0
+                ? {
+                    value: topSegmentShare,
+                    label: `${formatPercent(clampPercent(topSegmentShare))}% of segment signals`,
+                  }
+                : undefined,
+          },
+          {
+            label: "Unique campaigns",
+            value: summary.totalCampaigns.toLocaleString(),
+            helper:
+              summary.totalCampaigns > 0
+                ? "Campaigns tracked across all shops."
+                : "Campaign data updates once analytics events are recorded.",
+          },
+        ],
+      },
+    ];
+  }, [summary]);
+
+  const recentPerformance = useMemo<MarketingRecentPerformanceItem[]>(() => {
+    return analytics.map((item) => {
+      const openRate = item.metrics.sent > 0 ? (item.metrics.opened / item.metrics.sent) * 100 : 0;
+      const clickRate = item.metrics.sent > 0 ? (item.metrics.clicked / item.metrics.sent) * 100 : 0;
+
+      return {
+        shop: item.shop,
+        activeLabel: `${item.campaigns.length} active`,
+        openRateTag: {
+          label: `Open ${formatPercent(clampPercent(openRate))}%`,
+          variant: "success",
+        },
+        clickRateTag: {
+          label: `Click ${formatPercent(clampPercent(clickRate))}%`,
+          variant: "default",
+        },
+        unsubscribedTag:
+          item.metrics.unsubscribed > 0
+            ? {
+                label: `${item.metrics.unsubscribed.toLocaleString()} unsubscribed`,
+                variant: "destructive",
+              }
+            : undefined,
+        engagedContactsMessage:
+          item.engagedContacts > 0
+            ? `${item.engagedContacts.toLocaleString()} engaged contacts`
+            : "No engagement recorded yet.",
+        campaigns: item.campaigns.map((campaign) => ({
+          name: campaign,
+          href: `/cms/dashboard/${item.shop}?campaign=${encodeURIComponent(campaign)}`,
+        })),
+        segments: item.segments.slice(0, 4).map((segment) => ({
+          id: segment.id,
+          label: `${segment.id} · ${segment.count.toLocaleString()}`,
+        })),
+      };
+    });
+  }, [analytics]);
+
+  return {
+    summaryCards,
+    tools: marketingTools,
+    recentPerformance,
+    showRecentPerformance: recentPerformance.length > 0,
+  };
+}

--- a/apps/cms/src/app/cms/marketing/lib/marketingOverview.ts
+++ b/apps/cms/src/app/cms/marketing/lib/marketingOverview.ts
@@ -1,0 +1,51 @@
+export type MarketingTool = {
+  title: string;
+  description: string;
+  helper: string;
+  actionLabel: string;
+  href: string;
+};
+
+export function formatPercent(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
+export function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+}
+
+export const marketingTools: MarketingTool[] = [
+  {
+    title: "Email automations",
+    description:
+      "Design campaign flows, apply templates, and preview content before scheduling delivery.",
+    helper:
+      "Use segments to personalise copy and automatically include unsubscribe links in every send.",
+    actionLabel: "Open email composer",
+    href: "/cms/marketing/email",
+  },
+  {
+    title: "Discount programs",
+    description:
+      "Create stackable codes, toggle availability, and monitor redemptions directly from analytics.",
+    helper:
+      "Codes sync to storefront checkout within a minute and respect scheduling windows by default.",
+    actionLabel: "Manage discounts",
+    href: "/cms/marketing/discounts",
+  },
+  {
+    title: "Audience segments",
+    description:
+      "Group customers by behaviour, channel, or metadata and reuse segments across campaigns.",
+    helper:
+      "Segments update nightly from analytics events and can be previewed from the dashboard view.",
+    actionLabel: "Build segments",
+    href: "/cms/segments",
+  },
+];


### PR DESCRIPTION
## Summary
- extract marketing overview helpers into a shared lib and centralize derived data in a view-model hook
- create focused hero, summary cards, marketing tools grid, and recent performance subcomponents
- simplify the marketing overview page to compose the new pieces with cleaner, pre-derived props

## Testing
- pnpm --filter @apps/cms lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbba62bc4832f8c881ac7ae162656