### PR TITLE
Fix platform-core test tsconfig to include root files

### DIFF
--- a/packages/platform-core/tsconfig.test.json
+++ b/packages/platform-core/tsconfig.test.json
@@ -11,6 +11,11 @@
     "outDir": ".ts-jest"
   },
 
-  "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "__tests__/**/*",
+    "*.ts"
+  ]
 }
 


### PR DESCRIPTION
## Summary
- include top-level TypeScript entrypoints in the platform-core test tsconfig so Jest/ts-jest can transform them during unit tests

## Testing
- pnpm --filter @acme/platform-core exec jest --runTestsByPath __tests__/defaultFilterMappings.test.ts --config ../../jest.config.cjs --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cc15fa675c832f87fad00ba288d607