### PR TITLE
Handle CMS boolish defaults and email fallback in core env

### DIFF
--- a/packages/config/src/env/cms.schema.ts
+++ b/packages/config/src/env/cms.schema.ts
@@ -4,16 +4,24 @@ import { z } from "zod";
 const isProd = process.env.NODE_ENV === "production";
 
 const boolish = z.preprocess((val) => {
-  if (typeof val === "string") {
-    if (/^(true|1)$/i.test(val)) return true;
-    if (/^(false|0)$/i.test(val)) return false;
+  if (typeof val === "boolean") {
     return val;
   }
+
+  if (typeof val === "string") {
+    const normalized = val.trim();
+    if (normalized === "") return false;
+    if (/^(true|1)$/i.test(normalized)) return true;
+    if (/^(false|0)$/i.test(normalized)) return false;
+    return val;
+  }
+
   if (typeof val === "number") {
     if (val === 1) return true;
     if (val === 0) return false;
     return val;
   }
+
   return val;
 }, z.boolean());
 


### PR DESCRIPTION
## Summary
- treat empty or whitespace CMS feature flag inputs as explicit `false` values so disabled path lists can be parsed even when the flags are turned off
- preprocess `coreEnvSchema` input to trim email settings and inject a `noop` provider when neither `EMAIL_FROM` nor an email provider is specified, avoiding spurious validation errors

## Testing
- `pnpm --filter @acme/config test -- packages/config/src/env/__tests__/cms.test.ts packages/config/__tests__/coreEnvRefinement.test.ts` *(fails: Jest cannot parse the ESM test files in this environment, reporting “Cannot use import statement outside a module” before our targeted suites execute)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcf97cc14832f916bc4242e3c54ae