### PR TITLE
fix: guard rentalOrder findUnique when composite key missing

### DIFF
--- a/packages/platform-core/src/db/stubs/rentalOrder.ts
+++ b/packages/platform-core/src/db/stubs/rentalOrder.ts
@@ -13,8 +13,12 @@ interface FindManyArgs {
   };
 }
 
+type RentalOrderUniqueWhere =
+  | { shop_sessionId: { shop: string; sessionId: string } }
+  | { shop_trackingNumber: { shop: string; trackingNumber: string | null } };
+
 interface FindUniqueArgs {
-  where: { shop_sessionId: { shop: string; sessionId: string } };
+  where: RentalOrderUniqueWhere;
 }
 
 interface UpdateArgs {
@@ -43,11 +47,14 @@ export function createRentalOrderDelegate(): RentalOrderDelegate {
       });
     },
     async findUnique({ where }: FindUniqueArgs) {
-      const { shop, sessionId } = where.shop_sessionId;
-      return (
-        rentalOrders.find((o) => o.shop === shop && o.sessionId === sessionId) ||
-        null
-      );
+      if ("shop_sessionId" in where) {
+        const { shop, sessionId } = where.shop_sessionId;
+        return (
+          rentalOrders.find((o) => o.shop === shop && o.sessionId === sessionId) ||
+          null
+        );
+      }
+      return null;
     },
     async create({ data }) {
       rentalOrders.push({ ...data });


### PR DESCRIPTION
## Summary
- broaden the rentalOrder stub's unique where typing to cover both session and tracking number selectors
- guard findUnique so unsupported unique keys return null instead of throwing

## Testing
- pnpm --filter @acme/platform-core run test -- packages/platform-core/src/db/stubs/__tests__/rentalOrder.test.ts *(fails: coverage thresholds not met when running a single suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cc15a12318832fbf6333ec30e792e6