### PR TITLE
Ensure withEnv supplies default EMAIL_FROM

### DIFF
--- a/packages/config/test/utils/withEnv.ts
+++ b/packages/config/test/utils/withEnv.ts
@@ -4,7 +4,13 @@ export async function withEnv<T>(
 ): Promise<T> {
   const OLD = process.env;
   jest.resetModules();
-  process.env = { ...OLD, ...vars };
+  const nextEnv: NodeJS.ProcessEnv = { ...OLD, ...vars };
+  const hasEmailFrom =
+    typeof nextEnv.EMAIL_FROM === "string" && nextEnv.EMAIL_FROM.trim().length > 0;
+  if (!("EMAIL_FROM" in vars) && !hasEmailFrom) {
+    nextEnv.EMAIL_FROM = "from@example.com";
+  }
+  process.env = nextEnv;
   if (!("NODE_ENV" in vars)) {
     delete process.env.NODE_ENV;
   }


### PR DESCRIPTION
## Summary
- default `EMAIL_FROM` to a placeholder in the shared `withEnv` helper so email configuration tests receive the expected SMTP defaults when no value is provided

## Testing
- `pnpm --filter @acme/config test -- --runTestsByPath packages/config/__tests__/emailEnv.test.ts` *(fails: Jest cannot parse ESM imports in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd0815d08832f93fb362757846280