### PR TITLE
Fix fs mock initialization in return logistics test

### DIFF
--- a/packages/platform-core/src/repositories/__tests__/returnLogistics.server.test.ts
+++ b/packages/platform-core/src/repositories/__tests__/returnLogistics.server.test.ts
@@ -4,13 +4,13 @@ jest.mock("../../dataRoot", () => ({
   resolveDataRoot: jest.fn(() => "/data/root/shops"),
 }));
 
-const readFile = jest.fn();
-
 jest.mock("fs", () => ({
   promises: {
-    readFile,
+    readFile: jest.fn(),
   },
 }));
+
+const readFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
 
 import { readReturnLogistics, createReturnLabel } from "../returnLogistics.server";
 


### PR DESCRIPTION
## Summary
- update the return logistics repository test to grab the mocked fs.readFile from the mocked module instead of referencing a hoisted variable

## Testing
- pnpm exec jest --config jest.config.cjs --runTestsByPath packages/platform-core/src/repositories/__tests__/returnLogistics.server.test.ts --runInBand --detectOpenHandles --no-coverage

------
https://chatgpt.com/codex/tasks/task_e_68cc15c7e194832fae0f755453851e72