### PR TITLE
Ensure config test helper resets environment

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -52,6 +52,20 @@ mutableEnv.AUTH_TOKEN_TTL ||= "15m";
 mutableEnv.EMAIL_FROM ||= "test@example.com";
 mutableEnv.EMAIL_PROVIDER ||= "noop";
 
+type BaseEnvRecord = Record<string, string>;
+const globalWithBaseEnv = globalThis as typeof globalThis & {
+  __ACME_TEST_BASE_ENV__?: BaseEnvRecord;
+};
+
+if (!globalWithBaseEnv.__ACME_TEST_BASE_ENV__) {
+  const baselineEntries = Object.entries(process.env).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  globalWithBaseEnv.__ACME_TEST_BASE_ENV__ = Object.freeze(
+    Object.fromEntries(baselineEntries),
+  );
+}
+
 /* -------------------------------------------------------------------------- */
 /* 2.  Polyfills missing from the JSDOM / Node test runtime                    */
 /* -------------------------------------------------------------------------- */

--- a/packages/config/test/utils/withEnv.ts
+++ b/packages/config/test/utils/withEnv.ts
@@ -1,16 +1,48 @@
+type EnvValue = string | number | boolean | undefined;
+type EnvOverrides = Record<string, EnvValue>;
+
+const globalWithBaseEnv = globalThis as typeof globalThis & {
+  __ACME_TEST_BASE_ENV__?: Record<string, string>;
+};
+
+const cloneBaseEnv = (): NodeJS.ProcessEnv => {
+  const baseline = globalWithBaseEnv.__ACME_TEST_BASE_ENV__;
+  if (baseline) {
+    return { ...baseline } as NodeJS.ProcessEnv;
+  }
+  return { ...process.env };
+};
+
+const applyOverrides = (
+  baseEnv: NodeJS.ProcessEnv,
+  overrides: EnvOverrides,
+): NodeJS.ProcessEnv => {
+  const nextEnv: NodeJS.ProcessEnv = { ...baseEnv };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete nextEnv[key];
+      continue;
+    }
+    nextEnv[key] = typeof value === "string" ? value : String(value);
+  }
+  return nextEnv;
+};
+
 export async function withEnv<T>(
-  vars: NodeJS.ProcessEnv,
+  vars: EnvOverrides,
   loader: () => Promise<T>,
 ): Promise<T> {
-  const OLD = process.env;
-  jest.resetModules();
-  process.env = { ...OLD, ...vars };
+  const previousEnv = process.env;
+  const baseEnv = cloneBaseEnv();
+  const nextEnv = applyOverrides(baseEnv, vars);
   if (!("NODE_ENV" in vars)) {
-    delete process.env.NODE_ENV;
+    delete nextEnv.NODE_ENV;
   }
+  jest.resetModules();
+  process.env = nextEnv;
   try {
     return await loader();
   } finally {
-    process.env = OLD;
+    process.env = previousEnv;
   }
 }


### PR DESCRIPTION
## Summary
- capture the initial environment snapshot in `jest.setup.ts` so tests can start from a clean baseline
- update `packages/config/test/utils/withEnv.ts` to clone the baseline, apply overrides, and restore `process.env` reliably across test runs

## Testing
- pnpm exec jest --config jest.config.cjs packages/config/__tests__/authEnv.test.ts --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cbd029a820832f9caa61a6b47875cd