### PR TITLE
Require production Sanity env vars

### DIFF
--- a/packages/config/src/env/cms.schema.ts
+++ b/packages/config/src/env/cms.schema.ts
@@ -24,14 +24,21 @@ export const cmsEnvSchema = z.object({
   CMS_ACCESS_TOKEN: isProd
     ? z.string().min(1)
     : z.string().min(1).default("placeholder-token"),
-  // Provide placeholder Sanity values when real credentials are missing.
-  // These defaults allow the app to run even if the environment variables are
-  // not configured, including in production builds.
-  SANITY_API_VERSION: z.string().min(1).default("2021-10-21"),
-  SANITY_PROJECT_ID: z.string().min(1).default("dummy-project-id"),
-  SANITY_DATASET: z.string().min(1).default("production"),
-  SANITY_API_TOKEN: z.string().min(1).default("dummy-api-token"),
-  SANITY_PREVIEW_SECRET: z.string().min(1).default("dummy-preview-secret"),
+  SANITY_API_VERSION: isProd
+    ? z.string().min(1)
+    : z.string().min(1).default("2021-10-21"),
+  SANITY_PROJECT_ID: isProd
+    ? z.string().min(1)
+    : z.string().min(1).default("dummy-project-id"),
+  SANITY_DATASET: isProd
+    ? z.string().min(1)
+    : z.string().min(1).default("production"),
+  SANITY_API_TOKEN: isProd
+    ? z.string().min(1)
+    : z.string().min(1).default("dummy-api-token"),
+  SANITY_PREVIEW_SECRET: isProd
+    ? z.string().min(1)
+    : z.string().min(1).default("dummy-preview-secret"),
   SANITY_BASE_URL: z
     .string()
     .url()


### PR DESCRIPTION
## Summary
- require the Sanity CMS environment variables when NODE_ENV is production so misconfigured deploys fail fast

## Testing
- pnpm exec jest packages/config/src/env/__tests__/cms.env.test.ts --runInBand --coverage=false
- pnpm exec jest packages/config/src/env/__tests__/envLoaders.additional.test.ts --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbcfb2db88832f82e1c559a9946643