### PR TITLE
Refactor pricing form hooks for grid and JSON responsibilities

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/usePricingGridState.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/usePricingGridState.ts
@@ -1,0 +1,163 @@
+import { useCallback, useState, type ChangeEvent, type Dispatch, type SetStateAction } from "react";
+import type { PricingMatrix } from "@acme/types";
+
+import {
+  buildPricingFromForm,
+  type CoverageDraft,
+  type DamageDraft,
+  type DurationDraft,
+  type ValidationResult,
+} from "./pricingFormUtils";
+import { useCoverageRows } from "./useCoverageRows";
+import { useDamageRows } from "./useDamageRows";
+import { useDurationRows } from "./useDurationRows";
+
+interface UsePricingGridStateArgs {
+  initial: PricingMatrix;
+}
+
+export interface DurationControls {
+  rows: DurationDraft[];
+  add: () => void;
+  remove: (id: string) => void;
+  update: (id: string, updates: Partial<Omit<DurationDraft, "id">>) => void;
+  getErrors: (id: string) => { minDays?: string; rate?: string };
+}
+
+export interface DamageControls {
+  rows: DamageDraft[];
+  add: () => void;
+  remove: (id: string) => void;
+  update: (id: string, updates: Partial<Omit<DamageDraft, "id">>) => void;
+  getErrors: (id: string) => { code?: string; amount?: string };
+}
+
+export interface CoverageControls {
+  rows: CoverageDraft[];
+  update: (code: CoverageDraft["code"], updates: Partial<Omit<CoverageDraft, "code">>) => void;
+  getErrors: (code: CoverageDraft["code"]) => { fee?: string; waiver?: string };
+}
+
+export interface PricingGridDrafts {
+  baseRate: string;
+  durationRows: DurationDraft[];
+  damageRows: DamageDraft[];
+  coverageRows: CoverageDraft[];
+}
+
+export interface PricingGridErrors {
+  baseDailyRate?: string;
+  root?: string;
+}
+
+export interface PricingGridState {
+  drafts: PricingGridDrafts;
+  controls: {
+    onBaseRateChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    duration: DurationControls;
+    damage: DamageControls;
+    coverage: CoverageControls;
+  };
+  errors: PricingGridErrors;
+  setFieldErrors: Dispatch<SetStateAction<Record<string, string>>>;
+  clearFieldErrors: () => void;
+  hydrateFromMatrix: (matrix: PricingMatrix) => void;
+  getFormPricing: () => ValidationResult;
+}
+
+export function usePricingGridState({ initial }: UsePricingGridStateArgs): PricingGridState {
+  const [baseRate, setBaseRate] = useState(() => initial.baseDailyRate.toString());
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const {
+    rows: durationRows,
+    add: addDurationRow,
+    remove: removeDurationRow,
+    update: updateDurationRow,
+    hydrate: hydrateDurationRows,
+    getErrors: getDurationErrors,
+  } = useDurationRows({ initial: initial.durationDiscounts, fieldErrors });
+
+  const {
+    rows: damageRows,
+    add: addDamageRow,
+    remove: removeDamageRow,
+    update: updateDamageRow,
+    hydrate: hydrateDamageRows,
+    getErrors: getDamageErrors,
+  } = useDamageRows({ initial: initial.damageFees, fieldErrors });
+
+  const {
+    rows: coverageRows,
+    update: updateCoverageRow,
+    hydrate: hydrateCoverageRows,
+    getErrors: getCoverageErrors,
+  } = useCoverageRows({ initial: initial.coverage, fieldErrors });
+
+  const hydrateFromMatrix = useCallback(
+    (matrix: PricingMatrix) => {
+      setBaseRate(matrix.baseDailyRate.toString());
+      hydrateDurationRows(matrix.durationDiscounts);
+      hydrateDamageRows(matrix.damageFees);
+      hydrateCoverageRows(matrix.coverage);
+      setFieldErrors({});
+    },
+    [hydrateCoverageRows, hydrateDamageRows, hydrateDurationRows]
+  );
+
+  const onBaseRateChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setBaseRate(event.target.value);
+  }, []);
+
+  const getFormPricing = useCallback(
+    () =>
+      buildPricingFromForm({
+        baseRate,
+        durationRows,
+        damageRows,
+        coverageRows,
+      }),
+    [baseRate, coverageRows, damageRows, durationRows]
+  );
+
+  const clearFieldErrors = useCallback(() => setFieldErrors({}), []);
+
+  return {
+    drafts: {
+      baseRate,
+      durationRows,
+      damageRows,
+      coverageRows,
+    },
+    controls: {
+      onBaseRateChange,
+      duration: {
+        rows: durationRows,
+        add: addDurationRow,
+        remove: removeDurationRow,
+        update: updateDurationRow,
+        getErrors: getDurationErrors,
+      },
+      damage: {
+        rows: damageRows,
+        add: addDamageRow,
+        remove: removeDamageRow,
+        update: updateDamageRow,
+        getErrors: getDamageErrors,
+      },
+      coverage: {
+        rows: coverageRows,
+        update: updateCoverageRow,
+        getErrors: getCoverageErrors,
+      },
+    },
+    errors: {
+      baseDailyRate: fieldErrors.baseDailyRate,
+      root: fieldErrors.root,
+    },
+    setFieldErrors,
+    clearFieldErrors,
+    hydrateFromMatrix,
+    getFormPricing,
+  };
+}

--- a/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/usePricingJsonBridge.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/data/rental/pricing/usePricingJsonBridge.ts
@@ -1,0 +1,47 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { PricingMatrix } from "@acme/types";
+
+import { type PricingFormStatus, type ValidationResult } from "./pricingFormUtils";
+import { usePricingJsonControls } from "./usePricingJsonControls";
+
+interface UsePricingJsonBridgeArgs {
+  initial: PricingMatrix;
+  onHydrate: (matrix: PricingMatrix) => void;
+  onToast: (message: string) => void;
+  onValidationErrors: Dispatch<SetStateAction<Record<string, string>>>;
+  setStatus: Dispatch<SetStateAction<PricingFormStatus>>;
+  getFormPricing: () => ValidationResult;
+}
+
+export function usePricingJsonBridge({
+  initial,
+  onHydrate,
+  onToast,
+  onValidationErrors,
+  setStatus,
+  getFormPricing,
+}: UsePricingJsonBridgeArgs) {
+  const controls = usePricingJsonControls({
+    initial,
+    onHydrate,
+    onToast,
+    onValidationErrors,
+    setStatus,
+    getFormPricing,
+  });
+
+  return {
+    draft: controls.draft,
+    error: controls.error,
+    setError: controls.setError,
+    onDraftChange: controls.onDraftChange,
+    applyJson: controls.applyJson,
+    parseDraft: controls.parseDraft,
+    setDraftFromMatrix: controls.setDraftFromMatrix,
+    progressMessage: controls.progressMessage,
+    fileInputRef: controls.fileInputRef,
+    handleImportClick: controls.handleImportClick,
+    handleFileChange: controls.handleFileChange,
+    handleExport: controls.handleExport,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- extract pricing grid management into `usePricingGridState`
- add `usePricingJsonBridge` to wrap JSON import/export controls
- compose the pricing form state hook from the new grid and JSON helpers

## Testing
- pnpm --filter @apps/cms lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbbac2644832fb21c486762c61226