### PR TITLE
refactor: extract mapping list row and utilities

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListField.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListField.tsx
@@ -2,22 +2,15 @@
 
 import type { ComponentProps, ReactNode } from "react";
 
-import {
-  Button,
-  FormField,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@ui/components";
+import { Button, Input } from "@ui/components";
 
 import type { MappingRowsController } from "../useShopEditorSubmit";
 
 import ErrorChips from "./ErrorChips";
+import MappingListRow from "./MappingListRow";
+import { hasErrors, joinClassNames } from "./mappingListField.utils";
 
-type MappingFieldName = "key" | "value";
+export type MappingFieldName = "key" | "value";
 
 export interface MappingListFieldRowErrors {
   readonly key?: string[];
@@ -77,44 +70,7 @@ export interface MappingListFieldProps {
 }
 
 const DEFAULT_REMOVE_LABEL = "Remove";
-const BASE_ROW_CLASSNAME = "grid gap-4 sm:items-end";
-const DEFAULT_ROW_TEMPLATE = "sm:grid-cols-[2fr,1fr,auto]";
 const BASE_CONTAINER_CLASSNAME = "space-y-4";
-
-function hasErrors(messages?: readonly string[]) {
-  return Array.isArray(messages) && messages.length > 0;
-}
-
-function isSelectField<Field extends MappingFieldName>(
-  field: MappingListFieldFieldConfig<Field>,
-): field is MappingListFieldSelectConfig<Field> {
-  return field.kind === "select";
-}
-
-function joinClassNames(...classes: Array<string | undefined>) {
-  return classes.filter(Boolean).join(" ");
-}
-
-function composeDescribedBy(...ids: Array<string | undefined>) {
-  const filtered = ids.filter(Boolean);
-  return filtered.length > 0 ? filtered.join(" ") : undefined;
-}
-
-function renderError(errors?: string[], id?: string) {
-  if (!hasErrors(errors)) {
-    return undefined;
-  }
-
-  return (
-    <span id={id}>
-      <ErrorChips errors={errors} />
-    </span>
-  );
-}
-
-function getRowClassName(rowClassName?: string) {
-  return joinClassNames(BASE_ROW_CLASSNAME, rowClassName ?? DEFAULT_ROW_TEMPLATE);
-}
 
 export default function MappingListField({
   controller,
@@ -139,153 +95,20 @@ export default function MappingListField({
           <p className="text-sm text-muted-foreground">{emptyMessage}</p>
         ) : null
       ) : (
-        rows.map((row, index) => {
-          const keyId = `${idPrefix}-${keyField.field}-${index}`;
-          const valueId = `${idPrefix}-${valueField.field}-${index}`;
-          const currentRowErrors = rowErrors[index];
-          const keyMessages = currentRowErrors?.key;
-          const valueMessages = currentRowErrors?.value;
-          const generalMessages = currentRowErrors?.general;
-          const keyErrorId = hasErrors(keyMessages)
-            ? `${idPrefix}-${index}-${keyField.field}-errors`
-            : undefined;
-          const valueErrorId = hasErrors(valueMessages)
-            ? `${idPrefix}-${index}-${valueField.field}-errors`
-            : undefined;
-          const rowErrorId = hasErrors(generalMessages)
-            ? `${idPrefix}-${index}-row-errors`
-            : undefined;
-
-          const keyFieldNode = (
-            <FormField
-              label={keyField.label}
-              htmlFor={keyId}
-              required={keyField.required}
-              error={renderError(keyMessages, keyErrorId)}
-            >
-              {isSelectField(keyField) ? (
-                <Select
-                  name={keyField.name}
-                  value={row[keyField.field] === "" ? undefined : row[keyField.field]}
-                  onValueChange={(value) =>
-                    controller.update(index, keyField.field, value)
-                  }
-                >
-                  <SelectTrigger
-                    id={keyId}
-                    aria-describedby={composeDescribedBy(
-                      keyErrorId,
-                      rowErrorId,
-                    )}
-                  >
-                    <SelectValue placeholder={keyField.placeholder} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {keyField.options.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Input
-                  id={keyId}
-                  name={keyField.name}
-                  value={row[keyField.field]}
-                  onChange={(event) =>
-                    controller.update(index, keyField.field, event.target.value)
-                  }
-                  placeholder={keyField.placeholder}
-                  aria-describedby={composeDescribedBy(keyErrorId, rowErrorId)}
-                  type={keyField.type}
-                  inputMode={keyField.inputMode}
-                  autoComplete={keyField.autoComplete}
-                />
-              )}
-            </FormField>
-          );
-
-          const valueFieldNode = (
-            <FormField
-              label={valueField.label}
-              htmlFor={valueId}
-              required={valueField.required}
-              error={renderError(valueMessages, valueErrorId)}
-            >
-              {isSelectField(valueField) ? (
-                <Select
-                  name={valueField.name}
-                  value={
-                    row[valueField.field] === ""
-                      ? undefined
-                      : row[valueField.field]
-                  }
-                  onValueChange={(value) =>
-                    controller.update(index, valueField.field, value)
-                  }
-                >
-                  <SelectTrigger
-                    id={valueId}
-                    aria-describedby={composeDescribedBy(
-                      valueErrorId,
-                      rowErrorId,
-                    )}
-                  >
-                    <SelectValue placeholder={valueField.placeholder} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {valueField.options.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Input
-                  id={valueId}
-                  name={valueField.name}
-                  value={row[valueField.field]}
-                  onChange={(event) =>
-                    controller.update(
-                      index,
-                      valueField.field,
-                      event.target.value,
-                    )
-                  }
-                  placeholder={valueField.placeholder}
-                  aria-describedby={composeDescribedBy(valueErrorId, rowErrorId)}
-                  type={valueField.type}
-                  inputMode={valueField.inputMode}
-                  autoComplete={valueField.autoComplete}
-                />
-              )}
-            </FormField>
-          );
-
-          return (
-            <div key={`${idPrefix}-row-${index}`} className={getRowClassName(rowClassName)}>
-              {keyFieldNode}
-              {valueFieldNode}
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => controller.remove(index)}
-                className="self-start sm:self-auto"
-              >
-                {removeButtonLabel}
-              </Button>
-              {hasErrors(generalMessages) ? (
-                <div className="sm:col-span-3">
-                  <span id={rowErrorId}>
-                    <ErrorChips errors={generalMessages} />
-                  </span>
-                </div>
-              ) : null}
-            </div>
-          );
-        })
+        rows.map((row, index) => (
+          <MappingListRow
+            key={`${idPrefix}-row-${index}`}
+            controller={controller}
+            errors={rowErrors[index]}
+            idPrefix={idPrefix}
+            index={index}
+            keyField={keyField}
+            removeButtonLabel={removeButtonLabel}
+            row={row}
+            rowClassName={rowClassName}
+            valueField={valueField}
+          />
+        ))
       )}
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListRow.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListRow.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { MappingRowsController } from "../useShopEditorSubmit";
+import {
+  Button,
+  FormField,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@ui/components";
+
+import type {
+  MappingFieldName,
+  MappingListFieldFieldConfig,
+  MappingListFieldRowErrors,
+} from "./MappingListField";
+import {
+  composeDescribedBy,
+  getRowClassName,
+  hasErrors,
+  isSelectField,
+  renderError,
+} from "./mappingListField.utils";
+
+type MappingListRowData = MappingRowsController["rows"][number];
+
+interface MappingListRowProps {
+  readonly controller: MappingRowsController;
+  readonly errors?: MappingListFieldRowErrors;
+  readonly idPrefix: string;
+  readonly index: number;
+  readonly keyField: MappingListFieldFieldConfig<"key">;
+  readonly removeButtonLabel: string;
+  readonly row: MappingListRowData;
+  readonly rowClassName?: string;
+  readonly valueField: MappingListFieldFieldConfig<"value">;
+}
+
+function renderFieldControl<Field extends MappingFieldName>(
+  field: MappingListFieldFieldConfig<Field>,
+  {
+    describedBy,
+    id,
+    onChange,
+    value,
+  }: {
+    describedBy?: string;
+    id: string;
+    onChange: (value: string) => void;
+    value: string;
+  },
+) {
+  if (isSelectField(field)) {
+    return (
+      <Select
+        name={field.name}
+        value={value === "" ? undefined : value}
+        onValueChange={onChange}
+      >
+        <SelectTrigger id={id} aria-describedby={describedBy}>
+          <SelectValue placeholder={field.placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {field.options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <Input
+      id={id}
+      name={field.name}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={field.placeholder}
+      aria-describedby={describedBy}
+      type={field.type}
+      inputMode={field.inputMode}
+      autoComplete={field.autoComplete}
+    />
+  );
+}
+
+export default function MappingListRow({
+  controller,
+  errors,
+  idPrefix,
+  index,
+  keyField,
+  removeButtonLabel,
+  row,
+  rowClassName,
+  valueField,
+}: MappingListRowProps) {
+  const keyId = `${idPrefix}-${keyField.field}-${index}`;
+  const valueId = `${idPrefix}-${valueField.field}-${index}`;
+
+  const keyMessages = errors?.key;
+  const valueMessages = errors?.value;
+  const generalMessages = errors?.general;
+
+  const keyErrorId = hasErrors(keyMessages)
+    ? `${idPrefix}-${index}-${keyField.field}-errors`
+    : undefined;
+  const valueErrorId = hasErrors(valueMessages)
+    ? `${idPrefix}-${index}-${valueField.field}-errors`
+    : undefined;
+  const rowErrorId = hasErrors(generalMessages)
+    ? `${idPrefix}-${index}-row-errors`
+    : undefined;
+
+  const keyDescribedBy = composeDescribedBy(keyErrorId, rowErrorId);
+  const valueDescribedBy = composeDescribedBy(valueErrorId, rowErrorId);
+  const generalError = renderError(generalMessages, rowErrorId);
+
+  return (
+    <div className={getRowClassName(rowClassName)}>
+      <FormField
+        label={keyField.label}
+        htmlFor={keyId}
+        required={keyField.required}
+        error={renderError(keyMessages, keyErrorId)}
+      >
+        {renderFieldControl(keyField, {
+          describedBy: keyDescribedBy,
+          id: keyId,
+          onChange: (value) => controller.update(index, keyField.field, value),
+          value: row[keyField.field],
+        })}
+      </FormField>
+
+      <FormField
+        label={valueField.label}
+        htmlFor={valueId}
+        required={valueField.required}
+        error={renderError(valueMessages, valueErrorId)}
+      >
+        {renderFieldControl(valueField, {
+          describedBy: valueDescribedBy,
+          id: valueId,
+          onChange: (value) => controller.update(index, valueField.field, value),
+          value: row[valueField.field],
+        })}
+      </FormField>
+
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => controller.remove(index)}
+        className="self-start sm:self-auto"
+      >
+        {removeButtonLabel}
+      </Button>
+
+      {generalError ? <div className="sm:col-span-3">{generalError}</div> : null}
+    </div>
+  );
+}

--- a/apps/cms/src/app/cms/shop/[shop]/settings/components/mappingListField.utils.ts
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/components/mappingListField.utils.ts
@@ -1,0 +1,46 @@
+import { createElement } from "react";
+import type {
+  MappingFieldName,
+  MappingListFieldFieldConfig,
+  MappingListFieldSelectConfig,
+} from "./MappingListField";
+
+import ErrorChips from "./ErrorChips";
+
+const BASE_ROW_CLASSNAME = "grid gap-4 sm:items-end";
+const DEFAULT_ROW_TEMPLATE = "sm:grid-cols-[2fr,1fr,auto]";
+
+export function hasErrors(messages?: readonly string[]) {
+  return Array.isArray(messages) && messages.length > 0;
+}
+
+export function isSelectField<Field extends MappingFieldName>(
+  field: MappingListFieldFieldConfig<Field>,
+): field is MappingListFieldSelectConfig<Field> {
+  return field.kind === "select";
+}
+
+export function joinClassNames(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function composeDescribedBy(...ids: Array<string | undefined>) {
+  const filtered = ids.filter(Boolean);
+  return filtered.length > 0 ? filtered.join(" ") : undefined;
+}
+
+export function renderError(errors?: string[], id?: string) {
+  if (!hasErrors(errors)) {
+    return undefined;
+  }
+
+  return createElement(
+    "span",
+    { id },
+    createElement(ErrorChips, { errors }),
+  );
+}
+
+export function getRowClassName(rowClassName?: string) {
+  return joinClassNames(BASE_ROW_CLASSNAME, rowClassName ?? DEFAULT_ROW_TEMPLATE);
+}


### PR DESCRIPTION
## Summary
- move reusable mapping list helpers into mappingListField.utils
- add a MappingListRow component to render a single configured row
- simplify MappingListField to delegate row rendering and focus on layout

## Testing
- pnpm exec eslint apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListField.tsx apps/cms/src/app/cms/shop/[shop]/settings/components/MappingListRow.tsx apps/cms/src/app/cms/shop/[shop]/settings/components/mappingListField.utils.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbbbadc9d0832f9158414fe084224f