### PR TITLE
fix: email password reset token instead of returning it

### DIFF
--- a/apps/shop-bcd/src/app/api/password-reset/request/route.ts
+++ b/apps/shop-bcd/src/app/api/password-reset/request/route.ts
@@ -4,6 +4,7 @@ import { parseJsonBody } from "@shared-utils";
 import { z } from "zod";
 import crypto from "crypto";
 import { getUserByEmail, setResetToken } from "@platform-core/users";
+import { sendEmail } from "@acme/email";
 
 export const runtime = "nodejs";
 
@@ -22,8 +23,12 @@ export async function POST(req: Request) {
         ? new Date(Date.now() + 1000)
         : new Date(Date.now() + 3600_000);
     await setResetToken(user.id, token, expires);
-    // expose token for tests
-    return NextResponse.json({ ok: true, token });
+    await sendEmail(
+      user.email,
+      "Reset your Base Shop password",
+      `Use this code to reset your password: ${token}`
+    );
+    return NextResponse.json({ ok: true });
   } catch {
     // do not reveal whether email exists
     return NextResponse.json({ ok: true });

--- a/security/findings/Shopper API & UI flows.md
+++ b/security/findings/Shopper API & UI flows.md
@@ -1,0 +1,16 @@
+# Shopper API & UI flows Findings
+
+## Password reset token leak enables account takeover
+- **Component**: `apps/shop-bcd/src/app/api/password-reset/request/route.ts`
+- **CWE**: CWE-201 – Exposure of Sensitive Information to an Unauthorized Actor
+- **OWASP**: A02:2021 – Cryptographic Failures
+- **Risk**: High
+
+### Exploit narrative
+The password-reset request endpoint minted a reset token, persisted it, and returned the token in the JSON response. An attacker only needs to know a victim's email address to trigger this endpoint and read the secret token directly from the API response. With that token the attacker can immediately complete the `/api/password-reset/[token]` flow and choose a new password for the victim, taking over the account without needing email access.
+
+### Minimal patch
+Send the reset token to the account owner over email instead of returning it to the caller, and return a generic `{ ok: true }` response regardless of whether the address exists. This keeps the token secret while preserving the original non-enumeration behavior.
+
+### Tests
+`apps/shop-bcd/__tests__/password-reset.test.tsx` now asserts that the request endpoint omits the `token` field and that `@acme/email.sendEmail` is invoked with the generated token. The test fails against the vulnerable handler (because the token is still in the payload and no email is sent) and passes after the fix.


### PR DESCRIPTION
## Summary
- send password reset tokens by email and return a generic success payload
- extend the password reset integration test to mock the mailer and assert the token stays server-side
- document the exposed token vulnerability and its fix under security findings

## Testing
- pnpm exec jest apps/shop-bcd/__tests__/password-reset.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbbbda5e00832f9aa742c9a402760d