### PR TITLE
Ensure inventory alerts fire when low stock

### DIFF
--- a/packages/platform-core/src/repositories/inventory.prisma.server.ts
+++ b/packages/platform-core/src/repositories/inventory.prisma.server.ts
@@ -97,7 +97,8 @@ async function write(shop: string, items: InventoryItem[]): Promise<void> {
         i.quantity <= i.lowStockThreshold,
     );
     if (process.env.SKIP_STOCK_ALERT !== "1" && hasLowStock) {
-      // Stock alerts are skipped during build to avoid pulling in email dependencies.
+      const { checkAndAlert } = await import("../services/stockAlert.server");
+      await checkAndAlert(shop, normalized);
     }
   } catch (err) {
     console.error(`Failed to write inventory for ${shop}`, err);
@@ -174,7 +175,8 @@ async function update(
         i.quantity <= i.lowStockThreshold,
     );
     if (process.env.SKIP_STOCK_ALERT !== "1" && hasLowStock) {
-      // Stock alerts are skipped during build to avoid pulling in email dependencies.
+      const { checkAndAlert } = await import("../services/stockAlert.server");
+      await checkAndAlert(shop, all);
     }
 
     return updated;


### PR DESCRIPTION
## Summary
- trigger the stock alert service from the Prisma inventory repository when low-stock items are detected during write and update operations

## Testing
- pnpm --filter @acme/platform-core test -- --runTestsByPath packages/platform-core/src/repositories/__tests__/inventory.prisma.server.test.ts --coverage=false --collectCoverage=false *(fails coverage threshold enforcement after the suite passes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc15187308832f93a22431b515790b